### PR TITLE
Add new constructors to PCLVisualizer

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1965,7 +1965,7 @@ namespace pcl
         * \param[in] create_interactor if true (default), create an interactor, false otherwise
         */
         void construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
-                        const std::string &name, const bool create_interactor);
+                        const std::string &name, const bool create_interactor, const bool resize_window = true);
 
         /** \brief Internal function for object construction
           * \param[in] argc

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1959,25 +1959,34 @@ namespace pcl
         vtkSmartPointer<vtkRenderWindowInteractor> interactor_;
 #endif
       private:
-      /** \brief Internal function for object construction
-        * \param[in] custom vtk renderer
-        * \param[in] custom vtk render window
-        * \param[in] create_interactor if true, create an interactor, false otherwise
-        * \param[in] resize_window if true(default), resize window size to half of screen width and height and position to (0, 0), false otherwise
-        */
-        void construct (vtkSmartPointer<vtkRenderer> ren,
-                        const std::string &name, const bool create_interactor, const bool resize_window = true);
+        /** \brief Internal function for renderer setup
+         * \param[in] vtk renderer
+         */
+        void setupRenderer (vtkSmartPointer<vtkRenderer> ren);
 
-        /** \brief Internal function for object construction
-          * \param[in] argc
-          * \param[in] argv
-          * \param[in] custom vtk renderer
-          * \param[in] custom vtk render window
-          * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
-          * \param[in] create_interactor if true (default), create an interactor, false otherwise
-          */
-        void construct (int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren,
-                        const std::string &name, const bool create_interactor);
+        /** \brief Internal function for setting up FPS callback
+         * \param[in] vtk renderer
+         */
+        void setupFPSCallback (const vtkSmartPointer<vtkRenderer>& ren);
+
+        /** \brief Internal function for setting up render window
+         * \param[in] name the window name
+         */
+        void setupRenderWindow (const std::string& name);
+
+        /** \brief Internal function for setting up interactor style
+         */
+        void setupStyle ();
+
+        /** \brief Internal function for setting the default render window size and position on screen
+         */
+        void setDefaultWindowSizeAndPos ();
+
+        /** \brief Internal function for setting up camera parameters
+         * \param[in] argc
+         * \param[in] argv
+         */
+        void setupCamera (int &argc, char **argv);
 
         struct PCL_EXPORTS ExitMainLoopTimerCallback : public vtkCommand
         {

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -118,7 +118,7 @@ namespace pcl
           * \param[in] custom vtk render window
           * \param[in] create_interactor if true (default), create an interactor, false otherwise
           */
-        PCLVisualizer(vtkRenderer* ren, vtkRenderWindow* wind, const std::string &name = "", const bool create_interactor = true);
+        PCLVisualizer(vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string &name = "", const bool create_interactor = true);
 
         /** \brief PCL Visualizer constructor.
           * \param[in] argc
@@ -128,7 +128,7 @@ namespace pcl
           * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
           * \param[in] create_interactor if true (default), create an interactor, false otherwise
           */
-        PCLVisualizer(int &argc, char **argv, vtkRenderer* ren, vtkRenderWindow* wind, const std::string &name = "",
+        PCLVisualizer(int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string &name = "",
                       PCLVisualizerInteractorStyle* style = PCLVisualizerInteractorStyle::New(), 
                       const bool create_interactor = true);
 
@@ -1959,6 +1959,25 @@ namespace pcl
         vtkSmartPointer<vtkRenderWindowInteractor> interactor_;
 #endif
       private:
+      /** \brief Internal function for object construction
+        * \param[in] custom vtk renderer
+        * \param[in] custom vtk render window
+        * \param[in] create_interactor if true (default), create an interactor, false otherwise
+        */
+        void construct(vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, 
+                       const std::string &name, const bool create_interactor);
+
+      /** \brief Internal function for object construction
+        * \param[in] argc
+        * \param[in] argv
+        * \param[in] custom vtk renderer
+        * \param[in] custom vtk render window
+        * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
+        * \param[in] create_interactor if true (default), create an interactor, false otherwise
+        */
+        void construct(int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, 
+                       const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor );
+
         struct PCL_EXPORTS ExitMainLoopTimerCallback : public vtkCommand
         {
           static ExitMainLoopTimerCallback* New ()

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -112,6 +112,26 @@ namespace pcl
           */
         PCLVisualizer (int &argc, char **argv, const std::string &name = "",
             PCLVisualizerInteractorStyle* style = PCLVisualizerInteractorStyle::New (), const bool create_interactor = true);
+            
+        /** \brief PCL Visualizer constructor.
+          * \param[in] custom vtk renderer
+          * \param[in] custom vtk render window
+          * \param[in] create_interactor if true (default), create an interactor, false otherwise
+          */
+        PCLVisualizer(vtkRenderer* ren, vtkRenderWindow* wind, const std::string &name = "", const bool create_interactor = true);
+
+        /** \brief PCL Visualizer constructor.
+          * \param[in] argc
+          * \param[in] argv
+          * \param[in] custom vtk renderer
+          * \param[in] custom vtk render window
+          * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
+          * \param[in] create_interactor if true (default), create an interactor, false otherwise
+          */
+        PCLVisualizer(int &argc, char **argv, vtkRenderer* ren, vtkRenderWindow* wind, const std::string &name = "",
+                      PCLVisualizerInteractorStyle* style = PCLVisualizerInteractorStyle::New(), 
+                      const bool create_interactor = true);
+
 
         /** \brief PCL Visualizer destructor. */
         virtual ~PCLVisualizer ();

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1962,7 +1962,8 @@ namespace pcl
       /** \brief Internal function for object construction
         * \param[in] custom vtk renderer
         * \param[in] custom vtk render window
-        * \param[in] create_interactor if true (default), create an interactor, false otherwise
+        * \param[in] create_interactor if true, create an interactor, false otherwise
+        * \param[in] resize_window if true(default), resize window size to half of screen width and height and position to (0, 0), false otherwise
         */
         void construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
                         const std::string &name, const bool create_interactor, const bool resize_window = true);
@@ -1973,7 +1974,7 @@ namespace pcl
           * \param[in] custom vtk renderer
           * \param[in] custom vtk render window
           * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
-          * \param[in] create_interactor if true (default), create an interactor, false otherwise
+          * \param[in] create_interactor if true , create an interactor, false otherwise
           */
         void construct (int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
                         const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor);

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1965,7 +1965,7 @@ namespace pcl
         * \param[in] create_interactor if true, create an interactor, false otherwise
         * \param[in] resize_window if true(default), resize window size to half of screen width and height and position to (0, 0), false otherwise
         */
-        void construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
+        void construct (vtkSmartPointer<vtkRenderer> ren,
                         const std::string &name, const bool create_interactor, const bool resize_window = true);
 
         /** \brief Internal function for object construction
@@ -1974,10 +1974,10 @@ namespace pcl
           * \param[in] custom vtk renderer
           * \param[in] custom vtk render window
           * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
-          * \param[in] create_interactor if true , create an interactor, false otherwise
+          * \param[in] create_interactor if true (default), create an interactor, false otherwise
           */
-        void construct (int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
-                        const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor);
+        void construct (int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren,
+                        const std::string &name, const bool create_interactor);
 
         struct PCL_EXPORTS ExitMainLoopTimerCallback : public vtkCommand
         {

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -118,7 +118,7 @@ namespace pcl
           * \param[in] custom vtk render window
           * \param[in] create_interactor if true (default), create an interactor, false otherwise
           */
-        PCLVisualizer(vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string &name = "", const bool create_interactor = true);
+        PCLVisualizer (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string &name = "", const bool create_interactor = true);
 
         /** \brief PCL Visualizer constructor.
           * \param[in] argc
@@ -128,9 +128,9 @@ namespace pcl
           * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
           * \param[in] create_interactor if true (default), create an interactor, false otherwise
           */
-        PCLVisualizer(int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string &name = "",
-                      PCLVisualizerInteractorStyle* style = PCLVisualizerInteractorStyle::New(), 
-                      const bool create_interactor = true);
+        PCLVisualizer (int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string &name = "",
+                       PCLVisualizerInteractorStyle* style = PCLVisualizerInteractorStyle::New (),
+                       const bool create_interactor = true);
 
 
         /** \brief PCL Visualizer destructor. */
@@ -1964,19 +1964,19 @@ namespace pcl
         * \param[in] custom vtk render window
         * \param[in] create_interactor if true (default), create an interactor, false otherwise
         */
-        void construct(vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, 
-                       const std::string &name, const bool create_interactor);
+        void construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
+                        const std::string &name, const bool create_interactor);
 
-      /** \brief Internal function for object construction
-        * \param[in] argc
-        * \param[in] argv
-        * \param[in] custom vtk renderer
-        * \param[in] custom vtk render window
-        * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
-        * \param[in] create_interactor if true (default), create an interactor, false otherwise
-        */
-        void construct(int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, 
-                       const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor );
+        /** \brief Internal function for object construction
+          * \param[in] argc
+          * \param[in] argv
+          * \param[in] custom vtk renderer
+          * \param[in] custom vtk render window
+          * \param[in] style interactor style (defaults to PCLVisualizerInteractorStyle)
+          * \param[in] create_interactor if true (default), create an interactor, false otherwise
+          */
+        void construct (int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
+                        const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor);
 
         struct PCL_EXPORTS ExitMainLoopTimerCallback : public vtkCommand
         {

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -420,8 +420,8 @@ void pcl::visualization::PCLVisualizer::setDefaultWindowSizeAndPos ()
 {
   if (!win_)
     PCL_ERROR ("Pointer to render window is null");
-  int scr_size_x = win_->GetScreenSize ()[0],
-    scr_size_y = win_->GetScreenSize ()[1];
+  int scr_size_x = win_->GetScreenSize ()[0];
+  int scr_size_y = win_->GetScreenSize ()[1];
   win_->SetSize (scr_size_x / 2, scr_size_y / 2);
   win_->SetPosition (0, 0);
 }

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -315,7 +315,8 @@ pcl::visualization::PCLVisualizer::setupInteractor (
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string & name, const bool create_interactor)
+void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, 
+                                                   const std::string & name, const bool create_interactor, const bool resize_window)
 {
   if (!ren)
     PCL_ERROR ("Passed pointer to renderer is 0");
@@ -337,12 +338,15 @@ void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> 
 
   win_ = wind;
   win_->SetWindowName (name.c_str ());
+  if (resize_window)
+  {
+    int scr_size_x = win_->GetScreenSize ()[0],
+      scr_size_y = win_->GetScreenSize ()[1];
+    win_->SetSize (scr_size_x / 2, scr_size_y / 2);
+    win_->SetPosition (0, 0);
+  }
+  // Set default camera parameters
 
-  // Get screen size
-  int scr_size_x = win_->GetScreenSize ()[0];
-  int scr_size_y = win_->GetScreenSize ()[1];
-  // Set the window size as 1/2 of the screen size
-  win_->SetSize (scr_size_x / 2, scr_size_y / 2);
 
   // By default, don't use vertex buffer objects
   use_vbos_ = false;
@@ -371,10 +375,7 @@ void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> 
 /////////////////////////////////////////////////////////////////////////////////////////////
 void pcl::visualization::PCLVisualizer::construct (int & argc, char ** argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string & name, PCLVisualizerInteractorStyle * style, const bool create_interactor)
 {
-  construct (ren, wind, name, create_interactor);
-  int scr_size_x = win_->GetScreenSize ()[0];
-  int scr_size_y = win_->GetScreenSize ()[1];
-  // Set default camera parameters
+  construct (ren, wind, name, create_interactor, false);
   initCameraParameters ();
 
   // Parse the camera settings and update the internal camera
@@ -395,9 +396,10 @@ void pcl::visualization::PCLVisualizer::construct (int & argc, char ** argv, vtk
       }
     }
   }
-  // Set the window size as 1/2 of the screen size or the user given parameter
   if (!camera_set_ && !camera_file_loaded_)
   {
+    int scr_size_x = win_->GetScreenSize ()[0],
+      scr_size_y = win_->GetScreenSize ()[1];
     win_->SetSize (scr_size_x / 2, scr_size_y / 2);
     win_->SetPosition (0, 0);
   }

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -281,6 +281,173 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, const 
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
+pcl::visualization::PCLVisualizer::PCLVisualizer(vtkRenderer* ren, vtkRenderWindow* wind,
+                                                 const std::string &name, const bool create_interactor)
+  : interactor_()
+  , update_fps_(vtkSmartPointer<FPSCallback>::New())
+#if !((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 4))
+  , stopped_()
+  , timer_id_()
+#endif
+  , exit_main_loop_timer_callback_()
+  , exit_callback_()
+  , rens_(vtkSmartPointer<vtkRendererCollection>::New())
+  , win_(wind)
+  , style_(vtkSmartPointer<pcl::visualization::PCLVisualizerInteractorStyle>::New())
+  , cloud_actor_map_(new CloudActorMap)
+  , shape_actor_map_(new ShapeActorMap)
+  , coordinate_actor_map_(new CoordinateActorMap)
+  , camera_set_()
+  , camera_file_loaded_(false)
+{
+  if (!ren)
+    PCL_ERROR("Passed pointer to renderer is 0");
+
+  if (!wind)
+    PCL_ERROR("Passed pointer to render window is 0");
+  // Create a Renderer
+  ren->AddObserver(vtkCommand::EndEvent, update_fps_);
+  // Add it to the list of renderers
+  rens_->AddItem(ren);
+
+  // FPS callback
+  vtkSmartPointer<vtkTextActor> txt = vtkSmartPointer<vtkTextActor>::New();
+  update_fps_->actor = txt;
+  update_fps_->pcl_visualizer = this;
+  update_fps_->decimated = false;
+  ren->AddActor(txt);
+  txt->SetInput("0 FPS");
+  win_->SetWindowName(name.c_str());
+
+  // Get screen size
+  int scr_size_x = win_->GetScreenSize()[0];
+  int scr_size_y = win_->GetScreenSize()[1];
+  // Set the window size as 1/2 of the screen size
+  win_->SetSize(scr_size_x / 2, scr_size_y / 2);
+
+  // By default, don't use vertex buffer objects
+  use_vbos_ = false;
+
+  // Add all renderers to the window
+  rens_->InitTraversal();
+  vtkRenderer* renderer = NULL;
+  while ((renderer = rens_->GetNextItem()) != NULL)
+    win_->AddRenderer(renderer);
+
+  // Set renderer window in case no interactor is created
+  style_->setRenderWindow(win_);
+
+  // Create the interactor style
+  style_->Initialize();
+  style_->setRendererCollection(rens_);
+  style_->setCloudActorMap(cloud_actor_map_);
+  style_->setShapeActorMap(shape_actor_map_);
+  style_->UseTimersOn();
+  style_->setUseVbos(use_vbos_);
+
+  if (create_interactor)
+    createInteractor();
+
+  win_->SetWindowName(name.c_str());
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+pcl::visualization::PCLVisualizer::PCLVisualizer(int &argc, char **argv, vtkRenderer* ren, vtkRenderWindow* wind,
+                                                 const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor)
+  : interactor_()
+  , update_fps_(vtkSmartPointer<FPSCallback>::New())
+#if !((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 4))
+  , stopped_()
+  , timer_id_()
+#endif
+  , exit_main_loop_timer_callback_()
+  , exit_callback_()
+  , rens_(vtkSmartPointer<vtkRendererCollection>::New())
+  , win_(wind)
+  , style_(style)
+  , cloud_actor_map_(new CloudActorMap)
+  , shape_actor_map_(new ShapeActorMap)
+  , coordinate_actor_map_(new CoordinateActorMap)
+  , camera_set_()
+  , camera_file_loaded_(false)
+{
+  if (!ren)
+    PCL_ERROR("Passed pointer to renderer is 0");
+
+  if (!wind)
+    PCL_ERROR("Passed pointer to render window is 0");
+  ren->AddObserver(vtkCommand::EndEvent, update_fps_);
+  // Add it to the list of renderers
+  rens_->AddItem(ren);
+
+  // FPS callback
+  vtkSmartPointer<vtkTextActor> txt = vtkSmartPointer<vtkTextActor>::New();
+  update_fps_->actor = txt;
+  update_fps_->pcl_visualizer = this;
+  update_fps_->decimated = false;
+  ren->AddActor(txt);
+  txt->SetInput("0 FPS");
+
+  win_->SetWindowName(name.c_str());
+
+  // By default, don't use vertex buffer objects
+  use_vbos_ = false;
+
+  // Add all renderers to the window
+  rens_->InitTraversal();
+  vtkRenderer* renderer = NULL;
+  while ((renderer = rens_->GetNextItem()) != NULL)
+    win_->AddRenderer(renderer);
+
+  // Set renderer window in case no interactor is created
+  style_->setRenderWindow(wind);
+
+  // Create the interactor style
+  style_->Initialize();
+  style_->setRendererCollection(rens_);
+  style_->setCloudActorMap(cloud_actor_map_);
+  style_->setShapeActorMap(shape_actor_map_);
+  style_->UseTimersOn();
+
+  // Get screen size
+  int scr_size_x = win_->GetScreenSize()[0];
+  int scr_size_y = win_->GetScreenSize()[1];
+
+  // Set default camera parameters
+  initCameraParameters();
+
+  // Parse the camera settings and update the internal camera
+  camera_set_ = getCameraParameters(argc, argv);
+  // Calculate unique camera filename for camera parameter saving/restoring
+  if (!camera_set_)
+  {
+    std::string camera_file = getUniqueCameraFile(argc, argv);
+    if (!camera_file.empty())
+    {
+      if (boost::filesystem::exists(camera_file) && style_->loadCameraParameters(camera_file))
+      {
+        camera_file_loaded_ = true;
+      }
+      else
+      {
+        style_->setCameraFile(camera_file);
+      }
+    }
+  }
+  // Set the window size as 1/2 of the screen size or the user given parameter
+  if (!camera_set_ && !camera_file_loaded_)
+  {
+    win_->SetSize(scr_size_x / 2, scr_size_y / 2);
+    win_->SetPosition(0, 0);
+  }
+
+  if (create_interactor)
+    createInteractor();
+
+  win_->SetWindowName(name.c_str());
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
 void
 pcl::visualization::PCLVisualizer::createInteractor ()
 {

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -128,7 +128,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (const std::string &name, const
   , exit_main_loop_timer_callback_ ()
   , exit_callback_ ()
   , rens_ (vtkSmartPointer<vtkRendererCollection>::New ())
-  , win_ ()
+  , win_ (vtkSmartPointer<vtkRenderWindow>::New ())
   , style_ (vtkSmartPointer<pcl::visualization::PCLVisualizerInteractorStyle>::New ())
   , cloud_actor_map_ (new CloudActorMap)
   , shape_actor_map_ (new ShapeActorMap)
@@ -136,7 +136,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (const std::string &name, const
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct (vtkSmartPointer<vtkRenderer>::New (), vtkSmartPointer<vtkRenderWindow>::New (), name, create_interactor);
+  construct (vtkSmartPointer<vtkRenderer>::New (), name, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -150,7 +150,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, const 
   , exit_main_loop_timer_callback_ ()
   , exit_callback_ ()
   , rens_ (vtkSmartPointer<vtkRendererCollection>::New ())
-  , win_ ()
+  , win_ (vtkSmartPointer<vtkRenderWindow>::New ())
   , style_ (style)
   , cloud_actor_map_ (new CloudActorMap)
   , shape_actor_map_ (new ShapeActorMap)
@@ -158,7 +158,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, const 
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct (argc, argv, vtkSmartPointer<vtkRenderer>::New (), vtkSmartPointer<vtkRenderWindow>::New (), name, style, create_interactor);
+  construct (argc, argv, vtkSmartPointer<vtkRenderer>::New (), name, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -173,7 +173,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (vtkSmartPointer<vtkRenderer> r
   , exit_main_loop_timer_callback_ ()
   , exit_callback_ ()
   , rens_ (vtkSmartPointer<vtkRendererCollection>::New ())
-  , win_ ()
+  , win_ (wind)
   , style_ (vtkSmartPointer<pcl::visualization::PCLVisualizerInteractorStyle>::New ())
   , cloud_actor_map_ (new CloudActorMap)
   , shape_actor_map_ (new ShapeActorMap)
@@ -181,7 +181,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (vtkSmartPointer<vtkRenderer> r
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct (ren, wind, name, create_interactor);
+  construct (ren, name, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -196,7 +196,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, vtkSma
   , exit_main_loop_timer_callback_ ()
   , exit_callback_ ()
   , rens_ (vtkSmartPointer<vtkRendererCollection>::New ())
-  , win_ ()
+  , win_ (wind)
   , style_ (style)
   , cloud_actor_map_ (new CloudActorMap)
   , shape_actor_map_ (new ShapeActorMap)
@@ -204,7 +204,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, vtkSma
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct (argc, argv, ren, wind, name, style, create_interactor);
+  construct (argc, argv, ren, name, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -315,14 +315,14 @@ pcl::visualization::PCLVisualizer::setupInteractor (
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, 
+void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> ren, 
                                                    const std::string & name, const bool create_interactor, const bool resize_window)
 {
   if (!ren)
     PCL_ERROR ("Passed pointer to renderer is 0");
 
-  if (!wind)
-    PCL_ERROR ("Passed pointer to render window is 0");
+  if (!win_)
+    PCL_ERROR ("Pointer to render window is 0");
   // Create a Renderer
   ren->AddObserver (vtkCommand::EndEvent, update_fps_);
   // Add it to the list of renderers
@@ -336,7 +336,6 @@ void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> 
   ren->AddActor (txt);
   txt->SetInput ("0 FPS");
 
-  win_ = wind;
   win_->SetWindowName (name.c_str ());
   if (resize_window)
   {
@@ -373,9 +372,9 @@ void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> 
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-void pcl::visualization::PCLVisualizer::construct (int & argc, char ** argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string & name, PCLVisualizerInteractorStyle * style, const bool create_interactor)
+void pcl::visualization::PCLVisualizer::construct (int & argc, char ** argv, vtkSmartPointer<vtkRenderer> ren, const std::string & name, const bool create_interactor)
 {
-  construct (ren, wind, name, create_interactor, false);
+  construct (ren, name, create_interactor, false);
   initCameraParameters ();
 
   // Parse the camera settings and update the internal camera

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -136,7 +136,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (const std::string &name, const
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct(vtkSmartPointer<vtkRenderer>::New(), vtkSmartPointer<vtkRenderWindow>::New(), name, create_interactor);
+  construct (vtkSmartPointer<vtkRenderer>::New (), vtkSmartPointer<vtkRenderWindow>::New (), name, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -158,12 +158,12 @@ pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, const 
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct(argc, argv, vtkSmartPointer<vtkRenderer>::New(), vtkSmartPointer<vtkRenderWindow>::New(), name, style, create_interactor);
+  construct (argc, argv, vtkSmartPointer<vtkRenderer>::New (), vtkSmartPointer<vtkRenderWindow>::New (), name, style, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-pcl::visualization::PCLVisualizer::PCLVisualizer(vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
-                                                 const std::string &name, const bool create_interactor)
+pcl::visualization::PCLVisualizer::PCLVisualizer (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
+                                                  const std::string &name, const bool create_interactor)
   : interactor_ ()
   , update_fps_ (vtkSmartPointer<FPSCallback>::New ())
 #if !((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 4))
@@ -181,12 +181,12 @@ pcl::visualization::PCLVisualizer::PCLVisualizer(vtkSmartPointer<vtkRenderer> re
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct(ren, wind, name, create_interactor);
+  construct (ren, wind, name, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-pcl::visualization::PCLVisualizer::PCLVisualizer(int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
-                                                 const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor)
+pcl::visualization::PCLVisualizer::PCLVisualizer (int &argc, char **argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind,
+                                                  const std::string &name, PCLVisualizerInteractorStyle* style, const bool create_interactor)
   : interactor_ ()
   , update_fps_ (vtkSmartPointer<FPSCallback>::New ())
 #if !((VTK_MAJOR_VERSION == 5) && (VTK_MINOR_VERSION <= 4))
@@ -204,7 +204,7 @@ pcl::visualization::PCLVisualizer::PCLVisualizer(int &argc, char **argv, vtkSmar
   , camera_set_ ()
   , camera_file_loaded_ (false)
 {
-  construct(argc, argv, ren, wind, name, style, create_interactor);
+  construct (argc, argv, ren, wind, name, style, create_interactor);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -315,139 +315,92 @@ pcl::visualization::PCLVisualizer::setupInteractor (
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-void pcl::visualization::PCLVisualizer::construct(vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string & name, const bool create_interactor)
+void pcl::visualization::PCLVisualizer::construct (vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string & name, const bool create_interactor)
 {
   if (!ren)
-    PCL_ERROR("Passed pointer to renderer is 0");
+    PCL_ERROR ("Passed pointer to renderer is 0");
 
   if (!wind)
-    PCL_ERROR("Passed pointer to render window is 0");
+    PCL_ERROR ("Passed pointer to render window is 0");
   // Create a Renderer
-  ren->AddObserver(vtkCommand::EndEvent, update_fps_);
+  ren->AddObserver (vtkCommand::EndEvent, update_fps_);
   // Add it to the list of renderers
-  rens_->AddItem(ren);
+  rens_->AddItem (ren);
 
   // FPS callback
-  vtkSmartPointer<vtkTextActor> txt = vtkSmartPointer<vtkTextActor>::New();
+  vtkSmartPointer<vtkTextActor> txt = vtkSmartPointer<vtkTextActor>::New ();
   update_fps_->actor = txt;
   update_fps_->pcl_visualizer = this;
   update_fps_->decimated = false;
-  ren->AddActor(txt);
-  txt->SetInput("0 FPS");
+  ren->AddActor (txt);
+  txt->SetInput ("0 FPS");
 
   win_ = wind;
-  win_->SetWindowName(name.c_str());
+  win_->SetWindowName (name.c_str ());
 
   // Get screen size
-  int scr_size_x = win_->GetScreenSize()[0];
-  int scr_size_y = win_->GetScreenSize()[1];
+  int scr_size_x = win_->GetScreenSize ()[0];
+  int scr_size_y = win_->GetScreenSize ()[1];
   // Set the window size as 1/2 of the screen size
-  win_->SetSize(scr_size_x / 2, scr_size_y / 2);
+  win_->SetSize (scr_size_x / 2, scr_size_y / 2);
 
   // By default, don't use vertex buffer objects
   use_vbos_ = false;
 
   // Add all renderers to the window
-  rens_->InitTraversal();
+  rens_->InitTraversal ();
   vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem()) != NULL)
-    win_->AddRenderer(renderer);
+  while ((renderer = rens_->GetNextItem ()) != NULL)
+    win_->AddRenderer (renderer);
 
   // Set renderer window in case no interactor is created
-  style_->setRenderWindow(win_);
+  style_->setRenderWindow (win_);
 
   // Create the interactor style
-  style_->Initialize();
-  style_->setRendererCollection(rens_);
-  style_->setCloudActorMap(cloud_actor_map_);
-  style_->setShapeActorMap(shape_actor_map_);
-  style_->UseTimersOn();
-  style_->setUseVbos(use_vbos_);
+  style_->Initialize ();
+  style_->setRendererCollection (rens_);
+  style_->setCloudActorMap (cloud_actor_map_);
+  style_->setShapeActorMap (shape_actor_map_);
+  style_->UseTimersOn ();
+  style_->setUseVbos (use_vbos_);
 
   if (create_interactor)
-    createInteractor();
-
-  win_->SetWindowName(name.c_str());
+    createInteractor ();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-void pcl::visualization::PCLVisualizer::construct(int & argc, char ** argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string & name, PCLVisualizerInteractorStyle * style, const bool create_interactor)
+void pcl::visualization::PCLVisualizer::construct (int & argc, char ** argv, vtkSmartPointer<vtkRenderer> ren, vtkSmartPointer<vtkRenderWindow> wind, const std::string & name, PCLVisualizerInteractorStyle * style, const bool create_interactor)
 {
-  if (!ren)
-    PCL_ERROR("Passed pointer to renderer is 0");
-
-  if (!wind)
-    PCL_ERROR("Passed pointer to render window is 0");
-  ren->AddObserver(vtkCommand::EndEvent, update_fps_);
-  // Add it to the list of renderers
-  rens_->AddItem(ren);
-
-  // FPS callback
-  vtkSmartPointer<vtkTextActor> txt = vtkSmartPointer<vtkTextActor>::New();
-  update_fps_->actor = txt;
-  update_fps_->pcl_visualizer = this;
-  update_fps_->decimated = false;
-  ren->AddActor(txt);
-  txt->SetInput("0 FPS");
-
-  win_ = wind;
-  win_->SetWindowName(name.c_str());
-
-  // By default, don't use vertex buffer objects
-  use_vbos_ = false;
-
-  // Add all renderers to the window
-  rens_->InitTraversal();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem()) != NULL)
-    win_->AddRenderer(renderer);
-
-  // Set renderer window in case no interactor is created
-  style_->setRenderWindow(wind);
-
-  // Create the interactor style
-  style_->Initialize();
-  style_->setRendererCollection(rens_);
-  style_->setCloudActorMap(cloud_actor_map_);
-  style_->setShapeActorMap(shape_actor_map_);
-  style_->UseTimersOn();
-
-  // Get screen size
-  int scr_size_x = win_->GetScreenSize()[0];
-  int scr_size_y = win_->GetScreenSize()[1];
-
+  construct (ren, wind, name, create_interactor);
+  int scr_size_x = win_->GetScreenSize ()[0];
+  int scr_size_y = win_->GetScreenSize ()[1];
   // Set default camera parameters
-  initCameraParameters();
+  initCameraParameters ();
 
   // Parse the camera settings and update the internal camera
-  camera_set_ = getCameraParameters(argc, argv);
+  camera_set_ = getCameraParameters (argc, argv);
   // Calculate unique camera filename for camera parameter saving/restoring
   if (!camera_set_)
   {
-    std::string camera_file = getUniqueCameraFile(argc, argv);
-    if (!camera_file.empty())
+    std::string camera_file = getUniqueCameraFile (argc, argv);
+    if (!camera_file.empty ())
     {
-      if (boost::filesystem::exists(camera_file) && style_->loadCameraParameters(camera_file))
+      if (boost::filesystem::exists (camera_file) && style_->loadCameraParameters (camera_file))
       {
         camera_file_loaded_ = true;
       }
       else
       {
-        style_->setCameraFile(camera_file);
+        style_->setCameraFile (camera_file);
       }
     }
   }
   // Set the window size as 1/2 of the screen size or the user given parameter
   if (!camera_set_ && !camera_file_loaded_)
   {
-    win_->SetSize(scr_size_x / 2, scr_size_y / 2);
-    win_->SetPosition(0, 0);
+    win_->SetSize (scr_size_x / 2, scr_size_y / 2);
+    win_->SetPosition (0, 0);
   }
-
-  if (create_interactor)
-    createInteractor();
-
-  win_->SetWindowName(name.c_str());
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
New constructors allow to provide custom renderers and render windows. It gives the ability to use QVTKOpenGLWidget and lots of vtk render windows.