### PR TITLE
Add: markPoints with float coordinates for u and v

### DIFF
--- a/visualization/include/pcl/visualization/image_viewer.h
+++ b/visualization/include/pcl/visualization/image_viewer.h
@@ -441,6 +441,18 @@ namespace pcl
         markPoints (const std::vector<int>& uv, Vector3ub fg_color, Vector3ub bg_color = red_color, double size = 3.0,
                     const std::string &layer_id = "markers", double opacity = 1.0);
 
+        /** \brief Sets the pixel at coordinates(u,v) to color while setting the neighborhood to another (float coordinates version).
+          * \param[in] uv the u/x, v/y coordinate of the pixels to be marked
+          * \param[in] fg_color the pixel color
+          * \param[in] bg_color the neighborhood color
+          * \param[in] size edge of the square surrounding each pixel
+          * \param[in] layer_id the name of the layer (default: "markers")
+          * \param[in] opacity the opacity of the layer (default: 1.0)
+          */
+        void
+        markPoints (const std::vector<float>& uv, Vector3ub fg_color, Vector3ub bg_color = red_color, double size = 3.0,
+                    const std::string &layer_id = "markers", double opacity = 1.0);
+
         /** \brief Set the window title name
           * \param[in] name the window title
           */

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -936,6 +936,21 @@ pcl::visualization::ImageViewer::markPoints (
   if (uv.size () == 0)
     return;
 
+  std::vector<float> float_uv (uv.size ());
+  for (std::size_t i = 0; i < uv.size (); ++i)
+    float_uv[i] = static_cast<float> (uv[i]);
+  return (markPoints (float_uv, fg_color, bg_color, size, layer_id, opacity));
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl::visualization::ImageViewer::markPoints (
+    const std::vector<float>& uv, Vector3ub fg_color, Vector3ub bg_color, double size,
+    const std::string &layer_id, double opacity)
+{
+  if (uv.size () == 0)
+    return;
+
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
   LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
@@ -949,20 +964,15 @@ pcl::visualization::ImageViewer::markPoints (
 
   vtkSmartPointer<context_items::Markers> markers = vtkSmartPointer<context_items::Markers>::New ();
   markers->setOpacity (opacity);
-  std::vector<float> points (uv.size ());
-  std::size_t nb_points = points.size () / 2;
-  for (std::size_t i = 0; i < nb_points; ++i)
-  {
-    std::size_t ii = 2*i;
-    points[ii] = static_cast<float> (uv[ii]);
 #if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
-    points[ii] = static_cast<float> (uv[ii+1]);
+  markers->set (uv);
 #else
-    points[ii+1] = static_cast<float> (getSize ()[1] - uv[ii+1]);
-#endif
-  }
-
+  // translate v which is on odd indices
+  std::vector<float> points = uv;
+  for (std::size_t i = 1; i < points.size (); i+=2)
+    points[i] = getSize ()[1] - points[i];
   markers->set (points);
+#endif
   markers->setSize (size);
   markers->setColors (bg_color[0], bg_color[1], bg_color[2]);
   markers->setPointColors (fg_color[0], fg_color[1], fg_color[2]);


### PR DESCRIPTION
method to mark a series of points with u,v coordinates being floats to deal with subpixel acccuracy
