### PR TITLE
added missing include boost shared_ptr in pcl/Vertices.h

### DIFF
--- a/common/include/pcl/Vertices.h
+++ b/common/include/pcl/Vertices.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <ostream>
+#include <boost/shared_ptr.hpp>
 #include <pcl/pcl_macros.h>
 
 namespace pcl


### PR DESCRIPTION
`boost::shared_ptr` is used in the header but not included.