### PR TITLE
Made changes to allow OMP 2.0 compatibility

### DIFF
--- a/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
+++ b/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
@@ -226,11 +226,9 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::downsample (const Floa
 
   int width = (smoothed.width +1) / 2;
   int height = (smoothed.height +1) / 2;
-
-  int *ii = new int[width];
-  int *ii_ptr = ii;
+  std::vector<int> ii (width);
   for (int i = 0; i < width; ++i)
-    *ii_ptr++ = 2*i;
+    ii[i] = 2 * i;
 
   FloatImagePtr down (new FloatImage (width, height));
 #ifdef _OPENMP


### PR DESCRIPTION
changed klt to use a vector instead of an array as a private variable,
for MSVC compatibility.