### PR TITLE
Throw compile error when using brisk without SSE

### DIFF
--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -1715,12 +1715,7 @@ pcl::keypoints::brisk::Layer::halfsample (
     }
   }
 #else
-  (void) (srcimg);
-  (void) (srcwidth);
-  (void) (srcheight);
-  (void) (dstimg); 
-  (void) (dstwidth);
-  PCL_ERROR("brisk without SSE4.1 support not implemented");
+#error "brisk without SSE4.1 support not implemented"
 #endif
 }
 
@@ -1829,12 +1824,7 @@ pcl::keypoints::brisk::Layer::twothirdsample (
     p_dest2 = p_dest1 + dstwidth;
   }
 #else
-  (void) (srcimg);
-  (void) (srcwidth);
-  (void) (srcheight);
-  (void) (dstimg); 
-  (void) (dstwidth);
-  PCL_ERROR("brisk without SSE4.1 support not implemented");
+#error "brisk without SSE4.1 support not implemented"
 #endif
 }
 


### PR DESCRIPTION
Should fix #1517