### PR TITLE
sensor_origin_ and sensor_orientation_ default to identity.

### DIFF
--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -101,8 +101,8 @@ pcl::io::LZFDepth16ImageReader::read (
     }
   }
   cloud.sensor_origin_.setZero ();
-  cloud.sensor_orientation_.w () = 0.0f;
-  cloud.sensor_orientation_.x () = 1.0f;
+  cloud.sensor_orientation_.w () = 1.0f;
+  cloud.sensor_orientation_.x () = 0.0f;
   cloud.sensor_orientation_.y () = 0.0f;
   cloud.sensor_orientation_.z () = 0.0f;
   return (true);
@@ -179,8 +179,8 @@ pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename,
     
   }
   cloud.sensor_origin_.setZero ();
-  cloud.sensor_orientation_.w () = 0.0f;
-  cloud.sensor_orientation_.x () = 1.0f;
+  cloud.sensor_orientation_.w () = 1.0f;
+  cloud.sensor_orientation_.x () = 0.0f;
   cloud.sensor_orientation_.y () = 0.0f;
   cloud.sensor_orientation_.z () = 0.0f;
   return (true);

--- a/io/src/openni_grabber.cpp
+++ b/io/src/openni_grabber.cpp
@@ -615,8 +615,8 @@ pcl::OpenNIGrabber::convertToXYZPointCloud (const boost::shared_ptr<openni_wrapp
     }
   }
   cloud->sensor_origin_.setZero ();
-  cloud->sensor_orientation_.w () = 0.0f;
-  cloud->sensor_orientation_.x () = 1.0f;
+  cloud->sensor_orientation_.w () = 1.0f;
+  cloud->sensor_orientation_.x () = 0.0f;
   cloud->sensor_orientation_.y () = 0.0f;
   cloud->sensor_orientation_.z () = 0.0f;  
   return (cloud);
@@ -746,8 +746,8 @@ pcl::OpenNIGrabber::convertToXYZRGBPointCloud (const boost::shared_ptr<openni_wr
     }
   }
   cloud->sensor_origin_.setZero ();
-  cloud->sensor_orientation_.w () = 0.0;
-  cloud->sensor_orientation_.x () = 1.0;
+  cloud->sensor_orientation_.w () = 1.0;
+  cloud->sensor_orientation_.x () = 0.0;
   cloud->sensor_orientation_.y () = 0.0;
   cloud->sensor_orientation_.z () = 0.0;
   return (cloud);
@@ -836,8 +836,8 @@ pcl::OpenNIGrabber::convertToXYZIPointCloud (const boost::shared_ptr<openni_wrap
     }
   }
   cloud->sensor_origin_.setZero ();
-  cloud->sensor_orientation_.w () = 0.0;
-  cloud->sensor_orientation_.x () = 1.0;
+  cloud->sensor_orientation_.w () = 1.0;
+  cloud->sensor_orientation_.x () = 0.0;
   cloud->sensor_orientation_.y () = 0.0;
   cloud->sensor_orientation_.z () = 0.0;
   return (cloud);


### PR DESCRIPTION
sensor_origin_ and sensor_orientation_ now are set to the identity transformation (see https://github.com/PointCloudLibrary/pcl/issues/116)
