### PR TITLE
Fix function signature mismatching.

### DIFF
--- a/io/include/pcl/io/auto_io.h
+++ b/io/include/pcl/io/auto_io.h
@@ -95,11 +95,10 @@ namespace pcl
     /** \brief Save point cloud to a binary file when available else to ASCII.
       * \param[in] file_name the output file name
       * \param[in] cloud the point cloud
-      * \param[in] precision float precision when saving to ASCII files
       * \ingroup io
       */
     template<typename PointT> int
-    save (const std::string& file_name, const pcl::PointCloud<PointT>& cloud, unsigned precision = 5);
+    save (const std::string& file_name, const pcl::PointCloud<PointT>& cloud);
 
     /** \brief Saves a TextureMesh to a binary file when available else to ASCII.
       * \param[in] file_name the name of the file to write to disk

--- a/io/include/pcl/io/ifs_io.h
+++ b/io/include/pcl/io/ifs_io.h
@@ -174,7 +174,7 @@ namespace pcl
              const std::string &cloud_name = "cloud")
       {
         pcl::PCLPointCloud2 blob;
-        pcl::fromPCLPointCloud2<PointT> (blob, cloud);
+        pcl::toPCLPointCloud2<PointT> (cloud, blob);
         return (write (file_name, blob, cloud_name));
       }
   };

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -43,6 +43,7 @@
 #include <pcl/point_types.h>
 #include <pcl/common/io.h>
 #include <pcl/console/print.h>
+#include <pcl/io/auto_io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/io/ply_io.h>
 #include <pcl/io/ascii_io.h>
@@ -1366,6 +1367,43 @@ TEST (PCL, Locale)
   {
   }
 #endif
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename T> class AutoIOTest : public testing::Test { };
+typedef ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES PCL_NORMAL_POINT_TYPES)> PCLXyzNormalPointTypes;
+TYPED_TEST_CASE (AutoIOTest, PCLXyzNormalPointTypes);
+TYPED_TEST (AutoIOTest, AutoLoadCloudFiles)
+{
+  PointCloud<TypeParam> cloud;
+  PointCloud<TypeParam> cloud_pcd;
+  PointCloud<TypeParam> cloud_ply;
+  PointCloud<TypeParam> cloud_ifs;
+
+  cloud.width  = 10;
+  cloud.height = 5;
+  cloud.resize (cloud.width * cloud.height);
+  cloud.is_dense = true;
+
+  save ("test_autoio.pcd", cloud);
+  save ("test_autoio.ply", cloud);
+  save ("test_autoio.ifs", cloud);
+
+  load ("test_autoio.pcd", cloud_pcd);
+  EXPECT_EQ (cloud_pcd.width * cloud_pcd.height, cloud.width * cloud.height);
+  EXPECT_EQ (cloud_pcd.is_dense, cloud.is_dense);
+
+  load ("test_autoio.ply", cloud_ply);
+  EXPECT_EQ (cloud_ply.width * cloud_ply.height, cloud.width * cloud.height);
+  EXPECT_EQ (cloud_ply.is_dense, cloud.is_dense);
+
+  load ("test_autoio.ifs", cloud_ifs);
+  EXPECT_EQ (cloud_ifs.width * cloud_ifs.height, cloud.width * cloud.height);
+  EXPECT_EQ (cloud_ifs.is_dense, cloud.is_dense);
+
+  remove ("test_autoio.pcd");
+  remove ("test_autoio.ply");
+  remove ("test_autoio.ifs");
 }
 
 /* ---[ */


### PR DESCRIPTION
Fix #1624 

The function template pcl::io::save has a distinct signature on
declaration (pcl/io/auto_io.h) and definition (pcl/io/impl/auto_io.hpp).

On fixing that a bug popup on ifs_io.h. The conversion order between
PointCloud<> to/from PCLPointCloud2 was backward.