### PR TITLE
Fixed updateSphere method of PCLVisualizer

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -611,7 +611,7 @@ pcl::visualization::PCLVisualizer::addSphere (const PointT &center, double radiu
 template<typename PointT> bool
 pcl::visualization::PCLVisualizer::updateSphere (const PointT &center, double radius, double r, double g, double b, const std::string &id)
 {
-  if (contains (id))
+  if (!contains (id))
   {
     return (false);
   }


### PR DESCRIPTION
Previous pull request added "contains" helper method to check whether the actor('s "id") currently exists or not. However, in the "updateSphere" public method, the check should read

if(!contains(id)) return false;

as opposed to

if(contains(id)) return false;