### PR TITLE
Fix find_VTK (Fix Pull #1368)

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -395,7 +395,7 @@ endmacro(find_flann)
 
 macro(find_VTK)
   if(PCL_ALL_IN_ONE_INSTALLER AND NOT ANDROID)
-    if(VTK_MAJOR_VERSION GREATER 5)
+    if(EXISTS "${PCL_ROOT}/3rdParty/VTK/lib/cmake")
       set(VTK_DIR "${PCL_ROOT}/3rdParty/VTK/lib/cmake/vtk-@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@")
     else()
       set(VTK_DIR "${PCL_ROOT}/3rdParty/VTK/lib/vtk-@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@")


### PR DESCRIPTION
Pull #1368 was wrong. (Issue #1397)

In this part, it will need to conditional branch depending on the VTK version.
It can't be conditional branch by VTK_MAJOR_VERSION at the following
lines, because before find_package(VTK).
Even if VTK6, This conditional branch is always false.

This pull request will fix this issue #1397.
That can be conditional branch by check the existence for "VTK/lib/**cmake**"
directory.
It will check by the "[if(EXISTS path-to-directory)](https://cmake.org/cmake/help/latest/command/if.html)".

VTK6 : VTK/lib/**cmake**/vtk-6.x
VTK5 : VTK/lib/vtk-5.x

```
# VTK version conditional branch by check the existence for "VTK/lib/cmake" directory.
if(EXISTS "${PCL_ROOT}/3rdParty/VTK/lib/cmake")
  # VTK6
  set(VTK_DIR "${PCL_ROOT}/3rdParty/VTK/lib/cmake/vtk@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@")
else()
  # VTK5
  set(VTK_DIR "${PCL_ROOT}/3rdParty/VTK/lib/vtk@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@")
endif()
```