### PR TITLE
New variant of addModelFromPolyData

### DIFF
--- a/visualization/include/pcl/visualization/common/common.h
+++ b/visualization/include/pcl/visualization/common/common.h
@@ -100,7 +100,8 @@ namespace pcl
       PCL_VISUALIZER_COLOR,
       PCL_VISUALIZER_REPRESENTATION,
       PCL_VISUALIZER_IMMEDIATE_RENDERING,
-      PCL_VISUALIZER_SHADING
+      PCL_VISUALIZER_SHADING,
+      PCL_VISUALIZER_LUT
     };
 
     enum RenderingRepresentationProperties
@@ -115,6 +116,17 @@ namespace pcl
       PCL_VISUALIZER_SHADING_FLAT,
       PCL_VISUALIZER_SHADING_GOURAUD,
       PCL_VISUALIZER_SHADING_PHONG
+    };
+
+    /*! Look up table for color representation of vtkPolyDataMapper.\n
+     * See [mathworks colormap page](http://www.mathworks.com/help/matlab/ref/colormap.html#input_argument_name) for images representations of the LUTs */
+    enum LookUpTableRepresentationProperties
+    { //
+      PCL_VISUALIZER_LUT_JET,
+      PCL_VISUALIZER_LUT_JET_INVERSE,
+      PCL_VISUALIZER_LUT_HSV,
+      PCL_VISUALIZER_LUT_HSV_INVERSE,
+      PCL_VISUALIZER_LUT_GREY
     };
 
     //////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1403,6 +1403,18 @@ namespace pcl
                               const std::string &id = "PolyData",
                               int viewport = 0);
 
+        /** \brief Add a vtkPolyDataMapper as a mesh
+         * \param[in] polydatamapper vtkPolyDataMapper
+         * \param[in] id the model id/name (default: "PolyDataMapper")
+         * \param[in] viewport (optional) the id of the new viewport (default: 0)
+         * \return True if successful, false otherwise
+         * \note This allows to display a colored mesh, also see \ref PCL_VISUALIZER_LUT.
+         */
+       bool
+       addModelFromPolyData (vtkSmartPointer<vtkPolyDataMapper> polydatamapper,
+                             const std::string & id = "PolyDataMapper",
+                             int viewport = 0);
+
         /** \brief Add a PLYmodel as a mesh
           * \param[in] filename of the ply file
           * \param[in] id the model id/name (default: "PLYModel")


### PR DESCRIPTION
This allows to easily display colored meshes
- This adds a variant of the `addModelFromPolyData` function
- I also added visualization properties to choose the LookUpTable, it allows to control which color correspond to which value; note that this can be safely called even if the mesh has no color information (see [`case PCL_VISUALIZER_LUT`](https://github.com/PointCloudLibrary/pcl/pull/1143/files#diff-9c03ff6eb25cf5a57bad531b4ab8d9f3R1582)).

Test code
---
```cpp
#include <pcl/console/parse.h>
#include <pcl/point_types.h>
#include <pcl/io/ply_io.h>
#include <pcl/io/vtk_lib_io.h>
#include <pcl/search/kdtree.h>
#include <pcl/visualization/pcl_visualizer.h>

/** Determines whether to color the cloud with next LUT or not */
bool next_LUT_coloring = false;

/** @brief Convenience typedef */
typedef pcl::PointXYZRGB PointT;

/** @brief Convenience typedef */
typedef pcl::PointCloud<pcl::PointXYZRGB> PointCloudT;

/** @brief Prints the program help
 * @param[in] argc
 * @param[in] argv
 */
void
printHelp (int argc,
           char **argv)
{
  pcl::console::print_error ("Syntax is: %s mesh_a.ply mesh_b.ply -d\n", argv[0]);
  pcl::console::print_error ("                                (CAD)       (scan)\n\n");
  pcl::console::print_error ("The PLY files must be meshes and not only point clouds.\n", argv[0]);
}

/** @brief Compute the Euclidian distance from mesh_in to the closest point of mesh_out
 * @param[in] mesh_a the first input mesh
 * @param[in] mesh_b the second input mesh
 * @param[out] sqr_mesh_distances the distance vector to be filled
 * @note mesh_a = Computer Aided Design (CAD), mesh_b = scan
 * @warning The meshes should be aligned before computing these distances
 @remark PolygonMesh stores clouds as PointCloud2, an internal conversion to a PointCloud is done, this is not efficient.
 */
void
computeEuclidianDistance (const pcl::PolygonMesh &mesh_a,
                          const pcl::PolygonMesh &mesh_b,
                          vtkSmartPointer<vtkFloatArray> &sqr_mesh_distances)
{
  PointCloudT cloud_a, cloud_b;
  pcl::fromPCLPointCloud2 (mesh_a.cloud, cloud_a);
  pcl::fromPCLPointCloud2 (mesh_b.cloud, cloud_b);

  // Compare A to B
  pcl::search::KdTree<PointT> tree_b;
  tree_b.setInputCloud (cloud_b.makeShared ());

  // Fill distances for each point
  for (size_t i = 0; i < cloud_a.size (); ++i)
  {
    std::vector<int> indices (1);
    std::vector<float> sqr_distances (1);

    tree_b.nearestKSearch (cloud_a.points[i], 1, indices, sqr_distances);
    sqr_mesh_distances->InsertTuple1 (i, std::sqrt (sqr_distances[0]));

    if (i % 5000 == 0 && i != 0)
      PCL_INFO("i = %d\n", i); // Print info every 5000 points computed
  }
}

