### PR TITLE
[OCTREE] end iterator without parametrisation

### DIFF
--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -115,9 +115,9 @@ namespace pcl
           return Iterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
         };
 
-        const Iterator end (unsigned int max_depth_arg = 0u)
+        const Iterator end ()
         {
-          return Iterator (this, max_depth_arg? max_depth_arg : this->octree_depth_ , NULL);
+          return Iterator (this, 0, NULL);
         };
 
         // Octree leaf node iterators
@@ -129,9 +129,9 @@ namespace pcl
           return LeafNodeIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
         };
 
-        const LeafNodeIterator leaf_end (unsigned int max_depth_arg = 0u)
+        const LeafNodeIterator leaf_end ()
         {
-          return LeafNodeIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_, NULL);
+          return LeafNodeIterator (this, 0, NULL);
         };
 
         // Octree depth-first iterators
@@ -143,9 +143,9 @@ namespace pcl
           return DepthFirstIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
         };
 
-        const DepthFirstIterator depth_end (unsigned int max_depth_arg = 0u)
+        const DepthFirstIterator depth_end ()
         {
-          return DepthFirstIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_, NULL);
+          return DepthFirstIterator (this, 0, NULL);
         };
 
         // Octree breadth-first iterators
@@ -157,9 +157,9 @@ namespace pcl
           return BreadthFirstIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
         };
 
