### PR TITLE
Fix MSVC compile issue related with ssize_t

### DIFF
--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -61,6 +61,18 @@
 # define pcl_close(fd)               _close(fd)
 # define pcl_lseek(fd,offset,origin) _lseek(fd,offset,origin)
 # define pcl_read(fd,dest,size)      _read(fd,dest,size)
+/* ssize_t is also not available (copy/paste from MinGW) */
+#ifdef _MSC_VER
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+#undef ssize_t
+#ifdef _WIN64
+typedef __int64 ssize_t;
+#else
+typedef int ssize_t;
+#endif /* _WIN64 */
+#endif /* _SSIZE_T_DEFINED */
+#endif /* _MSC_VER */
 #else
 # include <sys/mman.h>
 # define pcl_open                    open

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -62,11 +62,6 @@
 # define pcl_close(fd)               close(fd)
 # define pcl_lseek(fd,offset,origin) lseek(fd,offset,origin)
 #endif
-
-#ifdef _MSC_VER
-typedef SSIZE_T ssize_t;
-#endif
-
 #include <boost/version.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -62,6 +62,11 @@
 # define pcl_close(fd)               close(fd)
 # define pcl_lseek(fd,offset,origin) lseek(fd,offset,origin)
 #endif
+
+#ifdef _MSC_VER
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <boost/version.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The issue is caused  because in MSVC the gnu ssize_t type is called SSIZE_T

Maintainer edit: Fixes #2023.