### PR TITLE
save inliers found during RANSAC

### DIFF
--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
@@ -81,6 +81,7 @@ namespace pcl
           , target_ ()
           , best_transformation_ ()
           , refine_ (false)
+          , save_inliers_ (false)
         {
           rejection_name_ = "CorrespondenceRejectorSampleConsensus";
         }
@@ -189,6 +190,24 @@ namespace pcl
         {
           return (refine_);
         }
+
+        /** \brief Get the inlier indices found by the correspondence rejector. This information is only saved if setSaveInliers(true) was called in advance.
+          * \param[out] inlier_indices Indices for the inliers
+          */
+        inline void
+        getInliersIndices (std::vector<int> &inlier_indices) { inlier_indices = inlier_indices_; }
+
+        /** \brief Set whether to save inliers or not
+          * \param[in] s True to save inliers / False otherwise
+          */
+        inline void
+        setSaveInliers (bool s) { save_inliers_ = s; }
+
+        /** \brief Get whether the rejector is configured to save inliers */
+        inline bool
+        getSaveInliers () { return save_inliers_; }
+
+
       protected:
 
         /** \brief Apply the rejection algorithm.
@@ -211,6 +230,9 @@ namespace pcl
         Eigen::Matrix4f best_transformation_;
 
         bool refine_;
+        std::vector<int> inlier_indices_;
+        bool save_inliers_;
+
       public:
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -156,6 +156,13 @@ pcl::registration::CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCo
        for (size_t i = 0; i < inliers.size (); ++i)
          remaining_correspondences[i] = original_correspondences[index_to_correspondence[inliers[i]]];
 
+       if (save_inliers_)
+       {
+         inlier_indices_.reserve (inliers.size ());
+         for (size_t i = 0; i < inliers.size (); ++i)
+           inlier_indices_.push_back (index_to_correspondence[inliers[i]]);
+       }
+
        // get best transformation
        Eigen::VectorXf model_coefficients;
        sac.getModelCoefficients (model_coefficients);


### PR DESCRIPTION
allows the user to configure the CorrespondenceRejectorSampleConsensus in order to save the inliers indices (up to now only the correspondences were saved). Default behaviour does not change.
