### PR TITLE
reorganization of an OpenCV dependency

### DIFF
--- a/common/include/pcl/impl/timers_opencv.hpp
+++ b/common/include/pcl/impl/timers_opencv.hpp
@@ -42,20 +42,17 @@
 
 namespace pcl
 {
-    namespace gpu
-    {
-        struct ScopeTimerCV
-        {
-            const char* name;
-            cv::TickMeter tm;
-            ScopeTimerCV(const char *name_) : name(name_) { tm.start(); }
-            ~ScopeTimerCV() 
-            {
-                tm.stop();
-                std::cout << "Time(" << name << ") = " << tm.getTimeMilli() << "ms" << std::endl;        
-            }
-        };
-    }
+  struct ScopeTimerCV
+  {
+      const char* name;
+      cv::TickMeter tm;
+      ScopeTimerCV(const char *name_) : name(name_) { tm.start(); }
+      ~ScopeTimerCV() 
+      {
+          tm.stop();
+          std::cout << "Time(" << name << ") = " << tm.getTimeMilli() << "ms" << std::endl;        
+      }
+  };
 }
 
 #endif /* PCL_GPU_SCOPE_TIMER_CV_H */

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -51,7 +51,7 @@
 #ifdef HAVE_OPENCV
   #include <opencv2/opencv.hpp>
   #include <opencv2/gpu/gpu.hpp>
-  #include <pcl/gpu/utils/timers_opencv.hpp>
+  #include <pcl/impl/timers_opencv.hpp>
 #endif
 
 using namespace std;

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -76,9 +76,9 @@
 #ifdef HAVE_OPENCV  
   #include <opencv2/highgui/highgui.hpp>
   #include <opencv2/imgproc/imgproc.hpp>
-  #include <pcl/gpu/utils/timers_opencv.hpp>
+  #include <pcl/impl/timers_opencv.hpp>
 //#include "video_recorder.h"
-typedef pcl::gpu::ScopeTimerCV ScopeTimeT;
+typedef pcl::ScopeTimerCV ScopeTimeT;
 #else
   typedef pcl::ScopeTime ScopeTimeT;
 #endif

--- a/gpu/kinfu/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu/tools/kinfu_app_sim.cpp
@@ -91,9 +91,9 @@
 #ifdef HAVE_OPENCV  
   #include <opencv2/highgui/highgui.hpp>
   #include <opencv2/imgproc/imgproc.hpp>
-  #include <pcl/gpu/utils/timers_opencv.hpp>
+  #include <pcl/impl/timers_opencv.hpp>
 //#include "video_recorder.h"
-typedef pcl::gpu::ScopeTimerCV ScopeTimeT;
+typedef pcl::ScopeTimerCV ScopeTimeT;
 #else
   typedef pcl::ScopeTime ScopeTimeT;
 #endif

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -52,7 +52,7 @@
 #ifdef HAVE_OPENCV
   #include <opencv2/opencv.hpp>
   //~ #include <opencv2/gpu/gpu.hpp>
-  //~ #include <pcl/gpu/utils/timers_opencv.hpp>
+  //~ #include <pcl/impl/timers_opencv.hpp>
 #endif
 
 using namespace std;

--- a/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
@@ -91,9 +91,9 @@
 #ifdef HAVE_OPENCV  
   #include <opencv2/highgui/highgui.hpp>
   #include <opencv2/imgproc/imgproc.hpp>
-  #include <pcl/gpu/utils/timers_opencv.hpp>
+  #include <pcl/impl/timers_opencv.hpp>
 //#include "video_recorder.h"
-typedef pcl::gpu::ScopeTimerCV ScopeTimeT;
+typedef pcl::ScopeTimerCV ScopeTimeT;
 #else
   typedef pcl::ScopeTime ScopeTimeT;
 #endif


### PR DESCRIPTION
Hi Jochen,
as we discussed a few days before (closed pull request #733), I looked for a better place for leaving 'timers_opencv.hpp'. I suggest to put the file to the includes for the 'common' module where other timers are declared already. Since the include path of the common module is used almost everywhere there is no need to change any 'CMakeLists' files. What do you think?
