### PR TITLE
To avoid a error window from VTK (6) due to the txtactor having no scalars.

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -137,6 +137,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (const std::string &name, const
   update_fps_->pcl_visualizer = this;
   update_fps_->decimated = false;
   ren->AddActor (txt);
+  txt->SetInput("0 FPS");
 
   // Create a RendererWindow
   win_ = vtkSmartPointer<vtkRenderWindow>::New ();


### PR DESCRIPTION
I'm not sure if it is a VTK 6 only - but I guess it shouldn't make VTK 5 fail -
![vtkerror](https://cloud.githubusercontent.com/assets/1165340/3771748/317ec494-18f8-11e4-8291-789f8f7ad173.png)
 anyone who can test?
