### PR TITLE
Kinfu cannot save points when until a cloud without normals is taken

### DIFF
--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -976,7 +976,13 @@ struct KinFuApp
   {      
     const SceneCloudView& view = scene_cloud_view_;
 
-    if (!view.cloud_ptr_->points.empty ())
+    // Points to export are either in cloud_ptr_ or combined_ptr_.
+    // If none have points, we have nothing to export.
+    if (view.cloud_ptr_->points.empty () && view.combined_ptr_->points.empty ())
+    {
+      cout << "Not writing cloud: Cloud is empty" << endl;
+    }
+    else
     {
       if(view.point_colors_ptr_->points.empty()) // no colors
       {


### PR DESCRIPTION
If you start Kinfu and press `N` (enable normal extraction), and then press `T` (take cloud) and `1` (save cloud to file), nothing happens for the save. It should save the cloud.

It starts working once you have pressed `T` with normals disabled.
