### PR TITLE
Remove glutLeaveMainLoop() call which is only implemented in FreeGLUT / ...

### DIFF
--- a/apps/src/grabcut_2d.cpp
+++ b/apps/src/grabcut_2d.cpp
@@ -446,7 +446,7 @@ keyboard_callback (unsigned char key, int, int)
     //   save ();
     //   break;
     case 'q': case 'Q':
-      glutLeaveMainLoop ();
+      exit (0);
       break;
     case 27:
       refining_ = false;


### PR DESCRIPTION
...OpenGLUT

glutLeaveMainLoop() is not part of the GLUT spec. We can safely use
exit() here instead.
