### PR TITLE
Fix build in MXE (M cross environment)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 ### ---[ PCL global CMake
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
+if(POLICY CMP0017)
+  # Do not include files in CMAKE_MODULE_PATH from files
+  # in CMake module directory. Fix MXE build
+  cmake_policy(SET CMP0017 NEW)
+endif()
+
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 OLD) # do not use VERSION option in project() command
 endif()


### PR DESCRIPTION
Add "cmake_policy(SET CMP0017 NEW)" to CMakeLists.txt

$ cmake --help-policy CMP0017

> Starting with CMake 2.8.4, if a cmake-module shipped with CMake (i.e.
> located in the CMake module directory) calls include() or
> find_package(), the files located in the the CMake module directory
> are preferred over the files in CMAKE_MODULE_PATH.  This makes sure
> that the modules belonging to CMake always get those files included
> which they expect, and against which they were developed and tested.
> In call other cases, the files found in CMAKE_MODULE_PATH still take
> precedence over the ones in the CMake module directory.  The OLD
> behaviour is to always prefer files from CMAKE_MODULE_PATH over files
> from the CMake modules directory.

Error message:

```
CMake Error at /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:97 (MESSAGE):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE) (found version
  "0.28")
Call Stack (most recent call first):
  /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:288 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-2.8/Modules/FindPkgConfig.cmake:102 (find_package_handle_standard_args)
  /mxe/src/cmake/FindTIFF.cmake:5 (find_package)
  /usr/share/cmake-2.8/Modules/Qt4ConfigDependentSettings.cmake:86 (find_package)
  /usr/share/cmake-2.8/Modules/FindQt4.cmake:1053 (INCLUDE)
  CMakeLists.txt:336 (find_package)
```

See https://github.com/mxe/mxe/pull/800
See https://github.com/mxe/mxe/issues/734