### PR TITLE
OrganizedConnectedComponentSegmentation fix

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
@@ -100,7 +100,7 @@ pcl::OrganizedConnectedComponentSegmentation<PointT, PointLT>::findLabeledRegion
       x = curr_x + directions [nIdx].d_x;
       y = curr_y + directions [nIdx].d_y;
       index = curr_idx + directions [nIdx].d_index;
-      if (x >= 0 && y < int(labels->width) && y >= 0 && y < int(labels->height) && labels->points[index].label == label)
+      if (x >= 0 && x < int(labels->width) && y >= 0 && y < int(labels->height) && labels->points[index].label == label)
         break;
     }
     


### PR DESCRIPTION
Fixed Issue #1798

Fixed a bug in the boundary checking code in
organized_connected_component_segmentation.hpp, line 103:

if (x >= 0 && y < int(labels->width) && y >= 0 && y < int(labels->height) && labels->points[index].label == label)
break;

Replaced the code **y** < int(labels->width) with **x** < int(labels->width), since the previous condition did not check the upper boundary of x and was obviously a typo that lead to out-of-bounds access
