### PR TITLE
Fix for bug 961: SACSegmentation crashes when setSamplesMaxDist() and a search object with indices is used

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -466,14 +466,19 @@ namespace pcl
         std::vector<int> indices;
         std::vector<float> sqr_dists;
 
-        samples_radius_search_->radiusSearch (shuffled_indices_[0], samples_radius_,
-                                              indices, sqr_dists );
+        // If indices have been set when the search object was constructed,
+        // radiusSearch() expects an index into the indices vector as its
+        // first parameter. This can't be determined efficiently, so we use
+        // the point instead of the index.
+        // Returned indices are converted automatically.
+        samples_radius_search_->radiusSearch (input_->at(shuffled_indices_[0]),
+                                              samples_radius_, indices, sqr_dists );
 
         if (indices.size () < sample_size - 1)
         {
           // radius search failed, make an invalid model
           for(unsigned int i = 1; i < sample_size; ++i)
-        	shuffled_indices_[i] = shuffled_indices_[0];
+            shuffled_indices_[i] = shuffled_indices_[0];
         }
         else
         {


### PR DESCRIPTION
As discussed on the tracker, the point is used for search instead of the point index. This avoids problems when a search object is used that has been constructed using indices.
