### PR TITLE
Improvements to OUR-CVFH Estimation, including mapping from clusters to features and doc fixes

### DIFF
--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -310,7 +310,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::sgurf (Eigen::Vector3f & c
 
   if ((min_axis / max_axis) > axis_ratio_)
   {
-    PCL_WARN("Both axis are equally easy/difficult to disambiguate\n");
+    PCL_WARN ("Both axes are equally easy/difficult to disambiguate\n");
 
     Eigen::Vector3f evy_copy = evy;
     Eigen::Vector3f evxminus = evx * -1;
@@ -376,6 +376,10 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeRFAndShapeDistribut
                                                                                      std::vector<pcl::PointIndices> & cluster_indices)
 {
   PointCloudOut ourcvfh_output;
+
+  cluster_axes_.clear ();
+  cluster_axes_.resize (centroids_dominant_orientations_.size ());
+  
   for (size_t i = 0; i < centroids_dominant_orientations_.size (); i++)
   {
 
@@ -383,6 +387,9 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeRFAndShapeDistribut
     PointInTPtr grid (new pcl::PointCloud<PointInT>);
     sgurf (centroids_dominant_orientations_[i], dominant_normals_[i], processed, transformations, grid, cluster_indices[i]);
 
+    // Make a note of how many transformations correspond to each cluster
+    cluster_axes_[i] = transformations.size ();
+    
     for (size_t t = 0; t < transformations.size (); t++)
     {
 
@@ -512,11 +519,15 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeRFAndShapeDistribut
       }
 
       ourcvfh_output.points.push_back (vfh_signature.points[0]);
-
+      ourcvfh_output.width = ourcvfh_output.points.size ();
       delete[] weights;
     }
   }
 
+  if (ourcvfh_output.points.size ())
+  {
+    ourcvfh_output.height = 1;
+  }
   output = ourcvfh_output;
 }
 

--- a/features/include/pcl/features/our_cvfh.h
+++ b/features/include/pcl/features/our_cvfh.h
@@ -92,7 +92,7 @@ namespace pcl
 
       /** \brief Creates an affine transformation from the RF axes
        * \param[in] evx the x-axis
-       * \param[in] evy the z-axis
+       * \param[in] evy the y-axis
        * \param[in] evz the z-axis
        * \param[out] transformPC the resulting transformation
        * \param[in] center_mat 4x4 matrix concatenated to the resulting transformation
@@ -262,6 +262,15 @@ namespace pcl
       {
         indices = clusters_;
       }
+    
+      /** \brief Gets the number of non-disambiguable axes that correspond to each centroid
+       * \param[out] cluster_axes vector mapping each centroid to the number of signatures
+       */
+      inline void
+      getClusterAxes (std::vector<short> & cluster_axes)
+      {
+        cluster_axes = cluster_axes_;
+      }
 
       /** \brief Sets the refinement factor for the clusters
        * \param[in] rc the factor used to decide if a point is used to estimate a stable cluster
@@ -391,6 +400,8 @@ namespace pcl
       std::vector<Eigen::Vector3f> dominant_normals_;
       /** \brief Indices to the points representing the stable clusters */
       std::vector<pcl::PointIndices> clusters_;
+      /** \brief Mapping from clusters to OUR-CVFH descriptors */
+      std::vector<short> cluster_axes_;
   };
 }
 


### PR DESCRIPTION
Fixes #737 by adding a `vector<short> cluster_axes_` to `OURCVFHEstimation`. This protected field consists of a count of the number of signatures that have been computed per cluster. It is set by `computeRFAndShapeDistribution` at the same time as `compute`'s output. When all axes are properly disambiguated, it will consist only of the value 1 (one entry per cluster). When some cluster i has multiple SGURF solutions, instead of 1, the vector will contain the number of SGURFs in location i.

Also fixes a typo in the documentation and another in the warning (plural of axis is axes, so "both axes" not "both axis").
