### PR TITLE
Use Q_* instead of slots and signals in Qt apps

### DIFF
--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_composer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_composer.h
@@ -76,7 +76,7 @@ namespace pcl
         explicit ComposerMainWindow (QWidget *parent = 0);
         ~ComposerMainWindow ();
   
-      signals:
+      Q_SIGNALS:
         /** \brief Signal emitted when the active project is switched - ie a different project tab is selected */
         void
         activeProjectChanged (ProjectModel* new_model, ProjectModel* previous_model);
@@ -93,7 +93,7 @@ namespace pcl
         void 
         saveSelectedCloudToFile ();
         
-      public slots:
+      public Q_SLOTS:
       //Slots for File Menu Actions
         void
         on_action_new_project__triggered (/*QString name = "unsaved project"*/);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
@@ -78,7 +78,7 @@ namespace pcl
       
       void 
       setInteractorStyle (interactor_styles::INTERACTOR_STYLES style);
-    public slots:
+    public Q_SLOTS:
       void 
       refresh ();
       
@@ -90,7 +90,7 @@ namespace pcl
       void 
       dataChanged ( const QModelIndex & topLeft, const QModelIndex & bottomRight );
       
-    protected slots:
+    protected Q_SLOTS:
       /** \brief Slot called when an item in the model changes
        * \param topLeft 
        * \param bottomRight

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_viewer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_viewer.h
@@ -62,7 +62,7 @@ namespace pcl
         virtual ~CloudViewer();
         ProjectModel* getModel () const;
 
-      public slots:
+      public Q_SLOTS:
         void 
         addModel (ProjectModel* new_model);
         
@@ -72,7 +72,7 @@ namespace pcl
         void
         addNewProject (ProjectModel* new_model);
         
-      signals:
+      Q_SIGNALS:
         void
         newModelSelected (ProjectModel *new_model);
 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
@@ -58,7 +58,7 @@ namespace pcl
         ItemInspector (QWidget* parent = 0);
         virtual ~ItemInspector();
       
-      public slots:
+      public Q_SLOTS:
         void 
         setModel (ProjectModel* new_model);
         void 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
@@ -112,7 +112,7 @@ namespace pcl
         /** \brief This is invoked to perform the manipulations specified on the model */
         void
         manipulateClouds (boost::shared_ptr<ManipulationEvent> manip_event);
-      public slots:
+      public Q_SLOTS:
         void 
         commandCompleted (CloudCommand* command);
         
@@ -157,7 +157,7 @@ namespace pcl
         /** \brief Selects all items in the model */
         void 
         selectAllItems (QStandardItem* item = 0 );
-      signals:  
+      Q_SIGNALS:
         void
         enqueueNewAction (AbstractTool* tool, ConstItemList data);
         

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
@@ -74,11 +74,11 @@ namespace pcl
         void 
         copyProperties (const PropertiesModel* to_copy);
         
-      public slots:
+      public Q_SLOTS:
         void
         propertyChanged (QStandardItem* property_item);
       
-      signals:
+      Q_SIGNALS:
         void 
         propertyChanged (const QStandardItem* property_item, const CloudComposerItem* parent_item_);
         

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/signal_multiplexer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/signal_multiplexer.h
@@ -108,7 +108,7 @@ namespace pcl
         QObject 
         *currentObject () const { return object; }
 
-      public slots:
+      public Q_SLOTS:
         /**
                 Sets the current object the signals that are managed by the
                 SignalMultiplexer instance should be connected to. Any connections
@@ -121,7 +121,7 @@ namespace pcl
         void 
         setCurrentObject (QObject *newObject);
 
-      signals:
+      Q_SIGNALS:
         /**
                 Emitted when a new object is set to receive the signals managed by
                 this SignalMultiplexer instance.

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
@@ -81,7 +81,7 @@ namespace pcl
       void
       enableAllTools ();
       
-    public slots:
+    public Q_SLOTS:
       void
       activeProjectChanged (ProjectModel* new_model, ProjectModel* previous_model);
       
@@ -98,7 +98,7 @@ namespace pcl
       /** \brief This slot is called whenever the current project model emits layoutChanged, and calls updateEnabledTools */
       void
       modelChanged ();
