### PR TITLE
add an if condition check for Q_HULL apps for dominant_plane_segmenation.cpp

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -219,13 +219,15 @@ if(build)
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/${subdir}")
   endforeach(subdir)
 
-  set(incs
-    "include/pcl/${SUBSYS_NAME}/dominant_plane_segmentation.h"
-    "include/pcl/${SUBSYS_NAME}/timer.h"
-    ${incs}
-    )
-  set(impl_incs "include/pcl/${SUBSYS_NAME}/impl/dominant_plane_segmentation.hpp")
-  set(srcs "src/dominant_plane_segmentation.cpp" ${srcs})
+  if(QHULL_FOUND)
+      set(incs
+        "include/pcl/${SUBSYS_NAME}/dominant_plane_segmentation.h"
+        "include/pcl/${SUBSYS_NAME}/timer.h"
+        ${incs}
+        )
+      set(impl_incs "include/pcl/${SUBSYS_NAME}/impl/dominant_plane_segmentation.hpp")
+      set(srcs "src/dominant_plane_segmentation.cpp" ${srcs})
+  endif()
 
   set(LIB_NAME "pcl_${SUBSYS_NAME}")
   PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${impl_incs} ${incs})


### PR DESCRIPTION
Origin Issue: compiler error when Q_HULL is OFF.

This pull request solves the issue.

When Q_HULL is missing, the dominant_plane_segmentation application should be turned off, since it relies on the Convex_hull class which is not built. 

Otherwise, it will generate an compiler issue. 
<p><code>[ 91%] Building CXX object apps/CMakeFiles/pcl_apps.dir/src/dominant_plane_segmentation.cpp.o
In file included from /home/zhaoyang/develop/pcl-forked/apps/src/dominant_plane_segmentation.cpp:38:0:
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/dominant_plane_segmentation.h:251:9: error: ‘ConvexHull’ in namespace ‘pcl’ does not name a type
         pcl::ConvexHull<PointType> hull_;
         ^
In file included from /home/zhaoyang/develop/pcl-forked/apps/src/dominant_plane_segmentation.cpp:39:0:
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp: In member function ‘void pcl::apps::DominantPlaneSegmentation<PointType>::compute_table_plane()’:
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp:127:3: error: ‘hull_’ was not declared in this scope
   hull_.setInputCloud (table_projected_);
   ^
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp: In member function ‘void pcl::apps::DominantPlaneSegmentation<PointType>::compute_fast(std::vector<typename pcl::PointCloud<PointT>::Ptr>&)’:
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp:257:3: error: ‘hull_’ was not declared in this scope
   hull_.setInputCloud (table_projected_);
   ^
In file included from /home/zhaoyang/develop/pcl-forked/apps/src/dominant_plane_segmentation.cpp:39:0:
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp: In member function ‘void pcl::apps::DominantPlaneSegmentation<PointType>::compute(std::vector<typename pcl::PointCloud<PointT>::Ptr>&)’:
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp:633:3: error: ‘hull_’ was not declared in this scope
   hull_.setInputCloud (table_projected_);
   ^
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp: In member function ‘void pcl::apps::DominantPlaneSegmentation<PointType>::compute_full(std::vector<typename pcl::PointCloud<PointT>::Ptr>&)’:
/home/zhaoyang/develop/pcl-forked/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp:796:3: error: ‘hull_’ was not declared in this scope
   hull_.setInputCloud (table_projected_);
</code></p>
