### PR TITLE
Fix CorrespondenceRejectorSurfaceNormal bug

### DIFF
--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -205,6 +205,7 @@ namespace pcl
         virtual ~DataContainerInterface () {}
         virtual double getCorrespondenceScore (int index) = 0;
         virtual double getCorrespondenceScore (const pcl::Correspondence &) = 0;
+        virtual double getCorrespondenceScoreFromNormals (const pcl::Correspondence &) = 0;
      };
 
     /** @b DataContainer is a container for the input and target point clouds and implements the interface 

--- a/registration/src/correspondence_rejection_surface_normal.cpp
+++ b/registration/src/correspondence_rejection_surface_normal.cpp
@@ -57,8 +57,7 @@ pcl::registration::CorrespondenceRejectorSurfaceNormal::getRemainingCorresponden
   // Test each correspondence
   for (size_t i = 0; i < original_correspondences.size (); ++i)
   {
-    if (boost::static_pointer_cast<DataContainer<pcl::PointXYZ, pcl::PointNormal> >
-        (data_container_)->getCorrespondenceScoreFromNormals (original_correspondences[i]) > threshold_)
+    if (data_container_->getCorrespondenceScoreFromNormals (original_correspondences[i]) > threshold_)
       remaining_correspondences[number_valid_correspondences++] = original_correspondences[i];
   }
   remaining_correspondences.resize (number_valid_correspondences);


### PR DESCRIPTION
In order to remove the hard-coded cast  `boost::static_pointer_cast<DataContainer<pcl::PointXYZ, pcl::PointNormal> >()` in correspondence_rejection_surface_normal.cpp I added getCorrespondenceScoreFromNormals() to DataContainerInterface.

This fixes the Segmentation fault mentioned in #868 (an open issue since 2014).



