### PR TITLE
Silence a warning about VERSION for CMake >= 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 ### ---[ PCL global CMake
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
+if(POLICY CMP0048)
+  cmake_policy(SET CMP0048 OLD) # do not use VERSION option in project() command
+endif()
+
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "possible configurations" FORCE)
 
 # In case the user does not setup CMAKE_BUILD_TYPE, assume it's RelWithDebInfo


### PR DESCRIPTION
When using CMake >=3 the following warning pop up:

```
  CMake Warning (dev) at CMakeLists.txt:11 (project):
     Policy CMP0048 is not set: project() command manages VERSION variables.
     Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
     command to set the policy and suppress this warning.

     The following variable(s) would be set to empty:

       PCL_VERSION
   This warning is for project developers.  Use -Wno-dev to suppress it.
```

This is due to the fact that CMake version 3.0 introduced the VERSION option to the project() command. In order to _not_ use this feature and not get annoying warnings, the [policy CMP0048](http://www.cmake.org/cmake/help/v3.0/policy/CMP0048.html#policy:CMP0048) has to be explicitly set to "OLD".
