### PR TITLE
Improve ASCIIReader::setInputFields and deprecate old version

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -298,6 +298,7 @@ if(build)
     endif(PNG_FOUND)
 
     set(impl_incs
+        "include/pcl/${SUBSYS_NAME}/impl/ascii_io.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/pcd_io.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/auto_io.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/lzf_image_io.hpp"

--- a/io/include/pcl/io/ascii_io.h
+++ b/io/include/pcl/io/ascii_io.h
@@ -101,6 +101,11 @@ namespace pcl
             Eigen::Vector4f &origin, Eigen::Quaternionf &orientation, int &file_version,
             const int offset = 0);
 
+      /** \brief Set the ascii file point fields.
+        */
+      template<typename PointT>
+      void setInputFields ();
+
       /** \brief Set the ascii file point fields using a list of fields.
         * \param[in] fields  is a list of point fields, in order, in the input ascii file
         */
@@ -112,7 +117,12 @@ namespace pcl
         * \param[in] p  a point type
         */
       template<typename PointT>
-      void setInputFields (const PointT p = PointT ());
+      PCL_DEPRECATED ("Use setInputFields<PointT> () instead")
+      inline void setInputFields (const PointT p)
+      {
+        (void) p;
+        setInputFields<PointT> ();
+      }
 
 
       /** \brief Set the Separting characters for the ascii point fields 2.
@@ -154,24 +164,9 @@ namespace pcl
 	};
 }
 
-//////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
-pcl::ASCIIReader::setInputFields (const PointT p)
-{
-  (void) p;
 
-  pcl::getFields<PointT> (fields_);
 
-  // Remove empty fields and adjust offset
-  int offset =0;
-  for (std::vector<pcl::PCLPointField>::iterator field_iter = fields_.begin ();
-       field_iter != fields_.end (); field_iter++)
-  {
-    if (field_iter->name == "_") 
-      field_iter = fields_.erase (field_iter);
-    field_iter->offset = offset;
-    offset += typeSize (field_iter->datatype);
-  }
-}
+
+#include <pcl/io/impl/ascii_io.hpp>
 
 #endif    // PCL_IO_ASCII_IO_H_

--- a/io/include/pcl/io/impl/ascii_io.hpp
+++ b/io/include/pcl/io/impl/ascii_io.hpp
@@ -1,0 +1,59 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_IO_ASCII_IO_HPP_
+#define PCL_IO_ASCII_IO_HPP_
+
+template<typename PointT> void
+pcl::ASCIIReader::setInputFields ()
+{
+  pcl::getFields<PointT> (fields_);
+
+  // Remove empty fields and adjust offset
+  int offset =0;
+  for (std::vector<pcl::PCLPointField>::iterator field_iter = fields_.begin ();
+       field_iter != fields_.end (); field_iter++)
+  {
+    if (field_iter->name == "_") 
+      field_iter = fields_.erase (field_iter);
+    field_iter->offset = offset;
+    offset += typeSize (field_iter->datatype);
+  }
+}
+
+
+#endif    //PCL_IO_ASCII_IO_HPP_

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -793,7 +793,7 @@ TEST (PCL, ASCIIReader)
   afile.close();
 
   ASCIIReader reader;
-  reader.setInputFields( pcl::PointXYZI() );
+  reader.setInputFields<pcl::PointXYZI> ();
 
   EXPECT_GE(reader.read("test_pcd.txt", rcloud), 0);
   EXPECT_EQ(cloud.points.size(), rcloud.points.size() );


### PR DESCRIPTION
Addresses the second issue in #1688.

We need to decide if we commit this to 1.8.1 or not, since it prevents compilation of the tests in MSVC. Closes #1688.