### PR TITLE
Transform point cloud in GICP align function

### DIFF
--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -48,7 +48,7 @@ namespace pcl
 {
   /** \brief GeneralizedIterativeClosestPoint is an ICP variant that implements the 
     * generalized iterative closest point algorithm as described by Alex Segal et al. in 
-    * http://www.stanford.edu/~avsegal/resources/papers/Generalized_ICP.pdf
+    * http://www.robots.ox.ac.uk/~avsegal/resources/papers/Generalized_ICP.pdf
     * The approach is based on using anistropic cost functions to optimize the alignment 
     * after closest point assignments have been made.
     * The original code uses GSL and ANN while in ours we use an eigen mapped BFGS and 

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -466,6 +466,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransfor
   final_transformation_(0,3) = previous_transformation_(0,3) + guess(0,3);
   final_transformation_(1,3) = previous_transformation_(1,3) + guess(1,3);
   final_transformation_(2,3) = previous_transformation_(2,3) + guess(2,3);
+
+  // Transform the point cloud
+  pcl::transformPointCloud (*input_, output, final_transformation_);
 }
 
 template <typename PointSource, typename PointTarget> void


### PR DESCRIPTION
Fixes #754 and #818 
I also fixed a dead link in the GICP documentation.

The new changes can be tested using the following code; which is a modified copy of [Interactive ICP](http://pointclouds.org/documentation/tutorials/interactive_icp.php) tutorial code. [Test project](https://gist.github.com/VictorLamoine/20ef23dcb7cf6ef93cdd)

I use a GICP object rather than an ICP object; here I use the `align` function with a guessed matrix 
`icp.align (*cloud_icp, transformation_matrix.inverse ().cast<float> ());`

Note that `transformation_matrix.inverse ()` is the exact transformation to align the point cloud. As a result the point cloud is perfeclty aligned after the first iteration.

If you want to see GICP working just use
`icp.align (*cloud_icp);`
And press space in the viewer to iterate!
