### PR TITLE
EarClipping algorithm improved + typing error in Clipper3D

### DIFF
--- a/surface/include/pcl/surface/ear_clipping.h
+++ b/surface/include/pcl/surface/ear_clipping.h
@@ -106,11 +106,10 @@ namespace pcl
         * \param[in] p the point to check
         */
       bool
-      isInsideTriangle (const Eigen::Vector2f& u,
-                        const Eigen::Vector2f& v,
-                        const Eigen::Vector2f& w,
-                        const Eigen::Vector2f& p);
-
+      isInsideTriangle (const Eigen::Vector3f& u,
+                        const Eigen::Vector3f& v,
+                        const Eigen::Vector3f& w,
+                        const Eigen::Vector3f& p);
 
       /** \brief Compute the cross product between 2D vectors.
        * \param[in] p1 the first 2D vector


### PR DESCRIPTION
Due to a commit-mistake, I mixed two different pull request in this one:
- In clipper3D.h there are two spelling mistakes using Clipper3d instead of Clipper3D as template parameters. This does not compile with MSVC2010.
- EarClipping algorithm failed for polygons, where are vertices have the same x or y component: http://www.pcl-users.org/earClipper-isEar-for-flat-triangles-in-XY-plane-td4028199.html. In the new implementation, the earClipping is calculated in 3D instead of projecting all points to the XY-plane.

Sorry about mixing about two different things, but the first one is really tiny.
