### PR TITLE
build: Fix missing definition of uint64_t

### DIFF
--- a/io/include/pcl/io/image.h
+++ b/io/include/pcl/io/image.h
@@ -166,7 +166,7 @@ namespace pcl
         * @return the timestamp of the image
         * @note the time value is not synchronized with the system time
         */
-        uint64_t
+        pcl::uint64_t
         getTimestamp () const
         {
           return (wrapper_->getTimestamp ());

--- a/io/include/pcl/io/image_depth.h
+++ b/io/include/pcl/io/image_depth.h
@@ -71,8 +71,8 @@ namespace pcl
           * \param[in] no_sample_value defines which values in the depth data are indicating that no depth (disparity) could be determined .
           * \attention The focal length may change, depending whether the depth stream is registered/mapped to the RGB stream or not.
           */
-        DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, uint64_t shadow_value, uint64_t no_sample_value);
-        DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, uint64_t shadow_value, uint64_t no_sample_value, Timestamp time);
+        DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, pcl::uint64_t shadow_value, pcl::uint64_t no_sample_value);
+        DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, pcl::uint64_t shadow_value, pcl::uint64_t no_sample_value, Timestamp time);
 
         /** \brief Destructor. Never throws an exception. */
         ~DepthImage ();
@@ -128,13 +128,13 @@ namespace pcl
         /** \brief method to access the shadow value, that indicates pixels lying in shadow in the depth image.
           * \return shadow value
           */
-        uint64_t
+        pcl::uint64_t
         getShadowValue () const;
 
         /** \brief method to access the no-sample value, that indicates pixels where no disparity could be determined for the depth image.
           * \return no-sample value
           */
-        uint64_t
+        pcl::uint64_t
         getNoSampleValue () const;
 
         /** \return the width of the depth image */
@@ -155,7 +155,7 @@ namespace pcl
           * \attention its not the system time, thus can not be used directly to synchronize different sensors.
           *            But definitely synchronized with other streams
           */
-        uint64_t
+        pcl::uint64_t
         getTimestamp () const;
 
         Timestamp
@@ -181,8 +181,8 @@ namespace pcl
 
         float baseline_;
         float focal_length_;
-        uint64_t shadow_value_;
-        uint64_t no_sample_value_;
+        pcl::uint64_t shadow_value_;
+        pcl::uint64_t no_sample_value_;
         Timestamp timestamp_;
     };
 

--- a/io/include/pcl/io/image_grabber.h
+++ b/io/include/pcl/io/image_grabber.h
@@ -148,7 +148,7 @@ namespace pcl
 
     /** \brief Query only the timestamp of an index, if it exists */
     bool
