### PR TITLE
Add a workaround for incorrect CUDA_HOST_COMPILER setting

### DIFF
--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -1,4 +1,16 @@
 # Find CUDA
+
+
+# Recent versions of cmake set CUDA_HOST_COMPILER to CMAKE_C_COMPILER which
+# on OSX defaults to clang (/usr/bin/cc), but this is not a supported cuda
+# compiler.  So, here we will preemptively set CUDA_HOST_COMPILER to gcc if
+# that compiler exists in /usr/bin.  This will not override an existing cache
+# value if the user has passed CUDA_HOST_COMPILER on the command line.
+if (NOT DEFINED CUDA_HOST_COMPILER AND CMAKE_C_COMPILER_ID STREQUAL "Clang" AND EXISTS /usr/bin/gcc)
+  set(CUDA_HOST_COMPILER /usr/bin/gcc CACHE FILEPATH "Host side compiler used by NVCC")
+  message(STATUS "Setting CMAKE_HOST_COMPILER to /usr/bin/gcc instead of ${CMAKE_C_COMPILER}.  See http://dev.pointclouds.org/issues/979")
+endif()
+
 set(CUDA_FIND_QUIETLY TRUE)
 find_package(CUDA 4)
 
@@ -30,4 +42,10 @@ if(CUDA_FOUND)
 	include(${PCL_SOURCE_DIR}/cmake/CudaComputeTargetFlags.cmake)
 	APPEND_TARGET_ARCH_FLAGS()
     
+  # Send a warning if CUDA_HOST_COMPILER is set to a compiler that is known
+  # to be unsupported.
+  if (CUDA_HOST_COMPILER STREQUAL CMAKE_C_COMPILER AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    message(WARNING "CUDA_HOST_COMPILER is set to an unsupported compiler: ${CMAKE_C_COMPILER}.  See http://dev.pointclouds.org/issues/979")
+  endif()
+
 endif()


### PR DESCRIPTION
Recent versions of cmake set CUDA_HOST_COMPILER to CMAKE_C_COMPILER
which on OSX defaults to clang (/usr/bin/cc), but this is not a
supported cuda compiler.  This commit adds a workaround to
preemptively set CUDA_HOST_COMPILER to gcc if that compiler exists in
/usr/bin.
