### PR TITLE
Results of HRI code sprint for stereo-based road area detection (stereo module)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -42,6 +42,7 @@ if(build)
         src/time_trigger.cpp
         src/gaussian.cpp
         src/colors.cpp
+        src/feature_histogram.cpp
         ${range_image_srcs}
         )
 
@@ -109,6 +110,7 @@ if(build)
         include/pcl/common/generate.h
         include/pcl/common/projection_matrix.h
         include/pcl/common/colors.h
+        include/pcl/common/feature_histogram.h
         )
 
     set(common_incs_impl

--- a/common/include/pcl/common/feature_histogram.h
+++ b/common/include/pcl/common/feature_histogram.h
@@ -1,0 +1,125 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCL_FEATURE_HISTOGRAM_H_
+#define PCL_FEATURE_HISTOGRAM_H_
+
+#include <vector>
+
+#include <pcl/pcl_macros.h>
+
+namespace pcl
+{ 
+  /** \brief Type for histograms for computing mean and variance of some floats.
+    *
+    * \author Timur Ibadov (ibadov.timur@gmail.com)
+    * \ingroup common
+    */
+  class PCL_EXPORTS FeatureHistogram
+  {
+    public:
+      /** \brief Public constructor.
+        * \param[in] number_of_bins number of bins in the histogram.
+        * \param[in] min lower threshold.
+        * \param[in] max upper threshold.
+        */
+      FeatureHistogram (const size_t number_of_bins, const float min,
+          const float max);
+
+      /** \brief Public destructor. */
+      virtual ~FeatureHistogram ();
+
+      /** \brief Get the lower threshold.
+        * \return lower threshold.
+        */
+      float
+      getThresholdMin () const;
+
+      /** \brief Get the upper threshold.
+        * \return upper threshold.
+        */
+      float
+      getThresholdMax () const;
+
+      /** \brief Get the number of elements was added to the histogram.
+        * \return number of elements in the histogram.
+        */
+      size_t
+      getNumberOfElements () const;
+
+      /** \brief Get number of bins in the histogram.
+        * \return number of bins in the histogram.
+        */
+      size_t
+      getNumberOfBins () const;
+
+      /** \brief Increase a bin, that corresponds the value.
+        * \param[in] value new value.
+        */
+      void
+      addValue (float value);
+
+      /** \brief Get value, corresponds to the greatest bin.
+        * \return mean value of the greatest bin.
+        */
+      float
+      getMeanValue ();
+
+      /** \brief Get variance of the value.
+        * \return variance of the greatest bin.
+        */
+      float
+      getVariance (float mean);
+
+    protected:
+      /** \brief Vector, that contain the histogram. */
+      std::vector <unsigned> histogram_;
+
+      /** \brief Min threshold. */
+      float threshold_min_;
+      /** \brief Max threshold. */
+      float threshold_max_;
+      /** \brief "Width" of a bin. */
+      float step_;
+
+      /** \brief Number of values was added to the histogram. */
+      size_t number_of_elements_;
+
+      /** \brief Number of bins. */
+      size_t number_of_bins_;
+  };
+}
+#endif // PCL_FEATURE_HISTOGRAM_H_

--- a/common/include/pcl/common/impl/intensity.hpp
+++ b/common/include/pcl/common/impl/intensity.hpp
@@ -273,6 +273,281 @@ namespace pcl
         set (p, intensity);
       }
     };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::PointXYZHSV>
