### PR TITLE
Patches for exporting dlls

### DIFF
--- a/gpu/people/include/pcl/gpu/people/person_attribs.h
+++ b/gpu/people/include/pcl/gpu/people/person_attribs.h
@@ -6,13 +6,15 @@
 #include <iosfwd>
 #include <boost/shared_ptr.hpp>
 
+#include <pcl/pcl_exports.h>
+
 namespace pcl
 {
   namespace gpu
   {
     namespace people
     {
-      class PersonAttribs
+      class PCL_EXPORTS PersonAttribs
       {
         public:
           typedef boost::shared_ptr<PersonAttribs> Ptr;

--- a/simulation/tools/simulation_io.hpp
+++ b/simulation/tools/simulation_io.hpp
@@ -23,7 +23,7 @@ namespace pcl
 {
   namespace simulation
   {
-    class SimExample
+    class PCL_EXPORTS SimExample
     {
       public:
         typedef boost::shared_ptr<SimExample> Ptr;


### PR DESCRIPTION
PCL_EXPORTS was forgotten on these two classes, resulting in linking error in the apps that depend on these classes.
