### PR TITLE
Pcd recorder improvements

### DIFF
--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -88,10 +88,10 @@ getTotalSystemMemory ()
   return memory;
 }
 
-const int BUFFER_SIZE = int (getTotalSystemMemory () / (640 * 480));
+const size_t BUFFER_SIZE = size_t (getTotalSystemMemory () / (640 * 480 * sizeof (pcl::PointXYZRGBA)));
 #else
 
-const int BUFFER_SIZE = 200;
+const size_t BUFFER_SIZE = 200;
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The recorder now has command-line support for device IDs just like openni_viewer.
This is a new pull request based on #672 without the changes to memory size calculation.
