### PR TITLE
Redo: Simulation: enable returning of organized point clouds

### DIFF
--- a/simulation/include/pcl/simulation/range_likelihood.h
+++ b/simulation/include/pcl/simulation/range_likelihood.h
@@ -117,7 +117,7 @@ namespace pcl
         // global=false - PointCloud is as would be captured by an RGB-D camera [default]
         // global=true  - PointCloud is transformed into the model/world frame using the camera pose
         void getPointCloud (pcl::PointCloud<pcl::PointXYZRGB>::Ptr pc,
-              bool make_global, const Eigen::Isometry3d & pose);
+              bool make_global, const Eigen::Isometry3d & pose, bool organized = false);
 
         // Convenience function to return RangeImagePlanar containing
         // simulated RGB-D:


### PR DESCRIPTION
This change was applied early and subsequently reverted. Target should be 1.9.0 (ABI change).
See [https://github.com/PointCloudLibrary/pcl/pull/1649](https://github.com/PointCloudLibrary/pcl/pull/1649)
@SergioRAgostinho 
