### PR TITLE
Change davidSDK repository link

### DIFF
--- a/doc/tutorials/content/davidsdk.rst
+++ b/doc/tutorials/content/davidsdk.rst
@@ -14,9 +14,9 @@ Install davidSDK
 You need a davidSDK to run the SDK on the server side, the official davidSDK does not come with a Makefile or a CMake project. An un-official fork provides a CMake project that enables to easily use the SDK under Linux (with minor tweaks)
 
   * `Official davidSDK download page <http://www.david-3d.com/en/support/downloads>`_
-  * `Victor Lamoine davidSDK fork <https://github.com/VictorLamoine/davidSDK>`_
+  * `Victor Lamoine davidSDK fork <https://github.com/InstitutMaupertuis/davidSDK>`_
 
-Please test `the example project <https://github.com/VictorLamoine/davidSDK/blob/master/README.md#example-project-using-the-davidsdk>`_ before going further.
+Please test `the example project <https://github.com/InstitutMaupertuis/davidSDK/blob/master/README.md#example-project-using-the-davidsdk>`_ before going further.
 
 .. note:: If you use the trial version of the server, the only format available is OBJ (used by default)
 


### PR DESCRIPTION
I changed davidSDK ownership to Institut Maupertuis organization, so I update the link in the tutorial.