### PR TITLE
Added 'Dist' template type to typedefs and other member functions

### DIFF
--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -58,7 +58,7 @@ pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (bool sorted)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename Dist>
-pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (const KdTreeFLANN<PointT> &k) 
+pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (const KdTreeFLANN<PointT, Dist> &k)
   : pcl::KdTree<PointT> (false)
   , flann_index_ (), cloud_ ()
   , index_mapping_ (), identity_mapping_ (false)
@@ -70,7 +70,7 @@ pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (const KdTreeFLANN<PointT> &k)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setEpsilon (float eps)
 {
   epsilon_ = eps;
@@ -79,7 +79,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setEpsilon (float eps)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setSortedResults (bool sorted)
 {
   sorted_ = sorted;
@@ -88,7 +88,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setSortedResults (bool sorted)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, const IndicesConstPtr &indices)
 {
   cleanup ();   // Perform an automatic cleanup of structures
@@ -98,7 +98,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, 
 
   input_   = cloud;
   indices_ = indices;
-  
+
   // Allocate enough data
   if (!input_)
   {
@@ -120,17 +120,17 @@ pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, 
     return;
   }
 
-  flann_index_.reset (new FLANNIndex (::flann::Matrix<float> (cloud_.get (), 
-                                                              index_mapping_.size (), 
+  flann_index_.reset (new FLANNIndex (::flann::Matrix<float> (cloud_.get (),
+                                                              index_mapping_.size (),
                                                               dim_),
                                       ::flann::KDTreeSingleIndexParams (15))); // max 15 points/leaf
   flann_index_->buildIndex ();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> int 
-pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k, 
-                                                std::vector<int> &k_indices, 
+template <typename PointT, typename Dist> int
+pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
+                                                std::vector<int> &k_indices,
                                                 std::vector<float> &k_distances) const
 {
   assert (point_representation_->isValid (point) && "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -147,12 +147,12 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
   ::flann::Matrix<int> k_indices_mat (&k_indices[0], 1, k);
   ::flann::Matrix<float> k_distances_mat (&k_distances[0], 1, k);
   // Wrap the k_indices and k_distances vectors (no data copy)
-  flann_index_->knnSearch (::flann::Matrix<float> (&query[0], 1, dim_), 
+  flann_index_->knnSearch (::flann::Matrix<float> (&query[0], 1, dim_),
                            k_indices_mat, k_distances_mat,
                            k, param_k_);
 
   // Do mapping to original point cloud
-  if (!identity_mapping_) 
+  if (!identity_mapping_)
   {
     for (size_t i = 0; i < static_cast<size_t> (k); ++i)
     {
@@ -165,7 +165,7 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> int 
+template <typename PointT, typename Dist> int
 pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius, std::vector<int> &k_indices,
                                               std::vector<float> &k_sqr_dists, unsigned int max_nn) const
 {
@@ -190,14 +190,14 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
   int neighbors_in_radius = flann_index_->radiusSearch (::flann::Matrix<float> (&query[0], 1, dim_),
       indices,
       dists,
-      static_cast<float> (radius * radius), 
+      static_cast<float> (radius * radius),
       params);
 
   k_indices = indices[0];
   k_sqr_dists = dists[0];
 
   // Do mapping to original point cloud
-  if (!identity_mapping_) 
+  if (!identity_mapping_)
   {
     for (int i = 0; i < neighbors_in_radius; ++i)
     {
@@ -210,7 +210,7 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::cleanup ()
 {
   // Data array cleanup
@@ -221,7 +221,7 @@ pcl::KdTreeFLANN<PointT, Dist>::cleanup ()
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud)
 {
   // No point in doing anything if the array is empty
@@ -255,7 +255,7 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, const std::vector<int> &indices)
 {
   // No point in doing anything if the array is empty
@@ -271,14 +271,14 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, co
   float* cloud_ptr = cloud_.get ();
   index_mapping_.reserve (original_no_of_points);
   // its a subcloud -> false
-  // true only identity: 
+  // true only identity:
   //     - indices size equals cloud size
   //     - indices only contain values between 0 and cloud.size - 1
   //     - no index is multiple times in the list
   //     => index is complete
   // But we can not guarantee that => identity_mapping_ = false
   identity_mapping_ = false;
-  
+
   for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
   {
     // Check if the point is invalid
@@ -287,7 +287,7 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, co
 
     // map from 0 - N -> indices [0] - indices [N]
     index_mapping_.push_back (*iIt);  // If the returned index should be for the indices vector
-    
+
     point_representation_->vectorize (cloud.points[*iIt], cloud_ptr);
     cloud_ptr += dim_;
   }
@@ -296,4 +296,3 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, co
 #define PCL_INSTANTIATE_KdTreeFLANN(T) template class PCL_EXPORTS pcl::KdTreeFLANN<T>;
 
 #endif  //#ifndef _PCL_KDTREE_KDTREE_IMPL_FLANN_H_
-

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -63,7 +63,7 @@ namespace pcl
     * the FLANN (Fast Library for Approximate Nearest Neighbor) project by Marius Muja and David Lowe.
     *
     * \author Radu B. Rusu, Marius Muja
-    * \ingroup kdtree 
+    * \ingroup kdtree
     */
   template <typename PointT, typename Dist = ::flann::L2_Simple<float> >
   class KdTreeFLANN : public pcl::KdTree<PointT>
@@ -86,11 +86,11 @@ namespace pcl
       typedef ::flann::Index<Dist> FLANNIndex;
 
       // Boost shared pointers
-      typedef boost::shared_ptr<KdTreeFLANN<PointT> > Ptr;
-      typedef boost::shared_ptr<const KdTreeFLANN<PointT> > ConstPtr;
+      typedef boost::shared_ptr<KdTreeFLANN<PointT, Dist> > Ptr;
+      typedef boost::shared_ptr<const KdTreeFLANN<PointT, Dist> > ConstPtr;
 
       /** \brief Default Constructor for KdTreeFLANN.
-        * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise. 
+        * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise.
         *
         * By setting sorted to false, the \ref radiusSearch operations will be faster.
         */
@@ -99,13 +99,13 @@ namespace pcl
       /** \brief Copy constructor
         * \param[in] k the tree to copy into this
         */
-      KdTreeFLANN (const KdTreeFLANN<PointT> &k);
+      KdTreeFLANN (const KdTreeFLANN<PointT, Dist> &k);
 
       /** \brief Copy operator
         * \param[in] k the tree to copy into this
-        */ 
-      inline KdTreeFLANN<PointT>&
-      operator = (const KdTreeFLANN<PointT>& k)
+        */
+      inline KdTreeFLANN<PointT, Dist>&
+      operator = (const KdTreeFLANN<PointT, Dist>& k)
       {
         KdTree<PointT>::operator=(k);
         flann_index_ = k.flann_index_;
@@ -125,13 +125,13 @@ namespace pcl
       void
       setEpsilon (float eps);
 
-      void 
+      void
       setSortedResults (bool sorted);
-      
-      inline Ptr makeShared () { return Ptr (new KdTreeFLANN<PointT> (*this)); } 
 
-      /** \brief Destructor for KdTreeFLANN. 
-        * Deletes all allocated data arrays and destroys the kd-tree structures. 
+      inline Ptr makeShared () { return Ptr (new KdTreeFLANN<PointT, Dist> (*this)); } 
+
+      /** \brief Destructor for KdTreeFLANN.
+        * Deletes all allocated data arrays and destroys the kd-tree structures.
         */
       virtual ~KdTreeFLANN ()
       {
@@ -142,32 +142,32 @@ namespace pcl
         * \param[in] cloud the const boost shared pointer to a PointCloud message
         * \param[in] indices the point indices subset that is to be used from \a cloud - if NULL the whole cloud is used
         */
-      void 
+      void
       setInputCloud (const PointCloudConstPtr &cloud, const IndicesConstPtr &indices = IndicesConstPtr ());
 
       /** \brief Search for k-nearest neighbors for the given query point.
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.points.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
+        *
         * \param[in] point a given \a valid (i.e., finite) query point
         * \param[in] k the number of neighbors to search for
         * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k 
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
         * a priori!)
         * \return number of neighbors found
-        * 
+        *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      int 
-      nearestKSearch (const PointT &point, int k, 
+      int
+      nearestKSearch (const PointT &point, int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const;
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.points.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
+        *
         * \param[in] point a given \a valid (i.e., finite) query point
         * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
         * \param[out] k_indices the resultant indices of the neighboring points
@@ -179,20 +179,20 @@ namespace pcl
         *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      int 
+      int
       radiusSearch (const PointT &point, double radius, std::vector<int> &k_indices,
                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const;
 
     private:
       /** \brief Internal cleanup method. */
-      void 
+      void
       cleanup ();
 
       /** \brief Converts a PointCloud to the internal FLANN point array representation. Returns the number
         * of points.
-        * \param cloud the PointCloud 
+        * \param cloud the PointCloud
         */
-      void 
+      void
       convertCloudToArray (const PointCloud &cloud);
 
       /** \brief Converts a PointCloud with a given set of indices to the internal FLANN point array
@@ -200,12 +200,12 @@ namespace pcl
         * \param[in] cloud the PointCloud data
         * \param[in] indices the point cloud indices
        */
-      void 
+      void
       convertCloudToArray (const PointCloud &cloud, const std::vector<int> &indices);
 
     private:
       /** \brief Class getName method. */
-      virtual std::string 
+      virtual std::string
       getName () const { return ("KdTreeFLANN"); }
 
       /** \brief A FLANN index object. */
@@ -213,10 +213,10 @@ namespace pcl
 
       /** \brief Internal pointer to data. */
       boost::shared_array<float> cloud_;
-      
+
       /** \brief mapping between internal and external indices. */
       std::vector<int> index_mapping_;
-      
+
       /** \brief whether the mapping bwwteen internal and external indices is identity */
       bool identity_mapping_;
 


### PR DESCRIPTION
The 'Dist' template type should be used consistently within the KdTreeFLANN class for users who implement custom distance functors.