### PR TITLE
Corrected issues in supervoxel tutorial

### DIFF
--- a/doc/tutorials/content/sources/supervoxel_clustering/CMakeLists.txt
+++ b/doc/tutorials/content/sources/supervoxel_clustering/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 project(supervoxel_clustering)
 
-find_package(PCL 1.7 REQUIRED)
+find_package(PCL 1.8 REQUIRED)
 
 include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})

--- a/doc/tutorials/content/supervoxel_clustering.rst
+++ b/doc/tutorials/content/supervoxel_clustering.rst
@@ -160,6 +160,6 @@ Create a ``CMakeLists.txt`` file with the following content (or download it :dow
 
 After you have made the executable, you can run it like so, assuming the pcd file is in the same folder as the executable::
 
-  $ ./supervoxel_clustering milk_cartoon_all_small_clorox.pcd
+  $ ./supervoxel_clustering milk_cartoon_all_small_clorox.pcd --NT
 
 Don't be afraid to play around with the parameters (especially the seed size, -s) to see what happens. The pcd file name should always be the first parameter!


### PR DESCRIPTION
Minimum version for PCL should be trunk (1.8) rather than 1.7

The default command for the example to work on the provided pointcloud should have the --NT option appended to it.