### PR TITLE
[VISU] Add another method 'getPointCloudRenderingProperties()'

### DIFF
--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -110,8 +110,45 @@ TEST (PCL, PCLVisualizer_camera)
 //  cerr << "reset camera viewer pose:" << endl << viewer_pose << endl;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+TEST (PCL, PCLVisualizer_getPointCloudRenderingProperties)
+{
+  PCLVisualizer::Ptr visualizer (new PCLVisualizer);
 
+  std::string cloud_id = "input_cloud";
+  visualizer->addPointCloud (cloud, cloud_id);
+  ASSERT_TRUE (visualizer->setPointCloudRenderingProperties (PCL_VISUALIZER_COLOR,
+                                                             1.d, 0.d, 0.d, cloud_id));
+  double r, g, b;
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_POINT_SIZE,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_OPACITY,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_LINE_WIDTH,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_FONT_SIZE,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_REPRESENTATION,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_IMMEDIATE_RENDERING,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_SHADING,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_LUT,
+                                                              r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_LUT_RANGE,
+                                                              r, g, b, cloud_id));
 
+  r = 666.d;
+  g = 666.d;
+  b = 666.d;
+  EXPECT_TRUE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_COLOR,
+                                                             r, g, b, cloud_id));
+
+  EXPECT_EQ (r, 1.d);
+  EXPECT_EQ (g, 0.d);
+  EXPECT_EQ (b, 0.d);
+}
 
 /* ---[ */
 int

--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -113,41 +113,41 @@ TEST (PCL, PCLVisualizer_camera)
 ////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PCLVisualizer_getPointCloudRenderingProperties)
 {
-  PCLVisualizer::Ptr visualizer (new PCLVisualizer);
+  PCLVisualizer visualizer;
 
   std::string cloud_id = "input_cloud";
-  visualizer->addPointCloud (cloud, cloud_id);
-  ASSERT_TRUE (visualizer->setPointCloudRenderingProperties (PCL_VISUALIZER_COLOR,
-                                                             1.d, 0.d, 0.d, cloud_id));
+  visualizer.addPointCloud (cloud, cloud_id);
+  ASSERT_TRUE (visualizer.setPointCloudRenderingProperties (PCL_VISUALIZER_COLOR,
+                                                            1., 0., 0., cloud_id));
   double r, g, b;
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_POINT_SIZE,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_OPACITY,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_LINE_WIDTH,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_FONT_SIZE,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_REPRESENTATION,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_IMMEDIATE_RENDERING,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_SHADING,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_LUT,
-                                                              r, g, b, cloud_id));
-  EXPECT_FALSE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_LUT_RANGE,
-                                                              r, g, b, cloud_id));
-
-  r = 666.d;
-  g = 666.d;
-  b = 666.d;
-  EXPECT_TRUE (visualizer->getPointCloudRenderingProperties (PCL_VISUALIZER_COLOR,
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_POINT_SIZE,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_OPACITY,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_LINE_WIDTH,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_FONT_SIZE,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_REPRESENTATION,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_IMMEDIATE_RENDERING,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_SHADING,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_LUT,
+                                                             r, g, b, cloud_id));
+  EXPECT_FALSE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_LUT_RANGE,
                                                              r, g, b, cloud_id));
 
-  EXPECT_EQ (r, 1.d);
-  EXPECT_EQ (g, 0.d);
-  EXPECT_EQ (b, 0.d);
+  r = 666.;
+  g = 666.;
+  b = 666.;
+  EXPECT_TRUE (visualizer.getPointCloudRenderingProperties (PCL_VISUALIZER_COLOR,
+                                                            r, g, b, cloud_id));
+
+  EXPECT_EQ (r, 1.);
+  EXPECT_EQ (g, 0.);
+  EXPECT_EQ (b, 0.);
 }
 
 /* ---[ */

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1179,6 +1179,18 @@ namespace pcl
         getPointCloudRenderingProperties (int property, double &value,
                                           const std::string &id = "cloud");
         
