### PR TITLE
Change non-standard logical OR comparison of Pascal type syntax to C

### DIFF
--- a/io/src/dinast_grabber.cpp
+++ b/io/src/dinast_grabber.cpp
@@ -342,7 +342,7 @@ pcl::DinastGrabber::getXYZIPointCloud ()
 
       
       // Get rid of the noise
-      if(cloud->points[depth_idx].z > 0.8f or cloud->points[depth_idx].z < 0.02f)
+      if(cloud->points[depth_idx].z > 0.8f || cloud->points[depth_idx].z < 0.02f)
       {
         cloud->points[depth_idx].x = std::numeric_limits<float>::quiet_NaN ();
       	cloud->points[depth_idx].y = std::numeric_limits<float>::quiet_NaN ();


### PR DESCRIPTION
Compiling latest master build with MSVC 2010 gives following errors:

```
11>..\..\io\src\dinast_grabber.cpp(345): error C2146: syntax error : missing ')' before identifier 'or'
11>..\..\io\src\dinast_grabber.cpp(345): error C2065: 'or' : undeclared identifier
11>..\..\io\src\dinast_grabber.cpp(345): error C2146: syntax error : missing ';' before identifier 'cloud'
11>..\..\io\src\dinast_grabber.cpp(345): error C2059: syntax error : ')'
11>..\..\io\src\dinast_grabber.cpp(346): error C2143: syntax error : missing ';' before '{'
```

The source contains invalid syntax (i.e. the "or" is undefined in current context):

``` c++
if(cloud->points[depth_idx].z > 0.8f or cloud->points[depth_idx].z < 0.02f)
```

Change the following "or" to standard C syntax logical OR comparison operator: ||
No need to reinvent the wheel.
