### PR TITLE
Preserve viewpoint on sift computation

### DIFF
--- a/common/include/pcl/PCLHeader.h
+++ b/common/include/pcl/PCLHeader.h
@@ -43,6 +43,12 @@ namespace pcl
     return (out);
   }
 
+  inline bool operator== (const PCLHeader &lhs, const PCLHeader &rhs)
+  {
+    return (&lhs == &rhs) ||
+      (lhs.seq == rhs.seq && lhs.stamp == rhs.stamp && lhs.frame_id == rhs.frame_id);
+  }
+
 } // namespace pcl
 
 #endif // PCL_ROSLIB_MESSAGE_HEADER_H

--- a/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
@@ -142,8 +142,12 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::detectKeypoints (PointCloudOut &output)
     scale *= 2;
   }
 
+  // Set final properties
   output.height = 1;
   output.width = static_cast<uint32_t> (output.points.size ());
+  output.header = input_->header;
+  output.sensor_origin_ = input_->sensor_origin_;
+  output.sensor_orientation_ = input_->sensor_orientation_;
 }
 
 

--- a/test/keypoints/test_keypoints.cpp
+++ b/test/keypoints/test_keypoints.cpp
@@ -81,6 +81,15 @@ TEST (PCL, SIFTKeypoint)
   ASSERT_EQ (keypoints.width, keypoints.points.size ());
   ASSERT_EQ (keypoints.height, 1);
   EXPECT_EQ (keypoints.points.size (), static_cast<size_t> (169));
+  EXPECT_EQ (keypoints.header, cloud_xyzi->header);
+  EXPECT_EQ (keypoints.sensor_origin_ (0), cloud_xyzi->sensor_origin_ (0));
+  EXPECT_EQ (keypoints.sensor_origin_ (1), cloud_xyzi->sensor_origin_ (1));
+  EXPECT_EQ (keypoints.sensor_origin_ (2), cloud_xyzi->sensor_origin_ (2));
+  EXPECT_EQ (keypoints.sensor_origin_ (3), cloud_xyzi->sensor_origin_ (3));
+  EXPECT_EQ (keypoints.sensor_orientation_.w (), cloud_xyzi->sensor_orientation_.w ());
+  EXPECT_EQ (keypoints.sensor_orientation_.x (), cloud_xyzi->sensor_orientation_.x ());
+  EXPECT_EQ (keypoints.sensor_orientation_.y (), cloud_xyzi->sensor_orientation_.y ());
+  EXPECT_EQ (keypoints.sensor_orientation_.z (), cloud_xyzi->sensor_orientation_.z ());
 
   // Change the values and re-compute
   sift_detector.setScales (0.05f, 5, 3);


### PR DESCRIPTION
Fixes #1498. Now the header, sensor_origin and sensor_orientation are copied to the keypoints resultant pointcloud. Added small checks on the tests.