### PR TITLE
Fixed a vector alignment bug occuring on 32bits systems

### DIFF
--- a/filters/include/pcl/filters/box_clipper3D.h
+++ b/filters/include/pcl/filters/box_clipper3D.h
@@ -97,10 +97,10 @@ namespace pcl
       clipLineSegment3D (PointT& from, PointT& to) const;
 
       virtual void
-      clipPlanarPolygon3D (std::vector<PointT>& polygon) const;
+      clipPlanarPolygon3D (std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon) const;
 
       virtual void
-      clipPlanarPolygon3D (const std::vector<PointT>& polygon, std::vector<PointT>& clipped_polygon) const;
+      clipPlanarPolygon3D (const std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon, std::vector<PointT>& clipped_polygon) const;
 
       virtual void
       clipPointCloud3D (const pcl::PointCloud<PointT> &cloud_in, std::vector<int>& clipped, const std::vector<int>& indices = std::vector<int> ()) const;

--- a/filters/include/pcl/filters/clipper3D.h
+++ b/filters/include/pcl/filters/clipper3D.h
@@ -39,6 +39,7 @@
 #define PCL_CLIPPER3D_H_
 #include <pcl/point_cloud.h>
 #include <vector>
+#include <Eigen/StdVector>
 
 namespace pcl
 {
@@ -82,7 +83,7 @@ namespace pcl
         * \param[in,out] polygon the polygon in any direction (ccw or cw) but ordered, thus two neighboring points define an edge of the polygon
         */
       virtual void
-      clipPlanarPolygon3D (std::vector<PointT>& polygon) const = 0;
+      clipPlanarPolygon3D (std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon) const = 0;
 
       /**
         * \brief interface to clip a planar polygon given by an ordered list of points
@@ -90,7 +91,7 @@ namespace pcl
         * \param[out] clipped_polygon the clipped polygon
         */
       virtual void
-      clipPlanarPolygon3D (const std::vector<PointT>& polygon, std::vector<PointT>& clipped_polygon) const = 0;
+      clipPlanarPolygon3D (const std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon, std::vector<PointT, Eigen::aligned_allocator<PointT> >& clipped_polygon) const = 0;
 
       /**
         * \brief interface to clip a point cloud

--- a/filters/include/pcl/filters/impl/box_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/box_clipper3D.hpp
@@ -183,7 +183,7 @@ pcl::BoxClipper3D<PointT>::clipLineSegment3D (PointT& point1, PointT& point2) co
  * @attention untested code
  */
 template<typename PointT> void
-pcl::BoxClipper3D<PointT>::clipPlanarPolygon3D (const std::vector<PointT>& polygon, std::vector<PointT>& clipped_polygon) const
+pcl::BoxClipper3D<PointT>::clipPlanarPolygon3D (const std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon, std::vector<PointT, Eigen::aligned_allocator<PointT> >& clipped_polygon) const
 {
   // not implemented -> clip everything
   clipped_polygon.clear ();
@@ -194,7 +194,7 @@ pcl::BoxClipper3D<PointT>::clipPlanarPolygon3D (const std::vector<PointT>& polyg
  * @attention untested code
  */
 template<typename PointT> void
-pcl::BoxClipper3D<PointT>::clipPlanarPolygon3D (std::vector<PointT>& polygon) const
+pcl::BoxClipper3D<PointT>::clipPlanarPolygon3D (std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon) const
 {
   // not implemented -> clip everything
   polygon.clear ();

--- a/filters/include/pcl/filters/impl/plane_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/plane_clipper3D.hpp
@@ -111,7 +111,7 @@ pcl::PlaneClipper3D<PointT>::clipLineSegment3D (PointT& point1, PointT& point2) 
  * @attention untested code
  */
 template<typename PointT> void
-pcl::PlaneClipper3D<PointT>::clipPlanarPolygon3D (const std::vector<PointT>& polygon, std::vector<PointT>& clipped_polygon) const
+pcl::PlaneClipper3D<PointT>::clipPlanarPolygon3D (const std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon, std::vector<PointT, Eigen::aligned_allocator<PointT> >& clipped_polygon) const
 {
   clipped_polygon.clear ();
   clipped_polygon.reserve (polygon.size ());
@@ -140,9 +140,9 @@ pcl::PlaneClipper3D<PointT>::clipPlanarPolygon3D (const std::vector<PointT>& pol
   if (previous_distance > 0)
     clipped_polygon.push_back (polygon [0]);
 
-  typename std::vector<PointT>::const_iterator prev_it = polygon.begin ();
+  typename std::vector<PointT, Eigen::aligned_allocator<PointT> >::const_iterator prev_it = polygon.begin ();
 
-  for (typename std::vector<PointT>::const_iterator pIt = prev_it + 1; pIt != polygon.end (); prev_it = pIt++)
+  for (typename std::vector<PointT, Eigen::aligned_allocator<PointT> >::const_iterator pIt = prev_it + 1; pIt != polygon.end (); prev_it = pIt++)
   {
     // if we intersect plane
     float distance = getDistance (*pIt);
@@ -168,9 +168,9 @@ pcl::PlaneClipper3D<PointT>::clipPlanarPolygon3D (const std::vector<PointT>& pol
  * @attention untested code
  */
 template<typename PointT> void
-pcl::PlaneClipper3D<PointT>::clipPlanarPolygon3D (std::vector<PointT>& polygon) const
+pcl::PlaneClipper3D<PointT>::clipPlanarPolygon3D (std::vector<PointT, Eigen::aligned_allocator<PointT> > &polygon) const
 {
-  std::vector<PointT> clipped;
+  std::vector<PointT, Eigen::aligned_allocator<PointT> > clipped;
   clipPlanarPolygon3D (polygon, clipped);
   polygon = clipped;
 }

--- a/filters/include/pcl/filters/plane_clipper3D.h
+++ b/filters/include/pcl/filters/plane_clipper3D.h
@@ -82,10 +82,10 @@ namespace pcl
       clipLineSegment3D (PointT& from, PointT& to) const;
 
       virtual void
-      clipPlanarPolygon3D (std::vector<PointT>& polygon) const;
+      clipPlanarPolygon3D (std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon) const;
 
       virtual void
-      clipPlanarPolygon3D (const std::vector<PointT>& polygon, std::vector<PointT>& clipped_polygon) const;
+      clipPlanarPolygon3D (const std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon, std::vector<PointT, Eigen::aligned_allocator<PointT> >& clipped_polygon) const;
 
       virtual void
       clipPointCloud3D (const pcl::PointCloud<PointT> &cloud_in, std::vector<int>& clipped, const std::vector<int>& indices = std::vector<int> ()) const;


### PR DESCRIPTION
The Clipper3D class and derived classes contained a bug for 32bits machines; ; it used std::vectors of PointT, leading to a link error in my case with PointXYZ which require 16 bytes alignment. I used the Eigen allocator to fix it.
