### PR TITLE
Fix #740: Segmentation fault when "r" is pressed

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -454,12 +454,11 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnChar ()
     case 'u': case 'U':
     case 'q': case 'Q':
     case 'x': case 'X':
+    case 'r': case 'R':
     {
       break;
     }
-    // R have a special !CTRL case
-    // S have special !ALT and !CTRL case
-    case 'r': case 'R':
+    // S have special !ALT case
     case 's': case 'S':
     {
       if (!keymod)


### PR DESCRIPTION
Segmentation fault when "r" is pressed in PCLVisualizer.
The previous pull request #703 does not handle the "r" keyboard event
correctly and pass the event to vtkInteractorStyleRubberBandPick,
which enables rubber-band selection mode when 'r' is pressed.
