### PR TITLE
Fixed parameters / added setter

### DIFF
--- a/features/include/pcl/features/usc.h
+++ b/features/include/pcl/features/usc.h
@@ -85,8 +85,8 @@ namespace pcl
       /** \brief Constructor. */
       UniqueShapeContext () :
         radii_interval_(0), theta_divisions_(0), phi_divisions_(0), volume_lut_(0),
-        azimuth_bins_(12), elevation_bins_(11), radius_bins_(15),
-        min_radius_(0.1), point_density_radius_(0.2), descriptor_length_ (), local_radius_ (2.5)
+        azimuth_bins_(14), elevation_bins_(14), radius_bins_(10),
+        min_radius_(0.1), point_density_radius_(0.1), descriptor_length_ (), local_radius_ (2.0)
       {
         feature_name_ = "UniqueShapeContext";
         search_radius_ = 2.5;
@@ -94,22 +94,22 @@ namespace pcl
 
       virtual ~UniqueShapeContext() { }
 
-      //inline void
-      //setAzimuthBins (size_t bins) { azimuth_bins_ = bins; }
+      inline void
+      setAzimuthBins (size_t bins) { azimuth_bins_ = bins; }
 
       /** \return The number of bins along the azimuth. */
       inline size_t
       getAzimuthBins () const { return (azimuth_bins_); }
 
-      //inline void
-      //setElevationBins (size_t bins) { elevation_bins_ = bins; }
+      inline void
+      setElevationBins (size_t bins) { elevation_bins_ = bins; }
 
       /** \return The number of bins along the elevation */
       inline size_t
       getElevationBins () const { return (elevation_bins_); }
 
-      //inline void
-      //setRadiusBins (size_t bins) { radius_bins_ = bins; }
+      inline void
+      setRadiusBins (size_t bins) { radius_bins_ = bins; }
 
       /** \return The number of bins along the radii direction. */
       inline size_t


### PR DESCRIPTION
Fixed the descriptor parameters matching the values of the original
paper (Tombari et al. 2010). The former values have been copied from
3DSC-descriptor and have not been adapted.

Furter the already existing setters for radial, elevation and azimut
bins are commented in (I do not understand, why they are commented
out).
