### PR TITLE
Fix bug in calculating camera FOV

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -229,8 +229,8 @@ pcl::visualization::PCLVisualizerInteractorStyle::setCameraParameters (const Eig
 
   // Get the width and height of the image - assume the calibrated centers are at the center of the image
   Eigen::Vector2i window_size;
-  window_size[0] = static_cast<int> (intrinsics (0, 2));
-  window_size[1] = static_cast<int> (intrinsics (1, 2));
+  window_size[0] = 2 * static_cast<int> (intrinsics (0, 2));
+  window_size[1] = 2 * static_cast<int> (intrinsics (1, 2));
 
   // Compute the vertical field of view based on the focal length and image heigh
   double fovy = 2 * atan (window_size[1] / (2. * intrinsics (1, 1))) * 180.0 / M_PI;


### PR DESCRIPTION
#1610 fix
See http://www.vtk.org/doc/nightly/html/classvtkCamera.html#a2aec83f16c1c492fe87336a5018ad531 for the correct formula.
This calculation also affects the PCLVisualizer window size.

Piece of code to test:
```
#include <iostream>

#include <boost/thread/thread.hpp>
#include <pcl/common/common_headers.h>
#include <pcl/visualization/pcl_visualizer.h>

using namespace std;
using namespace pcl;
using namespace Eigen;

int main(int argc, char **argv) {
  // intrinsics matrix
  Matrix3f intrinsics;
  intrinsics(0, 0) = 525.00;  // fx
  intrinsics(0, 1) = 000.00;
  intrinsics(0, 2) = 320.00;  // cx
  intrinsics(1, 0) = 000.00;
  intrinsics(1, 1) = 525.00;  // fy
  intrinsics(1, 2) = 240.00;  // cy
  intrinsics(2, 0) = 000.00;  //  
  intrinsics(2, 1) = 000.00;  //
  intrinsics(2, 2) = 001.00;  // 1
  cout << "Intrinsics " << endl << intrinsics << endl;

  // extrinsics matrix
  Matrix4f extrinsics = Matrix4f::Identity();
  cout << "Extrinsics " << endl << extrinsics << endl;
  
  visualization::PCLVisualizer viewer("viewer");
  viewer.setCameraParameters(intrinsics, extrinsics);

  // calculate true camera FOV
  double true_h = 2 * intrinsics(1, 2); 
  double true_fovy = 2 * atan(true_h / (2. * intrinsics(1, 1)));
  cout << "true fovy = " << true_fovy << endl;

  vector<visualization::Camera> cams;
  viewer.getCameras(cams);
  for(int i = 0; i < cams.size(); i++) {
    cout << "Cam " << i << " fovy = " << cams[i].fovy << endl;
    assert(cams[i].fovy == true_fovy);
  }
  
  while(!viewer.wasStopped()) {
    viewer.spinOnce(100);
    boost::this_thread::sleep(boost::posix_time::microseconds(500000));
  }

  return 0;
}
```