### PR TITLE
Fix compilation issues for ia_fpcs

### DIFF
--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -63,7 +63,7 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
 #ifdef _OPENMP
 #pragma omp parallel for \
   reduction (+:mean_dist, num) \
-  private (ids, dists_sqr) shared (s, tree, cloud, indices, max_dist_sqr) \
+  private (ids, dists_sqr) shared (tree, cloud) \
   default (none)num_threads (nr_threads)
 #endif
 
@@ -100,7 +100,7 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
 #ifdef _OPENMP
 #pragma omp parallel for \
   reduction (+:mean_dist, num) \
-  private (ids, dists_sqr) shared (s, tree, cloud, indices, max_dist_sqr) \
+  private (ids, dists_sqr) shared (tree, cloud, indices)    \
   default (none)num_threads (nr_threads)
 #endif
 


### PR DESCRIPTION
The OpenMP directive failed with some variables predetermined shared
and some directives where there was no such local variable.