### PR TITLE
Added dependency check to pcl_cuda_io

### DIFF
--- a/cuda/io/CMakeLists.txt
+++ b/cuda/io/CMakeLists.txt
@@ -11,7 +11,7 @@ mark_as_advanced("BUILD_${SUBSYS_NAME}")
 PCL_SUBSYS_DEPEND(build "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS})
 PCL_SET_SUBSYS_INCLUDE_DIR("${SUBSYS_NAME}" "${SUBSYS_PATH}")
 
-if (build)
+if (build AND HAVE_OPENNI)
     set(srcs
         src/disparity_to_cloud.cu
         src/cloud_to_pcl.cpp


### PR DESCRIPTION
- Several pcl_cuda_io headers depend on openni_image.h
