### PR TITLE
test_common_io fix

### DIFF
--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -206,13 +206,7 @@ TEST (PCL, concatenatePointCloud)
     EXPECT_EQ (cloud_all[i].rgba, cloud_xyz_rgba[i].rgba);
   }
   for (int i = 0; i < int (cloud_xyz_rgb.size ()); ++i)
-  {
     EXPECT_XYZ_EQ (cloud_all[cloud_xyz_rgba.size () + i], cloud_xyz_rgb[i]);
-    EXPECT_FLOAT_EQ (cloud_all[cloud_xyz_rgba.size () + i].r, 0);
-    EXPECT_FLOAT_EQ (cloud_all[cloud_xyz_rgba.size () + i].g, 0);
-    EXPECT_FLOAT_EQ (cloud_all[cloud_xyz_rgba.size () + i].b, 0);
-    EXPECT_EQ (cloud_all[cloud_xyz_rgba.size () + i].rgba, 0);
-  }
 
   cloud1.fields[rgb_idx].name = "rgba";
   // regular vs _


### PR DESCRIPTION
This PR addresses an issue with the conditions being tested in `concatenatePointCloud`.  

During the conversion from `PCLPointCloud2` to `PointCloud`, in the presence of a field which is indicated to be stripped (with the id `_`), the data values related to this field are not copied, therefore remaining uninitialized in the destination PointCloud variable. 

It appears the test assumed they would be default initialized, which is definitely not the case, hence making the test conditions inadequate. Why this didn't fail before, appears to be pure luck.


Fixes #1866