### PR TITLE
update covariances only if a new pointcloud was set

### DIFF
--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -142,6 +142,7 @@ namespace pcl
           input[i].data[3] = 1.0;
         
         pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputSource (cloud);
+        input_covariances_.clear ();
         input_covariances_.reserve (input_->size ());
       }
 
@@ -152,6 +153,7 @@ namespace pcl
       setInputTarget (const PointCloudTargetConstPtr &target)
       {
         pcl::IterativeClosestPoint<PointSource, PointTarget>::setInputTarget(target);
+        target_covariances_.clear ();
         target_covariances_.reserve (target_->size ());
       }
 

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -360,9 +360,11 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransfor
   // Set the mahalanobis matrices to identity
   mahalanobis_.resize (N, Eigen::Matrix3d::Identity ());
   // Compute target cloud covariance matrices
-  computeCovariances<PointTarget> (target_, tree_, target_covariances_);
+  if (target_covariances_.empty ())
+    computeCovariances<PointTarget> (target_, tree_, target_covariances_);
   // Compute input cloud covariance matrices
-  computeCovariances<PointSource> (input_, tree_reciprocal_, input_covariances_);
+  if (input_covariances_.empty ())
+    computeCovariances<PointSource> (input_, tree_reciprocal_, input_covariances_);
 
   base_transformation_ = guess;
   nr_iterations_ = 0;


### PR DESCRIPTION
this avoids unnecessary recalculations if only one of the pointclouds has been changed
