### PR TITLE
HSV to RGB color conversion: Fix scale when converting desaturated values.

### DIFF
--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -179,7 +179,7 @@ namespace pcl
     out.x = in.x; out.y = in.y; out.z = in.z;
     if (in.s == 0)
     {
-      out.r = out.g = out.b = static_cast<uint8_t> (in.v);
+      out.r = out.g = out.b = static_cast<uint8_t> (255 * in.v);
       return;
     } 
     float a = in.h / 60;


### PR DESCRIPTION
A pretty straightforward fix (the factor 255 was missing here).
