### PR TITLE
handle VTK legacy function (follow up to #2112)

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1587,7 +1587,9 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
     // using immediate more rendering.
     case PCL_VISUALIZER_IMMEDIATE_RENDERING:
     {
+#if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2
       actor->GetMapper ()->SetImmediateModeRendering (int (value));
+#endif
       actor->Modified ();
       break;
     }


### PR DESCRIPTION
This is a follow up to #2112, there is one last place that needs to be guarded with `#if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2` in order to compile with the latest VTK