### PR TITLE
Fix: OpenMP with current GCC version doesn't like inherited members

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/trajkovic_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_2d.hpp
@@ -219,7 +219,7 @@ pcl::TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (Poin
   const int occupency_map_size (indices.size ());
 
 #ifdef _OPENMP
-#pragma omp parallel for shared (output, keypoints_indices_) num_threads (threads_)
+#pragma omp parallel for shared (output) num_threads (threads_)
 #endif
   for (int i = 0; i < indices.size (); ++i)
   {

--- a/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
@@ -233,7 +233,7 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
   const int occupency_map_size (indices.size ());
 
 #ifdef _OPENMP
-#pragma omp parallel for shared (output, keypoints_indices_) num_threads (threads_)
+#pragma omp parallel for shared (output) num_threads (threads_)
 #endif
   for (int i = 0; i < indices.size (); ++i)
   {


### PR DESCRIPTION
During evaluation of OpenMP pragma GCC 4.8.1 (ubuntu) complains about the inherited member keypoints_indices_.
Fixes #647
