### PR TITLE
Fixed segfaulting in people_detector due to uninitialized variable

### DIFF
--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -100,6 +100,11 @@ pcl::gpu::people::PeopleDetector::allocate_buffers(int rows, int cols)
   cloud_host_.points.resize(cols * rows);
   cloud_host_.is_dense = false;
 
+  cloud_host_color_.width = cols;
+  cloud_host_color_.height = rows;
+  cloud_host_color_.resize(cols * rows);
+  cloud_host_color_.is_dense = false;
+
   hue_host_.width  = cols;
   hue_host_.height = rows;
   hue_host_.points.resize(cols * rows);


### PR DESCRIPTION
The probabilistic version of the people detection ends in a seg fault due to cloud_host_color_ being used uninitialized. So, I only added the initialization and now it works for me.
