### PR TITLE
Added vtkPolyLine.h header to example_supervoxels.cpp

### DIFF
--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -11,6 +11,7 @@
 #include <vtkImageReader2.h>
 #include <vtkImageData.h>
 #include <vtkImageFlip.h>
+#include <vtkPolyLine.h>
 
 // Types
 typedef pcl::PointXYZRGBA PointT;


### PR DESCRIPTION
In 1.7.0 the supervoxel example doesn't build with Visual Studio 2012 (and others: https://github.com/PointCloudLibrary/pcl/issues/202).
