### PR TITLE
Eigen with std::vector fixes

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/crh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/crh_estimator.h
@@ -43,7 +43,7 @@ namespace pcl
       void
       estimate (PointInTPtr & in, PointInTPtr & processed,
                 std::vector<pcl::PointCloud<FeatureT>, Eigen::aligned_allocator<pcl::PointCloud<FeatureT> > > & signatures,
-                std::vector<Eigen::Vector3f> & centroids)
+                std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
       {
 
         if (!feature_estimator_)

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/cvfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/cvfh_estimator.h
@@ -53,7 +53,7 @@ namespace pcl
       void
       estimate (PointInTPtr & in, PointInTPtr & processed,
                 typename pcl::PointCloud<FeatureT>::CloudVectorType & signatures,
-                std::vector<Eigen::Vector3f> & centroids)
+                std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
       {
 
         if (!normal_estimator_)

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/esf_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/esf_estimator.h
@@ -25,7 +25,7 @@ namespace pcl
         void
         estimate (PointInTPtr & in, PointInTPtr & processed,
                   typename pcl::PointCloud<FeatureT>::CloudVectorType & signatures,
-                  std::vector<Eigen::Vector3f> & centroids)
+                  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
         {
 
           typedef typename pcl::ESFEstimation<PointInT, FeatureT> ESFEstimation;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h
@@ -28,7 +28,7 @@ namespace pcl
       public:
         virtual void
         estimate (PointInTPtr & in, PointInTPtr & processed, std::vector<pcl::PointCloud<FeatureT>, Eigen::aligned_allocator<
-            pcl::PointCloud<FeatureT> > > & signatures, std::vector<Eigen::Vector3f> & centroids)=0;
+            pcl::PointCloud<FeatureT> > > & signatures, std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)=0;
 
         virtual bool computedNormals() = 0;
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/ourcvfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/ourcvfh_estimator.h
@@ -81,7 +81,7 @@ namespace pcl
 
         virtual void
         estimate (PointInTPtr & in, PointInTPtr & processed, typename pcl::PointCloud<FeatureT>::CloudVectorType & signatures,
-                  std::vector<Eigen::Vector3f> & centroids)
+                  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
         {
 
           valid_roll_transforms_.clear ();

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/vfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/vfh_estimator.h
@@ -28,7 +28,7 @@ namespace pcl
         void
         estimate (PointInTPtr & in, PointInTPtr & processed,
                   typename pcl::PointCloud<FeatureT>::CloudVectorType & signatures,
-                  std::vector<Eigen::Vector3f> & centroids)
+                  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
         {
 
           if (!normal_estimator_)

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/registered_views_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/registered_views_source.h
@@ -100,7 +100,7 @@ namespace pcl
         }
 
         void
-        assembleModelFromViewsAndPoses(ModelT & model, std::vector<Eigen::Matrix4f> & poses) {
+        assembleModelFromViewsAndPoses(ModelT & model, std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > & poses) {
           for(size_t i=0; i < model.views_->size(); i++) {
             Eigen::Matrix4f inv = poses[i];
             typename pcl::PointCloud<PointInT>::Ptr global_cloud(new pcl::PointCloud<PointInT>);
@@ -159,7 +159,7 @@ namespace pcl
               }
             }
 
-            std::vector<Eigen::Matrix4f> poses_to_assemble_;
+            std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > poses_to_assemble_;
 
             for (size_t i = 0; i < view_filenames.size (); i++)
             {

--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -121,7 +121,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
   // Get camera positions
   vtkPolyData *sphere = subdivide->GetOutput ();
 
-  std::vector<Eigen::Vector3f> cam_positions;
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > cam_positions;
   if (!use_vertices_)
   {
     vtkSmartPointer<vtkCellArray> cells_sphere = sphere->GetPolys ();

--- a/common/include/pcl/TextureMesh.h
+++ b/common/include/pcl/TextureMesh.h
@@ -98,7 +98,7 @@ namespace pcl
 
 
     std::vector<std::vector<pcl::Vertices> >    tex_polygons;     // polygon which is mapped with specific texture defined in TexMaterial
-    std::vector<std::vector<Eigen::Vector2f> >  tex_coordinates;  // UV coordinates
+    std::vector<std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > > tex_coordinates;  // UV coordinates
     std::vector<pcl::TexMaterial>               tex_materials;    // define texture material
 
     public:

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -372,7 +372,7 @@ inline void
 template<typename real>
 inline pcl::BivariatePolynomialT<real>
   pcl::PolynomialCalculationsT<real>::bivariatePolynomialApproximation (
-      std::vector<Eigen::Matrix<real, 3, 1> >& samplePoints, unsigned int polynomial_degree, bool& error) const
+      std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints, unsigned int polynomial_degree, bool& error) const
 {
   pcl::BivariatePolynomialT<real> ret;
   error = bivariatePolynomialApproximation (samplePoints, polynomial_degree, ret);
@@ -384,7 +384,7 @@ inline pcl::BivariatePolynomialT<real>
 template<typename real>
 inline bool
   pcl::PolynomialCalculationsT<real>::bivariatePolynomialApproximation (
-      std::vector<Eigen::Matrix<real, 3, 1> >& samplePoints, unsigned int polynomial_degree,
+      std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints, unsigned int polynomial_degree,
       pcl::BivariatePolynomialT<real>& ret) const
 {
   //MEASURE_FUNCTION_TIME;
@@ -415,7 +415,7 @@ inline bool
   real tmpX, tmpY;
   real *tmpC = new real[parameters_size];
   real* tmpCEndPtr = &tmpC[parameters_size-1];
-  for (typename std::vector<Eigen::Matrix<real, 3, 1> >::const_iterator it=samplePoints.begin ();
+  for (typename std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >::const_iterator it=samplePoints.begin ();
        it!=samplePoints.end (); ++it)
   {
     currentX= (*it)[0]; currentY= (*it)[1]; currentZ= (*it)[2];
@@ -465,7 +465,7 @@ inline bool
   //unsigned int posInC;
   //real tmpX, tmpY;
   //DVector<real> tmpC (parameters_size);
-  //for (typename std::vector<Eigen::Matrix<real, 3, 1> >::const_iterator it=samplePoints.begin ();
+  //for (typename std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >::const_iterator it=samplePoints.begin ();
   //     it!=samplePoints.end (); ++it)
   //{
     //currentX= (*it)[0]; currentY= (*it)[1]; currentZ= (*it)[2];

--- a/common/include/pcl/common/polynomial_calculations.h
+++ b/common/include/pcl/common/polynomial_calculations.h
@@ -93,12 +93,12 @@ namespace pcl
        *  error is set to true if the approximation did not work for any reason
        *  (not enough points, matrix not invertible, etc.) */
       inline BivariatePolynomialT<real>
-      bivariatePolynomialApproximation (std::vector<Eigen::Matrix<real, 3, 1> >& samplePoints,
+      bivariatePolynomialApproximation (std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints,
                                         unsigned int polynomial_degree, bool& error) const;
       
       //! Same as above, using a reference for the return value
       inline bool
-      bivariatePolynomialApproximation (std::vector<Eigen::Matrix<real, 3, 1> >& samplePoints,
+      bivariatePolynomialApproximation (std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints,
                                         unsigned int polynomial_degree, BivariatePolynomialT<real>& ret) const;
 
       //! Set the minimum value under which values are considered zero

--- a/features/include/pcl/features/cvfh.h
+++ b/features/include/pcl/features/cvfh.h
@@ -148,7 +148,7 @@ namespace pcl
         * \param[out] centroids vector to hold the centroids
         */
       inline void
-      getCentroidClusters (std::vector<Eigen::Vector3f> & centroids)
+      getCentroidClusters (std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
       {
         for (size_t i = 0; i < centroids_dominant_orientations_.size (); ++i)
           centroids.push_back (centroids_dominant_orientations_[i]);
@@ -158,7 +158,7 @@ namespace pcl
         * \param[out] centroids vector to hold the normal centroids
         */
       inline void
-      getCentroidNormalClusters (std::vector<Eigen::Vector3f> & centroids)
+      getCentroidNormalClusters (std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
       {
         for (size_t i = 0; i < dominant_normals_.size (); ++i)
           centroids.push_back (dominant_normals_[i]);
@@ -280,9 +280,9 @@ namespace pcl
 
     protected:
       /** \brief Centroids that were used to compute different CVFH descriptors */
-      std::vector<Eigen::Vector3f> centroids_dominant_orientations_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > centroids_dominant_orientations_;
       /** \brief Normal centroids that were used to compute different CVFH descriptors */
-      std::vector<Eigen::Vector3f> dominant_normals_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > dominant_normals_;
   };
 }
 

--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -237,7 +237,7 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeLRF (const PointInT& point, co
 {
   const unsigned int number_of_triangles = static_cast <unsigned int> (local_triangles.size ());
 
-  std::vector <Eigen::Matrix3f> scatter_matrices (number_of_triangles);
+  std::vector<Eigen::Matrix3f, Eigen::aligned_allocator<Eigen::Matrix3f> > scatter_matrices (number_of_triangles);
   std::vector <float> triangle_area (number_of_triangles);
   std::vector <float> distance_weight (number_of_triangles);
 

--- a/features/include/pcl/features/our_cvfh.h
+++ b/features/include/pcl/features/our_cvfh.h
@@ -192,7 +192,7 @@ namespace pcl
        * \param[out] centroids vector to hold the centroids
        */
       inline void
-      getCentroidClusters (std::vector<Eigen::Vector3f> & centroids)
+      getCentroidClusters (std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
       {
         for (size_t i = 0; i < centroids_dominant_orientations_.size (); ++i)
           centroids.push_back (centroids_dominant_orientations_[i]);
@@ -202,7 +202,7 @@ namespace pcl
        * \param[out] centroids vector to hold the normal centroids
        */
       inline void
-      getCentroidNormalClusters (std::vector<Eigen::Vector3f> & centroids)
+      getCentroidNormalClusters (std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)
       {
         for (size_t i = 0; i < dominant_normals_.size (); ++i)
           centroids.push_back (dominant_normals_[i]);
@@ -395,9 +395,9 @@ namespace pcl
 
     protected:
       /** \brief Centroids that were used to compute different OUR-CVFH descriptors */
-      std::vector<Eigen::Vector3f> centroids_dominant_orientations_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > centroids_dominant_orientations_;
       /** \brief Normal centroids that were used to compute different OUR-CVFH descriptors */
-      std::vector<Eigen::Vector3f> dominant_normals_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > dominant_normals_;
       /** \brief Indices to the points representing the stable clusters */
       std::vector<pcl::PointIndices> clusters_;
       /** \brief Mapping from clusters to OUR-CVFH descriptors */

--- a/features/include/pcl/features/principal_curvatures.h
+++ b/features/include/pcl/features/principal_curvatures.h
@@ -116,7 +116,7 @@ namespace pcl
 
     private:
       /** \brief A pointer to the input dataset that contains the point normals of the XYZ dataset. */
-      std::vector<Eigen::Vector3f> projected_normals_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > projected_normals_;
 
       /** \brief SSE aligned placeholder for the XYZ centroid of a surface patch. */
       Eigen::Vector3f xyz_centroid_;

--- a/filters/include/pcl/filters/covariance_sampling.h
+++ b/filters/include/pcl/filters/covariance_sampling.h
@@ -137,7 +137,7 @@ namespace pcl
       /** \brief The normals computed at each point in the input cloud */
       NormalsConstPtr input_normals_;
 
-      std::vector<Eigen::Vector3f> scaled_points_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > scaled_points_;
 
       bool
       initCompute ();

--- a/filters/include/pcl/filters/fast_bilateral.h
+++ b/filters/include/pcl/filters/fast_bilateral.h
@@ -122,7 +122,7 @@ namespace pcl
             x_dim_ = width;
             y_dim_ = height;
             z_dim_ = depth;
-            v_ = std::vector<Eigen::Vector2f> (width*height*depth, Eigen::Vector2f (0.0f, 0.0f));
+            v_ = std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > (width*height*depth, Eigen::Vector2f (0.0f, 0.0f));
           }
 
           inline Eigen::Vector2f&
@@ -164,24 +164,24 @@ namespace pcl
           z_size () const
           { return z_dim_; }
 
-          inline std::vector<Eigen::Vector2f >::iterator
+          inline std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::iterator
           begin ()
           { return v_.begin (); }
 
-          inline std::vector<Eigen::Vector2f >::iterator
+          inline std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::iterator
           end ()
           { return v_.end (); }
 
-          inline std::vector<Eigen::Vector2f >::const_iterator
+          inline std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::const_iterator
           begin () const
           { return v_.begin (); }
 
-          inline std::vector<Eigen::Vector2f >::const_iterator
+          inline std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::const_iterator
           end () const
           { return v_.end (); }
 
         private:
-          std::vector<Eigen::Vector2f > v_;
+          std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > v_;
           size_t x_dim_, y_dim_, z_dim_;
       };
 

--- a/filters/include/pcl/filters/impl/fast_bilateral.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral.hpp
@@ -136,7 +136,7 @@ pcl::FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
 
   if (early_division_)
   {
-    for (std::vector<Eigen::Vector2f >::iterator d = data.begin (); d != data.end (); ++d)
+    for (std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::iterator d = data.begin (); d != data.end (); ++d)
       *d /= ((*d)[0] != 0) ? (*d)[1] : 1;
 
     for (size_t x = 0; x < input_->width; x++)

--- a/filters/include/pcl/filters/impl/fast_bilateral_omp.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral_omp.hpp
@@ -158,7 +158,7 @@ pcl::FastBilateralFilterOMP<PointT>::applyFilter (PointCloud &output)
 
   if (early_division_)
   {
-    for (std::vector<Eigen::Vector2f >::iterator d = data.begin (); d != data.end (); ++d)
+    for (std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::iterator d = data.begin (); d != data.end (); ++d)
       *d /= ((*d)[0] != 0) ? (*d)[1] : 1;
 
 #ifdef _OPENMP

--- a/filters/include/pcl/filters/impl/voxel_grid_occlusion_estimation.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_occlusion_estimation.hpp
@@ -99,7 +99,7 @@ pcl::VoxelGridOcclusionEstimation<PointT>::occlusionEstimation (int& out_state,
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> int
 pcl::VoxelGridOcclusionEstimation<PointT>::occlusionEstimation (int& out_state,
-                                                                std::vector<Eigen::Vector3i>& out_ray,
+                                                                std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >& out_ray,
                                                                 const Eigen::Vector3i& in_target_voxel)
 {
   if (!initialized_)
@@ -130,7 +130,7 @@ pcl::VoxelGridOcclusionEstimation<PointT>::occlusionEstimation (int& out_state,
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> int
-pcl::VoxelGridOcclusionEstimation<PointT>::occlusionEstimationAll (std::vector<Eigen::Vector3i>& occluded_voxels)
+pcl::VoxelGridOcclusionEstimation<PointT>::occlusionEstimationAll (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >& occluded_voxels)
 {
   if (!initialized_)
   {
@@ -334,7 +334,7 @@ pcl::VoxelGridOcclusionEstimation<PointT>::rayTraversal (const Eigen::Vector3i& 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> int
-pcl::VoxelGridOcclusionEstimation<PointT>::rayTraversal (std::vector <Eigen::Vector3i>& out_ray,
+pcl::VoxelGridOcclusionEstimation<PointT>::rayTraversal (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >& out_ray,
                                                          const Eigen::Vector3i& target_voxel,
                                                          const Eigen::Vector4f& origin, 
                                                          const Eigen::Vector4f& direction,

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -689,12 +689,12 @@ namespace pcl
         * \note for efficiency, user must make sure that the saving of the leaf layout is enabled and filtering performed
         */
       inline std::vector<int> 
-      getNeighborCentroidIndices (float x, float y, float z, const std::vector<Eigen::Vector3i> &relative_coordinates)
+      getNeighborCentroidIndices (float x, float y, float z, const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > &relative_coordinates)
       {
         Eigen::Vector4i ijk (static_cast<int> (floorf (x * inverse_leaf_size_[0])), static_cast<int> (floorf (y * inverse_leaf_size_[1])), static_cast<int> (floorf (z * inverse_leaf_size_[2])), 0);
         std::vector<int> neighbors;
         neighbors.reserve (relative_coordinates.size ());
-        for (std::vector<Eigen::Vector3i>::const_iterator it = relative_coordinates.begin (); it != relative_coordinates.end (); it++)
+        for (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >::const_iterator it = relative_coordinates.begin (); it != relative_coordinates.end (); it++)
           neighbors.push_back (leaf_layout_[(ijk + (Eigen::Vector4i() << *it, 0).finished() - min_b_).dot (divb_mul_)]);
         return (neighbors);
       }

--- a/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
+++ b/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
@@ -109,7 +109,7 @@ namespace pcl
         */
       int
       occlusionEstimation (int& out_state,
-                           std::vector<Eigen::Vector3i>& out_ray,
+                           std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >& out_ray,
                            const Eigen::Vector3i& in_target_voxel);
 
       /** \brief Returns the voxel coordinates (i, j, k) of all occluded
@@ -118,7 +118,7 @@ namespace pcl
         * \return the voxel coordinates (i, j, k)
         */
       int
-      occlusionEstimationAll (std::vector<Eigen::Vector3i>& occluded_voxels);
+      occlusionEstimationAll (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >& occluded_voxels);
 
       /** \brief Returns the voxel grid filtered point cloud
         * \return The voxel grid filtered point cloud
@@ -202,7 +202,7 @@ namespace pcl
         * \return The estimated voxel state.
         */
       int
-      rayTraversal (std::vector <Eigen::Vector3i>& out_ray,
+      rayTraversal (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >& out_ray,
                     const Eigen::Vector3i& target_voxel,
                     const Eigen::Vector4f& origin, 
                     const Eigen::Vector4f& direction,

--- a/geometry/include/pcl/geometry/impl/polygon_operations.hpp
+++ b/geometry/include/pcl/geometry/impl/polygon_operations.hpp
@@ -180,7 +180,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
   approx_polygon.reserve (result.size ());
   if (refine)
   {
-    std::vector<Eigen::Vector3f> lines (result.size ());
+    std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > lines (result.size ());
     std::reverse (result.begin (), result.end ());
     for (unsigned rIdx = 0; rIdx < result.size (); ++rIdx)
     {

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/standalone_marching_cubes.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/standalone_marching_cubes.hpp
@@ -92,7 +92,7 @@ pcl::gpu::kinfuLS::StandaloneMarchingCubes<PointT>::getMeshFromTSDFCloud (const 
 
 //template <typename PointT> std::vector< typename pcl::gpu::StandaloneMarchingCubes<PointT>::MeshPtr >
 template <typename PointT> void
-pcl::gpu::kinfuLS::StandaloneMarchingCubes<PointT>::getMeshesFromTSDFVector (const std::vector<PointCloudPtr> &tsdf_clouds, const std::vector<Eigen::Vector3f> &tsdf_offsets)
+pcl::gpu::kinfuLS::StandaloneMarchingCubes<PointT>::getMeshesFromTSDFVector (const std::vector<PointCloudPtr> &tsdf_clouds, const std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &tsdf_offsets)
 {
   std::vector< MeshPtr > meshes_vector;
   

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
@@ -130,7 +130,7 @@ pcl::kinfuLS::WorldModel<PointT>::getExistingData(const double previous_origin_x
 
 template <typename PointT>
 void
-pcl::kinfuLS::WorldModel<PointT>::getWorldAsCubes (const double size, std::vector<typename WorldModel<PointT>::PointCloudPtr> &cubes, std::vector<Eigen::Vector3f> &transforms, double overlap)
+pcl::kinfuLS::WorldModel<PointT>::getWorldAsCubes (const double size, std::vector<typename WorldModel<PointT>::PointCloudPtr> &cubes, std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &transforms, double overlap)
 {
   
   if(world_->points.size () == 0)

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/standalone_marching_cubes.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/standalone_marching_cubes.h
@@ -102,7 +102,7 @@ namespace pcl
         * \param[in] tsdf_offsets Vector of the offsets for every pointcloud in TsdfClouds. This offset (in indices) indicates the position of the cloud with respect to the absolute origin of the world model
         */
       void
-      getMeshesFromTSDFVector (const std::vector<PointCloudPtr> &tsdf_clouds, const std::vector<Eigen::Vector3f> &tsdf_offsets);
+      getMeshesFromTSDFVector (const std::vector<PointCloudPtr> &tsdf_clouds, const std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &tsdf_offsets);
       
       /** \brief Returns the associated Tsdf Volume buffer in GPU 
         * \return pointer to the Tsdf Volume buffer in GPU

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
@@ -165,7 +165,7 @@ namespace pcl
           * \param[out] transforms a vector containing the xyz position of each cube in world coordinates.
           * \param[in] overlap optional overlap (in percent) between each cube (usefull to create overlapped meshes).
           */
-        void getWorldAsCubes (double size, std::vector<PointCloudPtr> &cubes, std::vector<Eigen::Vector3f> &transforms, double overlap = 0.0);
+        void getWorldAsCubes (double size, std::vector<PointCloudPtr> &cubes, std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &transforms, double overlap = 0.0);
         
         
       private:

--- a/gpu/kinfu_large_scale/tools/process_kinfu_large_scale_output.cpp
+++ b/gpu/kinfu_large_scale/tools/process_kinfu_large_scale_output.cpp
@@ -87,7 +87,7 @@ main (int argc, char** argv)
     wm.addSlice (cloud);
   
     std::vector<pcl::PointCloud<pcl::PointXYZI>::Ptr> clouds;
-    std::vector<Eigen::Vector3f> transforms;
+    std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > transforms;
   
     //Get world as a vector of cubes 
     wm.getWorldAsCubes (pcl::device::kinfuLS::VOLUME_X, clouds, transforms, 0.025); // 2.5% overlapp (12 cells with a 512-wide cube)

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -692,7 +692,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
   std::size_t f_idx = 0;
   std::string line;
   std::vector<std::string> st;
-  std::vector<Eigen::Vector2f> coordinates;
+  std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > coordinates;
   try
   {
     while (!fs.eof ())

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -367,7 +367,7 @@ pcl::io::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::TextureMe
 
   // Add dummy material
   mesh.tex_materials.push_back (pcl::TexMaterial ());
-  std::vector<Eigen::Vector2f> dummy;
+  std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > dummy;
   mesh.tex_coordinates.push_back (dummy);
 
   vtkIdType nr_points = poly_data->GetNumberOfPoints ();

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -724,7 +724,7 @@ NarfKeypoint::calculateInterestPoints ()
   typedef double RealForPolynomial;
   PolynomialCalculationsT<RealForPolynomial> polynomial_calculations;
   BivariatePolynomialT<RealForPolynomial> polynomial (2);
-  std::vector<Eigen::Matrix<RealForPolynomial, 3, 1> > sample_points;
+  std::vector<Eigen::Matrix<RealForPolynomial, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<RealForPolynomial, 3, 1> > > sample_points;
   std::vector<RealForPolynomial> x_values, y_values;
   std::vector<int> types;
   std::vector<bool> invalid_beams, old_invalid_beams;

--- a/ml/include/pcl/ml/densecrf.h
+++ b/ml/include/pcl/ml/densecrf.h
@@ -65,12 +65,12 @@ namespace pcl
        * coordinates as ijk of the voxel grid
        */
       void
-      setDataVector (const std::vector<Eigen::Vector3i> data);
+      setDataVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data);
 
       /** \brief The associated color of the data
        */
       void
-      setColorVector (const std::vector<Eigen::Vector3i> color);
+      setColorVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color);
 
       void
       setUnaryEnergy (const std::vector<float> unary);
@@ -96,8 +96,8 @@ namespace pcl
 
 
       void
-      addPairwiseNormals (std::vector<Eigen::Vector3i> &coord,
-                          std::vector<Eigen::Vector3f> &normals,
+      addPairwiseNormals (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > &coord,
+                          std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &normals,
                           float sx, float sy, float sz, 
                           float snx, float sny, float snz,
                           float w);
@@ -139,10 +139,10 @@ namespace pcl
       int N_, M_;
 
       /** \brief Data vector */
-      std::vector<Eigen::Vector3i> data_;
+      std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data_;
 
       /** \brief Color vector */
-      std::vector<Eigen::Vector3i> color_;
+      std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color_;
 
       /** TODO: double might use to much memory */
       /** \brief CRF unary potentials */

--- a/ml/src/densecrf.cpp
+++ b/ml/src/densecrf.cpp
@@ -58,7 +58,7 @@ pcl::DenseCrf::~DenseCrf ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::setDataVector (const std::vector<Eigen::Vector3i> data)
+pcl::DenseCrf::setDataVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data)
 {
   xyz_ = true;
   data_ = data;
@@ -66,7 +66,7 @@ pcl::DenseCrf::setDataVector (const std::vector<Eigen::Vector3i> data)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::setColorVector (const std::vector<Eigen::Vector3i> color)
+pcl::DenseCrf::setColorVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color)
 {
   rgb_ = true;
   color_ = color;
@@ -133,8 +133,8 @@ pcl::DenseCrf::addPairwiseBilateral (float sx, float sy, float sz,
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::addPairwiseNormals (std::vector<Eigen::Vector3i> &coord,
-                                   std::vector<Eigen::Vector3f> &normals,
+pcl::DenseCrf::addPairwiseNormals (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > &coord,
+                                   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &normals,
                                    float sx, float sy, float sz, 
                                    float snx, float sny, float snz,
                                    float w)

--- a/recognition/include/pcl/recognition/cg/hough_3d.h
+++ b/recognition/include/pcl/recognition/cg/hough_3d.h
@@ -447,7 +447,7 @@ namespace pcl
       bool needs_training_;
 
       /** \brief The result of the training. The vector between each model point and the centroid of the model adjusted by its local reference frame.*/
-      std::vector<Eigen::Vector3f> model_votes_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > model_votes_;
 
       /** \brief The minimum number of votes in the Hough space needed to infer the presence of a model instance into the scene cloud. */
       double hough_threshold_;

--- a/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h
+++ b/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h
@@ -33,13 +33,13 @@ namespace pcl
       std::string directory_;
       float HEAD_ST_DIAMETER_;
       float larger_radius_ratio_;
-      std::vector<Eigen::Vector3f> head_center_votes_;
-      std::vector<std::vector<Eigen::Vector3f> > head_center_votes_clustered_;
-      std::vector<std::vector<Eigen::Vector3f> > head_center_original_votes_clustered_;
-      std::vector<Eigen::Vector3f> angle_votes_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > head_center_votes_;
+      std::vector<std::vector<Eigen::Vector3f>, Eigen::aligned_allocator<Eigen::Vector3f> > head_center_votes_clustered_;
+      std::vector<std::vector<Eigen::Vector3f>, Eigen::aligned_allocator<Eigen::Vector3f> > head_center_original_votes_clustered_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > angle_votes_;
       std::vector<float> uncertainties_;
-      std::vector<Eigen::Vector3f> head_clusters_centers_;
-      std::vector<Eigen::Vector3f> head_clusters_rotation_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > head_clusters_centers_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > head_clusters_rotation_;
 
       pcl::PointCloud<pcl::PointXYZ>::Ptr input_;
       pcl::PointCloud<pcl::PointXYZI>::Ptr face_heat_map_;

--- a/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
@@ -177,7 +177,7 @@ pcl::Hough3DGrouping<PointModelT, PointSceneT, PointModelRfT, PointSceneRfT>::ho
     return (false);
   }
 
-  std::vector<Eigen::Vector3d> scene_votes (n_matches);
+  std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > scene_votes (n_matches);
   Eigen::Vector3d d_min, d_max, bin_size;
 
   d_min.setConstant (std::numeric_limits<double>::max ());

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -141,7 +141,7 @@ pcl::features::ISMVoteList<PointT>::findStrongestPeaks (
   double SIGMA_DIST = in_sigma;// rule of thumb: 10% of the object radius
   const double FINAL_EPS = SIGMA_DIST / 100;// another heuristic
 
-  std::vector<Eigen::Vector3f> peaks (NUM_INIT_PTS);
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > peaks (NUM_INIT_PTS);
   std::vector<double> peak_densities (NUM_INIT_PTS);
   double max_density = -1.0;
   for (int i = 0; i < NUM_INIT_PTS; i++)
@@ -1288,7 +1288,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeKMe
   Eigen::MatrixXf centers (number_of_clusters, feature_dimension);
   Eigen::MatrixXf old_centers (number_of_clusters, feature_dimension);
   std::vector<int> counters (number_of_clusters);
-  std::vector<Eigen::Vector2f> boxes (feature_dimension);
+  std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > boxes (feature_dimension);
   Eigen::Vector2f* box = &boxes[0];
 
   double best_compactness = std::numeric_limits<double>::max ();
@@ -1504,7 +1504,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::generateCe
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <int FeatureSize, typename PointT, typename NormalT> void
-pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::generateRandomCenter (const std::vector<Eigen::Vector2f>& boxes,
+pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::generateRandomCenter (const std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >& boxes,
   Eigen::VectorXf& center)
 {
   size_t dimension = boxes.size ();

--- a/recognition/include/pcl/recognition/implicit_shape_model.h
+++ b/recognition/include/pcl/recognition/implicit_shape_model.h
@@ -565,7 +565,7 @@ namespace pcl
           * \param[out] center it will the contain generated center
           */
         void
-        generateRandomCenter (const std::vector<Eigen::Vector2f>& boxes, Eigen::VectorXf& center);
+        generateRandomCenter (const std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >& boxes, Eigen::VectorXf& center);
 
         /** \brief Computes the square distance beetween two vectors.
           * \param[in] vec_1 first vector

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -266,13 +266,13 @@ namespace pcl
 
       
       /** \brief Input cloud points covariances. */
-      std::vector<Eigen::Matrix3d> input_covariances_;
+      std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> > input_covariances_;
 
       /** \brief Target cloud points covariances. */
-      std::vector<Eigen::Matrix3d> target_covariances_;
+      std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> > target_covariances_;
 
       /** \brief Mahalanobis matrices holder. */
-      std::vector<Eigen::Matrix3d> mahalanobis_;
+      std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> > mahalanobis_;
       
       /** \brief maximum number of optimizations */
       int max_inner_iterations_;
@@ -286,7 +286,7 @@ namespace pcl
       template<typename PointT>
       void computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud, 
                               const typename pcl::search::KdTree<PointT>::Ptr tree,
-                              std::vector<Eigen::Matrix3d>& cloud_covariances);
+                              std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >& cloud_covariances);
 
       /** \return trace of mat1^t . mat2 
         * \param mat1 matrix of dimension nxm

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -56,7 +56,7 @@ template <typename PointSource, typename PointTarget>
 template<typename PointT> void
 pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud, 
                                                                                     const typename pcl::search::KdTree<PointT>::Ptr kdtree,
-                                                                                    std::vector<Eigen::Matrix3d>& cloud_covariances)
+                                                                                    std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >& cloud_covariances)
 {
   if (k_correspondences_ > int (cloud->size ()))
   {
@@ -73,7 +73,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovarian
     cloud_covariances.resize (cloud->size ());
 
   typename pcl::PointCloud<PointT>::const_iterator points_iterator = cloud->begin ();
-  std::vector<Eigen::Matrix3d>::iterator matrices_iterator = cloud_covariances.begin ();
+  std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >::iterator matrices_iterator = cloud_covariances.begin ();
   for(;
       points_iterator != cloud->end ();
       ++points_iterator, ++matrices_iterator)

--- a/registration/include/pcl/registration/impl/lum.hpp
+++ b/registration/include/pcl/registration/impl/lum.hpp
@@ -304,8 +304,8 @@ pcl::registration::LUM<PointT>::computeEdge (const Edge &e)
   pcl::CorrespondencesPtr corrs = (*slam_graph_)[e].corrs_;
 
   // Build the average and difference vectors for all correspondences
-  std::vector <Eigen::Vector3f> corrs_aver (corrs->size ());
-  std::vector <Eigen::Vector3f> corrs_diff (corrs->size ());
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > corrs_aver (corrs->size ());
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > corrs_diff (corrs->size ());
   int oci = 0;  // oci = output correspondence iterator
   for (int ici = 0; ici != static_cast<int> (corrs->size ()); ++ici)  // ici = input correspondence iterator
   {

--- a/segmentation/include/pcl/segmentation/crf_segmentation.h
+++ b/segmentation/include/pcl/segmentation/crf_segmentation.h
@@ -169,11 +169,11 @@ namespace pcl
       /** \brief voxel grid data points
           packing order [x0y0z0, x1y0z0,x2y0z0,...,x0y1z0,x1y1z0,...,x0y0z1,x1y0z1,...]
       */
-      std::vector<Eigen::Vector3i> data_;
+      std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data_;
 
-      std::vector<Eigen::Vector3i> color_;
+      std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color_;
 
-      std::vector<Eigen::Vector3f> normal_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > normal_;
 
       /** \brief smoothness kernel parameters 
        * [0] = standard deviation x

--- a/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
@@ -220,8 +220,8 @@ pcl::CrfSegmentation<PointT>::createDataVectorFromVoxelGrid ()
   //data_.reserve (dim_.x () * dim_.y () * dim_.z ());
 
 /*
-  std::vector<Eigen::Vector3i> data;
-  std::vector<Eigen::Vector3i> color;
+  std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data;
+  std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color;
   // fill the data vector
   for (int kk = min_b.z (), k = 0; kk <= max_b.z (); kk++, k++)
   {

--- a/simulation/include/pcl/simulation/range_likelihood.h
+++ b/simulation/include/pcl/simulation/range_likelihood.h
@@ -225,7 +225,7 @@ namespace pcl
 
         gllib::Program::Ptr likelihood_program_;
         GLuint quad_vbo_;
-        std::vector<Eigen::Vector3f> vertices_;
+        std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > vertices_;
         float* score_buffer_;
         Quad quad_;
         SumReduce sum_reduce_;

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -358,7 +358,7 @@ namespace pcl
       /** \brief Temporary variable to store a triangle (as a set of point indices) **/
       pcl::Vertices triangle_;
       /** \brief Temporary variable to store point coordinates **/
-      std::vector<Eigen::Vector3f> coords_;
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > coords_;
 
       /** \brief A list of angles to neighbors **/
       std::vector<nnAngle> angles_;

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -138,7 +138,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
   int is_free=0, nr_parts=0, increase_nnn4fn=0, increase_nnn4s=0, increase_dist=0, nr_touched = 0;
   bool is_fringe;
   angles_.resize(nnn_);
-  std::vector<Eigen::Vector2f> uvn_nn (nnn_);
+  std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > uvn_nn (nnn_);
   Eigen::Vector2f uvn_s;
 
   // iterating through fringe points and finishing them until everything is done

--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -122,7 +122,7 @@ pcl::MarchingCubes<PointNT>::createSurface (std::vector<float> &leaf_node,
   center[1] = min_p_[1] + (max_p_[1] - min_p_[1]) * float (index_3d[1]) / float (res_y_);
   center[2] = min_p_[2] + (max_p_[2] - min_p_[2]) * float (index_3d[2]) / float (res_z_);
 
-  std::vector<Eigen::Vector3f> p;
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > p;
   p.resize (8);
   for (int i = 0; i < 8; ++i)
   {

--- a/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
@@ -90,7 +90,7 @@ pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
   w = M.fullPivLu ().solve (d);
 
   std::vector<double> weights (2*N);
-  std::vector<Eigen::Vector3d> centers (2*N);
+  std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > centers (2*N);
   for (unsigned int i = 0; i < N; ++i)
   {
     centers[i] = Eigen::Vector3f (input_->points[i].getVector3fMap ()).cast<double> ();
@@ -110,7 +110,7 @@ pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
 
         double f = 0.0;
         std::vector<double>::const_iterator w_it (weights.begin());
-        for (std::vector<Eigen::Vector3d>::const_iterator c_it = centers.begin ();
+        for (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >::const_iterator c_it = centers.begin ();
              c_it != centers.end (); ++c_it, ++w_it)
           f += *w_it * kernel (*c_it, point);
 

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -216,7 +216,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
   {
     // Update neighborhood, since point was projected, and computing relative
     // positions. Note updating only distances for the weights for speed
-    std::vector<Eigen::Vector3d> de_meaned (nn_indices.size ());
+    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > de_meaned (nn_indices.size ());
     for (size_t ni = 0; ni < nn_indices.size (); ++ni)
     {
       de_meaned[ni][0] = input_->points[nn_indices[ni]].x - point[0];

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -42,13 +42,13 @@
 #include <pcl/surface/texture_mapping.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointInT> std::vector<Eigen::Vector2f>
+template<typename PointInT> std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >
 pcl::TextureMapping<PointInT>::mapTexture2Face (
     const Eigen::Vector3f &p1, 
     const Eigen::Vector3f &p2, 
     const Eigen::Vector3f &p3)
 {
-  std::vector<Eigen::Vector2f> tex_coordinates;
+  std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > tex_coordinates;
   // process for each face
   Eigen::Vector3f p1p2 (p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2]);
   Eigen::Vector3f p1p3 (p3[0] - p1[0], p3[1] - p1[1], p3[2] - p1[2]);
@@ -153,12 +153,12 @@ pcl::TextureMapping<PointInT>::mapTexture2Mesh (pcl::TextureMesh &tex_mesh)
   Eigen::Vector3f facet[3];
 
   // texture coordinates for each mesh
-  std::vector<std::vector<Eigen::Vector2f> > texture_map;
+  std::vector<std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > >texture_map;
 
   for (size_t m = 0; m < tex_mesh.tex_polygons.size (); ++m)
   {
     // texture coordinates for each mesh
-    std::vector<Eigen::Vector2f> texture_map_tmp;
+    std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > texture_map_tmp;
 
     // processing for each face
     for (size_t i = 0; i < tex_mesh.tex_polygons[m].size (); ++i)
@@ -178,7 +178,7 @@ pcl::TextureMapping<PointInT>::mapTexture2Mesh (pcl::TextureMesh &tex_mesh)
       }
 
       // get texture coordinates of each face
-      std::vector<Eigen::Vector2f> tex_coordinates = mapTexture2Face (facet[0], facet[1], facet[2]);
+      std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > tex_coordinates = mapTexture2Face (facet[0], facet[1], facet[2]);
       for (size_t n = 0; n < tex_coordinates.size (); ++n)
         texture_map_tmp.push_back (tex_coordinates[n]);
     }// end faces
@@ -244,12 +244,12 @@ pcl::TextureMapping<PointInT>::mapTexture2MeshUV (pcl::TextureMesh &tex_mesh)
   float z_offset = 0 - z_lowest;
 
   // texture coordinates for each mesh
-  std::vector<std::vector<Eigen::Vector2f> > texture_map;
+  std::vector<std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > >texture_map;
 
   for (size_t m = 0; m < tex_mesh.tex_polygons.size (); ++m)
   {
     // texture coordinates for each mesh
-    std::vector<Eigen::Vector2f> texture_map_tmp;
+    std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > texture_map_tmp;
 
     // processing for each face
     for (size_t i = 0; i < tex_mesh.tex_polygons[m].size (); ++i)
@@ -303,7 +303,7 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
   pcl::fromPCLPointCloud2 (tex_mesh.cloud, *originalCloud);
 
   // texture coordinates for each mesh
-  std::vector<std::vector<Eigen::Vector2f> > texture_map;
+  std::vector<std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > > texture_map;
 
   for (size_t m = 0; m < cams.size (); ++m)
   {
@@ -317,7 +317,7 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
     pcl::transformPointCloud (*originalCloud, *camera_transformed_cloud, cam_trans.inverse ());
 
     // vector of texture coordinates for each face
-    std::vector<Eigen::Vector2f> texture_map_tmp;
+    std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > texture_map_tmp;
 
     // processing each face visible by this camera
     PointInT pt;
@@ -351,7 +351,7 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
   }// end cameras
 
   // push on extra empty UV map (for unseen faces) so that obj writer does not crash!
-  std::vector<Eigen::Vector2f> texture_map_tmp;
+  std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > texture_map_tmp;
   for (size_t i = 0; i < tex_mesh.tex_polygons[cams.size ()].size (); ++i)
     for (size_t j = 0; j < tex_mesh.tex_polygons[cams.size ()][i].vertices.size (); ++j)
     {
@@ -908,7 +908,7 @@ pcl::TextureMapping<PointInT>::textureMeshwithMultipleCameras (pcl::TextureMesh 
 
     if (static_cast<int> (mesh.tex_coordinates.size ()) <= current_cam)
     {
-      std::vector<Eigen::Vector2f> dummy_container;
+      std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > dummy_container;
       mesh.tex_coordinates.push_back (dummy_container);
     }
     mesh.tex_coordinates[current_cam].resize (3 * visibility.size ());
@@ -966,7 +966,7 @@ pcl::TextureMapping<PointInT>::textureMeshwithMultipleCameras (pcl::TextureMesh 
 
   if (mesh.tex_coordinates.size() <= cameras.size ())
   {
-   std::vector<Eigen::Vector2f> dummy_container;
+   std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > dummy_container;
    mesh.tex_coordinates.push_back(dummy_container);
    }
 

--- a/surface/include/pcl/surface/texture_mapping.h
+++ b/surface/include/pcl/surface/texture_mapping.h
@@ -351,7 +351,7 @@ namespace pcl
         * \param[in] p2 the second point
         * \param[in] p3 the third point
         */
-      std::vector<Eigen::Vector2f>
+      std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >
       mapTexture2Face (const Eigen::Vector3f &p1, const Eigen::Vector3f &p2, const Eigen::Vector3f &p3);
 
       /** \brief Returns the circumcenter of a triangle and the circle's radius.

--- a/test/common/test_vector_average.cpp
+++ b/test/common/test_vector_average.cpp
@@ -45,8 +45,8 @@ using namespace pcl;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, VectorAverage_mean)
 {
-  std::vector<Eigen::Vector3f> points;
-  std::vector<Eigen::Vector3f::Scalar> weights;
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > points;
+  std::vector<Eigen::Vector3f::Scalar, Eigen::aligned_allocator<Eigen::Vector3f::Scalar> > weights;
   points.push_back (Eigen::Vector3f (-0.558191f, 0.180822f, -0.809769f));
   weights.push_back (0.160842f);
   points.push_back (Eigen::Vector3f (-0.510641f, 0.290673f, -0.809169f));

--- a/tools/voxel_grid_occlusion_estimation.cpp
+++ b/tools/voxel_grid_occlusion_estimation.cpp
@@ -217,7 +217,7 @@ int main (int argc, char** argv)
   tt.tic ();
 
   // estimate the occluded space
-  std::vector <Eigen::Vector3i> occluded_voxels;
+  std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > occluded_voxels;
   vg.occlusionEstimationAll (occluded_voxels);
 
   print_info ("[done, "); print_value ("%g", tt.toc ()); print_info (" ms : "); print_value ("%d", (int)occluded_voxels.size ()); print_info (" occluded voxels]\n");

--- a/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
+++ b/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
@@ -482,7 +482,7 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::track (const PointClou
                                                                  std::vector<int>& status,
                                                                  Eigen::Affine3f& motion) const
 {
-  std::vector<Eigen::Array2f> next_pts (prev_keypoints->size ());
+  std::vector<Eigen::Array2f, Eigen::aligned_allocator<Eigen::Array2f> > next_pts (prev_keypoints->size ());
   Eigen::Array2f half_win ((track_width_-1)*0.5f, (track_height_-1)*0.5f);
   pcl::TransformationFromCorrespondences transformation_computer;
   const int nb_points = prev_keypoints->size ();

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3400,7 +3400,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
   // Get camera positions
   vtkPolyData *sphere = subdivide->GetOutput ();
 
-  std::vector<Eigen::Vector3f> cam_positions;
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > cam_positions;
   if (!use_vertices)
   {
     vtkSmartPointer<vtkCellArray> cells_sphere = sphere->GetPolys ();


### PR DESCRIPTION
Fixes #958 

```
$ grep "std::vector<Eigen" -rn /home/$USER/pcl | grep -vw 'aligned_allocator'
/home/victor/pcl/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h:230:      void getDetectedFaces(std::vector<Eigen::VectorXf> & faces)
/home/victor/pcl/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h:112:  void displayHeads(std::vector<Eigen::VectorXf> & heads, pcl::visualization::PCLVisualizer & vis)
/home/victor/pcl/apps/src/face_detection/openni_face_detection.cpp:70:    std::vector<Eigen::VectorXf> heads;
/home/victor/pcl/apps/src/face_detection/filesystem_face_detection.cpp:85:  std::vector<Eigen::VectorXf> heads;
```

These are fine: http://eigen.tuxfamily.org/dox/group__TopicFixedSizeVectorizable.html
