### PR TITLE
Fix wrong image number in tutorial index

### DIFF
--- a/doc/tutorials/content/index.rst
+++ b/doc/tutorials/content/index.rst
@@ -643,7 +643,7 @@ I/O
              In this tutorial we will learn how to setup and use DepthSense cameras within PCL on both Linux and Windows platforms.
      ======  ======
 
-     .. |i_o8| image:: images/creative_camera.jpg
+     .. |i_o9| image:: images/creative_camera.jpg
                :height: 70px
 
 .. _keypoints_tutorial:


### PR DESCRIPTION
Little mistake in #1230 
![capture](https://cloud.githubusercontent.com/assets/5566160/10341073/676a711e-6d13-11e5-8dca-6c4039b2a6a3.png)
