### PR TITLE
Support for correspondence estimation with different point types

### DIFF
--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -48,14 +48,6 @@
 
 namespace pcl
 {
-  namespace detail
-  {
-    //  Forward declaration of a helper class which helps specialize
-    //  nearestKSearchT and radiusSearchT
-    template<typename PointT, typename PointTDiff, typename Enabled = void>
-    class KdTreeHelper;
-  }
-
   /** \brief KdTree represents the base spatial locator class for kd-tree implementations.
     * \author Radu B Rusu, Bastian Steder, Michael Dixon
     * \ingroup kdtree

--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -171,20 +171,40 @@ namespace pcl
       }
 
       /** \brief Search for k-nearest neighbors for the given query point. 
-        * This method accepts a different template parameter for the point type.
+        * This method accepts a different template parameter for the point type
+        * and it is invoked if PointT is of a different type than PointTDiff.
         * \param[in] point the given query point
         * \param[in] k the number of neighbors to search for
         * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
         * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k 
         * a priori!)
-        * \return number of neighbors found
+        * \return number of neighbors found (int)
         */
-      template <typename PointTDiff> inline int 
+      template <typename PointTDiff> inline typename boost::disable_if<boost::is_same<PointT, PointTDiff>, int>::type
+      nearestKSearchT (const PointTDiff &point, int k,
+                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
+      {
+        PointT p;
+        copyPoint (point, p);
+        return (nearestKSearch (p, k, k_indices, k_sqr_distances));
+      }
+
+      /** \brief Search for k-nearest neighbors for the given query point.
+        * This method accepts a different template parameter for the point type,
+        * it is invoked if PointT is equal to PointTDiff and it is an alias
+        * to \a nearestKSearch.
+        * \param[in] point the given query point
+        * \param[in] k the number of neighbors to search for
+        * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
+        * a priori!)
+        * \return number of neighbors found (int)
+        */
+      template <typename PointTDiff> inline typename boost::enable_if<boost::is_same<PointT, PointTDiff>, int>::type
       nearestKSearchT (const PointTDiff &point, int k, 
                        std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
       {
-        const detail::KdTreeHelper<PointT, PointTDiff> tree (*this);
-        return tree.nearestKSearchT (point, k, k_indices, k_sqr_distances);
+        return (nearestKSearch (point, k, k_indices, k_sqr_distances));
       }
 
       /** \brief Search for k-nearest neighbors for the given query point (zero-copy).
@@ -261,6 +281,7 @@ namespace pcl
       }
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.
+        * This method is invoked if PointT is not equal to PointTDiff.
         * \param[in] point the given query point
         * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
         * \param[out] k_indices the resultant indices of the neighboring points
@@ -268,14 +289,34 @@ namespace pcl
         * \param[in] max_nn if given, bounds the maximum returned neighbors to this value. If \a max_nn is set to
         * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
         * returned.
-        * \return number of neighbors found in radius
+        * \return number of neighbors found in radius (int)
         */
-      template <typename PointTDiff> inline int 
+      template <typename PointTDiff> inline typename boost::disable_if<boost::is_same<PointT, PointTDiff>, int>::type
       radiusSearchT (const PointTDiff &point, double radius, std::vector<int> &k_indices,
                      std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
       {
-        const detail::KdTreeHelper<PointT, PointTDiff> tree (*this);
-        return tree.radiusSearchT (point, radius, k_indices, k_sqr_distances, max_nn);
+        PointT p;
+        copyPoint (point, p);
+        return (radiusSearch (p, radius, k_indices, k_sqr_distances, max_nn));
+      }
+
+      /** \brief Search for all the nearest neighbors of the query point in a given radius.
+        * This method is invoked if PointT is equal to PointTDiff and it is an alias
+        * to \a radiusSearch
+        * \param[in] point the given query point
+        * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+        * \param[out] k_indices the resultant indices of the neighboring points
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+        * \param[in] max_nn if given, bounds the maximum returned neighbors to this value. If \a max_nn is set to
+        * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
+        * returned.
+        * \return number of neighbors found in radius (int)
+        */
+      template <typename PointTDiff> inline typename boost::enable_if<boost::is_same<PointT, PointTDiff>, int>::type
+      radiusSearchT (const PointTDiff &point, double radius, std::vector<int> &k_indices,
+                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
+      {
+        return (radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn));
       }
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius (zero-copy).
@@ -368,151 +409,6 @@ namespace pcl
       virtual std::string 
       getName () const = 0;
   };
-
-  namespace detail
-  {
-    /** \class KdTreeHelper
-      * \brief A helper class whose specializations aids in preventing unnecessary
-      * copies when using \a KdTreeHelper<PointT>::nearestKSearchT() and \a
-      * KdTreeHelper<PointT>::radiusSearchT()
-      *
-      * This particular specialization is invoked when the the above search
-      * methods are invoked with point types different than the ones used
-      * in the underlying tree structure.
-      */
-    template<typename PointT, typename PointTDiff>
-    class KdTreeHelper<PointT, PointTDiff, typename boost::disable_if<boost::is_same<PointT, PointTDiff> >::type>
-    {
-      public:
-
-        /** \brief Constructor
-          * \param[in] tree - A reference to a kdtree object which implements
-          * the nearestKSearchT and radiusSearchT methods.
-          */
-        KdTreeHelper (const KdTree<PointT>& tree) : tree (tree) {}
-
-        /** \brief Search for k-nearest neighbors for the given query point
-          * of any type
-          * \param[in] point - the given query point
-          * \param[in] k - the number of neighbors to search for
-          * \param[out] k_indices - the resultant indices of the neighboring
-          * points (must be resized to \a k a priori!)
-          * \param[out] k_sqr_distances - the resultant squared distances to
-          * the neighboring points (must be resized to \a k a priori!)
-          * \return number of neighbors found
-          */
-        int nearestKSearchT (const PointTDiff& point,
-                             int k,
-                             std::vector<int>& k_indices,
-                             std::vector<float>& k_sqr_distances) const
-        {
-          PointT p;
-          copyPoint (point, p);
-          return tree.nearestKSearch (p, k, k_indices, k_sqr_distances);
-        }
-
-        /** \brief Search for all the nearest neighbors of the query point in
-          * a given radius.
-          * \param[in] point - the given query point
-          * \param[in] radius - the radius of the sphere bounding all of p_q's
-          * neighbors
-          * \param[out] k_indices - the resultant indices of the neighboring points
-          * \param[out] k_sqr_distances - the resultant squared distances to
-          * the neighboring points
-          * \param[in] max_nn - if given, bounds the maximum returned neighbors
-          * to this value. If \a max_nn is set to 0 or to a number higher than
-          * the number of points in the input cloud, all neighbors in \a radius
-          * will be returned.
-          * \return number of neighbors found in radius
-          */
-        int radiusSearchT (const PointTDiff& point,
-                           double radius,
-                           std::vector<int>& k_indices,
-                           std::vector<float>& k_sqr_distances,
-                           unsigned int max_nn = 0) const
-        {
-          PointT p;
-          copyPoint (point, p);
-          return tree.radiusSearch (p, radius, k_indices, k_sqr_distances, max_nn);
-        }
-
-      protected:
-
-        /** \brief A reference to a kdtree object, with its index already built
-          * which implements nearestKSearchT and radiusSearchT
-          */
-        const KdTree<PointT>& tree;
-    };
-
-    /** \class KdTreeHelper
-      * \brief A helper class whose specializations aids in preventing unnecessary
-      * copies when using \a KdTreeHelper<PointT>::nearestKSearchT() and \a
-      * KdTreeHelper<PointT>::radiusSearchT()
-      *
-      * This particular specialization is invoked when the the above search
-      * methods are invoked with the same point types as the underlying
-      * kdtree structure.
-      */
-    template<typename PointT, typename PointTDiff>
-    class KdTreeHelper<PointT, PointTDiff, typename boost::enable_if<boost::is_same<PointT, PointTDiff> >::type>
-    {
-      public:
-
-        /** \brief Constructor
-          * \param[in] tree - A reference to a tree object which implements
-          * the nearestKSearchT and radiusSearchT methods.
-          */
-        KdTreeHelper (const KdTree<PointT>& tree) : tree (tree) {}
-
-        /** \brief Search for k-nearest neighbors for the given query point
-          * of any type
-          * \param[in] point - the given query point
-          * \param[in] k - the number of neighbors to search for
-          * \param[out] k_indices - the resultant indices of the neighboring
-          * points (must be resized to \a k a priori!)
-          * \param[out] k_sqr_distances - the resultant squared distances to
-          * the neighboring points (must be resized to \a k a priori!)
-          * \return number of neighbors found
-          */
-        int nearestKSearchT (const PointT &point,
-                             int k,
-                             std::vector<int> &k_indices,
-                             std::vector<float> &k_sqr_distances) const
-        {
-          return tree.nearestKSearch (point, k, k_indices, k_sqr_distances);
-        }
-
-        /** \brief Search for all the nearest neighbors of the query point in
-          * a given radius.
-          * \param[in] point - the given query point
-          * \param[in] radius - the radius of the sphere bounding all of p_q's
-          * neighbors
-          * \param[out] k_indices - the resultant indices of the neighboring points
-          * \param[out] k_sqr_distances - the resultant squared distances to
-          * the neighboring points
-          * \param[in] max_nn - if given, bounds the maximum returned neighbors
-          * to this value. If \a max_nn is set to 0 or to a number higher than
-          * the number of points in the input cloud, all neighbors in \a radius
-          * will be returned.
-          * \return number of neighbors found in radius
-          */
-        int radiusSearchT (const PointTDiff& point,
-                           double radius,
-                           std::vector<int>& k_indices,
-                           std::vector<float>& k_sqr_distances,
-                           unsigned int max_nn = 0) const
-        {
-          return tree.radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
-        }
-
-      protected:
-
-        /** \brief A reference to a kdtree object, with its index already built
-          * which implements nearestKSearchT and radiusSearchT
-          */
-        const KdTree<PointT>& tree;
-    };
-  } // namespace detail
 }
 
 #endif  //#ifndef _PCL_KDTREE_KDTREE_H_

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -89,7 +89,6 @@ namespace pcl
         typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
         typedef typename KdTreeReciprocal::PointRepresentationConstPtr ReciprocalPointRepresentationConstPtr;
 
-        
         /** \brief Empty constructor. */
         CorrespondenceEstimationBase () 
           : corr_name_ ("CorrespondenceEstimationBase")
@@ -110,6 +109,19 @@ namespace pcl
       
         /** \brief Empty destructor */
         virtual ~CorrespondenceEstimationBase () {}
+
+        /** \brief An alias to setInputSource
+          * \param[in] cloud the input point cloud source
+          */
+        void
+        setInputCloud (const PointCloudSourceConstPtr &cloud)
+        {
+          setInputSource (cloud);
+        }
+
+        /** \brief An alias to getInputSource. */
+        PointCloudSourceConstPtr const
+        getInputCloud () const { return getInputSource (); }
 
         /** \brief Provide a pointer to the input source 
           * (e.g., the point cloud that we want to align to the target)
@@ -281,11 +293,11 @@ namespace pcl
         {
           point_representation_ = point_representation;
         }
-        
-        /** \brief Provide a boost shared pointer to the PointRepresentation to be used 
+
+        /** \brief Provide a boost shared pointer to the PointRepresentation to be used
           * when searching for nearest neighbors in the source cloud (only needed for reciprocal).
           *
-          * \param[in] point_representation the PointRepresentation to be used by the 
+          * \param[in] point_representation the PointRepresentation to be used by the
           * source k-D tree for nearest neighbor search
           */
         inline void
@@ -320,7 +332,7 @@ namespace pcl
 
         /** \brief The point representation used for reciprocal search (internal). */
         ReciprocalPointRepresentationConstPtr point_representation_source_;
-        
+
         /** \brief The transformed input source point cloud dataset. */
         PointCloudTargetPtr input_transformed_;
 
@@ -334,7 +346,7 @@ namespace pcl
         /** \brief Internal computation initalization. */
         bool
         initCompute ();
-        
+
         /** \brief Internal computation initalization for reciprocal correspondences. */
         bool
         initComputeReciprocal ();
@@ -343,10 +355,12 @@ namespace pcl
          * This way, we avoid rebuilding the kd-tree for the target cloud every time the determineCorrespondences () method
          * is called. */
         bool target_cloud_updated_;
+
         /** \brief Variable that stores whether we have a new source cloud, meaning we need to pre-process it again.
          * This way, we avoid rebuilding the reciprocal kd-tree for the source cloud every time the determineCorrespondences () method
          * is called. */
         bool source_cloud_updated_;
+
         /** \brief A flag which, if set, means the tree operating on the target cloud 
          * will never be recomputed*/
         bool force_no_recompute_;
@@ -381,9 +395,7 @@ namespace pcl
     template <typename PointSource, typename PointTarget, typename Scalar = float>
     class CorrespondenceEstimation : public CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>
     {
-      public:
-        typedef boost::shared_ptr<CorrespondenceEstimation<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const CorrespondenceEstimation<PointSource, PointTarget, Scalar> > ConstPtr;
+      protected:
 
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_transformed_;
@@ -392,26 +404,35 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::corr_name_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_indices_;
-        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::getClassName;
-        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
-        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::indices_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_fields_;
+
+      public:
+        typedef boost::shared_ptr<CorrespondenceEstimation<PointSource, PointTarget, Scalar> > Ptr;
+        typedef boost::shared_ptr<const CorrespondenceEstimation<PointSource, PointTarget, Scalar> > ConstPtr;
+
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::getClassName;
         using PCLBase<PointSource>::deinitCompute;
 
-        typedef pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::KdTree;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::KdTreePtr;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::KdTreeReciprocal;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::KdTreeReciprocalPtr;
 
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudSource;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudSourcePtr;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudSourceConstPtr;
 
-        typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudTarget;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudTargetPtr;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudTargetConstPtr;
+
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointRepresentationConstPtr;
+        using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::ReciprocalPointRepresentationConstPtr;
 
         /** \brief Empty constructor. */
         CorrespondenceEstimation () 
@@ -450,6 +471,41 @@ namespace pcl
           return (copy);
         }
      };
+
+    namespace detail
+    {
+      // Copy is performed if PointSource is of different type than PointTarget
+      template<typename KdTree, typename PointSource, typename PointTarget, typename Enabled = void>
+      struct NearestKSearchHelper;
+
+      // Copy is performed if PointSource is of different type than PointTarget
+      template<typename KdTree, typename PointSource, typename PointTarget>
+      struct NearestKSearchHelper<KdTree, PointSource, PointTarget, typename boost::enable_if<boost::mpl::not_<boost::is_same<PointSource, PointTarget> > >::type>
+      {
+        NearestKSearchHelper (const KdTree& tree) : tree (tree) {}
+
+        int operator() (const PointSource& p_q, int k, std::vector<int>& k_indices, std::vector<float>& k_sqr_distances)
+        {
+          return tree.nearestKSearchT (p_q, k, k_indices, k_sqr_distances);
+        }
+
+        const KdTree& tree;
+      };
+
+      // No copy is performed if PointSource is of same type as PointTarget
+      template<typename KdTree, typename PointSource, typename PointTarget>
+      struct NearestKSearchHelper<KdTree, PointSource, PointTarget, typename boost::enable_if<boost::is_same<PointSource, PointTarget> >::type>
+      {
+        NearestKSearchHelper (const KdTree& tree) : tree (tree) {}
+
+        int operator() (const PointSource &p_q, int k, std::vector<int> &k_indices, std::vector<float> &k_sqr_distances)
+        {
+          return tree.nearestKSearch (p_q, k, k_indices, k_sqr_distances);
+        }
+
+        const KdTree& tree;
+      };
+    }
   }
 }
 

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -62,14 +62,16 @@ namespace pcl
     template <typename PointSource, typename PointTarget, typename Scalar = float>
     class CorrespondenceEstimationBase: public PCLBase<PointSource>
     {
+      protected:
+
+        using PCLBase<PointSource>::deinitCompute;
+        using PCLBase<PointSource>::input_;
+        using PCLBase<PointSource>::indices_;
+
       public:
         typedef boost::shared_ptr<CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > Ptr;
         typedef boost::shared_ptr<const CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > ConstPtr;
 
-        // using PCLBase<PointSource>::initCompute;
-        using PCLBase<PointSource>::deinitCompute;
-        using PCLBase<PointSource>::input_;
-        using PCLBase<PointSource>::indices_;
         using PCLBase<PointSource>::setIndices;
 
         typedef pcl::search::KdTree<PointTarget> KdTree;
@@ -397,6 +399,11 @@ namespace pcl
     {
       protected:
 
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::getClassName;
+        using PCLBase<PointSource>::deinitCompute;
+
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_transformed_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::tree_;
@@ -409,13 +416,9 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_fields_;
 
       public:
+
         typedef boost::shared_ptr<CorrespondenceEstimation<PointSource, PointTarget, Scalar> > Ptr;
         typedef boost::shared_ptr<const CorrespondenceEstimation<PointSource, PointTarget, Scalar> > ConstPtr;
-
-        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
-        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;
-        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::getClassName;
-        using PCLBase<PointSource>::deinitCompute;
 
         using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::KdTree;
         using typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::KdTreePtr;
@@ -471,41 +474,6 @@ namespace pcl
           return (copy);
         }
      };
