### PR TITLE
Correct the doc of the virtual destructor of OctreePointCloudSearch class

### DIFF
--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -85,7 +85,7 @@ namespace pcl
         {
         }
 
-        /** \brief Empty class constructor. */
+        /** \brief Empty class destructor. */
         virtual
         ~OctreePointCloudSearch ()
         {


### PR DESCRIPTION
This patch contains a little correction. The documentation of OctreePointCloudSearch class.