### PR TITLE
Region growing tutorial fix

### DIFF
--- a/doc/tutorials/content/region_growing_segmentation.rst
+++ b/doc/tutorials/content/region_growing_segmentation.rst
@@ -161,14 +161,14 @@ This method simply launches the segmentation algorithm. After its work it will r
 
 .. literalinclude:: sources/region_growing_segmentation/region_growing_segmentation.cpp
    :language: cpp
-   :lines: 51-60
+   :lines: 51-63
 
 These lines are simple enough, so they won't be commented. They are intended for those who are not familiar with how to work with ``pcl::PointIndices``
 and how to access its elements.
 
 .. literalinclude:: sources/region_growing_segmentation/region_growing_segmentation.cpp
    :language: cpp
-   :lines: 62-67
+   :lines: 65-73
 
 The ``pcl::RegionGrowing`` class provides a method that returns the colored cloud where each cluster has its own color.
 So in this part of code the ``pcl::visualization::CloudViewer`` is instanciated for viewing the result of the segmentation - the same colored cloud.

--- a/doc/tutorials/content/sources/region_growing_segmentation/region_growing_segmentation.cpp
+++ b/doc/tutorials/content/sources/region_growing_segmentation/region_growing_segmentation.cpp
@@ -10,25 +10,24 @@
 #include <pcl/segmentation/region_growing.h>
 
 int
-main (int argc,
-      char** argv)
+main (int argc, char** argv)
 {
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
-  if (pcl::io::loadPCDFile<pcl::PointXYZ> ("region_growing_tutorial.pcd", *cloud) == -1)
+  if ( pcl::io::loadPCDFile <pcl::PointXYZ> ("region_growing_tutorial.pcd", *cloud) == -1)
   {
     std::cout << "Cloud reading failed." << std::endl;
     return (-1);
   }
 
   pcl::search::Search<pcl::PointXYZ>::Ptr tree = boost::shared_ptr<pcl::search::Search<pcl::PointXYZ> > (new pcl::search::KdTree<pcl::PointXYZ>);
-  pcl::PointCloud<pcl::Normal>::Ptr normals (new pcl::PointCloud<pcl::Normal>);
+  pcl::PointCloud <pcl::Normal>::Ptr normals (new pcl::PointCloud <pcl::Normal>);
   pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> normal_estimator;
   normal_estimator.setSearchMethod (tree);
   normal_estimator.setInputCloud (cloud);
   normal_estimator.setKSearch (50);
   normal_estimator.compute (*normals);
 
-  pcl::IndicesPtr indices (new std::vector<int>);
+  pcl::IndicesPtr indices (new std::vector <int>);
   pcl::PassThrough<pcl::PointXYZ> pass;
   pass.setInputCloud (cloud);
   pass.setFilterFieldName ("z");
@@ -46,22 +45,26 @@ main (int argc,
   reg.setSmoothnessThreshold (3.0 / 180.0 * M_PI);
   reg.setCurvatureThreshold (1.0);
 
-  std::vector<pcl::PointIndices> clusters;
+  std::vector <pcl::PointIndices> clusters;
   reg.extract (clusters);
 
   std::cout << "Number of clusters is equal to " << clusters.size () << std::endl;
   std::cout << "First cluster has " << clusters[0].indices.size () << " points." << endl;
-  std::cout << "These are the indices of the points of the initial" << std::endl << "cloud that belong to the first cluster:" << std::endl;
+  std::cout << "These are the indices of the points of the initial" <<
+    std::endl << "cloud that belong to the first cluster:" << std::endl;
   int counter = 0;
-  while (counter < 5 || counter > clusters[0].indices.size ())
+  while (counter < clusters[0].indices.size ())
   {
-    std::cout << clusters[0].indices[counter] << std::endl;
+    std::cout << clusters[0].indices[counter] << ", ";
     counter++;
+    if (counter % 10 == 0)
+      std::cout << std::endl;
   }
+  std::cout << std::endl;
 
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr colored_cloud = reg.getColoredCloud ();
+  pcl::PointCloud <pcl::PointXYZRGB>::Ptr colored_cloud = reg.getColoredCloud ();
   pcl::visualization::CloudViewer viewer ("Cluster viewer");
-  viewer.showCloud (colored_cloud);
+  viewer.showCloud(colored_cloud);
   while (!viewer.wasStopped ())
   {
   }


### PR DESCRIPTION
Only the first 5 point indices were printed. This fixes the printing (10 values are printed before printing a new line).

This was reported on the mailing list by [FTD2014](http://www.pcl-users.org/I-think-there-is-a-bug-td4035436.html).
