### PR TITLE
Fix: now the PCLVisualizer.close() method actually closes the window.

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1072,6 +1072,7 @@ namespace pcl
 #else
           stopped_ = true;
           // This tends to close the window...
+          win_->Finalize ();
           interactor_->TerminateApp ();
 #endif
         }


### PR DESCRIPTION
I've noticed that invoking the close() method on a PCLVisualizer does not properly close the window as can be seen running the following code snippet:

``` c++
#include <pcl/io/pcd_io.h>
#include <pcl/visualization/pcl_visualizer.h>

int main (int argc, char ** argv)
{
  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>());
  pcl::io::loadPCDFile("bunny.pcd", *cloud);
  {
    pcl::visualization::PCLVisualizer viewer;
    viewer.addPointCloud(cloud);
    viewer.spin();
    viewer.close(); // the window does not close
  }
  {
    pcl::visualization::PCLVisualizer viewer;
    viewer.addPointCloud(cloud);
    viewer.spin();
    viewer.close();
  }
  // both windows close now because the program terminates
}
```

This fix is inspired by the VTK tutorial code that can be found at http://www.vtk.org/Wiki/VTK/Examples/Cxx/Visualization/CloseWindow

Cheers!
Tommaso
