### PR TITLE
add missing stdint.h includes

### DIFF
--- a/io/include/pcl/io/openni_camera/openni_shift_to_depth_conversion.h
+++ b/io/include/pcl/io/openni_camera/openni_shift_to_depth_conversion.h
@@ -41,6 +41,7 @@
 #ifndef __OPENNI_SHIFT_TO_DEPTH_CONVERSION
 #define __OPENNI_SHIFT_TO_DEPTH_CONVERSION
 
+#include <stdint.h>
 #include <vector>
 #include <limits>
 

--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -1,6 +1,8 @@
 #ifndef PCL_OUTOFCORE_OUTOFCORE_CLOUD_H_
 #define PCL_OUTOFCORE_OUTOFCORE_CLOUD_H_
 
+#include <stdint.h>
+
 // PCL
 //#include <pcl/common/time.h>
 //#include <pcl/point_cloud.h>


### PR DESCRIPTION
glibc 2.17->2.18 cleaned some implicit includes in standard headers again and
these two includes were therefore missing to build with the new lib.
