### PR TITLE
Fix EnsensoGrabber compilation

### DIFF
--- a/io/src/ensenso_grabber.cpp
+++ b/io/src/ensenso_grabber.cpp
@@ -452,7 +452,7 @@ pcl::EnsensoGrabber::computeCalibrationMatrix (const std::vector<Eigen::Affine3d
                                                const Eigen::Affine3d &guess_tf,
                                                const bool pretty_format) const
 {
-  if ( (*ensenso_ptr->root_)[itmVersion][itmMajor] < 2 && (*ensenso_ptr->root_)[itmVersion][itmMinor] < 3)
+  if ( (*root_)[itmVersion][itmMajor] < 2 && (*root_)[itmVersion][itmMinor] < 3)
     PCL_WARN ("EnsensoSDK 1.3.x fixes bugs into extrinsic calibration matrix optimization, please update your SDK!\n"
               "http://www.ensenso.de/support/sdk-download/\n");
 


### PR DESCRIPTION
The current code cannot compile 

```bash
/home/dell/libraries/pcl/src/io/src/ensenso_grabber.cpp: In member function ‘bool pcl::EnsensoGrabber::computeCalibrationMatrix(const std::vector<Eigen::Transform<double, 3, 2>, Eigen::aligned_allocator<Eigen::Transform<double, 3, 2> > >&, std::string&, std::string, std::string, const Affine3d&, bool) const’:
/home/dell/libraries/pcl/src/io/src/ensenso_grabber.cpp:455:10: error: ‘ensenso_ptr’ was not declared in this scope
   if ( (*ensenso_ptr->root_)[itmVersion][itmMajor] < 2 && (*ensenso_ptr->root_)[itmVersion][itmMinor] < 3)
          ^
make[2]: *** [io/CMakeFiles/pcl_io.dir/src/ensenso_grabber.cpp.o] Erreur 1
make[1]: *** [io/CMakeFiles/pcl_io.dir/all] Erreur 2
```

Sorry for the inconvenience, I did not push the right branch
I tested the compilation, it's ok now.

Fixes changes made into #1236 