### PR TITLE
small bugfix for init of thread number

### DIFF
--- a/apps/src/convolve.cpp
+++ b/apps/src/convolve.cpp
@@ -64,7 +64,7 @@ main (int argc, char ** argv)
 {
   int viewport_source, viewport_convolved = 0;
   int direction = -1;
-  int nb_threads = 0;
+  int nb_threads = 1;
   char border_policy = 'Z';
   double threshold = 0.001;
   pcl::filters::Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB> convolution;


### PR DESCRIPTION
@nizar-sallem: When I tested this module, I first forgot the '-t' option for setting the number of threads. Therefore an init value of '0' was passed to the activated OpenMP-engine and caused an error. An initial value of '1' avoids this error.
