### PR TITLE
Simulation: enable returning of organized point clouds

### DIFF
--- a/simulation/include/pcl/simulation/range_likelihood.h
+++ b/simulation/include/pcl/simulation/range_likelihood.h
@@ -117,7 +117,7 @@ namespace pcl
         // global=false - PointCloud is as would be captured by an RGB-D camera [default]
         // global=true  - PointCloud is transformed into the model/world frame using the camera pose
         void getPointCloud (pcl::PointCloud<pcl::PointXYZRGB>::Ptr pc,
-              bool make_global, const Eigen::Isometry3d & pose);
+              bool make_global, const Eigen::Isometry3d & pose, bool organized = false);
 
         // Convenience function to return RangeImagePlanar containing
         // simulated RGB-D:


### PR DESCRIPTION
This pull request extends the functionality of the simulation module to return simulated point clouds in organised format as well as the default unorganised format.
The simulation module may not be complete but it is still usable for some tasks. We are using it for testing segmentation algorithms. 
Existing code would not need to be changed as the flag calling for organised point clouds defaults to the previous functionality.
Kind regards.