### PR TITLE
Avoid the use of undefined typedefs

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -145,6 +145,22 @@
 namespace pcl
 {
 
+  typedef Eigen::Map<Eigen::Array3f> Array3fMap;
+  typedef const Eigen::Map<const Eigen::Array3f> Array3fMapConst;
+  typedef Eigen::Map<Eigen::Array4f, Eigen::Aligned> Array4fMap;
+  typedef const Eigen::Map<const Eigen::Array4f, Eigen::Aligned> Array4fMapConst;
+  typedef Eigen::Map<Eigen::Vector3f> Vector3fMap;
+  typedef const Eigen::Map<const Eigen::Vector3f> Vector3fMapConst;
+  typedef Eigen::Map<Eigen::Vector4f, Eigen::Aligned> Vector4fMap;
+  typedef const Eigen::Map<const Eigen::Vector4f, Eigen::Aligned> Vector4fMapConst;
+
+  typedef Eigen::Matrix<uint8_t, 3, 1> Vector3c;
+  typedef Eigen::Map<Vector3c> Vector3cMap;
+  typedef const Eigen::Map<const Vector3c> Vector3cMapConst;
+  typedef Eigen::Matrix<uint8_t, 4, 1> Vector4c;
+  typedef Eigen::Map<Vector4c, Eigen::Aligned> Vector4cMap;
+  typedef const Eigen::Map<const Vector4c, Eigen::Aligned> Vector4cMapConst;
+
 #define PCL_ADD_UNION_POINT4D \
   union EIGEN_ALIGN16 { \
     float data[4]; \
@@ -156,14 +172,14 @@ namespace pcl
   };
 
 #define PCL_ADD_EIGEN_MAPS_POINT4D \
-  inline Eigen::Map<Eigen::Vector3f> getVector3fMap () { return (Eigen::Vector3f::Map (data)); } \
-  inline const Eigen::Map<const Eigen::Vector3f> getVector3fMap () const { return (Eigen::Vector3f::Map (data)); } \
-  inline Eigen::Map<Eigen::Vector4f, Eigen::Aligned> getVector4fMap () { return (Eigen::Vector4f::MapAligned (data)); } \
-  inline const Eigen::Map<const Eigen::Vector4f, Eigen::Aligned> getVector4fMap () const { return (Eigen::Vector4f::MapAligned (data)); } \
-  inline Eigen::Map<Eigen::Array3f> getArray3fMap () { return (Eigen::Array3f::Map (data)); } \
-  inline const Eigen::Map<const Eigen::Array3f> getArray3fMap () const { return (Eigen::Array3f::Map (data)); } \
-  inline Eigen::Map<Eigen::Array4f, Eigen::Aligned> getArray4fMap () { return (Eigen::Array4f::MapAligned (data)); } \
-  inline const Eigen::Map<const Eigen::Array4f, Eigen::Aligned> getArray4fMap () const { return (Eigen::Array4f::MapAligned (data)); }
+  inline pcl::Vector3fMap getVector3fMap () { return (pcl::Vector3fMap (data)); } \
+  inline pcl::Vector3fMapConst getVector3fMap () const { return (pcl::Vector3fMapConst (data)); } \
+  inline pcl::Vector4fMap getVector4fMap () { return (pcl::Vector4fMap (data)); } \
+  inline pcl::Vector4fMapConst getVector4fMap () const { return (pcl::Vector4fMapConst (data)); } \
+  inline pcl::Array3fMap getArray3fMap () { return (pcl::Array3fMap (data)); } \
+  inline pcl::Array3fMapConst getArray3fMap () const { return (pcl::Array3fMapConst (data)); } \
+  inline pcl::Array4fMap getArray4fMap () { return (pcl::Array4fMap (data)); } \
+  inline pcl::Array4fMapConst getArray4fMap () const { return (pcl::Array4fMapConst (data)); }
 
 #define PCL_ADD_POINT4D \
   PCL_ADD_UNION_POINT4D \
@@ -181,10 +197,10 @@ namespace pcl
   };
 
 #define PCL_ADD_EIGEN_MAPS_NORMAL4D \
-  inline Eigen::Map<Eigen::Vector3f> getNormalVector3fMap () { return (Eigen::Vector3f::Map (data_n)); } \
-  inline const Eigen::Map<const Eigen::Vector3f> getNormalVector3fMap () const { return (Eigen::Vector3f::Map (data_n)); } \
-  inline Eigen::Map<Eigen::Vector4f, Eigen::Aligned> getNormalVector4fMap () { return (Eigen::Vector4f::MapAligned (data_n)); } \
-  inline const Eigen::Map<const Eigen::Vector4f, Eigen::Aligned> getNormalVector4fMap () const { return (Eigen::Vector4f::MapAligned (data_n)); }
+  inline pcl::Vector3fMap getNormalVector3fMap () { return (pcl::Vector3fMap (data_n)); } \
+  inline pcl::Vector3fMapConst getNormalVector3fMap () const { return (pcl::Vector3fMapConst (data_n)); } \
+  inline pcl::Vector4fMap getNormalVector4fMap () { return (pcl::Vector4fMap (data_n)); } \
+  inline pcl::Vector4fMapConst getNormalVector4fMap () const { return (pcl::Vector4fMapConst (data_n)); }
 
 #define PCL_ADD_NORMAL4D \
   PCL_ADD_UNION_NORMAL4D \
