### PR TITLE
Add some key comments to pcl_visualizer.h

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -251,7 +251,10 @@ namespace pcl
           return (registerAreaPickingCallback (boost::bind (callback, boost::ref (instance), _1, cookie)));
         }
 
-        /** \brief Spin method. Calls the interactor and runs an internal loop. */
+        /** \brief Spin method. Calls the interactor and runs an internal loop. 
+		  * \The spin() or spinOnce() method is necessary when use the 
+		    pcl::visualization::PCLVisualizer class.
+		  */
         void
         spin ();
 
@@ -259,6 +262,8 @@ namespace pcl
           *  \param[in] time - How long (in ms) should the visualization loop be allowed to run.
           *  \param[in] force_redraw - if false it might return without doing anything if the
           *  interactor's framerate does not require a redraw yet.
+		  * \The spin() or spinOnce() method is necessary when use the 
+		     pcl::visualization::PCLVisualizer class.
           */
         void
         spinOnce (int time = 1, bool force_redraw = false);


### PR DESCRIPTION
The spin() or spinOnce() method is necessary when use the
pcl::visualization::PCLVisualizer class to display pointcloud.
