### PR TITLE
PCL 1.7.0rc1 fails to build on OS X

### DIFF
--- a/common/include/pcl/common/impl/sse.hpp
+++ b/common/include/pcl/common/impl/sse.hpp
@@ -44,50 +44,57 @@
 #define RETf inline __m128
 #define RETi inline __m128i
 
+namespace pcl {
+
+  namespace common {
+
 // set, load and store values
-RETf SET( const float &x ) { return _mm_set1_ps(x); }
-RETf SET( float x, float y, float z, float w ) { return _mm_set_ps(x,y,z,w); }
-RETi SET( const int &x ) { return _mm_set1_epi32(x); }
-RETf LD( const float &x ) { return _mm_load_ps(&x); }
-RETf LDu( const float &x ) { return _mm_loadu_ps(&x); }
-RETf STR( float &x, const __m128 y ) { _mm_store_ps(&x,y); return y; }
-RETf STR1( float &x, const __m128 y ) { _mm_store_ss(&x,y); return y; }
-RETf STRu( float &x, const __m128 y ) { _mm_storeu_ps(&x,y); return y; }
-RETf STR( float &x, const float y ) { return STR(x,SET(y)); }
+RETf sse_set( const float &x ) { return _mm_set1_ps(x); }
+RETf sse_set( float x, float y, float z, float w ) { return _mm_set_ps(x,y,z,w); }
+RETi sse_set( const int &x ) { return _mm_set1_epi32(x); }
+RETf sse_ld( const float &x ) { return _mm_load_ps(&x); }
+RETf sse_ldu( const float &x ) { return _mm_loadu_ps(&x); }
+RETf sse_str( float &x, const __m128 y ) { _mm_store_ps(&x,y); return y; }
+RETf sse_str1( float &x, const __m128 y ) { _mm_store_ss(&x,y); return y; }
+RETf sse_stru( float &x, const __m128 y ) { _mm_storeu_ps(&x,y); return y; }
+RETf sse_str( float &x, const float y ) { return sse_str(x,sse_set(y)); }
 
 // arithmetic operators
-RETi ADD( const __m128i x, const __m128i y ) { return _mm_add_epi32(x,y); }
-RETf ADD( const __m128 x, const __m128 y ) { return _mm_add_ps(x,y); }
-RETf ADD( const __m128 x, const __m128 y, const __m128 z ) {
-  return ADD(ADD(x,y),z); }
-RETf ADD( const __m128 a, const __m128 b, const __m128 c, const __m128 &d ) {
-  return ADD(ADD(ADD(a,b),c),d); }
-RETf SUB( const __m128 x, const __m128 y ) { return _mm_sub_ps(x,y); }
-RETf MUL( const __m128 x, const __m128 y ) { return _mm_mul_ps(x,y); }
-RETf MUL( const __m128 x, const float y ) { return MUL(x,SET(y)); }
-RETf MUL( const float x, const __m128 y ) { return MUL(SET(x),y); }
-RETf INC( __m128 &x, const __m128 y ) { return x = ADD(x,y); }
-RETf INC( float &x, const __m128 y ) { __m128 t=ADD(LD(x),y); return STR(x,t); }
-RETf DEC( __m128 &x, const __m128 y ) { return x = SUB(x,y); }
-RETf DEC( float &x, const __m128 y ) { __m128 t=SUB(LD(x),y); return STR(x,t); }
-RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
-RETf RCP( const __m128 x ) { return _mm_rcp_ps(x); }
-RETf RCPSQRT( const __m128 x ) { return _mm_rsqrt_ps(x); }
+RETi sse_add( const __m128i x, const __m128i y ) { return _mm_add_epi32(x,y); }
+RETf sse_add( const __m128 x, const __m128 y ) { return _mm_add_ps(x,y); }
+RETf sse_add( const __m128 x, const __m128 y, const __m128 z ) {
+  return sse_add(sse_add(x,y),z); }
+RETf sse_add( const __m128 a, const __m128 b, const __m128 c, const __m128 &d ) {
+  return sse_add(sse_add(sse_add(a,b),c),d); }
+RETf sse_sub( const __m128 x, const __m128 y ) { return _mm_sub_ps(x,y); }
+RETf sse_mul( const __m128 x, const __m128 y ) { return _mm_mul_ps(x,y); }
+RETf sse_mul( const __m128 x, const float y ) { return sse_mul(x,sse_set(y)); }
+RETf sse_mul( const float x, const __m128 y ) { return sse_mul(sse_set(x),y); }
+RETf sse_inc( __m128 &x, const __m128 y ) { return x = sse_add(x,y); }
+RETf sse_inc( float &x, const __m128 y ) { __m128 t=sse_add(sse_ld(x),y); return sse_str(x,t); }
+RETf sse_dec( __m128 &x, const __m128 y ) { return x = sse_sub(x,y); }
+RETf sse_dec( float &x, const __m128 y ) { __m128 t=sse_sub(sse_ld(x),y); return sse_str(x,t); }
+RETf sse_min( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
+RETf sse_rcp( const __m128 x ) { return _mm_rcp_ps(x); }
+RETf sse_rcpsqrt( const __m128 x ) { return _mm_rsqrt_ps(x); }
 
 // logical operators
-RETf AND( const __m128 x, const __m128 y ) { return _mm_and_ps(x,y); }
-RETi AND( const __m128i x, const __m128i y ) { return _mm_and_si128(x,y); }
-RETf ANDNOT( const __m128 x, const __m128 y ) { return _mm_andnot_ps(x,y); }
-RETf OR( const __m128 x, const __m128 y ) { return _mm_or_ps(x,y); }
-RETf XOR( const __m128 x, const __m128 y ) { return _mm_xor_ps(x,y); }
+RETf sse_and( const __m128 x, const __m128 y ) { return _mm_and_ps(x,y); }
+RETi sse_and( const __m128i x, const __m128i y ) { return _mm_and_si128(x,y); }
+RETf sse_andnot( const __m128 x, const __m128 y ) { return _mm_andnot_ps(x,y); }
+RETf sse_or( const __m128 x, const __m128 y ) { return _mm_or_ps(x,y); }
+RETf sse_xor( const __m128 x, const __m128 y ) { return _mm_xor_ps(x,y); }
 
 // comparison operators
-RETf CMPGT( const __m128 x, const __m128 y ) { return _mm_cmpgt_ps(x,y); }
-RETi CMPGT( const __m128i x, const __m128i y ) { return _mm_cmpgt_epi32(x,y); }
+RETf sse_cmpgt( const __m128 x, const __m128 y ) { return _mm_cmpgt_ps(x,y); }
+RETi sse_cmpgt( const __m128i x, const __m128i y ) { return _mm_cmpgt_epi32(x,y); }
 
 // conversion operators
-RETf CVT( const __m128i x ) { return _mm_cvtepi32_ps(x); }
-RETi CVT( const __m128 x ) { return _mm_cvttps_epi32(x); }
+RETf sse_cvt( const __m128i x ) { return _mm_cvtepi32_ps(x); }
+RETi sse_cvt( const __m128 x ) { return _mm_cvttps_epi32(x); }
+
+  } // namespace common
+} // namespace pcl
 
 #undef RETf
 #undef RETi

--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -76,22 +76,22 @@ pcl::people::HOG::gradMag( float *I, int h, int w, int d, float *M, float *O ) c
   for( x=0; x<w; x++ ) {
   // compute gradients (Gx, Gy) and squared magnitude (M2) for each channel
   for( c=0; c<d; c++ ) grad1( I+x*h+c*w*h, Gx+c*h4, Gy+c*h4, h, w, x );
-  for( y=0; y<d*h4/4; y++ ) _M2[y]=ADD(MUL(_Gx[y],_Gx[y]),MUL(_Gy[y],_Gy[y]));
+  for( y=0; y<d*h4/4; y++ ) _M2[y]=pcl::common::sse_add(pcl::common::sse_mul(_Gx[y],_Gx[y]),pcl::common::sse_mul(_Gy[y],_Gy[y]));
   // store gradients with maximum response in the first channel
   for(c=1; c<d; c++) {
     for( y=0; y<h4/4; y++ ) {
-    y1=h4/4*c+y; _m = CMPGT( _M2[y1], _M2[y] );
-    _M2[y] = OR( AND(_m,_M2[y1]), ANDNOT(_m,_M2[y]) );
-    _Gx[y] = OR( AND(_m,_Gx[y1]), ANDNOT(_m,_Gx[y]) );
-    _Gy[y] = OR( AND(_m,_Gy[y1]), ANDNOT(_m,_Gy[y]) );
+    y1=h4/4*c+y; _m = pcl::common::sse_cmpgt( _M2[y1], _M2[y] );
+    _M2[y] = pcl::common::sse_or( pcl::common::sse_and(_m,_M2[y1]), pcl::common::sse_andnot(_m,_M2[y]) );
+    _Gx[y] = pcl::common::sse_or( pcl::common::sse_and(_m,_Gx[y1]), pcl::common::sse_andnot(_m,_Gx[y]) );
+    _Gy[y] = pcl::common::sse_or( pcl::common::sse_and(_m,_Gy[y1]), pcl::common::sse_andnot(_m,_Gy[y]) );
     }
   }
   // compute gradient magnitude (M) and normalize Gx
   for( y=0; y<h4/4; y++ ) {
-    _m = MIN( RCPSQRT(_M2[y]), SET(1e10f) );
-    _M2[y] = RCP(_m);
-    _Gx[y] = MUL( MUL(_Gx[y],_m), SET(acMult) );
-    _Gx[y] = XOR( _Gx[y], AND(_Gy[y], SET(-0.f)) );
+    _m = pcl::common::sse_min( pcl::common::sse_rcpsqrt(_M2[y]), pcl::common::sse_set(1e10f) );
+    _M2[y] = pcl::common::sse_rcp(_m);
+    _Gx[y] = pcl::common::sse_mul( pcl::common::sse_mul(_Gx[y],_m), pcl::common::sse_set(acMult) );
+    _Gx[y] = pcl::common::sse_xor( _Gx[y], pcl::common::sse_and(_Gy[y], pcl::common::sse_set(-0.f)) );
   };
 
   memcpy( M+x*h, M2, h*sizeof(float) );
@@ -195,7 +195,7 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
       // macros for code conciseness
       #define GHinit yd=yb-yb0; yb+=sInv; H0=H+xb0*hb+yb0; xyd=xd*yd; \
       ms[0]=1-xd-yd+xyd; ms[1]=yd-xyd; ms[2]=xd-xyd; ms[3]=xyd;
-      #define GH(H,ma,mb) H1=H; STRu(*H1,ADD(LDu(*H1),MUL(ma,mb)));
+      #define GH(H,ma,mb) H1=H; pcl::common::sse_stru(*H1,pcl::common::sse_add(pcl::common::sse_ldu(*H1),pcl::common::sse_mul(ma,mb)));
       // leading rows, no top bin_size
       for( ; y<bin_size/2; y++ ) {
         yb0=-1; GHinit;
@@ -205,10 +205,10 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
       // main rows, has top and bottom bins, use SSE for minor speedup
       for( ; ; y++ ) {
         yb0 = (int) yb; if(yb0>=hb-1) break; GHinit;
-        _m0=SET(M0[y]); _m1=SET(M1[y]);
-        if(hasLf) { _m=SET(0,0,ms[1],ms[0]);
+        _m0=pcl::common::sse_set(M0[y]); _m1=pcl::common::sse_set(M1[y]);
+        if(hasLf) { _m=pcl::common::sse_set(0,0,ms[1],ms[0]);
         GH(H0+O0[y],_m,_m0); GH(H0+O1[y],_m,_m1); }
-        if(hasRt) { _m=SET(0,0,ms[3],ms[2]);
+        if(hasRt) { _m=pcl::common::sse_set(0,0,ms[3],ms[2]);
         GH(H0+O0[y]+hb,_m,_m0); GH(H0+O1[y]+hb,_m,_m1); }
       }      
       // final rows, no bottom bin_size
@@ -354,8 +354,8 @@ pcl::people::HOG::grad1 (float *I, float *Gx, float *Gy, int h, int w, int x) co
   if( h<4 || h%4>0 || (size_t(I)&15) || (size_t(Gx)&15) ) {
   for( y=0; y<h; y++ ) *Gx++=(*In++-*Ip++)*r;
   } else {
-  _G=(__m128*) Gx; _Ip=(__m128*) Ip; _In=(__m128*) In; _r = SET(r);
-  for(y=0; y<h; y+=4) *_G++=MUL(SUB(*_In++,*_Ip++),_r);
+  _G=(__m128*) Gx; _Ip=(__m128*) Ip; _In=(__m128*) In; _r = pcl::common::sse_set(r);
+  for(y=0; y<h; y+=4) *_G++=pcl::common::sse_mul(pcl::common::sse_sub(*_In++,*_Ip++),_r);
   }
   // compute column of Gy
   #define GRADY(r) *Gy++=(*In++-*Ip++)*r;
@@ -363,9 +363,9 @@ pcl::people::HOG::grad1 (float *I, float *Gx, float *Gy, int h, int w, int x) co
   // GRADY(1); Ip--; for(y=1; y<h-1; y++) GRADY(.5f); In--; GRADY(1);
   y1=((~((size_t) Gy) + 1) & 15)/4; if(y1==0) y1=4; if(y1>h-1) y1=h-1;
   GRADY(1); Ip--; for(y=1; y<y1; y++) GRADY(.5f);
-  _r = SET(.5f); _G=(__m128*) Gy;
+  _r = pcl::common::sse_set(.5f); _G=(__m128*) Gy;
   for(; y+4<h-1; y+=4, Ip+=4, In+=4, Gy+=4)
-  *_G++=MUL(SUB(LDu(*In),LDu(*Ip)),_r);
+  *_G++=pcl::common::sse_mul(pcl::common::sse_sub(pcl::common::sse_ldu(*In),pcl::common::sse_ldu(*Ip)),_r);
   for(; y<h-1; y++) GRADY(.5f); In--; GRADY(1);
   #undef GRADY
 #else
@@ -429,16 +429,16 @@ pcl::people::HOG::gradQuantize (float *O, float *M, int *O0, int *O1, float *M0,
   __m128i _o0, _o1, *_O0, *_O1; __m128 _o, _o0f, _m, *_M0, *_M1;
   // define useful constants
   const float oMult=(float)n_orients/M_PI; const int oMax=n_orients*nb;
-  const __m128 _norm=SET(norm), _oMult=SET(oMult), _nbf=SET((float)nb);
-  const __m128i _oMax=SET(oMax), _nb=SET(nb);
+  const __m128 _norm=pcl::common::sse_set(norm), _oMult=pcl::common::sse_set(oMult), _nbf=pcl::common::sse_set((float)nb);
+  const __m128i _oMax=pcl::common::sse_set(oMax), _nb=pcl::common::sse_set(nb);
 
   // perform the majority of the work with sse
   _O0=(__m128i*) O0; _O1=(__m128i*) O1; _M0=(__m128*) M0; _M1=(__m128*) M1;
   for( i=0; i<=n-4; i+=4 ) {
-  _o=MUL(LDu(O[i]),_oMult); _o0f=CVT(CVT(_o)); _o0=CVT(MUL(_o0f,_nbf));
-  _o1=ADD(_o0,_nb); _o1=AND(CMPGT(_oMax,_o1),_o1);
-  *_O0++=_o0; *_O1++=_o1; _m=MUL(LDu(M[i]),_norm);
-  *_M1=MUL(SUB(_o,_o0f),_m); *_M0=SUB(_m,*_M1); _M0++; _M1++;
+  _o=pcl::common::sse_mul(pcl::common::sse_ldu(O[i]),_oMult); _o0f=pcl::common::sse_cvt(pcl::common::sse_cvt(_o)); _o0=pcl::common::sse_cvt(pcl::common::sse_mul(_o0f,_nbf));
+  _o1=pcl::common::sse_add(_o0,_nb); _o1=pcl::common::sse_and(pcl::common::sse_cmpgt(_oMax,_o1),_o1);
+  *_O0++=_o0; *_O1++=_o1; _m=pcl::common::sse_mul(pcl::common::sse_ldu(M[i]),_norm);
+  *_M1=pcl::common::sse_mul(pcl::common::sse_sub(_o,_o0f),_m); *_M0=pcl::common::sse_sub(_m,*_M1); _M0++; _M1++;
   }
 
   // compute trailing locations without sse


### PR DESCRIPTION
When building from the `pcl:next` branch on OS X I get:

```
==> make -j1 in '/private/tmp/nav_ws/build_isolated/pcl'
[  4%] Built target pcl_common
[  4%] Built target pcl_octree
[  4%] Built target pcl_io_ply
[  9%] Built target pcl_io
[  9%] Built target pcl_convert_pcd_ascii_binary
[ 10%] Built target pcl_hdl_grabber
[ 10%] Built target pcl_pcd_convert_NaN_nan
[ 11%] Built target pcl_ply2obj
[ 11%] Built target pcl_ply2ply
[ 11%] Built target pcl_ply2raw
[ 11%] Built target pcl_plyheader
[ 11%] Built target pcl_kdtree
[ 12%] Built target pcl_search
[ 16%] Built target pcl_sample_consensus
[ 23%] Built target pcl_filters
[ 30%] Built target pcl_features
[ 33%] Built target pcl_segmentation
[ 38%] Built target pcl_visualization
[ 38%] Built target pcl_hdl_viewer_simple
[ 39%] Built target pcl_pcd_image_viewer
[ 39%] Built target pcl_timed_trigger_test
[ 40%] Built target pcl_viewer
[ 46%] Built target pcl_surface
[ 55%] Built target pcl_registration
[ 57%] Built target pcl_keypoints
[ 58%] Built target pcl_tracking
[ 62%] Built target pcl_recognition
[ 63%] Built target pcl_outofcore
[ 63%] Built target pcl_outofcore_print
[ 63%] Built target pcl_outofcore_process
[ 65%] Built target pcl_outofcore_viewer
[ 65%] Built target pcl_people
[ 65%] Built target pcl_gtest
[ 65%] Built target test_non_linear
[ 66%] Building CXX object test/CMakeFiles/test_people_detection.dir/test_people_groundBasedPeopleDetectionApp.cpp.o
In file included from /tmp/nav_ws/src/pcl/test/test_people_groundBasedPeopleDetectionApp.cpp:51:
In file included from /tmp/nav_ws/src/pcl/visualization/include/pcl/visualization/pcl_visualizer.h:47:
In file included from /tmp/nav_ws/src/pcl/visualization/include/pcl/visualization/common/actor_map.h:40:
In file included from /tmp/nav_ws/src/pcl/visualization/include/pcl/visualization/point_cloud_handlers.h:41:
In file included from /tmp/nav_ws/src/pcl/visualization/include/pcl/visualization/point_cloud_geometry_handlers.h:47:
In file included from /usr/local/include/vtk-5.10/vtkSmartPointer.h:23:
In file included from /usr/local/include/vtk-5.10/vtkSmartPointerBase.h:26:
In file included from /usr/local/include/vtk-5.10/vtkObjectBase.h:43:
In file included from /usr/local/include/vtk-5.10/vtkIndent.h:24:
In file included from /usr/local/include/vtk-5.10/vtkSystemIncludes.h:40:
In file included from /usr/local/include/vtk-5.10/vtkIOStream.h:108:
In file included from /usr/include/c++/4.2.1/backward/strstream:51:
/usr/include/c++/4.2.1/backward/backward_warning.h:32:2: warning: This file includes at least one deprecated or antiquated header. Please consider using one of the 32 headers
      found in section 17.4.1.2 of the C++ standard. Examples include substituting the <X> header for the <X.h> header for C++ includes, or <iostream> instead of the deprecated
      header <iostream.h>. To disable this warning use -Wno-deprecated. [-W#warnings]
#warning This file includes at least one deprecated or antiquated header. \
 ^
In file included from /tmp/nav_ws/src/pcl/test/test_people_groundBasedPeopleDetectionApp.cpp:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/ground_based_people_detection_app.h:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/person_classifier.h:45:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/hog.h:48:
/tmp/nav_ws/src/pcl/common/include/pcl/common/impl/sse.hpp:73:11: error: expected unqualified-id
RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
          ^
/usr/include/sys/param.h:217:21: note: expanded from macro 'MIN'
#define MIN(a,b) (((a)<(b))?(a):(b))
                    ^
In file included from /tmp/nav_ws/src/pcl/test/test_people_groundBasedPeopleDetectionApp.cpp:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/ground_based_people_detection_app.h:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/person_classifier.h:45:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/hog.h:48:
/tmp/nav_ws/src/pcl/common/include/pcl/common/impl/sse.hpp:73:11: error: expected ')'
RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
          ^
/usr/include/sys/param.h:217:21: note: expanded from macro 'MIN'
#define MIN(a,b) (((a)<(b))?(a):(b))
                    ^
/tmp/nav_ws/src/pcl/common/include/pcl/common/impl/sse.hpp:73:6: note: to match this '('
RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
     ^
/usr/include/sys/param.h:217:20: note: expanded from macro 'MIN'
#define MIN(a,b) (((a)<(b))?(a):(b))
                   ^
In file included from /tmp/nav_ws/src/pcl/test/test_people_groundBasedPeopleDetectionApp.cpp:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/ground_based_people_detection_app.h:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/person_classifier.h:45:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/hog.h:48:
/tmp/nav_ws/src/pcl/common/include/pcl/common/impl/sse.hpp:73:6: error: expected ')'
RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
     ^
/usr/include/sys/param.h:217:23: note: expanded from macro 'MIN'
#define MIN(a,b) (((a)<(b))?(a):(b))
                      ^
/tmp/nav_ws/src/pcl/common/include/pcl/common/impl/sse.hpp:73:6: note: to match this '('
RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
     ^
/usr/include/sys/param.h:217:19: note: expanded from macro 'MIN'
#define MIN(a,b) (((a)<(b))?(a):(b))
                  ^
In file included from /tmp/nav_ws/src/pcl/test/test_people_groundBasedPeopleDetectionApp.cpp:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/ground_based_people_detection_app.h:53:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/person_classifier.h:45:
In file included from /tmp/nav_ws/src/pcl/people/include/pcl/people/hog.h:48:
/tmp/nav_ws/src/pcl/common/include/pcl/common/impl/sse.hpp:73:6: error: expected ')'
RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
     ^
/usr/include/sys/param.h:217:28: note: expanded from macro 'MIN'
#define MIN(a,b) (((a)<(b))?(a):(b))
                           ^
/tmp/nav_ws/src/pcl/common/include/pcl/common/impl/sse.hpp:73:6: note: to match this '('
RETf MIN( const __m128 x, const __m128 y ) { return _mm_min_ps(x,y); }
     ^
/usr/include/sys/param.h:217:18: note: expanded from macro 'MIN'
#define MIN(a,b) (((a)<(b))?(a):(b))
                 ^
1 warning and 4 errors generated.
make[2]: *** [test/CMakeFiles/test_people_detection.dir/test_people_groundBasedPeopleDetectionApp.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/test_people_detection.dir/all] Error 2
make: *** [all] Error 2
```

It looks like the source of the issue is `people_detection`.
