### PR TITLE
Set compute3Dcentroid last component to 1

### DIFF
--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -58,6 +58,7 @@ namespace pcl
     * \param[out] centroid the output centroid
     * \return number of valid point used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
     * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last compononent of the vector is set to 1, this allow to transform the centroid vector with 4x4 matrices.
     * \ingroup common
     */
   template <typename PointT, typename Scalar> inline unsigned int
@@ -83,6 +84,7 @@ namespace pcl
     * \param[out] centroid the output centroid
     * \return number of valid point used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
     * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last compononent of the vector is set to 1, this allow to transform the centroid vector with 4x4 matrices.
     * \ingroup common
     */
   template <typename PointT, typename Scalar> inline unsigned int
@@ -110,6 +112,7 @@ namespace pcl
     * \param[out] centroid the output centroid
     * \return number of valid point used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
     * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last compononent of the vector is set to 1, this allow to transform the centroid vector with 4x4 matrices.
     * \ingroup common
     */
   template <typename PointT, typename Scalar> inline unsigned int
@@ -140,6 +143,7 @@ namespace pcl
     * \param[out] centroid the output centroid
     * \return number of valid point used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
     * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last compononent of the vector is set to 1, this allow to transform the centroid vector with 4x4 matrices.
     * \ingroup common
     */
   template <typename PointT, typename Scalar> inline unsigned int

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -70,8 +70,8 @@ pcl::compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
     ++cp;
     ++cloud_iterator;
   }
-  centroid[3] = 0;
   centroid /= static_cast<Scalar> (cp);
+  centroid[3] = 1;
   return (cp);
 }
 
@@ -95,8 +95,8 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
       centroid[1] += cloud[i].y;
       centroid[2] += cloud[i].z;
     }
-    centroid[3] = 0;
     centroid /= static_cast<Scalar> (cloud.size ());
+    centroid[3] = 1;
 
     return (static_cast<unsigned int> (cloud.size ()));
   }
@@ -115,8 +115,8 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
       centroid[2] += cloud[i].z;
       ++cp;
     }
-    centroid[3] = 0;
     centroid /= static_cast<Scalar> (cp);
+    centroid[3] = 1;
 
     return (cp);
   }
@@ -142,8 +142,8 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
       centroid[1] += cloud[indices[i]].y;
       centroid[2] += cloud[indices[i]].z;
     }
-    centroid[3] = 0;
     centroid /= static_cast<Scalar> (indices.size ());
+    centroid[3] = 1;
     return (static_cast<unsigned int> (indices.size ()));
   }
   // NaN or Inf values could exist => check for them
@@ -161,8 +161,8 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
       centroid[2] += cloud[indices[i]].z;
       ++cp;
     }
-    centroid[3] = 0;
     centroid /= static_cast<Scalar> (cp);
+    centroid[3] = 1;
     return (cp);
   }
 }
@@ -536,7 +536,7 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     //centroid.head<3> () = accu.tail<3> ();    -- does not compile with Clang 3.0
     centroid[0] = accu[6]; centroid[1] = accu[7]; centroid[2] = accu[8];
-    centroid[3] = 0;
+    centroid[3] = 1;
     covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
     covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
     covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];
@@ -603,7 +603,7 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   //centroid.head<3> () = vec;//= accu.tail<3> ();
   //centroid.head<3> () = accu.tail<3> ();    -- does not compile with Clang 3.0
   centroid[0] = accu[6]; centroid[1] = accu[7]; centroid[2] = accu[8];
-  centroid[3] = 0;
+  centroid[3] = 1;
   covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
   covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
   covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];

--- a/test/common/test_centroid.cpp
+++ b/test/common/test_centroid.cpp
@@ -101,6 +101,7 @@ TEST (PCL, compute3DCentroidFloat)
   EXPECT_EQ (centroid [0], 0);
   EXPECT_EQ (centroid [1], 0);
   EXPECT_EQ (centroid [2], 0);
+  EXPECT_EQ (centroid [3], 1);
 
   centroid [0] = -100;
   centroid [1] = -200;
@@ -115,6 +116,7 @@ TEST (PCL, compute3DCentroidFloat)
   EXPECT_EQ (centroid [0], 0.0);
   EXPECT_EQ (centroid [1], 1.0);
   EXPECT_EQ (centroid [2], 0.0);
+  EXPECT_EQ (centroid [3], 1.0);
 
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
@@ -128,6 +130,7 @@ TEST (PCL, compute3DCentroidFloat)
   EXPECT_EQ (centroid [0], 0);
   EXPECT_EQ (centroid [1], 0);
   EXPECT_EQ (centroid [2], 0);
+  EXPECT_EQ (centroid [3], 1);
 
   centroid [0] = -100;
   centroid [1] = -200;
@@ -142,6 +145,7 @@ TEST (PCL, compute3DCentroidFloat)
   EXPECT_EQ (centroid [0], 0.0);
   EXPECT_EQ (centroid [1], 1.0);
   EXPECT_EQ (centroid [2], 0.0);