-
-    namespace detail
-    {
-      // Copy is performed if PointSource is of different type than PointTarget
-      template<typename KdTree, typename PointSource, typename PointTarget, typename Enabled = void>
-      struct NearestKSearchHelper;
-
-      // Copy is performed if PointSource is of different type than PointTarget
-      template<typename KdTree, typename PointSource, typename PointTarget>
-      struct NearestKSearchHelper<KdTree, PointSource, PointTarget, typename boost::enable_if<boost::mpl::not_<boost::is_same<PointSource, PointTarget> > >::type>
-      {
-        NearestKSearchHelper (const KdTree& tree) : tree (tree) {}
-
-        int operator() (const PointSource& p_q, int k, std::vector<int>& k_indices, std::vector<float>& k_sqr_distances)
-        {
-          return tree.nearestKSearchT (p_q, k, k_indices, k_sqr_distances);
-        }
-
-        const KdTree& tree;
-      };
-
-      // No copy is performed if PointSource is of same type as PointTarget
-      template<typename KdTree, typename PointSource, typename PointTarget>
-      struct NearestKSearchHelper<KdTree, PointSource, PointTarget, typename boost::enable_if<boost::is_same<PointSource, PointTarget> >::type>
-      {
-        NearestKSearchHelper (const KdTree& tree) : tree (tree) {}
-
-        int operator() (const PointSource &p_q, int k, std::vector<int> &k_indices, std::vector<float> &k_sqr_distances)
-        {
-          return tree.nearestKSearch (p_q, k, k_indices, k_sqr_distances);
-        }
-
-        const KdTree& tree;
-      };
-    }
   }
 }
 

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -76,7 +76,7 @@ namespace pcl
         typedef typename KdTree::Ptr KdTreePtr;
 
         typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
