### PR TITLE
Fixing the problem that incorrect pxc library was selected under 32bit environment

### DIFF
--- a/cmake/Modules/FindPXCAPI.cmake
+++ b/cmake/Modules/FindPXCAPI.cmake
@@ -5,40 +5,29 @@
 # PXCAPI_FOUND - True if PXCAPI was found.
 # PXCAPI_INCLUDE_DIRS - Directories containing the PXCAPI include files.
 # PXCAPI_LIBRARIES - Libraries needed to use PXCAPI.
- 
+
+find_path(PXCAPI_DIR include/pxcimage.h
+          PATHS "${PXCAPI_DIR}" "C:/Program Files/Intel/PCSDK" "C:/Program Files (x86)/Intel/PCSDK"
+          DOC "PXCAPI include directories")
+
 if(PXCAPI_DIR)
   set(PXCAPI_INCLUDE_DIRS ${PXCAPI_DIR}/include ${PXCAPI_DIR}/sample/common/include)
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(PXCAPI_LIB_DIRS ${PXCAPI_DIR}/lib/x64 ${PXCAPI_DIR}/sample/common/lib/x64/v100)
-    set(PXCAPI_LIBS ${PXCAPI_DIR}/lib/x64/libpxc.lib ${PXCAPI_DIR}/sample/common/lib/x64/v100/libpxcutils.lib)
-  else(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(PXCAPI_LIB_DIRS ${PXCAPI_DIR}/lib/Win32 ${PXCAPI_DIR}/sample/common/lib/Win32/v100)
-    set(PXCAPI_LIBS ${PXCAPI_DIR}/lib/Win32/libpxc.lib ${PXCAPI_DIR}/sample/common/lib/Win32/v100/libpxcutils.lib)
-  endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-else()
-  find_path(PXCAPI_DIR include/pxcimage.h
-    PATHS "${PXCAPI_DIR}" "C:/Program Files/Intel/PCSDK" "C:/Program Files (x86)/Intel/PCSDK"
-    DOC "PXCAPI include directories")
 
-  if(PXCAPI_DIR)
-    set(PXCAPI_INCLUDE_DIRS ${PXCAPI_DIR}/include ${PXCAPI_DIR}/sample/common/include)
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set(PXCAPI_LIB_DIRS ${PXCAPI_DIR}/lib/x64 ${PXCAPI_DIR}/sample/common/lib/x64/v100)
-      set(PXCAPI_LIBS ${PXCAPI_DIR}/lib/x64/libpxc.lib ${PXCAPI_DIR}/sample/common/lib/x64/v100/libpxcutils.lib)
-    else(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set(PXCAPI_LIB_DIRS ${PXCAPI_DIR}/lib/Win32 ${PXCAPI_DIR}/sample/common/lib/Win32/v100)
-      set(PXCAPI_LIBS ${PXCAPI_DIR}/lib/Win32/libpxc.lib ${PXCAPI_DIR}/sample/common/lib/Win32/v100/libpxcutils.lib)
-    endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  else()
-  set(PXCAPI_DIR "directory not found (please enter)" CACHE FILEPATH "directory of PXCAPI")
-  endif()	
+  find_library(PXCAPI_LIB libpxc.lib
+               PATHS "${PXCAPI_DIR}/lib/" NO_DEFAULT_PATH
+               PATH_SUFFIXES x64 Win32)
+  find_library(PXCAPI_SAMPLE_LIB libpxcutils.lib
+               PATHS "${PXCAPI_DIR}/sample/common/lib" NO_DEFAULT_PATH
+               PATH_SUFFIXES x64/v100 Win32/v100)
+  set(PXCAPI_LIBS ${PXCAPI_LIB} ${PXCAPI_SAMPLE_LIB})
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PXCAPI DEFAULT_MSG
-                                  PXCAPI_LIBS PXCAPI_INCLUDE_DIRS PXCAPI_LIB_DIRS)
-							
+                                  PXCAPI_LIBS PXCAPI_INCLUDE_DIRS)
+
+mark_as_advanced(PXCAPI_LIB PXCAPI_SAMPLE_LIB)
+
 if(MSVC)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
 endif()
-							


### PR DESCRIPTION
Library path was hard coded in FindPXCAPI.cmake and this caused a problem that incorrect library file was selected under 32 bit environment.
This pull request adds some codes to choose corresponding library file according to the build environment.
