### PR TITLE
Fix: no precompiled classes for Clipper3D and its derivated classes

### DIFF
--- a/filters/include/pcl/filters/box_clipper3D.h
+++ b/filters/include/pcl/filters/box_clipper3D.h
@@ -122,8 +122,6 @@ namespace pcl
   };
 }
 
-#ifdef PCL_NO_PRECOMPILE
 #include <pcl/filters/impl/box_clipper3D.hpp>
-#endif
 
 #endif // PCL_BOX_CLIPPER3D_H_

--- a/filters/include/pcl/filters/clipper3D.h
+++ b/filters/include/pcl/filters/clipper3D.h
@@ -112,8 +112,4 @@ namespace pcl
   };
 }
 
-#ifdef PCL_NO_PRECOMPILE
-#include <pcl/filters/impl/clipper3D.hpp>
-#endif
-
 #endif // PCL_CLIPPER3D_H_

--- a/filters/include/pcl/filters/plane_clipper3D.h
+++ b/filters/include/pcl/filters/plane_clipper3D.h
@@ -102,8 +102,6 @@ namespace pcl
   };
 }
 
-#ifdef PCL_NO_PRECOMPILE
 #include <pcl/filters/impl/plane_clipper3D.hpp>
-#endif
 
 #endif // PCL_PLANE_CLIPPER3D_H_


### PR DESCRIPTION
Fix for issue #403.