+    {
+      inline float
+      operator () (const pcl::PointXYZHSV &p) const
+      {
+        return (p.v);
+      }
+
+      inline void
+      get (const pcl::PointXYZHSV &p, float &intensity) const
+      {
+        intensity = p.v;
+      }
+
+      inline void
+      set (pcl::PointXYZHSV &p, float intensity) const
+      {
+        p.v = intensity;
+        p.s = 0.0f;
+      }
+
+      inline void
+      demean (pcl::PointXYZHSV& p, float value) const
+      {
+        p.v -= value;
+      }
+
+      inline void
+      add (pcl::PointXYZHSV& p, float value) const
+      {
+        p.v += value;
+      }
+    };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::PointXYZL>
+    {
+      inline float
+      operator () (const pcl::PointXYZL &p) const
+      {
+        return (static_cast<float>(p.label));
+      }
+
+      inline void
+      get (const pcl::PointXYZL &p, float &intensity) const
+      {
+        intensity = static_cast<float>(p.label);
+      }
+
+      inline void
+      set (pcl::PointXYZL &p, float intensity) const
+      {
+        p.label = static_cast<uint32_t>(intensity);
+        
+      }
+
+      inline void
+      demean (pcl::PointXYZL& p, float value) const
+      {
+        p.label -= static_cast<uint32_t>(value);
+      }
+
+      inline void
+      add (pcl::PointXYZL& p, float value) const
+      {
+        p.label += static_cast<uint32_t>(value);
+      }
+    };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::PointXYZLNormal>
+    {
+      inline float
+      operator () (const pcl::PointXYZLNormal &p) const
+      {
+        return (static_cast<float>(p.label));
+      }
+
+      inline void
+      get (const pcl::PointXYZLNormal &p, float &intensity) const
+      {
+        intensity = static_cast<float>(p.label);
+      }
+
+      inline void
+      set (pcl::PointXYZLNormal &p, float intensity) const
+      {
+        p.label = static_cast<uint32_t>(intensity);
+        
+      }
+
+      inline void
+      demean (pcl::PointXYZLNormal& p, float value) const
+      {
+        p.label -= static_cast<uint32_t>(value);
+      }
+
+      inline void
+      add (pcl::PointXYZLNormal& p, float value) const
+      {
+        p.label += static_cast<uint32_t>(value);
+      }
+    };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::InterestPoint>
+    {
+      inline float
+      operator () (const pcl::InterestPoint &p) const
+      {
+        return (p.strength);
+      }
+
+      inline void
+      get (const pcl::InterestPoint &p, float &intensity) const
+      {
+        intensity = p.strength;
+      }
+
+      inline void
+      set (pcl::InterestPoint &p, float intensity) const
+      {
+        p.strength = intensity;
+      }
+
+      inline void
+      demean (pcl::InterestPoint& p, float value) const
+      {
+        p.strength -= value;
+      }
+
+      inline void
+      add (pcl::InterestPoint& p, float value) const
+      {
+        p.strength += value;
+      }
+    };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::PointWithRange>
+    {
+      inline float
+      operator () (const pcl::PointWithRange &p) const
+      {
+        return (p.range);
+      }
+
+      inline void
+      get (const pcl::PointWithRange &p, float &intensity) const
+      {
+        intensity = p.range;
+      }
+
+      inline void
+      set (pcl::PointWithRange &p, float intensity) const
+      {
+        p.range = intensity;
+      }
+
+      inline void
+      demean (pcl::PointWithRange& p, float value) const
+      {
+        p.range -= value;
+      }
+
+      inline void
+      add (pcl::PointWithRange& p, float value) const
+      {
+        p.range += value;
+      }
+    };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::PointWithScale>
+    {
+      inline float
+      operator () (const pcl::PointWithScale &p) const
+      {
+        return (p.scale);
+      }
+
+      inline void
+      get (const pcl::PointWithScale &p, float &intensity) const
+      {
+        intensity = p.scale;
+      }
+
+      inline void
+      set (pcl::PointWithScale &p, float intensity) const
+      {
+        p.scale = intensity;
+      }
+
+      inline void
+      demean (pcl::PointWithScale& p, float value) const
+      {
+        p.scale -= value;
+      }
+
+      inline void
+      add (pcl::PointWithScale& p, float value) const
+      {
+        p.scale += value;
+      }
+    };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::PointWithViewpoint>
+    {
+      inline float
+      operator () (const pcl::PointWithViewpoint &p) const
+      {
+        return (p.z);
+      }
+
+      inline void
+      get (const pcl::PointWithViewpoint &p, float &intensity) const
+      {
+        intensity = p.z;
+      }
+
+      inline void
+      set (pcl::PointWithViewpoint &p, float intensity) const
+      {
+        p.z = intensity;
+      }
+
+      inline void
+      demean (pcl::PointWithViewpoint& p, float value) const
+      {
+        p.z -= value;
+      }
+
+      inline void
+      add (pcl::PointWithViewpoint& p, float value) const
+      {
+        p.z += value;
+      }
+    };
+
+    template<>
+    struct IntensityFieldAccessor<pcl::PointSurfel>
+    {
+      inline float
+      operator () (const pcl::PointSurfel &p) const
+      {
+        return (p.curvature);
+      }
+
+      inline void
+      get (const pcl::PointSurfel &p, float &intensity) const
+      {
+        intensity = p.curvature;
+      }
+
+      inline void
+      set (pcl::PointSurfel &p, float intensity) const
+      {
+        p.curvature = intensity;
+      }
+
+      inline void
+      demean (pcl::PointSurfel& p, float value) const
+      {
+        p.curvature -= value;
+      }
+
+      inline void
+      add (pcl::PointSurfel& p, float value) const
+      {
+        p.curvature += value;
+      }
+    };
   }
 }
 

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -90,7 +90,8 @@
   (pcl::SHOT352)                \
   (pcl::SHOT1344)               \
   (pcl::PointUV)                \
-  (pcl::ReferenceFrame)
+  (pcl::ReferenceFrame)         \
+  (pcl::PointDEM)
 
 // Define all point types that include RGB data
 #define PCL_RGB_POINT_TYPES     \
@@ -117,7 +118,8 @@
   (pcl::PointWithRange)       \
   (pcl::PointWithViewpoint)   \
   (pcl::PointWithScale)       \
-  (pcl::PointSurfel)
+  (pcl::PointSurfel)          \
+  (pcl::PointDEM)
 
 // Define all point types with XYZ and label
 #define PCL_XYZL_POINT_TYPES  \
@@ -1590,6 +1592,39 @@ namespace pcl
     }
   
     friend std::ostream& operator << (std::ostream& os, const PointSurfel& p);
+  };
+
+  struct EIGEN_ALIGN16 _PointDEM
+  {
+    PCL_ADD_POINT4D;
+    float intensity;
+    float intensity_variance;
+    float height_variance;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  };
+
+  PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointDEM& p);
+  /** \brief A point structure representing Digital Elevation Map.
+    * \ingroup common
+    */
+  struct PointDEM : public _PointDEM
+  {
+    inline PointDEM (const _PointDEM &p)
+    {
+      x = p.x; y = p.y; x = p.z; data[3] = 1.0f;
+      intensity = p.intensity;
+      intensity_variance = p.intensity_variance;
+      height_variance = p.height_variance;
+    }
+
+    inline PointDEM ()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      intensity = 0.0f;
+      intensity_variance = height_variance = 0.0f;
+    }
+
+    friend std::ostream& operator << (std::ostream& os, const PointDEM& p);
   };
 
   template <int N> std::ostream& 

--- a/common/include/pcl/point_types.h
+++ b/common/include/pcl/point_types.h
@@ -332,6 +332,11 @@ namespace pcl
     * \ingroup common
     */
   struct PointSurfel;
+
+  /** \brief Members: float x, y, z, intensity, intensity_variance, height_variance
+    * \ingroup common
+    */
+  struct PointDEM;
 }
 
 /** @} */
