### PR TITLE
Fix tutorial generation warnings

### DIFF
--- a/doc/advanced/content/c_cache.rst
+++ b/doc/advanced/content/c_cache.rst
@@ -24,7 +24,7 @@ but it actually runs the equivalent of 'ccache g++'.
 
 Using colorgcc to colorize output
 ---------------------------------
-`colorgcc<https://github.com/johannes/colorgcc>`_ is a colorizer for the output
+`colorgcc <https://github.com/johannes/colorgcc>`_ is a colorizer for the output
 of GCC, and allows you to better interpret the compiler warnings/errors.
 
 To enable both colorgcc and ccache, perform the following steps:

--- a/doc/advanced/content/index.rst
+++ b/doc/advanced/content/index.rst
@@ -125,6 +125,5 @@ Contents
    compiler_optimizations
    single_compile_unit
    pcl_style_guide
-   branches_repository
    how_to_write_a_tutorial
 

--- a/doc/advanced/content/pcl2.rst
+++ b/doc/advanced/content/pcl2.rst
@@ -41,7 +41,6 @@ Proposals for the 2.x API:
  * make sure we can access a slice of the data as a *2D image*, thus allowing fast 2D displaying, [u, v] operations, etc
  * make sure we can access a slice of the data as a subpoint cloud: only certain points are chosen from the main point cloud
  * implement channels (of a single type!) as data holders, e.g.:
-
    * cloud["xyz"] => gets all 3D x,y,z data
    * cloud["normals"] => gets all surface normal data
    * etc
@@ -70,7 +69,6 @@ Proposals for the 2.x API:
      cloud = { "pos" => pos_space, "color" => color_space }
      pos_space = ( "float with euclidean 2-norm distance", { "x", "y", "z" }, [[(0.3,0,1.3) , ... , (1.2,3.1,2)], ... , [(1,0.3,1) , ... , (2,0,3.5)] )
      color_space = ( "uint8 with rgb distance", { "r", "g", "b" }, [[(0,255,0), ... , (128,255,32)] ... [(12,54,31) ... (255,0,192)]] )
-
 
 1.2 PointTypes 
 ^^^^^^^^^^^^^^
@@ -114,7 +112,7 @@ Anything involving a slice of data should use size_t for indices and not int. E.
 
 1.6 RANSAC
 ^^^^^^^^^^
- * Renaming the functions and internal variables: everything should be named with _src and _tgt: we have confusing names like indices_ and indices_tgt_ (and no indices_src_), setInputCloud and setInputTarget (duuh, everything is an input, it should be setTarget, setSource), in the code, a sample is named: selection, model_ and samples. getModelCoefficients is confusing with getModel (this one should be getBestSample).
+ * Renaming the functions and internal variables: everything should be named with _src and _tgt: we have confusing names like \indices_ and \indices_tgt_ (and no \indices_src_), setInputCloud and setInputTarget (duuh, everything is an input, it should be setTarget, setSource), in the code, a sample is named: selection, \model_ and samples. getModelCoefficients is confusing with getModel (this one should be getBestSample).
  * no const-correctness all over, it's pretty scary: all the get should be const, selectWithinDistance and so on too.
  * the getModel, getInliers function should not force you to fill a vector: you should just return a const reference to the internal vector: that could allow you to save a useless copy
  * some private members should be made protected in the sub sac models (like sac_model_registration) so that we can inherit from them.

--- a/doc/advanced/content/pcl_reg_eval.rst
+++ b/doc/advanced/content/pcl_reg_eval.rst
@@ -7,23 +7,23 @@ Data generation
 ===============
 - synthetic data
 - real word data (how to get ground truth?)
- - Kinect
- - PR2 laser scanner
- - SICK laser data
- - small range 3D scanner
- - mid range 3D scanner (Faro)
- - high end 3D scanner (Riegl, Velodyne)
+  - Kinect
+  - PR2 laser scanner
+  - SICK laser data
+  - small range 3D scanner
+  - mid range 3D scanner (Faro)
+  - high end 3D scanner (Riegl, Velodyne)
 - Point Types
- - 2D(?)
- - 3D
- - RGB
+  - 2D(?)
+  - 3D
+  - RGB
 - dynamics
- - static scans
- - scanning while driving (e.g. robots)
+  - static scans
+  - scanning while driving (e.g. robots)
 - size
- - room
- - building
- - outdoor (street)
+  - room
+  - building
+  - outdoor (street)
 
 Architecture
 ============
@@ -41,12 +41,14 @@ ICP
 ^^^
 - how does the algorithm cope with outliers
 - how are the point pairs evaluated:
- - does it use normal or RGB information
- - does it weight the pairs differently
- - which kind of point pairs are used:
-  - one-to-one
-  - one-to-many
-  - many-to-many
+
+  - does it use normal or RGB information
+  - does it weight the pairs differently
+  - which kind of point pairs are used:
+
+    - one-to-one
+    - one-to-many
+    - many-to-many
 
 Similar Projects
 ================

--- a/doc/advanced/content/pcl_registration.rst
+++ b/doc/advanced/content/pcl_registration.rst
@@ -60,7 +60,7 @@ Graph
 ^^^^^
 This should hold the SLAM graph. I would propose to use Boost::Graph for it, as it allows us to access a lot of algorithms.
 
-.. todo::
+.. note::
 
    define abstract structure.
 
@@ -159,7 +159,7 @@ GraphHandler
      void addConstraint (Graph &gr, PointCloud &from, PointCloud &to, Pose &pose);
    }
 
