### PR TITLE
Provide proper EuclideanClusterComparator method depreciation

### DIFF
--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -103,9 +103,10 @@
      std::vector<pcl::PointIndices> boundary_indices;
      mps.segmentAndRefine (regions, model_coefficients, inlier_indices, labels, label_indices, boundary_indices);
      
-     boost::shared_ptr<std::map<uint32_t, bool> > plane_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+     boost::shared_ptr<std::set<uint32_t> > plane_labels = boost::make_shared<std::set<uint32_t> > ();
      for (size_t i = 0; i < label_indices.size (); ++i)
-       (*plane_labels)[i] = (label_indices[i].indices.size () > (size_t) min_plane_size);
+      if (label_indices[i].indices.size () > (size_t) min_plane_size)
+        plane_labels->insert (i);
      typename PointCloud<PointT>::CloudVectorType clusters;
      
      typename EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator =

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -109,8 +109,8 @@
         plane_labels->insert (i);
      typename PointCloud<PointT>::CloudVectorType clusters;
      
-     typename EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator =
-        boost::make_shared <EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> > ();
+     typename EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator =
+        boost::make_shared <EuclideanClusterComparator<PointT, pcl::Label> > ();
      euclidean_cluster_comparator->setInputCloud (input_cloud);
      euclidean_cluster_comparator->setLabels (labels);
      euclidean_cluster_comparator->setExcludeLabels (plane_labels);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -108,7 +108,8 @@
        (*plane_labels)[i] = (label_indices[i].indices.size () > (size_t) min_plane_size);
      typename PointCloud<PointT>::CloudVectorType clusters;
      
-     typename EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator = boost::make_shared <EuclideanClusterComparator<PointT, pcl::Label> > ();
+     typename EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator =
+        boost::make_shared <EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> > ();
      euclidean_cluster_comparator->setInputCloud (input_cloud);
      euclidean_cluster_comparator->setLabels (labels);
      euclidean_cluster_comparator->setExcludeLabels (plane_labels);

--- a/apps/include/pcl/apps/organized_segmentation_demo.h
+++ b/apps/include/pcl/apps/organized_segmentation_demo.h
@@ -139,7 +139,7 @@ class OrganizedSegmentationDemo : public QMainWindow
     pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal>::Ptr rgb_comparator_;
     pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal> rgb_comp_;
     pcl::EdgeAwarePlaneComparator<PointT, pcl::Normal>::Ptr edge_aware_comparator_;
-    pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_;
+    pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator_;
 
   public Q_SLOTS:
     void toggleCapturePressed()

--- a/apps/include/pcl/apps/organized_segmentation_demo.h
+++ b/apps/include/pcl/apps/organized_segmentation_demo.h
@@ -139,7 +139,7 @@ class OrganizedSegmentationDemo : public QMainWindow
     pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal>::Ptr rgb_comparator_;
     pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal> rgb_comp_;
     pcl::EdgeAwarePlaneComparator<PointT, pcl::Normal>::Ptr edge_aware_comparator_;
-    pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator_;
+    pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_;
 
   public Q_SLOTS:
     void toggleCapturePressed()

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -260,9 +260,8 @@ class NILinemod
         scene->points[points_above_plane->indices[i]].label = 1;
       euclidean_cluster_comparator->setLabels (scene);
 
-      boost::shared_ptr<std::map<uint32_t, bool> > exclude_labels = boost::make_shared<std::map<uint32_t, bool> > ();
-      (*exclude_labels)[0] = true;
-      (*exclude_labels)[1] = false;
+      boost::shared_ptr<std::set<uint32_t> > exclude_labels = boost::make_shared<std::set<uint32_t> > ();
+      exclude_labels->insert (0);
 
       OrganizedConnectedComponentSegmentation<PointT, Label> euclidean_segmentation (euclidean_cluster_comparator);
       euclidean_segmentation.setInputCloud (cloud);

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -249,7 +249,7 @@ class NILinemod
       exppd.segment (*points_above_plane);
 
       // Use an organized clustering segmentation to extract the individual clusters
