### PR TITLE
pcd_grabber fix destruction

### DIFF
--- a/io/include/pcl/io/pcd_grabber.h
+++ b/io/include/pcl/io/pcd_grabber.h
@@ -160,7 +160,10 @@ namespace pcl
       PCDGrabber (const std::vector<std::string>& pcd_files, float frames_per_second = 0, bool repeat = false);
       
       /** \brief Virtual destructor. */
-      virtual ~PCDGrabber () throw () {}
+      virtual ~PCDGrabber () throw ()
+      {
+        stop ();
+      }
     
       // Inherited from FileGrabber
       const boost::shared_ptr< const pcl::PointCloud<PointT> >

--- a/io/src/pcd_grabber.cpp
+++ b/io/src/pcd_grabber.cpp
@@ -387,7 +387,6 @@ pcl::PCDGrabberBase::PCDGrabberBase (const std::vector<std::string>& pcd_files, 
 ///////////////////////////////////////////////////////////////////////////////////////////
 pcl::PCDGrabberBase::~PCDGrabberBase () throw ()
 {
-  stop ();
   delete impl_;
 }
 


### PR DESCRIPTION
PCDGrabberImpl::trigger () use the PCDGrabber\<PointT\>'s publish () virtual function, so the ~PCDGrabber\<PointT\> should stop the PCDGrabberBase