@@ -662,6 +667,16 @@ POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::_ReferenceFrame,
     (float[3], z_axis, z_axis)
 )
 POINT_CLOUD_REGISTER_POINT_WRAPPER(pcl::ReferenceFrame, pcl::_ReferenceFrame)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::_PointDEM,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, intensity, intensity)
+    (float, intensity_variance, intensity_variance)
+    (float, height_variance, height_variance)
+)
+POINT_CLOUD_REGISTER_POINT_WRAPPER(pcl::PointDEM, pcl::_PointDEM)
 
 namespace pcl 
 {

--- a/common/src/feature_histogram.cpp
+++ b/common/src/feature_histogram.cpp
@@ -1,0 +1,175 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pcl/common/feature_histogram.h>
+
+#include <algorithm>
+
+#include <pcl/console/print.h>
+
+pcl::FeatureHistogram::FeatureHistogram (size_t const number_of_bins,
+    const float min, const float max) : 
+    histogram_ (number_of_bins, 0)
+{
+  // Initialize thresholds.
+  if (min < max)
+  {
+    threshold_min_ = min;
+    threshold_max_ = max;
+    step_ = (max - min) / static_cast<float> (number_of_bins_);
+  }
+  else
+  {
+    threshold_min_ = 0.0f;
+    threshold_max_ = static_cast<float> (number_of_bins);
+    step_ = 1.0f;
+    PCL_WARN ("[FeatureHistogram::setThresholds] Variable \"max\" must be greater then \"min\".\n");
+  }
+
+  // Initialize sum.
+  number_of_elements_ = 0;
+
+  // Initialize size;
+  number_of_bins_ = number_of_bins;
+}
+
+pcl::FeatureHistogram::~FeatureHistogram ()
+{
+  
+}
+
+float
+pcl::FeatureHistogram::getThresholdMin () const
+{
+  return (threshold_min_);
+}
+
+float
+pcl::FeatureHistogram::getThresholdMax () const
+{
+  return (threshold_max_);
+}
+
+size_t
+pcl::FeatureHistogram::getNumberOfElements () const
+{
+  return (number_of_elements_);
+}
+
+size_t
+pcl::FeatureHistogram::getNumberOfBins () const
+{
+  return (number_of_bins_);
+}
+
+void
+pcl::FeatureHistogram::addValue (float value)
+{
+  // Check, if value in the allowed range.
+  if (threshold_min_ < value && value < threshold_max_)
+  {
+    // Increase the sum.
+    ++number_of_elements_;
+
+    // Increase the bin.
+    size_t bin_number = static_cast<size_t> ((value - threshold_min_) / step_);
+    ++histogram_[bin_number];
+  }
+}
+
+float
+pcl::FeatureHistogram::getMeanValue ()
+{
+    // Check, if the histogram is empty.
+  if (number_of_elements_ == 0)
+  {
+    return (0.0f);
+  }
+  // Smoothe the histogram and find a bin with a max smoothed value.
+  size_t max_idx = 0;
+  float max = 0.50f * histogram_[0] + 
+              0.25f * histogram_[1] * 2.0f;
+  for (size_t bin = 1; bin < histogram_.size () - 1; ++bin)
+  {
+    float smothed_value = 0.25f * histogram_[bin - 1] + 
+                          0.50f * histogram_[bin] + 
+                          0.25f * histogram_[bin + 1];
+    if (smothed_value > max)
+    {
+      max = smothed_value;
+      max_idx = bin;
+    }
+  }
+  // Check last bin.
+  float last_value = 0.50f * histogram_[histogram_.size () - 1] + 
+                     0.25f * histogram_[histogram_.size () - 2] * 2.0f;
+  if (last_value > max)
+  {
+    max_idx = histogram_.size ();
+  }
+
+  // Compute mean value.
+  float mean = step_ * (static_cast<float> (max_idx) + 0.5f) + threshold_min_;
+
+  return (mean);
+}
+
+float
+pcl::FeatureHistogram::getVariance (float mean)
+{
+  // Check, if the histogram is empty.
+  if (number_of_elements_ == 0)
+  {
+    return (0.0f);
+  }
+  // The histogram is not empty.
+  // Variable to accumulate the terms of variance.
+  float variances_sum = 0;
+
+  for (size_t bin = 0; bin < number_of_bins_; ++bin)
+  {
+    if (histogram_[bin] > 0)
+    {
+      // Value corresponding to the bin.
+      float value = step_ * (static_cast<float> (bin) + 0.5f) + threshold_min_;
+      float dif = value - mean;
+      variances_sum += static_cast<float> (histogram_[bin]) * dif * dif;
+    }
+  }
+
+  // Compute variance and return it.
+  return (variances_sum / static_cast<float> (number_of_elements_));
+}

--- a/common/src/point_types.cpp
+++ b/common/src/point_types.cpp
@@ -419,4 +419,14 @@ namespace pcl
     p.radius << " - " << p.confidence << " - " << p.curvature << ")";
     return (os);
   }
+
+  std::ostream& 
+  operator << (std::ostream& os, const PointDEM& p)
+  {
+    os << "(" << p.x << "," << p.y << "," << p.z << " - " 
+       << p.intensity << " - " << p.intensity_variance << " - " 
+       << p.height_variance << ")";
+    return (os);
+  }
+
 }

