### PR TITLE
Use reentrant interface of qhull (2015+) when available

### DIFF
--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -23,6 +23,8 @@
 
 #cmakedefine HAVE_QHULL_2011 1
 
+#cmakedefine HAVE_QHULL_2015 1
+
 #cmakedefine HAVE_CUDA 1
 
 #cmakedefine HAVE_FZAPI 1

--- a/surface/include/pcl/surface/qhull.h
+++ b/surface/include/pcl/surface/qhull.h
@@ -49,7 +49,16 @@
 
 extern "C"
 {
-#ifdef HAVE_QHULL_2011
+#ifdef HAVE_QHULL_2015
+#  include "libqhull_r/libqhull_r.h"
+#  include "libqhull_r/mem_r.h"
+#  include "libqhull_r/qset_r.h"
+#  include "libqhull_r/geom_r.h"
+#  include "libqhull_r/merge_r.h"
+#  include "libqhull_r/poly_r.h"
+#  include "libqhull_r/io_r.h"
+#  include "libqhull_r/stat_r.h"
+#elif defined HAVE_QHULL_2011
 #  include "libqhull/libqhull.h"
 #  include "libqhull/mem.h"
 #  include "libqhull/qset.h"


### PR DESCRIPTION
> New code should be written with libqhull_r. Existing users of libqhull should consider converting to libqhull_r. Although libqhull will be supported indefinitely, improvements may not be implemented. Reentrant qhull is 1-2% slower than non-reentrant qhull. 
http://www.qhull.org/html/qh-code.htm