-    signals:  
+    Q_SIGNALS:
       void
       enqueueToolAction (AbstractTool* tool);
       

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/work_queue.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/work_queue.h
@@ -61,7 +61,7 @@ namespace pcl
       public:
         WorkQueue (QObject* parent = 0);  
         virtual ~WorkQueue();  
-      public slots:
+      public Q_SLOTS:
         void
         enqueueNewAction (AbstractTool* new_tool, ConstItemList input_data);
         
@@ -70,7 +70,7 @@ namespace pcl
         
         void 
         checkQueue ();
-      signals:
+      Q_SIGNALS:
         void 
         commandProgress (QString command_text, double progress);
 

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/in_hand_scanner.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/in_hand_scanner.h
@@ -138,13 +138,13 @@ namespace pcl
         inline Integration&
         getIntegration () {return (*integration_);}
 
-      signals:
+      Q_SIGNALS:
 
         /** \brief Emitted when the running mode changes. */
         void
         runningModeChanged (RunningMode new_running_mode) const;
 
-      public slots:
+      public Q_SLOTS:
 
         /** \brief Start the grabber (enables the scanning pipeline). */
         void

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/main_window.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/main_window.h
@@ -83,7 +83,7 @@ namespace pcl
         explicit MainWindow (QWidget* parent = 0);
         ~MainWindow ();
 
-      public slots:
+      public Q_SLOTS:
 
         void showHelp ();
         void saveAs ();

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
@@ -92,13 +92,13 @@ namespace pcl
         /** \brief Destructor. */
         ~OfflineIntegration ();
 
-      public slots:
+      public Q_SLOTS:
 
         /** \brief Start the procedure from a path. */
         void
         start ();
 
-      private slots:
+      private Q_SLOTS:
 
         /** \brief Loads in new data. */
         void

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/opengl_viewer.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/opengl_viewer.h
@@ -248,7 +248,7 @@ namespace pcl
         void
         setScalingFactor (const double scale);
 
-      public slots:
+      public Q_SLOTS:
 
         /** \brief Requests the scene to be re-drawn (called periodically from a timer). */
         void

--- a/apps/include/pcl/apps/manual_registration.h
+++ b/apps/include/pcl/apps/manual_registration.h
@@ -149,7 +149,7 @@ class ManualRegistration : public QMainWindow
 
     Eigen::Matrix4f                   transform_;
 
-  public slots:
+  public Q_SLOTS:
     void 
     confirmSrcPointPressed();
     void 
@@ -169,7 +169,7 @@ class ManualRegistration : public QMainWindow
     void
     safePressed();
 
-  private slots:
+  private Q_SLOTS:
     void
     timeoutSlot();
 

--- a/apps/include/pcl/apps/openni_passthrough.h
+++ b/apps/include/pcl/apps/openni_passthrough.h
@@ -100,7 +100,7 @@ class OpenNIPassthrough : public QMainWindow
     Ui::MainWindow *ui_;
     QTimer *vis_timer_;
 
-  public slots:
+  public Q_SLOTS:
     void
     adjustPassThroughValues (int new_value)
     {
@@ -108,11 +108,11 @@ class OpenNIPassthrough : public QMainWindow
       PCL_INFO ("Changed passthrough maximum value to: %f\n", float (new_value) / 10.0f);
     }
     
-  private slots:
+  private Q_SLOTS:
     void
     timeoutSlot ();
     
-  signals:
+  Q_SIGNALS:
     void 
     valueChanged (int new_value);
 };

--- a/apps/include/pcl/apps/organized_segmentation_demo.h
+++ b/apps/include/pcl/apps/organized_segmentation_demo.h
@@ -141,7 +141,7 @@ class OrganizedSegmentationDemo : public QMainWindow
     pcl::EdgeAwarePlaneComparator<PointT, pcl::Normal>::Ptr edge_aware_comparator_;
     pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_;
 
-  public slots:
+  public Q_SLOTS:
     void toggleCapturePressed()
     {
       capture_ = !capture_;
@@ -177,7 +177,7 @@ class OrganizedSegmentationDemo : public QMainWindow
     }
     
 
-  private slots:
+  private Q_SLOTS:
   void
     timeoutSlot();
 

