### PR TITLE
missing PCL_EXPORTS for pcl::people::HOG class

### DIFF
--- a/people/include/pcl/people/hog.h
+++ b/people/include/pcl/people/hog.h
@@ -41,15 +41,7 @@
 #ifndef PCL_PEOPLE_HOG_H_
 #define PCL_PEOPLE_HOG_H_
 
-#define _USE_MATH_DEFINES
-#include <math.h>
-#include <string.h>
-
-#if defined(__SSE2__)
-#include <pcl/sse.h>
-#else
-#include <cstdlib>
-#endif
+#include <pcl/pcl_macros.h>
 
 namespace pcl
 { 
@@ -60,9 +52,9 @@ namespace pcl
       * \author Matteo Munaro, Stefano Ghidoni, Stefano Michieletto
       * \ingroup people
       */
-    class HOG
+    class PCL_EXPORTS HOG
     {
-  public:
+    public:
 
       /** \brief Constructor. */
       HOG ();
@@ -168,7 +160,7 @@ namespace pcl
       void 
       alFree (void* aligned) const;
       
-        protected:
+    protected:
       
       /** \brief image height (default = 128) */
       int h_;

--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -41,6 +41,16 @@
 
 #include <pcl/people/hog.h>
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <string.h>
+
+#if defined(__SSE2__)
+#include <pcl/sse.h>
+#else
+#include <cstdlib>
+#endif
+
 /** \brief Constructor. */
 pcl::people::HOG::HOG () 
 {


### PR DESCRIPTION
- missing PCL_EXPORTS for pcl::people::HOG class
- move includes to the cpp file
