### PR TITLE
Fix: wrong position and scale of context items when resizing ImageViewer (vtk6)

### DIFF
--- a/visualization/include/pcl/visualization/image_viewer.h
+++ b/visualization/include/pcl/visualization/image_viewer.h
@@ -53,6 +53,9 @@
 
 #include <vtkVersion.h>
 #include <vtkInteractorStyleImage.h>
+#if VTK_MAJOR_VERSION >= 6
+#include <vtkOpenGLContextActor.h>
+#endif
 
 class vtkImageSlice;
 class vtkContextActor;
@@ -67,6 +70,29 @@ namespace pcl
     static const Vector3ub green_color (0, 255, 0);
     static const Vector3ub red_color (255, 0, 0);
     static const Vector3ub blue_color (0, 0, 255);
+
+#if VTK_MAJOR_VERSION >= 6
+    /** \brief A special context actor for emulating the window resizing referring to 'vtkImageSlice'
+      * \author Michael Dingerkus
+      * \ingroup visualization
+      */
+    class PCL_EXPORTS ContextActor : public vtkOpenGLContextActor
+    {
+      public:
+        vtkTypeMacro(ContextActor, vtkOpenGLContextActor);
+
+        static ContextActor* New ();
+        ContextActor ();
+
+        virtual int RenderOverlay (vtkViewport *viewport);
+
+        static bool initial_viewport_set_;
+        static int initial_viewport_x_size_;
+        static int initial_viewport_y_size_;
+        static double initial_viewport_x_aspect_;
+        static double initial_viewport_y_aspect_;
+    };
+#endif
 
     /** \brief An image viewer interactor style, tailored for ImageViewer.
       * \author Radu B. Rusu


### PR DESCRIPTION
#1049 ...I think the only way to get the same resize behaviour than with 'vtkImageSlice', is to derive a new class of the context items context actor, which is drawing them, und to override its drawing function. After some testing I can say that this emulation function ('RenderOverlay') leads to precise results:

Before patch:
![imageviewer - vtk6 2 - before patch](https://cloud.githubusercontent.com/assets/4068805/5707057/f91b844c-9a85-11e4-8512-12c654370dc7.jpg)

After patch:
![imageviewer - vtk6 2 - after patch](https://cloud.githubusercontent.com/assets/4068805/5707069/0e639fba-9a86-11e4-8bbf-403fc79a1928.jpg)
