### PR TITLE
SAC Models Refactoring: isModelValid()

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -323,12 +323,8 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
 template <typename PointT> bool 
 pcl::SampleConsensusModelCircle2D<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 3)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCircle2D::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   if (radius_min_ != -std::numeric_limits<double>::max() && model_coefficients[2] < radius_min_)
     return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -439,12 +439,8 @@ pcl::SampleConsensusModelCircle3D<PointT>::doSamplesVerifyModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelCircle3D<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 7)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCircle3D::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   if (radius_min_ != -DBL_MAX && model_coefficients[3] < radius_min_)
     return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -490,13 +490,9 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::pointToAxisDistance (
 template <typename PointT, typename PointNT> bool 
 pcl::SampleConsensusModelCone<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 7)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCone::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
- 
+
   // Check against template, if given
   if (eps_angle_ > 0.0)
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -443,13 +443,9 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPointToCylinder (
 template <typename PointT, typename PointNT> bool 
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 7)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCylinder::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
- 
+
   // Check against template, if given
   if (eps_angle_ > 0.0)
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_parallel_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_parallel_plane.hpp
@@ -47,12 +47,8 @@
 template <typename PointT, typename PointNT> bool
 pcl::SampleConsensusModelNormalParallelPlane<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelNormalParallelPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
@@ -209,12 +209,8 @@ pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::getDistancesToModel (
 template <typename PointT, typename PointNT> bool 
 pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelNormalSphere::selectWithinDistance] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   if (radius_min_ != -std::numeric_limits<double>::max() && model_coefficients[3] < radius_min_)
     return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
@@ -90,12 +90,8 @@ pcl::SampleConsensusModelParallelLine<PointT>::getDistancesToModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelParallelLine<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 6)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusParallelLine::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
@@ -89,12 +89,8 @@ pcl::SampleConsensusModelParallelPlane<PointT>::getDistancesToModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelParallelPlane<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelParallelPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
@@ -89,12 +89,8 @@ pcl::SampleConsensusModelPerpendicularPlane<PointT>::getDistancesToModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelPerpendicularPlane<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelPerpendicularPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/model_types.h
+++ b/sample_consensus/include/pcl/sample_consensus/model_types.h
@@ -68,7 +68,7 @@ namespace pcl
   };
 }
 
