### PR TITLE
Update CUDA Compute Capability

### DIFF
--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -43,7 +43,9 @@ if(CUDA_FOUND)
 	
 	# Find a complete list for CUDA compute capabilities at http://developer.nvidia.com/cuda-gpus
 
-        if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "6.5")
+        if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "8.0")
+                set(__cuda_arch_bin "2.0 2.1(2.0) 3.0 3.5 5.0 5.2 6.0 6.1")
+        elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "6.5")
                 set(__cuda_arch_bin "2.0 2.1(2.0) 3.0 3.5 5.0 5.2")
         elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "6.0")
                 set(__cuda_arch_bin "2.0 2.1(2.0) 3.0 3.5 5.0")


### PR DESCRIPTION
CUDA SDK 8.0 support for Compute Capability 2.0 – 6.x (Fermi, Kepler, Maxwell, Pascal). (issues #1733)
Note: Fermi architecture (2.x) will no longer be supported from CUDA SDK next version.