### PR TITLE
registration/bfgs.h: PVS-Studio: identical sub-expressions to the left and to the right of the '!=' operator.

### DIFF
--- a/registration/include/pcl/registration/bfgs.h
+++ b/registration/include/pcl/registration/bfgs.h
@@ -437,7 +437,7 @@ BFGS<FunctorType>::interpolate (Scalar a, Scalar fa, Scalar fpa,
   // Ensure ymin <= ymax
   if (ymin > ymax) { Scalar tmp = ymin; ymin = ymax; ymax = tmp; };
 
-  if (order > 2 && !(fpb != fpb) && fpb != std::numeric_limits<Scalar>::infinity ()) 
+  if (order > 2 && !(fpb != fpa) && fpb != std::numeric_limits<Scalar>::infinity ())
   {
     fpa = fpa * (b - a);
     fpb = fpb * (b - a);


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V501](https://www.viva64.com/en/w/V501/) There are identical sub-expressions to the left and to the right of the '!=' operator: fpb != fpb bfgs.h 440
