### PR TITLE
Added installation of metslib includes if we are using the internal version

### DIFF
--- a/recognition/CMakeLists.txt
+++ b/recognition/CMakeLists.txt
@@ -166,4 +166,8 @@ if(build)
     PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/linemod" ${LINEMOD_INCLUDES})
     PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/impl/linemod" ${LINEMOD_IMPLS})
 
+    if (NOT HAVE_METSLIB)
+        PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/3rdparty/metslib" ${metslib_incs})
+    endif(NOT HAVE_METSLIB)
+
 endif(build)


### PR DESCRIPTION
If an external version of metslib was not found, the include files in pcl/recognition/3rdparty/metslib/ do not get installed into {prefix}/include. This results in the following compile error when using global hypothesis verification

/usr/local/include/pcl-1.8/pcl/recognition/hv/hv_go.h:14:52: fatal error: pcl/recognition/3rdparty/metslib/mets.hh: No such file or directory
