### PR TITLE
Fix missing include in hough_3d.

### DIFF
--- a/recognition/include/pcl/recognition/cg/hough_3d.h
+++ b/recognition/include/pcl/recognition/cg/hough_3d.h
@@ -42,6 +42,7 @@
 
 #include <pcl/recognition/cg/correspondence_grouping.h>
 #include <pcl/recognition/boost.h>
+#include <pcl/point_types.h>
 
 namespace pcl
 {


### PR DESCRIPTION
Added a missing include file (pcl/point_types.h) to pcl/recognition/cg/hough_3d.h to remove a dependency on file include orders. 

