### PR TITLE
Possible bug in `pcl::getApproximateIndices()`

### DIFF
--- a/kdtree/include/pcl/kdtree/impl/io.hpp
+++ b/kdtree/include/pcl/kdtree/impl/io.hpp
@@ -46,8 +46,8 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename Point1T, typename Point2T> void
 pcl::getApproximateIndices (
-    const typename pcl::PointCloud<Point1T>::Ptr &cloud_in, 
-    const typename pcl::PointCloud<Point2T>::Ptr &cloud_ref, 
+    const typename pcl::PointCloud<Point1T>::ConstPtr &cloud_in,
+    const typename pcl::PointCloud<Point2T>::ConstPtr &cloud_ref,
     std::vector<int> &indices)
 {
   pcl::KdTreeFLANN<Point2T> tree;
@@ -66,8 +66,8 @@ pcl::getApproximateIndices (
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::getApproximateIndices (
-    const typename pcl::PointCloud<PointT>::Ptr &cloud_in, 
-    const typename pcl::PointCloud<PointT>::Ptr &cloud_ref, 
+    const typename pcl::PointCloud<PointT>::ConstPtr &cloud_in,
+    const typename pcl::PointCloud<PointT>::ConstPtr &cloud_ref,
     std::vector<int> &indices)
 {
   pcl::KdTreeFLANN<PointT> tree;

--- a/kdtree/include/pcl/kdtree/io.h
+++ b/kdtree/include/pcl/kdtree/io.h
@@ -53,9 +53,9 @@ namespace pcl
     * \param[out] indices the resultant set of nearest neighbor indices of \a cloud_in in \a cloud_ref
     * \ingroup kdtree
     */
-  template <typename PointT> void 
-  getApproximateIndices (const typename pcl::PointCloud<PointT>::Ptr &cloud_in, 
-                         const typename pcl::PointCloud<PointT>::Ptr &cloud_ref,
+  template <typename PointT> void
+  getApproximateIndices (const typename pcl::PointCloud<PointT>::ConstPtr &cloud_in,
+                         const typename pcl::PointCloud<PointT>::ConstPtr &cloud_ref,
                          std::vector<int> &indices);
 
   /** \brief Get a set of approximate indices for a given point cloud into a reference point cloud. 
@@ -67,9 +67,9 @@ namespace pcl
     * \param[out] indices the resultant set of nearest neighbor indices of \a cloud_in in \a cloud_ref
     * \ingroup kdtree
     */
-  template <typename Point1T, typename Point2T> void 
-  getApproximateIndices (const typename pcl::PointCloud<Point1T>::Ptr &cloud_in, 
-                         const typename pcl::PointCloud<Point2T>::Ptr &cloud_ref,
+  template <typename Point1T, typename Point2T> void
+  getApproximateIndices (const typename pcl::PointCloud<Point1T>::ConstPtr &cloud_in,
+                         const typename pcl::PointCloud<Point2T>::ConstPtr &cloud_ref,
                          std::vector<int> &indices);
 }
 


### PR DESCRIPTION
There are two utility functions in '[kdtree/io.h](https://github.com/PointCloudLibrary/pcl/blob/master/kdtree/include/pcl/kdtree/io.h)' that were added by @rbrusu some two years ago:

``` c++
template <typename PointT> void 
getApproximateIndices (const typename pcl::PointCloud<PointT>::Ptr &cloud_in, 
                       const typename pcl::PointCloud<PointT>::Ptr &cloud_ref,
                       std::vector<int> &indices);
```

and

``` c++
template <typename Point1T, typename Point2T> void 
getApproximateIndices (const typename pcl::PointCloud<Point1T>::Ptr &cloud_in, 
                       const typename pcl::PointCloud<Point2T>::Ptr &cloud_ref,
                       std::vector<int> &indices);
```

I am not sure how the second one is supposed to work. Internally, it creates an instance of `pcl::KdTreeFLANN` with `Point2T` as a template parameter, but later calls `nearestKSearch()`, passing in the first cloud, which contains points of type `Point1T`. The signature of `pcl::KdTree::nearestKSearch()` is as follows:

``` c++
virtual int 
nearestKSearch (const pcl::PointCloud<PointT> &cloud, int index, int k, 
                std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
```

where `PointT` the template parameter of the tree (`Point2T` in our case). So obviously, it does not compile unless `Point1T == Point2T`. Do I miss something here?
