### PR TITLE
Add *_USE_STATIC options to PCLConfig

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -131,6 +131,7 @@ macro(find_qhull)
     get_filename_component(QHULL_ROOT "@QHULL_INCLUDE_DIRS@" PATH)
   endif(PCL_ALL_IN_ONE_INSTALLER)
 
+  set(QHULL_USE_STATIC @QHULL_USE_STATIC@)
   find_package(Qhull)
 endmacro(find_qhull)
 
@@ -218,6 +219,7 @@ macro(find_flann)
     get_filename_component(FLANN_ROOT "@FLANN_INCLUDE_DIRS@" PATH)
   endif(PCL_ALL_IN_ONE_INSTALLER)
 
+  set(FLANN_USE_STATIC @FLANN_USE_STATIC@)
   find_package(FLANN)
 endmacro(find_flann)
 


### PR DESCRIPTION
Add <code>QHULL_USE_STATIC</code> and <code>FLANN_USE_STATIC</code> options to PCLConfig.cmake.
PCLConfig.cmake will find same libraries that build PCL from source code.

Closes #2084