### PR TITLE
Use libreoffice's PPA to get latest Doxygen on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
   - sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
   - sudo add-apt-repository ppa:apokluda/boost1.53 -y
   - sudo add-apt-repository ppa:yade-users/external -y
+  - sudo add-apt-repository ppa:libreoffice/ppa -y
   - sudo apt-get update -d
 install:
   - sudo apt-get install cmake libvtk5-qt4-dev libflann-dev libeigen3-dev libopenni-dev libqhull-dev libboost-filesystem1.53-dev libboost-iostreams1.53-dev libboost-thread1.53-dev


### PR DESCRIPTION
The version that is packaged for Ubuntu 12.04 is rather old and does not support Markdown.
