### PR TITLE
Fixed rounding error angle calculation of parallel and anti-parallel vec...

### DIFF
--- a/common/include/pcl/common/common.h
+++ b/common/include/pcl/common/common.h
@@ -50,14 +50,26 @@
 /*@{*/
 namespace pcl
 {
-  /** \brief Compute the smallest angle between two vectors in the [ 0, PI ) interval in 3D.
+  /** \brief Compute the smallest angle between two 3D vectors in radians (default) or degree.
     * \param v1 the first 3D vector (represented as a \a Eigen::Vector4f)
     * \param v2 the second 3D vector (represented as a \a Eigen::Vector4f)
-    * \return the angle between v1 and v2
+    * \return the angle between v1 and v2 in radians or degrees
+    * \note Handles rounding error for parallel and anti-parallel vectors
     * \ingroup common
     */
   inline double 
-  getAngle3D (const Eigen::Vector4f &v1, const Eigen::Vector4f &v2);
+  getAngle3D (const Eigen::Vector4f &v1, const Eigen::Vector4f &v2, const bool in_degree = false);
+
+  /** \brief Compute the smallest angle between two 3D vectors in radians (default) or degree.
+    * \param v1 the first 3D vector (represented as a \a Eigen::Vector3f)
+    * \param v2 the second 3D vector (represented as a \a Eigen::Vector3f)
+    * \param in_degree determine if angle should be in radians or degrees
+    * \return the angle between v1 and v2 in radians or degrees
+    * \ingroup common
+    */
+  inline double
+  getAngle3D (const Eigen::Vector3f &v1, const Eigen::Vector3f &v2, const bool in_degree = false);
+
 
   /** \brief Compute both the mean and the standard deviation of an array of values
     * \param values the array of values

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -43,13 +43,27 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 inline double
-pcl::getAngle3D (const Eigen::Vector4f &v1, const Eigen::Vector4f &v2)
+pcl::getAngle3D (const Eigen::Vector4f &v1, const Eigen::Vector4f &v2, const bool in_degree)
 {
   // Compute the actual angle
-  double rad = v1.dot (v2) / sqrt (v1.squaredNorm () * v2.squaredNorm ());
-  if (rad < -1.0) rad = -1.0;
-  if (rad >  1.0) rad = 1.0;
-  return (acos (rad));
+  double rad = v1.normalized ().dot (v2.normalized ());
+  if (rad < -1.0)
+    rad = -1.0;
+  else if (rad >  1.0)
+    rad = 1.0;
+  return (in_degree ? acos (rad) * 180.0 / M_PI : acos (rad));
+}
+
+inline double
+pcl::getAngle3D (const Eigen::Vector3f &v1, const Eigen::Vector3f &v2, const bool in_degree)
+{
+  // Compute the actual angle
+  double rad = v1.normalized ().dot (v2.normalized ());
+  if (rad < -1.0)
+    rad = -1.0;
+  else if (rad >  1.0)
+    rad = 1.0;
+  return (in_degree ? acos (rad) * 180.0 / M_PI : acos (rad));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -375,7 +375,6 @@ LCCPSegmentation Parameters: \n\
 
     typedef LCCPSegmentation<PointT>::VertexIterator VertexIterator;
     typedef LCCPSegmentation<PointT>::AdjacencyIterator AdjacencyIterator;
-    typedef LCCPSegmentation<PointT>::VertexID VertexID;
     typedef LCCPSegmentation<PointT>::EdgeID EdgeID;
 
     std::set<EdgeID> edge_drawn;


### PR DESCRIPTION
This fixes angle convexity calculation for parallel and anti-parallel normals, where a rounding error occasionally caused NaN angles.
This solves issue  #1033. 
