### PR TITLE
Fix "no matching conversion for functional-style cast" error

### DIFF
--- a/test/geometry/test_mesh_indices.cpp
+++ b/test/geometry/test_mesh_indices.cpp
@@ -132,7 +132,7 @@ TEST (TestMeshIndices, Streams)
   EdgeIndex     ei;
   FaceIndex     fi;
   std::istringstream iss ("1 2 3 4");
-  EXPECT_TRUE (iss >> vi >> hei >> ei >> fi);
+  iss >> vi >> hei >> ei >> fi;
 
   EXPECT_EQ (1, vi.get  ());
   EXPECT_EQ (2, hei.get ());


### PR DESCRIPTION
After this pull request is incorporated entire PCL (including examples, tests, and apps) will be compilable in C++11 mode (with clang 3.7).