### PR TITLE
SAC Models Refactoring: isModelValid(), ver. 2

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -323,12 +323,8 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
 template <typename PointT> bool 
 pcl::SampleConsensusModelCircle2D<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 3)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCircle2D::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   if (radius_min_ != -std::numeric_limits<double>::max() && model_coefficients[2] < radius_min_)
     return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -439,12 +439,8 @@ pcl::SampleConsensusModelCircle3D<PointT>::doSamplesVerifyModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelCircle3D<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 7)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCircle3D::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   if (radius_min_ != -DBL_MAX && model_coefficients[3] < radius_min_)
     return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -496,13 +496,9 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::pointToAxisDistance (
 template <typename PointT, typename PointNT> bool 
 pcl::SampleConsensusModelCone<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 7)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCone::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
- 
+
   // Check against template, if given
   if (eps_angle_ > 0.0)
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -443,13 +443,9 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPointToCylinder (
 template <typename PointT, typename PointNT> bool 
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 7)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelCylinder::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
- 
+
   // Check against template, if given
   if (eps_angle_ > 0.0)
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_parallel_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_parallel_plane.hpp
@@ -47,12 +47,8 @@
 template <typename PointT, typename PointNT> bool
 pcl::SampleConsensusModelNormalParallelPlane<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelNormalParallelPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
@@ -209,12 +209,8 @@ pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::getDistancesToModel (
 template <typename PointT, typename PointNT> bool 
 pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelNormalSphere::selectWithinDistance] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   if (radius_min_ != -std::numeric_limits<double>::max() && model_coefficients[3] < radius_min_)
     return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
