### PR TITLE
fix error in Line 11 in  example code for estimate set of surface for a subset of points in the input dataset

### DIFF
--- a/doc/tutorials/content/how_features_work.rst
+++ b/doc/tutorials/content/how_features_work.rst
@@ -161,7 +161,7 @@ The following code snippet will estimate a set of surface normals for a subset o
 
      // Create a set of indices to be used. For simplicity, we're going to be using the first 10% of the points in cloud
      std::vector<int> indices (floor (cloud->points.size () / 10));
-     for (size_t i = 0; indices.size (); ++i) indices[i] = i;
+     for (size_t i = 0; i < indices.size (); ++i) indices[i] = i;
 
      // Create the normal estimation class, and pass the input dataset to it
      pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;


### PR DESCRIPTION
I found an error in the example code in how_features_work.rst. The error was in the example code for estimate set of surface for a subset of points in the input dataset. The error was on Line 11 for loop. 
Before correction,
![before_pcl_how_features_work](https://user-images.githubusercontent.com/26876782/35844936-e2f2154e-0b4a-11e8-8554-6493d328cd5f.png)

After correction,
![after_pcl_how_features_work](https://user-images.githubusercontent.com/26876782/35844986-389ab4b0-0b4b-11e8-9824-1209d862bd3c.png)

