### PR TITLE
Add remove text3d

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -669,7 +669,8 @@ pcl::visualization::PCLVisualizer::addText3D (
   else
     tid = id;
 
-  if (contains (tid))
+  std::string idToCheck = viewport > 0 ? tid.append(viewport, '*') : tid;
+  if (contains (idToCheck))
   {
     PCL_WARN ("[addText3D] The id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
     return (false);

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -669,11 +669,26 @@ pcl::visualization::PCLVisualizer::addText3D (
   else
     tid = id;
 
-  std::string id_to_check = viewport > 0 ? tid.append (viewport, '*') : tid;
-  if (contains (id_to_check))
+  if (viewport < 0)
+    return false;
+
+  // check all or an individual viewport for a similar id
+  rens_->InitTraversal ();
+  rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
+  for (size_t i = std::max (viewport, 1); rens_->GetNextItem () != NULL; ++i)
   {
-    PCL_WARN ("[addText3D] The id <%s> already exists in viewport [%d]! Please choose a different id and retry.\n", id.c_str (), viewport);
-    return (false);
+    const std::string uid = tid + std::string (i, '*');
+    if (contains (uid))
+    {
+      PCL_ERROR ( "[addText3D] The id <%s> already exists in viewport [%d]! "
+                  "Please choose a different id and retry.\n",
+                  tid.c_str (),
+                  i);
+      return false;
+    }
+
+    if (viewport > 0)
+      break;
   }
 
   vtkSmartPointer<vtkVectorText> textSource = vtkSmartPointer<vtkVectorText>::New ();
@@ -685,8 +700,8 @@ pcl::visualization::PCLVisualizer::addText3D (
 
   // Since each follower may follow a different camera, we need different followers
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  int i = 0;
+  vtkRenderer* renderer = rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
+  int i = 1;
   while ((renderer = rens_->GetNextItem ()) != NULL)
   {
     // Should we add the actor to all renderers or just to i-nth renderer?
@@ -704,10 +719,8 @@ pcl::visualization::PCLVisualizer::addText3D (
 
       // Save the pointer/ID pair to the global actor map. If we are saving multiple vtkFollowers
       // for multiple viewport
-      std::string alternate_tid = tid;
-      alternate_tid.append(i, '*');
-
-      (*shape_actor_map_)[(viewport == 0) ? tid : alternate_tid] = textActor;
+      const std::string uid = tid + std::string (i, '*');
+      (*shape_actor_map_)[uid] = textActor;
     }
 
     ++i;
@@ -735,10 +748,26 @@ pcl::visualization::PCLVisualizer::addText3D (
   else
     tid = id;
 
-  if (contains (tid))
+  if (viewport < 0)
+    return false;
+
+  // check all or an individual viewport for a similar id
+  rens_->InitTraversal ();
+  rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
+  for (size_t i = std::max (viewport, 1); rens_->GetNextItem () != NULL; ++i)
   {
-    PCL_WARN ("[addText3D] The id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
-    return (false);
+    const std::string uid = tid + std::string (i, '*');
+    if (contains (uid))
+    {
+      PCL_ERROR ( "[addText3D] The id <%s> already exists in viewport [%d]! "
+                  "Please choose a different id and retry.\n",
+                  tid.c_str (),
+                  i);
+      return false;
+    }
+
+    if (viewport > 0)
+      break;
   }
 
   vtkSmartPointer<vtkVectorText> textSource = vtkSmartPointer<vtkVectorText>::New ();
@@ -755,10 +784,21 @@ pcl::visualization::PCLVisualizer::addText3D (
   textActor->GetProperty ()->SetColor (r, g, b);
   textActor->SetOrientation (orientation);
 
-  addActorToRenderer (textActor, viewport);
-
   // Save the pointer/ID pair to the global actor map. If we are saving multiple vtkFollowers
-  (*shape_actor_map_)[tid] = textActor;
+  rens_->InitTraversal ();
+  rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
+  int i = 1;
+  for ( vtkRenderer* renderer = rens_->GetNextItem ();
+        renderer != NULL;
+        renderer = rens_->GetNextItem (), ++i)
+  {
+    if (viewport == 0 || viewport == i)
+    {
+      renderer->AddActor (textActor);
+      const std::string uid = tid + std::string (i, '*');
+      (*shape_actor_map_)[uid] = textActor;
+    }
+  }
 
   return (true);
 }

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -669,10 +669,10 @@ pcl::visualization::PCLVisualizer::addText3D (
   else
     tid = id;
 
-  std::string idToCheck = viewport > 0 ? tid.append(viewport, '*') : tid;
-  if (contains (idToCheck))
+  std::string id_to_check = viewport > 0 ? tid.append (viewport, '*') : tid;
+  if (contains (id_to_check))
   {
-    PCL_WARN ("[addText3D] The id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
+    PCL_WARN ("[addText3D] The id <%s> already exists in viewport [%d]! Please choose a different id and retry.\n", id.c_str (), viewport);
     return (false);
   }
 

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -916,9 +916,9 @@ bool
 pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int viewport)
 {
   // Check to see if the given ID entry exists
-  std::string idToCheck(id);
-  if(viewport > 0) idToCheck.append(viewport, '*');
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (idToCheck);
+  std::string id_to_check (id);
+  if (viewport > 0) id_to_check.append (viewport, '*');
+  ShapeActorMap::iterator am_it = shape_actor_map_->find (id_to_check);
 
   if (am_it == shape_actor_map_->end ())
   {

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -916,7 +916,9 @@ bool
 pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int viewport)
 {
   // Check to see if the given ID entry exists
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  std::string idToCheck(id);
+  if(viewport > 0) idToCheck.append(viewport, '*');
+  ShapeActorMap::iterator am_it = shape_actor_map_->find (idToCheck);
 
   if (am_it == shape_actor_map_->end ())
   {

--- a/visualization/test/CMakeLists.txt
+++ b/visualization/test/CMakeLists.txt
@@ -9,3 +9,5 @@
 #add_executable(demo_shapes test_shapes.cpp)
 #target_link_libraries(demo_shapes pcl_common pcl_io pcl_kdtree pcl_visualization)
 
+#add_executable(demo_shapes_multiport test_shapes_multiport.cpp)
+#target_link_libraries(demo_shapes_multiport pcl_common pcl_io pcl_kdtree pcl_visualization)

--- a/visualization/test/test_shapes_multiport.cpp
+++ b/visualization/test/test_shapes_multiport.cpp
@@ -41,7 +41,7 @@ main (int , char **)
 
   p.addText ("text", 200, 200, 1.0, 0, 0, "text", leftPort);
   
-  p.addText3D ("text3D", cloud->points[0], 1.0, 1.0, 0.0, 0.0, rightPort);
+  p.addText3D ("text3D", cloud->points[0], 1.0, 1.0, 0.0, 0.0, "", rightPort);
   p.spin ();
   p.removeCoordinateSystem ("first", 0);
   p.spin ();
@@ -49,7 +49,7 @@ main (int , char **)
   p.spin ();
   p.removeCoordinateSystem ("second", 0);
   p.spin ();
-  p.addText3D ("text3D_to_remove", cloud->points[1], 1.0, 0.0, 1.0, 0.0, rightPort);
+  p.addText3D ("text3D_to_remove", cloud->points[1], 1.0, 0.0, 1.0, 0.0, "", rightPort);
   p.spin ();
   p.removeText3D ("text3D_to_remove", rightPort);
   p.spin ();

--- a/visualization/test/test_shapes_multiport.cpp
+++ b/visualization/test/test_shapes_multiport.cpp
@@ -51,4 +51,6 @@ main (int , char **)
   p.spin ();
   p.addText3D ("text3D_to_remove", cloud->points[1], 1.0, 0.0, 1.0, 0.0, rightPort);
   p.spin ();
+  p.removeText3D ("text3D_to_remove", rightPort);
+  p.spin ();
 }

--- a/visualization/test/test_shapes_multiport.cpp
+++ b/visualization/test/test_shapes_multiport.cpp
@@ -1,0 +1,54 @@
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/io/pcd_io.h>
+
+using pcl::PointCloud;
+using pcl::PointXYZ;
+
+int 
+main (int , char **)
+{
+  srand (unsigned (time (0)));
+
+  PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ>);
+
+  cloud->points.resize (5);
+  for (size_t i = 0; i < cloud->points.size (); ++i)
+  {
+    cloud->points[i].x = float (i); 
+    cloud->points[i].y = float (i / 2);
+    cloud->points[i].z = 0.0f;
+  }
+
+  // Start the visualizer
+  pcl::visualization::PCLVisualizer p ("test_shapes");
+  int leftPort(0);
+  int rightPort(0);
+  p.createViewPort(0, 0, 0.5, 1, leftPort);
+  p.createViewPort(0.5, 0, 1, 1, rightPort);
+  p.setBackgroundColor (1, 1, 1);
+  p.addCoordinateSystem (1.0, "first");
+
+  //p.addPolygon (cloud, "polygon");
+  p.addPolygon<PointXYZ> (cloud, 1.0, 0.0, 0.0, "polygon", leftPort);
+  p.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "polygon", leftPort);
+  
+  p.addLine<PointXYZ, PointXYZ> (cloud->points[0], cloud->points[1], 0.0, 1.0, 0.0, "line", leftPort);
+  p.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 50, "line", leftPort);
+
+  p.addSphere<PointXYZ> (cloud->points[0], 1, 0.0, 1.0, 0.0, "sphere", leftPort);
+  p.setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 5, "sphere", leftPort);
+//  p.removePolygon ("poly");
+
+  p.addText ("text", 200, 200, 1.0, 0, 0, "text", leftPort);
+  
+  p.addText3D ("text3D", cloud->points[0], 1.0, 1.0, 0.0, 0.0, rightPort);
+  p.spin ();
+  p.removeCoordinateSystem ("first", 0);
+  p.spin ();
+  p.addCoordinateSystem (1.0, 5, 3, 1, "second");
+  p.spin ();
+  p.removeCoordinateSystem ("second", 0);
+  p.spin ();
+  p.addText3D ("text3D_to_remove", cloud->points[1], 1.0, 0.0, 1.0, 0.0, rightPort);
+  p.spin ();
+}


### PR DESCRIPTION
This supercedes and closes #2062, and fixes #2049.

I think you can do whatever you want with the text3D in terms of adding and removing (except for adding items with ids finishing in `*`). I tried a number of cases with both text3D overloads.