### PR TITLE
Fix: ImageViewer with VTK6

### DIFF
--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -130,6 +130,7 @@ pcl::visualization::ImageViewer::ImageViewer (const std::string& window_title)
 #endif
   slice_->SetMapper (map);
   ren_->AddViewProp (slice_);
+  ren_->GetActiveCamera ()->ParallelProjectionOn ();
   interactor_->SetInteractorStyle (interactor_style_);
 #endif
 
@@ -213,6 +214,9 @@ pcl::visualization::ImageViewer::addRGBImage (
 #else
   algo_->SetInputData (image);
   algo_->Update ();
+  slice_->GetMapper ()->SetInputConnection (algo_->GetOutputPort ());
+  ren_->ResetCamera ();
+  ren_->GetActiveCamera ()->SetParallelScale (0.5 * win_->GetSize ()[1]);
 #endif
 }
 
@@ -272,6 +276,9 @@ pcl::visualization::ImageViewer::addMonoImage (
 #else
   algo_->SetInputData (image);
   algo_->Update ();
+  slice_->GetMapper ()->SetInputConnection (algo_->GetOutputPort ());
+  ren_->ResetCamera ();
+  ren_->GetActiveCamera ()->SetParallelScale (0.5 * win_->GetSize ()[1]);
 #endif
 }
 


### PR DESCRIPTION
Hi,
several tests with grabbing tools and pcd tools using image viewer showed no results on screen. After long debugging sessions I came to the conclusion that the main reason was the missing connection between producer and consumer algorithm in vtk6. After this the display was there but hadn't the right scale. So I made some further changes to the code. Now it is working fine so far.
