### PR TITLE
Freeze doxylink version till upstream is fixed

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -325,7 +325,7 @@ function doc ()
   # Do not generate documentation for pull requests
   if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then exit; fi
   # Install sphinx
-  pip install --user sphinx pyparsing==2.1.9 sphinxcontrib-doxylink
+  pip install --user sphinx pyparsing==2.1.9 sphinxcontrib-doxylink==1.3
   # Configure
   mkdir $BUILD_DIR && cd $BUILD_DIR
   cmake -DDOXYGEN_USE_SHORT_NAMES=OFF \


### PR DESCRIPTION
Already opened an issue upstream https://github.com/sphinx-contrib/doxylink/issues/5 .

**Edit**: I suspect support for python 2.7 was dropped. I'm currently evaluating if migrating to python 3 is hassle free. 
**Edit2**: It isn't. Sticking to 2.7.

Proof of successful build https://travis-ci.org/PointCloudLibrary/pcl/builds/312160741

Will rebase and push the final commit.