### PR TITLE
Fix Bug

### DIFF
--- a/io/src/vlp_grabber.cpp
+++ b/io/src/vlp_grabber.cpp
@@ -127,7 +127,7 @@ pcl::VLPGrabber::toPointClouds (HDLDataPacket *dataPacket)
     for (int j = 0; j < HDL_LASER_PER_FIRING; j++)
     {
       double current_azimuth = firing_data.rotationalPosition;
-      if (j > VLP_MAX_NUM_LASERS)
+      if (!(j < VLP_MAX_NUM_LASERS))
       {
         current_azimuth += interpolated_azimuth_delta;
       }


### PR DESCRIPTION
VLP_MAX_NUM_LASERS is 16
0-15: current_azimuth = current_azimuth;
16-31: current_azimuth += interpolated_azimuth_delta;

so, it should be:
if (!(j < VLP_MAX_NUM_LASERS))
{
        current_azimuth += interpolated_azimuth_delta;
}