### PR TITLE
The remaining deprecation removals

### DIFF
--- a/filters/include/pcl/filters/conditional_removal.h
+++ b/filters/include/pcl/filters/conditional_removal.h
@@ -622,21 +622,6 @@ namespace pcl
         filter_name_ = "ConditionalRemoval";
       }
 
-      /** \brief a constructor that includes the condition.  
-        * \param condition the condition that each point must satisfy to avoid
-        * being removed by the filter
-        * \param extract_removed_indices extract filtered indices from indices vector
-        */
-      PCL_DEPRECATED ("ConditionalRemoval(ConditionBasePtr condition, bool extract_removed_indices = false) is deprecated, "
-      "please use the setCondition (ConditionBasePtr condition) function instead.")
-      ConditionalRemoval (ConditionBasePtr condition, bool extract_removed_indices = false) :
-        Filter<PointT>::Filter (extract_removed_indices), capable_ (false), keep_organized_ (false), condition_ (),
-        user_filter_value_ (std::numeric_limits<float>::quiet_NaN ())
-      {
-        filter_name_ = "ConditionalRemoval";
-        setCondition (condition);
-      }
-
       /** \brief Set whether the filtered points should be kept and set to the
         * value given through \a setUserFilterValue (default: NaN), or removed
         * from the PointCloud, thus potentially breaking its organized

--- a/io/include/pcl/io/png_io.h
+++ b/io/include/pcl/io/png_io.h
@@ -109,43 +109,6 @@ namespace pcl
     PCL_EXPORTS void
     savePNGFile (const std::string& file_name, const pcl::PCLImage& image);
 
-    /** \brief Saves RGB fields of cloud as image to PNG file. 
-      * \param[in] file_name the name of the file to write to disk
-      * \param[in] cloud point cloud to save
-      * \ingroup io
-      */
-    template <typename T>
-    PCL_DEPRECATED (
-    "pcl::io::savePNGFile<typename T> (file_name, cloud) is deprecated, please use a new generic "
-    "function pcl::io::savePNGFile (file_name, cloud, field_name) with \"rgb\" as the field name."
-    )
-    void
-    savePNGFile (const std::string& file_name, const pcl::PointCloud<T>& cloud)
-    {
-      std::vector<unsigned char> data(cloud.width * cloud.height * 3);
-
-      for (size_t i = 0; i < cloud.points.size (); ++i)
-      {
-        data[i*3 + 0] = cloud.points[i].r;
-        data[i*3 + 1] = cloud.points[i].g;
-        data[i*3 + 2] = cloud.points[i].b;        
-      }
-      saveRgbPNGFile(file_name, &data[0], cloud.width, cloud.height);
-    }
-    
-    /** \brief Saves Labeled Point cloud as image to PNG file. 
-     * \param[in] file_name the name of the file to write to disk
-     * \param[in] cloud point cloud to save
-     * \ingroup io
-     * Warning: Converts to 16 bit (for png), labels using more than 16 bits will cause problems
-     */
-    PCL_EXPORTS PCL_DEPRECATED (
-    "savePNGFile (file_name, cloud) is deprecated, please use a new generic function "
-    "savePNGFile (file_name, cloud, field_name) with \"label\" as the field name."
-    )
-    void
-    savePNGFile (const std::string& file_name, const pcl::PointCloud<pcl::PointXYZL>& cloud);
-
     /** \brief Saves the data from the specified field of the point cloud as image to PNG file.
      * \param[in] file_name the name of the file to write to disk
      * \param[in] cloud point cloud to save

--- a/io/src/png_io.cpp
+++ b/io/src/png_io.cpp
@@ -132,15 +132,3 @@ pcl::io::savePNGFile (const std::string& file_name, const pcl::PCLImage& image)
         PCL_ERROR ("[pcl::io::savePNGFile] Unsupported image encoding \"%s\".\n", image.encoding.c_str ());
     }
 }
-
-void
-pcl::io::savePNGFile (const std::string& file_name, const pcl::PointCloud<pcl::PointXYZL>& cloud)
-{
-	std::vector<unsigned short> data(cloud.width * cloud.height);
-	for (size_t i = 0; i < cloud.points.size (); ++i)
-	{
-		data[i] = static_cast<unsigned short> (cloud.points[i].label);      
-	}
-	saveShortPNGFile(file_name, &data[0], cloud.width, cloud.height,1);
-}
-

--- a/surface/include/pcl/surface/concave_hull.h
+++ b/surface/include/pcl/surface/concave_hull.h
@@ -132,11 +132,6 @@ namespace pcl
       {
         keep_information_ = value;
       }
-
-      /** \brief Returns the dimensionality (2 or 3) of the calculated hull. */
-      PCL_DEPRECATED ("[pcl::ConcaveHull::getDim] This method is deprecated. Please use getDimension () instead.")
-      int
-      getDim () const;
       
       /** \brief Returns the dimensionality (2 or 3) of the calculated hull. */
       inline int

--- a/surface/include/pcl/surface/impl/concave_hull.hpp
+++ b/surface/include/pcl/surface/impl/concave_hull.hpp
@@ -56,16 +56,6 @@
 #include <pcl/surface/qhull.h>
 
 //////////////////////////////////////////////////////////////////////////
