### PR TITLE
4PCS clang compile error bugfix

### DIFF
--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -554,8 +554,8 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   }
 
   // set intersection ratios
-  ratio[0] = (std::fabsf (sN) < small_error_) ? 0.f : sN / sD;
-  ratio[1] = (std::fabsf (tN) < small_error_) ? 0.f : tN / tD;
+  ratio[0] = (std::abs <float> (sN) < small_error_) ? 0.f : sN / sD;
+  ratio[1] = (std::abs <float> (tN) < small_error_) ? 0.f : tN / tD;
 
   Eigen::Vector3f x = w + (ratio[0] * u) - (ratio[1] * v);
   return (x.norm ());

--- a/test/registration/test_fpcs_ia.cpp
+++ b/test/registration/test_fpcs_ia.cpp
@@ -33,8 +33,6 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *
-* $Id$
-*
 */
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
replaced std::fabsf with std::abs <float> to get rid of clang compile error