### PR TITLE
Update find boost of cmake macro for support the latest versions

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -85,9 +85,16 @@ macro(find_boost)
     set(Boost_USE_MULTITHREAD @Boost_USE_MULTITHREAD@)
   endif(WIN32)
   if(${CMAKE_VERSION} VERSION_LESS 2.8.5)
-    SET(Boost_ADDITIONAL_VERSIONS "1.43" "1.43.0" "1.44" "1.44.0" "1.45" "1.45.0" "1.46.1" "1.46.0" "1.46" "1.47" "1.47.0")
+    set(Boost_ADDITIONAL_VERSIONS
+      "1.47.0" "1.47" "1.46.1"
+      "1.46.0" "1.46" "1.45.0" "1.45" "1.44.0" "1.44" "1.43.0" "1.43")
   else(${CMAKE_VERSION} VERSION_LESS 2.8.5)
-    SET(Boost_ADDITIONAL_VERSIONS "1.47" "1.47.0")
+    set(Boost_ADDITIONAL_VERSIONS
+      "@Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@.@Boost_SUBMINOR_VERSION@" "@Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@"
+      "1.61.0" "1.61" "1.60.0" "1.60"
+      "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"
+      "1.54.0" "1.54" "1.53.0" "1.53" "1.52.0" "1.52" "1.51.0" "1.51"
+      "1.50.0" "1.50" "1.49.0" "1.49" "1.48.0" "1.48" "1.47.0" "1.47")
   endif(${CMAKE_VERSION} VERSION_LESS 2.8.5)
   # Disable the config mode of find_package(Boost)
   set(Boost_NO_BOOST_CMAKE ON)

--- a/cmake/pcl_find_boost.cmake
+++ b/cmake/pcl_find_boost.cmake
@@ -14,9 +14,15 @@ else(PCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32 AND WIN32)
 endif(PCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32 AND WIN32)
 
 if(${CMAKE_VERSION} VERSION_LESS 2.8.5)
-  SET(Boost_ADDITIONAL_VERSIONS "1.43" "1.43.0" "1.44" "1.44.0" "1.45" "1.45.0" "1.46.1" "1.46.0" "1.46" "1.47" "1.47.0")
+  set(Boost_ADDITIONAL_VERSIONS
+    "1.47.0" "1.47" "1.46.1"
+    "1.46.0" "1.46" "1.45.0" "1.45" "1.44.0" "1.44" "1.43.0" "1.43")
 else(${CMAKE_VERSION} VERSION_LESS 2.8.5)
-  SET(Boost_ADDITIONAL_VERSIONS "1.47" "1.47.0" "1.48" "1.48.0" "1.49" "1.49.0")
+  set(Boost_ADDITIONAL_VERSIONS
+    "1.61.0" "1.61" "1.60.0" "1.60"
+    "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"
+    "1.54.0" "1.54" "1.53.0" "1.53" "1.52.0" "1.52" "1.51.0" "1.51"
+    "1.50.0" "1.50" "1.49.0" "1.49" "1.48.0" "1.48" "1.47.0" "1.47")
 endif(${CMAKE_VERSION} VERSION_LESS 2.8.5)
 
 # Disable the config mode of find_package(Boost)


### PR DESCRIPTION
This pull request will update find_boost() cmake macro for support the latest versions (1.48.0 - 1.61.0) of boost.
In Addition, Automatically adds the boost version that was used when building the PCL to PCLConfig.cmake.
This change will facilitate future management.