### PR TITLE
Add descriptor unpacking to GASD tutorial

### DIFF
--- a/doc/tutorials/content/gasd_estimation.rst
+++ b/doc/tutorials/content/gasd_estimation.rst
@@ -99,6 +99,13 @@ The following code snippet will estimate a GASD shape + color descriptor for an 
 
      // Get the alignment transform
      Eigen::Matrix4f trans = gasd.getTransform (trans);
+
+     // descriptor.points.size () should be of size 1
+     // Unpack histogram bins
+     for (size_t i = 0; i < size_t( descriptor.points[0].descriptorSize ()); ++i)
+     {
+       descriptor.points[0].histogram[i];
+     }
    }
 
 The following code snippet will estimate a GASD shape only descriptor for an input point cloud.
@@ -126,6 +133,13 @@ The following code snippet will estimate a GASD shape only descriptor for an inp
 
      // Get the alignment transform
      Eigen::Matrix4f trans = gasd.getTransform (trans);
+
+     // descriptor.points.size () should be of size 1
+     // Unpack histogram bins
+     for (size_t i = 0; i < size_t( descriptor.points[0].descriptorSize ()); ++i)
+     {
+       descriptor.points[0].histogram[i];
+     }
    }
 
 .. [GASD] http://www.cin.ufpe.br/~jpsml/uploads/8/2/6/7/82675770/pid4349755.pdf

--- a/doc/tutorials/content/gasd_estimation.rst
+++ b/doc/tutorials/content/gasd_estimation.rst
@@ -100,11 +100,10 @@ The following code snippet will estimate a GASD shape + color descriptor for an 
      // Get the alignment transform
      Eigen::Matrix4f trans = gasd.getTransform (trans);
 
-     // descriptor.points.size () should be of size 1
      // Unpack histogram bins
-     for (size_t i = 0; i < size_t( descriptor.points[0].descriptorSize ()); ++i)
+     for (size_t i = 0; i < size_t( descriptor[0].descriptorSize ()); ++i)
      {
-       descriptor.points[0].histogram[i];
+       descriptor[0].histogram[i];
      }
    }
 
@@ -134,11 +133,10 @@ The following code snippet will estimate a GASD shape only descriptor for an inp
      // Get the alignment transform
      Eigen::Matrix4f trans = gasd.getTransform (trans);
 
-     // descriptor.points.size () should be of size 1
      // Unpack histogram bins
-     for (size_t i = 0; i < size_t( descriptor.points[0].descriptorSize ()); ++i)
+     for (size_t i = 0; i < size_t( descriptor[0].descriptorSize ()); ++i)
      {
-       descriptor.points[0].histogram[i];
+       descriptor[0].histogram[i];
      }
    }
 


### PR DESCRIPTION
Extend GASD tutorial to illustrate how the descriptor should be unpacked.