### PR TITLE
Supervoxel coloring update

### DIFF
--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -68,7 +68,7 @@ namespace pcl
         voxels_ (new pcl::PointCloud<PointT> ()),
         normals_ (new pcl::PointCloud<Normal> ())
         {  } 
-      
+
       typedef boost::shared_ptr<Supervoxel<PointT> > Ptr;
       typedef boost::shared_ptr<const Supervoxel<PointT> > ConstPtr;
 
@@ -80,7 +80,7 @@ namespace pcl
       {
         centroid_arg = centroid_;
       }
-      
+
       /** \brief Gets the point normal for the supervoxel 
        * \param[out] normal_arg Point normal of the supervoxel
        * \note This isn't an average, it is a normal computed using all of the voxels in the supervoxel as support
@@ -96,7 +96,7 @@ namespace pcl
         normal_arg.normal_z = normal_.normal_z;
         normal_arg.curvature = normal_.curvature;
       }
-      
+
       /** \brief The normal calculated for the voxels contained in the supervoxel */
       pcl::Normal normal_;
       /** \brief The centroid of the supervoxel - average voxel */
@@ -105,7 +105,7 @@ namespace pcl
       typename pcl::PointCloud<PointT>::Ptr voxels_;
       /** \brief A Pointcloud of the normals for the points in the supervoxel */
       typename pcl::PointCloud<Normal>::Ptr normals_;
-                
+
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW  
   };
@@ -139,19 +139,19 @@ namespace pcl
             curvature_ (0.0f),
             owner_ (0)
             {}
-            
+
           /** \brief Gets the data of in the form of a point
            *  \param[out] point_arg Will contain the point value of the voxeldata
            */  
           void
           getPoint (PointT &point_arg) const;
-          
+
           /** \brief Gets the data of in the form of a normal
            *  \param[out] normal_arg Will contain the normal value of the voxeldata
            */            
           void
           getNormal (Normal &normal_arg) const;
-          
+
           Eigen::Vector3f xyz_;
           Eigen::Vector3f rgb_;
           Eigen::Vector4f normal_;
@@ -159,30 +159,29 @@ namespace pcl
           float distance_;
           int idx_;
           SupervoxelHelper* owner_;
-          
+
         public:
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW
       };
-      
+
       typedef pcl::octree::OctreePointCloudAdjacencyContainer<PointT, VoxelData> LeafContainerT;
       typedef std::vector <LeafContainerT*> LeafVectorT;
-      
+
       typedef typename pcl::PointCloud<PointT> PointCloudT;
       typedef typename pcl::PointCloud<Normal> NormalCloudT;
       typedef typename pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT> OctreeAdjacencyT;
       typedef typename pcl::octree::OctreePointCloudSearch <PointT> OctreeSearchT;
       typedef typename pcl::search::KdTree<PointT> KdTreeT;
       typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-           
+
       using PCLBase <PointT>::initCompute;
       using PCLBase <PointT>::deinitCompute;
       using PCLBase <PointT>::input_;
-      
+
       typedef boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, float> VoxelAdjacencyList;
       typedef VoxelAdjacencyList::vertex_descriptor VoxelID;
       typedef VoxelAdjacencyList::edge_descriptor EdgeID;
-      
-      
+
     public:
 
       /** \brief Constructor that sets default values for member variables. 
@@ -201,31 +200,31 @@ namespace pcl
       /** \brief Set the resolution of the octree voxels */
       void
       setVoxelResolution (float resolution);
-      
+
       /** \brief Get the resolution of the octree voxels */
       float 
       getVoxelResolution () const;
-      
+
       /** \brief Set the resolution of the octree seed voxels */
       void
       setSeedResolution (float seed_resolution);
-      
+
       /** \brief Get the resolution of the octree seed voxels */
       float 
       getSeedResolution () const;
-        
+
       /** \brief Set the importance of color for supervoxels */
       void
       setColorImportance (float val);
-      
+
       /** \brief Set the importance of spatial distance for supervoxels */
       void
       setSpatialImportance (float val);
-            
+
       /** \brief Set the importance of scalar normal product for supervoxels */
       void
       setNormalImportance (float val);
