### PR TITLE
Set RGB color handler as default in pcl_viewer

### DIFF
--- a/visualization/tools/pcd_viewer.cpp
+++ b/visualization/tools/pcd_viewer.cpp
@@ -592,10 +592,14 @@ main (int argc, char** argv)
     // Add every dimension as a possible color
     if (!fcolorparam)
     {
+      int idx = 0;
       for (size_t f = 0; f < cloud->fields.size (); ++f)
       {
         if (cloud->fields[f].name == "rgb" || cloud->fields[f].name == "rgba")
+        {
+          idx = f + 1;
           color_handler.reset (new pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2> (cloud));
+        }
         else
         {
           if (!isValidFieldName (cloud->fields[f].name))
@@ -606,6 +610,8 @@ main (int argc, char** argv)
         //p->addPointCloud<pcl::PointXYZ> (cloud_xyz, color_handler, cloud_name.str (), viewport);
         p->addPointCloud (cloud, color_handler, origin, orientation, cloud_name.str (), viewport);
       }
+      // Set RGB color handler as default
+      p->updateColorHandlerIndex (cloud_name.str (), idx);
     }
 
     // Additionally, add normals as a handler


### PR DESCRIPTION
pcl_viewer will use random color handler by default. It looks like this:
![pcd viewer_002](https://f.cloud.github.com/assets/1129415/2332084/648b59a8-a452-11e3-8ba5-58e0b0a121ec.png)
However, RGB color handler is more frequently used and we need to press keys to switch to the right color handle. So set it as default:
![pcd viewer_001](https://f.cloud.github.com/assets/1129415/2332172/7e13d566-a453-11e3-9c25-6a64b0fc13bb.png)
