### PR TITLE
VoxelGrid : Possibility to specify a minimum number of points per voxel

### DIFF
--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -205,7 +205,8 @@ namespace pcl
         filter_field_name_ (""), 
         filter_limit_min_ (-FLT_MAX), 
         filter_limit_max_ (FLT_MAX),
-        filter_limit_negative_ (false)
+        filter_limit_negative_ (false),
+        min_points_per_voxel_ (0)
       {
         filter_name_ = "VoxelGrid";
       }
@@ -260,6 +261,17 @@ namespace pcl
         */
       inline bool 
       getDownsampleAllData () { return (downsample_all_data_); }
+
+      /** \brief Set the minimum number of points required for a voxel to be used.
+        * \param[in] min_points_per_voxel the minimum number of points for required for a voxel to be used
+        */
+      inline void 
+      setMinimumPointsNumberPerVoxel (unsigned int min_points_per_voxel) { min_points_per_voxel_ = min_points_per_voxel; }
+
+      /** \brief Return the minimum number of points required for a voxel to be used.
+       */
+      inline unsigned int
+      getMinimumPointsNumberPerVoxel () { return min_points_per_voxel_; }
 
       /** \brief Set to true if leaf layout information needs to be saved for later access.
         * \param[in] save_leaf_layout the new value (true/false)
@@ -449,6 +461,9 @@ namespace pcl
 
       /** \brief Set to true if all fields need to be downsampled, or false if just XYZ. */
       bool downsample_all_data_;
+	  
+      /** \brief Minimum number of points per voxel for the centroid to be computed */
+      unsigned int min_points_per_voxel_;
 
       /** \brief Set to true if leaf layout information needs to be saved in \a leaf_layout_. */
       bool save_leaf_layout_;
@@ -517,7 +532,8 @@ namespace pcl
         filter_field_name_ (""), 
         filter_limit_min_ (-FLT_MAX), 
         filter_limit_max_ (FLT_MAX),
-        filter_limit_negative_ (false)
+        filter_limit_negative_ (false),
+        min_points_per_voxel_ (0)
       {
         filter_name_ = "VoxelGrid";
       }
@@ -572,6 +588,17 @@ namespace pcl
         */
       inline bool 
       getDownsampleAllData () { return (downsample_all_data_); }
+
+      /** \brief Set the minimum number of points required for a voxel to be used.
+        * \param[in] min_points_per_voxel the minimum number of points for required for a voxel to be used
+        */
+      inline void 
+      setMinimumPointsNumberPerVoxel (unsigned int min_points_per_voxel) { min_points_per_voxel_ = min_points_per_voxel; }
+
+	  /** \brief Return the minimum number of points required for a voxel to be used.
+       */
+	  inline unsigned int
+	  getMinimumPointsNumberPerVoxel () { return min_points_per_voxel_; }
 
       /** \brief Set to true if leaf layout information needs to be saved for later access.
         * \param[in] save_leaf_layout the new value (true/false)
@@ -783,6 +810,9 @@ namespace pcl
 
       /** \brief Set to true if all fields need to be downsampled, or false if just XYZ. */
       bool downsample_all_data_;
+
+	  /** \brief Minimum number of points per voxel for the centroid to be computed */
+	  unsigned int min_points_per_voxel_;
 
       /** \brief Set to true if leaf layout information needs to be saved in \a
         * leaf_layout. 


### PR DESCRIPTION
Hi,

I modified the VoxelGrid filter in order to be able to filter voxels which contains less than a given number of points (specified via setMinimumPointsNumberPerVoxel - set equal to 0 which leads to the same behaviour as previously).

Romain
