### PR TITLE
Fix the link markup (and wording) in matrix transform tutorial

### DIFF
--- a/doc/tutorials/content/matrix_transform.rst
+++ b/doc/tutorials/content/matrix_transform.rst
@@ -131,9 +131,9 @@ Add the following lines to your CMakeLists.txt file:
    :language: cmake
    :linenos:
 
-After you have made the executable, you can run it. Download the mesh here: <https://github.com/PointCloudLibrary/pcl/tree/master/test/cube.ply>`_
-
-Then run::
+After you have made the executable, run it passing a path to a PCD or PLY file.
+To reproduce the results shown below, you can download the `cube.ply
+<https://raw.github.com/PointCloudLibrary/pcl/master/test/cube.ply>`_ file::
 
   $ ./matrix_transform cube.ply
 


### PR DESCRIPTION
This fixes broken markup in matrix transform tutorial (added by #1894).