### PR TITLE
Fix inconsistency between method declaration and implementation that resulted in build failure

### DIFF
--- a/filters/include/pcl/filters/box_clipper3D.h
+++ b/filters/include/pcl/filters/box_clipper3D.h
@@ -100,7 +100,7 @@ namespace pcl
       clipPlanarPolygon3D (std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon) const;
 
       virtual void
-      clipPlanarPolygon3D (const std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon, std::vector<PointT>& clipped_polygon) const;
+      clipPlanarPolygon3D (const std::vector<PointT, Eigen::aligned_allocator<PointT> >& polygon, std::vector<PointT, Eigen::aligned_allocator<PointT> >& clipped_polygon) const;
 
       virtual void
       clipPointCloud3D (const pcl::PointCloud<PointT> &cloud_in, std::vector<int>& clipped, const std::vector<int>& indices = std::vector<int> ()) const;


### PR DESCRIPTION
If someone tries to use BoxClipper3D in their project the build will fail. Declaration of method clipPlanarPolygon3D differs from its implementation.
