### PR TITLE
Update Travis scripts to migrate to container-based infrastructure

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -10,6 +10,10 @@ ADVANCED_DIR=$BUILD_DIR/doc/advanced/html
 CMAKE_C_FLAGS="-Wall -Wextra -Wabi -O2"
 CMAKE_CXX_FLAGS="-Wall -Wextra -Wabi -O2"
 
+export FLANN_ROOT=$HOME/flann
+export VTK_DIR=$HOME/vtk
+export QHULL_ROOT=$HOME/qhull
+
 function build ()
 {
   case $CC in
@@ -69,29 +73,29 @@ function test ()
 {
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
-  cmake -DCMAKE_C_FLAGS=$CMAKE_C_FLAGS -DCMAKE_CXX_FLAGS=$CMAKE_CXX_FLAGS -DPCL_ONLY_CORE_POINT_TYPES=ON -DBUILD_global_tests=ON -DPCL_NO_PRECOMPILE=ON $PCL_DIR
+  cmake -DCMAKE_C_FLAGS=$CMAKE_C_FLAGS \
+        -DCMAKE_CXX_FLAGS=$CMAKE_CXX_FLAGS \
+        -DPCL_ONLY_CORE_POINT_TYPES=ON \
+        -DBUILD_global_tests=ON \
+        -DPCL_NO_PRECOMPILE=ON \
+        $PCL_DIR
   # Build and run tests
-  make pcl_filters -j3
-  make test_filters
-  make pcl_registration -j3
-  make test_registration
-  make test_registration_api
-  make tests -j3
+  make tests
 }
 
 function doc ()
 {
   # Do not generate documentation for pull requests
   if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then exit; fi
-  # Install doxygen and sphinx
-  sudo apt-get install doxygen doxygen-latex graphviz python-pip texlive-latex-base dvipng
-  sudo pip install sphinx sphinxcontrib-doxylink
+  # Add installed doxygen to path and install sphinx
+  export PATH=$HOME/doxygen/bin:$PATH
+  pip install --user sphinx sphinxcontrib-doxylink
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DDOXYGEN_USE_SHORT_NAMES=OFF \
         -DSPHINX_HTML_FILE_SUFFIX=php \
-        -DWITH_DOCS=1 \
-        -DWITH_TUTORIALS=1 \
+        -DWITH_DOCS=ON \
+        -DWITH_TUTORIALS=ON \
         $PCL_DIR
 
   git config --global user.email "documentation@pointclouds.org"
@@ -128,7 +132,198 @@ function doc ()
   fi
 }
 
-case $TASK in
+function install_flann()
+{
+  local pkg_ver=1.8.4
+  local pkg_file="flann-${pkg_ver}-src"
+  local pkg_url="http://people.cs.ubc.ca/~mariusm/uploads/FLANN/${pkg_file}.zip"
+  local pkg_md5sum="a0ecd46be2ee11a68d2a7d9c6b4ce701"
+  local FLANN_DIR=$HOME/flann
+  local config=$FLANN_DIR/include/flann/config.h
+  echo "Installing FLANN ${pkg_ver}"
+  if [[ -d $FLANN_DIR ]]; then
+    if [[ -e ${config} ]]; then
+      local version=`grep -Po "(?<=FLANN_VERSION_ \").*(?=\")" ${config}`
+      if [[ "$version" = "$pkg_ver" ]]; then
+        local modified=`stat -c %y ${config} | cut -d ' ' -f1`
+        echo " > Found cached installation of FLANN"
+        echo " > Version ${pkg_ver}, built on ${modified}"
+        return 0
+      fi
+    fi
+  fi
+  download ${pkg_url} ${pkg_md5sum}
+  if [[ $? -ne 0 ]]; then
+    return $?
+  fi
+  unzip pkg
+  cd ${pkg_file}
+  mkdir build && cd build
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$FLANN_DIR \
+    -DBUILD_MATLAB_BINDINGS=OFF \
+    -DBUILD_PYTHON_BINDINGS=OFF \
+    -DBUILD_CUDA_LIB=OFF \
+    -DBUILD_C_BINDINGS=OFF \
+    -DUSE_OPENMP=OFF
+  make -j2 && make install && touch ${config}
+  return $?
+}
+
+function install_vtk()
+{
+  local pkg_ver=5.10.1
+  local pkg_file="vtk-${pkg_ver}"
+  local pkg_url="http://www.vtk.org/files/release/${pkg_ver:0:4}/${pkg_file}.tar.gz"
+  local pkg_md5sum="264b0052e65bd6571a84727113508789"
+  local VTK_DIR=$HOME/vtk
+  local config=$VTK_DIR/include/vtk-${pkg_ver:0:4}/vtkConfigure.h
+  echo "Installing VTK ${pkg_ver}"
+  if [[ -d $VTK_DIR ]]; then
+    if [[ -e ${config} ]]; then
+      local version=`grep -Po "(?<=VTK_VERSION \").*(?=\")" ${config}`
+      if [[ "$version" = "$pkg_ver" ]]; then
+        local modified=`stat -c %y ${config} | cut -d ' ' -f1`
+        echo " > Found cached installation of VTK"
+        echo " > Version ${pkg_ver}, built on ${modified}"
+        return 0
+      fi
+    fi
+  fi
+  download ${pkg_url} ${pkg_md5sum}
+  if [[ $? -ne 0 ]]; then
+    return $?
+  fi
+  tar xvzf pkg
+  cd "VTK${pkg_ver}"
+  mkdir build && cd build
+  cmake .. \
+    -Wno-dev \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_INSTALL_PREFIX=$VTK_DIR \
+    -DBUILD_DOCUMENTATION=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_TESTING=OFF \
+    -DVTK_USE_BOOST=ON \
+    -DVTK_USE_CHARTS=ON \
+    -DVTK_USE_VIEWS=ON \
+    -DVTK_USE_RENDERING=ON \
+    -DVTK_USE_CHEMISTRY=OFF \
+    -DVTK_USE_HYBRID=OFF \
+    -DVTK_USE_PARALLEL=OFF \
+    -DVTK_USE_PATENTED=OFF \
+    -DVTK_USE_INFOVIS=ON \
+    -DVTK_USE_GL2PS=OFF \
+    -DVTK_USE_MYSQL=OFF \
+    -DVTK_USE_FFMPEG_ENCODER=OFF \
+    -DVTK_USE_TEXT_ANALYSIS=OFF \
+    -DVTK_WRAP_JAVA=OFF \
+    -DVTK_WRAP_PYTHON=OFF \
+    -DVTK_WRAP_TCL=OFF \
+    -DVTK_USE_QT=OFF \
+    -DVTK_USE_GUISUPPORT=OFF \
+    -DVTK_USE_SYSTEM_ZLIB=ON \
+    -DCMAKE_CXX_FLAGS="-D__STDC_CONSTANT_MACROS"
+  make -j2 && make install && touch ${config}
+  return $?
+}
+
+function install_qhull()
+{
+  local pkg_ver=2012.1
+  local pkg_file="qhull-${pkg_ver}"
+  local pkg_url="http://www.qhull.org/download/${pkg_file}-src.tgz"
+  local pkg_md5sum="d0f978c0d8dfb2e919caefa56ea2953c"
+  local QHULL_DIR=$HOME/qhull
+  local announce=$QHULL_DIR/share/doc/qhull/Announce.txt
+  echo "Installing QHull ${pkg_ver}"
+  if [[ -d $QHULL_DIR ]]; then
+    if [[ -e ${announce} ]]; then
+      local version=`grep -Po "(?<=Qhull )[0-9.]*(?= )" ${announce}`
+      if [[ "$version" = "$pkg_ver" ]]; then
+        local modified=`stat -c %y ${announce} | cut -d ' ' -f1`
+        echo " > Found cached installation of QHull"
+        echo " > Version ${pkg_ver}, built on ${modified}"
+        return 0
+      fi
+    fi
+  fi
+  download ${pkg_url} ${pkg_md5sum}
+  if [[ $? -ne 0 ]]; then
+    return $?
+  fi
+  tar xvzf pkg
+  cd ${pkg_file}
+  mkdir -p build && cd build
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS=-fPIC \
+    -DCMAKE_C_FLAGS=-fPIC \
+    -DCMAKE_INSTALL_PREFIX=$QHULL_DIR
+  make -j2 && make install && touch ${announce}
+  return $?
+}
+
+function install_doxygen()
+{
+  local pkg_ver=1.8.9.1
+  local pkg_file="doxygen-${pkg_ver}"
+  local pkg_url="http://ftp.stack.nl/pub/users/dimitri/${pkg_file}.src.tar.gz"
+  local pkg_md5sum="3d1a5c26bef358c10a3894f356a69fbc"
+  local DOXYGEN_DIR=$HOME/doxygen
+  local DOXYGEN_EXE=$DOXYGEN_DIR/bin/doxygen
+  echo "Installing Doxygen ${pkg_ver}"
+  if [[ -d $DOXYGEN_DIR ]]; then
+    if [[ -e $DOXYGEN_EXE ]]; then
+      local version=`$DOXYGEN_EXE --version`
+      if [[ "$version" = "$pkg_ver" ]]; then
+        local modified=`stat -c %y $DOXYGEN_EXE | cut -d ' ' -f1`
+        echo " > Found cached installation of Doxygen"
+        echo " > Version ${pkg_ver}, built on ${modified}"
+        return 0
+      fi
+    fi
+  fi
+  download ${pkg_url} ${pkg_md5sum}
+  if [[ $? -ne 0 ]]; then
+    return $?
+  fi
+  tar xvzf pkg
+  cd ${pkg_file}
+  ./configure --prefix $DOXYGEN_DIR
+  make -j2 && make install
+  return $?
+}
+
+function install_dependencies()
+{
+  install_flann
+  install_vtk
+  install_qhull
+  install_doxygen
+}
+
+function download()
+{
+  wget --output-document=pkg $1
+  if [[ $? -ne 0 ]]; then
+    return $?
+  fi
+  if [[ $# -ge 2 ]]; then
+    echo "$2  pkg" > "md5"
+    md5sum -c "md5" --quiet --status
+    if [[ $? -ne 0 ]]; then
+      echo "MD5 mismatch"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+case $1 in
+  install ) install_dependencies;;
   build ) build;;
   test ) test;;
   doc ) doc;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: cpp
 compiler:
   - gcc
