### PR TITLE
Fix: computation of normals for a subset of input_

### DIFF
--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -816,6 +816,22 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
     current_row -= input_->width;
   }
 
+  if (indices_->size () < input_->size ())
+    computeFeaturePart (distanceMap, bad_point, output);
+  else
+    computeFeatureFull (distanceMap, bad_point, output);
+
+  delete[] depthChangeMap;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointInT, typename PointOutT> void
+pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeatureFull (const float *distanceMap,
+                                                                             const float &bad_point,
+                                                                             PointCloudOut &output)
+{
+  unsigned index = 0;
+
   if (border_policy_ == BORDER_POLICY_IGNORE)
   {
     // Set all normals that we do not touch to NaN
@@ -993,9 +1009,173 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
       }
     }
   }
+}
 
-  delete[] depthChangeMap;
-  //delete[] distanceMap;
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointInT, typename PointOutT> void
+pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeaturePart (const float *distanceMap,
+                                                                             const float &bad_point,
+                                                                             PointCloudOut &output)
+{
+  if (border_policy_ == BORDER_POLICY_IGNORE)
+  {
+    output.is_dense = false;
+    unsigned border = int(normal_smoothing_size_);
+    int bottom = input_->height - border;
+    int right = input_->width - border;
+    if (use_depth_dependent_smoothing_)
+    {
+      // Iterating over the entire index vector
+      for (std::size_t idx = 0; idx < indices_->size (); ++idx)
+      {
+        unsigned pt_index = (*indices_)[idx];
+        unsigned u = pt_index % input_->width;
+        unsigned v = pt_index / input_->width;
+        if (v < border || v > bottom)
+        {
+          output.points[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output.points[idx].curvature = bad_point;
+          continue;
+        }
+
+        if (u < border || v > right)
+        {
+          output.points[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output.points[idx].curvature = bad_point;
+          continue;
+        }
+
+        const float depth = input_->points[pt_index].z;
+        if (!pcl_isfinite (depth))
+        {
+          output.points[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output.points[idx].curvature = bad_point;
+          continue;
+        }
+
+        float smoothing = (std::min)(distanceMap[pt_index], normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
+        if (smoothing > 2.0f)
+        {
+          setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
+          computePointNormal (u, v, pt_index, output [idx]);
+        }
+        else
+        {
+          output[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output[idx].curvature = bad_point;
+        }
+      }
+    }
+    else
+    {
+      float smoothing_constant = normal_smoothing_size_;
+      // Iterating over the entire index vector
+      for (std::size_t idx = 0; idx < indices_->size (); ++idx)
+      {
+        unsigned pt_index = (*indices_)[idx];
+        unsigned u = pt_index % input_->width;
+        unsigned v = pt_index / input_->width;
+        if (v < border || v > bottom)
+        {
+          output.points[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output.points[idx].curvature = bad_point;
+          continue;
+        }
+
+        if (u < border || v > right)
+        {
+          output.points[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output.points[idx].curvature = bad_point;
+          continue;
+        }
+
+        if (!pcl_isfinite (input_->points[pt_index].z))
+        {
+          output [idx].getNormalVector3fMap ().setConstant (bad_point);
+          output [idx].curvature = bad_point;
+          continue;
+        }
+
+        float smoothing = (std::min)(distanceMap[pt_index], smoothing_constant);
+
+        if (smoothing > 2.0f)
+        {
+          setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
+          computePointNormal (u, v, pt_index, output [idx]);
+        }
+        else
+        {
+          output [pt_index].getNormalVector3fMap ().setConstant (bad_point);
+          output [pt_index].curvature = bad_point;
+        }
+      }
+    }
+  }// border_policy_ == BORDER_POLICY_IGNORE
+  else if (border_policy_ == BORDER_POLICY_MIRROR)
+  {
+    output.is_dense = false;
+
+    if (use_depth_dependent_smoothing_)
+    {
+      for (std::size_t idx = 0; idx < indices_->size (); ++idx)
+      {
+        unsigned pt_index = (*indices_)[idx];
+        unsigned u = pt_index % input_->width;
+        unsigned v = pt_index / input_->width;
+
+        const float depth = input_->points[pt_index].z;
+        if (!pcl_isfinite (depth))
+        {
+          output[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output[idx].curvature = bad_point;
+          continue;
+        }
+
+        float smoothing = (std::min)(distanceMap[pt_index], normal_smoothing_size_ + static_cast<float>(depth)/10.0f);
+
+        if (smoothing > 2.0f)
+        {
+          setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
+          computePointNormalMirror (u, v, pt_index, output [idx]);
+        }
+        else
+        {
+          output[idx].getNormalVector3fMap ().setConstant (bad_point);
+          output[idx].curvature = bad_point;
+        }
+      }
+    }
+    else
+    {
+      float smoothing_constant = normal_smoothing_size_;
+      for (size_t idx = 0; idx < indices_->size (); ++idx)
+      {
+        unsigned pt_index = (*indices_)[idx];
+        unsigned u = pt_index % input_->width;
+        unsigned v = pt_index / input_->width;
+
+        if (!pcl_isfinite (input_->points[pt_index].z))
+        {
+          output [idx].getNormalVector3fMap ().setConstant (bad_point);
+          output [idx].curvature = bad_point;
+          continue;
+        }
+
+        float smoothing = (std::min)(distanceMap[pt_index], smoothing_constant);
+
+        if (smoothing > 2.0f)
+        {
+          setRectSize (static_cast<int> (smoothing), static_cast<int> (smoothing));
+          computePointNormalMirror (u, v, pt_index, output [idx]);
+        }
+        else
+        {
+          output [idx].getNormalVector3fMap ().setConstant (bad_point);
+          output [idx].curvature = bad_point;
+        }
+      }
+    }
+  } // border_policy_ == BORDER_POLICY_MIRROR
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/features/include/pcl/features/integral_image_normal.h
+++ b/features/include/pcl/features/integral_image_normal.h
@@ -71,6 +71,7 @@ namespace pcl
     using Feature<PointInT, PointOutT>::feature_name_;
     using Feature<PointInT, PointOutT>::tree_;
     using Feature<PointInT, PointOutT>::k_;
+    using Feature<PointInT, PointOutT>::indices_;
 
     public:
       typedef boost::shared_ptr<IntegralImageNormalEstimation<PointInT, PointOutT> > Ptr;
@@ -315,11 +316,27 @@ namespace pcl
       
     protected:
 
-      /** \brief Computes the normal for the complete cloud.
+      /** \brief Computes the normal for the complete cloud or only \a indices_ if provided.
         * \param[out] output the resultant normals
         */
       void
       computeFeature (PointCloudOut &output);
+
+      /** \brief Computes the normal for the complete cloud.
+        * \param[in] distance_map distance map
+        * \param[in] bad_point constant given to invalid normal components
+        * \param[out] output the resultant normals
+        */
+      void
+      computeFeatureFull (const float* distance_map, const float& bad_point, PointCloudOut& output);
+
+      /** \brief Computes the normal for part of the cloud specified by \a indices_
+        * \param[in] distance_map distance map
+        * \param[in] bad_point constant given to invalid normal components
+        * \param[out] output the resultant normals
+        */
+      void
+      computeFeaturePart (const float* distance_map, const float& bad_point, PointCloudOut& output);
 
       /** \brief Initialize the data structures, based on the normal estimation method chosen. */
       void


### PR DESCRIPTION
IntegralImageNormalEstimation computes normals for the whole point cloud and not for the given indices.
This is a quick hack that allows computation of normals for the only provided indices.
A cleaner solution is more than welcome but due to time constraints I will commit this to fix the bug for now.
