### PR TITLE
Fix for double free in KdTreeFLANN after copy operation #335.

### DIFF
--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -44,6 +44,8 @@
 #include <pcl/kdtree/kdtree.h>
 #include <pcl/kdtree/flann.h>
 
+#include <boost/shared_array.hpp>
+
 // Forward declarations
 namespace flann
 {
@@ -210,7 +212,7 @@ namespace pcl
       boost::shared_ptr<FLANNIndex> flann_index_;
 
       /** \brief Internal pointer to data. */
-      float* cloud_;
+      boost::shared_array<float> cloud_;
       
       /** \brief mapping between internal and external indices. */
       std::vector<int> index_mapping_;


### PR DESCRIPTION
This fix changes the float *cloud_ pointer into a boost::shared_array structure, and substitutes malloc/free with new[]/delete[] operators.
