### PR TITLE
Add new interface to getShapeActorMap

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1710,6 +1710,12 @@ namespace pcl
           return (cloud_actor_map_);
         }
         
+        /** \brief Return a pointer to the ShapeActorMap this visualizer uses. */
+        ShapeActorMapPtr
+        getShapeActorMap ()
+        {
+          return (shape_actor_map_);
+        }
 
         /** \brief Set the position in screen coordinates.
           * \param[in] x where to move the window to (X)


### PR DESCRIPTION
This PR basically adds a getter which complements existing `getCloudActorMap ()` method. I personally needed to work with added actors in the scene (grab them, change position). I tried to find any other existing way to do so, but couldn't. 

But all in all, I believe that `getShapeActorMap ()` would be an intuitive addition to `getCloudActorMap ()`.
