### PR TITLE
updated assembleRegion() in region_growing_rgb.hpp to speed up algorithm

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -585,15 +585,26 @@ pcl::RegionGrowingRGB<PointT, NormalT>::assembleRegions (std::vector<unsigned in
   }
 
   // now we need to erase empty regions
-  std::vector< pcl::PointIndices >::iterator i_region;
-  i_region = clusters_.begin ();
-  while(i_region != clusters_.end ())
+  if (clusters_.empty ()) 
+    return;
+
+  std::vector<pcl::PointIndices>::iterator itr1, itr2;
+  itr1 = clusters_.begin ();
+  itr2 = clusters_.end () - 1;
+
+  while (itr1 < itr2)
   {
-    if ( i_region->indices.empty () )
-      i_region = clusters_.erase (i_region);
-    else
-      i_region++;
+    while (!(itr1->indices.empty ()) && itr1 < itr2) 
+      itr1++;
+    while (  itr2->indices.empty ()  && itr1 < itr2) 
+      itr2--;
+	  
+    if (itr1 != itr2)
+      itr1->indices.swap (itr2->indices);
   }
+
+  if (itr2->indices.empty ())
+    clusters_.erase (itr2, clusters_.end ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
the original code perform std::vector<>::erase() in a while loop. since std::vector<> is an implementation of array, this operation moves big chunk of data at each iteration, and thus dramatically slows down the algorithm. 

Instead I copy all data into a std::list<>, perform erase() on it and then copy data back into the original std::vector<>. It's not a very neat tweak but still much faster.

Tested on region_growing_rgb_tutorial.pcd and other point clouds, outputs are identical to original code.
# 
# ![test_result](https://f.cloud.github.com/assets/4807473/2299532/7693dcce-a0ce-11e3-871e-46a05fca5d20.png)

![test_result2](https://f.cloud.github.com/assets/4807473/2299555/d2cf3c0e-a0ce-11e3-926f-f1e155868c4f.png)
