### PR TITLE
Removed compiler options resulting in a D8021 compiler error in Visual Studio 2012

### DIFF
--- a/apps/point_cloud_editor/CMakeLists.txt
+++ b/apps/point_cloud_editor/CMakeLists.txt
@@ -115,8 +115,6 @@ IF(BUILD)
 						pcl_filters
     )
 
-  SET(CMAKE_CXX_FLAGS "-Wno-invalid-offsetof -Wno-extra-tokens")
-
   PCL_ADD_INCLUDES(${SUBSYS_NAME} ${SUBSYS_NAME} ${INCS})
   PCL_MAKE_PKGCONFIG(${EXE_NAME} ${SUBSYS_NAME} "${SUBSYS_DESC}" "" "" "" "" "")
 


### PR DESCRIPTION
Pull request for issue #209
