### PR TITLE
Ensenso improvments

### DIFF
--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -42,6 +42,7 @@
 #define __PCL_IO_ENSENSO_GRABBER__
 
 #include <pcl/common/time.h>
+#include <pcl/common/io.h>
 #include <pcl/io/eigen.h>
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
@@ -67,13 +68,22 @@ namespace pcl
    */
   class PCL_EXPORTS EnsensoGrabber : public Grabber
   {
+      typedef std::pair<pcl::PCLImage, pcl::PCLImage> PairOfImages;
+
     public:
       typedef boost::shared_ptr<EnsensoGrabber> Ptr;
       typedef boost::shared_ptr<const EnsensoGrabber> ConstPtr;
 
       // Define callback signature typedefs
       typedef void
-      (sig_cb_ensenso_point_cloud) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&);
+      (sig_cb_ensenso_point_cloud) (const pcl::PointCloud<pcl::PointXYZ>::Ptr &);
+
+      typedef void
+      (sig_cb_ensenso_images) (const boost::shared_ptr<PairOfImages> &);
+
+      typedef void
+      (sig_cb_ensenso_point_cloud_images) (const pcl::PointCloud<pcl::PointXYZ>::Ptr &,
+                                           const boost::shared_ptr<PairOfImages> &);
 
       /** @brief Constructor */
       EnsensoGrabber ();
@@ -98,7 +108,7 @@ namespace pcl
       bool
       closeDevice ();
 
-      /** @brief Start the point cloud acquisition
+      /** @brief Start the point cloud and or image acquisition
        * @note Opens device "0" if no device is open */
       void
       start ();
@@ -428,6 +438,12 @@ namespace pcl
       /** @brief Boost point cloud signal */
       boost::signals2::signal<sig_cb_ensenso_point_cloud>* point_cloud_signal_;
 
+      /** @brief Boost images signal */
+      boost::signals2::signal<sig_cb_ensenso_images>* images_signal_;
+
+      /** @brief Boost images + point cloud signal */
+      boost::signals2::signal<sig_cb_ensenso_point_cloud_images>* point_cloud_images_signal_;
+
       /** @brief Whether an Ensenso device is opened or not */
       bool device_open_;
 
@@ -452,7 +468,20 @@ namespace pcl
       static
       getPCLStamp (const double ensenso_stamp);
 
-      /** @brief Continously asks for point clouds data from the device and publishes it if available. */
+      /** @brief Get OpenCV image type corresponding to the parameters given
+       * @param channels number of channels in the image
+       * @param bpe bytes per element
+       * @param isFlt is float
+       * @return the OpenCV type as a string */
+      std::string
+      static
+      getOpenCVType (const int channels,
+                     const int bpe,
+                     const bool isFlt);
+
+      /** @brief Continously asks for images and or point clouds data from the device and publishes them if available.
+       * PCL time stamps are filled for both the images and clouds grabbed (see @ref getPCLStamp)
+       * @note The cloud time stamp is the RAW image time stamp */
       void
       processGrabbing ();
   };


### PR DESCRIPTION
## Commit by commit
- Add `tcp_open_` and close TCP port on destruction
- Added as much const qualifiers as possible
- Small formatting and doc updates
- `EIGEN_MAKE_ALIGNED_OPERATOR_NEW` is not needed; there is no Eigen members
- `grabSingleCloud` can only be called when no device is running
- `camera_` wasn't public while `root_` was, it's easier for the user to access the `camera_` parameters now
- Added more transformations function needed for the extrinsic calibration code
- The extrinsic calibration code has been tested and works, I didn't get good results for the moment but it's most probably the data that is not good (not the code implementation).
- The image capture callback allows the user to display the images from the camera using VTK/OpenCV, you can collect clouds + images at the same time.
## Miscellaneous 

I fail to display the 2 images with `pcl::visualisation::ImageViewer` ()
I think it's best to wait for the `ImageViewer` to work properly before updating the tutorial.
