### PR TITLE
simplify smart ptr handling in Cloud::draw

### DIFF
--- a/apps/point_cloud_editor/src/cloud.cpp
+++ b/apps/point_cloud_editor/src/cloud.cpp
@@ -254,15 +254,8 @@ Cloud::drawWithHighlightColor () const
 void
 Cloud::draw (bool disable_highlight) const
 {
-  SelectionPtr selection_ptr;
-  try
-  {
-    selection_ptr = selection_wk_ptr_.lock();
-  }
-  catch (boost::bad_weak_ptr)
-  {
-    selection_ptr.reset();
-  }
+  SelectionPtr selection_ptr = selection_wk_ptr_.lock();
+
   glPushAttrib(GL_CURRENT_BIT | GL_POINT_BIT | GL_COLOR_BUFFER_BIT);
   {
     glPointSize(point_size_);


### PR DESCRIPTION
weak_ptr’s lock() never throws
shared_ptr(shared_ptr const & r) never throws too