### PR TITLE
Copy generated tutorials to Git repository folder (instead of moving)

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -113,9 +113,9 @@ function doc ()
 
   # Upload to GitHub if generation succeeded
   if [[ $? == 0 ]]; then
-    # Move generated tutorials to the doc directory
-    mv $TUTORIALS_DIR $DOC_DIR/tutorials
-    mv $ADVANCED_DIR $DOC_DIR/advanced
+    # Copy generated tutorials to the doc directory
+    cp -r $TUTORIALS_DIR/* $DOC_DIR/tutorials
+    cp -r $ADVANCED_DIR/* $DOC_DIR/advanced
     # Commit and push
     cd $DOC_DIR
     git add --all


### PR DESCRIPTION
With `mv` the following error occurs:

``` bash
mv: cannot move `/home/travis/build/PointCloudLibrary/pcl/build/doc/tutorials/html' to `/home/travis/build/PointCloudLibrary/pcl/build/doc/doxygen/html/tutorials/html': Directory not empty
```
