### PR TITLE
Include pcl/point_cloud.h and pcl/point_types.h headers.

### DIFF
--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -41,6 +41,9 @@
 
 #include <limits>
 
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
 namespace pcl
 {
   // r,g,b, i values are from 0 to 1


### PR DESCRIPTION
If these headers are not included, including `pcl/point_cloud_conversions.h` will result in does-not-name-a-type like errors if both `pcl/point_cloud.h` and `pcl/point_types.h` is not included (e.g. in a main.cc file).