### PR TITLE
A new interface to FLANN's multiple randomized trees for high-dimensional (feature) searches

### DIFF
--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -59,27 +59,47 @@ namespace pcl
     /** \brief @b search::FlannSearch is a generic FLANN wrapper class for the new search interface.
       * It is able to wrap any FLANN index type, e.g. the kd tree as well as indices for high-dimensional
       * searches and intended as a more powerful and cleaner successor to KdTreeFlann.
+      * 
+      * By default, this class creates a single kd tree for indexing the input data. However, for high dimensions
+      * (> 10), it is often better to use the multiple randomized kd tree index provided by FLANN in combination with
+      * the \ref flann::L2 distance functor. During search in this type of index, the number of checks to perform before
+      * terminating the search can be controlled. Here is a code example if a high-dimensional 2-NN search:
+      * 
+      * \code
+      * // Feature and distance type
+      * typedef SHOT352 FeatureT;
+      * typedef flann::L2<float> DistanceT;
+      * 
+      * // Search and index types
+      * typedef search::FlannSearch<FeatureT, DistanceT> SearchT;
+      * typedef typename SearchT::FlannIndexCreatorPtr CreatorPtrT;
+      * typedef typename SearchT::KdTreeMultiIndexCreator IndexT;
+      * typedef typename SearchT::PointRepresentationPtr RepresentationPtrT;
+      * 
+      * // Features
+      * PointCloud<FeatureT>::Ptr query, target;
+      * 
+      * // Fill query and target with calculated features...
+      * 
+      * // Instantiate search object with 4 randomized trees and 256 checks
+      * SearchT search (true, CreatorPtrT (new IndexT (4)));
+      * search.setPointRepresentation (RepresentationPtrT (new DefaultFeatureRepresentation<FeatureT>));
+      * search.setChecks (256);
+      * search.setInputCloud (target);
+      * 
+      * // Do search
+      * std::vector<std::vector<int> > k_indices;
+      * std::vector<std::vector<float> > k_sqr_distances;
+      * search.nearestKSearch (*query, std::vector<int> (), 2, k_indices, k_sqr_distances);
+      * \endcode
       *
       * \author Andreas Muetzel
+      * \author Anders Glent Buch (multiple randomized kd tree interface)
       * \ingroup search
       */
     template<typename PointT, typename FlannDistance=flann::L2_Simple <float> >
     class FlannSearch: public Search<PointT>
     {
-      typedef typename Search<PointT>::PointCloud PointCloud;
-      typedef typename Search<PointT>::PointCloudConstPtr PointCloudConstPtr;
-
-      typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
-      typedef flann::NNIndex< FlannDistance > Index;
-      typedef boost::shared_ptr<flann::NNIndex <FlannDistance > > IndexPtr;
-      typedef boost::shared_ptr<flann::Matrix <float> > MatrixPtr;
-      typedef boost::shared_ptr<const flann::Matrix <float> > MatrixConstPtr;
-
-      typedef pcl::PointRepresentation<PointT> PointRepresentation;
-      //typedef boost::shared_ptr<PointRepresentation> PointRepresentationPtr;
-      typedef boost::shared_ptr<const PointRepresentation> PointRepresentationConstPtr;
-
       using Search<PointT>::input_;
       using Search<PointT>::indices_;
       using Search<PointT>::sorted_results_;
@@ -87,6 +107,22 @@ namespace pcl
       public:
         typedef boost::shared_ptr<FlannSearch<PointT, FlannDistance> > Ptr;
         typedef boost::shared_ptr<const FlannSearch<PointT, FlannDistance> > ConstPtr;
+        
+        typedef typename Search<PointT>::PointCloud PointCloud;
+        typedef typename Search<PointT>::PointCloudConstPtr PointCloudConstPtr;
+
+        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
+        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+
+        typedef boost::shared_ptr<flann::Matrix <float> > MatrixPtr;
+        typedef boost::shared_ptr<const flann::Matrix <float> > MatrixConstPtr;
+
+        typedef flann::NNIndex< FlannDistance > Index;
+        typedef boost::shared_ptr<flann::NNIndex <FlannDistance > > IndexPtr;
+
+        typedef pcl::PointRepresentation<PointT> PointRepresentation;
+        typedef boost::shared_ptr<PointRepresentation> PointRepresentationPtr;
+        typedef boost::shared_ptr<const PointRepresentation> PointRepresentationConstPtr;
 
         /** \brief Helper class that creates a FLANN index from a given FLANN matrix. To
           * use a FLANN index type with FlannSearch, implement this interface and
@@ -153,6 +189,29 @@ namespace pcl
           private:
         };
 
+        /** \brief Creates a FLANN KdTreeIndex of multiple randomized trees from the given input data,
+         *  suitable for feature matching. Note that in this case, it is often more efficient to use the
+         *  \ref flann::L2 distance functor.
+          */
+        class KdTreeMultiIndexCreator: public FlannIndexCreator
+        {
+          public:
+          /** \param[in] trees Number of randomized trees to create.
+            */
+            KdTreeMultiIndexCreator (int trees = 4) : trees_ (trees) {}
+      
+            /** \brief Empty destructor */
+            virtual ~KdTreeMultiIndexCreator () {}
+
+          /** \brief Create a FLANN Index from the input data.
+            * \param[in] data The FLANN matrix containing the input.
+            * \return The FLANN index.
+            */
+            virtual IndexPtr createIndex (MatrixConstPtr data);
+          private:
+            int trees_;
+        };
+
         FlannSearch (bool sorted = true, FlannIndexCreatorPtr creator = FlannIndexCreatorPtr (new KdTreeIndexCreator ()));
 
         /** \brief Destructor for FlannSearch. */
@@ -177,6 +236,22 @@ namespace pcl
         getEpsilon ()
         {
           return (eps_);
+        }
+
+        /** \brief Set the number of checks to perform during approximate searches in multiple randomized trees.
+          * \param[in] number of checks to perform during approximate searches in multiple randomized trees.
+          */
+        inline void
+        setChecks (int checks)
+        {
+          checks_ = checks;
+        }
+
+        /** \brief Get the number of checks to perform during approximate searches in multiple randomized trees. */
+        inline int
+        getChecks ()
+        {
+          return (checks_);
         }
 
         /** \brief Provide a pointer to the input dataset.
@@ -276,6 +351,11 @@ namespace pcl
         /** Epsilon for approximate NN search.
           */
         float eps_;
+        
+        /** Number of checks to perform for approximate NN search using the multiple randomized tree index
+         */
+        int checks_;
+        
         bool input_copied_for_flann_;
 
         PointRepresentationConstPtr point_representation_;

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -61,8 +61,16 @@ pcl::search::FlannSearch<PointT, FlannDistance>::KMeansIndexCreator::createIndex
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename FlannDistance>
+typename pcl::search::FlannSearch<PointT, FlannDistance>::IndexPtr
+pcl::search::FlannSearch<PointT, FlannDistance>::KdTreeMultiIndexCreator::createIndex (MatrixConstPtr data)
+{
+  return (IndexPtr (new flann::KDTreeIndex<FlannDistance> (*data, flann::KDTreeIndexParams (trees_))));
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointT, typename FlannDistance>
 pcl::search::FlannSearch<PointT, FlannDistance>::FlannSearch(bool sorted, FlannIndexCreatorPtr creator) : pcl::search::Search<PointT> ("FlannSearch",sorted),
-  index_(), creator_ (creator), input_flann_(), eps_ (0), input_copied_for_flann_ (false), point_representation_ (new DefaultPointRepresentation<PointT>),
+  index_(), creator_ (creator), input_flann_(), eps_ (0), checks_ (32), input_copied_for_flann_ (false), point_representation_ (new DefaultPointRepresentation<PointT>),
   dim_ (0), index_mapping_(), identity_mapping_()
 {
   dim_ = point_representation_->getNumberOfDimensions ();
@@ -104,9 +112,10 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (const PointT &p
   float* cdata = can_cast ? const_cast<float*> (reinterpret_cast<const float*> (&point)): data;
   const flann::Matrix<float> m (cdata ,1, point_representation_->getNumberOfDimensions ());
 
-  flann::SearchParams p(-1);
+  flann::SearchParams p;
   p.eps = eps_;
   p.sorted = sorted_results_;
+  p.checks = checks_;
   if (indices.size() != static_cast<unsigned int> (k))
     indices.resize (k,-1);
   if (dists.size() != static_cast<unsigned int> (k))
@@ -169,6 +178,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
     flann::SearchParams p;
     p.sorted = sorted_results_;
     p.eps = eps_;
+    p.checks = checks_;
     index_->knnSearch (m,k_indices,k_sqr_distances,k, p);
 
     delete [] data;
@@ -197,6 +207,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
     flann::SearchParams p;
     p.sorted = sorted_results_;
     p.eps = eps_;
+    p.checks = checks_;
     index_->knnSearch (m,k_indices,k_sqr_distances,k, p);
 
     delete[] data;
@@ -237,6 +248,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (const PointT& poi
   p.sorted = sorted_results_;
   p.eps = eps_;
   p.max_neighbors = max_nn > 0 ? max_nn : -1;
+  p.checks = checks_;
   std::vector<std::vector<int> > i (1);
   std::vector<std::vector<float> > d (1);
   int result = index_->radiusSearch (m,i,d,static_cast<float> (radius * radius), p);
@@ -294,6 +306,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (
     flann::SearchParams p;
     p.sorted = sorted_results_;
     p.eps = eps_;
+    p.checks = checks_;
     // here: max_nn==0: take all neighbors. flann: max_nn==0: return no neighbors, only count them. max_nn==-1: return all neighbors
     p.max_neighbors = max_nn != 0 ? max_nn : -1;
     index_->radiusSearch (m,k_indices,k_sqr_distances,static_cast<float> (radius * radius), p);
@@ -324,6 +337,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (
     flann::SearchParams p;
     p.sorted = sorted_results_;
     p.eps = eps_;
+    p.checks = checks_;
     // here: max_nn==0: take all neighbors. flann: max_nn==0: return no neighbors, only count them. max_nn==-1: return all neighbors
     p.max_neighbors = max_nn != 0 ? max_nn : -1;
     index_->radiusSearch (m, k_indices, k_sqr_distances, static_cast<float> (radius * radius), p);


### PR DESCRIPTION
This PR addresses PCL's missing interface to a proper search structure for high-dimensional data, as discussed here:

[http://www.pcl-users.org/KdTree-radiusSearch-giving-bad-output-td3806817.html](http://www.pcl-users.org/KdTree-radiusSearch-giving-bad-output-td3806817.html)

CHANGES IN THE COMMIT:
- A new nested class **KdTreeIndexMultiCreator** inside **FlannSearch** for creating FLANN's multiple randomized tree index, suitable for approximate high-dimensional searches. The number of trees defaults to 4 (as in FLANN), but can be changed within the creator class constructor.
- A new member variable **checks_** for controlling the search accuracy during all instantiations of **flann::SearchParams** performed inside **FlannSearch**. The default value is set to the same as the one used in FLANN (32) upon construction of **FlannSearch**.
- Made the typedefs inside **FlannSearch** public, because they are needed from outside.

TODO:
- Automatic use of **DefaultFeatureRepresentation&lt;FeatureT&gt;** instead of the current **DefaultPointRepresentation&lt;FeatureT&gt;** when passing **KdTreeMultiIndexCreator** to the constructor of **FlannSearch**. Even though **DefaultPointRepresentation** already correctly vectorizes the feature part of features, it is semantically bad.
- Automatic initialization of the multi-index instead of the single one when **FlannSearch** is templated on a feature (dimension > 10).
- As far as I can see, **Histogram&lt;N&gt;** is the only feature that does not have a **DefaultPointRepresentation**, I guess because it does not have a fixed size like e.g. **SHOT352** has. It would be nice to provide point registrations of this class for _N = {1, ..., N_max}_, making **DefaultFeatureRepresentation** complete for all possible built-in PCL features. Otherwise, the user has to call **POINT_CLOUD_REGISTER_POINT_STRUCT()** when he wants to use a **Histogram<N>**.
- Unit test and tutorial, if needed?
