### PR TITLE
Add a helper class EventFrequency

### DIFF
--- a/common/include/pcl/common/time.h
+++ b/common/include/pcl/common/time.h
@@ -44,6 +44,7 @@
 #endif
 
 #include <cmath>
+#include <queue>
 #include <string>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
@@ -136,6 +137,62 @@ namespace pcl
       std::string title_;
   };
 
+  /** \brief A helper class to measure frequency of a certain event.
+    *
+    * To use this class create an instance and call event() function every time
+    * the event in question occurs. The estimated frequency can be retrieved
+    * with getFrequency() function.
+    *
+    * \author Sergey Alexandrov
+    * \ingroup common
+    */
+  class EventFrequency
+  {
+
+    public:
+
+      /** \brief Constructor.
+        *
+        * \param[i] window_size number of most recent events that are
+        * considered in frequency estimation (default: 30) */
+      EventFrequency (size_t window_size = 30)
+      : window_size_ (window_size)
+      {
+        stop_watch_.reset ();
+      }
+
+      /** \brief Notifies the class that the event occured. */
+      void event ()
+      {
+        event_time_queue_.push (stop_watch_.getTimeSeconds ());
+        if (event_time_queue_.size () > window_size_)
+          event_time_queue_.pop ();
+      }
+
+      /** \brief Retrieve the estimated frequency. */
+      double
+      getFrequency () const
+      {
+        if (event_time_queue_.size () < 2)
+          return (0.0);
+        return ((event_time_queue_.size () - 1) /
+                (event_time_queue_.back () - event_time_queue_.front ()));
+      }
+
+      /** \brief Reset frequency computation. */
+      void reset ()
+      {
+        stop_watch_.reset ();
+        event_time_queue_ = std::queue<double> ();
+      }
+
+    private:
+
+      pcl::StopWatch stop_watch_;
+      std::queue<double> event_time_queue_;
+      const size_t window_size_;
+
+  };
 
 #ifndef MEASURE_FUNCTION_TIME
 #define MEASURE_FUNCTION_TIME \


### PR DESCRIPTION
A helper class to measure frequency of a certain event.

To use this class create an instance and call `event()` function every time the event in question occurs. The estimated frequency can be retrieved with `getFrequency()` function.
