### PR TITLE
Put EIGEN_ALIGN16 after 'union' keyword

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -144,8 +144,7 @@ namespace pcl
 {
 
 #define PCL_ADD_POINT4D \
-  EIGEN_ALIGN16 \
-  union { \
+  union EIGEN_ALIGN16 { \
     float data[4]; \
     struct { \
       float x; \
@@ -163,8 +162,7 @@ namespace pcl
   inline const Eigen::Map<const Eigen::Array4f, Eigen::Aligned> getArray4fMap () const { return (Eigen::Array4f::MapAligned (data)); }
 
 #define PCL_ADD_NORMAL4D \
-  EIGEN_ALIGN16 \
-  union { \
+  union EIGEN_ALIGN16 { \
     float data_n[4]; \
     float normal[3]; \
     struct { \


### PR DESCRIPTION
The EIGEN_ALIGN16 macro preceded the union keyword in the code, gcc 4.8 however requires it to follow, as stated for example by this warning:
[...]/point_types.hpp:813:5: note: in expansion of macro ‘PCL_ADD_POINT4D’
[...]/point_types.hpp:124:9: note: attribute for ‘union tas::lidar::Point::<anonymous>’ must follow the ‘union’ keyword

Compiling my code gave several thousand of those messages and the alignment was ignored, as a colleague told me.
