### PR TITLE
BugFix: Filters used applyFilter twice.

### DIFF
--- a/filters/src/filter.cpp
+++ b/filters/src/filter.cpp
@@ -67,9 +67,6 @@ pcl::Filter<pcl::PCLPointCloud2>::filter (PCLPointCloud2 &output)
     applyFilter (output);
   }
 
-  // Apply the actual filter
-  applyFilter (output);
-
   deinitCompute ();
 }
 


### PR DESCRIPTION
In filters.cpp applyFilters were used twice so all filters using a PCLPointCloud2 instead of a PointcloudT were taking twice as much time to execute. 