### PR TITLE
Added missing functionality in OrganizedFastMesh

### DIFF
--- a/surface/include/pcl/surface/organized_fast_mesh.h
+++ b/surface/include/pcl/surface/organized_fast_mesh.h
@@ -88,8 +88,8 @@ namespace pcl
         : distance_tolerance_ (-1.0f)
         , depth_dependent_ (false)
         , triangle_pixel_size_ (1)
-        , triangulation_type_ (QUAD_MESH)
         , viewpoint_ (Eigen::Vector3f::Zero ())
+        , triangulation_type_ (QUAD_MESH)
         , store_shadowed_faces_ (false)
         , cos_angle_tolerance_ (fabsf (cosf (pcl::deg2rad (12.5f))))
       {


### PR DESCRIPTION
There were still some TODOs in the code. I just added this missing functionality in the course of cleaning up all my old code and pushing it (part after part) into the PCL. New functionality:
- Now allows for specifying a (optionally distance dependent) distance tolerance for filtering shadowed edges 8 (shadowed edges with a length within the tolerance are assumed to be caused by local noise, and not filtered out).
- Now allows for specifying a viewpoint other than the default (0, 0, 0).
- Removed (marked as deprecated) the old _unused_ function to specify a maximum edge length.  
  For sure not the last change to this file.
