### PR TITLE
Remove VTK legacy functions

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -600,7 +600,6 @@ pcl::visualization::PCLVisualizer::addSphere (const PointT &center, double radiu
   actor->GetProperty ()->SetRepresentationToSurface ();
   actor->GetProperty ()->SetInterpolationToFlat ();
   actor->GetProperty ()->SetColor (r, g, b);
-  actor->GetMapper ()->ImmediateModeRenderingOn ();
   actor->GetMapper ()->StaticOn ();
   actor->GetMapper ()->ScalarVisibilityOff ();
   actor->GetMapper ()->Update ();
@@ -1531,7 +1530,6 @@ pcl::visualization::PCLVisualizer::updatePointCloud (const typename pcl::PointCl
   double minmax[2];
   minmax[0] = std::numeric_limits<double>::min ();
   minmax[1] = std::numeric_limits<double>::max ();
-  am_it->second.actor->GetMapper ()->ImmediateModeRenderingOff ();
   am_it->second.actor->GetMapper ()->SetScalarRange (minmax);
 
   // Update the mapper
@@ -1567,7 +1565,6 @@ pcl::visualization::PCLVisualizer::updatePointCloud (const typename pcl::PointCl
   double minmax[2];
   minmax[0] = std::numeric_limits<double>::min ();
   minmax[1] = std::numeric_limits<double>::max ();
-  am_it->second.actor->GetMapper ()->ImmediateModeRenderingOff ();
   am_it->second.actor->GetMapper ()->SetScalarRange (minmax);
 
   // Update the mapper
@@ -1643,7 +1640,6 @@ pcl::visualization::PCLVisualizer::updatePointCloud (const typename pcl::PointCl
   // Update the data
   polydata->GetPointData ()->SetScalars (scalars);
 
-  am_it->second.actor->GetMapper ()->ImmediateModeRenderingOff ();
   am_it->second.actor->GetMapper ()->SetScalarRange (minmax);
 
   // Update the mapper

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1217,7 +1217,6 @@ pcl::visualization::PCLVisualizer::createActorFromVTKDataSet (const vtkSmartPoin
         mapper->ScalarVisibilityOn ();
       }
     }
-    mapper->ImmediateModeRenderingOff ();
 
     actor->SetNumberOfCloudPoints (int (std::max<vtkIdType> (1, data->GetNumberOfPoints () / 10)));
     actor->GetProperty ()->SetInterpolationToFlat ();
@@ -1297,7 +1296,6 @@ pcl::visualization::PCLVisualizer::createActorFromVTKDataSet (const vtkSmartPoin
         mapper->ScalarVisibilityOn ();
       }
     }
-    mapper->ImmediateModeRenderingOff ();
 
     //actor->SetNumberOfCloudPoints (int (std::max<vtkIdType> (1, data->GetNumberOfPoints () / 10)));
     actor->GetProperty ()->SetInterpolationToFlat ();
@@ -1583,7 +1581,6 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
     // using immediate more rendering.
     case PCL_VISUALIZER_IMMEDIATE_RENDERING:
     {
-      actor->GetMapper ()->SetImmediateModeRendering (int (value));
       actor->Modified ();
       break;
     }


### PR DESCRIPTION
Recently VTK removes some legacy functions that causes PCL to stop compiling. 

https://github.com/Kitware/VTK/commit/fc2ac65dc798d932974abc500f14b94e2a5208f9

The fix is applied according to the suggestion of the VTK devs. 

I tested and it compiles and runs without a problem on Ubuntu 16.04 latest PCL.