### PR TITLE
Fix NaN values handling in PCLPlotter

### DIFF
--- a/visualization/include/pcl/visualization/pcl_plotter.h
+++ b/visualization/include/pcl/visualization/pcl_plotter.h
@@ -465,6 +465,7 @@ namespace pcl
           * \param[in] data data who's frequency distribution is to be found
           * \param[in] nbins number of bins for the histogram
           * \param[out] histogram vector of pairs containing the histogram. The first field of the pair represent the middle value of the corresponding bin. The second field denotes the frequency of data in that bin.
+          * \note NaN values will be ignored!
           */
         void 
         computeHistogram (std::vector<double> const & data, int const nbins, std::vector<std::pair<double, double> > &histogram);

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -592,8 +592,11 @@ pcl::visualization::PCLPlotter::computeHistogram (
   double min = data[0], max = data[0];
   for (size_t i = 1; i < data.size (); i++)
   {
-    if (data[i] < min) min = data[i];
-    if (data[i] > max) max = data[i];
+    if (pcl_isfinite (data[i]))
+    {
+      if (data[i] < min) min = data[i];
+      if (data[i] > max) max = data[i];
+    }
   }
 
   //finding the size of each bins
@@ -609,9 +612,12 @@ pcl::visualization::PCLPlotter::computeHistogram (
   //fill the freq for each data
   for (size_t i = 0; i < data.size (); i++)
   {
-    int index = int (floor ((data[i] - min) / size));
-    if (index == nbins) index = nbins - 1; //including right boundary
-    histogram[index ].second++;
+    if (pcl_isfinite (data[i]))
+    {
+      unsigned int index = (unsigned int) (floor ((data[i] - min) / size));
+      if (index == nbins) index = nbins - 1; //including right boundary
+      histogram[index].second++;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1118 

Index must be positive
NaN values should be ignored