### PR TITLE
Fix build on Ubuntu arm64 platform

### DIFF
--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
@@ -45,6 +45,13 @@
 #include <QtGui/QColor>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 #include <pcl/apps/point_cloud_editor/statistics.h>
+#ifdef OPENGL_IS_A_FRAMEWORK
+# include <OpenGL/gl.h>
+# include <OpenGL/glu.h>
+#else
+# include <GL/gl.h>
+# include <GL/glu.h>
+#endif
 
 /// @brief A wrapper which allows to use any implementation of cloud provided by
 /// a third-party library.


### PR DESCRIPTION
This fixes the build when GL* structs are undefined.