@@ -90,12 +90,8 @@ pcl::SampleConsensusModelParallelLine<PointT>::getDistancesToModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelParallelLine<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 6)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusParallelLine::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
@@ -89,12 +89,8 @@ pcl::SampleConsensusModelParallelPlane<PointT>::getDistancesToModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelParallelPlane<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelParallelPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
@@ -89,12 +89,8 @@ pcl::SampleConsensusModelPerpendicularPlane<PointT>::getDistancesToModel (
 template <typename PointT> bool
 pcl::SampleConsensusModelPerpendicularPlane<PointT>::isModelValid (const Eigen::VectorXf &model_coefficients)
 {
-  // Needs a valid model coefficients
-  if (model_coefficients.size () != 4)
-  {
-    PCL_ERROR ("[pcl::SampleConsensusModelPerpendicularPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+  if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
     return (false);
-  }
 
   // Check against template, if given
   if (eps_angle_ > 0.0)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -509,10 +509,22 @@ namespace pcl
       }
 
       /** \brief Check whether a model is valid given the user constraints.
+        *
+        * Default implementation verifies that the number of coefficients in the supplied model is as expected for this
+        * SAC model type. Specific SAC models should extend this function by checking the user constraints (if any).
+        *
         * \param[in] model_coefficients the set of model coefficients
         */
-      virtual inline bool
-      isModelValid (const Eigen::VectorXf &model_coefficients) = 0;
+      virtual bool
+      isModelValid (const Eigen::VectorXf &model_coefficients)
+      {
+        if (model_coefficients.size () != model_size_)
+        {
+          PCL_ERROR ("[pcl::%s::isModelValid] Invalid number of model coefficients given (%lu)!\n", getClassName ().c_str (), model_coefficients.size ());
+          return (false);
+        }
+        return (true);
+      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices. Pure virtual.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -365,6 +365,13 @@ namespace pcl
         return (it->second);
       }
 
+      /** \brief Return the number of coefficients in the model. */
+      inline unsigned int
+      getModelSize () const
+      {
+        return model_size_;
+      }
+
       /** \brief Set the minimum and maximum allowable radius limits for the
         * model (applicable to models that estimate a radius)
         * \param[in] min_radius the minimum radius model
@@ -443,6 +450,7 @@ namespace pcl
       }
 
     protected:
+
       /** \brief Fills a sample array with random samples from the indices_ vector
         * \param[out] sample the set of indices of target_ to analyze
         */
@@ -550,6 +558,9 @@ namespace pcl
 
       /** \brief A vector holding the distances to the computed model. Used internally. */
       std::vector<double> error_sqr_dists_;
+
+      /** \brief The number of coefficients in the model. Every subclass should initialize this appropriately. */
+      unsigned int model_size_;
 
       /** \brief Boost-based random number generator. */
       inline int

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -81,6 +81,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, random), tmp_inliers_ () 
       {
         model_name_ = "SampleConsensusModelCircle2D";
+        model_size_ = 3;
       }
 
       /** \brief Constructor for base SampleConsensusModelCircle2D.
@@ -94,6 +95,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, indices, random), tmp_inliers_ ()
       {
         model_name_ = "SampleConsensusModelCircle2D";
+        model_size_ = 3;
       }
 
       /** \brief Copy constructor.
@@ -195,6 +197,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_CIRCLE2D); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -66,6 +66,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -202,7 +203,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -66,6 +66,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -204,7 +205,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -83,6 +83,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, random)
       {
         model_name_ = "SampleConsensusModelCircle3D";
+        model_size_ = 7;
       }
 
       /** \brief Constructor for base SampleConsensusModelCircle3D.
@@ -96,6 +97,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
         model_name_ = "SampleConsensusModelCircle3D";
+        model_size_ = 7;
       }
       
       /** \brief Empty destructor */
@@ -197,6 +199,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_CIRCLE3D); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -95,6 +95,7 @@ namespace pcl
         , tmp_inliers_ ()
       {
         model_name_ = "SampleConsensusModelCone";
+        model_size_ = 7;
       }
 
       /** \brief Constructor for base SampleConsensusModelCone.
@@ -114,6 +115,7 @@ namespace pcl
         , tmp_inliers_ ()
       {
         model_name_ = "SampleConsensusModelCone";
+        model_size_ = 7;
       }
 
       /** \brief Copy constructor.
@@ -268,6 +270,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_CONE); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Get the distance from a point to a line (represented by a point and a direction)
         * \param[in] pt a point
         * \param[in] model_coefficients the line coefficients (a point on the line, line direction)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -74,6 +74,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -288,7 +289,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -93,6 +93,7 @@ namespace pcl
         , tmp_inliers_ ()
       {
         model_name_ = "SampleConsensusModelCylinder";
+        model_size_ = 7;
       }
 
       /** \brief Constructor for base SampleConsensusModelCylinder.
@@ -110,6 +111,7 @@ namespace pcl
         , tmp_inliers_ ()
       {
         model_name_ = "SampleConsensusModelCylinder";
+        model_size_ = 7;
       }
 
       /** \brief Copy constructor.
@@ -240,6 +242,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_CYLINDER); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Get the distance from a point to a line (represented by a point and a direction)
         * \param[in] pt a point
         * \param[in] model_coefficients the line coefficients (a point on the line, line direction)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -74,6 +74,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -288,7 +289,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief Check if a sample of indices results in a good sample of points

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -82,6 +82,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, random)
       {
         model_name_ = "SampleConsensusModelLine";
+        model_size_ = 6;
       }
 
       /** \brief Constructor for base SampleConsensusModelLine.
@@ -95,6 +96,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
         model_name_ = "SampleConsensusModelLine";
+        model_size_ = 6;
       }
       
       /** \brief Empty destructor */
@@ -176,6 +178,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_LINE); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -67,6 +67,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -179,21 +180,6 @@ namespace pcl
 
     protected:
       using SampleConsensusModel<PointT>::model_size_;
-
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool 
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        if (model_coefficients.size () != 6)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelLine::selectWithinDistance] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
-          return (false);
-        }
-
-        return (true);
-      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -90,6 +90,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -192,7 +193,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
    private:

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -114,6 +114,7 @@ namespace pcl
         , eps_dist_ (0.0)
       {
         model_name_ = "SampleConsensusModelNormalParallelPlane";
+        model_size_ = 4;
       }
 
       /** \brief Constructor for base SampleConsensusModelNormalParallelPlane.
@@ -132,6 +133,7 @@ namespace pcl
         , eps_dist_ (0.0)
       {
         model_name_ = "SampleConsensusModelNormalParallelPlane";
+        model_size_ = 4;
       }
       
       /** \brief Empty destructor */
@@ -185,6 +187,8 @@ namespace pcl
     	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -82,7 +82,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModelPlane<PointT>::isModelValid;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -103,6 +103,7 @@ namespace pcl
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalPlane";
+        model_size_ = 4;
       }
 
       /** \brief Constructor for base SampleConsensusModelNormalPlane.
@@ -117,6 +118,7 @@ namespace pcl
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalPlane";
+        model_size_ = 4;
       }
       
       /** \brief Empty destructor */
