### PR TITLE
Add new mls projection method

### DIFF
--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -71,7 +71,6 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::process (PointCloudOut &output)
     normals_->points.clear ();
   }
 
-
   // Copy the header
   output.header = input_->header;
   output.width = output.height = 0;
@@ -180,14 +179,14 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
   // Note: this method is const because it needs to be thread-safe
   //       (MovingLeastSquaresOMP calls it from multiple threads)
 
-  mls_result.computeMLSSurface<PointInT>(*input_, index, nn_indices, search_radius_, order_);
+  mls_result.computeMLSSurface<PointInT> (*input_, index, nn_indices, search_radius_, order_);
 
   switch (upsample_method_)
   {
     case (NONE):
     {
-      MLSResult::MLSProjectionResults proj = mls_result.projectQueryPoint(projection_method_, nr_coeff_);
-      addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
+      MLSResult::MLSProjectionResults proj = mls_result.projectQueryPoint (projection_method_, nr_coeff_);
+      addProjectedPointNormal (index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
       break;
     }
 
@@ -198,8 +197,8 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
         for (float v_disp = -static_cast<float> (upsampling_radius_); v_disp <= upsampling_radius_; v_disp += static_cast<float> (upsampling_step_))
           if (u_disp*u_disp + v_disp*v_disp < upsampling_radius_*upsampling_radius_)
           {
-            MLSResult::MLSProjectionResults proj = mls_result.projectPointSimpleToPolynomialSurface(u_disp, v_disp);
-            addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
+            MLSResult::MLSProjectionResults proj = mls_result.projectPointSimpleToPolynomialSurface (u_disp, v_disp);
+            addProjectedPointNormal (index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
           }
       break;
     }
@@ -213,8 +212,8 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
       if (num_points_to_add <= 0)
       {
         // Just add the current point
-        MLSResult::MLSProjectionResults proj = mls_result.projectQueryPoint(projection_method_, nr_coeff_);
-        addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
+        MLSResult::MLSProjectionResults proj = mls_result.projectQueryPoint (projection_method_, nr_coeff_);
+        addProjectedPointNormal (index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
       }
       else
       {
@@ -234,7 +233,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
           else
             proj = mls_result.projectPointToMLSPlane (u, v);
 
-          addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
+          addProjectedPointNormal (index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
 
           num_added ++;
         }
@@ -403,7 +402,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
 
   if (upsample_method_ == DISTINCT_CLOUD)
   {
-    corresponding_input_indices_.reset(new PointIndices);
+    corresponding_input_indices_.reset (new PointIndices);
     for (size_t dp_i = 0; dp_i < distinct_cloud_->size (); ++dp_i) // dp_i = distinct_point_i
     {
       // Distinct cloud may have nan points, skip them
@@ -424,7 +423,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
 
       Eigen::Vector3d add_point = distinct_cloud_->points[dp_i].getVector3fMap ().template cast<double> ();
       MLSResult::MLSProjectionResults proj =  mls_results_[input_index].projectPoint (add_point, projection_method_,  5 * nr_coeff_);
-      addProjectedPointNormal(input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
+      addProjectedPointNormal (input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
     }
   }
 
@@ -432,7 +431,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
   // Then, project the newly obtained points to the MLS surface
   if (upsample_method_ == VOXEL_GRID_DILATION)
   {
-    corresponding_input_indices_.reset(new PointIndices);
+    corresponding_input_indices_.reset (new PointIndices);
 
     MLSVoxelGrid voxel_grid (input_, indices_, voxel_size_);
     for (int iteration = 0; iteration < dilation_iteration_num_; ++iteration)
@@ -460,8 +459,8 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
         continue;
 
       Eigen::Vector3d add_point = p.getVector3fMap ().template cast<double> ();
-      MLSResult::MLSProjectionResults proj = mls_results_[input_index].projectPoint(add_point, projection_method_,  5 * nr_coeff_);
-      addProjectedPointNormal(input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
+      MLSResult::MLSProjectionResults proj = mls_results_[input_index].projectPoint (add_point, projection_method_,  5 * nr_coeff_);
+      addProjectedPointNormal (input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
     }
   }
 }
@@ -481,7 +480,8 @@ pcl::MLSResult::MLSResult (const Eigen::Vector3d &a_query_point,
 {
 }
 
-void pcl::MLSResult::getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v, double &w) const
+void
+pcl::MLSResult::getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v, double &w) const
 {
   Eigen::Vector3d delta = pt - mean;
   u = delta.dot (u_axis);
@@ -489,14 +489,16 @@ void pcl::MLSResult::getMLSCoordinates (const Eigen::Vector3d &pt, double &u, do
   w = delta.dot (plane_normal);
 }
 
-void pcl::MLSResult::getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v) const
+void
+pcl::MLSResult::getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v) const
 {
   Eigen::Vector3d delta = pt - mean;
   u = delta.dot (u_axis);
   v = delta.dot (v_axis);
 }
 
-double pcl::MLSResult::getPolynomialValue (const double u, const double v) const
+double
+pcl::MLSResult::getPolynomialValue (const double u, const double v) const
 {
   // Compute the polynomial's terms at the current point
   // Example for second order: z = a + b*y + c*y^2 + d*x + e*x*y + f*x^2
@@ -515,54 +517,56 @@ double pcl::MLSResult::getPolynomialValue (const double u, const double v) const
     u_pow *= u;
   }
 
-  return result;
+  return (result);
 }
 
-pcl::MLSResult::PolynomialPartialDerivative pcl::MLSResult::getPolynomialPartialDerivative (const double u, const double v) const
+pcl::MLSResult::PolynomialPartialDerivative
+pcl::MLSResult::getPolynomialPartialDerivative (const double u, const double v) const
 {
   // Compute the displacement along the normal using the fitted polynomial
   // and compute the partial derivatives needed for estimating the normal
   PolynomialPartialDerivative d;
-  Eigen::VectorXd u_pow(order + 2), v_pow(order + 2);
+  Eigen::VectorXd u_pow (order + 2), v_pow (order + 2);
   int j = 0;
 
   d.z = d.z_u = d.z_v = d.z_uu = d.z_vv = d.z_uv = 0;
-  u_pow(0) = v_pow(0) = 1;
+  u_pow (0) = v_pow (0) = 1;
   for (int ui = 0; ui <= order; ++ui)
   {
     for (int vi = 0; vi <= order - ui; ++vi)
     {
       // Compute displacement along normal
-      d.z += u_pow(ui) * v_pow(vi) * c_vec[j];
+      d.z += u_pow (ui) * v_pow (vi) * c_vec[j];
 
       // Compute partial derivatives
       if (ui >= 1)
-        d.z_u += c_vec[j] * ui * u_pow(ui - 1) * v_pow(vi);
+        d.z_u += c_vec[j] * ui * u_pow (ui - 1) * v_pow (vi);
 
       if (vi >= 1)
-        d.z_v += c_vec[j] * vi * u_pow(ui) * v_pow(vi - 1);
+        d.z_v += c_vec[j] * vi * u_pow (ui) * v_pow (vi - 1);
 
       if (ui >= 1 && vi >= 1)
-        d.z_uv += c_vec[j] * ui * u_pow(ui - 1) * vi * v_pow(vi - 1);
+        d.z_uv += c_vec[j] * ui * u_pow (ui - 1) * vi * v_pow (vi - 1);
 
       if (ui >= 2)
-        d.z_uu += c_vec[j] * ui * (ui - 1) * u_pow(ui - 2) * v_pow(vi);
+        d.z_uu += c_vec[j] * ui * (ui - 1) * u_pow (ui - 2) * v_pow (vi);
 
       if (vi >= 2)
-        d.z_vv += c_vec[j] * vi * (vi - 1) * u_pow(ui) * v_pow(vi - 2);
+        d.z_vv += c_vec[j] * vi * (vi - 1) * u_pow (ui) * v_pow (vi - 2);
 
       if (ui == 0)
-        v_pow(vi + 1) = v_pow(vi) * v;
+        v_pow (vi + 1) = v_pow (vi) * v;
 
       ++j;
     }
-    u_pow(ui + 1) = u_pow(ui) * u;
+    u_pow (ui + 1) = u_pow (ui) * u;
   }
 
-  return d;
+  return (d);
 }
 
-Eigen::Vector2f pcl::MLSResult::calculatePrincipleCurvatures (const double u, const double v) const
+Eigen::Vector2f
+pcl::MLSResult::calculatePrincipleCurvatures (const double u, const double v) const
 {
   Eigen::Vector2f k(1e-5, 1e-5);
 
@@ -579,7 +583,7 @@ Eigen::Vector2f pcl::MLSResult::calculatePrincipleCurvatures (const double u, co
     double H = ((1.0 + d.z_v * d.z_v) * d.z_uu - 2.0 * d.z_u * d.z_v * d.z_uv + (1.0 + d.z_u * d.z_u) * d.z_vv) / (2.0 * Zlen * Zlen * Zlen);
     double disc2 = H * H - K;
     assert (disc2 >= 0.0);
-    double disc = std::sqrt(disc2);
+    double disc = std::sqrt (disc2);
     k[0] = H + disc;
     k[1] = H - disc;
 
@@ -590,10 +594,11 @@ Eigen::Vector2f pcl::MLSResult::calculatePrincipleCurvatures (const double u, co
     PCL_ERROR("No Polynomial fit data, unable to calculate the principle curvatures!\n");
   }
 
-  return k;
+  return (k);
 }
 
-pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointOrthogonalToPolynomialSurface (const double u, const double v, const double w) const
+pcl::MLSResult::MLSProjectionResults
+pcl::MLSResult::projectPointOrthogonalToPolynomialSurface (const double u, const double v, const double w) const
 {
   double gu = u;
   double gv = v;
@@ -627,8 +632,8 @@ pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointOrthogonalToPol
 
       Eigen::Vector2d err (e1, e2);
       Eigen::Vector2d update = J.inverse () * err;
-      gu -= update(0);
-      gv -= update(1);
+      gu -= update (0);
+      gv -= update (1);
 
       d = getPolynomialPartialDerivative (gu, gv);
       gw = d.z;
@@ -649,15 +654,16 @@ pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointOrthogonalToPol
     result.u = gu;
     result.v = gv;
     result.normal -= (d.z_u * u_axis + d.z_v * v_axis);
-    result.normal.normalize();
+    result.normal.normalize ();
   }
 
   result.point = mean + gu * u_axis + gv * v_axis + gw * plane_normal;
 
-  return result;
+  return (result);
 }
 
-pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointToMLSPlane(const double u, const double v) const
+pcl::MLSResult::MLSProjectionResults
+pcl::MLSResult::projectPointToMLSPlane (const double u, const double v) const
 {
   MLSProjectionResults result;
   result.u = u;
@@ -665,10 +671,11 @@ pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointToMLSPlane(cons
   result.normal = plane_normal;
   result.point = mean + u * u_axis + v * v_axis;
 
-  return result;
+  return (result);
 }
 
-pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointSimpleToPolynomialSurface (const double u, const double v) const
+pcl::MLSResult::MLSProjectionResults
+pcl::MLSResult::projectPointSimpleToPolynomialSurface (const double u, const double v) const
 {
   MLSProjectionResults result;
   double w = 0;
@@ -682,15 +689,16 @@ pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointSimpleToPolynom
     PolynomialPartialDerivative d = getPolynomialPartialDerivative (u, v);
     w = d.z;
     result.normal -= (d.z_u * u_axis + d.z_v * v_axis);
-    result.normal.normalize();
+    result.normal.normalize ();
   }
 
   result.point = mean + u * u_axis + v * v_axis + w * plane_normal;
 
-  return result;
+  return (result);
 }
 
-pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPoint(const Eigen::Vector3d &pt, ProjectionMethod method, int required_neighbors) const
+pcl::MLSResult::MLSProjectionResults
+pcl::MLSResult::projectPoint (const Eigen::Vector3d &pt, ProjectionMethod method, int required_neighbors) const
 {
   double u, v, w;
   getMLSCoordinates (pt, u, v, w);
@@ -708,10 +716,11 @@ pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPoint(const Eigen::V
     proj = projectPointToMLSPlane (u, v);
   }
 
-  return  proj;
+  return  (proj);
 }
 
-pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectQueryPoint(ProjectionMethod method, int required_neighbors) const
+pcl::MLSResult::MLSProjectionResults
+pcl::MLSResult::projectQueryPoint (ProjectionMethod method, int required_neighbors) const
 {
   MLSResult::MLSProjectionResults proj;
   if (order > 1 && num_neighbors >= required_neighbors && pcl_isfinite (c_vec[0]) && method != NONE)
@@ -729,7 +738,7 @@ pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectQueryPoint(Projectio
 
       // Compute tangent vectors using the partial derivates evaluated at (0,0) which is c_vec[order_+1] and c_vec[1]
       proj.normal = plane_normal - c_vec[order + 1] * u_axis - c_vec[1] * v_axis;
-      proj.normal.normalize();
+      proj.normal.normalize ();
     }
   }
   else
@@ -738,16 +747,16 @@ pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectQueryPoint(Projectio
     proj.point = mean;
   }
 
-  return proj;
+  return (proj);
 }
 
-template <typename PointT>
-void pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
-                                        int index,
-                                        const std::vector<int> &nn_indices,
-                                        double search_radius,
-                                        int polynomial_order,
-                                        boost::function<double(const double)> weight_func)
+template <typename PointT> void
+pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
+                                   int index,
+                                   const std::vector<int> &nn_indices,
+                                   double search_radius,
+                                   int polynomial_order,
+                                   boost::function<double(const double)> weight_func)
 {
   // Compute the plane coefficients
   EIGEN_ALIGN16 Eigen::Matrix3d covariance_matrix;

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -229,7 +229,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
             continue;
 
           MLSResult::MLSProjectionResults proj;
-          if (polynomial_fit_ && mls_result.num_neighbors >= 5 * nr_coeff_)
+          if (order_ > 1 && mls_result.num_neighbors >= 5 * nr_coeff_)
             proj = mls_result.projectPointSimpleToPolynomialSurface (u, v);
           else
             proj = mls_result.projectPointToMLSPlane (u, v);

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -47,6 +47,7 @@
 #include <pcl/common/centroid.h>
 #include <pcl/common/eigen.h>
 #include <pcl/common/geometry.h>
+#include <boost/bind.hpp>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -171,7 +172,6 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::process (PointCloudOut &output)
 template <typename PointInT, typename PointOutT> void
 pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
                                                                      const std::vector<int> &nn_indices,
-                                                                     std::vector<float> &nn_sqr_dists,
                                                                      PointCloudOut &projected_points,
                                                                      NormalCloud &projected_points_normals,
                                                                      PointIndices &corresponding_input_indices,
@@ -180,140 +180,40 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
   // Note: this method is const because it needs to be thread-safe
   //       (MovingLeastSquaresOMP calls it from multiple threads)
 
-  // Compute the plane coefficients
-  EIGEN_ALIGN16 Eigen::Matrix3d covariance_matrix;
-  Eigen::Vector4d xyz_centroid;
-
-  // Estimate the XYZ centroid
-  pcl::compute3DCentroid (*input_, nn_indices, xyz_centroid);
-
-  // Compute the 3x3 covariance matrix
-  pcl::computeCovarianceMatrix (*input_, nn_indices, xyz_centroid, covariance_matrix);
-  EIGEN_ALIGN16 Eigen::Vector3d::Scalar eigen_value;
-  EIGEN_ALIGN16 Eigen::Vector3d eigen_vector;
-  Eigen::Vector4d model_coefficients;
-  pcl::eigen33 (covariance_matrix, eigen_value, eigen_vector);
-  model_coefficients.head<3> ().matrix () = eigen_vector;
-  model_coefficients[3] = 0;
-  model_coefficients[3] = -1 * model_coefficients.dot (xyz_centroid);
-
-  // Projected query point
-  Eigen::Vector3d point = input_->points[index].getVector3fMap ().template cast<double> ();
-  double distance = point.dot (model_coefficients.head<3> ()) + model_coefficients[3];
-  point -= distance * model_coefficients.head<3> ();
-
-  float curvature = static_cast<float> (covariance_matrix.trace ());
-  // Compute the curvature surface change
-  if (curvature != 0)
-    curvature = fabsf (float (eigen_value / double (curvature)));
-
-
-  // Get a copy of the plane normal easy access
-  Eigen::Vector3d plane_normal = model_coefficients.head<3> ();
-  // Vector in which the polynomial coefficients will be put
-  Eigen::VectorXd c_vec;
-  // Local coordinate system (Darboux frame)
-  Eigen::Vector3d v_axis (0.0f, 0.0f, 0.0f), u_axis (0.0f, 0.0f, 0.0f);
-
-
-
-  // Perform polynomial fit to update point and normal
-  ////////////////////////////////////////////////////
-  if (polynomial_fit_ && static_cast<int> (nn_indices.size ()) >= nr_coeff_)
-  {
-    // Update neighborhood, since point was projected, and computing relative
-    // positions. Note updating only distances for the weights for speed
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > de_meaned (nn_indices.size ());
-    for (size_t ni = 0; ni < nn_indices.size (); ++ni)
-    {
-      de_meaned[ni][0] = input_->points[nn_indices[ni]].x - point[0];
-      de_meaned[ni][1] = input_->points[nn_indices[ni]].y - point[1];
-      de_meaned[ni][2] = input_->points[nn_indices[ni]].z - point[2];
-      nn_sqr_dists[ni] = static_cast<float> (de_meaned[ni].dot (de_meaned[ni]));
-    }
-
-    // Allocate matrices and vectors to hold the data used for the polynomial fit
-    Eigen::VectorXd weight_vec (nn_indices.size ());
-    Eigen::MatrixXd P (nr_coeff_, nn_indices.size ());
-    Eigen::VectorXd f_vec (nn_indices.size ());
-    Eigen::MatrixXd P_weight; // size will be (nr_coeff_, nn_indices.size ());
-    Eigen::MatrixXd P_weight_Pt (nr_coeff_, nr_coeff_);
-
-    // Get local coordinate system (Darboux frame)
-    v_axis = plane_normal.unitOrthogonal ();
-    u_axis = plane_normal.cross (v_axis);
-
-    // Go through neighbors, transform them in the local coordinate system,
-    // save height and the evaluation of the polynome's terms
-    double u_coord, v_coord, u_pow, v_pow;
-    for (size_t ni = 0; ni < nn_indices.size (); ++ni)
-    {
-      // (Re-)compute weights
-      weight_vec (ni) = exp (-nn_sqr_dists[ni] / sqr_gauss_param_);
-
-      // Transforming coordinates
-      u_coord = de_meaned[ni].dot (u_axis);
-      v_coord = de_meaned[ni].dot (v_axis);
-      f_vec (ni) = de_meaned[ni].dot (plane_normal);
-
-      // Compute the polynomial's terms at the current point
-      int j = 0;
-      u_pow = 1;
-      for (int ui = 0; ui <= order_; ++ui)
-      {
-        v_pow = 1;
-        for (int vi = 0; vi <= order_ - ui; ++vi)
-        {
-          P (j++, ni) = u_pow * v_pow;
-          v_pow *= v_coord;
-        }
-        u_pow *= u_coord;
-      }
-    }
-
-    // Computing coefficients
-    P_weight = P * weight_vec.asDiagonal ();
-    P_weight_Pt = P_weight * P.transpose ();
-    c_vec = P_weight * f_vec;
-    P_weight_Pt.llt ().solveInPlace (c_vec);
-  }
-
-  if (cache_mls_results_)
-  {
-    mls_result = MLSResult (point, plane_normal, u_axis, v_axis, c_vec, static_cast<int> (nn_indices.size ()), curvature);
-  }
+  pcl::computeMLSSurface<PointInT>(*input_, index, nn_indices, search_radius_, mls_result, polynomial_fit_, order_);
 
   switch (upsample_method_)
   {
     case (NONE):
     {
-      Eigen::Vector3d normal = plane_normal;
-
-      if (polynomial_fit_ && static_cast<int> (nn_indices.size ()) >= nr_coeff_ && pcl_isfinite (c_vec[0]))
+      MLSProjectionResults proj;
+      proj.normal = mls_result.plane_normal;
+      proj.point = mls_result.mean;
+      if (polynomial_fit_)
       {
-        point += (c_vec[0] * plane_normal);
+        if (projection_method_ == SIMPLE)
+        {
+          if (mls_result.num_neighbors >= nr_coeff_ && pcl_isfinite (mls_result.c_vec[0]))
+          {
+            proj.point += (mls_result.c_vec[0] * mls_result.plane_normal);
 
-        // Compute tangent vectors using the partial derivates evaluated at (0,0) which is c_vec[order_+1] and c_vec[1]
-        if (compute_normals_)
-          normal = plane_normal - c_vec[order_ + 1] * u_axis - c_vec[1] * v_axis;
+            // Compute tangent vectors using the partial derivates evaluated at (0,0) which is c_vec[order_+1] and c_vec[1]
+            if (compute_normals_)
+            {
+              proj.normal = mls_result.plane_normal - mls_result.c_vec[order_ + 1] * mls_result.u_axis - mls_result.c_vec[1] * mls_result.v_axis;
+              proj.normal.normalize();
+            }
+          }
+        }
+        else if (projection_method_ == ORTHOGONAL)
+        {
+          double u, v, w;
+          getMLSCoordinates (mls_result.query_point, mls_result, u, v ,w);
+          proj = pcl::projectPointOrthogonalToPolynomialSurface (u, v, w, mls_result);
+        }
       }
 
-      PointOutT aux;
-      aux.x = static_cast<float> (point[0]);
-      aux.y = static_cast<float> (point[1]);
-      aux.z = static_cast<float> (point[2]);
-      projected_points.push_back (aux);
-
-      if (compute_normals_)
-      {
-        pcl::Normal aux_normal;
-        aux_normal.normal_x = static_cast<float> (normal[0]);
-        aux_normal.normal_y = static_cast<float> (normal[1]);
-        aux_normal.normal_z = static_cast<float> (normal[2]);
-        aux_normal.curvature = curvature;
-        projected_points_normals.push_back (aux_normal);
-        corresponding_input_indices.indices.push_back (index);
-      }
+      addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
 
       break;
     }
@@ -325,17 +225,10 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
         for (float v_disp = -static_cast<float> (upsampling_radius_); v_disp <= upsampling_radius_; v_disp += static_cast<float> (upsampling_step_))
           if (u_disp*u_disp + v_disp*v_disp < upsampling_radius_*upsampling_radius_)
           {
-            PointOutT projected_point;
-            pcl::Normal projected_normal;
-            projectPointToMLSSurface (u_disp, v_disp, u_axis, v_axis, plane_normal, point,
-                                      curvature, c_vec,
-                                      static_cast<int> (nn_indices.size ()),
-                                      projected_point, projected_normal);
+            MLSProjectionResults proj;
+            proj = projectPointSimpleToPolynomialSurface(u_disp, v_disp, mls_result);
 
-            projected_points.push_back (projected_point);
-            corresponding_input_indices.indices.push_back (index);
-            if (compute_normals_)
-              projected_points_normals.push_back (projected_normal);
+            addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
           }
       break;
     }
@@ -349,55 +242,56 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
       if (num_points_to_add <= 0)
       {
         // Just add the current point
-        Eigen::Vector3d normal = plane_normal;
-        if (polynomial_fit_ && static_cast<int> (nn_indices.size ()) >= nr_coeff_ && pcl_isfinite (c_vec[0]))
+        MLSProjectionResults proj;
+        proj.normal = mls_result.plane_normal;
+        proj.point = mls_result.mean;
+        if (polynomial_fit_)
         {
-          // Projection onto MLS surface along Darboux normal to the height at (0,0)
-          point += (c_vec[0] * plane_normal);
-          // Compute tangent vectors using the partial derivates evaluated at (0,0) which is c_vec[order_+1] and c_vec[1]
-          if (compute_normals_)
-            normal = plane_normal - c_vec[order_ + 1] * u_axis - c_vec[1] * v_axis;
-        }
-        PointOutT aux;
-        aux.x = static_cast<float> (point[0]);
-        aux.y = static_cast<float> (point[1]);
-        aux.z = static_cast<float> (point[2]);
-        projected_points.push_back (aux);
-        corresponding_input_indices.indices.push_back (index);
+          if (projection_method_ == SIMPLE)
+          {
+            if (mls_result.num_neighbors >= nr_coeff_ && pcl_isfinite (mls_result.c_vec[0]))
+            {
+              // Projection onto MLS surface along Darboux normal to the height at (0,0)
+              proj.point += (mls_result.c_vec[0] * mls_result.plane_normal);
 
-        if (compute_normals_)
-        {
-          pcl::Normal aux_normal;
-          aux_normal.normal_x = static_cast<float> (normal[0]);
-          aux_normal.normal_y = static_cast<float> (normal[1]);
-          aux_normal.normal_z = static_cast<float> (normal[2]);
-          aux_normal.curvature = curvature;
-          projected_points_normals.push_back (aux_normal);
+              // Compute tangent vectors using the partial derivates evaluated at (0,0) which is c_vec[order_+1] and c_vec[1]
+              if (compute_normals_)
+              {
+                proj.normal = mls_result.plane_normal - mls_result.c_vec[order_ + 1] * mls_result.u_axis - mls_result.c_vec[1] * mls_result.v_axis;
+                proj.normal.normalize();
+              }
+            }
+          }
+          else if (projection_method_ == ORTHOGONAL)
+          {
+            double u, v, w;
+            getMLSCoordinates (mls_result.query_point, mls_result, u, v, w);
+            proj = pcl::projectPointOrthogonalToPolynomialSurface (u, v, w, mls_result);
+            break;
+          }
         }
+
+        addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
       }
       else
       {
         // Sample the local plane
         for (int num_added = 0; num_added < num_points_to_add;)
         {
-          float u_disp = (*rng_uniform_distribution_) (),
-              v_disp = (*rng_uniform_distribution_) ();
+          double u = (*rng_uniform_distribution_) ();
+          double v = (*rng_uniform_distribution_) ();
+
           // Check if inside circle; if not, try another coin flip
-          if (u_disp * u_disp + v_disp * v_disp > search_radius_ * search_radius_/4)
+          if (u * u + v * v > search_radius_ * search_radius_/4)
             continue;
 
+          MLSProjectionResults proj;
+          if (polynomial_fit_ && mls_result.num_neighbors >= 5 * nr_coeff_)
+            proj = projectPointSimpleToPolynomialSurface (u, v, mls_result);
+          else
+            proj = projectPointToMLSPlane (u, v, mls_result);
 
-          PointOutT projected_point;
-          pcl::Normal projected_normal;
-          projectPointToMLSSurface (u_disp, v_disp, u_axis, v_axis, plane_normal, point,
-                                    curvature, c_vec,
-                                    static_cast<int> (nn_indices.size ()),
-                                    projected_point, projected_normal);
-
-          projected_points.push_back (projected_point);
-          corresponding_input_indices.indices.push_back (index);
-          if (compute_normals_)
-            projected_points_normals.push_back (projected_normal);
+          addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
 
           num_added ++;
         }
@@ -410,61 +304,35 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT> void
-pcl::MovingLeastSquares<PointInT, PointOutT>::projectPointToMLSSurface (float &u_disp, float &v_disp,
-                                                                        Eigen::Vector3d &u, Eigen::Vector3d &v,
-                                                                        Eigen::Vector3d &plane_normal,
-                                                                        Eigen::Vector3d &mean,
-                                                                        float &curvature,
-                                                                        Eigen::VectorXd &c_vec,
-                                                                        int num_neighbors,
-                                                                        PointOutT &result_point,
-                                                                        pcl::Normal &result_normal) const
+pcl::MovingLeastSquares<PointInT, PointOutT>::addProjectedPointNormal(int index,
+                                                                      const Eigen::Vector3d &point,
+                                                                      const Eigen::Vector3d &normal,
+                                                                      double curvature,
+                                                                      PointCloudOut &projected_points,
+                                                                      NormalCloud &projected_points_normals,
+                                                                      PointIndices &corresponding_input_indices) const
 {
-  double n_disp = 0.0f;
-  double d_u = 0.0f, d_v = 0.0f;
+  PointOutT aux;
+  aux.x = static_cast<float> (point[0]);
+  aux.y = static_cast<float> (point[1]);
+  aux.z = static_cast<float> (point[2]);
 
-  // HARDCODED 5*nr_coeff_ to guarantee that the computed polynomial had a proper point set basis
-  if (polynomial_fit_ && num_neighbors >= 5*nr_coeff_ && pcl_isfinite (c_vec[0]))
+  // Copy additional point information if available
+  copyMissingFields (input_->points[index], aux);
+
+  projected_points.push_back (aux);
+  corresponding_input_indices.indices.push_back (index);
+
+  if (compute_normals_)
   {
-    // Compute the displacement along the normal using the fitted polynomial
-    // and compute the partial derivatives needed for estimating the normal
-    int j = 0;
-    float u_pow = 1.0f, v_pow = 1.0f, u_pow_prev = 1.0f, v_pow_prev = 1.0f;
-    for (int ui = 0; ui <= order_; ++ui)
-    {
-      v_pow = 1;
-      for (int vi = 0; vi <= order_ - ui; ++vi)
-      {
-        // Compute displacement along normal
-        n_disp += u_pow * v_pow * c_vec[j++];
-
-        // Compute partial derivatives
-        if (ui >= 1)
-          d_u += c_vec[j-1] * ui * u_pow_prev * v_pow;
-        if (vi >= 1)
-          d_v += c_vec[j-1] * vi * u_pow * v_pow_prev;
-
-        v_pow_prev = v_pow;
-        v_pow *= v_disp;
-      }
-      u_pow_prev = u_pow;
-      u_pow *= u_disp;
-    }
+    pcl::Normal aux_normal;
+    aux_normal.normal_x = static_cast<float> (normal[0]);
+    aux_normal.normal_y = static_cast<float> (normal[1]);
+    aux_normal.normal_z = static_cast<float> (normal[2]);
+    aux_normal.curvature = curvature;
+    projected_points_normals.push_back (aux_normal);
   }
-
-  result_point.x = static_cast<float> (mean[0] + u[0] * u_disp + v[0] * v_disp + plane_normal[0] * n_disp);
-  result_point.y = static_cast<float> (mean[1] + u[1] * u_disp + v[1] * v_disp + plane_normal[1] * n_disp);
-  result_point.z = static_cast<float> (mean[2] + u[2] * u_disp + v[2] * v_disp + plane_normal[2] * n_disp);
-
-  Eigen::Vector3d normal = plane_normal - d_u * u - d_v * v;
-  normal.normalize ();
-
-  result_normal.normal_x = static_cast<float> (normal[0]);
-  result_normal.normal_y = static_cast<float> (normal[1]);
-  result_normal.normal_z = static_cast<float> (normal[2]);
-  result_normal.curvature = curvature;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -503,13 +371,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performProcessing (PointCloudOut &
     if (cache_mls_results_)
       mls_result_index = index; // otherwise we give it a dummy location.
 
-    computeMLSPointNormal (index, nn_indices, nn_sqr_dists, projected_points, projected_points_normals, *corresponding_input_indices_, mls_results_[mls_result_index]);
-
-
-    // Copy all information from the input cloud to the output points (not doing any interpolation)
-    for (size_t pp = 0; pp < projected_points.size (); ++pp)
-      copyMissingFields (input_->points[(*indices_)[cp]], projected_points[pp]);
-
+    computeMLSPointNormal (index, nn_indices, projected_points, projected_points_normals, *corresponding_input_indices_, mls_results_[mls_result_index]);
 
     // Append projected points to output
     output.insert (output.end (), projected_points.begin (), projected_points.end ());
@@ -566,7 +428,7 @@ pcl::MovingLeastSquaresOMP<PointInT, PointOutT>::performProcessing (PointCloudOu
         if (this->cache_mls_results_)
           mls_result_index = index; // otherwise we give it a dummy location.
         
-        this->computeMLSPointNormal (index, nn_indices, nn_sqr_dists, projected_points[tn], projected_points_normals[tn], corresponding_input_indices[tn], this->mls_results_[mls_result_index]);
+        this->computeMLSPointNormal (index, nn_indices, projected_points[tn], projected_points_normals[tn], corresponding_input_indices[tn], this->mls_results_[mls_result_index]);
 
         // Copy all information from the input cloud to the output points (not doing any interpolation)
         for (size_t pp = pp_size; pp < projected_points[tn].size (); ++pp)
@@ -595,8 +457,10 @@ pcl::MovingLeastSquaresOMP<PointInT, PointOutT>::performProcessing (PointCloudOu
 template <typename PointInT, typename PointOutT> void
 pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &output)
 {
+
   if (upsample_method_ == DISTINCT_CLOUD)
   {
+    corresponding_input_indices_.reset(new PointIndices);
     for (size_t dp_i = 0; dp_i < distinct_cloud_->size (); ++dp_i) // dp_i = distinct_point_i
     {
       // Distinct cloud may have nan points, skip them
@@ -616,30 +480,25 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
         continue;
 
       Eigen::Vector3d add_point = distinct_cloud_->points[dp_i].getVector3fMap ().template cast<double> ();
+      double u, v, w;
+      getMLSCoordinates (add_point, mls_results_[input_index], u, v, w);
 
-      float u_disp = static_cast<float> ((add_point - mls_results_[input_index].mean).dot (mls_results_[input_index].u_axis)),
-            v_disp = static_cast<float> ((add_point - mls_results_[input_index].mean).dot (mls_results_[input_index].v_axis));
+      MLSProjectionResults proj;
+      if (polynomial_fit_ && mls_results_[input_index].num_neighbors >= 5 * nr_coeff_)
+      {
+        if (projection_method_ == SIMPLE)
+          proj = projectPointSimpleToPolynomialSurface (u, v, mls_results_[input_index]);
+        else if (projection_method_ == ORTHOGONAL)
+          proj = projectPointOrthogonalToPolynomialSurface (u, v, w, mls_results_[input_index]);
+        else
+          proj = projectPointToMLSPlane (u, v, mls_results_[input_index]);
+      }
+      else
+      {
+        proj = projectPointToMLSPlane(u, v, mls_results_[input_index]);
+      }
 
-      PointOutT result_point;
-      pcl::Normal result_normal;
-      projectPointToMLSSurface (u_disp, v_disp,
-                                mls_results_[input_index].u_axis, mls_results_[input_index].v_axis,
-                                mls_results_[input_index].plane_normal,
-                                mls_results_[input_index].mean,
-                                mls_results_[input_index].curvature,
-                                mls_results_[input_index].c_vec,
-                                mls_results_[input_index].num_neighbors,
-                                result_point, result_normal);
-
-      // Copy additional point information if available
-      copyMissingFields (input_->points[input_index], result_point);
-
-      // Store the id of the original point
-      corresponding_input_indices_->indices.push_back (input_index);
-
-      output.push_back (result_point);
-      if (compute_normals_)
-        normals_->push_back (result_normal);
+      addProjectedPointNormal(input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
     }
   }
 
@@ -647,6 +506,8 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
   // Then, project the newly obtained points to the MLS surface
   if (upsample_method_ == VOXEL_GRID_DILATION)
   {
+    corresponding_input_indices_.reset(new PointIndices);
+
     MLSVoxelGrid voxel_grid (input_, indices_, voxel_size_);
     for (int iteration = 0; iteration < dilation_iteration_num_; ++iteration)
       voxel_grid.dilate ();
@@ -673,45 +534,363 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
         continue;
 
       Eigen::Vector3d add_point = p.getVector3fMap ().template cast<double> ();
-      float u_disp = static_cast<float> ((add_point - mls_results_[input_index].mean).dot (mls_results_[input_index].u_axis)),
-            v_disp = static_cast<float> ((add_point - mls_results_[input_index].mean).dot (mls_results_[input_index].v_axis));
+      double u, v, w;
+      getMLSCoordinates (add_point, mls_results_[input_index], u, v, w);
 
-      PointOutT result_point;
-      pcl::Normal result_normal;
-      projectPointToMLSSurface (u_disp, v_disp,
-                                mls_results_[input_index].u_axis, mls_results_[input_index].v_axis,
-                                mls_results_[input_index].plane_normal,
-                                mls_results_[input_index].mean,
-                                mls_results_[input_index].curvature,
-                                mls_results_[input_index].c_vec,
-                                mls_results_[input_index].num_neighbors,
-                                result_point, result_normal);
+      MLSProjectionResults proj;
+      if (polynomial_fit_ && mls_results_[input_index].num_neighbors >= 5 * nr_coeff_)
+      {
+        if (projection_method_ == SIMPLE)
+          proj = projectPointSimpleToPolynomialSurface (u, v, mls_results_[input_index]);
+        else if (projection_method_ == ORTHOGONAL)
+          proj = projectPointOrthogonalToPolynomialSurface (u, v, w, mls_results_[input_index]);
+        else
+          proj = projectPointToMLSPlane (u, v, mls_results_[input_index]);
+      }
+      else
+      {
+        proj = projectPointToMLSPlane (u, v, mls_results_[input_index]);
+      }
 
-      // Copy additional point information if available
-      copyMissingFields (input_->points[input_index], result_point);
-
-      // Store the id of the original point
-      corresponding_input_indices_->indices.push_back (input_index);
-
-      output.push_back (result_point);
-
-      if (compute_normals_)
-        normals_->push_back (result_normal);
+      addProjectedPointNormal(input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-pcl::MLSResult::MLSResult (const Eigen::Vector3d &a_mean,
-                             const Eigen::Vector3d &a_plane_normal,
-                             const Eigen::Vector3d &a_u,
-                             const Eigen::Vector3d &a_v,
-                             const Eigen::VectorXd a_c_vec,
-                             const int a_num_neighbors,
-                             const float &a_curvature) :
-  mean (a_mean), plane_normal (a_plane_normal), u_axis (a_u), v_axis (a_v), c_vec (a_c_vec), num_neighbors (a_num_neighbors),
-  curvature (a_curvature), valid (true)
+pcl::MLSResult::MLSResult (const Eigen::Vector3d &a_query_point,
+                           const Eigen::Vector3d &a_mean,
+                           const Eigen::Vector3d &a_plane_normal,
+                           const Eigen::Vector3d &a_u,
+                           const Eigen::Vector3d &a_v,
+                           const Eigen::VectorXd &a_c_vec,
+                           const int a_num_neighbors,
+                           const float &a_curvature,
+                           const int a_order,
+                           const bool a_polynomial_fit):
+  query_point (a_query_point), mean (a_mean), plane_normal (a_plane_normal), u_axis (a_u), v_axis (a_v), c_vec (a_c_vec), num_neighbors (a_num_neighbors),
+  curvature (a_curvature), order (a_order), polynomial_fit(a_polynomial_fit), valid (true)
 {
+}
+
+void pcl::getMLSCoordinates (const Eigen::Vector3d &pt, const pcl::MLSResult &mls_result, double &u, double &v, double &w)
+{
+  u = (pt - mls_result.mean).dot (mls_result.u_axis);
+  v = (pt - mls_result.mean).dot (mls_result.v_axis);
+  w = (pt - mls_result.mean).dot (mls_result.plane_normal);
+}
+
+void pcl::getMLSCoordinates (const Eigen::Vector3d &pt, const pcl::MLSResult &mls_result, double &u, double &v)
+{
+  u = (pt - mls_result.mean).dot (mls_result.u_axis);
+  v = (pt - mls_result.mean).dot (mls_result.v_axis);
+}
+
+double pcl::getPolynomialValue (const double u, const double v, const pcl::MLSResult &mls_result)
+{
+  // Compute the polynomial's terms at the current point
+  // Example for second order: z = a + b*y + c*y^2 + d*x + e*x*y + f*x^2
+  double u_pow, v_pow, result;
+  int j = 0;
+  u_pow = 1;
+  result = 0;
+  for (int ui = 0; ui <= mls_result.order; ++ui)
+  {
+    v_pow = 1;
+    for (int vi = 0; vi <= mls_result.order - ui; ++vi)
+    {
+      result += mls_result.c_vec[j++] * u_pow * v_pow;
+      v_pow *= v;
+    }
+    u_pow *= u;
+  }
+
+  return result;
+}
+
+pcl::PolynomialPartialDerivative pcl::getPolynomialPartialDerivative (const double u, const double v, const pcl::MLSResult &mls_result)
+{
+  // Compute the displacement along the normal using the fitted polynomial
+  // and compute the partial derivatives needed for estimating the normal
+  PolynomialPartialDerivative d;
+  Eigen::VectorXd u_pow(mls_result.order + 2), v_pow(mls_result.order + 2);
+  int j = 0;
+
+  d.z = d.z_u = d.z_v = d.z_uu = d.z_vv = d.z_uv = 0;
+  u_pow(0) = v_pow(0) = 1;
+  for (int ui = 0; ui <= mls_result.order; ++ui)
+  {
+    for (int vi = 0; vi <= mls_result.order - ui; ++vi)
+    {
+      // Compute displacement along normal
+      d.z += u_pow(ui) * v_pow(vi) * mls_result.c_vec[j];
+
+      // Compute partial derivatives
+      if (ui >= 1)
+        d.z_u += mls_result.c_vec[j] * ui * u_pow(ui - 1) * v_pow(vi);
+
+      if (vi >= 1)
+        d.z_v += mls_result.c_vec[j] * vi * u_pow(ui) * v_pow(vi - 1);
+
+      if (ui >= 1 && vi >= 1)
+        d.z_uv += mls_result.c_vec[j] * ui * u_pow(ui - 1) * vi * v_pow(vi - 1);
+
+      if (ui >= 2)
+        d.z_uu += mls_result.c_vec[j] * ui * (ui - 1) * u_pow(ui - 2) * v_pow(vi);
+
+      if (vi >= 2)
+        d.z_vv += mls_result.c_vec[j] * vi * (vi - 1) * u_pow(ui) * v_pow(vi - 2);
+
+      if (ui == 0)
+        v_pow(vi + 1) = v_pow(vi) * v;
+
+      ++j;
+    }
+    u_pow(ui + 1) = u_pow(ui) * u;
+  }
+
+  return d;
+}
+
+Eigen::Vector2f pcl::calculatePrincipleCurvatures (const double u, const double v, const pcl::MLSResult &mls_result)
+{
+  Eigen::Vector2f k;
+
+  k << MLS_MINIMUM_PRINCIPLE_CURVATURE, MLS_MINIMUM_PRINCIPLE_CURVATURE;
+  // Note: this use the Monge Patch to derive the Gaussian curvature and Mean Curvature found here http://mathworld.wolfram.com/MongePatch.html
+  // Then:
+  //      k1 = H + sqrt(H^2 - K)
+  //      k1 = H - sqrt(H^2 - K)
+  if (mls_result.polynomial_fit && mls_result.c_vec.size () >= (mls_result.order + 1) * (mls_result.order + 2) / 2 && pcl_isfinite (mls_result.c_vec[0]))
+  {
+    PolynomialPartialDerivative d = getPolynomialPartialDerivative (u, v, mls_result);
+    double Z = 1 + d.z_u * d.z_u + d.z_v * d.z_v;
+    double Zlen = std::sqrt (Z);
+    double K = (d.z_uu * d.z_vv - d.z_uv * d.z_uv) / (Z * Z);
+    double H = ((1.0 + d.z_v * d.z_v) * d.z_uu - 2.0 * d.z_u * d.z_v * d.z_uv + (1.0 + d.z_u * d.z_u) * d.z_vv) / (2.0 * Zlen * Zlen * Zlen);
+    double disc2 = H * H - K;
+    assert (disc2 >= 0.0);
+    double disc = std::sqrt(disc2);
+    k[0] = H + disc;
+    k[1] = H - disc;
+
+    if (std::abs (k[0]) > std::abs (k[1])) std::swap (k[0], k[1]);
+  }
+  else
+  {
+    PCL_ERROR("No Polynomial fit data, unable to calculate the principle curvatures!\n");
+  }
+
+  return k;
+}
+
+pcl::MLSProjectionResults pcl::projectPointOrthogonalToPolynomialSurface (const double u, const double v, const double w, const pcl::MLSResult &mls_result)
+{
+  double gu = u;
+  double gv = v;
+  double gw = 0;
+
+  MLSProjectionResults result;
+  result.normal = mls_result.plane_normal;
+  if (mls_result.polynomial_fit && mls_result.c_vec.size () >= (mls_result.order + 1) * (mls_result.order + 2) / 2 && pcl_isfinite (mls_result.c_vec[0]))
+  {
+    PolynomialPartialDerivative d = getPolynomialPartialDerivative (gu, gv, mls_result);
+    gw = d.z;
+    double err_total;
+    double dist1 = std::abs (gw - w);
+    double dist2;
+    do
+    {
+      double e1 = (gu - u) + d.z_u * gw - d.z_u * w;
+      double e2 = (gv - v) + d.z_v * gw - d.z_v * w;
+
+      double F1u = 1 + d.z_uu * gw + d.z_u * d.z_u - d.z_uu * w;
+      double F1v = d.z_uv * gw + d.z_u * d.z_v - d.z_uv * w;
+
+      double F2u = d.z_uv * gw + d.z_v * d.z_u - d.z_uv * w;
+      double F2v = 1 + d.z_vv * gw + d.z_v * d.z_v - d.z_vv * w;
+
+      Eigen::MatrixXd J (2, 2);
+      J(0, 0) = F1u;
+      J(0, 1) = F1v;
+      J(1, 0) = F2u;
+      J(1, 1) = F2v;
+
+      Eigen::Vector2d err (e1, e2);
+      Eigen::MatrixXd update = J.inverse () * err;
+      gu -= update(0);
+      gv -= update(1);
+
+      d = getPolynomialPartialDerivative (gu, gv, mls_result);
+      gw = d.z;
+      dist2 = std::sqrt ((gu - u) * (gu - u) + (gv - v) * (gv - v) + (gw - w) * (gw - w));
+
+      err_total = std::sqrt (e1 * e1 + e2 * e2);
+
+    } while (err_total > MLS_PROJECTION_CONVERGENCE_TOLERANCE && dist2 < dist1);
+
+    if (dist2 > dist1) // the optimization was diverging reset the coordinates for simple projection
+    {
+      gu = u;
+      gv = v;
+      d = getPolynomialPartialDerivative (u, v, mls_result);
+      gw = d.z;
+    }
+
+    result.normal -= (d.z_u * mls_result.u_axis + d.z_v * mls_result.v_axis);
+    result.normal.normalize();
+  }
+
+  result.point = mls_result.mean + gu * mls_result.u_axis + gv * mls_result.v_axis + gw * mls_result.plane_normal;
+
+  return result;
+}
+
+pcl::MLSProjectionResults pcl::projectPointToMLSPlane(const double u, const double v, const pcl::MLSResult &mls_result)
+{
+  MLSProjectionResults result;
+  result.u = u;
+  result.v = v;
+  result.normal = mls_result.plane_normal;
+  result.point = mls_result.mean + u * mls_result.u_axis + v * mls_result.v_axis;
+
+  return result;
+}
+
+pcl::MLSProjectionResults pcl::projectPointSimpleToPolynomialSurface (const double u, const double v, const pcl::MLSResult &mls_result)
+{
+  MLSProjectionResults result;
+  double w = 0;
+
+  result.normal = mls_result.plane_normal;
+
+  if (mls_result.polynomial_fit && mls_result.c_vec.size () >= (mls_result.order + 1) * (mls_result.order + 2) / 2 && pcl_isfinite (mls_result.c_vec[0]))
+  {
+    PolynomialPartialDerivative d = getPolynomialPartialDerivative (u, v, mls_result);
+    w = d.z;
+    result.normal -= (d.z_u * mls_result.u_axis + d.z_v * mls_result.v_axis);
+    result.normal.normalize();
+  }
+
+  result.point = mls_result.mean + u * mls_result.u_axis + v * mls_result.v_axis + w * mls_result.plane_normal;
+
+  return result;
+}
+
+template <typename PointT>
+void pcl::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
+                             int index,
+                             const std::vector<int> &nn_indices,
+                             double search_radius,
+                             pcl::MLSResult &mls_result,
+                             bool polynomial_fit,
+                             int polynomial_order,
+                             boost::function<double(const double)> weight_func)
+{
+  // Compute the plane coefficients
+  EIGEN_ALIGN16 Eigen::Matrix3d covariance_matrix;
+  Eigen::Vector4d xyz_centroid;
+
+  // Estimate the XYZ centroid
+  pcl::compute3DCentroid (cloud, nn_indices, xyz_centroid);
+
+  // Compute the 3x3 covariance matrix
+  pcl::computeCovarianceMatrix (cloud, nn_indices, xyz_centroid, covariance_matrix);
+  EIGEN_ALIGN16 Eigen::Vector3d::Scalar eigen_value;
+  EIGEN_ALIGN16 Eigen::Vector3d eigen_vector;
+  Eigen::Vector4d model_coefficients;
+  pcl::eigen33 (covariance_matrix, eigen_value, eigen_vector);
+  model_coefficients.head<3> ().matrix () = eigen_vector;
+  model_coefficients[3] = 0;
+  model_coefficients[3] = -1 * model_coefficients.dot (xyz_centroid);
+
+  // Projected query point
+  mls_result.valid = true;
+  mls_result.query_point = cloud.points[index].getVector3fMap ().template cast<double> ();
+  double distance = mls_result.query_point.dot (model_coefficients.head<3> ()) + model_coefficients[3];
+  mls_result.mean = mls_result.query_point - distance * model_coefficients.head<3> ();
+
+  mls_result.curvature = static_cast<float> (covariance_matrix.trace ());
+  // Compute the curvature surface change
+  if (mls_result.curvature != 0)
+    mls_result.curvature = fabsf (float (eigen_value / double (mls_result.curvature)));
+
+  // Get a copy of the plane normal easy access
+  mls_result.plane_normal = model_coefficients.head<3> ();
+
+  // Local coordinate system (Darboux frame)
+  mls_result.v_axis = mls_result.plane_normal.unitOrthogonal ();
+  mls_result.u_axis = mls_result.plane_normal.cross (mls_result.v_axis);
+
+  // Perform polynomial fit to update point and normal
+  ////////////////////////////////////////////////////
+  mls_result.num_neighbors = static_cast<int> (nn_indices.size ());
+  mls_result.polynomial_fit = polynomial_fit;
+  if (polynomial_fit)
+  {
+    mls_result.order = polynomial_order;
+    int nr_coeff = (polynomial_order + 1) * (polynomial_order + 2) / 2;
+
+    if (mls_result.num_neighbors >= nr_coeff)
+    {
+      // Note: The max_sq_radius parameter is only used if weight_func was not defined
+      double max_sq_radius = 1;
+      if (weight_func == 0)
+      {
+        max_sq_radius = search_radius * search_radius;
+        weight_func = boost::bind (&pcl::computeMLSWeight, _1 , max_sq_radius);
+      }
+
+      // Allocate matrices and vectors to hold the data used for the polynomial fit
+      Eigen::VectorXd weight_vec (mls_result.num_neighbors);
+      Eigen::MatrixXd P (nr_coeff, mls_result.num_neighbors);
+      Eigen::VectorXd f_vec (mls_result.num_neighbors);
+      Eigen::MatrixXd P_weight; // size will be (nr_coeff_, nn_indices.size ());
+      Eigen::MatrixXd P_weight_Pt (nr_coeff, nr_coeff);
+
+      // Update neighborhood, since point was projected, and computing relative
+      // positions. Note updating only distances for the weights for speed
+      std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > de_meaned (mls_result.num_neighbors);
+      for (size_t ni = 0; ni < mls_result.num_neighbors; ++ni)
+      {
+        de_meaned[ni][0] = cloud.points[nn_indices[ni]].x - mls_result.mean[0];
+        de_meaned[ni][1] = cloud.points[nn_indices[ni]].y - mls_result.mean[1];
+        de_meaned[ni][2] = cloud.points[nn_indices[ni]].z - mls_result.mean[2];
+        weight_vec (ni) = weight_func (de_meaned[ni].dot (de_meaned[ni]));
+      }
+
+      // Go through neighbors, transform them in the local coordinate system,
+      // save height and the evaluation of the polynome's terms
+      double u_coord, v_coord, u_pow, v_pow;
+      for (size_t ni = 0; ni < mls_result.num_neighbors; ++ni)
+      {
+        // Transforming coordinates
+        u_coord = de_meaned[ni].dot (mls_result.u_axis);
+        v_coord = de_meaned[ni].dot (mls_result.v_axis);
+        f_vec (ni) = de_meaned[ni].dot (mls_result.plane_normal);
+
+        // Compute the polynomial's terms at the current point
+        int j = 0;
+        u_pow = 1;
+        for (int ui = 0; ui <= mls_result.order; ++ui)
+        {
+          v_pow = 1;
+          for (int vi = 0; vi <= mls_result.order - ui; ++vi)
+          {
+            P (j++, ni) = u_pow * v_pow;
+            v_pow *= v_coord;
+          }
+          u_pow *= u_coord;
+        }
+      }
+
+      // Computing coefficients
+      P_weight = P * weight_vec.asDiagonal ();
+      P_weight_Pt = P_weight * P.transpose ();
+      mls_result.c_vec = P_weight * f_vec;
+      P_weight_Pt.llt ().solveInPlace (mls_result.c_vec);
+    }
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -186,7 +186,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
   {
     case (NONE):
     {
-      MLSProjectionResults proj;
+      MLSResult::MLSProjectionResults proj;
       proj.normal = mls_result.plane_normal;
       proj.point = mls_result.mean;
       if (polynomial_fit_)
@@ -208,8 +208,8 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
         else if (projection_method_ == ORTHOGONAL)
         {
           double u, v, w;
-          getMLSCoordinates (mls_result.query_point, mls_result, u, v ,w);
-          proj = pcl::projectPointOrthogonalToPolynomialSurface (u, v, w, mls_result);
+          mls_result.getMLSCoordinates (mls_result.query_point, u, v ,w);
+          proj = mls_result.projectPointOrthogonalToPolynomialSurface (u, v, w);
         }
       }
 
@@ -225,8 +225,8 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
         for (float v_disp = -static_cast<float> (upsampling_radius_); v_disp <= upsampling_radius_; v_disp += static_cast<float> (upsampling_step_))
           if (u_disp*u_disp + v_disp*v_disp < upsampling_radius_*upsampling_radius_)
           {
-            MLSProjectionResults proj;
-            proj = projectPointSimpleToPolynomialSurface(u_disp, v_disp, mls_result);
+            MLSResult::MLSProjectionResults proj;
+            proj = mls_result.projectPointSimpleToPolynomialSurface(u_disp, v_disp);
 
             addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
           }
@@ -242,7 +242,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
       if (num_points_to_add <= 0)
       {
         // Just add the current point
-        MLSProjectionResults proj;
+        MLSResult::MLSProjectionResults proj;
         proj.normal = mls_result.plane_normal;
         proj.point = mls_result.mean;
         if (polynomial_fit_)
@@ -265,8 +265,8 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
           else if (projection_method_ == ORTHOGONAL)
           {
             double u, v, w;
-            getMLSCoordinates (mls_result.query_point, mls_result, u, v, w);
-            proj = pcl::projectPointOrthogonalToPolynomialSurface (u, v, w, mls_result);
+            mls_result.getMLSCoordinates (mls_result.query_point, u, v, w);
+            proj = mls_result.projectPointOrthogonalToPolynomialSurface (u, v, w);
             break;
           }
         }
@@ -285,11 +285,11 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::computeMLSPointNormal (int index,
           if (u * u + v * v > search_radius_ * search_radius_/4)
             continue;
 
-          MLSProjectionResults proj;
+          MLSResult::MLSProjectionResults proj;
           if (polynomial_fit_ && mls_result.num_neighbors >= 5 * nr_coeff_)
-            proj = projectPointSimpleToPolynomialSurface (u, v, mls_result);
+            proj = mls_result.projectPointSimpleToPolynomialSurface (u, v);
           else
-            proj = projectPointToMLSPlane (u, v, mls_result);
+            proj = mls_result.projectPointToMLSPlane (u, v);
 
           addProjectedPointNormal(index, proj.point, proj.normal, mls_result.curvature, projected_points, projected_points_normals, corresponding_input_indices);
 
@@ -481,21 +481,21 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
 
       Eigen::Vector3d add_point = distinct_cloud_->points[dp_i].getVector3fMap ().template cast<double> ();
       double u, v, w;
-      getMLSCoordinates (add_point, mls_results_[input_index], u, v, w);
+      mls_results_[input_index].getMLSCoordinates (add_point, u, v, w);
 
-      MLSProjectionResults proj;
+      MLSResult::MLSProjectionResults proj;
       if (polynomial_fit_ && mls_results_[input_index].num_neighbors >= 5 * nr_coeff_)
       {
         if (projection_method_ == SIMPLE)
-          proj = projectPointSimpleToPolynomialSurface (u, v, mls_results_[input_index]);
+          proj = mls_results_[input_index].projectPointSimpleToPolynomialSurface (u, v);
         else if (projection_method_ == ORTHOGONAL)
-          proj = projectPointOrthogonalToPolynomialSurface (u, v, w, mls_results_[input_index]);
+          proj = mls_results_[input_index].projectPointOrthogonalToPolynomialSurface (u, v, w);
         else
-          proj = projectPointToMLSPlane (u, v, mls_results_[input_index]);
+          proj = mls_results_[input_index].projectPointToMLSPlane (u, v);
       }
       else
       {
-        proj = projectPointToMLSPlane(u, v, mls_results_[input_index]);
+        proj = mls_results_[input_index].projectPointToMLSPlane (u, v);
       }
 
       addProjectedPointNormal(input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
@@ -535,21 +535,21 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
 
       Eigen::Vector3d add_point = p.getVector3fMap ().template cast<double> ();
       double u, v, w;
-      getMLSCoordinates (add_point, mls_results_[input_index], u, v, w);
+      mls_results_[input_index].getMLSCoordinates (add_point, u, v, w);
 
-      MLSProjectionResults proj;
+      MLSResult::MLSProjectionResults proj;
       if (polynomial_fit_ && mls_results_[input_index].num_neighbors >= 5 * nr_coeff_)
       {
         if (projection_method_ == SIMPLE)
-          proj = projectPointSimpleToPolynomialSurface (u, v, mls_results_[input_index]);
+          proj = mls_results_[input_index].projectPointSimpleToPolynomialSurface (u, v);
         else if (projection_method_ == ORTHOGONAL)
-          proj = projectPointOrthogonalToPolynomialSurface (u, v, w, mls_results_[input_index]);
+          proj = mls_results_[input_index].projectPointOrthogonalToPolynomialSurface (u, v, w);
         else
-          proj = projectPointToMLSPlane (u, v, mls_results_[input_index]);
+          proj = mls_results_[input_index].projectPointToMLSPlane (u, v);
       }
       else
       {
-        proj = projectPointToMLSPlane (u, v, mls_results_[input_index]);
+        proj = mls_results_[input_index].projectPointToMLSPlane (u, v);
       }
 
       addProjectedPointNormal(input_index, proj.point, proj.normal, mls_results_[input_index].curvature, output, *normals_, *corresponding_input_indices_);
@@ -565,7 +565,7 @@ pcl::MLSResult::MLSResult (const Eigen::Vector3d &a_query_point,
                            const Eigen::Vector3d &a_v,
                            const Eigen::VectorXd &a_c_vec,
                            const int a_num_neighbors,
-                           const float &a_curvature,
+                           const float a_curvature,
                            const int a_order,
                            const bool a_polynomial_fit):
   query_point (a_query_point), mean (a_mean), plane_normal (a_plane_normal), u_axis (a_u), v_axis (a_v), c_vec (a_c_vec), num_neighbors (a_num_neighbors),
@@ -573,20 +573,22 @@ pcl::MLSResult::MLSResult (const Eigen::Vector3d &a_query_point,
 {
 }
 
-void pcl::getMLSCoordinates (const Eigen::Vector3d &pt, const pcl::MLSResult &mls_result, double &u, double &v, double &w)
+void pcl::MLSResult::getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v, double &w) const
 {
-  u = (pt - mls_result.mean).dot (mls_result.u_axis);
-  v = (pt - mls_result.mean).dot (mls_result.v_axis);
-  w = (pt - mls_result.mean).dot (mls_result.plane_normal);
+  Eigen::Vector3d delta = pt - mean;
+  u = delta.dot (u_axis);
+  v = delta.dot (v_axis);
+  w = delta.dot (plane_normal);
 }
 
-void pcl::getMLSCoordinates (const Eigen::Vector3d &pt, const pcl::MLSResult &mls_result, double &u, double &v)
+void pcl::MLSResult::getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v) const
 {
-  u = (pt - mls_result.mean).dot (mls_result.u_axis);
-  v = (pt - mls_result.mean).dot (mls_result.v_axis);
+  Eigen::Vector3d delta = pt - mean;
+  u = delta.dot (u_axis);
+  v = delta.dot (v_axis);
 }
 
-double pcl::getPolynomialValue (const double u, const double v, const pcl::MLSResult &mls_result)
+double pcl::MLSResult::getPolynomialValue (const double u, const double v) const
 {
   // Compute the polynomial's terms at the current point
   // Example for second order: z = a + b*y + c*y^2 + d*x + e*x*y + f*x^2
@@ -594,12 +596,12 @@ double pcl::getPolynomialValue (const double u, const double v, const pcl::MLSRe
   int j = 0;
   u_pow = 1;
   result = 0;
-  for (int ui = 0; ui <= mls_result.order; ++ui)
+  for (int ui = 0; ui <= order; ++ui)
   {
     v_pow = 1;
-    for (int vi = 0; vi <= mls_result.order - ui; ++vi)
+    for (int vi = 0; vi <= order - ui; ++vi)
     {
-      result += mls_result.c_vec[j++] * u_pow * v_pow;
+      result += c_vec[j++] * u_pow * v_pow;
       v_pow *= v;
     }
     u_pow *= u;
@@ -608,38 +610,38 @@ double pcl::getPolynomialValue (const double u, const double v, const pcl::MLSRe
   return result;
 }
 
-pcl::PolynomialPartialDerivative pcl::getPolynomialPartialDerivative (const double u, const double v, const pcl::MLSResult &mls_result)
+pcl::MLSResult::PolynomialPartialDerivative pcl::MLSResult::getPolynomialPartialDerivative (const double u, const double v) const
 {
   // Compute the displacement along the normal using the fitted polynomial
   // and compute the partial derivatives needed for estimating the normal
   PolynomialPartialDerivative d;
-  Eigen::VectorXd u_pow(mls_result.order + 2), v_pow(mls_result.order + 2);
+  Eigen::VectorXd u_pow(order + 2), v_pow(order + 2);
   int j = 0;
 
   d.z = d.z_u = d.z_v = d.z_uu = d.z_vv = d.z_uv = 0;
   u_pow(0) = v_pow(0) = 1;
-  for (int ui = 0; ui <= mls_result.order; ++ui)
+  for (int ui = 0; ui <= order; ++ui)
   {
-    for (int vi = 0; vi <= mls_result.order - ui; ++vi)
+    for (int vi = 0; vi <= order - ui; ++vi)
     {
       // Compute displacement along normal
-      d.z += u_pow(ui) * v_pow(vi) * mls_result.c_vec[j];
+      d.z += u_pow(ui) * v_pow(vi) * c_vec[j];
 
       // Compute partial derivatives
       if (ui >= 1)
-        d.z_u += mls_result.c_vec[j] * ui * u_pow(ui - 1) * v_pow(vi);
+        d.z_u += c_vec[j] * ui * u_pow(ui - 1) * v_pow(vi);
 
       if (vi >= 1)
-        d.z_v += mls_result.c_vec[j] * vi * u_pow(ui) * v_pow(vi - 1);
+        d.z_v += c_vec[j] * vi * u_pow(ui) * v_pow(vi - 1);
 
       if (ui >= 1 && vi >= 1)
-        d.z_uv += mls_result.c_vec[j] * ui * u_pow(ui - 1) * vi * v_pow(vi - 1);
+        d.z_uv += c_vec[j] * ui * u_pow(ui - 1) * vi * v_pow(vi - 1);
 
       if (ui >= 2)
-        d.z_uu += mls_result.c_vec[j] * ui * (ui - 1) * u_pow(ui - 2) * v_pow(vi);
+        d.z_uu += c_vec[j] * ui * (ui - 1) * u_pow(ui - 2) * v_pow(vi);
 
       if (vi >= 2)
-        d.z_vv += mls_result.c_vec[j] * vi * (vi - 1) * u_pow(ui) * v_pow(vi - 2);
+        d.z_vv += c_vec[j] * vi * (vi - 1) * u_pow(ui) * v_pow(vi - 2);
 
       if (ui == 0)
         v_pow(vi + 1) = v_pow(vi) * v;
@@ -652,18 +654,17 @@ pcl::PolynomialPartialDerivative pcl::getPolynomialPartialDerivative (const doub
   return d;
 }
 
-Eigen::Vector2f pcl::calculatePrincipleCurvatures (const double u, const double v, const pcl::MLSResult &mls_result)
+Eigen::Vector2f pcl::MLSResult::calculatePrincipleCurvatures (const double u, const double v) const
 {
-  Eigen::Vector2f k;
+  Eigen::Vector2f k(MLS_MINIMUM_PRINCIPLE_CURVATURE, MLS_MINIMUM_PRINCIPLE_CURVATURE);
 
-  k << MLS_MINIMUM_PRINCIPLE_CURVATURE, MLS_MINIMUM_PRINCIPLE_CURVATURE;
   // Note: this use the Monge Patch to derive the Gaussian curvature and Mean Curvature found here http://mathworld.wolfram.com/MongePatch.html
   // Then:
   //      k1 = H + sqrt(H^2 - K)
   //      k1 = H - sqrt(H^2 - K)
-  if (mls_result.polynomial_fit && mls_result.c_vec.size () >= (mls_result.order + 1) * (mls_result.order + 2) / 2 && pcl_isfinite (mls_result.c_vec[0]))
+  if (polynomial_fit && c_vec.size () >= (order + 1) * (order + 2) / 2 && pcl_isfinite (c_vec[0]))
   {
-    PolynomialPartialDerivative d = getPolynomialPartialDerivative (u, v, mls_result);
+    PolynomialPartialDerivative d = getPolynomialPartialDerivative (u, v);
     double Z = 1 + d.z_u * d.z_u + d.z_v * d.z_v;
     double Zlen = std::sqrt (Z);
     double K = (d.z_uu * d.z_vv - d.z_uv * d.z_uv) / (Z * Z);
@@ -684,17 +685,17 @@ Eigen::Vector2f pcl::calculatePrincipleCurvatures (const double u, const double 
   return k;
 }
 
-pcl::MLSProjectionResults pcl::projectPointOrthogonalToPolynomialSurface (const double u, const double v, const double w, const pcl::MLSResult &mls_result)
+pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointOrthogonalToPolynomialSurface (const double u, const double v, const double w) const
 {
   double gu = u;
   double gv = v;
   double gw = 0;
 
   MLSProjectionResults result;
-  result.normal = mls_result.plane_normal;
-  if (mls_result.polynomial_fit && mls_result.c_vec.size () >= (mls_result.order + 1) * (mls_result.order + 2) / 2 && pcl_isfinite (mls_result.c_vec[0]))
+  result.normal = plane_normal;
+  if (polynomial_fit && c_vec.size () >= (order + 1) * (order + 2) / 2 && pcl_isfinite (c_vec[0]))
   {
-    PolynomialPartialDerivative d = getPolynomialPartialDerivative (gu, gv, mls_result);
+    PolynomialPartialDerivative d = getPolynomialPartialDerivative (gu, gv);
     gw = d.z;
     double err_total;
     double dist1 = std::abs (gw - w);
@@ -721,7 +722,7 @@ pcl::MLSProjectionResults pcl::projectPointOrthogonalToPolynomialSurface (const 
       gu -= update(0);
       gv -= update(1);
 
-      d = getPolynomialPartialDerivative (gu, gv, mls_result);
+      d = getPolynomialPartialDerivative (gu, gv);
       gw = d.z;
       dist2 = std::sqrt ((gu - u) * (gu - u) + (gv - v) * (gv - v) + (gw - w) * (gw - w));
 
@@ -733,46 +734,46 @@ pcl::MLSProjectionResults pcl::projectPointOrthogonalToPolynomialSurface (const 
     {
       gu = u;
       gv = v;
-      d = getPolynomialPartialDerivative (u, v, mls_result);
+      d = getPolynomialPartialDerivative (u, v);
       gw = d.z;
     }
 
-    result.normal -= (d.z_u * mls_result.u_axis + d.z_v * mls_result.v_axis);
+    result.normal -= (d.z_u * u_axis + d.z_v * v_axis);
     result.normal.normalize();
   }
 
-  result.point = mls_result.mean + gu * mls_result.u_axis + gv * mls_result.v_axis + gw * mls_result.plane_normal;
+  result.point = mean + gu * u_axis + gv * v_axis + gw * plane_normal;
 
   return result;
 }
 
-pcl::MLSProjectionResults pcl::projectPointToMLSPlane(const double u, const double v, const pcl::MLSResult &mls_result)
+pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointToMLSPlane(const double u, const double v) const
 {
   MLSProjectionResults result;
   result.u = u;
   result.v = v;
-  result.normal = mls_result.plane_normal;
-  result.point = mls_result.mean + u * mls_result.u_axis + v * mls_result.v_axis;
+  result.normal = plane_normal;
+  result.point = mean + u * u_axis + v * v_axis;
 
   return result;
 }
 
-pcl::MLSProjectionResults pcl::projectPointSimpleToPolynomialSurface (const double u, const double v, const pcl::MLSResult &mls_result)
+pcl::MLSResult::MLSProjectionResults pcl::MLSResult::projectPointSimpleToPolynomialSurface (const double u, const double v) const
 {
   MLSProjectionResults result;
   double w = 0;
 
-  result.normal = mls_result.plane_normal;
+  result.normal = plane_normal;
 
-  if (mls_result.polynomial_fit && mls_result.c_vec.size () >= (mls_result.order + 1) * (mls_result.order + 2) / 2 && pcl_isfinite (mls_result.c_vec[0]))
+  if (polynomial_fit && c_vec.size () >= (order + 1) * (order + 2) / 2 && pcl_isfinite (c_vec[0]))
   {
-    PolynomialPartialDerivative d = getPolynomialPartialDerivative (u, v, mls_result);
+    PolynomialPartialDerivative d = getPolynomialPartialDerivative (u, v);
     w = d.z;
-    result.normal -= (d.z_u * mls_result.u_axis + d.z_v * mls_result.v_axis);
+    result.normal -= (d.z_u * u_axis + d.z_v * v_axis);
     result.normal.normalize();
   }
 
-  result.point = mls_result.mean + u * mls_result.u_axis + v * mls_result.v_axis + w * mls_result.plane_normal;
+  result.point = mean + u * u_axis + v * v_axis + w * plane_normal;
 
   return result;
 }

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -293,7 +293,6 @@ namespace pcl
                               search_method_ (),
                               tree_ (),
                               order_ (2),
-                              polynomial_fit_ (true),
                               search_radius_ (0.0),
                               sqr_gauss_param_ (0.0),
                               compute_normals_ (false),
@@ -340,20 +339,10 @@ namespace pcl
 
       /** \brief Set the order of the polynomial to be fit.
         * \param[in] order the order of the polynomial
+        * \note Setting order > 1 indicates using a plynomial fit.
         */
       inline void 
-      setPolynomialOrder (int order)
-      {
-        order_ = order;
-        if (order_ < 2)
-        {
-          polynomial_fit_ = false;
-        }
-        else
-        {
-          polynomial_fit_ = true;
-        }
-      }
+      setPolynomialOrder (int order) { order_ = order; }
 
       /** \brief Get the order of the polynomial to be fit. */
       inline int 
@@ -362,11 +351,11 @@ namespace pcl
       /** \brief Sets whether the surface and normal are approximated using a polynomial, or only via tangent estimation.
         * \param[in] polynomial_fit set to true for polynomial fit
         */
+      PCL_DEPRECATED ("[pcl::surface::MovingLeastSquares::setPolynomialFit] setPolynomialFit is deprecated. Please use setPolynomialOrder instead.")
       inline void 
       setPolynomialFit (bool polynomial_fit)
       {
-        polynomial_fit_ = polynomial_fit;
-        if (polynomial_fit_)
+        if (polynomial_fit)
         {
           if (order_ < 2)
           {
@@ -380,8 +369,9 @@ namespace pcl
       }
 
       /** \brief Get the polynomial_fit value (true if the surface and normal are approximated using a polynomial). */
+      PCL_DEPRECATED ("[pcl::surface::MovingLeastSquares::getPolynomialFit] getPolynomialFit is deprecated. Please use getPolynomialOrder instead.")
       inline bool 
-      getPolynomialFit () const { return (polynomial_fit_); }
+      getPolynomialFit () const { return (order_ > 1); }
 
       /** \brief Set the sphere radius that is to be used for determining the k-nearest neighbors used for fitting.
         * \param[in] radius the sphere radius that is to contain all k-nearest neighbors
@@ -546,9 +536,6 @@ namespace pcl
 
       /** \brief The order of the polynomial to be fit. */
       int order_;
-
-      /** True if the surface and normal be approximated using a polynomial, false if tangent estimation is sufficient. */
-      bool polynomial_fit_;
 
       /** \brief The nearest neighbors search radius for each point. */
       double search_radius_;

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -67,18 +67,18 @@ namespace pcl
     /** \brief Data structure used to store the MLS polynomial partial derivatives */
     struct PolynomialPartialDerivative
     {
-      double z;     /**< \brief The z component of the polynomial evaluated at z(u, v). */
-      double z_u;   /**< \brief The partial derivative dz/du. */
-      double z_v;   /**< \brief The partial derivative dz/dv. */
-      double z_uu;  /**< \brief The partial derivative d^2z/du^2. */
-      double z_vv;  /**< \brief The partial derivative d^2z/dv^2. */
-      double z_uv;  /**< \brief The partial derivative d^2z/dudv. */
+      double z;    /**< \brief The z component of the polynomial evaluated at z(u, v). */
+      double z_u;  /**< \brief The partial derivative dz/du. */
+      double z_v;  /**< \brief The partial derivative dz/dv. */
+      double z_uu; /**< \brief The partial derivative d^2z/du^2. */
+      double z_vv; /**< \brief The partial derivative d^2z/dv^2. */
+      double z_uv; /**< \brief The partial derivative d^2z/dudv. */
     };
 
     /** \brief Data structure used to store the MLS projection results */
     struct MLSProjectionResults
     {
-      MLSProjectionResults () : u (0), v(0) {}
+      MLSProjectionResults () : u (0), v (0) {}
 
       double u;               /**< \brief The u-coordinate of the projected point in local MLS frame. */
       double v;               /**< \brief The u-coordinate of the projected point in local MLS frame. */
@@ -106,32 +106,32 @@ namespace pcl
       * \param[out] v The v-coordinate of the point in local MLS frame.
       * \param[out] w The w-coordinate of the point in local MLS frame.
       */
-    inline
-    void getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v, double &w) const;
+    inline void
+    getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v, double &w) const;
 
     /** \brief Given a point calculate it's 2D location in the MLS frame.
       * \param[in] pt The point
       * \param[out] u The u-coordinate of the point in local MLS frame.
       * \param[out] v The v-coordinate of the point in local MLS frame.
       */
-    inline
-    void getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v) const;
+    inline void
+    getMLSCoordinates (const Eigen::Vector3d &pt, double &u, double &v) const;
 
     /** \brief Calculate the polynomial
       * \param[in] u The u-coordinate of the point in local MLS frame.
       * \param[in] v The v-coordinate of the point in local MLS frame.
       * \return The polynomial value at the provide uv coordinates.
       */
-    inline
-    double getPolynomialValue (const double u, const double v) const;
+    inline double
+    getPolynomialValue (const double u, const double v) const;
 
     /** \brief Calculate the polynomial's first and second partial derivatives.
       * \param[in] u The u-coordinate of the point in local MLS frame.
       * \param[in] v The v-coordinate of the point in local MLS frame.
       * \return The polynomial partial derivatives at the provide uv coordinates.
       */
-    inline
-    PolynomialPartialDerivative getPolynomialPartialDerivative (const double u, const double v) const;
+    inline PolynomialPartialDerivative
+    getPolynomialPartialDerivative (const double u, const double v) const;
 
     /** \brief Calculate the principle curvatures using the polynomial surface.
       * \param[in] u The u-coordinate of the point in local MLS frame.
@@ -139,8 +139,8 @@ namespace pcl
       * \return The principle curvature [k1, k2] at the provided ub coordinates.
       * \note If an error occurs the MLS_MINIMUM_PRINCIPLE_CURVATURE is returned.
       */
-    inline
-    Eigen::Vector2f calculatePrincipleCurvatures (const double u, const double v) const;
+    inline Eigen::Vector2f
+    calculatePrincipleCurvatures (const double u, const double v) const;
 
     /** \brief Project a point orthogonal to the polynomial surface.
       * \param[in] u The u-coordinate of the point in local MLS frame.
@@ -151,16 +151,16 @@ namespace pcl
       * \note If the optimization diverges it performs a simple projection on to the polynomial surface.
       * \note This was implemented based on this https://math.stackexchange.com/questions/1497093/shortest-distance-between-point-and-surface
       */
-    inline
-    MLSProjectionResults projectPointOrthogonalToPolynomialSurface (const double u, const double v, const double w) const;
+    inline MLSProjectionResults
+    projectPointOrthogonalToPolynomialSurface (const double u, const double v, const double w) const;
 
     /** \brief Project a point onto the MLS plane.
       * \param[in] u The u-coordinate of the point in local MLS frame.
       * \param[in] v The v-coordinate of the point in local MLS frame.
       * \return The MLSProjectionResults for the input data.
       */
-    inline
-    MLSProjectionResults projectPointToMLSPlane (const double u, const double v) const;
+    inline MLSProjectionResults
+    projectPointToMLSPlane (const double u, const double v) const;
 
     /** \brief Project a point along the MLS plane normal to the polynomial surface.
       * \param[in] u The u-coordinate of the point in local MLS frame.
@@ -168,8 +168,8 @@ namespace pcl
       * \return The MLSProjectionResults for the input data.
       * \note If the MLSResults does not contain polynomial data it projects the point onto the mls plane.
       */
-    inline
-    MLSProjectionResults projectPointSimpleToPolynomialSurface (const double u, const double v) const;
+    inline MLSProjectionResults
+    projectPointSimpleToPolynomialSurface (const double u, const double v) const;
 
     /**
      * \brief Project a point using the specified method.
@@ -180,8 +180,8 @@ namespace pcl
      * \note If required_neighbors is not satisfied it projects to the mls plane.
      * \return The MLSProjectionResults for the input data.
      */
-    inline
-    MLSProjectionResults projectPoint(const Eigen::Vector3d &pt, ProjectionMethod method, int required_neighbors = 0) const;
+    inline MLSProjectionResults
+    projectPoint(const Eigen::Vector3d &pt, ProjectionMethod method, int required_neighbors = 0) const;
 
     /**
      * \brief Project the query point used to generate the mls surface about using the specified method.
@@ -191,8 +191,8 @@ namespace pcl
      * \note If required_neighbors is not satisfied it projects to the mls plane.
      * \return The MLSProjectionResults for the input data.
      */
-    inline
-    MLSProjectionResults projectQueryPoint(ProjectionMethod method, int required_neighbors = 0) const;
+    inline MLSProjectionResults
+    projectQueryPoint(ProjectionMethod method, int required_neighbors = 0) const;
 
     /** \brief Smooth a given point and its neighborghood using Moving Least Squares.
       * \param[in] index the index of the query point in the input cloud
@@ -201,13 +201,13 @@ namespace pcl
       * \param[in] polynomial_order the order of the polynomial to fit to the nearest neighbors
       * \param[in] weight_func defines the weight function for the polynomial fit
       */
-    template <typename PointT>
-    void computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
-                            int index,
-                            const std::vector<int> &nn_indices,
-                            double search_radius,
-                            int polynomial_order = 2,
-                            boost::function<double(const double)> weight_func = 0);
+    template <typename PointT> void
+    computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
+                       int index,
+                       const std::vector<int> &nn_indices,
+                       double search_radius,
+                       int polynomial_order = 2,
+                       boost::function<double(const double)> weight_func = 0);
 
     Eigen::Vector3d query_point;  /**< \brief The query point about which the mls surface was generated */
     Eigen::Vector3d mean;         /**< \brief The mean point of all the neighbors. */
@@ -220,15 +220,15 @@ namespace pcl
     int order;                    /**< \brief The order of the polynomial. If order > 1 then use polynomial fit */
     bool valid;                   /**< \brief If True, the mls results data is valid, otherwise False. */
 
-  private:
-    /**
-      * \brief The default weight function used when fitting a polynomial surface
-      * \param sq_dist the squared distance from a point to origin of the mls frame
-      * \param sq_mls_radius the squraed mls search radius used
-      * \return The weight for a point at squared distance from the origin of the mls frame
-      */
-    inline
-    double computeMLSWeight(const double sq_dist, const double sq_mls_radius) { return exp (-sq_dist / sq_mls_radius); }
+    private:
+      /**
+        * \brief The default weight function used when fitting a polynomial surface
+        * \param sq_dist the squared distance from a point to origin of the mls frame
+        * \param sq_mls_radius the squraed mls search radius used
+        * \return The weight for a point at squared distance from the origin of the mls frame
+        */
+      inline
+      double computeMLSWeight (const double sq_dist, const double sq_mls_radius) { return (exp (-sq_dist / sq_mls_radius)); }
 
   };
 
@@ -310,7 +310,7 @@ namespace pcl
                               rng_alg_ (),
                               rng_uniform_distribution_ ()
                               {};
-      
+
       /** \brief Empty destructor */
       virtual ~MovingLeastSquares () {}
 
@@ -334,25 +334,25 @@ namespace pcl
       }
 
       /** \brief Get a pointer to the search method used. */
-      inline KdTreePtr 
+      inline KdTreePtr
       getSearchMethod () const { return (tree_); }
 
       /** \brief Set the order of the polynomial to be fit.
         * \param[in] order the order of the polynomial
         * \note Setting order > 1 indicates using a plynomial fit.
         */
-      inline void 
+      inline void
       setPolynomialOrder (int order) { order_ = order; }
 
       /** \brief Get the order of the polynomial to be fit. */
-      inline int 
+      inline int
       getPolynomialOrder () const { return (order_); }
 
       /** \brief Sets whether the surface and normal are approximated using a polynomial, or only via tangent estimation.
         * \param[in] polynomial_fit set to true for polynomial fit
         */
       PCL_DEPRECATED ("[pcl::surface::MovingLeastSquares::setPolynomialFit] setPolynomialFit is deprecated. Please use setPolynomialOrder instead.")
-      inline void 
+      inline void
       setPolynomialFit (bool polynomial_fit)
       {
         if (polynomial_fit)
@@ -370,29 +370,29 @@ namespace pcl
 
       /** \brief Get the polynomial_fit value (true if the surface and normal are approximated using a polynomial). */
       PCL_DEPRECATED ("[pcl::surface::MovingLeastSquares::getPolynomialFit] getPolynomialFit is deprecated. Please use getPolynomialOrder instead.")
-      inline bool 
+      inline bool
       getPolynomialFit () const { return (order_ > 1); }
 
       /** \brief Set the sphere radius that is to be used for determining the k-nearest neighbors used for fitting.
         * \param[in] radius the sphere radius that is to contain all k-nearest neighbors
         * \note Calling this method resets the squared Gaussian parameter to radius * radius !
         */
-      inline void 
+      inline void
       setSearchRadius (double radius) { search_radius_ = radius; sqr_gauss_param_ = search_radius_ * search_radius_; }
 
       /** \brief Get the sphere radius used for determining the k-nearest neighbors. */
-      inline double 
+      inline double
       getSearchRadius () const { return (search_radius_); }
 
       /** \brief Set the parameter used for distance based weighting of neighbors (the square of the search radius works
         * best in general).
         * \param[in] sqr_gauss_param the squared Gaussian parameter
         */
-      inline void 
+      inline void
       setSqrGaussParam (double sqr_gauss_param) { sqr_gauss_param_ = sqr_gauss_param; }
 
       /** \brief Get the parameter for distance based weighting of neighbors. */
-      inline double 
+      inline double
       getSqrGaussParam () const { return (sqr_gauss_param_); }
 
       /** \brief Set the upsampling method to be used
@@ -407,7 +407,7 @@ namespace pcl
 
       /** \brief Get the distinct cloud used for the DISTINCT_CLOUD upsampling method. */
       inline PointCloudInConstPtr
-      getDistinctCloud () const { return distinct_cloud_; }
+      getDistinctCloud () const { return (distinct_cloud_); }
 
 
       /** \brief Set the radius of the circle in the local point plane that will be sampled
@@ -421,7 +421,7 @@ namespace pcl
         * \note Used only in the case of SAMPLE_LOCAL_PLANE upsampling
         */
       inline double
-      getUpsamplingRadius () const { return upsampling_radius_; }
+      getUpsamplingRadius () const { return (upsampling_radius_); }
 
       /** \brief Set the step size for the local plane sampling
         * \note Used only in the case of SAMPLE_LOCAL_PLANE upsampling
@@ -435,7 +435,7 @@ namespace pcl
         * \note Used only in the case of SAMPLE_LOCAL_PLANE upsampling
         */
       inline double
-      getUpsamplingStepSize () const { return upsampling_step_; }
+      getUpsamplingStepSize () const { return (upsampling_step_); }
 
       /** \brief Set the parameter that specifies the desired number of points within the search radius
         * \note Used only in the case of RANDOM_UNIFORM_DENSITY upsampling
@@ -450,7 +450,7 @@ namespace pcl
         * \note Used only in the case of RANDOM_UNIFORM_DENSITY upsampling
         */
       inline int
-      getPointDensity () const { return desired_num_points_in_radius_; }
+      getPointDensity () const { return (desired_num_points_in_radius_); }
 
       /** \brief Set the voxel size for the voxel grid
         * \note Used only in the VOXEL_GRID_DILATION upsampling method
@@ -464,7 +464,7 @@ namespace pcl
         * \note Used only in the VOXEL_GRID_DILATION upsampling method
         */
       inline float
-      getDilationVoxelSize () const { return voxel_size_; }
+      getDilationVoxelSize () const { return (voxel_size_); }
 
       /** \brief Set the number of dilation steps of the voxel grid
         * \note Used only in the VOXEL_GRID_DILATION upsampling method
@@ -477,7 +477,7 @@ namespace pcl
         * \note Used only in the VOXEL_GRID_DILATION upsampling method
         */
       inline int
-      getDilationIterations () const { return dilation_iteration_num_; }
+      getDilationIterations () const { return (dilation_iteration_num_); }
 
       /** \brief Set wether the mls results should be stored for each point in the input cloud
         * \param[in] True if the mls results should be stored, otherwise false.
@@ -489,7 +489,7 @@ namespace pcl
 
       /** \brief Get the cache_mls_results_ value (True if the mls results should be stored, otherwise false). */
       inline bool
-      getCacheMLSResults () const { return cache_mls_results_; }
+      getCacheMLSResults () const { return (cache_mls_results_); }
 
       /** \brief Set the method to be used when projection the point on to the MLS surface.
         * \param method
@@ -501,22 +501,23 @@ namespace pcl
 
       /** \brief Get the current projection method being used. */
       inline MLSResult::ProjectionMethod
-      getProjectionMethod () const { return projection_method_; }
+      getProjectionMethod () const { return (projection_method_); }
 
       /** \brief Get the MLSResults for input cloud
         * \note The results are only stored if setCacheMLSResults(true) was called or when using the upsampling method DISTINCT_CLOUD or VOXEL_GRID_DILATION.
         * \note This vector is align with the input cloud indicies, so use getCorrespondingIndices to get the correct results when using output cloud indicies.
         */
-      inline const std::vector<MLSResult>& getMLSResults() const { return mls_results_; }
+      inline const std::vector<MLSResult>&
+      getMLSResults () const { return (mls_results_); }
 
       /** \brief Base method for surface reconstruction for all points given in <setInputCloud (), setIndices ()>
         * \param[out] output the resultant reconstructed surface model
         */
-      void 
+      void
       process (PointCloudOut &output);
 
 
-      /** \brief Get the set of indices with each point in output having the 
+      /** \brief Get the set of indices with each point in output having the
         * corresponding point in input */
       inline PointIndicesPtr
       getCorrespondingIndices () const { return (corresponding_input_indices_); }
@@ -577,7 +578,7 @@ namespace pcl
       /** \brief Parameter that specifies the projection method to be used. */
       MLSResult::ProjectionMethod projection_method_;
 
-      
+
       /** \brief A minimalistic implementation of a voxel grid, necessary for the point cloud upsampling
         * \note Used only in the case of VOXEL_GRID_DILATION upsampling
         */
@@ -638,7 +639,7 @@ namespace pcl
       float voxel_size_;
 
       /** \brief Number of dilation steps for the VOXEL_GRID_DILATION upsampling method */
-      int dilation_iteration_num_; 
+      int dilation_iteration_num_;
 
       /** \brief Number of coefficients, to be computed from the requested order.*/
       int nr_coeff_;
@@ -700,15 +701,17 @@ namespace pcl
       copyMissingFields (const PointInT &point_in,
                          PointOutT &point_out) const;
 
-      /** \brief Abstract surface reconstruction method. 
+      /** \brief Abstract surface reconstruction method.
         * \param[out] output the result of the reconstruction 
         */
-      virtual void performProcessing (PointCloudOut &output);
+      virtual void
+      performProcessing (PointCloudOut &output);
 
       /** \brief Perform upsampling for the distinct-cloud and voxel-grid methods
         * \param[out] output the result of the reconstruction
        */
-      void performUpsampling (PointCloudOut &output);
+      void
+      performUpsampling (PointCloudOut &output);
 
     private:
       /** \brief Boost-based random number generator algorithm. */
@@ -717,13 +720,14 @@ namespace pcl
       /** \brief Random number generator using an uniform distribution of floats
         * \note Used only in the case of RANDOM_UNIFORM_DENSITY upsampling
         */
-      boost::shared_ptr<boost::variate_generator<boost::mt19937&, 
-                                                 boost::uniform_real<float> > 
+      boost::shared_ptr<boost::variate_generator<boost::mt19937&,
+                                                 boost::uniform_real<float> >
                        > rng_uniform_distribution_;
 
       /** \brief Abstract class get name method. */
-      std::string getClassName () const { return ("MovingLeastSquares"); }
-      
+      std::string
+      getClassName () const { return ("MovingLeastSquares"); }
+
     public:
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
@@ -783,7 +787,8 @@ namespace pcl
       /** \brief Abstract surface reconstruction method.
         * \param[out] output the result of the reconstruction
         */
-      virtual void performProcessing (PointCloudOut &output);
+      virtual void
+      performProcessing (PointCloudOut &output);
 
       /** \brief The maximum number of threads the scheduler should use. */
       unsigned int threads_;

--- a/test/surface/test_moving_least_squares.cpp
+++ b/test/surface/test_moving_least_squares.cpp
@@ -72,7 +72,7 @@ TEST (PCL, MovingLeastSquares)
   // Set parameters
   mls.setInputCloud (cloud);
   mls.setComputeNormals (true);
-  mls.setPolynomialFit (true);
+  mls.setPolynomialOrder (2);
   mls.setSearchMethod (tree);
   mls.setSearchRadius (0.03);
 
@@ -92,7 +92,7 @@ TEST (PCL, MovingLeastSquares)
   MovingLeastSquaresOMP<PointXYZ, PointNormal> mls_omp;
   mls_omp.setInputCloud (cloud);
   mls_omp.setComputeNormals (true);
-  mls_omp.setPolynomialFit (true);
+  mls_omp.setPolynomialOrder (2);
   mls_omp.setSearchMethod (tree);
   mls_omp.setSearchRadius (0.03);
   mls_omp.setNumberOfThreads (4);
@@ -123,7 +123,7 @@ TEST (PCL, MovingLeastSquares)
   // Set parameters
   mls_upsampling.setInputCloud (cloud);
   mls_upsampling.setComputeNormals (true);
-  mls_upsampling.setPolynomialFit (true);
+  mls_upsampling.setPolynomialOrder (2);
   mls_upsampling.setSearchMethod (tree);
   mls_upsampling.setSearchRadius (0.03);
   mls_upsampling.setUpsamplingMethod (MovingLeastSquares<PointXYZ, PointNormal>::SAMPLE_LOCAL_PLANE);


### PR DESCRIPTION
This PR adds a new projection method which projects the point orthogonal to the mls surface. This produces a better reconstruction in areas of high curvature when using a polynomial fit. There are several free function added that could be used by other mls techniques and meshing algorithms.

Note: This is builds on PR #1952 which has not been merged but I wanted to get this submitted to start discussions on the new features added.