### PR TITLE
Use EXPECT_NEAR to check transformed point coordinates

### DIFF
--- a/test/test_transforms.cpp
+++ b/test/test_transforms.cpp
@@ -334,28 +334,28 @@ TEST (PCL, Matrix4Affine3Transform)
   PointCloud<PointXYZ> c, ct;
   c.push_back (p);
   pcl::transformPointCloud (c, ct, affine);
-  EXPECT_FLOAT_EQ (pt.x, ct[0].x); 
-  EXPECT_FLOAT_EQ (pt.y, ct[0].y); 
-  EXPECT_FLOAT_EQ (pt.z, ct[0].z); 
+  EXPECT_NEAR (pt.x, ct[0].x, 1e-4);
+  EXPECT_NEAR (pt.y, ct[0].y, 1e-4);
+  EXPECT_NEAR (pt.z, ct[0].z, 1e-4);
 
   pcl::transformPointCloud (c, ct, transformation);
-  EXPECT_FLOAT_EQ (pt.x, ct[0].x); 
-  EXPECT_FLOAT_EQ (pt.y, ct[0].y); 
-  EXPECT_FLOAT_EQ (pt.z, ct[0].z); 
+  EXPECT_NEAR (pt.x, ct[0].x, 1e-4);
+  EXPECT_NEAR (pt.y, ct[0].y, 1e-4);
+  EXPECT_NEAR (pt.z, ct[0].z, 1e-4);
 
   affine = transformation;
 
   std::vector<int> indices (1); indices[0] = 0;
 
   pcl::transformPointCloud (c, indices, ct, affine);
-  EXPECT_FLOAT_EQ (pt.x, ct[0].x); 
-  EXPECT_FLOAT_EQ (pt.y, ct[0].y); 
-  EXPECT_FLOAT_EQ (pt.z, ct[0].z); 
+  EXPECT_NEAR (pt.x, ct[0].x, 1e-4);
+  EXPECT_NEAR (pt.y, ct[0].y, 1e-4);
+  EXPECT_NEAR (pt.z, ct[0].z, 1e-4);
 
   pcl::transformPointCloud (c, indices, ct, transformation);
-  EXPECT_FLOAT_EQ (pt.x, ct[0].x); 
-  EXPECT_FLOAT_EQ (pt.y, ct[0].y); 
-  EXPECT_FLOAT_EQ (pt.z, ct[0].z); 
+  EXPECT_NEAR (pt.x, ct[0].x, 1e-4);
+  EXPECT_NEAR (pt.y, ct[0].y, 1e-4);
+  EXPECT_NEAR (pt.z, ct[0].z, 1e-4);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The Matrix4Affine3Transform case in the `a_transforms_test` fails consistently in my environment (Eigen 3.2.7, clang 3.7.0) with the following errors:

```
3: pcl/test/test_transforms.cpp:342: Failure
3: Value of: ct[0].x
3:   Actual: -1.0601168
3: Expected: pt.x
3: Which is: -1.0601162
3: pcl/test/test_transforms.cpp:351: Failure
3: Value of: ct[0].x
3:   Actual: -1.0601168
3: Expected: pt.x
3: Which is: -1.0601162
3: pcl/test/test_transforms.cpp:356: Failure
3: Value of: ct[0].x
3:   Actual: -1.0601168
3: Expected: pt.x
3: Which is: -1.0601162
3: [  FAILED  ] PCL.Matrix4Affine3Transform (0 ms)
```

The `EXPECT_FLOAT_EQ` macro is used for checks there. Apparently, a precision problem. Since most other checks in this test case are done with `EXPECT_NEAR` and 1e-4 epsilon, I converted the problematic ones to this style.