### PR TITLE
[WIP] Set default alpha value to 255

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -339,7 +339,8 @@ namespace pcl
 
     inline RGB ()
     {
-      r = g = b = a = 0;
+      r = g = b = 0;
+      a = 255;
     }
   
     friend std::ostream& operator << (std::ostream& os, const RGB& p);


### PR DESCRIPTION
I think we should set the alpha value to 255 in the [pcl::RGB](http://docs.pointclouds.org/trunk/structpcl_1_1_r_g_b.html) struct.
This fixes the second test case of #1040.