### PR TITLE
Update select2DTool.cpp

### DIFF
--- a/apps/point_cloud_editor/src/select2DTool.cpp
+++ b/apps/point_cloud_editor/src/select2DTool.cpp
@@ -131,6 +131,9 @@ Select2DTool::isInSelectBox (const Point3D& pt,
   float max_x = std::max(final_x_, origin_x_)/(viewport[2]*0.5) - 1.0;
   float max_y = (viewport[3] - std::min(origin_y_, final_y_))/(viewport[3]*0.5) - 1.0;
   float min_y = (viewport[3] - std::max(origin_y_, final_y_))/(viewport[3]*0.5) - 1.0;
+  // Ignore the points behind the camera
+  if (w < 0)
+    return (false);
   // Check the left and right sides
   if ((x < min_x) || (x > max_x))
     return (false);


### PR DESCRIPTION
When making a rubberband selection, the selection box may contain the points not only in front of the camera, but the points behind the camera's back. This fix filters out the unsighted points behind the camera in a rubberband selection.