-        typedef typename KdTree::Ptr KdTreeReciprocalPtr;
+        typedef typename KdTreeReciprocal::Ptr KdTreeReciprocalPtr;
 
         typedef pcl::PointCloud<PointSource> PointCloudSource;
         typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
@@ -87,7 +87,9 @@ namespace pcl
         typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
 
         typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
+        typedef typename KdTreeReciprocal::PointRepresentationConstPtr ReciprocalPointRepresentationConstPtr;
 
+        
         /** \brief Empty constructor. */
         CorrespondenceEstimationBase () 
           : corr_name_ ("CorrespondenceEstimationBase")
@@ -96,6 +98,7 @@ namespace pcl
           , target_ ()
           , target_indices_ ()
           , point_representation_ ()
+          , point_representation_source_ ()
           , input_transformed_ ()
           , input_fields_ ()
           , target_cloud_updated_ (true)
@@ -278,6 +281,18 @@ namespace pcl
         {
           point_representation_ = point_representation;
         }
+        
+        /** \brief Provide a boost shared pointer to the PointRepresentation to be used 
+          * when searching for nearest neighbors in the source cloud (only needed for reciprocal).
+          *
+          * \param[in] point_representation the PointRepresentation to be used by the 
+          * source k-D tree for nearest neighbor search
+          */
+        inline void
+        setSourcePointRepresentation (const ReciprocalPointRepresentationConstPtr &point_representation)
+        {
+          point_representation_source_ = point_representation;
+        }
 
         /** \brief Clone and cast to CorrespondenceEstimationBase */
         virtual boost::shared_ptr< CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > clone () const = 0;
@@ -303,6 +318,9 @@ namespace pcl
         /** \brief The point representation used (internal). */
         PointRepresentationConstPtr point_representation_;
 
+        /** \brief The point representation used for reciprocal search (internal). */
+        ReciprocalPointRepresentationConstPtr point_representation_source_;
+        
         /** \brief The transformed input source point cloud dataset. */
         PointCloudTargetPtr input_transformed_;
 

