### PR TITLE
Fix: bug when same detector is used for more than one input

### DIFF
--- a/keypoints/include/pcl/keypoints/harris_3d.h
+++ b/keypoints/include/pcl/keypoints/harris_3d.h
@@ -74,6 +74,7 @@ namespace pcl
       using Keypoint<PointInT, PointOutT>::search_parameter_;
       using Keypoint<PointInT, PointOutT>::keypoints_indices_;
       using Keypoint<PointInT, PointOutT>::initCompute;
+      using PCLBase<PointInT>::setInputCloud;
 
       typedef enum {HARRIS = 1, NOBLE, LOWE, TOMASI, CURVATURE} ResponseMethod;
 
@@ -95,6 +96,12 @@ namespace pcl
       
       /** \brief Empty destructor */
       virtual ~HarrisKeypoint3D () {}
+
+      /** \brief Provide a pointer to the input dataset
+        * \param[in] cloud the const boost shared pointer to a PointCloud message
+        */
+      virtual void
+      setInputCloud (const PointCloudInConstPtr &cloud);
 
       /** \brief Set the method of the response to be calculated.
         * \param[in] type

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -52,6 +52,15 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT, typename NormalT> void
+pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::setInputCloud (const PointCloudInConstPtr &cloud)
+{
+  if (normals_ && input_ && (cloud != input_))
+    normals_.reset ();
+  input_ = cloud;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointInT, typename PointOutT, typename NormalT> void
 pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::setMethod (ResponseMethod method)
 {
   method_ = method;


### PR DESCRIPTION
When using same detector for more than one input (different clouds),
normals are not reset which causes false results or error if the clouds
sizes don't match.

This was reported in the mailing list http://www.pcl-users.org/Problem-with-Harris-3D-keypoint-detector-in-ICCV-2011-feature-matching-Tutorial-td4033177.html
