### PR TITLE
speeding up saving to .obj and .ply

### DIFF
--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -1009,16 +1009,16 @@ pcl::io::saveOBJFile (const std::string &file_name,
     nr_faces += static_cast<unsigned> (tex_mesh.tex_polygons[m].size ());
 
   // Write the header information
-  fs << "####" << std::endl;
-  fs << "# OBJ dataFile simple version. File name: " << file_name << std::endl;
-  fs << "# Vertices: " << nr_points << std::endl;
-  fs << "# Faces: " <<nr_faces << std::endl;
-  fs << "# Material information:" << std::endl;
-  fs << "mtllib " << mtl_file_name_nopath << std::endl;
-  fs << "####" << std::endl;
+  fs << "####" << '\n';
+  fs << "# OBJ dataFile simple version. File name: " << file_name << '\n';
+  fs << "# Vertices: " << nr_points << '\n';
+  fs << "# Faces: " <<nr_faces << '\n';
+  fs << "# Material information:" << '\n';
+  fs << "mtllib " << mtl_file_name_nopath << '\n';
+  fs << "####" << '\n';
 
   // Write vertex coordinates
-  fs << "# Vertices" << std::endl;
+  fs << "# Vertices" << '\n';
   for (unsigned i = 0; i < nr_points; ++i)
   {
     int xyz = 0;
@@ -1055,9 +1055,9 @@ pcl::io::saveOBJFile (const std::string &file_name,
       PCL_ERROR ("[pcl::io::saveOBJFile] Input point cloud has no XYZ data!\n");
       return (-2);
     }
-    fs << std::endl;
+    fs << '\n';
   }
-  fs << "# "<< nr_points <<" vertices" << std::endl;
+  fs << "# "<< nr_points <<" vertices" << '\n';
 
   // Write vertex normals
   for (unsigned i = 0; i < nr_points; ++i)
@@ -1096,17 +1096,17 @@ pcl::io::saveOBJFile (const std::string &file_name,
       PCL_ERROR ("[pcl::io::saveOBJFile] Input point cloud has no normals!\n");
       return (-2);
     }
-    fs << std::endl;
+    fs << '\n';
   }
   // Write vertex texture with "vt" (adding latter)
 
   for (unsigned m = 0; m < nr_meshes; ++m)
   {
-    fs << "# " << tex_mesh.tex_coordinates[m].size() << " vertex textures in submesh " << m <<  std::endl;
+    fs << "# " << tex_mesh.tex_coordinates[m].size() << " vertex textures in submesh " << m <<  '\n';
     for (size_t i = 0; i < tex_mesh.tex_coordinates[m].size (); ++i)
     {
       fs << "vt ";
-      fs <<  tex_mesh.tex_coordinates[m][i][0] << " " << tex_mesh.tex_coordinates[m][i][1] << std::endl;
+      fs <<  tex_mesh.tex_coordinates[m][i][0] << " " << tex_mesh.tex_coordinates[m][i][1] << '\n';
     }
   }
 
