### PR TITLE
Adds a check for when CreateFileMappingA fails

### DIFF
--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -199,7 +199,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   HANDLE fm = CreateFileMappingA (h_native_file, NULL, PAGE_READWRITE, 0, (DWORD) (data_idx + data_size), NULL);
   if (fm == NULL)
   {
-      throw pcl::IOException("[pcl::PCDWriter::writeBinary] Error during write ()!");
+      throw pcl::IOException("[pcl::PCDWriter::writeBinary] Error during memory map creation ()!");
       return (-1);
   }
   char *map = static_cast<char*>(MapViewOfFile (fm, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, data_idx + data_size));

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -197,6 +197,11 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   // Prepare the map
 #if _WIN32
   HANDLE fm = CreateFileMappingA (h_native_file, NULL, PAGE_READWRITE, 0, (DWORD) (data_idx + data_size), NULL);
+  if (fm == NULL)
+  {
+      throw pcl::IOException("[pcl::PCDWriter::writeBinary] Error during write ()!");
+      return (-1);
+  }
   char *map = static_cast<char*>(MapViewOfFile (fm, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, data_idx + data_size));
   CloseHandle (fm);
 


### PR DESCRIPTION
CreateFileMappingA returns a NULL handle when it fails for example due to insufficient disk space which leads to a crash when memcpy tries to access the map.