-      EuclideanClusterComparator<PointT, Normal, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Normal, Label>);
+      EuclideanClusterComparator<PointT, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Label>);
       euclidean_cluster_comparator->setInputCloud (cloud);
       euclidean_cluster_comparator->setDistanceThreshold (0.03f, false);
       // Set the entire scene to false, and the inliers of the objects located on top of the plane to true

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -249,7 +249,7 @@ class NILinemod
       exppd.segment (*points_above_plane);
 
       // Use an organized clustering segmentation to extract the individual clusters
-      EuclideanClusterComparator<PointT, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Label>);
+      EuclideanClusterComparator<PointT, Normal, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Normal, Label>);
       euclidean_cluster_comparator->setInputCloud (cloud);
       euclidean_cluster_comparator->setDistanceThreshold (0.03f, false);
       // Set the entire scene to false, and the inliers of the objects located on top of the plane to true

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -254,7 +254,7 @@ OrganizedSegmentationDemo::OrganizedSegmentationDemo (pcl::Grabber& grabber) : g
   euclidean_comparator_.reset (new pcl::EuclideanPlaneCoefficientComparator<PointT, pcl::Normal> ());
   rgb_comparator_.reset (new pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal> ());
   edge_aware_comparator_.reset (new pcl::EdgeAwarePlaneComparator<PointT, pcl::Normal> ());
-  euclidean_cluster_comparator_ = pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr (new pcl::EuclideanClusterComparator<PointT, pcl::Label> ());
+  euclidean_cluster_comparator_ = pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr (new pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> ());
 
   // Set up Organized Multi Plane Segmentation
   mps.setMinInliers (10000);

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -254,7 +254,7 @@ OrganizedSegmentationDemo::OrganizedSegmentationDemo (pcl::Grabber& grabber) : g
   euclidean_comparator_.reset (new pcl::EuclideanPlaneCoefficientComparator<PointT, pcl::Normal> ());
   rgb_comparator_.reset (new pcl::RGBPlaneCoefficientComparator<PointT, pcl::Normal> ());
   edge_aware_comparator_.reset (new pcl::EdgeAwarePlaneComparator<PointT, pcl::Normal> ());
-  euclidean_cluster_comparator_ = pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr (new pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> ());
+  euclidean_cluster_comparator_ = pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr (new pcl::EuclideanClusterComparator<PointT, pcl::Label> ());
 
   // Set up Organized Multi Plane Segmentation
   mps.setMinInliers (10000);

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -309,9 +309,10 @@ OrganizedSegmentationDemo::cloud_cb (const CloudConstPtr& cloud)
 
   if (use_clustering_ && regions.size () > 0)
   {
-    boost::shared_ptr<std::map<uint32_t, bool> > plane_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+    boost::shared_ptr<std::set<uint32_t> > plane_labels = boost::make_shared<std::set<uint32_t> > ();
     for (size_t i = 0; i < label_indices.size (); ++i)
-      (*plane_labels)[i] = (label_indices[i].indices.size () > 10000);
+      if (label_indices[i].indices.size () > 10000)
+        plane_labels->insert (i);
     
     euclidean_cluster_comparator_->setInputCloud (cloud);
     euclidean_cluster_comparator_->setLabels (labels);

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -194,7 +194,7 @@ class ObjectSelection
       if (cloud_->isOrganized ())
       {
         // Use an organized clustering segmentation to extract the individual clusters
-        typename EuclideanClusterComparator<PointT, Normal, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Normal, Label>);
+        typename EuclideanClusterComparator<PointT, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Label>);
         euclidean_cluster_comparator->setInputCloud (cloud);
         euclidean_cluster_comparator->setDistanceThreshold (0.03f, false);
         // Set the entire scene to false, and the inliers of the objects located on top of the plane to true

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -194,7 +194,7 @@ class ObjectSelection
       if (cloud_->isOrganized ())
       {
         // Use an organized clustering segmentation to extract the individual clusters
-        typename EuclideanClusterComparator<PointT, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Label>);
+        typename EuclideanClusterComparator<PointT, Normal, Label>::Ptr euclidean_cluster_comparator (new EuclideanClusterComparator<PointT, Normal, Label>);
         euclidean_cluster_comparator->setInputCloud (cloud);
         euclidean_cluster_comparator->setDistanceThreshold (0.03f, false);
         // Set the entire scene to false, and the inliers of the objects located on top of the plane to true

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -205,9 +205,8 @@ class ObjectSelection
           scene->points[points_above_plane->indices[i]].label = 1;
         euclidean_cluster_comparator->setLabels (scene);
 
