### PR TITLE
Made visualization, io and outofcore tools optional

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -345,6 +345,8 @@ if(build)
     PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/openni2" ${OPENNI2_INCLUDES})
     PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/impl" ${impl_incs})
 
-    add_subdirectory(tools)
+    if(BUILD_tools)
+        add_subdirectory(tools)
+    endif(BUILD_tools)
 
 endif(build)

--- a/outofcore/CMakeLists.txt
+++ b/outofcore/CMakeLists.txt
@@ -67,6 +67,8 @@ if(build)
     PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/impl" ${impl_incs})
     PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/visualization" ${visualization_incs})
 
-    add_subdirectory(tools)
+    if(BUILD_tools)
+        add_subdirectory(tools)
+    endif(BUILD_tools)
     
 endif(build)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,10 +4,10 @@ set (SUBSYS_DEPS common io filters sample_consensus segmentation search kdtree f
 set (DEFAULT ON)
 set (REASON "")
 
-PCL_SUBSYS_OPTION (build "${SUBSYS_NAME}" "${SUBSYS_DESC}" ${DEFAULT} "${REASON}")
-PCL_SUBSYS_DEPEND (build "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS})
+PCL_SUBSYS_OPTION (BUILD_tools "${SUBSYS_NAME}" "${SUBSYS_DESC}" ${DEFAULT} "${REASON}")
+PCL_SUBSYS_DEPEND (BUILD_tools "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS})
 
-if (build)
+if (BUILD_tools)
 
   PCL_ADD_EXECUTABLE(pcl_sac_segmentation_plane "${SUBSYS_NAME}" sac_segmentation_plane.cpp)
   target_link_libraries(pcl_sac_segmentation_plane pcl_common pcl_io pcl_sample_consensus pcl_segmentation)
@@ -207,8 +207,8 @@ if (build)
       target_link_libraries(pcl_vtk2pcd pcl_common pcl_io)
 
       if(BUILD_visualization)
-  
-        PCL_SUBSYS_DEPEND(build "${SUBSYS_NAME}" DEPS visualization)
+
+        PCL_SUBSYS_DEPEND(BUILD_tools "${SUBSYS_NAME}" DEPS visualization)
 
         PCL_ADD_EXECUTABLE(pcl_obj_rec_ransac_model_opps "${SUBSYS_NAME}" obj_rec_ransac_model_opps.cpp)
         target_link_libraries(pcl_obj_rec_ransac_model_opps pcl_common pcl_visualization pcl_recognition)
@@ -272,4 +272,4 @@ if (build)
   endif(Tide_FOUND)
   
 
-endif ()
+endif (BUILD_tools)

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -172,7 +172,9 @@ if(build)
     if(BUILD_TESTS)
         add_subdirectory(test)
     endif(BUILD_TESTS)
-
-    add_subdirectory(tools)
+    
+    if(BUILD_tools)
+        add_subdirectory(tools)
+    endif(BUILD_tools)
 
 endif(build)


### PR DESCRIPTION
Added so visualization, io and outofcore tools can be deselected/selected for building.

This is to minimize required projects for just compiling core libraries.

Not sure if there should be created a guideline for tools? as there is the common tool folder and apparently subfolders in ie. visualization, io and outofcore - mayby they should be moved instead?

note: converted a few tabs to 4 spaces.
