### PR TITLE
fix bugs in renderView

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3792,7 +3792,7 @@ pcl::visualization::PCLVisualizer::renderView (int xres, int yres, pcl::PointClo
                                     dheight * float (y) - 1.0f,
                                     depth[ptr],
                                     1.0f);
-      world_coords = mat1 * world_coords;
+      world_coords = mat2 * mat1 * world_coords;
 
       float w3 = 1.0f / world_coords[3];
       world_coords[0] *= w3;
@@ -3800,7 +3800,6 @@ pcl::visualization::PCLVisualizer::renderView (int xres, int yres, pcl::PointClo
       world_coords[1] *= -w3;
       world_coords[2] *= -w3;
 
-      world_coords = mat2 * world_coords;
       pt.x = static_cast<float> (world_coords[0]);
       pt.y = static_cast<float> (world_coords[1]);
       pt.z = static_cast<float> (world_coords[2]);


### PR DESCRIPTION
mat2 should applied before y,z axis flipping

If you look at the original code, world_coords[0], world_coods[1], world_coods[2] has been normalized by
world_coords[3], but itself not normalized to 1.0f. Then mat2 is applied to world_coods directly, so you will get distored result. See my closed pull request #1015. 

On the other hand, y or z axis flipping operation should be applied after mat2.
