### PR TITLE
Use Qt4 by default instead of Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,16 +335,16 @@ endif(WITH_CUDA)
 
 option(WITH_QT "Build QT Front-End" TRUE)
 if(WITH_QT)
-  # Find Qt5
-  include(cmake/pcl_find_qt5.cmake)
+  # Find Qt4
+  find_package(Qt4)
+  if (QT4_FOUND)
+    include("${QT_USE_FILE}")
+  endif (QT4_FOUND)
 
-  # Find QT4
-  if(NOT QT5_FOUND)
-      find_package(Qt4)
-      if (QT4_FOUND)
-        include("${QT_USE_FILE}")
-      endif (QT4_FOUND)
-  endif(NOT QT5_FOUND)
+  # Find QT5
+  if(NOT QT4_FOUND)
+      include(cmake/pcl_find_qt5.cmake)
+  endif(NOT QT4_FOUND)
 endif(WITH_QT)
 
 # Find VTK


### PR DESCRIPTION
Earlier version of VTK does not support Qt5 and PCL will not compile
correctly when Qt5 is used by default.
From VTK wiki (http://www.vtk.org/Wiki/VTK/Configure_and_Build):

```
Building VTK with Qt is a common use case for the creation of nice
user interfaces. Using Qt 4.8.* is recommended, but earlier versions
and Qt 5.* are in various stages of support.
...
Qt5.*
Warning: This has only been tested on Qt5.2.1, and only on a few systems.
```
