### PR TITLE
Fix only include OpenNI to the All-in-one installer when WITH_OPENNI selected

### DIFF
--- a/cmake/pcl_all_in_one_installer.cmake
+++ b/cmake/pcl_all_in_one_installer.cmake
@@ -22,61 +22,63 @@ if(BUILD_all_in_one_installer)
         list(APPEND PCL_3RDPARTY_COMPONENTS ${dep})
     endforeach(dep)
 
-    if(CMAKE_CL_64)
-        set(OPENNI_PACKAGE "OpenNI-Win64-1.5.4-Dev.msi")
-        set(OPENNI_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_PACKAGE}")
-        set(OPENNI_MD5 c8f9cbe8447a16d32572a4e2c2d00af0)
-        set(OPENNI_SENSOR_PACKAGE "Sensor-Win-OpenSource64-5.1.0.msi")
-        set(OPENNI_SENSOR_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_SENSOR_PACKAGE}")
-        set(OPENNI_SENSOR_MD5 badb880116436870943b1b7c447dfa22)
-    else(CMAKE_CL_64)
-        set(OPENNI_PACKAGE "OpenNI-Win32-1.5.4-Dev.msi")
-        set(OPENNI_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_PACKAGE}")
-        set(OPENNI_MD5 996d48f447b41a5501b7d22af27ab251)
-        set(OPENNI_SENSOR_PACKAGE "Sensor-Win-OpenSource32-5.1.0.msi")
-        set(OPENNI_SENSOR_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_SENSOR_PACKAGE}")
-        set(OPENNI_SENSOR_MD5 55da1f7541d7c9c98772bddf801c7e1c)	
-    endif(CMAKE_CL_64)
+    if(WITH_OPENNI)
+        if(CMAKE_CL_64)
+            set(OPENNI_PACKAGE "OpenNI-Win64-1.5.4-Dev.msi")
+            set(OPENNI_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_PACKAGE}")
+            set(OPENNI_MD5 c8f9cbe8447a16d32572a4e2c2d00af0)
+            set(OPENNI_SENSOR_PACKAGE "Sensor-Win-OpenSource64-5.1.0.msi")
+            set(OPENNI_SENSOR_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_SENSOR_PACKAGE}")
+            set(OPENNI_SENSOR_MD5 badb880116436870943b1b7c447dfa22)
+        else(CMAKE_CL_64)
+            set(OPENNI_PACKAGE "OpenNI-Win32-1.5.4-Dev.msi")
+            set(OPENNI_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_PACKAGE}")
+            set(OPENNI_MD5 996d48f447b41a5501b7d22af27ab251)
+            set(OPENNI_SENSOR_PACKAGE "Sensor-Win-OpenSource32-5.1.0.msi")
+            set(OPENNI_SENSOR_URL "http://sourceforge.net/projects/pointclouds/files/dependencies/${OPENNI_SENSOR_PACKAGE}")
+            set(OPENNI_SENSOR_MD5 55da1f7541d7c9c98772bddf801c7e1c)	
+        endif(CMAKE_CL_64)
 
-    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "  IntCmp $OpenNI_selected 0 noinstall_openni_packages\n")
+        set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "  IntCmp $OpenNI_selected 0 noinstall_openni_packages\n")
 
