### PR TITLE
Fix savePolygonFile* ASCII file support

### DIFF
--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -184,6 +184,8 @@ pcl::io::savePolygonFileVTK (const std::string &file_name,
 
   if (binary_format)
     poly_writer->SetFileTypeToBinary ();
+  else
+    poly_writer->SetFileTypeToASCII ();
 
   poly_writer->SetFileName (file_name.c_str ());
   return (poly_writer->Write ());
@@ -208,6 +210,8 @@ pcl::io::savePolygonFilePLY (const std::string &file_name,
 
   if (binary_format)
     poly_writer->SetFileTypeToBinary ();
+  else
+    poly_writer->SetFileTypeToASCII ();
 
   poly_writer->SetFileName (file_name.c_str ());
 	poly_writer->SetArrayName ("Colors");
@@ -232,6 +236,8 @@ pcl::io::savePolygonFileSTL (const std::string &file_name,
 
   if (binary_format)
     poly_writer->SetFileTypeToBinary ();
+  else
+    poly_writer->SetFileTypeToASCII ();
 
   poly_writer->SetFileName (file_name.c_str ());
   return (poly_writer->Write ());


### PR DESCRIPTION
Without the fix the following code outputs 2 binary files using VTK trunk:
```cpp
  pcl::PolygonMesh mesh;
  pcl::io::loadPolygonFile("/home/victor/input.ply", mesh);
  pcl::io::savePolygonFile("/home/victor/output_1.ply", mesh, true);
  pcl::io::savePolygonFile("/home/victor/output_2.ply", mesh, false);
```

I think the VTK guys switched again from ASCII to binary default format somewhere between VTK 6.1 and VTK trunk, not sure when exactly. We already had that discussion [here](https://github.com/PointCloudLibrary/pcl/pull/1319) and [here](https://github.com/PointCloudLibrary/pcl/commit/a15c0e68aebfed4a2052fddebaa4a2c7e7663353#commitcomment-13025969).

:snail: :turtle: 