### PR TITLE
Update finder scripts for Ensenso, OpenNI, and OpenNI2

### DIFF
--- a/cmake/Modules/FindEnsenso.cmake
+++ b/cmake/Modules/FindEnsenso.cmake
@@ -1,35 +1,48 @@
 ###############################################################################
-# - Try to find Ensenso SDK (IDS-Imaging)
-# Once done this will define
-#  ENSENSO_FOUND - System has Ensenso SDK
-#  ENSENSO_INCLUDE_DIRS - The Ensenso SDK include directories
-#  ENSENSO_LIBRARIES - The libraries needed to use Ensenso SDK
-#  ENSENSO_DEFINITIONS - Compiler switches required for using Ensenso SDK
-# -----------------------
+# Find Ensenso SDK (IDS-Imaging)
+#
+#     find_package(Ensenso)
+#
+# Variables defined by this module:
+#
+#  ENSENSO_FOUND               True if Ensenso SDK was found
+#  ENSENSO_INCLUDE_DIRS        The location(s) of Ensenso SDK headers
+#  ENSENSO_LIBRARIES           Libraries needed to use Ensenso SDK
 
 find_path(ENSENSO_INCLUDE_DIR nxLib.h
-          HINTS ${ENSENSO_ABI_HINT}
-          /opt/ensenso/development/c
-          "$ENV{PROGRAMFILES}/Ensenso/development/c" "$ENV{PROGRAMW6432}/Ensenso/development/c"
+          HINTS "${ENSENSO_ABI_HINT}"
+                "/opt/ensenso/development/c"
+                "$ENV{PROGRAMFILES}/Ensenso/development/c"
+                "$ENV{PROGRAMW6432}/Ensenso/development/c"
           PATH_SUFFIXES include/)
 
-find_library(ENSENSO_LIBRARY QUIET NAMES NxLib64 NxLib32 nxLib64 nxLib32
-             HINTS ${ENSENSO_ABI_HINT}
-             "$ENV{PROGRAMFILES}/Ensenso/development/c" "$ENV{PROGRAMW6432}/Ensenso/development/c"
+find_library(ENSENSO_LIBRARY QUIET
+             NAMES NxLib64 NxLib32 nxLib64 nxLib32
+             HINTS "${ENSENSO_ABI_HINT}"
+                   "$ENV{PROGRAMFILES}/Ensenso/development/c"
+                   "$ENV{PROGRAMW6432}/Ensenso/development/c"
              PATH_SUFFIXES lib/)
 
-set(ENSENSO_LIBRARIES ${ENSENSO_LIBRARY})
-set(ENSENSO_INCLUDE_DIRS ${ENSENSO_INCLUDE_DIR})
+if(ENSENSO_INCLUDE_DIR AND ENSENSO_LIBRARY)
+
+  # Include directories
+  set(ENSENSO_INCLUDE_DIRS ${ENSENSO_INCLUDE_DIR})
+  unset(ENSENSO_INCLUDE_DIR)
+  mark_as_advanced(ENSENSO_INCLUDE_DIRS)
+
+  # Libraries
+  set(ENSENSO_LIBRARIES ${ENSENSO_LIBRARY})
+  unset(ENSENSO_LIBRARY)
+  mark_as_advanced(ENSENSO_LIBRARIES)
+
+endif()
 
 include(FindPackageHandleStandardArgs)
-# handle the QUIETLY and REQUIRED arguments and set ENSENSO_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(ensenso DEFAULT_MSG
-                                  ENSENSO_LIBRARY ENSENSO_INCLUDE_DIR)
-
-mark_as_advanced(ENSENSO_INCLUDE_DIR ENSENSO_LIBRARY)
+find_package_handle_standard_args(ENSENSO
+  FOUND_VAR ENSENSO_FOUND
+  REQUIRED_VARS ENSENSO_LIBRARIES ENSENSO_INCLUDE_DIRS
+)
 
 if(ENSENSO_FOUND)
-  message(STATUS "Ensenso SDK found")
-endif(ENSENSO_FOUND)
-
+  message(STATUS "Ensenso found (include: ${ENSENSO_INCLUDE_DIRS}, lib: ${ENSENSO_LIBRARIES})")
+endif()

--- a/cmake/Modules/FindOpenNI.cmake
+++ b/cmake/Modules/FindOpenNI.cmake
@@ -1,13 +1,14 @@
 ###############################################################################
 # Find OpenNI
 #
-# This sets the following variables:
-# OPENNI_FOUND - True if OPENNI was found.
-# OPENNI_INCLUDE_DIRS - Directories containing the OPENNI include files.
-# OPENNI_LIBRARIES - Libraries needed to use OPENNI.
-# OPENNI_DEFINITIONS - Compiler flags for OPENNI.
+#     find_package(OpenNI)
 #
