### PR TITLE
Clarify Ensenso CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ endif(WITH_FZAPI)
 # IDS-Imaging - Ensenso
 option(WITH_ENSENSO "Build IDS-Imaging Ensenso's camera support" TRUE)
 if(WITH_ENSENSO)
-  set(ENSENSO_ABI_DIR "$ENV{PROGRAMW6432}/Ensenso/development/c" CACHE PATH "directory of Ensenso ABI")
+  set(ENSENSO_ABI_DIR "ENSENSO_ABI_DIR-NOTFOUND" CACHE PATH "directory of Ensenso ABI")
   find_package(Ensenso) # FindEnsenso.cmake
   if (ENSENSO_FOUND)
     set(HAVE_ENSENSO ON)


### PR DESCRIPTION
Minor change to Ensenso CMake configuration
Hints for both Linux/Windows Ensenso install path are provided [here](https://github.com/PointCloudLibrary/pcl/blob/master/PCLConfig.cmake.in#L258).

Related to #971 