--- a/stereo/CMakeLists.txt
+++ b/stereo/CMakeLists.txt
@@ -10,18 +10,23 @@ PCL_ADD_DOC("${SUBSYS_NAME}")
 
 if(build)
     set(incs
-        "include/pcl/${SUBSYS_NAME}/stereo_grabber.h"
-        "include/pcl/${SUBSYS_NAME}/stereo_matching.h"
+        include/pcl/${SUBSYS_NAME}/stereo_grabber.h
+        include/pcl/${SUBSYS_NAME}/stereo_matching.h
+        include/pcl/${SUBSYS_NAME}/disparity_map_converter.h
+        include/pcl/${SUBSYS_NAME}/digital_elevation_map.h
         )
 
     set(impl_incs
+        include/pcl/${SUBSYS_NAME}/impl/disparity_map_converter.hpp
         )
 
     set(srcs
         src/stereo_grabber.cpp
-		src/stereo_matching.cpp
-		src/stereo_block_based.cpp
-		src/stereo_adaptive_cost_so.cpp
+        src/stereo_matching.cpp
+        src/stereo_block_based.cpp
+        src/stereo_adaptive_cost_so.cpp
+        src/disparity_map_converter.cpp
+        src/digital_elevation_map.cpp
         )
 
     set(LIB_NAME "pcl_${SUBSYS_NAME}")

--- a/stereo/include/pcl/stereo/digital_elevation_map.h
+++ b/stereo/include/pcl/stereo/digital_elevation_map.h
@@ -1,0 +1,142 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PCL_DIGITAL_ELEVATION_MAP_H_
+#define PCL_DIGITAL_ELEVATION_MAP_H_
+
+#pragma warning(disable : 4996)
+#include <pcl/point_types.h>
+#include <pcl/stereo/disparity_map_converter.h>
+#pragma warning(default : 4996)
+
+namespace pcl
+{ 
+  /** \brief Build a Digital Elevation Map in the column-disparity space from a disparity map and a color image of the scene.
+    *
+    * Example of usage:
+    * 
+    * \code
+    *  pcl::PointCloud<pcl::PointDEM>::Ptr cloud (new
+    *      pcl::PointCloud<pcl::PointDEM>);
+    *  pcl::PointCloud<pcl::RGB>::Ptr left_image (new 
+    *    pcl::PointCloud<pcl::RGB>);
+    *  // Fill left image cloud.
+    *  
+    *  pcl::DigitalElevationMapBuilder demb;
+    *  demb.setBaseline (0.8387445f);
+    *  demb.setFocalLength (368.534700f);
+    *  demb.setImageCenterX (318.112200f);
+    *  demb.setImageCenterY (224.334900f);
+    *  demb.setDisparityThresholdMin (15.0f);
+    *  demb.setDisparityThresholdMax (80.0f);
+    *  demb.setResolution (64, 32);
+    *
+    *  // Left view of the scene.
+    *  demb.loadImage (left_image);
+    *  // Disparity map of the scene.
+    *  demb.loadDisparityMap ("disparity_map.txt", 640, 480);
+    *
+    *  demb.compute(*cloud);
+    * \endcode
+    *
+    * \author Timur Ibadov (ibadov.timur@gmail.com)
+    * \ingroup stereo
+    */
+  class PCL_EXPORTS DigitalElevationMapBuilder : public DisparityMapConverter <PointDEM>
+  {
+    public:
+      using DisparityMapConverter<PointDEM>::baseline_;
+      using DisparityMapConverter<PointDEM>::translateCoordinates;
+      using DisparityMapConverter<PointDEM>::image_;
+      using DisparityMapConverter<PointDEM>::disparity_map_;
+      using DisparityMapConverter<PointDEM>::disparity_map_width_;
+      using DisparityMapConverter<PointDEM>::disparity_map_height_;
+      using DisparityMapConverter<PointDEM>::disparity_threshold_min_;
+      using DisparityMapConverter<PointDEM>::disparity_threshold_max_;
+    
+      /** \brief DigitalElevationMapBuilder constructor. */
+      DigitalElevationMapBuilder ();
+      /** \brief Empty destructor. */
+      virtual ~DigitalElevationMapBuilder ();
+
+      /** \brief Set resolution of the DEM.
+        * \param[in] resolution_column the column resolution.
+        * \param[in] resolution_disparity the disparity resolution.
+        */
+      void
+      setResolution (size_t resolution_column, size_t resolution_disparity);
+
+      /** \brief Get column resolution of the DEM.
+        * \return column resolution of the DEM.
+        */
+      size_t
+      getColumnResolution () const;
+
+      /** \brief Get disparity resolution of the DEM.
+        * \return disparity resolution of the DEM.
+        */
+      size_t
+      getDisparityResolution () const;
+
+      /** \brief Set minimum amount of points in a DEM's cell.
+        * \param[in] min_points_in_cell minimum amount of points in a DEM's cell.
+        */
+      void
+      setMinPointsInCell (size_t min_points_in_cell);
+
+      /** \brief Get minimum amount of points in a DEM's cell.
+        * \return minimum amount of points in a DEM's cell.
+        */
+      size_t
+      getMinPointsInCell () const;
+
+      /** \brief Compute the Digital Elevation Map.
+        * \param[out] out_cloud the variable to return the resulting cloud.
+        */
+      void 
+      compute (pcl::PointCloud<PointDEM> &out_cloud);
+
+    protected:
+      /** \brief Column resolution of the DEM. */
+      size_t resolution_column_;
+      /** \brief disparity resolution of the DEM. */
+      size_t resolution_disparity_;
+
+      /** \brief Minimum amount of points in a DEM's cell. */
+      size_t min_points_in_cell_;
+  };
+}
+
+#endif // PCL_DIGITAL_ELEVATION_MAP_H_

