### PR TITLE
[WIP] Enabled OSX builds in Travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -3,6 +3,7 @@
 PCL_DIR=`pwd`
 BUILD_DIR=$PCL_DIR/build
 DOC_DIR=$BUILD_DIR/doc/doxygen/html
+GTEST_DIR=$HOME/gtest
 
 TUTORIALS_DIR=$BUILD_DIR/doc/tutorials/html
 ADVANCED_DIR=$BUILD_DIR/doc/advanced/html
@@ -17,30 +18,83 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   fi
 fi
 
+function before_install_linux ()
+{
+  if [ "$CC" == "clang" ]; then
+    sudo ln -s ../../bin/ccache /usr/lib/ccache/clang
+    sudo ln -s ../../bin/ccache /usr/lib/ccache/clang++
+    export CCACHE_CPP2=yes
+  fi 
+}
+
+function before_install_osx ()
+{
+  brew tap homebrew/science
+  brew install --only-dependencies --with-openni pcl
+  brew install ccache
+  export PATH="/usr/local/opt/ccache/libexec:$PATH"
+  export CCACHE_CPP2=yes
+  CMAKE_ARGS="  -DCMAKE_C_COMPILER=/usr/local/opt/ccache/libexec/cc \
+                -DCMAKE_CXX_COMPILER=/usr/local/opt/ccache/libexec/c++"
+
+  echo 'Which $CC:'
+  which cc
+  
+  if [[ "$TASK" == "test-core" || "$TASK" == "test-ext-1" || "$TASK" == "test-ext-2" ]] ; then
+    mkdir -p $GTEST_DIR
+    git clone https://github.com/google/googletest.git $GTEST_DIR
+    CMAKE_ARGS="$CMAKE_ARGS \
+                -DGTEST_SRC_DIR=$GTEST_DIR/googletest \
+                -DGTEST_INCLUDE_DIR=$GTEST_DIR/googletest/include"
+  elif [ "$TASK" == "doc" ]; then
+    brew install doxygen
+    export PATH=$HOME/Library/Python/2.7/lib/python/site-packages:$HOME/Library/Python/2.7/bin:$PATH
+  fi
+}
+
 function before_install ()
 {
-  if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    if [ "$CC" == "clang" ]; then
-      sudo ln -s ../../bin/ccache /usr/lib/ccache/clang
-      sudo ln -s ../../bin/ccache /usr/lib/ccache/clang++
-    fi
-  fi
+  case $TRAVIS_OS_NAME in
+    linux ) before_install_linux;;
+    osx ) before_install_osx;;
+  esac
+
+  echo "CCache Info:"
+  which ccache
+  ccache --version
+  ccache --max-size=2G
+  export CCACHE_SLOPPINESS=pch_defines,time_macros
+  ccache -s
+  ls -l ~/.ccache
+
+  echo "Echo PATH:"
+  echo $PATH
+
+  echo "Envs:"
+  env
 }
 
 function build ()
 {
-  case $CC in
-    clang ) build_lib;;
-    gcc ) build_lib_core;;
-  esac
+  # case $CC in
+  #   clang ) build_lib;;
+  #   gcc ) build_lib_core;;
+  # esac
+  build_lib
 }
 
 function build_lib ()
 {
   # A complete build
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//                 TASK: BUILD all PCL modules                   //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DPCL_QT_VERSION=4 \
         -DBUILD_simulation=ON \
@@ -48,12 +102,6 @@ function build_lib ()
         -DBUILD_examples=OFF \
         -DBUILD_tools=OFF \
         -DBUILD_apps=OFF \
-        -DBUILD_apps_3d_rec_framework=OFF \
-        -DBUILD_apps_cloud_composer=OFF \
-        -DBUILD_apps_in_hand_scanner=OFF \
-        -DBUILD_apps_modeler=OFF \
-        -DBUILD_apps_optronic_viewer=OFF \
-        -DBUILD_apps_point_cloud_editor=OFF \
         $PCL_DIR
   # Build
   make -j2
@@ -62,16 +110,43 @@ function build_lib ()
 function build_examples ()
 {
   # A complete build
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//                 TASK: BUILD PCL EXAMPLES                      //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DPCL_QT_VERSION=4 \
-        -DBUILD_simulation=ON \
         -DBUILD_global_tests=OFF \
         -DBUILD_examples=ON \
         -DBUILD_tools=OFF \
         -DBUILD_apps=OFF \
+        -DBUILD_2d=ON \
+        -DBUILD_features=ON \
+        -DBUILD_filters=ON \
+        -DBUILD_geometry=ON \
+        -DBUILD_io=ON \
+        -DBUILD_kdtree=ON \
+        -DBUILD_keypoints=ON \
+        -DBUILD_ml=ON \
+        -DBUILD_octree=ON \
+        -DBUILD_outofcore=ON \
+        -DBUILD_people=OFF \
+        -DBUILD_recognition=OFF \
+        -DBUILD_registration=OFF \
+        -DBUILD_sample_consensus=ON \
+        -DBUILD_search=ON \
+        -DBUILD_segmentation=ON \
+        -DBUILD_simulation=OFF \
+        -DBUILD_stereo=ON \
+        -DBUILD_surface=ON \
+        -DBUILD_tools=OFF \
+        -DBUILD_tracking=OFF \
+        -DBUILD_visualization=ON \
         $PCL_DIR
   # Build
   make -j2
@@ -80,16 +155,26 @@ function build_examples ()
 function build_tools ()
 {
   # A complete build
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//                 TASK: BUILD PCL TOOLS                         //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DPCL_QT_VERSION=4 \
-        -DBUILD_simulation=ON \
         -DBUILD_global_tests=OFF \
         -DBUILD_examples=OFF \
         -DBUILD_tools=ON \
         -DBUILD_apps=OFF \
+        -DBUILD_outofcore=OFF \
+        -DBUILD_people=OFF \
+        -DBUILD_simulation=OFF \
+        -DBUILD_stereo=OFF \
+        -DBUILD_tracking=OFF \
         $PCL_DIR
   # Build
   make -j2
@@ -98,9 +183,15 @@ function build_tools ()
 function build_apps ()
 {
   # A complete build
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//                 TASK: BUILD PCL APPS                          //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DPCL_QT_VERSION=4 \
         -DBUILD_simulation=OFF \
@@ -124,9 +215,15 @@ function build_apps ()
 function build_lib_core ()
 {
   # A reduced build, only pcl_common
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//                 TASK: BUILD pcl_common                        //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DBUILD_2d=OFF \
         -DBUILD_features=OFF \
@@ -157,9 +254,16 @@ function build_lib_core ()
 
 function test_core ()
 {
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//              TASK: BUILD and RUN PCL TESTS CORE               //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
+
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DPCL_NO_PRECOMPILE=ON \
         -DBUILD_tools=OFF \
@@ -212,9 +316,15 @@ function test_core ()
 
 function test_ext_1 ()
 {
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//              TASK: BUILD and RUN PCL EXTended 1               //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DPCL_NO_PRECOMPILE=ON \
         -DBUILD_tools=OFF \
@@ -267,9 +377,15 @@ function test_ext_1 ()
 
 function test_ext_2 ()
 {
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//              TASK: BUILD and RUN PCL EXTended 2               //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+        $CMAKE_ARGS \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DPCL_NO_PRECOMPILE=ON \
         -DBUILD_tools=OFF \
@@ -322,6 +438,11 @@ function test_ext_2 ()
 
 function doc ()
 {
+  echo "///////////////////////////////////////////////////////////////////"
+  echo "//                                                               //"
+  echo "//                 TASK: BUILD PCL DOCS                          //"
+  echo "//                                                               //"
+  echo "///////////////////////////////////////////////////////////////////"
   # Do not generate documentation for pull requests
   if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then exit; fi
   # Install sphinx
@@ -371,6 +492,8 @@ function doc ()
 case $1 in
   before-install ) before_install;;
   build ) build;;
+  build-lib-core ) build_lib_core;;
+  build-lib ) build_lib;;
   build-examples ) build_examples;;
   build-tools ) build_tools;;
   build-apps ) build_apps;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 sudo: required
 language: cpp
+
 cache:
   ccache: true
+  directories:
+    - $HOME/.ccache
+
 addons:
   apt:
     sources:
@@ -27,6 +31,7 @@ addons:
       - libvtk5-qt4-dev
       - libglew-dev
       - libopenni-dev
+
 before_install:
   - bash .travis.sh before-install
 
@@ -58,32 +63,60 @@ env:
 
 jobs:
   include:
-    - stage: Core Build
-      env: TASK="build"
+    # - stage: pcl_common build
+    #   os: linux
+    #   compiler: gcc
+    #   script: bash .travis.sh build-lib-core
+    # - os: osx
+    #   compiler: clang
+    #   script: bash .travis.sh build-lib-core
+    - stage: core build
+      os: linux
       compiler: gcc
-      script: bash .travis.sh $TASK
-    - env: TASK="build"
+      script: bash .travis.sh build-lib
+    - os: osx
       compiler: clang
-      script: bash .travis.sh $TASK
-    - stage: Extended Build and Tests
+      script: bash .travis.sh build-lib
+    - stage: extended build and tests
+      os: linux
+      compiler: gcc
+      script: bash .travis.sh build-examples
+    - os: linux
+      compiler: gcc
+      script: bash .travis.sh build-tools
+    # - os: linux
+    #   compiler: gcc
+    #   script: bash .travis.sh build-apps
+    - os: osx
       compiler: clang
-      env: TASK="build-examples"
-      script: bash .travis.sh $TASK
-    - compiler: clang
-      env: TASK="build-tools"
-      script: bash .travis.sh $TASK
-    # - compiler: clang
-    #   env: TASK="build-apps"
-    #   script: bash .travis.sh $TASK
-    - compiler: gcc
-      env: TASK="doc"
-      script: bash .travis.sh $TASK
-    - compiler: gcc
-      env: TASK="test-core"
-      script: bash .travis.sh $TASK
-    - compiler: gcc
-      env: TASK="test-ext-1"
-      script: bash .travis.sh $TASK
-    - compiler: gcc
-      env: TASK="test-ext-2"
-      script: bash .travis.sh $TASK
+      script: bash .travis.sh build-examples
+    # - os: osx
+    #   compiler: clang
+    #   script: bash .travis.sh build-tools
+    - os: osx
+      compiler: clang
+      script: bash .travis.sh build-apps
+    - os: linux
+      compiler: gcc
+      script: bash .travis.sh test-core
+    - os: linux
+      compiler: gcc
+      script: bash .travis.sh test-ext-1
+    - os: linux
+      compiler: gcc
+      script: bash .travis.sh test-ext-2
+    # - os: osx
+    #   compiler: clang
+    #   script: bash .travis.sh test-core
+    # - os: osx
+    #   compiler: clang
+    #   script: bash .travis.sh test-ext-1
+    # - os: osx
+    #   compiler: clang
+    #   script: bash .travis.sh test-ext-2
+    - os: linux
+      compiler: gcc
+      script: bash .travis.sh doc
+    # - os: osx
+    #   compiler: clang
+    #   script: bash .travis.sh doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 sudo: required
 language: cpp
 
+git:
+  depth: 1
+
 cache:
   ccache: true
   directories:
-    - $HOME/.ccache
+    - $HOME/Library/Caches/Homebrew
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   ccache: true
   directories:
     - $HOME/Library/Caches/Homebrew
+  timeout: 600
 
 addons:
   apt:


### PR DESCRIPTION
This is the first stage stage for enabling osx builds in our CI pipeline. Important points for the time being:

- **jobs**:
    - Due to the considerable number of jobs we're running at the moment, linux now only builds with gcc and osx only with clang.
    - Under the same argument, I decided to drop the job which only built pcl_common
- **cache**:
    - We no longer are setting envs to be able to visualize which job is running. See https://github.com/PointCloudLibrary/pcl/pull/1892#issuecomment-310877880 for more info.
    - I can't manage to get ccache to work with apple clang on osx. I've tried a number of things already so I'm open to suggestions
- **tools** osx tools still can't be built under 50 minutes, because caching is not working :/
- **apps** linux apps are still not being built, and only a partial number of apps are being built in osx. The moment I'm able to meet the VTK-QT4 on osx, they'll likely exceed the build time as well.
- **tests** on osx still not enabled due to a script problem, but I was able to confirm at some point in #1888 that they're failing. Same for my local machine. This was one of the main reasons I wanted to enable osx builds on the CI.
- **docs** still to be enabled properly on osx.
- **other**: added verbose to all jobs to that we're able to identify what is running by looking at the log.

This is just the first "easy to do" stage of enabling osx on Travis. The objective is to have all jobs running in both platforms.

Edit: I forgot to mention that the the build matrix had to be abandoned, because it still has a lot of limitations when integrated in conjunction with Travis jobs functionality.