-# For libusb-1.0, add USB_10_ROOT if not found
+# Variables defined by this module:
+#
+#  OPENNI_FOUND                True if OpenNI was found
+#  OPENNI_INCLUDE_DIRS         The location(s) of OpenNI headers
+#  OPENNI_LIBRARIES            Libraries needed to use OpenNI
+#  OPENNI_DEFINITIONS          Compiler flags for OpenNI
 
 find_package(PkgConfig QUIET)
 
@@ -47,31 +48,53 @@ if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(OPENNI_SUFFIX 64)
 endif(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
 
-#add a hint so that it can find it without the pkg-config
+# Add a hint so that it can find it without the pkg-config
 find_path(OPENNI_INCLUDE_DIR XnStatus.h
-          HINTS ${PC_OPENNI_INCLUDEDIR} ${PC_OPENNI_INCLUDE_DIRS} /usr/include/openni /usr/include/ni /opt/local/include/ni "${OPENNI_ROOT}" "$ENV{OPENNI_ROOT}"
+          HINTS ${PC_OPENNI_INCLUDEDIR}
+                ${PC_OPENNI_INCLUDE_DIRS}
+                /usr/include/openni
+                /usr/include/ni
+                /opt/local/include/ni
+                "${OPENNI_ROOT}"
+                "$ENV{OPENNI_ROOT}"
           PATHS "$ENV{OPEN_NI_INSTALL_PATH${OPENNI_SUFFIX}}/Include"
           PATH_SUFFIXES openni include Include)
-#add a hint so that it can find it without the pkg-config
+
+# Add a hint so that it can find it without the pkg-config
 find_library(OPENNI_LIBRARY
              NAMES OpenNI${OPENNI_SUFFIX}
-             HINTS ${PC_OPENNI_LIBDIR} ${PC_OPENNI_LIBRARY_DIRS} /usr/lib "${OPENNI_ROOT}" "$ENV{OPENNI_ROOT}"
+             HINTS ${PC_OPENNI_LIBDIR}
+                   ${PC_OPENNI_LIBRARY_DIRS}
+                   /usr/lib
+                   "${OPENNI_ROOT}"
+                   "$ENV{OPENNI_ROOT}"
              PATHS "$ENV{OPEN_NI_LIB${OPENNI_SUFFIX}}"
              PATH_SUFFIXES lib Lib Lib64)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(OPENNI_LIBRARIES ${OPENNI_LIBRARY} ${LIBUSB_1_LIBRARIES})
-else()
-  set(OPENNI_LIBRARIES ${OPENNI_LIBRARY})
+if(OPENNI_INCLUDE_DIR AND OPENNI_LIBRARY)
+
+  # Include directories
+  set(OPENNI_INCLUDE_DIRS ${OPENNI_INCLUDE_DIR})
+  unset(OPENNI_INCLUDE_DIR)
+  mark_as_advanced(OPENNI_INCLUDE_DIRS)
+
+  # Libraries
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(OPENNI_LIBRARIES ${OPENNI_LIBRARY} ${LIBUSB_1_LIBRARIES})
+  else()
+    set(OPENNI_LIBRARIES ${OPENNI_LIBRARY})
+  endif()
+  unset(OPENNI_LIBRARY)
+  mark_as_advanced(OPENNI_LIBRARIES)
+
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(OpenNI DEFAULT_MSG OPENNI_LIBRARY OPENNI_INCLUDE_DIR)
-
-mark_as_advanced(OPENNI_LIBRARY OPENNI_INCLUDE_DIR)
+find_package_handle_standard_args(OpenNI
+  FOUND_VAR OPENNI_FOUND
+  REQUIRED_VARS OPENNI_LIBRARIES OPENNI_INCLUDE_DIRS
+)
 
 if(OPENNI_FOUND)
-  # Add the include directories
-  set(OPENNI_INCLUDE_DIRS ${OPENNI_INCLUDE_DIR})
-  message(STATUS "OpenNI found (include: ${OPENNI_INCLUDE_DIRS}, lib: ${OPENNI_LIBRARY})")
-endif(OPENNI_FOUND)
+  message(STATUS "OpenNI found (include: ${OPENNI_INCLUDE_DIRS}, lib: ${OPENNI_LIBRARIES})")
+endif()

--- a/cmake/Modules/FindOpenNI2.cmake
+++ b/cmake/Modules/FindOpenNI2.cmake
@@ -1,13 +1,14 @@
 ###############################################################################
-# Find OpenNI 2
+# Find OpenNI2
 #
-# This sets the following variables:
-# OPENNI2_FOUND - True if OPENNI 2 was found.
-# OPENNI2_INCLUDE_DIRS - Directories containing the OPENNI 2 include files.
-# OPENNI2_LIBRARIES - Libraries needed to use OPENNI 2.
-# OPENNI2_DEFINITIONS - Compiler flags for OPENNI 2.
+#     find_package(OpenNI2)
 #
-# For libusb-1.0, add USB_10_ROOT if not found
+# Variables defined by this module:
+#
+#  OPENNI2_FOUND               True if OpenNI2 was found
+#  OPENNI2_INCLUDE_DIRS        The location(s) of OpenNI2 headers
+#  OPENNI2_LIBRARIES           Libraries needed to use OpenNI2
+#  OPENNI2_DEFINITIONS         Compiler flags for OpenNI2
 
 find_package(PkgConfig QUIET)
 
@@ -47,34 +48,45 @@ if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(OPENNI2_SUFFIX 64)
 endif(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
 
-find_path(OPENNI2_INCLUDE_DIRS OpenNI.h
-    PATHS
-    "$ENV{OPENNI2_INCLUDE${OPENNI2_SUFFIX}}"  # Win64 needs '64' suffix
-    /usr/include/openni2  # common path for deb packages
+find_path(OPENNI2_INCLUDE_DIR OpenNI.h
+          PATHS "$ENV{OPENNI2_INCLUDE${OPENNI2_SUFFIX}}"  # Win64 needs '64' suffix
+                "/usr/include/openni2"                    # common path for deb packages
 )
 
 find_library(OPENNI2_LIBRARY
-             NAMES OpenNI2  # No suffix needed on Win64
-             libOpenNI2     # Linux
-             PATHS "$ENV{OPENNI2_LIB${OPENNI2_SUFFIX}}"  # Windows default path, Win64 needs '64' suffix
-             "$ENV{OPENNI2_REDIST}"                      # Linux install does not use a separate 'lib' directory
-             )
+             NAMES OpenNI2      # No suffix needed on Win64
+                   libOpenNI2   # Linux
+             PATHS "$ENV{OPENNI2_LIB${OPENNI2_SUFFIX}}"   # Windows default path, Win64 needs '64' suffix
+                   "$ENV{OPENNI2_REDIST}"                 # Linux install does not use a separate 'lib' directory
+)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(OPENNI2_LIBRARIES ${OPENNI2_LIBRARY} ${LIBUSB_1_LIBRARIES})
-else()
-  set(OPENNI2_LIBRARIES ${OPENNI2_LIBRARY})
+if(OPENNI2_INCLUDE_DIR AND OPENNI2_LIBRARY)
+
+  # Include directories
+  set(OPENNI2_INCLUDE_DIRS ${OPENNI2_INCLUDE_DIR})
+  unset(OPENNI2_INCLUDE_DIR)
+  mark_as_advanced(OPENNI2_INCLUDE_DIRS)
+
+  # Libraries
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(OPENNI2_LIBRARIES ${OPENNI2_LIBRARY} ${LIBUSB_1_LIBRARIES})
+  else()
+    set(OPENNI2_LIBRARIES ${OPENNI2_LIBRARY})
+  endif()
+  unset(OPENNI2_LIBRARY)
+  mark_as_advanced(OPENNI2_LIBRARIES)
+
+  set(OPENNI2_REDIST_DIR $ENV{OPENNI2_REDIST${OPENNI2_SUFFIX}})
+  mark_as_advanced(OPENNI2_REDIST_DIR)
+
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(OpenNI2 DEFAULT_MSG OPENNI2_LIBRARY OPENNI2_INCLUDE_DIRS)
-
-mark_as_advanced(OPENNI2_LIBRARY OPENNI2_INCLUDE_DIRS)
+find_package_handle_standard_args(OpenNI2
+  FOUND_VAR OPENNI2_FOUND
+  REQUIRED_VARS OPENNI2_LIBRARIES OPENNI2_INCLUDE_DIRS
+)
 
 if(OPENNI2_FOUND)
-  # Add the include directories
-  set(OPENNI2_INCLUDE_DIRS ${OPENNI2_INCLUDE_DIR})
-  set(OPENNI2_REDIST_DIR $ENV{OPENNI2_REDIST${OPENNI2_SUFFIX}})
-  message(STATUS "OpenNI 2 found (include: ${OPENNI2_INCLUDE_DIRS}, lib: ${OPENNI2_LIBRARY}, redist: ${OPENNI2_REDIST_DIR})")
-endif(OPENNI2_FOUND)
-
+  message(STATUS "OpenNI2 found (include: ${OPENNI2_INCLUDE_DIRS}, lib: ${OPENNI2_LIBRARIES})")
+endif()


### PR DESCRIPTION
* Make sure `XXX_LIBRARIES` and `XXX_INCLUDE_DIRS` variables are not defined
  if the packages are not found
* Make `XXX_LIBRARIES` and `XXX_INCLUDE_DIRS` advanced options
* Some reformatting

Fixes #2059