### PR TITLE
Set CMAKE_CXX_FLAGS if they are set to default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,8 @@ endif()
 if(MSVC)
   SET(CMAKE_COMPILER_IS_MSVC 1)
   add_definitions ("-DBOOST_ALL_NO_LIB -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -DNOMINMAX /bigobj")
-  if("${CMAKE_CXX_FLAGS}" STREQUAL "")
-    SET(CMAKE_CXX_FLAGS "/bigobj /EHsc /fp:precise /wd4800 /wd4521 /wd4251 /wd4275 /wd4305 /wd4355 ${SSE_FLAGS}")
+  if("${CMAKE_CXX_FLAGS}" STREQUAL "/DWIN32 /D_WINDOWS /W3 /GR /EHsc")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /fp:precise /wd4800 /wd4521 /wd4251 /wd4275 /wd4305 /wd4355 ${SSE_FLAGS}")
 
     # Add extra code generation/link optimizations
     if(CMAKE_MSVC_CODE_LINK_OPTIMIZATION)


### PR DESCRIPTION
On Windows CMake sets CMAKE_CXX_FLAGS not to an empty string by default. Test
for the string and assume we can set optimized flags in case. Thanks to Ky
Waegel for noticing.
