### PR TITLE
TextureMapping template is now also defined for PointNormal.

### DIFF
--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -296,8 +296,8 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
 
   PCL_INFO ("You provided %d  cameras and a mesh containing %d sub-meshes.\n", cams.size (), tex_mesh.tex_polygons.size ());
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr originalCloud (new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::PointCloud<pcl::PointXYZ>::Ptr camera_transformed_cloud (new pcl::PointCloud<pcl::PointXYZ>);
+  typename pcl::PointCloud<PointInT>::Ptr originalCloud (new pcl::PointCloud<PointInT>);
+  typename pcl::PointCloud<PointInT>::Ptr camera_transformed_cloud (new pcl::PointCloud<PointInT>);
 
   // convert mesh's cloud to pcl format for ease
   pcl::fromPCLPointCloud2 (tex_mesh.cloud, *originalCloud);
@@ -320,7 +320,7 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
     std::vector<Eigen::Vector2f> texture_map_tmp;
 
     // processing each face visible by this camera
-    pcl::PointXYZ pt;
+    PointInT pt;
     size_t idx;
     for (size_t i = 0; i < tex_mesh.tex_polygons[m].size (); ++i)
     {
@@ -374,7 +374,7 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointInT> bool
-pcl::TextureMapping<PointInT>::isPointOccluded (const pcl::PointXYZ &pt, OctreePtr octree)
+pcl::TextureMapping<PointInT>::isPointOccluded (const PointInT &pt, OctreePtr octree)
 {
   Eigen::Vector3f direction;
   direction (0) = pt.x;
@@ -485,8 +485,8 @@ pcl::TextureMapping<PointInT>::removeOccludedPoints (const pcl::TextureMesh &tex
   // copy mesh
   cleaned_mesh = tex_mesh;
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_cloud (new pcl::PointCloud<pcl::PointXYZ>);
+  typename pcl::PointCloud<PointInT>::Ptr cloud (new pcl::PointCloud<PointInT>);
+  typename pcl::PointCloud<PointInT>::Ptr filtered_cloud (new pcl::PointCloud<PointInT>);
 
   // load points into a PCL format
   pcl::fromPCLPointCloud2 (tex_mesh.cloud, *cloud);
@@ -572,9 +572,9 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
   // clear polygons from cleaned_mesh
   sorted_mesh.tex_polygons.clear ();
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr original_cloud (new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::PointCloud<pcl::PointXYZ>::Ptr transformed_cloud (new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_cloud (new pcl::PointCloud<pcl::PointXYZ>);
+  typename pcl::PointCloud<PointInT>::Ptr original_cloud (new pcl::PointCloud<PointInT>);
+  typename pcl::PointCloud<PointInT>::Ptr transformed_cloud (new pcl::PointCloud<PointInT>);
+  typename pcl::PointCloud<PointInT>::Ptr filtered_cloud (new pcl::PointCloud<PointInT>);
 
   // load points into a PCL format
   pcl::fromPCLPointCloud2 (tex_mesh.cloud, *original_cloud);
@@ -613,7 +613,7 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
         {
           // point is not occluded
           // does it land on the camera's image plane?
-          pcl::PointXYZ pt = transformed_cloud->points[tex_mesh.tex_polygons[0][faces].vertices[current_pt_indice]];
+          PointInT pt = transformed_cloud->points[tex_mesh.tex_polygons[0][faces].vertices[current_pt_indice]];
           Eigen::Vector2f dummy_UV;
           if (!getPointUVCoordinates (pt, cameras[cam], dummy_UV))
           {
@@ -732,7 +732,7 @@ pcl::TextureMapping<PointInT>::showOcclusions (pcl::TextureMesh &tex_mesh, pcl::
                   double octree_voxel_size, bool show_nb_occlusions, int max_occlusions)
 {
   // load points into a PCL format
-  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
+  typename pcl::PointCloud<PointInT>::Ptr cloud (new pcl::PointCloud<PointInT>);
   pcl::fromPCLPointCloud2 (tex_mesh.cloud, *cloud);
 
   showOcclusions (cloud, colored_cloud, octree_voxel_size, show_nb_occlusions, max_occlusions);
@@ -746,7 +746,7 @@ pcl::TextureMapping<PointInT>::textureMeshwithMultipleCameras (pcl::TextureMesh 
   if (mesh.tex_polygons.size () != 1)
     return;
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr mesh_cloud (new pcl::PointCloud<pcl::PointXYZ>);
+  typename pcl::PointCloud<PointInT>::Ptr mesh_cloud (new pcl::PointCloud<PointInT>);
 
   pcl::fromPCLPointCloud2 (mesh.cloud, *mesh_cloud);
 
@@ -757,7 +757,7 @@ pcl::TextureMapping<PointInT>::textureMeshwithMultipleCameras (pcl::TextureMesh 
     PCL_INFO ("Processing camera %d of %d.\n", current_cam+1, cameras.size ());
     
     // transform mesh into camera's frame
-    pcl::PointCloud<pcl::PointXYZ>::Ptr camera_cloud (new pcl::PointCloud<pcl::PointXYZ>);
+    typename pcl::PointCloud<PointInT>::Ptr camera_cloud (new pcl::PointCloud<PointInT>);
     pcl::transformPointCloud (*mesh_cloud, *camera_cloud, cameras[current_cam].pose.inverse ());
 
     // CREATE UV MAP FOR CURRENT FACES
@@ -1035,7 +1035,7 @@ pcl::TextureMapping<PointInT>::getTriangleCircumcscribedCircleCentroid ( const p
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointInT> inline bool
-pcl::TextureMapping<PointInT>::getPointUVCoordinates(const pcl::PointXYZ &pt, const Camera &cam, pcl::PointXY &UV_coordinates)
+pcl::TextureMapping<PointInT>::getPointUVCoordinates(const PointInT &pt, const Camera &cam, pcl::PointXY &UV_coordinates)
 {
   if (pt.z > 0)
   {
@@ -1105,7 +1105,7 @@ pcl::TextureMapping<PointInT>::checkPointInsideTriangle(const pcl::PointXY &p1, 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointInT> inline bool
-pcl::TextureMapping<PointInT>::isFaceProjected (const Camera &camera, const pcl::PointXYZ &p1, const pcl::PointXYZ &p2, const pcl::PointXYZ &p3, pcl::PointXY &proj1, pcl::PointXY &proj2, pcl::PointXY &proj3)
+pcl::TextureMapping<PointInT>::isFaceProjected (const Camera &camera, const PointInT &p1, const PointInT &p2, const PointInT &p3, pcl::PointXY &proj1, pcl::PointXY &proj2, pcl::PointXY &proj3)
 {
   return (getPointUVCoordinates(p1, camera, proj1)
       &&

--- a/surface/include/pcl/surface/texture_mapping.h
+++ b/surface/include/pcl/surface/texture_mapping.h
@@ -99,8 +99,8 @@ namespace pcl
   {
     public:
      
-      typedef boost::shared_ptr< PointInT > Ptr;
-      typedef boost::shared_ptr< const PointInT > ConstPtr;
+      typedef boost::shared_ptr< TextureMapping < PointInT > > Ptr;
+      typedef boost::shared_ptr< const TextureMapping < PointInT > > ConstPtr;
 
       typedef pcl::PointCloud<PointInT> PointCloud;
       typedef typename PointCloud::Ptr PointCloudPtr;
@@ -193,7 +193,7 @@ namespace pcl
         * \returns false if the point is not visible by the camera
         */
       inline bool
-      getPointUVCoordinates (const pcl::PointXYZ &pt, const Camera &cam, Eigen::Vector2f &UV_coordinates)
+      getPointUVCoordinates (const PointInT &pt, const Camera &cam, Eigen::Vector2f &UV_coordinates)
       {
         // if the point is in front of the camera
         if (pt.z > 0)
@@ -243,7 +243,7 @@ namespace pcl
         * \returns true if the point is occluded.
         */
       inline bool
-      isPointOccluded (const pcl::PointXYZ &pt, const OctreePtr octree);
+      isPointOccluded (const PointInT &pt, const OctreePtr octree);
 
       /** \brief Remove occluded points from a point cloud
         * \param[in] input_cloud the cloud on which to perform occlusion detection
@@ -385,7 +385,7 @@ namespace pcl
         * \returns false if the point is not visible by the camera
         */
       inline bool
-      getPointUVCoordinates (const pcl::PointXYZ &pt, const Camera &cam, pcl::PointXY &UV_coordinates);
+      getPointUVCoordinates (const PointInT &pt, const Camera &cam, pcl::PointXY &UV_coordinates);
 
       /** \brief Returns true if all the vertices of one face are projected on the camera's image plane.
         * \param[in] camera camera on which to project the face.
@@ -398,7 +398,7 @@ namespace pcl
         */
       inline bool
       isFaceProjected (const Camera &camera, 
-                       const pcl::PointXYZ &p1, const pcl::PointXYZ &p2, const pcl::PointXYZ &p3, 
+                       const PointInT &p1, const PointInT &p2, const PointInT &p3, 
                        pcl::PointXY &proj1, pcl::PointXY &proj2, pcl::PointXY &proj3);
 
       /** \brief Returns True if a point lays within a triangle

--- a/surface/src/texture_mapping.cpp
+++ b/surface/src/texture_mapping.cpp
@@ -43,4 +43,8 @@
 
 
 // Instantiations of specific point types
-PCL_INSTANTIATE(TextureMapping, (pcl::PointXYZ))
+#ifdef PCL_ONLY_CORE_POINT_TYPES
+  PCL_INSTANTIATE(TextureMapping, (pcl::PointXYZ))
+#else
+  PCL_INSTANTIATE(TextureMapping, PCL_XYZ_POINT_TYPES)
+#endif


### PR DESCRIPTION
The pcl::TextureMapping<PointT> template was only defined for PointXYZ, and some hardcoded types in the implementation prevented the simple instanciation for new point types.

This has been corrected, it is now also instanciated for PointNormal (which has been tested). More types could be added but were not tested.

Also, the TextureMapping<PointT>::Ptr subtype was refering to shared_ptr<PointT>, which is not the common thing in PCL. This has been modified so that it now refers to shared_ptr<TextureMapping<...>>, and a new TextureMapping<PointT>::PointPtr subtype has been added.
