### PR TITLE
Fix error C3848 in VC14 when WITH_OPENNI2 selected

### DIFF
--- a/io/src/openni2/openni2_device_manager.cpp
+++ b/io/src/openni2/openni2_device_manager.cpp
@@ -51,7 +51,7 @@ namespace pcl
       class OpenNI2DeviceInfoComparator
       {
       public:
-        bool operator ()(const OpenNI2DeviceInfo& di1, const OpenNI2DeviceInfo& di2)
+        bool operator ()(const OpenNI2DeviceInfo& di1, const OpenNI2DeviceInfo& di2) const
         {
           return (di1.uri_.compare (di2.uri_) < 0);
         }


### PR DESCRIPTION
Fix compiler error C3848 in VC14 (Release configuration) when WITH_OPENNI2 is selected.
Add const qualifier to OpenNI2DeviceInfoComparator::operator() for fix this problem.