### PR TITLE
Fix #667: Imrpove PCL visualizer help

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -762,6 +762,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
                   "          g, G   : display scale grid (on/off)\n"
                   "          u, U   : display lookup table (on/off)\n"
                   "\n"
+                  "    o, O         : switch between perspective/parallel projection (default = perspective)\n"
                   "    r, R [+ ALT] : reset camera [to viewpoint = {0, 0, 0} -> center_{x, y, z}]\n"
                   "    CTRL + s, S  : save camera parameters\n"
                   "    CTRL + r, R  : restore camera parameters\n"


### PR DESCRIPTION
The key "o" was not displayed in PCL visualizer help
