### PR TITLE
Suppress log when PCL_FIND_QUIETLY is turned on.

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -184,7 +184,7 @@ endmacro(find_qhull)
 #remove this as soon as libopenni is shipped with FindOpenni.cmake
 macro(find_openni)
   if(PCL_FIND_QUIETLY)
-    set(openni_FIND_QUIETLY TRUE)
+    set(OpenNI_FIND_QUIETLY TRUE)
   endif()
 
   if(NOT OPENNI_ROOT AND ("@HAVE_OPENNI@" STREQUAL "TRUE"))
@@ -212,7 +212,7 @@ macro(find_openni)
     PATHS "$ENV{OPEN_NI_LIB${OPENNI_SUFFIX}}" "${OPENNI_LIBRARY_HINT}"
     PATH_SUFFIXES lib Lib Lib64)
 
-  find_package_handle_standard_args(openni DEFAULT_MSG OPENNI_LIBRARY OPENNI_INCLUDE_DIRS)
+  find_package_handle_standard_args(OpenNI DEFAULT_MSG OPENNI_LIBRARY OPENNI_INCLUDE_DIRS)
 
   if(OPENNI_FOUND)
     get_filename_component(OPENNI_LIBRARY_PATH ${OPENNI_LIBRARY} PATH)

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -183,6 +183,10 @@ endmacro(find_qhull)
 
 #remove this as soon as libopenni is shipped with FindOpenni.cmake
 macro(find_openni)
+  if(PCL_FIND_QUIETLY)
+    set(openni_FIND_QUIETLY TRUE)
+  endif()
+
   if(NOT OPENNI_ROOT AND ("@HAVE_OPENNI@" STREQUAL "TRUE"))
     set(OPENNI_INCLUDE_DIRS_HINT "@OPENNI_INCLUDE_DIRS@")
     get_filename_component(OPENNI_LIBRARY_HINT "@OPENNI_LIBRARY@" PATH)


### PR DESCRIPTION
The change will suppress `find_package_handle_standard_args(openni DEFAULT_MSG OPENNI_LIBRARY OPENNI_INCLUDE_DIRS)` from emitting a log.