### PR TITLE
spatial restriction for marching cube hoppe to avoid phantom surfaces…

### DIFF
--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -44,8 +44,12 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT>
-pcl::MarchingCubes<PointNT>::MarchingCubes () 
-: percentage_extend_grid_ (), iso_level_ (), dist_ignore_ (-1.0f)
+pcl::MarchingCubes<PointNT>::MarchingCubes (const float percentage_extend_grid,
+                                            const float iso_level,
+                                            const float dist_ignore)
+: percentage_extend_grid_ (percentage_extend_grid), 
+  iso_level_ (iso_level), 
+  dist_ignore_ (dist_ignore)
 {
 }
 
@@ -66,25 +70,10 @@ pcl::MarchingCubes<PointNT>::getBoundingBox (Eigen::Vector3f &upper_boundary,
   lower_boundary = min_pt.getVector3fMap ();
   upper_boundary = max_pt.getVector3fMap ();
 
-  Eigen::Vector3f size3_extend = 0.5f * percentage_extend_grid_ * (upper_boundary - lower_boundary);
+  const Eigen::Vector3f size3_extend = 0.5f * percentage_extend_grid_ * (upper_boundary - lower_boundary);
 
   lower_boundary -= size3_extend;
   upper_boundary += size3_extend;
-
-  Eigen::Vector3f bounding_box_size = upper_boundary - lower_boundary;
-
-  PCL_DEBUG ("[pcl::MarchingCubesHoppe::getBoundingBox] Size of Bounding Box is [%f, %f, %f]\n",
-             bounding_box_size.x (), bounding_box_size.y (), bounding_box_size.z ());
-  double max_size =
-      (std::max) ((std::max)(bounding_box_size.x (), bounding_box_size.y ()),
-          bounding_box_size.z ());
-  (void)max_size;
-  // ????
-  //  data_size_ = static_cast<uint64_t> (max_size / leaf_size_);
-  PCL_DEBUG ("[pcl::MarchingCubesHoppe::getBoundingBox] Lower left point is [%f, %f, %f]\n",
-             lower_boundary.x (), lower_boundary.y (), lower_boundary.z ());
-  PCL_DEBUG ("[pcl::MarchingCubesHoppe::getBoundingBox] Upper left point is [%f, %f, %f]\n",
-             upper_boundary.x (), upper_boundary.y (), upper_boundary.z ());
 }
 
 

--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -239,8 +239,6 @@ pcl::MarchingCubes<PointNT>::performReconstruction (pcl::PointCloud<PointNT> &po
   // the point cloud really generated from Marching Cubes, prev intermediate_cloud_
   pcl::PointCloud<PointNT> intermediate_cloud;
 
-  Eigen::Array3f upper_boundary, lower_boundary;
-
   // Create grid
   grid_ = std::vector<float> (res_x_*res_y_*res_z_, NAN);
 

--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -61,10 +61,8 @@ pcl::MarchingCubes<PointNT>::getBoundingBox ()
   const Eigen::Array3f size3_extend = 0.5f * percentage_extend_grid_ 
     * (upper_boundary_ - lower_boundary_);
 
-  //lower_boundary_ -= size3_extend;
-  //upper_boundary_ += size3_extend;
-  lower_boundary_ -= (upper_boundary_-lower_boundary_)*percentage_extend_grid_/2;
-  upper_boundary_ += (upper_boundary_-lower_boundary_)*percentage_extend_grid_/2;
+  lower_boundary_ -= size3_extend;
+  upper_boundary_ += size3_extend;
 }
 
 

--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -237,7 +237,7 @@ pcl::MarchingCubes<PointNT>::performReconstruction (pcl::PolygonMesh &output)
 
   performReconstruction (points, output.polygons);
 
-  pcl::toPCLPointCloud2(points, output.cloud);
+  pcl::toPCLPointCloud2 (points, output.cloud);
 }
 
 
