### PR TITLE
[WIP] Accelerate test builds on Travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -83,7 +83,7 @@ function test ()
         -DPCL_NO_PRECOMPILE=ON \
         $PCL_DIR
   # Build and run tests
-  make tests
+  make tests -j2
 }
 
 function doc ()


### PR DESCRIPTION
Test builds are slow because only single job is used. If I recall correctly, the reason for having a single job is that on the old infrastructure Travis chocked while linking certain test executables in parallel. Since now it's been a couple of years and also we have switched to container builds, let's try to use two jobs again.