### PR TITLE
Better message printing for pcd_viewer

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1602,10 +1602,28 @@ namespace pcl
         loadCameraParameters (const std::string &file);
 
         /** \brief Checks whether the camera parameters were manually loaded.
-          * \return True if valid "-cam" option is available in command line or a corresponding camera file is automatically loaded.
+          * \return True if valid "-cam" option is available in command line.
+          * \sa cameraFileLoaded ()
           */
         bool
         cameraParamsSet () const;
+
+        /** \brief Checks whether a camera file were automatically loaded.
+          * \return True if a valid camera file is automatically loaded.
+          * \note The camera file is saved by pressing "ctrl + s" during last run of the program
+          * and restored automatically when the program runs this time.
+          * \sa cameraParamsSet ()
+          */
+        bool
+        cameraFileLoaded () const;
+
+        /** \brief Get camera file for camera parameter saving/restoring.
+          * \note This will be valid only when valid "-cam" option were available in command line
+          * or a saved camera file were automatically loaded. 
+          * \sa cameraParamsSet (), cameraFileLoaded ()
+          */
+        std::string
+        getCameraFile () const;
 
         /** \brief Update camera parameters and render. */
         void
@@ -1866,8 +1884,11 @@ namespace pcl
         /** \brief Internal pointer to widget which contains a set of axes */
         vtkSmartPointer<vtkOrientationMarkerWidget> axes_widget_;
         
-        /** \brief Boolean that holds whether or not the camera parameters were manually initialized*/
+        /** \brief Boolean that holds whether or not the camera parameters were manually initialized */
         bool camera_set_;
+
+        /** \brief Boolean that holds whether or not a camera file were automatically loaded */
+        bool camera_file_loaded_;
 
         /** \brief Boolean that holds whether or not to use the vtkVertexBufferObjectMapper*/
         bool use_vbos_;

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -122,6 +122,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (const std::string &name, const
   , shape_actor_map_ (new ShapeActorMap)
   , coordinate_actor_map_ (new CoordinateActorMap)
   , camera_set_ ()
+  , camera_file_loaded_ (false)
 {
   // Create a Renderer
   vtkSmartPointer<vtkRenderer> ren = vtkSmartPointer<vtkRenderer>::New ();
@@ -187,6 +188,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, const 
   , shape_actor_map_ (new ShapeActorMap)
   , coordinate_actor_map_ ()
   , camera_set_ ()
+  , camera_file_loaded_ (false)
 {
   // Create a Renderer
   vtkSmartPointer<vtkRenderer> ren = vtkSmartPointer<vtkRenderer>::New ();
@@ -239,8 +241,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, const 
     {
       if (boost::filesystem::exists (camera_file) && style_->loadCameraParameters (camera_file))
       {
-        pcl::console::print_info ("\nRestore camera parameters from %s.\n", camera_file.c_str ());
-        camera_set_ = true;
+        camera_file_loaded_ = true;
       }
       else
       {
@@ -249,7 +250,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, const 
     }
   }
   // Set the window size as 1/2 of the screen size or the user given parameter
-  if (!camera_set_)
+  if (!camera_set_ && !camera_file_loaded_)
   {
     win_->SetSize (scr_size[0]/2, scr_size[1]/2);
     win_->SetPosition (0, 0);
@@ -1689,6 +1690,20 @@ bool
 pcl::visualization::PCLVisualizer::cameraParamsSet () const
 {
   return (camera_set_);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+bool
+pcl::visualization::PCLVisualizer::cameraFileLoaded () const
+{
+  return (camera_file_loaded_);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+std::string
+pcl::visualization::PCLVisualizer::getCameraFile () const
+{
+  return (style_->getCameraFile ());
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/tools/pcd_viewer.cpp
+++ b/visualization/tools/pcd_viewer.cpp
@@ -472,7 +472,7 @@ main (int argc, char** argv)
       // Set whether or not we should be using the vtkVertexBufferObjectMapper
       p->setUseVbos (use_vbos);
 
-      if (!p->cameraParamsSet ())
+      if (!p->cameraParamsSet () && !p->cameraFileLoaded ())
       {
         Eigen::Matrix3f rotation;
         rotation = orientation;
@@ -631,7 +631,7 @@ main (int argc, char** argv)
       p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name.str ());
 
     // Reset camera viewpoint to center of cloud if camera parameters were not passed manually and this is the first loaded cloud
-    if (i == 0 && !p->cameraParamsSet ())
+    if (i == 0 && !p->cameraParamsSet () && !p->cameraFileLoaded ())
     {
       p->resetCameraViewpoint (cloud_name.str ());
       p->resetCamera ();
@@ -639,6 +639,8 @@ main (int argc, char** argv)
 
     print_info ("[done, "); print_value ("%g", tt.toc ()); print_info (" ms : "); print_value ("%u", cloud->width * cloud->height); print_info (" points]\n");
     print_info ("Available dimensions: "); print_value ("%s\n", pcl::getFieldsList (*cloud).c_str ());
+    if (p->cameraFileLoaded ())
+      print_info ("Camera parameters restored from %s.\n", p->getCameraFile ().c_str ());
   }
 
   if (!mview && p)


### PR DESCRIPTION
Camera file restore message will print after the file is loaded.
