### PR TITLE
Fixed memory leak in Organized Edge Detection

### DIFF
--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -52,8 +52,8 @@ namespace pcl
       typedef typename PointCloudIn::Ptr PointCloudInPtr;
 
       PointCloudInPtr input_;
-      pcl::Convolution<PointInT> *convolution_;
-      kernel<PointInT>  *kernel_;
+      pcl::Convolution<PointInT> convolution_;
+      kernel<PointInT>  kernel_;
 
       /** \brief This function performs edge tracing for Canny Edge detector.
         *
@@ -132,8 +132,6 @@ namespace pcl
         non_max_suppression_radius_x_ (3),
         non_max_suppression_radius_y_ (3)
       {
-        convolution_ = new pcl::Convolution<PointInT> ();
-        kernel_ = new kernel<PointXYZI>();
       }
 
       /** \brief Set the output type.

--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -49,21 +49,21 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeSobel (
 {
   //pcl::console::TicToc tt;
   //tt.tic ();
-  convolution_->setInputCloud (input_);
+  convolution_.setInputCloud (input_);
   pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::SOBEL_X);
-  kernel_->fetchKernel (*kernel_x);
-  convolution_->setKernel (*kernel_x);
-  convolution_->filter (*magnitude_x);
+  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_X);
+  kernel_.fetchKernel (*kernel_x);
+  convolution_.setKernel (*kernel_x);
+  convolution_.filter (*magnitude_x);
   //PCL_ERROR ("Convolve X: %g\n", tt.toc ()); tt.tic ();
 
   pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::SOBEL_Y);
-  kernel_->fetchKernel (*kernel_y);
-  convolution_->setKernel (*kernel_y);
-  convolution_->filter (*magnitude_y);
+  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_Y);
+  kernel_.fetchKernel (*kernel_y);
+  convolution_.setKernel (*kernel_y);
+  convolution_.filter (*magnitude_y);
   //PCL_ERROR ("Convolve Y: %g\n", tt.toc ()); tt.tic ();
 
   const int height = input_->height;
@@ -93,21 +93,21 @@ pcl::Edge<PointInT, PointOutT>::sobelMagnitudeDirection (
     const pcl::PointCloud<PointInT> &input_y,
     pcl::PointCloud<PointOutT> &output)
 {
-  convolution_->setInputCloud (input_x.makeShared());
+  convolution_.setInputCloud (input_x.makeShared());
   pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::SOBEL_X);
-  kernel_->fetchKernel (*kernel_x);
-  convolution_->setKernel (*kernel_x);
-  convolution_->filter (*magnitude_x);
+  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_X);
+  kernel_.fetchKernel (*kernel_x);
+  convolution_.setKernel (*kernel_x);
+  convolution_.filter (*magnitude_x);
 
-  convolution_->setInputCloud (input_y.makeShared());
+  convolution_.setInputCloud (input_y.makeShared());
   pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::SOBEL_Y);
-  kernel_->fetchKernel (*kernel_y);
-  convolution_->setKernel (*kernel_y);
-  convolution_->filter (*magnitude_y);
+  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_Y);
+  kernel_.fetchKernel (*kernel_y);
+  convolution_.setKernel (*kernel_y);
+  convolution_.filter (*magnitude_y);
 
   const int height = input_x.height;
   const int width = input_x.width;
@@ -132,21 +132,21 @@ pcl::Edge<PointInT, PointOutT>::sobelMagnitudeDirection (
 template <typename PointInT, typename PointOutT> void
 pcl::Edge<PointInT, PointOutT>::detectEdgePrewitt (pcl::PointCloud<PointOutT> &output)
 {
-  convolution_->setInputCloud (input_);
+  convolution_.setInputCloud (input_);
 
   pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::PREWITT_X);
-  kernel_->fetchKernel (*kernel_x);
-  convolution_->setKernel (*kernel_x);
-  convolution_->filter (*magnitude_x);
+  kernel_.setKernelType (kernel<PointXYZI>::PREWITT_X);
+  kernel_.fetchKernel (*kernel_x);
+  convolution_.setKernel (*kernel_x);
+  convolution_.filter (*magnitude_x);
 
   pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::PREWITT_Y);
-  kernel_->fetchKernel (*kernel_y);
-  convolution_->setKernel (*kernel_y);
-  convolution_->filter (*magnitude_y);
+  kernel_.setKernelType (kernel<PointXYZI>::PREWITT_Y);
+  kernel_.fetchKernel (*kernel_y);
+  convolution_.setKernel (*kernel_y);
+  convolution_.filter (*magnitude_y);
 
   const int height = input_->height;
   const int width = input_->width;
@@ -171,21 +171,21 @@ pcl::Edge<PointInT, PointOutT>::detectEdgePrewitt (pcl::PointCloud<PointOutT> &o
 template <typename PointInT, typename PointOutT> void
 pcl::Edge<PointInT, PointOutT>::detectEdgeRoberts (pcl::PointCloud<PointOutT> &output)
 {
-  convolution_->setInputCloud (input_);
+  convolution_.setInputCloud (input_);
 
   pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::ROBERTS_X);
-  kernel_->fetchKernel (*kernel_x);
-  convolution_->setKernel (*kernel_x);
-  convolution_->filter (*magnitude_x);
+  kernel_.setKernelType (kernel<PointXYZI>::ROBERTS_X);
+  kernel_.fetchKernel (*kernel_x);
+  convolution_.setKernel (*kernel_x);
+  convolution_.filter (*magnitude_x);
 
   pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
   pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::ROBERTS_Y);
-  kernel_->fetchKernel (*kernel_y);
-  convolution_->setKernel (*kernel_y);
-  convolution_->filter (*magnitude_y);
+  kernel_.setKernelType (kernel<PointXYZI>::ROBERTS_Y);
+  kernel_.fetchKernel (*kernel_y);
+  convolution_.setKernel (*kernel_y);
+  convolution_.filter (*magnitude_y);
 
   const int height = input_->height;
   const int width = input_->width;
@@ -343,13 +343,13 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeCanny (pcl::PointCloud<PointOutT> &out
   // Noise reduction using gaussian blurring
   pcl::PointCloud<PointXYZI>::Ptr gaussian_kernel (new pcl::PointCloud<PointXYZI>);
   PointCloudInPtr smoothed_cloud (new PointCloudIn);
-  kernel_->setKernelSize (3);
-  kernel_->setKernelSigma (1.0);
-  kernel_->setKernelType (kernel<PointXYZI>::GAUSSIAN);
-  kernel_->fetchKernel (*gaussian_kernel);
-  convolution_->setKernel (*gaussian_kernel);
-  convolution_->setInputCloud (input_);
-  convolution_->filter (*smoothed_cloud);
+  kernel_.setKernelSize (3);
+  kernel_.setKernelSigma (1.0);
+  kernel_.setKernelType (kernel<PointXYZI>::GAUSSIAN);
+  kernel_.fetchKernel (*gaussian_kernel);
+  convolution_.setKernel (*gaussian_kernel);
+  convolution_.setInputCloud (input_);
+  convolution_.filter (*smoothed_cloud);
   //PCL_ERROR ("Gaussian blur: %g\n", tt.toc ()); tt.tic ();
   
   // Edge detection usign Sobel
@@ -416,19 +416,19 @@ pcl::Edge<PointInT, PointOutT>::canny (
 
   // Noise reduction using gaussian blurring
   pcl::PointCloud<PointXYZI>::Ptr gaussian_kernel (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelSize (3);
-  kernel_->setKernelSigma (1.0);
-  kernel_->setKernelType (kernel<PointXYZI>::GAUSSIAN);
-  kernel_->fetchKernel (*gaussian_kernel);
-  convolution_->setKernel (*gaussian_kernel);
+  kernel_.setKernelSize (3);
+  kernel_.setKernelSigma (1.0);
+  kernel_.setKernelType (kernel<PointXYZI>::GAUSSIAN);
+  kernel_.fetchKernel (*gaussian_kernel);
+  convolution_.setKernel (*gaussian_kernel);
 
   PointCloudIn smoothed_cloud_x;
-  convolution_->setInputCloud (input_x.makeShared());
-  convolution_->filter (smoothed_cloud_x);
+  convolution_.setInputCloud (input_x.makeShared());
+  convolution_.filter (smoothed_cloud_x);
 
   PointCloudIn smoothed_cloud_y;
-  convolution_->setInputCloud (input_y.makeShared());
-  convolution_->filter (smoothed_cloud_y);
+  convolution_.setInputCloud (input_y.makeShared());
+  convolution_.filter (smoothed_cloud_y);
 
 
   // Edge detection usign Sobel
@@ -480,18 +480,18 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeLoG (
     const float kernel_sigma, const float kernel_size,
     pcl::PointCloud<PointOutT> &output)
 {
-  convolution_->setInputCloud (input_);
+  convolution_.setInputCloud (input_);
 
   const int height = input_->height;
   const int width = input_->width;
 
   pcl::PointCloud<PointXYZI>::Ptr log_kernel (new pcl::PointCloud<PointXYZI>);
-  kernel_->setKernelType (kernel<PointXYZI>::LOG);
-  kernel_->setKernelSigma (kernel_sigma);
-  kernel_->setKernelSize (kernel_size);
-  kernel_->fetchKernel (*log_kernel);
-  convolution_->setKernel (*log_kernel);
-  convolution_->filter (output);
+  kernel_.setKernelType (kernel<PointXYZI>::LOG);
+  kernel_.setKernelSigma (kernel_sigma);
+  kernel_.setKernelSize (kernel_size);
+  kernel_.fetchKernel (*log_kernel);
+  convolution_.setKernel (*log_kernel);
+  convolution_.filter (output);
 }
 
 #endif

--- a/2d/include/pcl/2d/impl/keypoint.hpp
+++ b/2d/include/pcl/2d/impl/keypoint.hpp
@@ -53,17 +53,17 @@ pcl::keypoint::harrisCorner (ImageType &output, ImageType &input, const float si
   /*creating the gaussian kernels*/
   ImageType kernel_d;
   ImageType kernel_i;
