### PR TITLE
Fix error CMP0020

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ if(POLICY CMP0017)
   cmake_policy(SET CMP0017 NEW)
 endif()
 
+if(POLICY CMP0020 AND (WIN32 AND NOT MINGW))
+  cmake_policy(SET CMP0020 NEW) # Automatically link Qt executables to qtmain target on Windows
+endif()
+
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 OLD) # do not use VERSION option in project() command
 endif()


### PR DESCRIPTION
PCL that include Qt5 can't generate project,  because following errors
occurs in CMake outputs on Windows.

> Policy CMP0020 is not set:
> Automatically link Qt executables to qtmain target on Windows.
> Run "cmake --help-policy CMP0020" for policy details.
> Use the cmake_policy command to set the policy and suppress this warning.
> This warning is for project developers.
> Use -Wno-dev to suppress it.

Fix this issue by add setting the CMake policy.
https://cmake.org/cmake/help/v3.4/policy/CMP0020.html