### PR TITLE
Small Fix: included directory for OpenCV specific pcl header

### DIFF
--- a/gpu/kinfu/CMakeLists.txt
+++ b/gpu/kinfu/CMakeLists.txt
@@ -31,6 +31,9 @@ if (build)
 
     set(LIB_NAME "pcl_${SUBSYS_NAME}")
     include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/src" ${CUDA_INCLUDE_DIRS})
+    if(OpenCV_FOUND)
+      include_directories("${CMAKE_SOURCE_DIR}/gpu/utils/include")
+    endif()
 
     if (UNIX OR APPLE)
         set (CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}  "-Xcompiler;-fPIC;")


### PR DESCRIPTION
I tested the kinfu app together with OpenCV and couldn't run it because of a directory failure in the following line (../gpu/kinfu/tools/kinfu_app.cpp): 
# include < pcl/gpu/utils/timers_opencv.hpp >

This line appears also in other files (e.g. ../gpu/kinfu/src/kinfu.cpp), so I tried a redundant inclusion of the directory path with CMake at the highest possible level.
