### PR TITLE
Correct testPoint for organized nearest neighbor search

### DIFF
--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -224,7 +224,10 @@ namespace pcl
             float dist_z = point.z - query.z;
             float squared_distance = dist_x * dist_x + dist_y * dist_y + dist_z * dist_z;
             if (queue.size () < k)
+            {
               queue.push (Entry (index, squared_distance));
+              return queue.size () == k;
+            }
             else if (queue.top ().distance > squared_distance)
             {
               queue.pop ();


### PR DESCRIPTION
I was seeing occasional spikes in the computation time for organized kNN search. This is due to the search box not being updated when adding the k-th neighbor and subsequent iterations of the do-while loop in kNN search never trigger the else case in `testPoint`. This way we iterate over way too many points during search.

The plot below shows a histogram of the log10 computation time before (top) and after (bottom) the fix for `k=20` for every point on a particularly problematic point cloud. Note the grouping around -3 on the before plot. On this point cloud, this reduces the average computation time of nearest neighbor searches by a factor 20. On other clouds I see around a factor 2 improvement.

![organized_neighbor](https://user-images.githubusercontent.com/14992841/35508972-bb4aacd0-04f2-11e8-9d89-9f040fb834b5.png)