### PR TITLE
Fix VTK lightning when changing shape colour

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1461,9 +1461,6 @@ pcl::visualization::PCLVisualizer::setShapeRenderingProperties (
       actor->GetProperty ()->SetAmbient (0.8);
       actor->GetProperty ()->SetDiffuse (0.8);
       actor->GetProperty ()->SetSpecular (0.8);
-#if ((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION >= 4))
-      actor->GetProperty ()->SetLighting (0);
-#endif
       actor->Modified ();
       break;
     }


### PR DESCRIPTION
Reported on the [mailing-list](http://www.pcl-users.org/Shading-for-PCLVisualizer-addCylinder-td4038645.html#a4039178).
There is no reason to disable lightning when changing the shape colour.