### PR TITLE
VTK function change since version 7.1

### DIFF
--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -489,9 +489,13 @@ CPCSegmentation Parameters: \n\
           color = concave_color;
 
         // two times since we add also two points per edge
+#if (VTK_MAJOR_VERSION < 7) || (VTK_MAJOR_VERSION==7 && VTK_MINOR_VERSION==0)
         colors->InsertNextTupleValue (color);
         colors->InsertNextTupleValue (color);
-
+#else       
+        colors->InsertNextTypedTuple(color);
+        colors->InsertNextTypedTuple(color);
+#endif      
         pcl::Supervoxel<PointT>::Ptr supervoxel = supervoxel_clusters.at (sv_label);
         pcl::PointXYZRGBA vert_curr = supervoxel->centroid_;
 

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -489,12 +489,12 @@ CPCSegmentation Parameters: \n\
           color = concave_color;
 
         // two times since we add also two points per edge
-#if (VTK_MAJOR_VERSION < 7) || (VTK_MAJOR_VERSION==7 && VTK_MINOR_VERSION==0)
+#if (VTK_MAJOR_VERSION < 7) || (VTK_MAJOR_VERSION == 7 && VTK_MINOR_VERSION == 0)
         colors->InsertNextTupleValue (color);
         colors->InsertNextTupleValue (color);
 #else       
-        colors->InsertNextTypedTuple(color);
-        colors->InsertNextTypedTuple(color);
+        colors->InsertNextTypedTuple (color);
+        colors->InsertNextTypedTuple (color);
 #endif      
         pcl::Supervoxel<PointT>::Ptr supervoxel = supervoxel_clusters.at (sv_label);
         pcl::PointXYZRGBA vert_curr = supervoxel->centroid_;

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -409,12 +409,12 @@ LCCPSegmentation Parameters: \n\
           color = concave_color;
         
         // two times since we add also two points per edge
-#if (VTK_MAJOR_VERSION < 7) || (VTK_MAJOR_VERSION==7 && VTK_MINOR_VERSION==0)
+#if (VTK_MAJOR_VERSION < 7) || (VTK_MAJOR_VERSION == 7 && VTK_MINOR_VERSION == 0)
         colors->InsertNextTupleValue (color);
         colors->InsertNextTupleValue (color);
 #else       
-        colors->InsertNextTypedTuple(color);
-        colors->InsertNextTypedTuple(color);
+        colors->InsertNextTypedTuple (color);
+        colors->InsertNextTypedTuple (color);
 #endif      
         
         pcl::Supervoxel<PointT>::Ptr supervoxel = supervoxel_clusters.at (sv_label);

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -409,8 +409,13 @@ LCCPSegmentation Parameters: \n\
           color = concave_color;
         
         // two times since we add also two points per edge
+#if (VTK_MAJOR_VERSION < 7) || (VTK_MAJOR_VERSION==7 && VTK_MINOR_VERSION==0)
         colors->InsertNextTupleValue (color);
         colors->InsertNextTupleValue (color);
+#else       
+        colors->InsertNextTypedTuple(color);
+        colors->InsertNextTypedTuple(color);
+#endif      
         
         pcl::Supervoxel<PointT>::Ptr supervoxel = supervoxel_clusters.at (sv_label);
         pcl::PointXYZRGBA vert_curr = supervoxel->centroid_;


### PR DESCRIPTION
before VTK 7.1
  `InsertNextTupleValue` 
after
  `InsertNextTypedTuple`

This change is required if you use VTK version >= 7.1.

**Maintainer edit:** fixes #2060.