### PR TITLE
add missing lines of code in bspline_fitting tutorial

### DIFF
--- a/doc/tutorials/content/bspline_fitting.rst
+++ b/doc/tutorials/content/bspline_fitting.rst
@@ -59,7 +59,7 @@ You can find the input file at *pcl/test/bunny.pcd*.
 .. literalinclude:: sources/bspline_fitting/bspline_fitting.cpp
    :language: cpp
    :linenos:
-   :lines: 1-169
+   :lines: 1-220
 
 
 The explanation


### PR DESCRIPTION
In the source file in http://pointclouds.org/documentation/tutorials/bspline_fitting.php not the whole code is shown. 
Thus, people are having some trouble http://stackoverflow.com/questions/22293418/error-on-running-bsplines-example-in-pcl-1-7/22890743#22890743 and http://www.pcl-users.org/Fitting-trimmed-B-splines-to-unordered-point-clouds-problem-to-run-td4032826.html

This should solve it.
