### PR TITLE
Fix eigen_listsS and LUM on 32bit

### DIFF
--- a/registration/include/pcl/registration/boost_graph.h
+++ b/registration/include/pcl/registration/boost_graph.h
@@ -88,6 +88,16 @@ namespace boost
     {
       typedef allow_parallel_edge_tag type;
     };
+
+  namespace detail
+  {
+    template <>
+      struct is_random_access<eigen_listS>
+      {
+        enum { value = false };
+        typedef mpl::false_ type;
+      };
+  }
 }
 
 #endif    // PCL_REGISTRATION_BOOST_GRAPH_H_

--- a/registration/include/pcl/registration/lum.h
+++ b/registration/include/pcl/registration/lum.h
@@ -131,7 +131,7 @@ namespace pcl
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         };
 
-        typedef boost::adjacency_list<boost::eigen_vecS, boost::eigen_vecS, boost::bidirectionalS, VertexProperties, EdgeProperties> SLAMGraph;
+        typedef boost::adjacency_list<boost::eigen_vecS, boost::eigen_vecS, boost::bidirectionalS, VertexProperties, EdgeProperties, boost::no_property, boost::eigen_listS> SLAMGraph;
         typedef boost::shared_ptr<SLAMGraph> SLAMGraphPtr;
         typedef typename SLAMGraph::vertex_descriptor Vertex;
         typedef typename SLAMGraph::edge_descriptor Edge;


### PR DESCRIPTION
Use special Eigen aligned allocator for Boost graph edge list.
