### PR TITLE
src/linemod.cpp: PVS-Studio: CWE-762 Mismatched Memory Management Routines.

### DIFF
--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -354,7 +354,7 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
 
     detections.push_back (detection);
 
-    delete[] score_sums;
+    free(score_sums);
   }
 
   // release data


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V611](https://www.viva64.com/en/w/V611/) The memory was allocated using 'malloc/realloc' function but was released using the 'delete' operator. Consider inspecting operation logics behind the 'score_sums' variable. linemod.cpp 357
