### PR TITLE
Fixed spelling and grammar errors

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -462,7 +462,7 @@ namespace pcl
           * \param[in] ypos the Y position on screen where the text should be added
           * \param[in] r the red color value
           * \param[in] g the green color value
-          * \param[in] b the blue color vlaue
+          * \param[in] b the blue color value
           * \param[in] id the text object id (default: equal to the "text" parameter)
           * \param[in] viewport the view port (default: all)
           */
@@ -477,7 +477,7 @@ namespace pcl
           * \param[in] fontsize the fontsize of the text
           * \param[in] r the red color value
           * \param[in] g the green color value
-          * \param[in] b the blue color vlaue
+          * \param[in] b the blue color value
           * \param[in] id the text object id (default: equal to the "text" parameter)
           * \param[in] viewport the view port (default: all)
           */
@@ -503,7 +503,7 @@ namespace pcl
           * \param[in] ypos the new Y position on screen 
           * \param[in] r the red color value
           * \param[in] g the green color value
-          * \param[in] b the blue color vlaue
+          * \param[in] b the blue color value
           * \param[in] id the text object id (default: equal to the "text" parameter)
           */
         bool
@@ -518,7 +518,7 @@ namespace pcl
           * \param[in] fontsize the fontsize of the text
           * \param[in] r the red color value
           * \param[in] g the green color value
-          * \param[in] b the blue color vlaue
+          * \param[in] b the blue color value
           * \param[in] id the text object id (default: equal to the "text" parameter)
           */
         bool
@@ -579,7 +579,7 @@ namespace pcl
                    double r = 1.0, double g = 1.0, double b = 1.0,
                    const std::string &id = "", int viewport = 0);
 
-        /** \brief Check if the cloud, shape, or coordinate with the given id was already added to this vizualizer.
+        /** \brief Check if the cloud, shape, or coordinate with the given id was already added to this visualizer.
           * \param[in] id the id of the cloud, shape, or coordinate to check
           * \return true if a cloud, shape, or coordinate with the specified id was found
           */
@@ -1128,7 +1128,7 @@ namespace pcl
         int
         getGeometryHandlerIndex (const std::string &id);
 
-        /** \brief Update/set the color index of a renderered PointCloud based on its ID
+        /** \brief Update/set the color index of a rendered PointCloud based on its ID
           * \param[in] id the point cloud object id
           * \param[in] index the color handler index to use
           */
@@ -1323,7 +1323,7 @@ namespace pcl
         addArrow (const P1 &pt1, const P2 &pt2, double r, double g, double b,
                   const std::string &id = "arrow", int viewport = 0);
 
-        /** \brief Add a line arrow segment between two points, and (optianally) display the distance between them
+        /** \brief Add a line arrow segment between two points, and (optionally) display the distance between them
           *
           * Arrow head is attached on the **start** point (\c pt1) of the arrow.
           *
@@ -1661,8 +1661,8 @@ namespace pcl
         renderView (int xres, int yres, pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud);
 
         /** \brief The purpose of this method is to render a CAD model added to the visualizer from different viewpoints
-          * in order to simulate partial views of model. The viewpoint locations are the vertices of a tesselated sphere
-          * build from an icosaheadron. The tesselation paremeter controls how many times the triangles of the original
+          * in order to simulate partial views of model. The viewpoint locations are the vertices of a tessellated sphere
+          * build from an icosaheadron. The tessellation parameter controls how many times the triangles of the original
           * icosahedron are divided to approximate the sphere and thus the number of partial view generated for a model,
           * with a tesselation_level of 0, 12 views are generated if use_vertices=true and 20 views if use_vertices=false
           *
@@ -1673,8 +1673,8 @@ namespace pcl
           * \param[out] enthropies are values between 0 and 1 representing which percentage of the model is seen from the respective viewpoint.
           * \param[in] tesselation_level represents the number of subdivisions applied to the triangles of original icosahedron.
           * \param[in] view_angle field of view of the virtual camera. Default: 45
-          * \param[in] radius_sphere the tesselated sphere radius. Default: 1
-          * \param[in] use_vertices if true, use the vertices of tesselated icosahedron (12,42,...) or if false, use the faces of tesselated
+          * \param[in] radius_sphere the tessellated sphere radius. Default: 1
+          * \param[in] use_vertices if true, use the vertices of tessellated icosahedron (12,42,...) or if false, use the faces of tessellated
           * icosahedron (20,80,...). Default: true
           */
         void

