### PR TITLE
Fix super-voxel clustering tutorial alignment issues on 32 bits OS

### DIFF
--- a/doc/tutorials/content/sources/supervoxel_clustering/supervoxel_clustering.cpp
+++ b/doc/tutorials/content/sources/supervoxel_clustering/supervoxel_clustering.cpp
@@ -36,7 +36,7 @@ main (int argc, char ** argv)
   }
 
 
-  PointCloudT::Ptr cloud = boost::make_shared <PointCloudT> ();
+  PointCloudT::Ptr cloud = boost::shared_ptr <PointCloudT> (new PointCloudT ());
   pcl::console::print_highlight ("Loading point cloud...\n");
   if (pcl::io::loadPCDFile<PointT> (argv[1], *cloud))
   {


### PR DESCRIPTION
Reported on the mailing-list:
http://www.pcl-users.org/Eigen-assertion-failed-when-run-supervoxel-clustering-milk-cartoon-all-small-clorox-pcd-td4039716.html

Note that this may not solve the entire problem described but it at leasts corrects the user code for 32 bits users.