@@ -31,16 +32,29 @@ env:
     - secure: PZivWbaCWFA2BFFY8n3UMxdEWjz7rBh568u9LF5LH3HgWADnfiwWzNriACqX9fhe7tSmDru5Bk978s+xPPAY9v24cfiDEX5a5MQ/XVr2rP48n3vlUDWERDhIodJ73F9F9GGZXToGdNz0MBUAHgiv7Lb0GYUfmOYzUJjWghngLBw=
 matrix:
   include:
-    - compiler: clang
+    - compiler: gcc
       env: TASK="test"
     - env: TASK="doc"
+addons:
+  apt:
+    sources:
+      - kalakris-cmake
+      - boost-latest
+      - kubuntu-backports
+    packages:
+      - cmake
+      - libboost1.55-all-dev
+      - libeigen3-dev
+      - libgtest-dev
+      - doxygen-latex
+      - libusb-1.0-0-dev
+cache:
+  directories:
+  - $HOME/flann
+  - $HOME/vtk
+  - $HOME/qhull
+  - $HOME/doxygen
 before_install:
-  - sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y
-  - sudo add-apt-repository ppa:apokluda/boost1.53 -y
-  - sudo add-apt-repository ppa:yade-users/external -y
-  - sudo add-apt-repository ppa:libreoffice/ppa -y
-  - sudo apt-get update -d
-install:
-  - sudo apt-get install libvtk5-qt4-dev libflann-dev libeigen3-dev libopenni-dev libqhull-dev libboost-filesystem1.53-dev libboost-iostreams1.53-dev libboost-thread1.53-dev libboost-chrono1.53-dev libusb-1.0-0-dev libgtest-dev
+  - bash .travis.sh install
 script:
-  - bash .travis.sh
+  - bash .travis.sh $TASK


### PR DESCRIPTION
Travis is currently [migrating](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade) from legacy to container-based infrastructure. Benefits include quick build starting time, caching, more available resources, and no notorious 50 minutes limit.  One of the difficulties though is that on container-based infrastructure we have no sudo rights, which means that the additional software that we need may only be installed either from white-listed repositories, or from source. Not all of PCL dependencies are available in the white-listed PPAs, for example there is no VTK and FLANN.

Thanks to caching, installation of dependencies from source is not a big deal.  Effectively, it even reduces build time, because once the software is built, installed, and cached, Travis doesn't need to spend time to download and install it from scratch on each run.

The list of dependencies that the updated script installs:

 * From white-listed repositories:
     - CMake
     - Boost 1.55
     - Eigen 3
     - GTest
     - Latex packages for Doxygen
     - libusb 1.0

 * From source:
     - VTK 5.10.1
     - FLANN 1.8.4
     - QHull 2012.1t
     - Doxygen 1.8.9.1

According to my tests, compilation task succeeds in 100% cases. Test task manages to build everything, however one of the unit tests fails. We will need to either fix it or disable for the time being.