### PR TITLE
implementation of ball pivoting for surface reconstruction

### DIFF
--- a/surface/CMakeLists.txt
+++ b/surface/CMakeLists.txt
@@ -98,6 +98,7 @@ if(build)
         src/marching_cubes.cpp
         src/marching_cubes_hoppe.cpp
         src/marching_cubes_rbf.cpp
+        src/ball_pivoting.cpp
         src/bilateral_upsampling.cpp
         src/mls.cpp
         src/organized_fast_mesh.cpp
@@ -121,6 +122,7 @@ if(build)
         "include/pcl/${SUBSYS_NAME}/marching_cubes.h"
         "include/pcl/${SUBSYS_NAME}/marching_cubes_hoppe.h"
         "include/pcl/${SUBSYS_NAME}/marching_cubes_rbf.h"
+        "include/pcl/${SUBSYS_NAME}/ball_pivoting.h"
         "include/pcl/${SUBSYS_NAME}/bilateral_upsampling.h"
         "include/pcl/${SUBSYS_NAME}/mls.h"
         "include/pcl/${SUBSYS_NAME}/organized_fast_mesh.h"
@@ -143,6 +145,7 @@ if(build)
         "include/pcl/${SUBSYS_NAME}/impl/marching_cubes.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/marching_cubes_hoppe.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/marching_cubes_rbf.hpp"
+        "include/pcl/${SUBSYS_NAME}/impl/ball_pivoting.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/bilateral_upsampling.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/mls.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/organized_fast_mesh.hpp"

--- a/surface/CMakeLists.txt
+++ b/surface/CMakeLists.txt
@@ -123,6 +123,7 @@ if(build)
         "include/pcl/${SUBSYS_NAME}/marching_cubes_hoppe.h"
         "include/pcl/${SUBSYS_NAME}/marching_cubes_rbf.h"
         "include/pcl/${SUBSYS_NAME}/ball_pivoting.h"
+        "include/pcl/${SUBSYS_NAME}/ball_pivoting_front.h"
         "include/pcl/${SUBSYS_NAME}/bilateral_upsampling.h"
         "include/pcl/${SUBSYS_NAME}/mls.h"
         "include/pcl/${SUBSYS_NAME}/organized_fast_mesh.h"

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -2,7 +2,7 @@
  * Software License Agreement (BSD License)
  *
  *  Point Cloud Library (PCL) - www.pointclouds.org
- *  Copyright (c) 2014-, Open Perception, Inc.
+ *  Copyright (c) 2017-, Open Perception, Inc.
  *
  *  All rights reserved.
  *
@@ -38,10 +38,7 @@
 #ifndef PCL_BALL_PIVOTING_H_
 #define PCL_BALL_PIVOTING_H_
 
-#include <memory>
 #include <vector>
-#include <map>
-#include <set>
   
 #include "pcl/surface/boost.h"
 #include "pcl/surface/reconstruction.h"

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -106,7 +106,7 @@ namespace pcl
      * @return whether one triangle is found
      */
     bool
-    findSeed (pcl::Vertices::Ptr &seed, Eigen::Vector3f &center, bool &is_back_ball);
+    findSeed (pcl::Vertices &seed, Eigen::Vector3f &center, bool &is_back_ball);
   
     /**
      * pivoting around edge

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -38,22 +38,6 @@
 #ifndef PCL_BALL_PIVOTING_H_
 #define PCL_BALL_PIVOTING_H_
 
-/**
- * This class is an implementation of ball pivoting algorithm with some different details
- * @article{bernardini1999ball,
- *   title={The ball-pivoting algorithm for surface reconstruction},
- *   author={Bernardini, Fausto and Mittleman, Joshua and Rushmeier, Holly and Silva, Cl{\'a}udio and Taubin, Gabriel},
- *   journal={IEEE transactions on visualization and computer graphics},
- *   volume={5},
- *   number={4},
- *   pages={349--359},
- *   year={1999},
- *   publisher={IEEE}
- * }
- * author Tongxi Lou
- * email tongxi.lou@tum.de (tongxi.lou@gmx.de)
- */
-
 #include <memory>
 #include <vector>
 #include <map>
@@ -63,7 +47,24 @@
 #include "pcl/surface/reconstruction.h"
 
 namespace pcl
