### PR TITLE
Fix issue with finding pcl deployed out of path

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -717,11 +717,7 @@ if(WIN32 AND NOT MINGW)
   get_filename_component(PCL_ROOT "${PCL_DIR}" PATH)
 else(WIN32 AND NOT MINGW)
 # PCLConfig.cmake is installed to PCL_ROOT/share/pcl-x.y
-  if("${PCL_DIR}" STREQUAL "")
-    set(PCL_ROOT "@CMAKE_INSTALL_PREFIX@")
-  else("${PCL_DIR}" STREQUAL "")
-    get_filename_component(PCL_ROOT "${PCL_DIR}/../.." ABSOLUTE)
-  endif("${PCL_DIR}" STREQUAL "")
+  get_filename_component(PCL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 endif(WIN32 AND NOT MINGW)
 
 # check whether PCLConfig.cmake is found into a PCL installation or in a build tree

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -717,7 +717,11 @@ if(WIN32 AND NOT MINGW)
   get_filename_component(PCL_ROOT "${PCL_DIR}" PATH)
 else(WIN32 AND NOT MINGW)
 # PCLConfig.cmake is installed to PCL_ROOT/share/pcl-x.y
-  set(PCL_ROOT "@CMAKE_INSTALL_PREFIX@")
+  if("${PCL_DIR}" STREQUAL "")
+    set(PCL_ROOT "@CMAKE_INSTALL_PREFIX@")
+  else("${PCL_DIR}" STREQUAL "")
+    get_filename_component(PCL_ROOT "${PCL_DIR}/../.." ABSOLUTE)
+  endif("${PCL_DIR}" STREQUAL "")
 endif(WIN32 AND NOT MINGW)
 
 # check whether PCLConfig.cmake is found into a PCL installation or in a build tree


### PR DESCRIPTION
This allows the specification of PCL_DIR to override the install path generated during compilation. 