### PR TITLE
Put func after __attribute__ in PCL_DEPRECATE macro

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -301,12 +301,12 @@ log2f (float x)
 #endif
 
 #if (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < PCL_LINEAR_VERSION(4,5,0) && ! defined(__clang__)) || defined(__INTEL_COMPILER)
-#define PCL_DEPRECATED(func, message) func __attribute__ ((deprecated))
+#define PCL_DEPRECATED(func, message) __attribute__ ((deprecated)) func
 #endif
 
 // gcc supports this starting from 4.5 : http://gcc.gnu.org/bugzilla/show_bug.cgi?id=43666
 #if (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) >= PCL_LINEAR_VERSION(4,5,0)) || (defined(__clang__) && __has_extension(attribute_deprecated_with_message))
-#define PCL_DEPRECATED(func, message) func __attribute__ ((deprecated(message)))
+#define PCL_DEPRECATED(func, message) __attribute__ ((deprecated(message))) func
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
This pull request swaps `func` and `__attribute__` in `PCL_DEPRECATE` macro for _gcc_ and _clang_ compilers as proposed by @erickulcyk in #537.
