### PR TITLE
Fixed normal accumulator vector normalization when there is no normal information (0,0,0).

### DIFF
--- a/common/include/pcl/common/impl/accumulators.hpp
+++ b/common/include/pcl/common/impl/accumulators.hpp
@@ -102,8 +102,14 @@ namespace pcl
       template <typename PointT> void
       get (PointT& t, size_t) const
       {
-        t.getNormalVector4fMap () = normal;
-        t.getNormalVector4fMap ().normalize ();
+#if EIGEN_VERSION_AT_LEAST (3, 3, 0)
+        t.getNormalVector4fMap () = normal.normalized ();
+#else
+        if (normal.squaredNorm() > 0)
+          t.getNormalVector4fMap () = normal.normalized ();
+        else
+          t.getNormalVector4fMap () = Eigen::Vector4f::Zero ();
+#endif
       }
 
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW


### PR DESCRIPTION
When accumulating points with normal fields but without being initialized (or used yet), the accumulator will fill the normal fields with nan values due to a division by zero (when normalizing the normal vector).

This is a bug that was corrected in recent versions of Eigen (they now check if the divisor is > 0).
https://bitbucket.org/eigen/eigen/commits/12f866a74661131a38c71516007ebf6fc51abd3b
https://bitbucket.org/eigen/eigen/src/e8c837cc9c68df7675b6590e559d1636fb5d8205/Eigen/src/Core/Dot.h?at=default&fileviewer=file-view-default#Dot.h-139

However, even who is using the latest version of Eigen from Ubuntu 16.04 PPA is still affected by this issue.
This can break a typical point cloud processing pipeline in the preprocessing stage, for example:
-> capture Kinect data
-> remove all points with nans
-> voxel grid downsampling
-> more preprocessing stages (such as normal estimation, that might be skipped depending on the runtime user configuration)
-> remove all points with nans
-> cloud registration
-> post processing

After the second removal of points with nans there will be no points left (since they all had nan values in their normals when the user configured the system to skip the normal estimation).

Should this be fixed on the PCL side or should it be added to a warning list for the PCL users?