### PR TITLE
Added number of CUDA cores per SM for Pascal GPUs

### DIFF
--- a/gpu/containers/src/initialization.cpp
+++ b/gpu/containers/src/initialization.cpp
@@ -115,8 +115,10 @@ namespace
             int Cores;
         } SMtoCores;
 
-        SMtoCores gpuArchCoresPerSM[] =  { { 0x10, 8}, { 0x11, 8}, { 0x12, 8}, { 0x13, 8}, { 0x20, 32}, { 0x21, 48}, {0x30, 192}, {0x35, 192}, {0x50, 128}, {0x52, 128}, {-1, -1} };
-
+        SMtoCores gpuArchCoresPerSM[] = {
+            {0x10,   8}, {0x11,   8}, {0x12,   8}, {0x13,  8}, {0x20,  32}, {0x21, 48}, {0x30, 192},
+            {0x35, 192}, {0x50, 128}, {0x52, 128}, {0x60, 64}, {0x61, 128}, {-1, -1}
+        };
         int index = 0;
         while (gpuArchCoresPerSM[index].SM != -1) 
         {


### PR DESCRIPTION
I'm using the kinfu code and needed this to get it to work on a GTX 1080. Numbers of cores were found at [wikipedia](https://en.wikipedia.org/wiki/CUDA#Version_features_and_specifications).