### PR TITLE
Added optional polygon line width to visualizer

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1371,23 +1371,27 @@ namespace pcl
           * \param[in] polydata vtkPolyData
           * \param[in] id the model id/name (default: "PolyData")
           * \param[in] viewport (optional) the id of the new viewport (default: 0)
+          * \param[in] width (optional) the width of the polygon lines in pixels (default: 1.0)
           */
         bool
         addModelFromPolyData (vtkSmartPointer<vtkPolyData> polydata,
                               const std::string & id = "PolyData",
-                              int viewport = 0);
+                              int viewport = 0,
+                              float width = 1.0f);
 
         /** \brief Add a vtkPolydata as a mesh
           * \param[in] polydata vtkPolyData
           * \param[in] transform transformation to apply
           * \param[in] id the model id/name (default: "PolyData")
           * \param[in] viewport (optional) the id of the new viewport (default: 0)
+          * \param[in] width (optional) the width of the polygon lines in pixels (default: 1.0)
           */
         bool
         addModelFromPolyData (vtkSmartPointer<vtkPolyData> polydata,
                               vtkSmartPointer<vtkTransform> transform,
                               const std::string &id = "PolyData",
-                              int viewport = 0);
+                              int viewport = 0,
+                              float width = 1.0f);
 
         /** \brief Add a PLYmodel as a mesh
           * \param[in] filename of the ply file

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -2123,7 +2123,7 @@ pcl::visualization::PCLVisualizer::addSphere (const pcl::ModelCoefficients &coef
 ////////////////////////////////////////////////////////////////////////////////////////////
 bool
 pcl::visualization::PCLVisualizer::addModelFromPolyData (
-    vtkSmartPointer<vtkPolyData> polydata, const std::string & id, int viewport)
+    vtkSmartPointer<vtkPolyData> polydata, const std::string & id, int viewport, float width)
 {
   ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
@@ -2137,6 +2137,7 @@ pcl::visualization::PCLVisualizer::addModelFromPolyData (
   vtkSmartPointer<vtkLODActor> actor;
   createActorFromVTKDataSet (polydata, actor);
   actor->GetProperty ()->SetRepresentationToWireframe ();
+  actor->GetProperty ()->SetLineWidth (width);
   addActorToRenderer (actor, viewport);
 
   // Save the pointer/ID pair to the global actor map
@@ -2147,7 +2148,7 @@ pcl::visualization::PCLVisualizer::addModelFromPolyData (
 ////////////////////////////////////////////////////////////////////////////////////////////
 bool
 pcl::visualization::PCLVisualizer::addModelFromPolyData (
-    vtkSmartPointer<vtkPolyData> polydata, vtkSmartPointer<vtkTransform> transform, const std::string & id, int viewport)
+    vtkSmartPointer<vtkPolyData> polydata, vtkSmartPointer<vtkTransform> transform, const std::string & id, int viewport, float width)
 {
   ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
@@ -2171,6 +2172,7 @@ pcl::visualization::PCLVisualizer::addModelFromPolyData (
   vtkSmartPointer <vtkLODActor> actor;
   createActorFromVTKDataSet (trans_filter->GetOutput (), actor);
   actor->GetProperty ()->SetRepresentationToWireframe ();
+  actor->GetProperty ()->SetLineWidth (width);
   addActorToRenderer (actor, viewport);
 
   // Save the pointer/ID pair to the global actor map


### PR DESCRIPTION
This is a quick addition to the visualizer.
When adding a polygon you now can set the line width for the display.
Before it was fixed at 1 px (which is still the default).
It is especially useful for the Supervoxel as well as the LCCP example.
