### PR TITLE
Delete deprecated doxygen options

### DIFF
--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -51,7 +51,6 @@ SUBGROUPING            = YES
 INLINE_GROUPED_CLASSES = NO
 INLINE_SIMPLE_STRUCTS  = NO
 TYPEDEF_HIDES_STRUCT   = NO
-SYMBOL_CACHE_SIZE      = 0
 LOOKUP_CACHE_SIZE      = 0
 
 #---------------------------------------------------------------------------
@@ -88,7 +87,6 @@ ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = YES
 SHOW_FILES             = NO
-SHOW_DIRECTORIES       = NO
 SHOW_NAMESPACES        = YES
 FILE_VERSION_FILTER    = 
 LAYOUT_FILE            = "@PCL_SOURCE_DIR@/doc/doxygen/doxygen_layout.xml"

--- a/doc/doxygen/doxygen_layout.xml
+++ b/doc/doxygen/doxygen_layout.xml
@@ -18,7 +18,6 @@
       <tab type="files" visible="yes" title=""/>
       <tab type="globals" visible="yes" title=""/>
     </tab>
-    <tab type="dirs" visible="no" title=""/>
     <tab type="examples" visible="no" title=""/>  
   </navindex>
 


### PR DESCRIPTION
These two options are deprecated in doxygen (don't know from which version)

This deletes two warnings :

```
Warning: Tag `SYMBOL_CACHE_SIZE' at line 81 of file /home/dell/pcl/build/doc/doxygen/doxyfile has become obsolete.
To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
Warning: Tag `SHOW_DIRECTORIES' at line 118 of file /home/dell/pcl/build/doc/doxygen/doxyfile has become obsolete.
To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
```

There is still an error I don't understand (it was there before the change) :

```
error: the type 'dirs' is not supported for the entry tag within a navindex! Check your layout file!
```