/** @brief Callback to manage keyboard events in the viewer
 * @param[in] event the keyboard event
 * @param[in] nothing nothing
 *
 * @c space: Change the coloring mode of the cloud.
 */
void
keyboardEventOccurred (const pcl::visualization::KeyboardEvent& event,
                       void* nothing)
{
  if (event.getKeySym () == "space" && event.keyDown ())
    next_LUT_coloring = true;
}

/** @brief Main
 * @param[in] argc
 * @param[in] argv
 * @returns 0 if successful
 */
int
main (int argc,
      char** argv)
{
  if (argc < 3)
  {
    printHelp (argc, argv);
    return (-1);
  }
  // Parse the command line arguments for .ply files
  std::vector<int> p_file_indices;
  p_file_indices = pcl::console::parse_file_extension_argument (argc, argv, ".ply");
  if (p_file_indices.size () != 2)
  {
    pcl::console::print_error ("Need two PLY meshes to compute Euclidian distance.\n");
    return (-1);
  }

  pcl::PolygonMesh mesh_a, mesh_b;
  // Strange return value from loadPolygonFilePLY
  if (pcl::io::loadPolygonFilePLY (argv[p_file_indices[0]], mesh_a) == 0 || pcl::io::loadPolygonFilePLY (argv[p_file_indices[1]], mesh_b) == 0)
  {
    PCL_ERROR("Failed to read PLY file\n");
    return -1;
  }

  // Compute the euclidian distance
  vtkSmartPointer<vtkFloatArray> sqr_mesh_distances = vtkSmartPointer<vtkFloatArray>::New ();

  PCL_INFO("Compute Euclidian distances\n");
  computeEuclidianDistance (mesh_b, mesh_a, sqr_mesh_distances);

  PCL_INFO("Color cloud distances\n");
  vtkSmartPointer<vtkPolyData> poly_data = vtkSmartPointer<vtkPolyData>::New ();
  pcl::io::mesh2vtk (mesh_b, poly_data);
  poly_data->GetPointData ()->SetScalars (sqr_mesh_distances);
  vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New ();
#if VTK_MAJOR_VERSION <= 5
  mapper->SetInput (poly_data);
#else
  mapper->SetInputData (poly_data);
#endif

  // Viewer with 3 viewports
  pcl::visualization::PCLVisualizer viewer ("Visualizer");
  int v1 (0), v2 (1), v3 (2);
  viewer.createViewPort (0.0, 0.5, 0.5, 1.0, v1);
  viewer.createViewPort (0.0, 0.0, 0.5, 0.5, v2);
  viewer.createViewPort (0.5, 0.0, 1.0, 1.0, v3);

  viewer.addPolygonMesh (mesh_a, "CAD", v1);
  viewer.addPolygonMesh (mesh_b, "Scan", v2);
  viewer.addModelFromPolyData (mapper, "mesh", v3);
  viewer.setCameraPosition (-2.48092, -3.56434, 4.80596, 0.38444, 0.608177, 0.694498);
  viewer.setBackgroundColor (0.2, 0.2, 0.2);
  viewer.registerKeyboardCallback (&keyboardEventOccurred, (void*) NULL);
  viewer.resetCamera ();
  int lut_color = 1;

  while (!viewer.wasStopped ())
  {
    viewer.spinOnce ();
    // The user pressed "space" :
    if (next_LUT_coloring)
    {
      next_LUT_coloring = false;
      lut_color > 4 ? lut_color = 1 : lut_color++;
      switch (lut_color)
      {
        case 1:
          viewer.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LUT, pcl::visualization::PCL_VISUALIZER_LUT_JET, "mesh");
          break;
        case 2:
          viewer.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LUT, pcl::visualization::PCL_VISUALIZER_LUT_JET_INVERSE, "mesh");
          break;
        case 3:
          viewer.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LUT, pcl::visualization::PCL_VISUALIZER_LUT_HSV, "mesh");
          break;
        case 4:
          viewer.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LUT, pcl::visualization::PCL_VISUALIZER_LUT_HSV_INVERSE, "mesh");
          break;
        default:
          viewer.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LUT, pcl::visualization::PCL_VISUALIZER_LUT_GREY, "mesh");
          break;
      }
    }
  }

  return (0);
}
```

`JET`
---
![redtoblue](https://cloud.githubusercontent.com/assets/5566160/7551193/fb464a26-f67f-11e4-96c4-10a08636a698.png)

`JET_INVERSE`
---
![bluetored](https://cloud.githubusercontent.com/assets/5566160/7551192/f83671e4-f67f-11e4-9d12-c54aad09e45b.png)

`HSV`
---
![hsv](https://cloud.githubusercontent.com/assets/5566160/7670494/22f78abc-fca7-11e4-9d72-5852a3c0bb9e.png)

`HSV_INVERSE`
---
![hsv_inverted](https://cloud.githubusercontent.com/assets/5566160/7670495/322d3a5e-fca7-11e4-99d4-388dc6bb5b81.png)

`GREY`
---
![blacktowhite](https://cloud.githubusercontent.com/assets/5566160/7551194/ffcea994-f67f-11e4-8498-8ab789fc3ecf.png)
