### PR TITLE
Fixes issue #1651: aligned_malloc does not always return aligned memory

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -375,8 +375,6 @@ log2f (float x)
 
 #if defined(__APPLE__) || defined(_WIN64) || GLIBC_MALLOC_ALIGNED || FREEBSD_MALLOC_ALIGNED
   #define MALLOC_ALIGNED 1
-#else
-  #define MALLOC_ALIGNED 0
 #endif
 
 inline void*


### PR DESCRIPTION
See https://github.com/PointCloudLibrary/pcl/issues/1651.

On 32-bit Windows, for example, aligned_malloc did not use aligned memory allocation due to wrong preprocessor definitions.
Sets ALIGNED_MALLOC to 1 in case someone really checks that value.

Best,
Stefan