### PR TITLE
Improve pointcloud visualization with colormaps

### DIFF
--- a/visualization/include/pcl/visualization/common/common.h
+++ b/visualization/include/pcl/visualization/common/common.h
@@ -44,6 +44,8 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/visualization/eigen.h>
 #include <vtkMatrix4x4.h>
+#include <vtkSmartPointer.h>
+#include <vtkLookupTable.h>
 
 namespace pcl
 {
@@ -91,23 +93,18 @@ namespace pcl
     PCL_EXPORTS float
     viewScreenArea (const Eigen::Vector3d &eye, const Eigen::Vector3d &min_bb, const Eigen::Vector3d &max_bb, const Eigen::Matrix4d &view_projection_matrix, int width, int height);
 
-    /** \brief Set of rendering properties
-     * \c PCL_VISUALIZER_POINT_SIZE: integer starting from 1
-     * \c PCL_VISUALIZER_OPACITY: Float going from 0.0 (transparent) to 1.0 (opaque)
-     * \c PCL_VISUALIZER_LINE_WIDTH: Integer starting from 1
-     * \c PCL_VISUALIZER_COLOR: 3 floats (R, G, B) going from 0.0 (dark) to 1.0 (light)
-     */
+    /** \brief Set of rendering properties. */
     enum RenderingProperties
     {
-      PCL_VISUALIZER_POINT_SIZE,
-      PCL_VISUALIZER_OPACITY,
-      PCL_VISUALIZER_LINE_WIDTH,
+      PCL_VISUALIZER_POINT_SIZE,            /**< integer starting from 1 */
+      PCL_VISUALIZER_OPACITY,               /**< Float going from 0.0 (transparent) to 1.0 (opaque) */
+      PCL_VISUALIZER_LINE_WIDTH,            /**< Integer starting from 1 */
       PCL_VISUALIZER_FONT_SIZE,
-      PCL_VISUALIZER_COLOR,
+      PCL_VISUALIZER_COLOR,                 /**< 3 floats (R, G, B) going from 0.0 (dark) to 1.0 (light) */
       PCL_VISUALIZER_REPRESENTATION,
       PCL_VISUALIZER_IMMEDIATE_RENDERING,
       PCL_VISUALIZER_SHADING,
-      PCL_VISUALIZER_LUT
+      PCL_VISUALIZER_LUT,                   /**< colormap type \ref pcl::visualization::LookUpTableRepresentationProperties */
     };
 
     enum RenderingRepresentationProperties
@@ -124,16 +121,24 @@ namespace pcl
       PCL_VISUALIZER_SHADING_PHONG
     };
 
-    /*! Look up table for color representation of vtkPolyDataMapper.\n
-     * See [mathworks colormap page](http://www.mathworks.com/help/matlab/ref/colormap.html#input_argument_name) for images representations of the LUTs */
+    /*! Colormap properties. See [mathworks colormap page](http://www.mathworks.com/help/matlab/ref/colormap.html#input_argument_name) for image representations of the colormaps. */
     enum LookUpTableRepresentationProperties
