### PR TITLE
Fix to force CMAKE to reset QT_USE_FILE variable or it will obtain a wrong value from cache when rebuilding

### DIFF
--- a/cmake/pcl_find_qt5.cmake
+++ b/cmake/pcl_find_qt5.cmake
@@ -70,7 +70,7 @@ if(Qt5Core_FOUND)
         endmacro()
     endif()
 
-    set(QT_USE_FILE ${CMAKE_CURRENT_BINARY_DIR}/use-qt5.cmake CACHE PATH "")
+    set(QT_USE_FILE ${CMAKE_CURRENT_BINARY_DIR}/use-qt5.cmake CACHE PATH "" FORCE)
     file(WRITE ${QT_USE_FILE} "#")
 
     # Trick the remainder of the build system.


### PR DESCRIPTION
When running CMake for the second time pcl_find_qt5.cmake (74) was raising an error since the value read from CMake cache for QT_USE_FILE was the default use-qt4.cmake from the modules that come with CMake.

The FORCE option forces CMake to reset this value setting the correct value for QT_USE_FILE