-      
+
       /** \brief This method launches the segmentation algorithm and returns the supervoxels that were
        * obtained during the segmentation.
        * \param[out] supervoxel_clusters A map of labels to pointers to supervoxel structures
@@ -238,20 +237,20 @@ namespace pcl
        */
       virtual void
       setInputCloud (const typename pcl::PointCloud<PointT>::ConstPtr& cloud);
-      
+
       /** \brief This method sets the normals to be used for supervoxels (should be same size as input cloud)
       * \param[in] normal_cloud The input normals                         
       */
       virtual void
       setNormalCloud (typename NormalCloudT::ConstPtr normal_cloud);
-      
+
       /** \brief This method refines the calculated supervoxels - may only be called after extract
        * \param[in] num_itr The number of iterations of refinement to be done (2 or 3 is usually sufficient)
        * \param[out] supervoxel_clusters The resulting refined supervoxels
        */
       virtual void
       refineSupervoxels (int num_itr, std::map<uint32_t,typename Supervoxel<PointT>::Ptr > &supervoxel_clusters);
-      
+
       ////////////////////////////////////////////////////////////
       /** \brief Returns an RGB colorized cloud showing superpixels
         * Otherwise it returns an empty pointer.
@@ -260,20 +259,24 @@ namespace pcl
         * color(it's random). Points that are unlabeled will be black
         * \note This will expand the label_colors_ vector so that it can accomodate all labels
         */
+      PCL_DEPRECATED ("SupervoxelClustering::getColoredCloud is deprecated. Use the getLabeledCloud function instead. examples/segmentation/example_supervoxels.cpp shows how to use this to display and save with colorized labels.")
       typename pcl::PointCloud<PointXYZRGBA>::Ptr
-      getColoredCloud () const;
-      
+      getColoredCloud () const
+      { 
+        return boost::make_shared<pcl::PointCloud<PointXYZRGBA> > ();
+      }
+
       /** \brief Returns a deep copy of the voxel centroid cloud */
       typename pcl::PointCloud<PointT>::Ptr
       getVoxelCentroidCloud () const;
-      
+
       /** \brief Returns labeled cloud
         * Points that belong to the same supervoxel have the same label.
         * Labels for segments start from 1, unlabled points have label 0
         */
       typename pcl::PointCloud<PointXYZL>::Ptr
       getLabeledCloud () const;
-      
+
       /** \brief Returns an RGB colorized voxelized cloud showing superpixels
        * Otherwise it returns an empty pointer.
        * Points that belong to the same supervoxel have the same color.
@@ -281,9 +284,13 @@ namespace pcl
        * color(it's random). Points that are unlabeled will be black
        * \note This will expand the label_colors_ vector so that it can accomodate all labels
        */
+      PCL_DEPRECATED ("SupervoxelClustering::getColoredVoxelCloud is deprecated. Use the getLabeledVoxelCloud function instead. examples/segmentation/example_supervoxels.cpp shows how to use this to display and save with colorized labels.")
       pcl::PointCloud<pcl::PointXYZRGBA>::Ptr
-      getColoredVoxelCloud () const;
-      
+      getColoredVoxelCloud () const
+      {
+        return boost::make_shared<pcl::PointCloud<PointXYZRGBA> > ();
+      }
+
       /** \brief Returns labeled voxelized cloud
        * Points that belong to the same supervoxel have the same label.
        * Labels for segments start from 1, unlabled points have label 0
@@ -296,13 +303,13 @@ namespace pcl
        */
       void
       getSupervoxelAdjacencyList (VoxelAdjacencyList &adjacency_list_arg) const;
-      
+
       /** \brief Get a multimap which gives supervoxel adjacency
        *  \param[out] label_adjacency Multi-Map which maps a supervoxel label to all adjacent supervoxel labels
        */
       void 
       getSupervoxelAdjacency (std::multimap<uint32_t, uint32_t> &label_adjacency) const;
