### PR TITLE
Added FindOpenNI2.cmake search module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,13 @@ if (OPENNI_FOUND)
   include_directories(SYSTEM ${OPENNI_INCLUDE_DIRS})
 endif()
 
+# OpenNI 2
+find_package(OpenNI2)
+if (OPENNI2_FOUND)
+  set(HAVE_OPENNI2 ON)
+  include_directories(SYSTEM ${OPENNI2_INCLUDE_DIRS})
+endif()
+
 # Fotonic (FZ_API)
 find_package(FZAPI)
 if (FZAPI_FOUND)

--- a/cmake/Modules/FindOpenNI2.cmake
+++ b/cmake/Modules/FindOpenNI2.cmake
@@ -1,0 +1,79 @@
+###############################################################################
+# Find OpenNI 2
+#
+# This sets the following variables:
+# OPENNI2_FOUND - True if OPENNI 2 was found.
+# OPENNI2_INCLUDE_DIRS - Directories containing the OPENNI 2 include files.
+# OPENNI2_LIBRARIES - Libraries needed to use OPENNI 2.
+# OPENNI2_DEFINITIONS - Compiler flags for OPENNI 2.
+# 
+# For libusb-1.0, add USB_10_ROOT if not found
+
+find_package(PkgConfig QUIET)
+
+# Find LibUSB
+if(NOT WIN32)
+  pkg_check_modules(PC_USB_10 libusb-1.0)
+  find_path(USB_10_INCLUDE_DIR libusb-1.0/libusb.h
+            HINTS ${PC_USB_10_INCLUDEDIR} ${PC_USB_10_INCLUDE_DIRS} "${USB_10_ROOT}" "$ENV{USB_10_ROOT}"
+            PATH_SUFFIXES libusb-1.0)
+
+  find_library(USB_10_LIBRARY
+               NAMES usb-1.0 
+               HINTS ${PC_USB_10_LIBDIR} ${PC_USB_10_LIBRARY_DIRS} "${USB_10_ROOT}" "$ENV{USB_10_ROOT}"
+               PATH_SUFFIXES lib)
+               
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(USB_10 DEFAULT_MSG USB_10_LIBRARY USB_10_INCLUDE_DIR)
+   
+  if(NOT USB_10_FOUND)
+    message(STATUS "OpenNI 2 disabled because libusb-1.0 not found.")     
+    return()
+  else()
+    include_directories(SYSTEM ${USB_10_INCLUDE_DIR})
+  endif()
+endif(NOT WIN32)
+ 
+if(${CMAKE_VERSION} VERSION_LESS 2.8.2)
+  pkg_check_modules(PC_OPENNI2 openni2-dev)
+else()
+  pkg_check_modules(PC_OPENNI2 QUIET openni2-dev)
+endif()
+
+set(OPENNI2_DEFINITIONS ${PC_OPENNI_CFLAGS_OTHER})
+
+set(OPENNI2_SUFFIX)
+if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(OPENNI2_SUFFIX 64)
+endif(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+#add a hint so that it can find it without the pkg-config
+find_path(OPENNI2_INCLUDE_DIR OpenNI.h
+          HINTS ${PC_OPENNI2_INCLUDEDIR} ${PC_OPENNI2_INCLUDE_DIRS} /usr/include/openni2 /usr/include/ni "${OPENNI2_ROOT}" "$ENV{OPENNI2_ROOT}"
+          PATHS "$ENV{OPENNI2_INCLUDE${OPENNI2_SUFFIX}}"
+          PATH_SUFFIXES openni include Include)
+#add a hint so that it can find it without the pkg-config
+find_library(OPENNI2_LIBRARY 
+             NAMES OpenNI2	# No suffix needed on Win64
+             HINTS ${PC_OPENNI2_LIBDIR} ${PC_OPENNI2_LIBRARY_DIRS} /usr/lib "${OPENNI2_ROOT}" "$ENV{OPENNI2_ROOT}"
+             PATHS "$ENV{OPENNI2_LIB${OPENNI2_SUFFIX}}"
+             PATH_SUFFIXES lib Lib Lib64)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(OPENNI2_LIBRARIES ${OPENNI2_LIBRARY} ${LIBUSB_1_LIBRARIES})
+else()
+  set(OPENNI2_LIBRARIES ${OPENNI2_LIBRARY})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenNI2 DEFAULT_MSG OPENNI2_LIBRARY OPENNI2_INCLUDE_DIR)
+    
+mark_as_advanced(OPENNI2_LIBRARY OPENNI2_INCLUDE_DIR)
+
+if(OPENNI2_FOUND)  
+  # Add the include directories
+  set(OPENNI2_INCLUDE_DIRS ${OPENNI2_INCLUDE_DIR})
+  set(OPENNI2_REDIST_DIR $ENV{OPENNI2_REDIST${OPENNI2_SUFFIX}})
+  message(STATUS "OpenNI 2 found (include: ${OPENNI2_INCLUDE_DIRS}, lib: ${OPENNI2_LIBRARY}, redist: ${OPENNI2_REDIST_DIR})")
+endif(OPENNI2_FOUND)
+

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -16,6 +16,8 @@
 
 #cmakedefine HAVE_OPENNI 1
 
+#cmakedefine HAVE_OPENNI2 1
+
 #cmakedefine HAVE_QHULL 1
 
 #cmakedefine HAVE_QHULL_2011 1
@@ -42,6 +44,10 @@
 
 #ifdef DISABLE_OPENNI
 #undef HAVE_OPENNI
+#endif
+
+#ifdef DISABLE_OPENNI2
+#undef HAVE_OPENNI2
 #endif
 
 #ifdef DISABLE_QHULL


### PR DESCRIPTION
This is a clone of the `FindOpenNI.cmake` file, modified to locate OpenNI 2.

This has only been tested on Windows systems.
