### PR TITLE
Simulation: more access to camera parameters

### DIFF
--- a/simulation/include/pcl/simulation/range_likelihood.h
+++ b/simulation/include/pcl/simulation/range_likelihood.h
@@ -84,11 +84,11 @@ namespace pcl
          */
         void
         setCameraIntrinsicsParameters (int camera_width_in,
-                                      int camera_height_in,
-                                      float camera_fx_in,
-                                      float camera_fy_in,
-                                      float camera_cx_in,
-                                      float camera_cy_in)
+                                       int camera_height_in,
+                                       float camera_fx_in,
+                                       float camera_fy_in,
+                                       float camera_cx_in,
+                                       float camera_cy_in)
         {
           camera_width_ = camera_width_in;
           camera_height_ = camera_height_in;
@@ -96,6 +96,25 @@ namespace pcl
           camera_fy_ = camera_fy_in;
           camera_cx_ = camera_cx_in;
           camera_cy_ = camera_cy_in;
+        }
+        
+        /**
+         * Get the basic camera intrinsic parameters
+         */
+        void
+        getCameraIntrinsicsParameters (int &camera_width_in,
+                                       int &camera_height_in,
+                                       float &camera_fx_in,
+                                       float &camera_fy_in,
+                                       float &camera_cx_in,
+                                       float &camera_cy_in)
+        {
+          camera_width_in = camera_width_;
+          camera_height_in = camera_height_;
+          camera_fx_in = camera_fx_;
+          camera_fy_in = camera_fy_;
+          camera_cx_in = camera_cx_;
+          camera_cy_in = camera_cy_;
         }
         
         /**
@@ -145,6 +164,18 @@ namespace pcl
         const float*
         getScoreBuffer ();
 
+        float 
+        getZNear (){ return z_near_; }
+        
+        float 
+        getZFar (){ return z_far_; }
+        
+        void 
+        setZNear (float z){ z_near_ = z; }
+        
+        void 
+        setZFar (float z){ z_far_ = z; }
+        
       private:
         /**
          * Evaluate the likelihood/score for a set of particles


### PR DESCRIPTION
This gives the user of the simulation module the ability to retrieve camera parameters and also to set the clipping planes, which earlier were set to arbitrary values.
We are using the simulation module in its current state and we expect others are too. 
Kind regards.