-            
+
       /** \brief Static helper function which returns a pointcloud of normals for the input supervoxels 
        *  \param[in] supervoxel_clusters Supervoxel cluster map coming from this class
        *  \returns Cloud of PointNormals of the supervoxels
@@ -310,19 +317,12 @@ namespace pcl
        */
       static pcl::PointCloud<pcl::PointNormal>::Ptr
       makeSupervoxelNormalCloud (std::map<uint32_t,typename Supervoxel<PointT>::Ptr > &supervoxel_clusters);
-      
+
       /** \brief Returns the current maximum (highest) label */
       int
       getMaxLabel () const;
-      
+
     private:
-      
-      /** \brief This method initializes the label_colors_ vector (assigns random colors to labels)
-       * \note Checks to see if it is already big enough - if so, does not reinitialize it
-       */
-      void
-      initializeLabelColors ();
-      
       /** \brief This method simply checks if it is possible to execute the segmentation algorithm with
         * the current settings. If it is possible then it returns true.
         */
@@ -334,13 +334,13 @@ namespace pcl
        */
       void
       selectInitialSupervoxelSeeds (std::vector<int> &seed_indices);
-      
+
       /** \brief This method creates the internal supervoxel helpers based on the provided seed points
        *  \param[in] seed_indices Indices of the leaves to use as seeds
        */
       void
       createSupervoxelHelpers (std::vector<int> &seed_indices);
-      
+
       /** \brief This performs the superpixel evolution */
       void
       expandSupervoxels (int depth);
@@ -348,51 +348,48 @@ namespace pcl
       /** \brief This sets the data of the voxels in the tree */
       void 
       computeVoxelData ();
-     
+
       /** \brief Reseeds the supervoxels by finding the voxel closest to current centroid */
       void
       reseedSupervoxels ();
-      
+
       /** \brief Constructs the map of supervoxel clusters from the internal supervoxel helpers */
       void
       makeSupervoxels (std::map<uint32_t,typename Supervoxel<PointT>::Ptr > &supervoxel_clusters);
-      
+
       /** \brief Stores the resolution used in the octree */
       float resolution_;
-    
+
       /** \brief Stores the resolution used to seed the superpixels */
       float seed_resolution_;
-      
+
       /** \brief Distance function used for comparing voxelDatas */
       float
       voxelDataDistance (const VoxelData &v1, const VoxelData &v2) const;
-      
+
       /** \brief Transform function used to normalize voxel density versus distance from camera */
       void
       transformFunction (PointT &p);
-      
+
       /** \brief Contains a KDtree for the voxelized cloud */
       typename pcl::search::KdTree<PointT>::Ptr voxel_kdtree_;
-      
+
       /** \brief Octree Adjacency structure with leaves at voxel resolution */
       typename OctreeAdjacencyT::Ptr adjacency_octree_;
-      
+
       /** \brief Contains the Voxelized centroid Cloud */
       typename PointCloudT::Ptr voxel_centroid_cloud_;
-      
+
       /** \brief Contains the Voxelized centroid Cloud */
       typename NormalCloudT::ConstPtr input_normals_;
-      
+
       /** \brief Importance of color in clustering */
       float color_importance_;
       /** \brief Importance of distance from seed center in clustering */
       float spatial_importance_;
       /** \brief Importance of similarity in normals for clustering */
       float normal_importance_;
