### PR TITLE
fixing compile error (http://pastebin.com/ZD8NezKn)

### DIFF
--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -126,7 +126,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
   else
     // Iterate over each point
     for (size_t i = 0; i < cloud_in.points.size (); ++i)
-      copyPoint (cloud_in.points[i], cloud_out.points[i]);
+      copyPoint<PointInT, PointOutT> (cloud_in.points[i], cloud_out.points[i]);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -200,7 +200,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
 
   // Iterate over each point
   for (size_t i = 0; i < indices.size (); ++i)
-    copyPoint (cloud_in.points[indices[i]], cloud_out.points[i]);
+    copyPoint<PointInT, PointOutT> (cloud_in.points[indices[i]], cloud_out.points[i]);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -220,7 +220,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
 
   // Iterate over each point
   for (size_t i = 0; i < indices.size (); ++i)
-    copyPoint (cloud_in.points[indices[i]], cloud_out.points[i]);
+    copyPoint<PointInT, PointOutT> (cloud_in.points[indices[i]], cloud_out.points[i]);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -256,7 +256,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
                      const pcl::PointIndices &indices,
                      pcl::PointCloud<PointOutT> &cloud_out)
 {
-  copyPointCloud (cloud_in, indices.indices, cloud_out);
+  copyPointCloud<PointInT, PointOutT> (cloud_in, indices.indices, cloud_out);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -332,7 +332,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
     // Iterate over each idx
     for (size_t i = 0; i < indices[cc].indices.size (); ++i)
     {
-      copyPoint (cloud_in.points[indices[cc].indices[i]], cloud_out.points[cp]);
+      copyPoint<PointInT, PointOutT> (cloud_in.points[indices[cc].indices[i]], cloud_out.points[cp]);
       ++cp;
     }
   }

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -450,8 +450,8 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
       n3d.compute (*scene_normals);
     }
 
-    pcl::copyPointCloud (*input_, *cloud_voxelized);
-    pcl::copyPointCloud (*scene_normals, *cloud_voxelized);
+    pcl::copyPointCloud<pcl::PointXYZ, pcl::PointNormal> (*input_, *cloud_voxelized);
+    pcl::copyPointCloud<pcl::Normal, pcl::PointNormal> (*scene_normals, *cloud_voxelized);
 
     pcl::PointCloud<pcl::PointNormal>::Ptr cloud_voxelized_icp_normals (new pcl::PointCloud<pcl::PointNormal> ());
     pcl::VoxelGrid<pcl::PointNormal> voxel_grid_icp;
@@ -462,7 +462,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
     //compute normals
     pcl::PointCloud<pcl::PointNormal>::Ptr model_aligned_normals (new pcl::PointCloud<pcl::PointNormal> ());
-    pcl::copyPointCloud (*model_original_, *model_aligned_normals);
+    pcl::copyPointCloud<pcl::PointXYZ, pcl::PointNormal> (*model_original_, *model_aligned_normals);
 
     pcl::NormalEstimation<pcl::PointNormal, pcl::PointNormal> normal_est_;
     normal_est_.setKSearch (10);

