### PR TITLE
Add "WITH_OPENGL" option to make OpenGL and Glut inclusion conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,7 +403,10 @@ if(WITH_PCAP)
 endif(WITH_PCAP)
 
 # OpenGL and GLUT
-include("${PCL_SOURCE_DIR}/cmake/pcl_find_gl.cmake")
+option(WITH_OPENGL "Support for OpenGL" TRUE)
+if(WITH_OPENGL)
+  include("${PCL_SOURCE_DIR}/cmake/pcl_find_gl.cmake")
+endif(WITH_OPENGL)
 
 ### ---[ Create the config.h file
 set(pcl_config_h_in "${CMAKE_CURRENT_SOURCE_DIR}/pcl_config.h.in")


### PR DESCRIPTION
Crosscompilation of PCL fails on a system without OpenGL; this can be avoided making OpenGL inclusion conditional

regards,
Davide
