### PR TITLE
Removed normal related accessors and types from EuclideanClusterComparator

### DIFF
--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -103,15 +103,9 @@
      std::vector<pcl::PointIndices> boundary_indices;
      mps.segmentAndRefine (regions, model_coefficients, inlier_indices, labels, label_indices, boundary_indices);
      
-     std::vector<bool> plane_labels;
-     plane_labels.resize (label_indices.size (), false);
-     for (size_t i = 0; i < label_indices.size (); i++)
-     {
-       if (label_indices[i].indices.size () > min_plane_size)
-       {
-         plane_labels[i] = true;
-       }
-     }
+     boost::shared_ptr<std::map<uint32_t, bool> > plane_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+     for (size_t i = 0; i < label_indices.size (); ++i)
+       (*plane_labels)[i] = (label_indices[i].indices.size () > min_plane_size);
      typename PointCloud<PointT>::CloudVectorType clusters;
      
      typename EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator = boost::make_shared <EuclideanClusterComparator<PointT, pcl::Label> > ();

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -114,7 +114,7 @@
      }
      typename PointCloud<PointT>::CloudVectorType clusters;
      
-     typename EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator = boost::make_shared <EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> > ();
+     typename EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator = boost::make_shared <EuclideanClusterComparator<PointT, pcl::Label> > ();
      euclidean_cluster_comparator->setInputCloud (input_cloud);
      euclidean_cluster_comparator->setLabels (labels);
      euclidean_cluster_comparator->setExcludeLabels (plane_labels);

--- a/apps/include/pcl/apps/organized_segmentation_demo.h
+++ b/apps/include/pcl/apps/organized_segmentation_demo.h
@@ -139,7 +139,7 @@ class OrganizedSegmentationDemo : public QMainWindow
     pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal>::Ptr rgb_comparator_;
     pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal> rgb_comp_;
     pcl::EdgeAwarePlaneComparator<PointT, pcl::Normal>::Ptr edge_aware_comparator_;
-    pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_;
+    pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator_;
 
   public Q_SLOTS:
     void toggleCapturePressed()

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -260,8 +260,9 @@ class NILinemod
         scene->points[points_above_plane->indices[i]].label = 1;
       euclidean_cluster_comparator->setLabels (scene);
 
-      vector<bool> exclude_labels (2);  exclude_labels[0] = true; exclude_labels[1] = false;
-      euclidean_cluster_comparator->setExcludeLabels (exclude_labels);
+      boost::shared_ptr<std::map<uint32_t, bool> > exclude_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+      (*exclude_labels)[0] = true;
+      (*exclude_labels)[1] = false;
 
       OrganizedConnectedComponentSegmentation<PointT, Label> euclidean_segmentation (euclidean_cluster_comparator);
       euclidean_segmentation.setInputCloud (cloud);

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -249,7 +249,7 @@ class NILinemod
       exppd.segment (*points_above_plane);
 
       // Use an organized clustering segmentation to extract the individual clusters
-      EuclideanClusterComparator<PointT, Normal, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Normal, Label>);
+      EuclideanClusterComparator<PointT, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Label>);
       euclidean_cluster_comparator->setInputCloud (cloud);
       euclidean_cluster_comparator->setDistanceThreshold (0.03f, false);
       // Set the entire scene to false, and the inliers of the objects located on top of the plane to true

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -254,7 +254,7 @@ OrganizedSegmentationDemo::OrganizedSegmentationDemo (pcl::Grabber& grabber) : g
   euclidean_comparator_.reset (new pcl::EuclideanPlaneCoefficientComparator<PointT, pcl::Normal> ());
   rgb_comparator_.reset (new pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal> ());
   edge_aware_comparator_.reset (new pcl::EdgeAwarePlaneComparator<PointT, pcl::Normal> ());
-  euclidean_cluster_comparator_ = pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr (new pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> ());
+  euclidean_cluster_comparator_ = pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr (new pcl::EuclideanClusterComparator<PointT, pcl::Label> ());
 
   // Set up Organized Multi Plane Segmentation
   mps.setMinInliers (10000);

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -309,15 +309,9 @@ OrganizedSegmentationDemo::cloud_cb (const CloudConstPtr& cloud)
 
   if (use_clustering_ && regions.size () > 0)
   {
-    std::vector<bool> plane_labels;
-    plane_labels.resize (label_indices.size (), false);
-    for (size_t i = 0; i < label_indices.size (); i++)
-    {
-      if (label_indices[i].indices.size () > 10000)
-      {
-        plane_labels[i] = true;
-      }
-    }  
+    boost::shared_ptr<std::map<uint32_t, bool> > plane_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+    for (size_t i = 0; i < label_indices.size (); ++i)
+      (*plane_labels)[i] = (label_indices[i].indices.size () > 10000);
     
     euclidean_cluster_comparator_->setInputCloud (cloud);
     euclidean_cluster_comparator_->setLabels (labels);

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -194,7 +194,7 @@ class ObjectSelection
       if (cloud_->isOrganized ())
       {
         // Use an organized clustering segmentation to extract the individual clusters
-        typename EuclideanClusterComparator<PointT, Normal, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Normal, Label>);
+        typename EuclideanClusterComparator<PointT, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Label>);
         euclidean_cluster_comparator->setInputCloud (cloud);
         euclidean_cluster_comparator->setDistanceThreshold (0.03f, false);
         // Set the entire scene to false, and the inliers of the objects located on top of the plane to true

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -205,7 +205,9 @@ class ObjectSelection
           scene->points[points_above_plane->indices[i]].label = 1;
         euclidean_cluster_comparator->setLabels (scene);
 
