### PR TITLE
Added method to get point indices from convex_hull

### DIFF
--- a/surface/include/pcl/surface/concave_hull.h
+++ b/surface/include/pcl/surface/concave_hull.h
@@ -157,6 +157,16 @@ namespace pcl
           PCL_ERROR ("[pcl::%s::setDimension] Invalid input dimension specified!\n", getClassName ().c_str ());
       }
 
+      /** \brief Retrieve the indices of the input point cloud that for the convex hull.
+        *
+        * \note Should only be called after reconstruction was performed and if the ConcaveHull is
+        * set to preserve information via setKeepInformation ().
+        *
+        * \param[out] hull_point_indices The indices of the points forming the point cloud
+        */
+      void
+      getHullPointIndices (pcl::PointIndices &hull_point_indices) const;
+
     protected:
       /** \brief Class get name method. */
       std::string
@@ -197,6 +207,9 @@ namespace pcl
       
       /** \brief the dimensionality of the concave hull */
       int dim_;
+
+      /** \brief vector containing the point cloud indices of the convex hull points. */
+      pcl::PointIndices hull_indices_;
   };
 }
 

--- a/surface/include/pcl/surface/convex_hull.h
+++ b/surface/include/pcl/surface/convex_hull.h
@@ -166,6 +166,14 @@ namespace pcl
         return (dimension_);
       }
 
+      /** \brief Retrieve the indices of the input point cloud that for the convex hull.
+        *
+        * \note Should only be called after reconstruction was performed.
+        * \param[out] hull_point_indices The indices of the points forming the point cloud
+        */
+      void
+      getHullPointIndices (pcl::PointIndices &hull_point_indices) const;
+
     protected:
       /** \brief The actual reconstruction method. 
         * 
@@ -254,6 +262,9 @@ namespace pcl
 
       /* \brief z-axis - for checking valid projections. */
       const Eigen::Vector3d z_axis_;
+
+      /* \brief vector containing the point cloud indices of the convex hull points. */
+      pcl::PointIndices hull_indices_;
 
       public:
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/surface/include/pcl/surface/impl/concave_hull.hpp
+++ b/surface/include/pcl/surface/impl/concave_hull.hpp
@@ -579,18 +579,18 @@ pcl::ConcaveHull<PointInT>::performReconstruction (PointCloud &alpha_shape, std:
     distances.resize (1);
 
     // for each point in the concave hull, search for the nearest neighbor in the original point cloud
-
-    std::vector<int> indices;
-    indices.resize (alpha_shape.points.size ());
+    hull_indices_.header = input_->header;
+    hull_indices_.indices.clear ();
+    hull_indices_.indices.reserve (alpha_shape.points.size ());
 
     for (size_t i = 0; i < alpha_shape.points.size (); i++)
     {
       tree.nearestKSearch (alpha_shape.points[i], 1, neighbor, distances);
-      indices[i] = neighbor[0];
+      hull_indices_.indices.push_back (neighbor[0]);
     }
 
     // replace point with the closest neighbor in the original point cloud
-    pcl::copyPointCloud (*input_, indices, alpha_shape);
+    pcl::copyPointCloud (*input_, hull_indices_.indices, alpha_shape);
   }
 }
 #ifdef __GNUC__
@@ -617,6 +617,12 @@ pcl::ConcaveHull<PointInT>::performReconstruction (std::vector<pcl::Vertices> &p
   performReconstruction (hull_points, polygons);
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointInT> void
+pcl::ConcaveHull<PointInT>::getHullPointIndices (pcl::PointIndices &hull_point_indices) const
+{
+  hull_point_indices = hull_indices_;
+}
 
 #define PCL_INSTANTIATE_ConcaveHull(T) template class PCL_EXPORTS pcl::ConcaveHull<T>;
 

--- a/surface/include/pcl/surface/impl/convex_hull.hpp
+++ b/surface/include/pcl/surface/impl/convex_hull.hpp
@@ -260,8 +260,13 @@ pcl::ConvexHull<PointInT>::performReconstruction2D (PointCloud &hull, std::vecto
   polygons.resize (1);
   polygons[0].vertices.resize (hull.points.size ());
 
+  hull_indices_.header = input_->header;
+  hull_indices_.indices.clear ();
+  hull_indices_.indices.reserve (hull.points.size ());
+
   for (int j = 0; j < static_cast<int> (hull.points.size ()); j++)
   {
+    hull_indices_.indices.push_back ((*indices_)[idx_points[j].first]);
     hull.points[j] = input_->points[(*indices_)[idx_points[j].first]];
     polygons[0].vertices[j] = static_cast<unsigned int> (j);
   }
@@ -357,10 +362,15 @@ pcl::ConvexHull<PointInT>::performReconstruction3D (
   ++max_vertex_id;
   std::vector<int> qhid_to_pcidx (max_vertex_id);
 
+  hull_indices_.header = input_->header;
+  hull_indices_.indices.clear ();
+  hull_indices_.indices.reserve (num_vertices);
+
   FORALLvertices
   {
-    // Add vertices to hull point_cloud
-    hull.points[i] = input_->points[(*indices_)[qh_pointid (vertex->point)]];
+    // Add vertices to hull point_cloud and store index
+    hull_indices_.indices.push_back ((*indices_)[qh_pointid (vertex->point)]);
+    hull.points[i] = input_->points[(*indices_)[hull_indices_.indices.back ()]];
 
     qhid_to_pcidx[vertex->id] = i; // map the vertex id of qhull to the point cloud index
     ++i;
@@ -480,6 +490,12 @@ pcl::ConvexHull<PointInT>::reconstruct (PointCloud &points, std::vector<pcl::Ver
   points.is_dense = true;
 
   deinitCompute ();
+}
+//////////////////////////////////////////////////////////////////////////
+template <typename PointInT> void
+pcl::ConvexHull<PointInT>::getHullPointIndices (pcl::PointIndices &hull_point_indices) const
+{
+  hull_point_indices = hull_indices_;
 }
 
 #define PCL_INSTANTIATE_ConvexHull(T) template class PCL_EXPORTS pcl::ConvexHull<T>;


### PR DESCRIPTION
- Added method 'getHullPointIndices ()' to retrieve the indices of the
  input point cloud that form its convex hull. In some cases it is
  more convenient to work with convex hull in form of the points from
  the input point cloud (for example when it is organized) than with a
  new point cloud containing only the geometric information, but not
  the organization.