### PR TITLE
Fixed failed unit test since #212

### DIFF
--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -548,7 +548,7 @@ TEST (PCL, SampleConsensusPrerejective)
   // Normal estimator
   NormalEstimation<PointXYZ, Normal> norm_est;
   norm_est.setSearchMethod (tree);
-  norm_est.setRadiusSearch (0.05);
+  norm_est.setRadiusSearch (0.005);
   PointCloud<Normal> normals;
 
   // FPFH estimator


### PR DESCRIPTION
Fixed a typo in the normal estimation radius, making the unit test for SampleConsensusPrerejective fail