-    file(DOWNLOAD ${OPENNI_URL} "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_PACKAGE}" 
-        STATUS _openni_download_status LOG _openni_download_log
-        EXPECTED_MD5 ${OPENNI_MD5}
-       )
-    list(GET _openni_download_status 0 _error_code)
-    list(GET _openni_download_status 1 _error_message)
-    if(_error_code EQUAL 0)
-        install(
-            FILES "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_PACKAGE}" 
-            DESTINATION 3rdParty/OpenNI
-            COMPONENT OpenNI
-        )
-        list(APPEND PCL_3RDPARTY_COMPONENTS OpenNI)
-        set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS 
-            "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n    ExecWait 'msiexec /i \\\"$INSTDIR\\\\3rdParty\\\\OpenNI\\\\${OPENNI_PACKAGE}\\\" '")
-    else(_error_code EQUAL 0)
-        message("WARNING : Could not download ${OPENNI_URL}, error code : ${_error_code}, error message : ${_error_message}")
-    endif(_error_code EQUAL 0)
+        file(DOWNLOAD ${OPENNI_URL} "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_PACKAGE}" 
+            STATUS _openni_download_status LOG _openni_download_log
+            EXPECTED_MD5 ${OPENNI_MD5}
+           )
+        list(GET _openni_download_status 0 _error_code)
+        list(GET _openni_download_status 1 _error_message)
+        if(_error_code EQUAL 0)
+            install(
+                FILES "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_PACKAGE}" 
+                DESTINATION 3rdParty/OpenNI
+                COMPONENT OpenNI
+            )
+            list(APPEND PCL_3RDPARTY_COMPONENTS OpenNI)
+            set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS 
+                "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n    ExecWait 'msiexec /i \\\"$INSTDIR\\\\3rdParty\\\\OpenNI\\\\${OPENNI_PACKAGE}\\\" '")
+        else(_error_code EQUAL 0)
+            message("WARNING : Could not download ${OPENNI_URL}, error code : ${_error_code}, error message : ${_error_message}")
+        endif(_error_code EQUAL 0)
 
-    file(DOWNLOAD ${OPENNI_SENSOR_URL} "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_SENSOR_PACKAGE}" 
-        STATUS _openni_download_status LOG _openni_download_log
-        EXPECTED_MD5 ${OPENNI_SENSOR_MD5}
-       )
-    list(GET _openni_download_status 0 _error_code)
-    list(GET _openni_download_status 1 _error_message)
-    if(_error_code EQUAL 0)
-        install(
-            FILES "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_SENSOR_PACKAGE}"
-            DESTINATION 3rdParty/OpenNI
-            COMPONENT OpenNI
-        )
-        list(APPEND PCL_3RDPARTY_COMPONENTS OpenNI)
-        set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS 
-            "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n    ExecWait 'msiexec /i \\\"$INSTDIR\\\\3rdParty\\\\OpenNI\\\\${OPENNI_SENSOR_PACKAGE}\\\" '")
-    else(_error_code EQUAL 0)
-        message("WARNING : Could not download ${OPENNI_SENSOR_URL}, error code : ${_error_code}, error message : ${_error_message}")
-    endif(_error_code EQUAL 0)
-    list(REMOVE_DUPLICATES PCL_3RDPARTY_COMPONENTS)
-    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n  noinstall_openni_packages:\n")
+        file(DOWNLOAD ${OPENNI_SENSOR_URL} "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_SENSOR_PACKAGE}" 
+            STATUS _openni_download_status LOG _openni_download_log
+            EXPECTED_MD5 ${OPENNI_SENSOR_MD5}
+           )
+        list(GET _openni_download_status 0 _error_code)
+        list(GET _openni_download_status 1 _error_message)
+        if(_error_code EQUAL 0)
+            install(
+                FILES "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI_SENSOR_PACKAGE}"
+                DESTINATION 3rdParty/OpenNI
+                COMPONENT OpenNI
+            )
+            list(APPEND PCL_3RDPARTY_COMPONENTS OpenNI)
+            set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS 
+                "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n    ExecWait 'msiexec /i \\\"$INSTDIR\\\\3rdParty\\\\OpenNI\\\\${OPENNI_SENSOR_PACKAGE}\\\" '")
+        else(_error_code EQUAL 0)
+            message("WARNING : Could not download ${OPENNI_SENSOR_URL}, error code : ${_error_code}, error message : ${_error_message}")
+        endif(_error_code EQUAL 0)
+        list(REMOVE_DUPLICATES PCL_3RDPARTY_COMPONENTS)
+        set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n  noinstall_openni_packages:\n")
+    endif(WITH_OPENNI)
 endif(BUILD_all_in_one_installer)


### PR DESCRIPTION
This pull request will provide fix for to only include installer of OpenNI/Sensor to the All-in-one Installer when WITH_OPENNI is selected in CMake.
Currently, The Installer of OpenNI/Sensor always include to the All-in-one Installer.
However, If OpenNI is not valid, there is no need to include installer of OpenNI/Sensor to the All-in-one Installer.