### PR TITLE
Fixes Mac OSX 10.9 with libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   endif()
   if("${CMAKE_CXX_FLAGS}" STREQUAL "")
     SET(CMAKE_CXX_FLAGS "-ftemplate-depth=1024 -Qunused-arguments -Wno-invalid-offsetof ${SSE_FLAGS}") # Unfortunately older Clang versions do not have this: -Wno-unnamed-type-template-args
-    if(APPLE)
+    if(APPLE AND WITH_CUDA AND CUDA_FOUND)
       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
     endif(APPLE)
   endif()


### PR DESCRIPTION
Only switches to libstdc++ when you actually have CUDA and you enabled it. Related to https://github.com/PointCloudLibrary/pcl/pull/474