+       /** \brief Get the rendering properties of a PointCloud
+         * \param[in] property the property type
+         * \param[out] val1 the resultant property value
+         * \param[out] val2 the resultant property value
+         * \param[out] val3 the resultant property value
+         * \param[in] id the point cloud object id (default: cloud)
+         * \note The list of properties can be found in \ref pcl::visualization::LookUpTableRepresentationProperties.
+         */
+        bool
+        getPointCloudRenderingProperties (int property, double &val1, double &val2, double &val3,
+                                          const std::string &id = "cloud");
+
         /** \brief Set whether the point cloud is selected or not 
          *  \param[in] selected whether the cloud is selected or not (true = selected)
          *  \param[in] id the point cloud object id (default: cloud)

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1185,6 +1185,7 @@ namespace pcl
          * \param[out] val2 the resultant property value
          * \param[out] val3 the resultant property value
          * \param[in] id the point cloud object id (default: cloud)
+         * \return True if the property is effectively retrieved.
          * \note The list of properties can be found in \ref pcl::visualization::LookUpTableRepresentationProperties.
          */
         bool

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1188,7 +1188,7 @@ namespace pcl
          * \note The list of properties can be found in \ref pcl::visualization::LookUpTableRepresentationProperties.
          */
         bool
-        getPointCloudRenderingProperties (int property, double &val1, double &val2, double &val3,
+        getPointCloudRenderingProperties (RenderingProperties property, double &val1, double &val2, double &val3,
                                           const std::string &id = "cloud");
 
         /** \brief Set whether the point cloud is selected or not 

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1523,7 +1523,6 @@ pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (RenderingPr
     {
       double rgb[3];
       actor->GetProperty ()->GetColor (rgb);
-      actor->Modified ();
       val1 = rgb[0];
       val2 = rgb[1];
       val3 = rgb[2];

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1505,7 +1505,7 @@ pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (int propert
 }
 /////////////////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (int property, double &val1, double &val2, double &val3, const std::string &id)
+pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (RenderingProperties property, double &val1, double &val2, double &val3, const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
   CloudActorMap::iterator am_it = cloud_actor_map_->find (id);

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1503,6 +1503,40 @@ pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (int propert
   }
   return (true);
 }
+/////////////////////////////////////////////////////////////////////////////////////////////
+bool
+pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (int property, double &val1, double &val2, double &val3, const std::string &id)
+{
+  // Check to see if this ID entry already exists (has it been already added to the visualizer?)
+  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+
+  if (am_it == cloud_actor_map_->end ())
+    return (false);
+  // Get the actor pointer
+  vtkLODActor* actor = vtkLODActor::SafeDownCast (am_it->second.actor);
+  if (!actor)
+    return (false);
+
+  switch (property)
+  {
+    case PCL_VISUALIZER_COLOR:
+    {
+      double rgb[3];
+      actor->GetProperty ()->GetColor (rgb);
+      actor->Modified ();
+      val1 = rgb[0];
+      val2 = rgb[1];
+      val3 = rgb[2];
+      break;
+    }
+    default:
+    {
+      pcl::console::print_error ("[getPointCloudRenderingProperties] Unknown property (%d) specified!\n", property);
+      return (false);
+    }
+  }
+  return (true);
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 bool

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1505,7 +1505,11 @@ pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (int propert
 }
 /////////////////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (RenderingProperties property, double &val1, double &val2, double &val3, const std::string &id)
+pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (RenderingProperties property,
+                                                                     double &val1,
+                                                                     double &val2,
+                                                                     double &val3,
+                                                                     const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
   CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
@@ -1530,7 +1534,10 @@ pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (RenderingPr
     }
     default:
     {
-      pcl::console::print_error ("[getPointCloudRenderingProperties] Unknown property (%d) specified!\n", property);
+      pcl::console::print_error ("[getPointCloudRenderingProperties] "
+                                 "Property (%d) is either unknown or it requires a different "
+                                 "number of variables to retrieve its contents.\n",
+                                 property);
       return (false);
     }
   }


### PR DESCRIPTION
In this PR, I proposed another method `getPointCloudRenderingProperties()` to handle the color property. The prototype is different, that's why I had to add a new method: typically to retrieve r, g, b properties.

And in fact, this method handle only the COLOR property.