### PR TITLE
Fix: invalid array allocation in iss_3d.hpp

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -327,10 +327,16 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
     }
   }
 
+#ifdef _OPENMP
   Eigen::Vector3d *omp_mem = new Eigen::Vector3d[threads_];
 
   for (size_t i = 0; i < threads_; i++)
     omp_mem[i].setZero (3);
+#else
+  Eigen::Vector3d *omp_mem = new Eigen::Vector3d[1];
+
+  omp_mem[0].setZero (3);
+#endif
 
   double *prg_local_mem = new double[input_->size () * 3];
   double **prg_mem = new double * [input_->size ()];


### PR DESCRIPTION
If OPENMP is not used, the variable threads_ is zero by default. Thus
the array allocation

   Eigen::Vector3d *omp_mem = new Eigen::Vector3d[threads_];

leads to a valid but zero sized array and finally to an invalid write
at line 381-383 (375-377).
