### PR TITLE
Add ColorHandler to color points using custom data vector

### DIFF
--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -431,6 +431,79 @@ namespace pcl
         std::string field_name_;
     };
 
+    //////////////////////////////////////////////////////////////////////////////////////
+    /** \brief External data handler class for colors. Uses user provided 1D data 
+      * array to color each point using a min-max lookup table.
+      * \author Aleksandrs Ecins
+      * \ingroup visualization
+      */
+    template <typename PointT, typename Scalar>
+    class PointCloudColorHandlerCustomData : public PointCloudColorHandler<PointT>
+    {
+      typedef typename PointCloudColorHandler<PointT>::PointCloud PointCloud;
+      typedef typename PointCloud::Ptr PointCloudPtr;
+      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+
+      public:
+        typedef boost::shared_ptr<PointCloudColorHandlerCustomData<PointT, Scalar> > Ptr;
+        typedef boost::shared_ptr<const PointCloudColorHandlerCustomData<PointT, Scalar> > ConstPtr;
+
+        /** \brief Constructor from Eigen::VectorXd. */
+        PointCloudColorHandlerCustomData (const PointCloudConstPtr &cloud,
+                                          const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &data)
+          : data_ (data)
+        {
+          setInputCloud (cloud);
+        }
+                
+        /** \brief Constructor from std::vector. */
+        PointCloudColorHandlerCustomData (const PointCloudConstPtr &cloud,
+                                          const std::vector<Scalar> &data)
+        {
+          data_.resize (data.size ());
+          for (size_t i = 0; i < data.size (); i++)
+            data_[i] = data[i];
+          setInputCloud (cloud);
+        }
+        
+        /** \brief Destructor. */
+        virtual ~PointCloudColorHandlerCustomData () {}
+
+        /** \brief Get the data vector used. */
+        virtual Eigen::Matrix<Scalar, Eigen::Dynamic, 1>getData () const { return (data_); }        
+        
+        /** \brief Obtain the actual color for the input dataset as vtk scalars.
+          * \param[out] scalars the output scalars containing the color for the dataset
+          * \return true if the operation was successful (the handler is capable and 
+          * the input cloud was given as a valid pointer), false otherwise
+          */
+        virtual bool
+        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+
+        /** \brief Set the input cloud to be used.
+          * \param[in] cloud the input cloud to be used by the handler
+          */
+        virtual void
+        setInputCloud (const PointCloudConstPtr &cloud);
+
+      protected:
+        /** \brief Class getName method. */
+        virtual std::string
+        getName () const { return ("PointCloudColorHandlerCustomData"); }
+        
+        /** \brief Get the name of the field used. */
+        virtual std::string
+        getFieldName () const { return ("generic_data"); }
+        
+
+      private:
+        using PointCloudColorHandler<PointT>::cloud_;
+        using PointCloudColorHandler<PointT>::capable_;
+        using PointCloudColorHandler<PointT>::fields_;
+        
+        /** \brief Vector containing the data used for colouring. */        
+        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> data_;
+    };
 
     //////////////////////////////////////////////////////////////////////////////////////
     /** \brief RGBA handler class for colors. Uses the data present in the "rgba" field as


### PR DESCRIPTION
This pull request adds a `PointCloudColorHandlerCustomData` that allows coloring a pointcloud using a lookup table based on an external data vector. The data vector can be either an `std::vector` or an `Eigen::Vector`.
In the example below the distance of each point to the origin was computed and stored in an `std::vector` and visualized using the `BLUE2RED` colormap. Sample code can be found [here]
(https://dl.dropboxusercontent.com/u/4515184/pcl_colorhandler_custom_data.tar.gz).

```cpp
// Create data vector
for (size_t pointId = 0; pointId < cloud->size (); pointId++)
  distanceToOrigin[pointId] = cloud->points[pointId].getVector3fMap().norm();

// Create colorhandler
pcl::visualization::PointCloudColorHandlerCustomData<PointT, float> color_handler (cloud, distanceToOrigin);

// Add pointcloud to visualizer
visualizer.addPointCloud<PointT> (cloud, color_handler, "cloud"); 

// Change colormap
visualizer.setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_LUT, pcl::visualization::PCL_VISUALIZER_LUT_BLUE2RED, "cloud");
```
![colormapped](https://cloud.githubusercontent.com/assets/4580832/15980582/cf320958-2f3a-11e6-9261-7fccd409b717.png)
