### PR TITLE
Update documentation generation script for Travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -88,7 +88,9 @@ function doc ()
   sudo pip install sphinx sphinxcontrib-doxylink
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
-  cmake $PCL_DIR
+  cmake -DDOXYGEN_USE_SHORT_NAMES=OFF \
+        -DSPHINX_HTML_FILE_SUFFIX=php \
+        $PCL_DIR
 
   git config --global user.email "documentation@pointclouds.org"
   git config --global user.name "PointCloudLibrary (via TravisCI)"
@@ -105,17 +107,19 @@ function doc ()
   cd $DOC_DIR
   git clone git@github.com:PointCloudLibrary/documentation.git .
 
-  # Generate documentation
+  # Generate documentation and tutorials
   cd $BUILD_DIR
   make doc
-  cd $DOC_DIR
-  git commit -a -m "adding $TRAVIS_COMMIT"
-  git push
-
-  # Generate tutorials
-  cd $BUILD_DIR
   make tutorials
-  # upload to github...
+
+  # Move generated tutorials to the doc directory
+  mv $TUTORIALS_DIR $DOC_DIR/tutorials
+  mv $ADVANCED_DIR $DOC_DIR/advanced
+
+  # Upload to GitHub
+  cd $DOC_DIR
+  git commit --all --amend -m "Documentation for commit $TRAVIS_COMMIT"
+  git push --force
 }
 
 case $TASK in


### PR DESCRIPTION
This pull request introduces several changes to the Travis script:
- Use newly added _CMake_ options
  - to produce tutorial files with `.php` extension
  - to force _Doxygen_ use long descriptive filenames
- Push generated tutorials and advanced articles to the 'documentation' repository
- Use `--amend` option to avoid excessive storage usage (as discussed in #584)

Before merging this pull request we need to wipe out the 'documentation' repository to get rid of thousands of megabytes generated in the past months. I'm not sure if there is a way to do this other than delete the GitHub repository completely and recreate it.
