### PR TITLE
Fix a warning in root 'CMakeLists.txt'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     SET(CMAKE_CXX_FLAGS "-ftemplate-depth=1024 -Qunused-arguments -Wno-invalid-offsetof ${SSE_FLAGS}") # Unfortunately older Clang versions do not have this: -Wno-unnamed-type-template-args
     if(APPLE AND WITH_CUDA AND CUDA_FOUND)
       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-    endif(APPLE)
+    endif()
   endif()
   SET(CLANG_LIBRARIES "stdc++")
 endif()


### PR DESCRIPTION
This fixes a warning introduced by dd80835:

```
CMake Warning (dev) in CMakeLists.txt:
   A logical block opening on the line

     CMakeLists.txt:152 (if)

   closes on the line

     CMakeLists.txt:154 (endif)

   with mis-matching arguments.
 This warning is for project developers.  Use -Wno-dev to suppress it.
```
