### PR TITLE
Added const modifiers to OctreePointCloud function

### DIFF
--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -386,7 +386,7 @@ namespace pcl
          * \param[out] max_pt upper bound of voxel
          */
         inline void
-        getVoxelBounds (OctreeIteratorBase<OctreeT>& iterator, Eigen::Vector3f &min_pt, Eigen::Vector3f &max_pt)
+        getVoxelBounds (const OctreeIteratorBase<OctreeT>& iterator, Eigen::Vector3f &min_pt, Eigen::Vector3f &max_pt) const
         {
           this->genVoxelBoundsFromOctreeKey (iterator.getCurrentOctreeKey (),
               iterator.getCurrentOctreeDepth (), min_pt, max_pt);


### PR DESCRIPTION
- Added const keyword to function 'OctreePointCloud::getVoxelBounds ()',
  since it internally only calls a 'const' function
  ('OctreePointCloud::genVoxelBoundsFromOctreeKey ()')
- Added const modifier to 'OctreeIterator' input argument of
  'OctreePointCloud::getVoxelBounds ()', since only 'const' functions
  of 'OctreeIterator' are called
