### PR TITLE
Fix linemod compile errors

### DIFF
--- a/recognition/include/pcl/recognition/color_gradient_dot_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_dot_modality.h
@@ -43,75 +43,12 @@
 #include <pcl/point_types.h>
 
 #include <pcl/recognition/dot_modality.h>
+#include <pcl/recognition/point_types.h>
 #include <pcl/recognition/quantized_map.h>
 
 
 namespace pcl
 {
-
-  /** \brief A point structure for representing RGB color
-    * \ingroup common
-    */
-  struct EIGEN_ALIGN16 PointRGB
-  {
-    union
-    {
-      union
-      {
-        struct
-        {
-          uint8_t b;
-          uint8_t g;
-          uint8_t r;
-          uint8_t _unused;
-        };
-        float rgb;
-      };
-      uint32_t rgba;
-    };
-
-    inline PointRGB ()
-    {}
-
-    inline PointRGB (const uint8_t b, const uint8_t g, const uint8_t r)
-      : b (b), g (g), r (r), _unused (0)
-    {}
-
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  };
-
-
-  /** \brief A point structure representing Euclidean xyz coordinates, and the intensity value.
-    * \ingroup common
-    */
-  struct EIGEN_ALIGN16 GradientXY
-  {
-    union
-    {
-      struct
-      {
-        float x;
-        float y;
-        float angle;
-        float magnitude;
-      };
-      float data[4];
-    };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-    inline bool operator< (const GradientXY & rhs)
-    {
-      return (magnitude > rhs.magnitude);
-    }
-  };
-  inline std::ostream & operator << (std::ostream & os, const GradientXY & p)
-  {
-    os << "(" << p.x << "," << p.y << " - " << p.magnitude << ")";
-    return (os);
-  }
-
-  // --------------------------------------------------------------------------
-
   template <typename PointInT>
   class ColorGradientDOTModality
     : public DOTModality, public PCLBase<PointInT>

--- a/recognition/include/pcl/recognition/dot_modality.h
+++ b/recognition/include/pcl/recognition/dot_modality.h
@@ -35,8 +35,8 @@
  *
  */
 
-#ifndef PCL_FEATURES_QUANTIZABLE_MODALITY
-#define PCL_FEATURES_QUANTIZABLE_MODALITY
+#ifndef PCL_FEATURES_DOT_MODALITY
+#define PCL_FEATURES_DOT_MODALITY
 
 #include <vector>
 #include <pcl/pcl_macros.h>

--- a/recognition/include/pcl/recognition/point_types.h
+++ b/recognition/include/pcl/recognition/point_types.h
@@ -45,39 +45,6 @@
 
 namespace pcl
 {
-
-  /** \brief A point structure for representing RGB color
-    * \ingroup common
-    */
-  //struct EIGEN_ALIGN16 PointRGB
-  //{
-  //  union
-  //  {
-  //    union
-  //    {
-  //      struct
-  //      {
-  //        uint8_t b;
-  //        uint8_t g;
-  //        uint8_t r;
-  //        uint8_t _unused;
-  //      };
-  //      float rgb;
-  //    };
-  //    uint32_t rgba;
-  //  };
-
-  //  inline PointRGB ()
-  //  {}
-
-  //  inline PointRGB (const uint8_t b, const uint8_t g, const uint8_t r)
-  //    : b (b), g (g), r (r), _unused (0)
-  //  {}
-
-  //  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  //};
-
-
   /** \brief A point structure representing Euclidean xyz coordinates, and the intensity value.
     * \ingroup common
     */


### PR DESCRIPTION
* Two files had the same "#ifndef PCL_FEATURES_QUANTIZABLE_MODALITY"
* Two files had the same GradientXY structure defined