--- a/registration/include/pcl/registration/impl/correspondence_estimation.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation.hpp
@@ -45,20 +45,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::setInputCloud (const typename pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudSourceConstPtr &cloud)
-{
-  setInputSource (cloud); 
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename Scalar> typename pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::PointCloudSourceConstPtr const
-pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::getInputCloud ()
-{
-  return (getInputSource ()); 
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename Scalar> void
 pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::setInputTarget (
     const PointCloudTargetConstPtr &cloud)
 {
@@ -132,50 +118,28 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
 
   double max_dist_sqr = max_distance * max_distance;
 
-  typedef typename pcl::traits::fieldList<PointTarget>::type FieldListTarget;
   correspondences.resize (indices_->size ());
 
   std::vector<int> index (1);
   std::vector<float> distance (1);
   pcl::Correspondence corr;
   unsigned int nr_valid_correspondences = 0;
-  
+
   // Check if the template types are the same. If true, avoid a copy.
   // Both point types MUST be registered using the POINT_CLOUD_REGISTER_POINT_STRUCT macro!
- /* if (isSamePointType<PointSource, PointTarget> ())
+  detail::NearestKSearchHelper<KdTree, PointSource, PointTarget> search (*tree_);
+  for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
   {
-    // Iterate over the input set of source indices
-    for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
-    {
-      tree_->nearestKSearch (input_->points[*idx], 1, index, distance);
-      if (distance[0] > max_dist_sqr)
-        continue;
+    search ((*input_)[*idx], 1, index, distance);
+    if (distance[0] > max_dist_sqr)
+      continue;
 
-      corr.index_query = *idx;
-      corr.index_match = index[0];
-      corr.distance = distance[0];
-      correspondences[nr_valid_correspondences++] = corr;
-    }
+    corr.index_query = *idx;
+    corr.index_match = index[0];
+    corr.distance = distance[0];
+    correspondences[nr_valid_correspondences++] = corr;
   }
-  else*/
-  {
-    // Copy the source data to a target PointTarget format so we can search in the tree
-    PointCloudTargetPtr source_copy (new PointCloudTarget);
-    copyPointCloud (*input_, *source_copy);
-    // Iterate over the input set of source indices
-    for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
-    {
-      PointTarget pt = source_copy->points[*idx];
-      tree_->nearestKSearch (pt, 1, index, distance);
-      if (distance[0] > max_dist_sqr)
-        continue;
 
-      corr.index_query = *idx;
-      corr.index_match = index[0];
-      corr.distance = distance[0];
-      correspondences[nr_valid_correspondences++] = corr;
-    }
-  }
   correspondences.resize (nr_valid_correspondences);
   deinitCompute ();
 }
@@ -187,11 +151,7 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
 {
   if (!initCompute ())
     return;
-  
-  typedef typename pcl::traits::fieldList<PointSource>::type FieldListSource;
-  typedef typename pcl::traits::fieldList<PointTarget>::type FieldListTarget;
-  typedef typename pcl::intersect<FieldListSource, FieldListTarget>::type FieldList;
-  
+
   // setup tree for reciprocal search
   // Set the internal point representation of choice
   if (!initComputeReciprocal())
@@ -209,56 +169,28 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
 
   // Check if the template types are the same. If true, avoid a copy.
   // Both point types MUST be registered using the POINT_CLOUD_REGISTER_POINT_STRUCT macro!
-  /*if (isSamePointType<PointSource, PointTarget> ())
+  detail::NearestKSearchHelper<KdTree, PointSource, PointTarget> search (*tree_);
+  detail::NearestKSearchHelper<KdTreeReciprocal, PointTarget, PointSource> search_reciprocal (*tree_reciprocal_);
+
+  // Iterate over the input set of source indices
+  for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
   {
-    // Iterate over the input set of source indices
-    for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
-    {
-      tree_->nearestKSearch (input_->points[*idx], 1, index, distance);
-      if (distance[0] > max_dist_sqr)
-        continue;
+    search ((*input_)[*idx], 1, index, distance);
+    if (distance[0] > max_dist_sqr)
+      continue;
 
-      target_idx = index[0];
+    target_idx = index[0];
 
-      tree_reciprocal_->nearestKSearch (target_->points[target_idx], 1, index_reciprocal, distance_reciprocal);
-      if (distance_reciprocal[0] > max_dist_sqr || *idx != index_reciprocal[0])
-        continue;
+    search_reciprocal ((*target_)[target_idx], 1, index_reciprocal, distance_reciprocal);
+    if (distance_reciprocal[0] > max_dist_sqr || *idx != index_reciprocal[0])
+      continue;
 
-      corr.index_query = *idx;
-      corr.index_match = index[0];
-      corr.distance = distance[0];
-      correspondences[nr_valid_correspondences++] = corr;
-    }
+    corr.index_query = *idx;
+    corr.index_match = index[0];
+    corr.distance = distance[0];
+    correspondences[nr_valid_correspondences++] = corr;
   }
-  else*/
-  {
-    // Copy the source data to a target PointTarget format so we can search in the tree
-    PointCloudTargetPtr source_copy (new PointCloudTarget);
-    copyPointCloud (*input_, *source_copy);
-    // Copy the target data to a target PointSource format so we can search in the tree_reciprocal
-    PointCloudSourcePtr target_copy (new PointCloudSource);
-    copyPointCloud (*target_, *target_copy);
-    // Iterate over the input set of source indices
-    for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
-    {
-      PointTarget pt_src = source_copy->points[*idx];
-      tree_->nearestKSearch (pt_src, 1, index, distance);
-      if (distance[0] > max_dist_sqr)
-        continue;
 
-      target_idx = index[0];
-
-      PointSource pt_tgt = target_copy->points[target_idx];
-      tree_reciprocal_->nearestKSearch (pt_tgt, 1, index_reciprocal, distance_reciprocal);
-      if (distance_reciprocal[0] > max_dist_sqr || *idx != index_reciprocal[0])
-        continue;
-
-      corr.index_query = *idx;
-      corr.index_match = index[0];
-      corr.distance = distance[0];
-      correspondences[nr_valid_correspondences++] = corr;
-    }
-  }
   correspondences.resize (nr_valid_correspondences);
   deinitCompute ();
 }

--- a/registration/include/pcl/registration/impl/correspondence_estimation.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation.hpp
@@ -125,12 +125,9 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
   pcl::Correspondence corr;
   unsigned int nr_valid_correspondences = 0;
 
-  // Check if the template types are the same. If true, avoid a copy.
-  // Both point types MUST be registered using the POINT_CLOUD_REGISTER_POINT_STRUCT macro!
-  detail::NearestKSearchHelper<KdTree, PointSource, PointTarget> search (*tree_);
   for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
   {
-    search ((*input_)[*idx], 1, index, distance);
+    tree_->nearestKSearchT ((*input_)[*idx], 1, index, distance);
     if (distance[0] > max_dist_sqr)
       continue;
 
@@ -167,21 +164,16 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
   unsigned int nr_valid_correspondences = 0;
   int target_idx = 0;
 
-  // Check if the template types are the same. If true, avoid a copy.
-  // Both point types MUST be registered using the POINT_CLOUD_REGISTER_POINT_STRUCT macro!
-  detail::NearestKSearchHelper<KdTree, PointSource, PointTarget> search (*tree_);
-  detail::NearestKSearchHelper<KdTreeReciprocal, PointTarget, PointSource> search_reciprocal (*tree_reciprocal_);
-
   // Iterate over the input set of source indices
   for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
   {
-    search ((*input_)[*idx], 1, index, distance);
+    tree_->nearestKSearchT ((*input_)[*idx], 1, index, distance);
     if (distance[0] > max_dist_sqr)
       continue;
 
     target_idx = index[0];
 
-    search_reciprocal ((*target_)[target_idx], 1, index_reciprocal, distance_reciprocal);
+    tree_reciprocal_->nearestKSearchT ((*target_)[target_idx], 1, index_reciprocal, distance_reciprocal);
     if (distance_reciprocal[0] > max_dist_sqr || *idx != index_reciprocal[0])
       continue;
 

--- a/search/include/pcl/search/search.h
+++ b/search/include/pcl/search/search.h
@@ -48,14 +48,6 @@ namespace pcl
 {
   namespace search
   {
-    namespace detail
-    {
-      //  Forward declaration of a helper class which helps specialize
-      //  nearestKSearchT and radiusSearchT
-      template<typename PointT, typename PointTDiff, typename Enabled = void>
-      class SearchHelper;
-    }
-
     /** \brief Generic search class. All search wrappers must inherit from this.
       *
       * Each search method must implement 2 different types of search:

--- a/search/include/pcl/search/search.h
+++ b/search/include/pcl/search/search.h
@@ -156,19 +156,38 @@ namespace pcl
 
         /** \brief Search for k-nearest neighbors for the given query point.
           * This method accepts a different template parameter for the point type.
+          * Invoked if PointT and PointTDiff are different
           * \param[in] point the given query point
           * \param[in] k the number of neighbors to search for
           * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
           * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
           * a priori!)
-          * \return number of neighbors found
+          * \return number of neighbors found (int)
           */
-        template <typename PointTDiff> inline int
+        template <typename PointTDiff> inline typename boost::disable_if<boost::is_same<PointT, PointTDiff>, int>::type
         nearestKSearchT (const PointTDiff &point, int k,
                          std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
         {
-          search::detail::SearchHelper<PointT, PointTDiff> search (*this);
-          return search.nearestKSearchT (point, k, k_indices, k_sqr_distances);
+          PointT p;
+          copyPoint (point, p);
+          return (nearestKSearch (p, k, k_indices, k_sqr_distances));
+        }
+
+        /** \brief Search for k-nearest neighbors for the given query point.
+          * This method accepts a different template parameter for the point type.
+          * Invoked if PointT and PointTDiff are the same. No copy is performed.
+          * \param[in] point the given query point
+          * \param[in] k the number of neighbors to search for
+          * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
+          * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
+          * a priori!)
+          * \return number of neighbors found (int)
+          */
+        template <typename PointTDiff> inline typename boost::enable_if<boost::is_same<PointT, PointTDiff>, int>::type
+        nearestKSearchT (const PointTDiff &point, int k,
+                         std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
+        {
+          return (nearestKSearch (point, k, k_indices, k_sqr_distances));
         }
 
         /** \brief Search for k-nearest neighbors for the given query point.
@@ -226,21 +245,54 @@ namespace pcl
                         int k, std::vector< std::vector<int> >& k_indices,
                         std::vector< std::vector<float> >& k_sqr_distances) const;
 
-        /** \brief Search for the k-nearest neighbors for the given query point. Use this method if the query points are of a different type than the points in the data set (e.g. PointXYZRGBA instead of PointXYZ).
+        /** \brief Search for the k-nearest neighbors for the given query point.
+          * This method is used if the query points are of a different type than the points in the data set (e.g. PointXYZRGBA instead of PointXYZ).
           * \param[in] cloud the point cloud data
           * \param[in] indices a vector of point cloud indices to query for nearest neighbors
           * \param[in] k the number of neighbors to search for
           * \param[out] k_indices the resultant indices of the neighboring points, k_indices[i] corresponds to the neighbors of the query point i
           * \param[out] k_sqr_distances the resultant squared distances to the neighboring points, k_sqr_distances[i] corresponds to the neighbors of the query point i
-          * \note This method copies the input point cloud of type PointTDiff to a temporary cloud of type PointT (if the types are different) and performs the batch
+          * \note This method copies the input point cloud of type PointTDiff to a temporary cloud of type PointT and performs the batch
           * search on the new cloud. You should prefer the single-point search if you don't use a search algorithm that accelerates batch NN search.
           */
-        template <typename PointTDiff> void
+        template <typename PointTDiff> typename boost::disable_if<boost::is_same<PointT, PointTDiff>, void>::type
         nearestKSearchT (const pcl::PointCloud<PointTDiff> &cloud, const std::vector<int>& indices, int k, std::vector< std::vector<int> > &k_indices,
                          std::vector< std::vector<float> > &k_sqr_distances) const
         {
-          const search::detail::SearchHelper<PointT, PointTDiff> search (*this);
-          search.nearestKSearchT (cloud, indices, k, k_indices, k_sqr_distances);
+          // Copy all the data fields from the input cloud to the output one
+          typedef typename pcl::traits::fieldList<PointT>::type FieldListInT;
+          typedef typename pcl::traits::fieldList<PointTDiff>::type FieldListOutT;
+          typedef typename pcl::intersect<FieldListInT, FieldListOutT>::type FieldList;
+
+          pcl::PointCloud<PointT> pc;
+          if (indices.empty ())
+          {
+            pc.resize (cloud.size ());
+            for (size_t i = 0; i < cloud.size (); ++i)
+              pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointTDiff, PointT> (cloud[i], pc[i]));
+          }
+          else
+          {
+            pc.resize (indices.size ());
+            for (size_t i = 0; i < indices.size (); ++i)
+              pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointTDiff, PointT> (cloud[indices[i]], pc[i]));
+          }
+          nearestKSearch (pc, std::vector<int> (), k, k_indices, k_sqr_distances);
+        }
+
+        /** \brief Search for the k-nearest neighbors for the given query point.
+          * This method is used if the query points are of a similar type than the points in the data set (e.g. PointXYZRGBA instead of PointXYZ).
+          * \param[in] cloud the point cloud data
+          * \param[in] indices a vector of point cloud indices to query for nearest neighbors
+          * \param[in] k the number of neighbors to search for
+          * \param[out] k_indices the resultant indices of the neighboring points, k_indices[i] corresponds to the neighbors of the query point i
+          * \param[out] k_sqr_distances the resultant squared distances to the neighboring points, k_sqr_distances[i] corresponds to the neighbors of the query point i
+          */
+        template <typename PointTDiff> typename boost::enable_if<boost::is_same<PointT, PointTDiff>, void>::type
+        nearestKSearchT (const pcl::PointCloud<PointTDiff> &cloud, const std::vector<int>& indices, int k, std::vector< std::vector<int> > &k_indices,
+                         std::vector< std::vector<float> > &k_sqr_distances) const
+        {
+          nearestKSearch (cloud, indices, k, k_indices, k_sqr_distances);
         }
 
         /** \brief Search for all the nearest neighbors of the query point in a given radius.
@@ -258,6 +310,7 @@ namespace pcl
                       std::vector<float>& k_sqr_distances, unsigned int max_nn = 0) const = 0;
 
         /** \brief Search for all the nearest neighbors of the query point in a given radius.
+          * This method is invoked it PointT is not the same as PointTDiff
           * \param[in] point the given query point
           * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
           * \param[out] k_indices the resultant indices of the neighboring points
@@ -265,14 +318,33 @@ namespace pcl
           * \param[in] max_nn if given, bounds the maximum returned neighbors to this value. If \a max_nn is set to
           * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
           * returned.
-          * \return number of neighbors found in radius
+          * \return number of neighbors found in radius (int)
           */
-        template <typename PointTDiff> inline int
+        template <typename PointTDiff> inline typename boost::disable_if<boost::is_same<PointT, PointTDiff>, int>::type
         radiusSearchT (const PointTDiff &point, double radius, std::vector<int> &k_indices,
                        std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
         {
-          const search::detail::SearchHelper<PointT, PointTDiff> search (*this);
-          return search.radiusSearchT (point, radius, k_indices, k_sqr_distances, max_nn);
+          PointT p;
+          copyPoint (point, p);
+          return (radiusSearch (p, radius, k_indices, k_sqr_distances, max_nn));
+        }
+
+        /** \brief Search for all the nearest neighbors of the query point in a given radius.
+          * This method is invoked it PointT is the same as PointTDiff
+          * \param[in] point the given query point
+          * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+          * \param[out] k_indices the resultant indices of the neighboring points
+          * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
+          * \param[in] max_nn if given, bounds the maximum returned neighbors to this value. If \a max_nn is set to
+          * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
+          * returned.
+          * \return number of neighbors found in radius (int)
+          */
+        template <typename PointTDiff> inline typename boost::enable_if<boost::is_same<PointT, PointTDiff>, int>::type
+        radiusSearchT (const PointTDiff &point, double radius, std::vector<int> &k_indices,
+                       std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
+        {
+          return (radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn));
         }
 
         /** \brief Search for all the nearest neighbors of the query point in a given radius.
@@ -339,6 +411,7 @@ namespace pcl
                       unsigned int max_nn = 0) const;
 
         /** \brief Search for all the nearest neighbors of the query points in a given radius.
+          * This method is invoked if PointT is not the same as PointTDiff
           * \param[in] cloud the point cloud data
           * \param[in] indices a vector of point cloud indices to query for nearest neighbors
           * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
@@ -347,10 +420,10 @@ namespace pcl
           * \param[in] max_nn if given, bounds the maximum returned neighbors to this value. If \a max_nn is set to
           * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
           * returned.
-          * \note This method copies the input point cloud of type PointTDiff to a temporary cloud of type PointT (if the point types are different) and performs the batch
+          * \note This method copies the input point cloud of type PointTDiff to a temporary cloud of type PointT and performs the batch
           * search on the new cloud. You should prefer the single-point search if you don't use a search algorithm that accelerates batch NN search.
           */
-        template <typename PointTDiff> void
+        template <typename PointTDiff> typename boost::disable_if<boost::is_same<PointT, PointTDiff>, void>::type
         radiusSearchT (const pcl::PointCloud<PointTDiff> &cloud,
                        const std::vector<int>& indices,
                        double radius,
@@ -358,8 +431,47 @@ namespace pcl
                        std::vector< std::vector<float> > &k_sqr_distances,
                        unsigned int max_nn = 0) const
         {
-          const search::detail::SearchHelper<PointT, PointTDiff> search (*this);
-          search.radiusSearchT (cloud, indices, radius, k_indices, k_sqr_distances, max_nn);
+          // Copy all the data fields from the input cloud to the output one
+          typedef typename pcl::traits::fieldList<PointT>::type FieldListInT;
+          typedef typename pcl::traits::fieldList<PointTDiff>::type FieldListOutT;
+          typedef typename pcl::intersect<FieldListInT, FieldListOutT>::type FieldList;
+
+          pcl::PointCloud<PointT> pc;
+          if (indices.empty ())
+          {
+            pc.resize (cloud.size ());
+            for (size_t i = 0; i < cloud.size (); ++i)
+              pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointTDiff, PointT> (cloud[i], pc[i]));
+          }
+          else
+          {
+            pc.resize (indices.size ());
+            for (size_t i = 0; i < indices.size (); ++i)
+              pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointTDiff, PointT> (cloud[indices[i]], pc[i]));
+          }
+          radiusSearch (pc, std::vector<int> (), radius, k_indices, k_sqr_distances, max_nn);
+        }
+
+        /** \brief Search for all the nearest neighbors of the query points in a given radius.
+          * This method is invoked if PointT is the same as PointTDiff
+          * \param[in] cloud the point cloud data
+          * \param[in] indices a vector of point cloud indices to query for nearest neighbors
+          * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+          * \param[out] k_indices the resultant indices of the neighboring points, k_indices[i] corresponds to the neighbors of the query point i
+          * \param[out] k_sqr_distances the resultant squared distances to the neighboring points, k_sqr_distances[i] corresponds to the neighbors of the query point i
+          * \param[in] max_nn if given, bounds the maximum returned neighbors to this value. If \a max_nn is set to
+          * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
+          * returned.
+          */
+        template <typename PointTDiff> typename boost::enable_if<boost::is_same<PointT, PointTDiff>, void>::type
+        radiusSearchT (const pcl::PointCloud<PointTDiff> &cloud,
+                       const std::vector<int>& indices,
+                       double radius,
+                       std::vector< std::vector<int> > &k_indices,
+                       std::vector< std::vector<float> > &k_sqr_distances,
+                       unsigned int max_nn = 0) const
+        {
+          radiusSearch (cloud, indices, radius, k_indices, k_sqr_distances, max_nn);
         }
 
       protected:
@@ -388,282 +500,6 @@ namespace pcl
           const std::vector<float>& distances_;
         };
     }; // class Search
-
-    namespace detail
-    {
-      /** \class SearchHelper
-        * \brief A helper class whose specializations aids in preventing unnecessary
-        * copies when using \a Search<PointT>::nearestKSearchT() and \a
-        * Search<PointT>::radiusSearchT()
-        *
-        * This particular specialization is invoked when the the above search
-        * methods are invoked with point types different than the ones used
-        * in the underlying search structure.
-        */
-      template<typename PointT, typename PointTDiff>
-      class SearchHelper<PointT, PointTDiff, typename boost::disable_if<boost::is_same<PointT, PointTDiff> >::type>
-      {
-        public:
-
-          /** \brief Constructor
-            * \param[in] search - A reference to a search object which implements
-            * the nearestKSearchT and radiusSearchT methods.
-            */
-          SearchHelper (const Search<PointT>& search) : search (search) {}
-
-          /** \brief Search for k-nearest neighbors for the given query point
-            * of any type
-            * \param[in] point - the given query point
-            * \param[in] k - the number of neighbors to search for
-            * \param[out] k_indices - the resultant indices of the neighboring
-            * points (must be resized to \a k a priori!)
-            * \param[out] k_sqr_distances - the resultant squared distances to
-            * the neighboring points (must be resized to \a k a priori!)
-            * \return number of neighbors found
-            */
-          int nearestKSearchT (const PointTDiff& point,
-                               int k,
-                               std::vector<int>& k_indices,
-                               std::vector<float>& k_sqr_distances) const
-          {
-            PointT p;
-            copyPoint (point, p);
-            return search.nearestKSearch (p, k, k_indices, k_sqr_distances);
-          }
-
-          /** \brief Search for the k-nearest neighbors for all points in a
-            * given point cloud. The point cloud can be of any point type which
-            * includes XYZ coordinates (e.g. PointXYZRGBA instead of PointXYZ).
-            * \param[in] cloud - the point cloud data
-            * \param[in] indices - a vector of point cloud indices to query for
-            * nearest neighbors
-            * \param[in] k - the number of neighbors to search for
-            * \param[out] k_indices - the resultant indices of the neighboring
-            * points, k_indices[i] corresponds to the neighbors of the query
-            * point i
-            * \param[out] k_sqr_distances - the resultant squared distances to
-            * the neighboring points, k_sqr_distances[i] corresponds to the
-            * neighbors of the query point i
-            */
-          void nearestKSearchT (const pcl::PointCloud<PointTDiff>& cloud,
-                                const std::vector<int>& indices,
-                                int k,
-                                std::vector<std::vector<int> >& k_indices,
-                                std::vector<std::vector<float> >& k_sqr_distances) const
-          {
-            const pcl::PointCloud<PointT> pc = copyPointCloud (cloud, indices);
-            search.nearestKSearch (pc, std::vector<int> (), k, k_indices, k_sqr_distances);
-          }
-
-          /** \brief Search for all the nearest neighbors of the query point in
-            * a given radius.
-            * \param[in] point - the given query point
-            * \param[in] radius - the radius of the sphere bounding all of p_q's
-            * neighbors
-            * \param[out] k_indices - the resultant indices of the neighboring points
-            * \param[out] k_sqr_distances - the resultant squared distances to
-            * the neighboring points
-            * \param[in] max_nn - if given, bounds the maximum returned neighbors
-            * to this value. If \a max_nn is set to 0 or to a number higher than
-            * the number of points in the input cloud, all neighbors in \a radius
-            * will be returned.
-            * \return number of neighbors found in radius
-            */
-          int radiusSearchT (const PointTDiff& point,
-                             double radius,
-                             std::vector<int>& k_indices,
-                             std::vector<float>& k_sqr_distances,
-                             unsigned int max_nn = 0) const
-          {
-            PointT p;
-            copyPoint (point, p);
-            return search.radiusSearch (p, radius, k_indices, k_sqr_distances, max_nn);
-          }
-
-          /** \brief Search for all the nearest neighbors for all points in a
-            * given point cloud, in a given radius.
-            * \param[in] cloud - the point cloud data
-            * \param[in] indices - a vector of point cloud indices to query for
-            * nearest neighbors
-            * \param[in] radius - the radius of the sphere bounding all of p_q's
-            * neighbors
-            * \param[out] k_indices - the resultant indices of the neighboring
-            * points, k_indices[i] corresponds to the neighbors of the query point i
-            * \param[out] k_sqr_distances - the resultant squared distances to the
-            * neighboring points, k_sqr_distances[i] corresponds to the neighbors
-            * of the query point i
-            * \param[in] max_nn - if given, bounds the maximum returned neighbors
-            * to this value. If \a max_nn is set to 0 or to a number higher than
-            * the number of points in the input cloud, all neighbors in \a radius
-            * will be returned.
-            */
-          void radiusSearchT (const pcl::PointCloud<PointTDiff>& cloud,
-                              const std::vector<int>& indices,
-                              double radius,
-                              std::vector<std::vector<int> >& k_indices,
-                              std::vector<std::vector<float> >& k_sqr_distances,
-                              unsigned int max_nn = 0) const
-          {
-            const pcl::PointCloud<PointT> pc = copyPointCloud (cloud, indices);
-            radiusSearch (pc, std::vector<int> (), radius, k_indices, k_sqr_distances, max_nn);
-          }
-
-        protected:
-
-          typedef typename pcl::traits::fieldList<PointT>::type FieldListInT;
-          typedef typename pcl::traits::fieldList<PointTDiff>::type FieldListOutT;
-          typedef typename pcl::intersect<FieldListInT, FieldListOutT>::type FieldList;
-
-          /** \brief Creates a point cloud of point type PointT from a given point
-            * cloud of point type PointTDiff, copying every common existing fields
-            * between the two.
-            * \param[in] cloud - the original point cloud.
-            * \param[in] indices - a vector of indices masking the points of interest
-            * in \a cloud.
-            * \return A copy of \a cloud with point type PointT.
-            */
-          static pcl::PointCloud<PointT>
-          copyPointCloud (const pcl::PointCloud<PointTDiff>& cloud, const std::vector<int>& indices)
-          {
-            // Copy all the data fields from the input cloud to the output one
-            pcl::PointCloud<PointT> pc;
-            if (indices.empty ())
-            {
-              pc.resize (cloud.size ());
-              for (size_t i = 0; i < cloud.size (); ++i)
-                pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointTDiff, PointT> (cloud[i], pc[i]));
-            }
-            else
-            {
-              pc.resize (indices.size ());
-              for (size_t i = 0; i < indices.size (); ++i)
-                pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointTDiff, PointT> (cloud[indices[i]], pc[i]));
-            }
-            return pc;
-          }
-
-          /** \brief A reference to a search object, with its index already built
-            * which implements nearestKSearchT and radiusSearchT
-            */
-          const Search<PointT>& search;
-      };
-
-      /** \class SearchHelper
-        * \brief A helper class whose specializations aids in preventing unnecessary
-        * copies when using \a Search<PointT>::nearestKSearchT() and \a
-        * Search<PointT>::radiusSearchT()
-        *
-        * This particular specialization is invoked when the the above search
-        * methods are invoked with the same point types as the underlying
-        * search structure.
-        */
-      template<typename PointT, typename PointTDiff>
-      class SearchHelper<PointT, PointTDiff, typename boost::enable_if<boost::is_same<PointT, PointTDiff> >::type>
-      {
-        public:
-
-          /** \brief Constructor
-            * \param[in] search - A reference to a search object which implements
-            * the nearestKSearchT and radiusSearchT methods.
-            */
-          SearchHelper (const Search<PointT>& search) : search (search) {}
-
-          /** \brief Search for k-nearest neighbors for the given query point
-            * of any type
-            * \param[in] point - the given query point
-            * \param[in] k - the number of neighbors to search for
-            * \param[out] k_indices - the resultant indices of the neighboring
-            * points (must be resized to \a k a priori!)
-            * \param[out] k_sqr_distances - the resultant squared distances to
-            * the neighboring points (must be resized to \a k a priori!)
-            * \return number of neighbors found
-            */
-          int nearestKSearchT (const PointT &point, int k, std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
-          {
-            return search.nearestKSearch (point, k, k_indices, k_sqr_distances);
-          }
-
-          /** \brief Search for the k-nearest neighbors for all points in a
-            * given point cloud. The point cloud can be of any point type which
-            * includes XYZ coordinates (e.g. PointXYZRGBA instead of PointXYZ).
-            * \param[in] cloud - the point cloud data
-            * \param[in] indices - a vector of point cloud indices to query for
-            * nearest neighbors
-            * \param[in] k - the number of neighbors to search for
-            * \param[out] k_indices - the resultant indices of the neighboring
-            * points, k_indices[i] corresponds to the neighbors of the query
-            * point i
-            * \param[out] k_sqr_distances - the resultant squared distances to
-            * the neighboring points, k_sqr_distances[i] corresponds to the
-            * neighbors of the query point i
-            */
-          void nearestKSearchT (const pcl::PointCloud<PointTDiff>& cloud,
-                                const std::vector<int>& indices,
-                                int k,
-                                std::vector<std::vector<int> >& k_indices,
-                                std::vector<std::vector<float> >& k_sqr_distances) const
-          {
-            search.nearestKSearch (cloud, indices, k, k_indices, k_sqr_distances);
-          }
-
-          /** \brief Search for all the nearest neighbors of the query point in
-            * a given radius.
-            * \param[in] point - the given query point
-            * \param[in] radius - the radius of the sphere bounding all of p_q's
-            * neighbors
-            * \param[out] k_indices - the resultant indices of the neighboring points
-            * \param[out] k_sqr_distances - the resultant squared distances to
-            * the neighboring points
-            * \param[in] max_nn - if given, bounds the maximum returned neighbors
-            * to this value. If \a max_nn is set to 0 or to a number higher than
-            * the number of points in the input cloud, all neighbors in \a radius
-            * will be returned.
-            * \return number of neighbors found in radius
-            */
-          int radiusSearchT (const PointTDiff& point,
-                             double radius,
-                             std::vector<int>& k_indices,
-                             std::vector<float>& k_sqr_distances,
-                             unsigned int max_nn = 0) const
-          {
-            return search.radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
-          }
-
-          /** \brief Search for all the nearest neighbors for all points in a
-            * given point cloud, in a given radius.
-            * \param[in] cloud - the point cloud data
-            * \param[in] indices - a vector of point cloud indices to query for
-            * nearest neighbors
-            * \param[in] radius - the radius of the sphere bounding all of p_q's
-            * neighbors
-            * \param[out] k_indices - the resultant indices of the neighboring
-            * points, k_indices[i] corresponds to the neighbors of the query point i
-            * \param[out] k_sqr_distances - the resultant squared distances to the
-            * neighboring points, k_sqr_distances[i] corresponds to the neighbors
-            * of the query point i
-            * \param[in] max_nn - if given, bounds the maximum returned neighbors
-            * to this value. If \a max_nn is set to 0 or to a number higher than
-            * the number of points in the input cloud, all neighbors in \a radius
-            * will be returned.
-            */
-          void radiusSearchT (const pcl::PointCloud<PointTDiff>& cloud,
-                              const std::vector<int>& indices,
-                              double radius,
-                              std::vector<std::vector<int> >& k_indices,
-                              std::vector<std::vector<float> >& k_sqr_distances,
-                              unsigned int max_nn = 0) const
-          {
-            search.radiusSearch (cloud, indices, radius, k_indices, k_sqr_distances, max_nn);
-          }
-
-        protected:
-
-          /** \brief A reference to a search object, with its index already built
-            * which implements nearestKSearchT and radiusSearchT
-            */
-          const Search<PointT>& search;
-      };
-    } // namespace detail
   } // namespace search
 } // namespace pcl
 

