### PR TITLE
fixed memory leak + added header file to includes in cmake file

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -175,6 +175,7 @@ if(build)
         ${OPENNI_GRABBER_INCLUDES}
         ${DINAST_GRABBER_INCLUDES}
         ${FZAPI_GRABBER_INCLUDES}
+		${PXC_GRABBER_INCLUDES}
         )
 
     set(compression_incs

--- a/io/src/pxc_grabber.cpp
+++ b/io/src/pxc_grabber.cpp
@@ -180,8 +180,8 @@ pcl::PXCGrabber::processGrabbing ()
     }
 
     // query rgb and 3d data
-    PXCImage *color_image=pp_.QueryImage (PXCImage::IMAGE_TYPE_COLOR);
-    PXCImage *vertex_image=pp_.QueryImage (PXCImage::IMAGE_TYPE_DEPTH);
+    PXCImage *color_image = pp_.QueryImage (PXCImage::IMAGE_TYPE_COLOR);
+    PXCImage *vertex_image = pp_.QueryImage (PXCImage::IMAGE_TYPE_DEPTH);
 
     // acquiure access to data
     PXCImage::ImageData ddata;
@@ -292,8 +292,11 @@ pcl::PXCGrabber::processGrabbing ()
 
       point_cloud_signal_->operator() (cloud_tmp);
     }
-
-    pp_.ReleaseFrame();
+    
+    vertex_image->ReleaseAccess (&ddata);
+    color_image->ReleaseAccess (&idata);
+    
+    pp_.ReleaseFrame ();
 
     const double capture_time = stop_watch.getTimeSeconds ();
     total_time += capture_time;


### PR DESCRIPTION
fixed memory leak by releasing grabbed data and added a missing line to the cmake file (such that the header file of the pxc grabber is actually added to the project and more importantly also copied when installed)