-        vector<bool> exclude_labels (2);  exclude_labels[0] = true; exclude_labels[1] = false;
+        boost::shared_ptr<std::map<uint32_t, bool> > exclude_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+        (*exclude_labels)[0] = true;
+        (*exclude_labels)[1] = false;
         euclidean_cluster_comparator->setExcludeLabels (exclude_labels);
 
         OrganizedConnectedComponentSegmentation<PointT, Label> euclidean_segmentation (euclidean_cluster_comparator);

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -403,8 +403,7 @@ class HRCSSegmentation
             }
           }
         
-          pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> ());
-
+          pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Label> ());
           euclidean_cluster_comparator_->setInputCloud (cloud);
           euclidean_cluster_comparator_->setLabels (labels_ptr);
           euclidean_cluster_comparator_->setExcludeLabels (plane_labels);

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -393,15 +393,9 @@ class HRCSSegmentation
         pcl::PointCloud<PointT>::CloudVectorType clusters;
         if (ground_cloud->points.size () > 0)
         {
-          std::vector<bool> plane_labels;
-          plane_labels.resize (region_indices.size (), false);
-          for (size_t i = 0; i < region_indices.size (); i++)
-          {
-            if (region_indices[i].indices.size () > mps.getMinInliers ())
-            {
-              plane_labels[i] = true;
-            }
-          }
+          boost::shared_ptr<std::map<uint32_t, bool> > plane_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+          for (size_t i = 0; i < region_indices.size (); ++i)
+            (*plane_labels)[i] = (region_indices[i].indices.size () > mps.getMinInliers ());
         
           pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Label> ());
           euclidean_cluster_comparator_->setInputCloud (cloud);

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -50,12 +50,16 @@ namespace pcl
     *
     * \author Alex Trevor
     */