--- a/stereo/include/pcl/stereo/disparity_map_converter.h
+++ b/stereo/include/pcl/stereo/disparity_map_converter.h
@@ -1,0 +1,256 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PCL_DISPARITY_MAP_CONVERTER_H_
+#define PCL_DISPARITY_MAP_CONVERTER_H_
+
+#include <cstring>
+#include <vector>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace pcl
+{
+  /** \brief Compute point cloud from the disparity map.
+    *
+    * Example of usage:
+    * 
+    * \code
+    *  pcl::PointCloud<pcl::PointXYZI>::Ptr cloud (new 
+    *    pcl::PointCloud<pcl::PointXYZI>);
+    *  pcl::PointCloud<pcl::RGB>::Ptr left_image (new 
+    *    pcl::PointCloud<pcl::RGB>);
+    *  // Fill left image cloud.
+    *
+    *  pcl::DisparityMapConverter<pcl::PointXYZI> dmc;
+    *  dmc.setBaseline (0.8387445f);
+    *  dmc.setFocalLength (368.534700f);
+    *  dmc.setImageCenterX (318.112200f);
+    *  dmc.setImageCenterY (224.334900f);
+    *  dmc.setDisparityThresholdMin(15.0f);
+    *
+    *  // Left view of the scene.
+    *  dmc.setImage (left_image);
+    *  // Disparity map of the scene.
+    *  dmc.loadDisparityMap ("disparity_map.txt", 640, 480);
+    *
+    *  dmc.compute(*cloud);
+    * \endcode
+    *
+    * \author Timur Ibadov (ibadov.timur@gmail.com)
+    * \ingroup stereo
+    */
+  template <typename PointT>
+  class DisparityMapConverter
+  {
+    protected:
+      typedef pcl::PointCloud<PointT> PointCloud;
+
+    public:
+      /** \brief DisparityMapConverter constructor. */
+      DisparityMapConverter ();
+      /** \brief Empty destructor. */
+      virtual ~DisparityMapConverter ();
+
+      /** \brief Set x-coordinate of the image center.
+        * \param[in] center_x x-coordinate of the image center.
+        */
+      inline void
+      setImageCenterX (const float center_x);
+
+      /** \brief Get x-coordinate of the image center.
+        * \return x-coordinate of the image center.
+        */
+      inline float
+      getImageCenterX () const;
+
+      /** \brief Set y-coordinate of the image center.
+        * \param[in] center_y y-coordinate of the image center.
+        */
+      inline void
+      setImageCenterY (const float center_y);
+
+      /** \brief Get y-coordinate of the image center.
+        * \return y-coordinate of the image center.
+        */
+      inline float
+      getImageCenterY () const;
+
+      /** \brief Set focal length.
+        * \param[in] focal_length the focal length.
+        */
+      inline void
+      setFocalLength (const float focal_length);
+
+      /** \brief Get focal length.
+        * \return the focal length.
+        */
+      inline float
+      getFocalLength () const;
+
+      /** \brief Set baseline.
+        * \param[in] baseline baseline.
+        */
+      inline void
+      setBaseline (const float baseline);
+
+      /** \brief Get baseline.
+        * \return the baseline.
+        */
+      inline float
+      getBaseline () const;
+
+      /** \brief Set min disparity threshold.
+        * \param[in] disparity_threshold_min min disparity threshold.
+        */
+      inline void
+      setDisparityThresholdMin (const float disparity_threshold_min);
+
+      /** \brief Get min disparity threshold.
+        * \return min disparity threshold.
+        */
+      inline float
+      getDisparityThresholdMin () const;
+
+      /** \brief Set max disparity threshold.
+        * \param[in] disparity_threshold_max max disparity threshold.
+        */
+      inline void
+      setDisparityThresholdMax (const float disparity_threshold_max);
+
+      /** \brief Get max disparity threshold.
+        * \return max disparity threshold.
+        */
+      inline float
+      getDisparityThresholdMax () const;
+
+      /** \brief Set an image, that will be used for coloring of the output cloud.
+        * \param[in] image the image.
+        */
+      void
+      setImage (const pcl::PointCloud<pcl::RGB>::ConstPtr &image);
+
+      /** \brief Get the image, that is used for coloring of the output cloud.
+        * \return the image.
+        */
+      pcl::PointCloud<RGB>::Ptr
+      getImage ();
+
+      /** \brief Load the disparity map.
+        * \param[in] file_name the name of the disparity map file.
+        * \return "true" if the disparity map was successfully loaded; "false" otherwise
+        */
+      bool
+      loadDisparityMap (const std::string &file_name);
+
+      /** \brief Load the disparity map and initialize it's size.
+        * \param[in] file_name the name of the disparity map file.
+        * \param[in] width width of the disparity map.
+        * \param[in] height height of the disparity map.
+        * \return "true" if the disparity map was successfully loaded; "false" otherwise
+        */
+      bool
+      loadDisparityMap (const std::string &file_name, const size_t width, const size_t height);
+
+      /** \brief Set the disparity map.
+        * \param[in] disparity_map the disparity map.
+        */
+      void
+      setDisparityMap (const std::vector<float> &disparity_map);
+
+      /** \brief Set the disparity map and initialize it's size.
+        * \param[in] disparity_map the disparity map.
+        * \param[in] width width of the disparity map.
+        * \param[in] height height of the disparity map.
+        * \return "true" if the disparity map was successfully loaded; "false" otherwise
+        */
+      void
+      setDisparityMap (const std::vector<float> &disparity_map, 
+          const size_t width, const size_t height);
+
+      /** \brief Get the disparity map.
+        * \return the disparity map.
+        */
+      std::vector<float>
+      getDisparityMap ();
+
+      /** \brief Compute the output cloud.
+        * \param[out] out_cloud the variable to return the resulting cloud.
+        */
+      virtual void
+      compute (PointCloud &out_cloud);
+
+    protected:
+      /** \brief Translate point from image coordinates and disparity to 3D-coordinates
+        * \param[in] row
+        * \param[in] column
+        * \param[in] disparity
+        * \return the 3D point, that corresponds to the input parametres and the camera calibration.
+        */
+      PointXYZ 
+      translateCoordinates (size_t row, size_t column, float disparity) const;
+
+      /** \brief X-coordinate of the image center. */
+      float center_x_;
+      /** \brief Y-coordinate of the image center. */
+      float center_y_;
+      /** \brief Focal length. */
+      float focal_length_;
+      /** \brief Baseline. */
+      float baseline_;
+      
+      /** \brief Is color image is set. */
+      bool is_color_;
+      /** \brief Color image of the scene. */
+      pcl::PointCloud<pcl::RGB>::ConstPtr image_;
+
+      /** \brief Vector for the disparity map. */
+      std::vector<float> disparity_map_;
+      /** \brief X-size of the disparity map. */
+      size_t disparity_map_width_;
+      /** \brief Y-size of the disparity map. */
+      size_t disparity_map_height_;
+
+      /** \brief Thresholds of the disparity. */
+      float disparity_threshold_min_;
+      float disparity_threshold_max_;
+  };
+
+}
+
+#include <pcl/stereo/impl/disparity_map_converter.hpp>
+
+#endif // PCL_DISPARITY_MAP_CONVERTER_H_

