### PR TITLE
Remove reference to openni-dev in pkg-config files.

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -252,9 +252,6 @@ if(build)
     endif(PCAP_FOUND)
 
     set(EXT_DEPS eigen3)
-    if(OPENNI_FOUND)
-      list(APPEND EXT_DEPS openni-dev)
-    endif(OPENNI_FOUND)
     PCL_MAKE_PKGCONFIG(${LIB_NAME} ${SUBSYS_NAME} "${SUBSYS_DESC}"
       "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")
 

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -157,9 +157,6 @@ if(build)
     endif()
 
     set(EXT_DEPS "")
-    if(OPENNI_FOUND)
-      list(APPEND EXT_DEPS openni-dev)
-    endif(OPENNI_FOUND)
     PCL_MAKE_PKGCONFIG(${LIB_NAME} ${SUBSYS_NAME} "${SUBSYS_DESC}"
       "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")
 


### PR DESCRIPTION
OpenNI packages are not currently shipped with any pkg-config
files. Furthermore, Debian packages libopenni-dev and openni-dev are
currently not coinstallable and provide pkg-config files with
different namings. To workaround these issues, this patch disables
OpenNI check in pkg-config files.

This partially solves issue #221.
CC @thomas-moulard
