### PR TITLE
fix simulation build, missing glut library

### DIFF
--- a/simulation/tools/CMakeLists.txt
+++ b/simulation/tools/CMakeLists.txt
@@ -31,7 +31,7 @@ if(GLEW_FOUND)
       ${VTK_IO_TARGET_LINK_LIBRARIES} 
       ${OPENNI_INCLUDES})
     target_link_libraries(${LIB_NAME} pcl_simulation pcl_common pcl_io 
-	    ${VTK_IO_TARGET_LINK_LIBRARIES} ${OPENGL_LIBRARIES})
+	    ${VTK_IO_TARGET_LINK_LIBRARIES} ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
 
     PCL_ADD_EXECUTABLE(pcl_sim_terminal_demo ${SUBSYS_NAME} sim_terminal_demo.cpp)
     target_link_libraries (pcl_sim_terminal_demo


### PR DESCRIPTION
Building on mac:

```
Undefined symbols for architecture x86_64:
  "_glutCreateWindow", referenced from:
      pcl::simulation::SimExample::initializeGL(int, char**) in simulation_io.cpp.o
  "_glutInit", referenced from:
      pcl::simulation::SimExample::initializeGL(int, char**) in simulation_io.cpp.o
  "_glutInitDisplayMode", referenced from:
      pcl::simulation::SimExample::initializeGL(int, char**) in simulation_io.cpp.o
  "_glutInitWindowPosition", referenced from:
      pcl::simulation::SimExample::initializeGL(int, char**) in simulation_io.cpp.o
  "_glutInitWindowSize", referenced from:
      pcl::simulation::SimExample::initializeGL(int, char**) in simulation_io.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/libpcl_simulation_io.1.7.0.dylib] Error 1
make[1]: *** [simulation/tools/CMakeFiles/pcl_simulation_io.dir/all] Error 2
```