--- a/stereo/include/pcl/stereo/impl/disparity_map_converter.hpp
+++ b/stereo/include/pcl/stereo/impl/disparity_map_converter.hpp
@@ -1,0 +1,310 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PCL_DISPARITY_MAP_CONVERTER_IMPL_H_
+#define PCL_DISPARITY_MAP_CONVERTER_IMPL_H_
+
+#include <pcl/stereo/disparity_map_converter.h>
+
+#include <fstream>
+#include <limits>
+
+#include <pcl/point_types.h>
+#include <pcl/console/print.h>
+#include <pcl/common/intensity.h>
+
+template <typename PointT>
+pcl::DisparityMapConverter<PointT>::DisparityMapConverter () :
+    center_x_ (0.0f),
+    center_y_ (0.0f),
+    focal_length_ (0.0f),
+    baseline_ (0.0f),
+    is_color_ (false),
+    disparity_map_width_ (640),
+    disparity_map_height_ (480),
+    disparity_threshold_min_ (0.0f),
+    disparity_threshold_max_ (std::numeric_limits<float>::max ())
+{
+}
+
+template <typename PointT>
+pcl::DisparityMapConverter<PointT>::~DisparityMapConverter ()
+{
+}
+
+template <typename PointT> inline void
+pcl::DisparityMapConverter<PointT>::setImageCenterX (const float center_x)
+{
+  center_x_ = center_x;
+}
+
+template <typename PointT> inline float
+pcl::DisparityMapConverter<PointT>::getImageCenterX () const
+{
+  return center_x_;
+}
+
+template <typename PointT> inline void
+pcl::DisparityMapConverter<PointT>::setImageCenterY (const float center_y)
+{
+  center_y_ = center_y;
+}
+
+template <typename PointT> inline float
+pcl::DisparityMapConverter<PointT>::getImageCenterY () const
+{
+  return center_y_;
+}
+
+template <typename PointT> inline void
+pcl::DisparityMapConverter<PointT>::setFocalLength (const float focal_length)
+{
+  focal_length_ = focal_length;
+}
+
+template <typename PointT> inline float
+pcl::DisparityMapConverter<PointT>::getFocalLength () const
+{
+  return focal_length_;
+}
+
+template <typename PointT> inline void
+pcl::DisparityMapConverter<PointT>::setBaseline (const float baseline)
+{
+  baseline_ = baseline;
+}
+
+template <typename PointT> inline float
+pcl::DisparityMapConverter<PointT>::getBaseline () const
+{
+  return baseline_;
+}
+
+template <typename PointT> inline void
+pcl::DisparityMapConverter<PointT>::setDisparityThresholdMin (
+    const float disparity_threshold_min)
+{
+  disparity_threshold_min_ = disparity_threshold_min;
+}
+
+template <typename PointT> inline float
+pcl::DisparityMapConverter<PointT>::getDisparityThresholdMin () const
+{
+  return disparity_threshold_min_;
+}
+
+template <typename PointT> inline void
+pcl::DisparityMapConverter<PointT>::setDisparityThresholdMax (
+    const float disparity_threshold_max)
+{
+  disparity_threshold_max_ = disparity_threshold_max;
+}
+
+template <typename PointT> inline float
+pcl::DisparityMapConverter<PointT>::getDisparityThresholdMax () const
+{
+  return disparity_threshold_max_;
+}
+
+template <typename PointT> void
+pcl::DisparityMapConverter<PointT>::setImage (
+    const pcl::PointCloud<pcl::RGB>::ConstPtr &image)
+{
+  image_ = image;
+
+  // Set disparity map's size same with the image size.
+  disparity_map_width_ = image_->width;
+  disparity_map_height_ = image_->height;
+
+  is_color_ = true;
+}
+
+template <typename PointT> pcl::PointCloud<pcl::RGB>::Ptr
+pcl::DisparityMapConverter<PointT>::getImage ()
+{
+  pcl::PointCloud<pcl::RGB>::Ptr image_pointer (new pcl::PointCloud<pcl::RGB>);
+  *image_pointer = *image_;
+  return image_pointer;
+}
+
+template <typename PointT> bool
+pcl::DisparityMapConverter<PointT>::loadDisparityMap (
+    const std::string &file_name)
+{
+  std::fstream disparity_file;
+
+  // Open the disparity file
+  disparity_file.open (file_name.c_str (), std::fstream::in);
+  if (!disparity_file.is_open ())
+  {
+    PCL_ERROR ("[pcl::DisparityMapConverter::loadDisparityMap] Can't load the file.\n");
+    return false;
+  }
+
+  // Allocate memory for the disparity map.
+  disparity_map_.resize (disparity_map_width_ * disparity_map_height_);
+
+  // Reading the disparity map.
+  for (size_t row = 0; row < disparity_map_height_; ++row)
+  {
+    for (size_t column = 0; column < disparity_map_width_; ++column)
+    {
+      float disparity;
+      disparity_file >> disparity;
+
+      disparity_map_[column + row * disparity_map_width_] = disparity;
+    } // column
+  } // row
+
+  return true;
+}
+
+template <typename PointT> bool
+pcl::DisparityMapConverter<PointT>::loadDisparityMap (
+    const std::string &file_name, const size_t width, const size_t height)
+{
+  // Initialize disparity map's size. 
+  disparity_map_width_ = width;
+  disparity_map_height_ = height;
+
+  // Load the disparity map.
+  return loadDisparityMap (file_name);
+}
+
+template <typename PointT> void
+pcl::DisparityMapConverter<PointT>::setDisparityMap (
+    const std::vector<float> &disparity_map)
+{
+  disparity_map_ = disparity_map;
+}
+
+template <typename PointT> void
+pcl::DisparityMapConverter<PointT>::setDisparityMap (
+    const std::vector<float> &disparity_map, 
+    const size_t width, const size_t height)
+{
+  disparity_map_width_ = width;
+  disparity_map_height_ = height;
+
+  disparity_map_ = disparity_map;
+}
+
+template <typename PointT> std::vector<float>
+pcl::DisparityMapConverter<PointT>::getDisparityMap ()
+{
+  return disparity_map_;
+}
+
+template <typename PointT> void
+pcl::DisparityMapConverter<PointT>::compute (PointCloud &out_cloud)
+{
+  // Initialize the output cloud.
+  out_cloud.clear ();
+  out_cloud.width = disparity_map_width_;
+  out_cloud.height = disparity_map_height_;
+  out_cloud.resize (out_cloud.width * out_cloud.height);
+
+  if (is_color_ && !image_)
+  {
+    PCL_ERROR ("[pcl::DisparityMapConverter::compute] Memory for the image was not allocated.\n");
+    return;
+  }
+
+  for (size_t row = 0; row < disparity_map_height_; ++row)
+  {
+    for (size_t column = 0; column < disparity_map_width_; ++column)
+    {
+      // ID of current disparity point.
+      size_t disparity_point = column + row * disparity_map_width_;
+
+      // Disparity value.
+      float disparity = disparity_map_[disparity_point];
+
+      // New point for the output cloud.
+      PointT new_point;
+      
+      // Init color
+      if (is_color_)
+      {
+        pcl::common::IntensityFieldAccessor<PointT> intensity_accessor;
+        intensity_accessor.set (new_point, static_cast<float> (
+            image_->points[disparity_point].r +
+            image_->points[disparity_point].g +
+            image_->points[disparity_point].b) / 3.0f);
+      }
+
+      // Init coordinates.
+      if (disparity_threshold_min_ < disparity && disparity < disparity_threshold_max_)
+      {
+        // Compute new coordinates.
+        PointXYZ point_3D (translateCoordinates (row, column, disparity));
+        new_point.x = point_3D.x;
+        new_point.y = point_3D.y;
+        new_point.z = point_3D.z;
+      } 
+      else
+      {
+        new_point.x = std::numeric_limits<float>::quiet_NaN ();
+        new_point.y = std::numeric_limits<float>::quiet_NaN ();
+        new_point.z = std::numeric_limits<float>::quiet_NaN ();
+      }
+      // Put the point to the output cloud.
+      out_cloud[disparity_point] = new_point;
+    } // column
+  } // row
+}
+
+template <typename PointT> pcl::PointXYZ
+pcl::DisparityMapConverter<PointT>::translateCoordinates (
+    size_t row, size_t column, float disparity) const
+{
+  // Returning point.
+  PointXYZ point_3D;
+
+  if (disparity != 0.0f)
+  {
+    // Compute 3D-coordinates based on the image coordinates, the disparity and the camera parameters.
+    float z_value = focal_length_ * baseline_ / disparity;
+    point_3D.z = z_value;
+    point_3D.x = (static_cast<float> (column) - center_x_) * (z_value / focal_length_);
+    point_3D.y = (static_cast<float> (row) - center_y_) * (z_value / focal_length_);
+  }
+
+  return point_3D;
+}
+
+#define PCL_INSTANTIATE_DisparityMapConverter(T) template class PCL_EXPORTS pcl::DisparityMapConverter<T>;
+
+#endif // PCL_DISPARITY_MAP_CONVERTER_IMPL_H_