@@ -1117,9 +1117,9 @@ pcl::io::saveOBJFile (const std::string &file_name,
   {
     if (m > 0) f_idx += static_cast<unsigned> (tex_mesh.tex_polygons[m-1].size ());
 
-    fs << "# The material will be used for mesh " << m << std::endl;
-    fs << "usemtl " <<  tex_mesh.tex_materials[m].tex_name << std::endl;
-    fs << "# Faces" << std::endl;
+    fs << "# The material will be used for mesh " << m << '\n';
+    fs << "usemtl " <<  tex_mesh.tex_materials[m].tex_name << '\n';
+    fs << "# Faces" << '\n';
 
     for (size_t i = 0; i < tex_mesh.tex_polygons[m].size(); ++i)
     {
@@ -1135,11 +1135,11 @@ pcl::io::saveOBJFile (const std::string &file_name,
            << "/" << tex_mesh.tex_polygons[m][i].vertices.size () * (i+f_idx) +j+1
            << "/" << idx; // vertex index in obj file format starting with 1
       }
-      fs << std::endl;
+      fs << '\n';
     }
-    fs << "# "<< tex_mesh.tex_polygons[m].size() << " faces in mesh " << m << std::endl;
+    fs << "# "<< tex_mesh.tex_polygons[m].size() << " faces in mesh " << m << '\n';
   }
-  fs << "# End of File";
+  fs << "# End of File" << std::flush;
 
   // Close obj file
   fs.close ();
@@ -1152,22 +1152,22 @@ pcl::io::saveOBJFile (const std::string &file_name,
   m_fs.open (mtl_file_name.c_str ());
 
   // default
-  m_fs << "#" << std::endl;
-  m_fs << "# Wavefront material file" << std::endl;
-  m_fs << "#" << std::endl;
+  m_fs << "#" << '\n';
+  m_fs << "# Wavefront material file" << '\n';
+  m_fs << "#" << '\n';
   for(unsigned m = 0; m < nr_meshes; ++m)
   {
-    m_fs << "newmtl " << tex_mesh.tex_materials[m].tex_name << std::endl;
-    m_fs << "Ka "<< tex_mesh.tex_materials[m].tex_Ka.r << " " << tex_mesh.tex_materials[m].tex_Ka.g << " " << tex_mesh.tex_materials[m].tex_Ka.b << std::endl; // defines the ambient color of the material to be (r,g,b).
-    m_fs << "Kd "<< tex_mesh.tex_materials[m].tex_Kd.r << " " << tex_mesh.tex_materials[m].tex_Kd.g << " " << tex_mesh.tex_materials[m].tex_Kd.b << std::endl; // defines the diffuse color of the material to be (r,g,b).
-    m_fs << "Ks "<< tex_mesh.tex_materials[m].tex_Ks.r << " " << tex_mesh.tex_materials[m].tex_Ks.g << " " << tex_mesh.tex_materials[m].tex_Ks.b << std::endl; // defines the specular color of the material to be (r,g,b). This color shows up in highlights.
-    m_fs << "d " << tex_mesh.tex_materials[m].tex_d << std::endl; // defines the transparency of the material to be alpha.
-    m_fs << "Ns "<< tex_mesh.tex_materials[m].tex_Ns  << std::endl; // defines the shininess of the material to be s.
-    m_fs << "illum "<< tex_mesh.tex_materials[m].tex_illum << std::endl; // denotes the illumination model used by the material.
+    m_fs << "newmtl " << tex_mesh.tex_materials[m].tex_name << '\n';
+    m_fs << "Ka "<< tex_mesh.tex_materials[m].tex_Ka.r << " " << tex_mesh.tex_materials[m].tex_Ka.g << " " << tex_mesh.tex_materials[m].tex_Ka.b << '\n'; // defines the ambient color of the material to be (r,g,b).
+    m_fs << "Kd "<< tex_mesh.tex_materials[m].tex_Kd.r << " " << tex_mesh.tex_materials[m].tex_Kd.g << " " << tex_mesh.tex_materials[m].tex_Kd.b << '\n'; // defines the diffuse color of the material to be (r,g,b).
+    m_fs << "Ks "<< tex_mesh.tex_materials[m].tex_Ks.r << " " << tex_mesh.tex_materials[m].tex_Ks.g << " " << tex_mesh.tex_materials[m].tex_Ks.b << '\n'; // defines the specular color of the material to be (r,g,b). This color shows up in highlights.
+    m_fs << "d " << tex_mesh.tex_materials[m].tex_d << '\n'; // defines the transparency of the material to be alpha.
+    m_fs << "Ns "<< tex_mesh.tex_materials[m].tex_Ns  << '\n'; // defines the shininess of the material to be s.
+    m_fs << "illum "<< tex_mesh.tex_materials[m].tex_illum << '\n'; // denotes the illumination model used by the material.
                                             // illum = 1 indicates a flat material with no specular highlights, so the value of Ks is not used.
                                             // illum = 2 denotes the presence of specular highlights, and so a specification for Ks is required.
-    m_fs << "map_Kd " << tex_mesh.tex_materials[m].tex_file << std::endl;
-    m_fs << "###" << std::endl;
+    m_fs << "map_Kd " << tex_mesh.tex_materials[m].tex_file << '\n';
+    m_fs << "###" << '\n';
   }
   m_fs.close ();
   return (0);
@@ -1198,16 +1198,16 @@ pcl::io::saveOBJFile (const std::string &file_name,
   int normal_index = getFieldIndex (mesh.cloud, "normal_x");
 
   // Write the header information
-  fs << "####" << std::endl;
-  fs << "# OBJ dataFile simple version. File name: " << file_name << std::endl;
-  fs << "# Vertices: " << nr_points << std::endl;
+  fs << "####" << '\n';
+  fs << "# OBJ dataFile simple version. File name: " << file_name << '\n';
+  fs << "# Vertices: " << nr_points << '\n';
   if (normal_index != -1)
-    fs << "# Vertices normals : " << nr_points << std::endl;
-  fs << "# Faces: " <<nr_faces << std::endl;
-  fs << "####" << std::endl;
+    fs << "# Vertices normals : " << nr_points << '\n';
+  fs << "# Faces: " <<nr_faces << '\n';
+  fs << "####" << '\n';
 
   // Write vertex coordinates
-  fs << "# List of Vertices, with (x,y,z) coordinates, w is optional." << std::endl;
+  fs << "# List of Vertices, with (x,y,z) coordinates, w is optional." << '\n';
   for (int i = 0; i < nr_points; ++i)
   {
     int xyz = 0;
@@ -1237,14 +1237,14 @@ pcl::io::saveOBJFile (const std::string &file_name,
       PCL_ERROR ("[pcl::io::saveOBJFile] Input point cloud has no XYZ data!\n");
       return (-2);
     }
-    fs << std::endl;
+    fs << '\n';
   }
 
-  fs << "# "<< nr_points <<" vertices" << std::endl;
+  fs << "# "<< nr_points <<" vertices" << '\n';
 
   if(normal_index != -1)
   {
-    fs << "# Normals in (x,y,z) form; normals might not be unit." <<  std::endl;
+    fs << "# Normals in (x,y,z) form; normals might not be unit." <<  '\n';
     // Write vertex normals
     for (int i = 0; i < nr_points; ++i)
     {
@@ -1275,13 +1275,13 @@ pcl::io::saveOBJFile (const std::string &file_name,
         PCL_ERROR ("[pcl::io::saveOBJFile] Input point cloud has no normals!\n");
         return (-2);
       }
-      fs << std::endl;
+      fs << '\n';
     }
 
-    fs << "# "<< nr_points <<" vertices normals" << std::endl;
+    fs << "# "<< nr_points <<" vertices normals" << '\n';
   }
 
-  fs << "# Face Definitions" << std::endl;
+  fs << "# Face Definitions" << '\n';
   // Write down faces
   if(normal_index == -1)
   {
@@ -1291,7 +1291,7 @@ pcl::io::saveOBJFile (const std::string &file_name,
       size_t j = 0;
       for (; j < mesh.polygons[i].vertices.size () - 1; ++j)
         fs << mesh.polygons[i].vertices[j] + 1 << " ";
-      fs << mesh.polygons[i].vertices[j] + 1 << std::endl;
+      fs << mesh.polygons[i].vertices[j] + 1 << '\n';
     }
   }
   else
@@ -1302,7 +1302,7 @@ pcl::io::saveOBJFile (const std::string &file_name,
       size_t j = 0;
       for (; j < mesh.polygons[i].vertices.size () - 1; ++j)
         fs << mesh.polygons[i].vertices[j] + 1 << "//" << mesh.polygons[i].vertices[j] + 1 << " ";
-      fs << mesh.polygons[i].vertices[j] + 1 << "//" << mesh.polygons[i].vertices[j] + 1 << std::endl;
+      fs << mesh.polygons[i].vertices[j] + 1 << "//" << mesh.polygons[i].vertices[j] + 1 << '\n';
     }
   }
   fs << "# End of File" << std::endl;

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -1000,7 +1000,7 @@ pcl::PLYWriter::writeContentWithCameraASCII (int nr_points,
           fs << " ";
       }
     }
-    fs << std::endl;
+    fs << '\n';
   }
   // Append sensor information
   if (origin[3] != 0)