--- a/apps/include/pcl/apps/pcd_video_player.h
+++ b/apps/include/pcl/apps/pcd_video_player.h
@@ -135,7 +135,7 @@ class PCDVideoPlayer : public QMainWindow
     /** \brief Fixes the speed in steps of 5ms, default 5, gives 5+1 * 5ms = 30ms = 33,3 Hz playback speed */
     unsigned int speed_value_;
 
-  public slots:
+  public Q_SLOTS:
     void 
     playButtonPressed ()
     { play_mode_ = true; }
@@ -159,7 +159,7 @@ class PCDVideoPlayer : public QMainWindow
     void
     indexSliderValueChanged (int value);
 
-  private slots:
+  private Q_SLOTS:
     void
     timeoutSlot ();
 

--- a/apps/modeler/include/pcl/apps/modeler/abstract_worker.h
+++ b/apps/modeler/include/pcl/apps/modeler/abstract_worker.h
@@ -57,11 +57,11 @@ namespace pcl
         int
         exec();
 
-      public slots:
+      public Q_SLOTS:
         void
         process();
 
-      signals:
+      Q_SIGNALS:
         void
         dataUpdated(CloudMeshItem* cloud_mesh_item);
 

--- a/apps/modeler/include/pcl/apps/modeler/cloud_mesh_item_updater.h
+++ b/apps/modeler/include/pcl/apps/modeler/cloud_mesh_item_updater.h
@@ -52,7 +52,7 @@ namespace pcl
         CloudMeshItemUpdater (CloudMeshItem* cloud_mesh_item);
         ~CloudMeshItemUpdater ();
 
-      public slots:
+      public Q_SLOTS:
         void
         updateCloudMeshItem();
 

--- a/apps/modeler/include/pcl/apps/modeler/main_window.h
+++ b/apps/modeler/include/pcl/apps/modeler/main_window.h
@@ -66,7 +66,7 @@ namespace pcl
         RenderWindowItem*
         createRenderWindow();
 
-      public slots:
+      public Q_SLOTS:
         // slots for file menu
         void 
         slotOpenProject();
@@ -120,7 +120,7 @@ namespace pcl
         void 
         saveGlobalSettings();
 
-      private slots:
+      private Q_SLOTS:
         void 
         slotOpenRecentPointCloud();
         void 

--- a/apps/modeler/include/pcl/apps/modeler/parameter_dialog.h
+++ b/apps/modeler/include/pcl/apps/modeler/parameter_dialog.h
@@ -75,7 +75,7 @@ namespace pcl
         std::map<std::string, Parameter*>       name_parameter_map_;
         ParameterModel*                         parameter_model_;
 
-      protected slots:
+      protected Q_SLOTS:
         void
         reset();
     };

--- a/apps/modeler/include/pcl/apps/modeler/scene_tree.h
+++ b/apps/modeler/include/pcl/apps/modeler/scene_tree.h
@@ -69,7 +69,7 @@ namespace pcl
         void
         addTopLevelItem(RenderWindowItem* render_window_item);
 
-      public slots:
+      public Q_SLOTS:
         // slots for file menu
         void 
         slotOpenPointCloud();
@@ -99,7 +99,7 @@ namespace pcl
         void
         slotCloseRenderWindow();
 
-      signals:
+      Q_SIGNALS:
         void
         fileOpened(const QString& filename);
 
@@ -113,7 +113,7 @@ namespace pcl
         virtual bool
         dropMimeData(QTreeWidgetItem * parent, int index, const QMimeData * data, Qt::DropAction action);
 
-      private slots:
+      private Q_SLOTS:
         void
         slotUpdateOnSelectionChange(const QItemSelection& selected, const QItemSelection& deselected);
 

--- a/apps/modeler/include/pcl/apps/modeler/thread_controller.h
+++ b/apps/modeler/include/pcl/apps/modeler/thread_controller.h
@@ -57,11 +57,11 @@ namespace pcl
         bool
         runWorker(AbstractWorker* worker);
 
-      signals:
+      Q_SIGNALS:
         void
         prepared();
 
-      private slots:
+      private Q_SLOTS:
         void
         slotOnCloudMeshItemUpdate(CloudMeshItem* cloud_mesh_item);
     };

