### PR TITLE
Add missing include directive for boost/chrono.hpp.

### DIFF
--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -64,6 +64,7 @@
 #include <boost/mpl/vector.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/chrono.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
 #include <boost/shared_array.hpp>


### PR DESCRIPTION
The current master does not compile without this (required by pcl/io/image_ir.h).
