### PR TITLE
avoid non-existing phantom meshes and speed up for marching_cubes_hoppe

### DIFF
--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -309,8 +309,8 @@ pcl::MarchingCubes<PointNT>::performReconstructionProc ()
   // and copy the point cloud + connectivity into output
   intermediate_cloud_.clear();
 
-  // preallocate memory assuming a hull
-  intermediate_cloud_.reserve((size_t)(res_y_*res_z_ + res_x_*res_z_ + res_x_*res_y_) * 2);
+  // preallocate memory assuming a hull. suppose 6 point per voxel
+  intermediate_cloud_.reserve((size_t)(res_y_*res_z_ + res_x_*res_z_ + res_x_*res_y_) * 2 * 6);
 
   for (int x = 1; x < res_x_-1; ++x)
     for (int y = 1; y < res_y_-1; ++y)

--- a/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
@@ -60,8 +60,16 @@ pcl::MarchingCubesHoppe<PointNT>::~MarchingCubesHoppe ()
 template <typename PointNT> void
 pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
 {
+  const bool is_far_ignored = dist_ignore_ > 0.0f;
+
   for (int x = 0; x < res_x_; ++x)
+  {
+    const int y_start = x * res_y_*res_z_;
+
     for (int y = 0; y < res_y_; ++y)
+    {
+      const int z_start = y_start + y * res_z_;
+
       for (int z = 0; z < res_z_; ++z)
       {
         std::vector<int> nn_indices;
@@ -77,9 +85,12 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
 
         tree_->nearestKSearch (p, 1, nn_indices, nn_sqr_dists);
 
-        grid_[x * res_y_*res_z_ + y * res_z_ + z] = input_->points[nn_indices[0]].getNormalVector3fMap ().dot (
-            point - input_->points[nn_indices[0]].getVector3fMap ());
+        if(!is_far_ignored || nn_sqr_dists.front() > dist_ignore_)
+          grid_[z_start + z] = input_->points[nn_indices[0]].getNormalVector3fMap ().dot (
+              point - input_->points[nn_indices[0]].getVector3fMap ());
       }
+    }
+  }
 }
 
 

--- a/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
@@ -85,7 +85,7 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
 
         tree_->nearestKSearch (p, 1, nn_indices, nn_sqr_dists);
 
-        if(!is_far_ignored || nn_sqr_dists.front() > dist_ignore_)
+        if(!is_far_ignored || nn_sqr_dists.front() < dist_ignore_)
           grid_[z_start + z] = input_->points[nn_indices[0]].getNormalVector3fMap ().dot (
               point - input_->points[nn_indices[0]].getVector3fMap ());
       }

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -465,6 +465,10 @@ namespace pcl
        * or distance between voxel centroid and point are larger that it. */
       float dist_ignore_;
 
+      /** \brief the point cloud really generated from Marching Cubes
+       */
+      pcl::PointCloud<PointNT> intermediate_cloud_;
+
       /** \brief Convert the point cloud into voxel data. */
       virtual void
       voxelizeData () = 0;
@@ -486,8 +490,8 @@ namespace pcl
         * \param cloud point cloud to store the vertices of the polygon
        */
       void
-      createSurface (std::vector<float> &leaf_node,
-                     Eigen::Vector3i &index_3d,
+      createSurface (const std::vector<float> &leaf_node,
+                     const Eigen::Vector3i &index_3d,
                      pcl::PointCloud<PointNT> &cloud);
 
       /** \brief Get the bounding box for the input data points. */
@@ -525,6 +529,11 @@ namespace pcl
        virtual void
        performReconstruction (pcl::PointCloud<PointNT> &points,
                               std::vector<pcl::Vertices> &polygons);
+
+        /** \brief real marching cube part. called in two performReconstruction-s
+          */
+        virtual void
+        performReconstructionProc ();
 
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -430,6 +430,19 @@ namespace pcl
       getPercentageExtendGrid ()
       { return percentage_extend_grid_; }
 
+      /** \brief Method that sets the parameter that defines the distance to ignore the distance to ignore
+        * a grid
+        * \param[in] threshold of distance. if it is negative, then calculate in all grids; otherwise
+        * ignore grids with distance to point cloud(to nearest point) larger than distIgnore
+        */
+      inline void
+      setDistanceIgnore (float distIgnore)
+      { dist_ignore_ = distIgnore; }
+
+//      inline void // TODO need to reorder functions to make it valid
+//      setDistanceIgnoreToGridDiagram ()
+//      { dist_ignore_ = (max_p_ - min_p_).cwiseQuotient(Eigen::Vector3f(res_x_, res_y_, res_z_)).norm(); }
+
     protected:
       /** \brief The data structure storing the 3D grid */
       std::vector<float> grid_;
@@ -446,6 +459,11 @@ namespace pcl
 
       /** \brief The iso level to be extracted. */
       float iso_level_;
+
+      /** \brief ignore the distance function
+       * if it is negative
+       * or distance between voxel centroid and point are larger that it. */
+      float dist_ignore_;
 
       /** \brief Convert the point cloud into voxel data. */
       virtual void

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -439,10 +439,6 @@ namespace pcl
       setDistanceIgnore (float distIgnore)
       { dist_ignore_ = distIgnore; }
 
-//      inline void // TODO need to reorder functions to make it valid
-//      setDistanceIgnoreToGridDiagram ()
-//      { dist_ignore_ = (max_p_ - min_p_).cwiseQuotient(Eigen::Vector3f(res_x_, res_y_, res_z_)).norm(); }
-
     protected:
       /** \brief The data structure storing the 3D grid */
       std::vector<float> grid_;

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -63,6 +63,7 @@ namespace pcl
       using MarchingCubes<PointNT>::res_z_;
       using MarchingCubes<PointNT>::min_p_;
       using MarchingCubes<PointNT>::max_p_;
+      using MarchingCubes<PointNT>::dist_ignore_;
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 


### PR DESCRIPTION
our marching cube method is slow and phantom-prone due to sdf on each grid. this may be okay for some object reconstruction, but for my project of scene reconstruction it is annoying. thus i discard the grids which are far away from point cloud(should have no effect if the threshold is not set or set to non-positive). as i do computation remotely on lab computer, there are redundant commits