### PR TITLE
PLYReader: thread safe colors

### DIFF
--- a/io/include/pcl/io/ply_io.h
+++ b/io/include/pcl/io/ply_io.h
@@ -95,6 +95,8 @@ namespace pcl
         , rgb_offset_before_ (0)
         , do_resize_ (false)
         , polygons_ (0)
+        , r_(0), g_(0), b_(0)
+        , a_(0), rgba_(0)
       {}
 
       PLYReader (const PLYReader &p)
@@ -109,6 +111,8 @@ namespace pcl
         , rgb_offset_before_ (0)
         , do_resize_ (false)
         , polygons_ (0)
+        , r_(0), g_(0), b_(0)
+        , a_(0), rgba_(0)
       {
         *this = p;
       }
@@ -529,6 +533,12 @@ namespace pcl
       std::vector<pcl::Vertices> *polygons_;
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      
+    private:
+      // RGB values stored by vertexColorCallback()
+      int32_t r_, g_, b_;
+      // Color values stored by vertexAlphaCallback()
+      uint32_t a_, rgba_;
   };
 
   /** \brief Point Cloud Data (PLY) file format writer.

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -375,20 +375,19 @@ namespace pcl
 void
 pcl::PLYReader::vertexColorCallback (const std::string& color_name, pcl::io::ply::uint8 color)
 {
-  static int32_t r, g, b;
   if ((color_name == "red") || (color_name == "diffuse_red"))
   {
-    r = int32_t (color);
+    r_ = int32_t (color);
     rgb_offset_before_ = vertex_offset_before_;
   }
   if ((color_name == "green") || (color_name == "diffuse_green"))
   {
-    g = int32_t (color);
+    g_ = int32_t (color);
   }
   if ((color_name == "blue") || (color_name == "diffuse_blue"))
   {
-    b = int32_t (color);
-    int32_t rgb = r << 16 | g << 8 | b;
+    b_ = int32_t (color);
+    int32_t rgb = r_ << 16 | g_ << 8 | b_;
     memcpy (&cloud_->data[vertex_count_ * cloud_->point_step + rgb_offset_before_],
             &rgb,
             sizeof (pcl::io::ply::float32));
@@ -399,17 +398,16 @@ pcl::PLYReader::vertexColorCallback (const std::string& color_name, pcl::io::ply
 void
 pcl::PLYReader::vertexAlphaCallback (pcl::io::ply::uint8 alpha)
 {
-  static uint32_t a, rgba;
-  a = uint32_t (alpha);
+  a_ = uint32_t (alpha);
   // get anscient rgb value and store it in rgba
-  memcpy (&rgba, 
+  memcpy (&rgba_, 
           &cloud_->data[vertex_count_ * cloud_->point_step + rgb_offset_before_], 
           sizeof (pcl::io::ply::float32));
   // append alpha
-  rgba = rgba | a << 24;
+  rgba_ = rgba_ | a_ << 24;
   // put rgba back
   memcpy (&cloud_->data[vertex_count_ * cloud_->point_step + rgb_offset_before_], 
-          &rgba, 
+          &rgba_, 
           sizeof (uint32_t));
 }
 


### PR DESCRIPTION
Bug fix: PLYReader would give corrupted colors if used in a parallel
code.