-        boost::shared_ptr<std::map<uint32_t, bool> > exclude_labels = boost::make_shared<std::map<uint32_t, bool> > ();
-        (*exclude_labels)[0] = true;
-        (*exclude_labels)[1] = false;
+        boost::shared_ptr<std::set<uint32_t> > exclude_labels = boost::make_shared<std::set<uint32_t> > ();
+        exclude_labels->insert (0);
         euclidean_cluster_comparator->setExcludeLabels (exclude_labels);
 
         OrganizedConnectedComponentSegmentation<PointT, Label> euclidean_segmentation (euclidean_cluster_comparator);

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -397,7 +397,7 @@ class HRCSSegmentation
           for (size_t i = 0; i < region_indices.size (); ++i)
             (*plane_labels)[i] = (region_indices[i].indices.size () > mps.getMinInliers ());
         
-          pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Label> ());
+          pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> ());
           euclidean_cluster_comparator_->setInputCloud (cloud);
           euclidean_cluster_comparator_->setLabels (labels_ptr);
           euclidean_cluster_comparator_->setExcludeLabels (plane_labels);

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -393,9 +393,10 @@ class HRCSSegmentation
         pcl::PointCloud<PointT>::CloudVectorType clusters;
         if (ground_cloud->points.size () > 0)
         {
-          boost::shared_ptr<std::map<uint32_t, bool> > plane_labels = boost::make_shared<std::map<uint32_t, bool> > ();
+          boost::shared_ptr<std::set<uint32_t> > plane_labels = boost::make_shared<std::set<uint32_t> > ();
           for (size_t i = 0; i < region_indices.size (); ++i)
-            (*plane_labels)[i] = (region_indices[i].indices.size () > mps.getMinInliers ());
+            if ((region_indices[i].indices.size () > mps.getMinInliers ()))
+              plane_labels->insert (i);
         
           pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> ());
           euclidean_cluster_comparator_->setInputCloud (cloud);

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -398,7 +398,7 @@ class HRCSSegmentation
             if ((region_indices[i].indices.size () > mps.getMinInliers ()))
               plane_labels->insert (i);
         
-          pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Normal, pcl::Label> ());
+          pcl::EuclideanClusterComparator<PointT, pcl::Label>::Ptr euclidean_cluster_comparator_ (new pcl::EuclideanClusterComparator<PointT, pcl::Label> ());
           euclidean_cluster_comparator_->setInputCloud (cloud);
           euclidean_cluster_comparator_->setLabels (labels_ptr);
           euclidean_cluster_comparator_->setExcludeLabels (plane_labels);

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -289,6 +289,25 @@ log2f (float x)
     #define PCLAPI(rettype) PCL_EXTERN_C PCL_EXPORTS rettype PCL_CDECL
 #endif
 
