### PR TITLE
Compare pointers with 0 instead of false

### DIFF
--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -541,7 +541,7 @@ namespace pcl
           if ( indices[i].empty () )
             continue;
 
-          if ( children_[i] == false )
+          if (children_[i] == 0)
           {
             createChild (i);
           }
@@ -796,7 +796,7 @@ namespace pcl
         if(indices[i].empty ())
           continue;
 
-        if( children_[i] == false )
+        if (children_[i] == 0)
         {
           assert (i < 8);
           createChild (i);


### PR DESCRIPTION
This fixes "error: comparison between pointer and integer" when compiling with clang in c++11 mode.