### PR TITLE
Update row_step when using copyPointCloud on PCLPointCloud2

### DIFF
--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -425,7 +425,7 @@ pcl::copyPointCloud (
   cloud_out.fields       = cloud_in.fields;
   cloud_out.is_bigendian = cloud_in.is_bigendian;
   cloud_out.point_step   = cloud_in.point_step;
-  cloud_out.row_step     = cloud_in.row_step;
+  cloud_out.row_step     = cloud_in.point_step * static_cast<uint32_t> (indices.size ());
   cloud_out.is_dense     = cloud_in.is_dense;
 
   cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);
@@ -448,7 +448,7 @@ pcl::copyPointCloud (
   cloud_out.fields       = cloud_in.fields;
   cloud_out.is_bigendian = cloud_in.is_bigendian;
   cloud_out.point_step   = cloud_in.point_step;
-  cloud_out.row_step     = cloud_in.row_step;
+  cloud_out.row_step     = cloud_in.point_step * static_cast<uint32_t> (indices.size ());
   cloud_out.is_dense     = cloud_in.is_dense;
 
   cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);


### PR DESCRIPTION
Updates the row_step field on the output PCLPointCloud2 to reflect
changes in point cloud size. 

According to the [PointCloud2 documentation](http://www.ros.org/doc/api/sensor_msgs/html/msg/PointCloud2.html), `data` should have size equal to `(row_step*height)`. Clearly, this is almost always false if `cloud_out.row_step` is simply copied from `cloud_in`. This patch updates `cloud_out.row_step` according to the number of points selected by `indices`.