-  conv_2d->gaussianKernel  (5, sigma_d, kernel_d);
-  conv_2d->gaussianKernel  (5, sigma_i, kernel_i);
+  conv_2d.gaussianKernel  (5, sigma_d, kernel_d);
+  conv_2d.gaussianKernel  (5, sigma_i, kernel_i);
 
   /*scaling the image with differentiation scale*/
   ImageType smoothed_image;
-  conv_2d->convolve  (smoothed_image, kernel_d, input);
+  conv_2d.convolve  (smoothed_image, kernel_d, input);
 
   /*image derivatives*/
   ImageType I_x, I_y;
-  edge_detection->ComputeDerivativeXCentral  (I_x, smoothed_image);
-  edge_detection->ComputeDerivativeYCentral  (I_y, smoothed_image);
+  edge_detection.ComputeDerivativeXCentral  (I_x, smoothed_image);
+  edge_detection.ComputeDerivativeYCentral  (I_y, smoothed_image);
 
   /*second moment matrix*/
   ImageType I_x2, I_y2, I_xI_y;
@@ -73,9 +73,9 @@ pcl::keypoint::harrisCorner (ImageType &output, ImageType &input, const float si
 
   /*scaling second moment matrix with integration scale*/
   ImageType M00, M10, M11;
-  conv_2d->convolve  (M00, kernel_i, I_x2);
-  conv_2d->convolve  (M10, kernel_i, I_xI_y);
-  conv_2d->convolve  (M11, kernel_i, I_y2);
+  conv_2d.convolve  (M00, kernel_i, I_x2);
+  conv_2d.convolve  (M10, kernel_i, I_xI_y);
+  conv_2d.convolve  (M11, kernel_i, I_y2);
 
   /*harris function*/
   const size_t height = input.size ();
@@ -117,22 +117,22 @@ void
 pcl::keypoint::hessianBlob (ImageType &output, ImageType &input, const float sigma, bool SCALED){
   /*creating the gaussian kernels*/
   ImageType kernel, cornerness;
-  conv_2d->gaussianKernel  (5, sigma, kernel);
+  conv_2d.gaussianKernel  (5, sigma, kernel);
 
   /*scaling the image with differentiation scale*/
   ImageType smoothed_image;
-  conv_2d->convolve  (smoothed_image, kernel, input);
+  conv_2d.convolve  (smoothed_image, kernel, input);
 
   /*image derivatives*/
   ImageType I_x, I_y;
-  edge_detection->ComputeDerivativeXCentral  (I_x, smoothed_image);
-  edge_detection->ComputeDerivativeYCentral  (I_y, smoothed_image);
+  edge_detection.ComputeDerivativeXCentral  (I_x, smoothed_image);
+  edge_detection.ComputeDerivativeYCentral  (I_y, smoothed_image);
 
   /*second moment matrix*/
   ImageType I_xx, I_yy, I_xy;
-  edge_detection->ComputeDerivativeXCentral  (I_xx, I_x);
-  edge_detection->ComputeDerivativeYCentral  (I_xy, I_x);
-  edge_detection->ComputeDerivativeYCentral  (I_yy, I_y);
+  edge_detection.ComputeDerivativeXCentral  (I_xx, I_x);
+  edge_detection.ComputeDerivativeYCentral  (I_xy, I_x);
+  edge_detection.ComputeDerivativeYCentral  (I_yy, I_y);
   /*Determinant of Hessian*/
   const size_t height = input.size ();
   const size_t width = input[0].size ();

--- a/2d/include/pcl/2d/keypoint.h
+++ b/2d/include/pcl/2d/keypoint.h
@@ -49,13 +49,11 @@ namespace pcl
   class Keypoint
   {
     private:
-      Edge *edge_detection;
-      Convolution *conv_2d;
+      Edge edge_detection;
+      Convolution conv_2d;
     public:
       Keypoint  ()
       {
-        edge_detection = new Edge ();
-        conv_2d = new Convolution ();
       }
       
       void 

--- a/2d/src/examples.cpp
+++ b/2d/src/examples.cpp
@@ -48,39 +48,39 @@ using namespace pcl;
 
 void example_edge ()
 {
-  Edge<pcl::PointXYZRGB> *edge = new Edge<pcl::PointXYZRGB> ();
+  Edge<pcl::PointXYZRGB> edge;
 
   /*dummy clouds*/
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
 
   /*example 1*/
-  edge->output_type_ = Edge<pcl::PointXYZRGB>::OUTPUT_X_Y;
-  edge->detectEdgeRoberts (*output_cloud, *input_cloud);
+  edge.output_type_ = Edge<pcl::PointXYZRGB>::OUTPUT_X_Y;
+  edge.detectEdgeRoberts (*output_cloud, *input_cloud);
 
   /*example 2*/
-  edge->hysteresis_threshold_low_ = 20;
-  edge->hysteresis_threshold_high_ = 80;
-  edge->non_max_suppression_radius_x_ = 3;
-  edge->non_max_suppression_radius_y_ = 3;
-  edge->detectEdgeCanny (*output_cloud, *input_cloud);
+  edge.hysteresis_threshold_low_ = 20;
+  edge.hysteresis_threshold_high_ = 80;
+  edge.non_max_suppression_radius_x_ = 3;
+  edge.non_max_suppression_radius_y_ = 3;
+  edge.detectEdgeCanny (*output_cloud, *input_cloud);
 
   /*example 3*/
-  edge->detector_kernel_type_ = Edge<pcl::PointXYZRGB>::PREWITT;
-  edge->hysteresis_thresholding_ = true;
-  edge->hysteresis_threshold_low_ = 20;
-  edge->hysteresis_threshold_high_ = 80;
-  edge->non_maximal_suppression_ = true;
-  edge->non_max_suppression_radius_x_ = 1;
-  edge->non_max_suppression_radius_y_ = 1;
-  edge->output_type_ = Edge<pcl::PointXYZRGB>::OUTPUT_X_Y;
-  edge->detectEdge (*output_cloud, *input_cloud);
+  edge.detector_kernel_type_ = Edge<pcl::PointXYZRGB>::PREWITT;
+  edge.hysteresis_thresholding_ = true;
+  edge.hysteresis_threshold_low_ = 20;
+  edge.hysteresis_threshold_high_ = 80;
+  edge.non_maximal_suppression_ = true;
+  edge.non_max_suppression_radius_x_ = 1;
+  edge.non_max_suppression_radius_y_ = 1;
+  edge.output_type_ = Edge<pcl::PointXYZRGB>::OUTPUT_X_Y;
+  edge.detectEdge (*output_cloud, *input_cloud);
 }
 
 void example_convolution ()
 {
-  Kernel<pcl::PointXYZRGB> *kernel = new Kernel<pcl::PointXYZRGB> ();
-  Convolution<pcl::PointXYZRGB> *convolution = new Convolution<pcl::PointXYZRGB> ();
+  Kernel<pcl::PointXYZRGB> kernel;
+  Convolution<pcl::PointXYZRGB> convolution;
 
   /*dummy clouds*/
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -88,27 +88,27 @@ void example_convolution ()
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
 
   /*example 1 : Gaussian Smoothing*/
-  kernel->sigma_ = 2.0;
-  kernel->kernel_size_ = 3;
-  kernel->gaussianKernel (*kernel_cloud);
-  convolution->kernel_ = *kernel_cloud;
-  convolution->convolve (*output_cloud, *input_cloud);
+  kernel.sigma_ = 2.0;
+  kernel.kernel_size_ = 3;
+  kernel.gaussianKernel (*kernel_cloud);
+  convolution.kernel_ = *kernel_cloud;
+  convolution.convolve (*output_cloud, *input_cloud);
 
   /*example 2 : forward derivative in X direction*/
-  kernel->kernel_type_ = Kernel<pcl::PointXYZRGB>::DERIVATIVE_FORWARD_X;
-  kernel->fetchKernel (*kernel_cloud);
-  convolution->kernel_ = *kernel_cloud;
-  convolution->convolve (*output_cloud, *input_cloud);
+  kernel.kernel_type_ = Kernel<pcl::PointXYZRGB>::DERIVATIVE_FORWARD_X;
+  kernel.fetchKernel (*kernel_cloud);
+  convolution.kernel_ = *kernel_cloud;
+  convolution.convolve (*output_cloud, *input_cloud);
 
   /*example 3*/
-  kernel->kernel_type_ = Kernel<pcl::PointXYZRGB>::DERIVATIVE_FORWARD_X;
-  kernel->fetchKernel (convolution->kernel_);
-  convolution->convolve (*output_cloud, *input_cloud);
+  kernel.kernel_type_ = Kernel<pcl::PointXYZRGB>::DERIVATIVE_FORWARD_X;
+  kernel.fetchKernel (convolution.kernel_);
+  convolution.convolve (*output_cloud, *input_cloud);
 }
 
 void example_morphology ()
 {
-  Morphology<pcl::PointXYZRGB> *morphology = new Morphology<pcl::PointXYZRGB> ();
+  Morphology<pcl::PointXYZRGB> morphology;
 
   /*dummy clouds*/
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -116,15 +116,15 @@ void example_morphology ()
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
 
   /*example 1 : Gaussian Smoothing*/
-  morphology->structuringElementCircular (*structuring_element_cloud, 3);
-  morphology->structuring_element_ = *structuring_element_cloud;
-  morphology->operator_type_ = Morphology<pcl::PointXYZRGB>::EROSION_GRAY;
-  morphology->applyMorphologicalOperation (*output_cloud, *input_cloud);
+  morphology.structuringElementCircular (*structuring_element_cloud, 3);
+  morphology.structuring_element_ = *structuring_element_cloud;
+  morphology.operator_type_ = Morphology<pcl::PointXYZRGB>::EROSION_GRAY;
+  morphology.applyMorphologicalOperation (*output_cloud, *input_cloud);
 
   /*example 2 : forward derivative in X direction*/
-  morphology->structuringElementCircular (morphology->structuring_element_, 3);
-  morphology->operator_type_ = Morphology<pcl::PointXYZRGB>::EROSION_GRAY;
-  morphology->applyMorphologicalOperation (*output_cloud, *input_cloud);
+  morphology.structuringElementCircular (morphology.structuring_element_, 3);
+  morphology.operator_type_ = Morphology<pcl::PointXYZRGB>::EROSION_GRAY;
+  morphology.applyMorphologicalOperation (*output_cloud, *input_cloud);
 
 }
 


### PR DESCRIPTION
Hi,
after using the Organized Edge Detection over several frames, I discovered a memory leak in the Class Edge in 2D. Additionally there were similar leaks in Keypoints from 2D and in the example file.

Greets,
Nico
