### PR TITLE
[RFC] Added simple kinectv2 grabber and viewer

### DIFF
--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -75,12 +75,12 @@ namespace pcl
       using ConstPtr = boost::shared_ptr<const EnsensoGrabber>;
 
       // Define callback signature typedefs
-      using sig_cb_ensenso_point_cloud = void() (const pcl::PointCloud<pcl::PointXYZ>::Ptr &);
+      using sig_cb_ensenso_point_cloud = void(const pcl::PointCloud<pcl::PointXYZ>::Ptr&);
 
-      using sig_cb_ensenso_images void() (const boost::shared_ptr<PairOfImages> &);
+      using sig_cb_ensenso_images = void(const boost::shared_ptr<PairOfImages>&);
 
-      using sig_cb_ensenso_point_cloud_images = void()
-	    (const pcl::PointCloud<pcl::PointXYZ>::Ptr &, const boost::shared_ptr<PairOfImages> &);
+      using sig_cb_ensenso_point_cloud_images = void(const pcl::PointCloud<pcl::PointXYZ>::Ptr&,const boost::shared_ptr<PairOfImages>&);
+
      /** @endcond */
 
       /** @brief Constructor */


### PR DESCRIPTION
However as of now you need to edit the freenect2config.cmake to add a few variables and make some of them with CAPS - why is is necessary? Or should I make a findfreenect2.cmake instead?
@VictorLamoine can you guide me here?

~~For some reason the pointcloud behaves flaky and the colors are acting weird also - so would like some help in localizing the error(s).~~
Set is_dense to false seem to do the trick here.

@giacomodabisias can you have a look?

TODO:
- [x] Selectable packetpipline - thanks to @giacomodabisias 
- [x] Selectable kinectv2 unit by seriel number
- [x] Cmake search paths for windows (will probably be a envirotment variable as libfreenect2 is currently installed in the build folder, which can be arbitrary paths)
