### PR TITLE
Fixed grabber_test

### DIFF
--- a/test/io/test_grabbers.cpp
+++ b/test/io/test_grabbers.cpp
@@ -118,6 +118,7 @@ TEST (PCL, ImageGrabberTIFF)
   boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
     fxn = boost::bind (cloud_callback, &signal_received, &cloud_buffer, _1);
   grabber.registerCallback (fxn);
+  grabber.setCameraIntrinsics (525., 525., 320., 240.); // Setting old intrinsics which were used to generate these tests
   grabber.start ();
   for (size_t i = 0; i < grabber.size (); i++)
   {


### PR DESCRIPTION
Since we changed the default intrinsics from (525, 525, 240, 320) to (525, 525, 239.5, 319.5), the old test had been failing.
