### PR TITLE
Fix a bug in RegionGrowing with oversized output cluster vector.

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -298,6 +298,7 @@ pcl::RegionGrowing<PointT, NormalT>::extract (std::vector <pcl::PointIndices>& c
   }
 
   clusters_ = std::vector<pcl::PointIndices> (clusters.begin (), cluster_iter_input);
+  clusters.resize(clusters_.size());
 
   deinitCompute ();
 }


### PR DESCRIPTION
The `clusters` vector output by `RegionGrowing<PointT, NormalT>::extract()` function was not properly trimmed after filtering out clusters that are too small and too large. As a result many dozens/hundreds of zero-sized clusters seeped into the output vector.
