### PR TITLE
Avoid huge index jumps in RandomSample

### DIFF
--- a/2d/CMakeLists.txt
+++ b/2d/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SUBSYS_NAME 2d)
 set(SUBSYS_DESC "Point cloud 2d")
-set(SUBSYS_DEPS common io filters)
+set(SUBSYS_DEPS common filters)
 
 set(build TRUE)
 PCL_SUBSYS_OPTION(build "${SUBSYS_NAME}" "${SUBSYS_DESC}" ON)

--- a/filters/include/pcl/filters/random_sample.h
+++ b/filters/include/pcl/filters/random_sample.h
@@ -232,7 +232,6 @@ namespace pcl
       unifRand ()
       {
         return (static_cast<float> (rand () / double (RAND_MAX)));
-        //return (((214013 * seed_ + 2531011) >> 16) & 0x7FFF);
       }
    };
 }


### PR DESCRIPTION
I have noticed that using pcl::RandomSample to reduce a cloud of 125.000 points to a cloud of 50.000 will sometimes result in a large gap of several centimeters in x-direction in my Lidar data.

The problem is located in random_sample.hpp:

      float V = unifRand ();
      unsigned S = 0;
      float quot = static_cast<float> (top) / static_cast<float> (N);
      while (quot > V)
      {
        S++;
        top--;
        N--;
        quot = quot * static_cast<float> (top) / static_cast<float> (N);
      }
      index += S;
 
When V is close to 0, the index will make a huge jump (e.g. > 20.000), resulting in the gap we see in the attached screenshot.
To fix this, I have set a lower limit of 0.01 for the random number V and made good experiences with that.

![resampled torus](https://user-images.githubusercontent.com/31098817/33822112-b597d3a2-de56-11e7-9ca3-528b03a7f54b.png)
