### PR TITLE
Fix an issue with PCLVisualizer producing empty screenshots

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -99,6 +99,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::Initialize ()
 
   // Create the image filter and PNG writer objects
   wif_ = vtkSmartPointer<vtkWindowToImageFilter>::New ();
+  wif_->ReadFrontBufferOff ();
   snapshot_writer_ = vtkSmartPointer<vtkPNGWriter>::New ();
   snapshot_writer_->SetInputConnection (wif_->GetOutputPort ());
 


### PR DESCRIPTION
This (presumably) fixes #954. The fix was proposed in [this thread](http://www.pcl-users.org/pcl-visualization-PCLVisualizer-saveScreenshot-and-pcl-viewer-J-command-returning-black-image-td4028645.html).

I do not encounter the problem with my setup, adding this line does not change anything for me.
