### PR TITLE
Add OpenNI2 to the All-in-one Installer

### DIFF
--- a/cmake/pcl_all_in_one_installer.cmake
+++ b/cmake/pcl_all_in_one_installer.cmake
@@ -81,4 +81,51 @@ if(BUILD_all_in_one_installer)
         list(REMOVE_DUPLICATES PCL_3RDPARTY_COMPONENTS)
         set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n  noinstall_openni_packages:\n")
     endif(WITH_OPENNI)
+
+    if(WITH_OPENNI2)
+        if(CMAKE_CL_64)
+            set(OPENNI2_PACKAGE "OpenNI-Windows-x64-2.2.msi")
+            set(OPENNI2_ZIP "OpenNI-Windows-x64-2.2.0.33.zip")
+            set(OPENNI2_URL "http://com.occipital.openni.s3.amazonaws.com/${OPENNI2_ZIP}")
+            set(OPENNI2_MD5 d187f1dd0b091e27cebd03216b1bfff5)
+        else(CMAKE_CL_64)
+            set(OPENNI2_PACKAGE "OpenNI-Windows-x86-2.2.msi")
+            set(OPENNI2_ZIP "OpenNI-Windows-x86-2.2.0.33.zip")
+            set(OPENNI2_URL "http://com.occipital.openni.s3.amazonaws.com/${OPENNI2_ZIP}")
+            set(OPENNI2_MD5 59b38e23d951d59917a35f7f89efaf22)
+        endif(CMAKE_CL_64)
+
+        set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "  IntCmp $OpenNI2_selected 0 noinstall_openni2_packages\n")
+
+        file(DOWNLOAD ${OPENNI2_URL} "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI2_ZIP}" 
+            STATUS _openni2_download_status LOG _openni2_download_log
+            EXPECTED_MD5 ${OPENNI2_MD5}
+           )
+        list(GET _openni2_download_status 0 _error_code)
+        list(GET _openni2_download_status 1 _error_message)
+        if(_error_code EQUAL 0)
+            execute_process(
+                COMMAND ${CMAKE_COMMAND} -E tar -xzf ${OPENNI2_ZIP}
+                WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+                RESULT_VARIABLE _error_code
+                ERROR_VARIABLE _error_message
+            )
+            if(_error_code EQUAL 0)
+                install(
+                    FILES "${CMAKE_CURRENT_BINARY_DIR}/${OPENNI2_PACKAGE}" 
+                    DESTINATION 3rdParty/OpenNI2
+                    COMPONENT OpenNI2
+                )
+                list(APPEND PCL_3RDPARTY_COMPONENTS OpenNI2)
+                set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS 
+                    "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n    ExecWait 'msiexec /i \\\"$INSTDIR\\\\3rdParty\\\\OpenNI2\\\\${OPENNI2_PACKAGE}\\\" '")
+            else(_error_code EQUAL 0)
+                message("WARNING : Could not unzip ${OPENNI2_ZIP}, error code : ${_error_code}, error message : ${_error_message}")
+            endif(_error_code EQUAL 0)
+        else(_error_code EQUAL 0)
+            message("WARNING : Could not download ${OPENNI2_ZIP_URL}, error code : ${_error_code}, error message : ${_error_message}")
+        endif(_error_code EQUAL 0)
+        list(REMOVE_DUPLICATES PCL_3RDPARTY_COMPONENTS)
+        set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}\n  noinstall_openni2_packages:\n")
+    endif(WITH_OPENNI2)
 endif(BUILD_all_in_one_installer)


### PR DESCRIPTION
This pull request provides the following.

* Add script to include the installer of OpenNI2 to the All-in-one Installer when WITH_OPENNI2 is selected in CMake.  
This script will automatically download from [distribution source](http://structure.io/openni), and unzip the archive.  
And, It will include the installer of OpenNI2 to the All-in-one installer the same way as OpenNI1.