### PR TITLE
USC: fixed parameters / added descriptor-type

### DIFF
--- a/common/include/pcl/common/point_tests.h
+++ b/common/include/pcl/common/point_tests.h
@@ -75,6 +75,7 @@ namespace pcl
   template<> inline bool isFinite<pcl::SHOT1344> (const pcl::SHOT1344&) { return (true); }
   template<> inline bool isFinite<pcl::ReferenceFrame> (const pcl::ReferenceFrame&) { return (true); }
   template<> inline bool isFinite<pcl::ShapeContext1980> (const pcl::ShapeContext1980&) { return (true); }
+  template<> inline bool isFinite<pcl::UniqueShapeContext1960> (const pcl::UniqueShapeContext1960&) { return (true); }
   template<> inline bool isFinite<pcl::PFHSignature125> (const pcl::PFHSignature125&) { return (true); }
   template<> inline bool isFinite<pcl::PFHRGBSignature250> (const pcl::PFHRGBSignature250&) { return (true); }
   template<> inline bool isFinite<pcl::PPFSignature> (const pcl::PPFSignature&) { return (true); }

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -85,6 +85,7 @@
   (pcl::PointWithScale)         \
   (pcl::PointSurfel)            \
   (pcl::ShapeContext1980)       \
+  (pcl::UniqueShapeContext1960) \
   (pcl::SHOT352)                \
   (pcl::SHOT1344)               \
   (pcl::PointUV)                \
@@ -1201,6 +1202,18 @@ namespace pcl
     friend std::ostream& operator << (std::ostream& os, const ShapeContext1980& p);
   };
 
+  PCL_EXPORTS std::ostream& operator << (std::ostream& os, const UniqueShapeContext1960& p);
+  /** \brief A point structure representing a Unique Shape Context.
+    * \ingroup common
+    */
+  struct UniqueShapeContext1960
+  {
+    float descriptor[1960];
+    float rf[9];
+    static int descriptorSize () { return 1960; }
+
+    friend std::ostream& operator << (std::ostream& os, const UniqueShapeContext1960& p);
+  };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const SHOT352& p);
   /** \brief A point structure representing the generic Signature of Histograms of OrienTations (SHOT) - shape only.

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -457,6 +457,24 @@ namespace pcl
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   template <>
+  class DefaultPointRepresentation<UniqueShapeContext1960> : public PointRepresentation<UniqueShapeContext1960>
+  {
+    public:
+      DefaultPointRepresentation ()
+      {
+        nr_dimensions_ = 1960;
+      }
+
+      virtual void
+      copyToFloatArray (const UniqueShapeContext1960 &p, float * out) const
+      {
+        for (int i = 0; i < nr_dimensions_; ++i)
+          out[i] = p.descriptor[i];
+      }
+  };
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  template <>
   class DefaultPointRepresentation<SHOT352> : public PointRepresentation<SHOT352>
   {
     public:

--- a/common/include/pcl/point_types.h
+++ b/common/include/pcl/point_types.h
@@ -215,6 +215,11 @@ namespace pcl
     */
   struct ShapeContext1980;
 
+  /** \brief Members: float descriptor[1960], rf[9]
+    * \ingroup common
+    */
+  struct UniqueShapeContext1960;
+
   /** \brief Members: float pfh[125]
     * \ingroup common
     */
@@ -562,6 +567,11 @@ POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::NormalBasedSignature12,
 
 POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::ShapeContext1980,
     (float[1980], descriptor, shape_context)
+    (float[9], rf, rf)
+)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::UniqueShapeContext1960,
+    (float[1960], descriptor, shape_context)
     (float[9], rf, rf)
 )
 

--- a/common/src/point_types.cpp
+++ b/common/src/point_types.cpp
@@ -288,6 +288,16 @@ namespace pcl
   }
 
   std::ostream& 
