### PR TITLE
Replace C-style sqrtf with std::sqrt

### DIFF
--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -78,8 +78,8 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeSobel (
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
     output[i].magnitude = 
-      sqrtf ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-             (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
+                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
     output[i].direction = 
       atan2f ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }
@@ -121,8 +121,8 @@ pcl::Edge<PointInT, PointOutT>::sobelMagnitudeDirection (
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
     output[i].magnitude = 
-      sqrtf ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-             (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
+                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
     output[i].direction = 
       atan2f ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }
@@ -160,8 +160,8 @@ pcl::Edge<PointInT, PointOutT>::detectEdgePrewitt (pcl::PointCloud<PointOutT> &o
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
     output[i].magnitude = 
-      sqrtf ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-             (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
+                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
     output[i].direction = 
       atan2f ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }
@@ -199,8 +199,8 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeRoberts (pcl::PointCloud<PointOutT> &o
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
     output[i].magnitude = 
-      sqrtf ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-             (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
+                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
     output[i].direction = 
       atan2f ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
@@ -44,7 +44,7 @@ namespace pcl
 
             float avg_dist_neighbours = 0.0;
             for (size_t j = 1; j < nn_indices.size (); j++)
-              avg_dist_neighbours += sqrtf (nn_distances[j]);
+              avg_dist_neighbours += std::sqrt (nn_distances[j]);
 
             avg_dist_neighbours /= static_cast<float> (nn_indices.size ());
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
@@ -35,7 +35,7 @@ namespace pcl
     {
       float r1 = static_cast<float> (uniform_deviate (rand ()));
       float r2 = static_cast<float> (uniform_deviate (rand ()));
-      float r1sqr = sqrtf (r1);
+      float r1sqr = std::sqrt (r1);
       float OneMinR1Sqr = (1 - r1sqr);
       float OneMinR2 = (1 - r2);
       a1 *= OneMinR1Sqr;

--- a/apps/include/pcl/apps/nn_classification.h
+++ b/apps/include/pcl/apps/nn_classification.h
@@ -291,7 +291,7 @@ namespace pcl
           {
             result->first.push_back (classes_[it - sqr_distances->begin ()]);
             // TODO leave it squared, and relate param to sigma...
-            result->second.push_back (expf (-sqrtf (*it) / gaussian_param));
+            result->second.push_back (expf (-std::sqrt (*it) / gaussian_param));
           }
 
         // Return label/score list pair

--- a/common/include/pcl/common/distances.h
+++ b/common/include/pcl/common/distances.h
@@ -195,7 +195,7 @@ namespace pcl
   template<typename PointType1, typename PointType2> inline float
   euclideanDistance (const PointType1& p1, const PointType2& p2)
   {
-    return (sqrtf (squaredEuclideanDistance (p1, p2)));
+    return (std::sqrt (squaredEuclideanDistance (p1, p2)));
   }
 }
 /*@*/

--- a/common/include/pcl/common/impl/norms.hpp
+++ b/common/include/pcl/common/impl/norms.hpp
@@ -109,7 +109,7 @@ L2_Norm_SQR (FloatVectorT a, FloatVectorT b, int dim)
 template <typename FloatVectorT> inline float
 L2_Norm (FloatVectorT a, FloatVectorT b, int dim)
 {
-  return sqrtf(L2_Norm_SQR(a, b, dim));
+  return std::sqrt (L2_Norm_SQR(a, b, dim));
 }
 
 
@@ -129,9 +129,9 @@ JM_Norm (FloatVectorT a, FloatVectorT b, int dim)
   float norm = 0.0;
 
   for (int i = 0; i < dim; ++i)
-    norm += (sqrtf (a[i]) - sqrtf (b[i])) * (sqrtf (a[i]) - sqrtf (b[i]));
+    norm += (std::sqrt (a[i]) - std::sqrt (b[i])) * (std::sqrt (a[i]) - std::sqrt (b[i]));
 
-  return sqrtf (norm);
+  return std::sqrt (norm);
 }
 
 
@@ -141,7 +141,7 @@ B_Norm (FloatVectorT a, FloatVectorT b, int dim)
   float norm = 0.0, result;
 
   for (int i = 0; i < dim; ++i)
-    norm += sqrtf (a[i] * b[i]);
+    norm += std::sqrt (a[i] * b[i]);
 
   if (norm > 0)
     result = -logf (norm);
@@ -158,7 +158,7 @@ Sublinear_Norm (FloatVectorT a, FloatVectorT b, int dim)
   float norm = 0.0;
 
   for (int i = 0; i < dim; ++i)
-    norm += sqrtf (fabsf (a[i] - b[i]));
+    norm += std::sqrt (fabsf (a[i] - b[i]));
 
   return norm;
 }
@@ -199,7 +199,7 @@ PF_Norm (FloatVectorT a, FloatVectorT b, int dim, float P1, float P2)
 
   for (int i = 0; i < dim; ++i)
     norm += (P1 * a[i] - P2 * b[i]) * (P1 * a[i] - P2 * b[i]);
-  return sqrtf (norm);
+  return std::sqrt (norm);
 }
 
 

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -398,7 +398,7 @@ inline bool
   {
     return false;    
     // Reduce degree of polynomial
-    //polynomial_degree = (unsigned int) (0.5f* (sqrtf (8*samplePoints.size ()+1) - 3));
+    //polynomial_degree = (unsigned int) (0.5f* (std::sqrt (8*samplePoints.size ()+1) - 3));
     //parameters_size = BivariatePolynomialT<real>::getNoOfParametersFromDegree (polynomial_degree);
     //cout << "Not enough points, so degree of polynomial was decreased to "<<polynomial_degree
     //     << " ("<<samplePoints.size ()<<" points => "<<parameters_size<<" parameters)\n";

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -635,7 +635,7 @@ RangeImage::getImpactAngle (const PointWithRange& point1, const PointWithRange& 
     float r1Sqr = r1*r1,
           r2Sqr = r2*r2,
           dSqr  = squaredEuclideanDistance (point1, point2),
-          d     = sqrtf (dSqr);
+          d     = std::sqrt (dSqr);
     float cos_impact_angle = (r2Sqr + dSqr - r1Sqr)/ (2.0f*r2*d);
     cos_impact_angle = (std::max) (0.0f, (std::min) (1.0f, cos_impact_angle));
     impact_angle = acosf (cos_impact_angle);  // Using the cosine rule
@@ -770,9 +770,9 @@ RangeImage::getSurfaceAngleChange (int x, int y, int radius, float& angle_change
     //return acosf ( (Eigen::Vector3f (point.x, point.y, point.z)-getSensorPos ()).normalized ().dot ( (Eigen::Vector3f (neighbor1.x, neighbor1.y, neighbor1.z)-Eigen::Vector3f (point.x, point.y, point.z)).normalized ()));
   
   //float d1_squared = squaredEuclideanDistance (point, neighbor1),
-        //d1 = sqrtf (d1_squared),
+        //d1 = std::sqrt (d1_squared),
         //d2_squared = squaredEuclideanDistance (point, neighbor2),
-        //d2 = sqrtf (d2_squared),
+        //d2 = std::sqrt (d2_squared),
         //d3_squared = squaredEuclideanDistance (neighbor1, neighbor2);
   //float cos_surface_change = (d1_squared + d2_squared - d3_squared)/ (2.0f*d1*d2),
         //surface_change = acosf (cos_surface_change);
@@ -871,9 +871,9 @@ RangeImage::getAverageEuclideanDistance (int x, int y, int offset_x, int offset_
       else
         break;
     }
-    //std::cout << x<<","<<y<<"->"<<x2<<","<<y2<<": "<<sqrtf (pixel_distance)<<"m\n";
+    //std::cout << x<<","<<y<<"->"<<x2<<","<<y2<<": "<<std::sqrt (pixel_distance)<<"m\n";
     weight += 1.0f;
-    average_pixel_distance += sqrtf (pixel_distance);
+    average_pixel_distance += std::sqrt (pixel_distance);
   }
   average_pixel_distance /= weight;
   //std::cout << x<<","<<y<<","<<offset_x<<","<<offset_y<<" => "<<average_pixel_distance<<"\n";

--- a/common/include/pcl/range_image/impl/range_image_planar.hpp
+++ b/common/include/pcl/range_image/impl/range_image_planar.hpp
@@ -94,7 +94,7 @@ RangeImagePlanar::calculate3DPoint (float image_x, float image_y, float range, E
   //cout << __PRETTY_FUNCTION__ << " called.\n";
   float delta_x = (image_x+static_cast<float> (image_offset_x_)-center_x_)*focal_length_x_reciprocal_,
         delta_y = (image_y+static_cast<float> (image_offset_y_)-center_y_)*focal_length_y_reciprocal_;
-  point[2] = range / (sqrtf (delta_x*delta_x + delta_y*delta_y + 1));
+  point[2] = range / (std::sqrt (delta_x*delta_x + delta_y*delta_y + 1));
   point[0] = delta_x*point[2];
   point[1] = delta_y*point[2];
   point = to_world_system_ * point;

--- a/common/src/poses_from_matches.cpp
+++ b/common/src/poses_from_matches.cpp
@@ -121,12 +121,12 @@ pcl::PosesFromMatches::estimatePosesUsing2Correspondences (const pcl::PointCorre
       if (   distance_quotient_squared < min_distance_quotient_squared
           || distance_quotient_squared > max_distance_quotient_squared)
       {
-        //std::cout << "Skipping because of mismatching distances "<<sqrtf (distance1_squared)
-        //          << " and "<<sqrtf (distance1_corr_squared)<<".\n";
+        //std::cout << "Skipping because of mismatching distances "<<std::sqrt (distance1_squared)
+        //          << " and "<<std::sqrt (distance1_corr_squared)<<".\n";
         continue;
       }
       
-      float distance = sqrtf (distance_squared);
+      float distance = std::sqrt (distance_squared);
       
       Eigen::Vector3f corr3=corr1, corr4=corr2;
       corr3[0]+=distance; corr4[0]+=distance;

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -694,7 +694,7 @@ RangeImage::getNormalBasedUprightTransformation (const Eigen::Vector3f& point, f
         continue;
       }
       still_in_range = true;
-      float distance = sqrtf (distance_squared),
+      float distance = std::sqrt (distance_squared),
             weight = distance*max_dist_reciprocal;
       vector_average.add (neighbor, weight);
     }

--- a/features/include/pcl/features/impl/3dsc.hpp
+++ b/features/include/pcl/features/impl/3dsc.hpp
@@ -194,7 +194,7 @@ pcl::ShapeContext3DEstimation<PointInT, PointNT, PointOutT>::computePoint (
 
     /// ----- Compute current neighbour polar coordinates -----
     /// Get distance between the neighbour and the origin
-    float r = sqrtf (nn_dists[ne]);
+    float r = std::sqrt (nn_dists[ne]);
 
     /// Project point into the tangent plane
     Eigen::Vector3f proj;

--- a/features/include/pcl/features/impl/crh.hpp
+++ b/features/include/pcl/features/impl/crh.hpp
@@ -104,7 +104,7 @@ pcl::CRHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
   for (size_t i = 0; i < grid.points.size (); ++i)
   {
     bin = static_cast<int> ((((atan2 (grid.points[i].normal_y, grid.points[i].normal_x) + M_PI) * 180 / M_PI) / bin_angle)) % nbins;
-    w = sqrtf (grid.points[i].normal_y * grid.points[i].normal_y + grid.points[i].normal_x * grid.points[i].normal_x);
+    w = std::sqrt (grid.points[i].normal_y * grid.points[i].normal_y + grid.points[i].normal_x * grid.points[i].normal_x);
     sum_w += w;
     spatial_data[bin] += w;
   }

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -188,7 +188,7 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
     }
 
     // D3 ( herons formula )
-    d3v.push_back (sqrtf (sqrtf (s * (s-a) * (s-b) * (s-c))));
+    d3v.push_back (std::sqrt (std::sqrt (s * (s-a) * (s-b) * (s-c))));
     if (vxlcnt_sum <= 21)
     {
       wt_d3.push_back (0);

--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -338,7 +338,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
 
     flipNormalTowardsViewpoint (input_->points[point_index], vpx_, vpy_, vpz_, normal_x, normal_y, normal_z);
     
-    const float scale = 1.0f / sqrtf (normal_length);
+    const float scale = 1.0f / std::sqrt (normal_length);
 
     normal.normal_x = normal_x * scale;
     normal.normal_y = normal_y * scale;
@@ -697,7 +697,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormalMirro
 
     flipNormalTowardsViewpoint (input_->points[point_index], vpx_, vpy_, vpz_, normal_x, normal_y, normal_z);
     
-    const float scale = 1.0f / sqrtf (normal_length);
+    const float scale = 1.0f / std::sqrt (normal_length);
 
     normal.normal_x = normal_x * scale;
     normal.normal_y = normal_y * scale;

--- a/features/include/pcl/features/impl/intensity_spin.hpp
+++ b/features/include/pcl/features/impl/intensity_spin.hpp
@@ -72,7 +72,7 @@ pcl::IntensitySpinEstimation<PointInT, PointOutT>::computeIntensitySpinImage (
   {
     // Normalize distance and intensity values to: 0.0 <= d,i < nr_distance_bins,nr_intensity_bins
     const float eps = std::numeric_limits<float>::epsilon ();
-    float d = static_cast<float> (nr_distance_bins) * sqrtf (squared_distances[idx]) / (radius + eps);
+    float d = static_cast<float> (nr_distance_bins) * std::sqrt (squared_distances[idx]) / (radius + eps);
     float i = static_cast<float> (nr_intensity_bins) * 
               (cloud.points[indices[idx]].intensity - min_intensity) / (max_intensity - min_intensity + eps);
 

--- a/features/include/pcl/features/impl/linear_least_squares_normal.hpp
+++ b/features/include/pcl/features/impl/linear_least_squares_normal.hpp
@@ -139,7 +139,7 @@ pcl::LinearLeastSquaresNormalEstimation<PointInT, PointOutT>::computePointNormal
   }
   else
   {
-    const float normInv = 1.0f / sqrtf (length);
+    const float normInv = 1.0f / std::sqrt (length);
 
     normal.normal_x = -nx * normInv;
     normal.normal_y = -ny * normInv;
@@ -252,7 +252,7 @@ pcl::LinearLeastSquaresNormalEstimation<PointInT, PointOutT>::computeFeature (Po
       }
       else
       {
-        const float normInv = 1.0f / sqrtf (length);
+        const float normInv = 1.0f / std::sqrt (length);
 
         output.points[index].normal_x = nx * normInv;
         output.points[index].normal_y = ny * normInv;

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -170,7 +170,7 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
       standard_dev += diff * diff;
       diff_vector[point_i] = diff;
     }
-    standard_dev = sqrtf (standard_dev / static_cast<float> (features_at_scale_vectorized_[scale_i].size ()));
+    standard_dev = std::sqrt (standard_dev / static_cast<float> (features_at_scale_vectorized_[scale_i].size ()));
     PCL_DEBUG ("[pcl::MultiscaleFeaturePersistence::extractUniqueFeatures] Standard deviation for scale %f is %f\n", scale_values_[scale_i], standard_dev);
 
     // Select only points outside (mean +/- alpha * standard_dev)

--- a/features/include/pcl/features/impl/narf.hpp
+++ b/features/include/pcl/features/impl/narf.hpp
@@ -81,7 +81,7 @@ inline void Narf::copyToNarf36(Narf36& narf36) const
     //{
       //diff = (diff - middle_value)*normalization_factor2;
       //diff = 0.5f + 0.5f*diff;
-      ////diff = 0.5f + 0.5f*sqrtf(diff);
+      ////diff = 0.5f + 0.5f*std::sqrt(diff);
       ////diff = 0.5f + 0.5f*powf(diff, 0.3f);
     //}
     //ret += diff;

--- a/features/include/pcl/features/impl/normal_based_signature.hpp
+++ b/features/include/pcl/features/impl/normal_based_signature.hpp
@@ -167,7 +167,7 @@ pcl::NormalBasedSignatureEstimation<PointT, PointNT, PointFeature>::computeFeatu
           Xk_real += static_cast<float> (s_matrix (n, column_i) * cos (2.0f * M_PI / static_cast<double> (N_ * k * n)));
           Xk_imag += static_cast<float> (s_matrix (n, column_i) * sin (2.0f * M_PI / static_cast<double> (N_ * k * n)));
         }
-        dft_col[k] = sqrtf (Xk_real*Xk_real + Xk_imag*Xk_imag);
+        dft_col[k] = std::sqrt (Xk_real*Xk_real + Xk_imag*Xk_imag);
       }
       dft_matrix.col (column_i).matrix () = dft_col;
     }

--- a/features/include/pcl/features/impl/range_image_border_extractor.hpp
+++ b/features/include/pcl/features/impl/range_image_border_extractor.hpp
@@ -88,7 +88,7 @@ float RangeImageBorderExtractor::getNeighborDistanceChangeScore(
   float neighbor_distance_squared = squaredEuclideanDistance(neighbor, point);
   if (neighbor_distance_squared <= local_surface.max_neighbor_distance_squared)
     return 0.0f;
-  float ret = 1.0f - sqrtf(local_surface.max_neighbor_distance_squared / neighbor_distance_squared);
+  float ret = 1.0f - std::sqrt (local_surface.max_neighbor_distance_squared / neighbor_distance_squared);
   if (neighbor.range < point.range)
     ret = -ret;
   return ret;
@@ -376,15 +376,15 @@ bool RangeImageBorderExtractor::calculateMainPrincipalCurvature(int x, int y, in
   
   Eigen::Vector3f eigen_values, eigen_vector1, eigen_vector2;
   vector_average.doPCA(eigen_values, eigen_vector1, eigen_vector2, main_direction);
-  magnitude = sqrtf(eigen_values[2]);
+  magnitude = std::sqrt (eigen_values[2]);
   //magnitude = eigen_values[2];
   //magnitude = 1.0f - powf(1.0f-magnitude, 5);
   //magnitude = 1.0f - powf(1.0f-magnitude, 10);
   //magnitude += magnitude - powf(magnitude,2);
   //magnitude += magnitude - powf(magnitude,2);
   
-  //magnitude = sqrtf(local_surface->eigen_values[0]/local_surface->eigen_values.sum());
-  //magnitude = sqrtf(local_surface->eigen_values_no_jumps[0]/local_surface->eigen_values_no_jumps.sum());
+  //magnitude = std::sqrt (local_surface->eigen_values[0]/local_surface->eigen_values.sum());
+  //magnitude = std::sqrt (local_surface->eigen_values_no_jumps[0]/local_surface->eigen_values_no_jumps.sum());
 
   //if (surface_structure_[y*range_image_->width+x+1]==NULL||surface_structure_[y*range_image_->width+x-1]==NULL)
   //{

--- a/features/include/pcl/features/impl/rift.hpp
+++ b/features/include/pcl/features/impl/rift.hpp
@@ -78,7 +78,7 @@ pcl::RIFTEstimation<PointInT, GradientT, PointOutT>::computeRIFT (
 
     // Normalize distance and angle values to: 0.0 <= d,g < nr_distances_bins,nr_gradient_bins
     const float eps = std::numeric_limits<float>::epsilon ();
-    float d = static_cast<float> (nr_distance_bins) * sqrtf (sqr_distances[idx]) / (radius + eps);
+    float d = static_cast<float> (nr_distance_bins) * std::sqrt (sqr_distances[idx]) / (radius + eps);
     float g = static_cast<float> (nr_gradient_bins) * gradient_angle_from_center / (static_cast<float> (M_PI) + eps);
 
     // Compute the bin indices that need to be updated

--- a/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
+++ b/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
@@ -68,7 +68,7 @@ pcl::StatisticalMultiscaleInterestRegionExtraction<PointT>::generateCloudGraph (
     kdtree.nearestKSearch (static_cast<int> (point_i), 16, k_indices, k_distances);
 
     for (int k_i = 0; k_i < static_cast<int> (k_indices.size ()); ++k_i)
-      add_edge (point_i, k_indices[k_i], Weight (sqrtf (k_distances[k_i])), cloud_graph);
+      add_edge (point_i, k_indices[k_i], Weight (std::sqrt (k_distances[k_i])), cloud_graph);
   }
 
   const size_t E = num_edges (cloud_graph),
@@ -159,7 +159,7 @@ pcl::StatisticalMultiscaleInterestRegionExtraction<PointT>::computeF ()
       for (size_t point_j = 0; point_j < input_->points.size (); ++point_j)
       {
         float d_g = geodesic_distances_[point_i][point_j];
-        float phi_i_j = 1.0f / sqrtf (2.0f * static_cast<float> (M_PI) * scale_squared) * expf ( (-1) * d_g*d_g / (2.0f * scale_squared));
+        float phi_i_j = 1.0f / std::sqrt (2.0f * static_cast<float> (M_PI) * scale_squared) * expf ( (-1) * d_g*d_g / (2.0f * scale_squared));
 
         point_density_i += phi_i_j;
         phi_row[point_j] = phi_i_j;

--- a/features/include/pcl/features/impl/usc.hpp
+++ b/features/include/pcl/features/impl/usc.hpp
@@ -168,7 +168,7 @@ pcl::UniqueShapeContext<PointInT, PointOutT, PointRFT>::computePointDescriptor (
     // ----- Compute current neighbour polar coordinates -----
 
     // Get distance between the neighbour and the origin
-    float r = sqrtf (nn_dists[ne]);
+    float r = std::sqrt (nn_dists[ne]);
 
     // Project point into the tangent plane
     Eigen::Vector3f proj;

--- a/filters/include/pcl/filters/normal_refinement.h
+++ b/filters/include/pcl/filters/normal_refinement.h
@@ -118,7 +118,7 @@ namespace pcl
     }
     
     // Normalize if norm valid and non-zero
-    const float norm = sqrtf (nx * nx + ny * ny + nz * nz);
+    const float norm = std::sqrt (nx * nx + ny * ny + nz * nz);
     if (pcl_isfinite (norm) && norm > std::numeric_limits<float>::epsilon ())
     {
       point.normal_x = nx / norm;

--- a/geometry/include/pcl/geometry/impl/polygon_operations.hpp
+++ b/geometry/include/pcl/geometry/impl/polygon_operations.hpp
@@ -129,7 +129,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
     float line_y = polygon [currentInterval.second].x - polygon [currentInterval.first].x;
     float line_d = polygon [currentInterval.first].x * polygon [currentInterval.second].y - polygon [currentInterval.first].y * polygon [currentInterval.second].x;
     
-    float linelen = 1.0f / sqrtf (line_x * line_x + line_y * line_y);
+    float linelen = 1.0f / std::sqrt (line_x * line_x + line_y * line_y);
     
     line_x *= linelen;
     line_y *= linelen;

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -356,7 +356,7 @@ NarfKeypoint::calculateCompleteInterestImage ()
           continue;
         const Eigen::Vector3f& surface_change_direction = surface_change_directions[index2];
         
-        float distance = sqrtf (distance_squared);
+        float distance = std::sqrt (distance_squared);
         float distance_factor = radius_reciprocal*distance;
         float positive_score, current_negative_score;
         nkdGetScores (distance_factor, surface_change_score, pixelDistance,
@@ -392,7 +392,7 @@ NarfKeypoint::calculateCompleteInterestImage ()
                                          normalized_angle_diff,   angle_change_value);
         }
       }
-      angle_change_value = sqrtf (angle_change_value);
+      angle_change_value = std::sqrt (angle_change_value);
       interest_value = negative_score * angle_change_value;
       
       if (parameters_.add_points_on_straight_edges)
@@ -572,7 +572,7 @@ NarfKeypoint::calculateSparseInterestImage ()
                                        normalized_angle_diff,   angle_change_value);
       }
     }
-    angle_change_value = sqrtf (angle_change_value);
+    angle_change_value = std::sqrt (angle_change_value);
     float maximum_interest_value = angle_change_value;
     
     if (parameters_.add_points_on_straight_edges)
@@ -680,7 +680,7 @@ NarfKeypoint::calculateSparseInterestImage ()
                                                                normalized_angle_diff);
           }
         }
-        angle_change_value = sqrtf (angle_change_value);
+        angle_change_value = std::sqrt (angle_change_value);
         interest_value = negative_score * angle_change_value;
         if (parameters_.add_points_on_straight_edges)
         {

--- a/ml/src/permutohedral.cpp
+++ b/ml/src/permutohedral.cpp
@@ -85,11 +85,11 @@ pcl::Permutohedral::init (const std::vector<float> &feature, const int feature_d
   }
 
   // Expected standard deviation of our filter (p.6 in [Adams etal 2010])
-  float inv_std_dev = sqrtf (2.0f / 3.0f) * static_cast<float> (d_ + 1);
+  float inv_std_dev = std::sqrt (2.0f / 3.0f) * static_cast<float> (d_ + 1);
   
   // Compute the diagonal part of E (p.5 in [Adams etal 2010])
   for (int i = 0; i < d_; i++)
-    scale_factor (i) = 1.0f / sqrtf (static_cast<float> (i + 2) * static_cast<float> (i + 1)) * inv_std_dev;
+    scale_factor (i) = 1.0f / std::sqrt (static_cast<float> (i + 2) * static_cast<float> (i + 1)) * inv_std_dev;
 
   // Compute the simplex each feature lies in
   for (int k = 0; k < N_; k++)
@@ -353,10 +353,10 @@ pcl::Permutohedral::initOLD (const std::vector<float> &feature, const int featur
   }
 		
   // Expected standard deviation of our filter (p.6 in [Adams etal 2010])
-  float inv_std_dev = sqrtf (2.0f / 3.0f)* static_cast<float>(d_+1);
+  float inv_std_dev = std::sqrt (2.0f / 3.0f)* static_cast<float>(d_+1);
   // Compute the diagonal part of E (p.5 in [Adams etal 2010])
   for (int i=0; i<d_; i++)
-    scale_factor[i] = 1.0f / sqrtf (static_cast<float>(i+2)*static_cast<float>(i+1)) * inv_std_dev;
+    scale_factor[i] = 1.0f / std::sqrt (static_cast<float>(i+2)*static_cast<float>(i+1)) * inv_std_dev;
 		
   // Compute the simplex each feature lies in
   for (int k=0; k<N_; k++)

--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -151,7 +151,7 @@ pcl::people::HOG::gradMag( float *I, int h, int w, int d, float *M, float *O ) c
   // compute gradient magnitude (M) and normalize Gx
   for( y=0; y<h4; y++ ) 
   {
-  m = 1.0f/sqrtf(M2[y]);
+  m = 1.0f / std::sqrt (M2[y]);
   m = m < 1e10f ? m : 1e10f;
     M2[y] = 1.0f / m;
     Gx[y] = ((Gx[y] * m) * acMult);

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -915,7 +915,7 @@ computeMaxColorGradientsSobel (const typename pcl::PointCloud<pcl::RGB>::ConstPt
       if (sqr_mag_r > sqr_mag_g && sqr_mag_r > sqr_mag_b)
       {
         GradientXY gradient;
-        gradient.magnitude = sqrtf (static_cast<float> (sqr_mag_r));
+        gradient.magnitude = std::sqrt (static_cast<float> (sqr_mag_r));
         gradient.angle = atan2f (static_cast<float> (r_dy), static_cast<float> (r_dx)) * 180.0f / pi;
         if (gradient.angle < -180.0f) gradient.angle += 360.0f;
         if (gradient.angle >= 180.0f) gradient.angle -= 360.0f;
@@ -927,7 +927,7 @@ computeMaxColorGradientsSobel (const typename pcl::PointCloud<pcl::RGB>::ConstPt
       else if (sqr_mag_g > sqr_mag_b)
       {
         GradientXY gradient;
-        gradient.magnitude = sqrtf (static_cast<float> (sqr_mag_g));
+        gradient.magnitude = std::sqrt (static_cast<float> (sqr_mag_g));
         gradient.angle = atan2f (static_cast<float> (g_dy), static_cast<float> (g_dx)) * 180.0f / pi;
         if (gradient.angle < -180.0f) gradient.angle += 360.0f;
         if (gradient.angle >= 180.0f) gradient.angle -= 360.0f;
@@ -939,7 +939,7 @@ computeMaxColorGradientsSobel (const typename pcl::PointCloud<pcl::RGB>::ConstPt
       else
       {
         GradientXY gradient;
-        gradient.magnitude = sqrtf (static_cast<float> (sqr_mag_b));
+        gradient.magnitude = std::sqrt (static_cast<float> (sqr_mag_b));
         gradient.angle = atan2f (static_cast<float> (b_dy), static_cast<float> (b_dx)) * 180.0f / pi;
         if (gradient.angle < -180.0f) gradient.angle += 360.0f;
         if (gradient.angle >= 180.0f) gradient.angle -= 360.0f;

--- a/recognition/include/pcl/recognition/crh_alignment.h
+++ b/recognition/include/pcl/recognition/crh_alignment.h
@@ -213,7 +213,7 @@ namespace pcl
           multAB[k].r = a * c - b * d;
           multAB[k].i = b * c + a * d;
 
-          float tmp = sqrtf (multAB[k].r * multAB[k].r + multAB[k].i * multAB[k].i);
+          float tmp = std::sqrt (multAB[k].r * multAB[k].r + multAB[k].i * multAB[k].i);
 
           multAB[k].r /= tmp;
           multAB[k].i /= tmp;

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -208,9 +208,9 @@ namespace pcl
       // normalize normals
       for (int normal_index = 0; normal_index < nr_normals; ++normal_index)
       {
-        const float length = sqrtf (ref_normals[normal_index].x * ref_normals[normal_index].x +
-                                    ref_normals[normal_index].y * ref_normals[normal_index].y +
-                                    ref_normals[normal_index].z * ref_normals[normal_index].z);
+        const float length = std::sqrt (ref_normals[normal_index].x * ref_normals[normal_index].x +
+                                        ref_normals[normal_index].y * ref_normals[normal_index].y +
+                                        ref_normals[normal_index].z * ref_normals[normal_index].z);
 
         const float inv_length = 1.0f / length;
 
@@ -229,7 +229,7 @@ namespace pcl
             PointXYZ normal (static_cast<float> (x_index - range_x/2), 
                              static_cast<float> (y_index - range_y/2), 
                              static_cast<float> (z_index - range_z));
-            const float length = sqrtf (normal.x*normal.x + normal.y*normal.y + normal.z*normal.z);
+            const float length = std::sqrt (normal.x*normal.x + normal.y*normal.y + normal.z*normal.z);
             const float inv_length = 1.0f / (length + 0.00001f);
 
             normal.x *= inv_length;
@@ -670,7 +670,7 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals ()
       }
       else
       {
-        const float normInv = 1.0f / sqrtf (length);
+        const float normInv = 1.0f / std::sqrt (length);
 
         const float normal_x = nx * normInv;
         const float normal_y = ny * normInv;
@@ -891,7 +891,7 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
         //double l_ny = l_ddy * dummy_focal_length;
         //double l_nz = -l_det * l_d;
 
-        float l_sqrt = sqrtf (l_nx * l_nx + l_ny * l_ny + l_nz * l_nz);
+        float l_sqrt = std::sqrt (l_nx * l_nx + l_ny * l_ny + l_nz * l_nz);
 
         if (l_sqrt > 0)
         {

--- a/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
+++ b/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
@@ -119,7 +119,7 @@ pcl::PyramidFeatureHistogram<PointFeature>::comparePyramidFeatureHistograms (con
   float self_similarity_a = static_cast<float> (pyramid_a->nr_features),
         self_similarity_b = static_cast<float> (pyramid_b->nr_features);
   PCL_DEBUG ("[pcl::PyramidFeatureMatching::comparePyramidFeatureHistograms] Self similarity measures: %f, %f\n", self_similarity_a, self_similarity_b);
-  match_count /= sqrtf (self_similarity_a * self_similarity_b);
+  match_count /= std::sqrt (self_similarity_a * self_similarity_b);
 
   return match_count;
 }
@@ -187,7 +187,7 @@ pcl::PyramidFeatureHistogram<PointFeature>::initializeHistogram ()
     float aux = range_it->first - range_it->second;
     D += aux * aux;
   }
-  D = sqrtf (D);
+  D = std::sqrt (D);
   nr_levels = static_cast<size_t> (ceilf (Log2 (D)));
   PCL_DEBUG ("[pcl::PyramidFeatureHistogram::initializeHistogram] Pyramid will have %u levels with a hyper-parallelepiped diagonal size of %f\n", nr_levels, D);
 
@@ -200,8 +200,8 @@ pcl::PyramidFeatureHistogram<PointFeature>::initializeHistogram ()
     for (size_t dim_i = 0; dim_i < nr_dimensions; ++dim_i) 
     {
       bins_per_dimension[dim_i] = 
-        static_cast<size_t> (ceilf ((dimension_range_target_[dim_i].second - dimension_range_target_[dim_i].first) / (powf (2.0f, static_cast<float> (level_i)) * sqrtf (static_cast<float> (nr_dimensions)))));
-      bin_step[dim_i] = powf (2.0f, static_cast<float> (level_i)) * sqrtf (static_cast<float> (nr_dimensions));
+        static_cast<size_t> (ceilf ((dimension_range_target_[dim_i].second - dimension_range_target_[dim_i].first) / (powf (2.0f, static_cast<float> (level_i)) * std::sqrt (static_cast<float> (nr_dimensions)))));
+      bin_step[dim_i] = powf (2.0f, static_cast<float> (level_i)) * std::sqrt (static_cast<float> (nr_dimensions));
     }
     hist_levels[level_i] = PyramidFeatureHistogramLevel (bins_per_dimension, bin_step);
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -116,13 +116,13 @@ pcl::SampleConsensusModelCircle2D<PointT>::getDistancesToModel (const Eigen::Vec
   for (size_t i = 0; i < indices_->size (); ++i)
     // Calculate the distance from the point to the circle as the difference between
     // dist(point,circle_origin) and circle_radius
-    distances[i] = fabsf (sqrtf (
-                                ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
-                                ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
+    distances[i] = fabsf (std::sqrt (
+                                    ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
+                                    ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
-                                ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
-                                ( input_->points[(*indices_)[i]].y - model_coefficients[1] )
-                                ) - model_coefficients[2]);
+                                    ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
+                                    ( input_->points[(*indices_)[i]].y - model_coefficients[1] )
+                                    ) - model_coefficients[2]);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -146,13 +146,13 @@ pcl::SampleConsensusModelCircle2D<PointT>::selectWithinDistance (
   {
     // Calculate the distance from the point to the sphere as the difference between
     // dist(point,sphere_origin) and sphere_radius
-    float distance = fabsf (sqrtf (
-                                  ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
-                                  ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
+    float distance = fabsf (std::sqrt (
+                                      ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
+                                      ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
-                                  ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
-                                  ( input_->points[(*indices_)[i]].y - model_coefficients[1] )
-                                  ) - model_coefficients[2]);
+                                      ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
+                                      ( input_->points[(*indices_)[i]].y - model_coefficients[1] )
+                                      ) - model_coefficients[2]);
     if (distance < threshold)
     {
       // Returns the indices of the points whose distances are smaller than the threshold
@@ -180,13 +180,13 @@ pcl::SampleConsensusModelCircle2D<PointT>::countWithinDistance (
   {
     // Calculate the distance from the point to the sphere as the difference between
     // dist(point,sphere_origin) and sphere_radius
-    float distance = fabsf (sqrtf (
-                                  ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
-                                  ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
+    float distance = fabsf (std::sqrt (
+                                      ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
+                                      ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
-                                  ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
-                                  ( input_->points[(*indices_)[i]].y - model_coefficients[1] )
-                                  ) - model_coefficients[2]);
+                                      ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
+                                      ( input_->points[(*indices_)[i]].y - model_coefficients[1] )
+                                      ) - model_coefficients[2]);
     if (distance < threshold)
       nr_p++;
   }
@@ -261,7 +261,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
     {
       float dx = input_->points[inliers[i]].x - model_coefficients[0];
       float dy = input_->points[inliers[i]].y - model_coefficients[1];
-      float a = sqrtf ( (model_coefficients[2] * model_coefficients[2]) / (dx * dx + dy * dy) );
+      float a = std::sqrt ( (model_coefficients[2] * model_coefficients[2]) / (dx * dx + dy * dy) );
 
       projected_points.points[inliers[i]].x = a * dx + model_coefficients[0];
       projected_points.points[inliers[i]].y = a * dy + model_coefficients[1];
@@ -285,7 +285,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
     {
       float dx = input_->points[inliers[i]].x - model_coefficients[0];
       float dy = input_->points[inliers[i]].y - model_coefficients[1];
-      float a = sqrtf ( (model_coefficients[2] * model_coefficients[2]) / (dx * dx + dy * dy) );
+      float a = std::sqrt ( (model_coefficients[2] * model_coefficients[2]) / (dx * dx + dy * dy) );
 
       projected_points.points[i].x = a * dx + model_coefficients[0];
       projected_points.points[i].y = a * dy + model_coefficients[1];
@@ -308,12 +308,12 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
   for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
-    if (fabsf (sqrtf (
-                     ( input_->points[*it].x - model_coefficients[0] ) *
-                     ( input_->points[*it].x - model_coefficients[0] ) +
-                     ( input_->points[*it].y - model_coefficients[1] ) *
-                     ( input_->points[*it].y - model_coefficients[1] )
-                     ) - model_coefficients[2]) > threshold)
+    if (fabsf (std::sqrt (
+                         ( input_->points[*it].x - model_coefficients[0] ) *
+                         ( input_->points[*it].x - model_coefficients[0] ) +
+                         ( input_->points[*it].y - model_coefficients[1] ) *
+                         ( input_->points[*it].y - model_coefficients[1] )
+                         ) - model_coefficients[2]) > threshold)
       return (false);
 
   return (true);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
@@ -110,10 +110,9 @@ pcl::SampleConsensusModelSphere<PointT>::computeModelCoefficients (
   model_coefficients[1] = 0.5f * m13 / m11;
   model_coefficients[2] = 0.5f * m14 / m11;
   // Radius
-  model_coefficients[3] = sqrtf (
-                                 model_coefficients[0] * model_coefficients[0] +
-                                 model_coefficients[1] * model_coefficients[1] +
-                                 model_coefficients[2] * model_coefficients[2] - m15 / m11);
+  model_coefficients[3] = std::sqrt (model_coefficients[0] * model_coefficients[0] +
+                                     model_coefficients[1] * model_coefficients[1] +
+                                     model_coefficients[2] * model_coefficients[2] - m15 / m11);
 
   return (true);
 }
@@ -135,7 +134,7 @@ pcl::SampleConsensusModelSphere<PointT>::getDistancesToModel (
   for (size_t i = 0; i < indices_->size (); ++i)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
-    distances[i] = fabs (sqrtf (
+    distances[i] = fabs (std::sqrt (
                                ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                                ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -166,7 +165,7 @@ pcl::SampleConsensusModelSphere<PointT>::selectWithinDistance (
   // Iterate through the 3d points and calculate the distances from them to the sphere
   for (size_t i = 0; i < indices_->size (); ++i)
   {
-    double distance = fabs (sqrtf (
+    double distance = fabs (std::sqrt (
                           ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                           ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -206,16 +205,16 @@ pcl::SampleConsensusModelSphere<PointT>::countWithinDistance (
   {
     // Calculate the distance from the point to the sphere as the difference between
     // dist(point,sphere_origin) and sphere_radius
-    if (fabs (sqrtf (
-                    ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
-                    ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
+    if (fabs (std::sqrt (
+                        ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
+                        ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
-                    ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
-                    ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) +
+                        ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) *
+                        ( input_->points[(*indices_)[i]].y - model_coefficients[1] ) +
 
-                    ( input_->points[(*indices_)[i]].z - model_coefficients[2] ) *
-                    ( input_->points[(*indices_)[i]].z - model_coefficients[2] )
-                    ) - model_coefficients[3]) < threshold)
+                        ( input_->points[(*indices_)[i]].z - model_coefficients[2] ) *
+                        ( input_->points[(*indices_)[i]].z - model_coefficients[2] )
+                        ) - model_coefficients[3]) < threshold)
       nr_p++;
   }
   return (nr_p);

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -247,7 +247,7 @@ namespace pcl
             float yt = model_->input_->points[(*model_->tmp_inliers_)[i]].y - x[1];
             
             // g = sqrt ((x-a)^2 + (y-b)^2) - R
-            fvec[i] = sqrtf (xt * xt + yt * yt) - x[2];
+            fvec[i] = std::sqrt (xt * xt + yt * yt) - x[2];
           }
           return (0);
         }

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -263,7 +263,7 @@ namespace pcl
             cen_t[2] = model_->input_->points[(*model_->tmp_inliers_)[i]].z - x[2];
             
             // g = sqrt ((x-a)^2 + (y-b)^2 + (z-c)^2) - R
-            fvec[i] = sqrtf (cen_t.dot (cen_t)) - x[3];
+            fvec[i] = std::sqrt (cen_t.dot (cen_t)) - x[3];
           }
           return (0);
         }

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -112,7 +112,7 @@ namespace pcl
           // 2 * tan (85 degree) ~ 22.86
           float min_f = 0.043744332f * static_cast<float>(input_->width);
           //std::cout << "isValid: " << determinant3x3Matrix<Eigen::Matrix3f> (KR_ / sqrt (KR_KRT_.coeff (8))) << " >= " << (min_f * min_f) << std::endl;
-          return (determinant3x3Matrix<Eigen::Matrix3f> (KR_ / sqrtf (KR_KRT_.coeff (8))) >= (min_f * min_f));
+          return (determinant3x3Matrix<Eigen::Matrix3f> (KR_ / std::sqrt (KR_KRT_.coeff (8))) >= (min_f * min_f));
         }
         
         /** \brief Compute the camera matrix

--- a/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
@@ -189,7 +189,7 @@ namespace pcl
         float dx = input_->points[idx1].x - input_->points[idx2].x;
         float dy = input_->points[idx1].y - input_->points[idx2].y;
         float dz = input_->points[idx1].z - input_->points[idx2].z;
-        float dist = sqrtf (dx*dx + dy*dy + dz*dz);
+        float dist = std::sqrt (dx*dx + dy*dy + dz*dz);
 
         bool normal_ok = (normals_->points[idx1].getNormalVector3fMap ().dot (normals_->points[idx2].getNormalVector3fMap () ) > angular_threshold_ );
         bool dist_ok = (dist < euclidean_dist_threshold);

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -190,7 +190,7 @@ namespace pcl
         float dx = input_->points[idx1].x - input_->points[idx2].x;
         float dy = input_->points[idx1].y - input_->points[idx2].y;
         float dz = input_->points[idx1].z - input_->points[idx2].z;
-        float dist = sqrtf (dx*dx + dy*dy + dz*dz);
+        float dist = std::sqrt (dx*dx + dy*dy + dz*dz);
 
         return (dist < dist_threshold);
       }

--- a/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
@@ -90,7 +90,7 @@ namespace pcl
         float dx = input_->points[idx1].x - input_->points[idx2].x;
         float dy = input_->points[idx1].y - input_->points[idx2].y;
         float dz = input_->points[idx1].z - input_->points[idx2].z;
-        float dist = sqrtf (dx*dx + dy*dy + dz*dz);
+        float dist = std::sqrt (dx*dx + dy*dy + dz*dz);
         
         return ( (dist < distance_threshold_)
                  && (normals_->points[idx1].getNormalVector3fMap ().dot (normals_->points[idx2].getNormalVector3fMap () ) > angular_threshold_ ) );

--- a/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
@@ -116,7 +116,7 @@ namespace pcl
         float dx = input_->points[idx1].x - input_->points[idx2].x;
         float dy = input_->points[idx1].y - input_->points[idx2].y;
         float dz = input_->points[idx1].z - input_->points[idx2].z;
-        float dist = sqrtf (dx*dx + dy*dy + dz*dz);
+        float dist = std::sqrt (dx*dx + dy*dy + dz*dz);
         int dr = input_->points[idx1].r - input_->points[idx2].r;
         int dg = input_->points[idx1].g - input_->points[idx2].g;
         int db = input_->points[idx1].b - input_->points[idx2].b;

--- a/test/common/test_transforms.cpp
+++ b/test/common/test_transforms.cpp
@@ -52,7 +52,7 @@ using namespace pcl::io;
 using namespace std;
 
 const float PI = 3.14159265f;
-const float rho = sqrtf (2.0f) / 2.0f;  // cos(PI/4) == sin(PI/4)
+const float rho = std::sqrt (2.0f) / 2.0f;  // cos(PI/4) == sin(PI/4)
 
 PointCloud<PointXYZ> cloud;
 pcl::PCLPointCloud2 cloud_blob;

--- a/test/features/test_gradient_estimation.cpp
+++ b/test/features/test_gradient_estimation.cpp
@@ -100,7 +100,7 @@ TEST (PCL, IntensityGradientEstimation)
     float nx = -0.2f * p.x;
     float ny = -0.5f;
     float nz = 1.0f;
-    float magnitude = sqrtf (nx * nx + ny * ny + nz * nz);
+    float magnitude = std::sqrt (nx * nx + ny * ny + nz * nz);
     nx /= magnitude;
     ny /= magnitude;
     nz /= magnitude;

--- a/test/features/test_rift_estimation.cpp
+++ b/test/features/test_rift_estimation.cpp
@@ -58,7 +58,7 @@ TEST (PCL, RIFTEstimation)
       PointXYZI p;
       p.x = x;
       p.y = y;
-      p.z = sqrtf (400 - x * x - y * y);
+      p.z = std::sqrt (400 - x * x - y * y);
       p.intensity = expf ((-powf (x - 3.0f, 2.0f) + powf (y + 2.0f, 2.0f)) / (2.0f * 25.0f)) + expf ((-powf (x + 5.0f, 2.0f) + powf (y - 5.0f, 2.0f))
                                                                                  / (2.0f * 4.0f));
 
@@ -81,7 +81,7 @@ TEST (PCL, RIFTEstimation)
     float nx = p.x;
     float ny = p.y;
     float nz = p.z;
-    float magnitude = sqrtf (nx * nx + ny * ny + nz * nz);
+    float magnitude = std::sqrt (nx * nx + ny * ny + nz * nz);
     nx /= magnitude;
     ny /= magnitude;
     nz /= magnitude;

--- a/test/features/test_spin_estimation.cpp
+++ b/test/features/test_spin_estimation.cpp
@@ -247,7 +247,7 @@ TEST (PCL, IntensitySpinEstimation)
       PointXYZI p;
       p.x = x;
       p.y = y;
-      p.z = sqrtf (400.0f - x * x - y * y);
+      p.z = std::sqrt (400.0f - x * x - y * y);
       p.intensity = expf (-(powf (x - 3.0f, 2.0f) + powf (y + 2.0f, 2.0f)) / (2.0f * 25.0f)) + expf (-(powf (x + 5.0f, 2.0f) + powf (y - 5.0f, 2.0f))
                                                                                  / (2.0f * 4.0f));
 

--- a/test/geometry/test_iterator.cpp
+++ b/test/geometry/test_iterator.cpp
@@ -169,7 +169,7 @@ void checkGeneralLine (unsigned x_start, unsigned y_start, unsigned x_end, unsig
   else
     EXPECT_EQ (abs(dx) + abs(dy), idx);
   
-  float length = sqrtf (float (dx * dx + dy * dy));
+  float length = std::sqrt (float (dx * dx + dy * dy));
   float dir_x = float (dx) / length;
   float dir_y = float (dy) / length;
   

--- a/test/registration/test_registration_api.cpp
+++ b/test/registration/test_registration_api.cpp
@@ -493,7 +493,7 @@ TEST (PCL, TransformationEstimationPointToPlaneLLS)
       ny = 0.6f * p.y - 0.2f;
       nz = 1.0f;
 
-      float magnitude = sqrtf (nx * nx + ny * ny + nz * nz);
+      float magnitude = std::sqrt (nx * nx + ny * ny + nz * nz);
       nx /= magnitude;
       ny /= magnitude;
       nz /= magnitude;
@@ -627,7 +627,7 @@ TEST (PCL, TransformationEstimationPointToPlane)
       ny = 0.6f * p.y - 0.2f;
       nz = 1.0f;
 
-      float magnitude = sqrtf (nx * nx + ny * ny + nz * nz);
+      float magnitude = std::sqrt (nx * nx + ny * ny + nz * nz);
       nx /= magnitude;
       ny /= magnitude;
       nz /= magnitude;

--- a/tools/compute_cloud_error.cpp
+++ b/tools/compute_cloud_error.cpp
@@ -126,7 +126,7 @@ compute (const pcl::PCLPointCloud2::ConstPtr &cloud_source, const pcl::PCLPointC
       output_xyzi->points[point_i].z = xyz_source->points[point_i].z;
       output_xyzi->points[point_i].intensity = dist;
     }
-    rmse = sqrtf (rmse / static_cast<float> (xyz_source->points.size ()));
+    rmse = std::sqrt (rmse / static_cast<float> (xyz_source->points.size ()));
   }
   else if (correspondence_type == "nn")
   {
@@ -154,7 +154,7 @@ compute (const pcl::PCLPointCloud2::ConstPtr &cloud_source, const pcl::PCLPointC
       output_xyzi->points[point_i].z = xyz_source->points[point_i].z;
       output_xyzi->points[point_i].intensity = dist;
     }
-    rmse = sqrtf (rmse / static_cast<float> (xyz_source->points.size ()));
+    rmse = std::sqrt (rmse / static_cast<float> (xyz_source->points.size ()));
 
   }
   else if (correspondence_type == "nnplane")
@@ -190,7 +190,7 @@ compute (const pcl::PCLPointCloud2::ConstPtr &cloud_source, const pcl::PCLPointC
       output_xyzi->points[point_i].z = xyz_source->points[point_i].z;
       output_xyzi->points[point_i].intensity = dist * dist;
     }
-    rmse = sqrtf (rmse / static_cast<float> (xyz_source->points.size ()));
+    rmse = std::sqrt (rmse / static_cast<float> (xyz_source->points.size ()));
   }
   else
   {

--- a/tools/mesh_sampling.cpp
+++ b/tools/mesh_sampling.cpp
@@ -62,7 +62,7 @@ randomPointTriangle (float a1, float a2, float a3, float b1, float b2, float b3,
 {
   float r1 = static_cast<float> (uniform_deviate (rand ()));
   float r2 = static_cast<float> (uniform_deviate (rand ()));
-  float r1sqr = sqrtf (r1);
+  float r1sqr = std::sqrt (r1);
   float OneMinR1Sqr = (1 - r1sqr);
   float OneMinR2 = (1 - r2);
   a1 *= OneMinR1Sqr;


### PR DESCRIPTION
This replaces all C-style `sqrtf` with C++ style `std::sqrt` in all our codebase (besides from CUDA device code). Namespace prefix is to avoid problems with msvc (see #848).

Fixes #1787.