### PR TITLE
fixed issue #1348 by adding device sensor check for IR and depth modesetting

### DIFF
--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -93,8 +93,14 @@ pcl::io::openni2::OpenNI2Device::OpenNI2Device (const std::string& device_URI) :
     {
       setColorVideoMode (getDefaultColorMode ());
     }
-    setDepthVideoMode (getDefaultDepthMode ());
-    setIRVideoMode (getDefaultIRMode ());
+    if (openni_device_->hasSensor (openni::SENSOR_DEPTH))
+    {
+      setDepthVideoMode (getDefaultDepthMode ());
+    }
+    if (openni_device_->hasSensor (openni::SENSOR_IR))
+    {
+      setIRVideoMode (getDefaultIRMode ());
+    }
   }
 
   if (openni_device_->isFile ())


### PR DESCRIPTION
Fix for issue #1348, tested with release 1.8.1 and latest master on Gentoo Linux, VTK-6.1.0  and VTK-7.1.0, OpenNI-2.2.0.33, latest libfreenect. 

While it won't crash program should device lack IR and depth sensors, there is some peculiar stuff going on with threads; random crashes seem to appear upon startup.