### PR TITLE
Fixes libc++ error

### DIFF
--- a/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h
+++ b/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h
@@ -34,8 +34,8 @@ namespace pcl
       float HEAD_ST_DIAMETER_;
       float larger_radius_ratio_;
       std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > head_center_votes_;
-      std::vector<std::vector<Eigen::Vector3f>, Eigen::aligned_allocator<Eigen::Vector3f> > head_center_votes_clustered_;
-      std::vector<std::vector<Eigen::Vector3f>, Eigen::aligned_allocator<Eigen::Vector3f> > head_center_original_votes_clustered_;
+      std::vector<std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > > head_center_votes_clustered_;
+      std::vector<std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > > head_center_original_votes_clustered_;
       std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > angle_votes_;
       std::vector<float> uncertainties_;
       std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > head_clusters_centers_;

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -108,7 +108,7 @@ void pcl::RFFaceDetectorTrainer::faceVotesClustering()
       ind.push_back (static_cast<int>(i));
       votes_indices.push_back (ind);
 
-      std::vector < Eigen::Vector3f > votes_in_cluster;
+      std::vector < Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > votes_in_cluster;
       votes_in_cluster.push_back (center_vote);
       head_center_original_votes_clustered_.push_back (votes_in_cluster);
 


### PR DESCRIPTION
```
[ 95%] Building CXX object recognition/CMakeFiles/pcl_recognition.dir/src/face_detection/rf_face_detector_trainer.cpp.o
cd /tmp/pcl-K3KW2e/build/recognition && /usr/local/Library/ENV/4.3/clang++   -DEIGEN_USE_NEW_STDVECTOR -DEIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET -DPCLAPI_EXPORTS -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -Dqh_QHpointer -DvtkRenderingCore_AUTOINIT="4(vtkInteractionStyle,vtkRenderingFreeType,vtkRenderingFreeTypeOpenGL,vtkRenderingOpenGL)" -DvtkRenderingFreeType_AUTOINIT="1(vtkRenderingFreeTypeFontConfig)" -DvtkRenderingVolume_AUTOINIT="1(vtkRenderingVolumeOpenGL)" -ftemplate-depth=1024 -Qunused-arguments -Wno-invalid-offsetof   -fPIC -isystem /usr/local/include -isystem /usr/local/include/eigen3 -isystem /usr/local/opt/openni/include/ni -I/tmp/pcl-K3KW2e/recognition/include/pcl/recognition/3rdparty -isystem /usr/local/Cellar/qt/4.8.6/include -iframework /usr/local/Cellar/qt/4.8.6/lib -isystem /usr/local/Cellar/qt/4.8.6/include/QtGui -isystem /usr/local/Cellar/qt/4.8.6/lib/QtCore.framework/Headers -I/usr/local/include/vtk-6.1 -I/usr/include/libxml2 -I/usr/include/python2.7 -I/tmp/pcl-K3KW2e/build/include -I/tmp/pcl-K3KW2e/common/include -I/tmp/pcl-K3KW2e/io/include -I/tmp/pcl-K3KW2e/search/include -I/tmp/pcl-K3KW2e/kdtree/include -I/tmp/pcl-K3KW2e/octree/include -I/tmp/pcl-K3KW2e/features/include -I/tmp/pcl-K3KW2e/filters/include -I/tmp/pcl-K3KW2e/registration/include -I/tmp/pcl-K3KW2e/sample_consensus/include -I/tmp/pcl-K3KW2e/ml/include -I/tmp/pcl-K3KW2e/recognition/include    -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks  -o CMakeFiles/pcl_recognition.dir/src/face_detection/rf_face_detector_trainer.cpp.o -c /tmp/pcl-K3KW2e/recognition/src/face_detection/rf_face_detector_trainer.cpp
In file included from /tmp/pcl-K3KW2e/recognition/src/face_detection/rf_face_detector_trainer.cpp:8:
In file included from /tmp/pcl-K3KW2e/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h:11:
In file included from /tmp/pcl-K3KW2e/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h:11:
In file included from /tmp/pcl-K3KW2e/common/include/pcl/common/common.h:41:
In file included from /tmp/pcl-K3KW2e/common/include/pcl/pcl_base.h:49:
In file included from /usr/local/include/eigen3/Eigen/StdVector:15:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:502:5: error: implicit instantiation of undefined template '__static_assert_test<false>'
    static_assert((is_same<typename allocator_type::value_type, value_type>::value),
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__config:498:35: note: expanded from macro 'static_assert'
    typedef __static_assert_check<sizeof(__static_assert_test<(__b)>)> \
                                  ^
/tmp/pcl-K3KW2e/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h:37:93: note: in instantiation of template class 'std::__1::vector<std::__1::vector<Eigen::Matrix<float, 3, 1,
      0, 3, 1>, std::__1::allocator<Eigen::Matrix<float, 3, 1, 0, 3, 1> > >, Eigen::aligned_allocator<Eigen::Matrix<float, 3, 1, 0, 3, 1> > >' requested here
      std::vector<std::vector<Eigen::Vector3f>, Eigen::aligned_allocator<Eigen::Vector3f> > head_center_votes_clustered_;
                                                                                            ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__config:494:24: note: template is declared here
template <bool> struct __static_assert_test;
                       ^
ls
1 error generated.
make[2]: *** [recognition/CMakeFiles/pcl_recognition.dir/src/face_detection/rf_face_detector_trainer.cpp.o] Error 1
make[1]: *** [recognition/CMakeFiles/pcl_recognition.dir/all] Error 2
make: *** [all] Error 2

```