### PR TITLE
visualization::PCLVisualizer setupInteractor:

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -320,6 +320,7 @@ pcl::visualization::PCLVisualizer::setupInteractor (
   vtkRenderWindowInteractor *iren,
   vtkRenderWindow *win)
 {
+  assert(("You shouldn't create interactor when setup an interactor!",interactor_==NULL));
   win->AlphaBitPlanesOff ();
   win->PointSmoothingOff ();
   win->LineSmoothingOff ();
@@ -334,26 +335,11 @@ pcl::visualization::PCLVisualizer::setupInteractor (
 
   // Initialize and create timer, also create window
   iren->Initialize ();
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 4))
-#else
-  timer_id_ = iren->CreateRepeatingTimer (5000L);
-#endif
 
   // Set a simple PointPicker
   vtkSmartPointer<vtkPointPicker> pp = vtkSmartPointer<vtkPointPicker>::New ();
   pp->SetTolerance (pp->GetTolerance () * 2);
   iren->SetPicker (pp);
-
-  exit_main_loop_timer_callback_ = vtkSmartPointer<ExitMainLoopTimerCallback>::New ();
-  exit_main_loop_timer_callback_->pcl_visualizer = this;
-  exit_main_loop_timer_callback_->right_timer_id = -1;
-  iren->AddObserver (vtkCommand::TimerEvent, exit_main_loop_timer_callback_);
-
-  exit_callback_ = vtkSmartPointer<ExitCallback>::New ();
-  exit_callback_->pcl_visualizer = this;
-  iren->AddObserver (vtkCommand::ExitEvent, exit_callback_);
-
-  resetStoppedFlag ();
 }
 
 
@@ -364,6 +350,7 @@ pcl::visualization::PCLVisualizer::setupInteractor (
   vtkRenderWindow *win,
   vtkInteractorStyle *style)
 {
+  assert(("You shouldn't create interactor when setup an interactor!",interactor_==NULL));
   win->AlphaBitPlanesOff ();
   win->PointSmoothingOff ();
   win->LineSmoothingOff ();
@@ -378,26 +365,6 @@ pcl::visualization::PCLVisualizer::setupInteractor (
 
   // Initialize and create timer, also create window
   iren->Initialize ();
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 4))
-#else
-  timer_id_ = iren->CreateRepeatingTimer (5000L);
-#endif
-
-  // Set a simple PointPicker
-  // vtkSmartPointer<vtkPointPicker> pp = vtkSmartPointer<vtkPointPicker>::New ();
-  // pp->SetTolerance (pp->GetTolerance () * 2);
-  // iren->SetPicker (pp);
-
-  exit_main_loop_timer_callback_ = vtkSmartPointer<ExitMainLoopTimerCallback>::New ();
-  exit_main_loop_timer_callback_->pcl_visualizer = this;
-  exit_main_loop_timer_callback_->right_timer_id = -1;
-  iren->AddObserver (vtkCommand::TimerEvent, exit_main_loop_timer_callback_);
-
-  exit_callback_ = vtkSmartPointer<ExitCallback>::New ();
-  exit_callback_->pcl_visualizer = this;
-  iren->AddObserver (vtkCommand::ExitEvent, exit_callback_);
-
-  resetStoppedFlag ();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Assert to use it only when interactor_ is NULL

The resetStoppedFlag works only when interactor_ is not NULL
The ExitMainLoopTimerCallback uses the interactor_ so it can crash
The ExitCallback uses the interactor_ so it can crash
If we don't have callbacks we don't have to create the timer. (and don't have to destroy)