### PR TITLE
Add test for macro _USE_MATH_DEFINES.

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -69,7 +69,9 @@ namespace pcl
 #include <iostream>
 #include <stdarg.h>
 #include <stdio.h>
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 
 // MSCV doesn't have std::{isnan,isfinite}

--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -41,8 +41,6 @@
 
 #include <pcl/people/hog.h>
 
-#define _USE_MATH_DEFINES
-#include <math.h>
 #include <string.h>
 
 #if defined(__SSE2__)


### PR DESCRIPTION
Eliminating the warning message of repeated definition of macro when you defined it yourself.