-/** \brief Get dimension of concave hull  
-  * \return dimension
-  */                    
-template <typename PointInT> int
-pcl::ConcaveHull<PointInT>::getDim () const
-{
-  return (getDimension ());
-}
-
-//////////////////////////////////////////////////////////////////////////
 template <typename PointInT> void
 pcl::ConcaveHull<PointInT>::reconstruct (PointCloud &output)
 {

--- a/test/surface/test_concave_hull.cpp
+++ b/test/surface/test_concave_hull.cpp
@@ -122,10 +122,6 @@ TEST (PCL, ConcaveHull_planar_bunny)
   PointCloud<PointXYZ> hull_3d;
   concave_hull_3d.reconstruct (hull_3d);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  EXPECT_EQ (concave_hull_3d.getDim (), 3);         // test for PCL_DEPRECATED
-#pragma GCC diagnostic pop
   EXPECT_EQ (concave_hull_3d.getDimension (), 3);
 
   ModelCoefficients::Ptr plane_coefficients (new ModelCoefficients ());

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -293,16 +293,6 @@ namespace pcl
         /** \brief Disables the Orientatation Marker Widget so it is removed from the renderer */
         void
         removeOrientationMarkerWidgetAxes ();
-        
-        /** \brief Adds 3D axes describing a coordinate system to screen at 0,0,0.
-          * \param[in] scale the scale of the axes (default: 1)
-          * \param[in] viewport the view port where the 3D axes should be added (default: all)
-          */
-        PCL_DEPRECATED (
-        "addCoordinateSystem (scale, viewport) is deprecated, please use function "
-        "addCoordinateSystem (scale, id, viewport) with id a unique string identifier.")
-        void
-        addCoordinateSystem (double scale, int viewport);
 
         /** \brief Adds 3D axes describing a coordinate system to screen at 0,0,0.
           * \param[in] scale the scale of the axes (default: 1)
@@ -317,36 +307,11 @@ namespace pcl
           * \param[in] x the X position of the axes
           * \param[in] y the Y position of the axes
           * \param[in] z the Z position of the axes
-          * \param[in] viewport the view port where the 3D axes should be added (default: all)
-          */
-        PCL_DEPRECATED (
-        "addCoordinateSystem (scale, x, y, z, viewport) is deprecated, please use function "
-        "addCoordinateSystem (scale, x, y, z, id, viewport) with id a unique string identifier.")
-        void
-        addCoordinateSystem (double scale, float x, float y, float z, int viewport);
-
-        /** \brief Adds 3D axes describing a coordinate system to screen at x, y, z
-          * \param[in] scale the scale of the axes (default: 1)
-          * \param[in] x the X position of the axes
-          * \param[in] y the Y position of the axes
-          * \param[in] z the Z position of the axes
           * \param[in] id the coordinate system object id (default: reference)
           * \param[in] viewport the view port where the 3D axes should be added (default: all)
           */
         void
         addCoordinateSystem (double scale, float x, float y, float z, const std::string &id = "reference", int viewport = 0);
-
-         /** \brief Adds 3D axes describing a coordinate system to screen at x, y, z, Roll,Pitch,Yaw
-           *
-           * \param[in] scale the scale of the axes (default: 1)
-           * \param[in] t transformation matrix
-           * \param[in] viewport the view port where the 3D axes should be added (default: all)
-           */
-        PCL_DEPRECATED (
-        "addCoordinateSystem (scale, t, viewport) is deprecated, please use function "
-        "addCoordinateSystem (scale, t, id, viewport) with id a unique string identifier.")
-        void
-        addCoordinateSystem (double scale, const Eigen::Affine3f& t, int viewport);
 
          /** \brief Adds 3D axes describing a coordinate system to screen at x, y, z, Roll,Pitch,Yaw
            *
@@ -385,15 +350,6 @@ namespace pcl
 
         void
         addCoordinateSystem (double scale, const Eigen::Affine3f& t, const std::string &id = "reference", int viewport = 0);
-
-        /** \brief Removes a previously added 3D axes (coordinate system)
-          * \param[in] viewport view port where the 3D axes should be removed from (default: all)
-          */
-        PCL_DEPRECATED (
-        "removeCoordinateSystem (viewport) is deprecated, please use function "
-        "addCoordinateSystem (id, viewport) with id a unique string identifier.")
-        bool
-        removeCoordinateSystem (int viewport);
 
         /** \brief Removes a previously added 3D axes (coordinate system)
           * \param[in] id the coordinate system object id (default: reference)

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -607,31 +607,6 @@ pcl::visualization::PCLVisualizer::removeOrientationMarkerWidgetAxes ()
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, int viewport)
-{
-  addCoordinateSystem (scale, "reference", viewport);
-}
-
-void
-pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, float x, float y, float z, int viewport)
-{
-  addCoordinateSystem (scale, x, y, z, "reference", viewport);
-}
-
-void
-pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, const Eigen::Affine3f& t, int viewport)
-{
-  addCoordinateSystem (scale, t, "reference", viewport);
-}
-
-bool
-pcl::visualization::PCLVisualizer::removeCoordinateSystem (int viewport)
-{
-  return (removeCoordinateSystem ("reference", viewport));
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////////
-void
 pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, const std::string &id, int viewport)
 {
   if (scale <= 0.0)


### PR DESCRIPTION
These conclude the last deprecations we can remove for this version. There's a couple of new ones introduced in 1.8.x but I would recommend to only remove those in 1.10.x

filters: last change in 1.7.2 https://github.com/PointCloudLibrary/pcl/commit/38a6f8d554faa91ecbdf18f403c447d352e41a7b
surface: last change in 1.7.2 https://github.com/PointCloudLibrary/pcl/commit/36018a7c26bd20ec10b23a0f85e13f437fecc65c
io: last change in 1.7.2 https://github.com/PointCloudLibrary/pcl/commit/38a6f8d554faa91ecbdf18f403c447d352e41a7b
visualizer: last change in 1.7.2 https://github.com/PointCloudLibrary/pcl/commit/38a6f8d554faa91ecbdf18f403c447d352e41a7b
