### PR TITLE
Link to delayimp library for all MSVC versions

### DIFF
--- a/cmake/pcl_targets.cmake
+++ b/cmake/pcl_targets.cmake
@@ -196,7 +196,7 @@ macro(PCL_ADD_LIBRARY _name _component)
       target_link_libraries(${_name} gomp)
     endif()
 	
-	if(MSVC90 OR MSVC10)
+	if(MSVC)
 	  target_link_libraries(${_name} delayimp.lib)  # because delay load is enabled for openmp.dll
 	endif()
 


### PR DESCRIPTION
This fixes linking problems with MSVC 2015 : 

`
VCOMPD.lib(VCOMP140D.DLL) : error LNK2001: unresolved external symbol __delayLoadHelper2
`