### PR TITLE
Fix error C2065 in RealSense Grabber on MSVC

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -381,14 +381,18 @@ macro(find_rssdk)
   set(_RSSDK_INCLUDE_DIRS ${RSSDK_DIR}/include)
   set(RSSDK_RELEASE_NAME libpxc.lib)
   set(RSSDK_DEBUG_NAME libpxc_d.lib)
+  set(RSSDK_SUFFIX Win32)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(RSSDK_SUFFIX x64)
+  endif()
   find_library(RSSDK_LIBRARY
                NAMES ${RSSDK_RELEASE_NAME}
                PATHS "${RSSDK_DIR}/lib/" NO_DEFAULT_PATH
-               PATH_SUFFIXES x64 Win32)
+               PATH_SUFFIXES ${RSSDK_SUFFIX})
   find_library(RSSDK_LIBRARY_DEBUG
                NAMES ${RSSDK_DEBUG_NAME} ${RSSDK_RELEASE_NAME}
                PATHS "${RSSDK_DIR}/lib/" NO_DEFAULT_PATH
-               PATH_SUFFIXES x64 Win32)
+               PATH_SUFFIXES ${RSSDK_SUFFIX})
   if(NOT RSSDK_LIBRARY_DEBUG)
     set(RSSDK_LIBRARY_DEBUG ${RSSDK_LIBRARY})
   endif()

--- a/cmake/Modules/FindRSSDK.cmake
+++ b/cmake/Modules/FindRSSDK.cmake
@@ -27,14 +27,18 @@ if(RSSDK_DIR)
   # Libraries
   set(RSSDK_RELEASE_NAME libpxc.lib)
   set(RSSDK_DEBUG_NAME libpxc_d.lib)
+  set(RSSDK_SUFFIX Win32)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(RSSDK_SUFFIX x64)
+  endif()
   find_library(RSSDK_LIBRARY
                NAMES ${RSSDK_RELEASE_NAME}
                PATHS "${RSSDK_DIR}/lib/" NO_DEFAULT_PATH
-               PATH_SUFFIXES x64 Win32)
+               PATH_SUFFIXES ${RSSDK_SUFFIX})
   find_library(RSSDK_LIBRARY_DEBUG
                NAMES ${RSSDK_DEBUG_NAME} ${RSSDK_RELEASE_NAME}
                PATHS "${RSSDK_DIR}/lib/" NO_DEFAULT_PATH
-               PATH_SUFFIXES x64 Win32)
+               PATH_SUFFIXES ${RSSDK_SUFFIX})
   if(NOT RSSDK_LIBRARY_DEBUG)
     set(RSSDK_LIBRARY_DEBUG ${RSSDK_LIBRARY})
   endif()

--- a/io/include/pcl/io/real_sense_grabber.h
+++ b/io/include/pcl/io/real_sense_grabber.h
@@ -109,6 +109,9 @@ namespace pcl
 
         /** Set desired framerate, depth and color resolution. */
         Mode (unsigned int fps, unsigned int depth_width, unsigned int depth_height, unsigned int color_width, unsigned int color_height);
+
+        bool
+        operator== (const pcl::RealSenseGrabber::Mode& m) const;
       };
 
       enum TemporalFilteringType
@@ -272,9 +275,6 @@ namespace pcl
   };
 
 }
-
-bool
-operator== (const pcl::RealSenseGrabber::Mode& m1, const pcl::RealSenseGrabber::Mode& m2);
 
 #endif /* PCL_IO_REAL_SENSE_GRABBER_H */
 

--- a/io/src/real_sense_grabber.cpp
+++ b/io/src/real_sense_grabber.cpp
@@ -103,13 +103,13 @@ pcl::RealSenseGrabber::Mode::Mode (unsigned int f, unsigned int dw, unsigned int
 }
 
 bool
-operator== (const pcl::RealSenseGrabber::Mode& m1, const pcl::RealSenseGrabber::Mode& m2)
+pcl::RealSenseGrabber::Mode::operator== (const pcl::RealSenseGrabber::Mode& m) const
 {
-  return (m1.fps == m2.fps &&
-          m1.depth_width == m2.depth_width &&
-          m1.depth_height == m2.depth_height &&
-          m1.color_width == m2.color_width &&
-          m1.color_height == m2.color_height);
+  return (this->fps == m.fps &&
+          this->depth_width == m.depth_width &&
+          this->depth_height == m.depth_height &&
+          this->color_width == m.color_width &&
+          this->color_height == m.color_height);
 }
 
 pcl::RealSenseGrabber::RealSenseGrabber (const std::string& device_id, const Mode& mode, bool strict)


### PR DESCRIPTION
Fix this issue #1557 by add operator "==" to pcl::RealSenseGrabber::Mode.
RealSense grabber will be able to build with MSVC by apply this pull request.
In addition, Fix to find RealSense SDK library corresponding to target platform.