### PR TITLE
passthrough: Fix user_filter_value_ not being used at all

### DIFF
--- a/filters/src/passthrough.cpp
+++ b/filters/src/passthrough.cpp
@@ -125,7 +125,7 @@ pcl::PassThrough<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
       return;
     }
 
-    float badpt = std::numeric_limits<float>::quiet_NaN ();
+    float badpt = user_filter_value_;
     // Check whether we need to store filtered valued in place
     if (keep_organized_)
     {


### PR DESCRIPTION
This looks like it was accidentally not used.

Please verify that it builds before merging since I wrote this commit a while ago (but I guess Travis does this here).