### PR TITLE
Remove a wrong error normalization in SampleConsensusPrerejective

### DIFF
--- a/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
+++ b/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
@@ -220,7 +220,6 @@ pcl::SampleConsensusPrerejective<PointSource, PointTarget, FeatureT>::computeTra
   {
     getFitness (inliers, error);
     inlier_fraction = static_cast<float> (inliers.size ()) / static_cast<float> (input_->size ());
-    error /= static_cast<float> (inliers.size ());
     
     if (inlier_fraction >= inlier_fraction_ && error < lowest_error)
     {


### PR DESCRIPTION
Remove an extra normalization of the fitness error using the number of inliers, since this has already been done inside getFitness ().

This problem has probably never been encountered by anyone, since it only happens when a guess transformation is input.
