### PR TITLE
Suppress control reaches end of non-void function in io.h

### DIFF
--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -174,14 +174,14 @@ namespace pcl
           return (pcl::PCLPointField::INT8);
         if (type == 'U')
           return (pcl::PCLPointField::UINT8);
-	break;
+        break;
 
       case 2:
         if (type == 'I')
           return (pcl::PCLPointField::INT16);
         if (type == 'U')
           return (pcl::PCLPointField::UINT16);
-	break;
+        break;
 
       case 4:
         if (type == 'I')
@@ -190,16 +190,14 @@ namespace pcl
           return (pcl::PCLPointField::UINT32);
         if (type == 'F')
           return (pcl::PCLPointField::FLOAT32);
-	break;
+        break;
 
       case 8:
-        return (pcl::PCLPointField::FLOAT64);
-
-      default:
-	break;
-
-      return (-1);
+        if (type == 'F')
+          return (pcl::PCLPointField::FLOAT64);
+        break;
     }
+    return (-1);
   }
 
   /** \brief Obtains the type of the PCLPointField from a specific PCLPointField as a char

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -90,7 +90,7 @@ TEST (PCL, ComplexPCDFileASCII)
   EXPECT_EQ (blob.fields[1].name, "_");
   EXPECT_EQ (blob.fields[1].offset, 4 * 33);
   EXPECT_EQ (blob.fields[1].count, 10);
-  EXPECT_EQ (blob.fields[1].datatype, pcl::PCLPointField::FLOAT32);
+  EXPECT_EQ (blob.fields[1].datatype, (uint8_t) -1);
   
   EXPECT_EQ (blob.fields[2].name, "x");
   EXPECT_EQ (blob.fields[2].offset, 4 * 33 + 10 * 1);


### PR DESCRIPTION
There were some indentation changes (I shouldn't I know...) because of a previous use of a tab instead of spaces. It was looking very bad with my editor.