### PR TITLE
SAC Models Refactoring: getClassName()

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -434,7 +434,7 @@ namespace pcl
         return (computeVariance (error_sqr_dists_));
       }
 
-		protected:
+    protected:
       /** \brief Fills a sample array with random samples from the indices_ vector
         * \param[out] sample the set of indices of target_ to analyze
         */
@@ -629,7 +629,7 @@ namespace pcl
     typedef Eigen::Matrix<Scalar,InputsAtCompileTime,1> InputType;
     typedef Eigen::Matrix<Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
 
-    /** \brief Empty Construtor. */
+    /** \brief Empty Constructor. */
     Functor () : m_data_points_ (ValuesAtCompileTime) {}
 
     /** \brief Constructor

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -348,6 +348,13 @@ namespace pcl
       virtual SacModel 
       getModelType () const = 0;
 
+      /** \brief Get a string representation of the name of this class. */
+      inline const std::string&
+      getClassName () const
+      {
+        return (model_name_);
+      }
+
       /** \brief Return the size of a sample from which a model is computed */
       inline unsigned int 
       getSampleSize () const 
@@ -504,6 +511,9 @@ namespace pcl
         */
       virtual bool
       isSampleGood (const std::vector<int> &samples) const = 0;
+
+      /** \brief The model name. */
+      std::string model_name_;
 
       /** \brief A boost shared pointer to the point cloud data array. */
       PointCloudConstPtr input_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -60,6 +60,7 @@ namespace pcl
   class SampleConsensusModelCircle2D : public SampleConsensusModel<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
@@ -78,7 +79,9 @@ namespace pcl
         */
       SampleConsensusModelCircle2D (const PointCloudConstPtr &cloud, bool random = false) 
         : SampleConsensusModel<PointT> (cloud, random), tmp_inliers_ () 
-      {};
+      {
+        model_name_ = "SampleConsensusModelCircle2D";
+      }
 
       /** \brief Constructor for base SampleConsensusModelCircle2D.
         * \param[in] cloud the input point cloud dataset
@@ -89,7 +92,9 @@ namespace pcl
                                     const std::vector<int> &indices,
                                     bool random = false)
         : SampleConsensusModel<PointT> (cloud, indices, random), tmp_inliers_ ()
-      {};
+      {
+        model_name_ = "SampleConsensusModelCircle2D";
+      }
 
       /** \brief Copy constructor.
         * \param[in] source the model to copy into this
@@ -98,6 +103,7 @@ namespace pcl
         SampleConsensusModel<PointT> (), tmp_inliers_ () 
       {
         *this = source;
+        model_name_ = "SampleConsensusModelCircle2D";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -152,7 +152,7 @@ namespace pcl
                            const double threshold);
 
        /** \brief Recompute the 2d circle coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the 2d circle model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the 2d circle model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the optimization
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -152,7 +152,7 @@ namespace pcl
                            const double threshold);
 
        /** \brief Recompute the 3d circle coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the 3d circle model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the 3d circle model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the optimization
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -61,6 +61,7 @@ namespace pcl
   class SampleConsensusModelCircle3D : public SampleConsensusModel<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
@@ -79,7 +80,10 @@ namespace pcl
         */
       SampleConsensusModelCircle3D (const PointCloudConstPtr &cloud,
                                     bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random) {};
+        : SampleConsensusModel<PointT> (cloud, random)
+      {
+        model_name_ = "SampleConsensusModelCircle3D";
+      }
 
       /** \brief Constructor for base SampleConsensusModelCircle3D.
         * \param[in] cloud the input point cloud dataset
@@ -89,7 +93,10 @@ namespace pcl
       SampleConsensusModelCircle3D (const PointCloudConstPtr &cloud, 
                                     const std::vector<int> &indices,
                                     bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random) {};
+        : SampleConsensusModel<PointT> (cloud, indices, random)
+      {
+        model_name_ = "SampleConsensusModelCircle3D";
+      }
       
       /** \brief Empty destructor */
       virtual ~SampleConsensusModelCircle3D () {}