--- a/stereo/src/digital_elevation_map.cpp
+++ b/stereo/src/digital_elevation_map.cpp
@@ -1,0 +1,195 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pcl/stereo/digital_elevation_map.h>
+
+#include <pcl/console/print.h>
+#include <pcl/common/feature_histogram.h>
+
+pcl::DigitalElevationMapBuilder::DigitalElevationMapBuilder () :
+    resolution_column_ (64),
+    resolution_disparity_ (32),
+    min_points_in_cell_ (1)
+{
+}
+
+pcl::DigitalElevationMapBuilder::~DigitalElevationMapBuilder ()
+{
+  
+}
+
+void
+pcl::DigitalElevationMapBuilder::setResolution (size_t resolution_column, 
+    size_t resolution_disparity)
+{
+  resolution_column_ = resolution_column;
+  resolution_disparity_ = resolution_disparity;
+}
+
+size_t
+pcl::DigitalElevationMapBuilder::getColumnResolution () const
+{
+  return resolution_column_;
+}
+
+size_t
+pcl::DigitalElevationMapBuilder::getDisparityResolution () const
+{
+  return resolution_disparity_;
+}
+
+void 
+pcl::DigitalElevationMapBuilder::setMinPointsInCell (size_t min_points_in_cell)
+{
+  min_points_in_cell_ = min_points_in_cell;
+}
+
+size_t
+pcl::DigitalElevationMapBuilder::getMinPointsInCell () const
+{
+  return min_points_in_cell_;
+}
+
+// Build DEM.
+void 
+pcl::DigitalElevationMapBuilder::compute (pcl::PointCloud<PointDEM> &out_cloud)
+{
+  // Initialize.
+  // Initialize the output cloud.
+  out_cloud.clear ();
+  out_cloud.width = resolution_column_;
+  out_cloud.height = resolution_disparity_;
+  out_cloud.resize (out_cloud.width * out_cloud.height);
+
+  // Initialize steps.
+  const size_t kColumnStep = (disparity_map_width_ - 1) / resolution_column_ + 1;
+  const float kDisparityStep = (disparity_threshold_max_ -
+      disparity_threshold_min_) / resolution_disparity_;
+
+  // Initialize histograms.
+  const size_t kNumberOfHistograms = resolution_column_ * resolution_disparity_;
+
+  const float kHeightMin = -0.5f;
+  const float kHeightMax = 1.5f;
+  const float kHeightResolution = 0.01f;
+  const size_t kHeightBins = static_cast<size_t> ((kHeightMax - kHeightMin) / kHeightResolution);
+  // Histogram for initializing other height histograms.
+  FeatureHistogram height_histogram_example (kHeightBins, kHeightMin, kHeightMax);
+
+  const float kIntensityMin = 0.0f;
+  const float kIntensityMax = 255.0f;
+  const size_t kIntensityBins = 256;
+  // Histogram for initializing other intensity histograms.
+  FeatureHistogram intensity_histogram_example (kIntensityBins, kIntensityMin, kIntensityMax);
+
+  std::vector <FeatureHistogram> height_histograms 
+      (kNumberOfHistograms, height_histogram_example);
+  std::vector <FeatureHistogram> intensity_histograms 
+      (kNumberOfHistograms, intensity_histogram_example);
+
+  // Check, if an image was loaded.
+  if (!image_)
+  {
+    PCL_ERROR ("[pcl::DisparityMapConverter::compute] Memory for the image was not allocated.\n");
+    return;
+  }
+
+  for (size_t column = 0; column < disparity_map_width_; ++column)
+  {
+    for (size_t row = 0; row < disparity_map_height_; ++row)
+    {
+      float disparity = disparity_map_[column + row * disparity_map_width_];
+      if (disparity_threshold_min_ < disparity && disparity < disparity_threshold_max_)
+      {
+        // Find a height and an intensity of the point of interest.
+        PointXYZ point_3D = translateCoordinates (row, column, disparity);
+        float height = point_3D.y;
+
+        RGB point_RGB = image_->points[column + row * disparity_map_width_];
+        float intensity = static_cast<float> ((point_RGB.r + point_RGB.g + point_RGB.b) / 3);
+
+        // Calculate index of histograms.
+        size_t index_column = column / kColumnStep;
+        size_t index_disparity = static_cast<size_t> (
+            (disparity - disparity_threshold_min_) / kDisparityStep);
+
+        size_t index = index_column + index_disparity * resolution_column_;
+
+        // Increase the histograms.
+        height_histograms[index].addValue (height);
+        intensity_histograms[index].addValue (intensity);
+
+      } // if
+    } // row
+  } // column
+  
+  // For all histograms.
+  for (size_t index_column = 0; index_column < resolution_column_; ++index_column)
+  {
+    for (size_t index_disparity = 0; index_disparity < resolution_disparity_; ++index_disparity)
+    {
+      size_t index = index_column + index_disparity * resolution_column_;
+      // Compute the corresponding DEM cell.
+      size_t column = index_column * kColumnStep;
+      float disparity = disparity_threshold_min_ +
+          static_cast<float> (index_disparity) * kDisparityStep;
+      
+      PointXYZ point_3D = translateCoordinates (0, column, disparity);
+      PointDEM point_DEM;
+      point_DEM.x = point_3D.x;
+      point_DEM.z = point_3D.z;
+
+      if (height_histograms[index].getNumberOfElements () >= min_points_in_cell_)
+      {
+        point_DEM.y = height_histograms[index].getMeanValue ();
+        point_DEM.height_variance = 0.5f * baseline_ / disparity;
+
+        point_DEM.intensity = intensity_histograms[index].getMeanValue ();
+        point_DEM.intensity_variance = intensity_histograms[index].getVariance (point_DEM.intensity);
+      }
+      else // height_histograms[index].getNumberOfElements () < min_points_in_cell_
+      {
+        point_DEM.y = std::numeric_limits<float>::quiet_NaN ();
+        point_DEM.intensity = std::numeric_limits<float>::quiet_NaN ();
+        point_DEM.height_variance = std::numeric_limits<float>::quiet_NaN ();
+        point_DEM.intensity_variance = std::numeric_limits<float>::quiet_NaN ();
+      }
+
+      out_cloud.at (index_column, index_disparity) = point_DEM;
+      
+    } // index_disparity
+  } // index_column
+}

--- a/stereo/src/disparity_map_converter.cpp
+++ b/stereo/src/disparity_map_converter.cpp
@@ -1,0 +1,42 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <pcl/stereo/disparity_map_converter.h>
+
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/impl/instantiate.hpp>
+#include <pcl/point_types.h>
+PCL_INSTANTIATE(DisparityMapConverter, PCL_XYZ_POINT_TYPES);
+#endif    // PCL_NO_PRECOMPILE


### PR DESCRIPTION
Here is the first part HRCS' results (only for the stereo module).

Add in module stereo:
- DisparityMapConverter class for converting disparity maps to point clouds.
- DigitalElevationMapBuilder class for building Digital Elevation Maps from disparity maps.

Add in module common:
- A PointDEM point type for representing Digital Elevation Maps.