-{  
+{
+  /**
+   * This class is an implementation of ball pivoting algorithm(BPA) with some 
+   * different details. BPA exhibits linear time complexity (besides searching 
+   * complexity) and robustness to noise in real scanned data. The output mesh 
+   * is a manifold of an alpha-shape of the point set. BPA requires that the 
+   * points are distributed over the entire surface with a spatial frequency 
+   * greater than or equal to a certain minimum value (scale of pivoted ball).
+   *
+   * algorithm from
+   * Bernardini F., Mittleman J., Rushmeier H., Silva C., Taubin G., 
+   * "The ball-pivoting algorithm for surface reconstruction", TVCG'99
+   *
+   * author Tongxi Lou
+   * email tongxi.lou@tum.de (tongxi.lou@gmx.de if first one is canceled after graduation)
+   *
+   * \ingroup surface
+   */
   template<typename PointNT>
   class BallPivoting: public SurfaceReconstruction<PointNT>
   {

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -1,0 +1,418 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+  
+#ifndef PCL_BALL_PIVOTING_H_
+#define PCL_BALL_PIVOTING_H_
+
+/**
+ * This class is an implementation of ball pivoting algorithm with some different details
+ * @article{bernardini1999ball,
+ *   title={The ball-pivoting algorithm for surface reconstruction},
+ *   author={Bernardini, Fausto and Mittleman, Joshua and Rushmeier, Holly and Silva, Cl{\'a}udio and Taubin, Gabriel},
+ *   journal={IEEE transactions on visualization and computer graphics},
+ *   volume={5},
+ *   number={4},
+ *   pages={349--359},
+ *   year={1999},
+ *   publisher={IEEE}
+ * }
+ * author Tongxi Lou
+ * email tongxi.lou@tum.de (tongxi.lou@gmx.de)
+ */
+
+#include <memory>
+#include <vector>
+#include <map>
+#include <set>
+  
+#include "pcl/surface/boost.h"
+#include "pcl/surface/reconstruction.h"
+
+namespace pcl
+{  
+  template<typename PointNT>
+  class BallPivoting: public SurfaceReconstruction<PointNT>
+  {
+  protected:
+    /**
+     * This class describes the pivoting ball, which rolls on points and links the mesh.
+     */
+    class Edge
+    {
+    protected:
+      /** list of vertice index, should have length 2 */
+      std::vector<uint32_t> id_vertices_;
+      /** index of the opposite vertice, it and id_vertices_ form the last triangle */
+      uint32_t id_opposite_;
+      /** center point of the last ball, it may not be one in the cloud */
+      PointNT center_;
+      /** whether this ball it to the it rolled in the back face of surface (not normal direction) */
+      bool is_back_ball_;
+  
+    public:
+      Edge ();
+  
+      /**
+       * a fake constructor with only vertice index on edge
+       * @param id0 index of start point on edge
+       * @param id1 index of end point on edge
+       */
+      Edge (const uint32_t id0, const uint32_t id1);
+  
+      /**
+       * real constructor for edge with full information
+       * @param edge list of vertice index on edge
+       * @param id_opposite index of opposite vertice
+       * @param center center point of the ball
+       * @param is_back_ball whether the ball was rolling on the back surface
+       */
+      Edge (const std::vector<uint32_t> &edge, const uint32_t id_opposite, const PointNT &center,
+            const bool is_back_ball = false);
+  
+      ~Edge ();
+  
+      /**
+       * returns the center of ball
+       * @return
+       */
+      PointNT
+      getCenter () const;
+  
+      /**
+       * get the index of id-th vertice on edge, id should be either 0 or 1
+       * @param id
+       * @return
+       */
+      uint32_t
+      getIdVertice (const size_t id) const;
+  
+      /**
+       * get the index of opposite vertice
+       * @return
+       */
+      uint32_t
+      getIdOpposite () const;
+  
+      /**
+       * set the index of id-th vertice to be id_vertice
+       * @param id index inside edge. Should be 0 or 1
+       * @param id_vertice value of vertice index
+       */
+      void
+      setIdVertice (const size_t id, const uint32_t id_vertice);
+  
+      /**
+       * checks whether the ball was rolling on back surface
+       * @return
+       */
+      bool
+      isBackBall () const;
+  
+      /**
+       * get the signature of this edge, [index start vertice, index end vertice]
+       * @return
+       */
+      std::pair<uint32_t, uint32_t>
+      getSignature () const;
+  
+      /**
+       * get the reverse signature of this edge, [index end vertice, index start vertice]
+       * @return
+       */
+      std::pair<uint32_t, uint32_t>
+      getSignatureReverse () const;
+  
+      typedef boost::shared_ptr<Edge> Ptr;
+      typedef boost::shared_ptr<Edge const> ConstPtr;
+    };
+  
+    /**
+     * Front manages the edges, which ones are to be pivoted, which ones are pivoted.
+     */
+    class Front
+    {
+      typedef std::pair<uint32_t, uint32_t> Signature;
+    protected:
+      /** The set of edges to be pivoted */
+      std::map<Signature, Edge> front_;
+      /** The set of edges which are pivoted, but cannot reach suitable points. Edges here should be open boundary */
+      std::map<Signature, Edge> boundary_;
+      /** The set of successfully pivoted edges */
+      std::set<Signature> finished_;
+      /** The edge that is being pivoted and waiting for pivoting result: boundary or pivoted? */
+      typename Edge::Ptr current_edge_;
+  
+    public:
+      Front ();
+  
+      ~Front ();
+  
+      /**
+       * get one of the edges to pivot
+       * @return
+       */
+      typename Edge::Ptr
+      getActiveEdge ();
+  
+      /**
+       * add the three edges of one triangle to edges to pivot
+       * @param seed index of three vertices
+       * @param center the center of the ball
+       * @param is_back_ball whether the ball was pivoted on the back surface
+       */
+      void
+      addTriangle (const pcl::Vertices::ConstPtr &seed, const PointNT &center, const bool is_back_ball);
+  
+      /**
+       * extend the edges with one pivoted edge and vertice on new ball. the vertice on new ball should
+       * form two edges with the start vertice and end vertice of the old edge
+       * @param last_edge the edge which was pivoted and contributes two vertices to new edges
+       * @param id_vetice_extended index of the vertice to form new edges
+       * @param center center of the new ball
+       * @param is_back_ball whether ball is rolling on back surface
+       */
+      void
+      addPoint (const Edge &last_edge, const uint32_t id_vetice_extended, const PointNT &center, const bool is_back_ball);
+  
+      /**
+       * add one edge to edges to pivot
+       * @param edge
+       */
+      void
+      addEdge (const Edge &edge);
+  
+      /**
+       * checks whether edge is one the edges to pivot
+       * @param edge
+       * @return
+       */
+      bool
+      isEdgeOnFront (const Edge &edge) const;
+  
+      /**
+       * removes the edge with signature [id0,id1] or [id1,id0] in edges to pivoted
+       * @param id0
+       * @param id1
+       */
+      void
+      removeEdge (const uint32_t id0, const uint32_t id1);
+  
+      /**
+       * set the edge being pivoted as boundary or pivoted edge
+       * @param is_boundary
+       */
+      void
+      setFeedback (const bool is_boundary);
+  
+      /**
+       * reset the front
+       */
+      void
+      clear ();
+  
+      /**
+       * checks whether edge or the reversed edge is pivoted
+       * @param edge
+       * @return
+       */
+      bool
+      isEdgeFinished (const Edge &edge) const;
+  
+      typedef boost::shared_ptr<Front> Ptr;
+      typedef boost::shared_ptr<Front const> ConstPtr;
+    };
+
+  public:
+    typedef boost::shared_ptr<BallPivoting<PointNT> > Ptr;
+    typedef boost::shared_ptr<const BallPivoting<PointNT> > ConstPtr;
+
+    using SurfaceReconstruction<PointNT>::input_;
+    using SurfaceReconstruction<PointNT>::tree_;
+    
+    typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
+
+    typedef typename pcl::KdTree<PointNT> KdTree;
+    typedef typename pcl::KdTree<PointNT>::Ptr KdTreePtr;
+  
+  protected:
+    /** is_used_[id] indicates whether point input_[id] is used for meshing */
+    std::vector<bool> is_used_;
+    /** edge manager */
+    Front front_;
+    /** search radius. default value is -1, radius would be guessed if it is non-positive */
+    double radius_;
+    /** whether balls on the back surface would be considered */
+    bool is_allow_back_ball_;
+    /** whether the pivoting ball could flip from front face to back face or vice versa */
+    bool is_allow_flip_;
+    /** threshold for avoiding collinear points */
+    double threshold_collinear_cos_;
+    /** threshold for avoiding too near points */
+    double threshold_distance_near_;
+  
+    /**
+     * find one starting triangle for ball pivoting
+     * @param seed the index of triangle vertices
+     * @param center the center of ball
+     * @param is_back_ball whether the found seed is on back surface
+     * @return whether one triangle is found
+     */
+    bool
+    findSeed (pcl::Vertices::Ptr &seed, PointNT &center, bool &is_back_ball);
+  
+    /**
+     * pivoting around edge
+     * @param edge edge for pivoting
+     * @param id_extended index of the hitting vertice, which would bring more edges for pivoting
+     * @param center_new
+     * @param is_back_ball
+     * @return whether pivoting is successful, if not, it is a bounday
+     */
+    bool
+    pivot (const Edge &edge, uint32_t &id_extended, PointNT &center_new, bool &is_back_ball) const;
+  
+    /**
+     * pivot until the front has no edge to pivot
+     * @param polygons
+     */
+    void
+    proceedFront (std::vector<pcl::Vertices> &polygons);
+  
+    /**
+     * find the center of newly pivoted ball, if empty, then pivoting is not successful
+     * @param is_back_first whether to consider assumed center on back surface first. it changes the result if
+     *        flipping between front surface and back surface is enabled (setAllowFlip)
+     * @param index index of triangle vertices, which are all one ball surface
+     * @param is_back_ball whether the pivoted ball is on back surface
+     * @return
+     */
+    boost::shared_ptr<PointNT>
+    getBallCenter (const bool is_back_first, std::vector<uint32_t> &index, bool &is_back_ball) const;
+  
+  public:
+    BallPivoting ();
+  
+    ~BallPivoting ();
+  
+    /**
+     * set the radius of ball
+     * @param radius
+     */
+    void
+    setSearchRadius (const double radius)
+    { radius_ = radius; }
+  
+    /**
+     * get the radius of ball
+     * @return
+     */
+    double
+    getSearchRadius () const
+    { return radius_; }
+  
+    /**
+     * set whether ball on the back surface is allowed. if this value is set to true, the ball only pivots on the
+     * direction of the normal vectors
+     * @param is_allow_back_ball
+     */
+    void
+    setAllowBackBall (const bool is_allow_back_ball)
+    { is_allow_back_ball_ = is_allow_back_ball; }
+  
+    /**
+     * get whether ball on the back surface is allowed
+     * @return
+     */
+    bool
+    getAllowBackBall () const
+    { return is_allow_back_ball_; }
+  
+    /**
+     * set whether flipping between front surface and back surface is allow. if not, the ball would only pivot
+     * so it stays on one side of the surface, depending on where the center of seed ball was found
+     * @param is_allow_flip
+     */
+    void
+    setAllowFlip (const bool is_allow_flip)
+    { is_allow_flip_ = is_allow_flip; }
+  
+    /**
+     * get whether flipping between front surface and back surface is allow
+     * @return
+     */
+    bool
+    getAllowFlip () const
+    { return is_allow_flip_; }
+  
+    /**
+     * Create the surface.
+     * @param output the resultant polygonal mesh
+     */
+    void
+    performReconstruction (pcl::PolygonMesh &output);
+  
+    /**
+     * Create the surface.
+     * @param points the vertex positions of the resulting mesh
+     * @param polygons the connectivity of the resulting mesh
+     */
+    virtual void
+    performReconstruction (pcl::PointCloud<PointNT> &points,
+                           std::vector<pcl::Vertices> &polygons);
+
+    /**
+     * estimate one radius and set it as ball radius. num_sample_point points would be selected randomly in cloud,
+     * as least ratio_success of the sample points must have at least num_point_in_radius neighbors within
+     * the estimated radius.
+     * @param num_sample_point
+     * @param num_point_in_radius
+     * @param ratio_success
+     */
+    virtual void
+    setEstimatedRadius (const int num_sample_point, const int num_point_in_radius, const float ratio_success);
+
+
+  public:
+   	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  };
+} // namespace pcl
+
+#ifdef PCL_NO_PRECOMPILE
+#include <pcl/surface/impl/ball_pivoting.hpp>
+#endif
+  
+#endif // PCL_BALL_PIVOTING_H_

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -86,7 +86,7 @@ namespace pcl
     /** is_used_[id] indicates whether point input_[id] is used for meshing */
     std::vector<bool> is_used_;
     /** edge manager */
-    bpa::Front front_;
+    ball_pivoting::BallPivotingFront front_;
     /** search radius. default value is -1, radius would be guessed if it is non-positive */
     double radius_;
     /** whether balls on the back surface would be considered */
@@ -117,7 +117,7 @@ namespace pcl
      * @return whether pivoting is successful, if not, it is a bounday
      */
     bool
-    pivot (const bpa::Front::Edge &edge, uint32_t &id_extended, 
+    pivot (const ball_pivoting::BallPivotingFront::Edge &edge, uint32_t &id_extended, 
     	   Eigen::Vector3f &center_new, bool &is_back_ball) const;
   
     /**

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -94,6 +94,87 @@ namespace pcl
     double threshold_collinear_cos_;
     /** threshold for avoiding too near points */
     double threshold_distance_near_;
+
+    /**
+     * @brief getPlaneBetweenPoints returns the plane between two points,
+     *        it is perpendicular to point0-point1 and crosses their mid-point
+     * @param point0
+     * @param point1
+     * @return
+     */
+    static
+    Eigen::Vector4f
+    getPlaneBetweenPoints (const Eigen::Vector3f &point0, 
+                           const Eigen::Vector3f &point1);
+
+    /**
+     * @brief getIdPointsInSphere returns the index of points which are in sphere
+     *        with center and radius as given
+     * @param center
+     * @param radius
+     * @return
+     */
+    std::vector<int>
+    getIdPointsInSphere (const Eigen::Vector3f &center, const double radius) const;
+
+    /**
+     * @brief getNumPointsInSphere returns the number of points in sphere with given center and radius
+     * @param center
+     * @param radius
+     * @return
+     */
+    size_t
+    getNumPointsInSphere (const Eigen::Vector3f &center, const float radius) const;
+
+    /**
+     * checks whether normal is consistent with the normal vectors of points with indexes
+     * @tparam PointNT
+     * @param normal
+     * @param index
+     * @return
+     */
+    bool
+    isNormalConsistent (const Eigen::Vector3f &normal, 
+                        const std::vector<uint32_t> &indexes) const;
+
+    /**
+     * get the center of circle where three point are on
+     * @param point0
+     * @param point1
+     * @param point2
+     * @return
+     */
+    static
+    Eigen::Vector3f
+    getCircleCenter (const Eigen::Vector3f &point0, 
+                     const Eigen::Vector3f &point1, 
+                     const Eigen::Vector3f &point2);
+
+    /**
+     * get the normal vector of a triangle, (p1-p0)x(p2-p0)
+     * @tparam PointNT
+     * @param cloud
+     * @param index
+     * @return
+     */
+    Eigen::Vector3f
+    getNormalTriangle (const std::vector<uint32_t> &indexes) const;
+  
+    /**
+     * get the signed rotation angle from (point0-center) to (point1-center) on plane
+     * @param point0
+     * @param point1
+     * @param center
+     * @param plane the rotation is along the normal vector of plane
+     * @return
+     */
+    static
+    float
+    getRotationAngle (const Eigen::Vector3f &point0, 
+                      const Eigen::Vector3f &point1, 
+                      const Eigen::Vector3f &center, 
+                      const Eigen::Vector4f &plane);
+
   
     /**
      * find one starting triangle for ball pivoting
@@ -136,9 +217,19 @@ namespace pcl
     getBallCenter (const bool is_back_first, std::vector<uint32_t> &index, bool &is_back_ball) const;
   
   public:
-    BallPivoting ();
+    BallPivoting ():
+      radius_ (-1.0), 
+      is_allow_back_ball_ (false), 
+      is_allow_flip_ (false),
+      threshold_collinear_cos_ (cos (10.0 * M_PI / 180.0)), 
+      threshold_distance_near_ (1e-6)
+    {
+    }
+
   
-    ~BallPivoting ();
+    ~BallPivoting ()
+    {
+    }
   
     /**
      * set the radius of ball
@@ -202,7 +293,7 @@ namespace pcl
      * @param points the vertex positions of the resulting mesh
      * @param polygons the connectivity of the resulting mesh
      */
-    virtual void
+    void
     performReconstruction (pcl::PointCloud<PointNT> &points,
                            std::vector<pcl::Vertices> &polygons);
 
@@ -214,8 +305,10 @@ namespace pcl
      * @param num_point_in_radius
      * @param ratio_success
      */
-    virtual void
-    setEstimatedRadius (const int num_sample_point, const int num_point_in_radius, const float ratio_success);
+    void
+    setSearchRadiusAutomatically (const int num_sample_point = 0, 
+                                  const int num_point_in_radius = 6, 
+                                  const float ratio_success = 0.995f);
 
 
   public:

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -246,6 +246,24 @@ namespace pcl
     double
     getSearchRadius () const
     { return radius_; }
+
+    /**
+     * estimate one radius and set it as ball radius. num_sample_point points would be selected randomly in cloud,
+     * as least ratio_success of the sample points must have at least num_point_in_radius neighbors within
+     * the estimated radius.
+     * @param num_sample_point the expected number of samples for estimating radius. With non-positive value (<1),
+     *        the radius would be estimated with 20% of the input points.
+     * @param num_point_in_radius the expected number of points in each sphere with sampled points as centers and 
+     *        estimated radius as radius. This parameter should be at least 3, as at lease 3 points are needed for
+     *        triangulation. Default value is 6 for better success rate.
+     * @param ratio_success how much of the spheres with sampled points as centers and estimated radius as radius 
+     *        contain at least $num_point_in_radius$ points. This value should be [0,1], a rectification inside the 
+     *        function would ensure it.
+     */
+    void
+    setSearchRadiusAutomatically (const int num_sample_point = 0, 
+                                  const int num_point_in_radius = 6, 
+                                  const float ratio_success = 0.995f);
   
     /**
      * set whether ball on the back surface is allowed. if this value is set to true, the ball only pivots on the
@@ -296,20 +314,6 @@ namespace pcl
     void
     performReconstruction (pcl::PointCloud<PointNT> &points,
                            std::vector<pcl::Vertices> &polygons);
-
-    /**
-     * estimate one radius and set it as ball radius. num_sample_point points would be selected randomly in cloud,
-     * as least ratio_success of the sample points must have at least num_point_in_radius neighbors within
-     * the estimated radius.
-     * @param num_sample_point
-     * @param num_point_in_radius
-     * @param ratio_success
-     */
-    void
-    setSearchRadiusAutomatically (const int num_sample_point = 0, 
-                                  const int num_point_in_radius = 6, 
-                                  const float ratio_success = 0.995f);
-
 
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/surface/include/pcl/surface/ball_pivoting.h
+++ b/surface/include/pcl/surface/ball_pivoting.h
@@ -407,7 +407,7 @@ namespace pcl
 
 
   public:
-   	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
 } // namespace pcl
 

--- a/surface/include/pcl/surface/ball_pivoting_front.h
+++ b/surface/include/pcl/surface/ball_pivoting_front.h
@@ -1,0 +1,238 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+  
+#ifndef PCL_BALL_PIVOTING_FRONT_H_
+#define PCL_BALL_PIVOTING_FRONT_H_
+
+namespace pcl
+{
+  namespace bpa
+  {
+    /**
+     * Front manages the edges, which ones are to be pivoted, which ones are pivoted.
+     */
+    class Front
+    {
+    public:
+      typedef std::pair<uint32_t, uint32_t> Signature;
+
+      /**
+       * This class describes the pivoting ball, which rolls on points and links the mesh.
+       * Its partial definition describes an edge of the reconstructed triangle.
+       */
+      class Edge
+      {
+      protected:
+        /** list of vertice index, should have length 2 */
+        std::vector<uint32_t> id_vertices_;
+        /** index of the opposite vertice, it and id_vertices_ form the last triangle */
+        uint32_t id_opposite_;
+        /** center point of the last ball, it may not be one in the cloud */
+        Eigen::Vector3f center_;
+        /** whether this ball it to the it rolled in the back face of surface (not normal direction) */
+        bool is_back_ball_;
+    
+      public:
+        Edge ();
+    
+        /**
+         * a fake constructor with only vertice index on edge
+         * @param id0 index of start point on edge
+         * @param id1 index of end point on edge
+         */
+        Edge (const uint32_t id0, const uint32_t id1);
+    
+        /**
+         * real constructor for edge with full information
+         * @param edge list of vertice index on edge
+         * @param id_opposite index of opposite vertice
+         * @param center center point of the ball
+         * @param is_back_ball whether the ball was rolling on the back surface
+         */
+        Edge (const std::vector<uint32_t> &edge, const uint32_t id_opposite, 
+              const Eigen::Vector3f &center, const bool is_back_ball = false);
+    
+        ~Edge ();
+    
+        /**
+         * returns the center of ball
+         * @return
+         */
+        Eigen::Vector3f
+        getCenter () const
+        { return center_; }
+    
+        /**
+         * get the index of id-th vertice on edge, id should be either 0 or 1
+         * @param id
+         * @return
+         */
+        uint32_t
+        getIdVertice (const size_t id) const
+        { return id_vertices_.at (id); }
+    
+        /**
+         * get the index of opposite vertice
+         * @return
+         */
+        uint32_t
+        getIdOpposite () const
+        { return id_opposite_; }
+    
+        /**
+         * set the index of id-th vertice to be id_vertice
+         * @param id index inside edge. Should be 0 or 1
+         * @param id_vertice value of vertice index
+         */
+        void
+        setIdVertice (const size_t id, const uint32_t id_vertice)
+        { id_vertices_.at (id) = id_vertice; }
+    
+        /**
+         * checks whether the ball was rolling on back surface
+         * @return
+         */
+        bool
+        isBackBall () const
+        { return is_back_ball_; }
+    
+        /**
+         * get the signature of this edge, [index start vertice, index end vertice]
+         * @return
+         */
+        Signature
+        getSignature () const
+        { return Signature (id_vertices_.at (0), id_vertices_.at (1)); }
+    
+        /**
+         * get the reverse signature of this edge, [index end vertice, index start vertice]
+         * @return
+         */
+        Signature
+        getSignatureReverse () const
+        { return Signature (id_vertices_.at (1), id_vertices_.at (0)); }
+    
+        typedef boost::shared_ptr<Edge> Ptr;
+        typedef boost::shared_ptr<Edge const> ConstPtr;
+      };
+
+    protected:
+      /** The set of edges to be pivoted */
+      std::map<Signature, Edge> active_edges;
+      /** The set of successfully pivoted edges */
+      std::set<Signature> finished_signatures_;
+      /** The edge that is being pivoted and waiting for pivoting result: boundary or pivoted? */
+      Edge::Ptr current_edge_;
+  
+    public:
+      Front ();
+  
+      ~Front ();
+  
+      /**
+       * get one of the edges to pivot
+       * @return
+       */
+      Edge::Ptr
+      getActiveEdge ();
+  
+      /**
+       * add the three edges of one triangle to edges to pivot
+       * @param seed index of three vertices
+       * @param center the center of the ball
+       * @param is_back_ball whether the ball was pivoted on the back surface
+       */
+      void
+      addTriangle (const pcl::Vertices::ConstPtr &seed, const Eigen::Vector3f &center, 
+      	           const bool is_back_ball);
+  
+      /**
+       * extend the edges with one pivoted edge and vertice on new ball. the vertice on new ball should
+       * form two edges with the start vertice and end vertice of the old edge
+       * @param last_edge the edge which was pivoted and contributes two vertices to new edges
+       * @param id_vetice_extended index of the vertice to form new edges
+       * @param center center of the new ball
+       * @param is_back_ball whether ball is rolling on back surface
+       */
+      void
+      addPoint (const Edge &last_edge, const uint32_t id_vetice_extended, 
+      	        const Eigen::Vector3f &center, const bool is_back_ball);
+  
+      /**
+       * add one edge to edges to pivot
+       * @param edge
+       */
+      void
+      addEdge (const Edge &edge);
+  
+      /**
+       * checks whether edge is one the edges to pivot
+       * @param edge
+       * @return
+       */
+      bool
+      isEdgeOnFront (const Edge &edge) const;
+  
+      /**
+       * removes the edge with signature [id0,id1] or [id1,id0] in edges to pivoted
+       * @param id0
+       * @param id1
+       */
+      void
+      removeEdge (const uint32_t id0, const uint32_t id1);
+  
+      /**
+       * reset the front
+       */
+      void
+      clear ();
+  
+      /**
+       * checks whether edge or the reversed edge is pivoted
+       * @param edge
+       * @return
+       */
+      bool
+      isEdgeFinished (const Edge &edge) const;
+  
+      typedef boost::shared_ptr<Front> Ptr;
+      typedef boost::shared_ptr<Front const> ConstPtr;
+    };
+  }
+}
+
+#endif // PCL_BALL_PIVOTING_FRONT_H_

--- a/surface/include/pcl/surface/ball_pivoting_front.h
+++ b/surface/include/pcl/surface/ball_pivoting_front.h
@@ -152,7 +152,7 @@ namespace pcl
 
     protected:
       /** The set of edges to be pivoted */
-      std::map<Signature, Edge> active_edges;
+      std::map<Signature, Edge> active_edges_;
       /** The set of successfully pivoted edges */
       std::set<Signature> finished_signatures_;
       /** The edge that is being pivoted and waiting for pivoting result: boundary or pivoted? */
@@ -177,7 +177,7 @@ namespace pcl
        * @param is_back_ball whether the ball was pivoted on the back surface
        */
       void
-      addTriangle (const pcl::Vertices::ConstPtr &seed, const Eigen::Vector3f &center, 
+      addTriangle (const pcl::Vertices &seed, const Eigen::Vector3f &center, 
       	           const bool is_back_ball);
   
       /**
@@ -228,6 +228,15 @@ namespace pcl
        */
       bool
       isEdgeFinished (const Edge &edge) const;
+
+      /**
+       * adds the signature of edge to finished list
+       * @param edge
+       * @return
+       */
+      void
+      setEdgeAsFinished (const Edge &edge)
+      { finished_signatures_.insert (edge.getSignature ()); }
   
       typedef boost::shared_ptr<BallPivotingFront> Ptr;
       typedef boost::shared_ptr<BallPivotingFront const> ConstPtr;

--- a/surface/include/pcl/surface/ball_pivoting_front.h
+++ b/surface/include/pcl/surface/ball_pivoting_front.h
@@ -40,12 +40,12 @@
 
 namespace pcl
 {
-  namespace bpa
+  namespace ball_pivoting
   {
     /**
-     * Front manages the edges, which ones are to be pivoted, which ones are pivoted.
+     * BallPivotingFront manages the edges: which ones are to be pivoted, which ones are pivoted.
      */
-    class Front
+    class BallPivotingFront
     {
     public:
       typedef std::pair<uint32_t, uint32_t> Signature;
@@ -159,9 +159,9 @@ namespace pcl
       Edge::Ptr current_edge_;
   
     public:
-      Front ();
+      BallPivotingFront ();
   
-      ~Front ();
+      ~BallPivotingFront ();
   
       /**
        * get one of the edges to pivot
@@ -229,8 +229,8 @@ namespace pcl
       bool
       isEdgeFinished (const Edge &edge) const;
   
-      typedef boost::shared_ptr<Front> Ptr;
-      typedef boost::shared_ptr<Front const> ConstPtr;
+      typedef boost::shared_ptr<BallPivotingFront> Ptr;
+      typedef boost::shared_ptr<BallPivotingFront const> ConstPtr;
     };
   }
 }

--- a/surface/include/pcl/surface/ball_pivoting_front.h
+++ b/surface/include/pcl/surface/ball_pivoting_front.h
@@ -60,23 +60,19 @@ namespace pcl
        */
       struct Edge
       {
-      protected:
+      public:
         /** index of starting point */
-        uint32_t id_point_start_;
+        const uint32_t id_point_start_;
         /** index of ending point */
-        uint32_t id_point_end_;
+        const uint32_t id_point_end_;
         /** index of the opposite point, it and id_vertices_ form the last triangle */
-        uint32_t id_point_opposite_;
+        const uint32_t id_point_opposite_;
         /** center point of the last ball, it may not be one in the cloud */
-        Eigen::Vector3f center_;
+        const Eigen::Vector3f center_;
         /** whether this ball it to the it rolled in the back face of surface (not normal direction) */
-        bool is_back_ball_;
+        const bool is_back_ball_;
     
       public:
-        Edge ()
-        {
-        }
-
         /**
          * real constructor for edge with full information
          * @param id_point_start index of starting vertex
@@ -85,7 +81,8 @@ namespace pcl
          * @param center center point of the ball
          * @param is_back_ball whether the ball was rolling on the back surface
          */
-        Edge (const uint32_t id_point_start, const uint32_t id_point_end, 
+        Edge (const uint32_t id_point_start = 0, 
+              const uint32_t id_point_end = 0, 
               const uint32_t id_point_opposite = 0, 
               const Eigen::Vector3f &center = Eigen::Vector3f::Zero (), 
               const bool is_back_ball = false):
@@ -96,52 +93,6 @@ namespace pcl
           is_back_ball_ (is_back_ball)
         {
         }
-
-        ~Edge ()
-        {
-        }
-    
-        /**
-         * returns the center of ball
-         * @return
-         */
-        const Eigen::Vector3f&
-        getCenter () const
-        { return center_; }
-    
-        /**
-         * get the index of starting point of edge
-         * @param id
-         * @return
-         */
-        uint32_t
-        getIdPointStart () const
-        { return id_point_start_; }
-
-         /**
-         * get the index of ending point of edge
-         * @param id
-         * @return
-         */
-        uint32_t
-        getIdPointEnd () const
-        { return id_point_end_; }
-    
-        /**
-         * get the index of opposite point
-         * @return
-         */
-        uint32_t
-        getIdPointOpposite () const
-        { return id_point_opposite_; }
-       
-        /**
-         * checks whether the ball was rolling on back surface
-         * @return
-         */
-        bool
-        isBackBall () const
-        { return is_back_ball_; }
     
         /**
          * get the signature of this edge, [index start vertice, index end vertice]
@@ -165,7 +116,7 @@ namespace pcl
 
     protected:
       /** The set of edges to be pivoted */
-      std::map<Signature, Edge> active_edges_;
+      std::map<Signature, const Edge> active_edges_;
       /** The set of successfully pivoted edges */
       std::set<Signature> finished_signatures_;
       /** The edge that is being pivoted and waiting for pivoting result: boundary or pivoted? */

--- a/surface/include/pcl/surface/impl/ball_pivoting.hpp
+++ b/surface/include/pcl/surface/impl/ball_pivoting.hpp
@@ -2,7 +2,7 @@
  * Software License Agreement (BSD License)
  *
  *  Point Cloud Library (PCL) - www.pointclouds.org
- *  Copyright (c) 2014-, Open Perception, Inc.
+ *  Copyright (c) 2017-, Open Perception, Inc.
  *
  *  All rights reserved.
  *
@@ -382,9 +382,9 @@ namespace pcl
   BallPivoting<PointNT>::pivot (const ball_pivoting::BallPivotingFront::Edge &edge, uint32_t &id_extended, 
                                 Eigen::Vector3f &center_new, bool &is_back_ball) const
   {
-    const uint32_t id0 = edge.getIdVertice (0);
-    const uint32_t id1 = edge.getIdVertice (1);
-    const uint32_t id_op = edge.getIdOpposite ();
+    const uint32_t id0 = edge.getIdPointStart ();
+    const uint32_t id1 = edge.getIdPointEnd ();
+    const uint32_t id_op = edge.getIdPointOpposite ();
     const Eigen::Vector3f center = edge.getCenter ();
     const Eigen::Vector3f v0 = input_->at (id0).getVector3fMap ();
     const Eigen::Vector3f v1 = input_->at (id1).getVector3fMap ();
@@ -478,8 +478,8 @@ namespace pcl
       bool is_back_ball;
       if (!front_.isEdgeFinished (*edge) && pivot (*edge, id_ext, center_new, is_back_ball))
       {
-        const uint32_t id0 = edge->getIdVertice (0);
-        const uint32_t id1 = edge->getIdVertice (1);
+        const uint32_t id0 = edge->getIdPointStart ();
+        const uint32_t id1 = edge->getIdPointEnd ();
         pcl::Vertices triangle;
         // add to polygons
         triangle.vertices.reserve (3);

--- a/surface/include/pcl/surface/impl/ball_pivoting.hpp
+++ b/surface/include/pcl/surface/impl/ball_pivoting.hpp
@@ -1,0 +1,859 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_BALL_PIVOTING_HPP_
+#define PCL_BALL_PIVOTING_HPP_
+
+#include <algorithm>
+#include <cmath>
+
+#include <boost/make_shared.hpp>
+#include <boost/range/algorithm/random_shuffle.hpp>
+
+#include <pcl/surface/ball_pivoting.h>
+  
+namespace pcl
+{
+  /**
+   * @brief get_plane_between returns the plane between two points,
+   *        it is perpendicular to v0-v1 and crosses their mid-point
+   * @param point0
+   * @param point1
+   * @return
+   */
+  Eigen::Vector4f
+  get_plane_between (const Eigen::Vector3f &point0, const Eigen::Vector3f &point1)
+  {
+    const Eigen::Vector3f normal = (point1 - point0).normalized ();
+    Eigen::Vector4f plane;
+    // (v1+v0)/2 is on plane
+    plane << normal, -(point1 + point0).dot (normal) * 0.5f;
+    return plane;
+  }
+  
+  /**
+   * @brief is_positions_near checks whether any pair of three points are near
+   * @param pos0
+   * @param pos1
+   * @param pos2
+   * @param threshold threshold for whether two points are near
+   * @return
+   */
+  bool
+  is_positions_near (const Eigen::Vector3f &pos0, const Eigen::Vector3f &pos1, 
+                     const Eigen::Vector3f &pos2, const float threshold)
+  {
+    return (pos0 - pos1).norm () < threshold || (pos1 - pos2).norm () < threshold 
+      || (pos2 - pos0).norm () < threshold;
+  }
+  
+  /**
+   * @brief get_id_point_in_sphere returns the index of points which are in sphere
+   *        with center and radius as given
+   * @param kdtree kdtree containing the point cloud
+   * @param center
+   * @param radius
+   * @return
+   */
+  template<typename PointNT>
+  std::vector<int>
+  get_id_point_in_sphere (const typename PCLSurfaceBase<PointNT>::KdTreePtr &kdtree, 
+                          const PointNT &center, const double radius)
+  {
+    std::vector<int> indices;
+    std::vector<float> sqr_distances;
+    kdtree->radiusSearch (center, radius, indices, sqr_distances);
+    return indices;
+  }
+  
+  /**
+   * @brief num_point_in_sphere returns the number of points in sphere with given center and radius
+   * @param center
+   * @param radius
+   * @param kdtree
+   * @return
+   */
+  template<typename PointNT>
+  size_t
+  num_point_in_sphere (const PointNT &center, const float radius, 
+                       const typename PCLSurfaceBase<PointNT>::KdTreePtr &kdtree)
+  {
+    return get_id_point_in_sphere (kdtree, center, radius).size ();
+  }
+  
+  /**
+   * @brief vec2pointnormal returns a point with vector as coordinate
+   * @param vector
+   * @return
+   */
+  template<typename PointNT>
+  boost::shared_ptr<PointNT>
+  vec2pointnormal (const Eigen::Vector3f &vector)
+  {
+    boost::shared_ptr<PointNT> point = boost::shared_ptr<PointNT> (new PointNT ());
+    point->getVector3fMap () = vector;
+    return point;
+  }
+  
+  /**
+   * checks whether normal is consistent with the normal vectors of points with indexes
+   * @tparam PointNT
+   * @param normal
+   * @param index
+   * @param cloud
+   * @return
+   */
+  template<typename PointNT>
+  bool
+  is_normal_consistent (const Eigen::Vector3f &normal, const std::vector<uint32_t> &indexes,
+                        const typename pcl::PointCloud<PointNT>::ConstPtr &cloud)
+  {
+    assert(indexes.size () == 3);
+    int count_consistent = 0;
+    for (size_t id = 0; id < 3; ++id)
+    {
+      if (normal.dot (cloud->at (indexes.at (id)).getNormalVector3fMap ()) > 0.0f)
+      {
+        ++count_consistent;
+      }
+    }
+    return count_consistent >= 2;
+  }
+  
+  /**
+   * get the center of circle where three point are on
+   * @param point0
+   * @param point1
+   * @param point2
+   * @return
+   */
+  Eigen::Vector3f
+  get_circle_center (const Eigen::Vector3f &point0, const Eigen::Vector3f &point1, 
+                     const Eigen::Vector3f &point2)
+  {
+    // https://en.wikipedia.org/wiki/Circumscribed_circle#Cartesian_coordinates_from_cross-_and_dot-products
+    const Eigen::Vector3f vec2 = point0 - point1;
+    const Eigen::Vector3f vec0 = point1 - point2;
+    const Eigen::Vector3f vec1 = point2 - point0;
+    const float area = vec0.cross (vec1).norm ();
+    const float determinator = 2.0f * area * area;
+  
+    const float alpha = vec0.dot (vec0) * vec2.dot (-vec1) / determinator;
+    const float beta = vec1.dot (vec1) * -vec2.dot (vec0) / determinator;
+    const float gamma = vec2.dot (vec2) * vec1.dot (-vec0) / determinator;
+  
+    return alpha * point0 + beta * point1 + gamma * point2;
+  }
+  
+  /**
+   * get the normal vector of a triangle, (p1-p0)x(p2-p0)
+   * @tparam PointNT
+   * @param cloud
+   * @param index
+   * @return
+   */
+  template<typename PointNT>
+  Eigen::Vector3f
+  get_normal_triangle (const typename pcl::PointCloud<PointNT>::ConstPtr &cloud, 
+                       const std::vector<uint32_t> &indexes)
+  {
+    assert(indexes.size () == 3);
+    const Eigen::Vector3f p0 = cloud->at (indexes.at (0)).getVector3fMap ();
+    return (cloud->at (indexes.at (1)).getVector3fMap () - p0)
+      .cross (cloud->at (indexes.at (2)).getVector3fMap () - p0)
+      .normalized ();
+  }
+  
+  /**
+   * reorder the vertices of triangle so the normal vector of triangle is consistent with normals of vertices
+   * @tparam PointNT
+   * @param cloud
+   * @param triangle
+   */
+  template<typename PointNT>
+  void
+  reorder (const typename pcl::PointCloud<PointNT>::ConstPtr &cloud, pcl::Vertices &triangle)
+  {
+    if (!is_normal_consistent (get_normal_triangle<PointNT> (cloud, triangle.vertices), 
+                               triangle.vertices, cloud))
+    {
+      // if the order (0,1,2) is not consistent, (0,2,1) should be consistent
+      std::swap (triangle.vertices.at (1), triangle.vertices.at (2));
+    }
+  }
+  
+  /**
+   * get the distance from point to plane
+   * @tparam PointNT
+   * @param plane
+   * @param point
+   * @return
+   */
+  template<typename PointNT>
+  float
+  get_distance_point_plane (const Eigen::Vector4f &plane, const PointNT &point)
+  {
+    // plane is (a,b,c,d), point is (x,y,z), then distance is ax+by+cz+d
+    return point.getVector3fMap ().dot (plane.segment (0, 3)) + plane (3);
+  }
+  
+  /**
+   * get the signed rotation angle from (point0-center) to (point1-center) on plane
+   * @param point0
+   * @param point1
+   * @param center
+   * @param plane the rotation is along the normal vector of plane
+   * @return
+   */
+  float
+  get_angle_rotation (const Eigen::Vector3f &point0, const Eigen::Vector3f &point1, 
+                      const Eigen::Vector3f &center, const Eigen::Vector4f &plane)
+  {
+    const Eigen::Vector3f vc0 = (point0 - center).normalized ();
+    const Eigen::Vector3f vc1 = (point1 - center).normalized ();
+  
+    const float sin_val = vc0.cross (-Eigen::Vector3f (plane.segment (0, 3))).dot (vc1);
+    const float cos_val = vc0.dot (vc1);
+    float angle = atan2 (sin_val, cos_val);
+    if (angle < 0.0f) // -pi~pi -> 0~2pi
+    {
+      angle += (float) (2.0 * M_PI);
+    }
+    return angle;
+  }
+  
+  /**
+   * estimate a radius for the ball pivoting algorithm. the returned estimation is the minimal value, so that
+   * at least min_success_rate of the sample points have at least num_in_radius neighbors
+   * @tparam PointNT
+   * @param kdtree
+   * @param num_sample_point
+   * @param num_in_radius
+   * @param min_success_rate
+   * @return
+   */
+  template<typename PointNT>
+  double
+  guess_radius (const typename PCLSurfaceBase<PointNT>::KdTreePtr &kdtree,
+                const int num_sample_point = 500,
+                const int num_in_radius = 5, const float min_success_rate = 0.95f)
+  {
+    std::vector<float> farthest_distances;
+    const typename pcl::PointCloud<PointNT>::ConstPtr &cloud = kdtree->getInputCloud ();
+  
+    // sample num_sample_point points in cloud per index
+    std::vector<int> index_samples;
+    index_samples.reserve (cloud->size ());
+    for (size_t id = 0; id < cloud->size (); ++id)
+    {
+      index_samples.push_back ((int) id);
+    }
+    boost::range::random_shuffle (index_samples);
+    index_samples.resize (num_sample_point);
+  
+    farthest_distances.reserve (num_sample_point);
+    for (int id = 0; id < num_sample_point; ++id)
+    {
+      std::vector<int> indices;
+      std::vector<float> sqr_distances;
+      kdtree->nearestKSearch (cloud->at (index_samples.at (id)), num_in_radius, 
+                              indices, sqr_distances);
+      farthest_distances.push_back (sqr_distances.back ());
+    }
+  
+    // ascending summary of num_in_radius-th nearest neighbor
+    std::sort (farthest_distances.begin (), farthest_distances.end ());
+  
+    return sqrt (farthest_distances.at (
+          (int) floor (min_success_rate * (float) num_sample_point)));
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::BallPivoting ():
+    radius_ (-1.0), 
+    is_allow_back_ball_ (false), 
+    is_allow_flip_ (false),
+    threshold_collinear_cos_ (cos (10.0 * M_PI / 180.0)), 
+    threshold_distance_near_ (1e-6)
+  {
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::~BallPivoting ()
+  {
+  }
+  
+  template<typename PointNT>
+  boost::shared_ptr<PointNT>
+  BallPivoting<PointNT>::getBallCenter (const bool is_back_first, 
+                                        std::vector<uint32_t> &index, 
+                                        bool &is_back_ball) const
+  {
+    boost::shared_ptr<PointNT> center;
+    // for checking whether three points are collinear
+    const Eigen::Vector3f pos0 (input_->at (index.at (0)).getVector3fMap ());
+    const Eigen::Vector3f pos1 (input_->at (index.at (1)).getVector3fMap ());
+    const Eigen::Vector3f pos2 (input_->at (index.at (2)).getVector3fMap ());
+  
+    const Eigen::Vector3f vec0 = (pos1 - pos0).normalized ();
+    const Eigen::Vector3f vec1 = (pos2 - pos0).normalized ();
+  
+    // the three points should not be too near or collinear
+    if (!is_positions_near (pos0, pos1, pos2, threshold_distance_near_) &&
+        fabs (vec0.dot (vec1)) < threshold_collinear_cos_)
+    {
+      Eigen::Vector3f center_circle = get_circle_center (pos0, pos1, pos2);
+  
+      // move to distance radius_ along normal direction
+      float radius_planar = (center_circle - pos0).norm ();
+      if (radius_planar < radius_)
+      {
+        Eigen::Vector3f normal = vec0.cross (vec1).normalized ();
+        boost::shared_ptr<PointNT> center_candidate;
+        const float dist_normal = sqrt ((float) radius_ * radius_ - radius_planar * radius_planar);
+        if (!is_normal_consistent<PointNT> (normal, index, input_))
+        {
+          // reorder the vertices of triangle and reverse the normal vector
+          normal = -normal;
+          std::swap (index.at (0), index.at (2));
+        }
+        normal *= dist_normal;
+  
+        if (is_back_first)
+        {
+          center_candidate = vec2pointnormal<PointNT> (Eigen::Vector3f (center_circle - normal));
+          if (num_point_in_sphere (*center_candidate, radius_, tree_) <= 3)
+          {
+            center = center_candidate;
+            is_back_ball = true;
+          }
+          else if (is_allow_flip_)
+          {
+            center_candidate = vec2pointnormal<PointNT> (Eigen::Vector3f (center_circle + normal));
+            if (num_point_in_sphere (*center_candidate, radius_, tree_) <= 3)
+            {
+              center = center_candidate;
+              is_back_ball = false;
+            }
+          }
+        }
+        else
+        {
+          center_candidate = vec2pointnormal<PointNT> (Eigen::Vector3f (center_circle + normal));
+          if (num_point_in_sphere (*center_candidate, radius_, tree_) <= 3)
+          {
+            center = center_candidate;
+            is_back_ball = false;
+          }
+          else if (is_allow_flip_)
+          {
+            center_candidate = vec2pointnormal<PointNT> (Eigen::Vector3f (center_circle - normal));
+            if (num_point_in_sphere (*center_candidate, radius_, tree_) <= 3)
+            {
+              center = center_candidate;
+              is_back_ball = true;
+            }
+          }
+        }
+      }
+    }
+  
+    return center;
+  }
+  
+  template<typename PointNT>
+  bool
+  BallPivoting<PointNT>::pivot (const Edge &edge, uint32_t &id_extended, 
+                                PointNT &center_new, bool &is_back_ball) const
+  {
+    const uint32_t id0 = edge.getIdVertice (0);
+    const uint32_t id1 = edge.getIdVertice (1);
+    const uint32_t id_op = edge.getIdOpposite ();
+    const Eigen::Vector3f center = edge.getCenter ().getVector3fMap ();
+    const Eigen::Vector3f v0 = input_->at (id0).getVector3fMap ();
+    const Eigen::Vector3f v1 = input_->at (id1).getVector3fMap ();
+    const Eigen::Vector3f mid = (v0 + v1) * 0.5f;
+    // pivot opposite to normal direction, change direction for angle
+    const Eigen::Vector4f plane = edge.isBackBall () ? get_plane_between (v0, v1) 
+                                                     : get_plane_between (v1, v0);
+    pcl::PointCloud<PointNT> center_candidates;
+    std::vector<float> dot_candidates;
+    std::vector<uint32_t> id_candidates;
+    std::vector<bool> is_back_candidates;
+  
+    const double search_radius = sqrt (radius_ * radius_ - (v0 - mid).dot (Eigen::Vector3f (v0 - mid))) 
+                               + radius_;
+    std::vector<uint32_t> point3 (3, 0);
+    std::vector<int> indices = get_id_point_in_sphere<PointNT> (tree_, *vec2pointnormal<PointNT> (mid), 
+                                                                search_radius);
+  
+    center_candidates.reserve (indices.size ());
+    dot_candidates.reserve (indices.size ());
+    id_candidates.reserve (indices.size ());
+    is_back_candidates.reserve (indices.size ());
+    for (std::vector<int>::iterator it = indices.begin (); it != indices.end (); ++it)
+    {
+      point3.at (0) = id0;
+      point3.at (1) = id1;
+      point3.at (2) = (uint32_t) (*it);
+  
+      if (point3.at (2) == id0 || point3.at (2) == id1 || point3.at (2) == id_op ||
+          !is_normal_consistent<PointNT> (get_normal_triangle<PointNT> (input_, point3), point3, input_) ||
+          fabs (get_distance_point_plane<PointNT> (plane, input_->at (*it))) > radius_)
+      {
+        continue;
+      }
+  
+      // the three points are different, the normal of triangle is consistent to the normal vectors or vertices
+      // and the cloud[point3[2]] has distance to plane smaller than radius
+      bool is_back_bool;
+      boost::shared_ptr<PointNT> center_jr = getBallCenter (edge.isBackBall (), point3, is_back_bool);
+  
+      if (center_jr)
+      {
+        center_candidates.push_back (*center_jr);
+        dot_candidates.push_back (get_angle_rotation (center, center_jr->getVector3fMap (), mid, plane));
+        id_candidates.push_back ((uint32_t) *it);
+        is_back_candidates.push_back (is_back_bool);
+      }
+    }
+  
+    // get the first hit point
+    if (!center_candidates.empty ())
+    {
+      int id_min =
+        std::distance (dot_candidates.begin (), std::min_element (dot_candidates.begin (), 
+                                                                  dot_candidates.end ()));
+      id_extended = id_candidates.at (id_min);
+      center_new = center_candidates.at (id_min);
+      is_back_ball = is_back_candidates.at (id_min);
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::setEstimatedRadius (const int num_sample_point, 
+                                             const int num_point_in_radius,
+                                             const float ratio_success)
+  {
+    if (input_ && tree_ && tree_->getInputCloud ())
+    {
+      radius_ = guess_radius<PointNT> (tree_, num_sample_point, num_point_in_radius, ratio_success);
+    }
+    else
+    {
+      PCL_ERROR ("InputCloud or KdTree is empty!\n");
+    }
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::proceedFront (std::vector<pcl::Vertices> &polygons)
+  {
+    typename BallPivoting::Edge::Ptr edge;
+    while (edge = front_.getActiveEdge ())
+    {
+      uint32_t id_ext;
+      PointNT center_new;
+      bool is_back_ball;
+      if (!front_.isEdgeFinished (*edge) && pivot (*edge, id_ext, center_new, is_back_ball))
+      {
+        const uint32_t id0 = edge->getIdVertice (0);
+        const uint32_t id1 = edge->getIdVertice (1);
+        pcl::Vertices triangle;
+        // add to polygons
+        triangle.vertices.reserve (3);
+        triangle.vertices.push_back (id0);
+        triangle.vertices.push_back (id1);
+        triangle.vertices.push_back (id_ext);
+        polygons.push_back (triangle);
+  
+        is_used_.at (id_ext) = true;
+        front_.addPoint (*edge, id_ext, center_new, is_back_ball);
+  
+        // pivoting succeeds, not boundary
+        front_.setFeedback (false);
+      }
+      else
+      {
+        // not pivoted
+        front_.setFeedback (true);
+      }
+    }
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::performReconstruction (pcl::PointCloud<PointNT> &points,
+                                                std::vector<pcl::Vertices> &polygons)
+  {
+    if (!(input_ && tree_ && tree_->getInputCloud ()))
+    {
+      PCL_ERROR ("InputCloud or KdTree is empty!\n");
+      points.clear ();
+      polygons.clear ();
+      return;
+    }
+
+    is_used_.clear ();
+    is_used_.resize (input_->size (), false);
+    front_ = Front ();
+  
+    // if radius is not valid, guess with default configuration (see default parameters of guess_radius)
+    if (radius_ < 0.0)
+    {
+      radius_ = guess_radius<PointNT> (tree_);
+    }
+  
+    // proceed until not seed can bt found
+    while (true)
+    {
+      proceedFront (polygons);
+  
+      pcl::Vertices::Ptr seed;
+      PointNT center;
+      bool is_back_ball;
+      if (findSeed (seed, center, is_back_ball))
+      {
+        // add to mesh
+        polygons.push_back (*seed);
+        // add for pivoting
+        front_.addTriangle (seed, center, is_back_ball);
+      }
+      else
+      {
+        // cannot find proper seed
+        break;
+      }
+    }
+
+    points = *input_;
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::performReconstruction (pcl::PolygonMesh &output)
+  {
+    typename pcl::PointCloud<PointNT> points;
+
+    performReconstruction (points, output.polygons);
+
+    pcl::toPCLPointCloud2 (points, output.cloud);
+  }
+  
+  template<typename PointNT>
+  bool
+  BallPivoting<PointNT>::findSeed (pcl::Vertices::Ptr &seed, PointNT &center, bool &is_back_ball)
+  {
+    const double search_radius = radius_ * 2.0;
+  
+    // search in all points
+    for (size_t id_search = 0; id_search < is_used_.size (); ++id_search)
+    {
+      if (is_used_.at (id_search))
+      {
+        // actually ignore used or obsolete points
+        continue;
+      }
+  
+      std::vector<uint32_t> index3 (3, 0);
+      std::vector<int> indices = get_id_point_in_sphere<PointNT> (
+          tree_, input_->at (id_search), search_radius);
+      if (indices.size () < 3)
+      {
+        continue;
+      }
+  
+      for (size_t idn1 = 1; idn1 < indices.size (); ++idn1)
+      {
+        const uint32_t index1 = indices.at (idn1);
+        if (is_used_.at (index1) || index1 == (uint32_t) id_search)
+        {
+          continue;
+        }
+  
+        for (size_t idn2 = 0; idn2 < idn1; ++idn2)
+        {
+          const uint32_t index2 = indices.at (idn2);
+  
+          if (is_used_.at (index2) || index1 == index2 || index2 == (uint32_t) id_search)
+          {
+            continue;
+          }
+  
+          index3.at (0) = (uint32_t) id_search;
+          index3.at (1) = index1;
+          index3.at (2) = index2;
+  
+          bool is_back_ball;
+          boost::shared_ptr<PointNT> center_ = getBallCenter (false, index3, is_back_ball);
+          if (!center_ && is_allow_back_ball_)
+          {
+            center_ = getBallCenter (true, index3, is_back_ball);
+          }
+          if (center_)
+          {
+            seed = pcl::Vertices::Ptr (new pcl::Vertices ());
+            seed->vertices = index3;
+            center = *center_;
+            is_back_ball = is_back_ball;
+            is_used_.at (index3.at (0)) = true;
+            is_used_.at (index3.at (1)) = true;
+            is_used_.at (index3.at (2)) = true;
+  
+            return true;
+          }
+        }
+      }
+  
+      is_used_.at (id_search) = true;
+    }
+    return false;
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::Edge::Edge ()
+  {
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::Edge::Edge (const uint32_t id0, const uint32_t id1)
+  {
+    id_vertices_.resize (2);
+    id_vertices_.at (0) = id0;
+    id_vertices_.at (1) = id1;
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::Edge::Edge (const std::vector<uint32_t> &edge, const uint32_t id_opposite, 
+  	                             const PointNT &center, const bool is_back_ball):
+    id_vertices_ (edge), 
+    id_opposite_ (id_opposite), 
+    center_ (center), 
+    is_back_ball_ (is_back_ball)
+  {
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::Edge::~Edge ()
+  {
+  }
+  
+  template<typename PointNT>
+  PointNT
+  BallPivoting<PointNT>::Edge::getCenter () const
+  {
+    return center_;
+  }
+  
+  template<typename PointNT>
+  uint32_t
+  BallPivoting<PointNT>::Edge::getIdVertice (const size_t id) const
+  {
+    return id_vertices_.at (id);
+  }
+  
+  template<typename PointNT>
+  uint32_t
+  BallPivoting<PointNT>::Edge::getIdOpposite () const
+  {
+    return id_opposite_;
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::Edge::setIdVertice (const size_t id, const uint32_t id_vertice)
+  {
+    id_vertices_.at (id) = id_vertice;
+  }
+  
+  template<typename PointNT>
+  bool
+  BallPivoting<PointNT>::Edge::isBackBall () const
+  {
+    return is_back_ball_;
+  }
+  
+  template<typename PointNT>
+  std::pair<uint32_t, uint32_t>
+  BallPivoting<PointNT>::Edge::getSignature () const
+  {
+    return std::pair<uint32_t, uint32_t> (id_vertices_.at (0), id_vertices_.at (1));
+  }
+  
+  template<typename PointNT>
+  std::pair<uint32_t, uint32_t>
+  BallPivoting<PointNT>::Edge::getSignatureReverse () const
+  {
+    return std::pair<uint32_t, uint32_t> (id_vertices_.at (1), id_vertices_.at (0));
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::Front::Front ()
+  {
+    clear ();
+  }
+  
+  template<typename PointNT>
+  BallPivoting<PointNT>::Front::~Front ()
+  {
+  }
+  
+  template<typename PointNT>
+  typename BallPivoting<PointNT>::Edge::Ptr
+  BallPivoting<PointNT>::Front::getActiveEdge ()
+  {
+    typename Edge::Ptr re;
+    if (!front_.empty ())
+    {
+      re = boost::make_shared<Edge> (front_.begin ()->second);
+      current_edge_ = re;
+      front_.erase (front_.begin ());
+    }
+    return re;
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::Front::setFeedback (const bool is_boundary)
+  {
+    if (is_boundary)
+    {
+      boundary_[current_edge_->getSignature ()] = *current_edge_;
+    }
+    finished_.insert (current_edge_->getSignature ());
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::Front::addTriangle (const pcl::Vertices::ConstPtr &seed, 
+                                             const PointNT &center,
+                                             const bool is_back_ball)
+  {
+    for (size_t idv = 0; idv < 3; ++idv)
+    {
+      std::vector<uint32_t> edge (2, 0);
+      edge.at (0) = seed->vertices.at (idv);
+      edge.at (1) = seed->vertices.at ((idv + 2) % 3);
+  
+      addEdge (Edge (edge, seed->vertices.at ((idv + 1) % 3), center, is_back_ball));
+    }
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::Front::addPoint (const Edge &last_edge, const uint32_t id_vertice_extended, 
+                                          const PointNT &center, const bool is_back_ball)
+  {
+    std::vector<uint32_t> edge (2, 0);
+  
+    edge.at (0) = last_edge.getIdVertice (0);
+    edge.at (1) = id_vertice_extended;
+    addEdge (Edge (edge, last_edge.getIdVertice (1), center, is_back_ball));
+  
+    edge.at (0) = id_vertice_extended;
+    edge.at (1) = last_edge.getIdVertice (1);
+    addEdge (Edge (edge, last_edge.getIdVertice (0), center, is_back_ball));
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::Front::addEdge (const Edge &edge)
+  {
+    if (!isEdgeOnFront (edge))
+    {
+      front_[Signature (edge.getIdVertice (0), edge.getIdVertice (1))] = edge;
+    }
+  }
+  
+  template<typename PointNT>
+  bool
+  BallPivoting<PointNT>::Front::isEdgeOnFront (const Edge &edge) const
+  {
+    // toggle comment to delete one-directionally
+    return front_.find (edge.getSignature ()) != front_.end () ||
+           front_.find (edge.getSignatureReverse ()) != front_.end ();
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::Front::removeEdge (const uint32_t id0, const uint32_t id1)
+  {
+    if (!front_.empty ())
+    {
+      typename std::map<Signature, Edge>::iterator loc = front_.find (Signature (id0, id1));
+      if (loc != front_.end ())
+      {
+        front_.erase (loc);
+      }
+      else // comment to delete one-directionally
+      {
+        loc = front_.find (Signature (id1, id0));
+        if (loc != front_.end ())
+        {
+          front_.erase (loc);
+        }
+      }
+    }
+  }
+  
+  template<typename PointNT>
+  void
+  BallPivoting<PointNT>::Front::clear ()
+  {
+    front_.clear ();
+    boundary_.clear ();
+    current_edge_.reset ();
+  }
+  
+  template<typename PointNT>
+  bool
+  BallPivoting<PointNT>::Front::isEdgeFinished (const Edge &edge) const
+  {
+    return finished_.find (edge.getSignature ()) != finished_.end () ||
+           finished_.find (edge.getSignatureReverse ()) != finished_.end ();
+  }
+} // namespace pcl
+
+#define PCL_INSTANTIATE_BallPivoting(T) template class PCL_EXPORTS pcl::BallPivoting<T>;
+
+#endif // PCL_BALL_PIVOTING_HPP_

--- a/surface/include/pcl/surface/impl/ball_pivoting.hpp
+++ b/surface/include/pcl/surface/impl/ball_pivoting.hpp
@@ -371,7 +371,7 @@ namespace pcl
   
   template<typename PointNT>
   bool
-  BallPivoting<PointNT>::pivot (const bpa::Front::Edge &edge, uint32_t &id_extended, 
+  BallPivoting<PointNT>::pivot (const ball_pivoting::BallPivotingFront::Edge &edge, uint32_t &id_extended, 
                                 Eigen::Vector3f &center_new, bool &is_back_ball) const
   {
     const uint32_t id0 = edge.getIdVertice (0);
@@ -462,7 +462,7 @@ namespace pcl
   void
   BallPivoting<PointNT>::proceedFront (std::vector<pcl::Vertices> &polygons)
   {
-    bpa::Front::Edge::Ptr edge = front_.getActiveEdge ();
+    ball_pivoting::BallPivotingFront::Edge::Ptr edge = front_.getActiveEdge ();
     while (edge)
     {
       uint32_t id_ext;

--- a/surface/include/pcl/surface/impl/ball_pivoting.hpp
+++ b/surface/include/pcl/surface/impl/ball_pivoting.hpp
@@ -382,15 +382,15 @@ namespace pcl
   BallPivoting<PointNT>::pivot (const ball_pivoting::BallPivotingFront::Edge &edge, uint32_t &id_extended, 
                                 Eigen::Vector3f &center_new, bool &is_back_ball) const
   {
-    const uint32_t id0 = edge.getIdPointStart ();
-    const uint32_t id1 = edge.getIdPointEnd ();
-    const uint32_t id_op = edge.getIdPointOpposite ();
-    const Eigen::Vector3f center = edge.getCenter ();
+    const uint32_t id0 = edge.id_point_start_;
+    const uint32_t id1 = edge.id_point_end_;
+    const uint32_t id_op = edge.id_point_opposite_;
+    const Eigen::Vector3f &center = edge.center_;
     const Eigen::Vector3f v0 = input_->at (id0).getVector3fMap ();
     const Eigen::Vector3f v1 = input_->at (id1).getVector3fMap ();
     const Eigen::Vector3f mid = (v0 + v1) * 0.5f;
     // pivot opposite to normal direction, change direction for angle
-    const Eigen::Vector4f plane = edge.isBackBall () ? get_plane_between (v0, v1) 
+    const Eigen::Vector4f plane = edge.is_back_ball_ ? get_plane_between (v0, v1) 
                                                      : get_plane_between (v1, v0);
     std::vector<Eigen::Vector3f> center_candidates; // only store, no need to align
     std::vector<float> dot_candidates;
@@ -422,7 +422,7 @@ namespace pcl
       // the three points are different, the normal of triangle is consistent to the normal vectors or vertices
       // and the cloud[point3[2]] has distance to plane smaller than radius
       bool is_back_bool;
-      boost::shared_ptr<Eigen::Vector3f> center_jr = getBallCenter (edge.isBackBall (), point3, is_back_bool);
+      boost::shared_ptr<Eigen::Vector3f> center_jr = getBallCenter (edge.is_back_ball_, point3, is_back_bool);
   
       if (center_jr)
       {
@@ -478,8 +478,8 @@ namespace pcl
       bool is_back_ball;
       if (!front_.isEdgeFinished (*edge) && pivot (*edge, id_ext, center_new, is_back_ball))
       {
-        const uint32_t id0 = edge->getIdPointStart ();
-        const uint32_t id1 = edge->getIdPointEnd ();
+        const uint32_t id0 = edge->id_point_start_;
+        const uint32_t id1 = edge->id_point_end_;
         pcl::Vertices triangle;
         // add to polygons
         triangle.vertices.reserve (3);

--- a/surface/include/pcl/surface/impl/ball_pivoting.hpp
+++ b/surface/include/pcl/surface/impl/ball_pivoting.hpp
@@ -142,11 +142,14 @@ namespace pcl
                                            const Eigen::Vector3f &center, 
                                            const Eigen::Vector4f &plane)
   {
-    const Eigen::Vector3f vc0 = (point0 - center).normalized ();
-    const Eigen::Vector3f vc1 = (point1 - center).normalized ();
+    const Eigen::Vector3f vec0 = (point0 - center).normalized ();
+    const Eigen::Vector3f vec1 = (point1 - center).normalized ();
   
-    const float sin_val = vc0.cross (-Eigen::Vector3f (plane.segment (0, 3))).dot (vc1);
-    const float cos_val = vc0.dot (vc1);
+    // Use vec0 as "X-axis" and the cross product of vec0 and -plane.normal as "Y-axis",
+    // and use atan2 to get the unique angle (the range of atan2 is 2*pi).
+    // Reverse the normal vector of plane should make the angle alpha to be 2*pi-alpha
+    const float sin_val = vec0.cross (-Eigen::Vector3f (plane.segment (0, 3))).dot (vec1);
+    const float cos_val = vec0.dot (vec1);
     float angle = std::atan2 (sin_val, cos_val);
     if (angle < 0.0f) // -pi~pi -> 0~2pi
     {
@@ -269,7 +272,7 @@ namespace pcl
       point3.at (0) = id0;
       point3.at (1) = id1;
       point3.at (2) = (uint32_t) (*it);
-  
+
       if (point3.at (2) == id0 || point3.at (2) == id1 || point3.at (2) == id_op ||
           !isNormalConsistent (getNormalTriangle (point3), point3) ||
           std::fabs (plane.segment (0, 3).dot (input_->at (*it).getVector3fMap ()) + plane[3]) > radius_)
@@ -348,8 +351,9 @@ namespace pcl
     std::sort (farthest_distances.begin (), farthest_distances.end ());
   
     // find the thresholding value
+    const float ratio_success_rectified = std::max (0.0f, std::min (1.0f, ratio_success));
     radius_ = std::sqrt (farthest_distances.at (
-          (int) floor (ratio_success * (float) num_sample_point_real)));
+          (int) floor (ratio_success_rectified * (float) num_sample_point_real)));
   }
   
   template<typename PointNT>

--- a/surface/src/ball_pivoting.cpp
+++ b/surface/src/ball_pivoting.cpp
@@ -1,0 +1,42 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/impl/instantiate.hpp>
+#include <pcl/point_types.h>
+#include <pcl/surface/ball_pivoting.h>
+#include <pcl/surface/impl/ball_pivoting.hpp>
+
+// Instantiations of specific point types
+PCL_INSTANTIATE(BallPivoting, (pcl::PointNormal)(pcl::PointXYZRGBNormal)(pcl::PointXYZINormal))

--- a/surface/src/ball_pivoting.cpp
+++ b/surface/src/ball_pivoting.cpp
@@ -81,29 +81,27 @@ namespace pcl
     BallPivotingFront::getActiveEdge ()
     {
       Edge::Ptr re;
-      if (!active_edges.empty ())
+      if (!active_edges_.empty ())
       {
-        re = boost::make_shared<Edge> (active_edges.begin ()->second);
+        re = boost::make_shared<Edge> (active_edges_.begin ()->second);
         current_edge_ = re;
-        active_edges.erase (active_edges.begin ());
-
-        finished_signatures_.insert (re->getSignature ());
+        active_edges_.erase (active_edges_.begin ());
       }
       return re;
     }
     
     void
-    BallPivotingFront::addTriangle (const pcl::Vertices::ConstPtr &seed, 
+    BallPivotingFront::addTriangle (const pcl::Vertices &seed, 
                                     const Eigen::Vector3f &center,
                                     const bool is_back_ball)
     {
       for (size_t idv = 0; idv < 3; ++idv)
       {
         std::vector<uint32_t> edge (2, 0);
-        edge.at (0) = seed->vertices.at (idv);
-        edge.at (1) = seed->vertices.at ((idv + 2) % 3);
+        edge.at (0) = seed.vertices.at (idv);
+        edge.at (1) = seed.vertices.at ((idv + 2) % 3);
     
-        addEdge (Edge (edge, seed->vertices.at ((idv + 1) % 3), center, is_back_ball));
+        addEdge (Edge (edge, seed.vertices.at ((idv + 1) % 3), center, is_back_ball));
       }
     }
     
@@ -127,33 +125,33 @@ namespace pcl
     {
       if (!isEdgeOnFront (edge))
       {
-        active_edges[Signature (edge.getIdVertice (0), edge.getIdVertice (1))] = edge;
+        active_edges_[Signature (edge.getIdVertice (0), edge.getIdVertice (1))] = edge;
       }
     }
     
     bool
     BallPivotingFront::isEdgeOnFront (const Edge &edge) const
     {
-      return active_edges.find (edge.getSignature ()) != active_edges.end () ||
-             active_edges.find (edge.getSignatureReverse ()) != active_edges.end ();
+      return active_edges_.find (edge.getSignature ()) != active_edges_.end () ||
+             active_edges_.find (edge.getSignatureReverse ()) != active_edges_.end ();
     }
     
     void
     BallPivotingFront::removeEdge (const uint32_t id0, const uint32_t id1)
     {
-      if (!active_edges.empty ())
+      if (!active_edges_.empty ())
       {
-        typename std::map<Signature, Edge>::iterator loc = active_edges.find (Signature (id0, id1));
-        if (loc != active_edges.end ())
+        typename std::map<Signature, Edge>::iterator loc = active_edges_.find (Signature (id0, id1));
+        if (loc != active_edges_.end ())
         {
-          active_edges.erase (loc);
+          active_edges_.erase (loc);
         }
         else // comment to delete one-directionally
         {
-          loc = active_edges.find (Signature (id1, id0));
-          if (loc != active_edges.end ())
+          loc = active_edges_.find (Signature (id1, id0));
+          if (loc != active_edges_.end ())
           {
-            active_edges.erase (loc);
+            active_edges_.erase (loc);
           }
         }
       }
@@ -162,7 +160,7 @@ namespace pcl
     void
     BallPivotingFront::clear ()
     {
-      active_edges.clear ();
+      active_edges_.clear ();
       finished_signatures_.clear ();
       current_edge_.reset ();
     }

--- a/surface/src/ball_pivoting.cpp
+++ b/surface/src/ball_pivoting.cpp
@@ -42,21 +42,21 @@
 
 namespace pcl
 {
-  namespace bpa
+  namespace ball_pivoting
   {
-    Front::Edge::Edge ()
+    BallPivotingFront::Edge::Edge ()
     {
     }
     
-    Front::Edge::Edge (const uint32_t id0, const uint32_t id1)
+    BallPivotingFront::Edge::Edge (const uint32_t id0, const uint32_t id1)
     {
       id_vertices_.resize (2);
       id_vertices_.at (0) = id0;
       id_vertices_.at (1) = id1;
     }
     
-    Front::Edge::Edge (const std::vector<uint32_t> &edge, const uint32_t id_opposite, 
-                       const Eigen::Vector3f &center, const bool is_back_ball):
+    BallPivotingFront::Edge::Edge (const std::vector<uint32_t> &edge, const uint32_t id_opposite, 
+                                   const Eigen::Vector3f &center, const bool is_back_ball):
       id_vertices_ (edge), 
       id_opposite_ (id_opposite), 
       center_ (center), 
@@ -64,21 +64,21 @@ namespace pcl
     {
     }
     
-    Front::Edge::~Edge ()
+    BallPivotingFront::Edge::~Edge ()
     {
     }
     
-    Front::Front::Front ()
+    BallPivotingFront::BallPivotingFront ()
     {
       clear ();
     }
     
-    Front::Front::~Front ()
+    BallPivotingFront::~BallPivotingFront ()
     {
     }
     
-    Front::Edge::Ptr
-    Front::Front::getActiveEdge ()
+    BallPivotingFront::Edge::Ptr
+    BallPivotingFront::getActiveEdge ()
     {
       Edge::Ptr re;
       if (!active_edges.empty ())
@@ -93,9 +93,9 @@ namespace pcl
     }
     
     void
-    Front::Front::addTriangle (const pcl::Vertices::ConstPtr &seed, 
-                               const Eigen::Vector3f &center,
-                               const bool is_back_ball)
+    BallPivotingFront::addTriangle (const pcl::Vertices::ConstPtr &seed, 
+                                    const Eigen::Vector3f &center,
+                                    const bool is_back_ball)
     {
       for (size_t idv = 0; idv < 3; ++idv)
       {
@@ -108,8 +108,8 @@ namespace pcl
     }
     
     void
-    Front::Front::addPoint (const Edge &last_edge, const uint32_t id_vertice_extended, 
-                            const Eigen::Vector3f &center, const bool is_back_ball)
+    BallPivotingFront::addPoint (const Edge &last_edge, const uint32_t id_vertice_extended, 
+                                 const Eigen::Vector3f &center, const bool is_back_ball)
     {
       std::vector<uint32_t> edge (2, 0);
     
@@ -123,7 +123,7 @@ namespace pcl
     }
     
     void
-    Front::Front::addEdge (const Edge &edge)
+    BallPivotingFront::addEdge (const Edge &edge)
     {
       if (!isEdgeOnFront (edge))
       {
@@ -132,14 +132,14 @@ namespace pcl
     }
     
     bool
-    Front::Front::isEdgeOnFront (const Edge &edge) const
+    BallPivotingFront::isEdgeOnFront (const Edge &edge) const
     {
       return active_edges.find (edge.getSignature ()) != active_edges.end () ||
              active_edges.find (edge.getSignatureReverse ()) != active_edges.end ();
     }
     
     void
-    Front::Front::removeEdge (const uint32_t id0, const uint32_t id1)
+    BallPivotingFront::removeEdge (const uint32_t id0, const uint32_t id1)
     {
       if (!active_edges.empty ())
       {
@@ -160,7 +160,7 @@ namespace pcl
     }
     
     void
-    Front::Front::clear ()
+    BallPivotingFront::clear ()
     {
       active_edges.clear ();
       finished_signatures_.clear ();
@@ -168,7 +168,7 @@ namespace pcl
     }
     
     bool
-    Front::Front::isEdgeFinished (const Edge &edge) const
+    BallPivotingFront::isEdgeFinished (const Edge &edge) const
     {
       return finished_signatures_.find (edge.getSignature ()) != finished_signatures_.end () ||
              finished_signatures_.find (edge.getSignatureReverse ()) != finished_signatures_.end ();

--- a/surface/src/ball_pivoting.cpp
+++ b/surface/src/ball_pivoting.cpp
@@ -37,8 +37,6 @@
 
 #include <boost/make_shared.hpp>
 
-#include <pcl/impl/instantiate.hpp>
-#include <pcl/point_types.h>
 #include <pcl/surface/ball_pivoting.h>
 #include <pcl/surface/impl/ball_pivoting.hpp>
 
@@ -147,5 +145,9 @@ namespace pcl
   } // namespace pcl::bpa
 } // namespace pcl
 
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/point_types.h>
+#include <pcl/impl/instantiate.hpp>
 // Instantiations of specific point types
 PCL_INSTANTIATE(BallPivoting, (pcl::PointNormal)(pcl::PointXYZRGBNormal)(pcl::PointXYZINormal))
+#endif    // PCL_NO_PRECOMPILE

--- a/surface/src/ball_pivoting.cpp
+++ b/surface/src/ball_pivoting.cpp
@@ -1,7 +1,9 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2017, Willow Garage, Inc.
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2017-, Open Perception, Inc.
+ *
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +16,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *   * Neither the name of the copyright holder(s) nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/surface/src/ball_pivoting.cpp
+++ b/surface/src/ball_pivoting.cpp
@@ -82,11 +82,11 @@ namespace pcl
     BallPivotingFront::addPoint (const Edge &last_edge, const uint32_t id_vertice_extended, 
                                  const Eigen::Vector3f &center, const bool is_back_ball)
     {
-      addEdge (Edge (last_edge.getIdPointStart (), id_vertice_extended,
-                     last_edge.getIdPointEnd (), center, is_back_ball));
+      addEdge (Edge (last_edge.id_point_start_, id_vertice_extended,
+                     last_edge.id_point_end_, center, is_back_ball));
     
-      addEdge (Edge (id_vertice_extended, last_edge.getIdPointEnd (),
-                     last_edge.getIdPointStart (), center, is_back_ball));
+      addEdge (Edge (id_vertice_extended, last_edge.id_point_end_,
+                     last_edge.id_point_start_, center, is_back_ball));
     }
     
     void
@@ -94,7 +94,8 @@ namespace pcl
     {
       if (!isEdgeOnFront (edge) && !isEdgeFinished (edge))
       {
-        active_edges_[edge.getSignature ()] = edge;
+        active_edges_.insert (std::pair<Signature, const Edge> (
+              edge.getSignature (), edge));
       }
     }
     
@@ -110,7 +111,8 @@ namespace pcl
     {
       if (!active_edges_.empty ())
       {
-        typename std::map<Signature, Edge>::iterator loc = active_edges_.find (Signature (id0, id1));
+        typename std::map<Signature, const Edge>::iterator loc = 
+          active_edges_.find (Signature (id0, id1));
         if (loc != active_edges_.end ())
         {
           active_edges_.erase (loc);

--- a/surface/src/ball_pivoting.cpp
+++ b/surface/src/ball_pivoting.cpp
@@ -33,10 +33,148 @@
  *
  */
 
+#include <boost/make_shared.hpp>
+
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>
 #include <pcl/surface/ball_pivoting.h>
 #include <pcl/surface/impl/ball_pivoting.hpp>
+
+namespace pcl
+{
+  namespace bpa
+  {
+    Front::Edge::Edge ()
+    {
+    }
+    
+    Front::Edge::Edge (const uint32_t id0, const uint32_t id1)
+    {
+      id_vertices_.resize (2);
+      id_vertices_.at (0) = id0;
+      id_vertices_.at (1) = id1;
+    }
+    
+    Front::Edge::Edge (const std::vector<uint32_t> &edge, const uint32_t id_opposite, 
+                       const Eigen::Vector3f &center, const bool is_back_ball):
+      id_vertices_ (edge), 
+      id_opposite_ (id_opposite), 
+      center_ (center), 
+      is_back_ball_ (is_back_ball)
+    {
+    }
+    
+    Front::Edge::~Edge ()
+    {
+    }
+    
+    Front::Front::Front ()
+    {
+      clear ();
+    }
+    
+    Front::Front::~Front ()
+    {
+    }
+    
+    Front::Edge::Ptr
+    Front::Front::getActiveEdge ()
+    {
+      Edge::Ptr re;
+      if (!active_edges.empty ())
+      {
+        re = boost::make_shared<Edge> (active_edges.begin ()->second);
+        current_edge_ = re;
+        active_edges.erase (active_edges.begin ());
+
+        finished_signatures_.insert (re->getSignature ());
+      }
+      return re;
+    }
+    
+    void
+    Front::Front::addTriangle (const pcl::Vertices::ConstPtr &seed, 
+                               const Eigen::Vector3f &center,
+                               const bool is_back_ball)
+    {
+      for (size_t idv = 0; idv < 3; ++idv)
+      {
+        std::vector<uint32_t> edge (2, 0);
+        edge.at (0) = seed->vertices.at (idv);
+        edge.at (1) = seed->vertices.at ((idv + 2) % 3);
+    
+        addEdge (Edge (edge, seed->vertices.at ((idv + 1) % 3), center, is_back_ball));
+      }
+    }
+    
+    void
+    Front::Front::addPoint (const Edge &last_edge, const uint32_t id_vertice_extended, 
+                            const Eigen::Vector3f &center, const bool is_back_ball)
+    {
+      std::vector<uint32_t> edge (2, 0);
+    
+      edge.at (0) = last_edge.getIdVertice (0);
+      edge.at (1) = id_vertice_extended;
+      addEdge (Edge (edge, last_edge.getIdVertice (1), center, is_back_ball));
+    
+      edge.at (0) = id_vertice_extended;
+      edge.at (1) = last_edge.getIdVertice (1);
+      addEdge (Edge (edge, last_edge.getIdVertice (0), center, is_back_ball));
+    }
+    
+    void
+    Front::Front::addEdge (const Edge &edge)
+    {
+      if (!isEdgeOnFront (edge))
+      {
+        active_edges[Signature (edge.getIdVertice (0), edge.getIdVertice (1))] = edge;
+      }
+    }
+    
+    bool
+    Front::Front::isEdgeOnFront (const Edge &edge) const
+    {
+      return active_edges.find (edge.getSignature ()) != active_edges.end () ||
+             active_edges.find (edge.getSignatureReverse ()) != active_edges.end ();
+    }
+    
+    void
+    Front::Front::removeEdge (const uint32_t id0, const uint32_t id1)
+    {
+      if (!active_edges.empty ())
+      {
+        typename std::map<Signature, Edge>::iterator loc = active_edges.find (Signature (id0, id1));
+        if (loc != active_edges.end ())
+        {
+          active_edges.erase (loc);
+        }
+        else // comment to delete one-directionally
+        {
+          loc = active_edges.find (Signature (id1, id0));
+          if (loc != active_edges.end ())
+          {
+            active_edges.erase (loc);
+          }
+        }
+      }
+    }
+    
+    void
+    Front::Front::clear ()
+    {
+      active_edges.clear ();
+      finished_signatures_.clear ();
+      current_edge_.reset ();
+    }
+    
+    bool
+    Front::Front::isEdgeFinished (const Edge &edge) const
+    {
+      return finished_signatures_.find (edge.getSignature ()) != finished_signatures_.end () ||
+             finished_signatures_.find (edge.getSignatureReverse ()) != finished_signatures_.end ();
+    }
+  } // namespace pcl::bpa
+} // namespace pcl
 
 // Instantiations of specific point types
 PCL_INSTANTIATE(BallPivoting, (pcl::PointNormal)(pcl::PointXYZRGBNormal)(pcl::PointXYZINormal))

--- a/test/surface/CMakeLists.txt
+++ b/test/surface/CMakeLists.txt
@@ -38,10 +38,10 @@ if (build)
     #             FILES test_poisson.cpp
     #             LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features
     #             ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
-    PCL_ADD_TEST(ball_pivoting test_ball_pivoting
-                 FILES test_ball_pivoting.cpp
-                 LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features pcl_search
-                 ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
+    #PCL_ADD_TEST(ball_pivoting test_ball_pivoting
+    #             FILES test_ball_pivoting.cpp
+    #             LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features pcl_search
+    #             ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
 
     if(QHULL_FOUND)
       PCL_ADD_TEST(surface_convex_hull test_convex_hull

--- a/test/surface/CMakeLists.txt
+++ b/test/surface/CMakeLists.txt
@@ -38,6 +38,10 @@ if (build)
     #             FILES test_poisson.cpp
     #             LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features
     #             ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
+    PCL_ADD_TEST(ball_pivoting test_ball_pivoting
+                 FILES test_ball_pivoting.cpp
+                 LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features pcl_search
+                 ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
 
     if(QHULL_FOUND)
       PCL_ADD_TEST(surface_convex_hull test_convex_hull

--- a/test/surface/CMakeLists.txt
+++ b/test/surface/CMakeLists.txt
@@ -38,10 +38,10 @@ if (build)
     #             FILES test_poisson.cpp
     #             LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features
     #             ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
-    #PCL_ADD_TEST(ball_pivoting test_ball_pivoting
-    #             FILES test_ball_pivoting.cpp
-    #             LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features pcl_search
-    #             ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
+    PCL_ADD_TEST(ball_pivoting test_ball_pivoting
+                 FILES test_ball_pivoting.cpp
+                 LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features pcl_search
+                 ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
 
     if(QHULL_FOUND)
       PCL_ADD_TEST(surface_convex_hull test_convex_hull

--- a/test/surface/CMakeLists.txt
+++ b/test/surface/CMakeLists.txt
@@ -41,7 +41,7 @@ if (build)
     PCL_ADD_TEST(ball_pivoting test_ball_pivoting
                  FILES test_ball_pivoting.cpp
                  LINK_WITH pcl_gtest pcl_io pcl_kdtree pcl_surface pcl_features pcl_search
-                 ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
+                 ARGUMENTS "")
 
     if(QHULL_FOUND)
       PCL_ADD_TEST(surface_convex_hull test_convex_hull

--- a/test/surface/test_ball_pivoting.cpp
+++ b/test/surface/test_ball_pivoting.cpp
@@ -41,10 +41,7 @@
 
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/io/vtk_io.h>
 #include <pcl/features/normal_3d.h>
-#include <pcl/surface/mls.h>
-#include <pcl/surface/gp3.h>
 #include <pcl/surface/ball_pivoting.h>
 #include <pcl/common/common.h>
 
@@ -66,30 +63,34 @@ search::KdTree<PointNormal>::Ptr tree4;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, BallPivotingTest)
 {
+  pcl::PolygonMesh mesh_fixed_radius;
+  pcl::PolygonMesh mesh_found_radius;
+
   BallPivoting<PointNormal> pivoter;
   pivoter.setInputCloud (cloud_with_normals);
   pivoter.setSearchMethod (tree2);
-  pivoter.setSearchRadius (0.02); // pivoter.setEstimatedRadius (10, 5, 0.9f); is random
 
-  PointCloud<PointNormal> points;
-  std::vector<Vertices> vertices;
-  pivoter.reconstruct (points, vertices);
+  pivoter.setSearchRadius (0.02);
+  pivoter.reconstruct (mesh_fixed_radius);
+
+  pivoter.setEstimatedRadius (100, 5, 0.95f); 
+  pivoter.reconstruct (mesh_found_radius);
   
-  EXPECT_NEAR (points.points[points.size()/2].x, 0.01097, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].y, 0.11058, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].z, 0.039648, 1e-3);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 204);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 208);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 206);
+  const std::vector<Vertices> &polygons_fixed_radius = mesh_fixed_radius.polygons;
+  EXPECT_EQ (polygons_fixed_radius[100].vertices[0], 88);
+  EXPECT_EQ (polygons_fixed_radius[100].vertices[1], 89);
+  EXPECT_EQ (polygons_fixed_radius[100].vertices[2], 98);
+  EXPECT_EQ (polygons_fixed_radius[200].vertices[0], 118);
+  EXPECT_EQ (polygons_fixed_radius[200].vertices[1], 121);
+  EXPECT_EQ (polygons_fixed_radius[200].vertices[2], 119);
 
-  pivoter.setEstimatedRadius (10, 5, 0.9f); 
-
-  EXPECT_NEAR (points.points[points.size()/2].x, 0.01097, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].y, 0.11058, 1e-3);
-  EXPECT_NEAR (points.points[points.size()/2].z, 0.039648, 1e-3);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 204);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 208);
-  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 206);
+  const std::vector<Vertices> &polygons_found_radius = mesh_found_radius.polygons;
+  EXPECT_EQ (polygons_found_radius[100].vertices[0], 82);
+  EXPECT_EQ (polygons_found_radius[100].vertices[1], 84);
+  EXPECT_EQ (polygons_found_radius[100].vertices[2], 88);
+  EXPECT_EQ (polygons_found_radius[200].vertices[0], 30);
+  EXPECT_EQ (polygons_found_radius[200].vertices[1], 40);
+  EXPECT_EQ (polygons_found_radius[200].vertices[2], 41);
 }
 
 
@@ -133,7 +134,7 @@ main (int argc, char** argv)
     pcl::PCLPointCloud2 cloud_blob1;
     loadPCDFile (argv[2], cloud_blob1);
     fromPCLPointCloud2 (cloud_blob1, *cloud1);
-        // Create search tree
+    // Create search tree
     tree3.reset (new search::KdTree<PointXYZ> (false));
     tree3->setInputCloud (cloud1);
 

--- a/test/surface/test_ball_pivoting.cpp
+++ b/test/surface/test_ball_pivoting.cpp
@@ -75,7 +75,7 @@ TEST (PCL, BallPivotingTest)
 
   pivoter.setEstimatedRadius (100, 5, 0.95f); 
   pivoter.reconstruct (mesh_found_radius);
-  
+
   const std::vector<Vertices> &polygons_fixed_radius = mesh_fixed_radius.polygons;
   EXPECT_EQ (polygons_fixed_radius[100].vertices[0], 88);
   EXPECT_EQ (polygons_fixed_radius[100].vertices[1], 89);

--- a/test/surface/test_ball_pivoting.cpp
+++ b/test/surface/test_ball_pivoting.cpp
@@ -40,25 +40,12 @@
 #include <gtest/gtest.h>
 
 #include <pcl/point_types.h>
-#include <pcl/io/pcd_io.h>
-//#include <pcl/features/normal_3d.h>
 #include <pcl/surface/ball_pivoting.h>
 #include <pcl/common/common.h>
 
 using namespace pcl;
 using namespace pcl::io;
 using namespace std;
-
-/*PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ>);
-PointCloud<PointNormal>::Ptr cloud_with_normals (new PointCloud<PointNormal>);
-search::KdTree<PointXYZ>::Ptr tree;
-search::KdTree<PointNormal>::Ptr tree2;
-
-// add by ktran to test update functions
-PointCloud<PointXYZ>::Ptr cloud1 (new PointCloud<PointXYZ>);
-PointCloud<PointNormal>::Ptr cloud_with_normals1 (new PointCloud<PointNormal>);
-search::KdTree<PointXYZ>::Ptr tree3;
-search::KdTree<PointNormal>::Ptr tree4;*/
 
 // custom cloud and tree
 PointCloud<PointNormal>::Ptr cloud_custom (new PointCloud<PointNormal>);
@@ -74,38 +61,43 @@ TEST (PCL, BallPivotingTest)
   pivoter.setInputCloud (cloud_custom);
   pivoter.setSearchMethod (tree_custom);
 
+  // reconstruction with custom radius
   pivoter.setSearchRadius (0.02);
   pivoter.reconstruct (mesh_fixed_radius);
 
+  // reconstruction with estimated radius
   pivoter.setEstimatedRadius (100, 5, 0.95f); 
   pivoter.reconstruct (mesh_found_radius);
 
+  // test reconstruction with custom radius
   const std::vector<Vertices> &polygons_fixed_radius = mesh_fixed_radius.polygons;
-  EXPECT_EQ (polygons_fixed_radius[100].vertices[0], 99);
-  EXPECT_EQ (polygons_fixed_radius[100].vertices[1], 102);
-  EXPECT_EQ (polygons_fixed_radius[100].vertices[2], 101);
-  EXPECT_EQ (polygons_fixed_radius[200].vertices[0], 199);
-  EXPECT_EQ (polygons_fixed_radius[200].vertices[1], 202);
-  EXPECT_EQ (polygons_fixed_radius[200].vertices[2], 201);
+  EXPECT_EQ (polygons_fixed_radius[100].vertices[0], 101);
+  EXPECT_EQ (polygons_fixed_radius[100].vertices[1], 100);
+  EXPECT_EQ (polygons_fixed_radius[100].vertices[2], 102);
+  EXPECT_EQ (polygons_fixed_radius[200].vertices[0], 201);
+  EXPECT_EQ (polygons_fixed_radius[200].vertices[1], 200);
+  EXPECT_EQ (polygons_fixed_radius[200].vertices[2], 202);
 
+  // test reconstruction with estimated radius
   const std::vector<Vertices> &polygons_found_radius = mesh_found_radius.polygons;
-  EXPECT_EQ (polygons_found_radius[100].vertices[0], 99);
-  EXPECT_EQ (polygons_found_radius[100].vertices[1], 102);
-  EXPECT_EQ (polygons_found_radius[100].vertices[2], 101);
-  EXPECT_EQ (polygons_found_radius[200].vertices[0], 199);
-  EXPECT_EQ (polygons_found_radius[200].vertices[1], 202);
-  EXPECT_EQ (polygons_found_radius[200].vertices[2], 201);
+  EXPECT_EQ (polygons_found_radius[100].vertices[0], 101);
+  EXPECT_EQ (polygons_found_radius[100].vertices[1], 100);
+  EXPECT_EQ (polygons_found_radius[100].vertices[2], 102);
+  EXPECT_EQ (polygons_found_radius[200].vertices[0], 201);
+  EXPECT_EQ (polygons_found_radius[200].vertices[1], 200);
+  EXPECT_EQ (polygons_found_radius[200].vertices[2], 202);
 }
 
 /**
  * return a point cloud similar to triangle strip in computer graphics, 
- * it generally extends to +X direction, with normal in +Z and points on Z=0.
+ * it generally extends to +X direction, with normal in +Z and points on z=0.
  */
 pcl::PointCloud<pcl::PointNormal>::Ptr
 compose_strip_cloud (const size_t size_cloud)
 {
   const Eigen::Vector3f normal (0.0f, 0.0f, 1.0f);
-  const Eigen::Vector3f odd_shift = Eigen::Vector3f (0.5f, std::sqrt (3.0f) / 2.0f, 0.0f) / 100.0f;
+  const Eigen::Vector3f odd_shift = 
+    Eigen::Vector3f (0.5f, std::sqrt (3.0f) / 2.0f, 0.0f) / 100.0f;
   const Eigen::Vector3f even_shift = Eigen::Vector3f (1.0f, 0.0f, 0.0f) / 100.0f;
   Eigen::Vector3f base = Eigen::Vector3f::Zero ();
 
@@ -119,13 +111,8 @@ compose_strip_cloud (const size_t size_cloud)
     pcl::PointNormal point;
     if (id_point % 2 == 1)
     {
-      // 1,3,5,7,9...-th points
-      position += odd_shift;
-    }
-    else
-    {
-      // 0,2,4,6,8...-th points
-      base += even_shift;
+      position += odd_shift; // shift in this iteration
+      base += even_shift; // shift in following iterations
     }
     point.getVector3fMap () = position;
     point.getNormalVector3fMap () = normal;
@@ -139,65 +126,9 @@ compose_strip_cloud (const size_t size_cloud)
 int
 main (int argc, char** argv)
 {
-/*  if (argc < 2)
-  {
-    std::cerr << "No test file given. Please download `bun0.pcd` and pass its path to the test." << std::endl;
-    return (-1);
-  }
-
-  // Load file
-  pcl::PCLPointCloud2 cloud_blob;
-  loadPCDFile (argv[1], cloud_blob);
-  fromPCLPointCloud2 (cloud_blob, *cloud);
-
-  // Create search tree
-  tree.reset (new search::KdTree<PointXYZ> (false));
-  tree->setInputCloud (cloud);
-
-  // Normal estimation
-  NormalEstimation<PointXYZ, Normal> n;
-  PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
-  n.setInputCloud (cloud);
-  //n.setIndices (indices[B);
-  n.setSearchMethod (tree);
-  n.setKSearch (20);
-  n.compute (*normals);
-
-  // Concatenate XYZ and normal information
-  pcl::concatenateFields (*cloud, *normals, *cloud_with_normals);
-      
-  // Create search tree
-  tree2.reset (new search::KdTree<PointNormal>);
-  tree2->setInputCloud (cloud_with_normals);
-
-  // Process for update cloud
-  if(argc == 3){
-    pcl::PCLPointCloud2 cloud_blob1;
-    loadPCDFile (argv[2], cloud_blob1);
-    fromPCLPointCloud2 (cloud_blob1, *cloud1);
-    // Create search tree
-    tree3.reset (new search::KdTree<PointXYZ> (false));
-    tree3->setInputCloud (cloud1);
-
-    // Normal estimation
-    NormalEstimation<PointXYZ, Normal> n1;
-    PointCloud<Normal>::Ptr normals1 (new PointCloud<Normal> ());
-    n1.setInputCloud (cloud1);
-
-    n1.setSearchMethod (tree3);
-    n1.setKSearch (20);
-    n1.compute (*normals1);
-
-    // Concatenate XYZ and normal information
-    pcl::concatenateFields (*cloud1, *normals1, *cloud_with_normals1);
-    // Create search tree
-    tree4.reset (new search::KdTree<PointNormal>);
-    tree4->setInputCloud (cloud_with_normals1);
-  }*/
-
-  // use composed point cloud for unit test
+  // use composed point cloud (strip) for unit test
   cloud_custom= compose_strip_cloud (1000);
-  tree_custom.reset (new search::KdTree<PointNormal>);
+  tree_custom.reset (new search::KdTree<PointNormal> ());
   tree_custom->setInputCloud (cloud_custom);
 
   // Testing

--- a/test/surface/test_ball_pivoting.cpp
+++ b/test/surface/test_ball_pivoting.cpp
@@ -1,0 +1,160 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id: test_surface.cpp 6579 2012-07-27 18:57:32Z rusu $
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <pcl/point_types.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/io/vtk_io.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/surface/mls.h>
+#include <pcl/surface/gp3.h>
+#include <pcl/surface/ball_pivoting.h>
+#include <pcl/common/common.h>
+
+using namespace pcl;
+using namespace pcl::io;
+using namespace std;
+
+PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ>);
+PointCloud<PointNormal>::Ptr cloud_with_normals (new PointCloud<PointNormal>);
+search::KdTree<PointXYZ>::Ptr tree;
+search::KdTree<PointNormal>::Ptr tree2;
+
+// add by ktran to test update functions
+PointCloud<PointXYZ>::Ptr cloud1 (new PointCloud<PointXYZ>);
+PointCloud<PointNormal>::Ptr cloud_with_normals1 (new PointCloud<PointNormal>);
+search::KdTree<PointXYZ>::Ptr tree3;
+search::KdTree<PointNormal>::Ptr tree4;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (PCL, BallPivotingTest)
+{
+  BallPivoting<PointNormal> pivoter;
+  pivoter.setInputCloud (cloud_with_normals);
+  pivoter.setSearchMethod (tree2);
+  pivoter.setSearchRadius (0.02); // pivoter.setEstimatedRadius (10, 5, 0.9f); is random
+
+  PointCloud<PointNormal> points;
+  std::vector<Vertices> vertices;
+  pivoter.reconstruct (points, vertices);
+  
+  EXPECT_NEAR (points.points[points.size()/2].x, 0.01097, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].y, 0.11058, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].z, 0.039648, 1e-3);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 204);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 208);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 206);
+
+  pivoter.setEstimatedRadius (10, 5, 0.9f); 
+
+  EXPECT_NEAR (points.points[points.size()/2].x, 0.01097, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].y, 0.11058, 1e-3);
+  EXPECT_NEAR (points.points[points.size()/2].z, 0.039648, 1e-3);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[0], 204);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[1], 208);
+  EXPECT_EQ (vertices[vertices.size ()/2].vertices[2], 206);
+}
+
+
+/* ---[ */
+int
+main (int argc, char** argv)
+{
+  if (argc < 2)
+  {
+    std::cerr << "No test file given. Please download `bun0.pcd` and pass its path to the test." << std::endl;
+    return (-1);
+  }
+
+  // Load file
+  pcl::PCLPointCloud2 cloud_blob;
+  loadPCDFile (argv[1], cloud_blob);
+  fromPCLPointCloud2 (cloud_blob, *cloud);
+
+  // Create search tree
+  tree.reset (new search::KdTree<PointXYZ> (false));
+  tree->setInputCloud (cloud);
+
+  // Normal estimation
+  NormalEstimation<PointXYZ, Normal> n;
+  PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
+  n.setInputCloud (cloud);
+  //n.setIndices (indices[B);
+  n.setSearchMethod (tree);
+  n.setKSearch (20);
+  n.compute (*normals);
+
+  // Concatenate XYZ and normal information
+  pcl::concatenateFields (*cloud, *normals, *cloud_with_normals);
+      
+  // Create search tree
+  tree2.reset (new search::KdTree<PointNormal>);
+  tree2->setInputCloud (cloud_with_normals);
+
+  // Process for update cloud
+  if(argc == 3){
+    pcl::PCLPointCloud2 cloud_blob1;
+    loadPCDFile (argv[2], cloud_blob1);
+    fromPCLPointCloud2 (cloud_blob1, *cloud1);
+        // Create search tree
+    tree3.reset (new search::KdTree<PointXYZ> (false));
+    tree3->setInputCloud (cloud1);
+
+    // Normal estimation
+    NormalEstimation<PointXYZ, Normal> n1;
+    PointCloud<Normal>::Ptr normals1 (new PointCloud<Normal> ());
+    n1.setInputCloud (cloud1);
+
+    n1.setSearchMethod (tree3);
+    n1.setKSearch (20);
+    n1.compute (*normals1);
+
+    // Concatenate XYZ and normal information
+    pcl::concatenateFields (*cloud1, *normals1, *cloud_with_normals1);
+    // Create search tree
+    tree4.reset (new search::KdTree<PointNormal>);
+    tree4->setInputCloud (cloud_with_normals1);
+  }
+
+  // Testing
+  testing::InitGoogleTest (&argc, argv);
+  return (RUN_ALL_TESTS ());
+}
+/* ]--- */

--- a/test/surface/test_ball_pivoting.cpp
+++ b/test/surface/test_ball_pivoting.cpp
@@ -66,7 +66,7 @@ TEST (PCL, BallPivotingTest)
   pivoter.reconstruct (mesh_fixed_radius);
 
   // reconstruction with estimated radius
-  pivoter.setEstimatedRadius (100, 5, 0.95f); 
+  pivoter.setSearchRadiusAutomatically (100, 5, 0.95f); 
   pivoter.reconstruct (mesh_found_radius);
 
   // test reconstruction with custom radius


### PR DESCRIPTION
algorithm from
```
@article{bernardini1999ball,
   title={The ball-pivoting algorithm for surface reconstruction},
   author={Bernardini, Fausto and Mittleman, Joshua and Rushmeier, Holly and Silva, Cl{\'a}udio and Taubin, Gabriel},
   journal={IEEE transactions on visualization and computer graphics},
   volume={5},
   number={4},
   pages={349--359},
   year={1999},
   publisher={IEEE}
 }
```

general structure from https://github.com/rodschulz/BPA
fitted from https://github.com/t-lou/bpa_remake

example
![snapshot00](https://user-images.githubusercontent.com/16481337/28598897-02fee580-71a7-11e7-998d-a15a8e663c54.png)
input point cloud
![snapshot01](https://user-images.githubusercontent.com/16481337/28598896-02fd9c8e-71a7-11e7-9c51-1c07abe214de.png)
output surface
