### PR TITLE
fix "index out of bounds" in pcl::LineRGBD::refineDetectionsAlongDepth()

### DIFF
--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -663,10 +663,12 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
     typename LineRGBD<PointXYZT, PointRGBT>::Detection & detection = detections_[detection_index];
 
     // find depth with most valid points
-    const size_t start_x = detection.region.x;
-    const size_t start_y = detection.region.y;
-    const size_t end_x = start_x + detection.region.width;
-    const size_t end_y = start_y + detection.region.height;
+    const size_t start_x = std::max (detection.region.x, 0);
+    const size_t start_y = std::max (detection.region.y, 0);
+    const size_t end_x = std::min (static_cast<size_t> (detection.region.x + detection.region.width),
+                                   static_cast<size_t> (cloud_xyz_->width));
+    const size_t end_y = std::min (static_cast<size_t> (detection.region.y + detection.region.height),
+                                   static_cast<size_t> (cloud_xyz_->height));
 
 
     float min_depth = std::numeric_limits<float>::max ();


### PR DESCRIPTION
LineRGBD::detect() crashes when the detected region is partially off screen.
This patch should fix the problem.