### PR TITLE
Misleading indentation

### DIFF
--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -418,7 +418,8 @@ pcl::people::HOG::acosTable () const
 {
   int i, n=25000, n2=n/2; float t, ni;
   static float a[25000]; static bool init=false;
-  if( init ) return a+n2; ni = 2.02f/(float) n;
+  if( init ) return a+n2;
+  ni = 2.02f/(float) n;
   for( i=0; i<n; i++ ) {
     t = i*ni - 1.01f;
     t = t<-1 ? -1 : (t>1 ? 1 : t);

--- a/recognition/include/pcl/recognition/ransac_based/auxiliary.h
+++ b/recognition/include/pcl/recognition/ransac_based/auxiliary.h
@@ -96,13 +96,13 @@ namespace pcl
       template<typename T> void
       expandBoundingBoxToContainPoint (T bbox[6], const T p[3])
       {
-             if ( p[0] < bbox[0] ) bbox[0] = p[0];
+        if      ( p[0] < bbox[0] ) bbox[0] = p[0];
         else if ( p[0] > bbox[1] ) bbox[1] = p[0];
 
-             if ( p[1] < bbox[2] ) bbox[2] = p[1];
+        if      ( p[1] < bbox[2] ) bbox[2] = p[1];
         else if ( p[1] > bbox[3] ) bbox[3] = p[1];
 
-             if ( p[2] < bbox[4] ) bbox[4] = p[2];
+        if      ( p[2] < bbox[4] ) bbox[4] = p[2];
         else if ( p[2] > bbox[5] ) bbox[5] = p[2];
       }
 


### PR DESCRIPTION
This fixes 2 of the 3 files which cause gcc to warn about misleading-intentation. Small changes, but ```auxiliary.h``` is included several times causing  duplicate warnings.

Compiling with gcc 7.2.1 gave 159 warnings (only 78 of which were unique).
This pull request fixes 23 warnings.

I've put them into two commits, which I can rebase and squash before merging.

For the file which I didn't fix in this pull request, 3 misleading indentation warnings remain.
I can fix and add to this, but first I just wanted to ask for feedback.

The 3rd is ```outofcore/src/cJSON.cpp``` lines 41 & 469 are easy.
line 496 not so straightforward to maintain the style of that file- which seems to like piling lines of code on the same line.

```
cJSON.cpp: In function ‘int cJSON_strcasecmp(const char*, const char*)’:
cJSON.cpp:41:2: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  if (!s1) return (s1==s2)?0:1;if (!s2) return 1;
  ^~
cJSON.cpp:41:31: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (!s1) return (s1==s2)?0:1;if (!s2) return 1;
                               ^~
cJSON.cpp: In function ‘char* print_object(cJSON*, int, int)’:
cJSON.cpp:469:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   if (fmt) *ptr++='\n';*ptr=0;
   ^~
cJSON.cpp:469:24: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
   if (fmt) *ptr++='\n';*ptr=0;
                        ^
cJSON.cpp: In function ‘cJSON* cJSON_DetachItemFromArray(cJSON*, int)’:
cJSON.cpp:496:2: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  if (c->prev) c->prev->next=c->next;if (c->next) c->next->prev=c->prev;if (c==array->child) array->child=c->next;c->prev=c->next=0;return c;}
  ^~
cJSON.cpp:496:37: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (c->prev) c->prev->next=c->next;if (c->next) c->next->prev=c->prev;if (c==array->child) array->child=c->next;c->prev=c->next=0;return c;}
                                     ^~

```