@@ -155,6 +157,9 @@ namespace pcl
       getModelType () const { return (SACMODEL_NORMAL_PLANE); }
 
     	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    protected:
+      using SampleConsensusModel<PointT>::model_size_;
   };
 }
 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -77,6 +77,7 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -157,7 +158,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
   };

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -97,6 +97,7 @@ namespace pcl
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalSphere";
+        model_size_ = 4;
       }
 
       /** \brief Constructor for base SampleConsensusModelNormalSphere.
@@ -111,6 +112,7 @@ namespace pcl
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalSphere";
+        model_size_ = 4;
       }
       
       /** \brief Empty destructor */
@@ -150,6 +152,8 @@ namespace pcl
     	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -67,6 +67,7 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelLine<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelLine<PointT>::PointCloudPtr PointCloudPtr;
@@ -164,7 +165,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief The axis along which we need to search for a line. */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -85,6 +85,7 @@ namespace pcl
         , eps_angle_ (0.0)
       {
         model_name_ = "SampleConsensusModelParallelLine";
+        model_size_ = 6;
       }
 
       /** \brief Constructor for base SampleConsensusModelParallelLine.
@@ -100,6 +101,7 @@ namespace pcl
         , eps_angle_ (0.0)
       {
         model_name_ = "SampleConsensusModelParallelLine";
+        model_size_ = 6;
       }
 
       /** \brief Empty destructor */
@@ -157,13 +159,14 @@ namespace pcl
       getModelType () const { return (SACMODEL_PARALLEL_LINE); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
       bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
-    protected:
       /** \brief The axis along which we need to search for a line. */
       Eigen::Vector3f axis_;
 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -67,6 +67,7 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
@@ -168,7 +169,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief The axis along which we need to search for a plane perpendicular to. */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -86,6 +86,7 @@ namespace pcl
         , sin_angle_ (-1.0)
       {
         model_name_ = "SampleConsensusModelParallelPlane";
+        model_size_ = 4;
       }
 
       /** \brief Constructor for base SampleConsensusModelParallelPlane.
@@ -102,6 +103,7 @@ namespace pcl
         , sin_angle_ (-1.0)
       {
         model_name_ = "SampleConsensusModelParallelPlane";
+        model_size_ = 4;
       }
       
       /** \brief Empty destructor */
@@ -161,6 +163,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_PARALLEL_PLANE); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -90,6 +90,7 @@ namespace pcl
         , eps_angle_ (0.0)
       {
         model_name_ = "SampleConsensusModelPerpendicularPlane";
+        model_size_ = 4;
       }
 
       /** \brief Constructor for base SampleConsensusModelPerpendicularPlane.
@@ -105,6 +106,7 @@ namespace pcl
         , eps_angle_ (0.0)
       {
         model_name_ = "SampleConsensusModelPerpendicularPlane";
+        model_size_ = 4;
       }
       
       /** \brief Empty destructor */
@@ -164,6 +166,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_PERPENDICULAR_PLANE); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -72,6 +72,7 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
@@ -171,7 +172,7 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients);
 
       /** \brief The axis along which we need to search for a plane perpendicular to. */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -155,6 +155,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, random)
       {
         model_name_ = "SampleConsensusModelPlane";
+        model_size_ = 4;
       }
 
       /** \brief Constructor for base SampleConsensusModelPlane.
@@ -168,6 +169,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
         model_name_ = "SampleConsensusModelPlane";
+        model_size_ = 4;
       }
       
       /** \brief Empty destructor */
@@ -249,6 +251,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_PLANE); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -140,6 +140,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -252,21 +253,6 @@ namespace pcl
 
     protected:
       using SampleConsensusModel<PointT>::model_size_;
-
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool 
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        // Needs a valid model coefficients
-        if (model_coefficients.size () != 4)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelPlane::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
-          return (false);
-        }
-        return (true);
-      }
 
     private:
       /** \brief Check if a sample of indices results in a good sample of points

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -84,6 +84,7 @@ namespace pcl
         // Call our own setInputCloud
         setInputCloud (cloud);
         model_name_ = "SampleConsensusModelRegistration";
+        model_size_ = 16;
       }
 
       /** \brief Constructor for base SampleConsensusModelRegistration.
@@ -103,6 +104,7 @@ namespace pcl
         computeOriginalIndexMapping ();
         computeSampleDistanceThreshold (cloud, indices);
         model_name_ = "SampleConsensusModelRegistration";
+        model_size_ = 16;
       }
       
       /** \brief Empty destructor */
