### PR TITLE
Use always euclidean distance

### DIFF
--- a/doc/tutorials/content/sources/template_alignment/template_alignment.cpp
+++ b/doc/tutorials/content/sources/template_alignment/template_alignment.cpp
@@ -129,7 +129,7 @@ class TemplateAlignment
 
     TemplateAlignment () :
       min_sample_distance_ (0.05f),
-      max_correspondence_distance_ (0.01f*0.01f),
+      max_correspondence_distance_ (0.01f),
       nr_iterations_ (500)
     {
       // Intialize the parameters in the Sample Consensus Intial Alignment (SAC-IA) algorithm

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -204,8 +204,10 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
     return;
   }
 
+  double sqr_dist_threshold = corr_dist_threshold_*corr_dist_threshold_;
+
   if (!error_functor_)
-    error_functor_.reset (new TruncatedError (static_cast<float> (corr_dist_threshold_)));
+    error_functor_.reset (new TruncatedError (static_cast<float> (sqr_dist_threshold)));
 
 
   std::vector<int> sample_indices (nr_samples_);
@@ -220,7 +222,7 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
   {
     // If guess is not the Identity matrix we check it.
     transformPointCloud (*input_, input_transformed, final_transformation_);
-    lowest_error = computeErrorMetric (input_transformed, static_cast<float> (corr_dist_threshold_));
+    lowest_error = computeErrorMetric (input_transformed, static_cast<float> (sqr_dist_threshold));
     i_iter = 1;
   }
 
@@ -237,7 +239,7 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
 
     // Tranform the data and compute the error
     transformPointCloud (*input_, input_transformed, transformation_);
-    error = computeErrorMetric (input_transformed, static_cast<float> (corr_dist_threshold_));
+    error = computeErrorMetric (input_transformed, static_cast<float> (sqr_dist_threshold));
 
     // If the new error is lower, update the final transformation
     if (i_iter == 0 || error < lowest_error)

--- a/registration/include/pcl/registration/impl/registration.hpp
+++ b/registration/include/pcl/registration/impl/registration.hpp
@@ -129,10 +129,11 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename Scalar> inline double
-pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max_range)
+pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max_distance)
 {
 
   double fitness_score = 0.0;
+  double max_dist_sqr = max_distance * max_distance;
 
   // Transform the input dataset using the final transformation
   PointCloudSource input_transformed;
@@ -149,7 +150,7 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max
     tree_->nearestKSearch (input_transformed.points[i], 1, nn_indices, nn_dists);
     
     // Deal with occlusions (incomplete targets)
-    if (nn_dists[0] <= max_range)
+    if (nn_dists[0] <= max_dist_sqr)
     {
       // Add to the fitness score
       fitness_score += nn_dists[0];

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -380,11 +380,11 @@ namespace pcl
       }
 
       /** \brief Obtain the Euclidean fitness score (e.g., sum of squared distances from the source to the target)
-        * \param[in] max_range maximum allowable distance between a point and its correspondence in the target 
+        * \param[in] max_distance maximum allowable distance between a point and its correspondence in the target 
         * (default: double::max)
         */
       inline double 
-      getFitnessScore (double max_range = std::numeric_limits<double>::max ());
+      getFitnessScore (double max_distance = std::sqrt (std::numeric_limits<double>::max ()));
 
       /** \brief Obtain the Euclidean fitness score (e.g., sum of squared distances from the source to the target)
         * from two sets of correspondence distances (distances between source and target points)


### PR DESCRIPTION
As supposed in: http://www.pcl-developers.org/In-Registration-Distance-set-with-setMaxCorrespondenceDistance-td5708244.html

Changing getFitnessScore() could be a bit dangerous, but at the moment, the documentation says:
[in]    max_range   maximum allowable distance between a point and its correspondence in the target (default: double::max)

So I think if somebody did not read the source code, he will expect that the distance is given euclidean and not square.
