### PR TITLE
Kinfu: Add commandline options for depth intrinsics

### DIFF
--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -1144,14 +1144,14 @@ int
 print_cli_help ()
 {
   cout << "\nKinFu parameters:" << endl;
-  cout << "    --help, -h                      : print this message" << endl;  
-  cout << "    --registration, -r              : try to enable registration (source needs to support this)" << endl;
-  cout << "    --current-cloud, -cc            : show current frame cloud" << endl;
-  cout << "    --save-views, -sv               : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << endl;  
-  cout << "    --integrate-colors, -ic         : enable color integration mode (allows to get cloud with colors)" << endl;   
-  cout << "    --scale-truncation, -st         : scale the truncation distance and raycaster based on the volume size" << endl;
-  cout << "    -volume_size <size_in_meters>   : define integration volume size" << endl;
-  cout << "    --depth-intrinsics <fx>,<fy>[,<cx>,<cy> : Set the intrinsics of the depth camera" << endl;
+  cout << "    --help, -h                              : print this message" << endl;  
+  cout << "    --registration, -r                      : try to enable registration (source needs to support this)" << endl;
+  cout << "    --current-cloud, -cc                    : show current frame cloud" << endl;
+  cout << "    --save-views, -sv                       : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << endl;  
+  cout << "    --integrate-colors, -ic                 : enable color integration mode (allows to get cloud with colors)" << endl;   
+  cout << "    --scale-truncation, -st                 : scale the truncation distance and raycaster based on the volume size" << endl;
+  cout << "    -volume_size <size_in_meters>           : define integration volume size" << endl;
+  cout << "    --depth-intrinsics <fx>,<fy>[,<cx>,<cy> : set the intrinsics of the depth camera" << endl;
   cout << "Valid depth data sources:" << endl; 
   cout << "    -dev <device> (default), -oni <oni_file>, -pcd <pcd_file or directory>" << endl;
   cout << "";


### PR DESCRIPTION
By default, kinfu uses a focal length for the depth camera of 525.0 (see kinfu.cpp:83). This is substantially different from the true value which is somewhere around 585.0.

Instead of changing the default I introduced a new command line flag to pcl_kinfu_app: `--depth-intrinsics fx,fy[,cx,cy]`

This allows the user to set the values she has calibrated herself.
