### PR TITLE
Changes necessary for lccp pull request #718

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -767,85 +767,31 @@ pcl::SupervoxelClustering<PointT>::getMaxLabel () const
 
 namespace pcl
 { 
-  
   namespace octree
   {
     //Explicit overloads for RGB types
     template<>
     void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::addPoint (const pcl::PointXYZRGB &new_point)
-    {
-      ++num_points_;
-      //Same as before here
-      data_.xyz_[0] += new_point.x;
-      data_.xyz_[1] += new_point.y;
-      data_.xyz_[2] += new_point.z;
-      //Separate sums for r,g,b since we cant sum in uchars
-      data_.rgb_[0] += static_cast<float> (new_point.r); 
-      data_.rgb_[1] += static_cast<float> (new_point.g); 
-      data_.rgb_[2] += static_cast<float> (new_point.b); 
-    }
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::addPoint (const pcl::PointXYZRGB &new_point);
     
     template<>
     void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::addPoint (const pcl::PointXYZRGBA &new_point)
-    {
-      ++num_points_;
-      //Same as before here
-      data_.xyz_[0] += new_point.x;
-      data_.xyz_[1] += new_point.y;
-      data_.xyz_[2] += new_point.z;
-      //Separate sums for r,g,b since we cant sum in uchars
-      data_.rgb_[0] += static_cast<float> (new_point.r); 
-      data_.rgb_[1] += static_cast<float> (new_point.g); 
-      data_.rgb_[2] += static_cast<float> (new_point.b); 
-    }
-    
-
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::addPoint (const pcl::PointXYZRGBA &new_point);
     
     //Explicit overloads for RGB types
     template<> void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::computeData ()
-    {
-      data_.rgb_[0] /= (static_cast<float> (num_points_));
-      data_.rgb_[1] /= (static_cast<float> (num_points_));
-      data_.rgb_[2] /= (static_cast<float> (num_points_));
-      data_.xyz_[0] /= (static_cast<float> (num_points_));
-      data_.xyz_[1] /= (static_cast<float> (num_points_));
-      data_.xyz_[2] /= (static_cast<float> (num_points_));    
-    }
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::computeData ();
     
     template<> void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::computeData ()
-    {
-      data_.rgb_[0] /= (static_cast<float> (num_points_));
-      data_.rgb_[1] /= (static_cast<float> (num_points_));
-      data_.rgb_[2] /= (static_cast<float> (num_points_));
-      data_.xyz_[0] /= (static_cast<float> (num_points_));
-      data_.xyz_[1] /= (static_cast<float> (num_points_));
-      data_.xyz_[2] /= (static_cast<float> (num_points_));
-    }
-
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::computeData ();
+    
     //Explicit overloads for XYZ types
     template<>
     void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::addPoint (const pcl::PointXYZ &new_point)
-    {
-      ++num_points_;
-      //Same as before here
-      data_.xyz_[0] += new_point.x;
-      data_.xyz_[1] += new_point.y;
-      data_.xyz_[2] += new_point.z;
-    }
-
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::addPoint (const pcl::PointXYZ &new_point);
+    
     template<> void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::computeData ()
-    {
-      data_.xyz_[0] /= (static_cast<float> (num_points_));
-      data_.xyz_[1] /= (static_cast<float> (num_points_));
-      data_.xyz_[2] /= (static_cast<float> (num_points_));
-    }
-
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::computeData ();
   }
 }
 
