### PR TITLE
Fix Android cross-compilation error

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -390,6 +390,8 @@ aligned_malloc (size_t size)
   ptr = _mm_malloc (size, 16);
 #elif defined (_MSC_VER)
   ptr = _aligned_malloc (size, 16);
+#elif defined (ANDROID)
+  ptr = memalign (16, size);
 #else
   #error aligned_malloc not supported on your platform
   ptr = 0;
@@ -406,6 +408,8 @@ aligned_free (void* ptr)
   ptr = _mm_free (ptr);
 #elif defined (_MSC_VER)
   _aligned_free (ptr);
+#elif defined (ANDROID)
+  free (ptr);
 #else
   #error aligned_free not supported on your platform
 #endif


### PR DESCRIPTION
39cb8b69882df46e6caa967873bebe13ada29f38 introduced a cross-compilation error
for Android where a build would fail with

[...]
pcl/common/include/pcl/pcl_macros.h:394:4: error: #error aligned_malloc not
supported on your platform
   #error aligned_malloc not supported on your platform
    ^
pcl/common/include/pcl/pcl_macros.h:410:4: error: #error aligned_free not
supported on your platform
   #error aligned_free not supported on your platform
    ^
[...]

This patch adds a new CPP branch for Android to pcl_macros.h. The calls to
memalign() and free() were checked against the malloc.h files from the
Android NDK r13b.

Fixes #1773 