### PR TITLE
Fix ply segfault

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -270,6 +270,7 @@ namespace pcl
     memcpy (&cloud_->data[vertex_count_ * cloud_->point_step + vertex_offset_before_],
             &value,
             sizeof (Scalar));
+
     vertex_offset_before_ += static_cast<int> (sizeof (Scalar));
   }
 
@@ -301,7 +302,7 @@ namespace pcl
   boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> >
   pcl::PLYReader::listPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
-    if ((element_name == "range_grid") && (property_name == "vertex_indices") && polygons_) 
+    if ((element_name == "range_grid") && (property_name == "vertex_indices") )
     {
       return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
         boost::bind (&pcl::PLYReader::rangeGridVertexIndicesBeginCallback, this, _1),
@@ -309,7 +310,7 @@ namespace pcl
         boost::bind (&pcl::PLYReader::rangeGridVertexIndicesEndCallback, this)
       );
     }
-    else if ((element_name == "face") && (property_name == "vertex_indices"))
+    else if ((element_name == "face") && (property_name == "vertex_indices") && polygons_ )
     {
       return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
         boost::bind (&pcl::PLYReader::faceVertexIndicesBeginCallback, this, _1),


### PR DESCRIPTION
fixes #675 by ignoring faces when the polygon object is not defined, preventing the offending callbacks from being hit.

Attempting to parse the following ply file:

```
ply
format ascii 1.0
element vertex 4
property float x
property float y
property float z
element face 2
property list uchar int vertex_indices
end_header
0 0 0
0 0 1
0 1 0
0 1 1
3 0 1 2 
3 2 1 3
```
now produces the warning:

[pcl::PLYReader] cloud.ply:8: property 'list uint8 int32 vertex_indices' of element 'face' is not handled
Failed to find match for field 'x'.
Failed to find match for field 'y'.
Failed to find match for field 'z'.

optionally a more specific warning could be produced in ply_io.cpp something like:

```c++
else if ((element_name == "face") && (property_name == "vertex_indices") )
{
  if ( !polygons_){
    PCL_WARN( "[pcl::PLYReader] polygon ply loading into PointCloud, ignoring faces, use PolygonMesh for a full decode" );
  }else{
    return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
        boost::bind (&pcl::PLYReader::faceVertexIndicesBeginCallback, this, _1),
        boost::bind (&pcl::PLYReader::faceVertexIndicesElementCallback, this, _1),
        boost::bind (&pcl::PLYReader::faceVertexIndicesEndCallback, this)
      );
  }
}

```