### PR TITLE
Fixed MSVC openmp compatibility

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
@@ -167,7 +167,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
 #ifdef _OPENMP
   #pragma omp parallel for num_threads(threads_) default(shared)
 #endif  
-  for (unsigned idx = 0; idx < surface_->size (); ++idx)
+  for (int idx = 0; idx < surface_->size (); ++idx)
   {
     cloud->points [idx].x = surface_->points [idx].x;
     cloud->points [idx].y = surface_->points [idx].y;
@@ -187,7 +187,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
 #ifdef _OPENMP
   #pragma omp parallel for num_threads(threads_) default (shared)
 #endif    
-  for (unsigned idx = 0; idx < intensity_gradients_->size (); ++idx)
+  for (int idx = 0; idx < intensity_gradients_->size (); ++idx)
   {
     float len = intensity_gradients_->points [idx].gradient_x * intensity_gradients_->points [idx].gradient_x +
                 intensity_gradients_->points [idx].gradient_y * intensity_gradients_->points [idx].gradient_y +
@@ -230,7 +230,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
 #ifdef _OPENMP
   #pragma omp parallel for num_threads(threads_) default(shared)
 #endif  
-    for (size_t idx = 0; idx < response->points.size (); ++idx)
+    for (int idx = 0; idx < response->points.size (); ++idx)
     {
       if (!isFinite (response->points[idx]) || response->points[idx].intensity < threshold_)
         continue;
@@ -278,7 +278,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::responseTomasi (PointCloudO
 #ifdef _OPENMP
   #pragma omp parallel for default (shared) private (pointOut, covar, covariance, solver) num_threads(threads_)
 #endif  
-  for (unsigned pIdx = 0; pIdx < input_->size (); ++pIdx)
+  for (int pIdx = 0; pIdx < input_->size (); ++pIdx)
   {
     const PointInT& pointIn = input_->points [pIdx];
     pointOut.intensity = 0.0; //std::numeric_limits<float>::quiet_NaN ();


### PR DESCRIPTION
By changing this array to a vector, i introduced a bug in all versions of OpenMP, since private variables are not copied. I changed this to firstprivate. This fixes the issue, as well as finally providing this with MSVC compatibility. 