### PR TITLE
Fix for Breaking Changes in VC14 

### DIFF
--- a/surface/include/pcl/surface/3rdparty/poisson4/hash.h
+++ b/surface/include/pcl/surface/3rdparty/poisson4/hash.h
@@ -1,6 +1,7 @@
 #ifndef HASH_INCLUDED
 #define HASH_INCLUDED
 #if defined _WIN32 && !defined __MINGW32__
+#define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 #include <hash_map>
 using namespace stdext;
 #else // !_WIN32 || __MINGW32__

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -13557,7 +13557,7 @@ bool ON_WriteOneObjectArchive(
 
   while(pObject)
   {
-    rc = archive.Write3dmStartSection( version, "Archive created by ON_WriteOneObjectArchive "__DATE__" "__TIME__ );
+    rc = archive.Write3dmStartSection( version, "Archive created by ON_WriteOneObjectArchive " __DATE__ " " __TIME__ );
     if ( !rc )
       break;
 


### PR DESCRIPTION
Fix for Breaking Changes in VC14 about "hash_map" and "adjacent string literals".
Please refer [here](https://msdn.microsoft.com/en-us/library/bb531344.aspx?f=255&MSPPError=-2147217396) for details of Breaking Changes in VC14.