+// Macro for pragma operator
+#if (defined (__GNUC__) || defined(__clang__))
+  #define PCL_PRAGMA(x) _Pragma (#x)
+#elif _MSC_VER
+  #define PCL_PRAGMA(x) __pragma (#x)
+#else
+  #define PCL_PRAGMA
+#endif
+
+// Macro for emitting pragma warning
+#if (defined (__GNUC__) || defined(__clang__))
+  #define PCL_PRAGMA_WARNING(x) PCL_PRAGMA (GCC warning x)
+#elif _MSC_VER
+  #define PCL_PRAGMA_WARNING(x) PCL_PRAGMA (warning (x))
+#else
+  #define PCL_PRAGMA_WARNING
+#endif
+
+
 // Macro to deprecate old functions
 //
 // Usage:

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -61,6 +61,13 @@
 
 namespace pcl
 {
+  namespace deprecated
+  {
+    /** \class DeprecatedType
+    * \brief A dummy type to aid in template parameter deprecation
+    */
+    struct T {};
+  }
 
   namespace fields
   {

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -42,159 +42,163 @@
 
 #include <pcl/segmentation/boost.h>
 #include <pcl/segmentation/comparator.h>
+#include <pcl/point_types.h>
 
 namespace pcl
 {
-  template<typename PointT, typename PointLT = pcl::Label>
-  class EuclideanClusterComparator2: public Comparator<PointT>
+  namespace experimental
   {
-    protected:
+    template<typename PointT, typename PointLT = pcl::Label>
+    class EuclideanClusterComparator : public ::pcl::Comparator<PointT>
+    {
+      protected:
 
-      using pcl::Comparator<PointT>::input_;
+        using pcl::Comparator<PointT>::input_;
 
-    public:
-      using typename Comparator<PointT>::PointCloud;
-      using typename Comparator<PointT>::PointCloudConstPtr;
-      
-      typedef typename pcl::PointCloud<PointLT> PointCloudL;
-      typedef typename PointCloudL::Ptr PointCloudLPtr;
-      typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+      public:
+        using typename Comparator<PointT>::PointCloud;
+        using typename Comparator<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<EuclideanClusterComparator2<PointT, PointLT> > Ptr;
-      typedef boost::shared_ptr<const EuclideanClusterComparator2<PointT, PointLT> > ConstPtr;
+        typedef typename pcl::PointCloud<PointLT> PointCloudL;
+        typedef typename PointCloudL::Ptr PointCloudLPtr;
+        typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
 
-      typedef std::set<uint32_t> ExcludeLabelSet;
-      typedef boost::shared_ptr<ExcludeLabelSet> ExcludeLabelSetPtr;
-      typedef boost::shared_ptr<const ExcludeLabelSet> ExcludeLabelSetConstPtr;
+        typedef boost::shared_ptr<EuclideanClusterComparator<PointT, PointLT> > Ptr;
+        typedef boost::shared_ptr<const EuclideanClusterComparator<PointT, PointLT> > ConstPtr;
 
-      virtual void 
-      setInputCloud (const PointCloudConstPtr& cloud)
-      {
-        input_ = cloud;
-        Eigen::Matrix3f rot = input_->sensor_orientation_.toRotationMatrix ();
-        z_axis_ = rot.col (2);
-      }
-      
-      /** \brief Set the tolerance in meters for difference in perpendicular distance (d component of plane equation) to the plane between neighboring points, to be considered part of the same plane.
-        * \param[in] distance_threshold the tolerance in meters 
-        * \param depth_dependent
-        */
-      inline void
-      setDistanceThreshold (float distance_threshold, bool depth_dependent)
-      {
-        distance_threshold_ = distance_threshold;
-        depth_dependent_ = depth_dependent;
-      }
+        typedef std::set<uint32_t> ExcludeLabelSet;
+        typedef boost::shared_ptr<ExcludeLabelSet> ExcludeLabelSetPtr;
+        typedef boost::shared_ptr<const ExcludeLabelSet> ExcludeLabelSetConstPtr;
 
-      /** \brief Get the distance threshold in meters (d component of plane equation) between neighboring points, to be considered part of the same plane. */
-      inline float
-      getDistanceThreshold () const
-      {
-        return (distance_threshold_);
-      }
+        /** \brief Default constructor for EuclideanClusterComparator. */
+        EuclideanClusterComparator ()
+          : distance_threshold_ (0.005f)
+          , depth_dependent_ ()
+          , z_axis_ ()
+        {}
 
-      /** \brief Set label cloud
-        * \param[in] labels The label cloud
-        */
-      void
-      setLabels (const PointCloudLPtr& labels)
-      {
-        labels_ = labels;
-      }
-
-      const ExcludeLabelSetConstPtr&
-      getExcludeLabels () const
-      {
-        return exclude_labels_;
-      }
-
-      /** \brief Set labels in the label cloud to exclude.
-        * \param exclude_labels a vector of bools corresponding to whether or not a given label should be considered
-        */
-      void
-      setExcludeLabels (const ExcludeLabelSetConstPtr &exclude_labels)
-      {
-        exclude_labels_ = exclude_labels;
-      }
-
-      /** \brief Compare points at two indices by their euclidean distance
-        * \param idx1 The first index for the comparison
-        * \param idx2 The second index for the comparison
-        */
-      virtual bool
-      compare (int idx1, int idx2) const
-      {
-        if (labels_ && exclude_labels_)
+        virtual void
+        setInputCloud (const PointCloudConstPtr& cloud)
         {
-          assert (labels_->size () == input_->size ());
-          const uint32_t &label1 = (*labels_)[idx1].label;
-          const uint32_t &label2 = (*labels_)[idx2].label;
-
-          const std::set<uint32_t>::const_iterator it1 = exclude_labels_->find (label1);
-          if (it1 == exclude_labels_->end ())
-            return false;
-
-          const std::set<uint32_t>::const_iterator it2 = exclude_labels_->find (label2);
-          if (it2 == exclude_labels_->end ())
-            return false;
-        }
-        
-        float dist_threshold = distance_threshold_;
-        if (depth_dependent_)
-        {
-          Eigen::Vector3f vec = input_->points[idx1].getVector3fMap ();
-          float z = vec.dot (z_axis_);
-          dist_threshold *= z * z;
+          input_ = cloud;
+          Eigen::Matrix3f rot = input_->sensor_orientation_.toRotationMatrix ();
+          z_axis_ = rot.col (2);
         }
 
-        const float dist = ((*input_)[idx1].getVector3fMap ()
-                              - (*input_)[idx2].getVector3fMap ()).norm ();
-        return (dist < dist_threshold);
-      }
-      
-    protected:
+        /** \brief Set the tolerance in meters for difference in perpendicular distance (d component of plane equation) to the plane between neighboring points, to be considered part of the same plane.
+          * \param[in] distance_threshold the tolerance in meters
+          * \param depth_dependent
+          */
+        inline void
+        setDistanceThreshold (float distance_threshold, bool depth_dependent)
+        {
+          distance_threshold_ = distance_threshold;
+          depth_dependent_ = depth_dependent;
+        }
 
-      /** \brief Default constructor for EuclideanClusterComparator2. */
-      EuclideanClusterComparator2 ()
-        : distance_threshold_ (0.005f)
-        , depth_dependent_ ()
-        , z_axis_ ()
-      {}
+        /** \brief Get the distance threshold in meters (d component of plane equation) between neighboring points, to be considered part of the same plane. */
+        inline float
+        getDistanceThreshold () const
+        {
+          return (distance_threshold_);
+        }
+
+        /** \brief Set label cloud
+          * \param[in] labels The label cloud
+          */
+        void
+        setLabels (const PointCloudLPtr& labels)
+        {
+          labels_ = labels;
+        }
+
+        const ExcludeLabelSetConstPtr&
+        getExcludeLabels () const
+        {
+          return exclude_labels_;
+        }
+
+        /** \brief Set labels in the label cloud to exclude.
+          * \param exclude_labels a vector of bools corresponding to whether or not a given label should be considered
+          */
+        void
+        setExcludeLabels (const ExcludeLabelSetConstPtr &exclude_labels)
+        {
+          exclude_labels_ = exclude_labels;
+        }
+
+        /** \brief Compare points at two indices by their euclidean distance
+          * \param idx1 The first index for the comparison
+          * \param idx2 The second index for the comparison
+          */
+        virtual bool
+        compare (int idx1, int idx2) const
+        {
+          if (labels_ && exclude_labels_)
+          {
+            assert (labels_->size () == input_->size ());
+            const uint32_t &label1 = (*labels_)[idx1].label;
+            const uint32_t &label2 = (*labels_)[idx2].label;
+
+            const std::set<uint32_t>::const_iterator it1 = exclude_labels_->find (label1);
+            if (it1 == exclude_labels_->end ())
+              return false;
+
+            const std::set<uint32_t>::const_iterator it2 = exclude_labels_->find (label2);
+            if (it2 == exclude_labels_->end ())
+              return false;
+          }
+
+          float dist_threshold = distance_threshold_;
+          if (depth_dependent_)
+          {
+            Eigen::Vector3f vec = input_->points[idx1].getVector3fMap ();
+            float z = vec.dot (z_axis_);
+            dist_threshold *= z * z;
+          }
+
+          const float dist = ((*input_)[idx1].getVector3fMap ()
+                                - (*input_)[idx2].getVector3fMap ()).norm ();
+          return (dist < dist_threshold);
+        }
+
+      protected:
 
 
-      /** \brief Set of labels with similar size as the input point cloud,
-        * aggregating points into groups based on a similar label identifier.
-        *
-        * It needs to be set in conjunction with the \ref exclude_labels_
-        * member in order to provided a masking functionality.
-        */
-      PointCloudLPtr labels_;
+        /** \brief Set of labels with similar size as the input point cloud,
+          * aggregating points into groups based on a similar label identifier.
+          *
+          * It needs to be set in conjunction with the \ref exclude_labels_
+          * member in order to provided a masking functionality.
+          */
+        PointCloudLPtr labels_;
 
-      /** \brief Specifies which labels should be excluded com being clustered.
-        *
-        * If a label is not specified, it's assumed by default that it's
-        * intended be excluded
-        */
-      ExcludeLabelSetConstPtr exclude_labels_;
+        /** \brief Specifies which labels should be excluded com being clustered.
+          *
+          * If a label is not specified, it's assumed by default that it's
+          * intended be excluded
+          */
+        ExcludeLabelSetConstPtr exclude_labels_;
 
-      float distance_threshold_;
+        float distance_threshold_;
 
-      bool depth_dependent_;
+        bool depth_dependent_;
 
-      Eigen::Vector3f z_axis_;
-  };
+        Eigen::Vector3f z_axis_;
+    };
+  } // namespace experimental
+
 
   /** \brief EuclideanClusterComparator is a comparator used for finding clusters based on euclidian distance.
     *
     * \author Alex Trevor
     */
-  PCL_PRAGMA_WARNING ("EuclideanClusterComparator will no longer be templated on a PointNormal type in future minor release")
-  template<typename PointT, typename PointNT, typename PointLT = pcl::Label>
-  class EuclideanClusterComparator: public EuclideanClusterComparator2<PointT, PointLT>
+  template<typename PointT, typename PointNT, typename PointLT = deprecated::T>
+  class EuclideanClusterComparator : public experimental::EuclideanClusterComparator<PointT, PointLT>
   {
     protected:
 
-      using EuclideanClusterComparator2<PointT, PointLT>::exclude_labels_;
+      using experimental::EuclideanClusterComparator<PointT, PointLT>::exclude_labels_;
 
     public:
 
@@ -205,9 +209,10 @@ namespace pcl
       typedef boost::shared_ptr<EuclideanClusterComparator<PointT, PointNT, PointLT> > Ptr;
       typedef boost::shared_ptr<const EuclideanClusterComparator<PointT, PointNT, PointLT> > ConstPtr;
 
-      using EuclideanClusterComparator2<PointT, PointLT>::setExcludeLabels;
+      using experimental::EuclideanClusterComparator<PointT, PointLT>::setExcludeLabels;
 
-      /** \brief Empty constructor for EuclideanClusterComparator. */
+      /** \brief Default constructor for EuclideanClusterComparator. */
+      PCL_DEPRECATED ("Remove PointNT from template parameters.")
       EuclideanClusterComparator ()
         : normals_ ()
         , angular_threshold_ (0.0f)
@@ -217,19 +222,25 @@ namespace pcl
        * \param[in] normals the input normal cloud
        */
       inline void
-      PCL_DEPRECATED ("EuclideanClusterComparator no longer makes use of normals.")
+      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
+                      "this function has no effect on the behavior of the comparator. Therefore it is "
+                      "deprecated and will be removed in future releases.")
       setInputNormals (const PointCloudNConstPtr& normals) { normals_ = normals; }
 
       /** \brief Get the input normals. */
       inline PointCloudNConstPtr
-      PCL_DEPRECATED ("EuclideanClusterComparator no longer makes use of normals.")
+      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
+                      "this function has no effect on the behavior of the comparator. Therefore it is "
+                      "deprecated and will be removed in future releases.")
       getInputNormals () const { return (normals_); }
 
       /** \brief Set the tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane.
         * \param[in] angular_threshold the tolerance in radians
         */
       inline void
-      PCL_DEPRECATED ("EuclideanClusterComparator no longer makes use of the angular threshold.")
+      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
+                      "this function has no effect on the behavior of the comparator. Therefore it is "
+                      "deprecated and will be removed in future releases.")
       setAngularThreshold (float angular_threshold)
       {
         angular_threshold_ = std::cos (angular_threshold);
@@ -237,7 +248,9 @@ namespace pcl
 
       /** \brief Get the angular threshold in radians for difference in normal direction between neighboring points, to be considered part of the same plane. */
       inline float
-      PCL_DEPRECATED ("EuclideanClusterComparator no longer makes use of the angular threshold.")
+      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
+                      "this function has no effect on the behavior of the comparator. Therefore it is "
+                      "deprecated and will be removed in future releases.")
       getAngularThreshold () const { return (std::acos (angular_threshold_) ); }
 
       /** \brief Set labels in the label cloud to exclude.
@@ -259,6 +272,10 @@ namespace pcl
 
       float angular_threshold_;
   };
+
+  template<typename PointT, typename PointLT>
+  class EuclideanClusterComparator<PointT, PointLT, deprecated::T>
+    : public experimental::EuclideanClusterComparator<PointT, PointLT> {};
 }
 
 #endif // PCL_SEGMENTATION_PLANE_COEFFICIENT_COMPARATOR_H_

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -63,9 +63,9 @@ namespace pcl
       typedef boost::shared_ptr<EuclideanClusterComparator2<PointT, PointLT> > Ptr;
       typedef boost::shared_ptr<const EuclideanClusterComparator2<PointT, PointLT> > ConstPtr;
 
-      typedef std::map<uint32_t, bool> ExcludeLabelMap;
-      typedef boost::shared_ptr<ExcludeLabelMap> ExcludeLabelMapPtr;
-      typedef boost::shared_ptr<const ExcludeLabelMap> ExcludeLabelMapConstPtr;
+      typedef std::set<uint32_t> ExcludeLabelSet;
+      typedef boost::shared_ptr<ExcludeLabelSet> ExcludeLabelSetPtr;
+      typedef boost::shared_ptr<const ExcludeLabelSet> ExcludeLabelSetConstPtr;
 
       virtual void 
       setInputCloud (const PointCloudConstPtr& cloud)
@@ -102,7 +102,7 @@ namespace pcl
         labels_ = labels;
       }
 
-      const ExcludeLabelMapConstPtr&
+      const ExcludeLabelSetConstPtr&
       getExcludeLabels () const
       {
         return exclude_labels_;
@@ -112,7 +112,7 @@ namespace pcl
         * \param exclude_labels a vector of bools corresponding to whether or not a given label should be considered
         */
       void