@@ -101,6 +108,7 @@ namespace pcl
         SampleConsensusModel<PointT> (), tmp_inliers_ () 
       {
         *this = source;
+        model_name_ = "SampleConsensusModelCircle3D";
       }
 
       /** \brief Copy constructor.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -41,6 +41,7 @@
 
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/model_types.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/common/common.h>
 #include <pcl/common/distances.h>
 #include <limits.h>
@@ -274,8 +275,9 @@ namespace pcl
       pointToAxisDistance (const Eigen::Vector4f &pt, const Eigen::VectorXf &model_coefficients);
 
       /** \brief Get a string representation of the name of this class. */
-      std::string 
-      getName () const { return ("SampleConsensusModelCone"); }
+      PCL_DEPRECATED ("[pcl::SampleConsensusModelCone::getName] getName is deprecated. Please use getClassName instead.")
+      std::string
+      getName () const { return (model_name_); }
 
     protected:
       /** \brief Check whether a model is valid given the user constraints.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -163,8 +163,8 @@ namespace pcl
 
       /** \brief Set the minimum and maximum allowable opening angle for a cone model
         * given from a user.
-        * \param[in] min_angle the minimum allwoable opening angle of a cone model
-        * \param[in] max_angle the maximum allwoable opening angle of a cone model
+        * \param[in] min_angle the minimum allowable opening angle of a cone model
+        * \param[in] max_angle the maximum allowable opening angle of a cone model
         */
       inline void
       setMinMaxOpeningAngle (const double &min_angle, const double &max_angle)
@@ -173,9 +173,9 @@ namespace pcl
         max_angle_ = max_angle;
       }
 
-      /** \brief Get the opening angle which we need minumum to validate a cone model.
-        * \param[out] min_angle the minimum allwoable opening angle of a cone model
-        * \param[out] max_angle the maximum allwoable opening angle of a cone model
+      /** \brief Get the opening angle which we need minimum to validate a cone model.
+        * \param[out] min_angle the minimum allowable opening angle of a cone model
+        * \param[out] max_angle the maximum allowable opening angle of a cone model
         */
       inline void
       getMinMaxOpeningAngle (double &min_angle, double &max_angle) const
@@ -224,7 +224,7 @@ namespace pcl
 
 
       /** \brief Recompute the cone coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the cone model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the cone model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the optimization
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -65,6 +65,7 @@ namespace pcl
   class SampleConsensusModelCone : public SampleConsensusModel<PointT>, public SampleConsensusModelFromNormals<PointT, PointNT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
@@ -92,6 +93,7 @@ namespace pcl
         , max_angle_ (std::numeric_limits<double>::max ())
         , tmp_inliers_ ()
       {
+        model_name_ = "SampleConsensusModelCone";
       }
 
       /** \brief Constructor for base SampleConsensusModelCone.
@@ -110,6 +112,7 @@ namespace pcl
         , max_angle_ (std::numeric_limits<double>::max ())
         , tmp_inliers_ ()
       {
+        model_name_ = "SampleConsensusModelCone";
       }
 
       /** \brief Copy constructor.
@@ -121,6 +124,7 @@ namespace pcl
         axis_ (), eps_angle_ (), min_angle_ (), max_angle_ (), tmp_inliers_ ()
       {
         *this = source;
+        model_name_ = "SampleConsensusModelCone";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -43,6 +43,7 @@
 
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/model_types.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/common/common.h>
 #include <pcl/common/distances.h>
 
@@ -274,8 +275,9 @@ namespace pcl
                               Eigen::Vector4f &pt_proj);
 
       /** \brief Get a string representation of the name of this class. */
-      std::string 
-      getName () const { return ("SampleConsensusModelCylinder"); }
+      PCL_DEPRECATED ("[pcl::SampleConsensusModelCylinder::getName] getName is deprecated. Please use getClassName instead.")
+      std::string
+      getName () const { return (model_name_); }
 
     protected:
       /** \brief Check whether a model is valid given the user constraints.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -65,6 +65,7 @@ namespace pcl
   class SampleConsensusModelCylinder : public SampleConsensusModel<PointT>, public SampleConsensusModelFromNormals<PointT, PointNT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
@@ -90,6 +91,7 @@ namespace pcl
         , eps_angle_ (0)
         , tmp_inliers_ ()
       {
+        model_name_ = "SampleConsensusModelCylinder";
       }
 
       /** \brief Constructor for base SampleConsensusModelCylinder.
@@ -106,6 +108,7 @@ namespace pcl
         , eps_angle_ (0)
         , tmp_inliers_ ()
       {
+        model_name_ = "SampleConsensusModelCylinder";
       }
 
       /** \brief Copy constructor.
@@ -119,6 +122,7 @@ namespace pcl
         tmp_inliers_ ()
       {
         *this = source;
+        model_name_ = "SampleConsensusModelCylinder";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -138,7 +138,7 @@ namespace pcl
       }
 
       /** \brief Set the angle epsilon (delta) threshold.
-        * \param[in] ea the maximum allowed difference between the cyilinder axis and the given axis.
+        * \param[in] ea the maximum allowed difference between the cylinder axis and the given axis.
         */
       inline void 
       setEpsAngle (const double ea) { eps_angle_ = ea; }