@@ -214,10 +230,10 @@ namespace pcl
   inline const Eigen::Vector4i getRGBVector4i () const { return (Eigen::Vector4i (r, g, b, a)); } \
   inline Eigen::Vector4i getRGBAVector4i () { return (Eigen::Vector4i (r, g, b, a)); } \
   inline const Eigen::Vector4i getRGBAVector4i () const { return (Eigen::Vector4i (r, g, b, a)); } \
-  inline Vector3cMap getBGRVector3cMap () { return (Vector3cMap (reinterpret_cast<uint8_t*> (&rgba))); } \
-  inline Vector3cMapConst getBGRVector3cMap () const { return (Vector3cMapConst (reinterpret_cast<const uint8_t*> (&rgba))); } \
-  inline Vector4cMap getBGRAVector4cMap () { return (Vector4cMap (reinterpret_cast<uint8_t*> (&rgba))); } \
-  inline Vector4cMapConst getBGRAVector4cMap () const { return (Vector4cMapConst (reinterpret_cast<const uint8_t*> (&rgba))); }
+  inline pcl::Vector3cMap getBGRVector3cMap () { return (pcl::Vector3cMap (reinterpret_cast<uint8_t*> (&rgba))); } \
+  inline pcl::Vector3cMapConst getBGRVector3cMap () const { return (pcl::Vector3cMapConst (reinterpret_cast<const uint8_t*> (&rgba))); } \
+  inline pcl::Vector4cMap getBGRAVector4cMap () { return (pcl::Vector4cMap (reinterpret_cast<uint8_t*> (&rgba))); } \
+  inline pcl::Vector4cMapConst getBGRAVector4cMap () const { return (pcl::Vector4cMapConst (reinterpret_cast<const uint8_t*> (&rgba))); }
 
 #define PCL_ADD_RGB \
   PCL_ADD_UNION_RGB \
@@ -240,22 +256,6 @@ namespace pcl
     { \
         uint32_t intensity; \
     }; \
-
-  typedef Eigen::Map<Eigen::Array3f> Array3fMap;
-  typedef const Eigen::Map<const Eigen::Array3f> Array3fMapConst;
-  typedef Eigen::Map<Eigen::Array4f, Eigen::Aligned> Array4fMap;
-  typedef const Eigen::Map<const Eigen::Array4f, Eigen::Aligned> Array4fMapConst;
-  typedef Eigen::Map<Eigen::Vector3f> Vector3fMap;
-  typedef const Eigen::Map<const Eigen::Vector3f> Vector3fMapConst;
-  typedef Eigen::Map<Eigen::Vector4f, Eigen::Aligned> Vector4fMap;
-  typedef const Eigen::Map<const Eigen::Vector4f, Eigen::Aligned> Vector4fMapConst;
-
-  typedef Eigen::Matrix<uint8_t, 3, 1> Vector3c;
-  typedef Eigen::Map<Vector3c> Vector3cMap;
-  typedef const Eigen::Map<const Vector3c> Vector3cMapConst;
-  typedef Eigen::Matrix<uint8_t, 4, 1> Vector4c;
-  typedef Eigen::Map<Vector4c, Eigen::Aligned> Vector4cMap;
-  typedef const Eigen::Map<const Vector4c, Eigen::Aligned> Vector4cMapConst;
 
 
   struct _PointXYZ


### PR DESCRIPTION
When using the macro **PCL_ADD_RGB** outside of **pcl::**, I get a compiler error because that macro uses typedefs (**Vector3c, Vector3cMap, Vector3cMapConst, Vector4c, Vector4cMap** and **Vector4cMapConst**) which are so far undefined. All this occurs inside **point_types.hpp**. A possible solution is to just move the typedefs above the definition of **PCL_ADD_RGB**, but this still doesn't allow users to use the macro outside of **pcl::**.

For instance, creating a new external project (http://pointclouds.org/documentation/tutorials/using_pcl_pcl_config.php) with an executable with the following code would produce an error.

``` c++
#include <pcl/point_types.h>

struct MyRGBType
{
  PCL_ADD_RGB;
};

int main (int argc, char** argv)
{
  return (0);
}
```

This PR only changes the **PCL_ADD_EIGEN_MAPS_RGB** to not use the typedefs. Then the above works.
