### PR TITLE
Updated documentation of point picking event for indexing

### DIFF
--- a/visualization/include/pcl/visualization/point_picking_event.h
+++ b/visualization/include/pcl/visualization/point_picking_event.h
@@ -92,12 +92,12 @@ namespace pcl
         {}
 
         /** \brief Obtain the ID of a point that the user just clicked on.
-	 *  \warning If the cloud contains NaNs the index returned by this function will not correspond to the
-	 * original indices. To get the correct index either sanitize the input cloud to remove NaNs or use the 
-	 * PointPickingEvent::getPoint function to get the x,y,z of the picked point and then search the original 
-	 * cloud for the correct index. An example of how to do this can be found in the pp_callback function in
-	 * visualization/tools/pcd_viewer.cpp
-	 */
+          *  \warning If the cloud contains NaNs the index returned by this function will not correspond to the
+          * original indices. To get the correct index either sanitize the input cloud to remove NaNs or use the 
+          * PointPickingEvent::getPoint function to get the x,y,z of the picked point and then search the original 
+          * cloud for the correct index. An example of how to do this can be found in the pp_callback function in
+          * visualization/tools/pcd_viewer.cpp
+          */
         inline int
         getPointIndex () const
         {
@@ -138,11 +138,11 @@ namespace pcl
           * \param[out] index_1 index of the first point selected by user
           * \param[out] index_2 index of the second point selected by user
           * \return true, if two points are available and have been clicked by the user, false otherwise
-	  * \warning If the cloud contains NaNs the index returned by this function will not correspond to the
-	  * original indices. To get the correct index either sanitize the input cloud to remove NaNs or use the 
-	  * PointPickingEvent::getPoint function to get the x,y,z of the picked point and then search the original 
-	  * cloud for the correct index. An example of how to do this can be found in the pp_callback function in
-	  * visualization/tools/pcd_viewer.cpp
+          * \warning If the cloud contains NaNs the index returned by this function will not correspond to the
+          * original indices. To get the correct index either sanitize the input cloud to remove NaNs or use the 
+          * PointPickingEvent::getPoint function to get the x,y,z of the picked point and then search the original 
+          * cloud for the correct index. An example of how to do this can be found in the pp_callback function in
+          * visualization/tools/pcd_viewer.cpp
           */
         inline bool
         getPointIndices (int &index_1, int &index_2) const


### PR DESCRIPTION
 Issue #266
There is no issue here in how it works, we just need a note in pcl_visualizer that picked indices wont correspond to original indices if there are nan's in the cloud... and direct the person to pp_callback in pcd_viewer.cpp for an example of how to find the correct indices.

This patch updates the point picker documentation to reflect that indices won't match up for clouds with NaNs.
