### PR TITLE
added inline to function in point_types_conversions.h

### DIFF
--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -350,7 +350,7 @@ namespace pcl
    *  \param[in] focal the focal length
    *  \param[out] out the output pointcloud
    *  **/
-  void
+  inline void
   PointCloudDepthAndRGBtoXYZRGBA (PointCloud<Intensity>&  depth,
                                   PointCloud<RGB>&        image,
                                   float&                  focal,


### PR DESCRIPTION
the inline keyword is necessary to prevent multiple definitions errors
