### PR TITLE
Fix in PCLVisualizer

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1887,7 +1887,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   vtkSmartPointer<vtkPolyData> polydata = static_cast<vtkPolyDataMapper*>(am_it->second.actor->GetMapper ())->GetInput ();
   if (!polydata)
     return (false);
-  vtkSmartPointer<vtkCellArray> cells = polydata->GetStrips ();
+  vtkSmartPointer<vtkCellArray> cells = polydata->GetPolys ();
   if (!cells)
     return (false);
   vtkSmartPointer<vtkPoints> points   = polydata->GetPoints ();


### PR DESCRIPTION
Hi,
I tested the 'openni_fast_mesh' demo and got a warning of the visualisation modul that the polygon mesh named 'surface' is already existing. 

After debugging I found the reason in 'PCLVisualizer::updatePolygonMesh'. commit #686 replaced 'SetStrips()' by 'SetPolys()' in 'addPolygonMesh'. But then there must be also a replacement of 'GetStrips()' by 'GetPolys()' in 'updatePolygonMesh'.