-.. todo::
+.. note::
 
    I'm not sure about this one.
 

--- a/doc/advanced/content/pcl_style_guide.rst
+++ b/doc/advanced/content/pcl_style_guide.rst
@@ -336,7 +336,7 @@ download it to some known location and then:
 * open .emacs 
 * add the following before any C/C++ custom hooks
 
-.. code-block:: lisp
+::
 
    (load-file "/location/to/pcl-c-style.el")
    (add-hook 'c-mode-common-hook 'pcl-set-c-style)

--- a/doc/tutorials/content/compiling_pcl_dependencies_windows.rst
+++ b/doc/tutorials/content/compiling_pcl_dependencies_windows.rst
@@ -149,7 +149,7 @@ like::
     Now, in the CMake log, you should see something like::
     
       Reading boost project directories (per BUILD_PROJECTS) 
-
+      
       + date_time
       + thread
       + serialization
@@ -158,7 +158,6 @@ like::
       + mpi
       +-- optional python bindings disabled since PYTHON_FOUND is false. 
       + tr1
-
 
     Now, click "Generate". A Visual Studio solution file will be genrated inside the build folder 
     (e.g. C:/PCL_dependencies/boost-cmake/build). Open the `Boost.sln` file, then right click on 

--- a/doc/tutorials/content/qt_visualizer.rst
+++ b/doc/tutorials/content/qt_visualizer.rst
@@ -168,6 +168,7 @@ After that is the constructor implementation; we setup the ui and the window tit
 | Here we create a PCL Visualizer name ``viewer`` and we also specify that we don't want an interactor to be created.
 | We don't want an interactor to be created because our ``qvtkWidget`` is already an interactor and it's the one we want to use.
 | So the next step is to configure our newly created PCL Visualiser interactor to use the ``qvtkWidget``.
+
 The ``update()`` method of the ``qvtkWidget`` should be called each time you modify the PCL visualizer; if you don't call it you don't know if the 
 visualizer will be updated before the user try to pan/spin/zoom.
 
@@ -193,6 +194,7 @@ Here we connect slots and signals, this links UI actions to functions. Here is a
    :lines: 53-57
 
 | This is the last part of our constructor; we add the point cloud to the visualizer, call the method ``pSliderValueChanged`` to change the point size to 2.
+
 We finaly reset the camera within the PCL Visualizer not avoid the user having to zoom out and update the qvtkwidget to be 
 sure the modifications will be displayed.
 
@@ -234,6 +236,7 @@ There are two options here :
   * You didn't configure the Qt project; just go to the build folder an run ``cmake ../src && make -j2 && ./pcl_visualizer``
 
 | Notice that when changing the slider color, the cloud is not updated until you release the slider (``sliderReleased ()`` slot).
+
 If you wanted to update the point cloud when the slider value is changed you could just call the ``RGBsliderReleased ()`` function inside the
 ``*sliderValueChanged (int)`` functions. The connect between  ``sliderReleased ()`` / ``RGBsliderReleased ()`` would become useless then.
 


### PR DESCRIPTION
Fix some warnings when generating tutorials using `sphinx-build`

[new output (117 lines)](https://gist.github.com/VictorLamoine/b96bd9bcae1e8f6eb3bf)
[old output (146 lines)](https://gist.github.com/VictorLamoine/b96bd9bcae1e8f6eb3bf#file-old-output)