@@ -856,26 +802,10 @@ namespace pcl
 {
   
   template<> void
-  pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData::getPoint (pcl::PointXYZRGB &point_arg) const
-  {
-    point_arg.rgba = static_cast<uint32_t>(rgb_[0]) << 16 | 
-                     static_cast<uint32_t>(rgb_[1]) << 8 | 
-                     static_cast<uint32_t>(rgb_[2]);  
-    point_arg.x = xyz_[0];
-    point_arg.y = xyz_[1];
-    point_arg.z = xyz_[2];
-  }
+  pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData::getPoint (pcl::PointXYZRGB &point_arg) const;
   
   template<> void
-  pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData::getPoint (pcl::PointXYZRGBA &point_arg ) const
-  {
-    point_arg.rgba = static_cast<uint32_t>(rgb_[0]) << 16 | 
-                      static_cast<uint32_t>(rgb_[1]) << 8 | 
-                      static_cast<uint32_t>(rgb_[2]);  
-    point_arg.x = xyz_[0];
-    point_arg.y = xyz_[1];
-    point_arg.z = xyz_[2];
-  }
+  pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData::getPoint (pcl::PointXYZRGBA &point_arg ) const;
   
   template<typename PointT> void
   pcl::SupervoxelClustering<PointT>::VoxelData::getPoint (PointT &point_arg ) const
@@ -896,7 +826,6 @@ namespace pcl
     normal_arg.curvature = curvature_;
   }
 }
-  
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -115,7 +115,8 @@ namespace pcl
    *   \note Usually, color isn't needed (and can be detrimental)- spatial structure is mainly used
     * - J. Papon, A. Abramov, M. Schoeler, F. Woergoetter
     *   Voxel Cloud Connectivity Segmentation - Supervoxels from PointClouds
-    *   In Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR) 2013 
+    *   In Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR) 2013
+    *  \ingroup segmentation 
     *  \author Jeremie Papon (jpapon@gmail.com)
     */
   template <typename PointT>

--- a/segmentation/src/supervoxel_clustering.cpp
+++ b/segmentation/src/supervoxel_clustering.cpp
@@ -40,15 +40,118 @@
 #include <pcl/point_types.h>
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/segmentation/impl/supervoxel_clustering.hpp>
-
 #include <pcl/octree/impl/octree_pointcloud_adjacency.hpp>
-#include <pcl/octree/impl/octree_pointcloud.hpp>
-#include <pcl/octree/impl/octree_base.hpp>
-#include <pcl/octree/impl/octree_iterator.hpp>
 
