### PR TITLE
fix to pcl::Poisson performReconstruction

### DIFF
--- a/surface/include/pcl/surface/impl/poisson.hpp
+++ b/surface/include/pcl/surface/impl/poisson.hpp
@@ -271,7 +271,7 @@ pcl::Poisson<PointNT>::performReconstruction (pcl::PointCloud<PointNT> &points,
 
   // Write output PolygonMesh
   // Write vertices
-  points.points.resize (int (mesh.outOfCorePointCount () + mesh.inCorePoints.size ()));
+  points.resize (int (mesh.outOfCorePointCount () + mesh.inCorePoints.size ()));
   poisson::Point3D<float> p;
   for (int i = 0; i < int(mesh.inCorePoints.size ()); i++)
   {


### PR DESCRIPTION
to properly set the dimensions of the output cloud
