### PR TITLE
Improve doxygen doc return

### DIFF
--- a/common/include/pcl/console/parse.h
+++ b/common/include/pcl/console/parse.h
@@ -62,7 +62,7 @@ namespace pcl
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] argument_name the string value to search for
-      * \return index of found argument or -1 of arguments does not appear in list
+      * \return index of found argument or -1 if arguments do not appear in list
      */
     PCL_EXPORTS int
     find_argument (int argc, char** argv, const char* argument_name);
@@ -72,7 +72,7 @@ namespace pcl
       * \param[in] argv the command line arguments
       * \param[in] argument_name the name of the argument to search for
       * \param[out] value The value of the argument
-      * \return index of found argument or -1 of arguments does not appear in list
+      * \return index of found argument or -1 if arguments do not appear in list
      */
     template<typename Type> int
     parse (int argc, char** argv, const char* argument_name, Type& value)
@@ -90,114 +90,117 @@ namespace pcl
       return (index - 1);
     }
 
-    /** \brief Parse for a specific given command line argument. Returns the value
-      * sent as a string.
+    /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] val the resultant value
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_argument (int argc, char** argv, const char* str, std::string &val);
 
-    /** \brief Parse for a specific given command line argument. Returns the value
-      * sent as a boolean.
+    /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] val the resultant value
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_argument (int argc, char** argv, const char* str, bool &val);
 
-    /** \brief Parse for a specific given command line argument. Returns the value
-      * sent as a double.
+    /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] val the resultant value
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_argument (int argc, char** argv, const char* str, float &val);
     
-    /** \brief Parse for a specific given command line argument. Returns the value
-      * sent as a double.
+    /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] val the resultant value
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_argument (int argc, char** argv, const char* str, double &val);
 
-    /** \brief Parse for a specific given command line argument. Returns the value
-      * sent as an int.
+    /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] val the resultant value
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_argument (int argc, char** argv, const char* str, int &val);
 
-    /** \brief Parse for a specific given command line argument. Returns the value
-      * sent as an unsigned int.
+    /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] val the resultant value
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_argument (int argc, char** argv, const char* str, unsigned int &val);
 
-    /** \brief Parse for a specific given command line argument. Returns the value
-      * sent as an int.
+    /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] val the resultant value
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_argument (int argc, char** argv, const char* str, char &val);
 
     /** \brief Parse for specific given command line arguments (2x values comma
-      * separated). Returns the values sent as doubles.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] f the first output value
       * \param[out] s the second output value
       * \param[in] debug whether to print debug info or not
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_2x_arguments (int argc, char** argv, const char* str, float &f, float &s, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (2x values comma
-      * separated). Returns the values sent as doubles.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] f the first output value
       * \param[out] s the second output value
       * \param[in] debug whether to print debug info or not
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_2x_arguments (int argc, char** argv, const char* str, double &f, double &s, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (2x values comma
-      * separated). Returns the values sent as ints.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] f the first output value
       * \param[out] s the second output value
       * \param[in] debug whether to print debug info or not
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_2x_arguments (int argc, char** argv, const char* str, int &f, int &s, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
-      * separated). Returns the values sent as doubles.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
@@ -205,12 +208,13 @@ namespace pcl
       * \param[out] s the second output value
       * \param[out] t the third output value
       * \param[in] debug whether to print debug info or not
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_3x_arguments (int argc, char** argv, const char* str, float &f, float &s, float &t, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
-      * separated). Returns the values sent as doubles.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
@@ -218,12 +222,13 @@ namespace pcl
       * \param[out] s the second output value
       * \param[out] t the third output value
       * \param[in] debug whether to print debug info or not
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_3x_arguments (int argc, char** argv, const char* str, double &f, double &s, double &t, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
-      * separated). Returns the values sent as ints.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
@@ -231,103 +236,111 @@ namespace pcl
       * \param[out] s the second output value
       * \param[out] t the third output value
       * \param[in] debug whether to print debug info or not
+      * return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_3x_arguments (int argc, char** argv, const char* str, int &f, int &s, int &t, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
-      * separated). Returns the values sent as doubles.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] v the vector into which the parsed values will be copied
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_x_arguments (int argc, char** argv, const char* str, std::vector<double>& v);
 
     /** \brief Parse for specific given command line arguments (N values comma
-      * separated). Returns the values sent as ints.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] v the vector into which the parsed values will be copied
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_x_arguments (int argc, char** argv, const char* str, std::vector<float>& v);
 
     /** \brief Parse for specific given command line arguments (N values comma
-      * separated). Returns the values sent as ints.
+      * separated).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] v the vector into which the parsed values will be copied
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
     parse_x_arguments (int argc, char** argv, const char* str, std::vector<int>& v);
 
-    /** \brief Parse for specific given command line arguments (multiple occurances
-      * of the same command line parameter). Returns the values sent as a vector.
+    /** \brief Parse for specific given command line arguments (multiple occurences
+      * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] values the resultant output values
+      * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<int> &values);
 
-    /** \brief Parse for specific given command line arguments (multiple occurances
-      * of the same command line parameter). Returns the values sent as a vector.
+    /** \brief Parse for specific given command line arguments (multiple occurences
+      * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] values the resultant output values
+      * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<float> &values);
 
-    /** \brief Parse for specific given command line arguments (multiple occurances
-      * of the same command line parameter). Returns the values sent as a vector.
+    /** \brief Parse for specific given command line arguments (multiple occurences
+      * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] values the resultant output values
+      * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<double> &values);
 
     /** \brief Parse for a specific given command line argument (multiple occurences
-      * of the same command line parameter). Returns the value sent as a vector.
+      * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the string value to search for
       * \param[out] values the resultant output values
+      * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<std::string> &values);
 
-    /** \brief Parse for specific given command line arguments (multiple occurances
-      * of 2x argument groups, separated by commas). Returns 2 vectors holding the
-      * given values.
+    /** \brief Parse command line arguments for file names with given extension (multiple occurences
+      * of 2x argument groups, separated by commas).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] values_f the first vector of output values
       * \param[out] values_s the second vector of output values
+      * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
     parse_multiple_2x_arguments (int argc, char** argv, const char* str, 
                                  std::vector<double> &values_f, 
                                  std::vector<double> &values_s);
 
-    /** \brief Parse for specific given command line arguments (multiple occurances
-      * of 3x argument groups, separated by commas). Returns 3 vectors holding the
-      * given values.
+    /** \brief Parse command line arguments for file names with given extension (multiple occurences
+      * of 3x argument groups, separated by commas).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] str the command line argument to search for
       * \param[out] values_f the first vector of output values
       * \param[out] values_s the second vector of output values
       * \param[out] values_t the third vector of output values
+      * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
     parse_multiple_3x_arguments (int argc, char** argv, const char* str, 
@@ -335,11 +348,11 @@ namespace pcl
                                  std::vector<double> &values_s, 
                                  std::vector<double> &values_t);
 
-    /** \brief Parse command line arguments for file names. Returns a vector with
-      * file names indices.
+    /** \brief Parse command line arguments for file names with given extension
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
       * \param[in] ext the extension to search for
+      * \return a vector with file names indices
       */
     PCL_EXPORTS std::vector<int>
     parse_file_extension_argument (int argc, char** argv, const std::string &ext);


### PR DESCRIPTION
Return was included in the brief of the function
Not it is separated in the `\return` command

The return description did not match the function, I corrected the messages!
