### PR TITLE
fix ub in pcl::TimeTrigger

### DIFF
--- a/common/src/time_trigger.cpp
+++ b/common/src/time_trigger.cpp
@@ -123,7 +123,7 @@ pcl::TimeTrigger::stop ()
 void 
 pcl::TimeTrigger::thread_function ()
 {
-  static double time = 0;
+  double time = 0;
   while (!quit_)
   {
     time = getTime ();


### PR DESCRIPTION
If multiple TimeTrigger object exist, their threads write and read the
same static variable. This is an undefined behaviour.