### PR TITLE
Move io_exception.h/cpp out of IMAGE_INCLUDES/SOURCES lists

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -20,7 +20,6 @@ if(build)
     include/pcl/io/image_yuv422.h
     include/pcl/io/image_ir.h
     include/pcl/io/image_depth.h
-    include/pcl/io/io_exception.h
   )
 
   set(IMAGE_SOURCES
@@ -28,7 +27,6 @@ if(build)
     src/image_yuv422.cpp
     src/image_ir.cpp
     src/image_depth.cpp
-    src/io_exception.cpp
   )
 
     ## OpenNI 2.x
@@ -201,6 +199,8 @@ if(build)
         src/image_grabber.cpp
         src/hdl_grabber.cpp
         src/robot_eye_grabber.cpp
+        src/file_io.cpp
+        src/io_exception.cpp
         ${VTK_IO_SOURCE}
         ${OPENNI_GRABBER_SOURCES}
         ${OPENNI2_GRABBER_SOURCES}
@@ -208,7 +208,6 @@ if(build)
         ${DINAST_GRABBER_SOURCES}
         ${FZAPI_GRABBER_SOURCES}
         ${PXC_GRABBER_SOURCES}
-        src/file_io.cpp
         )
     if(PNG_FOUND)
       list(APPEND srcs
@@ -244,6 +243,7 @@ if(build)
         "include/pcl/${SUBSYS_NAME}/hdl_grabber.h"
         "include/pcl/${SUBSYS_NAME}/robot_eye_grabber.h"
         "include/pcl/${SUBSYS_NAME}/point_cloud_image_extractors.h"
+        "include/pcl/${SUBSYS_NAME}/io_exception.h"
         ${VTK_IO_INCLUDES}
         ${OPENNI_GRABBER_INCLUDES}
         ${OPENNI2_GRABBER_INCLUDES}


### PR DESCRIPTION
`pcl::io::IOException` is of a general usage, however at the moment it is listed among "IMAGE" source group.
