### PR TITLE
Add missing include and forward declaration in pcl_plotter.h

### DIFF
--- a/visualization/include/pcl/visualization/pcl_plotter.h
+++ b/visualization/include/pcl/visualization/pcl_plotter.h
@@ -50,12 +50,13 @@
 #include <pcl/common/io.h>
 
 class PCLVisualizerInteractor;
-template <typename T> class vtkSmartPointer;
+class vtkRenderWindow;
 class vtkRenderWindowInteractor;
 class vtkContextView;
 class vtkChartXY;
 class vtkColorSeries;
 
+#include <vtkSmartPointer.h>
 #include <vtkCommand.h>
 #include <vtkChart.h>
 


### PR DESCRIPTION
Forward declaration of vtkRenderWindow was missing in pcl_plotter.h.
Also it is not sufficient to forward declare vtkSmartPointer, the
corresponding header shound be included.
