### PR TITLE
Fixed MSVC linker crash.

### DIFF
--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -141,7 +141,14 @@ if(build)
         src/usc.cpp
         src/range_image_border_extractor.cpp
        )
-
+	
+    if(MSVC)
+      # Workaround to aviod hitting the MSVC 4GB linker memory limit when building pcl_features.
+      # Disable whole program optimization (/GL) and link-time code generation (/LTCG).
+      string(REPLACE "/GL" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+      string(REPLACE "/LTCG" "" CMAKE_SHARED_LINKER_FLAGS_RELEASE ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}) 
+    endif(MSVC)
+	
     set(LIB_NAME pcl_${SUBSYS_NAME})
     PCL_ADD_LIBRARY(${LIB_NAME} ${SUBSYS_NAME} ${srcs} ${incs} ${impl_incs})
     target_link_libraries(${LIB_NAME} pcl_common pcl_search pcl_kdtree pcl_octree pcl_filters)


### PR DESCRIPTION
- Linking pcl_features hit 4GB memory limit in release mode. Disabled whole program optimization and link-time code generation as a workaround.

Addresses issue #349.