-// Define the number of samples in SacModel needs
+// Define the number of samples a SacModel needs
 typedef std::map<pcl::SacModel, unsigned int>::value_type SampleSizeModel;
 const static SampleSizeModel sample_size_pairs[] = {SampleSizeModel (pcl::SACMODEL_PLANE, 3),
                                                     SampleSizeModel (pcl::SACMODEL_LINE, 2),
@@ -89,10 +89,33 @@ const static SampleSizeModel sample_size_pairs[] = {SampleSizeModel (pcl::SACMOD
                                                     SampleSizeModel (pcl::SACMODEL_NORMAL_PARALLEL_PLANE, 3),
                                                     SampleSizeModel (pcl::SACMODEL_STICK, 2)};
 
+// Define the number of model coefficients in a SacModel
+typedef std::map<pcl::SacModel, unsigned int>::value_type ModelSizeModel;
+const static ModelSizeModel model_size_pairs[] =   {SampleSizeModel (pcl::SACMODEL_PLANE, 4),
+                                                    SampleSizeModel (pcl::SACMODEL_LINE, 6),
+                                                    SampleSizeModel (pcl::SACMODEL_CIRCLE2D, 3),
+                                                    SampleSizeModel (pcl::SACMODEL_CIRCLE3D, 7),
+                                                    SampleSizeModel (pcl::SACMODEL_SPHERE, 4),
+                                                    SampleSizeModel (pcl::SACMODEL_CYLINDER, 7),
+                                                    SampleSizeModel (pcl::SACMODEL_CONE, 7),
+                                                    //SampleSizeModel (pcl::SACMODEL_TORUS, ),
+                                                    SampleSizeModel (pcl::SACMODEL_PARALLEL_LINE, 6),
+                                                    SampleSizeModel (pcl::SACMODEL_PERPENDICULAR_PLANE, 4),
+                                                    //SampleSizeModel (pcl::PARALLEL_LINES, ),
+                                                    SampleSizeModel (pcl::SACMODEL_NORMAL_PLANE, 4),
+                                                    SampleSizeModel (pcl::SACMODEL_NORMAL_SPHERE, 4),
+                                                    SampleSizeModel (pcl::SACMODEL_REGISTRATION, 16),
+                                                    SampleSizeModel (pcl::SACMODEL_REGISTRATION_2D, 16),
+                                                    SampleSizeModel (pcl::SACMODEL_PARALLEL_PLANE, 4),
+                                                    SampleSizeModel (pcl::SACMODEL_NORMAL_PARALLEL_PLANE, 4),
+                                                    SampleSizeModel (pcl::SACMODEL_STICK, 7)};
+
 namespace pcl
 {
   const static std::map<pcl::SacModel, unsigned int> SAC_SAMPLE_SIZE (sample_size_pairs, sample_size_pairs
       + sizeof (sample_size_pairs) / sizeof (SampleSizeModel));
+  const static std::map<pcl::SacModel, unsigned int> SAC_MODEL_SIZE (model_size_pairs, model_size_pairs
+      + sizeof (model_size_pairs) / sizeof (ModelSizeModel));
 }
 
 #endif  //#ifndef PCL_SAMPLE_CONSENSUS_MODEL_TYPES_H_

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -510,10 +510,22 @@ namespace pcl
       }
 
       /** \brief Check whether a model is valid given the user constraints.
+        *
+        * Default implementation verifies that the number of coefficients in the supplied model is as expected for this
+        * SAC model type. Specific SAC models should extend this function by checking the user constraints (if any).
+        *
         * \param[in] model_coefficients the set of model coefficients
         */
-      virtual inline bool
-      isModelValid (const Eigen::VectorXf &model_coefficients) = 0;
+      virtual bool
+      isModelValid (const Eigen::VectorXf &model_coefficients)
+      {
+        if (model_coefficients.size () != getModelSize ())
+        {
+          PCL_ERROR ("[pcl::%s::isModelValid] Invalid number of model coefficients given (%lu)!\n", getClassName ().c_str (), model_coefficients.size ());
+          return (false);
+        }
+        return (true);
+      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices. Pure virtual.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -365,6 +365,16 @@ namespace pcl
         return (it->second);
       }
 
+      /** \brief Return the number of coefficients in the model. */
+      inline unsigned int
+      getModelSize () const
+      {
+        std::map<pcl::SacModel, unsigned int>::const_iterator it = SAC_MODEL_SIZE.find (getModelType ());
+        if (it == SAC_MODEL_SIZE.end ())
+          throw InvalidSACModelTypeException ("No model size defined for given model type!\n");
+        return (it->second);
+      }
+
       /** \brief Set the minimum and maximum allowable radius limits for the
         * model (applicable to models that estimate a radius)
         * \param[in] min_radius the minimum radius model

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -66,6 +66,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -198,7 +199,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -66,6 +66,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -200,7 +201,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -74,6 +74,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -283,7 +284,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -74,6 +74,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -283,7 +284,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -67,6 +67,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -176,20 +177,6 @@ namespace pcl
       getModelType () const { return (SACMODEL_LINE); }
 
     protected:
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool 
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        if (model_coefficients.size () != 6)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelLine::selectWithinDistance] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
-          return (false);
-        }
-
-        return (true);
-      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -90,6 +90,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -188,7 +189,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
    private:

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -82,7 +82,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModelPlane<PointT>::isModelValid;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -77,6 +77,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -153,7 +154,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
   };

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -67,6 +67,7 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelLine<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelLine<PointT>::PointCloudPtr PointCloudPtr;
@@ -160,7 +161,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
     protected:

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -67,6 +67,7 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
@@ -164,7 +165,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief The axis along which we need to search for a plane perpendicular to. */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -72,6 +72,7 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
@@ -167,7 +168,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief The axis along which we need to search for a plane perpendicular to. */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -140,6 +140,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -247,22 +248,6 @@ namespace pcl
       /** \brief Return an unique id for this model (SACMODEL_PLANE). */
       inline pcl::SacModel 
       getModelType () const { return (SACMODEL_PLANE); }
-
-    protected:
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool 
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        // Needs a valid model coefficients
-        if (model_coefficients.size () != 4)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
-          return (false);
-        }
-        return (true);
-      }
 
     private:
       /** \brief Check if a sample of indices results in a good sample of points

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -62,6 +62,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -214,18 +215,6 @@ namespace pcl
       getModelType () const { return (SACMODEL_REGISTRATION); }
 
     protected:
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        // Needs a valid model coefficients
-        if (model_coefficients.size () != 16)
-          return (false);
-
-        return (true);
-      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -60,6 +60,7 @@ namespace pcl
       using pcl::SampleConsensusModelRegistration<PointT>::correspondences_;
       using pcl::SampleConsensusModelRegistration<PointT>::sample_dist_thresh_;
       using pcl::SampleConsensusModelRegistration<PointT>::computeOriginalIndexMapping;
+      using pcl::SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename pcl::SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename pcl::SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -66,6 +66,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -200,15 +201,11 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      inline bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients)
       {
-        // Needs a valid model coefficients
-        if (model_coefficients.size () != 4)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelSphere::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+        if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
           return (false);
-        }
 
         if (radius_min_ != -std::numeric_limits<double>::max() && model_coefficients[3] < radius_min_)
           return (false);

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -70,6 +70,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -180,20 +181,6 @@ namespace pcl
       getModelType () const { return (SACMODEL_STICK); }
 
     protected:
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool 
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        if (model_coefficients.size () != 7)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelStick::selectWithinDistance] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
-          return (false);
-        }
-
-        return (true);
-      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices.


### PR DESCRIPTION
The `isModelValid()` function in every SAC model class begins by verifying that the number of coefficients in the passed model is as expected. This pull request extracts this check into the base implementation of this function.