### PR TITLE
Fix for point_cloud_editor using QT5

### DIFF
--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
@@ -45,6 +45,13 @@
 
 #include <QtGui>
 #include <QMainWindow>
+#include <QActionGroup>
+#include <QSpinBox>
+#include <QSlider>
+#include <QMessageBox>
+#include <QMenu>
+#include <QMenuBar>
+#include <QToolBar>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 
 // Forward declaration to prevent circular inclusion

--- a/cmake/pcl_find_qt5.cmake
+++ b/cmake/pcl_find_qt5.cmake
@@ -55,6 +55,8 @@ if(Qt5Core_FOUND)
     # set(CMAKE_AUTOMOC ON)
     # set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+    set(QT_QTOPENGL_INCLUDE_DIR Qt5OpenGL_INCLUDE_DIRS)
+
     # Replace qt4 macros.
     macro(qt4_wrap_cpp)
         qt5_wrap_cpp(${ARGN})


### PR DESCRIPTION
It's using QT_QTOPENGL_INCLUDE_DIR for Qt4 and Qt5 adds the headers directly of the widgets.
