### PR TITLE
small fix: compiler error with 'point cloud editor'

### DIFF
--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
@@ -348,7 +348,7 @@ class Cloud : public Statistics
     /// @param pts a vector used to store the points whose coordinates are
     /// transformed.
     void
-    getDisplaySpacePoints (std::vector<Point3D>& pts) const;
+    getDisplaySpacePoints (Point3DVector& pts) const;
 
     /// @brief Returns a const reference to the internal representation of this
     /// object.

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/localTypes.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/localTypes.h
@@ -62,6 +62,9 @@ typedef pcl::PointXYZRGBA Point3D;
 /// The type used as internal representation of a cloud object.
 typedef pcl::PointCloud<Point3D> Cloud3D;
 
+/// The type for the 3D point vector in the point cloud.
+typedef pcl::PointCloud<Point3D>::VectorType Point3DVector;
+
 /// The type for boost shared pointer pointing to a PCL cloud object.
 typedef Cloud3D::Ptr PclCloudPtr;
 

--- a/apps/point_cloud_editor/src/cloud.cpp
+++ b/apps/point_cloud_editor/src/cloud.cpp
@@ -418,7 +418,7 @@ Cloud::getDisplaySpacePoint (unsigned int index) const
 }
 
 void
-Cloud::getDisplaySpacePoints (std::vector<Point3D>& pts) const
+Cloud::getDisplaySpacePoints (Point3DVector& pts) const
 {
   for(unsigned int i = 0; i < cloud_.size(); ++i)
     pts.push_back(getDisplaySpacePoint(i));

--- a/apps/point_cloud_editor/src/select2DTool.cpp
+++ b/apps/point_cloud_editor/src/select2DTool.cpp
@@ -94,7 +94,7 @@ Select2DTool::end (int x, int y, BitMask modifiers, BitMask)
   GLfloat project[16];
   glGetFloatv(GL_PROJECTION_MATRIX, project);
 
-  std::vector<Point3D> ptsvec;
+  Point3DVector ptsvec;
   cloud_ptr_->getDisplaySpacePoints(ptsvec);
   for(unsigned int i = 0; i < ptsvec.size(); ++i)
   {


### PR DESCRIPTION
Point vectors should use the 'PointVector' type with [Eigen-aligned allocator]
(https://github.com/PointCloudLibrary/pcl/blob/master/common/include/pcl/point_cloud.h#L426).