-      setExcludeLabels (const ExcludeLabelMapConstPtr &exclude_labels)
+      setExcludeLabels (const ExcludeLabelSetConstPtr &exclude_labels)
       {
         exclude_labels_ = exclude_labels;
       }
@@ -130,12 +130,12 @@ namespace pcl
           const uint32_t &label1 = (*labels_)[idx1].label;
           const uint32_t &label2 = (*labels_)[idx2].label;
 
-          const std::map<uint32_t, bool>::const_iterator it1 = exclude_labels_->find (label1);
-          if ((it1 == exclude_labels_->end ()) || it1->second)
+          const std::set<uint32_t>::const_iterator it1 = exclude_labels_->find (label1);
+          if (it1 == exclude_labels_->end ())
             return false;
 
-          const std::map<uint32_t, bool>::const_iterator it2 = exclude_labels_->find (label2);
-          if ((it2 == exclude_labels_->end ()) || it2->second)
+          const std::set<uint32_t>::const_iterator it2 = exclude_labels_->find (label2);
+          if (it2 == exclude_labels_->end ())
             return false;
         }
         
@@ -175,7 +175,7 @@ namespace pcl
         * If a label is not specified, it's assumed by default that it's
         * intended be excluded
         */
-      ExcludeLabelMapConstPtr exclude_labels_;
+      ExcludeLabelSetConstPtr exclude_labels_;
 
       float distance_threshold_;
 


### PR DESCRIPTION
Here's something for us to discuss: in order allow us saving time cleaning things in the future, I created an intermediate class (which can't be directly instantiated), and implements what's gonna be the final functionality of the ECC. It will just suffer a rename later on.

I replaced the map for a set as pointed out before.

Closes #2091 