### PR TITLE
Add a family of data buffers useful for temporal filtering in grabbers

### DIFF
--- a/io/include/pcl/io/buffers.h
+++ b/io/include/pcl/io/buffers.h
@@ -1,0 +1,283 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_IO_BUFFERS_H
+#define PCL_IO_BUFFERS_H
+
+#include <vector>
+#include <limits>
+#include <cassert>
+
+#include <boost/cstdint.hpp>
+#include <boost/thread/mutex.hpp>
+
+namespace pcl
+{
+
+  namespace io
+  {
+
+    /** An abstract base class for fixed-size data buffers.
+      *
+      * A new chunk of data can be inserted using the push() method; the data
+      * elements stored in the buffer can be accessed using operator[]().
+      *
+      * Concrete implementations of this interface (such as AverageBuffer or
+      * MedianBuffer) may perform arbitrary data processing under the hood and
+      * provide access to certain quantities computed based on the input data
+      * rather than the data themselves.
+      *
+      * \author Sergey Alexandrov
+      * \ingroup io */
+    template <typename T>
+    class Buffer
+    {
+
+      public:
+
+        typedef T value_type;
+
+        virtual
+        ~Buffer ();
+
+        /** Access an element at a given index. */
+        virtual T
+        operator[] (size_t idx) const = 0;
+
+        /** Insert a new chunk of data into the buffer.
+          *
+          * Note that the \a data parameter is not `const`-qualified. This is
+          * done to allow deriving classes to implement no-copy data insertion,
+          * where the data is "stolen" from the input argument. */
+        virtual void
+        push (std::vector<T>& data) = 0;
+
+        /** Get the size of the buffer. */
+        inline size_t
+        size () const
+        {
+          return (size_);
+        }
+
+      protected:
+
+        Buffer (size_t size);
+
+        const size_t size_;
+
+    };
+
+    /** A simple buffer that only stores data.
+      *
+      * The buffer is thread-safe. */
+    template <typename T>
+    class SingleBuffer : public Buffer<T>
+    {
+
+      public:
+
+        /** Construct a buffer of given size. */
+        SingleBuffer (size_t size);
+
+        virtual
+        ~SingleBuffer ();
+
+        virtual T
+        operator[] (size_t idx) const;
+
+        virtual void
+        push (std::vector<T>& data);
+
+      private:
+
+        std::vector<T> data_;
+        mutable boost::mutex data_mutex_;
+
+        using Buffer<T>::size_;
+
+    };
+
+    /** A buffer that computes running window median of the data inserted.
+      *
+      * The buffer and window sizes are specified at construction time. The
+      * buffer size defines the number of elements in each data chunk that is
+      * inserted in the buffer. The window size is the number of last data
+      * chunks that are considered for median computation. The median is
+      * computed separately for 1st, 2nd, etc. element in data chunks.
+      *
+      * The data can contain invalid elements. For integral types zeros are
+      * assumed to be invalid elements, whereas for floating-point types it is
+      * quiet NaN. Invalid elements are ignored when computing median.
+      *
+      * The buffer is thread-safe. */
+    template <typename T>
+    class MedianBuffer : public Buffer<T>
+    {
+
+      public:
+
+        /** Construct a buffer of given size with given running window size.
+          *
+          * \param[in] size buffer size
+          * \param[in] window_size running window size over which the median
+          * value should be computed (0..255) */
+        MedianBuffer (size_t size, unsigned char window_size);
+
+        virtual
+        ~MedianBuffer ();
+
+        /** Access an element at a given index.
+          *
+          * This operation is constant time. */
+        virtual T
+        operator[] (size_t idx) const;
+
+        /** Insert a new chunk of data into the buffer.
+          *
+          * This operation is linear in buffer size and window size.
+          *
+          * \param[in] data input data chunk, the memory will be "stolen" */
+        virtual void
+        push (std::vector<T>& data);
+
+      private:
+
+        /** Compare two data elements.
+          *
+          * Invalid value is assumed to be larger than everything else. If both values
+          * are invalid, they are assumed to be equal.
+          *
+          * \return -1 if \c a < \c b, 0 if \c a == \c b, 1 if \c a > \c b */
+        static int compare (T a, T b);
+
+        const unsigned char window_size_;
+        const unsigned char midpoint_;
+
+        /// Data pushed into the buffer (last window_size_ chunks), logically
+        /// organized as a circular buffer
+        std::vector<std::vector<T> > data_;
+
+        /// Index of the last pushed data chunk in the data_ circular buffer
+        unsigned char data_current_idx_;
+
+        /// Indices that the argsort function would produce for data_ (with
+        /// dimensions swapped)
+        std::vector<std::vector<unsigned char> > data_argsort_indices_;
+
+        /// Number of invalid values in the buffer
+        std::vector<unsigned char> data_invalid_count_;
+
+        mutable boost::mutex data_mutex_;
+
+        using Buffer<T>::size_;
+
+    };
+
+    /** A buffer that computes running window average of the data inserted.
+      *
+      * The buffer and window sizes are specified at construction time. The
+      * buffer size defines the number of elements in each data chunk that is
+      * inserted in the buffer. The window size is the number of last data
+      * chunks that are considered for average computation. The average is
+      * computed separately for 1st, 2nd, etc. element in data chunks.
+      *
+      * The data can contain invalid elements. For integral types zeros are
+      * assumed to be invalid elements, whereas for floating-point types it is
+      * quiet NaN. Invalid elements are ignored when computing average.
+      *
+      * The buffer is thread-safe. */
+    template <typename T>
+    class AverageBuffer : public Buffer<T>
+    {
+
+      public:
+
+        /** Construct a buffer of given size with given running window size.
+          *
+          * \param[in] size buffer size
+          * \param[in] window_size running window size over which the median
+          * value should be computed (0..255) */
+        AverageBuffer (size_t size, unsigned char window_size);
+
+        virtual
+        ~AverageBuffer ();
+
+        /** Access an element at a given index.
+          *
+          * This operation is constant time. */
+        virtual T
+        operator[] (size_t idx) const;
+
+        /** Insert a new chunk of data into the buffer.
+          *
+          * This operation is linear in buffer size.
+          *
+          * \param[in] data input data chunk, the memory will be "stolen" */
+        virtual void
+        push (std::vector<T>& data);
+
+      private:
+
+        const unsigned char window_size_;
+
+        /// Data pushed into the buffer (last window_size_ chunks), logically
+        /// organized as a circular buffer
+        std::vector<std::vector<T> > data_;
+
+        /// Index of the last pushed data chunk in the data_ circular buffer
+        unsigned char data_current_idx_;
+
+        /// Current sum of the buffer
+        std::vector<T> data_sum_;
+
+        /// Number of invalid values in the buffer
+        std::vector<unsigned char> data_invalid_count_;
+
+        mutable boost::mutex data_mutex_;
+
+        using Buffer<T>::size_;
+
+    };
+
+  }
+
+}
+
+#include <pcl/io/impl/buffers.hpp>
+
+#endif /* PCL_IO_BUFFERS_H */
+

