### PR TITLE
Small fix: shift the setting of Qhull include directories to toplevel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,9 @@ if(WITH_QHULL)
     set(QHULL_USE_STATIC ON)
   endif(NOT PCL_SHARED_LIBS OR WIN32)
   find_package(Qhull)
+  if(QHULL_FOUND)
+    include_directories(${QHULL_INCLUDE_DIRS})
+  endif(QHULL_FOUND)
 endif(WITH_QHULL)
 
 # Cuda

--- a/surface/CMakeLists.txt
+++ b/surface/CMakeLists.txt
@@ -10,7 +10,6 @@ PCL_ADD_DOC("${SUBSYS_NAME}")
 
 if(build)
     if(QHULL_FOUND)
-        include_directories(${QHULL_INCLUDE_DIRS})
         set(HULL_INCLUDES
             "include/pcl/${SUBSYS_NAME}/concave_hull.h"
             "include/pcl/${SUBSYS_NAME}/convex_hull.h"


### PR DESCRIPTION
When trying tools, demos and tests with necessary Qhull I got the same compiler error, namely that several qhull includes can't be opened/found. In the 'CMakeLists.txt' files the Qhull include directories are only set for the 'surface' module, but not for other tools, demos and tests. So I propose a shift of the setting to the toplevel 'CMakeLists.txt' file to make it available for all.