### PR TITLE
Fix out of bound memory access in linemod

### DIFF
--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -268,7 +268,7 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
       {
         copy_back_counter = 0;
 
-        for (size_t mem_index = 0; mem_index < mem_size; mem_index += 16)
+        for (size_t mem_index = 0; mem_index < mem_size_mod_16_base; mem_index += 16)
         {
           score_sums[mem_index+0]  = static_cast<unsigned short> (score_sums[mem_index+0]  + tmp_score_sums[mem_index+0]);
           score_sums[mem_index+1]  = static_cast<unsigned short> (score_sums[mem_index+1]  + tmp_score_sums[mem_index+1]);
@@ -584,7 +584,7 @@ pcl::LINEMOD::detectTemplates (const std::vector<QuantizableModality*> & modalit
       {
         copy_back_counter = 0;
 
-        for (size_t mem_index = 0; mem_index < mem_size; mem_index += 16)
+        for (size_t mem_index = 0; mem_index < mem_size_mod_16_base; mem_index += 16)
         {
           score_sums[mem_index+0]  = static_cast<unsigned short> (score_sums[mem_index+0]  + tmp_score_sums[mem_index+0]);
           score_sums[mem_index+1]  = static_cast<unsigned short> (score_sums[mem_index+1]  + tmp_score_sums[mem_index+1]);
@@ -1058,7 +1058,7 @@ pcl::LINEMOD::detectTemplatesSemiScaleInvariant (
         {
           copy_back_counter = 0;
 
-          for (size_t mem_index = 0; mem_index < mem_size; mem_index += 16)
+          for (size_t mem_index = 0; mem_index < mem_size_mod_16_base; mem_index += 16)
           {
             score_sums[mem_index+0]  = static_cast<unsigned short> (score_sums[mem_index+0]  + tmp_score_sums[mem_index+0]);
             score_sums[mem_index+1]  = static_cast<unsigned short> (score_sums[mem_index+1]  + tmp_score_sums[mem_index+1]);

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -354,7 +354,12 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
 
     detections.push_back (detection);
 
+#ifdef __SSE2__
+    aligned_free (score_sums);
+    aligned_free (tmp_score_sums);
+#else
     delete[] score_sums;
+#endif
   }
 
   // release data


### PR DESCRIPTION
For example, if mem_size is 1, score_sums[mem_index+1] to score_sums[mem_index+15] are all invalid. This causes crashes when mem_size is not a multiple of 16.

Also, number of aligned_malloc and aligned_free did not match.