### PR TITLE
Improve removeShape and removeAllShapes performance

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -1176,6 +1176,9 @@ pcl::visualization::PCLVisualizerInteractorStyle::updateLookUpTableDisplay (bool
   ShapeActorMap::iterator sm_it;
   bool actor_found = false;
 
+  if (!lut_enabled_ && !add_lut)
+    return;
+
   if (lut_actor_id_ != "")  // Search if provided actor id is in CloudActorMap or ShapeActorMap
   {
     am_it = cloud_actors_->find (lut_actor_id_);
@@ -1278,7 +1281,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::updateLookUpTableDisplay (bool
     CurrentRenderer->RemoveActor (lut_actor_);
     lut_enabled_ = false;
   }
-  else if (!lut_enabled_ && add_lut)  // Add actor
+  else if (!lut_enabled_ && add_lut && actor_found)  // Add actor
   {
     CurrentRenderer->AddActor (lut_actor_);
     lut_actor_->SetVisibility (true);

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -803,8 +803,12 @@ pcl::visualization::PCLVisualizer::removeShape (const std::string &id, int viewp
   {
     if (removeActorFromRenderer (am_it->second, viewport))
     {
+      bool update_LUT (true);
+      if (!style_->lut_actor_id_.empty() && am_it->first != style_->lut_actor_id_)
+        update_LUT = false;
       shape_actor_map_->erase (am_it);
-      style_->updateLookUpTableDisplay (false);
+      if (update_LUT)
+        style_->updateLookUpTableDisplay (false);
       return (true);
     }
   }
@@ -812,8 +816,12 @@ pcl::visualization::PCLVisualizer::removeShape (const std::string &id, int viewp
   {
     if (removeActorFromRenderer (ca_it->second.actor, viewport))
     {
+      bool update_LUT (true);
+      if (!style_->lut_actor_id_.empty() && ca_it->first != style_->lut_actor_id_)
+        update_LUT = false;
       cloud_actor_map_->erase (ca_it);
-      style_->updateLookUpTableDisplay (false);
+      if (update_LUT)
+        style_->updateLookUpTableDisplay (false);
       return (true);
     }
   }
@@ -863,6 +871,9 @@ pcl::visualization::PCLVisualizer::removeAllPointClouds (int viewport)
 bool
 pcl::visualization::PCLVisualizer::removeAllShapes (int viewport)
 {
+  bool display_lut (style_->lut_enabled_);
+  style_->lut_enabled_ = false; // Temporally disable LUT to fasten shape removal
+
   // Check to see if the given ID entry exists
   ShapeActorMap::iterator am_it = shape_actor_map_->begin ();
   while (am_it != shape_actor_map_->end ())
@@ -871,6 +882,12 @@ pcl::visualization::PCLVisualizer::removeAllShapes (int viewport)
       am_it = shape_actor_map_->begin ();
     else
       ++am_it;
+  }
+
+  if (display_lut)
+  {
+    style_->lut_enabled_ = true;
+    style_->updateLookUpTableDisplay (true);
   }
   return (true);
 }


### PR DESCRIPTION
Fixes #1322.

All the cases are quite hard to understand and I'm pretty sure this is not perfect but this at least makes `removeShape` and `removeAllShapes` much faster in many situations.

Results
===

 c550f3ad11fad9b0d7c61cfb70ba5f5b7b427d79
---
```
removeAllShapes (5000 shapes) took 3650 ms
removeAllShapes (5000 shapes) took 3575 ms
removeAllShapes (5000 shapes) took 3644 ms
```

Master
---
Results can go up to 486 secs when setLookUpTableID is not activated and LUT displayed.

PR branch
---
- With setLookUpTableID line activated
    - LUT not enabled
    ```
    removeAllShapes (5000 shapes) took 3628 ms
    removeAllShapes (5000 shapes) took 3581 ms
    removeAllShapes (5000 shapes) took 3648 ms
    ```
    - LUT enabled
    ```
    removeAllShapes (5000 shapes) took 3570 ms
    removeAllShapes (5000 shapes) took 3572 ms
    removeAllShapes (5000 shapes) took 3663 ms
    ```

- Without setLookUpTableID
    - LUT not enabled
    ```
    removeAllShapes (5000 shapes) took 5865 ms
    removeAllShapes (5000 shapes) took 3650 ms
    removeAllShapes (5000 shapes) took 5927 ms
    ```
    - LUT enabled
    ```    
    removeAllShapes (5000 shapes) took 3634 ms
    removeAllShapes (5000 shapes) took 3867 ms
    removeAllShapes (5000 shapes) took 3662 ms
    ```
        
Test code:
===
```cpp
#include <pcl/io/vtk_lib_io.h>
#include <pcl/visualization/pcl_visualizer.h>
#include <pcl/console/time.h>

#define NUMBER_OF_SHAPES 5000
bool remove_all_shapes = false;

void
keyboardEventOccurred (const pcl::visualization::KeyboardEvent& event,
                       void* nothing)
{
  if (event.getKeySym () == "a" && event.keyDown ())
    remove_all_shapes = true;
}

int
main (int argc,
      char * argv[])
{
  pcl::visualization::PCLVisualizer viewer;
  pcl::console::TicToc time;

  for (int i = 0; i < NUMBER_OF_SHAPES; ++i)
  {
    pcl::PointXYZ center;
    center.x = 1024 * rand () / (RAND_MAX + 1.0f);
    center.y = 1024 * rand () / (RAND_MAX + 1.0f);
    center.z = 1024 * rand () / (RAND_MAX + 1.0f);
    viewer.addSphere (center, 0.05, "sphere_" + boost::lexical_cast<std::string> (i));
  }

  // Add colored mesh
  pcl::PolygonMesh mesh;
  pcl::io::loadPolygonFilePLY ("/home/victor/mesh.ply", mesh);
  vtkSmartPointer<vtkPolyData> poly_data = vtkSmartPointer<vtkPolyData>::New ();
  pcl::io::mesh2vtk (mesh, poly_data);
  vtkSmartPointer<vtkFloatArray> mesh_distances = vtkSmartPointer<vtkFloatArray>::New ();
  for (unsigned int i = 0; i < mesh.cloud.height * mesh.cloud.width; ++i)
    mesh_distances->InsertTuple1 (i, i);
  poly_data->GetPointData ()->SetScalars (mesh_distances);
  viewer.addModelFromPolyData (poly_data, "mesh");
  //viewer.setLookUpTableID("mesh"); // TODO: Remove this line if using an old PCL version (setLookUpTableID doesn't exist)

  viewer.registerKeyboardCallback (&keyboardEventOccurred, (void*) NULL);
  while (!viewer.wasStopped ())
  {
    viewer.spinOnce ();
    // The user pressed "a" :
    if (remove_all_shapes)
    {
      // removeAllShapes
      time.tic ();
      viewer.removeAllShapes ();
      std::cout << "removeAllShapes (" << NUMBER_OF_SHAPES << " shapes) took " << time.toc () << " ms" << std::endl;
      remove_all_shapes = false;
    }
  }

  return 0;
}
```