### PR TITLE
fixed issue #1161 regarding pcl::PCA<PointT>:

### DIFF
--- a/common/include/pcl/common/pca.h
+++ b/common/include/pcl/common/pca.h
@@ -143,7 +143,7 @@ namespace pcl
       virtual void
       setIndices (const IndicesPtr &indices)
       {
-        Base::setIndices(indices);
+        Base::setIndices (indices);
         compute_done_ = false;
       }
 
@@ -153,7 +153,7 @@ namespace pcl
       virtual void
       setIndices (const IndicesConstPtr &indices)
       {
-        Base::setIndices(indices);
+        Base::setIndices (indices);
         compute_done_ = false;
       }
 
@@ -163,7 +163,7 @@ namespace pcl
       virtual void
       setIndices (const PointIndicesConstPtr &indices)
       {
-        Base::setIndices(indices);
+        Base::setIndices (indices);
         compute_done_ = false;
       }
 
@@ -178,7 +178,7 @@ namespace pcl
       virtual void
       setIndices (size_t row_start, size_t col_start, size_t nb_rows, size_t nb_cols)
       {
-        Base::setIndices(row_start, col_start, nb_rows, nb_cols);
+        Base::setIndices (row_start, col_start, nb_rows, nb_cols);
         compute_done_ = false;
       }
 

--- a/common/include/pcl/common/pca.h
+++ b/common/include/pcl/common/pca.h
@@ -137,6 +137,51 @@ namespace pcl
         compute_done_ = false;
       }
 
+      /** \brief Provide a pointer to the vector of indices that represents the input data.
+        * \param[in] indices a pointer to the indices that represent the input data.
+        */
+      virtual void
+      setIndices (const IndicesPtr &indices)
+      {
+        Base::setIndices(indices);
+        compute_done_ = false;
+      }
+
+      /** \brief Provide a pointer to the vector of indices that represents the input data.
+        * \param[in] indices a pointer to the indices that represent the input data.
+        */
+      virtual void
+      setIndices (const IndicesConstPtr &indices)
+      {
+        Base::setIndices(indices);
+        compute_done_ = false;
+      }
+
+      /** \brief Provide a pointer to the vector of indices that represents the input data.
+        * \param[in] indices a pointer to the indices that represent the input data.
+        */
+      virtual void
+      setIndices (const PointIndicesConstPtr &indices)
+      {
+        Base::setIndices(indices);
+        compute_done_ = false;
+      }
+
+      /** \brief Set the indices for the points laying within an interest region of
+        * the point cloud.
+        * \note you shouldn't call this method on unorganized point clouds!
+        * \param[in] row_start the offset on rows
+        * \param[in] col_start the offset on columns
+        * \param[in] nb_rows the number of rows to be considered row_start included
+        * \param[in] nb_cols the number of columns to be considered col_start included
+        */
+      virtual void
+      setIndices (size_t row_start, size_t col_start, size_t nb_rows, size_t nb_cols)
+      {
+        Base::setIndices(row_start, col_start, nb_rows, nb_cols);
+        compute_done_ = false;
+      }
+
       /** \brief Mean accessor
         * \throw InitFailedException
         */


### PR DESCRIPTION
in "common/pca.h" implemented functions for setIndices which set compute_done_ to false, since PCA needs to be recomputed whenever indices change