### PR TITLE
Fix Eigen error

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3773,7 +3773,7 @@ pcl::visualization::PCLVisualizer::renderView (int xres, int yres, pcl::PointClo
       mat2 (i, j) = static_cast<float> (view_transform->Element[i][j]);
     }
 
-  mat1 = mat1.inverse ();
+  mat1 = mat1.inverse ().eval ();
 
   int ptr = 0;
   for (int y = 0; y < yres; ++y)


### PR DESCRIPTION
Fixes http://www.pcl-users.org/simple-renderView-example-td4035597.html

```
test_pcl: /usr/include/eigen3/Eigen/src/LU/Inverse.h:294: void Eigen::internal::inverse_impl<MatrixType>::evalTo(Dest&) const [with Dest = Eigen::Matrix<float, 4, 4>; MatrixType = Eigen::Matrix<float, 4, 4>]: Assertion `( (Size<=1) || (Size>4) || (extract_data(m_matrix)!=extract_data(dst))) && "Aliasing problem detected in inverse(), you need to do inverse().eval() here."' failed.
```