@@ -196,7 +196,7 @@ namespace pcl
                            const double threshold);
 
       /** \brief Recompute the cylinder coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the cylinder model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the cylinder model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the optimization
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -63,6 +63,7 @@ namespace pcl
   class SampleConsensusModelLine : public SampleConsensusModel<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
@@ -78,7 +79,10 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelLine (const PointCloudConstPtr &cloud, bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random) {};
+        : SampleConsensusModel<PointT> (cloud, random)
+      {
+        model_name_ = "SampleConsensusModelLine";
+      }
 
       /** \brief Constructor for base SampleConsensusModelLine.
         * \param[in] cloud the input point cloud dataset
@@ -88,7 +92,10 @@ namespace pcl
       SampleConsensusModelLine (const PointCloudConstPtr &cloud, 
                                 const std::vector<int> &indices,
                                 bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random) {};
+        : SampleConsensusModel<PointT> (cloud, indices, random)
+      {
+        model_name_ = "SampleConsensusModelLine";
+      }
       
       /** \brief Empty destructor */
       virtual ~SampleConsensusModelLine () {}

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -132,7 +132,7 @@ namespace pcl
                            const double threshold);
 
       /** \brief Recompute the line coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the line model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the line model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the model coefficients
         * \param[out] optimized_coefficients the resultant recomputed coefficients after optimization

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -84,6 +84,7 @@ namespace pcl
   class SampleConsensusModelNormalParallelPlane : public SampleConsensusModelNormalPlane<PointT, PointNT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
@@ -112,6 +113,7 @@ namespace pcl
         , cos_angle_ (-1.0)
         , eps_dist_ (0.0)
       {
+        model_name_ = "SampleConsensusModelNormalParallelPlane";
       }
 
       /** \brief Constructor for base SampleConsensusModelNormalParallelPlane.
@@ -129,6 +131,7 @@ namespace pcl
         , cos_angle_ (-1.0)
         , eps_dist_ (0.0)
       {
+        model_name_ = "SampleConsensusModelNormalParallelPlane";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -76,6 +76,7 @@ namespace pcl
   class SampleConsensusModelNormalPlane : public SampleConsensusModelPlane<PointT>, public SampleConsensusModelFromNormals<PointT, PointNT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
@@ -101,6 +102,7 @@ namespace pcl
         : SampleConsensusModelPlane<PointT> (cloud, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
+        model_name_ = "SampleConsensusModelNormalPlane";
       }
 
       /** \brief Constructor for base SampleConsensusModelNormalPlane.
@@ -114,6 +116,7 @@ namespace pcl
         : SampleConsensusModelPlane<PointT> (cloud, indices, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
+        model_name_ = "SampleConsensusModelNormalPlane";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -69,6 +69,7 @@ namespace pcl
   class SampleConsensusModelNormalSphere : public SampleConsensusModelSphere<PointT>, public SampleConsensusModelFromNormals<PointT, PointNT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
@@ -95,6 +96,7 @@ namespace pcl
         : SampleConsensusModelSphere<PointT> (cloud, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
+        model_name_ = "SampleConsensusModelNormalSphere";
       }
 
       /** \brief Constructor for base SampleConsensusModelNormalSphere.
@@ -108,6 +110,7 @@ namespace pcl
         : SampleConsensusModelSphere<PointT> (cloud, indices, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
+        model_name_ = "SampleConsensusModelNormalSphere";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -66,6 +66,8 @@ namespace pcl
   class SampleConsensusModelParallelLine : public SampleConsensusModelLine<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
+
       typedef typename SampleConsensusModelLine<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelLine<PointT>::PointCloudPtr PointCloudPtr;
       typedef typename SampleConsensusModelLine<PointT>::PointCloudConstPtr PointCloudConstPtr;
@@ -82,6 +84,7 @@ namespace pcl
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {
+        model_name_ = "SampleConsensusModelParallelLine";
       }
 
       /** \brief Constructor for base SampleConsensusModelParallelLine.
@@ -96,6 +99,7 @@ namespace pcl
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {
+        model_name_ = "SampleConsensusModelParallelLine";
       }
 
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -66,6 +66,8 @@ namespace pcl
   class SampleConsensusModelParallelPlane : public SampleConsensusModelPlane<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
+
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr PointCloudConstPtr;
@@ -83,6 +85,7 @@ namespace pcl
         , eps_angle_ (0.0)
         , sin_angle_ (-1.0)
       {
+        model_name_ = "SampleConsensusModelParallelPlane";
       }
 
       /** \brief Constructor for base SampleConsensusModelParallelPlane.
@@ -98,6 +101,7 @@ namespace pcl
         , eps_angle_ (0.0)
         , sin_angle_ (-1.0)
       {
+        model_name_ = "SampleConsensusModelParallelPlane";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -71,6 +71,8 @@ namespace pcl
   class SampleConsensusModelPerpendicularPlane : public SampleConsensusModelPlane<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
+
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr PointCloudConstPtr;
@@ -87,6 +89,7 @@ namespace pcl
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {
+        model_name_ = "SampleConsensusModelPerpendicularPlane";
       }
 
       /** \brief Constructor for base SampleConsensusModelPerpendicularPlane.
@@ -101,6 +104,7 @@ namespace pcl
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {
+        model_name_ = "SampleConsensusModelPerpendicularPlane";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -136,6 +136,7 @@ namespace pcl
   class SampleConsensusModelPlane : public SampleConsensusModel<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
@@ -151,7 +152,10 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelPlane (const PointCloudConstPtr &cloud, bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random) {};
+        : SampleConsensusModel<PointT> (cloud, random)
+      {
+        model_name_ = "SampleConsensusModelPlane";
+      }
 
       /** \brief Constructor for base SampleConsensusModelPlane.
         * \param[in] cloud the input point cloud dataset
@@ -161,7 +165,10 @@ namespace pcl
       SampleConsensusModelPlane (const PointCloudConstPtr &cloud, 
                                  const std::vector<int> &indices,
                                  bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random) {};
+        : SampleConsensusModel<PointT> (cloud, indices, random)
+      {
+        model_name_ = "SampleConsensusModelPlane";
+      }
       
       /** \brief Empty destructor */
       virtual ~SampleConsensusModelPlane () {}

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -205,7 +205,7 @@ namespace pcl
                            const double threshold);
 
       /** \brief Recompute the plane coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the plane model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the plane model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the model coefficients
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -58,6 +58,7 @@ namespace pcl
   class SampleConsensusModelRegistration : public SampleConsensusModel<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
@@ -82,6 +83,7 @@ namespace pcl
       {
         // Call our own setInputCloud
         setInputCloud (cloud);
+        model_name_ = "SampleConsensusModelRegistration";
       }
 
       /** \brief Constructor for base SampleConsensusModelRegistration.
@@ -100,6 +102,7 @@ namespace pcl
       {
         computeOriginalIndexMapping ();
         computeSampleDistanceThreshold (cloud, indices);
+        model_name_ = "SampleConsensusModelRegistration";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -51,6 +51,7 @@ namespace pcl
   class SampleConsensusModelRegistration2D : public pcl::SampleConsensusModelRegistration<PointT>
   {
     public:
+      using pcl::SampleConsensusModelRegistration<PointT>::model_name_;
       using pcl::SampleConsensusModelRegistration<PointT>::input_;
       using pcl::SampleConsensusModelRegistration<PointT>::target_;
       using pcl::SampleConsensusModelRegistration<PointT>::indices_;
@@ -78,6 +79,7 @@ namespace pcl
       {
         // Call our own setInputCloud
         setInputCloud (cloud);
+        model_name_ = "SampleConsensusModelRegistration2D";
       }
 
       /** \brief Constructor for base SampleConsensusModelRegistration2D.
@@ -93,6 +95,7 @@ namespace pcl
       {
         computeOriginalIndexMapping ();
         computeSampleDistanceThreshold (cloud, indices);
+        model_name_ = "SampleConsensusModelRegistration2D";
       }
       
       /** \brief Empty destructor */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -60,6 +60,7 @@ namespace pcl
   class SampleConsensusModelSphere : public SampleConsensusModel<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
