### PR TITLE
[PLYReader] Fix bad orientation & origin propreties

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -621,8 +621,8 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
     cloud_->data.swap (data);
   }
 
-  orientation = Eigen::Quaternionf (orientation_);
-  origin = origin_;
+  orientation_ = Eigen::Quaternionf (orientation);
+  origin_ = origin;
 
   for (size_t i = 0; i < cloud_->fields.size (); ++i)
   {
@@ -681,8 +681,8 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
     cloud_->data.swap (data);
   }
 
-  orientation = Eigen::Quaternionf (orientation_);
-  origin = origin_;
+  orientation_ = Eigen::Quaternionf (orientation);
+  origin_ = origin;
 
   for (size_t i = 0; i < cloud_->fields.size (); ++i)
   {


### PR DESCRIPTION
Fixes #626 

See [pcl::PLYReader::read](http://docs.pointclouds.org/trunk/classpcl_1_1_p_l_y_reader.html#ae44ab90c39f7077ad8a9b1646d95c301)

When `pcl::PLYReader::read` is called, the orientation & origin of the cloud are specified.
But without the fix, the value passed is modified and the `orientation_` proprety remains unmodified.

The same is happening with `origin` and `origin_`

Is that right @nizar-sallem ?