--- a/io/include/pcl/io/impl/buffers.hpp
+++ b/io/include/pcl/io/impl/buffers.hpp
@@ -1,0 +1,293 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_IO_IMPL_BUFFERS_HPP
+#define PCL_IO_IMPL_BUFFERS_HPP
+
+#include <iostream>
+#include <cstring>
+
+#include <pcl/pcl_macros.h>
+
+template <typename T>
+struct buffer_traits
+{
+  static T invalid () { return 0; }
+  static bool is_invalid (T value) { return value == invalid (); };
+};
+
+template <>
+struct buffer_traits <float>
+{
+  static float invalid () { return std::numeric_limits<float>::quiet_NaN (); };
+  static bool is_invalid (float value) { return pcl_isnan (value); };
+};
+
+template <>
+struct buffer_traits <double>
+{
+  static double invalid () { return std::numeric_limits<double>::quiet_NaN (); };
+  static bool is_invalid (double value) { return pcl_isnan (value); };
+};
+
+template <typename T>
+pcl::io::Buffer<T>::Buffer (size_t size)
+: size_ (size)
+{
+}
+
+template <typename T>
+pcl::io::Buffer<T>::~Buffer ()
+{
+}
+
+template <typename T>
+pcl::io::SingleBuffer<T>::SingleBuffer (size_t size)
+: Buffer<T> (size)
+, data_ (size, buffer_traits<T>::invalid ())
+{
+}
+
+template <typename T>
+pcl::io::SingleBuffer<T>::~SingleBuffer ()
+{
+}
+
+template <typename T> T
+pcl::io::SingleBuffer<T>::operator[] (size_t idx) const
+{
+  assert (idx < size_);
+  return (data_[idx]);
+}
+
+template <typename T> void
+pcl::io::SingleBuffer<T>::push (std::vector<T>& data)
+{
+  assert (data.size () == size_);
+  boost::mutex::scoped_lock lock (data_mutex_);
+  data_.swap (data);
+  data.clear ();
+}
+
+template <typename T>
+pcl::io::MedianBuffer<T>::MedianBuffer (size_t size,
+                                        unsigned char window_size)
+: Buffer<T> (size)
+, window_size_ (window_size)
+, midpoint_ (window_size_ / 2)
+, data_current_idx_ (window_size_ - 1)
+{
+  assert (size_ > 0);
+  assert (window_size_ > 0);
+
+  data_.resize (window_size_);
+  for (size_t i = 0; i < window_size_; ++i)
+    data_[i].resize (size_, buffer_traits<T>::invalid ());
+
+  data_argsort_indices_.resize (size_);
+  for (size_t i = 0; i < size_; ++i)
+  {
+    data_argsort_indices_[i].resize (window_size_);
+    for (size_t j = 0; j < window_size_; ++j)
+      data_argsort_indices_[i][j] = j;
+  }
+
+  data_invalid_count_.resize (size_, window_size_);
+}
+
+template <typename T>
+pcl::io::MedianBuffer<T>::~MedianBuffer ()
+{
+}
+
+template <typename T> T
+pcl::io::MedianBuffer<T>::operator[] (size_t idx) const
+{
+  assert (idx < size_);
+  int midpoint = (window_size_ - data_invalid_count_[idx]) / 2;
+  return (data_[data_argsort_indices_[idx][midpoint]][idx]);
+}
+
+template <typename T> void
+pcl::io::MedianBuffer<T>::push (std::vector<T>& data)
+{
+  assert (data.size () == size_);
+  boost::mutex::scoped_lock lock (data_mutex_);
+
+  if (++data_current_idx_ >= window_size_)
+    data_current_idx_ = 0;
+
+  // New data will replace the column with index data_current_idx_. Before
+  // overwriting it, we go through all the new-old value pairs and update
+  // data_argsort_indices_ to maintain sorted order.
+  for (size_t i = 0; i < size_; ++i)
+  {
+    const T& new_value = data[i];
+    const T& old_value = data_[data_current_idx_][i];
+    bool new_is_invalid = buffer_traits<T>::is_invalid (new_value);
+    bool old_is_invalid = buffer_traits<T>::is_invalid (old_value);
+    if (compare (new_value, old_value) == 0)
+      continue;
+    std::vector<unsigned char>& argsort_indices = data_argsort_indices_[i];
+    // Rewrite the argsort indices before or after the position where we insert
+    // depending on the relation between the old and new values
+    if (compare (new_value, old_value) == 1)
+    {
+      for (int j = 0; j < window_size_; ++j)
+        if (argsort_indices[j] == data_current_idx_)
+        {
+          int k = j + 1;
+          while (k < window_size_ && compare (new_value, data_[argsort_indices[k]][i]) == 1)
+          {
+            std::swap (argsort_indices[k - 1], argsort_indices[k]);
+            ++k;
+          }
+          break;
+        }
+    }
+    else
+    {
+      for (int j = window_size_ - 1; j >= 0; --j)
+        if (argsort_indices[j] == data_current_idx_)
+        {
+          int k = j - 1;
+          while (k >= 0 && compare (new_value, data_[argsort_indices[k]][i]) == -1)
+          {
+            std::swap (argsort_indices[k], argsort_indices[k + 1]);
+            --k;
+          }
+          break;
+        }
+    }
+
+    if (new_is_invalid && !old_is_invalid)
+      ++data_invalid_count_[i];
+    else if (!new_is_invalid && old_is_invalid)
+      --data_invalid_count_[i];
+  }
+
+  // Finally overwrite the data
+  data_[data_current_idx_].swap (data);
+  data.clear ();
+}
+
+template <typename T> int
+pcl::io::MedianBuffer<T>::compare (T a, T b)
+{
+  bool a_is_invalid = buffer_traits<T>::is_invalid (a);
+  bool b_is_invalid = buffer_traits<T>::is_invalid (b);
+  if (a_is_invalid && b_is_invalid)
+    return 0;
+  if (a_is_invalid)
+    return 1;
+  if (b_is_invalid)
+    return -1;
+  if (a == b)
+    return 0;
+  return a > b ? 1 : -1;
+}
+
+template <typename T>
+pcl::io::AverageBuffer<T>::AverageBuffer (size_t size,
+                                          unsigned char window_size)
+: Buffer<T> (size)
+, window_size_ (window_size)
+, data_current_idx_ (window_size_ - 1)
+{
+  assert (size_ > 0);
+  assert (window_size_ > 0);
+
+  data_.resize (window_size_);
+  for (size_t i = 0; i < window_size_; ++i)
+    data_[i].resize (size_, buffer_traits<T>::invalid ());
+
+  data_sum_.resize (size_, 0);
+  data_invalid_count_.resize (size_, window_size_);
+}
+
+template <typename T>
+pcl::io::AverageBuffer<T>::~AverageBuffer ()
+{
+}
+
+template <typename T> T
+pcl::io::AverageBuffer<T>::operator[] (size_t idx) const
+{
+  assert (idx < size_);
+  if (data_invalid_count_[idx] == window_size_)
+    return (buffer_traits<T>::invalid ());
+  else
+    return (data_sum_[idx] / static_cast<T> (window_size_ - data_invalid_count_[idx]));
+}
+
+template <typename T> void
+pcl::io::AverageBuffer<T>::push (std::vector<T>& data)
+{
+  assert (data.size () == size_);
+  boost::mutex::scoped_lock lock (data_mutex_);
+
+  if (++data_current_idx_ >= window_size_)
+    data_current_idx_ = 0;
+
+  // New data will replace the column with index data_current_idx_. Before
+  // overwriting it, we go through the old values and subtract them from the
+  // data_sum_
+  for (size_t i = 0; i < size_; ++i)
+  {
+    const float& new_value = data[i];
+    const float& old_value = data_[data_current_idx_][i];
+    bool new_is_invalid = buffer_traits<T>::is_invalid (new_value);
+    bool old_is_invalid = buffer_traits<T>::is_invalid (old_value);
+
+    if (!old_is_invalid)
+      data_sum_[i] -= old_value;
+    if (!new_is_invalid)
+      data_sum_[i] += new_value;
+
+    if (new_is_invalid && !old_is_invalid)
+      ++data_invalid_count_[i];
+    else if (!new_is_invalid && old_is_invalid)
+      --data_invalid_count_[i];
+  }
+
+  // Finally overwrite the data
+  data_[data_current_idx_].swap (data);
+  data.clear ();
+}
+
+#endif /* PCL_IO_IMPL_BUFFERS_HPP */
+

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -26,3 +26,8 @@ endif ()
 PCL_ADD_TEST(point_cloud_image_extractors test_point_cloud_image_extractors
              FILES test_point_cloud_image_extractors.cpp
              LINK_WITH pcl_gtest pcl_io)
