### PR TITLE
[WIP] Fix is_dense flag not properly set

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -59,7 +59,7 @@ pcl::PLYReader::elementDefinitionCallback (const std::string& element_name, std:
       cloud_->width = static_cast<uint32_t> (count);
       cloud_->height = 1;
     }
-    cloud_->is_dense = false;
+    cloud_->is_dense = true;
     cloud_->point_step = 0;
     cloud_->row_step = 0;
     vertex_count_ = 0;
@@ -267,6 +267,9 @@ namespace pcl
   template<typename Scalar> void
   PLYReader::vertexScalarPropertyCallback (Scalar value)
   {
+    if (!pcl_isfinite (value))
+      cloud_->is_dense = false;
+
     memcpy (&cloud_->data[vertex_count_ * cloud_->point_step + vertex_offset_before_],
             &value,
             sizeof (Scalar));

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -941,7 +941,7 @@ TEST_F (PLYTest, LoadPLYFileColoredASCIIIntoBlob)
   EXPECT_EQ (cloud_blob.point_step, 16);
   EXPECT_EQ (cloud_blob.row_step, 16 * 4);
   EXPECT_EQ (cloud_blob.data.size(), 16 * 4);
-  // EXPECT_TRUE (cloud_blob.is_dense);   // this is failing and it shouldnt?
+  EXPECT_TRUE (cloud_blob.is_dense);
 
   // scope blob data
   ps = cloud_blob.point_step;
@@ -989,7 +989,7 @@ TEST_F (PLYTest, LoadPLYFileColoredASCIIIntoPolygonMesh)
   EXPECT_EQ (mesh.cloud.point_step, 16);
   EXPECT_EQ (mesh.cloud.row_step, 16 * 4);
   EXPECT_EQ (mesh.cloud.data.size(), 16 * 4);
-  // EXPECT_TRUE (mesh.cloud.is_dense);   // this is failing and it shouldnt?
+  EXPECT_TRUE (mesh.cloud.is_dense);
 
   // scope blob data
   ps = mesh.cloud.point_step;
@@ -1033,7 +1033,7 @@ TYPED_TEST (PLYPointCloudTest, LoadPLYFileColoredASCIIIntoPointCloud)
   EXPECT_EQ (cloud_rgb.height, 1);
   EXPECT_EQ (cloud_rgb.width, 4);
   EXPECT_EQ (cloud_rgb.points.size(), 4);
-  // EXPECT_TRUE (cloud_rgb.is_dense); // this is failing and it shouldnt?
+  EXPECT_TRUE (cloud_rgb.is_dense);
 
   // scope cloud data
   ASSERT_EQ (cloud_rgb[0].rgba, PLYTest::rgba_1_);


### PR DESCRIPTION
Fixes #1455.
- [x] Update documentation about what dense cloud is.
- [x] Add some checks to make the cloud non-dense if normal, color etc.. is not finite in the PLY reader.
- [x] Write a test for a non dense cloud.
- [ ] Fix bug with binary PLY files

```
test_pcl_1: /home/victor/libraries/pcl/src/io/src/ply_io.cpp:503: void pcl::PLYReader::objInfoCallback(const string&): Assertion `st.size () == 3' failed.
Abandon
```
