### PR TITLE
Match template PCL style guide for the Eclipse formatter

### DIFF
--- a/doc/advanced/content/files/PCL_eclipse_profile.xml
+++ b/doc/advanced/content/files/PCL_eclipse_profile.xml
@@ -127,7 +127,7 @@
 <setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="insert"/>
 <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
 <setting id="org.eclipse.cdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
-<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_angle_bracket_in_template_parameters" value="do not insert"/>
+<setting id="org.eclipse.cdt.core.formatter.insert_space_before_opening_angle_bracket_in_template_parameters" value="insert"/>
 <setting id="org.eclipse.cdt.core.formatter.tabulation.char" value="space"/>
 <setting id="org.eclipse.cdt.core.formatter.insert_space_before_closing_angle_bracket_in_template_parameters" value="do not insert"/>
 <setting id="org.eclipse.cdt.core.formatter.insert_new_line_before_colon_in_constructor_initializer_list" value="do not insert"/>


### PR DESCRIPTION
This adds a space before the opening angle bracket:

```
template<typename T1, typename T2> class map
{
};
map<int, int> m;
```

to

```
template <typename T1, typename T2> class map
{
};
map<int, int> m;
```

This matches both
http://www.pointclouds.org/documentation/advanced/pcl_style_guide.php#classes
and
http://www.pointclouds.org/documentation/advanced/pcl_style_guide.php#id2
