### PR TITLE
Bugfix for IntegralImageNormalEstimation

### DIFF
--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -731,30 +731,65 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
   memset (depthChangeMap, 255, input_->points.size ());
 
   unsigned index = 0;
-  for (unsigned int ri = 0; ri < input_->height-1; ++ri)
+  for (unsigned int ri = 1; ri < input_->height-1; ++ri)
   {
-    for (unsigned int ci = 0; ci < input_->width-1; ++ci, ++index)
+    for (unsigned int ci = 1; ci < input_->width-1; ++ci, ++index)
     {
       index = ri * input_->width + ci;
+      const float depth  = input_->points[index].z;
 
-      const float depth  = input_->points [index].z;
-      const float depthR = input_->points [index + 1].z;
-      const float depthD = input_->points [index + input_->width].z;
+      // NW N NE
+      //  W . E
+      // SW S SE
+      const unsigned int NE = index - input_->width + 1;
+      const unsigned int  E = index                 + 1;
+      const unsigned int SE = index + input_->width + 1;
+      const unsigned int  S = index + input_->width    ;
+      const unsigned int SW = index + input_->width - 1;
 
       //const float depthDependendDepthChange = (max_depth_change_factor_ * (fabs(depth)+1.0f))/(500.0f*0.001f);
       const float depthDependendDepthChange = (max_depth_change_factor_ * (fabsf (depth) + 1.0f) * 2.0f);
 
-      if (fabs (depth - depthR) > depthDependendDepthChange
-        || !pcl_isfinite (depth) || !pcl_isfinite (depthR))
+      if (!pcl_isfinite (depth))
       {
         depthChangeMap[index] = 0;
-        depthChangeMap[index+1] = 0;
+        depthChangeMap[   NE] = 0;
+        depthChangeMap[    E] = 0;
+        depthChangeMap[   SE] = 0;
+        depthChangeMap[    S] = 0;
+        depthChangeMap[   SW] = 0;
+        continue;
       }
-      if (fabs (depth - depthD) > depthDependendDepthChange
-        || !pcl_isfinite (depth) || !pcl_isfinite (depthD))
+
+      if (!pcl_isfinite (input_->points[NE].z) ||
+           fabs (depth - input_->points[NE].z) > depthDependendDepthChange)
       {
         depthChangeMap[index] = 0;
-        depthChangeMap[index + input_->width] = 0;
+        depthChangeMap[   NE] = 0;
+      }
+      if (!pcl_isfinite (input_->points[E].z) ||
+           fabs (depth - input_->points[E].z) > depthDependendDepthChange)
+      {
+        depthChangeMap[index] = 0;
+        depthChangeMap[    E] = 0;
+      }
+      if (!pcl_isfinite (input_->points[SE].z) ||
+           fabs (depth - input_->points[SE].z) > depthDependendDepthChange)
+      {
+        depthChangeMap[index] = 0;
+        depthChangeMap[   SE] = 0;
+      }
+      if (!pcl_isfinite (input_->points[S].z) ||
+           fabs (depth - input_->points[S].z) > depthDependendDepthChange)
+      {
+        depthChangeMap[index] = 0;
+        depthChangeMap[    S] = 0;
+      }
+      if (!pcl_isfinite (input_->points[SW].z) ||
+           fabs (depth - input_->points[SW].z) > depthDependendDepthChange)
+      {
+        depthChangeMap[index] = 0;
+        depthChangeMap[   SW] = 0;
       }
     }
   }
