### PR TITLE
Use depth camera intrinsics unless RGB image registration is active.

### DIFF
--- a/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
@@ -49,10 +49,18 @@
 #include <Eigen/Core>
 #include <vector>
 
+// Focal lengths of RGB camera
+#define KINFU_DEFAULT_RGB_FOCAL_X 525.f
+#define KINFU_DEFAULT_RGB_FOCAL_Y 525.f
+
+// Focal lengths of depth (i.e. NIR) camera
+#define KINFU_DEFAULT_DEPTH_FOCAL_X 585.f
+#define KINFU_DEFAULT_DEPTH_FOCAL_Y 585.f
+
 namespace pcl
 {
   namespace gpu
-  {        
+  {
     /** \brief KinfuTracker class encapsulates implementation of Microsoft Kinect Fusion algorithm
       * \author Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
       */
@@ -82,6 +90,16 @@ namespace pcl
           */
         void
         setDepthIntrinsics (float fx, float fy, float cx = -1, float cy = -1);
+        
+        /** \brief Get Depth camera intrinsics
+          * \param[out] fx focal length x 
+          * \param[out] fy focal length y
+          * \param[out] cx principal point x
+          * \param[out] cy principal point y
+          */
+        void
+        getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy);
+        
 
         /** \brief Sets initial camera pose relative to volume coordiante space
           * \param[in] pose Initial camera pose

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -80,7 +80,7 @@ pcl::gpu::KinfuTracker::KinfuTracker (int rows, int cols) : rows_(rows), cols_(c
   tsdf_volume_ = TsdfVolume::Ptr( new TsdfVolume(volume_resolution) );
   tsdf_volume_->setSize(volume_size);
   
-  setDepthIntrinsics (525.f, 525.f); // default values, can be overwritten
+  setDepthIntrinsics (KINFU_DEFAULT_DEPTH_FOCAL_X, KINFU_DEFAULT_DEPTH_FOCAL_Y); // default values, can be overwritten
   
   init_Rcam_ = Eigen::Matrix3f::Identity ();// * AngleAxisf(-30.f/180*3.1415926, Vector3f::UnitX());
   init_tcam_ = volume_size * 0.5f - Vector3f (0, 0, volume_size (2) / 2 * 1.2f);
@@ -111,6 +111,16 @@ pcl::gpu::KinfuTracker::setDepthIntrinsics (float fx, float fy, float cx, float 
   fy_ = fy;
   cx_ = (cx == -1) ? cols_/2-0.5f : cx;
   cy_ = (cy == -1) ? rows_/2-0.5f : cy;  
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl::gpu::KinfuTracker::getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy)
+{
+  fx = fx_;
+  fy = fy_;
+  cx = cx_;
+  cy = cy_;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -700,6 +700,8 @@ struct KinFuApp
   {        
     registration_ = capture_.providesCallback<pcl::ONIGrabber::sig_cb_openni_image_depth_image> ();
     cout << "Registration mode: " << (registration_ ? "On" : "Off (not supported by source)") << endl;
+    if (registration_)
+        kinfu_.setDepthIntrinsics(KINFU_DEFAULT_RGB_FOCAL_X, KINFU_DEFAULT_RGB_FOCAL_Y);
   }
 
   void 


### PR DESCRIPTION
Fixes #392
