### PR TITLE
fixed bug in quad mesh construction (wrong index order caused invalid quads)

### DIFF
--- a/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
+++ b/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
@@ -114,9 +114,9 @@ pcl::OrganizedFastMesh<PointInT>::makeQuadMesh (std::vector<pcl::Vertices>& poly
                                      index_down += triangle_pixel_size_,
                                      index_down_right += triangle_pixel_size_)
     {
-      if (isValidQuad (i, index_down, index_right, index_down_right))
+      if (isValidQuad (i, index_right, index_down_right, index_down))
         if (store_shadowed_faces_ || !isShadowedQuad (i, index_right, index_down_right, index_down))
-          addQuad (i, index_down, index_right, index_down_right, idx++, polygons);
+          addQuad (i, index_right, index_down_right, index_down, idx++, polygons);
     }
   }
   polygons.resize (idx);


### PR DESCRIPTION
Title says it all. It seems that we mixed up the index order for the quads when speeding up the for loops. The resulting quads were invalid: instead of adding (and checking) A-B-D-C it was doing A-B-C-D resulting in broken quads. 

AB 
CD

Now fixed. Didn't find any bug reports mentioning broken quad meshes though. 
