### PR TITLE
Fixed documentation for removeNaNFromPointCloud()

### DIFF
--- a/filters/include/pcl/filters/filter_indices.h
+++ b/filters/include/pcl/filters/filter_indices.h
@@ -44,11 +44,18 @@
 
 namespace pcl
 {
-  /** \brief Removes points with x, y, or z equal to NaN
+  /** \brief Removes points with x, y, or z equal to NaN (dry run).
+    *
+    * This function only computes the mapping between the points in the input
+    * cloud and the cloud that would result from filtering. It does not
+    * actually construct and output the filtered cloud.
+    *
+    * \note This function does not modify the input point cloud!
+    *
     * \param cloud_in the input point cloud
-    * \param index the mapping (ordered): cloud_out.points[i] = cloud_in.points[index[i]]
-    * \note The density of the point cloud is lost.
-    * \note Can be called with cloud_in == cloud_out
+    * \param index the mapping (ordered): filtered_cloud.points[i] = cloud_in.points[index[i]]
+    *
+    * \see removeNaNFromPointCloud
     * \ingroup filters
     */
   template<typename PointT> void


### PR DESCRIPTION
The old (misleading) documentation was copied over from another overload of this function.
