### PR TITLE
Update Ensenso tutorial for Ensenso X devices

### DIFF
--- a/doc/tutorials/content/ensenso_cameras.rst
+++ b/doc/tutorials/content/ensenso_cameras.rst
@@ -44,6 +44,36 @@ Note that this program opens the TCP port of the nxLib tree, this allows you to 
 The capture parameters (exposure, gain etc..) are set to default values.
 If you have performed and stored an extrinsic calibration it will be temporary reset.
 
+If you are using an Ensenso X device you have to calibrate the device before trying to run the PCL driver. If you don't you will get an error like this:
+
+.. code-block:: cpp
+  Initialising nxLib
+  Opening Ensenso stereo camera id = 0
+  openDevice: NxLib error ExecutionFailed (17) occurred while accessing item /Execute.
+
+  {
+          "ErrorSymbol": "InvalidCalibrationData",
+          "ErrorText": "Stereo camera calibration data is corrupted or not supported yet by the current software version.",
+          "Execute": {
+                  "Command": "Open",
+                  "Parameters": {
+                          "AllowFirmwareUpload": null,
+                          "Cameras": "171197",
+                          "FirmwareUpload": {
+                                  "Camera": null,
+                                  "Projector": null
+                          },
+                          "LoadCalibration": null,
+                          "Projector": null,
+                          "Threads": null
+                  }
+          },
+          "Time": 8902,
+          "TimeExecute": 8901,
+          "TimeFinalize": 0.03477,
+          "TimePrepare": 0.01185
+  }
+
 .. code-block:: cpp
 
   ensenso_ptr->enumDevices ();


### PR DESCRIPTION
I've been contacted by email, the guy was not able to use the driver with his Ensenso X device because he forgot to calibrate the lenses before using the PCL driver.

This PR adds a warning inside the tutorial to guide new users.