@@ -1151,7 +1151,7 @@ pcl::PLYWriter::writeContentWithRangeGridASCII (int nr_points,
     if (is_valid_line)
     {
       grids[i].push_back (valid_points);
-      fs << line.str () << std::endl;
+      fs << line.str () << '\n';
       ++valid_points;
     }
   }
@@ -1166,7 +1166,7 @@ pcl::PLYWriter::writeContentWithRangeGridASCII (int nr_points,
            it != grids [i].end ();
            ++it)
         fs << " " << *it;
-      fs << std::endl;
+      fs << '\n';
     }
   }
 
@@ -1580,7 +1580,7 @@ pcl::io::savePLYFile (const std::string &file_name, const pcl::PolygonMesh &mesh
       PCL_ERROR ("[pcl::io::savePLYFile] Input point cloud has no XYZ data!\n");
       return (-2);
     }
-    fs << std::endl;
+    fs << '\n';
   }
 
   // Write down faces
@@ -1590,7 +1590,7 @@ pcl::io::savePLYFile (const std::string &file_name, const pcl::PolygonMesh &mesh
     size_t j = 0;
     for (j = 0; j < mesh.polygons[i].vertices.size () - 1; ++j)
       fs << mesh.polygons[i].vertices[j] << " ";
-    fs << mesh.polygons[i].vertices[j] << std::endl;
+    fs << mesh.polygons[i].vertices[j] << '\n';
   }
 
   // Close file

