### PR TITLE
Add missing header to `example_lccp_segmentation.cpp`

### DIFF
--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -40,6 +40,7 @@
 #include <cmath>
 #include <limits.h>
 
+#include <boost/format.hpp>
 
 
 // PCL input/output


### PR DESCRIPTION
Fixes #981.
