### PR TITLE
Update ply_io.cpp

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -301,7 +301,7 @@ namespace pcl
   boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> >
   pcl::PLYReader::listPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
-    if ((element_name == "range_grid") && (property_name == "vertex_indices")) 
+    if ((element_name == "range_grid") && (property_name == "vertex_indices") && polygons_) 
     {
       return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
         boost::bind (&pcl::PLYReader::rangeGridVertexIndicesBeginCallback, this, _1),


### PR DESCRIPTION
Reading a binary PLY file with faces and "vertex_indices" property crashes, if only a PointCloud is provided. Since the polygons_ member is set to 0 and untouched otherwise.

Worked in PCL 1.6, doesn't work right now with 1.7.1.

The ply2pcd sample program provided with PCL crashes as well.

I moved the PR made to my fork => https://github.com/fran6co/pcl/pull/1
