### PR TITLE
Prevent undefined behaviour when drawing axis

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -575,6 +575,8 @@ pcl::visualization::PCLVisualizer::removeCoordinateSystem (int viewport)
 void
 pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, const std::string &id, int viewport)
 {
+  if (scale <= 0.0)
+    scale = 1.0;
   vtkSmartPointer<vtkAxes> axes = vtkSmartPointer<vtkAxes>::New ();
   axes->SetOrigin (0, 0, 0);
   axes->SetScaleFactor (scale);
@@ -622,6 +624,8 @@ pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, const std:
 void
 pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, float x, float y, float z, const std::string& id, int viewport)
 {
+  if (scale <= 0.0)
+    scale = 1.0;
   vtkSmartPointer<vtkAxes> axes = vtkSmartPointer<vtkAxes>::New ();
   axes->SetOrigin (0, 0, 0);
   axes->SetScaleFactor (scale);
@@ -700,6 +704,8 @@ double q[4];
 void
 pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, const Eigen::Affine3f& t, const std::string& id, int viewport)
 {
+  if (scale <= 0.0)
+    scale = 1.0;
   vtkSmartPointer<vtkAxes> axes = vtkSmartPointer<vtkAxes>::New ();
   axes->SetOrigin (0, 0, 0);
   axes->SetScaleFactor (scale);


### PR DESCRIPTION
Drawing XYZ axis with a negative size makes no sense
Worse, drawing axis with a 0 size may cause errors :

```
Warning: In /build/buildd/vtk-5.8.0/Graphics/vtkTubeFilter.cxx, line 362
vtkTubeFilter (0x1fbaae0): Coincident points!

Warning: In /build/buildd/vtk-5.8.0/Graphics/vtkTubeFilter.cxx, line 236
vtkTubeFilter (0x1fbaae0): Could not generate points!

Warning: In /build/buildd/vtk-5.8.0/Graphics/vtkTubeFilter.cxx, line 362
vtkTubeFilter (0x1fbaae0): Coincident points!

Warning: In /build/buildd/vtk-5.8.0/Graphics/vtkTubeFilter.cxx, line 236
vtkTubeFilter (0x1fbaae0): Could not generate points!

Warning: In /build/buildd/vtk-5.8.0/Graphics/vtkTubeFilter.cxx, line 362
vtkTubeFilter (0x1fbaae0): Coincident points!

Warning: In /build/buildd/vtk-5.8.0/Graphics/vtkTubeFilter.cxx, line 236
vtkTubeFilter (0x1fbaae0): Could not generate points!
```

I solved the problem by transforming bad values into the default value (size = 1.0) without throwing any error/warning
