### PR TITLE
Fixed setCameraPosition in PCLVisualizer.

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1952,6 +1952,7 @@ pcl::visualization::PCLVisualizer::setCameraPosition (
       cam->SetPosition (pos_x, pos_y, pos_z);
       cam->SetFocalPoint (view_x, view_y, view_z);
       cam->SetViewUp (up_x, up_y, up_z);
+      renderer->ResetCameraClippingRange ();
     }
     ++i;
   }


### PR DESCRIPTION
After setting the new camera position the camera clipping planes
where not adjusted which resulted in a black render window.
The site which pointed me in the right direction was
http://www.vmateevitsi.com/2011/10/25/vtkcamera-problem-with-setposition/
