### PR TITLE
OpenNI2 grabber does not work.

### DIFF
--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -695,7 +695,7 @@ pcl::io::OpenNI2Grabber::convertToXYZRGBPointCloud (const Image::Ptr &image, con
   value_idx = 0;
   point_idx = 0;
   RGBValue color;
-  color.Alpha = 0;
+  color.Alpha = 0xff;
 
   for (unsigned yIdx = 0; yIdx < image_height_; ++yIdx, point_idx += skip)
   {

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -660,7 +660,7 @@ pcl::io::OpenNI2Grabber::convertToXYZRGBPointCloud (const Image::Ptr &image, con
 
   // fill in XYZ values
   unsigned step = cloud->width / depth_width_;
-  unsigned skip = cloud->width * step - cloud->width;
+  unsigned skip = cloud->width - (depth_width_ * step);
 
   int value_idx = 0;
   int point_idx = 0;
@@ -690,7 +690,7 @@ pcl::io::OpenNI2Grabber::convertToXYZRGBPointCloud (const Image::Ptr &image, con
 
   // fill in the RGB values
   step = cloud->width / image_width_;
-  skip = cloud->width * step - cloud->width;
+  skip = cloud->width - (image_width_ * step);
 
   value_idx = 0;
   point_idx = 0;


### PR DESCRIPTION
There were two issues fixed.

1) Alpha value specified in openni2_grabber.cpp was 0 and the cloud retrieved from the grabber was completely transparent. The pcl_openni2_viewer did not show any thing because of this.

2) Calculation of index value is wrong and it cause segmentation  violation in convertToXYZRGBPointCloud().