### PR TITLE
[TEST] OCTREE Iterator begin/end method and add test

### DIFF
--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -72,33 +72,11 @@ namespace pcl
 
     class OctreePointCloud : public OctreeT
     {
-        // iterators are friends
-        friend class OctreeIteratorBase<OctreeT> ;
-        friend class OctreeDepthFirstIterator<OctreeT> ;
-        friend class OctreeBreadthFirstIterator<OctreeT> ;
-        friend class OctreeLeafNodeIterator<OctreeT> ;
-
       public:
         typedef OctreeT Base;
 
         typedef typename OctreeT::LeafNode LeafNode;
         typedef typename OctreeT::BranchNode BranchNode;
-
-        // Octree default iterators
-        typedef OctreeDepthFirstIterator<OctreeT> Iterator;
-        typedef const OctreeDepthFirstIterator<OctreeT> ConstIterator;
-
-        // Octree leaf node iterators
-        typedef OctreeLeafNodeIterator<OctreeT> LeafNodeIterator;
-        typedef const OctreeLeafNodeIterator<OctreeT> ConstLeafNodeIterator;
-
-        // Octree depth-first iterators
-        typedef OctreeDepthFirstIterator<OctreeT> DepthFirstIterator;
-        typedef const OctreeDepthFirstIterator<OctreeT> ConstDepthFirstIterator;
-
-        // Octree breadth-first iterators
-        typedef OctreeBreadthFirstIterator<OctreeT> BreadthFirstIterator;
-        typedef const OctreeBreadthFirstIterator<OctreeT> ConstBreadthFirstIterator;
 
         /** \brief Octree pointcloud constructor.
          * \param[in] resolution_arg octree resolution at lowest octree level

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency.h
@@ -95,40 +95,6 @@ namespace pcl
         typedef boost::shared_ptr<PointCloud> PointCloudPtr;
         typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
 
-        // Iterators are friends
-        friend class OctreeIteratorBase<OctreeAdjacencyT>;
-        friend class OctreeDepthFirstIterator<OctreeAdjacencyT>;
-        friend class OctreeBreadthFirstIterator<OctreeAdjacencyT>;
-        friend class OctreeLeafNodeIterator<OctreeAdjacencyT>;
-
-        // Octree default iterators
-        typedef OctreeDepthFirstIterator<OctreeAdjacencyT> Iterator;
-        typedef const OctreeDepthFirstIterator<OctreeAdjacencyT> ConstIterator;
-
-        Iterator depth_begin (unsigned int max_depth_arg = 0)
-        {
-          return Iterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
-        }
-
-        const Iterator depth_end (unsigned int max_depth_arg = 0)
-        {
-          return Iterator (this, max_depth_arg? max_depth_arg : this->octree_depth_, NULL);
-        }
-
-        // Octree leaf node iterators
-        typedef OctreeLeafNodeIterator<OctreeAdjacencyT> LeafNodeIterator;
-        typedef const OctreeLeafNodeIterator<OctreeAdjacencyT> ConstLeafNodeIterator;
-
-        LeafNodeIterator leaf_begin (unsigned int max_depth_arg = 0)
-        {
-          return LeafNodeIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
-        }
-
-        const LeafNodeIterator leaf_end (unsigned int max_depth_arg = 0)
-        {
-          return LeafNodeIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_, NULL);
-        }
-
         // BGL graph
         typedef boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, PointT, float> VoxelAdjacencyList;
         typedef typename VoxelAdjacencyList::vertex_descriptor VoxelID;

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -690,46 +690,6 @@ struct OctreePointCloudAdjacencyBeginEndIteratorsTest
   OctreeT oct_a_, oct_b_;
 };
 
-TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, DepthBegin)
-{
-  // Useful types
-  typedef typename OctreeT::Iterator IteratorT;
-
-  // Default initialization
-  IteratorT it_a_1 = oct_a_.depth_begin ();
-  IteratorT it_a_2 = oct_a_.depth_begin ();
-  IteratorT it_b = oct_b_.depth_begin ();
-
-  EXPECT_EQ (it_a_1, it_a_2);
-  EXPECT_NE (it_a_1, it_b);
-  EXPECT_NE (it_a_2, it_b);
-
-  // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.depth_begin ();
-  IteratorT it_m_1 = oct_a_.depth_begin (1);
-  IteratorT it_m_md = oct_a_.depth_begin (oct_a_.getTreeDepth ());
-  IteratorT it_m_b_1 = oct_b_.depth_begin (1);
-
-  EXPECT_NE (it_m_1, it_m_md);
-  EXPECT_EQ (it_m_md, it_m); // should default to tree depth
-  EXPECT_NE (it_m_1, it_m_b_1);
-}
-
-TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, DepthEnd)
-{
-  // Useful types
-  typedef typename OctreeT::Iterator IteratorT;
-
-  // Default initialization
-  IteratorT it_a_1 = oct_a_.depth_end ();
-  IteratorT it_a_2 = oct_a_.depth_end ();
-  IteratorT it_b = oct_b_.depth_end ();
-
-  EXPECT_EQ (it_a_1, it_a_2);
-  EXPECT_NE (it_a_1, it_b);
-  EXPECT_NE (it_a_2, it_b);
-}
-
 TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafBegin)
 {
   // Useful types
@@ -764,6 +724,86 @@ TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafEnd)
   IteratorT it_a_1 = oct_a_.leaf_end ();
   IteratorT it_a_2 = oct_a_.leaf_end ();
   IteratorT it_b = oct_b_.leaf_end ();
+
+  EXPECT_EQ (it_a_1, it_a_2);
+  EXPECT_NE (it_a_1, it_b);
+  EXPECT_NE (it_a_2, it_b);
+}
+
+TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, DepthBegin)
+{
+  // Useful types
+  typedef typename OctreeT::DepthFirstIterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a_1 = oct_a_.depth_begin ();
+  IteratorT it_a_2 = oct_a_.depth_begin ();
+  IteratorT it_b = oct_b_.depth_begin ();
+
+  EXPECT_EQ (it_a_1, it_a_2);
+  EXPECT_NE (it_a_1, it_b);
+  EXPECT_NE (it_a_2, it_b);
+
+  // Different max depths are not the same iterators
+  IteratorT it_m = oct_a_.depth_begin ();
+  IteratorT it_m_1 = oct_a_.depth_begin (1);
+  IteratorT it_m_md = oct_a_.depth_begin (oct_a_.getTreeDepth ());
+  IteratorT it_m_b_1 = oct_b_.depth_begin (1);
+
+  EXPECT_NE (it_m_1, it_m_md);
+  EXPECT_EQ (it_m_md, it_m); // should default to tree depth
+  EXPECT_NE (it_m_1, it_m_b_1);
+}
+
+TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, DepthEnd)
+{
+  // Useful types
+  typedef typename OctreeT::DepthFirstIterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a_1 = oct_a_.depth_end ();
+  IteratorT it_a_2 = oct_a_.depth_end ();
+  IteratorT it_b = oct_b_.depth_end ();
+
+  EXPECT_EQ (it_a_1, it_a_2);
+  EXPECT_NE (it_a_1, it_b);
+  EXPECT_NE (it_a_2, it_b);
+}
+
+TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, BreadthBegin)
+{
+  // Useful types
+  typedef typename OctreeT::BreadthFirstIterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a_1 = oct_a_.breadth_begin ();
+  IteratorT it_a_2 = oct_a_.breadth_begin ();
+  IteratorT it_b = oct_b_.breadth_begin ();
+
+  EXPECT_EQ (it_a_1, it_a_2);
+  EXPECT_NE (it_a_1, it_b);
+  EXPECT_NE (it_a_2, it_b);
+
+  // Different max depths are not the same iterators
+  IteratorT it_m = oct_a_.breadth_begin ();
+  IteratorT it_m_1 = oct_a_.breadth_begin (1);
+  IteratorT it_m_md = oct_a_.breadth_begin (oct_a_.getTreeDepth ());
+  IteratorT it_m_b_1 = oct_b_.breadth_begin (1);
+
+  EXPECT_NE (it_m_1, it_m_md);
+  EXPECT_EQ (it_m_md, it_m); // should default to tree depth
+  EXPECT_NE (it_m_1, it_m_b_1);
+}
+
+TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, BreadthEnd)
+{
+  // Useful types
+  typedef typename OctreeT::BreadthFirstIterator IteratorT;
+
+  // Default initialization
+  IteratorT it_a_1 = oct_a_.breadth_end ();
+  IteratorT it_a_2 = oct_a_.breadth_end ();
+  IteratorT it_b = oct_b_.breadth_end ();
 
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);


### PR DESCRIPTION
I propose to delete begin()/end() iterator method definitions in class `OctreePointCloud` and `OctreePointCloudAdjacency`. As these classes derived from `OctreeBase`, which defines all iterator methods, it is not necessary and confusing to redefine them.

I also add some test over the `OctreePointCloudAdjacency` to check the basic iterator behavior (construction, comparison).
  