### PR TITLE
Fix detection of the Ensenso SDK on Windows when the path contains spaces

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -270,7 +270,7 @@ macro(find_ensenso)
   endif()
 
   if(NOT ENSENSO_ROOT AND ("@HAVE_ENSENSO@" STREQUAL "TRUE"))
-    get_filename_component(ENSENSO_ABI_HINT @ENSENSO_INCLUDE_DIR@ PATH)
+    get_filename_component(ENSENSO_ABI_HINT "@ENSENSO_INCLUDE_DIR@" PATH)
   endif()
 
   find_path(ENSENSO_INCLUDE_DIR nxLib.h


### PR DESCRIPTION
By default on Windows, the Ensenso SDK is installed in the `Program Files` directory. Searching for it currently fails because of the space in `Program Files`. I fixed this by quoting the `@ENSENSO_INCLUDE_DIR@` placeholder in `PCLConfig.cmake.in`.