-    { //
-      PCL_VISUALIZER_LUT_JET,
-      PCL_VISUALIZER_LUT_JET_INVERSE,
-      PCL_VISUALIZER_LUT_HSV,
-      PCL_VISUALIZER_LUT_HSV_INVERSE,
-      PCL_VISUALIZER_LUT_GREY
+    {
+      PCL_VISUALIZER_LUT_JET,           /**< Jet colormap */
+      PCL_VISUALIZER_LUT_JET_INVERSE,   /**< Inverse jet colormap */
+      PCL_VISUALIZER_LUT_HSV,           /**< HSV colormap */
+      PCL_VISUALIZER_LUT_HSV_INVERSE,   /**< Inverse HSV colormap */
+      PCL_VISUALIZER_LUT_GREY,          /**< Grey colormap (black to white) */
+      PCL_VISUALIZER_LUT_BLUE2RED,      /**< Blue to red colormap (blue to white to red) */
     };
+
+    /** \brief Generate a lookup table for a colormap.
+      * \param[in] colormap_type
+      * \param[out] table a vtk lookup table
+      * \note The list of available colormaps can be found in \ref pcl::visualization::LookUpTableRepresentationProperties.
+      */    
+    PCL_EXPORTS bool
+    getColormapLUT  (LookUpTableRepresentationProperties colormap_type, vtkSmartPointer<vtkLookupTable> &table);
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     /** \brief Camera class holds a set of camera parameters together with the window pos/size. */

--- a/visualization/include/pcl/visualization/common/common.h
+++ b/visualization/include/pcl/visualization/common/common.h
@@ -105,6 +105,7 @@ namespace pcl
       PCL_VISUALIZER_IMMEDIATE_RENDERING,
       PCL_VISUALIZER_SHADING,
       PCL_VISUALIZER_LUT,                   /**< colormap type \ref pcl::visualization::LookUpTableRepresentationProperties */
+      PCL_VISUALIZER_LUT_RANGE              /**< two doubles (min and max) or \ref pcl::visualization::LookUpTableRepresentationProperties::PCL_VISUALIZER_LUT_RANGE_AUTO */
     };
 
     enum RenderingRepresentationProperties
@@ -130,6 +131,7 @@ namespace pcl
       PCL_VISUALIZER_LUT_HSV_INVERSE,   /**< Inverse HSV colormap */
       PCL_VISUALIZER_LUT_GREY,          /**< Grey colormap (black to white) */
       PCL_VISUALIZER_LUT_BLUE2RED,      /**< Blue to red colormap (blue to white to red) */
