### PR TITLE
Fix YouTube iframe not being displayed in Ensenso tutorial

### DIFF
--- a/doc/tutorials/content/ensenso_cameras.rst
+++ b/doc/tutorials/content/ensenso_cameras.rst
@@ -87,4 +87,7 @@ the package can be found in the `Institut Maupertuis repository <https://github.
 
 The following video shows the automatic calibration procedure on a Fanuc R1000iA 80f industrial robot:
 
+.. raw:: html
+
   <iframe width="800" height="500" src="https://www.youtube.com/embed/2g6gdx8fKX8" frameborder="0" allowfullscreen></iframe>
+


### PR DESCRIPTION
I forgot the raw HTML tag!
http://www.pointclouds.org/documentation/tutorials/ensenso_cameras.php