### PR TITLE
Fix nan equality in filter test

### DIFF
--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -198,9 +198,9 @@ TEST (ExtractIndices, Filters)
   EXPECT_EQ (output.points[0].x, cloud->points[0].x);
   EXPECT_EQ (output.points[0].y, cloud->points[0].y);
   EXPECT_EQ (output.points[0].z, cloud->points[0].z);
-  EXPECT_EQ (output.points[1].x, std::numeric_limits<float>::quiet_NaN());
-  EXPECT_EQ (output.points[1].y, std::numeric_limits<float>::quiet_NaN());
-  EXPECT_EQ (output.points[1].z, std::numeric_limits<float>::quiet_NaN());
+  EXPECT_TRUE (std::isnan (output.points[1].x));
+  EXPECT_TRUE (std::isnan (output.points[1].y));
+  EXPECT_TRUE (std::isnan (output.points[1].z));
 
   ei2.setNegative (true);
   ei2.setKeepOrganized (true);
@@ -212,9 +212,9 @@ TEST (ExtractIndices, Filters)
   EXPECT_EQ (output.width, cloud->width);
   EXPECT_EQ (output.height, cloud->height);
 
-  EXPECT_EQ (output.points[0].x, std::numeric_limits<float>::quiet_NaN());
-  EXPECT_EQ (output.points[0].y, std::numeric_limits<float>::quiet_NaN());
-  EXPECT_EQ (output.points[0].z, std::numeric_limits<float>::quiet_NaN());
+  EXPECT_TRUE (std::isnan (output.points[0].x));
+  EXPECT_TRUE (std::isnan (output.points[0].y));
+  EXPECT_TRUE (std::isnan (output.points[0].z));
   EXPECT_EQ (output.points[1].x, cloud->points[1].x);
   EXPECT_EQ (output.points[1].y, cloud->points[1].y);
   EXPECT_EQ (output.points[1].z, cloud->points[1].z);


### PR DESCRIPTION
Wip of #1477. Replaced the original check with  std::isnan check.