### PR TITLE
Fixed assignment operators for SacModelCone and SacModelCylinder.

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -138,6 +138,7 @@ namespace pcl
       operator = (const SampleConsensusModelCone &source)
       {
         SampleConsensusModel<PointT>::operator=(source);
+        SampleConsensusModelFromNormals<PointT, PointNT>::operator=(source);
         axis_ = source.axis_;
         eps_angle_ = source.eps_angle_;
         min_angle_ = source.min_angle_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -136,6 +136,7 @@ namespace pcl
       operator = (const SampleConsensusModelCylinder &source)
       {
         SampleConsensusModel<PointT>::operator=(source);
+        SampleConsensusModelFromNormals<PointT, PointNT>::operator=(source);
         axis_ = source.axis_;
         eps_angle_ = source.eps_angle_;
         tmp_inliers_ = source.tmp_inliers_;


### PR DESCRIPTION
Consider the following code:

// all the other fields of anotherSacCylinderPtr are set appropriately
anotheSacCylinderPtr->setInputNormals(someCloudContainingNormals);
typedef pcl::SampleConsensusModelCylinder<pcl::PointXYZ, pcl::Normal> SacCylinder;
SacCylinder::Ptr b(new SacCylinder);
*b = *anotherSacCylinderPtr;

then using b just like that in a SacMethod yields the error that no input point cloud having normal information was given.
Same goes for the cone model.

Cheers,
Stefan