### PR TITLE
Fix error C3016 on MSVC with OpenMP

### DIFF
--- a/filters/include/pcl/filters/impl/convolution_3d.hpp
+++ b/filters/include/pcl/filters/impl/convolution_3d.hpp
@@ -240,7 +240,7 @@ pcl::filters::Convolution3D<PointInT, PointOutT, KernelT>::convolve (PointCloudO
 #ifdef _OPENMP
 #pragma omp parallel for shared (output) private (nn_indices, nn_distances) num_threads (threads_)
 #endif
-  for (std::size_t point_idx = 0; point_idx < surface_->size (); ++point_idx)
+  for (int64_t point_idx = 0; point_idx < static_cast<int64_t> (surface_->size ()); ++point_idx)
   {
     const PointInT& point_in = surface_->points [point_idx];
     PointOutT& point_out = output [point_idx];


### PR DESCRIPTION
This pull request was fixed error C3016 (issue #1499).

MSVC doesn't support an OpenMP versions earlier higher than 2.0.
The index variable in an OpenMP 2.0 for statement must be a signed integral type.
The error C3016 occurs on MSVC, because <code>std::size_t</code> is unsigned integral type.
Fix this issue by replacing index to the 64bit signed integral type.