### PR TITLE
visualization: Return when camera file is not open

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -189,6 +189,10 @@ pcl::visualization::PCLVisualizerInteractorStyle::loadCameraParameters (const st
   bool ret;
 
   fs.open (file.c_str ());
+  if (!fs.is_open ())
+  {
+    return (false);
+  }
   while (!fs.eof ())
   {
     getline (fs, line);


### PR DESCRIPTION
I think there is no need to enter the busy-loop when the file is not open.