### PR TITLE
Fix bug: frame type is not correct in statistics

### DIFF
--- a/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
@@ -138,7 +138,6 @@ namespace pcl
 
         // prepare for next frame
         this->switchBuffers ();
-        i_frame_ = false;
 
         // reset object count
         object_count_ = 0;
@@ -165,6 +164,8 @@ namespace pcl
           PCL_INFO ("Total compression percentage: %f%%\n", (bytes_per_XYZ + bytes_per_color) / (sizeof (int) + 3.0f * sizeof (float)) * 100.0f);
           PCL_INFO ("Compression ratio: %f\n\n", static_cast<float> (sizeof (int) + 3.0f * sizeof (float)) / static_cast<float> (bytes_per_XYZ + bytes_per_color));
         }
+        
+        i_frame_ = false;
       } else {
         if (b_show_statistics_)
         PCL_INFO ("Info: Dropping empty point cloud\n");


### PR DESCRIPTION
In the statistics result of octree compression, frame type is always
prediction frame because i_frame_ attribute is not used in a correct
way in octree_pointcloud_compression.hpp.

'i_frame_' should be set to be false after showing statistics result.
