### PR TITLE
Fixes #791 (bad access in the quadrants vector)

### DIFF
--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -496,7 +496,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeRFAndShapeDistribut
             weights[ii] *= 0.5f - wz * 0.5f;
         }
 
-        int h_index = static_cast<int> (std::floor (size_hists * (d / distance_normalization_factor)));
+        int h_index = std::ceil (size_hists * (d / distance_normalization_factor)) - 1;
         for (int j = 0; j < num_hists; j++)
           quadrants[j][h_index] += hist_incr * weights[j];
 


### PR DESCRIPTION
As per the description in #791, `d == distance_normalization` in some cases, which produces a bad access in the octants/quadrants vector.

By using the floor function (minus one), we guarantee that the result will fall between 0 and 12 inclusive, but never reach 13. The subtraction by an integer makes the `static_cast` unnecessary.
