### PR TITLE
Reduce the computation time needed for bilateral upsampling 

### DIFF
--- a/surface/include/pcl/surface/bilateral_upsampling.h
+++ b/surface/include/pcl/surface/bilateral_upsampling.h
@@ -145,6 +145,12 @@ namespace pcl
       void
       performProcessing (pcl::PointCloud<PointOutT> &output);
 
+      /** \brief Computes the distance for depth and RGB.
+        * \param[out] val_exp_depth distance values for depth
+        * \param[out] val_exp_rgb distance values for RGB */
+      void
+      computeDistances (Eigen::MatrixXf &val_exp_depth, Eigen::VectorXf &val_exp_rgb);
+
     private:
       int window_size_;
       float sigma_color_, sigma_depth_;


### PR DESCRIPTION
I took a couple of exponential functions out from the innermost loops in order to reduce the computation time. The values for those exponential functions are now saved in a matrix (val_exp_depth_matrix) and a vector (val_exp_rgb_vector), and they are referenced inside the loops. The bilateral upsampling seems to work a lot faster now.

I'm new to github, so I apologize if there are some peculiarities in the commits. I read from the guidelines that there shouldn't be any merge commits, but I don't know how to get rid of them. Also tried to squash the commits into one, but again failed to do so.
