### PR TITLE
Removing unused vtkRegressionTestImage.h

### DIFF
--- a/visualization/include/pcl/visualization/pcl_painter2D.h
+++ b/visualization/include/pcl/visualization/pcl_painter2D.h
@@ -59,8 +59,6 @@
 #include <vtkPoints2D.h>
 #include "vtkCommand.h"
 
-#include <vtkRegressionTestImage.h>
-
 namespace pcl
 {
   namespace visualization


### PR DESCRIPTION
vtkRegressionTestImage.h causes missing header compiler error with VS2012 vtk6 with build_test turned off. I checked and found it is not used at all, so just removed it.
