### PR TITLE
Disable CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE

### DIFF
--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -2,7 +2,7 @@
 
 
 
-if(MSVC11)
+if(MSVC)
 	# Setting this to true brakes Visual Studio builds.
 	set(CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE OFF CACHE BOOL "CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE")
 endif()


### PR DESCRIPTION
Disable the [CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE](https://cmake.org/cmake/help/v3.4/module/FindCUDA.html?highlight=cuda_attach_vs_build_rule_to_cuda_file) option in all MSVC
versions.