### PR TITLE
Fixed in visualization warning C4099 with MSVC : type name first seen using class now seen using struct

### DIFF
--- a/visualization/include/pcl/visualization/common/common.h
+++ b/visualization/include/pcl/visualization/common/common.h
@@ -47,7 +47,7 @@
 
 namespace pcl
 {
-  class RGB;
+  struct RGB;
 
   namespace visualization
   {


### PR DESCRIPTION
This is a small fix : pcl::RGB is defined as a struct and was declared in common.h as a class, causing Visual Studio to output a warning.
