### PR TITLE
qhull 2011 doesn't need to send the output to the stdout

### DIFF
--- a/surface/include/pcl/surface/impl/convex_hull.hpp
+++ b/surface/include/pcl/surface/impl/convex_hull.hpp
@@ -133,8 +133,10 @@ pcl::ConvexHull<PointInT>::performReconstruction2D (PointCloud &hull, std::vecto
   // output from qh_produce_output(), use NULL to skip qh_produce_output()
   FILE *outfile = NULL;
 
+#ifndef HAVE_QHULL_2011
   if (compute_area_)
     outfile = stderr;
+#endif
 
   // option flags for qhull, see qh_opt.htm
   const char* flags = qhull_flags.c_str ();
@@ -178,6 +180,12 @@ pcl::ConvexHull<PointInT>::performReconstruction2D (PointCloud &hull, std::vecto
    
   // Compute convex hull
   int exitcode = qh_new_qhull (dimension, static_cast<int> (indices_->size ()), points, ismalloc, const_cast<char*> (flags), outfile, errfile);
+#ifdef HAVE_QHULL_2011
+  if (compute_area_)
+  {
+    qh_prepare_output();
+  }
+#endif
     
   // 0 if no error from qhull or it doesn't find any vertices
   if (exitcode != 0 || qh num_vertices == 0)
@@ -283,8 +291,10 @@ pcl::ConvexHull<PointInT>::performReconstruction3D (
   // output from qh_produce_output(), use NULL to skip qh_produce_output()
   FILE *outfile = NULL;
 
+#ifndef HAVE_QHULL_2011
   if (compute_area_)
     outfile = stderr;
+#endif
 
   // option flags for qhull, see qh_opt.htm
   const char *flags = qhull_flags.c_str ();
@@ -304,6 +314,12 @@ pcl::ConvexHull<PointInT>::performReconstruction3D (
 
   // Compute convex hull
   int exitcode = qh_new_qhull (dimension, static_cast<int> (indices_->size ()), points, ismalloc, const_cast<char*> (flags), outfile, errfile);
+#ifdef HAVE_QHULL_2011
+  if (compute_area_)
+  {
+    qh_prepare_output();
+  }
+#endif
 
   // 0 if no error from qhull
   if (exitcode != 0)


### PR DESCRIPTION
As per 2011 version of qhull (http://www.qhull.org/news/qhull-news.html#bugs) needs qh_prepare_output to be called when passing a NULL outfile for getting the area and volume.
