### PR TITLE
Fixed missing reset of number of iterations in ndt2d.

### DIFF
--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -377,6 +377,9 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
 {
   PointCloudSource intm_cloud = output;
 
+  nr_iterations_ = 0;
+  converged_ = false;
+
   if (guess != Eigen::Matrix4f::Identity ())
   {
     transformation_ = guess;


### PR DESCRIPTION
When reusing the NormalDistributionsTransform2D class for aligning multiple point clouds for the same reference point cloud, the computeTransformation was not resetting the number of iterations, which caused later calls to the align method to only run one iteration.
