### PR TITLE
adding check if array with distances to model is empty

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
@@ -100,6 +100,13 @@ pcl::MaximumLikelihoodSampleConsensus<PointT>::computeModel (int debug_verbosity
     // Iterate through the 3d points and calculate the distances from them to the model
     sac_model_->getDistancesToModel (model_coefficients, distances);
 
+    if (distances.empty ())
+    {
+      //iterations_++;
+      ++skipped_count;
+      continue;
+    }
+    
     // Use Expectiation-Maximization to find out the right value for d_cur_penalty
     // ---[ Initial estimate for the gamma mixing parameter = 1/2
     double gamma = 0.5;


### PR DESCRIPTION
In function "computeModel" after getting distances to the model (line 101) there is no check if array is empty. As result, the following for-loop (line 114) crashes because it tries to read values from empty array.
