### PR TITLE
Replaced std::fill_n. This command does not work as intended in VS2012 Release Mode

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3746,11 +3746,12 @@ pcl::visualization::PCLVisualizer::updateCells (vtkSmartPointer<vtkIdTypeArray> 
       cells->SetNumberOfComponents (2);
       cells->SetNumberOfTuples (nr_points);
       vtkIdType *cell = cells->GetPointer (0);
-      // Fill it with 1s
-      std::fill_n (cell, nr_points * 2, 1);
-      cell++;
       for (vtkIdType i = 0; i < nr_points; ++i, cell += 2)
-        *cell = i;
+      {
+        *cell = 1;
+        *(cell+1) = i;
+      }
+
       // Save the results in initcells
       initcells = vtkSmartPointer<vtkIdTypeArray>::New ();
       initcells->DeepCopy (cells);


### PR DESCRIPTION
The std::fill_n command appears to have no effect in VS2012 Release Mode (perhaps it gets optimized away?)
This caused a crash in pcl_viewer and other examples based on pcl_visualization on Windows with VS2012 due to cells with an arbitrary number of points.
