### PR TITLE
Update fast_bilateral.hpp

### DIFF
--- a/filters/include/pcl/filters/impl/fast_bilateral.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral.hpp
@@ -137,7 +137,7 @@ pcl::FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
   if (early_division_)
   {
     for (std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::iterator d = data.begin (); d != data.end (); ++d)
-      *d /= ((*d)[0] != 0) ? (*d)[1] : 1;
+      *d /= ((*d)[1] != 0) ? (*d)[1] : 1;
 
     for (size_t x = 0; x < input_->width; x++)
       for (size_t y = 0; y < input_->height; y++)


### PR DESCRIPTION
Since we can divide per 0, we must check d[1] and not D[0].