### PR TITLE
Updated deprecated function call in pcl::Registration

### DIFF
--- a/doc/tutorials/content/sources/pairwise_incremental_registration/pairwise_incremental_registration.cpp
+++ b/doc/tutorials/content/sources/pairwise_incremental_registration/pairwise_incremental_registration.cpp
@@ -257,7 +257,7 @@ void pairAlign (const PointCloud::Ptr cloud_src, const PointCloud::Ptr cloud_tgt
   // Set the point representation
   reg.setPointRepresentation (boost::make_shared<const MyPointRepresentation> (point_representation));
 
-  reg.setInputCloud (points_with_normals_src);
+  reg.setInputSource (points_with_normals_src);
   reg.setInputTarget (points_with_normals_tgt);
 
 
@@ -275,7 +275,7 @@ void pairAlign (const PointCloud::Ptr cloud_src, const PointCloud::Ptr cloud_tgt
     points_with_normals_src = reg_result;
 
     // Estimate
-    reg.setInputCloud (points_with_normals_src);
+    reg.setInputSource (points_with_normals_src);
     reg.align (*reg_result);
 
 		//accumulate transformation between each Iteration


### PR DESCRIPTION
setInputCloud became setInputSource in PCL 1.7
