### PR TITLE
Fixed typo and rearragend items in the issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,4 @@
-:warning: This is a issue tracker, please use our mailing list for questions: www.pcl-users.org. :warning: 
+<!--- WARNING: This is an issue tracker, please use our mailing list for questions: www.pcl-users.org. -->
 
 <!--- Provide a general summary of the issue in the Title above -->
 
@@ -8,6 +8,10 @@
 * Compiler:
 * PCL Version:
 
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
 ## Expected Behavior
 <!--- If you're describing a bug, tell us what should happen -->
 <!--- If you're suggesting a change/improvement, tell us how it should work -->
@@ -16,15 +20,10 @@
 <!--- If describing a bug, tell us what happens instead of the expected behavior -->
 <!--- If suggesting a change/improvement, explain the difference from current behavior -->
 
-## Possible Solution
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
-
 ## Code to Reproduce
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug. Include code to reproduce, if relevant -->
 
-## Context
-<!--- How has this issue affected you? What are you trying to accomplish? -->
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->
-
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->


### PR DESCRIPTION
Just rearranged things in a way which seem more natural to me. It replicates the order I normally follow every time someone submits an issue adhering to the template.

I also suppressed the display of the warning message on the actual issue, this it provides no relevant info for the issue at all after it is already created.