### PR TITLE
fix a few bugs 

### DIFF
--- a/gpu/kinfu/tools/plot_camera_poses.m
+++ b/gpu/kinfu/tools/plot_camera_poses.m
@@ -84,9 +84,9 @@ function octave_axis_equal(h)
 % workaround for axis auto not working in 3d
 % tanks http://octave.1599824.n4.nabble.com/axis-equal-help-tp1636701p1636702.html
 figure(h);
-xl = get (gca, "xlim");
-yl = get (gca, "ylim");
-zl = get (gca, "zlim");
+xl = get (gca, 'xlim');
+yl = get (gca, 'ylim');
+zl = get (gca, 'zlim');
 span = max ([diff(xl), diff(yl), diff(zl)]);
 xlim (mean (xl) + span*[-0.5, 0.5])
 ylim (mean (yl) + span*[-0.5, 0.5])

--- a/gpu/kinfu/tools/plot_camera_poses.m
+++ b/gpu/kinfu/tools/plot_camera_poses.m
@@ -65,6 +65,7 @@ for n=1:3
   a=r*p(n,:)';
   plot3([t(1),t(1)+a(1)], [t(2),t(2)+a(2)], [t(3),t(3)+a(3)], 'color', c{n});
 end
+end
 
 function R=q2rot(q)
 % conversion code from http://en.wikipedia.org/wiki/Rotation_matrix%Quaternion	

--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -44,6 +44,7 @@
 #ifndef __CUDACC__
 //https://bugreports.qt-project.org/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
+#include <boost/version.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>


### PR DESCRIPTION
1. in file 'gpu\kinfu\tools\plot_camera_poses.m':
a). change _"_ to _'_, to be compatible with matlab
b). add closing 'end' to fix syntax error 

2. in file 'io/include/pcl/io/boost.h':
add "include <boost/version.hpp>" to enable BOOST_VERSION check code snippets, to avoid `chrono` being not a type error.