### PR TITLE
Fix the removed indices of UniformSampling

### DIFF
--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -48,7 +48,7 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
   // Has the input dataset been set already?
   if (!input_)
   {
-    PCL_WARN ("[pcl::%s::detectKeypoints] No input dataset given!\n", getClassName ().c_str ());
+    PCL_WARN ("[pcl::%s::applyFilter] No input dataset given!\n", getClassName ().c_str ());
     output.width = output.height = 0;
     output.points.clear ();
     return;
@@ -79,7 +79,7 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
   // Set up the division multiplier
   divb_mul_ = Eigen::Vector4i (1, div_b_[0], div_b_[0] * div_b_[1], 0);
 
-  Filter<PointT>::removed_indices_->clear();
+  Filter<PointT>::removed_indices_->clear ();
   // First pass: build a set of leaves with the point index closest to the leaf center
   for (size_t cp = 0; cp < indices_->size (); ++cp)
   {
@@ -126,6 +126,10 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
       }
 
       leaf.idx = (*indices_)[cp];
+    }
+    else if (Filter<PointT>::extract_removed_indices_)
+    {
+      Filter<PointT>::removed_indices_->push_back ((*indices_)[cp]);
     }
   }
 

--- a/test/filters/CMakeLists.txt
+++ b/test/filters/CMakeLists.txt
@@ -30,6 +30,11 @@ if (build)
                  LINK_WITH pcl_gtest pcl_filters pcl_io pcl_kdtree
                  ARGUMENTS "${PCL_SOURCE_DIR}/test/milk_cartoon_all_small_clorox.pcd")
 
+    PCL_ADD_TEST(filters_uniform test_uniform_sampling
+                 FILES test_uniform_sampling.cpp
+                 LINK_WITH pcl_gtest pcl_filters pcl_io
+                 ARGUMENTS "${PCL_SOURCE_DIR}/test/milk_cartoon_all_small_clorox.pcd")
+
     if (BUILD_features)
       PCL_ADD_TEST(filters_sampling test_filters_sampling
                    FILES test_sampling.cpp

--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -1,0 +1,100 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2014-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/filters/uniform_sampling.h>
+
+using namespace pcl;
+
+PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ>);
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (UniformSamplingRemoveIndicesSize, Uniform_Sampling)
+{
+  const bool keep_remove_indices = true;
+  UniformSampling<PointXYZ> us (keep_remove_indices);
+  us.setInputCloud (cloud);
+  us.setRadiusSearch (0.003);
+  PointCloud<PointXYZ>::Ptr cloud_filtered (new PointCloud<PointXYZ> ());
+  us.filter (*cloud_filtered);
+
+  const IndicesConstPtr& remove_indices = us.getRemovedIndices ();
+
+  EXPECT_EQ(remove_indices->size () + cloud_filtered->points.size (),
+            cloud->points.size ());
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (UniformSamplingRemoveIndicesSizeWithSetIndices, Uniform_Sampling)
+{
+  IndicesPtr indices (new std::vector<int>);
+  for (std::size_t i = 0; i < cloud->points.size (); i += 2)
+    indices->push_back (i);
+
+  const bool keep_remove_indices = true;
+  UniformSampling<PointXYZ> us (keep_remove_indices);
+  us.setInputCloud (cloud);
+  us.setIndices (indices);
+  us.setRadiusSearch (0.003);
+  PointCloud<PointXYZ>::Ptr cloud_filtered (new PointCloud<PointXYZ> ());
+  us.filter (*cloud_filtered);
+
+  const IndicesConstPtr& remove_indices = us.getRemovedIndices ();
+
+  EXPECT_EQ(remove_indices->size () + cloud_filtered->points.size (),
+            cloud->points.size () - indices->size ());
+}
+
+int
+main (int argc,
+      char** argv)
+{
+  // Load a standard PCD file from disk
+  if (argc < 2)
+  {
+    std::cerr << "No test file given. Please download `milk_cartoon_all_small_clorox.pcd` and pass its path to the test." << std::endl;
+    return (-1);
+  }
+
+  char* file_name = argv[1];
+  // Load a standard PCD file from disk
+  io::loadPCDFile (file_name, *cloud);
+
+  testing::InitGoogleTest (&argc, argv);
+  return (RUN_ALL_TESTS ());
+}


### PR DESCRIPTION
This ensures that all removed indices are set and not only those of the indices that are visited.