+
+PCL_ADD_TEST(buffers test_buffers
+             FILES test_buffers.cpp
+             LINK_WITH pcl_gtest)
+

--- a/test/io/test_buffers.cpp
+++ b/test/io/test_buffers.cpp
@@ -1,0 +1,233 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <pcl/io/buffers.h>
+
+using namespace pcl::io;
+
+template <typename T>
+class BuffersTest : public ::testing::Test
+{
+
+  public:
+
+    BuffersTest ()
+    {
+      if (std::numeric_limits<T>::has_quiet_NaN)
+        invalid_ = std::numeric_limits<T>::quiet_NaN ();
+      else
+        invalid_ = 0;
+    }
+
+    template <typename Buffer> void
+    checkBuffer (Buffer& buffer, const T* data, const T* expected, size_t size)
+    {
+      const T* dptr = data;
+      const T* eptr = expected;
+      for (size_t i = 0; i < size; ++i)
+      {
+        std::vector<T> d (buffer.size ());
+        memcpy (d.data (), dptr, buffer.size () * sizeof (T));
+        buffer.push (d);
+        for (size_t j = 0; j < buffer.size (); ++j)
+          if (isnan (eptr[j]))
+            EXPECT_TRUE (isnan (buffer[j]));
+          else
+            EXPECT_EQ (eptr[j], buffer[j]);
+        dptr += buffer.size ();
+        eptr += buffer.size ();
+      }
+    }
+
+    T invalid_;
+
+};
+
+typedef ::testing::Types<char, int, float> DataTypes;
+TYPED_TEST_CASE (BuffersTest, DataTypes);
+
+TYPED_TEST (BuffersTest, SingleBuffer)
+{
+  SingleBuffer<TypeParam> sb (1);
+  const TypeParam data[] = {5, 4, 3, 2, 1};
+  this->checkBuffer (sb, data, data, sizeof (data) / sizeof (TypeParam));
+}
+
+TYPED_TEST (BuffersTest, MedianBufferWindow1)
+{
+  MedianBuffer<TypeParam> mb (1, 1);
+  const TypeParam data[] = {5, 4, 3, 2, 1};
+  this->checkBuffer (mb, data, data, sizeof (data) / sizeof (TypeParam));
+}
+
+TYPED_TEST (BuffersTest, MedianBufferWindow2)
+{
+  {
+    MedianBuffer<TypeParam> mb (1, 2);
+    const TypeParam data[] = {5, 4, 3, 2, 1};
+    const TypeParam median[] = {5, 5, 4, 3, 2};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+  }
+  {
+    MedianBuffer<TypeParam> mb (1, 2);
+    const TypeParam data[] = {3, 4, 1, 3, 4};
+    const TypeParam median[] = {3, 4, 4, 3, 4};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+  }
+}
+
+TYPED_TEST (BuffersTest, MedianBufferWindow3)
+{
+  {
+    MedianBuffer<TypeParam> mb (1, 3);
+    const TypeParam data[] = {5, 4, 3, 2, 1, -1, -1};
+    const TypeParam median[] = {5, 5, 4, 3, 2, 1, -1};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+  }
+  {
+    MedianBuffer<TypeParam> mb (1, 3);
+    const TypeParam data[] = {3, 4, 1, 3, 4, -1, -1};
+    const TypeParam median[] = {3, 4, 3, 3, 3, 3, -1};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+  }
+  {
+    MedianBuffer<TypeParam> mb (1, 3);
+    const TypeParam data[] = {-4, -1, 3, -4, 1, 3, 4, -1};
+    const TypeParam median[] = {-4, -1, -1, -1, 1, 1, 3, 3};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+  }
+}
+
+TYPED_TEST (BuffersTest, MedianBufferWindow4)
+{
+  {
+    MedianBuffer<TypeParam> mb (1, 4);
+    const TypeParam data[] = {5, 4, 3, 2, 1, -1, -1};
+    const TypeParam median[] = {5, 5, 4, 4, 3, 2, 1};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+  }
+  {
+    MedianBuffer<TypeParam> mb (1, 4);
+    const TypeParam data[] = {-4, -1, 3, -4, 1, 3, 4, -2};
+    const TypeParam median[] = {-4, -1, -1, -1, 1, 3, 3, 3};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+  }
+}
+
+TYPED_TEST (BuffersTest, MedianBufferPushInvalid)
+{
+  const TypeParam& invalid = this->invalid_;
+  MedianBuffer<TypeParam> mb (1, 3);
+  const TypeParam data[] = {5, 4, 3, invalid, 1, invalid, invalid, invalid, 9, 3, 1};
+  const TypeParam median[] = {5, 5, 4, 4, 3, 1, 1, invalid, 9, 9, 3};
+  this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam));
+}
+
+TYPED_TEST (BuffersTest, MedianBufferSize3Window3)
+{
+  {
+    MedianBuffer<TypeParam> mb (3, 3);
+    const TypeParam data[] = {3, 3, 3, 1, 1, 1, -1, -1, -1};
+    const TypeParam median[] = {3, 3, 3, 3, 3, 3, 1, 1, 1};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam) / mb.size ());
+  }
+  {
+    MedianBuffer<TypeParam> mb (3, 3);
+    const TypeParam data[] = {3, 2, 1, 1, 1, 1, 3, 2, 1, 1, 2, 3};
+    const TypeParam median[] = {3, 2, 1, 3, 2, 1, 3, 2, 1, 1, 2, 1};
+    this->checkBuffer (mb, data, median, sizeof (data) / sizeof (TypeParam) / mb.size ());
+  }
+}
+
+TYPED_TEST (BuffersTest, AverageBufferWindow1)
+{
+  AverageBuffer<TypeParam> ab (1, 1);
+  const TypeParam data[] = {5, 4, 3, 2, 1};
+  this->checkBuffer (ab, data, data, sizeof (data) / sizeof (TypeParam));
+}
+
+TYPED_TEST (BuffersTest, AverageBufferWindow2)
+{
+  {
+    AverageBuffer<TypeParam> ab (1, 2);
+    const TypeParam data[] = {5, 3, 3, 1, 1};
+    const TypeParam average[] = {5, 4, 3, 2, 1};
+    this->checkBuffer (ab, data, average, sizeof (data) / sizeof (TypeParam));
+  }
+  {
+    AverageBuffer<TypeParam> ab (1, 2);
+    const TypeParam data[] = {3, 5, 1, 13, 3};
+    const TypeParam average[] = {3, 4, 3, 7, 8};
+    this->checkBuffer (ab, data, average, sizeof (data) / sizeof (TypeParam));
+  }
+}
+
+TYPED_TEST (BuffersTest, AverageBufferWindow3)
+{
+  {
+    AverageBuffer<TypeParam> ab (1, 3);
+    const TypeParam data[] = {5, 3, 1, 2, -3, 4, -7};
+    const TypeParam average[] = {5, 4, 3, 2, 0, 1, -2};
+    this->checkBuffer (ab, data, average, sizeof (data) / sizeof (TypeParam));
+  }
+  {
+    AverageBuffer<TypeParam> ab (1, 3);
+    const TypeParam data[] = {3, -5, 2, -3, 4, -1, -3};
+    const TypeParam average[] = {3, -1, 0, -2, 1, 0, 0};
+    this->checkBuffer (ab, data, average, sizeof (data) / sizeof (TypeParam));
+  }
+}
+
+TYPED_TEST (BuffersTest, AverageBufferPushInvalid)
+{
+  const TypeParam& invalid = this->invalid_;
+  AverageBuffer<TypeParam> ab (1, 3);
+  const TypeParam data[] = {5, 3, 7, invalid, 1, invalid, invalid, invalid, 9, 3, -3};
+  const TypeParam median[] = {5, 4, 5, 5, 4, 1, 1, invalid, 9, 6, 3};
+  this->checkBuffer (ab, data, median, sizeof (data) / sizeof (TypeParam));
+}
+
+int main (int argc, char **argv)
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}
+


### PR DESCRIPTION
This pull request adds a family of data buffers. All the buffers share a common interface and allow data insertion and retrieval. On top of that, some of the buffers compute certain statistics about the underlying data over a certain window, transparently for the user. This is useful for implementation of temporal filtering (average, median) in IO grabbers.

These classes are shared by both [RealSense](https://github.com/taketwo/rs) and [DepthSense](https://github.com/taketwo/ds) grabbers, which I will be merging soon.

As usual, the classes are covered with unit tests.