### PR TITLE
Fix class GeneralizedIterativeClosestPoint6D doesn't exported

### DIFF
--- a/registration/include/pcl/registration/gicp6d.h
+++ b/registration/include/pcl/registration/gicp6d.h
@@ -102,7 +102,7 @@ namespace pcl
    * \author Martin Holzkothen, Michael Korn
    * \ingroup registration
    */
-  class GeneralizedIterativeClosestPoint6D : public GeneralizedIterativeClosestPoint<PointXYZRGBA, PointXYZRGBA>
+  class PCL_EXPORTS GeneralizedIterativeClosestPoint6D : public GeneralizedIterativeClosestPoint<PointXYZRGBA, PointXYZRGBA>
   {
     typedef PointXYZRGBA PointSource;
     typedef PointXYZRGBA PointTarget;


### PR DESCRIPTION
This pull request fix the bug that test_registration build fail.
The cause of build failure is pcl::GeneralizedIterativeClosestPoint6D doesn't been exported.
I have verified this issue in the following environments.
Probably, this issue will be reproduced in other environments.
- Windows 8.1
- Visual Studio 2013
