### PR TITLE
PCL_DEPRECATED doesn't work with template functions in VS2012?

### DIFF
--- a/io/include/pcl/io/png_io.h
+++ b/io/include/pcl/io/png_io.h
@@ -142,8 +142,8 @@ namespace pcl
       * \ingroup io
       */
     PCL_DEPRECATED (template <typename T> void savePNGFile (const std::string& file_name, const pcl::PointCloud<T>& cloud),
-    "pcl::io::savePNGFile<typename T> (file_name, cloud) is deprecated, please use a new generic "
-    "function pcl::io::savePNGFile (file_name, cloud, field_name) with \"rgb\" as the field name."
+    "pcl::io::savePNGFile<typename T> (file_name, cloud) is deprecated, please use a new generic \
+     function pcl::io::savePNGFile (file_name, cloud, field_name) with \"rgb\" as the field name."
     );
     template <typename T> void
     savePNGFile (const std::string& file_name, const pcl::PointCloud<T>& cloud)
@@ -166,8 +166,8 @@ namespace pcl
      * Warning: Converts to 16 bit (for png), labels using more than 16 bits will cause problems
      */
     PCL_DEPRECATED (void savePNGFile (const std::string& file_name, const pcl::PointCloud<pcl::PointXYZL>& cloud),
-    "pcl::io::savePNGFile (file_name, cloud) is deprecated, please use a new generic function "
-    "pcl::io::savePNGFile (file_name, cloud, field_name) with \"label\" as the field name."
+    "pcl::io::savePNGFile (file_name, cloud) is deprecated, please use a new generic function \
+     pcl::io::savePNGFile (file_name, cloud, field_name) with \"label\" as the field name."
     );
     void
     savePNGFile (const std::string& file_name, const pcl::PointCloud<pcl::PointXYZL>& cloud)


### PR DESCRIPTION
Hi all,

This is the error message I get:

---

error C2143: syntax error : missing ';' before ''template<'' \io\include\pcl\io\png_io.h    147

---

The line 144~147 of png_io.h is:

---

```
PCL_DEPRECATED (template <typename T> void savePNGFile (const std::string& file_name, const pcl::PointCloud<T>& cloud),
"pcl::io::savePNGFile<typename T> (file_name, cloud) is deprecated, please use a new generic "
"function pcl::io::savePNGFile (file_name, cloud, field_name) with \"rgb\" as the field name."
);
```

---

I think it's a VS2012 problem with deprecated, but I don't know how to fix it or workaround it.
