### PR TITLE
Created shape generator in simulation module

### DIFF
--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -124,7 +124,6 @@ EXCLUDE                = "@PCL_SOURCE_DIR@/cmake" \
                          "@PCL_SOURCE_DIR@/surface/include/pcl/surface/on_nurbs" \
                          "@PCL_SOURCE_DIR@/surface/include/pcl/surface/openNURBS" \
                          "@PCL_SOURCE_DIR@/surface/include/pcl/surface/impl/nurbs" \
-                         "@PCL_SOURCE_DIR@/simulation" \
                          "@PCL_SOURCE_DIR@/test/gtest-1.6.0"
 EXCLUDE_SYMLINKS       = YES
 EXCLUDE_PATTERNS       = 

--- a/examples/simulation/CMakeLists.txt
+++ b/examples/simulation/CMakeLists.txt
@@ -1,0 +1,6 @@
+if(BUILD_simulation)
+
+  PCL_SUBSYS_DEPEND(build ${SUBSYS_NAME} DEPS simulation)
+  PCL_ADD_EXAMPLE(pcl_example_shape_generator FILES example_shape_generator.cpp LINK_WITH pcl_common pcl_simulation pcl_io)
+  
+endif(BUILD_simulation)

--- a/examples/simulation/example_shape_generator.cpp
+++ b/examples/simulation/example_shape_generator.cpp
@@ -1,0 +1,169 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <iostream>
+#include <pcl/simulation/shape_generator.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/console/parse.h>
+
+using namespace pcl::simulation;
+
+int
+main (int argc,
+      char ** argv)
+{
+  pcl::console::print_info (
+  "\n\
+----------------------------------------------------------------------------------\n\
+  This example will create an animal by combining shapes\n\
+  Use the -l parameter to change the labeling of the body parts\n\
+  Syntax: %s options\n\
+  -l [0/1/2]:\n\
+    0 (Single): The object will get a single label\n\
+    1 (Merge): Head and torso of the animal will get a unique label (default)\n\
+    2 (Append): The labels of the head and torso parts keep their unique label\n\n\
+  -d point_density: sample with point_density points per square unit (default: 1000)\n\
+  Check results with pcl_viewer by displaying the label field\n\
+----------------------------------------------------------------------------------\n", argv[0]);
+
+  // depending on the value of label_handler we will create labels for head and torso (part), labels for each part (append) or a single label for the full object (single).
+  MultiShape::LabelHandling label_handler = MultiShape::Merge;
+  float point_density = 1000;
+  if (pcl::console::find_switch (argc, argv, "-l"))
+  {
+    unsigned int label_handling;
+    pcl::console::parse_argument (argc, argv, "-l", label_handling);
+    if (label_handling == 0)
+      label_handler = MultiShape::Single;
+    else if (label_handling == 1)
+      label_handler = MultiShape::Merge;
+    else if (label_handling == 2)
+      label_handler = MultiShape::Append;
+    else
+    {
+      PCL_INFO ("Could not recognize -l argument using Merge (default)\n");
+    }
+  }
+
+  if (pcl::console::find_switch (argc, argv, "-d"))
+    pcl::console::parse_argument (argc, argv, "-d", point_density);
+
+  GeometricShapePtrVector torso_shapes, head_shapes;
+
+  // ----- Add the Torso -------------
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cylinder (2, 6)));
+  torso_shapes.back ()->rotate (GeometricShapeBase::ZAxis, 90);
+
+  // Leg 1
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cylinder (0.5, 4)));
+  torso_shapes.back ()->translate (-2, -2, -1.5);
+
+  // Leg 2
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cylinder (0.5, 4)));
+  torso_shapes.back ()->translate (2, -2, -1.5);
+
+  // Leg 3
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cylinder (0.5, 4)));
+  torso_shapes.back ()->translate (-2, -2, 1.5);
+
+  // Leg 4
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cylinder (0.5, 4)));
+  torso_shapes.back ()->translate (2, -2, 1.5);
+
+  // Back Spike 1
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cone (1, 2)));
+  torso_shapes.back ()->translate (2, 2, 0);
+
+  // Back Spike 2
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cone (1, 2)));
+  torso_shapes.back ()->translate (1, 2, 0);
+
+  // Back Spike 3
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Cone (1, 2)));
+  torso_shapes.back ()->translate (0, 2, 0);
+
+  // Tail
+  torso_shapes.push_back (GeometricShapeBase::Ptr (new Torus (3, 0.3, 0, M_PI / 2.f)));
+  torso_shapes.back ()->translate (5, -0.5, 0);
+  torso_shapes.back ()->rotate (GeometricShapeBase::XAxis, -90);
+  torso_shapes.back ()->rotate (GeometricShapeBase::ZAxis, 40);
+
+  // Add all torso parts to one object
+  // We use Merge because that way we keep separate labels for the parts and can decide later on if we want to keep or merge them
+  // Note: Using Append at this level would not change the results, since it only makes a difference if parts of the multishape contain parts already.
+  GeometricShapeBase::Ptr torso (new MultiShape (torso_shapes, true, MultiShape::Merge));
+
+  // ----- Add the head -------------
+  head_shapes.push_back (GeometricShapeBase::Ptr (new Sphere (1.5)));
+  head_shapes.back ()->translate (-3.2, 2.2, 0);
+
+  // Ear 1
+  head_shapes.push_back (GeometricShapeBase::Ptr (new Torus (1, 0.2)));
+  head_shapes.back ()->translate (0, 1.5, 0.8);
+  head_shapes.back ()->rotate (GeometricShapeBase::XAxis, -80);
+  head_shapes.back ()->translate (-3.2, 2.2, 0);
+
+  // Ear 2
+  head_shapes.push_back (GeometricShapeBase::Ptr (new Torus (1, 0.2)));
+  head_shapes.back ()->translate (0, 1.5, -0.8);
+  head_shapes.back ()->rotate (GeometricShapeBase::XAxis, 80);
+  head_shapes.back ()->translate (-3.2, 2.2, 0);
+
+  // Trunk
+  head_shapes.push_back (GeometricShapeBase::Ptr (new Torus (2, 0.3, 0, M_PI / 3.f)));
+  head_shapes.back ()->translate (-1.4, -2, 0);
+  head_shapes.back ()->rotate (GeometricShapeBase::XAxis, -90);
+  head_shapes.back ()->rotate (GeometricShapeBase::ZAxis, 90);
+  head_shapes.back ()->translate (-3.2, 2.2, 0);
+
+  // Add all head parts to one object
+  // We use Merge because that way we keep separate labels for the parts and can decide later on if we want to keep or merge them
+  // Note: Using Append at this level would not change the results, since it only makes a difference if parts of the multishape contain parts already.
+  GeometricShapeBase::Ptr head (new MultiShape (head_shapes, true, MultiShape::Merge));
+
+  // ------ Add head and torso again to one object, since torso and head consist of several parts label_handler=Merge and label_handler=Append yield different results --------
+  MultiShape::Ptr animal (new MultiShape (torso, head, true, label_handler));
+  PCL_INFO ("Animal generation\n");
+
+  // Generate the points on the shape with a density of point_density points per square unit
+  GeometricShapeBase::PointCloudT::Ptr animal_cloud_ptr = animal->generate (point_density);
+  PCL_INFO ("Animal generation finished\n");
+  PCL_INFO ("Saving pcd file shape_example.pcd\n");
+  
+  pcl::io::savePCDFileASCII ("shape_example.pcd", *animal_cloud_ptr);
+  return 0;
+}

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -7,46 +7,69 @@ find_package(OpenGL)
 find_package(GLEW)
 
 PCL_SUBSYS_OPTION(build "${SUBSYS_NAME}" "${SUBSYS_DESC}" OFF)
-PCL_SUBSYS_DEPEND(build "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS} EXT_DEPS opengl glew)
+PCL_SUBSYS_DEPEND(build "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS} OPT_DEPS opengl glew)
 
 PCL_ADD_DOC("${SUBSYS_NAME}")
- 
+
+
 if(build)
-    set(srcs 
-         src/camera.cpp
-         src/model.cpp
-         src/range_likelihood.cpp
-         src/scene.cpp
-         src/glsl_shader.cpp
-         src/sum_reduce.cpp
-        )
+  # Include the parts dependend on OpenGL and GLEW
+  if(OpenGL_FOUND AND GLEW_FOUND)
+      set(srcs
+          src/camera.cpp
+          src/model.cpp
+          src/range_likelihood.cpp
+          src/scene.cpp
+          src/glsl_shader.cpp
+          src/sum_reduce.cpp
+          )
 
-    set(incs 
-        "include/pcl/${SUBSYS_NAME}/camera.h"
-        "include/pcl/${SUBSYS_NAME}/model.h"
-        "include/pcl/${SUBSYS_NAME}/range_likelihood.h"
-        "include/pcl/${SUBSYS_NAME}/scene.h"
-        "include/pcl/${SUBSYS_NAME}/glsl_shader.h"
-        "include/pcl/${SUBSYS_NAME}/sum_reduce.h"
-        )
+      set(incs
+          "include/pcl/${SUBSYS_NAME}/camera.h"
+          "include/pcl/${SUBSYS_NAME}/model.h"
+          "include/pcl/${SUBSYS_NAME}/range_likelihood.h"
+          "include/pcl/${SUBSYS_NAME}/scene.h"
+          "include/pcl/${SUBSYS_NAME}/glsl_shader.h"
+          "include/pcl/${SUBSYS_NAME}/sum_reduce.h"          
+          )
+      add_subdirectory(tools)
+      include_directories("${GLEW_INCLUDE_DIR}")
+  else(OpenGL_FOUND AND GLEW_FOUND)
+      set(srcs "")
+      set(incs "")
+      set(OPENGL_LIBRARIES "")
+      set(GLEW_LIBRARIES "")
+  endif(OpenGL_FOUND AND GLEW_FOUND)
 
-    set(LIB_NAME "pcl_${SUBSYS_NAME}")
-    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include"
-                        "${GLEW_INCLUDE_DIR}")
+  set(gen_srcs
+      src/shape_generator_base.cpp
+      src/shape_generator_shapes.cpp
+      src/shape_generator_complex.cpp
+      src/shape_generator_io.cpp
+      )
+      
+  set(gen_incs
+      "include/pcl/${SUBSYS_NAME}/shape_generator_base.h"
+      "include/pcl/${SUBSYS_NAME}/shape_generator_shapes.h"
+      "include/pcl/${SUBSYS_NAME}/shape_generator_complex.h"
+      "include/pcl/${SUBSYS_NAME}/shape_generator_io.h"
+      )
 
-    PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${incs})
+  set(LIB_NAME "pcl_${SUBSYS_NAME}")
 
-    target_link_libraries("${LIB_NAME}" pcl_common pcl_io
-                          ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES})
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-    set(EXT_DEPS eigen3)
-    PCL_MAKE_PKGCONFIG("${LIB_NAME}" "${SUBSYS_NAME}" "${SUBSYS_DESC}"
-                      "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")
+  PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${incs} ${gen_srcs} ${gen_incs})
 
-    # Install include files
-    PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}" ${incs})
-    #PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/impl" ${impl_incs})
+  target_link_libraries("${LIB_NAME}" pcl_common pcl_io
+                        ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES})
 
-    add_subdirectory(tools)
+  set(EXT_DEPS eigen3)
+  PCL_MAKE_PKGCONFIG("${LIB_NAME}" "${SUBSYS_NAME}" "${SUBSYS_DESC}"
+                    "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")
 
+  # Install include files
+  PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}" ${incs} ${gen_incs})
+  #PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/impl" ${impl_incs})
+  
 endif(build)

--- a/simulation/include/pcl/simulation/shape_generator.h
+++ b/simulation/include/pcl/simulation/shape_generator.h
@@ -1,0 +1,46 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_SIMULATION_SHAPE_GENERATOR_H_
+#define PCL_SIMULATION_SHAPE_GENERATOR_H_
+
+#include <pcl/simulation/shape_generator_base.h>
+#include <pcl/simulation/shape_generator_shapes.h>
+#include <pcl/simulation/shape_generator_complex.h>
+#include <pcl/simulation/shape_generator_io.h>
+
+#endif // PCL_SIMULATION_SHAPE_GENERATOR_H_

