### PR TITLE
Add distance to the plane threshold to PlaneClipper3D

### DIFF
--- a/filters/include/pcl/filters/impl/plane_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/plane_clipper3D.hpp
@@ -40,6 +40,7 @@
 template<typename PointT>
 pcl::PlaneClipper3D<PointT>::PlaneClipper3D (const Eigen::Vector4f& plane_params)
 : plane_params_ (plane_params)
+, threshold_(std::numeric_limits<double>::min ())
 {
 }
 
@@ -75,7 +76,17 @@ pcl::PlaneClipper3D<PointT>::getDistance (const PointT& point) const
 template<typename PointT> bool
 pcl::PlaneClipper3D<PointT>::clipPoint3D (const PointT& point) const
 {
-  return ((plane_params_[0] * point.x + plane_params_[1] * point.y + plane_params_[2] * point.z ) >= -plane_params_[3]);
+  bool pt_is_on_plane = ((plane_params_[0] * point.x + plane_params_[1] * point.y + plane_params_[2] * point.z ) >= -plane_params_[3]);
+  if (!pt_is_on_plane)
+  {
+    // Calculate the distance from the point to the plane normal as the dot product
+    // D = (P-A).N/|N|
+    Eigen::Vector4f pt (point.x, point.y, point.z, 1);
+    float distance = fabsf (plane_params_.dot (pt));
+    pt_is_on_plane = (distance < threshold_);
+  }
+
+  return pt_is_on_plane;
 }
 
 /**

--- a/filters/include/pcl/filters/plane_clipper3D.h
+++ b/filters/include/pcl/filters/plane_clipper3D.h
@@ -75,6 +75,22 @@ namespace pcl
         */
       const Eigen::Vector4f& getPlaneParameters () const;
 
+      /**
+       * \brief Set distance to the plane threshold.
+       * \details Distance threshold determines how close a point must be to the plane model in order
+       * to be considered as inlier. This allows to get the same results as produced by
+       * SAC segmentation methods. Default threshold value is std::numeric_limits<double>::min.
+       * \param[in] threshold distance to the plane threshold
+        */
+      inline void
+      setDistanceThreshold (double threshold)  { threshold_ = threshold; }
+
+      /**
+       * \brief Get the distance to the plane threshold as set by the user.
+       */
+      inline double
+      getDistanceThreshold () { return (threshold_); }
+
       virtual bool
       clipPoint3D (const PointT& point) const;
 


### PR DESCRIPTION
PlaneClipper clips points that fall exactly on the specified plane. However, SAC segmentation methods allow to provide a threshold (distance to the plane). If set, then any point that lies within the threshold's distance from the plane is considered to be on the plane.