@@ -214,6 +216,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_REGISTRATION); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -62,6 +62,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::input_;
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -217,19 +218,6 @@ namespace pcl
 
     protected:
       using SampleConsensusModel<PointT>::model_size_;
-
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        // Needs a valid model coefficients
-        if (model_coefficients.size () != 16)
-          return (false);
-
-        return (true);
-      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -80,6 +80,7 @@ namespace pcl
         // Call our own setInputCloud
         setInputCloud (cloud);
         model_name_ = "SampleConsensusModelRegistration2D";
+        model_size_ = 16;
       }
 
       /** \brief Constructor for base SampleConsensusModelRegistration2D.
@@ -96,6 +97,7 @@ namespace pcl
         computeOriginalIndexMapping ();
         computeSampleDistanceThreshold (cloud, indices);
         model_name_ = "SampleConsensusModelRegistration2D";
+        model_size_ = 16;
       }
       
       /** \brief Empty destructor */
@@ -142,6 +144,8 @@ namespace pcl
       { return (projection_matrix_); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check if a sample of indices results in a good sample of points
         * indices.
         * \param[in] samples the resultant index samples

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -60,6 +60,7 @@ namespace pcl
       using pcl::SampleConsensusModelRegistration<PointT>::correspondences_;
       using pcl::SampleConsensusModelRegistration<PointT>::sample_dist_thresh_;
       using pcl::SampleConsensusModelRegistration<PointT>::computeOriginalIndexMapping;
+      using pcl::SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename pcl::SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename pcl::SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -82,6 +82,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, random), tmp_inliers_ ()
       {
         model_name_ = "SampleConsensusModelSphere";
+        model_size_ = 4;
       }
 
       /** \brief Constructor for base SampleConsensusModelSphere.
@@ -95,6 +96,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, indices, random), tmp_inliers_ ()
       {
         model_name_ = "SampleConsensusModelSphere";
+        model_size_ = 4;
       }
       
       /** \brief Empty destructor */
@@ -197,6 +199,8 @@ namespace pcl
       inline pcl::SacModel getModelType () const { return (SACMODEL_SPHERE); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -66,6 +66,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -204,15 +205,11 @@ namespace pcl
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */
-      inline bool 
+      virtual bool
       isModelValid (const Eigen::VectorXf &model_coefficients)
       {
-        // Needs a valid model coefficients
-        if (model_coefficients.size () != 4)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelSphere::isModelValid] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
+        if (!SampleConsensusModel<PointT>::isModelValid (model_coefficients))
           return (false);
-        }
 
         if (radius_min_ != -std::numeric_limits<double>::max() && model_coefficients[3] < radius_min_)
           return (false);

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -86,6 +86,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, random)
       {
         model_name_ = "SampleConsensusModelStick";
+        model_size_ = 7;
       }
 
       /** \brief Constructor for base SampleConsensusModelStick.
@@ -99,6 +100,7 @@ namespace pcl
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
         model_name_ = "SampleConsensusModelStick";
+        model_size_ = 7;
       }
       
       /** \brief Empty destructor */
@@ -180,6 +182,8 @@ namespace pcl
       getModelType () const { return (SACMODEL_STICK); }
 
     protected:
+      using SampleConsensusModel<PointT>::model_size_;
+
       /** \brief Check whether a model is valid given the user constraints.
         * \param[in] model_coefficients the set of model coefficients
         */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -70,6 +70,7 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
+      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
@@ -183,21 +184,6 @@ namespace pcl
 
     protected:
       using SampleConsensusModel<PointT>::model_size_;
-
-      /** \brief Check whether a model is valid given the user constraints.
-        * \param[in] model_coefficients the set of model coefficients
-        */
-      inline bool 
-      isModelValid (const Eigen::VectorXf &model_coefficients)
-      {
-        if (model_coefficients.size () != 7)
-        {
-          PCL_ERROR ("[pcl::SampleConsensusModelStick::selectWithinDistance] Invalid number of model coefficients given (%lu)!\n", model_coefficients.size ());
-          return (false);
-        }
-
-        return (true);
-      }
 
       /** \brief Check if a sample of indices results in a good sample of points
         * indices.


### PR DESCRIPTION
This is a new edition of #1075. As discussed, rather than having a global map, the model sizes are stored in a protected member field. The rest is the same as before.