--- a/simulation/include/pcl/simulation/shape_generator_base.h
+++ b/simulation/include/pcl/simulation/shape_generator_base.h
@@ -1,0 +1,217 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_SIMULATION_SHAPE_GENERATOR_BASE_H_
+#define PCL_SIMULATION_SHAPE_GENERATOR_BASE_H_
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/common/transforms.h>
+#include <pcl/io/io.h>
+
+#include <boost/make_shared.hpp>
+#include <boost/math/constants/constants.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/random.hpp>
+#include <boost/array.hpp>
+#include <boost/assign.hpp>
+#include <boost/math/special_functions/modf.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <Eigen/StdVector>
+
+#include <ctime>
+
+namespace pcl
+{
+  namespace simulation
+  {
+    /** \brief The abstract base class for all geometric shapes. This class defines basic cloud handling as well as transformations.
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \ingroup simulation
+      */
+    class GeometricShapeBase
+    {
+      public:
+        friend class CutShape;
+        friend class MultiShape;
+
+        typedef pcl::PointXYZLNormal PointT;
+        typedef pcl::PointCloud<PointT> PointCloudT;
+        typedef boost::shared_ptr<GeometricShapeBase> Ptr;
+
+        /** \brief Predefined rotation axes for use with rotate */
+        enum Axis
+        {
+          XAxis, /**< Rotate around the x-axis */
+          YAxis, /**< Rotate around the y-axis */
+          ZAxis  /**< Rotate around the z-axis */
+        };
+
+        /** \brief Default constructor used to initialize most member variables.*/
+        GeometricShapeBase ();
+
+        /** \brief Generate points on the shape surface.
+          * \param[in] resolution The density of points per square unit
+          * \returns A shared pointer to the generated cloud
+          * \note This function is abstract in the base class and needs to be implemented for all child classes.
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution) = 0;
+
+        /** \brief Center the shape around center.
+          * \param[in] new_centroid The point to which the shape will be centered. Default (0, 0, 0)
+          * \returns Returns the translation which has been applied to the shape to center it.
+          */
+        Eigen::Vector3f
+        center (const Eigen::Vector3f &new_centroid = Eigen::Vector3f (0, 0, 0));
+
+        /** \brief Translate the shape in a given direction.
+          * \param[in] translation The translation vector
+          */
+        void
+        translate (const Eigen::Vector3f &translation);
+
+        /** \brief Translate the shape in a given direction.
+          * \param[in] x The x direction of the translation
+          * \param[in] y The y direction of the translation
+          * \param[in] z The z direction of the translation
+          */
+        inline void
+        translate (float x,
+                   float y,
+                   float z)
+        {
+          translate (Eigen::Vector3f (x, y, z));
+        }
+
+        /** \brief Rotate Shape around the x, y or z axis.
+          * \param[in] axis Select x, y or z  axis
+          * \param[in] degree The amount of rotation in degrees
+          * \param[in] in_place True: Shape is rotated around its center. False: Shape is rotated around (0, 0, 0). Default true.
+          */
+        void
+        rotate (GeometricShapeBase::Axis axis,
+                float degree,
+                bool in_place = true);
+
+        /** \brief Rotate Shape around a custom axis.
+          * \param[in] axis Custom axis. Does not need to be normalized.
+          * \param[in] degree The amount of rotation in degrees
+          * \param[in] in_place True: Shape is rotated around its center. False: Shape is rotated around (0, 0, 0). Default true.
+          */
+        void
+        rotate (const Eigen::Vector3f& axis,
+                     float degree,
+                     bool in_place = true);
+
+        /** \brief Reverse all transformations.*/
+        inline void
+        reverseTransformations ()
+        {
+          pcl::transformPoint (centroid_, centroid_, effective_transform_.inverse ());
+          effective_transform_.setIdentity ();
+        }
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        
+      protected:
+        typedef Eigen::Affine3f EigenTransformT;
+
+        /** \brief Random number generator*/
+        boost::random::mt19937 gen_;
+
+        /** \brief Uniform distribution needed for most samplings*/
+        boost::random::uniform_real_distribution<float> dist01_;
+
+        /** \brief The effective transformations which have been applied to the shape*/
+        EigenTransformT effective_transform_;
+
+        /** \brief Stores the shapes centroid (this is usually the centroid of the bounding box)*/
+        Eigen::Vector3f centroid_;
+
+        static uint shape_id_;
+        /// Functions
+        /** \brief Apply the effective transformations to the pointcloud
+          * \param[in,out] cloud_ptr The cloud to transform
+          * \note This should be called at the end of the generate method in all child classes. It makes sure, that we apply all transformation to the generated points
+          */
+        inline void
+        applyTransformations (PointCloudT::Ptr cloud_ptr) const
+        {
+          pcl::transformPointCloudWithNormals (*cloud_ptr, *cloud_ptr, effective_transform_);
+        }
+
+        /** \brief Check if a point is inside the shape in the shapes own reference frame.
+          * \param[in] point The query point.
+          * \returns The query result.
+          * \note This function returns true if the Point is inside the object in the objects own reference frame (i.e. the frame in which generate also places points). Applied transformations are handled by the base class.
+          */
+        virtual bool
+        isInside (const PointT &point) const = 0;
+
+        /** \brief Delete all points from the other cloud which are inside or outside this shape.
+          * \param[in,out] other_cloud_arg The query pointcloud.
+          * \param[in] delete_inliers If true delete inliers, if false delete outliers.
+          */
+        void
+        deletePointsFromOtherCloud (PointCloudT::Ptr other_cloud_arg,
+                                    bool delete_inliers = true) const;
+        
+        /** \brief Calculates the number of points which should be sampled given the area and the resolution.
+          * \param[in] area The size of the area we want to sample on
+          * \param[in] resolution The resolution in points per square unit for the samplings
+          * \returns The number of points which should be sampled on the area.
+          */        
+        inline unsigned int 
+        calculateNumberOfPoints (const float area, 
+                                 const float resolution)
+        {
+          float num_points_float = area * resolution;
+          int num_points;
+          float frac;
+          frac = boost::math::modf (num_points_float , &num_points);
+          if (dist01_ (gen_) < frac)
+            num_points++;
+          return (num_points);
+        }
+    };
+    typedef std::vector<GeometricShapeBase::Ptr> GeometricShapePtrVector;
+  }  // End namespace simulation
+}  // End namespace pcl
+
+#endif // PCL_SIMULATION_SHAPE_GENERATOR_BASE_H_

--- a/simulation/include/pcl/simulation/shape_generator_complex.h
+++ b/simulation/include/pcl/simulation/shape_generator_complex.h
@@ -1,0 +1,202 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_SIMULATION_SHAPE_GENERATOR_COMPLEX_H_
+#define PCL_SIMULATION_SHAPE_GENERATOR_COMPLEX_H_
+
+#include <pcl/simulation/shape_generator_base.h>
+
+namespace pcl
+{
+  namespace simulation
+  {
+    /** \brief A class which allows the creation of complex objects by assembling multiple shapes.
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \note Use the constructor to combine multipe shapes represented by a vector of pointers or two seperate pointer to the abstract base class GeometricShapeBase deleting points which are in the overlap.
+      * \note The MultiShape's center will equal to (0,0,0), since we are combining multiple shapes with different centers.
+      * \ingroup simulation
+      */
+    class MultiShape : public GeometricShapeBase
+    {
+      public:
+        typedef boost::shared_ptr<MultiShape> Ptr;
+
+        /** \brief Option how the labels of the parts are treated.
+          * Assume three shapes consisting of 3 and 4 and 2 parts with part labels (0,1,2) + (0,1,2,3) + (0,1) are combined.
+          */
+        enum LabelHandling
+        {
+          /** All parts will get a single label.
+            * (0,1,2) + (0,1,2,3) + (0,1) --> (0,0,0)(0,0,0,0)(0,0) */
+          Single,
+          /** Every shape gets its unique label. If shape-parts already have different labels they will be merged (default behaviour).
+            * (0,1,2) + (0,1,2,3) + (0,1) --> (0,0,0)(1,1,1,1)(2,2) */
+          Merge,
+          /** Keep all part-labels unique, thus append new labels if shapes have multiple labels already.
+            * (0,1,2) + (0,1,2,3) + (0,1) --> (0,1,2)(3,4,5,6)(7,8) */
+          Append,
+          /** Preserve the labeling of the shapes.
+            * (0,1,2) + (0,1,2,3) + (0,1) --> (0,1,2)(0,1,2,3)(0,1) */
+          Preserve
+        };
+        
+        /** \brief Constructor to generate a MultiShape object from several GeometricShape Pointers.
+          * \param[in] shape_ptrs Vector of GeometricShapeBase::Ptr used to set the input shapes which should be combined to a complex MultiShape
+          * \param[in] delete_overlap If true we remove points of the shapes which lie in an overlapping region of any two shapes. Default true.
+          * \param[in] label_handling Define the way labels of the parts are handled. See enum LabelHandling for details. Dafault: Merge.
+          * \note The shapes used in the constructor will be modified.
+          */
+        MultiShape (GeometricShapePtrVector shape_ptrs,
+                    bool delete_overlap = true,
+                    LabelHandling label_handling = Merge) :
+          shapes_ptrs_ (shape_ptrs),
+          delete_overlap_ (delete_overlap),
+          label_handling_ (label_handling)
+        {
+        };
+
+        /** \brief Constructor to generate a MultiShape object from two GeometricShapes.
+          * \param[in] shape1 First shape
+          * \param[in] shape2 Second shape
+          * \param[in] delete_overlap If true we remove points of the shapes which lie in an overlapping region of any two shapes. Default true.
+          * \param[in] label_handling Define the way labels of the parts are handled. See enum LabelHandling for details. Dafault: Merge.
+          * \note The shapes used in the constructor will be modified.
+          * \note If more than two shapes should be combined use the constructor taking GeometricShapePtrVector as a argument.
+          */
+        MultiShape (GeometricShapeBase::Ptr shape1,
+                    GeometricShapeBase::Ptr shape2,
+                    bool delete_overlap = true,
+                    LabelHandling label_handling = Merge) :
+          delete_overlap_ (delete_overlap),
+          label_handling_ (label_handling)
+        {
+          shapes_ptrs_.clear ();
+          shapes_ptrs_.push_back (shape1);
+          shapes_ptrs_.push_back (shape2);
+        }
+        
+        /** \brief Generates points for shape.
+          * \param[in] resolution The density of points per square unit
+          * \returns A shared pointer to the generated cloud
+          * \note Generats points on all shapes in shapes_ptrs_ and combines them.
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+      protected:
+        /** \brief The vector of pointers of the underlying geometric shapes.*/
+        GeometricShapePtrVector shapes_ptrs_;
+
+        /** \brief If this variable is true we prune points which are in the overlap of any two shapes */
+        bool delete_overlap_;
+
+        /** \brief The way labels are handled*/
+        LabelHandling label_handling_;
+
+        /** \brief An empty protected default constructor which is needed for the RecipeFile class. This constructor is not exposed to the user. */
+        MultiShape ()
+        {
+        }
+
+        /** \brief Check if point lies within any of the shapes
+          * \param[in] point The query point
+          * \returns True if the query point lies within any of the shapes used in the constructor
+          */
+        bool
+        isInside (const PointT &point) const;
+    };
+
+    /** \brief A class which allows the creation of hollow shapes / cavities.
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \note This shape will have a single label.
+      * \ingroup simulation
+      */
+    class CutShape : public GeometricShapeBase
+    {
+      public:
+        typedef boost::shared_ptr<CutShape> Ptr;
+
+        /** \brief Constructor to generate a Cutshape from to GeometricShapeBase::Ptrs.
+          * \param[in] outer_shape_ptr This points to the object which will be cut.
+          * \param[in] inner_shape_ptr This points to the object which will cut the outer shape.
+          * \note The shapes used in the constructor will be modified.
+          * \note The CutShape's center will equal the outer object's center.
+          */
+        CutShape (GeometricShapeBase::Ptr outer_shape_ptr,
+                  GeometricShapeBase::Ptr inner_shape_ptr) :
+          outer_shape_ptr_ (outer_shape_ptr),
+          inner_shape_ptr_ (inner_shape_ptr)
+        {
+          centroid_ = outer_shape_ptr_->centroid_;
+        }
+        /** \brief Generates points on the shape.
+          * \param[in] resolution The density of points per square unit
+          * \returns A shared pointer to the generated cloud
+          * \note Removes all outer shape points which are in the inner shape. Flips inner shape points and removes all inner shape points which are outside the outer shape.
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        
+      protected:
+        /** \brief outer_shape_ptr_ is a pointer to the shape which will be cut by the shape in inner_shape_ptr_*/
+        GeometricShapeBase::Ptr outer_shape_ptr_, inner_shape_ptr_;
+
+        /** \brief Returns true if the query point lies within outer_shape_ptr_ but not within inner_shape_ptr_
+          * \param[in] point The query point
+          * \returns True if the query point lies within outer_shape_ptr_ but not within inner_shape_ptr_.
+          */
+        bool
+        isInside (const PointT &point) const;
+
+        /** \brief Static helper function to flip normals of CloudPtr. inner_shape_ptr_ normals need to be flipped when combining outer and inner shapes.
+          * \param[in,out] CloudPtr The cloud which normals get flipped.
+          */
+        inline static void
+        flipNormals (PointCloudT::Ptr CloudPtr)
+        {
+          for (PointCloudT::iterator itr = CloudPtr->begin (); itr != CloudPtr->end (); ++itr)
+          {
+            itr->getNormalVector3fMap () *= -1;
+          }
+        }
+    };
+  }  // End namespace simulation
+}  // End namespace pcl
+
+#endif // PCL_SIMULATION_SHAPE_GENERATOR_COMPLEX_H_

