### PR TITLE
Removed unused member from ply_parser

### DIFF
--- a/io/include/pcl/io/ply/ply_parser.h
+++ b/io/include/pcl/io/ply/ply_parser.h
@@ -304,8 +304,7 @@ namespace pcl
           typedef int flags_type;
           enum flags { };
 
-          ply_parser (flags_type flags = 0) : 
-            flags_ (flags), 
+          ply_parser () :
             comment_callback_ (), obj_info_callback_ (), end_header_callback_ (), 
             line_number_ (0), current_element_ ()
           {}
@@ -391,8 +390,6 @@ namespace pcl
             end_element_callback_type end_element_callback;
             std::vector<boost::shared_ptr<property> > properties;
           };
-
-          flags_type flags_;
           
           info_callback_type info_callback_;
           warning_callback_type warning_callback_;

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -517,8 +517,7 @@ pcl::PLYReader::vertexListPropertyEndCallback () {}
 bool
 pcl::PLYReader::parse (const std::string& istream_filename)
 {
-  pcl::io::ply::ply_parser::flags_type ply_parser_flags = 0;
-  pcl::io::ply::ply_parser ply_parser (ply_parser_flags);
+  pcl::io::ply::ply_parser ply_parser;
 
   ply_parser.info_callback (boost::bind (&pcl::PLYReader::infoCallback, this, boost::ref (istream_filename), _1, _2));
   ply_parser.warning_callback (boost::bind (&pcl::PLYReader::warningCallback, this, boost::ref (istream_filename), _1, _2));

--- a/io/tools/ply/ply2obj.cpp
+++ b/io/tools/ply/ply2obj.cpp
@@ -294,8 +294,7 @@ ply_to_obj_converter::face_end ()
 bool 
 ply_to_obj_converter::convert (std::istream&, const std::string& istream_filename, std::ostream& ostream, const std::string&)
 {
-  pcl::io::ply::ply_parser::flags_type ply_parser_flags = 0;
-  pcl::io::ply::ply_parser ply_parser (ply_parser_flags);
+  pcl::io::ply::ply_parser ply_parser;
 
   ply_parser.info_callback (boost::bind (&ply_to_obj_converter::info_callback, this, boost::ref (istream_filename), _1, _2));
   ply_parser.warning_callback (boost::bind (&ply_to_obj_converter::warning_callback, this, boost::ref (istream_filename), _1, _2));

--- a/io/tools/ply/ply2ply.cpp
+++ b/io/tools/ply/ply2ply.cpp
@@ -339,9 +339,7 @@ ply_to_ply_converter::end_header_callback()
 bool 
 ply_to_ply_converter::convert (const std::string &ifilename, std::istream&, std::ostream& ostream)
 {
-  pcl::io::ply::ply_parser::flags_type ply_parser_flags = 0;
-
-  pcl::io::ply::ply_parser ply_parser(ply_parser_flags);
+  pcl::io::ply::ply_parser ply_parser;
 
   ply_parser.info_callback(boost::bind(&ply_to_ply_converter::info_callback, this, boost::ref(ifilename), _1, _2));
   ply_parser.warning_callback(boost::bind(&ply_to_ply_converter::warning_callback, this, boost::ref(ifilename), _1, _2));

--- a/io/tools/ply/ply2raw.cpp
+++ b/io/tools/ply/ply2raw.cpp
@@ -303,8 +303,7 @@ ply_to_raw_converter::face_end () {}
 bool 
 ply_to_raw_converter::convert (std::istream&, const std::string& istream_filename, std::ostream& ostream, const std::string&)
 {
-  pcl::io::ply::ply_parser::flags_type ply_parser_flags = 0;
-  pcl::io::ply::ply_parser ply_parser (ply_parser_flags);
+  pcl::io::ply::ply_parser ply_parser;
 
   ply_parser.info_callback (boost::bind (&ply_to_raw_converter::info_callback, this, boost::ref (istream_filename), _1, _2));
   ply_parser.warning_callback (boost::bind (&ply_to_raw_converter::warning_callback, this, boost::ref (istream_filename), _1, _2));


### PR DESCRIPTION
Addresses a unused member warning which was popping up in the CI.

https://travis-ci.org/PointCloudLibrary/pcl/jobs/299802506#L2086-L2088