### PR TITLE
Fix: addRectangle as of VTK 5.8 handling y coordinates

### DIFF
--- a/visualization/include/pcl/visualization/impl/image_viewer.hpp
+++ b/visualization/include/pcl/visualization/impl/image_viewer.hpp
@@ -267,7 +267,7 @@ pcl::visualization::ImageViewer::addRectangle (
     if (pp_2d[i].x > max_pt_2d.x) max_pt_2d.x = pp_2d[i].x;
     if (pp_2d[i].y > max_pt_2d.y) max_pt_2d.y = pp_2d[i].y;
   }
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 10))
+#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 7))
   min_pt_2d.y = float (image->height) - min_pt_2d.y;
   max_pt_2d.y = float (image->height) - max_pt_2d.y;
 #endif
@@ -277,7 +277,7 @@ pcl::visualization::ImageViewer::addRectangle (
                    static_cast<unsigned char> (255.0 * g), 
                    static_cast<unsigned char> (255.0 * b));
   rect->setOpacity (opacity);
-  rect->set (min_pt_2d.x, min_pt_2d.y, (max_pt_2d.x - min_pt_2d.x), (max_pt_2d.y - min_pt_2d.y));  
+  rect->set (min_pt_2d.x, min_pt_2d.y, max_pt_2d.x, max_pt_2d.y);
   am_it->actor->GetScene ()->AddItem (rect);
 
   return (true);
@@ -332,7 +332,7 @@ pcl::visualization::ImageViewer::addRectangle (
     if (pp_2d[i].x > max_pt_2d.x) max_pt_2d.x = pp_2d[i].x;
     if (pp_2d[i].y > max_pt_2d.y) max_pt_2d.y = pp_2d[i].y;
   }
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 10))
+#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 7))
   min_pt_2d.y = float (image->height) - min_pt_2d.y;
   max_pt_2d.y = float (image->height) - max_pt_2d.y;
 #endif
@@ -342,7 +342,7 @@ pcl::visualization::ImageViewer::addRectangle (
                    static_cast<unsigned char> (255.0 * g), 
                    static_cast<unsigned char> (255.0 * b));
   rect->setOpacity (opacity);
-  rect->set (min_pt_2d.x, min_pt_2d.y, (max_pt_2d.x - min_pt_2d.x), (max_pt_2d.y - min_pt_2d.y));
+  rect->set (min_pt_2d.x, min_pt_2d.y, max_pt_2d.x, max_pt_2d.y);
   am_it->actor->GetScene ()->AddItem (rect);
 
   return (true);

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -743,12 +743,12 @@ pcl::visualization::ImageViewer::addRectangle (
                    static_cast<unsigned char> (255.0 * g),
                    static_cast<unsigned char> (255.0 * b));
   rect->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
+#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7))
   rect->set (static_cast<float> (x_min), static_cast<float> (y_min),
-             static_cast<float> (x_max - x_min), static_cast<float> (y_max - y_min));
+             static_cast<float> (x_max), static_cast<float> (y_max));
 #else
   rect->set (static_cast<float> (x_min), static_cast<float> (getSize ()[1] - y_min),
-             static_cast<float> (x_max - x_min), static_cast<float> (y_max - y_min));
+             static_cast<float> (x_max), static_cast<float> (getSize ()[1] - y_max));
 #endif
   am_it->actor->GetScene ()->AddItem (rect);
 
@@ -786,10 +786,10 @@ pcl::visualization::ImageViewer::addRectangle (
                    static_cast<unsigned char> (255.0 * g),
                    static_cast<unsigned char> (255.0 * b));
   rect->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
-  rect->set (min_pt.x, min_pt.y, (max_pt.x - min_pt.x), (max_pt.y - min_pt.y));
+#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7))
+  rect->set (min_pt.x, min_pt.y, max_pt.x, max_pt.y);
 #else
-  rect->set (min_pt.x, static_cast<float> (getSize ()[1]) - min_pt.y, (max_pt.x - min_pt.x), (max_pt.y - min_pt.y));
+  rect->set (min_pt.x, static_cast<float> (getSize ()[1]) - min_pt.y, max_pt.x, max_pt.y);
 #endif
   am_it->actor->GetScene ()->AddItem (rect);
 

--- a/visualization/src/vtk/pcl_context_item.cpp
+++ b/visualization/src/vtk/pcl_context_item.cpp
@@ -150,9 +150,9 @@ pcl::visualization::context_items::Rectangle::Paint (vtkContext2D *painter)
   float p[] = 
   { 
     params[0], params[1], 
-    params[0]+params[2], params[1],
-    params[0]+params[2], params[1]+params[3],
-    params[0],       params[1]+params[3],
+    params[2], params[1],
+    params[2], params[3],
+    params[0], params[3],
     params[0], params[1]
   };
 


### PR DESCRIPTION
VTK 5.8 axis seems to include the getSize[1] offset already.
Speed up the computation of the rectangle.
