### PR TITLE
Modify STRICT_ALIGN because macro expansion w/defined is undefined

### DIFF
--- a/io/src/lzf.cpp
+++ b/io/src/lzf.cpp
@@ -54,7 +54,11 @@
 typedef unsigned int LZF_HSLOT;
 typedef unsigned int LZF_STATE[1 << (HLOG)];
 
-#define STRICT_ALIGN !(defined(__i386) || defined (__amd64))
+#if !(defined(__i386) || defined (__amd64))
+# define STRICT_ALIGN 1
+#else
+# define STRICT_ALIGN 0
+#endif
 #if !STRICT_ALIGN
 /* for unaligned accesses we need a 16 bit datatype. */
 # if USHRT_MAX == 65535


### PR DESCRIPTION
Modify STRICT_ALIGN because macro expansion producing 'defined' has
undefined behavior.

Signed-off-by: Kevin Dalley <kevin@kelphead.org>

Edit: Fixes #2042 