### PR TITLE
Switching from gl.h to qgl.h

### DIFF
--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
@@ -41,7 +41,7 @@
 #ifndef SELECT_2D_TOOL_H_
 #define SELECT_2D_TOOL_H_
 
-#include <GL/gl.h>
+#include <qgl.h>
 #include <pcl/apps/point_cloud_editor/toolInterface.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 

--- a/apps/point_cloud_editor/src/cloud.cpp
+++ b/apps/point_cloud_editor/src/cloud.cpp
@@ -38,10 +38,7 @@
 /// @author  Yue Li and Matthew Hielsberg
 
 #include <algorithm>
-//#include <QtOpenGL>
-//#include <qgl.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+#include <qgl.h>
 #include <pcl/apps/point_cloud_editor/cloud.h>
 #include <pcl/apps/point_cloud_editor/selection.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -41,7 +41,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QMouseEvent>
-#include <GL/gl.h>
+#include <qgl.h>
 #include <GL/glu.h>
 #include <pcl/filters/filter.h>
 #include <pcl/io/pcd_io.h>

--- a/apps/point_cloud_editor/src/select1DTool.cpp
+++ b/apps/point_cloud_editor/src/select1DTool.cpp
@@ -38,7 +38,7 @@
 /// @author  Yue Li and Matthew Hielsberg
 
 #include <algorithm>
-#include <GL/gl.h>
+#include <qgl.h>
 #include <pcl/apps/point_cloud_editor/select1DTool.h>
 #include <pcl/apps/point_cloud_editor/cloud.h>
 #include <pcl/apps/point_cloud_editor/selection.h>


### PR DESCRIPTION
The point_cloud_editor app uses the OpenGL headers directly. This leads to compilation problems under Windows (C2086) as windows.h would need to be included first. Using the corresponding QT headers solves this.