--- a/registration/include/pcl/registration/impl/correspondence_estimation.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation.hpp
@@ -164,7 +164,7 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
     for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
     {
       // Copy the source data to a target PointTarget format so we can search in the tree
-      copyPoint (input_->points[*idx], pt);
+      copyPoint<PointSource, PointTarget> (input_->points[*idx], pt);
 
       tree_->nearestKSearch (pt, 1, index, distance);
       if (distance[0] > max_dist_sqr)
@@ -235,7 +235,7 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
     for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
     {
       // Copy the source data to a target PointTarget format so we can search in the tree
-      copyPoint (input_->points[*idx], pt_src);
+      copyPoint<PointSource, PointTarget> (input_->points[*idx], pt_src);
 
       tree_->nearestKSearch (pt_src, 1, index, distance);
       if (distance[0] > max_dist_sqr)
@@ -244,7 +244,7 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
       target_idx = index[0];
 
       // Copy the target data to a target PointSource format so we can search in the tree_reciprocal
-      copyPoint (target_->points[target_idx], pt_tgt);
+      copyPoint<PointSource, PointTarget> (target_->points[target_idx], pt_tgt);
 
       tree_reciprocal_->nearestKSearch (pt_tgt, 1, index_reciprocal, distance_reciprocal);
       if (distance_reciprocal[0] > max_dist_sqr || *idx != index_reciprocal[0])

--- a/registration/include/pcl/registration/impl/correspondence_estimation_normal_shooting.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_normal_shooting.hpp
@@ -135,7 +135,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
       {
         PointSource pt_src;
         // Copy the source data to a target PointTarget format so we can search in the tree
-        copyPoint (input_->points[*idx_i], pt_src);
+        copyPoint<PointSource, PointTarget> (input_->points[*idx_i], pt_src);
 
         // computing the distance between a point and a line in 3d. 
         // Reference - http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
@@ -265,7 +265,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
       {
         PointSource pt_src;
         // Copy the source data to a target PointTarget format so we can search in the tree
-        copyPoint (input_->points[*idx_i], pt_src);
+        copyPoint<PointSource, PointTarget> (input_->points[*idx_i], pt_src);
 
         // computing the distance between a point and a line in 3d. 
         // Reference - http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html

--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -84,7 +84,7 @@ TEST (PCL, copyPointCloud)
   cloud_xyz_rgba.push_back (pt_xyz_rgba);
 
   CloudXYZRGBNormal cloud_xyz_rgb_normal;
-  pcl::copyPointCloud (cloud_xyz_rgba, cloud_xyz_rgb_normal);
+  pcl::copyPointCloud<PointXYZRGBA, PointXYZRGBNormal> (cloud_xyz_rgba, cloud_xyz_rgb_normal);
   EXPECT_EQ (int (cloud_xyz_rgb_normal.size ()), 5);
   for (int i = 0; i < 5; ++i)
   {
@@ -106,7 +106,7 @@ TEST (PCL, copyPointCloud)
 
   vector<int, Eigen::aligned_allocator<int> > indices_aligned;
   indices_aligned.push_back (1); indices_aligned.push_back (2); indices_aligned.push_back (3); 
-  pcl::copyPointCloud (cloud_xyz_rgba, indices_aligned, cloud_xyz_rgb_normal);
+  pcl::copyPointCloud<PointXYZRGBA, PointXYZRGBNormal> (cloud_xyz_rgba, indices_aligned, cloud_xyz_rgb_normal);
   EXPECT_EQ (int (cloud_xyz_rgb_normal.size ()), 3);
   for (int i = 0; i < 3; ++i)
   {
@@ -327,7 +327,7 @@ TEST (PCL, CopyPointCloudWithIndicesAndRGBToRGBA)
   indices.push_back (2);
   indices.push_back (3);
 
-  pcl::copyPointCloud (cloud_xyz_rgba, indices, cloud_xyz_rgb);
+  pcl::copyPointCloud<PointXYZRGBA, PointXYZRGB> (cloud_xyz_rgba, indices, cloud_xyz_rgb);
 
   EXPECT_EQ (indices.size (), cloud_xyz_rgb.size ());
   for (size_t i = 0; i < indices.size (); ++i)


### PR DESCRIPTION
pcl/common/include/pcl/point_traits.h(153) : error C2499: 'pcl::traits::fieldList<PointT>' : a class cannot be its own base class
This is the "first" error, but it can be traced to missing template types. Adding these types fixes
the compilation error. I've found the hint here: http://www.pcl-users.org/failed-to-build-kinfu-td4032311.html

Note: I was building on Win7-64bit with MSVC2010 (SP1) in Debug mode.
Note#2: I'm not sure about correspondence_estimation_normal_shooting, cause pt_src is actually PointSource, not PointTarget
        but the comment says otherwise, it compiles at least.