-template class pcl::SupervoxelClustering<pcl::PointXYZRGBA>;
-template class pcl::SupervoxelClustering<pcl::PointXYZRGB>;
-template class pcl::SupervoxelClustering<pcl::PointXYZ>;
+namespace pcl
+{ 
+  namespace octree
+  {
+    //Explicit overloads for RGB types
+    template<>
+    void
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::addPoint (const pcl::PointXYZRGB &new_point)
+    {
+      ++num_points_;
+      //Same as before here
+      data_.xyz_[0] += new_point.x;
+      data_.xyz_[1] += new_point.y;
+      data_.xyz_[2] += new_point.z;
+      //Separate sums for r,g,b since we cant sum in uchars
+      data_.rgb_[0] += static_cast<float> (new_point.r); 
+      data_.rgb_[1] += static_cast<float> (new_point.g); 
+      data_.rgb_[2] += static_cast<float> (new_point.b); 
+    }
+    
+    template<>
+    void
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::addPoint (const pcl::PointXYZRGBA &new_point)
+    {
+      ++num_points_;
+      //Same as before here
+      data_.xyz_[0] += new_point.x;
+      data_.xyz_[1] += new_point.y;
+      data_.xyz_[2] += new_point.z;
+      //Separate sums for r,g,b since we cant sum in uchars
+      data_.rgb_[0] += static_cast<float> (new_point.r); 
+      data_.rgb_[1] += static_cast<float> (new_point.g); 
+      data_.rgb_[2] += static_cast<float> (new_point.b); 
+    }
+    
+    
+    
+    //Explicit overloads for RGB types
+    template<> void
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::computeData ()
+    {
+      data_.rgb_[0] /= (static_cast<float> (num_points_));
+      data_.rgb_[1] /= (static_cast<float> (num_points_));
+      data_.rgb_[2] /= (static_cast<float> (num_points_));
+      data_.xyz_[0] /= (static_cast<float> (num_points_));
+      data_.xyz_[1] /= (static_cast<float> (num_points_));
+      data_.xyz_[2] /= (static_cast<float> (num_points_));    
+    }
+    
+    template<> void
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::computeData ()
+    {
+      data_.rgb_[0] /= (static_cast<float> (num_points_));
+      data_.rgb_[1] /= (static_cast<float> (num_points_));
+      data_.rgb_[2] /= (static_cast<float> (num_points_));
+      data_.xyz_[0] /= (static_cast<float> (num_points_));
+      data_.xyz_[1] /= (static_cast<float> (num_points_));
+      data_.xyz_[2] /= (static_cast<float> (num_points_));
+    }
+    
+    //Explicit overloads for XYZ types
+    template<>
+    void
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::addPoint (const pcl::PointXYZ &new_point)
+    {
+      ++num_points_;
+      //Same as before here
+      data_.xyz_[0] += new_point.x;
+      data_.xyz_[1] += new_point.y;
+      data_.xyz_[2] += new_point.z;
+    }
+    
+    template<> void
+    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::computeData ()
+    {
+      data_.xyz_[0] /= (static_cast<float> (num_points_));
+      data_.xyz_[1] /= (static_cast<float> (num_points_));
+      data_.xyz_[2] /= (static_cast<float> (num_points_));
+    }
+    
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+namespace pcl
+{
+  template<> void
+  pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData::getPoint (pcl::PointXYZRGB &point_arg) const
+  {
+    point_arg.rgba = static_cast<uint32_t>(rgb_[0]) << 16 | 
+    static_cast<uint32_t>(rgb_[1]) << 8 | 
+    static_cast<uint32_t>(rgb_[2]);  
+    point_arg.x = xyz_[0];
+    point_arg.y = xyz_[1];
+    point_arg.z = xyz_[2];
+  }
+  
+  template<> void
+  pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData::getPoint (pcl::PointXYZRGBA &point_arg ) const
+  {
+    point_arg.rgba = static_cast<uint32_t>(rgb_[0]) << 16 | 
+    static_cast<uint32_t>(rgb_[1]) << 8 | 
+    static_cast<uint32_t>(rgb_[2]);  
+    point_arg.x = xyz_[0];
+    point_arg.y = xyz_[1];
+    point_arg.z = xyz_[2];
+  }
+}
 
 typedef pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData VoxelDataT;
 typedef pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData VoxelDataRGBT;
@@ -58,6 +161,10 @@ typedef pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ, VoxelData
 typedef pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB, VoxelDataRGBT> AdjacencyContainerRGBT;
 typedef pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA, VoxelDataRGBAT> AdjacencyContainerRGBAT;
 
+template class pcl::SupervoxelClustering<pcl::PointXYZ>;
+template class pcl::SupervoxelClustering<pcl::PointXYZRGB>;
+template class pcl::SupervoxelClustering<pcl::PointXYZRGBA>;
+
 template class pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ, VoxelDataT>;
 template class pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB, VoxelDataRGBT>;
 template class pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA, VoxelDataRGBAT>;
@@ -65,10 +172,3 @@ template class pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA
 template class pcl::octree::OctreePointCloudAdjacency<pcl::PointXYZ, AdjacencyContainerT>;
 template class pcl::octree::OctreePointCloudAdjacency<pcl::PointXYZRGB, AdjacencyContainerRGBT>;
 template class pcl::octree::OctreePointCloudAdjacency<pcl::PointXYZRGBA, AdjacencyContainerRGBAT>;
-
-//template class pcl::octree::OctreeBase<AdjacencyContainerRGBT, pcl::octree::OctreeContainerEmpty>;
-//template class pcl::octree::OctreeBase<AdjacencyContainerRGBAT, pcl::octree::OctreeContainerEmpty>;
-
-//template class pcl::octree::OctreeBreadthFirstIterator<pcl::octree::OctreeBase<AdjacencyContainerRGBT, pcl::octree::OctreeContainerEmpty> >;
-//template class pcl::octree::OctreeBreadthFirstIterator<pcl::octree::OctreeBase<AdjacencyContainerRGBAT, pcl::octree::OctreeContainerEmpty> >;
-


### PR DESCRIPTION
This pull request moves the template specializations for supervoxels from the implementation file to the cpp file. This avoids problems that can occur when LCCP is merged (pull request #718), and is best practice anyways.
