### PR TITLE
further fix for issue #1012 when compiling on Windows 32bit (MSVC2010). ...

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -169,7 +169,7 @@ namespace pcl
     * \author Patrick Mihelich, Radu B. Rusu
     */
   template <typename PointT>
-  class PointCloud
+  class PCL_EXPORTS PointCloud
   {
     public:
       /** \brief Default constructor. Sets \ref is_dense to true, \ref width


### PR DESCRIPTION
...If class BearingAngleImage is exported using PCL_EXPORTS, its base class pcl::PointCloud must be exported as well.
