### PR TITLE
ensure that libqhull is present before attempting to build ni_linemod and global_classification

### DIFF
--- a/apps/3d_rec_framework/tools/apps/CMakeLists.txt
+++ b/apps/3d_rec_framework/tools/apps/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_executable(pcl_global_classification src/global_classification.cpp)
-target_link_libraries(pcl_global_classification pcl_apps pcl_3d_rec_framework pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface)
+if (QHULL_FOUND)
+  add_executable(pcl_global_classification src/global_classification.cpp)
+  target_link_libraries(pcl_global_classification pcl_apps pcl_3d_rec_framework pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface)
+endif()
 
 add_executable(pcl_local_or_mian src/local_recognition_mian_dataset.cpp)
 target_link_libraries(pcl_local_or_mian pcl_apps pcl_3d_rec_framework pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -199,6 +199,9 @@ if(build)
       PCL_ADD_EXECUTABLE_OPT_BUNDLE(pcl_openni_planar_convex_hull ${SUBSYS_NAME} src/openni_planar_convex_hull.cpp)
       target_link_libraries(pcl_openni_planar_convex_hull pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface)
 
+      PCL_ADD_EXECUTABLE_OPT_BUNDLE(pcl_ni_linemod ${SUBSYS_NAME} src/ni_linemod.cpp)
+      target_link_libraries(pcl_ni_linemod pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_features pcl_surface pcl_search)
+
       endif() # QHULL_FOUND
 
       # Install include files
@@ -217,9 +220,6 @@ if(build)
 
       PCL_ADD_EXECUTABLE_OPT_BUNDLE(pcl_ni_brisk ${SUBSYS_NAME} src/ni_brisk.cpp)
       target_link_libraries(pcl_ni_brisk pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_features pcl_keypoints pcl_surface pcl_search)
-
-      PCL_ADD_EXECUTABLE_OPT_BUNDLE(pcl_ni_linemod ${SUBSYS_NAME} src/ni_linemod.cpp)
-      target_link_libraries(pcl_ni_linemod pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_features pcl_surface pcl_search)
 
       PCL_ADD_EXECUTABLE_OPT_BUNDLE(pcl_ni_susan ${SUBSYS_NAME} src/ni_susan.cpp)
       target_link_libraries(pcl_ni_susan pcl_common pcl_visualization pcl_features pcl_keypoints pcl_search)


### PR DESCRIPTION
Updated the CMakeLists to put apps that use pcl::ConvexHull within tests to see if libqhull is found. 
Fixes Issue #387 
