### PR TITLE
Fix drawing correspondences

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1086,7 +1086,8 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   const pcl::Correspondences &correspondences,
   int nth,
   const std::string &id,
-  int viewport)
+  int viewport,
+  bool overwrite)
 {
   if (correspondences.empty ())
   {
@@ -1096,10 +1097,13 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
   ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
-  if (am_it != shape_actor_map_->end ())
+  if (am_it != shape_actor_map_->end () && overwrite == false)
   {
     PCL_WARN ("[addCorrespondences] A set of correspondences with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
     return (false);
+  } else if (am_it == shape_actor_map_->end () && overwrite == true)
+  {
+    overwrite = false; // Correspondences doesn't exist, add them instead of updating them
   }
 
   int n_corr = int (correspondences.size () / nth);
@@ -1182,14 +1186,27 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   line_data->GetCellData ()->SetScalars (line_colors);
 
   // Create an Actor
-  vtkSmartPointer<vtkLODActor> actor;
-  createActorFromVTKDataSet (line_data, actor);
-  actor->GetProperty ()->SetRepresentationToWireframe ();
-  actor->GetProperty ()->SetOpacity (0.5);
-  addActorToRenderer (actor, viewport);
+  if (!overwrite)
+  {
+    vtkSmartPointer<vtkLODActor> actor;
+    createActorFromVTKDataSet (line_data, actor);
+    actor->GetProperty ()->SetRepresentationToWireframe ();
+    actor->GetProperty ()->SetOpacity (0.5);
+    addActorToRenderer (actor, viewport);
 
-  // Save the pointer/ID pair to the global actor map
-  (*shape_actor_map_)[id] = actor;
+    // Save the pointer/ID pair to the global actor map
+    (*shape_actor_map_)[id] = actor;
+  }
+  else
+  {
+    vtkSmartPointer<vtkLODActor> actor = vtkLODActor::SafeDownCast (am_it->second);
+    // Update the mapper
+#if VTK_MAJOR_VERSION < 6
+    reinterpret_cast<vtkPolyDataMapper*>(actor->GetMapper ())->SetInput (line_data);
+#else
+    reinterpret_cast<vtkPolyDataMapper*> (actor->GetMapper ())->SetInputData (line_data);
+#endif
+  }
 
   return (true);
 }
@@ -1201,108 +1218,10 @@ pcl::visualization::PCLVisualizer::updateCorrespondences (
   const typename pcl::PointCloud<PointT>::ConstPtr &target_points,
   const pcl::Correspondences &correspondences,
   int nth,
-  const std::string &id)
+  const std::string &id,
+  int viewport)
 {
-  if (correspondences.empty ())
-  {
-    PCL_DEBUG ("[updateCorrespondences] An empty set of correspondences given! Nothing to display.\n");
-    return (false);
-  }
-
-  // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
-  if (am_it == shape_actor_map_->end ())
-    return (false);
-
-  vtkSmartPointer<vtkLODActor> actor = vtkLODActor::SafeDownCast (am_it->second);
-  vtkSmartPointer<vtkPolyData> line_data = reinterpret_cast<vtkPolyDataMapper*>(actor->GetMapper ())->GetInput ();
-
-  int n_corr = int (correspondences.size () / nth);
-
-  // Prepare colors
-  vtkSmartPointer<vtkUnsignedCharArray> line_colors = vtkSmartPointer<vtkUnsignedCharArray>::New ();
-  line_colors->SetNumberOfComponents (3);
-  line_colors->SetName ("Colors");
-  line_colors->SetNumberOfTuples (n_corr);
-
-  // Prepare coordinates
-  vtkSmartPointer<vtkPoints> line_points = vtkSmartPointer<vtkPoints>::New ();
-  line_points->SetNumberOfPoints (2 * n_corr);
-
-  vtkSmartPointer<vtkIdTypeArray> line_cells_id = vtkSmartPointer<vtkIdTypeArray>::New ();
-  line_cells_id->SetNumberOfComponents (3);
-  line_cells_id->SetNumberOfTuples (n_corr);
-  vtkIdType *line_cell_id = line_cells_id->GetPointer (0);
-  vtkSmartPointer<vtkCellArray> line_cells = line_data->GetLines ();
-
-  vtkSmartPointer<vtkFloatArray> line_tcoords = vtkSmartPointer<vtkFloatArray>::New ();
-  line_tcoords->SetNumberOfComponents (1);
-  line_tcoords->SetNumberOfTuples (n_corr * 2);
-  line_tcoords->SetName ("Texture Coordinates");
-
-  double tc[3] = {0.0, 0.0, 0.0};
-
-  Eigen::Affine3f source_transformation;
-  source_transformation.linear () = source_points->sensor_orientation_.matrix ();
-  source_transformation.translation () = source_points->sensor_origin_.head (3);
-  Eigen::Affine3f target_transformation;
-  target_transformation.linear () = target_points->sensor_orientation_.matrix ();
-  target_transformation.translation () = target_points->sensor_origin_.head (3);
-
-  int j = 0, idx = 0;
-  // Draw lines between the best corresponding points
-  for (size_t i = 0; i < correspondences.size (); i += nth, idx = j * 3, ++j)
-  {
-    if (correspondences[i].index_match == -1)
-    {
-      PCL_WARN ("[updateCorrespondences] No valid index_match for correspondence %d\n", i);
-      continue;
-    }
-
-    PointT p_src (source_points->points[correspondences[i].index_query]);
-    PointT p_tgt (target_points->points[correspondences[i].index_match]);
-
-    p_src.getVector3fMap () = source_transformation * p_src.getVector3fMap ();
-    p_tgt.getVector3fMap () = target_transformation * p_tgt.getVector3fMap ();
-
-    int id1 = j * 2 + 0, id2 = j * 2 + 1;
-    // Set the points
-    line_points->SetPoint (id1, p_src.x, p_src.y, p_src.z);
-    line_points->SetPoint (id2, p_tgt.x, p_tgt.y, p_tgt.z);
-    // Set the cell ID
-    *line_cell_id++ = 2;
-    *line_cell_id++ = id1;
-    *line_cell_id++ = id2;
-    // Set the texture coords
-    tc[0] = 0.; line_tcoords->SetTuple (id1, tc);
-    tc[0] = 1.; line_tcoords->SetTuple (id2, tc);
-
-    float rgb[3];
-    rgb[0] = vtkMath::Random (32, 255); // min / max
-    rgb[1] = vtkMath::Random (32, 255);
-    rgb[2] = vtkMath::Random (32, 255);
-    line_colors->InsertTuple (i, rgb);
-  }
-  line_colors->SetNumberOfTuples (j);
-  line_cells_id->SetNumberOfTuples (j);
-  line_cells->SetCells (n_corr, line_cells_id);
-  line_points->SetNumberOfPoints (j*2);
-  line_tcoords->SetNumberOfTuples (j*2);
- 
-  // Fill in the lines
-  line_data->SetPoints (line_points);
-  line_data->SetLines (line_cells);
-  line_data->GetPointData ()->SetTCoords (line_tcoords);
-  line_data->GetCellData ()->SetScalars (line_colors);
-
-  // Update the mapper
-#if VTK_MAJOR_VERSION < 6
-  reinterpret_cast<vtkPolyDataMapper*>(actor->GetMapper ())->SetInput (line_data);
-#else
-  reinterpret_cast<vtkPolyDataMapper*> (actor->GetMapper ())->SetInputData (line_data);
-#endif
-
-  return (true);
+  return (addCorrespondences<PointT> (source_points, target_points, correspondences, nth, id, viewport, true));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1030,6 +1030,7 @@ namespace pcl
           * \param[in] nth display only the Nth correspondence (e.g., skip the rest)
           * \param[in] id the polygon object id (default: "correspondences")
           * \param[in] viewport the view port where the correspondences should be added (default: all)
+          * \param[in] overwrite allow to overwrite already existing correspondences
           */
         template <typename PointT> bool
         addCorrespondences (const typename pcl::PointCloud<PointT>::ConstPtr &source_points,
@@ -1037,7 +1038,8 @@ namespace pcl
                             const pcl::Correspondences &correspondences,
                             int nth,
                             const std::string &id = "correspondences",
-                            int viewport = 0);
+                            int viewport = 0,
+                            bool overwrite = false);
 
         /** \brief Add the specified correspondences to the display.
           * \param[in] source_points The source points
@@ -1064,6 +1066,7 @@ namespace pcl
           * \param[in] correspondences The mapping from source points to target points. Each element must be an index into target_points
           * \param[in] nth display only the Nth correspondence (e.g., skip the rest)
           * \param[in] id the polygon object id (default: "correspondences")
+          * \param[in] viewport the view port where the correspondences should be updated (default: all)
           */
         template <typename PointT> bool
         updateCorrespondences (
@@ -1071,7 +1074,28 @@ namespace pcl
             const typename pcl::PointCloud<PointT>::ConstPtr &target_points,
             const pcl::Correspondences &correspondences,
             int nth,
-            const std::string &id = "correspondences");
+            const std::string &id = "correspondences",
+            int viewport = 0);
+
+        /** \brief Update the specified correspondences to the display.
+          * \param[in] source_points The source points
+          * \param[in] target_points The target points
+          * \param[in] correspondences The mapping from source points to target points. Each element must be an index into target_points
+          * \param[in] id the polygon object id (default: "correspondences")
+          * \param[in] viewport the view port where the correspondences should be updated (default: all)
+          */
+        template <typename PointT> bool
+        updateCorrespondences (
+            const typename pcl::PointCloud<PointT>::ConstPtr &source_points,
+            const typename pcl::PointCloud<PointT>::ConstPtr &target_points,
+            const pcl::Correspondences &correspondences,
+            const std::string &id = "correspondences",
+            int viewport = 0)
+        {
+          // If Nth not given, display all correspondences
+          return (updateCorrespondences<PointT> (source_points, target_points,
+                                              correspondences, 1, id, viewport));
+        }
 
         /** \brief Remove the specified correspondences from the display.
           * \param[in] id the polygon correspondences object id (i.e., given on \ref addCorrespondences)


### PR DESCRIPTION
Fixes #367 (and more)
## Test code

``` cpp
#include <pcl/common/common.h>
#include <pcl/common/transforms.h>
#include <pcl/visualization/pcl_visualizer.h>

typedef pcl::PointXYZ PointT;
typedef pcl::PointCloud<PointT> PointCloudT;

int
main (int argc,
char** argv)
{
srand (time (NULL));

// Initialize point cloud sensor pose
Eigen::Matrix3f rotation;
rotation =
Eigen::AngleAxisf (0.02 * M_PI, Eigen::Vector3f::UnitZ ())
* Eigen::AngleAxisf (0.05 * M_PI, Eigen::Vector3f::UnitY ())
* Eigen::AngleAxisf (0.19 * M_PI, Eigen::Vector3f::UnitX ());

Eigen::Affine3f cloud_1_sensor_pose;
cloud_1_sensor_pose.linear () = rotation;
cloud_1_sensor_pose.translation () << 1, 0, 0;

// Create & initialize clouds
PointCloudT::Ptr cloud_1 (new PointCloudT);
PointCloudT::Ptr cloud_2 (new PointCloudT);
cloud_1->sensor_origin_ << cloud_1_sensor_pose.translation (), 1;
cloud_1->sensor_orientation_ = cloud_1_sensor_pose.rotation ();

cloud_1->resize (5);
cloud_2->resize (cloud_1->size ());
for (size_t i = 0; i < cloud_1->size (); ++i)
{
cloud_1->points[i].x = 0.5;
cloud_1->points[i].y = 1024 * rand () / (RAND_MAX + 1.0f);
cloud_1->points[i].z = 1024 * rand () / (RAND_MAX + 1.0f);

cloud_2->points[i].x = -0.5;
cloud_2->points[i].y = 1024 * rand () / (RAND_MAX + 1.0f);
cloud_2->points[i].z = 1024 * rand () / (RAND_MAX + 1.0f);
}

// #1 Using pcl::correspondences
pcl::Correspondences corr_1;
corr_1.resize (cloud_1->size ());

for (size_t i = 0; i < corr_1.size (); ++i)
{
corr_1[i].index_query = i;
corr_1[i].index_match = i;
}

// #2 Using a std::vector
std::vector<int> corr_2;
for (size_t i = 0; i < cloud_1->size (); ++i)
{
corr_2.push_back (i);
}

// Set the third correspondence to "none"; no line should be drawn between
// the points "3"
corr_1[2].index_match = -1;
corr_2[2] = -1;

// Draw texts on points (and care about the sensor position)
pcl::visualization::PCLVisualizer viewer ("Correspondence viewer");

for (size_t i = 0; i < cloud_1->size (); ++i)
{
std::string point_name;
point_name = boost::lexical_cast<std::string> (i);

PointT point_1 ( (*cloud_1)[i]);
point_1 = pcl::transformPoint (point_1, cloud_1_sensor_pose);

PointT point_2 ( (*cloud_2)[i]);
viewer.addText3D (point_name, point_1, .05);
point_name.append (" ");
viewer.addText3D (point_name, point_2, .05);
}

pcl::visualization::PointCloudColorHandlerCustom<PointT> cloud_1_color (cloud_1, 255, 0, 0);
viewer.addPointCloud (cloud_1, cloud_1_color, "cloud_1");
pcl::visualization::PointCloudColorHandlerCustom<PointT> cloud_2_color (cloud_2, 0, 255, 0);
viewer.addPointCloud (cloud_2, cloud_2_color, "cloud_2");

// Add correspondences in the visualizer (TODO: test with corr_1 and corr_2)
viewer.addCorrespondences<PointT> (cloud_1, cloud_2, corr_1);

// TODO Test updating already existing correspondences, also tested "updating" non existing correspondences
//corr_1.resize(1);
//viewer.updateCorrespondences<PointT> (cloud_1, cloud_2, corr_1, 1);

viewer.setBackgroundColor (.15, .15, .15); // Just in case lines are black
viewer.addCoordinateSystem (0.1);
viewer.resetCamera ();

while (!viewer.wasStopped ())
{
viewer.spinOnce ();
}

return (0);
} 
```
## Commit by commit
- Fix the variant where the user provided a `std::vector`, it wasn't working at all.
- An additional line was drawn between last point and (0,0,0) when the correspondence size was smaller than the cloud size. The color affectation (last line was always black) was also wrong, I replaced it with a simpler method (using only VTK).
- The `sensor_orientation_` and `sensor_origin_` fields were ignored.
- Correspondences unset (`index_match` == `-1`) were not handled. This resulted in lines being drawn between `index_query` and 0,0,0.
- `addCorrespondence` has now an optional bool to overwrite existing correspondences. `updateCorrespondences` now rely on `addCorrespondences`.

Tested with VTK 5.8, 6.1, 6.2
