### PR TITLE
Fix Boost modules on Windows

### DIFF
--- a/cmake/pcl_find_boost.cmake
+++ b/cmake/pcl_find_boost.cmake
@@ -24,14 +24,15 @@ if(Boost_SERIALIZATION_FOUND)
 endif(Boost_SERIALIZATION_FOUND)
 
 # Required boost modules
-find_package(Boost 1.40.0 REQUIRED COMPONENTS system filesystem thread date_time iostreams)
-
+set(BOOST_REQUIRED_MODULES system filesystem thread date_time iostreams)
 # Starting with Boost 1.50, boost_thread depends on chrono. As this is not
 # taken care of automatically on Windows, we add an explicit dependency as a
 # workaround.
 if(WIN32 AND Boost_VERSION VERSION_GREATER "104900")
-  find_package(Boost 1.40.0 REQUIRED COMPONENTS chrono)
+  set(BOOST_REQUIRED_MODULES ${BOOST_REQUIRED_MODULES} chrono)
 endif(WIN32 AND Boost_VERSION VERSION_GREATER "104900")
+
+find_package(Boost 1.40.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_MODULES})
 
 if(Boost_FOUND)
   set(BOOST_FOUND TRUE)


### PR DESCRIPTION
The second call of find_package(Boost) for the chrono module removes the previously found modules from the @Boost_LIBRARIES@ variable. 
