### PR TITLE
Add TrajkovicKeypoint2D/3D to CMake build

### DIFF
--- a/keypoints/CMakeLists.txt
+++ b/keypoints/CMakeLists.txt
@@ -19,6 +19,8 @@ if(build)
         src/susan.cpp
         src/iss_3d.cpp
         src/brisk_2d.cpp
+        src/trajkovic_2d.cpp
+        src/trajkovic_3d.cpp        
         )
     set(incs
         "include/pcl/${SUBSYS_NAME}/keypoint.h"
@@ -33,6 +35,8 @@ if(build)
         "include/pcl/${SUBSYS_NAME}/susan.h"
         "include/pcl/${SUBSYS_NAME}/iss_3d.h"
         "include/pcl/${SUBSYS_NAME}/brisk_2d.h"
+        "include/pcl/${SUBSYS_NAME}/trajkovic_2d.h"
+        "include/pcl/${SUBSYS_NAME}/trajkovic_3d.h"        
         )
     set(impl_incs
         "include/pcl/${SUBSYS_NAME}/impl/keypoint.hpp"
@@ -45,6 +49,8 @@ if(build)
         "include/pcl/${SUBSYS_NAME}/impl/susan.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/iss_3d.hpp"
         "include/pcl/${SUBSYS_NAME}/impl/brisk_2d.hpp"
+        "include/pcl/${SUBSYS_NAME}/impl/trajkovic_2d.hpp"
+        "include/pcl/${SUBSYS_NAME}/impl/trajkovic_3d.hpp"        
         )
     
     set(LIB_NAME "pcl_${SUBSYS_NAME}")

--- a/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
@@ -234,9 +234,9 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
 #ifdef _OPENMP
 #pragma omp parallel for shared (output) num_threads (threads_)
 #endif
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (int i = 0; i < static_cast<int>(indices.size ()); ++i)
   {
-    int idx = indices[i];
+    int idx = indices[static_cast<size_t>(i)];
     if ((response_->points[idx] < second_threshold_) || occupency_map[idx])
       continue;
 


### PR DESCRIPTION
The files which have been added to PCL in #409 are missing in the CMakeLists.txt of the keypoints module.

Fix Microsoft Visual Studio 2015 compile error: "trajkovic_3d.hpp(235): error C3016: 'i': index variable in OpenMP 'for' statement must have signed integral type" by changing index type from size_t to int.