### PR TITLE
Remove -DEIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,8 +240,6 @@ include("${PCL_SOURCE_DIR}/cmake/pcl_find_boost.cmake")
 # Eigen (required)
 find_package(Eigen REQUIRED)
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-add_definitions(-DEIGEN_USE_NEW_STDVECTOR
-                -DEIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET)
 # FLANN (required)
 if(NOT PCL_SHARED_LIBS OR (WIN32 AND NOT MINGW))
   set(FLANN_USE_STATIC ON)

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -119,8 +119,6 @@ macro(find_eigen)
           "$ENV{PROGRAMFILES}/Eigen" "$ENV{PROGRAMW6432}/Eigen"   
     PATH_SUFFIXES eigen3 include/eigen3 include)
   find_package_handle_standard_args(eigen DEFAULT_MSG EIGEN_INCLUDE_DIRS)
-  set(EIGEN_DEFINITIONS ${EIGEN_DEFINITIONS} -DEIGEN_USE_NEW_STDVECTOR 
-      -DEIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET)
 endmacro(find_eigen)
 
 #remove this as soon as qhull is shipped with FindQhull.cmake


### PR DESCRIPTION
This has been removed from Eigen 3.1.0-alpha1 (released in 2011).
http://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.1.0-alpha1
https://bitbucket.org/eigen/eigen/commits/c13088f10146
