### PR TITLE
fix: misaligned context items in ImageViewer

### DIFF
--- a/visualization/include/pcl/visualization/impl/image_viewer.hpp
+++ b/visualization/include/pcl/visualization/impl/image_viewer.hpp
@@ -124,7 +124,7 @@ pcl::visualization::ImageViewer::addMask (
     search.projectPoint (mask[i], p_projected);
 
     xy.push_back (p_projected.x);
-    #if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 10))
+    #if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
     xy.push_back (image_height_f - p_projected.y);
     #else
     xy.push_back (p_projected.y);
@@ -182,7 +182,7 @@ pcl::visualization::ImageViewer::addPlanarPolygon (
     pcl::PointXY p;
     search.projectPoint (polygon.getContour ()[i], p);
     xy.push_back (p.x);
-    #if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 10))
+    #if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 7))
     xy.push_back (image_height_f - p.y);
     #else
     xy.push_back (p.y);
@@ -270,7 +270,7 @@ pcl::visualization::ImageViewer::addRectangle (
     if (pp_2d[i].x > max_pt_2d.x) max_pt_2d.x = pp_2d[i].x;
     if (pp_2d[i].y > max_pt_2d.y) max_pt_2d.y = pp_2d[i].y;
   }
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 7))
+#if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   min_pt_2d.y = float (image->height) - min_pt_2d.y;
   max_pt_2d.y = float (image->height) - max_pt_2d.y;
 #endif
@@ -335,7 +335,7 @@ pcl::visualization::ImageViewer::addRectangle (
     if (pp_2d[i].x > max_pt_2d.x) max_pt_2d.x = pp_2d[i].x;
     if (pp_2d[i].y > max_pt_2d.y) max_pt_2d.y = pp_2d[i].y;
   }
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 7))
+#if ((VTK_MAJOR_VERSION >= 6) ||((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   min_pt_2d.y = float (image->height) - min_pt_2d.y;
   max_pt_2d.y = float (image->height) - max_pt_2d.y;
 #endif

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -705,7 +705,7 @@ pcl::visualization::ImageViewer::addCircle (
                      static_cast<unsigned char> (255.0 * g),
                      static_cast<unsigned char> (255.0 * b));
   circle->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
+#if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   circle->set (static_cast<float> (x), static_cast<float> (y), static_cast<float> (radius));
 #else
   circle->set (static_cast<float> (x), static_cast<float> (getSize ()[1] - y), static_cast<float> (radius));
@@ -745,7 +745,7 @@ pcl::visualization::ImageViewer::addFilledRectangle (
                    static_cast<unsigned char> (255.0 * g),
                    static_cast<unsigned char> (255.0 * b));
   rect->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
+#if ((VTK_MAJOR_VERSION >= 6) || (VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7))
   rect->set (static_cast<float> (x_min), static_cast<float> (y_min),
              static_cast<float> (x_max - x_min), static_cast<float> (y_max - y_min));
 #else
@@ -788,7 +788,7 @@ pcl::visualization::ImageViewer::addRectangle (
                    static_cast<unsigned char> (255.0 * g),
                    static_cast<unsigned char> (255.0 * b));
   rect->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7))
+#if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   rect->set (static_cast<float> (x_min), static_cast<float> (y_min),
              static_cast<float> (x_max), static_cast<float> (y_max));
 #else
@@ -831,7 +831,7 @@ pcl::visualization::ImageViewer::addRectangle (
                    static_cast<unsigned char> (255.0 * g),
                    static_cast<unsigned char> (255.0 * b));
   rect->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7))
+#if ((VTK_MAJOR_VERSION >= 6) ||((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   rect->set (min_pt.x, min_pt.y, max_pt.x, max_pt.y);
 #else
   rect->set (min_pt.x, static_cast<float> (getSize ()[1]) - min_pt.y, max_pt.x, max_pt.y);
@@ -873,7 +873,7 @@ pcl::visualization::ImageViewer::addLine (unsigned int x_min, unsigned int y_min
                    static_cast<unsigned char> (255.0 * g),
                    static_cast<unsigned char> (255.0 * b));
   line->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
+#if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   line->set (static_cast<float> (x_min), static_cast<float> (y_min),
              static_cast<float> (x_max), static_cast<float> (y_max));
 #else
@@ -917,7 +917,7 @@ pcl::visualization::ImageViewer::addText (unsigned int x, unsigned int y,
                    static_cast<unsigned char> (255.0 * g),
                    static_cast<unsigned char> (255.0 * b));
   text->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTKOR_VERSION > 10))
+#if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   text->set (static_cast<float> (x), static_cast<float> (y), text_string);
 #else
   text->set (static_cast<float> (x), static_cast<float> (getSize ()[1] - y), text_string);
@@ -960,7 +960,7 @@ pcl::visualization::ImageViewer::markPoint (
   disk->setColors (bg_color[0], bg_color[1], bg_color[2]);
   disk->setOpacity (opacity);
 
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
+#if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   point->set (static_cast<float> (u), static_cast<float> (v));
   disk->set (static_cast<float> (u), static_cast<float> (v), static_cast<float> (radius));
 #else
@@ -1009,7 +1009,7 @@ pcl::visualization::ImageViewer::markPoints (
 
   vtkSmartPointer<context_items::Markers> markers = vtkSmartPointer<context_items::Markers>::New ();
   markers->setOpacity (opacity);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 10))
+#if ((VTK_MAJOR_VERSION >= 6) || ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION > 7)))
   markers->set (uv);
 #else
   // translate v which is on odd indices


### PR DESCRIPTION
This is the announced workaround for the misaligned context items (#998). The issue of the workaround is a change in vtk version handling. 

tool/demo for testing: "pcl_pcd_select_object_plane" with input file: "trunk/test/milk_cartoon_all_small_clorox.pcd"

first test: vtk 5.8

before:
![imageviewer - vtk5 8 - before](https://cloud.githubusercontent.com/assets/4068805/5506562/afe32cf0-879b-11e4-80c5-7b25c958af28.jpg)
after:
![imageviewer - vtk5 8 - after](https://cloud.githubusercontent.com/assets/4068805/5506572/be0e4634-879b-11e4-8d21-ed89a81ce528.jpg)

second test: vtk 6.2, actual trunk
before:
![imageviewer - vtk6 2 - before](https://cloud.githubusercontent.com/assets/4068805/5506583/d546f792-879b-11e4-8183-9a7ae1473af0.jpg)
after:
![imageviewer - vtk6 2 - after](https://cloud.githubusercontent.com/assets/4068805/5506589/e270d7ee-879b-11e4-8064-fc2157bca5ce.jpg)
