### PR TITLE
fix for add/remove TEXT3D in multiport view

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -669,7 +669,8 @@ pcl::visualization::PCLVisualizer::addText3D (
   else
     tid = id;
 
-  if (contains (tid))
+  std::string idToCheck = viewport > 0 ? tid.append(viewport, '*') : tid;
+  if (contains (idToCheck))
   {
     PCL_WARN ("[addText3D] The id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
     return (false);

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -669,10 +669,10 @@ pcl::visualization::PCLVisualizer::addText3D (
   else
     tid = id;
 
-  std::string idToCheck = viewport > 0 ? tid.append(viewport, '*') : tid;
-  if (contains (idToCheck))
+  std::string id_to_check = viewport > 0 ? tid.append (viewport, '*') : tid;
+  if (contains (id_to_check))
   {
-    PCL_WARN ("[addText3D] The id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
+    PCL_WARN ("[addText3D] The id <%s> already exists in viewport [%d]! Please choose a different id and retry.\n", id.c_str (), viewport);
     return (false);
   }
 

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -916,9 +916,9 @@ bool
 pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int viewport)
 {
   // Check to see if the given ID entry exists
-  std::string idToCheck(id);
-  if(viewport > 0) idToCheck.append(viewport, '*');
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (idToCheck);
+  std::string id_to_check (id);
+  if (viewport > 0) id_to_check.append (viewport, '*');
+  ShapeActorMap::iterator am_it = shape_actor_map_->find (id_to_check);
 
   if (am_it == shape_actor_map_->end ())
   {

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -916,7 +916,9 @@ bool
 pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int viewport)
 {
   // Check to see if the given ID entry exists
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  std::string idToCheck(id);
+  if(viewport > 0) idToCheck.append(viewport, '*');
+  ShapeActorMap::iterator am_it = shape_actor_map_->find (idToCheck);
 
   if (am_it == shape_actor_map_->end ())
   {

--- a/visualization/test/CMakeLists.txt
+++ b/visualization/test/CMakeLists.txt
@@ -9,3 +9,5 @@
 #add_executable(demo_shapes test_shapes.cpp)
 #target_link_libraries(demo_shapes pcl_common pcl_io pcl_kdtree pcl_visualization)
 
+#add_executable(demo_shapes_multiport test_shapes_multiport.cpp)
+#target_link_libraries(demo_shapes_multiport pcl_common pcl_io pcl_kdtree pcl_visualization)

--- a/visualization/test/test_shapes_multiport.cpp
+++ b/visualization/test/test_shapes_multiport.cpp
@@ -51,4 +51,6 @@ main (int , char **)
   p.spin ();
   p.addText3D ("text3D_to_remove", cloud->points[1], 1.0, 0.0, 1.0, 0.0, rightPort);
   p.spin ();
+  p.removeText3D ("text3D_to_remove", rightPort);
+  p.spin ();
 }

--- a/visualization/test/test_shapes_multiport.cpp
+++ b/visualization/test/test_shapes_multiport.cpp
@@ -1,0 +1,54 @@
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/io/pcd_io.h>
+
+using pcl::PointCloud;
+using pcl::PointXYZ;
+
+int 
+main (int , char **)
+{
+  srand (unsigned (time (0)));
+
+  PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ>);
+
+  cloud->points.resize (5);
+  for (size_t i = 0; i < cloud->points.size (); ++i)
+  {
+    cloud->points[i].x = float (i); 
+    cloud->points[i].y = float (i / 2);
+    cloud->points[i].z = 0.0f;
+  }
+
+  // Start the visualizer
+  pcl::visualization::PCLVisualizer p ("test_shapes");
+  int leftPort(0);
+  int rightPort(0);
+  p.createViewPort(0, 0, 0.5, 1, leftPort);
+  p.createViewPort(0.5, 0, 1, 1, rightPort);
+  p.setBackgroundColor (1, 1, 1);
+  p.addCoordinateSystem (1.0, "first");
+
+  //p.addPolygon (cloud, "polygon");
+  p.addPolygon<PointXYZ> (cloud, 1.0, 0.0, 0.0, "polygon", leftPort);
+  p.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "polygon", leftPort);
+  
+  p.addLine<PointXYZ, PointXYZ> (cloud->points[0], cloud->points[1], 0.0, 1.0, 0.0, "line", leftPort);
+  p.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 50, "line", leftPort);
+
+  p.addSphere<PointXYZ> (cloud->points[0], 1, 0.0, 1.0, 0.0, "sphere", leftPort);
+  p.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 5, "sphere", leftPort);
+//  p.removePolygon ("poly");
+
+  p.addText ("text", 200, 200, 1.0, 0, 0, "text", leftPort);
+  
+  p.addText3D ("text3D", cloud->points[0], 1.0, 1.0, 0.0, 0.0, rightPort);
+  p.spin ();
+  p.removeCoordinateSystem ("first", 0);
+  p.spin ();
+  p.addCoordinateSystem (1.0, 5, 3, 1, "second");
+  p.spin ();
+  p.removeCoordinateSystem ("second", 0);
+  p.spin ();
+  p.addText3D ("text3D_to_remove", cloud->points[1], 1.0, 0.0, 1.0, 0.0, rightPort);
+  p.spin ();
+}


### PR DESCRIPTION
Added check for viewport when adding Text3D and removing Text3D. Added test cases for multi-port scenario for shapes.

**Maintainer edit:** fixes #2049.