### PR TITLE
Move default argument values from definition to declaration

### DIFF
--- a/features/include/pcl/features/grsd.h
+++ b/features/include/pcl/features/grsd.h
@@ -111,10 +111,13 @@ namespace pcl
       /** \brief Get the type of the local surface based on the min and max radius computed. 
         * \return the integer that represents the type of the local surface with values as
         * Plane (1), Cylinder (2), Noise or corner (0), Sphere (3) and Edge (4) 
-	*/
+        */
       static inline int
-      getSimpleType (float min_radius, float max_radius, double min_radius_plane, double max_radius_noise,
-		     double min_radius_cylinder, double max_min_radius_diff);
+      getSimpleType (float min_radius, float max_radius,
+                     double min_radius_plane = 0.100,
+                     double max_radius_noise = 0.015,
+                     double min_radius_cylinder = 0.175,
+                     double max_min_radius_diff = 0.050);
 
     protected:
 

--- a/features/include/pcl/features/impl/grsd.hpp
+++ b/features/include/pcl/features/impl/grsd.hpp
@@ -43,10 +43,10 @@
 ///////// STATIC /////////
 template <typename PointInT, typename PointNT, typename PointOutT> int
 pcl::GRSDEstimation<PointInT, PointNT, PointOutT>::getSimpleType (float min_radius, float max_radius,
-								  double min_radius_plane = 0.100,
-                                                                  double max_radius_noise = 0.015,
-								  double min_radius_cylinder = 0.175,
-					                          double max_min_radius_diff = 0.050)
+                                                                  double min_radius_plane,
+                                                                  double max_radius_noise,
+                                                                  double min_radius_cylinder,
+                                                                  double max_min_radius_diff)
 {
   if (min_radius > min_radius_plane)
     return (1); // plane


### PR DESCRIPTION
Fixes a bug introduced in #790.
