### PR TITLE
VS2013 fix

### DIFF
--- a/gpu/octree/src/cuda/octree_host.cu
+++ b/gpu/octree/src/cuda/octree_host.cu
@@ -40,6 +40,7 @@
 #include "internal.hpp"
 #include "utils/boxutils.hpp"
 
+#include<algorithm>
 #include<limits>
 
 using namespace pcl::gpu;


### PR DESCRIPTION
std::min need one more include since VS 2013 (see http://msdn.microsoft.com/en-us/library/bb531344.aspx)
