### PR TITLE
Change to simple style of specify triplet

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,11 +30,7 @@ init:
   - cd %APPVEYOR_BUILD_FOLDER%
 
 install:
-  - vcpkg install boost:%PLATFORM%-windows
-                  eigen3:%PLATFORM%-windows
-                  flann:%PLATFORM%-windows
-                  qhull:%PLATFORM%-windows
-
+  - vcpkg install boost eigen3 flann qhull --triplet %PLATFORM%-windows
 
 build:
   parallel: true


### PR DESCRIPTION
Change to simple style of specify triplet.
The <code>--triplet</code> option sets the triplet for all packages that don’t explicitly specify a triplet.
@alexkaratarakis Thank you for your advice!