### PR TITLE
Error when compiling for VTK 6

### DIFF
--- a/tools/obj2pcd.cpp
+++ b/tools/obj2pcd.cpp
@@ -109,7 +109,7 @@ main (int argc, char** argv)
   if (copy_normals)
   {
     vtkSmartPointer<vtkPolyDataNormals> ng = vtkSmartPointer<vtkPolyDataNormals>::New ();
-#if OBJ_MAJOR_VERSION < 6
+#if VTK_MAJOR_VERSION < 6
     ng->SetInput (polydata);
 #else
     ng->SetInputData (polydata);


### PR DESCRIPTION
```
/tmp/pcl-GU4R/tools/obj2pcd.cpp:113:9: error: no member named 'SetInput' in 'vtkPolyDataNormals'; did you mean 'GetInput'?
    ng->SetInput (polydata);
        ^~~~~~~~
        GetInput
/tmp/pcl-GU4R/tools/obj2pcd.cpp:113:9: error: no matching member function for call to 'GetInput'
    ng->SetInput (polydata);
    ~~~~^~~~~~~~
/usr/local/include/vtk-6.1/vtkPolyDataAlgorithm.h:60:18: note: candidate function not viable: no known conversion from 'vtkSmartPointer<vtkPolyData>' to 'int' for 1st argument
  vtkDataObject *GetInput(int port);
                 ^
/usr/local/include/vtk-6.1/vtkPolyDataAlgorithm.h:59:18: note: candidate function not viable: requires 0 arguments, but 1 was provided
  vtkDataObject* GetInput();
                 ^
Linking CXX executable ../bin/pcl_morph
cd /tmp/pcl-GU4R/macbuild/tools && /usr/local/Cellar/cmake/3.0.0/bin/cmake -E cmake_link_script CMakeFiles/pcl_morph.dir/link.txt --verbose=1
```
