### PR TITLE
Convert translation in millimeters

### DIFF
--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -213,7 +213,7 @@ namespace pcl
        * @param[out] json The calibration data in JSON format
        * @param[in] setup Moving or Fixed, please refer to the Ensenso documentation
        * @param[in] target Please refer to the Ensenso documentation
-       * @param[in] guess_tf Guess transformation for the calibration matrix
+       * @param[in] guess_tf Guess transformation for the calibration matrix (translation in meters)
        * @param[in] pretty_format JSON formatting style
        * @return True if successful, false otherwise
        * @warning This can take up to 120 seconds

--- a/io/src/ensenso_grabber.cpp
+++ b/io/src/ensenso_grabber.cpp
@@ -481,12 +481,12 @@ pcl::EnsensoGrabber::computeCalibrationMatrix (const std::vector<Eigen::Affine3d
         return (false);
       tf.setJson (json);
 
-
       // Rotation
       double theta = tf[itmRotation][itmAngle].asDouble ();  // Angle of rotation
       double x = tf[itmRotation][itmAxis][0].asDouble ();   // X component of Euler vector
       double y = tf[itmRotation][itmAxis][1].asDouble ();   // Y component of Euler vector
       double z = tf[itmRotation][itmAxis][2].asDouble ();   // Z component of Euler vector
+      tf.erase(); // Delete tmpTF node
 
       (*root_)[itmLink][itmRotation][itmAngle].set (theta);
       (*root_)[itmLink][itmRotation][itmAxis][0].set (x);
@@ -494,9 +494,9 @@ pcl::EnsensoGrabber::computeCalibrationMatrix (const std::vector<Eigen::Affine3d
       (*root_)[itmLink][itmRotation][itmAxis][2].set (z);
 
       // Translation
-      (*root_)[itmLink][itmTranslation][0].set (guess_tf.translation ()[0]);
-      (*root_)[itmLink][itmTranslation][1].set (guess_tf.translation ()[1]);
-      (*root_)[itmLink][itmTranslation][2].set (guess_tf.translation ()[2]);
+      (*root_)[itmLink][itmTranslation][0].set (guess_tf.translation ()[0] * 1000.0);
+      (*root_)[itmLink][itmTranslation][1].set (guess_tf.translation ()[1] * 1000.0);
+      (*root_)[itmLink][itmTranslation][2].set (guess_tf.translation ()[2] * 1000.0);
     }
 
     // Feed all robot poses into the calibration command


### PR DESCRIPTION
* Delete useless temporary `/tmpTF` node
* Translations are expressed in millimeters in the Ensenso API; this fix does the conversion and clarifies the documentation about the `guess_tf` usage.