-    getTimestampAtIndex (size_t idx, uint64_t &timestamp) const;
+    getTimestampAtIndex (size_t idx, pcl::uint64_t &timestamp) const;
 
     /** \brief Manually set RGB image files.
      * \param[in] rgb_image_files A vector of [tiff/png/jpg/ppm] files to use as input. There must be a 1-to-1 correspondence between these and the depth images you set

--- a/io/include/pcl/io/image_ir.h
+++ b/io/include/pcl/io/image_ir.h
@@ -76,7 +76,7 @@ namespace pcl
         unsigned
         getFrameID () const;
 
-        uint64_t
+        pcl::uint64_t
         getTimestamp () const;
 
         Timestamp

--- a/io/include/pcl/io/image_metadata_wrapper.h
+++ b/io/include/pcl/io/image_metadata_wrapper.h
@@ -42,6 +42,7 @@
 #define PCL_IO_IMAGE_METADATA_WRAPPER_H_
 
 #include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl
 {
@@ -72,7 +73,7 @@ namespace pcl
         getFrameID () const = 0;
 
         // Microseconds from some arbitrary start point
-        virtual uint64_t
+        virtual pcl::uint64_t
         getTimestamp () const = 0;
     };
 

--- a/io/src/image_depth.cpp
+++ b/io/src/image_depth.cpp
@@ -47,7 +47,7 @@
 using pcl::io::FrameWrapper;
 using pcl::io::IOException;
 
-pcl::io::DepthImage::DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, uint64_t shadow_value, uint64_t no_sample_value)
+pcl::io::DepthImage::DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, pcl::uint64_t shadow_value, pcl::uint64_t no_sample_value)
 : wrapper_ (depth_metadata)
 , baseline_ (baseline)
 , focal_length_ (focal_length)
@@ -57,7 +57,7 @@ pcl::io::DepthImage::DepthImage (FrameWrapper::Ptr depth_metadata, float baselin
 {}
 
 
-pcl::io::DepthImage::DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, uint64_t shadow_value, uint64_t no_sample_value, Timestamp timestamp)
+pcl::io::DepthImage::DepthImage (FrameWrapper::Ptr depth_metadata, float baseline, float focal_length, pcl::uint64_t shadow_value, pcl::uint64_t no_sample_value, Timestamp timestamp)
 : wrapper_(depth_metadata)
 , baseline_ (baseline)
 , focal_length_ (focal_length)
@@ -106,14 +106,14 @@ pcl::io::DepthImage::getFocalLength () const
 }
 
 
-uint64_t
+pcl::uint64_t
 pcl::io::DepthImage::getShadowValue () const
 {
   return (shadow_value_);
 }
 
 
-uint64_t
+pcl::uint64_t
 pcl::io::DepthImage::getNoSampleValue () const
 {
   return (no_sample_value_);
@@ -141,7 +141,7 @@ pcl::io::DepthImage::getFrameID () const
 }
 
 
-uint64_t
+pcl::uint64_t
 pcl::io::DepthImage::getTimestamp () const
 {
   return (wrapper_->getTimestamp ());

--- a/io/src/image_grabber.cpp
+++ b/io/src/image_grabber.cpp
@@ -119,7 +119,7 @@ struct pcl::ImageGrabberBase::ImageGrabberImpl
   //! Checks if a timestamp is given in the filename
   //! And returns if so
   bool
-  getTimestampFromFilepath (const std::string &filepath, uint64_t &timestamp) const;
+  getTimestampFromFilepath (const std::string &filepath, pcl::uint64_t &timestamp) const;
 
   size_t
   numFrames () const;
@@ -495,7 +495,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::rewindOnce ()
 bool
 pcl::ImageGrabberBase::ImageGrabberImpl::getTimestampFromFilepath (
     const std::string &filepath, 
-    uint64_t &timestamp) const
+    pcl::uint64_t &timestamp) const
 {
   // For now, we assume the file is of the form frame_[22-char POSIX timestamp]_*
   char timestamp_str[256];
@@ -504,7 +504,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getTimestampFromFilepath (
                             timestamp_str);
   if (result > 0)
   {
-    // Convert to uint64_t, microseconds since 1970-01-01
+    // Convert to pcl::uint64_t, microseconds since 1970-01-01
     boost::posix_time::ptime cur_date = boost::posix_time::from_iso_string (timestamp_str);
     boost::posix_time::ptime zero_date (
         boost::gregorian::date (1970,boost::gregorian::Jan,1));
@@ -625,7 +625,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudVTK (size_t idx,
       }
     }
     // Handle timestamps
-    uint64_t timestamp;
+    pcl::uint64_t timestamp;
     if (getTimestampFromFilepath (depth_image_file, timestamp))
     {
       cloud_color.header.stamp = timestamp;
@@ -657,7 +657,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudVTK (size_t idx,
       }
     }
     // Handle timestamps
-    uint64_t timestamp;
+    pcl::uint64_t timestamp;
     if (getTimestampFromFilepath (depth_image_file, timestamp))
     {
       cloud.header.stamp = timestamp;
@@ -748,7 +748,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudPCLZF (size_t idx,
       depth.readOMP (depth_pclzf_file, cloud_color, num_threads_);
     }
     // handle timestamps
-    uint64_t timestamp;
+    pcl::uint64_t timestamp;
     if (getTimestampFromFilepath (depth_pclzf_file, timestamp))
     {
       cloud_color.header.stamp = timestamp;
@@ -789,7 +789,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudPCLZF (size_t idx,
     else
       depth.readOMP (depth_pclzf_file, cloud, num_threads_);
     // handle timestamps
-    uint64_t timestamp;
+    pcl::uint64_t timestamp;
     if (getTimestampFromFilepath (depth_pclzf_file, timestamp))
     {
       cloud.header.stamp = timestamp;
@@ -1082,7 +1082,7 @@ pcl::ImageGrabberBase::getDepthFileNameAtIndex (size_t idx) const
 
 ////////////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::ImageGrabberBase::getTimestampAtIndex (size_t idx, uint64_t &timestamp) const
+pcl::ImageGrabberBase::getTimestampAtIndex (size_t idx, pcl::uint64_t &timestamp) const
 {
   std::string filename;
   if (impl_->pclzf_mode_)

--- a/io/src/image_ir.cpp
+++ b/io/src/image_ir.cpp
@@ -101,7 +101,7 @@ pcl::io::IRImage::getFrameID () const
 }
 
 
-uint64_t
+pcl::uint64_t
 pcl::io::IRImage::getTimestamp () const
 {
   return (wrapper_->getTimestamp ());

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -907,8 +907,8 @@ void pcl::io::OpenNI2Grabber::processDepthFrame (openni::VideoStream& stream)
   float focalLength = device_->getDepthFocalLength ();
 
   float baseline = device_->getBaseline();
-  uint64_t no_sample_value = device_->getShadowValue();
-  uint64_t shadow_value = no_sample_value;
+  pcl::uint64_t no_sample_value = device_->getShadowValue();
+  pcl::uint64_t shadow_value = no_sample_value;
   
   boost::shared_ptr<DepthImage> image  = 
    boost::make_shared<DepthImage> (frameWrapper, baseline, focalLength, shadow_value, no_sample_value);


### PR DESCRIPTION
On gcc 4.8.2 (fedora 20) without c++11 enabled the definition of
uint64_t is missing.  Switch to the pcl typdef for boost::uint64.
