### PR TITLE
Fixed bug incorrectly copying adjacent points in fromPCLPointCloud2()

### DIFF
--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -180,11 +180,14 @@ namespace pcl
     cloud.points.resize (num_points);
     uint8_t* cloud_data = reinterpret_cast<uint8_t*>(&cloud.points[0]);
 
-    // Check if we can copy adjacent points in a single memcpy
+    // Check if we can copy adjacent points in a single memcpy.  We can do so if there
+    // is exactly one field to copy and it is the same size as the source and destination
+    // point types.
     if (field_map.size() == 1 &&
         field_map[0].serialized_offset == 0 &&
         field_map[0].struct_offset == 0 &&
-        msg.point_step == sizeof(PointT))
+        field_map[0].size == msg.point_step &&
+        field_map[0].size == sizeof(PointT))
     {
       uint32_t cloud_row_step = static_cast<uint32_t> (sizeof (PointT) * cloud.width);
       const uint8_t* msg_data = &msg.data[0];


### PR DESCRIPTION
fixes #1802.
fromPCLPointCloud2() tried to copy clouds an entire row at a time, provided the source and destination point types were the same size, even if only part of each point was to be copied.  This would incorrectly overwrite all fields of the destination points with irrelevant source data.