### PR TITLE
patches : use template type PlointLT, instead of hardcode type pcl::Label

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
@@ -120,7 +120,7 @@ pcl::OrganizedConnectedComponentSegmentation<PointT, PointLT>::segment (pcl::Poi
   std::vector<unsigned> run_ids;
 
   unsigned invalid_label = std::numeric_limits<unsigned>::max ();
-  pcl::Label invalid_pt;
+  PointLT invalid_pt;
   invalid_pt.label = std::numeric_limits<unsigned>::max ();
   labels.points.resize (input_->points.size (), invalid_pt);
   labels.width = input_->width;

--- a/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
@@ -123,7 +123,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segment (std::ve
   compare_->setDistanceThreshold (static_cast<float> (distance_threshold_), true);
 
   // Set up the output
-  OrganizedConnectedComponentSegmentation<PointT,pcl::Label> connected_component (compare_);
+  OrganizedConnectedComponentSegmentation<PointT,PointLT> connected_component (compare_);
   connected_component.setInputCloud (input_);
   connected_component.segment (labels, label_indices);
 


### PR DESCRIPTION
correctly use template type PlointLT, instead of hardcode type pcl::Label in organized_multi_plane_segmentation.