### PR TITLE
Removed check for source normals

### DIFF
--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
@@ -159,9 +159,6 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCl
     if (!pcl_isfinite (source_it->x) ||
         !pcl_isfinite (source_it->y) ||
         !pcl_isfinite (source_it->z) ||
-        !pcl_isfinite (source_it->normal_x) ||
-        !pcl_isfinite (source_it->normal_y) ||
-        !pcl_isfinite (source_it->normal_z) ||
         !pcl_isfinite (target_it->x) ||
         !pcl_isfinite (target_it->y) ||
         !pcl_isfinite (target_it->z) ||

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
@@ -186,9 +186,6 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it,
     if (!pcl_isfinite (source_it->x) ||
         !pcl_isfinite (source_it->y) ||
         !pcl_isfinite (source_it->z) ||
-        !pcl_isfinite (source_it->normal_x) ||
-        !pcl_isfinite (source_it->normal_y) ||
-        !pcl_isfinite (source_it->normal_z) ||
         !pcl_isfinite (target_it->x) ||
         !pcl_isfinite (target_it->y) ||
         !pcl_isfinite (target_it->z) ||


### PR DESCRIPTION
Removed check for source normals, since only the target cloud is required to have normals.
Fix for #342.
