### PR TITLE
[TUTO] Fix the tutorial qt_visualizer compilation issue: qt4 -> qt5.

### DIFF
--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -11,10 +11,10 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package (Qt5 REQUIRED Widgets)
+find_package(Qt5 REQUIRED Widgets)
 
-find_package (VTK REQUIRED)
-find_package (PCL 1.7.1 REQUIRED)
+find_package(VTK REQUIRED)
+find_package(PCL 1.7.1 REQUIRED)
 
 # Fix a compilation bug under ubuntu 16.04 (Xenial)
 list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
@@ -23,10 +23,10 @@ include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
-set (project_SOURCES main.cpp pclviewer.cpp)
+set(project_SOURCES main.cpp pclviewer.cpp)
 
-add_executable (${PROJECT_NAME} ${project_SOURCES})
+add_executable(${PROJECT_NAME} ${project_SOURCES})
 
-target_link_libraries (${PROJECT_NAME} ${PCL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
 
 qt5_use_modules(${PROJECT_NAME} Widgets)

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -1,28 +1,32 @@
-cmake_minimum_required (VERSION 2.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.11)
 
-project      (pcl-colorize_cloud)
-find_package (Qt4 REQUIRED)
+project(pcl_colorize_cloud)
+
+# init_qt: Let's do the CMake job for us
+set(CMAKE_AUTOMOC ON) # For meta object compiler
+set(CMAKE_AUTORCC ON) # Resource files
+set(CMAKE_AUTOUIC ON) # UI files
+
+# Find includes in corresponding build directories
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Find the QtWidgets library
+find_package (Qt5 REQUIRED Widgets)
+
 find_package (VTK REQUIRED)
 find_package (PCL 1.7.1 REQUIRED)
 
-include_directories (${PCL_INCLUDE_DIRS})
-link_directories    (${PCL_LIBRARY_DIRS})
-add_definitions     (${PCL_DEFINITIONS})
+# Fix a compilation bug under ubuntu 16.04 (Xenial)
+list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
+
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 set  (project_SOURCES main.cpp pclviewer.cpp)
-set  (project_HEADERS pclviewer.h)
-set  (project_FORMS   pclviewer.ui)
-set  (VTK_LIBRARIES   vtkRendering vtkGraphics vtkHybrid QVTK)
 
-QT4_WRAP_CPP (project_HEADERS_MOC   ${project_HEADERS})
-QT4_WRAP_UI  (project_FORMS_HEADERS ${project_FORMS})
+ADD_EXECUTABLE  (pcl_colorize_cloud ${project_SOURCES})
 
-INCLUDE         (${QT_USE_FILE})
-ADD_DEFINITIONS (${QT_DEFINITIONS})
+TARGET_LINK_LIBRARIES (${PROJECT_NAME} ${QT_LIBRARIES} ${PCL_LIBRARIES})
 
-ADD_EXECUTABLE  (colorize_cloud ${project_SOURCES}
-                                ${project_FORMS_HEADERS}
-                                ${project_HEADERS_MOC})
-
-TARGET_LINK_LIBRARIES (colorize_cloud ${QT_LIBRARIES} ${PCL_LIBRARIES} ${VTK_LIBRARIES})
-
+qt5_use_modules(${PROJECT_NAME} Widgets)

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -23,10 +23,10 @@ include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
-set  (project_SOURCES main.cpp pclviewer.cpp)
+set (project_SOURCES main.cpp pclviewer.cpp)
 
-ADD_EXECUTABLE  (pcl_colorize_cloud ${project_SOURCES})
+add_executable (${PROJECT_NAME} ${project_SOURCES})
 
-TARGET_LINK_LIBRARIES (${PROJECT_NAME} ${QT_LIBRARIES} ${PCL_LIBRARIES})
+target_link_libraries (${PROJECT_NAME} ${PCL_LIBRARIES})
 
 qt5_use_modules(${PROJECT_NAME} Widgets)

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(PCL 1.7.1 REQUIRED)
 list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
 
 include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
 set(project_SOURCES main.cpp pclviewer.cpp)

--- a/doc/tutorials/content/sources/qt_colorize_cloud/pclviewer.cpp
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/pclviewer.cpp
@@ -1,5 +1,5 @@
 #include "pclviewer.h"
-#include "../build/ui_pclviewer.h"
+#include "ui_pclviewer.h"
 
 PCLViewer::PCLViewer (QWidget *parent) :
     QMainWindow (parent),

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -1,28 +1,32 @@
-cmake_minimum_required (VERSION 2.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.11)
 
-project      (pcl-visualizer)
-find_package (Qt4 REQUIRED)
+project(pcl_visualizer)
+
+# init_qt: Let's do the CMake job for us
+set(CMAKE_AUTOMOC ON) # For meta object compiler
+set(CMAKE_AUTORCC ON) # Resource files
+set(CMAKE_AUTOUIC ON) # UI files
+
+# Find includes in corresponding build directories
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Find the QtWidgets library
+find_package (Qt5 REQUIRED Widgets)
+
 find_package (VTK REQUIRED)
 find_package (PCL 1.7.1 REQUIRED)
 
-include_directories (${PCL_INCLUDE_DIRS})
-link_directories    (${PCL_LIBRARY_DIRS})
-add_definitions     (${PCL_DEFINITIONS})
+# Fix a compilation bug under ubuntu 16.04 (Xenial)
+list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
+
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 set  (project_SOURCES main.cpp pclviewer.cpp)
-set  (project_HEADERS pclviewer.h)
-set  (project_FORMS   pclviewer.ui)
-set  (VTK_LIBRARIES   vtkRendering vtkGraphics vtkHybrid QVTK)
 
-QT4_WRAP_CPP (project_HEADERS_MOC   ${project_HEADERS})
-QT4_WRAP_UI  (project_FORMS_HEADERS ${project_FORMS})
+ADD_EXECUTABLE  (pcl_visualizer ${project_SOURCES})
 
-INCLUDE         (${QT_USE_FILE})
-ADD_DEFINITIONS (${QT_DEFINITIONS})
+TARGET_LINK_LIBRARIES (${PROJECT_NAME} ${QT_LIBRARIES} ${PCL_LIBRARIES})
 
-ADD_EXECUTABLE  (pcl_visualizer ${project_SOURCES}
-                                ${project_FORMS_HEADERS}
-                                ${project_HEADERS_MOC})
-
-TARGET_LINK_LIBRARIES (pcl_visualizer ${QT_LIBRARIES} ${PCL_LIBRARIES} ${VTK_LIBRARIES})
-
+qt5_use_modules(${PROJECT_NAME} Widgets)

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(PCL 1.7.1 REQUIRED)
 list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
 
 include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
 set(project_SOURCES main.cpp pclviewer.cpp)

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -11,10 +11,10 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package (Qt5 REQUIRED Widgets)
+find_package(Qt5 REQUIRED Widgets)
 
-find_package (VTK REQUIRED)
-find_package (PCL 1.7.1 REQUIRED)
+find_package(VTK REQUIRED)
+find_package(PCL 1.7.1 REQUIRED)
 
 # Fix a compilation bug under ubuntu 16.04 (Xenial)
 list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
@@ -23,10 +23,10 @@ include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
-set  (project_SOURCES main.cpp pclviewer.cpp)
+set(project_SOURCES main.cpp pclviewer.cpp)
 
-ADD_EXECUTABLE  (pcl_visualizer ${project_SOURCES})
+add_executable(${PROJECT_NAME} ${project_SOURCES})
 
-TARGET_LINK_LIBRARIES (${PROJECT_NAME} ${QT_LIBRARIES} ${PCL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
 
 qt5_use_modules(${PROJECT_NAME} Widgets)

--- a/doc/tutorials/content/sources/qt_visualizer/pclviewer.cpp
+++ b/doc/tutorials/content/sources/qt_visualizer/pclviewer.cpp
@@ -1,5 +1,5 @@
 #include "pclviewer.h"
-#include "../build/ui_pclviewer.h"
+#include "ui_pclviewer.h"
 
 PCLViewer::PCLViewer (QWidget *parent) :
   QMainWindow (parent),


### PR DESCRIPTION
When I try to compile and execute the example `doc/tutorials/content/sources/qt_visualizer`, I got a mysterious and immediat error concerning `realloc()`. After some research I found this comment that describes the issue:  
https://stackoverflow.com/questions/36725763/c-realloc-invalid-pointer#comments-36725978

It's not possible to have a program that links to both Qt4 and Qt5 libraries. The dependance from Qt4 comes from the file CMakeLists.txt given as example, and the dependance from Qt5 comes from VTK library.

The purpose of this pull request is to provide an example of PCL using Qt5 as graphical interface, instead of Qt4.

Documentation ressources:
https://github.com/euler0/mini-cmake-qt/blob/master/CMakeLists.txt
http://doc.qt.io/qt-5/cmake-manual.html
https://wiki.qt.io/Using_CMake_build_system