### PR TITLE
Fix geometry::distance + geometry::squaredDistance

### DIFF
--- a/common/include/pcl/common/geometry.h
+++ b/common/include/pcl/common/geometry.h
@@ -59,7 +59,7 @@ namespace pcl
     template <typename PointT> inline float 
     distance (const PointT& p1, const PointT& p2)
     {
-      Eigen::Vector3f diff = p1 -p2;
+      Eigen::Vector3f diff = p1.getVector3fMap () - p2.getVector3fMap ();
       return (diff.norm ());
     }
 
@@ -67,7 +67,7 @@ namespace pcl
     template<typename PointT> inline float 
     squaredDistance (const PointT& p1, const PointT& p2)
     {
-      Eigen::Vector3f diff = p1 -p2;
+      Eigen::Vector3f diff = p1.getVector3fMap () - p2.getVector3fMap ();
       return (diff.squaredNorm ());
     }
 

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -3,6 +3,7 @@ PCL_ADD_TEST(common_test_wrappers test_wrappers FILES test_wrappers.cpp LINK_WIT
 PCL_ADD_TEST(common_test_macros test_macros FILES test_macros.cpp LINK_WITH pcl_gtest pcl_common)
 PCL_ADD_TEST(common_vector_average test_vector_average FILES test_vector_average.cpp LINK_WITH pcl_gtest)
 PCL_ADD_TEST(common_common test_common FILES test_common.cpp LINK_WITH pcl_gtest pcl_common)
+PCL_ADD_TEST(common_geometry test_geometry FILES test_geometry.cpp LINK_WITH pcl_gtest pcl_common)
 PCL_ADD_TEST(common_copy_point test_copy_point FILES test_copy_point.cpp LINK_WITH pcl_gtest pcl_common)
 PCL_ADD_TEST(common_centroid test_centroid FILES test_centroid.cpp LINK_WITH pcl_gtest pcl_common)
 PCL_ADD_TEST(common_int test_plane_intersection FILES test_plane_intersection.cpp LINK_WITH pcl_gtest pcl_common)

--- a/test/common/test_geometry.cpp
+++ b/test/common/test_geometry.cpp
@@ -1,0 +1,76 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <pcl/common/geometry.h>
+#include <pcl/point_types.h>
+
+using namespace pcl;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename T> class XYZPointTypesTest : public ::testing::Test { };
+typedef ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_XYZ_POINT_TYPES)> XYZPointTypes;
+TYPED_TEST_CASE(XYZPointTypesTest, XYZPointTypes);
+
+TYPED_TEST(XYZPointTypesTest, Distance)
+{
+  TypeParam p1, p2;
+  p1.x = 3; p1.y = 4; p1.z = 5;
+  p2.y = 1; p2.x = 1; p2.z = 1.5;
+  double distance = geometry::distance (p1, p2);
+  EXPECT_NEAR (distance, 5.024938, 1e-4);
+}
+
+TYPED_TEST(XYZPointTypesTest, SquaredDistance)
+{
+  TypeParam p1, p2;
+  p1.x = 3; p1.y = 4; p1.z = 5;
+  p2.y = 1; p2.x = 1; p2.z = 1.5;
+  double distance = geometry::squaredDistance (p1, p2);
+  EXPECT_NEAR (distance, 25.25, 1e-4);
+}
+
+/* ---[ */
+int
+main (int argc, char** argv)
+{
+  testing::InitGoogleTest (&argc, argv);
+  return (RUN_ALL_TESTS ());
+}
+/* ]--- */


### PR DESCRIPTION
Without this fix, trying to use these functions results in a compilation
error, since `operator-` is not defined on `Point` types (see included
test).