### PR TITLE
fixed hdl grabber according to velodyne manual

### DIFF
--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -425,11 +425,11 @@ pcl::HDLGrabber::computeXYZI (pcl::PointXYZI& point, int azimuth,
 
   distanceM += correction.distanceCorrection;
 
-  double xyDistance = distanceM * correction.cosVertCorrection - correction.sinVertOffsetCorrection;
+  double xyDistance = distanceM * correction.cosVertCorrection;
 
   point.x = static_cast<float> (xyDistance * sinAzimuth - correction.horizontalOffsetCorrection * cosAzimuth);
   point.y = static_cast<float> (xyDistance * cosAzimuth + correction.horizontalOffsetCorrection * sinAzimuth);
-  point.z = static_cast<float> (distanceM * correction.sinVertCorrection + correction.cosVertOffsetCorrection);
+  point.z = static_cast<float> (distanceM * correction.sinVertCorrection + correction.verticalOffsetCorrection);
   point.intensity = static_cast<float> (laserReturn.intensity);
 }
 


### PR DESCRIPTION
The changed code differs from the [velodyne official manual] (http://www.velodynelidar.com/lidar/products/manual/63-HDL64ES2h%20HDL-64E%20S2%20CD%20HDL-64E%20S2%20Users%20Manual.pdf), at approx page 31. Same issue is also being discussed with the developer of VeloView.