### PR TITLE
Speed-up SampleConsensusModel::computeVariance

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -421,8 +421,9 @@ namespace pcl
       computeVariance (const std::vector<double> &error_sqr_dists)
       {
         std::vector<double> dists (error_sqr_dists);
-        std::sort (dists.begin (), dists.end ());
-        double median_error_sqr = dists[dists.size () >> 1];
+        const size_t medIdx = dists.size () >> 1;
+        std::nth_element (dists.begin (), dists.begin () + medIdx, dists.end ());
+        double median_error_sqr = dists[medIdx];
         return (2.1981 * median_error_sqr);
       }
 


### PR DESCRIPTION
Reduce complexity, by replacing std::sort with std::nth_element (linear time). In my scenarios performance improved in ~10 times