### PR TITLE
Fix default angle step for the RoPS feature

### DIFF
--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -49,7 +49,7 @@ pcl::ROPSEstimation <PointInT, PointOutT>::ROPSEstimation () :
   number_of_rotations_ (3),
   support_radius_ (1.0f),
   sqr_support_radius_ (1.0f),
-  step_ (30.0f),
+  step_ (22.5f),
   triangles_ (0),
   triangles_of_the_point_ (0)
 {


### PR DESCRIPTION
I was using the ROPSEstimation class with all default parameters, i.e. without explicitly calling the setters as e.g. done in the tutorial. Or so I thought. The angle increment **step_** was being initialized to a wrong value. The correct way is used in **setNumberOfRotations()**, so I used the same formula for computing the correct value for the initializer list.
