### PR TITLE
kinfu LS: fix volume size calculation from pointers.

### DIFF
--- a/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
+++ b/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
@@ -97,7 +97,7 @@ namespace pcl
                 int z_step = buffer.voxels_size.y * volume.step / sizeof(*pos);
                                     
                 ///Get the size of the whole TSDF memory
-                int size = buffer.tsdf_memory_end - buffer.tsdf_memory_start;
+                int size = buffer.tsdf_memory_end - buffer.tsdf_memory_start + 1;
                                   
                 ///Move along z axis
       #pragma unroll
@@ -123,7 +123,7 @@ namespace pcl
                 int z_step = buffer.voxels_size.y * volume.step / sizeof(*pos);
                             
                 ///Get the size of the whole TSDF memory 
-                int size = buffer.tsdf_memory_end - buffer.tsdf_memory_start;
+                int size = buffer.tsdf_memory_end - buffer.tsdf_memory_start + 1;
                               
                 ///Move pointer to the Z origin
                 pos+= minBounds.z * z_step;
@@ -453,7 +453,7 @@ namespace pcl
           
           // As the pointer is incremented in the for loop, we have to make sure that the pointer is never outside the memory
           if(pos > buffer.tsdf_memory_end)
-            pos -= (buffer.tsdf_memory_end - buffer.tsdf_memory_start);
+            pos -= (buffer.tsdf_memory_end - buffer.tsdf_memory_start + 1);
           
           float inv_z = 1.0f / (v_z + Rcurr_inv.data[2].z * z_scaled);
           if (inv_z < 0)


### PR DESCRIPTION
  tsdf_memory_end is the last valid memory address, not the first invalid.
  The size must be (tsdf_memory_end - tsdf_memory_start + 1).
  Apparently, a similar fix was already applied to pointer_shift.cu.

  This fixes some artifacts at volume boundaries in the reconstruction.