### PR TITLE
noise generation seed based on system time instead of constant

### DIFF
--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -1,4 +1,5 @@
 #include <GL/glew.h>
+#include <time.h>
 
 #include <pcl/pcl_config.h>
 #ifdef OPENGL_IS_A_FRAMEWORK
@@ -13,7 +14,7 @@
 #include <pcl/simulation/range_likelihood.h>
 
 // For adding noise:
-static boost::minstd_rand generator (27u); // seed
+static boost::minstd_rand generator (static_cast<unsigned int>(std::time(0))); // seed
 
 //#define SIMULATION_DEBUG 1
 #define DO_TIMING_PROFILE 0


### PR DESCRIPTION
pcl::simulation::RangeLikelihood generates the same sequence of random numbers for different program runs due to a constant seed of the used number generator. To avoid this the generator should be seeded with a pseudo random value like the current system time.
