### PR TITLE
[VISU] Fix add/remove of 3D text without custom viewport

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -672,10 +672,18 @@ pcl::visualization::PCLVisualizer::addText3D (
   if (viewport < 0)
     return false;
 
+  // If there is no custom viewport and the viewport number is not 0, exit
+  if (rens_->GetNumberOfItems () <= viewport)
+  {
+    PCL_ERROR ("[addText3D] The viewport [%d] doesn't exist (id <%s>)! ",
+               viewport,
+               tid.c_str ());
+    return false;
+  }
+
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
-  for (size_t i = std::max (viewport, 1); rens_->GetNextItem () != NULL; ++i)
+  for (size_t i = viewport; rens_->GetNextItem () != NULL; ++i)
   {
     const std::string uid = tid + std::string (i, '*');
     if (contains (uid))
@@ -700,8 +708,8 @@ pcl::visualization::PCLVisualizer::addText3D (
 
   // Since each follower may follow a different camera, we need different followers
   rens_->InitTraversal ();
-  vtkRenderer* renderer = rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
-  int i = 1;
+  vtkRenderer* renderer;
+  int i = 0;
   while ((renderer = rens_->GetNextItem ()) != NULL)
   {
     // Should we add the actor to all renderers or just to i-nth renderer?
@@ -751,10 +759,18 @@ pcl::visualization::PCLVisualizer::addText3D (
   if (viewport < 0)
     return false;
 
+  // If there is no custom viewport and the viewport number is not 0, exit
+  if (rens_->GetNumberOfItems () <= viewport)
+  {
+    PCL_ERROR ("[addText3D] The viewport [%d] doesn't exist (id <%s>)! ",
+               viewport,
+               tid.c_str ());
+    return false;
+  }
+
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
-  for (size_t i = std::max (viewport, 1); rens_->GetNextItem () != NULL; ++i)
+  for (size_t i = viewport; rens_->GetNextItem () != NULL; ++i)
   {
     const std::string uid = tid + std::string (i, '*');
     if (contains (uid))
@@ -786,8 +802,7 @@ pcl::visualization::PCLVisualizer::addText3D (
 
   // Save the pointer/ID pair to the global actor map. If we are saving multiple vtkFollowers
   rens_->InitTraversal ();
-  rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
-  int i = 1;
+  int i = 0;
   for ( vtkRenderer* renderer = rens_->GetNextItem ();
         renderer != NULL;
         renderer = rens_->GetNextItem (), ++i)

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -899,10 +899,18 @@ pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int view
 
   bool success = true;
 
+  // If there is no custom viewport and the viewport number is not 0, exit
+  if (rens_->GetNumberOfItems () <= viewport)
+  {
+    PCL_ERROR ("[addText3D] The viewport [%d] doesn't exist (id <%s>)! ",
+               viewport,
+               id.c_str ());
+    return false;
+  }
+
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  rens_->GetNextItem (); //discard first because it's not a renderer for the viewps
-  for (size_t i = std::max (viewport, 1); rens_->GetNextItem () != NULL; ++i)
+  for (size_t i = viewport; rens_->GetNextItem () != NULL; ++i)
   {
     const std::string uid = id + std::string (i, '*');
     ShapeActorMap::iterator am_it = shape_actor_map_->find (uid);

--- a/visualization/test/CMakeLists.txt
+++ b/visualization/test/CMakeLists.txt
@@ -14,3 +14,6 @@ target_link_libraries(demo_shapes_multiport pcl_common pcl_io pcl_kdtree pcl_vis
 
 add_executable(demo_text_simple text_simple.cpp)
 target_link_libraries(demo_text_simple pcl_common pcl_visualization)
+
+add_executable(demo_text_simple_multiport text_simple_multiport.cpp)
+target_link_libraries(demo_text_simple_multiport pcl_common pcl_visualization)

--- a/visualization/test/CMakeLists.txt
+++ b/visualization/test/CMakeLists.txt
@@ -11,3 +11,6 @@ target_link_libraries(demo_shapes pcl_common pcl_io pcl_kdtree pcl_visualization
 
 add_executable(demo_shapes_multiport test_shapes_multiport.cpp)
 target_link_libraries(demo_shapes_multiport pcl_common pcl_io pcl_kdtree pcl_visualization)
+
+add_executable(demo_text_simple text_simple.cpp)
+target_link_libraries(demo_text_simple pcl_common pcl_visualization)

--- a/visualization/test/CMakeLists.txt
+++ b/visualization/test/CMakeLists.txt
@@ -6,8 +6,8 @@
 #target_link_libraries(test_geometry pcl_common pcl_features pcl_filters pcl_io pcl_kdtree pcl_visualization)
 #add_test(vis_test_geometry test_geometry)
 
-#add_executable(demo_shapes test_shapes.cpp)
-#target_link_libraries(demo_shapes pcl_common pcl_io pcl_kdtree pcl_visualization)
+add_executable(demo_shapes test_shapes.cpp)
+target_link_libraries(demo_shapes pcl_common pcl_io pcl_kdtree pcl_visualization)
 
-#add_executable(demo_shapes_multiport test_shapes_multiport.cpp)
-#target_link_libraries(demo_shapes_multiport pcl_common pcl_io pcl_kdtree pcl_visualization)
+add_executable(demo_shapes_multiport test_shapes_multiport.cpp)
+target_link_libraries(demo_shapes_multiport pcl_common pcl_io pcl_kdtree pcl_visualization)

--- a/visualization/test/text_simple.cpp
+++ b/visualization/test/text_simple.cpp
@@ -6,7 +6,7 @@ int
 main (int argc, char** argv)
 {
   pcl::visualization::PCLVisualizer viz ("Visualizator");
-  viz.addCoordinateSystem(1.0);
+  viz.addCoordinateSystem (1.0);
 
   viz.addText3D ("Following text", pcl::PointXYZ(0.0, 0.0, 0.0),
                  1.0, 1.0, 0.0, 0.0, "id_following");

--- a/visualization/test/text_simple.cpp
+++ b/visualization/test/text_simple.cpp
@@ -1,0 +1,24 @@
+#include <pcl/point_types.h>
+
+#include <pcl/visualization/pcl_visualizer.h>
+
+int
+main (int argc, char** argv)
+{
+  pcl::visualization::PCLVisualizer viz ("Visualizator");
+  viz.addCoordinateSystem(1.0);
+
+  viz.addText3D ("Following text", pcl::PointXYZ(0.0, 0.0, 0.0),
+                 1.0, 1.0, 0.0, 0.0, "id_following");
+  viz.spin ();
+  double orientation[3] = {0., 0., 0.};
+  viz.addText3D ("Fixed text", pcl::PointXYZ(0.0, 0.0, 0.0), orientation,
+                 1.0, 0.0, 1.0, 0.0, "id_fixed");
+  viz.spin ();
+  viz.removeText3D ("id_following");
+  viz.spin ();
+  viz.removeText3D ("id_fixed");
+  viz.spin ();
+
+  return (0);
+}

--- a/visualization/test/text_simple_multiport.cpp
+++ b/visualization/test/text_simple_multiport.cpp
@@ -6,13 +6,13 @@ int
 main (int argc, char** argv)
 {
   pcl::visualization::PCLVisualizer viz ("Visualizator");
-  int leftPort(0);
-  int rightPort(0);
+  int leftPort (0);
+  int rightPort (0);
 
-  viz.createViewPort(0, 0, 0.5, 1, leftPort);
-  viz.createViewPort(0.5, 0, 1, 1, rightPort);
+  viz.createViewPort (0, 0, 0.5, 1, leftPort);
+  viz.createViewPort (0.5, 0, 1, 1, rightPort);
 
-  viz.addCoordinateSystem(1.0);
+  viz.addCoordinateSystem (1.0);
 
   viz.addText3D ("Following text", pcl::PointXYZ(0.0, 0.0, 0.0),
                  1.0, 1.0, 0.0, 0.0, "id_following", leftPort);

--- a/visualization/test/text_simple_multiport.cpp
+++ b/visualization/test/text_simple_multiport.cpp
@@ -1,0 +1,30 @@
+#include <pcl/point_types.h>
+
+#include <pcl/visualization/pcl_visualizer.h>
+
+int
+main (int argc, char** argv)
+{
+  pcl::visualization::PCLVisualizer viz ("Visualizator");
+  int leftPort(0);
+  int rightPort(0);
+
+  viz.createViewPort(0, 0, 0.5, 1, leftPort);
+  viz.createViewPort(0.5, 0, 1, 1, rightPort);
+
+  viz.addCoordinateSystem(1.0);
+
+  viz.addText3D ("Following text", pcl::PointXYZ(0.0, 0.0, 0.0),
+                 1.0, 1.0, 0.0, 0.0, "id_following", leftPort);
+  viz.spin ();
+  double orientation[3] = {0., 0., 0.};
+  viz.addText3D ("Fixed text", pcl::PointXYZ(0.0, 0.0, 0.0), orientation,
+                 1.0, 0.0, 1.0, 0.0, "id_fixed", rightPort);
+  viz.spin ();
+  viz.removeText3D ("id_following", leftPort);
+  viz.spin ();
+  viz.removeText3D ("id_fixed", rightPort);
+  viz.spin ();
+
+  return (0);
+}


### PR DESCRIPTION
This PR in relative to issue #2109.

The tiny changes I had enable to display text3D when you don't use any viewport.

I am sure the deletions break the internal logic of the visualizer and I need helps to fix/understand it.