### PR TITLE
Fixes 1224 for CUDA >= 6.x when calling fmin.

### DIFF
--- a/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
+++ b/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
@@ -247,7 +247,7 @@ namespace pcl
 
                 if (sdf >= -tranc_dist_mm)
                 {
-                  float tsdf = fmin (1, sdf / tranc_dist_mm);
+                  float tsdf = fmin (1.f, sdf / tranc_dist_mm);
 
                   int weight_prev;
                   float tsdf_prev;


### PR DESCRIPTION
'error : calling a host function("fmin ") from a device function'
Removes implicit cast from integer to float.