### PR TITLE
Fixed search for static QVTK.lib in VTK build directory.

### DIFF
--- a/cmake/Modules/FindQVTK.cmake
+++ b/cmake/Modules/FindQVTK.cmake
@@ -8,7 +8,8 @@
 # if QVTK_FOUND then QVTK_INCLUDE_DIR is appended to VTK_INCLUDE_DIRS and 
 # QVTK_LIBRARY is appended to QVTK_LIBRARY_DIR
 
-find_library (QVTK_LIBRARY QVTK HINTS ${VTK_DIR} ${VTK_DIR}/bin)
+find_library (QVTK_LIBRARY QVTK HINTS ${VTK_DIR} ${VTK_DIR}/bin
+	PATH_SUFFIXES Release Debug)
 find_path (QVTK_INCLUDE_DIR QVTKWidget.h HINT ${VTK_INCLUDE_DIRS})
 find_package_handle_standard_args(QVTK DEFAULT_MSG
   QVTK_LIBRARY QVTK_INCLUDE_DIR)


### PR DESCRIPTION
This allows linking directly against a VTK 5 build directory, rather than needing an install directory.
