### PR TITLE
Fix a bug in FPCSInitialAlignment

### DIFF
--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -339,7 +339,8 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   const float too_close_sqr = max_base_diameter_sqr_*0.01;
 
   Eigen::VectorXf coefficients (4);
-  pcl::SampleConsensusModelPlane <PointTarget> plane (target_, target_indices_);
+  pcl::SampleConsensusModelPlane <PointTarget> plane (target_);
+  plane.setIndices (target_indices_);
   Eigen::Vector4f centre_pt;
   float nearest_to_plane = FLT_MAX;
 


### PR DESCRIPTION
`target_indices_` is a pointer. Sample consensus model does not have a constructor that would accept a pointer to indices vector. However, it has a constructor where second parameter is a boolean. Therefore an implicit cast happens here and instead of setting indices we actually request using random seed.  This commit sets indices in a separate call. Another option would be to pass by reference to value to the constructor, however this would involve copying the vector instead of simply sharing.