+  EXPECT_EQ (centroid [3], 1.0);
 
   pindices.indices = indices;
   EXPECT_EQ (compute3DCentroid (cloud, indices, centroid), 4);
@@ -149,6 +153,7 @@ TEST (PCL, compute3DCentroidFloat)
   EXPECT_EQ (centroid [0], 0.0);
   EXPECT_EQ (centroid [1], 1.0);
   EXPECT_EQ (centroid [2], 0.0);
+  EXPECT_EQ (centroid [3], 1.0);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -202,6 +207,7 @@ TEST (PCL, compute3DCentroidDouble)
   EXPECT_EQ (centroid [0], 0);
   EXPECT_EQ (centroid [1], 0);
   EXPECT_EQ (centroid [2], 0);
+  EXPECT_EQ (centroid [3], 1);
 
   centroid [0] = -100;
   centroid [1] = -200;
@@ -229,6 +235,7 @@ TEST (PCL, compute3DCentroidDouble)
   EXPECT_EQ (centroid [0], 0);
   EXPECT_EQ (centroid [1], 0);
   EXPECT_EQ (centroid [2], 0);
+  EXPECT_EQ (centroid [3], 1);
 
   centroid [0] = -100;
   centroid [1] = -200;
@@ -243,6 +250,7 @@ TEST (PCL, compute3DCentroidDouble)
   EXPECT_EQ (centroid [0], 0.0);
   EXPECT_EQ (centroid [1], 1.0);
   EXPECT_EQ (centroid [2], 0.0);
+  EXPECT_EQ (centroid [3], 1.0);
   
   pindices.indices = indices;
   EXPECT_EQ (compute3DCentroid (cloud, indices, centroid), 4);
@@ -250,6 +258,7 @@ TEST (PCL, compute3DCentroidDouble)
   EXPECT_EQ (centroid [0], 0.0);
   EXPECT_EQ (centroid [1], 1.0);
   EXPECT_EQ (centroid [2], 0.0);
+  EXPECT_EQ (centroid [3], 1.0);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -286,6 +295,7 @@ TEST (PCL, compute3DCentroidCloudIterator)
   EXPECT_EQ (centroid_f[0], 0.0f);
   EXPECT_EQ (centroid_f[1], 1.0f);
   EXPECT_EQ (centroid_f[2], 0.0f);
+  EXPECT_EQ (centroid_f[3], 1.0f);
   
   Eigen::Vector4d centroid_d;
   it.reset ();
@@ -294,6 +304,7 @@ TEST (PCL, compute3DCentroidCloudIterator)
   EXPECT_EQ (centroid_d[0], 0.0);
   EXPECT_EQ (centroid_d[1], 1.0);
   EXPECT_EQ (centroid_d[2], 0.0);
+  EXPECT_EQ (centroid_d[3], 1.0);
 }
 
 

--- a/test/features/test_base_feature.cpp
+++ b/test/features/test_base_feature.cpp
@@ -62,14 +62,14 @@ TEST (PCL, BaseFeature)
   EXPECT_NEAR (centroid3[0], -0.0290809, 1e-4);
   EXPECT_NEAR (centroid3[1], 0.102653, 1e-4);
   EXPECT_NEAR (centroid3[2], 0.027302, 1e-4);
-  EXPECT_NEAR (centroid3[3], 0, 1e-4);
+  EXPECT_NEAR (centroid3[3], 1, 1e-4);
 
   // compute3Dcentroid
   compute3DCentroid (cloud, centroid3);
   EXPECT_NEAR (centroid3[0], -0.0290809, 1e-4);
   EXPECT_NEAR (centroid3[1], 0.102653, 1e-4);
   EXPECT_NEAR (centroid3[2], 0.027302, 1e-4);
-  EXPECT_NEAR (centroid3[3], 0, 1e-4);
+  EXPECT_NEAR (centroid3[3], 1, 1e-4);
 
   // computeNDCentroid (indices)
   Eigen::VectorXf centroidn;

--- a/test/test_transforms.cpp
+++ b/test/test_transforms.cpp
@@ -79,7 +79,7 @@ TEST (PCL, DeMean)
   EXPECT_NEAR (centroid[0], -0.0290809, 1e-4);
   EXPECT_NEAR (centroid[1],  0.102653,  1e-4);
   EXPECT_NEAR (centroid[2],  0.027302,  1e-4);
-  EXPECT_NEAR (centroid[3],  0,         1e-4);
+  EXPECT_NEAR (centroid[3],  1,         1e-4);
 
   // Check standard demean
   demeanPointCloud (cloud, centroid, cloud_demean);


### PR DESCRIPTION
When computing a centroid in an `Eigen::Vector4f` the last component should be 1 because the centroid is a point; not a direction.

For the moment the last component of the computed centroid is 0.
This means that if a 4x4 matrix is used to transform the centroid, only the rotation will be taken in account. (not the translation)
This is the behavior when transforming a direction; the centroid is not a direction.
