### PR TITLE
Changed the Glasbey Color Lookup, such that label ids get consistent colors.

### DIFF
--- a/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
+++ b/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
@@ -522,24 +522,27 @@ pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor (vtkSmart
   reinterpret_cast<vtkUnsignedCharArray*> (&(*scalars))->SetNumberOfTuples (nr_points);
   unsigned char* colors = reinterpret_cast<vtkUnsignedCharArray*> (&(*scalars))->GetPointer (0);
 
-  std::set<uint32_t> labels;
+
   std::map<uint32_t, pcl::RGB> colormap;
+  if (!static_mapping_)
+  {
+    std::set<uint32_t> labels;
+    // First pass: find unique labels
+    for (vtkIdType i = 0; i < nr_points; ++i)
+      labels.insert (cloud_->points[i].label);
 
-  // First pass: find unique labels
-  for (vtkIdType i = 0; i < nr_points; ++i)
-    labels.insert (cloud_->points[i].label);
-
-  // Assign Glasbey colors in ascending order of labels
-  size_t color = 0;
-  for (std::set<uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter, ++color)
-    colormap[*iter] = GlasbeyLUT::at (color % GlasbeyLUT::size ());
+    // Assign Glasbey colors in ascending order of labels
+    size_t color = 0;
+    for (std::set<uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter, ++color)
+      colormap[*iter] = GlasbeyLUT::at (color % GlasbeyLUT::size ());
+  }
 
   int j = 0;
   for (vtkIdType cp = 0; cp < nr_points; ++cp)
   {
     if (pcl::isFinite (cloud_->points[cp]))
     {
-      const pcl::RGB& color = colormap[cloud_->points[cp].label];
+      const pcl::RGB& color = static_mapping_ ? GlasbeyLUT::at (cloud_->points[cp].label % GlasbeyLUT::size ()) : colormap[cloud_->points[cp].label];
       colors[j    ] = color.r;
       colors[j + 1] = color.g;
       colors[j + 2] = color.b;

--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -512,17 +512,23 @@ namespace pcl
         typedef boost::shared_ptr<PointCloudColorHandlerLabelField<PointT> > Ptr;
         typedef boost::shared_ptr<const PointCloudColorHandlerLabelField<PointT> > ConstPtr;
 
-        /** \brief Constructor. */
-        PointCloudColorHandlerLabelField ()
+        /** \brief Constructor.
+          * \param[in] static_mapping Use a static colormapping from label_id to color (default true) */
+        PointCloudColorHandlerLabelField (const bool static_mapping = true)
+          : PointCloudColorHandler<PointT> ()
         {
           capable_ = false;
+          static_mapping_ = static_mapping;
         }
 
-        /** \brief Constructor. */
-        PointCloudColorHandlerLabelField (const PointCloudConstPtr &cloud)
+        /** \brief Constructor.
+          * \param[in] static_mapping Use a static colormapping from label_id to color (default true) */
+        PointCloudColorHandlerLabelField (const PointCloudConstPtr &cloud,
+                                          const bool static_mapping = true)
           : PointCloudColorHandler<PointT> (cloud)
         {
           setInputCloud (cloud);
+          static_mapping_ = static_mapping;
         }
 
         /** \brief Destructor. */
@@ -557,6 +563,7 @@ namespace pcl
         using PointCloudColorHandler<PointT>::capable_;
         using PointCloudColorHandler<PointT>::field_idx_;
         using PointCloudColorHandler<PointT>::fields_;
+        bool static_mapping_;
     };
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -906,8 +913,10 @@ namespace pcl
         typedef boost::shared_ptr<PointCloudColorHandlerLabelField<PointCloud> > Ptr;
         typedef boost::shared_ptr<const PointCloudColorHandlerLabelField<PointCloud> > ConstPtr;
 
-        /** \brief Constructor. */
-        PointCloudColorHandlerLabelField (const PointCloudConstPtr &cloud);
+        /** \brief Constructor.
+          * \param[in] static_mapping Use a static colormapping from label_id to color (default true) */
+        PointCloudColorHandlerLabelField (const PointCloudConstPtr &cloud,
+                                          const bool static_mapping = true);
 
         /** \brief Empty destructor */
         virtual ~PointCloudColorHandlerLabelField () {}
@@ -928,6 +937,8 @@ namespace pcl
         /** \brief Get the name of the field used. */
         virtual std::string
         getFieldName () const { return ("label"); }
+    private:
+        bool static_mapping_;
     };
 
   }

--- a/visualization/tools/pcd_viewer.cpp
+++ b/visualization/tools/pcd_viewer.cpp
@@ -137,6 +137,8 @@ printHelp (int, char **argv)
   print_info ("\n");
   print_info ("                     -use_point_picking       = enable the usage of picking points on screen (default "); print_value ("disabled"); print_info (")\n");
   print_info ("\n");
+  print_info ("                     -optimal_label_colors    = maps existing labels to the optimal sequential glasbey colors, label_ids will not be mapped to fixed colors (default "); print_value ("disabled"); print_info (")\n");
+  print_info ("\n");
 
   print_info ("\n(Note: for multiple .pcd files, provide multiple -{fc,ps,opaque} parameters; they will be automatically assigned to the right file)\n");
 }
@@ -276,6 +278,10 @@ main (int argc, char** argv)
   bool use_pp   = pcl::console::find_switch (argc, argv, "-use_point_picking");
   if (use_pp) 
     print_highlight ("Point picking enabled.\n");
+
+  bool use_optimal_l_colors = pcl::console::find_switch (argc, argv, "-optimal_label_colors");
+  if (use_optimal_l_colors)
+    print_highlight ("Optimal glasbey colors are being assigned to existing labels.\nNote: No static mapping between label ids and colors\n");
 
   // If VBOs are not enabled, then try to use immediate rendering
   bool use_immediate_rendering = false;
@@ -602,7 +608,7 @@ main (int argc, char** argv)
         else if (cloud->fields[f].name == "label")
         {
           label_idx = f + 1;
-          color_handler.reset (new pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2> (cloud));
+          color_handler.reset (new pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2> (cloud, !use_optimal_l_colors));
         }
         else
         {


### PR DESCRIPTION
This is especially important, if labels have a semantic meaning (classes) (say 1=chair, 2=door, 3=floor, 4=wall ).
If a chair is missing in a pointcloud (label 1 is absent) than the colors of all objects would change.
Additionally, it is much faster, since we do not iterate through clouds multiple times as well as saving time on various map lookups.