### PR TITLE
supervoxel expansion fix #1459

### DIFF
--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -48,12 +48,9 @@
 #include <pcl/octree/octree.h>
 #include <pcl/octree/octree_pointcloud_adjacency.h>
 #include <pcl/search/search.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/common/distances.h>
 #include <pcl/segmentation/boost.h>
-
-
-
-//DEBUG TODO REMOVE
-#include <pcl/common/time.h>
 
 
 namespace pcl
@@ -358,7 +355,7 @@ namespace pcl
 
       /** \brief This performs the superpixel evolution */
       void
-      expandSupervoxels (int depth);
+      expandSupervoxels ();
 
       /** \brief This sets the data of the voxels in the tree */
       void 
@@ -450,7 +447,7 @@ namespace pcl
           void
           removeAllLeaves ();
 
-          void 
+          void
           expand ();
 
           void 
@@ -530,8 +527,6 @@ namespace pcl
       typedef boost::ptr_list<SupervoxelHelper> HelperListT;
       HelperListT supervoxel_helpers_;
 
-      //TODO DEBUG REMOVE
-      StopWatch timer_;
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 


### PR DESCRIPTION
So, I got some time recently to get a second look at this problem. I've made two changes.

1. The trouble I described above crops up when the expansion of the supervoxels is not finished, yet the termination condition (variable `depth`) of the `for` loop in the `expandSupervoxels()` call tells it to finish too early. I re-implemented it by tracking directly whether all voxels are assigned to supervoxels. If there is no change during an expansion step, I add a new `SupervoxelHelper` to handle these 'outliers' as well. Tackling the outlier case will for sure slow down the process. However, if the voxel size is set appropriately, their would normally be no outliers and no additional SupervoxelHelpers would be required.
2. I changed the seeding. The problem with the previous approach (apart from using octree which is a bit of an overkill) is that for some settings of voxel and supervoxel sizes I got a lot of duplicates in the seed indices. Needless to say, it is especially sad knowing that SupervoxelHelper would be created several times for the same node. I wonder how it worked earlier.

Please, have a look at the changes and let me know if something needs additional fixing or testing.