### PR TITLE
Revert 8ed661a, which introduced an undeclared variable and broke compilation

### DIFF
--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -107,6 +107,16 @@ pcl::PPFHashMapSearch::nearestNeighborSearch (float &f1, float &f2, float &f3, f
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget> void
+pcl::PPFRegistration<PointSource, PointTarget>::setInputTarget (const PointCloudTargetConstPtr &cloud)
+{
+  Registration<PointSource, PointTarget>::setInputTarget (cloud);
+
+  scene_search_tree_ = typename pcl::KdTreeFLANN<PointTarget>::Ptr (new pcl::KdTreeFLANN<PointTarget>);
+  scene_search_tree_->setInputCloud (target_);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointSource, typename PointTarget> void
 pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f& guess)
 {
   if (!search_method_)
@@ -148,7 +158,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
     // For every other point in the scene => now have pair (s_r, s_i) fixed
     std::vector<int> indices;
     std::vector<float> distances;
-    tree_->radiusSearch (target_->points[scene_reference_index],
+    scene_search_tree_->radiusSearch (target_->points[scene_reference_index],
                                      search_method_->getModelDiameter () /2,
                                      indices,
                                      distances);

--- a/registration/include/pcl/registration/ppf_registration.h
+++ b/registration/include/pcl/registration/ppf_registration.h
@@ -234,6 +234,12 @@ namespace pcl
       inline PPFHashMapSearch::Ptr
       getSearchMethod () { return search_method_; }
 
+      /** \brief Provide a pointer to the input target (e.g., the point cloud that we want to align the input source to)
+       * \param cloud the input point cloud target
+       */
+      void
+      setInputTarget (const PointCloudTargetConstPtr &cloud);
+
 
     private:
       /** \brief Method that calculates the transformation between the input_ and target_ point clouds, based on the PPF features */
@@ -250,6 +256,9 @@ namespace pcl
       /** \brief position and rotation difference thresholds below which two
         * poses are considered to be in the same cluster (for the clustering phase of the algorithm) */
       float clustering_position_diff_threshold_, clustering_rotation_diff_threshold_;
+
+      /** \brief use a kd-tree with range searches of range max_dist to skip an O(N) pass through the point cloud */
+      typename pcl::KdTreeFLANN<PointTarget>::Ptr scene_search_tree_;
 
       /** \brief static method used for the std::sort function to order two PoseWithVotes
        * instances by their number of votes*/


### PR DESCRIPTION
I wasn't able to compile on Mavericks with this change, so this pull request reverts it. It seems that there's probably a real fix for this involving tree_, but I can't try and figure it out now. It's probably worth it for someone else to find the real fix.
