### PR TITLE
fix: ImageViewer => opacity handling for layer rectangles of context items

### DIFF
--- a/visualization/include/pcl/visualization/impl/image_viewer.hpp
+++ b/visualization/include/pcl/visualization/impl/image_viewer.hpp
@@ -109,7 +109,7 @@ pcl::visualization::ImageViewer::addMask (
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addMask] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
-    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, true);
+    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, false);
   }
 
   // Construct a search object to get the camera parameters
@@ -168,7 +168,7 @@ pcl::visualization::ImageViewer::addPlanarPolygon (
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addPlanarPolygon] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
-    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, true);
+    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, false);
   }
   
   // Construct a search object to get the camera parameters and fill points
@@ -232,7 +232,7 @@ pcl::visualization::ImageViewer::addRectangle (
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addRectangle] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
-    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, true);
+    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, false);
   }
 
   // Construct a search object to get the camera parameters
@@ -314,7 +314,7 @@ pcl::visualization::ImageViewer::addRectangle (
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addRectangle] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
-    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, true);
+    am_it = createLayer (layer_id, getSize ()[0] - 1, getSize ()[1] - 1, opacity, false);
   }
 
   // Construct a search object to get the camera parameters


### PR DESCRIPTION
Even in 'image_viewer.hpp' context items need no layer fill boxes with opacity, like in 'image_viewer.cpp'.

tool/demo for testing: "pcl_pcd_select_object_plane" with input file: "trunk/test/milk_cartoon_all_small_clorox.pcd"

before:
![imageviewer - before](https://cloud.githubusercontent.com/assets/4068805/5515017/29b712ba-8857-11e4-98f5-f51f13796796.jpg)

after:
![imageviewer - after](https://cloud.githubusercontent.com/assets/4068805/5515018/3434316e-8857-11e4-8cce-71c030c9b663.jpg)

for better visibility the opacity of the added planar polygon was set to '0.1' (pcl_pcd_select_object_plane.cpp, line 468):
![pcd_select_object_plane](https://cloud.githubusercontent.com/assets/4068805/5515035/dff5ba22-8857-11e4-8b17-252bcc61e331.jpg)

See also the associated issues #998 and #1049.