--- a/io/src/vtk_io.cpp
+++ b/io/src/vtk_io.cpp
@@ -63,7 +63,7 @@ pcl::io::saveVTKFile (const std::string &file_name,
   unsigned int point_size = static_cast<unsigned int> (triangles.cloud.data.size () / nr_points);
 
   // Write the header information
-  fs << "# vtk DataFile Version 3.0\nvtk output\nASCII\nDATASET POLYDATA\nPOINTS " << nr_points << " float" << std::endl;
+  fs << "# vtk DataFile Version 3.0\nvtk output\nASCII\nDATASET POLYDATA\nPOINTS " << nr_points << " float" << '\n';
 
   // Iterate through the points
   for (unsigned int i = 0; i < nr_points; ++i)
@@ -93,13 +93,13 @@ pcl::io::saveVTKFile (const std::string &file_name,
       PCL_ERROR ("[pcl::io::saveVTKFile] Input point cloud has no XYZ data!\n");
       return (-2);
     }
-    fs << std::endl;
+    fs << '\n';
   }
 
   // Write vertices
-  fs << "\nVERTICES " << nr_points << " " << 2*nr_points << std::endl;
+  fs << "\nVERTICES " << nr_points << " " << 2*nr_points << '\n';
   for (unsigned int i = 0; i < nr_points; ++i)
-    fs << "1 " << i << std::endl;
+    fs << "1 " << i << '\n';
 
   // Write polygons
   // compute the correct number of values:
@@ -107,14 +107,14 @@ pcl::io::saveVTKFile (const std::string &file_name,
   size_t correct_number = triangle_size;
   for (size_t i = 0; i < triangle_size; ++i)
     correct_number += triangles.polygons[i].vertices.size ();
-  fs << "\nPOLYGONS " << triangle_size << " " << correct_number << std::endl;
+  fs << "\nPOLYGONS " << triangle_size << " " << correct_number << '\n';
   for (size_t i = 0; i < triangle_size; ++i)
   {
     fs << triangles.polygons[i].vertices.size () << " ";
     size_t j = 0;
     for (j = 0; j < triangles.polygons[i].vertices.size () - 1; ++j)
       fs << triangles.polygons[i].vertices[j] << " ";
-    fs << triangles.polygons[i].vertices[j] << std::endl;
+    fs << triangles.polygons[i].vertices[j] << '\n';
   }
 
   // Write RGB values
@@ -137,7 +137,7 @@ pcl::io::saveVTKFile (const std::string &file_name,
         int b = color.b;
         fs << static_cast<float> (r) / 255.0f << " " << static_cast<float> (g) / 255.0f << " " << static_cast<float> (b) / 255.0f;
       }
-      fs << std::endl;
+      fs << '\n';
     }
   }
 
@@ -166,7 +166,7 @@ pcl::io::saveVTKFile (const std::string &file_name,
   unsigned int point_size = static_cast<unsigned int> (cloud.data.size () / nr_points);
 
   // Write the header information
-  fs << "# vtk DataFile Version 3.0\nvtk output\nASCII\nDATASET POLYDATA\nPOINTS " << nr_points << " float" << std::endl;
+  fs << "# vtk DataFile Version 3.0\nvtk output\nASCII\nDATASET POLYDATA\nPOINTS " << nr_points << " float" << '\n';
 
   // Iterate through the points
   for (unsigned int i = 0; i < nr_points; ++i)
@@ -196,13 +196,13 @@ pcl::io::saveVTKFile (const std::string &file_name,
       PCL_ERROR ("[pcl::io::saveVTKFile] Input point cloud has no XYZ data!\n");
       return (-2);
     }
-    fs << std::endl;
+    fs << '\n';
   }
 
   // Write vertices
-  fs << "\nVERTICES " << nr_points << " " << 2*nr_points << std::endl;
+  fs << "\nVERTICES " << nr_points << " " << 2*nr_points << '\n';
   for (unsigned int i = 0; i < nr_points; ++i)
-    fs << "1 " << i << std::endl;
+    fs << "1 " << i << '\n';
 
   // Write RGB values
   int field_index = getFieldIndex (cloud, "rgb");
@@ -224,7 +224,7 @@ pcl::io::saveVTKFile (const std::string &file_name,
         int b = color.b;
         fs << static_cast<float> (r) / 255.0f << " " << static_cast<float> (g) / 255.0f << " " << static_cast<float> (b) / 255.0f;
       }
-      fs << std::endl;
+      fs << '\n';
     }
   }
 


### PR DESCRIPTION
By replacing std::endl with '\n', saving to disk can be sped up by roughly 15 times. 

Issue: #1573 