### PR TITLE
Fix "tests" target in test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,7 @@ if(build)
     enable_testing()
     include_directories(${PCL_INCLUDE_DIRS})
 
-    add_custom_target(tests "${CMAKE_CTEST_COMMAND}" " -V")
+    add_custom_target(tests "${CMAKE_CTEST_COMMAND}" "-V" VERBATIM)
 
     add_subdirectory(2d)
     add_subdirectory(common)


### PR DESCRIPTION
This is a follow-up to #460 which turned out to be only a partial fix as the `-V` option was not really passed to `ctest`. Without it we could not see which particular test case failed e.g. in this [job](https://travis-ci.org/PointCloudLibrary/pcl/jobs/18403708).
