### PR TITLE
Add spaces between function name and braces in 'range_likelihood.cpp'

### DIFF
--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -14,7 +14,7 @@
 #include <pcl/simulation/range_likelihood.h>
 
 // For adding noise:
-static boost::minstd_rand generator (static_cast<unsigned int>(std::time(0))); // seed
+static boost::minstd_rand generator (static_cast<unsigned int> (std::time (0))); // seed
 
 //#define SIMULATION_DEBUG 1
 #define DO_TIMING_PROFILE 0


### PR DESCRIPTION
Should have asked the author of #539 to adjust the style, but totally forgot about that.
