### PR TITLE
Fix compile error C2440 of pcl_visualization on MSVC

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1492,7 +1492,7 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
       actor->GetMapper ()->ScalarVisibilityOn ();
       actor->GetMapper ()->SetScalarRange (range[0], range[1]);
       vtkSmartPointer<vtkLookupTable> table;
-      if (!pcl::visualization::getColormapLUT (static_cast<LookUpTableRepresentationProperties>(value), table))
+      if (!pcl::visualization::getColormapLUT (static_cast<LookUpTableRepresentationProperties>(static_cast<int>(value)), table))
         break;
       table->SetRange (range[0], range[1]);
       actor->GetMapper ()->SetLookupTable (table);
@@ -1738,7 +1738,7 @@ pcl::visualization::PCLVisualizer::setShapeRenderingProperties (
       actor->GetMapper ()->ScalarVisibilityOn ();
       actor->GetMapper ()->SetScalarRange (range[0], range[1]);
       vtkSmartPointer<vtkLookupTable> table = vtkSmartPointer<vtkLookupTable>::New ();
-      getColormapLUT (static_cast<LookUpTableRepresentationProperties>(value), table);
+      getColormapLUT (static_cast<LookUpTableRepresentationProperties>(static_cast<int>(value)), table);
       table->SetRange (range[0], range[1]);
       actor->GetMapper ()->SetLookupTable (table);
       style_->updateLookUpTableDisplay (false);


### PR DESCRIPTION
The pcl_visualization occur compile error C2440 on MSVC. (issue #1634)
This error occurs because that can not directly cast to enum type from double type in MSVC.
It must explicitly cast to int type from double type before cast to enum type.