### PR TITLE
Fix pcd_viewer color handling when invalid fields are present in pcd

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -2980,10 +2980,10 @@ pcl::visualization::PCLVisualizer::updateColorHandlerIndex (const std::string &i
     return (false);
   }
 
-  int color_handler_size = int (am_it->second.color_handlers.size ());
-  if (index >= color_handler_size)
+  size_t color_handler_size = am_it->second.color_handlers.size ();
+  if (!(size_t (index) < color_handler_size))
   {
-    pcl::console::print_warn (stderr, "[updateColorHandlerIndex] Invalid index <%d> given! Maximum range is: 0-%lu.\n", index, static_cast<unsigned long> (am_it->second.color_handlers.size ()));
+    pcl::console::print_warn (stderr, "[updateColorHandlerIndex] Invalid index <%d> given! Index must be less than %d.\n", index, int (color_handler_size));
     return (false);
   }
   // Get the handler

--- a/visualization/tools/pcd_viewer.cpp
+++ b/visualization/tools/pcd_viewer.cpp
@@ -617,22 +617,26 @@ main (int argc, char** argv)
     {
       int rgb_idx = 0;
       int label_idx = 0;
+      int invalid_fields_count = 0;
       for (size_t f = 0; f < cloud->fields.size (); ++f)
       {
+        if (!isValidFieldName (cloud->fields[f].name))
+        {
+          ++invalid_fields_count;
+          continue;
+        }
         if (cloud->fields[f].name == "rgb" || cloud->fields[f].name == "rgba")
         {
-          rgb_idx = f + 1;
+          rgb_idx = f - invalid_fields_count + 1 /* first is ColorHandlerRandom */;
           color_handler.reset (new pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2> (cloud));
         }
         else if (cloud->fields[f].name == "label")
         {
-          label_idx = f + 1;
+          label_idx = f - invalid_fields_count + 1;
           color_handler.reset (new pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2> (cloud, !use_optimal_l_colors));
         }
         else
         {
-          if (!isValidFieldName (cloud->fields[f].name))
-            continue;
           color_handler.reset (new pcl::visualization::PointCloudColorHandlerGenericField<pcl::PCLPointCloud2> (cloud, cloud->fields[f].name));
         }
         // Add the cloud to the renderer


### PR DESCRIPTION
Hi all,

I'm still very new to the pcl library (few hours), but I think that I have already fixed a bug. Please correct me if I'm wrong, I'm really a newbie here.

I have a .pcd file with dimensions like this:

```
Available dimensions: x y z _ rgb _
```

I have noticed that pcd_viewer does not show this .pcd in rgb colors. After some investigation it seems that it is caused by preceding invalid field before `rgb` field.

I'm still wondering what are these invalid fields doing in my pointcloud. Is this supposed to be a normal result of serialization to binary .pcd?

Cheers,
Jiri