### PR TITLE
Fix compilation with Boost 1.46.1

### DIFF
--- a/filters/include/pcl/filters/random_sample.h
+++ b/filters/include/pcl/filters/random_sample.h
@@ -134,7 +134,7 @@ namespace pcl
 
     private:
       /** \brief Boost-based random number generator algorithm. */
-      boost::random::mt19937 rng_alg_;
+      boost::mt19937 rng_alg_;
 
       /** \brief Boost-based random number generator distribution. */
       boost::shared_ptr<boost::uniform_01<boost::mt19937> > rng_;
@@ -218,7 +218,7 @@ namespace pcl
 
     private:
       /** \brief Boost-based random number generator algorithm. */
-      boost::random::mt19937 rng_alg_;
+      boost::mt19937 rng_alg_;
 
       /** \brief Boost-based random number generator distribution. */
       boost::shared_ptr<boost::uniform_01<boost::mt19937> > rng_;


### PR DESCRIPTION
Fix compilation with Boost 1.46.1: boost::mt19937 instead of boost::random::mt19937.
Can anyone with a newer Boost version please verify that this works.
