### PR TITLE
Fixes for gp3 algorithm

### DIFF
--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -226,7 +226,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
               break;
             if (sfn_[nnIdx[doubleEdges[j].index]] != nnIdx[i])
               visibility = isVisible(uvn_nn[i], uvn_nn[doubleEdges[j].index], doubleEdges[j].second, Eigen::Vector2f::Zero());
-            if (!visibility == false)
+            if (!visibility)
               break;
           }
           angles_[i].visible = visibility;
@@ -420,7 +420,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
               angleMax = angle1;
             }
             double angleR = angles_[i].angle + M_PI;
-            if (angleR >= 2*M_PI)
+            if (angleR >= M_PI)
               angleR -= 2*M_PI;
             if ((source_[nnIdx[i]] == ffn_[nnIdx[i]]) || (source_[nnIdx[i]] == sfn_[nnIdx[i]]))
             {
@@ -1479,7 +1479,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::connectPoint (
                     neighbor_update = sfn_[next_index];
 
                     /* sfn[next_index] */
-                    if ((ffn_[sfn_[next_index]] = ffn_[current_index_]) || (sfn_[sfn_[next_index]] == ffn_[current_index_]))
+                    if ((ffn_[sfn_[next_index]] == ffn_[current_index_]) || (sfn_[sfn_[next_index]] == ffn_[current_index_]))
                     {
                       state_[sfn_[next_index]] = COMPLETED;
                     }


### PR DESCRIPTION
Line 229: The intention of the code seems to be to check whether any edge leads to visibility == false and then break. The visibility check seems to be inverted in this line, though. Compare this to lines 225, 472, and 478.

Line 423: `angleR` is computed from `angles_[i].angle`, which is computed using atan2. This function's return value range is `[-M_PI, M_PI]`. `angleR` is later compared to `angleMin` and `angleMax`, which are computed from `angle1` and `angle2`, which are also computed using atan2. Therefore I think that the wrap-around check should be at `M_PI`, not `2*M_PI`.

Line 1482: There seems to be a typo where a = is missing in a comparison such that an assignment is done instead. Compare this to the analogous line 1459.

I think there may also be a bug where the `connectPoint` function adds a triangle in a place which is designated as a gap by the triangulation function, and then the ffn_/sfn_ are not updated correctly there, but I'm not sure and I don't have a fix for that.

I tested the changes using `test_gp3`. The result is nearly identical to before.

Original result: https://drive.google.com/open?id=0Bxrkk2CLB8MbQXdZWDBDNHJ1UlU
With this PR: https://drive.google.com/open?id=0Bxrkk2CLB8MbVTVDYnR3czUtV00
(Image upload to github did not work for some reason.)