### PR TITLE
Fixed modulo by zero bug in features/harris_2d

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/harris_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_2d.hpp
@@ -253,7 +253,7 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCl
     const int occupency_map_size (occupency_map.size ());
 
 #ifdef _OPENMP
-#pragma omp parallel for shared (output, occupency_map) private (width, height) num_threads(threads_)   
+#pragma omp parallel for shared (output, occupency_map) firstprivate (width, height) num_threads(threads_)
 #endif
     for (int i = 0; i < occupency_map_size; ++i)
     {


### PR DESCRIPTION
Member, "width" is initialized within member function. However, within OMP-for loop, members are declared as private (without initialization). Solved this issue using a "firstprivate" specifier.