--- a/simulation/include/pcl/simulation/shape_generator_io.h
+++ b/simulation/include/pcl/simulation/shape_generator_io.h
@@ -1,0 +1,159 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_SIMULATION_SHAPE_GENERATOR_IO_H_
+#define PCL_SIMULATION_SHAPE_GENERATOR_IO_H_
+
+#include <pcl/simulation/shape_generator.h>
+
+#include <string>
+#include <fstream>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+namespace pcl
+{
+  namespace simulation
+  {
+    /** \brief Class for reading recipe files.
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \note The center of this shape will equal (0,0,0), regardless of the transformations applied in the recipe file. This is due to different shapes with different centers being combined.
+      * \ingroup simulation
+      */
+    class RecipeFile : public MultiShape
+    {
+      public:
+        typedef boost::shared_ptr<RecipeFile> Ptr;
+        typedef std::vector<std::string> RecipeLinesT;
+        typedef std::set<std::string> ParentRecipeNamesT;
+
+        /** \brief Constructor for recipe files.
+          * \param[in] recipe_file_name Filename of the recipe which should be processed.
+          * \param[in] parent_recipe_names_set A set including the recipe filenames of the parents. If a recipe calls another recipe it should provide its own parent_recipe_names_set_ as an argument. If this is the first recipe, do not provide this argument.
+          */
+        RecipeFile (const std::string &recipe_file_name,
+                    const ParentRecipeNamesT &parent_recipe_names_set = ParentRecipeNamesT ());
+
+        /** \brief Check if the parsing was successful.
+          * \returns True if parsing was successful.
+          */
+        inline bool
+        parsedSuccessful () const
+        {
+          return (parsing_successful_);
+        }
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+      private:
+        /** \brief Path to recipe name. */
+        boost::filesystem::path recipe_file_name_;
+
+        /** \brief Stores the lines of a recipe. */
+        RecipeLinesT recipe_lines_;
+
+        /** \brief Recipes can call other recipes. This stores how deep we recursed down the recipes. Only used for formatting the terminal output.*/
+        unsigned int recursion_depth_;
+
+        /** \brief Prefix string to be used for intendenting the terminal output. */
+        std::string prefix_;
+
+        /** \brief This stores the current recipe filename as well as the filenames of all parent recipes.
+          * \note If a new recipe is encountered we check if this has already been called for on of the parents. That way we detect infinite loops due to recipes calling on of it's parents recipes.
+          */
+        ParentRecipeNamesT parent_recipe_names_set_;
+
+        /** \brief If no error occured this will be set to true. */
+        bool parsing_successful_;
+
+        /** \brief Static helper function to prepare/clean recipe lines (prune it of comments and excess spaces.
+          * \param[in] line Line to clean
+          * \returns The cleaned line.
+          */
+        static std::string
+        cleanLine (std::string line);
+
+        /** \brief Static helper function to convert a string to a float using boost.
+          * \param[in] str String to convert.
+          * \returns The corresponding float value.
+          */
+        inline static float
+        toFloat (const std::string &str)
+        {
+          return (boost::lexical_cast<float> (str));
+        }
+
+        /** \brief Reads the recipe in recipe_file_name_.
+          * \note Adds lines to recipe_lines_. If successful it will set parsing_successful_ to true.
+          */
+        void
+        readRecipe ();
+
+        /** \brief Reads the lines and adds all parsed shapes to shapes.
+          * \param[in] lines This vector holds the recipe lines which should be processed.
+          * \param[out] shapes The instructions found in lines will be translated into shapes.
+          * \param[out] delete_overlap_flag If Delete_Overlap instruction is found in lines this variable will be set to that value. Otherwise this variable is true.
+          * \param[out] label_handling If Label instructions are found in lines, this variable will be set. Otherwise it is Merge.
+          * \returns True if the lines were parsed successfully. If an error occured (like unknown instructions) it will return false.
+          * \note This is the main functionality for the class. It defines the instructions which can be translated by the recipe.
+          */
+        bool
+        parseLines (const RecipeFile::RecipeLinesT& lines,
+                    GeometricShapePtrVector& shapes,
+                    bool& delete_overlap_flag,
+                    MultiShape::LabelHandling &label_handling);
+
+        /** \brief Helper function to treat blocks encountered in a recipe (like Multi_begin, Cut_begin ...). 
+          * \param[in,out] itr Line Iterator which needs to be defined in the caller function. Since blocks span multiple lines this functions iterates itr as well.
+          * \param[in] end_itr Iterator pointing to the last line of the instructions currently parsed. Is required since we increment itr in this function.
+          * \param[in] delimiter A vector of strings denoting the delimiters of the block.
+          * \param[out] blocks The blocks which were found excluding the delimiters. The number of blocks is equal to the number of delimeters provided.
+          * \returns Function returns true processing the block was successful. If a delimeter was not found or if we reached the end of the instructions this will return false.
+          */
+        bool
+        parseBlock (RecipeLinesT::const_iterator &itr,
+                    const RecipeLinesT::const_iterator end_itr,
+                    const RecipeLinesT delimiter,
+                    std::vector<RecipeLinesT> &blocks);
+
+    };
+  }  // End namespace simulation
+}  // End namespace pcl
+
+#endif // PCL_SIMULATION_SHAPE_GENERATOR_IO_H_

--- a/simulation/include/pcl/simulation/shape_generator_shapes.h
+++ b/simulation/include/pcl/simulation/shape_generator_shapes.h
@@ -1,0 +1,410 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_SIMULATION_SHAPE_GENERATOR_SHAPES_H_
+#define PCL_SIMULATION_SHAPE_GENERATOR_SHAPES_H_
+
+#include <pcl/simulation/shape_generator_base.h>
+
+namespace pcl
+{
+  namespace simulation
+  {
+    /** \brief  Class which can be used to sample on any polygon given by a set of vertices and faces.
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \note We do check if all vertices in a face a planar and convex, but we do not check if the shape is convex.
+      * \note If you provide vertices and faces which belong to a concave polygon the shape can still be sampled but the isInside function will not work properly. This is why you cannot use a concave polygon together with MultiShape or CutShape.
+      * \ingroup simulation
+      */
+    class ConvexPolygon : public GeometricShapeBase
+    {
+      public:
+        typedef boost::shared_ptr<ConvexPolygon> Ptr;
+        typedef std::vector<Eigen::Vector3f> VerticeVectorT;
+        typedef std::vector<std::vector<unsigned int> > FaceInformationT;
+
+        /** \brief  Standard constructor which requires the call of setPolygons afterwards. */
+        ConvexPolygon () :
+          faces_set_ (false),
+          area_ (0)
+        {
+        }
+
+        /** \brief  Constructor which already initializes the polygon using setPolygons.
+          * \param[in] vertices_vector std::vector of Eigen::Vector3f points which describe the polygon's vertices.
+          * \param[in] face_information A vector of a vector of indices which describe how vertices are connected.
+          */
+        ConvexPolygon (const VerticeVectorT &vertices_vector,
+                       const FaceInformationT &face_information) :
+          faces_set_ (false),
+          area_ (0)
+        {
+          setPolygons (vertices_vector, face_information);
+        }
+
+        /** \brief  Sets the vertices and the faces of the polyon
+          * \param[in] vertices_vector std::vector of Eigen::Vector3f points which describe the polygon's vertices.
+          * \param[in] face_information A vector of a vector of indices which describe how vertices are connected.
+          * \note Normals are pointing in the right-hand grip rule direction of a face (ascending vertex order).
+          */
+        void
+        setPolygons (const VerticeVectorT &vertices_vector,
+                     const FaceInformationT &face_information);
+
+        /** \brief  Returns the total area of the polygon
+          * \returns The area of the polygon. If faces have not been set, returns 0.
+          */
+        float
+        getPolygonArea ()
+        {
+          return (area_);
+        }
+
+        /** \brief  Generate points on the shape
+          * \param[in] resolution points per square unit
+          * \returns A shared pointer to the generated cloud
+          * \note This function will call the sampleOnFace function of all faces.
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+      protected:
+        /** \brief  Class which holds the face information of the polygon, like normal, face-area.
+          * \author Markus Schoeler (mschoeler@gwdg.de)
+          * \note Each face is represented by one or multiple triangles. All points of a face need to lie in a common plane.
+          * \note We only copy the indices of the vertices, but not their coordinates, this is why we need to set the parent and make this class friend of ConvexPolygon.
+          * \ingroup simulation
+          */
+        struct Face
+        {
+          typedef boost::shared_ptr<Face> Ptr;
+          ConvexPolygon* parent_;
+          std::vector<unsigned int> vertex_list_;
+          Eigen::Vector3f normal_;
+          std::vector<float> triangle_areas_;
+          float face_area_;
+
+          Face (ConvexPolygon* parent) :
+            parent_ (parent),
+            face_area_ (0)
+          {
+          }
+
+          /** \brief Samples random points on the face with resolution points per square unit.            
+             * \param[in] resolution points per square unit
+             * \param[in,out] cloud_ptr the cloud to which we add points
+             * \param[in] label the label of the new sampled points (default = 0)
+             */
+          void
+          sampleOnFace (float resolution, 
+                        PointCloudT::Ptr cloud_ptr, 
+                        int label = 0);
+
+          /** \brief Check if query point lies on the side of the plane which points away from the normals.
+             * \param[in] point Query point
+             * \returns True if point lies on the side of the plane pointing away from the normal.
+             */
+          inline bool
+          isInside (const PointT &point)
+          {
+            return (normal_.dot (point.getVector3fMap () - parent_->vertices_[vertex_list_[0]]) < 0);
+          }
+          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        };  // END struct Face
+
+        friend class Face;
+
+        /** \brief  A vector with the vertex coordinates */
+        VerticeVectorT vertices_;
+
+        /** \brief  A vector with the face pointers. */
+        std::vector<Face::Ptr> faces_;
+
+        /** \brief  Is true when faces have been set using setPolygons. */
+        bool faces_set_;
+
+        /** \brief  Stores the total area of the object. */
+        float area_;
+
+        /** \brief  Checks if query point is inside the shape.
+          * \param[in] point Query point
+          * \returns True if point lies within the convex polygon
+          * \note For a convex polygon this yields true if all Face's isInside function return true. (Conjunction)
+          * \note Since this is not valid for polygons with concavities we cannot use this isInside function for concave polygons.
+          */
+        virtual bool
+        isInside (const PointT &point) const;
+    };
+
+    /** \brief  Class defining a sphere shape
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \ingroup simulation
+      */
+    class Sphere : public GeometricShapeBase
+    {
+      public:
+        typedef boost::shared_ptr<Sphere> Ptr;
+
+        /** \brief  Default constructor for the shape
+          * \param[in] radius Sphere's radius
+          */
+        Sphere (float radius) :
+          radius_ (radius)
+        {
+        }
+
+        /** \brief  Generate points on the shape
+          * \param[in] resolution points per square unit
+          * \returns A shared pointer to the generated cloud
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        
+      protected:
+        float radius_;
+
+        /** \brief  Checks if query point is inside the shape.
+          * \param[in] point Query point
+          * \returns True if point lies within the shape.
+          */
+        virtual bool
+        isInside (const PointT &point) const;
+    };
+
+    /** \brief  Class defining a cylinder shape
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \ingroup simulation
+      */
+    class Cylinder : public GeometricShapeBase
+    {
+      public:
+        typedef boost::shared_ptr<Cylinder> Ptr;
+
+        /** \brief  Default constructor for the shape
+          * \param[in] radius Cylinder's radius (x,z- plane)
+          * \param[in] height Cylinder's height (y-axis)
+          */
+        Cylinder (float radius,
+                  float height) :
+          radius_ (radius),
+          height_ (height)
+        {
+        }
+
+        /** \brief  Generate points on the shape
+          * \param[in] resolution points per square unit
+          * \returns A shared pointer to the generated cloud
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+      protected:
+        float radius_, height_;
+
+        /** \brief  Checks if query point is inside the shape.
+          * \param[in] point Query point
+          * \returns True if point lies within the shape.
+          */
+        virtual bool
+        isInside (const PointT &point) const;
+
+        /** \brief  Add points on the cylinder middle
+          * \param[in] resolution points per square unit
+          * \param[in,out] cloud_ptr add point to the cloud_ptr
+          * \returns A shared pointer to the generated cloud
+          */
+        void
+        addCylinderMiddle (float resolution,
+                           PointCloudT::Ptr cloud_ptr);
+
+        /** \brief  Add points on the cylinder top and bottom
+          * \param[in] resolution points per square unit
+          * \param[in,out] cloud_ptr add point to the cloud_ptr
+          * \returns A shared pointer to the generated cloud
+          */
+        void
+        addCylinderTopAndBottom (float resolution, 
+                                 PointCloudT::Ptr cloud_ptr);
+    };
+
+    /** \brief  Class defining a cone shape
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \ingroup simulation
+      */
+    class Cone : public GeometricShapeBase
+    {
+      public:
+        typedef boost::shared_ptr<Cone> Ptr;
+
+        /** \brief  Default constructor for the shape
+          * \param[in] radius Cone's radius (x,z- plane)
+          * \param[in] height Cone's height (y-axis)
+          */
+        Cone (float radius,
+              float height) :
+          radius_ (radius),
+          height_ (height)
+        {
+        }
+
+        /** \brief  Generate points on the shape
+          * \param[in] resolution points per square unit
+          * \returns A shared pointer to the generated cloud
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      protected:
+        float radius_, height_;
+
+        /** \brief  Checks if query point is inside the shape.
+          * \param[in] point Query point
+          * \returns True if point lies within the shape.
+          */
+        virtual bool
+        isInside (const PointT &point) const;
+    };
+
+    /** \brief  Class defining a wedge shape
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \ingroup simulation
+      */
+    class Wedge : public ConvexPolygon
+    {
+      public:
+        typedef boost::shared_ptr<Wedge> Ptr;
+        /** \brief  Default constructor for the shape
+          * \param[in] width Wedges bottom width (x-axis)
+          * \param[in] depth Wedges bottom depth (z-axis)
+          * \param[in] upwidth Wedges top width (x-axis)
+          * \param[in] updepth Wedges top depth (z-axis)
+          * \param[in] height Wedges height (y-axis)
+          * \note This is a good example how one can implement a shape which inherits it's whole functionality from ConvexPolygon
+          */
+        Wedge (float width,
+               float depth,
+               float upwidth,
+               float updepth,
+               float height);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      protected:
+        /** \brief Enumerator for accessing the eight corners */
+        enum Corner
+        {
+          FrontBottomLeft, FrontBottomRight, BackBottomLeft, BackBottomRight, FrontTopLeft, FrontTopRight, BackTopLeft, BackTopRight
+        };
+    };
+
+    /** \brief  Class defining a cuboid shape (special wedge case)
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \ingroup simulation
+      */
+    class Cuboid : public Wedge
+    {
+      public:
+        typedef boost::shared_ptr<Cuboid> Ptr;
+        
+        /** \brief  Default constructor for the shape
+          * \param[in] width Cuboid width (x-axis)
+          * \param[in] height Cuboid height (y-axis)
+          * \param[in] depth Cuboid depth (z-axis)
+          * \note This is just a lightweight wrapper for a special case of a wedge.
+          */
+        Cuboid (float width,
+                float height,
+                float depth) :
+          Wedge (width, depth, width, depth, height)
+        {
+        }
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    };
+
+    /** \brief  Class defining a full as well as partial torus shape
+      * \author Markus Schoeler (mschoeler@gwdg.de)
+      * \ingroup simulation
+      */
+    class Torus : public GeometricShapeBase
+    {
+      public:
+        typedef boost::shared_ptr<Torus> Ptr;
+
+        /** \brief  Constructor for a full torus
+          * \param[in] R Torus's outer radius
+          * \param[in] r Torus's inner radius
+          * \note Creates a full torus in the x,z plane.
+          */
+        Torus (float R,
+               float r);
+
+        /** \brief  Constructor for a partial torus
+          * \param[in] R Torus's outer radius
+          * \param[in] r Torus's inner radius
+          * \param[in] min_theta Start of the torus segment in degrees. 0 is parallel to x-, 90 is parallel to z-axis.
+          * \param[in] max_theta End of the torus segment in degrees. 0 is parallel to x-, 90 is parallel to z-axis.
+          * \note Creates a partial torus in the x,z plane.
+          */
+        Torus (float R,
+               float r,
+               float min_theta,
+               float max_theta);
+
+        /** \brief  Generate points on the shape
+          * \param[in] resolution points per square unit
+          * \returns A shared pointer to the generated cloud
+          */
+        virtual PointCloudT::Ptr
+        generate (float resolution);
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        
+      protected:
+        bool is_full_;
+        float R_, r_, min_theta_, max_theta_;
+
+        /** \brief  Checks if query point is inside the shape.
+          * \param[in] point Query point
+          * \returns True if point lies within the shape.
+          */
+        virtual bool
+        isInside (const PointT &point) const;
+    };
+  }  // End namespace simulation
+}  // End namespace pcl
+
+#endif // PCL_SIMULATION_SHAPE_GENERATOR_SHAPES_H_