-      
-      /** \brief Stores the colors used for the superpixel labels*/
-      std::vector<uint32_t> label_colors_;
-      
+
       /** \brief Internal storage class for supervoxels 
        * \note Stores pointers to leaves of clustering internal octree, 
        * \note so should not be used outside of clustering class 
@@ -415,58 +412,58 @@ namespace pcl
           typedef std::set<LeafContainerT*, typename SupervoxelHelper::compareLeaves> LeafSetT;
           typedef typename LeafSetT::iterator iterator;
           typedef typename LeafSetT::const_iterator const_iterator;
-          
+
           SupervoxelHelper (uint32_t label, SupervoxelClustering* parent_arg):
             label_ (label),
             parent_ (parent_arg)
           { }
-          
+
           void
           addLeaf (LeafContainerT* leaf_arg);
-        
+
           void
           removeLeaf (LeafContainerT* leaf_arg);
-        
+
           void
           removeAllLeaves ();
-          
+
           void 
           expand ();
-          
+
           void 
           refineNormals ();
-          
+
           void 
           updateCentroid ();
-          
+
           void 
           getVoxels (typename pcl::PointCloud<PointT>::Ptr &voxels) const;
-          
+
           void 
           getNormals (typename pcl::PointCloud<Normal>::Ptr &normals) const;
-          
+
           typedef float (SupervoxelClustering::*DistFuncPtr)(const VoxelData &v1, const VoxelData &v2);
-          
+
           uint32_t
           getLabel () const 
           { return label_; }
-          
+
           Eigen::Vector4f 
           getNormal () const 
           { return centroid_.normal_; }
-          
+
           Eigen::Vector3f 
           getRGB () const 
           { return centroid_.rgb_; }
-          
+
           Eigen::Vector3f
           getXYZ () const 
           { return centroid_.xyz_;}
-          
+
           void
           getXYZ (float &x, float &y, float &z) const
           { x=centroid_.xyz_[0]; y=centroid_.xyz_[1]; z=centroid_.xyz_[2]; }
-          
+
           void
           getRGB (uint32_t &rgba) const
           { 
@@ -474,7 +471,7 @@ namespace pcl
                    static_cast<uint32_t>(centroid_.rgb_[1]) << 8 | 
                    static_cast<uint32_t>(centroid_.rgb_[2]); 
           }
-          
+
           void 
           getNormal (pcl::Normal &normal_arg) const 
           { 
@@ -483,15 +480,14 @@ namespace pcl
             normal_arg.normal_z = centroid_.normal_[2];
             normal_arg.curvature = centroid_.curvature_;
           }
-          
+
           void
           getNeighborLabels (std::set<uint32_t> &neighbor_labels) const;
-          
+
           VoxelData
           getCentroid () const
           { return centroid_; }
-            
-          
+
           size_t
           size () const { return leaves_.size (); }
         private:
@@ -504,19 +500,17 @@ namespace pcl
           //Type VoxelData may have fixed-size Eigen objects inside
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW
       };
-      
+
       //Make boost::ptr_list can access the private class SupervoxelHelper
       friend void boost::checked_delete<> (const typename pcl::SupervoxelClustering<PointT>::SupervoxelHelper *);
-      
+
       typedef boost::ptr_list<SupervoxelHelper> HelperListT;
       HelperListT supervoxel_helpers_;
-      
+
       //TODO DEBUG REMOVE
       StopWatch timer_;
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-      
-     
 
   };
 

--- a/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
+++ b/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
@@ -531,13 +531,8 @@ pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor (vtkSmart
 
   // Assign Glasbey colors in ascending order of labels
   size_t color = 0;
-  for (std::set<uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter)
-  {
-    if (color < GLASBEY_LUT_SIZE)
-      colormap[*iter] = getGlasbeyColor (color++);
-    else
-      colormap[*iter] = getRandomColor ();
-  }
+  for (std::set<uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter, ++color)
+    colormap[*iter] = getGlasbeyColor (color % GLASBEY_LUT_SIZE);
 
   int j = 0;
   for (vtkIdType cp = 0; cp < nr_points; ++cp)

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -628,13 +628,8 @@ pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getCo
 
   // Assign Glasbey colors in ascending order of labels
   size_t color = 0;
-  for (std::set<uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter)
-  {
-    if (color < GLASBEY_LUT_SIZE)
-      colormap[*iter] = getGlasbeyColor (color++);
-    else
-      colormap[*iter] = getRandomColor ();
-  }
+  for (std::set<uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter, ++color)
+    colormap[*iter] = getGlasbeyColor (color % GLASBEY_LUT_SIZE);
 
   // If XYZ present, check if the points are invalid
   int x_idx = pcl::getFieldIndex (*cloud_, "x");


### PR DESCRIPTION
This changes supervoxel clustering so that it uses the changes from #849 (new label color handler).
The functions for getting RGB clouds have been deprecated, and the example updated.
The label color handler was also updated so that it uses modulo the max label, rather than random colors. This fixes the problem where colors change if the cloud is updated and is faster.

Also, spacing in the header file was fixed so git doesn't complain anymore.
