### PR TITLE
Improve ply2pcd help

### DIFF
--- a/tools/ply2pcd.cpp
+++ b/tools/ply2pcd.cpp
@@ -50,7 +50,7 @@ using namespace pcl::console;
 void
 printHelp (int, char **argv)
 {
-  print_error ("Syntax is: %s input.ply output.pcd\n", argv[0]);
+  print_error ("Syntax is: %s [-format 0|1] input.ply output.pcd\n", argv[0]);
 }
 
 bool


### PR DESCRIPTION
`ply2pcd` help doesn't print the "format" option.
The print help function now looks similar to `pcd2ply` help.
