### PR TITLE
ObjRecRANSAC class is marked as deprecated

### DIFF
--- a/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
+++ b/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
@@ -83,7 +83,7 @@ namespace pcl
       * \author Chavdar Papazov
       * \ingroup recognition
       */
-    PCL_DEPRECATE_CLASS (class PCL_EXPORTS ObjRecRANSAC,
+    PCL_DEPRECATED_CLASS (class PCL_EXPORTS ObjRecRANSAC,
       "The class ObjRecRANSAC will be gone in the next major release.")
     {
       public:


### PR DESCRIPTION
This is a pull request concerning  the removal of RANSAC-based object recognition.
http://www.pcl-developers.org/Removal-of-ransac-based-object-recognition-td5709176.html

Chavo asked on the forum to provide a pull request instead of him.
I'll try, but it will be my first pull request to PCL, so I may be too verbose, as I'm just learning it.
I would deeply appreciate help from the community!

I marked ObjRecRANSAC class  in `obj_rec_ransac.h` as deprecated. 
I think it is the main file that implements the whole algorithm. 
It uses other files in the folder as includes. 
So, I believe that marking this class as deprecated should therefore be sufficient, but comments from Chavo would be invaluable.

However I'm not clear about .cpp files, test and tools. Should I delete or mark somehow tests and tools?

As I'm not the author of the implementation, I could miss something, but here what I found:
On the whole, files that would be affected by deletion are:
In  `recognition/include/pcl/recognition/ransac_based/`:
- auxiliary.h
- bvh.h
- hypothesis.h
- model_library.h
- obj_rec_ransac.h
- orr_graph.h
- orr_octree.h
- orr_octree_zprojection.h
- rigid_transform_space.h
- simple_octree.h
- trimmed_icp.h
- voxel_structure.h

and in `recognition/include/pcl/recognition/`
- auxiliary.h
- bvh.h
- model_library.h
- obj_rec_ransac.h
- orr_graph.h
- orr_octree.h
- orr_octree_zprojection.h
- rigid_transform_space.h
- simple_octree.h
- trimmed_icp.h
- voxel_structure.h

But these are just references, like so:

```
// ...recognition/include/pcl/recognition/auxiliary.h
#include <pcl/recognition/ransac_based/auxiliary.h>
#error "Using pcl/recognition/auxiliary.h is deprecated, please use pcl/recognition/ransac_based/auxiliary.h instead."
```

In `pcl/recognition/src/ransac_based/`:
- model_library.cpp
- obj_rec_ransac.cpp
- orr_octree.cpp
- orr_octree_zprojection.cpp

In `tools/`:
- obj_rec_ransac_accepted_hypotheses.cpp
- obj_rec_ransac_hash_table.cpp
- obj_rec_ransac_model_opps.cpp
- obj_rec_ransac_orr_octree.cpp
- obj_rec_ransac_orr_octree_zprojection.cpp
- obj_rec_ransac_result.cpp
- obj_rec_ransac_scene_opps.cpp

In `test/`:
- test_recognition_ransac_based_ORROctree.cpp