--- a/simulation/simulation.doxy
+++ b/simulation/simulation.doxy
@@ -1,0 +1,21 @@
+/**
+  \addtogroup simulation Module simulation
+
+  \section  secSimulationPresentation Overview
+  The <b>pcl_simulation</b> library provides algorithms for generating and simulating data.
+  
+  \section  secShapeGenerator Shape generator overview
+  The shape generator can create and combine shapes to labeled artificial scenes. Its main purpose is to provide an easy way to benchmark or test algorithms. 
+	
+  \section secSimulationRequirements Requirements
+  - \ref common "common"
+  - \ref io "io"
+  - \ref surface "surface"
+  - \ref kdtree "kdtree"
+  - \ref octree "octree"
+  - \ref features "features"
+  - \ref search "search"
+  - \ref visualization "visualization"
+  - \ref filters "filters"
+  - \ref geometry "geometry"
+*/

--- a/simulation/src/shape_generator_base.cpp
+++ b/simulation/src/shape_generator_base.cpp
@@ -1,0 +1,127 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/simulation/shape_generator_base.h>
+
+pcl::simulation::GeometricShapeBase::GeometricShapeBase ()
+{  
+  gen_.seed (0);
+  dist01_ = boost::random::uniform_real_distribution<float> (0, 1);
+  effective_transform_.setIdentity ();
+  centroid_ = Eigen::Vector3f (0, 0, 0);
+}
+
+Eigen::Vector3f
+pcl::simulation::GeometricShapeBase::center (const Eigen::Vector3f &new_centroid)
+{
+  Eigen::Vector3f translation;
+  translation = new_centroid - centroid_;
+  translate (translation);
+  return (translation);
+}
+
+void
+pcl::simulation::GeometricShapeBase::translate (const Eigen::Vector3f &translation)
+{
+  EigenTransformT T;
+  T = Eigen::Translation<float, 3> (translation[0], translation[1], translation[2]);
+  pcl::transformPoint (centroid_, centroid_, T);
+  effective_transform_ = T * effective_transform_;
+}
+
+void
+pcl::simulation::GeometricShapeBase::rotate (pcl::simulation::GeometricShapeBase::Axis axis,
+                                             float degree,
+                                             bool in_place)
+{
+  switch (axis)
+  {
+    case XAxis:
+      rotate (Eigen::Vector3f (1, 0, 0), degree, in_place);
+      break;
+    case YAxis:
+      rotate (Eigen::Vector3f (0, 1, 0), degree, in_place);
+      break;
+    case ZAxis:
+      rotate (Eigen::Vector3f (0, 0, 1), degree, in_place);
+      break;
+  }
+}
+
+void
+pcl::simulation::GeometricShapeBase::rotate (const Eigen::Vector3f &axis,
+                                             float degree,
+                                             bool in_place)
+{
+  EigenTransformT trans;
+  if (in_place)
+  {
+    trans = Eigen::Translation<float, 3> (centroid_[0], centroid_[1], centroid_[2]) *
+            Eigen::AngleAxis<float> (degree * M_PI / 180.f, axis.normalized ()) *
+            Eigen::Translation<float, 3> (-centroid_[0], -centroid_[1], -centroid_[2]);
+  }
+  else
+  {
+    trans = Eigen::AngleAxis<float> (degree * M_PI / 180.f, axis.normalized ());
+  }
+  effective_transform_ = trans * effective_transform_;
+  pcl::transformPoint (centroid_, centroid_, trans);
+}
+
+void
+pcl::simulation::GeometricShapeBase::deletePointsFromOtherCloud (PointCloudT::Ptr other_cloud_arg,
+                                                                 bool delete_inliers) const
+{
+  // Do a inverse transformation of the given cloud. This way I can check for inliers/outliers by solving the known equations for the geometric shape.
+  PointCloudT inverse_transformed_cloud;
+  pcl::transformPointCloudWithNormals (*other_cloud_arg, inverse_transformed_cloud, effective_transform_.inverse ());
+  PointCloudT::iterator itrOrig = other_cloud_arg->begin ();
+  PointCloudT::iterator itrTrans = inverse_transformed_cloud.begin ();
+  while (itrTrans != inverse_transformed_cloud.end ())
+  {
+    if (isInside (*itrTrans) == delete_inliers)
+    {
+      itrOrig = other_cloud_arg->erase (itrOrig);
+      ++itrTrans;
+    }
+    else
+    {
+      ++itrOrig;
+      ++itrTrans;
+    }
+  }
+}

