### PR TITLE
Fix CMake for PNG

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -295,7 +295,7 @@ if(build)
     link_directories(${VTK_LINK_DIRECTORIES})
     target_link_libraries("${LIB_NAME}" pcl_common pcl_io_ply ${VTK_LIBRARIES} )
     if(PNG_FOUND)
-      target_link_libraries("${LIB_NAME}" "${PNG_LIBRARY}")
+      target_link_libraries("${LIB_NAME}" ${PNG_LIBRARY})
     endif(PNG_FOUND)
 
     if(LIBUSB_1_FOUND)


### PR DESCRIPTION
With the quotation mark, the "optimized/debug" will be misinterpreted (at least on CMake v3.0.2).