--- a/test/registration/test_correspondence_estimation.cpp
+++ b/test/registration/test_correspondence_estimation.cpp
@@ -119,6 +119,59 @@ TEST (CorrespondenceEstimation, CorrespondenceEstimationSetSearchMethod)
   
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename T> class CorrespondenceEstimationTest : public ::testing::Test { };
+typedef ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES)> XYZPointTypes;
+TYPED_TEST_CASE (CorrespondenceEstimationTest, XYZPointTypes);
+TYPED_TEST (CorrespondenceEstimationTest, DifferentPointTypes)
+{
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud1 (new pcl::PointCloud<pcl::PointXYZ> ());
+  typename pcl::PointCloud<TypeParam>::Ptr cloud2 (new pcl::PointCloud<TypeParam> ());
+  pcl::Correspondences corr, rec_corr;
+
+  // Populate cloud1
+  cloud1->resize (4);
+  (*cloud1)[0].getVector3fMap () = Eigen::Vector3f (1.f, 0.f, 0.f);
+  (*cloud1)[1].getVector3fMap () = Eigen::Vector3f (2.f, 0.f, 0.f);
+  (*cloud1)[2].getVector3fMap () = Eigen::Vector3f (0.f, 0.f, 12.f);
+  (*cloud1)[3].getVector3fMap () = Eigen::Vector3f (9.f, 0.f, 0.f);
+  cloud1->is_dense = true;
+
+  // Populate cloud2
+  cloud2->resize (3);
+  (*cloud2)[0].getVector3fMap () = Eigen::Vector3f (0.f, 0.f, 0.f);
+  (*cloud2)[1].getVector3fMap () = Eigen::Vector3f (10.f, 0.f, 0.f);
+  (*cloud2)[2].getVector3fMap () = Eigen::Vector3f (0.f, 0.f, 10.f);
+  cloud2->is_dense = true;
+
+  // Compute correspondences
+  pcl::registration::CorrespondenceEstimation<pcl::PointXYZ, TypeParam, double> ce;
+  ce.setInputSource (cloud1);
+  ce.setInputTarget (cloud2);
+  ce.determineCorrespondences (corr);
+  ce.determineReciprocalCorrespondences (rec_corr);
+
+  // Correspondences
+  ASSERT_EQ (corr.size (), 4);
+  ASSERT_EQ (corr[0].index_query, 0);
+  ASSERT_EQ (corr[0].index_match, 0);
+  ASSERT_EQ (corr[1].index_query, 1);
+  ASSERT_EQ (corr[1].index_match, 0);
+  ASSERT_EQ (corr[2].index_query, 2);
+  ASSERT_EQ (corr[2].index_match, 2);
+  ASSERT_EQ (corr[3].index_query, 3);
+  ASSERT_EQ (corr[3].index_match, 1);
+
+  // Reciprocal Correspondences
+  ASSERT_EQ (rec_corr.size (), 3);
+  ASSERT_EQ (rec_corr[0].index_query, 0);
+  ASSERT_EQ (rec_corr[0].index_match, 0);
+  ASSERT_EQ (rec_corr[1].index_query, 2);
+  ASSERT_EQ (rec_corr[1].index_match, 2);
+  ASSERT_EQ (rec_corr[2].index_query, 3);
+  ASSERT_EQ (rec_corr[2].index_match, 1);
+}
+
 /* ---[ */
 int
   main (int argc, char** argv)


### PR DESCRIPTION
Fixes #329. Credits for @aichim, @jpapon and @taketwo .
Added unit test for XYZ point types.

Still have some doubts: 
- `pcl::registration::CorrespondenceEstimation` seems to support with all point types. Is it supposed to work with more weird cases of source and target point types, e.g. between XYZ points types <-> Normal point types? Not sure if this is possible.
- Should I also add a test for Normal point types?  RGB? Is KDTree flexible enough for this?
