### PR TITLE
Solving compiling error for pcl_gpu_octree

### DIFF
--- a/gpu/octree/src/cuda/octree_builder.cu
+++ b/gpu/octree/src/cuda/octree_builder.cu
@@ -43,6 +43,7 @@
 #include "utils/scan_block.hpp"
 #include "utils/morton.hpp"
 
+#include <thrust/device_ptr.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/reduce.h>


### PR DESCRIPTION
Error message: identifier "device_ptr" is undefined.
Solved by adding #include <thrust/device_ptr.h> to the head of the file.

Compiling environment: Win7 64bit, VS 2010, CUDA 5.5 RC
