### PR TITLE
Add missing typedefs to PointCloud for stl container compatibility

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -428,6 +428,14 @@ namespace pcl
       typedef boost::shared_ptr<PointCloud<PointT> > Ptr;
       typedef boost::shared_ptr<const PointCloud<PointT> > ConstPtr;
 
+      // std container compatibility typedefs according to
+      // http://en.cppreference.com/w/cpp/concept/Container
+      typedef PointT        value_type;
+      typedef PointT&       reference;
+      typedef const PointT& const_reference;
+      typedef typename VectorType::difference_type difference_type;
+      typedef typename VectorType::size_type size_type;
+
       // iterators
       typedef typename VectorType::iterator iterator;
       typedef typename VectorType::const_iterator const_iterator;


### PR DESCRIPTION
Hi there,

I added some typedefs to the PointCloud class, which should enable it to be used with more stl algorithms. This patch originates in the following [pcl-users thread](http://www.pcl-users.org/Copy-same-points-of-a-pointcloud-from-one-point-cloud-to-another-td4043071.html) where sb. wanted to copy the fields of a point cloud A into a point cloud C, but only if the xyz value was in a point cloud B.
Instead of doing that manually in a loop I thought why not use stl methods for that, specifically set_intersection. There I ran into compilation problems originating in these missing typedefs. With this patch, [the example](https://gist.github.com/stefanbuettner/7cdf64608740fee19f9bd0d589943f26#file-componentbasedpointcloudintersection-cpp) compiles and works as expected.

Best,
Stefan
