### PR TITLE
Move RGBValue to anonymous namespace

### DIFF
--- a/io/src/oni_grabber.cpp
+++ b/io/src/oni_grabber.cpp
@@ -46,7 +46,7 @@
 #include <pcl/exceptions.h>
 #include <iostream>
 
-namespace pcl
+namespace
 {
   typedef union
   {
@@ -60,6 +60,10 @@ namespace pcl
     float float_value;
     long long_value;
   } RGBValue;
+}
+
+namespace pcl
+{
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ONIGrabber::ONIGrabber (const std::string& file_name, bool repeat, bool stream)

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -53,7 +53,7 @@
 
 using namespace pcl::io::openni2;
 
-namespace pcl
+namespace
 {
   // Treat color as chars, float32, or uint32
   typedef union


### PR DESCRIPTION
This is to avoid ODR violation when compiling with both OpenNI and OpenNI2 enabled. Fixes #1814.