### PR TITLE
Removal of PCA deprecated constructor

### DIFF
--- a/common/include/pcl/common/impl/pca.hpp
+++ b/common/include/pcl/common/impl/pca.hpp
@@ -46,20 +46,6 @@
 #include <pcl/exceptions.h>
 
 /////////////////////////////////////////////////////////////////////////////////////////
-/** \brief Constructor with direct computation
-  * \param[in] cloud input m*n matrix (ie n vectors of R(m))
-  * \param[in] basis_only flag to compute only the PCA basis
-  */
-template<typename PointT>
-pcl::PCA<PointT>::PCA (const pcl::PointCloud<PointT> &cloud, bool basis_only)
-{
-  Base ();
-  basis_only_ = basis_only;
-  setInputCloud (cloud.makeShared ());
-  compute_done_ = initCompute ();
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> bool
 pcl::PCA<PointT>::initCompute () 
 {

--- a/common/include/pcl/common/pca.h
+++ b/common/include/pcl/common/pca.h
@@ -93,13 +93,6 @@ namespace pcl
         , mean_ ()
         , eigenvalues_  ()
       {}
-      
-      /** \brief Constructor with direct computation
-        * X input m*n matrix (ie n vectors of R(m))
-        * basis_only flag to compute only the PCA basis
-        */
-      PCL_DEPRECATED ("Use PCA (bool basis_only); setInputCloud (X.makeShared ()); instead")
-      PCA (const pcl::PointCloud<PointT>& X, bool basis_only = false);
 
       /** Copy Constructor
         * \param[in] pca PCA object


### PR DESCRIPTION
Deprecation attribute was last modified in 1.7.2. https://github.com/PointCloudLibrary/pcl/commit/38a6f8d554faa91ecbdf18f403c447d352e41a7b