### PR TITLE
Stale set up

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,27 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+# daysUntilClose: 7
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - "status: needs review"
+  - "status: needs testing"
+  - "status: needs decision"
+  - "status: ready to merge"
+# Label to use when marking as stale
+staleLabel: "status: stale"
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: |
+  This pull request has been automatically marked as stale because it hasn't had
+  any activity in the past 60 days. Commenting or adding a new commit to the
+  pull request will revert this.
+  
+  Come back whenever you have time. We look forward to your contribution.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+only: pulls


### PR DESCRIPTION
I recently requested @jspricke to set up [Stale](https://github.com/probot/stale). My original idea was to have it automatically tag PRs which have no updates passed a certain time and remove them at some point, so I can have an easier job navigating the PR list. Jochen already set it up on PCL's repo so now is the time do decide exactly what type of behavior we want from it.

I configured it already for my (revised) needs but it would be good if you could also voice you opinions on what you consider to be the desired behavior.

Jochen already expressed his opinion on an email exchange we had and I quote.
> > Sérgio Agostinho  [2017-11-22 17:07]:
> > I want to configure it to close PRs which we have no feedback in more than 90 days.
>
> Honestly, I don't think that's the right way to handle PRs. PRs means someone had an issue, looked into the code and wants to give something back. I know it's bad to leave these contributions lying around for a long time, but they are still valuable. I'm aware of a number of PRs a lot of people use, but no one took the time to integrate. Or just as well, people finding a patch, improve it and rebase it for merging.
> 
> On the other hand, issues would be a different point and are mostly less valuable in my point of view. If you find a mayor bug, it may make sense to open an issue, but normally I wouldn't expect someone to work on a bug just because I opened an issue.
> 
> I know it's bad to don't give feedback to contributors, but that's the reality in open source and as long as it's all voluntary, it will not change. Closing PRs would just be more frustrating and give the impression that we don't want contributions.
