### PR TITLE
Corrected elapsed time console print in line 73

### DIFF
--- a/examples/keypoints/example_get_keypoints_indices.cpp
+++ b/examples/keypoints/example_get_keypoints_indices.cpp
@@ -70,7 +70,7 @@ main(int argc, char** argv)
   detector.setThreshold (1e-6);
   pcl::StopWatch watch;
   detector.compute (*keypoints);
-  pcl::console::print_highlight ("Detected %zd points in %dms\n", keypoints->size (), watch.getTimeSeconds ());
+  pcl::console::print_highlight ("Detected %zd points in %lfs\n", keypoints->size (), watch.getTimeSeconds ());
   pcl::PointIndicesConstPtr keypoints_indices = detector.getKeypointsIndices ();
   if (!keypoints_indices->indices.empty ())
   {


### PR DESCRIPTION
Corrected return value for watch.getTimeSeconds() from int to double. Also corrected message that said time was in milliseconds, when watch.getTimeSeconds() returns elapsed time in seconds.
