### PR TITLE
QT_QT_INCLUDE_DIR is not defined using homebrew QT

### DIFF
--- a/apps/point_cloud_editor/CMakeLists.txt
+++ b/apps/point_cloud_editor/CMakeLists.txt
@@ -92,7 +92,6 @@ IF(BUILD)
 
   INCLUDE_DIRECTORIES("${CMAKE_CURRENT_BINARY_DIR}"
                       "${CMAKE_CURRENT_SOURCE_DIR}/include"
-                      "${QT_QT_INCLUDE_DIR}"
                       "${QT_QTOPENGL_INCLUDE_DIR}"
 		      )
 


### PR DESCRIPTION
In any case point_cloud_editor doesn't need it.

The error is:

```
-- Found Doxygen: /usr/local/bin/doxygen (found version "1.8.5")
-- Found PCAP: /usr/lib/libpcap.dylib
CMake Error at apps/point_cloud_editor/CMakeLists.txt:93 (INCLUDE_DIRECTORIES):
  include_directories given empty-string as include directory.
```
