### PR TITLE
Fixed sac_model_plane to make sure a valid plane is optimized

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
@@ -248,6 +248,12 @@ pcl::SampleConsensusModelPlane<PointT>::optimizeModelCoefficients (
   optimized_coefficients[2] = eigen_vector [2];
   optimized_coefficients[3] = 0;
   optimized_coefficients[3] = -1 * optimized_coefficients.dot (xyz_centroid);
+
+  // Make sure it results in a valid model
+  if (!isModelValid (optimized_coefficients))
+  {
+    optimized_coefficients = model_coefficients;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently if you use `pcl::SACSegmentation` to find planes with some additional constraint attached (e.g. `SACMODEL_PERPENDICULAR_PLANE`), if `setOptimizeCoefficients (true)` is given there's a chance it will yield zero inliers even if there is very clearly a plane present. This is because `SACModelPlane::optimizeModelCoefficients` never tries to keep its result in the feasible set, and infeasible models yield zero inliers by design. Adding a tiny fix which says "If the optimized model is no longer in the feasible set, revert to the unoptimized one."
