### PR TITLE
Remove `using SampleConsensusModel<PointT>::isModelValid`

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -66,7 +66,6 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -66,7 +66,6 @@ namespace pcl
       using SampleConsensusModel<PointT>::indices_;
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -74,7 +74,6 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -74,7 +74,6 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -90,7 +90,6 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -77,7 +77,6 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normals_;
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -67,7 +67,6 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelLine<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelLine<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -67,7 +67,6 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -72,7 +72,6 @@ namespace pcl
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -66,7 +66,6 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
-      using SampleConsensusModel<PointT>::isModelValid;
 
       typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
       typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;


### PR DESCRIPTION
(Hopefully) fixes the problem reported [here](http://www.pcl-users.org/Building-PCL-1-8-error-while-building-pcl-sample-consensus-td4039723.html).

This commit removes `using SampleConsensusModel<PointT>::isModelValid` in the classes that override the function. I should admit that I can not reproduce the error myself (only have Visual Studio 2013, and it compiles fine with and without this pull request). This pull request also compiles fine with clang on Linux, so no regression expected, while potentially fixing the issue.