### PR TITLE
Split Travis task into build and test

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+PCL_DIR=`pwd`
+BUILD_DIR=$PCL_DIR/build
+DOC_DIR=$BUILD_DIR/doc/doxygen/html
+
+CMAKE_C_FLAGS="-Wall -Wextra -Wabi -O2"
+CMAKE_CXX_FLAGS="-Wall -Wextra -Wabi -O2"
+
+function build ()
+{
+  # Configure
+  mkdir $BUILD_DIR && cd $BUILD_DIR
+  cmake -DCMAKE_C_FLAGS=$CMAKE_C_FLAGS -DCMAKE_CXX_FLAGS=$CMAKE_CXX_FLAGS -DPCL_ONLY_CORE_POINT_TYPES=ON -DBUILD_global_tests=OFF $PCL_DIR
+  # Build
+  make -j2
+}
+
+function test ()
+{
+  # Configure
+  mkdir $BUILD_DIR && cd $BUILD_DIR
+  cmake -DCMAKE_C_FLAGS=$CMAKE_C_FLAGS -DCMAKE_CXX_FLAGS=$CMAKE_CXX_FLAGS -DPCL_ONLY_CORE_POINT_TYPES=ON -DBUILD_global_tests=ON -DPCL_NO_PRECOMPILE=ON $PCL_DIR
+  # Build and run tests
+  make pcl_filters -j3
+  make test_filters
+  make pcl_registration -j3
+  make test_registration
+  make test_registration_api
+  make tests -j3
+}
+
+case $TASK in
+  build ) build;;
+  test ) test;;
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,19 @@ language: cpp
 compiler:
   - gcc
   - clang
+env:
+  matrix:
+    - TASK="build"
+matrix:
+  include:
+    - compiler: clang
+      env: TASK="test"
 before_install:
   - sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
   - sudo add-apt-repository ppa:apokluda/boost1.53 -y
   - sudo add-apt-repository ppa:yade-users/external -y
   - sudo apt-get update -d
+install:
   - sudo apt-get install cmake libvtk5-qt4-dev libflann-dev libeigen3-dev libopenni-dev libqhull-dev libboost-filesystem1.53-dev libboost-iostreams1.53-dev libboost-thread1.53-dev
 script:
-  - mkdir build && cd build
-  - cmake -DBUILD_global_tests=ON -DCMAKE_C_FLAGS="-Wall -Wextra -Wabi -O2" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wabi -O2" -DPCL_ONLY_CORE_POINT_TYPES=ON .. && make -j2 && make test
+  - bash .travis.sh


### PR DESCRIPTION
Travis builds often fail because of the 50-minutes timeout. Typically, `clang` manages to build the project, however does not have enough time to run all the tests. The situation with `gcc` is even worse as it seldom manages to finish compilation in 50 minutes.

This pull requests splits Travis task into two parts: building and testing, which allows either one to fit the time limit. In the "build" task global tests are disabled, which reduces the number of targets, so that even `gcc` is able to compile everything else in time. In the "test" task only `clang` is used and only the tests and their dependencies are built. Furthermore, the `PCL_NO_PRECOMPILE` flag is set.

This pull requests overlaps with #412 in that it also restructures '.travis.yml' and adds '.travis.sh'. As soon as either of these pull requests gets merged I will update the other one.

There is a weird sequence of `make` calls in the function that implements "test" run:

``` sh
# Build and run tests
make pcl_filters -j3
make test_filters
make pcl_registration -j3
make test_registration
make test_registration_api
make tests -j3
```

It turned out that Travis fails to build 'test_registration', 'test_registration_api', and 'test_filters' targets when there are several parallel jobs and no pre-compilation. The reason is that these test cases are so huge that compiler runs out of memory. Apparently, a better solution would be to split them into several parts, but that is a separate issue anyways.
