### PR TITLE
Fixes manual registration and segmentation demo for boost 1.57

### DIFF
--- a/apps/include/pcl/apps/manual_registration.h
+++ b/apps/include/pcl/apps/manual_registration.h
@@ -42,7 +42,9 @@
 #include <QTimer>
 
 // Boost
+#ifndef Q_MOC_RUN
 #include <boost/thread/thread.hpp>
+#endif
 
 // PCL
 #include <pcl/console/print.h>

--- a/common/include/pcl/common/time_trigger.h
+++ b/common/include/pcl/common/time_trigger.h
@@ -40,9 +40,11 @@
 #define PCL_COMMON_TIME_TRIGGER_H_
 
 #include <pcl/pcl_macros.h>
+#ifndef Q_MOC_RUN
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
 #include <boost/signals2.hpp>
+#endif
 
 namespace pcl
 {

--- a/segmentation/include/pcl/segmentation/boost.h
+++ b/segmentation/include/pcl/segmentation/boost.h
@@ -45,6 +45,7 @@
 #pragma GCC system_header 
 #endif
 
+#ifndef Q_MOC_RUN
 // Marking all Boost headers as system headers to remove warnings
 #include <boost/version.hpp>
 #include <boost/make_shared.hpp>
@@ -55,6 +56,6 @@
 #if (BOOST_VERSION >= 104400) 
   #include <boost/graph/boykov_kolmogorov_max_flow.hpp>
 #endif 
-
+#endif
 
 #endif    // PCL_SEGMENTATION_BOOST_H_


### PR DESCRIPTION
Manual registration and segmentation didn't work with boost 1.57.