@@ -779,11 +814,11 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
   {
     for (size_t ci = 1; ci < input_->width; ++ci)
     {
-      const float upLeft  = previous_row [ci - 1] + 1.4f; //distanceMap[(ri-1)*input_->width + ci-1] + 1.4f;
-      const float up      = previous_row [ci] + 1.0f;     //distanceMap[(ri-1)*input_->width + ci] + 1.0f;
-      const float upRight = previous_row [ci + 1] + 1.4f; //distanceMap[(ri-1)*input_->width + ci+1] + 1.4f;
-      const float left    = current_row  [ci - 1] + 1.0f;  //distanceMap[ri*input_->width + ci-1] + 1.0f;
-      const float center  = current_row  [ci];             //distanceMap[ri*input_->width + ci];
+      const float upLeft  = previous_row [ci - 1] + 1.0f;
+      const float up      = previous_row [ci] + 1.0f;
+      const float upRight = previous_row [ci + 1] + 1.0f;
+      const float left    = current_row  [ci - 1] + 1.0f;
+      const float center  = current_row  [ci];
 
       const float minValue = std::min (std::min (upLeft, up), std::min (left, upRight));
 
@@ -801,11 +836,11 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
   {
     for (int ci = input_->width-2; ci >= 0; --ci)
     {
-      const float lowerLeft  = next_row [ci - 1] + 1.4f;    //distanceMap[(ri+1)*input_->width + ci-1] + 1.4f;
-      const float lower      = next_row [ci] + 1.0f;        //distanceMap[(ri+1)*input_->width + ci] + 1.0f;
-      const float lowerRight = next_row [ci + 1] + 1.4f;    //distanceMap[(ri+1)*input_->width + ci+1] + 1.4f;
-      const float right      = current_row [ci + 1] + 1.0f; //distanceMap[ri*input_->width + ci+1] + 1.0f;
-      const float center     = current_row [ci];            //distanceMap[ri*input_->width + ci];
+      const float lowerLeft  = next_row [ci - 1] + 1.0f;
+      const float lower      = next_row [ci] + 1.0f;
+      const float lowerRight = next_row [ci + 1] + 1.0f;
+      const float right      = current_row [ci + 1] + 1.0f;
+      const float center     = current_row [ci];
 
       const float minValue = std::min (std::min (lowerLeft, lower), std::min (right, lowerRight));
 
@@ -867,7 +902,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
             continue;
           }
 
-          float smoothing = (std::min)(distanceMap[index], normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
+          float smoothing = (std::min)(distanceMap[index] * 2 + 1, normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
 
           if (smoothing > 2.0f)
           {
@@ -901,7 +936,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
             continue;
           }
 
-          float smoothing = (std::min)(distanceMap[index], smoothing_constant);
+          float smoothing = (std::min)(distanceMap[index] * 2 + 1, smoothing_constant);
 
           if (smoothing > 2.0f)
           {
@@ -941,7 +976,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
             continue;
           }
 
-          float smoothing = (std::min)(distanceMap[index], normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
+          float smoothing = (std::min)(distanceMap[index] * 2 + 1, normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
 
           if (smoothing > 2.0f)
           {
@@ -977,7 +1012,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
             continue;
           }
 
-          float smoothing = (std::min)(distanceMap[index], smoothing_constant);
+          float smoothing = (std::min)(distanceMap[index] * 2 + 1, smoothing_constant);
 
           if (smoothing > 2.0f)
           {

--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -904,7 +904,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
 
           float smoothing = (std::min)(distanceMap[index] * 2 + 1, normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
 
-          if (smoothing > 2.0f)
+          if (smoothing >= minimum_normal_smoothing_size_)
           {
             setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
             computePointNormal (ci, ri, index, output [index]);
@@ -938,7 +938,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
 
           float smoothing = (std::min)(distanceMap[index] * 2 + 1, smoothing_constant);
 
-          if (smoothing > 2.0f)
+          if (smoothing >= minimum_normal_smoothing_size_)
           {
             setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
             computePointNormal (ci, ri, index, output [index]);
@@ -978,7 +978,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
 
           float smoothing = (std::min)(distanceMap[index] * 2 + 1, normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
 
-          if (smoothing > 2.0f)
+          if (smoothing >= minimum_normal_smoothing_size_)
           {
             setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
             computePointNormalMirror (ci, ri, index, output [index]);
@@ -1014,7 +1014,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
 
           float smoothing = (std::min)(distanceMap[index] * 2 + 1, smoothing_constant);
 
-          if (smoothing > 2.0f)
+          if (smoothing >= minimum_normal_smoothing_size_)
           {
             setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
             computePointNormalMirror (ci, ri, index, output [index]);

--- a/features/include/pcl/features/integral_image_normal.h
+++ b/features/include/pcl/features/integral_image_normal.h
@@ -111,6 +111,7 @@ namespace pcl
         , use_depth_dependent_smoothing_ (false)
         , max_depth_change_factor_ (20.0f*0.001f)
         , normal_smoothing_size_ (10.0f)
+        , minimum_normal_smoothing_size_ (3.0f)
         , init_covariance_matrix_ (false)
         , init_average_3d_gradient_ (false)
         , init_simple_3d_gradient_ (false)
@@ -175,6 +176,8 @@ namespace pcl
       /** \brief Set the normal smoothing size
         * \param[in] normal_smoothing_size factor which influences the size of the area used to smooth normals
         * (depth dependent if useDepthDependentSmoothing is true)
+        * \note The actual smoothing size used at each point will also depend on the distance from the point to
+        * the closest depth discontinuity. \sa setMinimumNormalSmoothingSize().
         */
       void
       setNormalSmoothingSize (float normal_smoothing_size)
@@ -186,6 +189,24 @@ namespace pcl
           return;
         }
         normal_smoothing_size_ = normal_smoothing_size;
+      }
+
+      /** \brief Set the minimum normal smoothing size.
+        * If computation of the normal is not possible using the area of this size (because there is a depth
+        * discontinuity in this region), the output normal and curvature values will be set to quiet NaNs.
+        * \param[in] minimum_normal_smoothing_size factor which influences the minimum allowed size of the area
+        * used to smooth normals
+        */
+      void
+      setMinimumNormalSmoothingSize (float minimum_normal_smoothing_size)
+      {
+        if (minimum_normal_smoothing_size < 3)
+        {
+          PCL_ERROR ("[pcl::%s::setMinimumNormalSmoothingSize] Invalid minimum normal smoothing size given! (%f). Allowed ranges are: 3 <= N. Defaulting to %f.\n", 
+                      feature_name_.c_str (), minimum_normal_smoothing_size, minimum_normal_smoothing_size_);
+          return;
+        }
+        minimum_normal_smoothing_size_ = minimum_normal_smoothing_size;
       }
 
       /** \brief Set the normal estimation method. The current implemented algorithms are:
@@ -396,8 +417,11 @@ namespace pcl
       /** \brief Threshold for detecting depth discontinuities */
       float max_depth_change_factor_;
 
-      /** \brief */
+      /** \brief Desired width of the region used to compute normal. */
       float normal_smoothing_size_;
+
+      /** \brief Minimum allowed width of the region used to compute normal. */
+      float minimum_normal_smoothing_size_;
 
       /** \brief True when a dataset has been received and the covariance_matrix data has been initialized. */
       bool init_covariance_matrix_;


### PR DESCRIPTION
This pull request fixes the bugs in IntegralImageNormalEstimation reported by James Stout in this [pcl-dev tread](http://www.pcl-developers.org/Bugs-in-IntegralImageNormalEstimation-distance-map-computation-td5708055.html) and also introduces a new minimum normal smoothing size parameter.

The introduced fixes seem to play well with
- COVARIANCE_MATRIX
  
  ![cm](https://f.cloud.github.com/assets/1241736/793457/7ed28158-ec09-11e2-9645-8bd1609e7ee0.png)
- SIMPLE_3D_GRADIENT
  
  ![sg](https://f.cloud.github.com/assets/1241736/793458/900623f8-ec09-11e2-8fb9-e710a529f826.png)
- AVERAGE_DEPTH_CHANGE
  
  ![adc](https://f.cloud.github.com/assets/1241736/793459/97694008-ec09-11e2-8a0d-f598ada71431.png)
  (the green borders is an okay thing for this method)

As for AVERAGE_3D_GRADIENT, there are weird artifacts. Unfortunately I did not have time to dig deeper into this problem.
![ag](https://f.cloud.github.com/assets/1241736/793466/031a427a-ec0a-11e2-919e-a18540e62c8c.png)
