### PR TITLE
In pcl::Feature set output cloud width and height to meaningful values when not specified in input

### DIFF
--- a/features/include/pcl/features/impl/feature.hpp
+++ b/features/include/pcl/features/impl/feature.hpp
@@ -201,10 +201,12 @@ pcl::Feature<PointInT, PointOutT>::compute (PointCloudOut &output)
   // Resize the output dataset
   if (output.points.size () != indices_->size ())
     output.points.resize (indices_->size ());
+
   // Check if the output will be computed for all points or only a subset
-  if (indices_->size () != input_->points.size ())
+  // If the input width or height are not set, set output width as size
+  if (indices_->size () != input_->points.size () || input_->width * input_->height == 0)
   {
-    output.width = static_cast<int> (indices_->size ());
+    output.width = static_cast<uint32_t> (indices_->size ());
     output.height = 1;
   }
   else


### PR DESCRIPTION
Changing in compute will apply for all features.
(Some specific features will still set width and height as needed in computeFeatures)

Refer #589
