### PR TITLE
Fix bug when trying to remove shape when no LUT is displayed / no shape has color information

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -1270,10 +1270,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::updateLookUpTableDisplay (bool
     }
   }
 
-  if (!actor_found)
-    PCL_WARN ("[updateLookUpTableDisplay] No actor was found with LUT information!\n");
-
-  if (!actor_found || (lut_enabled_ && add_lut))  // Remove actor
+  if ( (!actor_found && lut_enabled_) || (lut_enabled_ && add_lut))  // Remove actor
   {
     CurrentRenderer->RemoveActor (lut_actor_);
     lut_enabled_ = false;


### PR DESCRIPTION
Fixes #1320

I also removed the warning which was intrusive and not very useful; warnings are still displayed when the user asked for a specific shape LUT to be displayed but the shape was not found.