### PR TITLE
Add doc generation to Travis build script

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -30,7 +30,23 @@ function test ()
   make tests -j3
 }
 
+function doc ()
+{
+  # Do not generate documentation for pull requests
+  if [[ $TRAVIS_PULL_REQUEST ]]; then exit; fi
+  # Install doxygen and graphviz
+  sudo apt-get install doxygen graphviz
+  # Configure
+  mkdir $BUILD_DIR && cd $BUILD_DIR
+  cmake $PCL_DIR
+  # Generate documentation
+  make doc
+  # Do something with the generated documentation in $DOC_DIR
+  # Upload via ftp?
+}
+
 case $TASK in
   build ) build;;
   test ) test;;
+  doc ) doc;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   include:
     - compiler: clang
       env: TASK="test"
+    - env: TASK="doc"
 before_install:
   - sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
   - sudo add-apt-repository ppa:apokluda/boost1.53 -y


### PR DESCRIPTION
This is a follow-up to #408.

This pull request adds a shell script for Travis which can do either normal build+test or doc generation depending on the environment variable `$TASK`. The variable is set in '.travis.yml':

``` yaml
env:
  matrix:
    - TASK="build"
matrix:
  include:
    - env: TASK="doc"
```

In principle, this could be set up simpler:

``` yaml
env:
  matrix:
    - TASK="build"
    - TASK="doc"
```

However this version would incur unnecessary work for Travis, because it schedules as many jobs as there are pairs compiler + environment variable. In our case compiler setting is irrelevant for doc generation. With the proposed setup there are a total of three jobs: build with `gcc`, build with `clang`, and doc generation with `gcc,clang` (see [Travis log](https://travis-ci.org/PointCloudLibrary/pcl/builds/15728892)).

The script checks if the current build is triggered by a pull request, in which case it skips documentation generation.

At the moment the generated documentation is not published anywhere, so obviously '.travis.sh' has to be updated before merging this pull request. Note that there is a mechanism to encrypt information (e.g. ssh password) which you will want to put into the '.travis.yml' file and still keep it private. See [encryption-keys](http://about.travis-ci.org/docs/user/encryption-keys/).
