### PR TITLE
io/pcd_grabber.h: Only include openni includes if HAVE_OPENNI is defined

### DIFF
--- a/io/include/pcl/io/pcd_grabber.h
+++ b/io/include/pcl/io/pcd_grabber.h
@@ -43,14 +43,14 @@
 #include <pcl/common/io.h>
 #include <pcl/io/grabber.h>
 #include <pcl/io/file_grabber.h>
-#include <pcl/io/openni_camera/openni_image.h>
-#include <pcl/io/openni_camera/openni_image_rgb24.h>
 #include <pcl/common/time_trigger.h>
 #include <string>
 #include <vector>
 #include <pcl/ros/conversions.h>
 
 #ifdef HAVE_OPENNI
+#include <pcl/io/openni_camera/openni_image.h>
+#include <pcl/io/openni_camera/openni_image_rgb24.h>
 #include <pcl/io/openni_camera/openni_depth_image.h>
 #endif
 


### PR DESCRIPTION
Some io/openni_camera includes are being used outside the check for HAVE_OPENNI causing "pcl/io/pcd_grabber.h:46:47: fatal error: pcl/io/openni_camera/openni_image.h: No such file or directory".
