### PR TITLE
Fix VTK compatibility

### DIFF
--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -120,6 +120,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
 
   // Get camera positions
   vtkPolyData *sphere = subdivide->GetOutput ();
+  sphere->Update ();
 
   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > cam_positions;
   if (!use_vertices_)


### PR DESCRIPTION
https://github.com/fran6co/pcl/commit/4d1ee479e8fc791b5a7b0f75ecb109105bbe6d48#diff-4206b5bbfa76680243fec88c91dfbd3cL119 removed the update call which is in fact needed for VTK 5. It does not hurt VTK 6 support.

Reported by Ber461 on the [mailing list](http://www.pcl-users.org/Segmentation-fault-on-trunk-version-of-pcl-apps-RenderViewsTesselatedSphere-td4036447.html).
