### PR TITLE
Corrected initial traversal index

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1860,6 +1860,7 @@ pcl::visualization::PCLVisualizer::setCameraParameters (const Eigen::Matrix3f &i
 
       renderer->Render ();
     }
+    ++i;
   }
 }
 


### PR DESCRIPTION
Initial index was wrong when multiple viewports are present.