--- a/apps/optronic_viewer/include/pcl/apps/optronic_viewer/filter_window.h
+++ b/apps/optronic_viewer/include/pcl/apps/optronic_viewer/filter_window.h
@@ -72,7 +72,7 @@ namespace pcl
           std::vector<CloudFilter*> & filter_list);
         virtual ~FilterWindow ();
 
-      public slots:
+      public Q_SLOTS:
         /** \brief Called if a different item in the filter list is selected. */
         virtual void itemSelected (int id);
         /** \brief Called when the 'finish' button is pressed. */
@@ -80,7 +80,7 @@ namespace pcl
         /** \brief Called when the 'next' button is pressed. */
         virtual void next ();
 
-      signals:
+      Q_SIGNALS:
         /** \brief Ommitted when a filter is created. */
         void filterCreated ();
 

--- a/apps/optronic_viewer/include/pcl/apps/optronic_viewer/main_window.h
+++ b/apps/optronic_viewer/include/pcl/apps/optronic_viewer/main_window.h
@@ -111,7 +111,7 @@ namespace pcl
             return theSingleton;
           }
 
-        public slots:
+        public Q_SLOTS:
           void selectedSensorChanged (int index);
           void cloud_callback (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr cloud);
           void refresh ();
@@ -124,7 +124,7 @@ namespace pcl
           // find connected devices
           void findConnectedDevices ();
 
-          private slots:
+          private Q_SLOTS:
             void addFilter ();
             void updateFilter (QListWidgetItem*);
             void filterSelectionChanged ();

--- a/apps/optronic_viewer/include/pcl/apps/optronic_viewer/openni_grabber.h
+++ b/apps/optronic_viewer/include/pcl/apps/optronic_viewer/openni_grabber.h
@@ -72,7 +72,7 @@ namespace pcl
           /** \brief Callback that is used to get cloud data from the grabber. */
           void cloudCallback (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr & cloud);
 
-        signals:
+        Q_SIGNALS:
           /** \brief Omitted when a new cloud is received. */
           void cloudReceived (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr cloud);
 

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
@@ -70,7 +70,7 @@ class CloudEditorWidget : public QGLWidget
     void
     loadFile(const std::string &filename);
 
-  public slots:
+  public Q_SLOTS:
     /// @brief Loads a new cloud.
     void
     load ();
@@ -186,8 +186,6 @@ class CloudEditorWidget : public QGLWidget
     /// @brief Turn on the dialog box showing the statistics of the cloud.
     void
     showStat ();
-
-  //signals:
 
   protected:  
     /// initializes GL

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseParameterForm.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseParameterForm.h
@@ -84,7 +84,7 @@ class DenoiseParameterForm : public QDialog
       return (ok_);
     }
 
-  private slots:
+  private Q_SLOTS:
     /// @brief Accepts and stores the current user inputs, and turns off the
     /// dialog box.
     void

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
@@ -100,7 +100,7 @@ class MainWindow : public QMainWindow
     int
     getSelectedSpinBoxValue ();
 
-  private slots:
+  private Q_SLOTS:
     void
     about ();
 

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
@@ -61,11 +61,11 @@ class StatisticsDialog : public QDialog
     /// @brief Destructor
     ~StatisticsDialog ();
     
-  public slots:
+  public Q_SLOTS:
     /// @brief update the dialog box.
     void update ();
     
-  private slots:
+  private Q_SLOTS:
     void accept ();
     
   private:

--- a/doc/tutorials/content/sources/qt_colorize_cloud/pclviewer.h
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/pclviewer.h
@@ -39,7 +39,7 @@ class PCLViewer : public QMainWindow
     /** @brief Destructor */
     ~PCLViewer ();
 
-  public slots:
+  public Q_SLOTS:
     /** @brief Triggered whenever the "Save file" button is clicked */
     void
     saveFileButtonPressed ();

--- a/doc/tutorials/content/sources/qt_visualizer/pclviewer.h
+++ b/doc/tutorials/content/sources/qt_visualizer/pclviewer.h
@@ -30,7 +30,7 @@ public:
   explicit PCLViewer (QWidget *parent = 0);
   ~PCLViewer ();
 
-public slots:
+public Q_SLOTS:
   void
   randomButtonPressed ();
 


### PR DESCRIPTION
This is to avoid compile or runtime problems when including 3rd party headers. In particular, boost signals library is known to cause problems, see #1028.