### PR TITLE
[OCTREE] Fix the unit 'test_octree' by removing some 'assert()'.

### DIFF
--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -129,13 +129,18 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 template<typename PointT, typename LeafContainerT, typename BranchContainerT, typename OctreeT> bool
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::isVoxelOccupiedAtPoint (const PointT& point_arg) const
 {
+  if (!isPointWithinBoundingBox (point_arg))
+  {
+    return false;
+  }
+
   OctreeKey key;
 
   // generate key for point
   this->genOctreeKeyforPoint (point_arg, key);
 
   // search for key in octree
-  return (isPointWithinBoundingBox (point_arg) && this->existLeaf (key));
+  return (this->existLeaf (key));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -154,18 +159,25 @@ template<typename PointT, typename LeafContainerT, typename BranchContainerT, ty
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::isVoxelOccupiedAtPoint (
     const double point_x_arg, const double point_y_arg, const double point_z_arg) const
 {
-  OctreeKey key;
+  // create a new point with the argument coordinates
+  PointT point;
+  point.x = point_x_arg;
+  point.y = point_y_arg;
+  point.z = point_z_arg;
 
-  // generate key for point
-  this->genOctreeKeyforPoint (point_x_arg, point_y_arg, point_z_arg, key);
-
-  return (this->existLeaf (key));
+  // search for voxel at point in octree
+  return (this->isVoxelOccupiedAtPoint (point));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT, typename LeafContainerT, typename BranchContainerT, typename OctreeT> void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::deleteVoxelAtPoint (const PointT& point_arg)
 {
+  if (!isPointWithinBoundingBox (point_arg))
+  {
+    return;
+  }
+
   OctreeKey key;
 
   // generate key for point


### PR DESCRIPTION
The function which failed on my computer was `Octree_Pointcloud_Test` in [test/octree/test_octree.cpp](https://github.com/PointCloudLibrary/pcl/blob/master/test/octree/test_octree.cpp). In this function at line 749, we have:
```c++
if (!octreeA.isVoxelOccupiedAtPoint (newPoint))
```
and in this context the `octreeA` is empty. The first step of the function `isVoxelOccupiedAtPoint` is to query the key corresponding to the point argument `newPoint`. The generated key for this point is of course out of the score of the current octree because `octreeA` is empty.

To fix this test, on one hand the easy way is to remove the `assert()` call in `pcl::octree::OctreePointCloud::genOctreeKeyforPoint()` and on the other hand the harder way is to allow `pcl::octree::OctreePointCloud::genOctreeKeyforPoint()` to return a status (a bool) to be able to check if everything goes well or not: this means to change its prototype. I chose the first solution to minimize the number of changes.

This pull request is relative to issue #677.