### PR TITLE
Fix a bug in PointCloudColorHandlerLabelField

### DIFF
--- a/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
+++ b/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
@@ -539,7 +539,10 @@ pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor (vtkSmart
   {
     if (pcl::isFinite (cloud_->points[cp]))
     {
-      memcpy (&colors[j], &colormap[cloud_->points[cp].label].rgba, 3);
+      const pcl::RGB& color = colormap[cloud_->points[cp].label];
+      colors[j    ] = color.r;
+      colors[j + 1] = color.g;
+      colors[j + 2] = color.b;
       j += 3;
     }
   }

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -654,7 +654,10 @@ pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getCo
       if (!pcl_isfinite (x_data) || !pcl_isfinite (y_data) || !pcl_isfinite (z_data))
         continue;
 
-      memcpy (&colors[j], &colormap[label].rgba, 3);
+      const pcl::RGB& color = colormap[label];
+      colors[j    ] = color.r;
+      colors[j + 1] = color.g;
+      colors[j + 2] = color.b;
       j += 3;
     }
   }
@@ -666,7 +669,11 @@ pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getCo
     {
       uint32_t label;
       memcpy (&label, &cloud_->data[point_offset], field_size);
-      memcpy (&colors[j], &colormap[label].rgba, 3);
+
+      const pcl::RGB& color = colormap[label];
+      colors[j    ] = color.r;
+      colors[j + 1] = color.g;
+      colors[j + 2] = color.b;
       j += 3;
     }
   }


### PR DESCRIPTION
`memcpy` should not be used to copy the contents of `pcl::RGB` variables into a _vtk_ color scalars array, because it results in red and blue channels being swapped in visualizer.