### PR TITLE
Solving a linker error with median_filter.cpp

### DIFF
--- a/filters/src/median_filter.cpp
+++ b/filters/src/median_filter.cpp
@@ -43,7 +43,7 @@
 #include <pcl/point_types.h>
 #include <pcl/impl/instantiate.hpp>
 
-PCL_INSTANTIATE (MedianFilter, (pcl::PointXYZ)(pcl::PointXYZRGB)(pcl::PointXYZRGBA)(pcl::PointXYZRGBNormal))
+PCL_INSTANTIATE (MedianFilter, PCL_XYZ_POINT_TYPES)
 
 #endif    // PCL_NO_PRECOMPILE
 


### PR DESCRIPTION
Solving a linker error with point type XYZI which is not pre-compiled for this filter. The solution that worked was to include the #include <pcl/filters/impl/median_filter.hpp> A better solution is to change the source file to instantiate common point types.
