### PR TITLE
Fix the L1 normalization of the RoPS feature

### DIFF
--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -191,11 +191,11 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeFeature (PointCloudOut &output
 
     float norm = 0.0f;
     for (unsigned int i_dim = 0; i_dim < feature_size; i_dim++)
-      norm += feature[i_dim];
-    if (abs (norm) < std::numeric_limits <float>::epsilon ())
-      norm = 1.0f / norm;
-    else
+      norm += abs (feature[i_dim]);
+    if (norm < std::numeric_limits <float>::epsilon ())
       norm = 1.0f;
+    else
+      norm = 1.0f / norm;
 
     for (unsigned int i_dim = 0; i_dim < feature_size; i_dim++)
       output.points[i_point].histogram[i_dim] = feature[i_dim] * norm;


### PR DESCRIPTION
There were two issues with the existing normalization code:
1. The L1 norm was not computed with the sum-of-absolute values, and this results in a wrong L1 norm since the RoPS descriptor contains negatives.
2. The small-value if statement was reversed, and caused division by small values instead of avoiding this.
