### PR TITLE
fixing FindGlew on mavericks

### DIFF
--- a/cmake/Modules/FindGLEW.cmake
+++ b/cmake/Modules/FindGLEW.cmake
@@ -42,16 +42,17 @@ ELSE (WIN32)
 
   IF (APPLE)
 # These values for Apple could probably do with improvement.
-  if (${CMAKE_VERSION_SYSTEM} VERSION_LESS "10.9.0")
+  if (${CMAKE_SYSTEM_VERSION} VERSION_LESS "13.0.0")
     FIND_PATH( GLEW_INCLUDE_DIR glew.h
       /System/Library/Frameworks/GLEW.framework/Versions/A/Headers
       ${OPENGL_LIBRARY_DIR}
       )
     SET(GLEW_GLEW_LIBRARY "-framework GLEW" CACHE STRING "GLEW library for OSX")
-  else (${CMAKE_VERSION_SYSTEM} VERSION_LESS "10.9.0")
-    find_package(Glew)
+  else (${CMAKE_SYSTEM_VERSION} VERSION_LESS "13.0.0")
+    find_package(PkgConfig)
+    pkg_check_modules(glew GLEW)
     SET(GLEW_GLEW_LIBRARY ${GLEW_LIBRARIES} CACHE STRING "GLEW library for OSX")
-  endif (${CMAKE_VERSION_SYSTEM} VERSION_LESS "10.9.0")
+  endif (${CMAKE_SYSTEM_VERSION} VERSION_LESS "13.0.0")
     SET(GLEW_cocoa_LIBRARY "-framework Cocoa" CACHE STRING "Cocoa framework for OSX")
   ELSE (APPLE)
 


### PR DESCRIPTION
the pull-req https://github.com/PointCloudLibrary/pcl/pull/529 requires following fix:
1. `CMAKE_SYSTEM_VERSION` instead of `CMAKE_VERSION_SYSTEM` [cmake doc](http://www.cmake.org/cmake/help/v2.8.12/cmake.html#variable:CMAKE_SYSTEM_VERSION)
2. `CMAKE_SYSTEM_VERSION` returns `13.0.0` in mavericks
3. use pkg-config to find Glew on mavericks. calling `find_package(Glew)` would be an infinite recursive call.

``` sh
$ uname -a
Darwin dhcp204.jsk.t.u-tokyo.ac.jp 13.0.0 Darwin Kernel Version 13.0.0: Thu Sep 19 22:22:27 PDT 2013; root:xnu-2422.1.72~6/RELEASE_X86_64 x86_64
```
