### PR TITLE
Resolved bug with ModelOutlierRemoval using indices

### DIFF
--- a/filters/include/pcl/filters/impl/model_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/model_outlier_removal.hpp
@@ -216,7 +216,9 @@ pcl::ModelOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &indices)
   // check distance of pointcloud to model
   std::vector<double> distances;
   //TODO: get signed distances !
+  model_->setIndices(indices_); // added to reduce computation and arrange distances with indices
   model_->getDistancesToModel (model_coefficients_, distances);
+
   bool thresh_result;
 
   // Filter for non-finite entries and the specified field limits
@@ -230,7 +232,7 @@ pcl::ModelOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &indices)
       continue;
     }
 
-    // use threshold function to seperate outliers from inliers: 
+    // use threshold function to separate outliers from inliers:
     thresh_result = threshold_function_ (distances[iii]);
 
     // in normal mode: define outliers as false thresh_result


### PR DESCRIPTION
I found a bug in ModelOutlierRemoval when setIndices is used.

The model_ was not initialized with the same indices giving a index misalignement when performing the threshold.

This pull request corrects this bug and optimizes the computation of distances only to the selected indices.