+      PCL_VISUALIZER_LUT_RANGE_AUTO     /**< Set LUT range to min and max values of the data */
     };
 
     /** \brief Generate a lookup table for a colormap.

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1148,6 +1148,18 @@ namespace pcl
         setPointCloudRenderingProperties (int property, double val1, double val2, double val3,
                                           const std::string &id = "cloud", int viewport = 0);
 
+        /** \brief Set the rendering properties of a PointCloud (2x values - e.g., LUT minmax values)
+          * \param[in] property the property type
+          * \param[in] val1 the first value to be set
+          * \param[in] val2 the second value to be set
+          * \param[in] id the point cloud object id (default: cloud)
+          * \param[in] viewport the view port where the Point Cloud's rendering properties should be modified (default: all)
+          * \note The list of properties can be found in \ref pcl::visualization::LookUpTableRepresentationProperties.
+          */
+        bool
+        setPointCloudRenderingProperties (int property, double val1, double val2,
+                                          const std::string &id = "cloud", int viewport = 0);
+        
        /** \brief Set the rendering properties of a PointCloud
          * \param[in] property the property type
          * \param[in] value the value to be set

--- a/visualization/src/common/common.cpp
+++ b/visualization/src/common/common.cpp
@@ -37,6 +37,7 @@
 
 #include <pcl/point_types.h>
 #include <pcl/visualization/common/common.h>
+#include <pcl/console/print.h>
 #include <stdlib.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -355,6 +356,91 @@ pcl::visualization::viewScreenArea (
   }
 
   return (fabsf (float (sum * 0.5f)));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+bool
+pcl::visualization::getColormapLUT (LookUpTableRepresentationProperties colormap_type, vtkSmartPointer<vtkLookupTable> &table)
+{
+  table = vtkSmartPointer<vtkLookupTable>::New ();
+  switch (colormap_type)
+  {
+    case PCL_VISUALIZER_LUT_JET:
+    {
+      table->SetHueRange (0, 0.667);
+      table->SetSaturationRange (1, 1);
+      table->SetAlphaRange (1, 1);
+      break;
+    }
+      
+    case PCL_VISUALIZER_LUT_JET_INVERSE:
+    {
+      table->SetHueRange (0.667, 0);
+      table->SetSaturationRange (1, 1);
+      table->SetAlphaRange (1, 1);
+      break;
+    }
+      
+    case PCL_VISUALIZER_LUT_HSV:
+    {
+      table->SetHueRange (0, 1);
+      table->SetSaturationRange (1, 1);
+      table->SetAlphaRange (1, 1);
+      break;
+    }
+      
+    case PCL_VISUALIZER_LUT_HSV_INVERSE:
+    {
+      table->SetHueRange (1, 0);
+      table->SetSaturationRange (1, 1);
+      table->SetAlphaRange (1, 1);
+      break;
+    }
+      
+    case PCL_VISUALIZER_LUT_GREY:
+    {
+      table->SetValueRange (0, 1);
+      table->SetHueRange (0, 0);
+      table->SetSaturationRange (0, 0);
+      table->SetAlphaRange (1, 1);
+      break;
+    }
+      
+    case PCL_VISUALIZER_LUT_BLUE2RED:
+    {
+      table->SetSaturationRange (1, 1);
+      table->SetAlphaRange (1, 1);
+      table->SetNumberOfTableValues (256);
+
+      double red[3]   = {1.0, 0.0, 0.0};
+      double white[3] = {1.0, 1.0, 1.0};
+      double blue[3]  = {0.0, 0.0, 1.0};
+      
+      for (size_t i = 0; i < 128; i++)
+      {
+        double weight = static_cast<double>(i) / 128.0;
+        table->SetTableValue  ( i,
+                                white[0] * weight + blue[0] * (1 - weight),
+                                white[1] * weight + blue[1] * (1 - weight),
+                                white[2] * weight + blue[2] * (1 - weight)  );
+      }
+      
+      for (size_t i = 128; i < 256; i++)
+      {
+        double weight = (static_cast<double>(i) -128.0) / 128.0;
+        table->SetTableValue  ( i,
+                                red[0] * weight + white[0] * (1 - weight),
+                                red[1] * weight + white[1] * (1 - weight),
+                                red[2] * weight + white[2] * (1 - weight)  );
+      }
+      break;
+    } 
+    default:
+      PCL_WARN ("[pcl::visualization::getColormapLUT] Requested colormap type does not exist!\n");
+      return false;
+  }
+  table->Build ();
+  return true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1333,6 +1333,58 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 bool
+pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
+    int property, double val1, double val2, const std::string &id, int)
+{
+  // Check to see if this ID entry already exists (has it been already added to the visualizer?)
+  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+
+  if (am_it == cloud_actor_map_->end ())
+  {
+    pcl::console::print_error ("[setPointCloudRenderingProperties] Could not find any PointCloud datasets with id <%s>!\n", id.c_str ());
+    return (false);
+  }
+  // Get the actor pointer
+  vtkLODActor* actor = vtkLODActor::SafeDownCast (am_it->second.actor);
+  if (!actor)
+    return (false);
+
+  switch (property)
+  {
+    case PCL_VISUALIZER_LUT_RANGE:
+    {
+      // Check if the mapper has scalars
+      if (!actor->GetMapper ()->GetInput ()->GetPointData ()->GetScalars ())
+        break;
+      
+      // Check that scalars are not unisgned char (i.e. check if a LUT is used to colormap scalars assuming vtk ColorMode is Default)
+      if (actor->GetMapper ()->GetInput ()->GetPointData ()->GetScalars ()->IsA ("vtkUnsignedCharArray"))
+        break;
+
+      // Check that range values are correct
+      if (val1 >= val2)
+      {
+        PCL_WARN ("[setPointCloudRenderingProperties] Range max must be greater than range min!\n");
+        return (false);
+      }
+      
+      // Update LUT
+      actor->GetMapper ()->GetLookupTable ()->SetRange (val1, val2);
+      actor->GetMapper()->UseLookupTableScalarRangeOn ();
+      style_->updateLookUpTableDisplay (false);
+      break;
+    }
+    default:
+    {
+      pcl::console::print_error ("[setPointCloudRenderingProperties] Unknown property (%d) specified!\n", property);
+      return (false);
+    }
+  }
+  return (true);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+bool
 pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (int property, double &value, const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
@@ -1445,6 +1497,28 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
       table->SetRange (range[0], range[1]);
       actor->GetMapper ()->SetLookupTable (table);
       style_->updateLookUpTableDisplay (false);
+      break;
+    }
+    case PCL_VISUALIZER_LUT_RANGE:
+    {
+      // Check if the mapper has scalars
+      if (!actor->GetMapper ()->GetInput ()->GetPointData ()->GetScalars ())
+        break;
+      
+      // Check that scalars are not unisgned char (i.e. check if a LUT is used to colormap scalars assuming vtk ColorMode is Default)
+      if (actor->GetMapper ()->GetInput ()->GetPointData ()->GetScalars ()->IsA ("vtkUnsignedCharArray"))
+        break;
+
+      switch (int(value))
+      {
+        case PCL_VISUALIZER_LUT_RANGE_AUTO:
+          double range[2];
+          actor->GetMapper ()->GetInput ()->GetPointData ()->GetScalars ()->GetRange (range);
+          actor->GetMapper ()->GetLookupTable ()->SetRange (range[0], range[1]);
+          actor->GetMapper ()->UseLookupTableScalarRangeOn ();
+          style_->updateLookUpTableDisplay (false);
+          break;
+      }
       break;
     }
     default:

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1738,38 +1738,8 @@ pcl::visualization::PCLVisualizer::setShapeRenderingProperties (
       actor->GetMapper ()->ScalarVisibilityOn ();
       actor->GetMapper ()->SetScalarRange (range[0], range[1]);
       vtkSmartPointer<vtkLookupTable> table = vtkSmartPointer<vtkLookupTable>::New ();
+      getColormapLUT (static_cast<LookUpTableRepresentationProperties>(value), table);
       table->SetRange (range[0], range[1]);
-
-      switch (int (value))
-      {
-        case PCL_VISUALIZER_LUT_JET:
-          table->SetHueRange (0, 0.667);
-          table->SetSaturationRange (1, 1);
-          table->SetAlphaRange (1, 1);
-          break;
-        case PCL_VISUALIZER_LUT_JET_INVERSE:
-          table->SetHueRange (0.667, 0);
-          table->SetSaturationRange (1, 1);
-          table->SetAlphaRange (1, 1);
-          break;
-        case PCL_VISUALIZER_LUT_HSV:
-          table->SetHueRange (0, 1);
-          table->SetSaturationRange (1, 1);
-          table->SetAlphaRange (1, 1);
-          break;
-        case PCL_VISUALIZER_LUT_HSV_INVERSE:
-          table->SetHueRange (1, 0);
-          table->SetSaturationRange (1, 1);
-          table->SetAlphaRange (1, 1);
-          break;
-        case PCL_VISUALIZER_LUT_GREY:
-          table->SetValueRange (0, 1);
-          table->SetHueRange (0, 0);
-          table->SetSaturationRange (0, 0);
-          table->SetAlphaRange (1, 1);
-          break;
-      }
-      table->Build ();
       actor->GetMapper ()->SetLookupTable (table);
       style_->updateLookUpTableDisplay (false);
       break;


### PR DESCRIPTION
This pull request addresses #1574. The following functionality is added:
- Can control which colormap is used to visualize the cloud
- Can control the range of the colormap used to visualize the cloud
- JET, HSV and GREY colormaps are generated the same way as the ones for [meshes](https://github.com/PointCloudLibrary/pcl/blob/master/visualization/src/pcl_visualizer.cpp#L1644).
- Added BLUE2RED colormap

Here is a minimal example [code](https://dl.dropboxusercontent.com/u/4515184/color_pointcloud.tar.gz) to test the new functionality.
If the maintainers agree to these changes I would also like to update the colormaps for mesh visualization.

Here is an example of a pointcloud of a bicycle helmet visualized using different colormaps:
![hsv_auto](https://cloud.githubusercontent.com/assets/4580832/14236117/fbe5da5c-f9dd-11e5-92ec-6846f80f705c.png)
![hsv_0-0 1](https://cloud.githubusercontent.com/assets/4580832/14236118/fd9ff6ca-f9dd-11e5-9391-1a0cb2e58c38.png)
![b2r_0-0 1](https://cloud.githubusercontent.com/assets/4580832/14236119/00365cd0-f9de-11e5-9dfb-0ffb60d209c6.png)