### PR TITLE
Fix: 'opacity' workaround in ImageViewer (PCLVisualizer)

### DIFF
--- a/visualization/include/pcl/visualization/impl/image_viewer.hpp
+++ b/visualization/include/pcl/visualization/impl/image_viewer.hpp
@@ -197,6 +197,7 @@ pcl::visualization::ImageViewer::addPlanarPolygon (
   poly->setColors (static_cast<unsigned char> (r * 255.0), 
                    static_cast<unsigned char> (g * 255.0), 
                    static_cast<unsigned char> (b * 255.0));
+  poly->setOpacity (opacity);
   poly->set (xy);
   am_it->actor->GetScene ()->AddItem (poly);
 

--- a/visualization/include/pcl/visualization/vtk/pcl_context_item.h
+++ b/visualization/include/pcl/visualization/vtk/pcl_context_item.h
@@ -64,7 +64,6 @@ namespace pcl
       void setColors (unsigned char rgb[3]) { memcpy (colors, rgb, 3 * sizeof (unsigned char)); }
       void setOpacity (double opacity) { SetOpacity (opacity); };
       unsigned char colors[3];
-      double opacity;
       std::vector<float> params;
     };
 

--- a/visualization/src/vtk/pcl_context_item.cpp
+++ b/visualization/src/vtk/pcl_context_item.cpp
@@ -138,8 +138,8 @@ pcl::visualization::context_items::Text::set (float x, float y, const std::strin
 bool
 pcl::visualization::context_items::Circle::Paint (vtkContext2D *painter)
 {
-  painter->GetPen ()->SetColor (colors);
-  painter->GetBrush ()->SetColor (colors);
+  painter->GetBrush ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawWedge (params[0], params[1], params[2], params[3], 0.0, 360.0);
   return (true);
 }
@@ -148,8 +148,8 @@ pcl::visualization::context_items::Circle::Paint (vtkContext2D *painter)
 bool
 pcl::visualization::context_items::Disk::Paint (vtkContext2D *painter)
 {
-  painter->GetBrush ()->SetColor (colors);
-  painter->GetPen ()->SetColor (colors);
+  painter->GetBrush ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawEllipse (params[0], params[1], params[2], params[2]);
   return (true);
 }
@@ -158,7 +158,7 @@ pcl::visualization::context_items::Disk::Paint (vtkContext2D *painter)
 bool
 pcl::visualization::context_items::Rectangle::Paint (vtkContext2D *painter)
 {
-  painter->GetPen ()->SetColor (colors);
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   float p[] = 
   { 
     params[0], params[1], 
@@ -176,8 +176,8 @@ pcl::visualization::context_items::Rectangle::Paint (vtkContext2D *painter)
 bool
 pcl::visualization::context_items::FilledRectangle::Paint (vtkContext2D *painter)
 {
-  painter->GetBrush ()->SetColor (colors);
-  painter->GetPen ()->SetColor (colors);
+  painter->GetBrush ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawRect (params[0], params[1], params[2], params[3]);
   return (true);
 }
@@ -186,7 +186,7 @@ pcl::visualization::context_items::FilledRectangle::Paint (vtkContext2D *painter
 bool
 pcl::visualization::context_items::Line::Paint (vtkContext2D *painter)
 {
-  painter->GetPen ()->SetColor (colors);
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawLine (params[0], params[1], params[2], params[3]);
   return (true);
 }
@@ -195,8 +195,8 @@ pcl::visualization::context_items::Line::Paint (vtkContext2D *painter)
 bool
 pcl::visualization::context_items::Polygon::Paint (vtkContext2D *painter)
 {
-  painter->GetBrush ()->SetColor (colors);
-  painter->GetPen ()->SetColor (colors);
+  painter->GetBrush ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawPolygon (&params[0], static_cast<int> (params.size () / 2));
   return (true);
 }
@@ -205,7 +205,7 @@ pcl::visualization::context_items::Polygon::Paint (vtkContext2D *painter)
 bool
 pcl::visualization::context_items::Point::Paint (vtkContext2D *painter)
 {
-  painter->GetPen ()->SetColor (colors);
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawPoint (params[0], params[1]);
   return (true);
 }
@@ -214,7 +214,7 @@ pcl::visualization::context_items::Point::Paint (vtkContext2D *painter)
 bool
 pcl::visualization::context_items::Points::Paint (vtkContext2D *painter)
 {
-  painter->GetPen ()->SetColor (colors);
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawPoints (&params[0], static_cast<int> (params.size () / 2));
   return (true);
 }
@@ -225,6 +225,7 @@ pcl::visualization::context_items::Text::Paint (vtkContext2D *painter)
 {
   vtkTextProperty *text_property = painter->GetTextProp ();
   text_property->SetColor (255.0 * colors[0], 255.0 * colors[1], 255.0 * colors[2]);
+  text_property->SetOpacity (GetOpacity ());
   text_property->SetFontFamilyToArial ();
   text_property->SetFontSize (10);
   text_property->SetJustificationToLeft ();
@@ -257,10 +258,10 @@ pcl::visualization::context_items::Markers::Paint (vtkContext2D *painter)
     size = 2.3 * painter->GetPen ()->GetWidth ();
 
   painter->GetPen ()->SetWidth (size);
-  painter->GetPen ()->SetColor (colors);
+  painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawPointSprites (0, &params[0], nb_points);
   painter->GetPen ()->SetWidth (1);
-  painter->GetPen ()->SetColor (point_colors);
+  painter->GetPen ()->SetColor (point_colors[0], point_colors[1], point_colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->DrawPointSprites (0, &params[0], nb_points);
   return (true);
 }


### PR DESCRIPTION
Hi,
during testing the ImageViewer with 'PCLContextItem' (vtkContextItem) I realized that different values of 'opacity' settings had no effekt on screen. I found out that the vtk pens and brushes have to be set with rgba-colors on client side in the 'paint' functions. After several tests I can say that everything works fine. 

The 'opacity' member in 'struct PCLContextItem' is needless, because its almost a member of 'vtkContextItem'.
