### PR TITLE
fix a mistake in getPrincipalTransformation

### DIFF
--- a/common/include/pcl/common/impl/transforms.hpp
+++ b/common/include/pcl/common/impl/transforms.hpp
@@ -350,7 +350,7 @@ pcl::getPrincipalTransformation (const pcl::PointCloud<PointT> &cloud,
   double rel1 = eigen_vals.coeff (0) / eigen_vals.coeff (1);
   double rel2 = eigen_vals.coeff (1) / eigen_vals.coeff (2);
   
-  transform.translation () = centroid.head (3);
+  transform.translation () = - centroid.head (3);
   transform.linear () = eigen_vects;
   
   return (std::min (rel1, rel2));


### PR DESCRIPTION
obviously, centroid should be subtracted