### PR TITLE
Small features: more comfortable thread handling

### DIFF
--- a/apps/src/convolve.cpp
+++ b/apps/src/convolve.cpp
@@ -116,7 +116,20 @@ main (int argc, char ** argv)
   {
     if (nb_threads <= 0)
       nb_threads = 1;
+#ifndef _OPENMP
+    if (nb_threads > 1)
+    {
+      pcl::console::print_info ("OpenMP not activated. Number of threads: 1\n");
+      nb_threads = 1;
+    }
+#endif
   }
+#ifdef _OPENMP
+  else
+  {
+    nb_threads = omp_get_num_procs();
+  }
+#endif
   convolution.setNumberOfThreads (nb_threads);
 
   // borders policy if any
@@ -188,6 +201,12 @@ main (int argc, char ** argv)
     }
   }
   convolved_label << pcl::getTime () - t0 << "s";
+#ifdef _OPENMP
+  convolved_label << "\ncpu cores: " << omp_get_num_procs() << " ";
+#else
+  convolved_label << "\n";
+#endif  
+  convolved_label << "threads: " << nb_threads;
   // Display
   boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer (new pcl::visualization::PCLVisualizer ("Convolution"));
   // viewport stuff


### PR DESCRIPTION
For a more convenient program handling I suggest the following additions:
1. case: if OpenMP is not activated, and the user enters a thread number > 1, this makes no sense and the user should be informed.
2. case: if the user spares the option '-t' and OpenMP is activated, the thread number should be optimized by OpenMP.
3. the number of threads and processor cores might be displayed additionally for better information.
