### PR TITLE
[OCTREE] Fix pcl_octree_viewer

### DIFF
--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -339,6 +339,9 @@ private:
 
     for (tree_it = octree.begin(depth); tree_it!=tree_it_end; ++tree_it)
     {
+      if (tree_it.getCurrentOctreeDepth () != depth)
+        continue;
+
       Eigen::Vector3f voxel_min, voxel_max;
       octree.getVoxelBounds(tree_it, voxel_min, voxel_max);
 

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -35,7 +35,7 @@
  *  \author Raphael Favier
  * */
 
-#include <pcl/io/pcd_io.h>
+#include <pcl/io/auto_io.h>
 #include <pcl/common/time.h>
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/visualization/point_cloud_handlers.h>
@@ -175,9 +175,8 @@ private:
   {
     std::cout << "Loading file " << filename.c_str() << std::endl;
     //read cloud
-    if (pcl::io::loadPCDFile(filename, *cloud))
+    if (pcl::io::load (filename, *cloud))
     {
-      std::cerr << "ERROR: Cannot open file " << filename << "! Aborting..." << std::endl;
       return false;
     }
 


### PR DESCRIPTION
Fixes issue #1840 

To avoid the display of spurious point, check the detph of an octree node before to print it.
Be able to read PLY file.
Fix the display of the octree cube.