### PR TITLE
Slightly improved approx. meshing by allowing to use different offsets when iterating over rows and columns

### DIFF
--- a/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
+++ b/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
@@ -89,30 +89,30 @@ pcl::OrganizedFastMesh<PointInT>::reconstructPolygons (std::vector<pcl::Vertices
 template <typename PointInT> void
 pcl::OrganizedFastMesh<PointInT>::makeQuadMesh (std::vector<pcl::Vertices>& polygons)
 {
-  int last_column = input_->width - triangle_pixel_size_;
-  int last_row = input_->height - triangle_pixel_size_;
+  int last_column = input_->width - triangle_pixel_size_columns_;
+  int last_row = input_->height - triangle_pixel_size_rows_;
 
   int i = 0, index_down = 0, index_right = 0, index_down_right = 0, idx = 0;
-  int y_big_incr = triangle_pixel_size_ * input_->width,
-      x_big_incr = y_big_incr + triangle_pixel_size_;
+  int y_big_incr = triangle_pixel_size_rows_ * input_->width,
+      x_big_incr = y_big_incr + triangle_pixel_size_columns_;
   // Reserve enough space
   polygons.resize (input_->width * input_->height);
 
   // Go over the rows first
-  for (int y = 0; y < last_row; y += triangle_pixel_size_)
+  for (int y = 0; y < last_row; y += triangle_pixel_size_rows_)
   {
     // Initialize a new row
     i = y * input_->width;
-    index_right = i + triangle_pixel_size_;
+    index_right = i + triangle_pixel_size_columns_;
     index_down = i + y_big_incr;
     index_down_right = i + x_big_incr;
 
     // Go over the columns
-    for (int x = 0; x < last_column; x += triangle_pixel_size_,
-                                     i += triangle_pixel_size_,
-                                     index_right += triangle_pixel_size_,
-                                     index_down += triangle_pixel_size_,
-                                     index_down_right += triangle_pixel_size_)
+    for (int x = 0; x < last_column; x += triangle_pixel_size_columns_,
+                                     i += triangle_pixel_size_columns_,
+                                     index_right += triangle_pixel_size_columns_,
+                                     index_down += triangle_pixel_size_columns_,
+                                     index_down_right += triangle_pixel_size_columns_)
     {
       if (isValidQuad (i, index_right, index_down_right, index_down))
         if (store_shadowed_faces_ || !isShadowedQuad (i, index_right, index_down_right, index_down))
@@ -126,30 +126,30 @@ pcl::OrganizedFastMesh<PointInT>::makeQuadMesh (std::vector<pcl::Vertices>& poly
 template <typename PointInT> void
 pcl::OrganizedFastMesh<PointInT>::makeRightCutMesh (std::vector<pcl::Vertices>& polygons)
 {
-  int last_column = input_->width - triangle_pixel_size_;
-  int last_row = input_->height - triangle_pixel_size_;
+  int last_column = input_->width - triangle_pixel_size_columns_;
+  int last_row = input_->height - triangle_pixel_size_rows_;
 
   int i = 0, index_down = 0, index_right = 0, index_down_right = 0, idx = 0;
-  int y_big_incr = triangle_pixel_size_ * input_->width,
-      x_big_incr = y_big_incr + triangle_pixel_size_;
+  int y_big_incr = triangle_pixel_size_rows_ * input_->width,
+      x_big_incr = y_big_incr + triangle_pixel_size_columns_;
   // Reserve enough space
   polygons.resize (input_->width * input_->height * 2);
 
   // Go over the rows first
-  for (int y = 0; y < last_row; y += triangle_pixel_size_)
+  for (int y = 0; y < last_row; y += triangle_pixel_size_rows_)
   {
     // Initialize a new row
     i = y * input_->width;
-    index_right = i + triangle_pixel_size_;
+    index_right = i + triangle_pixel_size_columns_;
     index_down = i + y_big_incr;
     index_down_right = i + x_big_incr;
 
     // Go over the columns
-    for (int x = 0; x < last_column; x += triangle_pixel_size_,
-                                     i += triangle_pixel_size_,
-                                     index_right += triangle_pixel_size_,
-                                     index_down += triangle_pixel_size_,
-                                     index_down_right += triangle_pixel_size_)
+    for (int x = 0; x < last_column; x += triangle_pixel_size_columns_,
+                                     i += triangle_pixel_size_columns_,
+                                     index_right += triangle_pixel_size_columns_,
+                                     index_down += triangle_pixel_size_columns_,
+                                     index_down_right += triangle_pixel_size_columns_)
     {
       if (isValidTriangle (i, index_down_right, index_right))
         if (store_shadowed_faces_ || !isShadowedTriangle (i, index_down_right, index_right))
@@ -167,30 +167,30 @@ pcl::OrganizedFastMesh<PointInT>::makeRightCutMesh (std::vector<pcl::Vertices>& 
 template <typename PointInT> void
 pcl::OrganizedFastMesh<PointInT>::makeLeftCutMesh (std::vector<pcl::Vertices>& polygons)
 {
-  int last_column = input_->width - triangle_pixel_size_;
-  int last_row = input_->height - triangle_pixel_size_;
+  int last_column = input_->width - triangle_pixel_size_columns_;
+  int last_row = input_->height - triangle_pixel_size_rows_;
 
   int i = 0, index_down = 0, index_right = 0, index_down_right = 0, idx = 0;
-  int y_big_incr = triangle_pixel_size_ * input_->width,
-      x_big_incr = y_big_incr + triangle_pixel_size_;
+  int y_big_incr = triangle_pixel_size_rows_ * input_->width,
+      x_big_incr = y_big_incr + triangle_pixel_size_columns_;
   // Reserve enough space
   polygons.resize (input_->width * input_->height * 2);
 
   // Go over the rows first
-  for (int y = 0; y < last_row; y += triangle_pixel_size_)
+  for (int y = 0; y < last_row; y += triangle_pixel_size_rows_)
   {
     // Initialize a new row
     i = y * input_->width;
-    index_right = i + triangle_pixel_size_;
+    index_right = i + triangle_pixel_size_columns_;
     index_down = i + y_big_incr;
     index_down_right = i + x_big_incr;
 
     // Go over the columns
-    for (int x = 0; x < last_column; x += triangle_pixel_size_,
-                                     i += triangle_pixel_size_,
-                                     index_right += triangle_pixel_size_,
-                                     index_down += triangle_pixel_size_,
-                                     index_down_right += triangle_pixel_size_)
+    for (int x = 0; x < last_column; x += triangle_pixel_size_columns_,
+                                     i += triangle_pixel_size_columns_,
+                                     index_right += triangle_pixel_size_columns_,
+                                     index_down += triangle_pixel_size_columns_,
+                                     index_down_right += triangle_pixel_size_columns_)
     {
       if (isValidTriangle (i, index_down, index_right))
         if (store_shadowed_faces_ || !isShadowedTriangle (i, index_down, index_right))
@@ -208,30 +208,30 @@ pcl::OrganizedFastMesh<PointInT>::makeLeftCutMesh (std::vector<pcl::Vertices>& p
 template <typename PointInT> void
 pcl::OrganizedFastMesh<PointInT>::makeAdaptiveCutMesh (std::vector<pcl::Vertices>& polygons)
 {
-  int last_column = input_->width - triangle_pixel_size_;
-  int last_row = input_->height - triangle_pixel_size_;
+  int last_column = input_->width - triangle_pixel_size_columns_;
+  int last_row = input_->height - triangle_pixel_size_rows_;
 
   int i = 0, index_down = 0, index_right = 0, index_down_right = 0, idx = 0;
-  int y_big_incr = triangle_pixel_size_ * input_->width,
-      x_big_incr = y_big_incr + triangle_pixel_size_;
+  int y_big_incr = triangle_pixel_size_rows_ * input_->width,
+      x_big_incr = y_big_incr + triangle_pixel_size_columns_;
   // Reserve enough space
-  polygons.resize (input_->width * input_->height * 4);
+  polygons.resize (input_->width * input_->height * 2);
 
   // Go over the rows first
-  for (int y = 0; y < last_row; y += triangle_pixel_size_)
+  for (int y = 0; y < last_row; y += triangle_pixel_size_rows_)
   {
     // Initialize a new row
     i = y * input_->width;
-    index_right = i + triangle_pixel_size_;
+    index_right = i + triangle_pixel_size_columns_;
     index_down = i + y_big_incr;
     index_down_right = i + x_big_incr;
 
     // Go over the columns
-    for (int x = 0; x < last_column; x += triangle_pixel_size_,
-                                     i += triangle_pixel_size_,
-                                     index_right += triangle_pixel_size_,
-                                     index_down += triangle_pixel_size_,
-                                     index_down_right += triangle_pixel_size_)
+    for (int x = 0; x < last_column; x += triangle_pixel_size_columns_,
+                                     i += triangle_pixel_size_columns_,
+                                     index_right += triangle_pixel_size_columns_,
+                                     index_down += triangle_pixel_size_columns_,
+                                     index_down_right += triangle_pixel_size_columns_)
     {
       const bool right_cut_upper = isValidTriangle (i, index_down_right, index_right);
       const bool right_cut_lower = isValidTriangle (i, index_down, index_down_right);

--- a/surface/include/pcl/surface/organized_fast_mesh.h
+++ b/surface/include/pcl/surface/organized_fast_mesh.h
@@ -86,7 +86,8 @@ namespace pcl
       /** \brief Constructor. Triangulation type defaults to \a QUAD_MESH. */
       OrganizedFastMesh ()
       : max_edge_length_squared_ (0.025f)
-      , triangle_pixel_size_ (1)
+      , triangle_pixel_size_rows_ (1)
+      , triangle_pixel_size_columns_ (1)
       , triangulation_type_ (QUAD_MESH)
       , store_shadowed_faces_ (false)
       , cos_angle_tolerance_ (fabsf (cosf (pcl::deg2rad (12.5f))))
@@ -113,7 +114,28 @@ namespace pcl
       inline void
       setTrianglePixelSize (int triangle_size)
       {
-        triangle_pixel_size_ = std::max (1, (triangle_size - 1));
+        setTrianglePixelSizeRows (triangle_size);
+        setTrianglePixelSizeColumns (triangle_size);
+      }
+
+      /** \brief Set the edge length (in pixels) used for iterating over rows when constructing the fixed mesh.
+        * \param[in] triangle_size edge length in pixels
+        * (Default: 1 = neighboring pixels are connected)
+        */
+      inline void
+      setTrianglePixelSizeRows (int triangle_size)
+      {
+        triangle_pixel_size_rows_ = std::max (1, (triangle_size - 1));
+      }
+
+      /** \brief Set the edge length (in pixels) used for iterating over columns when constructing the fixed mesh.
+        * \param[in] triangle_size edge length in pixels
+        * (Default: 1 = neighboring pixels are connected)
+        */
+      inline void
+      setTrianglePixelSizeColumns (int triangle_size)
+      {
+        triangle_pixel_size_columns_ = std::max (1, (triangle_size - 1));
       }
 
       /** \brief Set the triangulation type (see \a TriangulationType)
@@ -139,8 +161,11 @@ namespace pcl
       /** \brief max (squared) length of edge */
       float max_edge_length_squared_;
 
-      /** \brief size of triangle edges (in pixels) */
-      int triangle_pixel_size_;
+      /** \brief size of triangle edges (in pixels) for iterating over rows. */
+      int triangle_pixel_size_rows_;
+
+      /** \brief size of triangle edges (in pixels) for iterating over columns*/
+      int triangle_pixel_size_columns_;
 
       /** \brief Type of meshing scheme (quads vs. triangles, left cut vs. right cut ... */
       TriangulationType triangulation_type_;


### PR DESCRIPTION
This is a slight improvement of approximate meshing by using different offsets for iterating over rows and columns when constructing the approximate mesh. This may make less sense for RGB-D images, but can be helpful, e.g., when processing 3D scans composed of multiple 2D laser range scans where the point density in the individual 2D scans is considerably higher than between the scans.

Regarding API changes, two functions are added: setTrianglePixelSizeRows and setTrianglePixelColumns for setting the two increments. setTrianglePixelSize is still available to set both equally (as was the behavior beforehand).
