### PR TITLE
Patches for Qt 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,11 +276,17 @@ find_package(Qhull)
 # Cuda
 include(${PCL_SOURCE_DIR}/cmake/pcl_find_cuda.cmake)
 
+# Find Qt5
+include(cmake/pcl_find_qt5.cmake)
+
 # Find QT4
-find_package(Qt4)
-if (QT4_FOUND)
-  include(${QT_USE_FILE})
-endif (QT4_FOUND)
+if(NOT QT5_FOUND)
+    find_package(Qt4)
+    if (QT4_FOUND)
+      include(${QT_USE_FILE})
+    endif (QT4_FOUND)
+endif()
+
 # Find VTK
 find_package(VTK)
 if(VTK_FOUND)

--- a/apps/in_hand_scanner/src/in_hand_scanner.cpp
+++ b/apps/in_hand_scanner/src/in_hand_scanner.cpp
@@ -44,6 +44,9 @@
 #include <QtCore>
 #include <QKeyEvent>
 #include <QPainter>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#include <QtConcurrent/QtConcurrent>
+#endif
 
 #include <pcl/exceptions.h>
 #include <pcl/common/time.h>

--- a/apps/in_hand_scanner/src/offline_integration.cpp
+++ b/apps/in_hand_scanner/src/offline_integration.cpp
@@ -50,6 +50,9 @@
 #include <QFileDialog>
 #include <QtCore>
 #include <QKeyEvent>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#include <QtConcurrent/QtConcurrent>
+#endif
 
 #include <pcl/io/pcd_io.h>
 #include <pcl/common/transforms.h>

--- a/apps/modeler/include/pcl/apps/modeler/render_window.h
+++ b/apps/modeler/include/pcl/apps/modeler/render_window.h
@@ -51,7 +51,7 @@ namespace pcl
     class RenderWindow : public QVTKWidget
     {
       public:
-        RenderWindow(RenderWindowItem* render_window_item, QWidget *parent = 0, Qt::WFlags flags = 0);
+        RenderWindow(RenderWindowItem* render_window_item, QWidget *parent = 0, Qt::WindowFlags flags = 0);
         ~RenderWindow();
 
         virtual QSize

--- a/apps/modeler/src/parameter_dialog.cpp
+++ b/apps/modeler/src/parameter_dialog.cpp
@@ -96,7 +96,11 @@ pcl::modeler::ParameterDialog::exec()
   tableView.setItemDelegate(&parameterDelegate);
 
   tableView.horizontalHeader()->setStretchLastSection(true);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+  tableView.horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+#else
   tableView.horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
+#endif
   tableView.setShowGrid(true);
   tableView.verticalHeader()->hide();
   tableView.setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/apps/modeler/src/render_window.cpp
+++ b/apps/modeler/src/render_window.cpp
@@ -49,7 +49,7 @@
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-pcl::modeler::RenderWindow::RenderWindow(RenderWindowItem* render_window_item, QWidget *parent, Qt::WFlags flags)
+pcl::modeler::RenderWindow::RenderWindow(RenderWindowItem* render_window_item, QWidget *parent, Qt::WindowFlags flags)
   : QVTKWidget(parent, flags),
   axes_(vtkSmartPointer<vtkCubeAxesActor>::New()),
   render_window_item_(render_window_item)

--- a/cmake/pcl_find_qt5.cmake
+++ b/cmake/pcl_find_qt5.cmake
@@ -1,0 +1,76 @@
+# Qt5
+
+# See: http://qt-project.org/doc/qt-5.0/qtdoc/cmake-manual.html
+# See: http://qt-project.org/doc/qt-5.0/qtdoc/modules.html
+
+# Qt5 Modules
+set(qt5_modules
+
+# Essentials
+    Qt5Core
+    Qt5Gui
+    # Qt5Multimedia
+    # Qt5Network
+    # Qt5Qml
+    # Qt5Quick
+    # Qt5SQL
+    # Qt5Test
+    # Qt5WebKit
+    # Qt5WebKitWidgets
+    Qt5Widgets
+
+# Add-ons
+    # Qt5ActiveQt
+    Qt5Concurrent
+    # Qt5DBus
+    # Qt5GraphicalEffects
+    # Qt5ImageFormats
+    Qt5OpenGL
+    # Qt5PrintSupport
+    # Qt5Declarative
+    # Qt5Script
+    # Qt5ScriptTools
+    # Qt5Svg
+    # Qt5Xml
+    # Qt5XmlPatterns
+)
+
+# Populate qt4-style cmake variables.
+foreach(qt5_module ${qt5_modules})
+    find_package(${qt5_module} QUIET)
+    if(${qt5_module}_FOUND)
+        include_directories(${${qt5_module}_INCLUDE_DIRS})
+        add_definitions(${${qt5_module}_DEFINITIONS})
+        list(APPEND CMAKE_CXX_FLAGS ${${qt5_module}_EXECUTABLE_COMPILE_FLAGS})
+        list(APPEND QT_LIBRARIES ${${qt5_module}_LIBRARIES})
+    endif()
+endforeach()
+
+# Prepare qt4-style cmake variables and macros.
+if(Qt5Core_FOUND)
+
+    set(QT5_FOUND TRUE CACHE INTERNAL "")
+
+    # FIXME: CMake's automoc seems to break macosx parallel builds.
+    # set(CMAKE_AUTOMOC ON)
+    # set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+    # Replace qt4 macros.
+    macro(qt4_wrap_cpp)
+        qt5_wrap_cpp(${ARGN})
+    endmacro()
+    macro(qt4_add_resources)
+        qt5_add_resources(${ARGN})
+    endmacro()
+    if(Qt5Widgets_FOUND)
+        macro(qt4_wrap_ui)
+            qt5_wrap_ui(${ARGN})
+        endmacro()
+    endif()
+
+    set(QT_USE_FILE ${CMAKE_CURRENT_BINARY_DIR}/use-qt5.cmake CACHE PATH "")
+    file(WRITE ${QT_USE_FILE} "#")
+
+    # Trick the remainder of the build system.
+    set(QT4_FOUND TRUE)
+endif()

--- a/io/include/pcl/io/openni_camera/openni.h
+++ b/io/include/pcl/io/openni_camera/openni.h
@@ -45,7 +45,10 @@
 #endif
 
 #include <XnOS.h>
+//work around for qt 5 bug: https://bugreports.qt-project.org/browse/QTBUG-29331
+#ifndef Q_MOC_RUN
 #include <XnCppWrapper.h>
+#endif // Q_MOC_RUN
 #include <XnVersion.h>
 
 #endif


### PR DESCRIPTION
QT 5 fixes are from https://bitbucket.org/manctl/pcl/commits/095d858dd4f843ecfa637708d25a5202467f44d1, with a work around for QT bug 29331: https://bugreports.qt-project.org/browse/QTBUG-29331.
