### PR TITLE
Changing default IsOrganized behavior

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -330,7 +330,7 @@ namespace pcl
       inline bool
       isOrganized () const
       {
-        return (height != 1);
+        return (height > 1);
       }
       
       /** \brief Return an Eigen MatrixXf (assumes float values) mapped to the specified dimensions of the PointCloud.


### PR DESCRIPTION
Currently a cloud of height 0 yields "isOrganized() = true". For anyone who made a PointCloud with the default constructor then modified cloud.points directly (I know, I know, we're supposed to use the wrapper function), this led to pretty bad issues -- I found it in EuclideanClusterExtraction, but it's probably elsewhere.
