### PR TITLE
[c++] replace auto_ptr with unique_ptr

### DIFF
--- a/visualization/include/pcl/visualization/cloud_viewer.h
+++ b/visualization/include/pcl/visualization/cloud_viewer.h
@@ -37,7 +37,7 @@
 #define PCL_CLOUD_VIEWER_H_
 
 #include <pcl/visualization/pcl_visualizer.h> //pcl vis
-#include <boost/move/unique_ptr.hpp> // unique ptr for pre-C++11
+#include <boost/scoped_ptr.hpp> // scoped_ptr for pre-C++11
 
 #include <string>
 
@@ -200,7 +200,7 @@ namespace pcl
       private:
         /** \brief Private implementation. */
         struct CloudViewer_impl;
-	boost::movelib::unique_ptr<CloudViewer_impl> impl_;
+	boost::scoped_ptr<CloudViewer_impl> impl_;
         
         boost::signals2::connection 
         registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)>);

--- a/visualization/include/pcl/visualization/cloud_viewer.h
+++ b/visualization/include/pcl/visualization/cloud_viewer.h
@@ -199,7 +199,7 @@ namespace pcl
       private:
         /** \brief Private implementation. */
         struct CloudViewer_impl;
-        std::auto_ptr<CloudViewer_impl> impl_;
+        std::unique_ptr<CloudViewer_impl> impl_;
         
         boost::signals2::connection 
         registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)>);

--- a/visualization/include/pcl/visualization/cloud_viewer.h
+++ b/visualization/include/pcl/visualization/cloud_viewer.h
@@ -37,6 +37,7 @@
 #define PCL_CLOUD_VIEWER_H_
 
 #include <pcl/visualization/pcl_visualizer.h> //pcl vis
+#include <boost/move/unique_ptr.hpp> // unique ptr for pre-C++11
 
 #include <string>
 
@@ -199,7 +200,7 @@ namespace pcl
       private:
         /** \brief Private implementation. */
         struct CloudViewer_impl;
-        std::unique_ptr<CloudViewer_impl> impl_;
+	boost::movelib::unique_ptr<CloudViewer_impl> impl_;
         
         boost::signals2::connection 
         registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)>);


### PR DESCRIPTION
C++11 deprecated auto_ptr and c++17 removes it.

It looks like this is just a straight forward replacement... it's being used in the pimpl pattern.