### PR TITLE
Incorrect method name in correspondence_rejector_trimmed.h

### DIFF
--- a/registration/include/pcl/registration/correspondence_rejection_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_trimmed.h
@@ -91,7 +91,7 @@ namespace pcl
 
         /** \brief Get the maximum distance used for thresholding in correspondence rejection. */
         inline float 
-        getOverlapRadio () { return overlap_ratio_; };
+        getOverlapRatio () { return overlap_ratio_; };
 
         /** \brief Set a minimum number of correspondences. If the specified overlap ratio causes to have
           * less correspondences,  \a CorrespondenceRejectorTrimmed will try to return at least


### PR DESCRIPTION
getOverlapRatio was incorrectly called getOverlapRadio. Changed to reflect the API.
