### PR TITLE
kinfu LS: shifting: extract data in chunks.

### DIFF
--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/cyclical_buffer.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/cyclical_buffer.h
@@ -65,7 +65,7 @@ namespace pcl
       class PCL_EXPORTS CyclicalBuffer
       {
         public:
-        
+          typedef PointCloud<PointXYZI> PointCloudXYZI;
           
           /** \brief Constructor for a cubic CyclicalBuffer.
             * \param[in] distance_threshold distance between cube center and target point at which we decide to shift.
@@ -217,6 +217,9 @@ namespace pcl
           
           /** \brief buffer used to extract Intensity values from GPU */
           DeviceArray<float> cloud_buffer_device_intensities_;
+
+          /** \brief buffer used to keep track of extraction status */
+          DeviceArray2D<int> last_data_transfer_matrix_device_;
 
           /** \brief distance threshold (cube's center to target point) to trigger shift */
           double distance_threshold_;

--- a/gpu/kinfu_large_scale/src/internal.h
+++ b/gpu/kinfu_large_scale/src/internal.h
@@ -352,10 +352,23 @@ namespace pcl
         * \param[in] shiftZ Offset in indices that will be cleared from the TSDF volume. The clearing start from buffer.OriginZ and stops in OriginZ + shiftZ
         * \param[out] output_xyz buffer large enought to store point cloud xyz values
         * \param[out] output_intensities buffer large enought to store point cloud intensity values
+        * \param[inout] last_data_transfer_matrix a VOLUME_Y * VOLUME_X matrix, an int for every thread, to track progress
+        * \param[out] data_transfer_finished contains 0 if the transfer is incomplete (due to full buffer), 1 otherwise
         * \return number of point stored to passed buffer
         */ 
       PCL_EXPORTS size_t
-      extractSliceAsCloud (const PtrStep<short2>& volume, const float3& volume_size, const pcl::gpu::kinfuLS::tsdf_buffer* buffer, const int shiftX, const int shiftY, const int shiftZ, PtrSz<PointType> output_xyz, PtrSz<float> output_intensities);
+      extractSliceAsCloud (const PtrStep<short2>& volume, const float3& volume_size,
+        const pcl::gpu::kinfuLS::tsdf_buffer* buffer, const int shiftX, const int shiftY, const int shiftZ,
+        PtrSz<PointType> output_xyz, PtrSz<float> output_intensities,
+        PtrStep<int> last_data_transfer_matrix, int & data_transfer_finished
+        );
+
+      /** \brief Returns the size of the data transfer matrix required by extractSliceAsCloud
+        * \param[out] height the height of the matrix
+        * \param[out] width the width of the matrix, in number of (integer) elements
+        */
+      PCL_EXPORTS void
+      getDataTransferCompletionMatrixSize(size_t & height, size_t & width);
 
       /** \brief Performs normals computation for given poins using tsdf volume
         * \param[in] volume tsdf volume


### PR DESCRIPTION
Currently, if the extraction buffer fills up while shifting, the extraction results in incomplete data.
This patch rewrites the extraction procedure so that the kernel saves its state and terminates.
The buffer is then cleared and the kernel resumes from where it left, until all data is extracted.

To test this patch, you can reduce to a lower value (let's say, 10 000) the constant DEFAULT_CLOUD_BUFFER_SIZE in
  gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h

Unfortunately, while I was testing the patch, I noticed crashes on modern hardware (GTX 980).
I had to remove the warp-synchronous programming (which is no longer supported). This means adding a lot of __syncthreads, with some overhead.

I also removed the copy to shared memory, needed to reorder the writes to global memory. It seems that even my GTX 670 is able to reorder them without help. This reduces execution time of the kernel by about 1/3.