### PR TITLE
Invalid cast to LeafNode* in OctreePointCloudVoxelCentroid

### DIFF
--- a/octree/include/pcl/octree/impl/octree_pointcloud_voxelcentroid.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_voxelcentroid.hpp
@@ -48,20 +48,16 @@ pcl::octree::OctreePointCloudVoxelCentroid<PointT, LeafContainerT, BranchContain
     const PointT& point_arg, PointT& voxel_centroid_arg) const
 {
   OctreeKey key;
-  LeafNode* leaf = 0;
+  LeafContainerT* leaf = NULL;
 
   // generate key
   genOctreeKeyforPoint (point_arg, key);
 
   leaf = this->findLeaf (key);
-
   if (leaf)
-  {
-    LeafContainerT* container = leaf;
-    container->getCentroid (voxel_centroid_arg);
-  }
+    leaf->getCentroid (voxel_centroid_arg);
 
-  return (leaf != 0);
+  return (leaf != NULL);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #960. Credits to @ThomasGuerneve for the original PR.