+  operator << (std::ostream& os, const UniqueShapeContext1960& p)
+  {
+    for (int i = 0; i < 9; ++i)
+    os << (i == 0 ? "(" : "") << p.rf[i] << (i < 8 ? ", " : ")");
+    for (size_t i = 0; i < 1960; ++i)
+      os << (i == 0 ? "(" : "") << p.descriptor[i] << (i < 1959 ? ", " : ")");
+    return (os);
+  }
+
+  std::ostream& 
   operator << (std::ostream& os, const SHOT352& p)
   {
     for (int i = 0; i < 9; ++i)

--- a/features/include/pcl/features/impl/usc.hpp
+++ b/features/include/pcl/features/impl/usc.hpp
@@ -246,7 +246,7 @@ pcl::UniqueShapeContext<PointInT, PointOutT, PointRFT>::computePointDescriptor (
 template <typename PointInT, typename PointOutT, typename PointRFT> void
 pcl::UniqueShapeContext<PointInT, PointOutT, PointRFT>::computeFeature (PointCloudOut &output)
 {
-  assert (descriptor_length_ == 1980);
+  assert (descriptor_length_ == 1960);
 
   output.is_dense = true;
 

--- a/features/include/pcl/features/usc.h
+++ b/features/include/pcl/features/usc.h
@@ -54,13 +54,13 @@ namespace pcl
     *     International Workshop on 3D Object Retrieval (3DOR 10) -
     *     in conjuction with ACM Multimedia 2010
     *
-    * The suggested PointOutT is pcl::ShapeContext1980
+    * The suggested PointOutT is pcl::UniqueShapeContext1960
     *
     * \author Alessandro Franchi, Federico Tombari, Samuele Salti (original code)
     * \author Nizar Sallem (port to PCL)
     * \ingroup features
     */
-  template <typename PointInT, typename PointOutT = pcl::ShapeContext1980, typename PointRFT = pcl::ReferenceFrame>
+  template <typename PointInT, typename PointOutT = pcl::UniqueShapeContext1960, typename PointRFT = pcl::ReferenceFrame>
   class UniqueShapeContext : public Feature<PointInT, PointOutT>,
                              public FeatureWithLocalReferenceFrames<PointInT, PointRFT>
   {
@@ -85,31 +85,22 @@ namespace pcl
       /** \brief Constructor. */
       UniqueShapeContext () :
         radii_interval_(0), theta_divisions_(0), phi_divisions_(0), volume_lut_(0),
-        azimuth_bins_(12), elevation_bins_(11), radius_bins_(15),
-        min_radius_(0.1), point_density_radius_(0.2), descriptor_length_ (), local_radius_ (2.5)
+        azimuth_bins_(14), elevation_bins_(14), radius_bins_(10),
+        min_radius_(0.1), point_density_radius_(0.1), descriptor_length_ (), local_radius_ (2.0)
       {
         feature_name_ = "UniqueShapeContext";
-        search_radius_ = 2.5;
+        search_radius_ = 2.0;
       }
 
       virtual ~UniqueShapeContext() { }
-
-      //inline void
-      //setAzimuthBins (size_t bins) { azimuth_bins_ = bins; }
 
       /** \return The number of bins along the azimuth. */
       inline size_t
       getAzimuthBins () const { return (azimuth_bins_); }
 
-      //inline void
-      //setElevationBins (size_t bins) { elevation_bins_ = bins; }
-
       /** \return The number of bins along the elevation */
       inline size_t
       getElevationBins () const { return (elevation_bins_); }
-
-      //inline void
-      //setRadiusBins (size_t bins) { radius_bins_ = bins; }
 
       /** \return The number of bins along the radii direction. */
       inline size_t

--- a/features/src/usc.cpp
+++ b/features/src/usc.cpp
@@ -43,9 +43,9 @@
 #include <pcl/impl/instantiate.hpp>
 // Instantiations of specific point types
 #ifdef PCL_ONLY_CORE_POINT_TYPES
-  PCL_INSTANTIATE_PRODUCT(UniqueShapeContext, ((pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA))((pcl::ShapeContext1980))((pcl::ReferenceFrame)))
+  PCL_INSTANTIATE_PRODUCT(UniqueShapeContext, ((pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA))((pcl::UniqueShapeContext1960))((pcl::ReferenceFrame)))
 #else
-  PCL_INSTANTIATE_PRODUCT(UniqueShapeContext, (PCL_XYZ_POINT_TYPES)((pcl::ShapeContext1980))((pcl::ReferenceFrame)))
+  PCL_INSTANTIATE_PRODUCT(UniqueShapeContext, (PCL_XYZ_POINT_TYPES)((pcl::UniqueShapeContext1960))((pcl::ReferenceFrame)))
 #endif
 #endif    // PCL_NO_PRECOMPILE
 

--- a/test/features/test_ptr.cpp
+++ b/test/features/test_ptr.cpp
@@ -56,7 +56,7 @@ TEST (PCL, FeaturePtr)
   VFHEstimation<PointXYZ, PointNormal, VFHSignature308>::Ptr vfh (new VFHEstimation<PointXYZ, PointNormal, VFHSignature308> ());
   vfh->setViewPoint (1.0f, 1.0f, 1.0f);
 
-  UniqueShapeContext<PointXYZ, ShapeContext1980, ReferenceFrame>::Ptr usc (new UniqueShapeContext<PointXYZ, ShapeContext1980, ReferenceFrame> ());
+  UniqueShapeContext<PointXYZ, UniqueShapeContext1960, ReferenceFrame>::Ptr usc (new UniqueShapeContext<PointXYZ, UniqueShapeContext1960, ReferenceFrame> ());
   usc->setMinimalRadius (5);
 
   StatisticalMultiscaleInterestRegionExtraction<PointXYZ>::Ptr smire (new StatisticalMultiscaleInterestRegionExtraction<PointXYZ> ());

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -106,6 +106,16 @@ checkDesc<ShapeContext1980>(const pcl::PointCloud<ShapeContext1980>& d0, const p
 }
 
 ///////////////////////////////////////////////////////////////////////////////////
+template <> void
+checkDesc<UniqueShapeContext1960>(const pcl::PointCloud<UniqueShapeContext1960>& d0, const pcl::PointCloud<UniqueShapeContext1960>& d1)
+{
+  ASSERT_EQ (d0.size (), d1.size ());
+  for (size_t i = 0; i < d1.size (); ++i)
+    for (size_t j = 0; j < 1960; ++j)
+      ASSERT_EQ (d0.points[i].descriptor[j], d1.points[i].descriptor[j]);
+}
+
+///////////////////////////////////////////////////////////////////////////////////
 template <typename FeatureEstimation, typename PointT, typename NormalT, typename OutputT>
 struct createSHOTDesc
 {
@@ -187,9 +197,6 @@ struct createSHOTDesc<UniqueShapeContext<PointT, OutputT>, PointT, NormalT, Outp
                 const bool) const
   {
     UniqueShapeContext<PointT, OutputT> usc;
-    //usc.setAzimuthBins (4);
-    //usc.setElevationBins (4);
-    //usc.setRadiusBins (4);
     usc.setMinimalRadius (0.004);
     usc.setPointDensityRadius (0.008);
     usc.setLocalRadius (0.04);
@@ -920,26 +927,20 @@ TEST (PCL,3DSCEstimation)
 TEST (PCL, USCEstimation)
 {
   float meshRes = 0.002f;
-  //size_t nBinsL = 4;
-  //size_t nBinsK = 4;
-  //size_t nBinsJ = 4;
   float radius = 20.0f * meshRes;
   float rmin = radius / 10.0f;
   float ptDensityRad = radius / 5.0f;
 
   // estimate
-  UniqueShapeContext<PointXYZ, ShapeContext1980> uscd;
+  UniqueShapeContext<PointXYZ, UniqueShapeContext1960> uscd;
   uscd.setInputCloud (cloud.makeShared ());
   uscd.setSearchMethod (tree);
   uscd.setRadiusSearch (radius);
-  //uscd.setAzimuthBins (nBinsL);
-  //uscd.setElevationBins (nBinsK);
-  //uscd.setRadiusBins (nBinsJ);
   uscd.setMinimalRadius (rmin);
   uscd.setPointDensityRadius (ptDensityRad);
   uscd.setLocalRadius (radius);
   // Compute the features
-  PointCloud<ShapeContext1980>::Ptr uscds (new PointCloud<ShapeContext1980>);
+  PointCloud<UniqueShapeContext1960>::Ptr uscds (new PointCloud<UniqueShapeContext1960>);
   uscd.compute (*uscds);
   EXPECT_EQ (uscds->size (), cloud.size ());
 
@@ -955,17 +956,17 @@ TEST (PCL, USCEstimation)
 
   //EXPECT_EQ ((*uscds)[0].descriptor.size (), 64);
 
-  EXPECT_NEAR ((*uscds)[160].descriptor[56], 53.0597f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[160].descriptor[734], 80.1063f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[160].descriptor[1222], 93.8412f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[160].descriptor[1605], 0.f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[160].descriptor[1887], 32.6679f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[160].descriptor[355], 123.0733f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[160].descriptor[494], 154.9401f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[160].descriptor[897], 0.f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[160].descriptor[1178], 62.7496f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[160].descriptor[1878], 31.3748f, 1e-4f);
 
-  EXPECT_NEAR ((*uscds)[168].descriptor[72], 65.3358f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[168].descriptor[430], 88.8147f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[168].descriptor[987], 0.f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[168].descriptor[1563], 128.273f, 1e-4f);
-  EXPECT_NEAR ((*uscds)[168].descriptor[1915], 59.2098f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[168].descriptor[57], 39.4986f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[168].descriptor[704], 0.f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[168].descriptor[906], 48.8803f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[168].descriptor[1175], 83.4680f, 1e-4f);
+  EXPECT_NEAR ((*uscds)[168].descriptor[1756], 65.1737f, 1e-4f);
 
   // Test results when setIndices and/or setSearchSurface are used
   boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));
@@ -973,8 +974,8 @@ TEST (PCL, USCEstimation)
     test_indices->push_back (static_cast<int> (i));
 
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
-  testSHOTIndicesAndSearchSurface<UniqueShapeContext<PointXYZ, ShapeContext1980>, PointXYZ, Normal, ShapeContext1980> (cloud.makeShared (), normals, test_indices);
-  testSHOTLocalReferenceFrame<UniqueShapeContext<PointXYZ, ShapeContext1980>, PointXYZ, Normal, ShapeContext1980> (cloud.makeShared (), normals, test_indices);
+  testSHOTIndicesAndSearchSurface<UniqueShapeContext<PointXYZ, UniqueShapeContext1960>, PointXYZ, Normal, UniqueShapeContext1960> (cloud.makeShared (), normals, test_indices);
+  testSHOTLocalReferenceFrame<UniqueShapeContext<PointXYZ, UniqueShapeContext1960>, PointXYZ, Normal, UniqueShapeContext1960> (cloud.makeShared (), normals, test_indices);
 }
 
 /* ---[ */


### PR DESCRIPTION
Fixed the descriptor parameters matching the values of the original
paper (Tombari et al. 2010). The former values have been copied from
3DSC-descriptor and have not been adapted.

Added a descriptor type UniqueShapeContext1960.
