### PR TITLE
Update CMakeLists.txt: Fixes pcl_recognition build error due to metslib (Windows)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,8 @@ if (PKG_CONFIG_FOUND)
   else()
     include_directories(${PCL_SOURCE_DIR}/recognition/include/pcl/recognition/3rdparty/)
   endif()
+else()
+    include_directories(${PCL_SOURCE_DIR}/recognition/include/pcl/recognition/3rdparty/)
 endif()
 
 # LibPNG


### PR DESCRIPTION
Added default metslib include when pkgconfig is not present (fixes pcl_recognition build error for Windows users).
