### PR TITLE
Fix in ImageViewer (PCLVisualizer)

### DIFF
--- a/visualization/include/pcl/visualization/impl/image_viewer.hpp
+++ b/visualization/include/pcl/visualization/impl/image_viewer.hpp
@@ -136,6 +136,7 @@ pcl::visualization::ImageViewer::addMask (
                      static_cast<unsigned char> (g*255.0), 
                      static_cast<unsigned char> (b*255.0));
   points->setOpacity (opacity);
+  points->set (xy);
   am_it->actor->GetScene ()->AddItem (points);
   return (true);
 }


### PR DESCRIPTION
Hi,
during testing the 'pcl_ni_linemod' demo/tool I got a repreducable unwanted program abort. I found out, that the reason is the missing invocation of 'set' in '::addMask'.
