### PR TITLE
Update kdtree_flann.h

### DIFF
--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -227,10 +227,10 @@ namespace pcl
       int total_nr_points_;
 
       /** \brief The KdTree search parameters for K-nearest neighbors. */
-      ::flann::SearchParams param_k_;
+      ::flann::SearchParams *param_k_;
 
       /** \brief The KdTree search parameters for radius search. */
-      ::flann::SearchParams param_radius_;
+      ::flann::SearchParams *param_radius_;
   };
 }
 


### PR DESCRIPTION
The adding star operators for the KdTree search parameter solves the problem of conflict while compiling along wih the flann libraries of opencv. Please review my code and note the changes.