--- a/simulation/src/shape_generator_complex.cpp
+++ b/simulation/src/shape_generator_complex.cpp
@@ -1,0 +1,152 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/simulation/shape_generator_complex.h>
+typedef pcl::simulation::GeometricShapeBase::PointCloudT PointCloudT;
+
+// ------------------ Multishape definitions --------------------------------
+
+bool
+pcl::simulation::MultiShape::isInside (const PointT &point) const
+{
+  // since the is_inside methods for all shapes expects a point in its respective reference frame, we have to manually transform the point into the shape reference frames
+  for (std::size_t cs = 0; cs < shapes_ptrs_.size (); ++cs)
+  {
+    PointT Backtransformed_Point = pcl::transformPoint (point, shapes_ptrs_[cs]->effective_transform_.inverse ());
+    if (shapes_ptrs_[cs]->isInside (Backtransformed_Point))
+      return (true);
+  }
+  return (false);
+}
+
+PointCloudT::Ptr
+pcl::simulation::MultiShape::generate (float resolution)
+{
+  PointCloudT::Ptr cloud_ptr (new PointCloudT ());
+  std::vector <PointCloudT::Ptr> part_clouds;
+  part_clouds.resize (shapes_ptrs_.size ());
+  for (std::size_t cs = 0; cs < shapes_ptrs_.size (); ++cs)
+  {
+    part_clouds[cs] = shapes_ptrs_[cs]->generate (resolution);
+  }
+  
+// if delete overlap is true, than compare each cloud to each other cloud and delete the points within the other cloud
+  if (delete_overlap_)
+    for (std::size_t cs1 = 0; cs1 < shapes_ptrs_.size (); ++cs1)
+    {
+      for (std::size_t cs2 = 0; cs2 < shapes_ptrs_.size (); ++cs2)
+      {
+        if (cs1 != cs2)
+        {
+          shapes_ptrs_[cs1]->deletePointsFromOtherCloud (part_clouds[cs2]);
+        }
+      }
+    }
+
+  // if we want to keep labels of parts separate we need to define a mapping from part_id, label_id -> new_label_id
+  unsigned int current_max_label = 0;
+  // add points to the shape using the actual label handling policy
+  for (std::size_t cs = 0; cs < part_clouds.size (); ++cs)
+  {
+    PointCloudT::Ptr part_cloud_ptr = part_clouds[cs];
+    std::map <unsigned int, unsigned int> part_label_to_object_label_map;
+    for (PointCloudT::iterator itr = part_cloud_ptr->begin (); itr < part_cloud_ptr->end (); ++itr)
+    {
+      switch (label_handling_)
+      {
+        case Single:
+          itr->label = 0;
+          break;
+        case Merge:
+          itr->label = cs;
+          break;
+        case Append:
+          if (part_label_to_object_label_map.find (itr->label) == part_label_to_object_label_map.end ())
+          {
+            part_label_to_object_label_map[itr->label] = current_max_label;
+            ++current_max_label;
+          }
+          itr->label = part_label_to_object_label_map[itr->label];
+          break;
+        case Preserve:
+          // we do not need to change the label here, since we will preserve the id which has been assigned to the part already.
+          break;
+      }
+      cloud_ptr->push_back (*itr);
+    }
+  }
+  
+  applyTransformations (cloud_ptr);
+  return (cloud_ptr);
+}
+
+// ------------------ Cut shape definitions --------------------------------
+
+PointCloudT::Ptr
+pcl::simulation::CutShape::generate (float resolution)
+{
+  PointCloudT::Ptr cloud_ptr (new PointCloudT ());
+  PointCloudT::Ptr outer_cloud_ptr = outer_shape_ptr_->generate (resolution);
+  PointCloudT::Ptr inner_cloud_ptr = inner_shape_ptr_->generate (resolution); 
+
+  // delete the inliers of the outer_shape.
+  inner_shape_ptr_->deletePointsFromOtherCloud (outer_cloud_ptr, true);
+
+  // delete the outliers from the inner shape.
+  outer_shape_ptr_->deletePointsFromOtherCloud (inner_cloud_ptr, false);
+
+  // flip normals of the inner shape.
+  flipNormals (inner_cloud_ptr);
+
+  // combine both clouds.
+  *cloud_ptr = *outer_cloud_ptr + *inner_cloud_ptr;
+
+  // apply transformation which may have been set before generate was called
+  applyTransformations (cloud_ptr);
+  return (cloud_ptr);
+}
+
+bool
+pcl::simulation::CutShape::isInside (const PointT &point) const
+{
+  // since the is_inside for _OuterShape and _InsideShape expects a point in its own reference frame, we have to manually transform the point into the Outside and Inside shape reference frame
+  PointT outside_backtransformed_point, inside_backtransformed_point;
+  outside_backtransformed_point = pcl::transformPoint (point, outer_shape_ptr_->effective_transform_.inverse ());
+  inside_backtransformed_point = pcl::transformPoint (point, inner_shape_ptr_->effective_transform_.inverse ());
+
+  return (outer_shape_ptr_->isInside (outside_backtransformed_point) && !inner_shape_ptr_->isInside (inside_backtransformed_point));
+}

--- a/simulation/src/shape_generator_io.cpp
+++ b/simulation/src/shape_generator_io.cpp
@@ -1,0 +1,373 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/simulation/shape_generator_io.h>
+
+pcl::simulation::RecipeFile::RecipeFile (const std::string &recipe_file_name,
+                                         const ParentRecipeNamesT &parent_recipe_names_set) :
+  recipe_file_name_ (recipe_file_name),
+  parent_recipe_names_set_ (parent_recipe_names_set)
+{
+  parent_recipe_names_set_.insert (recipe_file_name);
+  recursion_depth_ = parent_recipe_names_set_.size ();
+  prefix_ = std::string (recursion_depth_ * 2, ' ');
+  readRecipe ();
+}
+
+std::string
+pcl::simulation::RecipeFile::cleanLine (std::string line)
+{
+  RecipeLinesT parsed_line;
+  boost::algorithm::trim_if (line, boost::algorithm::is_any_of ("\t "));
+  // ignore hash-tags (for comments)
+  std::size_t hash_pos = line.find_first_of ("#");
+  if (hash_pos != std::string::npos)
+    line.erase (hash_pos);
+  return (line);
+}
+
+bool
+pcl::simulation::RecipeFile::parseBlock (RecipeLinesT::const_iterator &itr,
+                                         const RecipeLinesT::const_iterator end_itr,
+                                         const RecipeLinesT delimiter,
+                                         std::vector<RecipeLinesT> &blocks)
+{
+  blocks.clear ();
+  // first delimiter is reserved for the block opening string, thus size - 1
+  blocks.resize (delimiter.size () - 1);
+  // this treats the case of nested blocks.
+  unsigned int nested_blocks_counter = 0;
+  // first delimiter is reserved for the block opening string.
+
+  std::string opening_delimiter = delimiter[0];
+  std::string closing_delimiter = delimiter[delimiter.size () - 1];
+
+  unsigned int delimiter_counter = 1;
+  while (delimiter_counter != delimiter.size ())
+  {
+    bool delimiter_found = false;
+    while (!delimiter_found)
+    {
+      PCL_INFO ("%sRead lines within block (next delimiter %s). Current line: %s\n", prefix_.c_str (), delimiter[delimiter_counter].c_str (), itr->c_str ());
+
+      // check if we have nested blocks if so, we need to treat delimiters which would normally trigger the transition between blocks as part of the block.
+      bool ignore_delimiters;
+      if (*itr == opening_delimiter)
+      {
+        ++nested_blocks_counter;
+      }
+
+      if (nested_blocks_counter > 0)
+      {
+        PCL_INFO ("%sCurrently within nested block, ignoring delimiters\n", prefix_.c_str ());
+        ignore_delimiters = true;
+        if (*itr == closing_delimiter)
+          --nested_blocks_counter;
+      }
+      else
+      {
+//         PCL_INFO ("%sCurrently NOT within nested block\n");
+        ignore_delimiters = false;
+      }
+
+      if (*itr == delimiter[delimiter_counter] && !ignore_delimiters)
+      {
+        delimiter_found = true;
+        ++itr;
+        ++delimiter_counter;
+      }
+      else
+      {
+        blocks[delimiter_counter - 1].push_back (*itr);
+        ++itr;
+        if (itr == end_itr)
+        {
+          PCL_WARN ("%sCould not find %s\n", prefix_.c_str (), delimiter[delimiter_counter].c_str ());
+          return (false);
+        }
+      }
+    }
+  }
+  // the iterator points now to the line after the last delimiter, but needs to point to the last line of the block (RecipeFile::parseLines increments for itself). Thus decrement.
+  --itr;
+  return (true);
+}
+
+bool
+pcl::simulation::RecipeFile::parseLines (const RecipeLinesT& lines,
+                                         GeometricShapePtrVector &shapes,
+                                         bool &delete_overlap_flag,
+                                         MultiShape::LabelHandling &label_handling)
+{
+
+  shapes.clear ();
+  delete_overlap_flag = true;
+  label_handling = Merge;
+  for (RecipeLinesT::const_iterator itr = lines.begin (); itr != lines.end (); ++itr)
+  {
+    PCL_INFO ("%sParsing Line: %s\n", prefix_.c_str (), itr->c_str ());
+
+    // ignore empty lines
+    if (itr->size () == 0)
+    {
+      continue;
+    }
+
+    RecipeLinesT substrings;
+    boost::algorithm::split (substrings, *itr, boost::algorithm::is_any_of ("\t "), boost::algorithm::token_compress_on);
+
+    // Cylinder
+    if (substrings[0] == "Cylinder" && substrings.size () == 3)
+    {
+      shapes.push_back (Cylinder::Ptr (new Cylinder (toFloat (substrings[1]), toFloat (substrings[2]))));
+      continue;
+    }
+
+    // Cuboid
+    if (substrings[0] == "Cuboid" && substrings.size () == 4)
+    {
+      shapes.push_back (Cuboid::Ptr (new Cuboid (toFloat (substrings[1]), toFloat (substrings[2]), toFloat (substrings[3]))));
+      continue;
+    }
+
+    // Sphere
+    if (substrings[0] == "Sphere" && substrings.size () == 2)
+    {
+      shapes.push_back (Sphere::Ptr (new Sphere (toFloat (substrings[1]))));
+      continue;
+    }
+
+    // Cone
+    if (substrings[0] == "Cone" && substrings.size () == 3)
+    {
+      shapes.push_back (Cone::Ptr (new Cone (toFloat (substrings[1]), toFloat (substrings[2]))));
+      continue;
+    }
+
+    // Torus (full or part)
+    if (substrings[0] == "Torus" && (substrings.size () == 3 || substrings.size () == 5))
+    {
+      if (substrings.size () == 3)
+        shapes.push_back (Torus::Ptr (new Torus (toFloat (substrings[1]), toFloat (substrings[2]))));
+      else
+        shapes.push_back (
+            Torus::Ptr (new Torus (toFloat (substrings[1]), toFloat (substrings[2]), toFloat (substrings[3]) * M_PI / 180.f, toFloat (substrings[4]) * M_PI / 180.f)));
+      continue;
+    }
+
+    // Wedge
+    if (substrings[0] == "Wedge" && substrings.size () == 6)
+    {
+      shapes.push_back (
+          Wedge::Ptr (new Wedge (toFloat (substrings[1]), toFloat (substrings[2]), toFloat (substrings[3]), toFloat (substrings[4]), toFloat (substrings[5]))));
+      continue;
+    }
+
+    // Transformations
+    if (substrings[0] == "T" && substrings.size () == 4)
+    {
+      if (shapes.size () == 0)
+      {
+        PCL_WARN ("No shapes created yet, ignoring transformation\n");
+        continue;
+      }
+      shapes.back ()->translate (toFloat (substrings[1]), toFloat (substrings[2]), toFloat (substrings[3]));
+      continue;
+    }
+    if ((substrings[0] == "R" || substrings[0] == "RC") &&
+        (substrings.size () == 3 || substrings.size () == 5))
+    {
+      if (shapes.size () == 0)
+      {
+        PCL_WARN ("No shapes created yet, ignoring transformation\n");
+        continue;
+      }
+      Eigen::Vector3f axis;
+      bool rotate_in_place = (substrings[0] == "R");
+      if (substrings[1] == "x" || substrings[1] == "y" || substrings[1] == "z")
+      {
+        if (substrings[1] == "x")
+          axis = Eigen::Vector3f (1, 0, 0);
+        else if (substrings[1] == "y")
+          axis = Eigen::Vector3f (0, 1, 0);
+        else if (substrings[1] == "z")
+          axis = Eigen::Vector3f (0, 0, 1);
+        shapes.back ()->rotate (axis, toFloat (substrings[2]), rotate_in_place);
+      }
+      else
+      {
+        axis = Eigen::Vector3f (toFloat (substrings[1]), toFloat (substrings[2]), toFloat (substrings[3]));
+        shapes.back ()->rotate (axis, toFloat (substrings[4]));
+      }
+
+      continue;
+    }
+
+    // Multi Shape Object
+    if (substrings[0] == "Multi_begin" && substrings.size () == 1)
+    {
+      ++itr;
+      std::vector<RecipeLinesT> blocks;
+      RecipeLinesT delimiter;
+      delimiter.push_back ("Multi_begin");
+      delimiter.push_back ("Multi_end");
+      // check if the block was parsed sucessfully, before processing the lines
+      if (parseBlock (itr, lines.end (), delimiter, blocks))
+      {
+        GeometricShapePtrVector shapes_from_block_ptr;
+        bool overlap_flag_from_block;
+        LabelHandling label_handling_from_block;
+        // check if the lines were parsed sucessfully, before adding the new object to the vector
+        if (parseLines (blocks[0], shapes_from_block_ptr, overlap_flag_from_block, label_handling_from_block))
+          shapes.push_back (MultiShape::Ptr (new MultiShape (shapes_from_block_ptr, overlap_flag_from_block, label_handling_from_block)));
+        else
+          PCL_WARN ("%sError while reading the multi block. Skipping it.\n", prefix_.c_str ());
+      }
+      else
+      {
+        PCL_WARN ("%sCould not find Multi_end. Skipping the rest.\n", prefix_.c_str ());
+        return (false);
+      }
+      continue;
+    }
+
+    // Cutshape Object
+    if (substrings[0] == "Cut_begin" && substrings.size () == 1)
+    {
+      ++itr;
+      std::vector<RecipeLinesT> blocks;
+      RecipeLinesT delimiter;
+      delimiter.push_back ("Cut_begin");
+      delimiter.push_back ("by");
+      delimiter.push_back ("Cut_end");
+      // check if the block was parsed sucessfully, before processing the lines
+      if (parseBlock (itr, lines.end (), delimiter, blocks))
+      {
+        GeometricShapePtrVector shapes_from_cut_block_ptr, shapes_from_cutter_block_ptr;
+        bool overlap_flag_from_cut_block, overlap_flag_from_cutter_block;
+        LabelHandling label_handling_from_cut_block, label_handling_from_cutter_block;
+        // check if the lines were parsed sucessfully, before adding the new object to the vector
+        if (parseLines (blocks[0], shapes_from_cut_block_ptr, overlap_flag_from_cut_block, label_handling_from_cut_block)
+            && parseLines (blocks[1], shapes_from_cutter_block_ptr, overlap_flag_from_cutter_block, label_handling_from_cutter_block))
+        {
+          MultiShape::Ptr ToCut (new MultiShape (shapes_from_cut_block_ptr, overlap_flag_from_cut_block, Single));
+          MultiShape::Ptr Cutter (new MultiShape (shapes_from_cutter_block_ptr, overlap_flag_from_cutter_block, Single));
+          shapes.push_back (CutShape::Ptr (new CutShape (ToCut, Cutter)));
+        }
+        else
+          PCL_WARN ("%sError while reading the cut block. Skipping it.\n", prefix_.c_str ());
+      }
+      else
+      {
+        PCL_WARN ("%sCould not find the delimiters of the cut block. Skipping the rest.\n", prefix_.c_str ());
+        return (false);
+      }
+      continue;
+    }
+
+    // Recipe Object
+    if (substrings[0] == "Recipe" && substrings.size () == 2)
+    {
+      // check if the recipe filename has been processed for a predecessor. If that is the case we would create an infinite loop.
+      if (parent_recipe_names_set_.find (substrings[1]) == parent_recipe_names_set_.end ())
+      {
+        RecipeFile::Ptr new_recipe (new RecipeFile (substrings[1], parent_recipe_names_set_));
+        // check if the parsing was successful before adding the new object to the vector
+        if (new_recipe->parsedSuccessful ())
+          shapes.push_back (new_recipe);
+      }
+      else
+        PCL_WARN ("%sRecursive loop detected when trying to parse recipe %s. Skipping this line.\n", prefix_.c_str (), substrings[1].c_str ());
+      continue;
+    }
+
+    // Lines for setting options
+    if (substrings[0] == "Delete_overlap" && substrings.size () == 2)
+    {
+      if (substrings[1] == "True")
+        delete_overlap_flag = true;
+      else if (substrings[1] == "False")
+        delete_overlap_flag = false;
+      else
+        PCL_WARN ("%sDelete_overlap only takes True or False as options. Found %s. Skipping this line.\n", prefix_.c_str (), substrings[1].c_str ());
+      continue;
+    }
+
+    if (substrings[0] == "Label" && substrings.size () == 2)
+    {
+      if (substrings[1] == "Single")
+        label_handling = Single;
+      else if (substrings[1] == "Merge")
+        label_handling = Merge;
+      else if (substrings[1] == "Append")
+        label_handling = Append;
+      else if (substrings[1] == "Preserve")
+        label_handling = Preserve;
+      else
+        PCL_WARN ("%s%s is not a valid label handling instruction. Valid strings: Single, Merge, Append, Preserve. Skipping this line.\n", prefix_.c_str (), substrings[1].c_str ());
+      continue;
+    }
+
+    PCL_WARN ("%sCould not parse line: %s. Skipping this line.\n", prefix_.c_str (), itr->c_str ());
+  }
+  return (shapes.size () > 0);
+}
+
+void
+pcl::simulation::RecipeFile::readRecipe ()
+{
+  PCL_INFO ("%sOpening file %s\n", prefix_.c_str (), recipe_file_name_.c_str ());
+  boost::filesystem::ifstream recipe_file (recipe_file_name_);
+  if (!recipe_file.is_open ())
+  {
+    PCL_WARN ("%sCould not open recipe file %s.\n", prefix_.c_str (), recipe_file_name_.c_str ());
+    parsing_successful_ = false;
+    return;
+  }
+
+  recipe_lines_.clear ();
+  std::string line;
+  // clean and add lines to the memory.
+  while (std::getline (recipe_file, line))
+  {
+    line = cleanLine (line);
+    if (!line.empty ())
+      recipe_lines_.push_back (line);
+  }
+  parsing_successful_ = parseLines (recipe_lines_, shapes_ptrs_, delete_overlap_, label_handling_);
+  PCL_INFO ("%sClosing file %s\n", prefix_.c_str (), recipe_file_name_.c_str ());
+}

