### PR TITLE
Remove deprecated 'register' storage class specifier

### DIFF
--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -76,12 +76,12 @@ pcl::io::LZFDepth16ImageReader::read (
   cloud.height   = getHeight ();
   cloud.is_dense = true;
   cloud.resize (getWidth () * getHeight ());
-  register int depth_idx = 0, point_idx = 0;
+  int depth_idx = 0, point_idx = 0;
   double constant_x = 1.0 / parameters_.focal_length_x,
          constant_y = 1.0 / parameters_.focal_length_y;
   for (uint32_t v = 0; v < cloud.height; ++v)
   {
-    for (register uint32_t u = 0; u < cloud.width; ++u, ++point_idx, depth_idx += 2)
+    for (uint32_t u = 0; u < cloud.width; ++u, ++point_idx, depth_idx += 2)
     {
       PointT &pt = cloud.points[point_idx];
       unsigned short val;
@@ -220,7 +220,7 @@ pcl::io::LZFRGB24ImageReader::read (
   cloud.height = getHeight ();
   cloud.resize (getWidth () * getHeight ());
 
-  register int rgb_idx = 0;
+  int rgb_idx = 0;
   unsigned char *color_r = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
   unsigned char *color_g = reinterpret_cast<unsigned char*> (&uncompressed_data[getWidth () * getHeight ()]);
   unsigned char *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
@@ -325,7 +325,7 @@ pcl::io::LZFYUV422ImageReader::read (
   unsigned char *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
   unsigned char *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
   
-  register int y_idx = 0;
+  int y_idx = 0;
   for (int i = 0; i < wh2; ++i, y_idx += 2)
   {
     int v = color_v[i] - 128;
@@ -444,7 +444,7 @@ pcl::io::LZFBayer8ImageReader::read (
   cloud.width  = getWidth ();
   cloud.height = getHeight ();
   cloud.resize (getWidth () * getHeight ());
-  register int rgb_idx = 0;
+  int rgb_idx = 0;
   for (size_t i = 0; i < cloud.size (); ++i, rgb_idx += 3)
   {
     PointT &pt = cloud.points[i];

--- a/io/src/debayer.cpp
+++ b/io/src/debayer.cpp
@@ -59,7 +59,7 @@ pcl::io::DeBayer::debayerBilinear (
 
   // padding skip for destination image
   unsigned rgb_line_skip = rgb_line_step - width * 3;
-  register unsigned yIdx, xIdx;
+  unsigned yIdx, xIdx;
   // first two pixel values for first two lines
   // Bayer         0 1 2
   //         0     G r g
@@ -428,7 +428,7 @@ pcl::io::DeBayer::debayerEdgeAware (
 
   // padding skip for destination image
   unsigned rgb_line_skip = rgb_line_step - width * 3;
-  register unsigned yIdx, xIdx;
+  unsigned yIdx, xIdx;
   int dh, dv;
 
   // first two pixel values for first two lines
@@ -816,7 +816,7 @@ pcl::io::DeBayer::debayerEdgeAwareWeighted (
 
   // padding skip for destination image
   unsigned rgb_line_skip = rgb_line_step - width * 3;
-  register unsigned yIdx, xIdx;
+  unsigned yIdx, xIdx;
   int dh, dv;
 
   // first two pixel values for first two lines

--- a/io/src/image_yuv422.cpp
+++ b/io/src/image_yuv422.cpp
@@ -83,7 +83,7 @@ pcl::io::ImageYUV422::fillRGB (unsigned width, unsigned height, unsigned char* r
       THROW_IO_EXCEPTION ("Downsampling only possible for power of two scale in both dimensions. Request was %d x %d -> %d x %d.", wrapper_->getWidth (), wrapper_->getHeight (), width, height);
   }
 
-  register const uint8_t* yuv_buffer = (uint8_t*) wrapper_->getData ();
+  const uint8_t* yuv_buffer = (uint8_t*) wrapper_->getData ();
 
   unsigned rgb_line_skip = 0;
   if (rgb_line_step != 0)
@@ -91,9 +91,9 @@ pcl::io::ImageYUV422::fillRGB (unsigned width, unsigned height, unsigned char* r
 
   if (wrapper_->getWidth () == width && wrapper_->getHeight () == height)
   {
-    for ( register unsigned yIdx = 0; yIdx < height; ++yIdx, rgb_buffer += rgb_line_skip )
+    for (unsigned yIdx = 0; yIdx < height; ++yIdx, rgb_buffer += rgb_line_skip)
     {
-      for ( register unsigned xIdx = 0; xIdx < width; xIdx += 2, rgb_buffer += 6, yuv_buffer += 4 )
+      for (unsigned xIdx = 0; xIdx < width; xIdx += 2, rgb_buffer += 6, yuv_buffer += 4)
       {
         int v = yuv_buffer[2] - 128;
         int u = yuv_buffer[0] - 128;
@@ -110,13 +110,13 @@ pcl::io::ImageYUV422::fillRGB (unsigned width, unsigned height, unsigned char* r
   }
   else
   {
-    register unsigned yuv_step = wrapper_->getWidth () / width;
-    register unsigned yuv_x_step = yuv_step << 1;
-    register unsigned yuv_skip = (wrapper_->getHeight () / height - 1) * ( wrapper_->getWidth () << 1 );
+    unsigned yuv_step = wrapper_->getWidth () / width;
+    unsigned yuv_x_step = yuv_step << 1;
+    unsigned yuv_skip = (wrapper_->getHeight () / height - 1) * ( wrapper_->getWidth () << 1 );
 
-    for ( register unsigned yIdx = 0; yIdx < wrapper_->getHeight (); yIdx += yuv_step, yuv_buffer += yuv_skip, rgb_buffer += rgb_line_skip )
+    for (unsigned yIdx = 0; yIdx < wrapper_->getHeight (); yIdx += yuv_step, yuv_buffer += yuv_skip, rgb_buffer += rgb_line_skip)
     {
-      for ( register unsigned xIdx = 0; xIdx < wrapper_->getWidth (); xIdx += yuv_step, rgb_buffer += 3, yuv_buffer += yuv_x_step )
+      for (unsigned xIdx = 0; xIdx < wrapper_->getWidth (); xIdx += yuv_step, rgb_buffer += 3, yuv_buffer += yuv_x_step)
       {
         int v = yuv_buffer[2] - 128;
         int u = yuv_buffer[0] - 128;
@@ -144,14 +144,14 @@ pcl::io::ImageYUV422::fillGrayscale (unsigned width, unsigned height, unsigned c
   if (gray_line_step != 0)
     gray_line_skip = gray_line_step - width;
 
-  register unsigned yuv_step = wrapper_->getWidth () / width;
-  register unsigned yuv_x_step = yuv_step << 1;
-  register unsigned yuv_skip = (wrapper_->getHeight () / height - 1) * ( wrapper_->getWidth () << 1 );
-  register const uint8_t* yuv_buffer = ( (uint8_t*) wrapper_->getData () + 1);
+  unsigned yuv_step = wrapper_->getWidth () / width;
+  unsigned yuv_x_step = yuv_step << 1;
+  unsigned yuv_skip = (wrapper_->getHeight () / height - 1) * ( wrapper_->getWidth () << 1 );
+  const uint8_t* yuv_buffer = ( (uint8_t*) wrapper_->getData () + 1);
 
-  for ( register unsigned yIdx = 0; yIdx < wrapper_->getHeight (); yIdx += yuv_step, yuv_buffer += yuv_skip, gray_buffer += gray_line_skip )
+  for (unsigned yIdx = 0; yIdx < wrapper_->getHeight (); yIdx += yuv_step, yuv_buffer += yuv_skip, gray_buffer += gray_line_skip)
   {
-    for ( register unsigned xIdx = 0; xIdx < wrapper_->getWidth (); xIdx += yuv_step, ++gray_buffer, yuv_buffer += yuv_x_step )
+    for (unsigned xIdx = 0; xIdx < wrapper_->getWidth (); xIdx += yuv_step, ++gray_buffer, yuv_buffer += yuv_x_step)
     {
       *gray_buffer = *yuv_buffer;
     }

--- a/keypoints/src/agast_2d.cpp
+++ b/keypoints/src/agast_2d.cpp
@@ -392,11 +392,11 @@ namespace pcl
         int total = 0;
         int n_expected_corners = int (corners.capacity ());
         pcl::PointUV h;
-        register int x, y;
-        register int width_b  = img_width - 3; //2, +1 due to faster test x>width_b
-        register int height_b = img_height - 2;
-        register int_fast16_t offset0, offset1, offset2, offset3, offset4, offset5, offset6, offset7, offset8, offset9, offset10, offset11;
-        register int width;
+        int x, y;
+        int width_b  = img_width - 3; //2, +1 due to faster test x>width_b
+        int height_b = img_height - 2;
+        int_fast16_t offset0, offset1, offset2, offset3, offset4, offset5, offset6, offset7, offset8, offset9, offset10, offset11;
+        int width;
 
         corners.resize (0);
 
@@ -426,9 +426,9 @@ namespace pcl
               break;
             else
             {
-              register const T1* const p = im + y * width + x;
-              register const T2 cb = *p + T2 (threshold);
-              register const T2 c_b = *p - T2 (threshold);
+              const T1* const p = im + y * width + x;
+              const T2 cb = *p + T2 (threshold);
+              const T2 c_b = *p - T2 (threshold);
               if (p[offset0] > cb)
                 if (p[offset2] > cb)
                 if (p[offset5] > cb)
@@ -1464,9 +1464,9 @@ namespace pcl
               break;    
             else
             {
-              register const T1* const p = im + y * width + x;
-              register const T2 cb = *p + T2 (threshold);
-              register const T2 c_b = *p - T2 (threshold);
+              const T1* const p = im + y * width + x;
+              const T2 cb = *p + T2 (threshold);
+              const T2 c_b = *p - T2 (threshold);
               if (p[offset0] > cb)
                 if (p[offset2] > cb)
                 if (p[offset5] > cb)
@@ -2486,23 +2486,23 @@ namespace pcl
         T2 bmax = T2 (im_bmax); // 255;
         int b_test = int ((bmax + bmin) / 2);
 
-        register int_fast16_t offset0  = s_offset0;
-        register int_fast16_t offset1  = s_offset1;
-        register int_fast16_t offset2  = s_offset2;
-        register int_fast16_t offset3  = s_offset3;
-        register int_fast16_t offset4  = s_offset4;
-        register int_fast16_t offset5  = s_offset5;
-        register int_fast16_t offset6  = s_offset6;
-        register int_fast16_t offset7  = s_offset7;
-        register int_fast16_t offset8  = s_offset8;
-        register int_fast16_t offset9  = s_offset9;
-        register int_fast16_t offset10 = s_offset10;
-        register int_fast16_t offset11 = s_offset11;
+        int_fast16_t offset0  = s_offset0;
+        int_fast16_t offset1  = s_offset1;
+        int_fast16_t offset2  = s_offset2;
+        int_fast16_t offset3  = s_offset3;
+        int_fast16_t offset4  = s_offset4;
+        int_fast16_t offset5  = s_offset5;
+        int_fast16_t offset6  = s_offset6;
+        int_fast16_t offset7  = s_offset7;
+        int_fast16_t offset8  = s_offset8;
+        int_fast16_t offset9  = s_offset9;
+        int_fast16_t offset10 = s_offset10;
+        int_fast16_t offset11 = s_offset11;
 
         while (1)
         {
-          register const T2 cb = *p + T2 (b_test);
-          register const T2 c_b = *p - T2 (b_test);
+          const T2 cb = *p + T2 (b_test);
+          const T2 c_b = *p - T2 (b_test);
           if (p[offset0] > cb)
             if (p[offset5] > cb)
               if (p[offset2] < c_b)
@@ -8246,11 +8246,11 @@ namespace pcl
         int total = 0;
         int n_expected_corners = int (corners.capacity ());
         pcl::PointUV h;
-        register int x, y;
-        register int xsize_b = int (img_width) - 2;
-        register int ysize_b = int (img_height) - 1;
-        register int_fast16_t offset0, offset1, offset2, offset3, offset4, offset5, offset6, offset7;
-        register int width;
+        int x, y;
+        int xsize_b = int (img_width) - 2;
+        int ysize_b = int (img_height) - 1;
+        int_fast16_t offset0, offset1, offset2, offset3, offset4, offset5, offset6, offset7;
+        int width;
 
         corners.resize (0);
 
@@ -8276,9 +8276,9 @@ namespace pcl
               break;
             else
             {
-              register const T1* const p = im + y * width + x;
-              register const T2 cb = *p + T2 (threshold);
-              register const T2 c_b = *p - T2 (threshold);
+              const T1* const p = im + y * width + x;
+              const T2 cb = *p + T2 (threshold);
+              const T2 c_b = *p - T2 (threshold);
               if (p[offset0] > cb)
                 if (p[offset2] > cb)
                 if (p[offset3] > cb)
@@ -8612,9 +8612,9 @@ namespace pcl
               break;
             else
             {
-              register const T1* const p = im + y * width + x;
-              register const T2 cb = *p + T2 (threshold);
-              register const T2 c_b = *p - T2 (threshold);
+              const T1* const p = im + y * width + x;
+              const T2 cb = *p + T2 (threshold);
+              const T2 c_b = *p - T2 (threshold);
               if (p[offset0] > cb)
                 if (p[offset2] > cb)
                 if (p[offset3] > cb)
@@ -9015,19 +9015,19 @@ namespace pcl
         T2 bmax = T2 (im_bmax);
         int b_test = int ((bmax + bmin) / 2);
 
-        register int_fast16_t offset0 = s_offset0;
-        register int_fast16_t offset1 = s_offset1;
-        register int_fast16_t offset2 = s_offset2;
-        register int_fast16_t offset3 = s_offset3;
-        register int_fast16_t offset4 = s_offset4;
-        register int_fast16_t offset5 = s_offset5;
-        register int_fast16_t offset6 = s_offset6;
-        register int_fast16_t offset7 = s_offset7;
+        int_fast16_t offset0 = s_offset0;
+        int_fast16_t offset1 = s_offset1;
+        int_fast16_t offset2 = s_offset2;
+        int_fast16_t offset3 = s_offset3;
+        int_fast16_t offset4 = s_offset4;
+        int_fast16_t offset5 = s_offset5;
+        int_fast16_t offset6 = s_offset6;
+        int_fast16_t offset7 = s_offset7;
 
         while (1)
         {
-          register const T2 cb = *p + T2 (b_test);
-          register const T2 c_b = *p - T2 (b_test);
+          const T2 cb = *p + T2 (b_test);
+          const T2 c_b = *p - T2 (b_test);
           if (p[offset0] > cb)
             if (p[offset2] > cb)
               if (p[offset3] > cb)
@@ -9490,11 +9490,11 @@ namespace pcl
         int total = 0;
         int n_expected_corners = int (corners.capacity ());
         pcl::PointUV h;
-        register int x, y;
-        register int xsize_b = int (img_width) - 4;
-        register int ysize_b = int (img_height) - 3;
-        register int_fast16_t offset0, offset1, offset2, offset3, offset4, offset5, offset6, offset7, offset8, offset9, offset10, offset11, offset12, offset13, offset14, offset15;
-        register int width;
+        int x, y;
+        int xsize_b = int (img_width) - 4;
+        int ysize_b = int (img_height) - 3;
+        int_fast16_t offset0, offset1, offset2, offset3, offset4, offset5, offset6, offset7, offset8, offset9, offset10, offset11, offset12, offset13, offset14, offset15;
+        int width;
 
         corners.resize (0);
 
@@ -9526,9 +9526,9 @@ namespace pcl
               break;
             else
             {
-              register const T1* const p = im + y * width + x;
-              register const T2 cb = *p + T2 (threshold);
-              register const T2 c_b = *p - T2 (threshold);
+              const T1* const p = im + y * width + x;
+              const T2 cb = *p + T2 (threshold);
+              const T2 c_b = *p - T2 (threshold);
               if (p[offset0] > cb)
                 if (p[offset2] > cb)
                 if (p[offset4] > cb)
@@ -11608,27 +11608,27 @@ namespace pcl
         T2 bmax = T2 (im_bmax);
         int b_test = int ((bmax + bmin) / 2);
 
-        register int_fast16_t offset0  = s_offset0;
-        register int_fast16_t offset1  = s_offset1;
-        register int_fast16_t offset2  = s_offset2;
-        register int_fast16_t offset3  = s_offset3;
-        register int_fast16_t offset4  = s_offset4;
-        register int_fast16_t offset5  = s_offset5;
-        register int_fast16_t offset6  = s_offset6;
-        register int_fast16_t offset7  = s_offset7;
-        register int_fast16_t offset8  = s_offset8;
-        register int_fast16_t offset9  = s_offset9;
-        register int_fast16_t offset10 = s_offset10;
-        register int_fast16_t offset11 = s_offset11;
-        register int_fast16_t offset12 = s_offset12;
-        register int_fast16_t offset13 = s_offset13;
-        register int_fast16_t offset14 = s_offset14;
-        register int_fast16_t offset15 = s_offset15;
+        int_fast16_t offset0  = s_offset0;
+        int_fast16_t offset1  = s_offset1;
+        int_fast16_t offset2  = s_offset2;
+        int_fast16_t offset3  = s_offset3;
+        int_fast16_t offset4  = s_offset4;
+        int_fast16_t offset5  = s_offset5;
+        int_fast16_t offset6  = s_offset6;
+        int_fast16_t offset7  = s_offset7;
+        int_fast16_t offset8  = s_offset8;
+        int_fast16_t offset9  = s_offset9;
+        int_fast16_t offset10 = s_offset10;
+        int_fast16_t offset11 = s_offset11;
+        int_fast16_t offset12 = s_offset12;
+        int_fast16_t offset13 = s_offset13;
+        int_fast16_t offset14 = s_offset14;
+        int_fast16_t offset15 = s_offset15;
 
         while (1)
         {
-          register const T2 cb = *p + T2 (b_test);
-          register const T2 c_b = *p - T2 (b_test);
+          const T2 cb = *p + T2 (b_test);
+          const T2 c_b = *p - T2 (b_test);
           if (p[offset0] > cb)
             if (p[offset2] > cb)
               if (p[offset4] > cb)

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -123,15 +123,15 @@ pcl::keypoints::brisk::ScaleSpace::getKeypoints (
 
       // let's do the subpixel and float scale refinement:
       pcl::keypoints::brisk::Layer& l = pyramid_[0];
-      register int s_0_0 = l.getAgastScore (point.u-1, point.v-1, 1);
-      register int s_1_0 = l.getAgastScore (point.u,   point.v-1, 1);
-      register int s_2_0 = l.getAgastScore (point.u+1, point.v-1, 1);
-      register int s_2_1 = l.getAgastScore (point.u+1, point.v,   1);
-      register int s_1_1 = l.getAgastScore (point.u,   point.v,   1);
-      register int s_0_1 = l.getAgastScore (point.u-1, point.v,   1);
-      register int s_0_2 = l.getAgastScore (point.u-1, point.v+1, 1);
-      register int s_1_2 = l.getAgastScore (point.u,   point.v+1, 1);
-      register int s_2_2 = l.getAgastScore (point.u+1, point.v+1, 1);
+      int s_0_0 = l.getAgastScore (point.u-1, point.v-1, 1);
+      int s_1_0 = l.getAgastScore (point.u,   point.v-1, 1);
+      int s_2_0 = l.getAgastScore (point.u+1, point.v-1, 1);
+      int s_2_1 = l.getAgastScore (point.u+1, point.v,   1);
+      int s_1_1 = l.getAgastScore (point.u,   point.v,   1);
+      int s_0_1 = l.getAgastScore (point.u-1, point.v,   1);
+      int s_0_2 = l.getAgastScore (point.u-1, point.v+1, 1);
+      int s_1_2 = l.getAgastScore (point.u,   point.v+1, 1);
+      int s_2_2 = l.getAgastScore (point.u+1, point.v+1, 1);
       float delta_x, delta_y;
       float max = subpixel2D (s_0_0, s_0_1, s_0_2,
                               s_1_0, s_1_1, s_1_2,
@@ -169,15 +169,15 @@ pcl::keypoints::brisk::ScaleSpace::getKeypoints (
           continue;
 
         // get the patch on this layer:
-        register int s_0_0 = l.getAgastScore (point.u-1, point.v-1, 1);
-        register int s_1_0 = l.getAgastScore (point.u,   point.v-1, 1);
-        register int s_2_0 = l.getAgastScore (point.u+1, point.v-1, 1);
-        register int s_2_1 = l.getAgastScore (point.u+1, point.v,   1);
-        register int s_1_1 = l.getAgastScore (point.u,   point.v,   1);
-        register int s_0_1 = l.getAgastScore (point.u-1, point.v,   1);
-        register int s_0_2 = l.getAgastScore (point.u-1, point.v+1, 1);
-        register int s_1_2 = l.getAgastScore (point.u,   point.v+1, 1);
-        register int s_2_2 = l.getAgastScore (point.u+1, point.v+1, 1);
+        int s_0_0 = l.getAgastScore (point.u-1, point.v-1, 1);
+        int s_1_0 = l.getAgastScore (point.u,   point.v-1, 1);
+        int s_2_0 = l.getAgastScore (point.u+1, point.v-1, 1);
+        int s_2_1 = l.getAgastScore (point.u+1, point.v,   1);
+        int s_1_1 = l.getAgastScore (point.u,   point.v,   1);
+        int s_0_1 = l.getAgastScore (point.u-1, point.v,   1);
+        int s_0_2 = l.getAgastScore (point.u-1, point.v+1, 1);
+        int s_1_2 = l.getAgastScore (point.u,   point.v+1, 1);
+        int s_2_2 = l.getAgastScore (point.u+1, point.v+1, 1);
         float delta_x, delta_y;
         float max = subpixel2D (s_0_0, s_0_1, s_0_2,
                                 s_1_0, s_1_1, s_1_2,
@@ -515,24 +515,24 @@ pcl::keypoints::brisk::ScaleSpace::refine3D (
     {
       // guess the lower intra octave...
       pcl::keypoints::brisk::Layer& l = pyramid_[0];
-      register int s_0_0 = l.getAgastScore_5_8 (x_layer - 1, y_layer - 1, 1);
+      int s_0_0 = l.getAgastScore_5_8 (x_layer - 1, y_layer - 1, 1);
       max_below_uchar = static_cast<unsigned char> (s_0_0);
-      register int s_1_0 = l.getAgastScore_5_8 (x_layer, y_layer - 1, 1);
+      int s_1_0 = l.getAgastScore_5_8 (x_layer, y_layer - 1, 1);
 
       if (s_1_0 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_1_0);
-      register int s_2_0 = l.getAgastScore_5_8 (x_layer + 1, y_layer - 1, 1);
+      int s_2_0 = l.getAgastScore_5_8 (x_layer + 1, y_layer - 1, 1);
       if (s_2_0 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_2_0);
-      register int s_2_1 = l.getAgastScore_5_8 (x_layer + 1, y_layer,   1);
+      int s_2_1 = l.getAgastScore_5_8 (x_layer + 1, y_layer,   1);
       if (s_2_1 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_2_1);
-      register int s_1_1 = l.getAgastScore_5_8 (x_layer,   y_layer,   1);
+      int s_1_1 = l.getAgastScore_5_8 (x_layer,   y_layer,   1);
       if (s_1_1 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_1_1);
-      register int s_0_1 = l.getAgastScore_5_8 (x_layer - 1, y_layer,   1);
+      int s_0_1 = l.getAgastScore_5_8 (x_layer - 1, y_layer,   1);
       if (s_0_1 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_0_1);
-      register int s_0_2 = l.getAgastScore_5_8 (x_layer - 1, y_layer + 1, 1);
+      int s_0_2 = l.getAgastScore_5_8 (x_layer - 1, y_layer + 1, 1);
       if (s_0_2 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_0_2);
-      register int s_1_2 = l.getAgastScore_5_8 (x_layer,   y_layer + 1, 1);
+      int s_1_2 = l.getAgastScore_5_8 (x_layer,   y_layer + 1, 1);
       if (s_1_2 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_1_2);
-      register int s_2_2 = l.getAgastScore_5_8 (x_layer + 1, y_layer +1 , 1);
+      int s_2_2 = l.getAgastScore_5_8 (x_layer + 1, y_layer +1 , 1);
       if (s_2_2 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_2_2);
 
       max_below_float = subpixel2D (s_0_0, s_0_1, s_0_2,
@@ -550,15 +550,15 @@ pcl::keypoints::brisk::ScaleSpace::refine3D (
     }
 
     // get the patch on this layer:
-    register int s_0_0 = this_layer.getAgastScore (x_layer - 1, y_layer - 1, 1);
-    register int s_1_0 = this_layer.getAgastScore (x_layer,     y_layer - 1, 1);
-    register int s_2_0 = this_layer.getAgastScore (x_layer + 1, y_layer - 1, 1);
-    register int s_2_1 = this_layer.getAgastScore (x_layer + 1, y_layer,     1);
-    register int s_1_1 = this_layer.getAgastScore (x_layer,     y_layer,     1);
-    register int s_0_1 = this_layer.getAgastScore (x_layer - 1, y_layer,     1);
-    register int s_0_2 = this_layer.getAgastScore (x_layer - 1, y_layer + 1, 1);
-    register int s_1_2 = this_layer.getAgastScore (x_layer,     y_layer + 1, 1);
-    register int s_2_2 = this_layer.getAgastScore (x_layer + 1, y_layer + 1, 1);
+    int s_0_0 = this_layer.getAgastScore (x_layer - 1, y_layer - 1, 1);
+    int s_1_0 = this_layer.getAgastScore (x_layer,     y_layer - 1, 1);
+    int s_2_0 = this_layer.getAgastScore (x_layer + 1, y_layer - 1, 1);
+    int s_2_1 = this_layer.getAgastScore (x_layer + 1, y_layer,     1);
+    int s_1_1 = this_layer.getAgastScore (x_layer,     y_layer,     1);
+    int s_0_1 = this_layer.getAgastScore (x_layer - 1, y_layer,     1);
+    int s_0_2 = this_layer.getAgastScore (x_layer - 1, y_layer + 1, 1);
+    int s_1_2 = this_layer.getAgastScore (x_layer,     y_layer + 1, 1);
+    int s_2_2 = this_layer.getAgastScore (x_layer + 1, y_layer + 1, 1);
     float delta_x_layer, delta_y_layer;
     float max_layer = subpixel2D (s_0_0, s_0_1, s_0_2,
                                   s_1_0, s_1_1, s_1_2,
@@ -614,15 +614,15 @@ pcl::keypoints::brisk::ScaleSpace::refine3D (
     if (!ismax) return (0.0);
 
     // get the patch on this layer:
-    register int s_0_0 = this_layer.getAgastScore (x_layer - 1, y_layer - 1, 1);
-    register int s_1_0 = this_layer.getAgastScore (x_layer,     y_layer - 1, 1);
-    register int s_2_0 = this_layer.getAgastScore (x_layer + 1, y_layer - 1, 1);
-    register int s_2_1 = this_layer.getAgastScore (x_layer + 1, y_layer,     1);
-    register int s_1_1 = this_layer.getAgastScore (x_layer,     y_layer,     1);
-    register int s_0_1 = this_layer.getAgastScore (x_layer - 1, y_layer,     1);
-    register int s_0_2 = this_layer.getAgastScore (x_layer - 1, y_layer + 1, 1);
-    register int s_1_2 = this_layer.getAgastScore (x_layer,     y_layer + 1, 1);
-    register int s_2_2 = this_layer.getAgastScore (x_layer + 1, y_layer + 1, 1);
+    int s_0_0 = this_layer.getAgastScore (x_layer - 1, y_layer - 1, 1);
+    int s_1_0 = this_layer.getAgastScore (x_layer,     y_layer - 1, 1);
+    int s_2_0 = this_layer.getAgastScore (x_layer + 1, y_layer - 1, 1);
+    int s_2_1 = this_layer.getAgastScore (x_layer + 1, y_layer,     1);
+    int s_1_1 = this_layer.getAgastScore (x_layer,     y_layer,     1);
+    int s_0_1 = this_layer.getAgastScore (x_layer - 1, y_layer,     1);
+    int s_0_2 = this_layer.getAgastScore (x_layer - 1, y_layer + 1, 1);
+    int s_1_2 = this_layer.getAgastScore (x_layer,     y_layer + 1, 1);
+    int s_2_2 = this_layer.getAgastScore (x_layer + 1, y_layer + 1, 1);
     float delta_x_layer, delta_y_layer;
     float max_layer = subpixel2D (s_0_0, s_0_1, s_0_2,
                                   s_1_0, s_1_1, s_1_2,
@@ -790,15 +790,15 @@ pcl::keypoints::brisk::ScaleSpace::getScoreMaxAbove (
   }
 
   //find dx/dy:
-  register int s_0_0 = layer_above.getAgastScore (max_x - 1, max_y - 1, 1);
-  register int s_1_0 = layer_above.getAgastScore (max_x,     max_y - 1, 1);
-  register int s_2_0 = layer_above.getAgastScore (max_x + 1, max_y - 1, 1);
-  register int s_2_1 = layer_above.getAgastScore (max_x + 1, max_y,     1);
-  register int s_1_1 = layer_above.getAgastScore (max_x,     max_y,     1);
-  register int s_0_1 = layer_above.getAgastScore (max_x - 1, max_y,     1);
-  register int s_0_2 = layer_above.getAgastScore (max_x - 1, max_y + 1, 1);
-  register int s_1_2 = layer_above.getAgastScore (max_x,     max_y + 1, 1);
-  register int s_2_2 = layer_above.getAgastScore (max_x + 1, max_y + 1, 1);
+  int s_0_0 = layer_above.getAgastScore (max_x - 1, max_y - 1, 1);
+  int s_1_0 = layer_above.getAgastScore (max_x,     max_y - 1, 1);
+  int s_2_0 = layer_above.getAgastScore (max_x + 1, max_y - 1, 1);
+  int s_2_1 = layer_above.getAgastScore (max_x + 1, max_y,     1);
+  int s_1_1 = layer_above.getAgastScore (max_x,     max_y,     1);
+  int s_0_1 = layer_above.getAgastScore (max_x - 1, max_y,     1);
+  int s_0_2 = layer_above.getAgastScore (max_x - 1, max_y + 1, 1);
+  int s_1_2 = layer_above.getAgastScore (max_x,     max_y + 1, 1);
+  int s_2_2 = layer_above.getAgastScore (max_x + 1, max_y + 1, 1);
   float dx_1, dy_1;
   float refined_max = subpixel2D (s_0_0, s_0_1, s_0_2,
                                   s_1_0, s_1_1, s_1_2,
@@ -976,15 +976,15 @@ pcl::keypoints::brisk::ScaleSpace::getScoreMaxBelow (
   }
 
   //find dx/dy:
-  register int s_0_0 = layer_below.getAgastScore (max_x - 1, max_y - 1, 1);
-  register int s_1_0 = layer_below.getAgastScore (max_x,     max_y - 1, 1);
-  register int s_2_0 = layer_below.getAgastScore (max_x + 1, max_y - 1, 1);
-  register int s_2_1 = layer_below.getAgastScore (max_x + 1, max_y,     1);
-  register int s_1_1 = layer_below.getAgastScore (max_x,     max_y,     1);
-  register int s_0_1 = layer_below.getAgastScore (max_x - 1, max_y,     1);
-  register int s_0_2 = layer_below.getAgastScore (max_x - 1, max_y + 1, 1);
-  register int s_1_2 = layer_below.getAgastScore (max_x,     max_y + 1, 1);
-  register int s_2_2 = layer_below.getAgastScore (max_x + 1, max_y + 1, 1);
+  int s_0_0 = layer_below.getAgastScore (max_x - 1, max_y - 1, 1);
+  int s_1_0 = layer_below.getAgastScore (max_x,     max_y - 1, 1);
+  int s_2_0 = layer_below.getAgastScore (max_x + 1, max_y - 1, 1);
+  int s_2_1 = layer_below.getAgastScore (max_x + 1, max_y,     1);
+  int s_1_1 = layer_below.getAgastScore (max_x,     max_y,     1);
+  int s_0_1 = layer_below.getAgastScore (max_x - 1, max_y,     1);
+  int s_0_2 = layer_below.getAgastScore (max_x - 1, max_y + 1, 1);
+  int s_1_2 = layer_below.getAgastScore (max_x,     max_y + 1, 1);
+  int s_2_2 = layer_below.getAgastScore (max_x + 1, max_y + 1, 1);
   float dx_1, dy_1;
   float refined_max = subpixel2D (s_0_0, s_0_1, s_0_2,
                                   s_1_0, s_1_1, s_1_2,
@@ -1176,20 +1176,20 @@ pcl::keypoints::brisk::ScaleSpace::subpixel2D (
     float& delta_x, float& delta_y)
 {
   // the coefficients of the 2d quadratic function least-squares fit:
-  register int tmp1 =        s_0_0 + s_0_2 - 2*s_1_1 + s_2_0 + s_2_2;
-  register int coeff1 = 3 * (tmp1 + s_0_1 - ((s_1_0 + s_1_2) << 1) + s_2_1);
-  register int coeff2 = 3 * (tmp1 - ((s_0_1 + s_2_1) << 1) + s_1_0 + s_1_2);
-  register int tmp2 =                                  s_0_2 - s_2_0;
-  register int tmp3 =                         (s_0_0 + tmp2 - s_2_2);
-  register int tmp4 =                                   tmp3 -2 * tmp2;
-  register int coeff3 =                    -3 * (tmp3 + s_0_1 - s_2_1);
-  register int coeff4 =                    -3 * (tmp4 + s_1_0 - s_1_2);
-  register int coeff5 =            (s_0_0 - s_0_2 - s_2_0 + s_2_2) << 2;
-  register int coeff6 = -(s_0_0  + s_0_2 - ((s_1_0 + s_0_1 + s_1_2 + s_2_1) << 1) - 5 * s_1_1  + s_2_0  + s_2_2) << 1;
+  int tmp1 =        s_0_0 + s_0_2 - 2*s_1_1 + s_2_0 + s_2_2;
+  int coeff1 = 3 * (tmp1 + s_0_1 - ((s_1_0 + s_1_2) << 1) + s_2_1);
+  int coeff2 = 3 * (tmp1 - ((s_0_1 + s_2_1) << 1) + s_1_0 + s_1_2);
+  int tmp2 =                                  s_0_2 - s_2_0;
+  int tmp3 =                         (s_0_0 + tmp2 - s_2_2);
+  int tmp4 =                                   tmp3 -2 * tmp2;
+  int coeff3 =                    -3 * (tmp3 + s_0_1 - s_2_1);
+  int coeff4 =                    -3 * (tmp4 + s_1_0 - s_1_2);
+  int coeff5 =            (s_0_0 - s_0_2 - s_2_0 + s_2_2) << 2;
+  int coeff6 = -(s_0_0  + s_0_2 - ((s_1_0 + s_0_1 + s_1_2 + s_2_1) << 1) - 5 * s_1_1  + s_2_0  + s_2_2) << 1;
 
 
   // 2nd derivative test:
-  register int H_det = 4 * coeff1 * coeff2 - coeff5 * coeff5;
+  int H_det = 4 * coeff1 * coeff2 - coeff5 * coeff5;
 
   if (H_det == 0)
   {

--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -77,7 +77,7 @@ pcl::search::OrganizedNeighbor<PointT>::radiusSearch (const               PointT
   k_sqr_distances.reserve (max_nn);
 
   unsigned yEnd  = (bottom + 1) * input_->width + right + 1;
-  register unsigned idx  = top * input_->width + left;
+  unsigned idx  = top * input_->width + left;
   unsigned skip = input_->width - right + left - 1;
   unsigned xEnd = idx - left + right + 1;
 

--- a/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
@@ -125,7 +125,7 @@ namespace pcl
       inline unsigned
       findRoot (const std::vector<unsigned>& runs, unsigned index) const
       {
-        register unsigned idx = index;
+        unsigned idx = index;
         while (runs[idx] != idx)
           idx = runs[idx];
 


### PR DESCRIPTION
Officially deprecated since c++11, but became [useless](http://www.drdobbs.com/keywords-that-arent-or-comments-by-anoth/184403859) [long](http://stackoverflow.com/a/30809775/1525865) [ago](http://stackoverflow.com/a/3208184/1525865).