-        const BreadthFirstIterator breadth_end (unsigned int max_depth_arg = 0u)
+        const BreadthFirstIterator breadth_end ()
         {
-          return BreadthFirstIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_, NULL);
+          return BreadthFirstIterator (this, 0, NULL);
         };
 
 

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -130,12 +130,17 @@ namespace pcl
          */
         bool operator==(const OctreeIteratorBase& other) const
         {
-          return (this == &other) ||
-                    ((octree_ == other.octree_) &&
-                     ((!(current_state_) && !(other.current_state_)) || // end state case
-                      ((max_octree_depth_ == other.max_octree_depth_) &&
-                       (current_state_ && other.current_state_ &&  // null dereference protection
-                        (current_state_->key_ == other.current_state_->key_)))));
+          if (this == &other)  // same object
+            return true;
+          if (octree_ != other.octree_)  // refer to different octrees
+            return false;
+          if (!current_state_ && !other.current_state_)  // both are end iterators
+            return true;
+          if (max_octree_depth_ == other.max_octree_depth_ &&
+              current_state_ && other.current_state_ &&  // null dereference protection
+              current_state_->key_ == other.current_state_->key_)
+            return true;
+          return false;
         }
 
         /** \brief Inequal comparison operator

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -132,10 +132,10 @@ namespace pcl
         {
           return (this == &other) ||
                     ((octree_ == other.octree_) &&
-                     (max_octree_depth_ == other.max_octree_depth_) &&
-                     ((current_state_ == other.current_state_) || // end state case
-                      (current_state_ && other.current_state_ &&  // null dereference protection
-                        (current_state_->key_ == other.current_state_->key_))));
+                     ((!(current_state_) && !(other.current_state_)) || // end state case
+                      ((max_octree_depth_ == other.max_octree_depth_) &&
+                       (current_state_ && other.current_state_ &&  // null dereference protection
+                        (current_state_->key_ == other.current_state_->key_)))));
         }
 
         /** \brief Inequal comparison operator

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -420,6 +420,71 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, BreadthEnd)
   EXPECT_NE (it_m_1, it_m_b_1);
 }
 
+TEST_F (OctreeBaseBeginEndIteratorsTest, ForLoop)
+{
+  // Useful types
+  typedef typename OctreeT::Iterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a;
+  IteratorT it_a_end = oct_a_.end ();
+
+  unsigned int node_count = 0;
+  unsigned int branch_count = 0;
+  unsigned int leaf_count = 0;
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a = oct_a_.begin (); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 64);
+  ASSERT_EQ (branch_count, 9);
+  ASSERT_EQ (branch_count + leaf_count, node_count);
+  ASSERT_EQ (oct_a_.getLeafCount (), leaf_count);
+  ASSERT_EQ (oct_a_.getBranchCount (), branch_count);
+
+  // Iterate over the octree oct_a_ with a depth max of 1.
+  // As oct_a_ has a depth level of 2, we should only iterate
+  // over 9 branch node: the root node + 8 node at depth 1
+  node_count = 0;
+  branch_count = 0;
+  leaf_count = 0;
+  unsigned int max_depth = 1;
+  for (it_a = oct_a_.begin (max_depth); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 0);
+  ASSERT_EQ (branch_count, 9);
+  ASSERT_EQ (branch_count + leaf_count, node_count);
+  ASSERT_EQ (oct_a_.getBranchCount (), branch_count);
+}
+
 ////////////////////////////////////////////////////////
 //     OctreePointCloudAdjacency Begin/End Iterator Construction
 ////////////////////////////////////////////////////////

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -380,7 +380,15 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, BreadthEnd)
   EXPECT_NE (it_a_2, it_b);
 }
 
-TEST_F (OctreeBaseBeginEndIteratorsTest, ForLoop)
+////////////////////////////////////////////////////////
+//        OctreeBase Iterator For Loop Case
+////////////////////////////////////////////////////////
+
+struct OctreeBaseIteratorsForLoopTest : public OctreeBaseBeginEndIteratorsTest
+{
+};
+
+TEST_F (OctreeBaseIteratorsForLoopTest, DefaultIterator)
 {
   // Useful types
   typedef typename OctreeT::Iterator IteratorT;
@@ -424,6 +432,197 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, ForLoop)
   leaf_count = 0;
   unsigned int max_depth = 1;
   for (it_a = oct_a_.begin (max_depth); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 0);
+  ASSERT_EQ (branch_count, 9);
+  ASSERT_EQ (branch_count + leaf_count, node_count);
+  ASSERT_EQ (oct_a_.getBranchCount (), branch_count);
+}
+
+TEST_F (OctreeBaseIteratorsForLoopTest, LeafNodeIterator)
+{
+  // Useful types
+  typedef typename OctreeT::LeafNodeIterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a;
+  IteratorT it_a_end = oct_a_.leaf_end ();
+
+  unsigned int node_count = 0;
+  unsigned int branch_count = 0;
+  unsigned int leaf_count = 0;
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a = oct_a_.leaf_begin (); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 64);
+  ASSERT_EQ (branch_count, 0);
+  ASSERT_EQ (oct_a_.getLeafCount (), leaf_count);
+
+  // Iterate over the octree oct_a_ with a depth max of 1.
+  // As oct_a_ has a depth level of 2, we should only iterate
+  // over 9 branch node: the root node + 8 node at depth 1
+  node_count = 0;
+  branch_count = 0;
+  leaf_count = 0;
+  unsigned int max_depth = 1;
+  for (it_a = oct_a_.leaf_begin (max_depth); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 0);
+  ASSERT_EQ (branch_count, 0);
+}
+
+TEST_F (OctreeBaseIteratorsForLoopTest, DepthFirstIterator)
+{
+  // Useful types
+  typedef typename OctreeT::DepthFirstIterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a;
+  IteratorT it_a_end = oct_a_.depth_end ();
+
+  unsigned int node_count = 0;
+  unsigned int branch_count = 0;
+  unsigned int leaf_count = 0;
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a = oct_a_.depth_begin (); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 64);
+  ASSERT_EQ (branch_count, 9);
+  ASSERT_EQ (branch_count + leaf_count, node_count);
+  ASSERT_EQ (oct_a_.getLeafCount (), leaf_count);
+  ASSERT_EQ (oct_a_.getBranchCount (), branch_count);
+
+  // Iterate over the octree oct_a_ with a depth max of 1.
+  // As oct_a_ has a depth level of 2, we should only iterate
+  // over 9 branch node: the root node + 8 node at depth 1
+  node_count = 0;
+  branch_count = 0;
+  leaf_count = 0;
+  unsigned int max_depth = 1;
+  for (it_a = oct_a_.depth_begin (max_depth); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 0);
+  ASSERT_EQ (branch_count, 9);
+  ASSERT_EQ (branch_count + leaf_count, node_count);
+  ASSERT_EQ (oct_a_.getBranchCount (), branch_count);
+}
+
+TEST_F (OctreeBaseIteratorsForLoopTest, BreadthFirstIterator)
+{
+  // Useful types
+  typedef typename OctreeT::BreadthFirstIterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a;
+  IteratorT it_a_end = oct_a_.breadth_end ();
+
+  unsigned int node_count = 0;
+  unsigned int branch_count = 0;
+  unsigned int leaf_count = 0;
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a = oct_a_.breadth_begin (); it_a != it_a_end; ++it_a)
+  {
+    // store node, branch and leaf count
+    const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
+    if (node->getNodeType () == pcl::octree::BRANCH_NODE)
+    {
+      branch_count++;
+    }
+    else if (node->getNodeType () == pcl::octree::LEAF_NODE)
+    {
+      leaf_count++;
+    }
+    node_count++;
+  }
+
+  // Check the node_count, branch_count and leaf_count values
+  ASSERT_EQ (leaf_count, 64);
+  ASSERT_EQ (branch_count, 9);
+  ASSERT_EQ (branch_count + leaf_count, node_count);
+  ASSERT_EQ (oct_a_.getLeafCount (), leaf_count);
+  ASSERT_EQ (oct_a_.getBranchCount (), branch_count);
+
+  // Iterate over the octree oct_a_ with a depth max of 1.
+  // As oct_a_ has a depth level of 2, we should only iterate
+  // over 9 branch node: the root node + 8 node at depth 1
+  node_count = 0;
+  branch_count = 0;
+  leaf_count = 0;
+  unsigned int max_depth = 1;
+  for (it_a = oct_a_.breadth_begin (max_depth); it_a != it_a_end; ++it_a)
   {
     // store node, branch and leaf count
     const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -258,16 +258,6 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, End)
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
-
-  // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.end ();
-  IteratorT it_m_1 = oct_a_.end (1);
-  IteratorT it_m_2 = oct_a_.end (2);
-  IteratorT it_m_b_1 = oct_b_.end (1);
-
-  EXPECT_NE (it_m_1, it_m_2);
-  EXPECT_EQ (it_m_2, it_m); // tree depth is 2
-  EXPECT_NE (it_m_1, it_m_b_1);
 }
 
 TEST_F (OctreeBaseBeginEndIteratorsTest, LeafBegin)
@@ -308,16 +298,6 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, LeafEnd)
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
-
-  // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.leaf_end ();
-  IteratorT it_m_1 = oct_a_.leaf_end (1);
-  IteratorT it_m_2 = oct_a_.leaf_end (2);
-  IteratorT it_m_b_1 = oct_b_.leaf_end (1);
-
-  EXPECT_NE (it_m_1, it_m_2);
-  EXPECT_EQ (it_m_2, it_m); // tree depth is 2
-  EXPECT_NE (it_m_1, it_m_b_1);
 }
 
 TEST_F (OctreeBaseBeginEndIteratorsTest, DepthBegin)
@@ -358,16 +338,6 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, DepthEnd)
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
-
-  // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.depth_end ();
-  IteratorT it_m_1 = oct_a_.depth_end (1);
-  IteratorT it_m_2 = oct_a_.depth_end (2);
-  IteratorT it_m_b_1 = oct_b_.depth_end (1);
-
-  EXPECT_NE (it_m_1, it_m_2);
-  EXPECT_EQ (it_m_2, it_m); // tree depth is 2
-  EXPECT_NE (it_m_1, it_m_b_1);
 }
 
 TEST_F (OctreeBaseBeginEndIteratorsTest, BreadthBegin)
@@ -408,16 +378,6 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, BreadthEnd)
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
-
-  // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.breadth_end ();
-  IteratorT it_m_1 = oct_a_.breadth_end (1);
-  IteratorT it_m_2 = oct_a_.breadth_end (2);
-  IteratorT it_m_b_1 = oct_b_.breadth_end (1);
-
-  EXPECT_NE (it_m_1, it_m_2);
-  EXPECT_EQ (it_m_2, it_m); // tree depth is 2
-  EXPECT_NE (it_m_1, it_m_b_1);
 }
 
 TEST_F (OctreeBaseBeginEndIteratorsTest, ForLoop)
@@ -569,16 +529,6 @@ TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, DepthEnd)
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
-
-  // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.depth_end ();
-  IteratorT it_m_1 = oct_a_.depth_end (1);
-  IteratorT it_m_md = oct_a_.depth_end (oct_a_.getTreeDepth ());
-  IteratorT it_m_b_1 = oct_b_.depth_end (1);
-
-  EXPECT_NE (it_m_1, it_m_md);
-  EXPECT_EQ (it_m_md, it_m); // should default to tree depth
-  EXPECT_NE (it_m_1, it_m_b_1);
 }
 
 TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafBegin)
@@ -619,16 +569,6 @@ TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafEnd)
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
-
-  // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.leaf_end ();
-  IteratorT it_m_1 = oct_a_.leaf_end (1);
-  IteratorT it_m_md = oct_a_.leaf_end (oct_a_.getTreeDepth ());
-  IteratorT it_m_b_1 = oct_b_.leaf_end (1);
-
-  EXPECT_NE (it_m_1, it_m_md);
-  EXPECT_EQ (it_m_md, it_m); // should default to tree depth
-  EXPECT_NE (it_m_1, it_m_b_1);
 }
 
 int


### PR DESCRIPTION
I add an octree test to check the behavior of current iterator with a 'for loop' (which is the main usage in reality I think). This test curently fails. In the second for loop, I got this message: 
```
test_octree_iterator: /home/frozar/wk/pcl_repo/octree/include/pcl/octree/octree_iterator.h:190:
pcl::octree::OctreeNode* pcl::octree::OctreeIteratorBase<OctreeT>::getCurrentOctreeNode() const [with OctreeT = pcl::octree::OctreeBase<int>]:
Assertion `current_state_!=0' failed.
```

I think that the iterator goes over every node of depth egal to 0 and 1, as expected, but it is never equal to the end iterator. If you look at the source:
https://github.com/PointCloudLibrary/pcl/blob/6d4c5c8590a49e1d6069a1cf1fd380f107091b78/octree/include/pcl/octree/octree_iterator.h#L131-L139

to be equal, two iterators must have the same `max_octree_depth` value. I'm not sure checking that is fair. When you look at the creation of the end iterator:
https://github.com/PointCloudLibrary/pcl/blob/6d4c5c8590a49e1d6069a1cf1fd380f107091b78/octree/include/pcl/octree/octree_base.h#L118-L121

the default `max_depth_arg` is 0, so max depth of the end iterator will be the depth of the octree by default. So in a for loop, when one specifies a max depth inferior to the depth of an octree, the exit condition will never match.

### Proposition
 - delete the check `max_octree_depth_ == other.max_octree_depth_`
 - delete the `max_depth_arg` for the end iterators, it is not necessary