### PR TITLE
Fix find path for Eigen on Windows

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -122,7 +122,7 @@ macro(find_eigen)
   find_path(EIGEN_INCLUDE_DIRS Eigen/Core
     HINTS ${PC_EIGEN_INCLUDEDIR} ${PC_EIGEN_INCLUDE_DIRS} 
           "${EIGEN_ROOT}" "$ENV{EIGEN_ROOT}"
-    PATHS "$ENV{PROGRAMFILES}/Eigen 3.0.0" "$ENV{PROGRAMW6432}/Eigen 3.0.0"
+    PATHS "$ENV{PROGRAMFILES}/Eigen3" "$ENV{PROGRAMW6432}/Eigen3"
           "$ENV{PROGRAMFILES}/Eigen" "$ENV{PROGRAMW6432}/Eigen"   
     PATH_SUFFIXES eigen3 include/eigen3 include)
   find_package_handle_standard_args(eigen DEFAULT_MSG EIGEN_INCLUDE_DIRS)

--- a/cmake/Modules/FindEigen.cmake
+++ b/cmake/Modules/FindEigen.cmake
@@ -22,7 +22,7 @@ endif()
 find_path(EIGEN_INCLUDE_DIR Eigen/Core
     HINTS ${PC_EIGEN_INCLUDEDIR} ${PC_EIGEN_INCLUDE_DIRS} "${EIGEN_ROOT}" "$ENV{EIGEN_ROOT}"
     PATHS "$ENV{PROGRAMFILES}/Eigen" "$ENV{PROGRAMW6432}/Eigen"
-          "$ENV{PROGRAMFILES}/Eigen 3.0.0" "$ENV{PROGRAMW6432}/Eigen 3.0.0"
+          "$ENV{PROGRAMFILES}/Eigen3" "$ENV{PROGRAMW6432}/Eigen3"
     PATH_SUFFIXES eigen3 include/eigen3 include)
 
 if(EIGEN_INCLUDE_DIR)


### PR DESCRIPTION
Eigen will be installed in Eigen3 directory by default settings.
The default setting of CMAKE_INSTALL_PREFIX has become "C:/Program Files/Eigen3" (or "C:/Program Files (x86)/Eigen3") from Eigen 3.3.x. Also, It was never ".../Eigen 3.0.0" in Eigen 3.x.