### PR TITLE
Fix to #1390

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -467,6 +467,14 @@ void
 pcl::visualization::PCLVisualizer::spinOnce (int time, bool force_redraw)
 {
   resetStoppedFlag ();
+  #if (defined (__APPLE__)\
+    && ( (VTK_MAJOR_VERSION > 6) || ( (VTK_MAJOR_VERSION == 6) && (VTK_MINOR_VERSION >= 1))))
+    if (!win_->IsDrawable ())
+    {
+      close ();
+      return;
+    }
+  #endif
 
   if (time <= 0)
     time = 1;


### PR DESCRIPTION
Made a small change to the version mentioned in #1390, and removed the check for the ```__MACH__``` definition, because apparently [it should be also valid for IOS](http://www.vtk.org/doc/nightly/html/classvtkRenderWindow.html#a1c220caf00768e887eaf8f0496ab4696).