### PR TITLE
Fix occasional seg fault with KLDAdaptiveParticleFilterOMPTracker

### DIFF
--- a/tracking/include/pcl/tracking/impl/kld_adaptive_particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/kld_adaptive_particle_filter.hpp
@@ -82,7 +82,7 @@ pcl::tracking::KLDAdaptiveParticleFilterTracker<PointInT, StateT>::resample ()
       ++k;
     ++n;
   }
-  while (k < 2 || (n < maximum_particle_number_ && n < calcKLBound (k)));
+  while (n < maximum_particle_number_ && (k < 2 || n < calcKLBound (k)));
   
   particles_ = S;               // swap
   particle_num_ = static_cast<int> (particles_->points.size ());


### PR DESCRIPTION
During the resampling step of the KLDAdaptiveParticleFilterTracker, a
situation occasionally occurs where the number of particles generated
exceeds the maximum_particle_number_. This results in a vector being
accessed past its end, leading to a segfault. This happens when the
variable k in the resampling step is less than 2. To fix this, the
condition on the while loop has been slightly modified. This fixes issue #1391.