--- a/visualization/include/pcl/visualization/registration_visualizer.h
+++ b/visualization/include/pcl/visualization/registration_visualizer.h
@@ -45,9 +45,9 @@
 namespace pcl
 {
   /** \brief @b RegistrationVisualizer represents the base class for rendering
-   * the intermediate positions ocupied by the source point cloud during it's registration
+   * the intermediate positions occupied by the source point cloud during it's registration
    * to the target point cloud. A registration algorithm is considered as input and
-   * it's covergence is rendered.
+   * it's convergence is rendered.
    * \author Gheorghe Lisca
    * \ingroup visualization
    */
@@ -74,7 +74,7 @@ namespace pcl
 
       /** \brief Set the registration algorithm whose intermediate steps will be rendered.
        * The method creates the local callback function pcl::RegistrationVisualizer::update_visualizer_ and
-       * binds it to the local biffers update function pcl::RegistrationVisualizer::updateIntermediateCloud().
+       * binds it to the local buffers update function pcl::RegistrationVisualizer::updateIntermediateCloud().
        * The local callback function pcl::RegistrationVisualizer::update_visualizer_ is then linked to
        * the pcl::Registration::update_visualizer_ callback function.
        * \param registration represents the registration method whose intermediate steps will be rendered.
@@ -82,10 +82,10 @@ namespace pcl
       bool
       setRegistration (pcl::Registration<PointSource, PointTarget> &registration)
       {
-        // Update the name of the registration method to be desplayed
+        // Update the name of the registration method to be displayed
         registration_method_name_ = registration.getClassName();
 
-        // Create the local callback function and bind it to the local function resposable for updating
+        // Create the local callback function and bind it to the local function responsible for updating
         // the local buffers
         update_visualizer_ = boost::bind (&RegistrationVisualizer<PointSource, PointTarget>::updateIntermediateCloud,
                                           this, _1, _2, _3, _4);
@@ -117,19 +117,19 @@ namespace pcl
       /** \brief Updates visualizer local buffers cloud_intermediate, cloud_intermediate_indices, cloud_target_indices with
        * the newest registration intermediate results.
        * \param cloud_src represents the initial source point cloud
-       * \param indices_src represents the incices of the intermediate source points used for the estimation of rigid transformation
+       * \param indices_src represents the indices of the intermediate source points used for the estimation of rigid transformation
        * \param cloud_tgt represents the target point cloud
-       * \param indices_tgt represents the incices of the target points used for the estimation of rigid transformation
+       * \param indices_tgt represents the indices of the target points used for the estimation of rigid transformation
        */
       void
       updateIntermediateCloud (const pcl::PointCloud<PointSource> &cloud_src, const std::vector<int> &indices_src,
                                const pcl::PointCloud<PointTarget> &cloud_tgt, const std::vector<int> &indices_tgt);
 
-      /** \brief Set maximum number of corresponcence lines whch will be rendered. */
+      /** \brief Set maximum number of correspondence lines which will be rendered. */
       inline void
       setMaximumDisplayedCorrespondences (const int maximum_displayed_correspondences)
       {
-        // This method is usualy called form other thread than visualizer thread
+        // This method is usually called form other thread than visualizer thread
         // therefore same visualizer_updating_mutex_ will be used
 
         // Lock maximum_displayed_correspondences_
@@ -142,7 +142,7 @@ namespace pcl
         visualizer_updating_mutex_.unlock();
       }
 
-      /** \brief Return maximum number of corresponcence lines which are rendered. */
+      /** \brief Return maximum number of correspondence lines which are rendered. */
       inline size_t
       getMaximumDisplayedCorrespondences()
       {
@@ -150,7 +150,7 @@ namespace pcl
       }
 
     private:
-      /** \brief Initialize and run the visualization loop. This function will be runned in the internal thread viewer_thread_ */
+      /** \brief Initialize and run the visualization loop. This function will run in the internal thread viewer_thread_ */
       void
       runDisplay ();
 
@@ -187,7 +187,7 @@ namespace pcl
       /** \brief The local buffer for target point cloud. */
       pcl::PointCloud<PointTarget> cloud_target_;
 
-      /** \brief The mutex used for the sincronization of updating and rendering of the local buffers. */
+      /** \brief The mutex used for the synchronization of updating and rendering of the local buffers. */
       boost::mutex visualizer_updating_mutex_;
 
       /** \brief The local buffer for intermediate point cloud obtained during registration process. */


### PR DESCRIPTION
`pcl_visualizer.h` and `registration_visualizer.h` had numerous spelling mistakes and a grammar error.