### PR TITLE
[TEST] Fix the compilation of 'test_visualisation'

### DIFF
--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SUBSYS_NAME visualization)
 set(SUBSYS_DESC "Point cloud visualization library")
-set(SUBSYS_DEPS common io kdtree geometry search)
+set(SUBSYS_DEPS common io kdtree geometry search octree)
 
 if(NOT VTK_FOUND)
     set(DEFAULT FALSE)


### PR DESCRIPTION
I tried to compilation `test_visualisation` with the following command line (enable only what is necessary for the `test_visualisation` target):
```bash
rm -rf ./* && cmake -DPCL_ONLY_CORE_POINT_TYPES=ON -DPCL_NO_PRECOMPILE=ON -DBUILD_tools=OFF -DBUILD_examples=OFF -DBUILD_apps=OFF -DBUILD_2d=OFF -DBUILD_features=OFF -DBUILD_filters=OFF -DBUILD_outofcore=OFF -DBUILD_people=OFF -DBUILD_recognition=OFF -DBUILD_registration=OFF -DBUILD_sample_consensus=OFF -DBUILD_ml=OFF -DBUILD_stereo=OFF -DBUILD_surface=OFF -DBUILD_geometry=ON -DBUILD_io=ON -DBUILD_kdtree=ON -DBUILD_octree=ON -DBUILD_search=ON -DBUILD_visualization=ON -DBUILD_global_tests=ON -DBUILD_tests_common=OFF -DBUILD_tests_geometry=OFF -DBUILD_tests_io=OFF -DBUILD_tests_kdtree=OFF -DBUILD_tests_octree=OFF -DBUILD_tests_search=OFF -DBUILD_tests_surface=OFF -DBUILD_tests_segmentation=OFF -DBUILD_tests_features=OFF -DBUILD_tests_filters=OFF -DBUILD_tests_keypoints=OFF -DBUILD_tests_people=OFF -DBUILD_tests_outofcore=OFF -DBUILD_tests_recognition=OFF -DBUILD_tests_registration=OFF -DBUILD_tests_segmentation=OFF -DBUILD_tests_sample_consensus=OFF -DBUILD_tests_visualization=ON -DGTEST_INCLUDE_DIR=/home/frozar/soft/googletest/googletest/include -DGTEST_SRC_DIR=/home/frozar/soft/googletest/googletest -DCMAKE_BUILD_TYPE=Debug .. && make -j8
```

I got the following compilation error:
```
Scanning dependencies of target test_visualization
[ 98%] Building CXX object test/visualization/CMakeFiles/test_visualization.dir/test_visualization.cpp.o
In file included from /home/frozar/wk/pcl_repo/search/include/pcl/search/pcl_search.h:45:0,
                 from /home/frozar/wk/pcl_repo/features/include/pcl/features/impl/feature.hpp:44,
                 from /home/frozar/wk/pcl_repo/features/include/pcl/features/feature.h:498,
                 from /home/frozar/wk/pcl_repo/features/include/pcl/features/normal_3d.h:44,
                 from /home/frozar/wk/pcl_repo/test/visualization/test_visualization.cpp:44:
/home/frozar/wk/pcl_repo/search/include/pcl/search/octree.h:43:38: fatal error: pcl/octree/octree_search.h: Aucun fichier ou dossier de ce type
compilation terminated.
```

This test of visualisation seems to depend on `octree` headers. So in this PR, I propose to update the CMakeLists.txt associated.