### PR TITLE
Added fast correspondence estimation using a lookup table (40-60 times faster than using a k-d tree).

### DIFF
--- a/registration/CMakeLists.txt
+++ b/registration/CMakeLists.txt
@@ -16,6 +16,7 @@ if(build)
         "include/pcl/${SUBSYS_NAME}/convergence_criteria.h"
         "include/pcl/${SUBSYS_NAME}/default_convergence_criteria.h"
         "include/pcl/${SUBSYS_NAME}/correspondence_estimation.h"
+        "include/pcl/${SUBSYS_NAME}/correspondence_estimation_lookup_table.h"
         "include/pcl/${SUBSYS_NAME}/correspondence_estimation_normal_shooting.h"
         "include/pcl/${SUBSYS_NAME}/correspondence_estimation_backprojection.h"
         "include/pcl/${SUBSYS_NAME}/correspondence_estimation_organized_projection.h"
@@ -80,6 +81,7 @@ if(build)
     set(impl_incs 
         "include/pcl/${SUBSYS_NAME}/impl/default_convergence_criteria.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/correspondence_estimation.hpp"
+        "include/pcl/${SUBSYS_NAME}/impl/correspondence_estimation_lookup_table.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/correspondence_estimation_normal_shooting.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/correspondence_estimation_backprojection.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/correspondence_estimation_organized_projection.hpp"
@@ -128,6 +130,7 @@ if(build)
     set(srcs
         src/registration.cpp
         src/correspondence_estimation.cpp
+        src/correspondence_estimation_lookup_table.cpp
         src/correspondence_estimation_normal_shooting.cpp
         src/correspondence_estimation_backprojection.cpp
         src/correspondence_estimation_organized_projection.cpp

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -213,7 +213,7 @@ namespace pcl
           * recomputed, regardless of calls to setInputTarget. Only use if you are 
           * confident that the tree will be set correctly.
           */
-        inline void
+        virtual void
         setSearchMethodTarget (const KdTreePtr &tree, 
                                bool force_no_recompute = false) 
         { 
@@ -241,7 +241,7 @@ namespace pcl
           * recomputed, regardless of calls to setInputSource. Only use if you are 
           * extremely confident that the tree will be set correctly.
           */
-        inline void
+        virtual void
         setSearchMethodSource (const KdTreeReciprocalPtr &tree, 
                                bool force_no_recompute = false) 
         { 

--- a/registration/include/pcl/registration/correspondence_estimation_lookup_table.h
+++ b/registration/include/pcl/registration/correspondence_estimation_lookup_table.h
@@ -1,0 +1,359 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2011, Willow Garage, Inc.
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ *
+ */
+
+#ifndef PCL_REGISTRATION_CORRESPONDENCE_ESTIMATION_LOOKUP_TABLE_H_
+#define PCL_REGISTRATION_CORRESPONDENCE_ESTIMATION_LOOKUP_TABLE_H_
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <pcl/pcl_macros.h>
+#include <pcl/pcl_base.h>
+#include <pcl/common/common.h>
+#include <pcl/common/transforms.h>
+#include <pcl/search/search.h>
+#include <pcl/search/kdtree.h>
+#include <pcl/registration/correspondence_types.h>
+#include <pcl/registration/correspondence_estimation.h>
+
+namespace pcl
+{
+  namespace registration
+  {
+    /** \brief @b CorrespondenceLookupTableCell represents a match between
+      * a CorrespondenceLookupTable cell and the closest point in the reference point cloud
+      *
+      * \author Carlos M. Costa
+      * \ingroup registration
+      */
+    struct CorrespondenceLookupTableCell
+    {
+      /** \brief Index of the closest point in the reference point cloud */
+      int closest_point_index;
+
+      /** \brief Distance to the closest point */
+      float distance_to_closest_point;
+
+      /** \brief Empty constructor.
+        * Sets \ref closest_point_index to 0, \ref distance_to_closest_point to FLT_MAX.
+        */
+      inline CorrespondenceLookupTableCell ()
+      : closest_point_index (0), distance_to_closest_point (std::numeric_limits<float>::max ()) {}
+
+      /** \brief Constructor. */
+      inline CorrespondenceLookupTableCell (int index, float distance)
+      : closest_point_index (index), distance_to_closest_point(distance) {}
+
+      /** \brief Empty destructor. */
+      virtual ~CorrespondenceLookupTableCell () {}
+    };
+
+    /** \brief @b LookupTable provides fast correspondence estimation
+      * by pre-computing the closest point for each cell within a uniform volume grid.
+      * It is recommended for 2D point cloud registration or 3D point cloud registration of
+      * small volumes (it requires more memory than kd-trees but it is much faster).
+      *
+      * \author Carlos M. Costa
+      * \ingroup registration
+      */
+    template <typename PointT>
+    class CorrespondenceLookupTable
+    {
+      public:
+        /** \brief Empty constructor. */
+        CorrespondenceLookupTable ()
+          : cell_resolution_ (0.01)
+          , cell_resolution_inverse_ (100.0)
+          , lookup_table_margin_ (1.0, 1.0, 1.0, 0.0)
+          , number_cells_x_ (0)
+          , number_cells_y_ (0)
+          , number_cells_z_ (0)
+          , number_of_queries_on_lookup_table_ (0)
+          , number_of_queries_on_search_tree_ (0) {}
+
+        /** \brief Empty destructor. */
+        virtual ~CorrespondenceLookupTable () {}
+
+        /** \brief Set the lookup table cell resolution.
+          * \param[in] cell_resolution is the lookup table cell size
+          */
+        inline void
+        setCellResolution (double cell_resolution) { cell_resolution_ = cell_resolution; cell_resolution_inverse_ = 1.0 / cell_resolution_; }
+
+        /** \brief Get the lookup table cell size */
+        inline double
+        getCellResolution () { return (cell_resolution_); }
+
+        /** \brief Set the lookup table margin (in x, y and z axis).
+          * \param[in] lookup_table_margin is the extra space that will be filled with extra cells around the data bounding box
+          * in order to have pre-computed correspondences available when registering point clouds that are not aligned
+          */
+        inline void
+        setLookupTableMargin (Eigen::Vector4f lookup_table_margin) { lookup_table_margin_ = lookup_table_margin; }
+
+        /** \brief Gets the lookup table margin. */
+        inline Eigen::Vector4f
+        getLookupTableMargin () { return (lookup_table_margin_); }
+
+        /** \brief Gets the lookup table minimum bounds. */
+        inline Eigen::Vector4f
+        getMinimumBounds () { return (minimum_bounds_); }
+
+        /** \brief Gets the lookup table maximum bounds. */
+        inline Eigen::Vector4f
+        getMaximumBounds () { return (maximum_bounds_); }
+
+        /** \brief Gets the number of queries performed on the lookup table */
+        inline size_t
+        getNumberOfQueriesOnLookupTable () { return (number_of_queries_on_lookup_table_); }
+
+        /** \brief Resets the number of queries performed on the lookup table */
+        inline void
+        resetNumberOfQueriesOnLookupTable () { number_of_queries_on_lookup_table_ = 0; }
+
+        /** \brief Gets the number of queries performed on the lookup table */
+        inline size_t
+        getNumberOfQueriesOnSearchTree () { return (number_of_queries_on_search_tree_); }
+
+        /** \brief Resets the number of queries performed on the lookup table */
+        inline void
+        resetNumberOfQueriesOnSearchTree () { number_of_queries_on_search_tree_ = 0; }
+
+        /**
+          * \brief Computes the lookup table minimum and maximum bounds with the additional margin that was set previously.
+          * @param pointcloud Point cloud with the data
+          * @return True if the computed bounds are valid
+          */
+        virtual bool
+        computeLookupTableBounds (const pcl::PointCloud<PointT>& pointcloud);
+
+        /**
+          * \brief Initialize the lookup table using the provided tree.
+          * @param tree Search tree with the point data
+          * @return True if the lookup table was initialized successfully
+          */
+        virtual bool
+        initLookupTable (const typename pcl::search::Search<PointT>::Ptr& tree);
+
+        /**
+         * Gets the pre-computed correspondence associated with the provided query point.
+         * @param query_point Coordinates of the query point
+         * @param maximum_correspondence_distance_squared The maximum distance squared that a valid correspondence can have
+         * @param correspondence The correspondence found for the provided query point. If the query point is outside the pre-computed cells,
+         * the search tree will be used for finding the correspondence
+         * @return True if it was found a valid correspondence
+         */
+        bool
+        getCorrespondence (const PointT& query_point, double maximum_correspondence_distance_squared, pcl::registration::CorrespondenceLookupTableCell& correspondance);
+
+      protected:
+        /** \brief 3 Dimensional array containing the pre-computed correspondences. */
+        std::vector<pcl::registration::CorrespondenceLookupTableCell> lookup_table_;
+
+        /** \brief Search tree associated with the lookup table. */
+        typename pcl::search::Search<PointT>::Ptr search_tree_;
+
+        /** \brief Resolution of the lookup table. */
+        double cell_resolution_;
+
+        /** \brief Inverse of the resolution of the lookup table. */
+        double cell_resolution_inverse_;
+
+        /** \brief Margin added to the data bounding box in order to create extra cells in the lookup table surrounding the point cloud data. */
+        Eigen::Vector4f lookup_table_margin_;
+
+        /** \brief Lookup table minimum bounds. */
+        Eigen::Vector4f minimum_bounds_;
+
+        /** \brief Lookup table maximum bounds. */
+        Eigen::Vector4f maximum_bounds_;
+
+        /** \brief Number of cells in the x dimension. */
+        size_t number_cells_x_;
+
+        /** \brief Number of cells in the y dimension. */
+        size_t number_cells_y_;
+
+        /** \brief Number of cells in the z dimension. */
+        size_t number_cells_z_;
+
+        /** \brief Number of queries performed on the lookup table */
+        size_t number_of_queries_on_lookup_table_;
+
+        /** \brief Number of queries performed on the search tree (because they were outside the lookup table bounds) */
+        size_t number_of_queries_on_search_tree_;
+    };
+
+    /** \brief @b CorrespondenceEstimationLookupTable provides fast correspondence estimation
+      * by using a lookup table with pre-computed correspondences.
+      *
+      * \author Carlos M. Costa
+      * \ingroup registration
+      */
+    template <typename PointSource, typename PointTarget, typename Scalar = float>
+    class CorrespondenceEstimationLookupTable: public CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>
+    {
+      public:
+        typedef boost::shared_ptr<CorrespondenceEstimationLookupTable<PointSource, PointTarget, Scalar> > Ptr;
+        typedef boost::shared_ptr<const CorrespondenceEstimationLookupTable<PointSource, PointTarget, Scalar> > ConstPtr;
+
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::corr_name_;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::force_no_recompute_;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::force_no_recompute_reciprocal_;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::indices_;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::tree_;
+        using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::tree_reciprocal_;
+        using PCLBase<PointSource>::deinitCompute;
+
+        typedef pcl::search::KdTree<PointTarget> KdTree;
+        typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+
+        typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
+        typedef typename KdTree::Ptr KdTreeReciprocalPtr;
+
+        typedef pcl::PointCloud<PointSource> PointCloudSource;
+        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
+        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+
+        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
+        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
+        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+
+        typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
+
+        /** \brief Empty constructor. */
+        CorrespondenceEstimationLookupTable ()
+        {
+          corr_name_  = "CorrespondenceEstimationLookupTable";
+        }
+
+        /** \brief Empty destructor. */
+        virtual ~CorrespondenceEstimationLookupTable () {}
+
+        /** \brief Get the source lookup table. */
+        inline CorrespondenceLookupTable<PointSource>&
+        getSourceCorrespondencesLookupTable () { return (source_correspondences_lookup_table_); }
+
+        /** \brief Get the target lookup table. */
+        inline CorrespondenceLookupTable<PointTarget>&
+        getTargetCorrespondencesLookupTable () { return (target_correspondences_lookup_table_); }
+
+        /** \brief Internal computation initialization. */
+        bool
+        initComputeReciprocal ();
+
+        /** \brief Internal computation initialization for reciprocal correspondences. */
+        bool
+        initCompute ();
+
+        /** \brief Provide a pointer to the search object used for finding correspondences in
+          * the source cloud (used for reciprocal correspondence finding).
+          * \param[in] tree a pointer to the spatial search object.
+          * \param[in] force_no_recompute If set to true, this tree and the associated lookup table
+          * will never be recomputed, regardless of calls to setInputSource.
+          */
+        virtual void
+        setSearchMethodSource (const KdTreeReciprocalPtr &tree,
+                               bool force_no_recompute = false)
+        {
+          CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::setSearchMethodSource (tree, force_no_recompute);
+          //if (!force_no_recompute)
+          //  source_correspondences_lookup_table_.initLookupTable(tree);
+        }
+
+        /** \brief Provide a pointer to the search object used for finding correspondences in the target cloud.
+          * \param[in] tree a pointer to the spatial search object.
+          * \param[in] force_no_recompute If set to true, this tree and the associated lookup table
+          * will never be recomputed, regardless of calls to setInputTarget.
+          */
+        virtual void
+        setSearchMethodTarget (const KdTreePtr &tree,
+                               bool force_no_recompute = false)
+        {
+          CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::setSearchMethodTarget (tree, force_no_recompute);
+          if (!force_no_recompute)
+            target_correspondences_lookup_table_.initLookupTable(tree);
+        }
+
+        /** \brief Determine the correspondences between input and target cloud.
+          * \param[out] correspondences The found correspondences (index of query point, index of target point, distance)
+          * \param[in] max_distance Maximum allowed distance between correspondences
+          */
+        virtual void
+        determineCorrespondences (pcl::Correspondences &correspondences,
+                                  double max_distance = std::numeric_limits<double>::max ());
+
+        /** \brief Determine the reciprocal correspondences between input and target cloud.
+          * A correspondence is considered reciprocal if the Src_i -> Tgt_i
+          * correspondence is the same as Tgt_i -> Src_i.
+          *
+          * \param[out] correspondences The found correspondences (index of query and target point, distance)
+          * \param[in] max_distance Maximum allowed distance between correspondences
+          */
+        virtual void
+        determineReciprocalCorrespondences (pcl::Correspondences &correspondences,
+                                            double max_distance = std::numeric_limits<double>::max ());
+
+        /** \brief Clone and cast to CorrespondenceEstimationBase */
+        virtual boost::shared_ptr< CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> >
+        clone () const
+        {
+          Ptr copy (new CorrespondenceEstimationLookupTable<PointSource, PointTarget, Scalar> (*this));
+          return (copy);
+        }
+
+      protected:
+        /** \brief LookupTable containing the pre-computed source correspondences */
+        CorrespondenceLookupTable<PointSource> source_correspondences_lookup_table_;
+
+        /** \brief LookupTable containing the pre-computed target correspondences */
+        CorrespondenceLookupTable<PointTarget> target_correspondences_lookup_table_;
+     };
+  }
+}
+
+#include <pcl/registration/impl/correspondence_estimation_lookup_table.hpp>
+
+#endif /* PCL_REGISTRATION_CORRESPONDENCE_ESTIMATION_LOOKUP_TABLE_H_ */

--- a/registration/include/pcl/registration/impl/correspondence_estimation_lookup_table.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_lookup_table.hpp
@@ -1,0 +1,283 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2011, Willow Garage, Inc.
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ *
+ */
+
+#ifndef PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_LOOKUP_TABLE_H_
+#define PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_LOOKUP_TABLE_H_
+
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointT>
+bool
+pcl::registration::CorrespondenceLookupTable<PointT>::computeLookupTableBounds (const pcl::PointCloud<PointT>& pointcloud)
+{
+  if (pointcloud.size () < 2)
+    return false;
+
+  pcl::getMinMax3D (pointcloud, minimum_bounds_, maximum_bounds_);
+  for (size_t i = 0; i < 3; ++i) {
+    minimum_bounds_ (i) -= lookup_table_margin_ (i);
+    maximum_bounds_ (i) += lookup_table_margin_ (i);
+  }
+
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointT>
+bool
+pcl::registration::CorrespondenceLookupTable<PointT>::initLookupTable (const typename pcl::search::Search<PointT>::Ptr& tree)
+{
+  if (!computeLookupTableBounds (*(tree->getInputCloud ())))
+    return false;
+
+  search_tree_ = tree;
+
+  number_cells_x_ = std::max ((size_t)(((maximum_bounds_ (0) - minimum_bounds_ (0)) * cell_resolution_inverse_) + 0.5), (size_t)1);
+  number_cells_y_ = std::max ((size_t)(((maximum_bounds_ (1) - minimum_bounds_ (1)) * cell_resolution_inverse_) + 0.5), (size_t)1);
+  number_cells_z_ = std::max ((size_t)(((maximum_bounds_ (2) - minimum_bounds_ (2)) * cell_resolution_inverse_) + 0.5), (size_t)1);
+  size_t number_cells = number_cells_z_ * number_cells_y_ * number_cells_x_;
+
+  lookup_table_.resize (number_cells);
+
+  std::vector<int> index (1);
+  std::vector<float> distance (1);
+
+  int correspondence_number = 0;
+  PointT query_point;
+  query_point.z = minimum_bounds_(2);
+
+  for (size_t z = 0; z < number_cells_z_; ++z) {
+    query_point.y = minimum_bounds_(1);
+    for (size_t y = 0; y < number_cells_y_; ++y) {
+      query_point.x = minimum_bounds_(0);
+      for (size_t x = 0; x < number_cells_x_; ++x) {
+        search_tree_->nearestKSearch (query_point, 1, index, distance);
+        pcl::registration::CorrespondenceLookupTableCell& corr = lookup_table_[correspondence_number++];
+        corr.closest_point_index = index[0];
+        corr.distance_to_closest_point = distance[0];
+        query_point.x += cell_resolution_;
+      }
+      query_point.y += cell_resolution_;
+    }
+    query_point.z += cell_resolution_;
+  }
+
+  PCL_DEBUG ("[pcl::registration::LookupTable::initLookupTable] Initialized correspondence estimation LookupTable with %f resolution containing [x:%u|y:%u|z:%u]=%u cells from a point cloud with %u points\n",
+             cell_resolution_, number_cells_x_, number_cells_y_, number_cells_z_, number_cells, tree->getInputCloud ()->size ());
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointT>
+bool
+pcl::registration::CorrespondenceLookupTable<PointT>::getCorrespondence (const PointT& query_point, double maximum_correspondence_distance_squared, pcl::registration::CorrespondenceLookupTableCell& correspondance)
+{
+  int x_index = (int)(((query_point.x - minimum_bounds_ (0)) * cell_resolution_inverse_) + 0.5);
+  int y_index = (int)(((query_point.y - minimum_bounds_ (1)) * cell_resolution_inverse_) + 0.5);
+  int z_index = (int)(((query_point.z - minimum_bounds_ (2)) * cell_resolution_inverse_) + 0.5);
+
+  size_t correspondence_index = x_index + y_index * number_cells_x_ + z_index * number_cells_x_ * number_cells_y_;
+  if (x_index >= 0 && x_index < (int)number_cells_x_ &&
+      y_index >= 0 && y_index < (int)number_cells_y_ &&
+      z_index >= 0 && z_index < (int)number_cells_z_ &&
+      correspondence_index < lookup_table_.size())
+  {
+    correspondance = lookup_table_[correspondence_index];
+    ++number_of_queries_on_lookup_table_;
+  }
+  else if (search_tree_)
+  {
+    std::vector<int> index (1);
+    std::vector<float> distance (1);
+    search_tree_->nearestKSearch (query_point, 1, index, distance);
+    correspondance.closest_point_index = index[0];
+    correspondance.distance_to_closest_point = distance[0];
+    ++number_of_queries_on_search_tree_;
+  }
+  else
+  	return false;
+
+  if (correspondance.distance_to_closest_point <= maximum_correspondence_distance_squared)
+    return true;
+  else
+    return false;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointSource, typename PointTarget, typename Scalar> bool
+pcl::registration::CorrespondenceEstimationLookupTable<PointSource, PointTarget, Scalar>::initComputeReciprocal ()
+{
+  if (CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal ())
+  {
+    if (!force_no_recompute_reciprocal_)
+      return source_correspondences_lookup_table_.initLookupTable(tree_reciprocal_);
+    return true;
+  }
+  return false;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointSource, typename PointTarget, typename Scalar> bool
+pcl::registration::CorrespondenceEstimationLookupTable<PointSource, PointTarget, Scalar>::initCompute ()
+{
+  if (CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute ())
+  {
+    if (!force_no_recompute_)
+      return target_correspondences_lookup_table_.initLookupTable(tree_);
+    return true;
+  }
+  return false;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointSource, typename PointTarget, typename Scalar> void
+pcl::registration::CorrespondenceEstimationLookupTable<PointSource, PointTarget, Scalar>::determineCorrespondences (
+    pcl::Correspondences &correspondences, double max_distance)
+{
+  if (!initCompute ())
+    return;
+
+  double max_distance_squared = max_distance * max_distance;
+  correspondences.resize (indices_->size ());
+  pcl::registration::CorrespondenceLookupTableCell correspondence_cell;
+  size_t number_valid_correspondences = 0;
+
+  if (pcl::isSamePointType<PointSource, PointTarget> ())
+  {
+    for (std::vector<int>::const_iterator input_index = indices_->begin (); input_index != indices_->end (); ++input_index)
+    {
+      if (target_correspondences_lookup_table_.getCorrespondence(input_->points[*input_index], max_distance_squared, correspondence_cell))
+      {
+        pcl::Correspondence& correspondence = correspondences[number_valid_correspondences++];
+        correspondence.index_query = *input_index;
+        correspondence.index_match = correspondence_cell.closest_point_index;
+        correspondence.distance = correspondence_cell.distance_to_closest_point;
+      }
+    }
+  }
+  else
+  {
+    PointTarget pt;
+    for (std::vector<int>::const_iterator input_index = indices_->begin (); input_index != indices_->end (); ++input_index)
+    {
+      copyPoint (input_->points[*input_index], pt);
+      if (target_correspondences_lookup_table_.getCorrespondence(input_->points[*input_index], max_distance_squared, correspondence_cell))
+      {
+      	pcl::Correspondence& correspondence = correspondences[number_valid_correspondences++];
+        correspondence.index_query = *input_index;
+        correspondence.index_match = correspondence_cell.closest_point_index;
+        correspondence.distance = correspondence_cell.distance_to_closest_point;
+      }
+    }
+  }
+  correspondences.resize (number_valid_correspondences);
+  deinitCompute ();
+
+  PCL_DEBUG ("[pcl::registration::CorrespondenceEstimationLookupTable::determineCorrespondences] Computed %u correspondences (%u using the LookupTable and %u using the search tree)\n",
+             number_valid_correspondences, target_correspondences_lookup_table_.getNumberOfQueriesOnLookupTable(), target_correspondences_lookup_table_.getNumberOfQueriesOnSearchTree());
+  target_correspondences_lookup_table_.resetNumberOfQueriesOnLookupTable();
+  target_correspondences_lookup_table_.resetNumberOfQueriesOnSearchTree();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointSource, typename PointTarget, typename Scalar> void
+pcl::registration::CorrespondenceEstimationLookupTable<PointSource, PointTarget, Scalar>::determineReciprocalCorrespondences (
+    pcl::Correspondences &correspondences, double max_distance)
+{
+  if (!initCompute ())
+    return;
+
+  if (!initComputeReciprocal())
+    return;
+
+  double max_distance_squared = max_distance * max_distance;
+  correspondences.resize (indices_->size());
+  pcl::registration::CorrespondenceLookupTableCell correspondence_cell;
+  pcl::registration::CorrespondenceLookupTableCell reciprocal_correspondence_cell;
+  unsigned int number_valid_correspondences = 0;
+
+  if (pcl::isSamePointType<PointSource, PointTarget> ())
+  {
+    for (std::vector<int>::const_iterator input_index = indices_->begin (); input_index != indices_->end (); ++input_index)
+    {
+      if (target_correspondences_lookup_table_.getCorrespondence(input_->points[*input_index], max_distance_squared, correspondence_cell) &&
+          source_correspondences_lookup_table_.getCorrespondence(target_->points[correspondence_cell.closest_point_index], max_distance_squared, reciprocal_correspondence_cell) &&
+          *input_index == reciprocal_correspondence_cell.closest_point_index)
+      {
+      	pcl::Correspondence& correspondence = correspondences[number_valid_correspondences++];
+        correspondence.index_query = *input_index;
+        correspondence.index_match = correspondence_cell.closest_point_index;
+        correspondence.distance = correspondence_cell.distance_to_closest_point;
+      }
+    }
+  }
+  else
+  {
+    PointTarget pt_src;
+    for (std::vector<int>::const_iterator input_index = indices_->begin (); input_index != indices_->end (); ++input_index)
+    {
+      pcl::copyPoint (input_->points[*input_index], pt_src);
+      if (target_correspondences_lookup_table_.getCorrespondence(input_->points[*input_index], max_distance_squared, correspondence_cell))
+      {
+        PointSource pt_tgt;
+        pcl::copyPoint (target_->points[correspondence_cell.closest_point_index], pt_tgt);
+        if (source_correspondences_lookup_table_.getCorrespondence(target_->points[correspondence_cell.closest_point_index], max_distance_squared, reciprocal_correspondence_cell) &&
+            *input_index == reciprocal_correspondence_cell.closest_point_index)
+        {
+         pcl::Correspondence& correspondence = correspondences[number_valid_correspondences++];
+          correspondence.index_query = *input_index;
+          correspondence.index_match = correspondence_cell.closest_point_index;
+          correspondence.distance = correspondence_cell.distance_to_closest_point;
+        }
+      }
+    }
+  }
+  correspondences.resize (number_valid_correspondences);
+  deinitCompute ();
+
+  PCL_DEBUG ("[pcl::registration::CorrespondenceEstimationLookupTable::determineReciprocalCorrespondences] Computed %u correspondences (%u using the LookupTable, %u using the search tree, %u using the reciprocal LookupTable and %u using the reciprocal search tree)\n",
+               number_valid_correspondences, target_correspondences_lookup_table_.getNumberOfQueriesOnLookupTable(), target_correspondences_lookup_table_.getNumberOfQueriesOnSearchTree(),
+               source_correspondences_lookup_table_.getNumberOfQueriesOnLookupTable(), source_correspondences_lookup_table_.getNumberOfQueriesOnSearchTree());
+  target_correspondences_lookup_table_.resetNumberOfQueriesOnLookupTable();
+  target_correspondences_lookup_table_.resetNumberOfQueriesOnSearchTree();
+  source_correspondences_lookup_table_.resetNumberOfQueriesOnLookupTable();
+  source_correspondences_lookup_table_.resetNumberOfQueriesOnSearchTree();
+}
+
+#endif /* PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_LOOKUP_TABLE_H_ */

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -173,6 +173,10 @@ namespace pcl
       void
       setCorrespondenceEstimation (const CorrespondenceEstimationPtr &ce) { correspondence_estimation_ = ce; }
 
+      /** \brief Get a pointer to the correspondence estimation object. */
+      inline CorrespondenceEstimationPtr
+      getCorrespondenceEstimation () { return (correspondence_estimation_); }
+
       /** \brief Provide a pointer to the input source 
         * (e.g., the point cloud that we want to align to the target)
         *

--- a/registration/src/correspondence_estimation_lookup_table.cpp
+++ b/registration/src/correspondence_estimation_lookup_table.cpp
@@ -1,0 +1,40 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2011, Willow Garage, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ *
+ */
+
+#include <pcl/registration/correspondence_estimation_lookup_table.h>


### PR DESCRIPTION
Added fast correspondence estimation using a lookup table that precomputes the closest point between each voxel grid cell and a reference point cloud.

This approach can be 40 to 60 times faster than using a k-d tree to retrieve the closest point (simple memory access vs tree search) and when used with ICP it can make point cloud registration 5 to 9 times faster.

For small volumes or for 2d point cloud registration, a lookup table can provide a significant registration speedup at the cost of higher memory usage (in relation to a k-d tree).

For real-time applications, such as 3 or 6 DoF robot self-localization, in which the sensor data is continuously registered with a static / dynamic map, fast registration and low CPU load is typically more important then memory usage. As such, this approach might be more suitable than k-d trees.

Currently, the lookup table relies on a k-d tree to initialize each voxel grid cell.
For small volumes this usually takes less than a second, but as the volume / cell resolution increases the initialization can take some time.

In the future, i'm planning to use the distance transform approach to initialize the lookup table, given that it can be much faster.