### PR TITLE
added float.h include to fix FLT_MAX and FLT_MIN not found problem

### DIFF
--- a/gpu/octree/src/cuda/octree_builder.cu
+++ b/gpu/octree/src/cuda/octree_builder.cu
@@ -34,6 +34,7 @@
  *  Author: Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
  */
 
+#include <cfloat>
 #include "internal.hpp"
 
 #include "pcl/gpu/utils/timers_cuda.hpp"


### PR DESCRIPTION
Added float.h to avoid FLT_MAX and FLT_MIN not found problem when compiling pcl with cuda 7