### PR TITLE
Make path to cmake modules relative to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(PCL)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
 ### ---[ Find universal dependencies
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
 
 # ---[ Include pkgconfig
 include (FindPkgConfig)


### PR DESCRIPTION
There was a problem when including the PCL as a dependency using the add_subdirectory(...) command. The cmake modules would not be found, since one would not invoke the CMakeLists.txt from the PCL root. Here is the cmake documentation (from http://www.cmake.org/Wiki/CMake_Useful_Variables):

_CMAKE_SOURCE_DIR_
    this is the directory, from which cmake was started, i.e. the top level source directory

_CMAKE_CURRENT_SOURCE_DIR_
    this is the directory where the currently processed CMakeLists.txt is located in
