### PR TITLE
Declare `const InterestPoint&` explicitly to avoid compilation error on openmp-enabled clang

### DIFF
--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -380,7 +380,8 @@ Narf::extractForInterestPoints (const RangeImage& range_image, const PointCloud<
   //!!! nizar 20110408 : for OpenMP sake on MSVC this must be kept signed
   for (int interest_point_idx = 0; interest_point_idx < int (interest_points.points.size ()); ++interest_point_idx)
   {
-    Vector3fMapConst point = interest_points.points[interest_point_idx].getVector3fMap ();
+    const InterestPoint& interest_point = interest_points.points[interest_point_idx];
+    Vector3fMapConst point = interest_point.getVector3fMap ();
     
     Narf* feature = new Narf;
     if (!feature->extractFromRangeImage(range_image, point, descriptor_size, support_size))


### PR DESCRIPTION
Fixes #1458

Verified that it works with:

- openmp-enabled clang trunk (clang version 3.9.0 (https://github.com/llvm-mirror/clang.git 93de2a0297b6b058f67fe1b622f2a084ea752291))
- Xcode-bundled clang (Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM
3.6.0svn))

To be honest, I'm not exactly sure why the error (reported in #1458, I saw too) happens, however, I guess clang cannot propagate `const` with chained expressions (e.g. `a.b().c()`) with openmp. 

Declaring `const InterestPoint&` explicitly doesn't change code logically so I think this should be safe.