@@ -79,7 +80,9 @@ namespace pcl
       SampleConsensusModelSphere (const PointCloudConstPtr &cloud,
                                   bool random = false) 
         : SampleConsensusModel<PointT> (cloud, random), tmp_inliers_ ()
-      {}
+      {
+        model_name_ = "SampleConsensusModelSphere";
+      }
 
       /** \brief Constructor for base SampleConsensusModelSphere.
         * \param[in] cloud the input point cloud dataset
@@ -90,7 +93,9 @@ namespace pcl
                                   const std::vector<int> &indices,
                                   bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random), tmp_inliers_ ()
-      {}
+      {
+        model_name_ = "SampleConsensusModelSphere";
+      }
       
       /** \brief Empty destructor */
       virtual ~SampleConsensusModelSphere () {}
@@ -102,6 +107,7 @@ namespace pcl
         SampleConsensusModel<PointT> (), tmp_inliers_ () 
       {
         *this = source;
+        model_name_ = "SampleConsensusModelSphere";
       }
 
       /** \brief Copy constructor.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -154,7 +154,7 @@ namespace pcl
                            const double threshold);
 
       /** \brief Recompute the sphere coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the sphere model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the sphere model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the optimization
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -136,7 +136,7 @@ namespace pcl
                            const double threshold);
 
       /** \brief Recompute the stick coefficients using the given inlier set and return them to the user.
-        * @note: these are the coefficients of the stick model after refinement (eg. after SVD)
+        * @note: these are the coefficients of the stick model after refinement (e.g. after SVD)
         * \param[in] inliers the data inliers found as supporting the model
         * \param[in] model_coefficients the initial guess for the model coefficients
         * \param[out] optimized_coefficients the resultant recomputed coefficients after optimization
@@ -168,7 +168,7 @@ namespace pcl
                             const Eigen::VectorXf &model_coefficients, 
                             const double threshold);
 
-      /** \brief Return an unique id for this model (SACMODEL_STACK). */
+      /** \brief Return an unique id for this model (SACMODEL_STICK). */
       inline pcl::SacModel 
       getModelType () const { return (SACMODEL_STICK); }
 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -64,6 +64,7 @@ namespace pcl
   class SampleConsensusModelStick : public SampleConsensusModel<PointT>
   {
     public:
+      using SampleConsensusModel<PointT>::model_name_;
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
@@ -82,7 +83,10 @@ namespace pcl
         */
       SampleConsensusModelStick (const PointCloudConstPtr &cloud,
                                  bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random) {};
+        : SampleConsensusModel<PointT> (cloud, random)
+      {
+        model_name_ = "SampleConsensusModelStick";
+      }
 
       /** \brief Constructor for base SampleConsensusModelStick.
         * \param[in] cloud the input point cloud dataset
@@ -92,7 +96,10 @@ namespace pcl
       SampleConsensusModelStick (const PointCloudConstPtr &cloud, 
                                  const std::vector<int> &indices,
                                  bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random) {};
+        : SampleConsensusModel<PointT> (cloud, indices, random)
+      {
+        model_name_ = "SampleConsensusModelStick";
+      }
       
       /** \brief Empty destructor */
       virtual ~SampleConsensusModelStick () {}


### PR DESCRIPTION
I have came across a bug in SAC Sphere model. While investigating how to fix it I have dug in the model sources and was surprised by a large amount of code repetition. Therefore, I decided to do a bit of refactoring together with fixing the bug. I will submit the changes in a series of pull request to simplify review process.

This pull request adds `getClassName()` function to all SAC models. (The same kind of function is contained in many other PCL classes such as `Filter`, `Registration`, `Feature`, etc.). It comes in handy e.g. when logging errors.