### PR TITLE
Implementation of an OpenMP-parallelized version of Moving Least Squares

### DIFF
--- a/surface/src/mls.cpp
+++ b/surface/src/mls.cpp
@@ -46,5 +46,8 @@
 PCL_INSTANTIATE_PRODUCT(MovingLeastSquares, ((pcl::PointXYZ)(pcl::PointXYZRGB)(pcl::PointXYZRGBA))
                                             ((pcl::PointXYZ)(pcl::PointXYZRGB)(pcl::PointXYZRGBA)(pcl::PointXYZRGBNormal)(pcl::PointNormal)))
 
+PCL_INSTANTIATE_PRODUCT(MovingLeastSquaresOMP, ((pcl::PointXYZ)(pcl::PointXYZRGB)(pcl::PointXYZRGBA))
+                                               ((pcl::PointXYZ)(pcl::PointXYZRGB)(pcl::PointXYZRGBA)(pcl::PointXYZRGBNormal)(pcl::PointNormal)))
+
 /// Ideally, we should instantiate like below, but it takes large amounts of main memory for compilation
 //PCL_INSTANTIATE_PRODUCT(MovingLeastSquares, (PCL_XYZ_POINT_TYPES)(PCL_XYZ_POINT_TYPES))

--- a/test/surface/test_moving_least_squares.cpp
+++ b/test/surface/test_moving_least_squares.cpp
@@ -89,13 +89,13 @@ TEST (PCL, MovingLeastSquares)
 
 
   // Testing OpenMP version
-  MovingLeastSquares<PointXYZ, PointNormal> mls_omp;
+  MovingLeastSquaresOMP<PointXYZ, PointNormal> mls_omp;
   mls_omp.setInputCloud (cloud);
   mls_omp.setComputeNormals (true);
   mls_omp.setPolynomialFit (true);
   mls_omp.setSearchMethod (tree);
   mls_omp.setSearchRadius (0.03);
-  //mls_omp.setNumberOfThreads (4);
+  mls_omp.setNumberOfThreads (4);
 
   // Reconstruct
   mls_normals->clear ();


### PR DESCRIPTION
As discussed on pcl-devel (http://www.pcl-developers.org/Open-MP-enabled-Moving-Least-Squares-td5707681.html), here's a patch that adds OpenMP parallelization for Moving Least Squares through a class MovingLeastSquaresOMP. Tests are re-enabled and pass without errors. I have been using the patch for quite a while now and it seems stable. I didn't test the upsampling methods thoroughly, though.
