### PR TITLE
explicitly include vtkVersion module&macros

### DIFF
--- a/visualization/include/pcl/visualization/vtk.h
+++ b/visualization/include/pcl/visualization/vtk.h
@@ -48,6 +48,7 @@
 #endif
 #endif
 
+#include <vtkVersion.h>
 #include <vtkAppendPolyData.h>
 #include <vtkAssemblyPath.h>
 #include <vtkAxesActor.h>


### PR DESCRIPTION
Otherwise VTK_MAJOR_VERSION is not defined if VTK was built with
VTK_LEGACY_REMOVE=1.
