### PR TITLE
Add gitignore for build and install directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+install


### PR DESCRIPTION
The `build` and `install` directories should not pollute the git workspace.