### PR TITLE
Fix: fix silly bug in GICP preventing the inner optimization loop

### DIFF
--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -227,6 +227,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigidTr
 
   int inner_iterations_ = 0;
   int result = bfgs.minimizeInit (x);
+  result = BFGSSpace::Running;
   do
   {
     inner_iterations_++;


### PR DESCRIPTION
Should have done this before but just couldn't find time previously.
Now PCL GICP result is exactly same as original GICP code.
