### PR TITLE
compile-time support for VTK7.1

### DIFF
--- a/io/include/pcl/io/impl/vtk_lib_io.hpp
+++ b/io/include/pcl/io/impl/vtk_lib_io.hpp
@@ -61,6 +61,13 @@
 #include <vtkStructuredGrid.h>
 #include <vtkVertexGlyphFilter.h>
 
+// Support for VTK 7.1 upwards
+#ifdef vtkGenericDataArray_h
+#define SetTupleValue SetTypedTuple
+#define InsertNextTupleValue InsertNextTypedTuple
+#define GetTupleValue GetTypedTuple
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::io::vtkPolyDataToPointCloud (vtkPolyData* const polydata, pcl::PointCloud<PointT>& cloud)
@@ -502,6 +509,12 @@ pcl::io::pointCloudTovtkStructuredGrid (const pcl::PointCloud<PointT>& cloud, vt
     structured_grid->GetPointData ()->AddArray (colors);
   }
 }
+
+#ifdef vtkGenericDataArray_h
+#undef SetTupleValue
+#undef InsertNextTupleValue
+#undef GetTupleValue
+#endif
 
 #endif  //#ifndef PCL_IO_VTK_IO_H_
 

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -46,6 +46,13 @@
 #include <vtkImageShiftScale.h>
 #include <vtkPNGWriter.h>
 
+// Support for VTK 7.1 upwards
+#ifdef vtkGenericDataArray_h
+#define SetTupleValue SetTypedTuple
+#define InsertNextTupleValue InsertNextTypedTuple
+#define GetTupleValue GetTypedTuple
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 int
 pcl::io::loadPolygonFile (const std::string &file_name, pcl::PolygonMesh& mesh)

--- a/surface/src/vtk_smoothing/vtk_utils.cpp
+++ b/surface/src/vtk_smoothing/vtk_utils.cpp
@@ -49,6 +49,12 @@
 #include <vtkPointData.h>
 #include <vtkFloatArray.h>
 
+// Support for VTK 7.1 upwards
+#ifdef vtkGenericDataArray_h
+#define SetTupleValue SetTypedTuple
+#define InsertNextTupleValue InsertNextTypedTuple
+#define GetTupleValue GetTypedTuple
+#endif
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 int

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -64,6 +64,13 @@
 
 #include <pcl/visualization/common/shapes.h>
 
+// Support for VTK 7.1 upwards
+#ifdef vtkGenericDataArray_h
+#define SetTupleValue SetTypedTuple
+#define InsertNextTupleValue InsertNextTypedTuple
+#define GetTupleValue GetTypedTuple
+#endif
+
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::visualization::PCLVisualizer::addPointCloud (
@@ -1842,5 +1849,11 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
 
   return (true);
 }
+
+#ifdef vtkGenericDataArray_h
+#undef SetTupleValue
+#undef InsertNextTupleValue
+#undef GetTupleValue
+#endif
 
 #endif

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -104,6 +104,13 @@
 #include <boost/filesystem.hpp>
 #include <pcl/console/parse.h>
 
+// Support for VTK 7.1 upwards
+#ifdef vtkGenericDataArray_h
+#define SetTupleValue SetTypedTuple
+#define InsertNextTupleValue InsertNextTypedTuple
+#define GetTupleValue GetTypedTuple
+#endif
+
 #if defined(_WIN32)
   // Remove macros defined in Windows.h
   #undef near


### PR DESCRIPTION
The *TupleValue function family got removed in favor of the *TypedTuple functions.

To preserve backward compatibility with older VTK versions,
this introduces local macro-overloads for the used functions.