### PR TITLE
updated estimateProjectionMatrix() to make the down-sampled image have t...

### DIFF
--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -350,14 +350,14 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
   std::vector<int> indices;
   indices.reserve (input_->size () >> (pyramid_level_ << 1));
   
-  for (unsigned yIdx = 0, idx = 0; yIdx < input_->height; yIdx += ySkip, idx += input_->width * (ySkip - 1))
+  for (unsigned yIdx = 0, idx = 0; yIdx < input_->height; yIdx += ySkip, idx += input_->width * ySkip)
   {
-    for (unsigned xIdx = 0; xIdx < input_->width; xIdx += xSkip, idx += xSkip)
+    for (unsigned xIdx = 0, idx2 = idx; xIdx < input_->width; xIdx += xSkip, idx2 += xSkip)
     {
-      if (!mask_ [idx])
+      if (!mask_ [idx2])
         continue;
 
-      indices.push_back (idx);
+      indices.push_back (idx2);
     }
   }
 


### PR DESCRIPTION
...he same number of points for each row (e.g. given a 5x5 input with x/yskip=2, the downsampled image now has 3 points for each row instead of 3,2,3 points for each row), which could cause segfault if the user assumes all rows having the same number of points