### PR TITLE
Fix Eigen::allocator_type for std::map

### DIFF
--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -94,7 +94,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computePointPFHSignature (
         key = std::pair<int, int> (p1, p2);
 
         // Check to see if we already estimated this pair in the global hashmap
-        std::map<std::pair<int, int>, Eigen::Vector4f, std::less<std::pair<int, int> >, Eigen::aligned_allocator<Eigen::Vector4f> >::iterator fm_it = feature_map_.find (key);
+        std::map<std::pair<int, int>, Eigen::Vector4f, std::less<std::pair<int, int> >, Eigen::aligned_allocator<std::pair<const std::pair<int, int>, Eigen::Vector4f> > >::iterator fm_it = feature_map_.find (key);
         if (fm_it != feature_map_.end ())
           pfh_tuple_ = fm_it->second;
         else

--- a/features/include/pcl/features/pfh.h
+++ b/features/include/pcl/features/pfh.h
@@ -208,7 +208,7 @@ namespace pcl
       float d_pi_; 
 
       /** \brief Internal hashmap, used to optimize efficiency of redundant computations. */
-      std::map<std::pair<int, int>, Eigen::Vector4f, std::less<std::pair<int, int> >, Eigen::aligned_allocator<Eigen::Vector4f> > feature_map_;
+      std::map<std::pair<int, int>, Eigen::Vector4f, std::less<std::pair<int, int> >, Eigen::aligned_allocator<std::pair<const std::pair<int, int>, Eigen::Vector4f> > > feature_map_;
 
       /** \brief Queue of pairs saved, used to constrain memory usage. */
       std::queue<std::pair<int, int> > key_list_;


### PR DESCRIPTION
This was causing a static assert while building the PCL with the latest openmp-enabled clang/libcxx (3.8.0-trunk) on osx 10.10.

ref: http://eigen.tuxfamily.org/dox/classEigen_1_1aligned__allocator.html


CMake build options I used:

```
% cmake -DPCL_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..
```

build result:

```
% make
...
[ 27%] Building CXX object features/CMakeFiles/pcl_features.dir/src/cppf.cpp.o
In file included from /Users/ryuyamamoto/cv/pcl/features/src/cppf.cpp:40:
In file included from /Users/ryuyamamoto/cv/pcl/features/include/pcl/features/impl/cppf.hpp:44:
In file included from /Users/ryuyamamoto/cv/pcl/features/include/pcl/features/cppf.h:43:
In file included from /Users/ryuyamamoto/cv/pcl/features/include/pcl/features/feature.h:498:
In file included from /Users/ryuyamamoto/cv/pcl/features/include/pcl/features/impl/feature.hpp:44:
In file included from /Users/ryuyamamoto/cv/pcl/search/include/pcl/search/pcl_search.h:44:
In file included from /Users/ryuyamamoto/cv/pcl/search/include/pcl/search/kdtree.h:44:
In file included from /Users/ryuyamamoto/cv/pcl/kdtree/include/pcl/kdtree/kdtree_flann.h:45:
In file included from /Users/ryuyamamoto/cv/pcl/kdtree/include/pcl/kdtree/flann.h:50:
In file included from /usr/local/Cellar/flann/1.8.4_1/include/flann/flann.hpp:41:
In file included from /usr/local/Cellar/flann/1.8.4_1/include/flann/util/matrix.h:35:
In file included from /usr/local/Cellar/flann/1.8.4_1/include/flann/util/serialization.h:5:
/usr/local/bin/../include/c++/v1/map:837:5: error: implicit instantiation of undefined template '__static_assert_test<false>'
    static_assert((is_same<typename allocator_type::value_type, value_type>::value),
    ^
/usr/local/bin/../include/c++/v1/__config:632:35: note: expanded from macro 'static_assert'
    typedef __static_assert_check<sizeof(__static_assert_test<(__b)>)> \
                                  ^
/Users/ryuyamamoto/cv/pcl/features/include/pcl/features/pfh.h:211:131: note: in instantiation of template class 'std::__1::map<std::__1::pair<int, int>, Eigen::Matrix<float, 4, 1, 0, 4, 1>,
      std::__1::less<std::__1::pair<int, int> >, Eigen::aligned_allocator<Eigen::Matrix<float, 4, 1, 0, 4, 1> > >' requested here
      std::map<std::pair<int, int>, Eigen::Vector4f, std::less<std::pair<int, int> >, Eigen::aligned_allocator<Eigen::Vector4f> > feature_map_;
                                                                                                                                  ^
/usr/local/bin/../include/c++/v1/__config:627:24: note: template is declared here
template <bool> struct __static_assert_test;
                       ^
1 error generated.
make[2]: *** [features/CMakeFiles/pcl_features.dir/src/cppf.cpp.o] Error 1
make[1]: *** [features/CMakeFiles/pcl_features.dir/all] Error 2
make: *** [all] Error 2
```

This patch fixes the above build failure. Also I confirmed that the patch doesn't affect builds with osx default clang (based on llvm3.6.0) on my local environment. 