@@ -273,10 +273,12 @@ pcl::MarchingCubes<PointNT>::performReconstruction (pcl::PointCloud<PointNT> &po
 
   // Run the actual marching cubes algorithm, store it into a point cloud,
   // and copy the point cloud + connectivity into output
-  intermediate_cloud.clear();
+  intermediate_cloud.clear ();
 
   // preallocate memory assuming a hull. suppose 6 point per voxel
-  intermediate_cloud.reserve((size_t)(res_y_*res_z_ + res_x_*res_z_ + res_x_*res_y_) * 2 * 6);
+  double size_reserve = std::min((double) intermediate_cloud.points.max_size (),
+      2.0 * 6.0 * (double) (res_y_*res_z_ + res_x_*res_z_ + res_x_*res_y_));
+  intermediate_cloud.reserve ((size_t) size_reserve);
 
   for (int x = 1; x < res_x_-1; ++x)
     for (int y = 1; y < res_y_-1; ++y)
@@ -289,7 +291,7 @@ pcl::MarchingCubes<PointNT>::performReconstruction (pcl::PointCloud<PointNT> &po
           createSurface (leaf_node, index_3d, intermediate_cloud);
       }
 
-  points.swap(intermediate_cloud);
+  points.swap (intermediate_cloud);
 
   polygons.resize (points.size () / 3);
   for (size_t i = 0; i < polygons.size (); ++i)

--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -45,7 +45,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT>
 pcl::MarchingCubes<PointNT>::MarchingCubes () 
-: min_p_ (), max_p_ (), percentage_extend_grid_ (), iso_level_ ()
+: min_p_ (), max_p_ (), percentage_extend_grid_ (), iso_level_ (), dist_ignore_ (-1.0f)
 {
 }
 
@@ -97,8 +97,8 @@ pcl::MarchingCubes<PointNT>::interpolateEdge (Eigen::Vector3f &p1,
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT> void
-pcl::MarchingCubes<PointNT>::createSurface (std::vector<float> &leaf_node,
-                                            Eigen::Vector3i &index_3d,
+pcl::MarchingCubes<PointNT>::createSurface (const std::vector<float> &leaf_node,
+                                            const Eigen::Vector3i &index_3d,
                                             pcl::PointCloud<PointNT> &cloud)
 {
   int cubeindex = 0;
@@ -191,7 +191,7 @@ template <typename PointNT> void
 pcl::MarchingCubes<PointNT>::getNeighborList1D (std::vector<float> &leaf,
                                                 Eigen::Vector3i &index3d)
 {
-  leaf = std::vector<float> (8, 0.0f);
+  leaf.resize(8);
 
   leaf[0] = getGridValue (index3d);
   leaf[1] = getGridValue (index3d + Eigen::Vector3i (1, 0, 0));
@@ -201,6 +201,15 @@ pcl::MarchingCubes<PointNT>::getNeighborList1D (std::vector<float> &leaf,
   leaf[5] = getGridValue (index3d + Eigen::Vector3i (1, 1, 0));
   leaf[6] = getGridValue (index3d + Eigen::Vector3i (1, 1, 1));
   leaf[7] = getGridValue (index3d + Eigen::Vector3i (0, 1, 1));
+
+  for(int i = 0; i < 8; ++i)
+  {
+    if(std::isnan(leaf[i]))
+    {
+      leaf.clear();
+      break;
+    }
+  }
 }
 
 
@@ -233,36 +242,12 @@ pcl::MarchingCubes<PointNT>::performReconstruction (pcl::PolygonMesh &output)
     return;
   }
 
-  // Create grid
-  grid_ = std::vector<float> (res_x_*res_y_*res_z_, 0.0f);
+  // real part of marching cube
+  performReconstructionProc();
 
-  // Populate tree
-  tree_->setInputCloud (input_);
+  pcl::toPCLPointCloud2 (intermediate_cloud_, output.cloud);
 
-  getBoundingBox ();
-
-  // Transform the point cloud into a voxel grid
-  // This needs to be implemented in a child class
-  voxelizeData ();
-
-
-
-  // Run the actual marching cubes algorithm, store it into a point cloud,
-  // and copy the point cloud + connectivity into output
-  pcl::PointCloud<PointNT> cloud;
-
-  for (int x = 1; x < res_x_-1; ++x)
-    for (int y = 1; y < res_y_-1; ++y)
-      for (int z = 1; z < res_z_-1; ++z)
-      {
-        Eigen::Vector3i index_3d (x, y, z);
-        std::vector<float> leaf_node;
-        getNeighborList1D (leaf_node, index_3d);
-        createSurface (leaf_node, index_3d, cloud);
-      }
-  pcl::toPCLPointCloud2 (cloud, output.cloud);
-
-  output.polygons.resize (cloud.size () / 3);
+  output.polygons.resize (intermediate_cloud_.size () / 3);
   for (size_t i = 0; i < output.polygons.size (); ++i)
   {
     pcl::Vertices v;
@@ -288,30 +273,10 @@ pcl::MarchingCubes<PointNT>::performReconstruction (pcl::PointCloud<PointNT> &po
     return;
   }
 
-  // Create grid
-  grid_ = std::vector<float> (res_x_*res_y_*res_z_, 0.0f);
+  // real part of marching cube
+  performReconstructionProc();
 
-  // Populate tree
-  tree_->setInputCloud (input_);
-
-  getBoundingBox ();
-
-  // Transform the point cloud into a voxel grid
-  // This needs to be implemented in a child class
-  voxelizeData ();
-
-  // Run the actual marching cubes algorithm, store it into a point cloud,
-  // and copy the point cloud + connectivity into output
-  points.clear ();
-  for (int x = 1; x < res_x_-1; ++x)
-    for (int y = 1; y < res_y_-1; ++y)
-      for (int z = 1; z < res_z_-1; ++z)
-      {
-        Eigen::Vector3i index_3d (x, y, z);
-        std::vector<float> leaf_node;
-        getNeighborList1D (leaf_node, index_3d);
-        createSurface (leaf_node, index_3d, points);
-      }
+  points.swap(intermediate_cloud_);
 
   polygons.resize (points.size () / 3);
   for (size_t i = 0; i < polygons.size (); ++i)
@@ -324,6 +289,40 @@ pcl::MarchingCubes<PointNT>::performReconstruction (pcl::PointCloud<PointNT> &po
   }
 }
 
+template <typename PointNT> void
+pcl::MarchingCubes<PointNT>::performReconstructionProc ()
+{
+  // Create grid
+  // grid_ = std::vector<float> (res_x_*res_y_*res_z_, 0.0f);
+  grid_ = std::vector<float> (res_x_*res_y_*res_z_, NAN);
+
+  // Populate tree
+  tree_->setInputCloud (input_);
+
+  getBoundingBox ();
+
+  // Transform the point cloud into a voxel grid
+  // This needs to be implemented in a child class
+  voxelizeData ();
+
+  // Run the actual marching cubes algorithm, store it into a point cloud,
+  // and copy the point cloud + connectivity into output
+  intermediate_cloud_.clear();
+
+  // preallocate memory assuming a hull. suppose 6 point per voxel
+  intermediate_cloud_.reserve((size_t)(res_y_*res_z_ + res_x_*res_z_ + res_x_*res_y_) * 2 * 6);
+
+  for (int x = 1; x < res_x_-1; ++x)
+    for (int y = 1; y < res_y_-1; ++y)
+      for (int z = 1; z < res_z_-1; ++z)
+      {
+        Eigen::Vector3i index_3d (x, y, z);
+        std::vector<float> leaf_node;
+        getNeighborList1D (leaf_node, index_3d);
+        if(!leaf_node.empty())
+          createSurface (leaf_node, index_3d, intermediate_cloud_);
+      }
+}
 
 
 #define PCL_INSTANTIATE_MarchingCubes(T) template class PCL_EXPORTS pcl::MarchingCubes<T>;

--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -61,8 +61,10 @@ pcl::MarchingCubes<PointNT>::getBoundingBox ()
   const Eigen::Array3f size3_extend = 0.5f * percentage_extend_grid_ 
     * (upper_boundary_ - lower_boundary_);
 
-  lower_boundary_ -= size3_extend;
-  upper_boundary_ += size3_extend;
+  //lower_boundary_ -= size3_extend;
+  //upper_boundary_ += size3_extend;
+  lower_boundary_ -= (upper_boundary_-lower_boundary_)*percentage_extend_grid_/2;
+  upper_boundary_ += (upper_boundary_-lower_boundary_)*percentage_extend_grid_/2;
 }
 
 

--- a/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
@@ -44,13 +44,6 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT>
-pcl::MarchingCubesHoppe<PointNT>::MarchingCubesHoppe ()
-  : MarchingCubes<PointNT> ()
-{
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointNT>
 pcl::MarchingCubesHoppe<PointNT>::~MarchingCubesHoppe ()
 {
 }
@@ -58,13 +51,9 @@ pcl::MarchingCubesHoppe<PointNT>::~MarchingCubesHoppe ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT> void
-pcl::MarchingCubesHoppe<PointNT>::voxelizeData (const Eigen::Vector3f &upper_boundary,
-                                                const Eigen::Vector3f &lower_boundary)
+pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
 {
   const bool is_far_ignored = dist_ignore_ > 0.0f;
-
-  const Eigen::Vector3f delta = (upper_boundary - lower_boundary).cwiseQuotient (
-      Eigen::Vector3f (res_x_, res_y_, res_z_));
 
   for (int x = 0; x < res_x_; ++x)
   {
@@ -78,7 +67,7 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData (const Eigen::Vector3f &upper_bou
       {
         std::vector<int> nn_indices (1, 0);
         std::vector<float> nn_sqr_dists (1, 0.0f);
-        const Eigen::Vector3f point = lower_boundary + delta.cwiseProduct (Eigen::Vector3f (x, y, z));
+        const Eigen::Vector3f point = (lower_boundary_ + size_voxel_ * Eigen::Array3f (x, y, z)).matrix ();
         PointNT p;
 
         p.getVector3fMap () = point;

--- a/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
@@ -62,9 +62,9 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
 {
   const bool is_far_ignored = dist_ignore_ > 0.0f;
 
-  const Eigen::Vector3f min_p = min_p_.segment(0, 3);
-  const Eigen::Vector3f delta = ( max_p_ - min_p_ ).segment(0, 3).cwiseQuotient(
-        Eigen::Vector3f((float)res_x_, (float)res_y_, (float)res_z_) );
+  const Eigen::Vector3f min_p = min_p_.segment (0, 3);
+  const Eigen::Vector3f delta = ( max_p_ - min_p_ ).segment (0, 3).cwiseQuotient (
+      Eigen::Vector3f (res_x_, res_y_, res_z_));
 
   for (int x = 0; x < res_x_; ++x)
   {
@@ -76,9 +76,9 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
 
       for (int z = 0; z < res_z_; ++z)
       {
-        std::vector<int> nn_indices(1, 0);
-        std::vector<float> nn_sqr_dists(1, 0.0f);
-        const Eigen::Vector3f point = min_p + delta.cwiseProduct(Eigen::Vector3f(x, y, z));
+        std::vector<int> nn_indices (1, 0);
+        std::vector<float> nn_sqr_dists (1, 0.0f);
+        const Eigen::Vector3f point = min_p + delta.cwiseProduct (Eigen::Vector3f (x, y, z));
         PointNT p;
 
         p.getVector3fMap () = point;
@@ -89,7 +89,7 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
         {
           const Eigen::Vector3f normal = input_->points[nn_indices[0]].getNormalVector3fMap ();
 
-          if(normal.norm() > 0.5f)
+          if(!std::isnan (normal(0)) && normal.norm () > 0.5f)
             grid_[z_start + z] = normal.dot (
                 point - input_->points[nn_indices[0]].getVector3fMap ());
         }

--- a/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
@@ -74,11 +74,11 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
 
         tree_->nearestKSearch (p, 1, nn_indices, nn_sqr_dists);
 
-        if( !is_far_ignored || nn_sqr_dists[0] < dist_ignore_ )
+        if (!is_far_ignored || nn_sqr_dists[0] < dist_ignore_)
         {
           const Eigen::Vector3f normal = input_->points[nn_indices[0]].getNormalVector3fMap ();
 
-          if(!std::isnan (normal(0)) && normal.norm () > 0.5f)
+          if (!std::isnan (normal (0)) && normal.norm () > 0.5f)
             grid_[z_start + z] = normal.dot (
                 point - input_->points[nn_indices[0]].getVector3fMap ());
         }

--- a/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
@@ -58,12 +58,12 @@ pcl::MarchingCubesHoppe<PointNT>::~MarchingCubesHoppe ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT> void
-pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
+pcl::MarchingCubesHoppe<PointNT>::voxelizeData (const Eigen::Vector3f &upper_boundary,
+                                                const Eigen::Vector3f &lower_boundary)
 {
   const bool is_far_ignored = dist_ignore_ > 0.0f;
 
-  const Eigen::Vector3f min_p = min_p_.segment (0, 3);
-  const Eigen::Vector3f delta = ( max_p_ - min_p_ ).segment (0, 3).cwiseQuotient (
+  const Eigen::Vector3f delta = (upper_boundary - lower_boundary).cwiseQuotient (
       Eigen::Vector3f (res_x_, res_y_, res_z_));
 
   for (int x = 0; x < res_x_; ++x)
@@ -78,7 +78,7 @@ pcl::MarchingCubesHoppe<PointNT>::voxelizeData ()
       {
         std::vector<int> nn_indices (1, 0);
         std::vector<float> nn_sqr_dists (1, 0.0f);
-        const Eigen::Vector3f point = min_p + delta.cwiseProduct (Eigen::Vector3f (x, y, z));
+        const Eigen::Vector3f point = lower_boundary + delta.cwiseProduct (Eigen::Vector3f (x, y, z));
         PointNT p;
 
         p.getVector3fMap () = point;

--- a/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
@@ -47,25 +47,16 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT>
-pcl::MarchingCubesRBF<PointNT>::MarchingCubesRBF ()
-  : MarchingCubes<PointNT> (),
-    off_surface_epsilon_ (0.1f)
-{
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointNT>
 pcl::MarchingCubesRBF<PointNT>::~MarchingCubesRBF ()
 {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT> void
-pcl::MarchingCubesRBF<PointNT>::voxelizeData (const Eigen::Vector3f &upper_boundary,
-                                              const Eigen::Vector3f &lower_boundary)
+pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
 {
   // Initialize data structures
-  unsigned int N = static_cast<unsigned int> (input_->size ());
+  const unsigned int N = static_cast<unsigned int> (input_->size ());
   Eigen::MatrixXd M (2*N, 2*N),
                   d (2*N, 1);
 
@@ -100,15 +91,13 @@ pcl::MarchingCubesRBF<PointNT>::voxelizeData (const Eigen::Vector3f &upper_bound
     weights[i + N] = w (i + N, 0);
   }
 
-  const Eigen::Vector3d delta = (upper_boundary - lower_boundary).cast<double> ().cwiseQuotient (
-      Eigen::Vector3d (res_x_, res_y_, res_z_));
-  const Eigen::Vector3d base = lower_boundary.cast<double> ();
-
   for (int x = 0; x < res_x_; ++x)
     for (int y = 0; y < res_y_; ++y)
       for (int z = 0; z < res_z_; ++z)
       {
-        Eigen::Vector3d point = base + delta.cwiseProduct (Eigen::Vector3d (x, y, z));
+        const Eigen::Vector3f point_f = (lower_boundary_ + size_voxel_ * Eigen::Array3f (x, y, z)).matrix ();
+        const Eigen::Vector3d point = point_f.cast<double> ();
+//          .matrix ().cast<double> ();
 
         double f = 0.0;
         std::vector<double>::const_iterator w_it (weights.begin());

--- a/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
@@ -95,9 +95,9 @@ pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
     for (int y = 0; y < res_y_; ++y)
       for (int z = 0; z < res_z_; ++z)
       {
-        const Eigen::Vector3f point_f = (lower_boundary_ + size_voxel_ * Eigen::Array3f (x, y, z)).matrix ();
+        const Eigen::Vector3f point_f = (size_voxel_ * Eigen::Array3f (x, y, z) 
+            + lower_boundary_).matrix ();
         const Eigen::Vector3d point = point_f.cast<double> ();
-//          .matrix ().cast<double> ();
 
         double f = 0.0;
         std::vector<double>::const_iterator w_it (weights.begin());

--- a/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
@@ -61,7 +61,8 @@ pcl::MarchingCubesRBF<PointNT>::~MarchingCubesRBF ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT> void
-pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
+pcl::MarchingCubesRBF<PointNT>::voxelizeData (const Eigen::Vector3f &upper_boundary,
+                                              const Eigen::Vector3f &lower_boundary)
 {
   // Initialize data structures
   unsigned int N = static_cast<unsigned int> (input_->size ());
@@ -99,14 +100,15 @@ pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
     weights[i + N] = w (i + N, 0);
   }
 
+  const Eigen::Vector3d delta = (upper_boundary - lower_boundary).cast<double> ().cwiseQuotient (
+      Eigen::Vector3d (res_x_, res_y_, res_z_));
+  const Eigen::Vector3d base = lower_boundary.cast<double> ();
+
   for (int x = 0; x < res_x_; ++x)
     for (int y = 0; y < res_y_; ++y)
       for (int z = 0; z < res_z_; ++z)
       {
-        Eigen::Vector3d point;
-        point[0] = min_p_[0] + (max_p_[0] - min_p_[0]) * float (x) / float (res_x_);
-        point[1] = min_p_[1] + (max_p_[1] - min_p_[1]) * float (y) / float (res_y_);
-        point[2] = min_p_[2] + (max_p_[2] - min_p_[2]) * float (z) / float (res_z_);
+        Eigen::Vector3d point = base + delta.cwiseProduct (Eigen::Vector3d (x, y, z));
 
         double f = 0.0;
         std::vector<double>::const_iterator w_it (weights.begin());

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -430,6 +430,15 @@ namespace pcl
       getPercentageExtendGrid ()
       { return percentage_extend_grid_; }
 
+      /** \brief Method that sets the parameter that defines the distance to ignore the distance to ignore
+        * a grid
+        * \param[in] threshold of distance. if it is negative, then calculate in all grids; otherwise
+        * ignore grids with distance to point cloud(to nearest point) larger than distIgnore
+        */
+      inline void
+      setDistanceIgnore (float distIgnore)
+      { dist_ignore_ = distIgnore; }
+
     protected:
       /** \brief The data structure storing the 3D grid */
       std::vector<float> grid_;
@@ -446,6 +455,15 @@ namespace pcl
 
       /** \brief The iso level to be extracted. */
       float iso_level_;
+
+      /** \brief ignore the distance function
+       * if it is negative
+       * or distance between voxel centroid and point are larger that it. */
+      float dist_ignore_;
+
+      /** \brief the point cloud really generated from Marching Cubes
+       */
+      pcl::PointCloud<PointNT> intermediate_cloud_;
 
       /** \brief Convert the point cloud into voxel data. */
       virtual void
@@ -468,8 +486,8 @@ namespace pcl
         * \param cloud point cloud to store the vertices of the polygon
        */
       void
-      createSurface (std::vector<float> &leaf_node,
-                     Eigen::Vector3i &index_3d,
+      createSurface (const std::vector<float> &leaf_node,
+                     const Eigen::Vector3i &index_3d,
                      pcl::PointCloud<PointNT> &cloud);
 
       /** \brief Get the bounding box for the input data points. */
@@ -507,6 +525,11 @@ namespace pcl
        virtual void
        performReconstruction (pcl::PointCloud<PointNT> &points,
                               std::vector<pcl::Vertices> &polygons);
+
+        /** \brief real marching cube part. called in two performReconstruction-s
+          */
+        virtual void
+        performReconstructionProc ();
 
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -461,10 +461,6 @@ namespace pcl
        * or distance between voxel centroid and point are larger that it. */
       float dist_ignore_;
 
-      /** \brief the point cloud really generated from Marching Cubes
-       */
-      pcl::PointCloud<PointNT> intermediate_cloud_;
-
       /** \brief Convert the point cloud into voxel data. */
       virtual void
       voxelizeData () = 0;
@@ -525,11 +521,6 @@ namespace pcl
        virtual void
        performReconstruction (pcl::PointCloud<PointNT> &points,
                               std::vector<pcl::Vertices> &polygons);
-
-        /** \brief real marching cube part. called in two performReconstruction-s
-          */
-        virtual void
-        performReconstructionProc ();
 
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -446,9 +446,6 @@ namespace pcl
       /** \brief The grid resolution */
       int res_x_, res_y_, res_z_;
 
-      /** \brief Min and max data points. */
-      Eigen::Vector4f min_p_, max_p_;
-
       /** \brief Parameter that defines how much free space should be left inside the grid between
         * the bounding box of the point cloud and the grid limits, as a percentage of the bounding box.*/
       float percentage_extend_grid_;
@@ -461,9 +458,13 @@ namespace pcl
        * or distance between voxel centroid and point are larger that it. */
       float dist_ignore_;
 
-      /** \brief Convert the point cloud into voxel data. */
+      /** \brief Convert the point cloud into voxel data. 
+        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
+        * \param[in] lower_boundary The upper boundary of point cloud (after extension)
+        */
       virtual void
-      voxelizeData () = 0;
+      voxelizeData (const Eigen::Vector3f &upper_boundary,
+                    const Eigen::Vector3f &lower_boundary) = 0;
 
       /** \brief Interpolate along the voxel edge.
         * \param[in] p1 The first point on the edge
@@ -479,16 +480,24 @@ namespace pcl
       /** \brief Calculate out the corresponding polygons in the leaf node
         * \param leaf_node the leaf node to be checked
         * \param index_3d the 3d index of the leaf node to be checked
+        * \param upper_boundary the upper boundary of point cloud
+        * \param lower_boundary the lower boundary of point cloud
         * \param cloud point cloud to store the vertices of the polygon
-       */
+        */
       void
       createSurface (const std::vector<float> &leaf_node,
                      const Eigen::Vector3i &index_3d,
+                     const Eigen::Vector3f &upper_boundary,
+                     const Eigen::Vector3f &lower_boundary,
                      pcl::PointCloud<PointNT> &cloud);
 
-      /** \brief Get the bounding box for the input data points. */
+      /** \brief Get the bounding box for the input data points. 
+        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
+        * \param[in] lower_boundary The upper boundary of point cloud (after extension)
+        */
       void
-      getBoundingBox ();
+      getBoundingBox (Eigen::Vector3f &upper_boundary,
+                      Eigen::Vector3f &lower_boundary) const;
 
 
       /** \brief Method that returns the scalar value at the given grid position.

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -374,11 +374,13 @@ namespace pcl
       typedef typename pcl::KdTree<PointNT> KdTree;
       typedef typename pcl::KdTree<PointNT>::Ptr KdTreePtr;
 
-
       /** \brief Constructor. */
       MarchingCubes (const float percentage_extend_grid = 0.0f,
-                     const float iso_level = 0.0f,
-                     const float dist_ignore = -1.0f);
+                     const float iso_level = 0.0f) :
+        percentage_extend_grid_ (percentage_extend_grid),
+        iso_level_ (iso_level) 
+      {
+      }
 
       /** \brief Destructor. */
       virtual ~MarchingCubes ();
@@ -404,7 +406,6 @@ namespace pcl
       inline void
       setGridResolution (int res_x, int res_y, int res_z)
       { res_x_ = res_x; res_y_ = res_y; res_z_ = res_z; }
-
 
       /** \brief Method to get the marching cubes grid resolution.
         * \param[in] res_x the resolution of the grid along the x-axis
@@ -432,21 +433,19 @@ namespace pcl
       getPercentageExtendGrid ()
       { return percentage_extend_grid_; }
 
-      /** \brief Method that sets the parameter that defines the distance to ignore the distance to ignore
-        * a grid
-        * \param[in] threshold of distance. if it is negative, then calculate in all grids; otherwise
-        * ignore grids with distance to point cloud(to nearest point) larger than distIgnore
-        */
-      inline void
-      setDistanceIgnore (float distIgnore)
-      { dist_ignore_ = distIgnore; }
-
     protected:
       /** \brief The data structure storing the 3D grid */
       std::vector<float> grid_;
 
       /** \brief The grid resolution */
       int res_x_, res_y_, res_z_;
+
+      /** \brief bounding box */
+      Eigen::Array3f upper_boundary_;
+      Eigen::Array3f lower_boundary_;
+
+      /** \brief size of voxels */
+      Eigen::Array3f size_voxel_;
 
       /** \brief Parameter that defines how much free space should be left inside the grid between
         * the bounding box of the point cloud and the grid limits, as a percentage of the bounding box.*/
@@ -455,18 +454,10 @@ namespace pcl
       /** \brief The iso level to be extracted. */
       float iso_level_;
 
-      /** \brief ignore the distance function
-       * if it is negative
-       * or distance between voxel centroid and point are larger that it. */
-      float dist_ignore_;
-
       /** \brief Convert the point cloud into voxel data. 
-        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
-        * \param[in] lower_boundary The upper boundary of point cloud (after extension)
         */
       virtual void
-      voxelizeData (const Eigen::Vector3f &upper_boundary,
-                    const Eigen::Vector3f &lower_boundary) = 0;
+      voxelizeData () = 0;
 
       /** \brief Interpolate along the voxel edge.
         * \param[in] p1 The first point on the edge
@@ -482,24 +473,17 @@ namespace pcl
       /** \brief Calculate out the corresponding polygons in the leaf node
         * \param leaf_node the leaf node to be checked
         * \param index_3d the 3d index of the leaf node to be checked
-        * \param upper_boundary the upper boundary of point cloud
-        * \param lower_boundary the lower boundary of point cloud
         * \param cloud point cloud to store the vertices of the polygon
         */
       void
       createSurface (const std::vector<float> &leaf_node,
                      const Eigen::Vector3i &index_3d,
-                     const Eigen::Vector3f &upper_boundary,
-                     const Eigen::Vector3f &lower_boundary,
                      pcl::PointCloud<PointNT> &cloud);
 
       /** \brief Get the bounding box for the input data points. 
-        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
-        * \param[in] lower_boundary The upper boundary of point cloud (after extension)
         */
       void
-      getBoundingBox (Eigen::Vector3f &upper_boundary,
-                      Eigen::Vector3f &lower_boundary) const;
+      getBoundingBox ();
 
 
       /** \brief Method that returns the scalar value at the given grid position.

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -376,7 +376,9 @@ namespace pcl
 
 
       /** \brief Constructor. */
-      MarchingCubes ();
+      MarchingCubes (const float percentage_extend_grid = 0.0f,
+                     const float iso_level = 0.0f,
+                     const float dist_ignore = -1.0f);
 
       /** \brief Destructor. */
       virtual ~MarchingCubes ();

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -63,6 +63,7 @@ namespace pcl
       using MarchingCubes<PointNT>::res_z_;
       using MarchingCubes<PointNT>::min_p_;
       using MarchingCubes<PointNT>::max_p_;
+      using MarchingCubes<PointNT>::dist_ignore_;
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -61,7 +61,9 @@ namespace pcl
       using MarchingCubes<PointNT>::res_x_;
       using MarchingCubes<PointNT>::res_y_;
       using MarchingCubes<PointNT>::res_z_;
-      using MarchingCubes<PointNT>::dist_ignore_;
+      using MarchingCubes<PointNT>::size_voxel_;
+      using MarchingCubes<PointNT>::upper_boundary_;
+      using MarchingCubes<PointNT>::lower_boundary_;
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 
@@ -70,18 +72,35 @@ namespace pcl
 
 
       /** \brief Constructor. */
-      MarchingCubesHoppe ();
+      MarchingCubesHoppe (const float percentage_extend_grid = 0.0f,
+                          const float iso_level = 0.0f,
+                          const float dist_ignore = -1.0f) :
+        MarchingCubes<PointNT> (percentage_extend_grid, iso_level),
+        dist_ignore_ (dist_ignore)
+      {}
 
       /** \brief Destructor. */
       ~MarchingCubesHoppe ();
 
       /** \brief Convert the point cloud into voxel data.
-        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
-        * \param[in] lower_boundary The lower boundary of point cloud (after extension)
         */
       void
-      voxelizeData (const Eigen::Vector3f &upper_boundary, 
-                    const Eigen::Vector3f &lower_boundary);
+      voxelizeData ();
+
+      /** \brief Method that sets the parameter that defines the distance to ignore the distance to ignore
+        * a grid
+        * \param[in] threshold of distance. if it is negative, then calculate in all grids; otherwise
+        * ignore grids with distance to point cloud(to nearest point) larger than distIgnore
+        */
+      inline void
+      setDistanceIgnore (float dist_ignore)
+      { dist_ignore_ = dist_ignore; }
+
+    protected:
+      /** \brief ignore the distance function
+       * if it is negative
+       * or distance between voxel centroid and point are larger that it. */
+      float dist_ignore_;
 
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -61,8 +61,6 @@ namespace pcl
       using MarchingCubes<PointNT>::res_x_;
       using MarchingCubes<PointNT>::res_y_;
       using MarchingCubes<PointNT>::res_z_;
-      using MarchingCubes<PointNT>::min_p_;
-      using MarchingCubes<PointNT>::max_p_;
       using MarchingCubes<PointNT>::dist_ignore_;
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
@@ -77,10 +75,13 @@ namespace pcl
       /** \brief Destructor. */
       ~MarchingCubesHoppe ();
 
-      /** \brief Convert the point cloud into voxel data. */
+      /** \brief Convert the point cloud into voxel data.
+        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
+        * \param[in] lower_boundary The lower boundary of point cloud (after extension)
+        */
       void
-      voxelizeData ();
-
+      voxelizeData (const Eigen::Vector3f &upper_boundary, 
+                    const Eigen::Vector3f &lower_boundary);
 
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -94,13 +94,13 @@ namespace pcl
         * \param[in] threshold of distance. Default value is -1.0. Set to negative if all voxels are
         * to be involved.
         */
-      void
+      inline void
       setDistanceIgnore (const float dist_ignore)
       { dist_ignore_ = dist_ignore; }
 
       /** \brief get the distance for ignoring voxels which are far from point cloud.
        * */
-      float
+      inline float
       getDistanceIgnore () const
       { return dist_ignore_; }
 

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -88,14 +88,21 @@ namespace pcl
       void
       voxelizeData ();
 
-      /** \brief Method that sets the parameter that defines the distance to ignore the distance to ignore
-        * a grid
-        * \param[in] threshold of distance. if it is negative, then calculate in all grids; otherwise
-        * ignore grids with distance to point cloud(to nearest point) larger than distIgnore
+      /** \brief Method that sets the distance for ignoring voxels which are far from point cloud.
+        * If the distance is negative, then the distance functions would be calculated in all voxels;
+        * otherwise, only voxels with distance lower than dist_ignore would be involved in marching cube.
+        * \param[in] threshold of distance. Default value is -1.0. Set to negative if all voxels are
+        * to be involved.
         */
-      inline void
-      setDistanceIgnore (float dist_ignore)
+      void
+      setDistanceIgnore (const float dist_ignore)
       { dist_ignore_ = dist_ignore; }
+
+      /** \brief get the distance for ignoring voxels which are far from point cloud.
+       * */
+      float
+      getDistanceIgnore () const
+      { return dist_ignore_; }
 
     protected:
       /** \brief ignore the distance function

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -72,12 +72,13 @@ namespace pcl
 
 
       /** \brief Constructor. */
-      MarchingCubesHoppe (const float percentage_extend_grid = 0.0f,
-                          const float iso_level = 0.0f,
-                          const float dist_ignore = -1.0f) :
+      MarchingCubesHoppe (const float dist_ignore = -1.0f,
+                          const float percentage_extend_grid = 0.0f,
+                          const float iso_level = 0.0f) :
         MarchingCubes<PointNT> (percentage_extend_grid, iso_level),
         dist_ignore_ (dist_ignore)
-      {}
+      {
+      }
 
       /** \brief Destructor. */
       ~MarchingCubesHoppe ();

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -78,9 +78,13 @@ namespace pcl
       /** \brief Destructor. */
       ~MarchingCubesRBF ();
 
-      /** \brief Convert the point cloud into voxel data. */
+      /** \brief Convert the point cloud into voxel data.
+        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
+        * \param[in] lower_boundary The lower boundary of point cloud (after extension)
+        */
       void
-      voxelizeData ();
+      voxelizeData (const Eigen::Vector3f &upper_boundary,
+                    const Eigen::Vector3f &lower_boundary);
 
 
       /** \brief Set the off-surface points displacement value.

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -63,6 +63,9 @@ namespace pcl
       using MarchingCubes<PointNT>::res_x_;
       using MarchingCubes<PointNT>::res_y_;
       using MarchingCubes<PointNT>::res_z_;
+      using MarchingCubes<PointNT>::size_voxel_;
+      using MarchingCubes<PointNT>::upper_boundary_;
+      using MarchingCubes<PointNT>::lower_boundary_;
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 
@@ -71,18 +74,21 @@ namespace pcl
 
 
       /** \brief Constructor. */
-      MarchingCubesRBF ();
+      MarchingCubesRBF (const float percentage_extend_grid = 0.0f,
+                        const float iso_level = 0.0f,
+                        const float off_surface_epsilon = 0.1f) :
+        MarchingCubes<PointNT> (percentage_extend_grid, iso_level),
+        off_surface_epsilon_ (off_surface_epsilon)
+      {
+      }
 
       /** \brief Destructor. */
       ~MarchingCubesRBF ();
 
       /** \brief Convert the point cloud into voxel data.
-        * \param[in] upper_boundary The upper boundary of point cloud (after extension)
-        * \param[in] lower_boundary The lower boundary of point cloud (after extension)
         */
       void
-      voxelizeData (const Eigen::Vector3f &upper_boundary,
-                    const Eigen::Vector3f &lower_boundary);
+      voxelizeData ();
 
 
       /** \brief Set the off-surface points displacement value.

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -74,9 +74,9 @@ namespace pcl
 
 
       /** \brief Constructor. */
-      MarchingCubesRBF (const float percentage_extend_grid = 0.0f,
-                        const float iso_level = 0.0f,
-                        const float off_surface_epsilon = 0.1f) :
+      MarchingCubesRBF (const float off_surface_epsilon = 0.1f,
+                        const float percentage_extend_grid = 0.0f,
+                        const float iso_level = 0.0f) :
         MarchingCubes<PointNT> (percentage_extend_grid, iso_level),
         off_surface_epsilon_ (off_surface_epsilon)
       {

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -63,8 +63,6 @@ namespace pcl
       using MarchingCubes<PointNT>::res_x_;
       using MarchingCubes<PointNT>::res_y_;
       using MarchingCubes<PointNT>::res_z_;
-      using MarchingCubes<PointNT>::min_p_;
-      using MarchingCubes<PointNT>::max_p_;
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 

--- a/test/surface/test_marching_cubes.cpp
+++ b/test/surface/test_marching_cubes.cpp
@@ -76,12 +76,12 @@ TEST (PCL, MarchingCubesTest)
   std::vector<Vertices> vertices;
   hoppe.reconstruct (points, vertices);
 
-  EXPECT_NEAR (points.points[points.size()/2].x, -0.042528, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].y, 0.080196, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].z, 0.043159, 1e-3);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 10854);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 10855);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 10856);
+  EXPECT_NEAR (points.points[points.size()/2].x, -0.037143, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].y,  0.098213, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].z, -0.044911, 1e-3);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 11202);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 11203);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 11204);
 
 
   MarchingCubesRBF<PointNormal> rbf;
@@ -92,12 +92,12 @@ TEST (PCL, MarchingCubesTest)
   rbf.setOffSurfaceDisplacement (0.02f);
   rbf.reconstruct (points, vertices);
 
-  EXPECT_NEAR (points.points[points.size()/2].x, -0.033919, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].y, 0.151683, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].z, -0.000086, 1e-3);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 4284);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 4285);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 4286);
+  EXPECT_NEAR (points.points[points.size()/2].x, -0.025630, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].y,  0.135228, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].z,  0.035766, 1e-3);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 4275);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 4276);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 4277);
 }
 
 


### PR DESCRIPTION
… in complex point clouds. 

For indoor reconstruction, the MC Hoppe algorithm tends to form significant phantom surfaces where it should be concave. It is likely to be caused by signed distance functions(SDF) generated by far away points. Thus a spatial threshold is added in my branch to ignore SDFs which are far from points. The structure of marching cube is also optimized(separate common parts)