--- a/simulation/src/shape_generator_shapes.cpp
+++ b/simulation/src/shape_generator_shapes.cpp
@@ -1,0 +1,494 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/simulation/shape_generator_shapes.h>
+typedef pcl::simulation::GeometricShapeBase::PointCloudT PointCloudT;
+
+
+void
+pcl::simulation::ConvexPolygon::Face::sampleOnFace (float resolution, 
+                                                    PointCloudT::Ptr cloud_ptr, 
+                                                    int label)
+{
+  std::size_t num_triangles = triangle_areas_.size ();
+  // sample points for each triangle in the face
+  for (std::size_t ctriangle = 0; ctriangle < num_triangles; ++ctriangle)
+  {
+    unsigned int num_points = parent_->calculateNumberOfPoints (triangle_areas_[ctriangle], resolution);
+    for (unsigned int ci = 0; ci < num_points; ++ci)
+    {
+      float a, b;
+      a = parent_->dist01_ (parent_->gen_);
+      b = parent_->dist01_ (parent_->gen_);
+      PointT new_point;
+      const Eigen::Vector3f p1 = parent_->vertices_[vertex_list_[0]];
+      const Eigen::Vector3f p12 = parent_->vertices_[vertex_list_[ctriangle + 1]] - parent_->vertices_[vertex_list_[0]];
+      const Eigen::Vector3f p13 = parent_->vertices_[vertex_list_[ctriangle + 2]] - parent_->vertices_[vertex_list_[0]];
+      new_point.getNormalVector3fMap () = normal_;
+      if (a + b <= 1)
+        new_point.getVector3fMap () = p1 + a * p12 + b * p13;
+      else
+        new_point.getVector3fMap () = p1 + (1 - a) * p12 + (1 - b) * p13;
+      new_point.label = label;
+      cloud_ptr->push_back (new_point);
+    }
+  }
+}
+
+void
+pcl::simulation::ConvexPolygon::setPolygons (const VerticeVectorT &vertices_vector,
+                                             const FaceInformationT &face_information)
+{
+  area_ = 0;
+  vertices_ = vertices_vector;
+  for (std::size_t cface = 0; cface < face_information.size (); ++cface)
+  {
+    Face::Ptr new_face (new Face (this));
+    new_face->vertex_list_ = face_information[cface];
+
+    bool normal_calculated = false;
+    Eigen::Vector3f old_normal;
+    std::size_t num_triangles = new_face->vertex_list_.size () - 2;
+
+    if (num_triangles < 1)
+      PCL_ERROR ("ERROR ConvexPolygon::ConvexPolygon: Cannot add face number %d, because it needs at least 3 vertices.\n", cface + 1);
+
+    new_face->triangle_areas_.resize (num_triangles);
+    // use the first three nodes to calculate the normal, but check all nodes if the normals would differ. If that is the case the points do not lie in a common plane.
+    for (std::size_t ctriangle = 0; ctriangle < num_triangles; ++ctriangle)
+    {
+      const Eigen::Vector3f p12 = vertices_[new_face->vertex_list_[ctriangle + 1]] - vertices_[new_face->vertex_list_[0]];
+      const Eigen::Vector3f p13 = vertices_[new_face->vertex_list_[ctriangle + 2]] - vertices_[new_face->vertex_list_[0]];
+
+      Eigen::Vector3f cross_vec = p12.cross (p13);
+      float current_triangle_area = cross_vec.norm () / 2;
+      new_face->triangle_areas_[ctriangle] = current_triangle_area;
+      new_face->face_area_ += current_triangle_area;
+      Eigen::Vector3f new_normal = cross_vec.normalized ();
+      area_ += current_triangle_area;
+      // normals for the whole planar patch should be the same. This performs a simple check.
+      if (normal_calculated)
+      {
+        float dot_normal = new_normal.dot (old_normal);
+        if (dot_normal < 0.99)
+          PCL_ERROR ("ERROR ConvexPolygon::ConvexPolygon: Cannot add face number %d, because it is not a planar and convex face.\n", cface + 1);
+      }
+      else
+      {
+        normal_calculated = true;
+        new_face->normal_ = new_normal;
+      }
+      old_normal = new_normal;
+    }
+    faces_.push_back (new_face);
+  }
+  faces_set_ = true;
+}
+
+PointCloudT::Ptr
+pcl::simulation::ConvexPolygon::generate (float resolution)
+{
+  PointCloudT::Ptr cloud_ptr (new PointCloudT ());
+  if (!faces_set_)
+  {
+    PCL_WARN ("ConvexPolygon::generate: Please run setPolygons before calling generate\n");
+    return (cloud_ptr);
+  }
+  
+  for (std::size_t cf = 0; cf < faces_.size (); ++cf)
+  {
+    faces_[cf]->sampleOnFace (resolution, cloud_ptr);
+  }
+  // apply transformation which may have been set before generate was called
+  applyTransformations (cloud_ptr);
+  return (cloud_ptr);
+}
+
+bool
+pcl::simulation::ConvexPolygon::isInside (const PointT &point) const
+{
+  for (std::size_t cf = 0; cf < faces_.size (); ++cf)
+  {
+    // skip empty triangles
+    if (faces_[cf]->face_area_ == 0)
+      continue;
+    if (!faces_[cf]->isInside (point))
+      return (false);
+  }
+  return (true);
+}
+
+PointCloudT::Ptr
+pcl::simulation::Sphere::generate (float resolution)
+{
+  PointCloudT::Ptr cloud_ptr (new PointCloudT ());
+  float area = 4 * M_PI * pow (radius_, 2);
+  unsigned int num_points = calculateNumberOfPoints (area, resolution);
+  while (cloud_ptr->size () < num_points)
+  {
+    float x (-1 + 2 * dist01_ (gen_)), y (-1 + 2 * dist01_ (gen_)), z (-1 + 2 * dist01_ (gen_));
+    if (x * x + y * y + z * z <= 1)
+    {
+      float theta = atan2 (sqrt (x * x + y * y), z);
+      float phi = atan2 (y, x);
+      PointT p;
+      p.x = radius_ * cos (phi) * sin (theta);
+      p.y = radius_ * sin (phi) * sin (theta);
+      p.z = radius_ * cos (theta);
+      p.normal_x = cos (phi) * sin (theta);
+      p.normal_y = sin (phi) * sin (theta);
+      p.normal_z = cos (theta);
+      cloud_ptr->push_back (p);
+    }
+  }
+  // apply transformation which may have been set before generate was called
+  applyTransformations (cloud_ptr);
+  return (cloud_ptr);
+}
+
+bool
+pcl::simulation::Sphere::isInside (const PointT &point) const
+{
+  return (point.x * point.x + point.y * point.y + point.z * point.z < radius_ * radius_);
+}
+
+void
+pcl::simulation::Cylinder::addCylinderMiddle (float resolution, 
+                                              PointCloudT::Ptr cloud_ptr)
+{
+  float circum = 2 * M_PI * radius_;
+  float area = circum * height_;
+  unsigned int  num_points = calculateNumberOfPoints (area, resolution);
+  for (unsigned int  ci = 0; ci < num_points; ++ci)
+  {
+    PointT p;
+    p.y = (dist01_ (gen_) * height_) - (height_ / 2);
+    float phi = dist01_ (gen_) * 2 * M_PI;
+    p.x = cos (phi) * radius_;
+    p.z = sin (phi) * radius_;
+    p.normal_x = cos (phi);
+    p.normal_z = sin (phi);
+    p.normal_y = 0;
+    cloud_ptr->push_back (p);
+  }
+}
+
+void
+pcl::simulation::Cylinder::addCylinderTopAndBottom (float resolution, 
+                                                    PointCloudT::Ptr cloud_ptr)
+{
+  float area = 2 * (M_PI * radius_ * radius_);
+  unsigned int  num_points = calculateNumberOfPoints (area, resolution);
+  for (unsigned int  ci = 0; ci < num_points;)
+  {
+    float z = (2 * dist01_ (gen_) * radius_) - (radius_);
+    float x = (2 * dist01_ (gen_) * radius_) - (radius_);
+    if (z * z + x * x <= radius_ * radius_)
+    {
+      bool top = dist01_ (gen_) > 0.5;
+      float y = height_ / 2 * (top ? 1 : -1);
+      PointT p;
+      p.x = x;
+      p.y = y;
+      p.z = z;
+      p.normal_x = 0;
+      p.normal_z = 0;
+      p.normal_y = (top ? 1 : -1);
+      ++ci;
+      cloud_ptr->push_back (p);
+    }
+  }
+}
+
+PointCloudT::Ptr
+pcl::simulation::Cylinder::generate (float resolution)
+{
+  PointCloudT::Ptr cloud_ptr (new PointCloudT ());
+
+  addCylinderMiddle (resolution, cloud_ptr);
+  addCylinderTopAndBottom (resolution, cloud_ptr);
+
+  // apply transformation which may have been set before generate was called
+  applyTransformations (cloud_ptr);
+  return (cloud_ptr);
+}
+
+bool
+pcl::simulation::Cylinder::isInside (const PointT &point) const
+{
+  return ((point.x * point.x + point.z * point.z < radius_ * radius_) && (point.y < height_ / 2) && (point.y > -height_ / 2));
+}
+
+pcl::simulation::Wedge::Wedge (float width,
+                               float depth,
+                               float upwidth,
+                               float updepth,
+                               float height)
+{
+  VerticeVectorT vertices;
+  FaceInformationT faces;
+  vertices.resize (8);
+
+  vertices[FrontBottomLeft] = Eigen::Vector3f (0, 0, 0);
+  vertices[FrontBottomRight] = Eigen::Vector3f (width, 0, 0);
+  vertices[BackBottomLeft] = Eigen::Vector3f (0, 0, -depth);
+  vertices[BackBottomRight] = Eigen::Vector3f (width, 0, -depth);
+
+  float delx = (width - upwidth) / 2;
+  float delz = - (depth - updepth) / 2;
+  vertices[FrontTopLeft] = Eigen::Vector3f (delx, height, delz);
+  vertices[FrontTopRight] = Eigen::Vector3f (delx + upwidth, height, delz);
+  vertices[BackTopLeft] = Eigen::Vector3f (delx, height, delz - updepth);
+  vertices[BackTopRight] = Eigen::Vector3f (delx + upwidth, height, delz - updepth);
+
+  faces.resize (6);
+  faces[0] = boost::assign::list_of (FrontBottomLeft) (BackBottomLeft) (BackBottomRight) (FrontBottomRight);
+  faces[1] = boost::assign::list_of (FrontTopLeft) (FrontTopRight) (BackTopRight) (BackTopLeft);
+  faces[2] = boost::assign::list_of (FrontTopRight) (FrontTopLeft) (FrontBottomLeft) (FrontBottomRight);
+  faces[3] = boost::assign::list_of (BackTopRight) (BackBottomRight) (BackBottomLeft) (BackTopLeft);
+  faces[4] = boost::assign::list_of (FrontTopLeft) (BackTopLeft) (BackBottomLeft) (FrontBottomLeft);
+  faces[5] = boost::assign::list_of (FrontTopRight) (FrontBottomRight) (BackBottomRight) (BackTopRight);
+
+  // set centroid to the center of the shape and center the shape to the coordinate system
+  centroid_ = Eigen::Vector3f (width / 2, height / 2, -depth / 2);
+  center ();
+
+  setPolygons (vertices, faces);
+}
+
+PointCloudT::Ptr
+pcl::simulation::Cone::generate (float resolution)
+{
+  PointCloudT::Ptr cloud_ptr (new PointCloudT ());
+
+  boost::random::triangle_distribution<float> height_distribution (0, 0, height_);
+  float l = sqrt (radius_ * radius_ + height_ * height_);
+  float area = M_PI * radius_ * l;
+  unsigned int num_points = calculateNumberOfPoints (area, resolution);
+  float cosalpha = height_ / l;
+  float sinalpha = radius_ / l;
+  for (unsigned int  ci = 0; ci < num_points; ++ci)
+  {
+    float h = height_distribution (gen_);
+    float phi = dist01_ (gen_) * 2 * M_PI;
+    PointT p;
+    p.y = h;
+    p.x = cos (phi) * (1 - h / height_) * radius_;
+    p.z = sin (phi) * (1 - h / height_) * radius_;
+    p.normal_y = sinalpha;
+    p.normal_x = cosalpha * cos (phi);
+    p.normal_z = cosalpha * sin (phi);
+    cloud_ptr->push_back (p);
+  }
+
+  // Bottom
+  area = M_PI * radius_ * radius_;
+  num_points = calculateNumberOfPoints (area, resolution);
+  for (unsigned int  ci = 0; ci < num_points;)
+  {
+    float y = 0;
+    float x = (2 * dist01_ (gen_) * radius_) - radius_;
+    float z = (2 * dist01_ (gen_) * radius_) - radius_;
+    if (z * z + x * x < radius_ * radius_)
+    {
+      PointT p;
+      p.x = x;
+      p.y = y;
+      p.z = z;
+      p.normal_x = 0;
+      p.normal_y = -1;
+      p.normal_z = 0;
+      cloud_ptr->push_back (p);
+      ++ci;
+    }
+  }
+
+  // The center of the sampling is a (0, height_ / 2, 0)
+  // This will effectively center the cone at 0 0 0
+  effective_transform_ = effective_transform_ * Eigen::Translation<float, 3> (0, -height_ / 2, 0);
+// apply transformation which may have been set before generate was called
+  applyTransformations (cloud_ptr);
+  return (cloud_ptr);
+}
+
+bool
+pcl::simulation::Cone::isInside (const PointT &point) const
+{
+  bool inside = true;
+
+  // check for correct height (y-value)
+  inside &= (point.y > 0);
+  inside &= (point.y < height_);
+  if (!inside)
+    return (false);
+
+  float radius_of_h = (1 - point.y / height_) * radius_;
+  inside &= (point.x * point.x + point.z * point.z < radius_of_h * radius_of_h);
+  return inside;
+}
+
+pcl::simulation::Torus::Torus (float R,
+                               float r) :
+    is_full_ (true),
+    R_ (R),
+    r_ (r),
+    min_theta_ (0),
+    max_theta_ (2 * M_PI)
+{
+}
+
+pcl::simulation::Torus::Torus (float R,
+                               float r,
+                               float min_theta,
+                               float max_theta) :
+    is_full_ (false),
+    R_ (R),
+    r_ (r),
+    min_theta_ (min_theta),
+    max_theta_ (max_theta)
+{
+}
+
+PointCloudT::Ptr
+pcl::simulation::Torus::generate (float resolution)
+{
+  PointCloudT::Ptr cloud_ptr (new PointCloudT ());
+  if (max_theta_ < min_theta_)
+    max_theta_ += 2 * M_PI;
+
+  float area = 4 * M_PI * M_PI * R_ * r_ * (max_theta_ - min_theta_) / (2 * M_PI);
+  unsigned int num_points = calculateNumberOfPoints (area, resolution);
+
+  // initialze the random number generator to generate equidensity points on the torus (theta can be drawn uniformly, phi has to be weighted by the number of points on the circumference of the torus (distance from the center (R+r cos (phi) )
+  const unsigned int  NUM_SEGMENTS = 50;
+  std::vector<float> intervals, weights;
+  intervals.resize (NUM_SEGMENTS + 1);
+  weights.resize (NUM_SEGMENTS + 1);
+  for (unsigned int  cs = 0; cs <= NUM_SEGMENTS; ++cs)
+  {
+    float segment_position = 2 * M_PI / NUM_SEGMENTS * cs;
+    intervals[cs] = segment_position;
+    weights[cs] = std::cos (segment_position) * r_ + R_;
+  }
+  boost::random::piecewise_linear_distribution<float> phi_dist (intervals.begin (), intervals.end (), weights.begin ());
+  for (unsigned int  ci = 0; ci < num_points; ++ci)
+  {
+    PointT p;
+    float phi = phi_dist (gen_);
+    float theta = min_theta_ + dist01_ (gen_) * (max_theta_ - min_theta_);
+    p.x = (R_ + r_ * cos (phi)) * cos (theta);
+    p.z = (R_ + r_ * cos (phi)) * sin (theta);
+    p.y = r_ * sin (phi);
+    p.normal_x = cos (phi) * cos (theta);
+    p.normal_y = sin (phi);
+    p.normal_z = cos (phi) * sin (theta);
+    cloud_ptr->push_back (p);
+  }
+
+  // if the Torus is not full, generate also the surfaces on the sides
+  if (!is_full_)
+  {
+    // probability distribution of the drawn r scales with the radius
+    std::vector<float> intervals = boost::assign::list_of (0.0) (r_);
+    std::vector<float> weights = boost::assign::list_of (0.0) (r_);
+    boost::random::piecewise_linear_distribution<float> radius_distribution (intervals.begin (), intervals.end (), weights.begin ());
+    area = 2 * M_PI * r_ * r_;
+    num_points = calculateNumberOfPoints (area, resolution);
+    float cosmin_theta_ = cos (min_theta_);
+    float cosmax_theta_ = cos (max_theta_);
+    float sinmin_theta_ = sin (min_theta_);
+    float sinmax_theta_ = sin (max_theta_);
+    for (unsigned int  ci = 0; ci < num_points; ++ci)
+    {
+      PointT p;
+      float phi = dist01_ (gen_) * 2 * M_PI;
+      float cos_theta, sin_theta;
+      bool MinFace = dist01_ (gen_) > 0.5;
+      if (MinFace)
+      {
+        cos_theta = cosmin_theta_;
+        sin_theta = sinmin_theta_;
+      }
+      else
+      {
+        cos_theta = cosmax_theta_;
+        sin_theta = sinmax_theta_;
+      }
+      float r = radius_distribution (gen_);
+      p.x = (R_ + r * cos (phi)) * cos_theta;
+      p.z = (R_ + r * cos (phi)) * sin_theta;
+      p.y = r * sin (phi);
+      p.normal_x = -sin_theta * (MinFace ? -1 : 1);
+      p.normal_y = 0;
+      p.normal_z = cos_theta * (MinFace ? -1 : 1);
+      cloud_ptr->push_back (p);
+    }
+  }
+  // apply transformation which may have been set before generate was called
+  applyTransformations (cloud_ptr);
+  return (cloud_ptr);
+}
+
+bool
+pcl::simulation::Torus::isInside (const PointT &point) const
+{
+  // check if the heigth is within the maximum torus height (will negate most points)
+  if (point.y > r_ || point.y < -r_)
+    return (false);
+
+  // check for right distance from the centroid (is it possible to be within the minor circle)
+  float r_sq = point.x * point.x + point.z * point.z;
+  if ( (r_sq < (R_ - r_) * (R_ - r_)) || (r_sq > ( (R_ + r_) * (R_ + r_))))
+    return (false);
+
+  // check theta range in case of not full Torus
+  if (!is_full_)
+  {
+    float theta = atan2 (point.z, point.x);
+    if (theta < min_theta_ || theta > max_theta_)
+      return (false);
+  }
+
+  // check for correct height inside the circle
+  r_sq = sqrt (r_sq);
+  float y_max_sq = r_ * r_ - (R_ - r_sq) * (R_ - r_sq);
+
+  if (point.y * point.y < y_max_sq)
+    return (true);
+  else
+    return (false);
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -153,6 +153,16 @@ if (BUILD_tools)
   PCL_ADD_EXECUTABLE(pcl_grid_min "${SUBSYS_NAME}" grid_min.cpp)
   target_link_libraries(pcl_grid_min pcl_common pcl_io pcl_filters)
 
+  if(BUILD_simulation)
+    PCL_SUBSYS_DEPEND(BUILD_tools "${SUBSYS_NAME}" DEPS simulation)
+    
+    PCL_ADD_EXECUTABLE(pcl_generate_shape "${SUBSYS_NAME}" generate_shape.cpp)
+    target_link_libraries(pcl_generate_shape pcl_common pcl_io pcl_simulation)
+
+    PCL_ADD_EXECUTABLE(pcl_convert2pcd "${SUBSYS_NAME}" convert2pcd.cpp)
+    target_link_libraries(pcl_convert2pcd pcl_common pcl_io pcl_simulation)
+  endif(BUILD_simulation)
+  
   if(BUILD_OPENNI AND OPENNI_FOUND)
     PCL_ADD_EXECUTABLE(pcl_oni2pcd "${SUBSYS_NAME}" oni2pcd.cpp)
     target_link_libraries(pcl_oni2pcd pcl_common pcl_io)

--- a/tools/convert2pcd.cpp
+++ b/tools/convert2pcd.cpp
@@ -1,0 +1,200 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Author: Markus Schoeler */
+
+#include <pcl/io/pcd_io.h>
+#include <pcl/io/vtk_lib_io.h>
+#include <pcl/console/print.h>
+#include <pcl/console/parse.h>
+#include <pcl/console/time.h>
+#include <pcl/simulation/shape_generator_shapes.h>
+#include <boost/filesystem.hpp>
+
+using namespace pcl;
+using namespace pcl::io;
+using namespace pcl::console;
+
+void
+printHelp (int,
+           char **argv)
+{
+  PCL_INFO ("Syntax is: %s input.(ply,obj,stl) [options]\n", argv[0]);
+  PCL_INFO ("where options are: \n");
+  PCL_INFO ("     -d x : sets the point density of the sampling to x per square unit (default 1).\n");
+  PCL_INFO ("     -n x : sets the approximate number of points sampled (cannot be used together with -d).\n");
+}
+
+int
+main (int argc,
+      char** argv)
+{
+  PCL_INFO ("Convert a PLY, OBJ or STL file to PCD file with normals (calculated) by sampling on the faces.\n");
+  
+  if (argc < 2)
+  {
+    printHelp (argc, argv);
+    return (-1);
+  }
+  float point_density = 1;
+  bool n_param_defined = pcl::console::find_switch (argc, argv, "-n");
+  bool d_param_defined = pcl::console::find_switch (argc, argv, "-d");
+
+  if (n_param_defined && d_param_defined)
+  {
+    PCL_ERROR ("You cannot define both -n and -d parameters\n");
+    printHelp (argc, argv);
+    return (-1);
+  }
+
+  // Parse the command line arguments for .pcd, .stl and .obj files
+  std::vector<int> pcd_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
+  std::vector<int> obj_file_indices = parse_file_extension_argument (argc, argv, ".obj");
+  std::vector<int> stl_file_indices = parse_file_extension_argument (argc, argv, ".stl");
+  std::vector<int> ply_file_indices = parse_file_extension_argument (argc, argv, ".ply");
+
+  bool pcd_file_defined = (pcd_file_indices.size () == 1);
+  bool obj_file_defined = (obj_file_indices.size () == 1);
+  bool stl_file_defined = (stl_file_indices.size () == 1);
+  bool ply_file_defined = (ply_file_indices.size () == 1);
+
+  std::string input_filename;
+
+  if (obj_file_defined + stl_file_defined + ply_file_defined != 1)
+  {
+    PCL_ERROR ("Need exactly one input PLY, OBJ or STL file.\n");
+    printHelp (argc, argv);
+    return (-2);
+  }
+
+  TicToc tt;
+
+  // Load the input file
+  vtkSmartPointer<vtkPolyData> polydata;
+  if (obj_file_defined)
+  {
+    input_filename = argv[obj_file_indices[0]];
+    vtkSmartPointer<vtkOBJReader> reader = vtkSmartPointer<vtkOBJReader>::New ();
+    reader->SetFileName (input_filename.c_str ());
+    reader->Update ();
+    polydata = reader->GetOutput ();
+  }
+  else if (stl_file_defined)
+  {
+    input_filename = argv[stl_file_indices[0]];
+    vtkSmartPointer<vtkSTLReader> reader = vtkSmartPointer<vtkSTLReader>::New ();
+    reader->SetFileName (input_filename.c_str ());
+    reader->Update ();
+    polydata = reader->GetOutput ();
+  }
+  else if (ply_file_defined)
+  {
+    input_filename = argv[stl_file_indices[0]];
+    vtkSmartPointer<vtkPLYReader> reader = vtkSmartPointer<vtkPLYReader>::New ();
+    reader->SetFileName (input_filename.c_str ());
+    reader->Update ();
+    polydata = reader->GetOutput ();
+  }
+
+  PCL_INFO ("Loading %s\n", input_filename.c_str ());
+  boost::filesystem::path pcd_filename;
+  if (!pcd_file_defined)
+  {
+    pcd_filename = input_filename;
+    pcd_filename.replace_extension (".pcd");
+  }
+  else
+    pcd_filename = argv[pcd_file_indices[0]];
+
+  vtkSmartPointer<vtkPoints> vertices = polydata->GetPoints ();
+  vtkSmartPointer<vtkCellArray> polygons = polydata->GetPolys ();
+
+  PCL_INFO ("Found %d vertices and %d polygons\n", vertices->GetNumberOfPoints (), polygons->GetNumberOfCells ());
+  unsigned int poly_counter = 0;
+  // fill the vertices
+  std::vector<Eigen::Vector3f> vertices_eigen;
+  vertices_eigen.resize (vertices->GetNumberOfPoints ());
+  for (vtkIdType i = 0; i < vertices->GetNumberOfPoints (); ++i)
+  {
+    double point[3];
+    vertices->GetPoint (i, point);
+    vertices_eigen[i] = Eigen::Vector3f (point[0], point[1], point[2]);
+  }
+
+  // fill the polygons
+  std::vector<std::vector<unsigned int> > polygon_vector;
+  polygon_vector.resize (polygons->GetNumberOfCells ());
+  vtkIdType *indices;
+  vtkIdType number_of_points;
+  for (polygons->InitTraversal (); polygons->GetNextCell (number_of_points, indices); ++poly_counter)
+  {
+    polygon_vector[poly_counter].resize (number_of_points);
+    for (vtkIdType cp = 0; cp < number_of_points; ++cp)
+    {
+      polygon_vector[poly_counter][cp] = indices[cp];
+    }
+  }
+
+  // create shape,
+  pcl::simulation::ConvexPolygon polygon_shape (vertices_eigen, polygon_vector);
+
+  // get or calculate point density
+  if (d_param_defined)
+    pcl::console::parse_argument (argc, argv, "-d", point_density);  
+  if (n_param_defined)
+  {
+    float num_points;
+    pcl::console::parse_argument (argc, argv, "-n", num_points);
+    point_density = num_points / polygon_shape.getPolygonArea ();
+  }
+  
+  // sample and save pointcloud  
+  pcl::simulation::GeometricShapeBase::PointCloudT::Ptr shape_cloud = polygon_shape.generate (point_density);
+  
+  if (shape_cloud->size () == 0)
+  {
+    PCL_ERROR ("Not points have been sampled, you should try increasing the density using the -d paramter or set the number of points using the -n parameter\n");
+    return (1);
+  }  
+  PCL_INFO ("Saving PCD file %s with %d points (Density: %f pts per sq-unit)\n", pcd_filename.c_str (), shape_cloud->size (), point_density);
+  pcl::PointCloud<pcl::PointNormal> cloud_with_normals;
+  pcl::copyPointCloud (*shape_cloud, cloud_with_normals);
+
+  pcl::io::savePCDFile (pcd_filename.generic_string (), cloud_with_normals);
+  return (0);
+}
+

--- a/tools/generate_shape.cpp
+++ b/tools/generate_shape.cpp
@@ -1,0 +1,130 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Point Cloud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2014-, Open Perception, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of the copyright holder(s) nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Author: Markus Schoeler */
+
+#include <iostream>
+#include <fstream>
+#include <pcl/simulation/shape_generator_io.h>
+
+#include <pcl/io/pcd_io.h>
+#include <pcl/console/parse.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+void
+displayHelp (const std::string &executable_filename)
+{
+  pcl::console::print_info (
+  "\n----------------------------\n\
+  pcl::generate_shape  \n\
+  Syntax: %s (Filename of recipe) [-d x]\n\
+  \n\
+  Optional parameter -d: Set point density of sampling to x points per unit square. Default 200.\n\
+  RecipeFile: An ASCII file containing one or more of the following commands (each command goes into a seperate line):\n\
+  Primitive shapes:\n\
+    Cylinder r h: Create a cylinder with radius r (x/z - plane) and height h (y-axis)\n\
+    Cuboid x y z: Create a cuboid with width x, height y and depth z\n\
+    Sphere r: Create a sphere with radius r\n\
+    Cone r h: Create a cone with radius r (x/z - plane) and height h (y-axis)\n\
+    Wedge bx bz tx tz h: Create a wedge with bottom_width bx, bottom_depth bz, top_width tx, top_depth tz and height h (y-axis)\n\
+    Torus R r: Create a full torus with outer radius R and inner radius r (x/z-plane)\n\
+    Torus R r t_min t_max: Create a section of a torus from t_min till t_max in degrees (measured from the x-axis)\n\
+  Transformations (these get applied to the last shape):\n\
+    T dx dy dz: Translation along dx, dy and dz\n\
+    R [x/y/z] alpha: Rotation around the x,y or z axis of alpha degrees. The axis goes through the object's middle.\n\
+    R ax ay az alpha: Rotation around the axis (ax,ay,az) of alpha degrees. The axis goes through the object's middle.\n\
+    RC [x/y/z] alpha: Rotation around the x,y or z axis of alpha degrees. The axis goes through the center (0,0,0).\n\
+    RC ax ay az alpha: Rotation around the axis (ax,ay,az) of alpha degrees. The axis goes through the center (0,0,0).\n\
+  \n\
+  Special block instructions:\n\
+    Multi block: Everything enclosed in this block will be treated as one object for the next instructions\n\
+      Multi_begin\n\
+      Multi_end\n\
+      \n\
+    Cut block: Everything between \"Cut_begin\" and \"by\" will be cut by everything which comes between \"by\" and \"Cut_end\"\n\
+      Cut_begin: Start cut block\n\
+      by: Goto cutter part\n\
+      Cut_end: End cut block\n\n\
+    Recipe (Filename of recipe): Includes the recipe from another recipe file. This can also be used within other blocks.\n\
+  Other options which can be set in the recipe file or Multi blocks:\n\
+    Delete_overlap [True/False]: Set if points which have overlap with other shapes get removed. Default: true\n\
+    Label [Single, Merge, Append, Preserve]: Determines how labels of the shapes in a Multi block or recipe file are treated. \n\
+          Single: All parts will get a single label.\n\
+          Merge: Every part gets its unique label. If parts already have multiple labels they will be merged (default behaviour).\n\
+          Append: Keep all labels unique, thus append new labels if parts have multiple labels already.\n\
+          Preserve: Preserve the labels of the shapes. Label 0 in part 1 and label 0 in part 2 will stay label 0.\n\
+    \n", executable_filename.c_str ());
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  float point_density = 200;
+  if (argc < 2)
+  {
+    displayHelp (argv[0]);
+    exit (1);
+  }
+  if (pcl::console::find_switch (argc, argv, "-d"))
+    pcl::console::parse_argument (argc, argv, "-d", point_density);
+
+  std::string recipe_filename (argv[1]);
+  /// Create pcd_filename for the output pcd file
+  boost::filesystem::path pcd_filename (recipe_filename);
+  pcd_filename.replace_extension (".pcd");
+
+  pcl::simulation::RecipeFile recipe (recipe_filename);
+  if (recipe.parsedSuccessful ())
+  {
+    PCL_INFO ("Generating objects\n");
+    pcl::simulation::GeometricShapeBase::PointCloudT::Ptr cloud_ptr = recipe.generate (point_density);    
+    PCL_INFO ("Generation finished\n");
+    PCL_INFO ("Writing File: %s\n", pcd_filename.c_str ());
+    pcl::io::savePCDFileASCII (pcd_filename.string (), *cloud_ptr);
+  }
+  else
+  {
+    PCL_ERROR ("Error occured while parsing file %s\n", recipe_filename.c_str ());
+    exit (2);
+  }
+  return (0);
+}


### PR DESCRIPTION
This pull-request is the second part of my GSOC 2014 project.
- Adds the shape generator to PCL within the simulation module.
- Added simulation to doxygen generation
- Added an example under pcl_example_shape_generator.
- Added two tools, generate_shape and convert2pcd
  - generate_shape uses instructions found in text files to assemble scenes and objects
  - convert2pcd can read stl and obj file and samples on the faces with a given point density and saves a pcd file (unlike obj2pcd it samples on faces rather than on the vertices, allowing constant point density).

![comparison_obj2pcd_convert2pcd](https://cloud.githubusercontent.com/assets/3592251/4207431/3d686a4e-3856-11e4-9a05-9360b3f0cfc3.png)