-  template<typename PointT, typename PointLT>
+  template<typename PointT, typename PointLT = pcl::Label>
   class EuclideanClusterComparator: public Comparator<PointT>
   {
+    protected:
+
+      using pcl::Comparator<PointT>::input_;
+
     public:
-      typedef typename Comparator<PointT>::PointCloud PointCloud;
-      typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using typename Comparator<PointT>::PointCloud;
+      using typename Comparator<PointT>::PointCloudConstPtr;
       
       typedef typename pcl::PointCloud<PointLT> PointCloudL;
       typedef typename PointCloudL::Ptr PointCloudLPtr;
@@ -64,8 +68,10 @@ namespace pcl
       typedef boost::shared_ptr<EuclideanClusterComparator<PointT, PointLT> > Ptr;
       typedef boost::shared_ptr<const EuclideanClusterComparator<PointT, PointLT> > ConstPtr;
 
-      using pcl::Comparator<PointT>::input_;
-      
+      typedef std::map<uint32_t, bool> ExcludeLabelMap;
+      typedef boost::shared_ptr<ExcludeLabelMap> ExcludeLabelMapPtr;
+      typedef boost::shared_ptr<const ExcludeLabelMap> ExcludeLabelMapConstPtr;
+
       /** \brief Empty constructor for EuclideanClusterComparator. */
       EuclideanClusterComparator ()
         : distance_threshold_ (0.005f)
@@ -110,18 +116,24 @@ namespace pcl
         * \param[in] labels The label cloud
         */
       void
-      setLabels (PointCloudLPtr& labels)
+      setLabels (const PointCloudLPtr& labels)
       {
         labels_ = labels;
+      }
+
+      const ExcludeLabelMapConstPtr&
+      getExcludeLabels () const
+      {
+        return exclude_labels_;
       }
 
       /** \brief Set labels in the label cloud to exclude.
         * \param exclude_labels a vector of bools corresponding to whether or not a given label should be considered
         */
       void
-      setExcludeLabels (std::vector<bool>& exclude_labels)
+      setExcludeLabels (const ExcludeLabelMapConstPtr &exclude_labels)
       {
-        exclude_labels_ = boost::make_shared<std::vector<bool> >(exclude_labels);
+        exclude_labels_ = exclude_labels;
       }
 
       /** \brief Compare points at two indices by their euclidean distance
@@ -134,9 +146,15 @@ namespace pcl
         if (labels_ && exclude_labels_)
         {
           assert (labels_->size () == input_->size ());
-          const uint32_t &label1 = labels_->at (idx1).label;
-          const uint32_t &label2 = labels_->at (idx2).label;
-          if ( (*exclude_labels_)[label1] || (*exclude_labels_)[label2])
+          const uint32_t &label1 = (*labels_)[idx1].label;
+          const uint32_t &label2 = (*labels_)[idx2].label;
+
+          const std::map<uint32_t, bool>::const_iterator it1 = exclude_labels_->find (label1);
+          if ((it1 == exclude_labels_->end ()) || it1->second)
+            return false;
+
+          const std::map<uint32_t, bool>::const_iterator it2 = exclude_labels_->find (label2);
+          if ((it2 == exclude_labels_->end ()) || it2->second)
             return false;
         }
         
@@ -148,19 +166,32 @@ namespace pcl
           dist_threshold *= z * z;
         }
 
-        float dx = input_->points[idx1].x - input_->points[idx2].x;
-        float dy = input_->points[idx1].y - input_->points[idx2].y;
-        float dz = input_->points[idx1].z - input_->points[idx2].z;
-        float dist = std::sqrt (dx*dx + dy*dy + dz*dz);
+        const float dist = ((*input_)[idx1].getVector3fMap ()
+                              - (*input_)[idx2].getVector3fMap ()).norm ();
         return (dist < dist_threshold);
       }
       
     protected:
+
+      /** \brief Set of labels with similar size as the input point cloud,
+        * aggregating points into groups based on a similar label identifier.
+        *
+        * It needs to be set in conjunction with the \ref exclude_labels_
+        * member in order to provided a masking functionality.
+        */
       PointCloudLPtr labels_;
 
-      boost::shared_ptr<std::vector<bool> > exclude_labels_;
+      /** \brief Specifies which labels should be excluded com being clustered.
+        *
+        * If a label is not specified, it's assumed by default that it's
+        * intended be excluded
+        */
+      ExcludeLabelMapConstPtr exclude_labels_;
+
       float distance_threshold_;
+
       bool depth_dependent_;
+
       Eigen::Vector3f z_axis_;
   };
 }

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -131,14 +131,14 @@ namespace pcl
       virtual bool
       compare (int idx1, int idx2) const
       {
-        int label1 = labels_->points[idx1].label;
-        int label2 = labels_->points[idx2].label;
-        
-        if (label1 == -1 || label2 == -1)
-          return false;
-        
-        if ( (*exclude_labels_)[label1] || (*exclude_labels_)[label2])
-          return false;
+        if (labels_ && exclude_labels_)
+        {
+          assert (labels_->size () == input_->size ());
+          const uint32_t &label1 = labels_->at (idx1).label;
+          const uint32_t &label2 = labels_->at (idx2).label;
+          if ( (*exclude_labels_)[label1] || (*exclude_labels_)[label2])
+            return false;
+        }
         
         float dist_threshold = distance_threshold_;
         if (depth_dependent_)

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -50,31 +50,25 @@ namespace pcl
     *
     * \author Alex Trevor
     */
-  template<typename PointT, typename PointNT, typename PointLT>
+  template<typename PointT, typename PointLT>
   class EuclideanClusterComparator: public Comparator<PointT>
   {
     public:
       typedef typename Comparator<PointT>::PointCloud PointCloud;
       typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
       
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
-      
       typedef typename pcl::PointCloud<PointLT> PointCloudL;
       typedef typename PointCloudL::Ptr PointCloudLPtr;
       typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
 
-      typedef boost::shared_ptr<EuclideanClusterComparator<PointT, PointNT, PointLT> > Ptr;
-      typedef boost::shared_ptr<const EuclideanClusterComparator<PointT, PointNT, PointLT> > ConstPtr;
+      typedef boost::shared_ptr<EuclideanClusterComparator<PointT, PointLT> > Ptr;
+      typedef boost::shared_ptr<const EuclideanClusterComparator<PointT, PointLT> > ConstPtr;
 
       using pcl::Comparator<PointT>::input_;
       
       /** \brief Empty constructor for EuclideanClusterComparator. */
       EuclideanClusterComparator ()
-        : normals_ ()
-        , angular_threshold_ (0.0f)
-        , distance_threshold_ (0.005f)
+        : distance_threshold_ (0.005f)
         , depth_dependent_ ()
         , z_axis_ ()
       {
@@ -94,38 +88,6 @@ namespace pcl
         z_axis_ = rot.col (2);
       }
       
-      /** \brief Provide a pointer to the input normals.
-        * \param[in] normals the input normal cloud
-        */
-      inline void
-      setInputNormals (const PointCloudNConstPtr &normals)
-      {
-        normals_ = normals;
-      }
-
-      /** \brief Get the input normals. */
-      inline PointCloudNConstPtr
-      getInputNormals () const
-      {
-        return (normals_);
-      }
-
-      /** \brief Set the tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane.
-        * \param[in] angular_threshold the tolerance in radians
-        */
-      virtual inline void
-      setAngularThreshold (float angular_threshold)
-      {
-        angular_threshold_ = cosf (angular_threshold);
-      }
-      
-      /** \brief Get the angular threshold in radians for difference in normal direction between neighboring points, to be considered part of the same plane. */
-      inline float
-      getAngularThreshold () const
-      {
-        return (acos (angular_threshold_) );
-      }
-
       /** \brief Set the tolerance in meters for difference in perpendicular distance (d component of plane equation) to the plane between neighboring points, to be considered part of the same plane.
         * \param[in] distance_threshold the tolerance in meters 
         * \param depth_dependent
@@ -162,8 +124,7 @@ namespace pcl
         exclude_labels_ = boost::make_shared<std::vector<bool> >(exclude_labels);
       }
 
-      /** \brief Compare points at two indices by their plane equations.  True if the angle between the normals is less than the angular threshold,
-        * and the difference between the d component of the normals is less than distance threshold, else false
+      /** \brief Compare points at two indices by their euclidean distance
         * \param idx1 The first index for the comparison
         * \param idx2 The second index for the comparison
         */
@@ -191,16 +152,13 @@ namespace pcl
         float dy = input_->points[idx1].y - input_->points[idx2].y;
         float dz = input_->points[idx1].z - input_->points[idx2].z;
         float dist = std::sqrt (dx*dx + dy*dy + dz*dz);
-
         return (dist < dist_threshold);
       }
       
     protected:
-      PointCloudNConstPtr normals_;
       PointCloudLPtr labels_;
 
       boost::shared_ptr<std::vector<bool> > exclude_labels_;
-      float angular_threshold_;
       float distance_threshold_;
       bool depth_dependent_;
       Eigen::Vector3f z_axis_;


### PR DESCRIPTION
**Edit: The description below can be considered deprecated. Please jump into https://github.com/PointCloudLibrary/pcl/pull/1542#issuecomment-314195212**

Addresses #1514. If the normals are specified, it uses the planar equation for performing the comparison. If not it defaults to the old behaviour. 

I'm starting the PR, but it still needs some discussion because there are things I'm not fully sure. 

In the [original comment for the comparison function](https://github.com/PointCloudLibrary/pcl/blob/master/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h#L165-L166) it mentions that two checks are made, one between the direction of the normals, which cannot exceed a certain angular threshold, and a second one saying that the 'd' component of the normal cannot exceed a certain distance threshold. I think the first statement is pretty clear, and for the second one I assumed the rationale was, if the planar equation is given by `a1*x1 + b1*y1 + c1*z1 + d1 = 0`with `(a1, b1, c1)` being the normal components in point `(x1, y1, z1)`. This meant that

`| d1 - d2 | = |(a2*x2 + b2*y2 + c2*z2) - (a1*x1 + b1*y1 + c1*z1)| < thrs`

Now the way the current function is implemented, it just compares if the distance between two points is below this threshold, which is wrong. 

I'm still unsure about the following points:
- there's a boolean variable called `depth_dependent_` which I still do not fully understand, but it seems to normalize/scale the threshold. Can anyone shed some light on the rationale behind it?
- Can I assume that all normals have unit norm? Because otherwise this d component residue will be a lot different, depending on the norm of the normal, and I'll need to normalize them beforehand. 
- There are currently only a few files making use of the euclidean cluster comparison e.g., ni_linemod.cpp, pcd_select_object_plane.cpp, organized_segmentation_demo.cpp, stereo_ground_segmentation.cpp,  and none of these ever even sets the inputs norms. So what I did was to retain the old behaviour if no normals were specified. Personally this doesn't feel correct, and I think it would be best to print an error message and abort the comparison if possible. Comments on how to proceed are appreciated. 
- Finally, I wanted to write some unit tests for this. I don't see much tests in segmentation folder. Should I start another file just for the euclidean_cluster_comparator (and probably euclidean segmentation) or is there a more adequate filename (agregating more other tests).
- What's the logical difference between the [EuclideanClusterComparator](http://docs.pointclouds.org/trunk/classpcl_1_1_euclidean_cluster_comparator.html) and the [EuclideanPlaneCoefficientComparator](http://docs.pointclouds.org/trunk/classpcl_1_1_euclidean_plane_coefficient_comparator.html)? 

Sorry for the trouble
