### PR TITLE
Fix Eigen incompatibility by explicitly converting double to int to index into Eigen vector.

### DIFF
--- a/surface/include/pcl/surface/impl/bilateral_upsampling.hpp
+++ b/surface/include/pcl/surface/impl/bilateral_upsampling.hpp
@@ -116,7 +116,7 @@ pcl::BilateralUpsampling<PointInT, PointOutT>::performProcessing (PointCloudOut 
                 abs (input_->points[y_w * input_->width + x_w].g - input_->points[y * input_->width + x].g) +
                 abs (input_->points[y_w * input_->width + x_w].b - input_->points[y * input_->width + x].b));
             
-            float val_exp_rgb = val_exp_rgb_vector(d_color);
+            float val_exp_rgb = val_exp_rgb_vector(int(d_color));
 
             if (pcl_isfinite (input_->points[y_w*input_->width + x_w].z))
             {


### PR DESCRIPTION
This addresses a bug in `pcl::BilateralUpsampling::performProcessing(...)` than manifests as the following error:
```
.../surface/include/pcl/surface/impl/bilateral_upsampling.hpp:119:19: error: no viable conversion from 'typename internal::enable_if<(!IsRowMajor) && (!(internal::get_compile_time_incr<typename IvcType<float>::type>::value == 1 || internal::is_integral<float>::value)), IndexedView<Matrix<float, -1, 1, 0, -1, 1>, typename IvcType<float>::type, IvcIndex> >::type' (aka 'Eigen::IndexedView<Eigen::Matrix<float, -1, 1, 0, -1, 1>, float, Eigen::internal::SingleRange>') to 'float'
            float val_exp_rgb = val_exp_rgb_vector(d_color);
                  ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The intent of this code appears to be to index into `Eigen::VectorXf
val_exp_rgb_vector` using `float d_color`, where the indexing operator
expects an integer argument. I would guess that in earlier versions of
Eigen, an implicit conversion was performed from float to int, and that
in later versions of Eigen this implicit conversion was disabled.

This commit substitutes an explicit conversion:
```
            float val_exp_rgb = val_exp_rgb_vector(int(d_color));
```

This solves the build, but I may have misinterpreted the intent and
original behavior.