### PR TITLE
[OCTREE] Implementation of the iterator 'OctreeLeafNodeBreadthIterator'.

### DIFF
--- a/octree/include/pcl/octree/impl/octree_iterator.hpp
+++ b/octree/include/pcl/octree/impl/octree_iterator.hpp
@@ -326,7 +326,7 @@ namespace pcl
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-    OctreeLeafNodeBreadthIterator<OctreeT>::OctreeLeafNodeBreadthIterator (unsigned int max_depth_arg) :
+    OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator (unsigned int max_depth_arg) :
         OctreeBreadthFirstIterator<OctreeT> (max_depth_arg)
     {
       reset ();
@@ -334,7 +334,7 @@ namespace pcl
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-    OctreeLeafNodeBreadthIterator<OctreeT>::OctreeLeafNodeBreadthIterator (OctreeT* octree_arg, unsigned int max_depth_arg) :
+    OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator (OctreeT* octree_arg, unsigned int max_depth_arg) :
         OctreeBreadthFirstIterator<OctreeT> (octree_arg, max_depth_arg)
     {
       reset ();
@@ -342,7 +342,7 @@ namespace pcl
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-    OctreeLeafNodeBreadthIterator<OctreeT>::OctreeLeafNodeBreadthIterator (OctreeT* octree_arg,
+    OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator (OctreeT* octree_arg,
                                                                            unsigned int max_depth_arg,
                                                                            IteratorState* current_state,
                                                                            const std::deque<IteratorState>& fifo)
@@ -354,7 +354,7 @@ namespace pcl
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-    void OctreeLeafNodeBreadthIterator<OctreeT>::reset ()
+    void OctreeLeafNodeBreadthFirstIterator<OctreeT>::reset ()
     {
       OctreeBreadthFirstIterator<OctreeT>::reset ();
       ++*this;
@@ -362,8 +362,8 @@ namespace pcl
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-    OctreeLeafNodeBreadthIterator<OctreeT>&
-    OctreeLeafNodeBreadthIterator<OctreeT>::operator++ ()
+    OctreeLeafNodeBreadthFirstIterator<OctreeT>&
+    OctreeLeafNodeBreadthFirstIterator<OctreeT>::operator++ ()
     {          
       do
       {
@@ -375,10 +375,10 @@ namespace pcl
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-    OctreeLeafNodeBreadthIterator<OctreeT>
-    OctreeLeafNodeBreadthIterator<OctreeT>::operator++ (int)
+    OctreeLeafNodeBreadthFirstIterator<OctreeT>
+    OctreeLeafNodeBreadthFirstIterator<OctreeT>::operator++ (int)
     {
-      OctreeLeafNodeBreadthIterator _Tmp = *this;
+      OctreeLeafNodeBreadthFirstIterator _Tmp = *this;
       ++*this;
       return (_Tmp);
     }

--- a/octree/include/pcl/octree/impl/octree_iterator.hpp
+++ b/octree/include/pcl/octree/impl/octree_iterator.hpp
@@ -323,6 +323,65 @@ namespace pcl
       while (this->current_state_ && (this->getCurrentOctreeDepth () != fixed_depth_))
         OctreeBreadthFirstIterator<OctreeT>::operator++ ();
     }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    template<typename OctreeT>
+    OctreeLeafNodeBreadthIterator<OctreeT>::OctreeLeafNodeBreadthIterator (unsigned int max_depth_arg) :
+        OctreeBreadthFirstIterator<OctreeT> (max_depth_arg)
+    {
+      reset ();
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    template<typename OctreeT>
+    OctreeLeafNodeBreadthIterator<OctreeT>::OctreeLeafNodeBreadthIterator (OctreeT* octree_arg, unsigned int max_depth_arg) :
+        OctreeBreadthFirstIterator<OctreeT> (octree_arg, max_depth_arg)
+    {
+      reset ();
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    template<typename OctreeT>
+    OctreeLeafNodeBreadthIterator<OctreeT>::OctreeLeafNodeBreadthIterator (OctreeT* octree_arg,
+                                                                           unsigned int max_depth_arg,
+                                                                           IteratorState* current_state,
+                                                                           const std::deque<IteratorState>& fifo)
+        : OctreeBreadthFirstIterator<OctreeT> (octree_arg,
+                                               max_depth_arg,
+                                               current_state,
+                                               fifo)
+    {}
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    template<typename OctreeT>
+    void OctreeLeafNodeBreadthIterator<OctreeT>::reset ()
+    {
+      OctreeBreadthFirstIterator<OctreeT>::reset ();
+      ++*this;
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    template<typename OctreeT>
+    OctreeLeafNodeBreadthIterator<OctreeT>&
+    OctreeLeafNodeBreadthIterator<OctreeT>::operator++ ()
+    {          
+      do
+      {
+        OctreeBreadthFirstIterator<OctreeT>::operator++ ();
+      } while ((this->current_state_) && (this->current_state_->node_->getNodeType () != LEAF_NODE));
+
+      return (*this);
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    template<typename OctreeT>
+    OctreeLeafNodeBreadthIterator<OctreeT>
+    OctreeLeafNodeBreadthIterator<OctreeT>::operator++ (int)
+    {
+      OctreeLeafNodeBreadthIterator _Tmp = *this;
+      ++*this;
+      return (_Tmp);
+    }
   }
 }
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -91,9 +91,9 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
   OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::addPointsFromInputCloud ();
   
   LeafContainerT *leaf_container;
-  typename OctreeAdjacencyT::LeafNodeIterator leaf_itr;
+  typename OctreeAdjacencyT::LeafNodeDepthFirstIterator leaf_itr;
   leaf_vector_.reserve (this->getLeafCount ());
-  for ( leaf_itr = this->leaf_begin () ; leaf_itr != this->leaf_end (); ++leaf_itr)
+  for ( leaf_itr = this->leaf_depth_begin () ; leaf_itr != this->leaf_depth_end (); ++leaf_itr)
   {
     OctreeKey leaf_key = leaf_itr.getCurrentOctreeKey ();
     leaf_container = &(leaf_itr.getLeafContainer ());
@@ -221,7 +221,7 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
   voxel_adjacency_graph.clear ();
   //Add a vertex for each voxel, store ids in map
   std::map <LeafContainerT*, VoxelID> leaf_vertex_id_map;
-  for (typename OctreeAdjacencyT::LeafNodeIterator leaf_itr = this->leaf_begin () ; leaf_itr != this->leaf_end (); ++leaf_itr)
+  for (typename OctreeAdjacencyT::LeafNodeDepthFirstIterator leaf_itr = this->leaf_depth_begin () ; leaf_itr != this->leaf_depth_end (); ++leaf_itr)
   {
     OctreeKey leaf_key = leaf_itr.getCurrentOctreeKey ();
     PointT centroid_point;

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -233,8 +233,8 @@ namespace pcl
         friend class OctreeIteratorBase<OctreeT> ;
         friend class OctreeDepthFirstIterator<OctreeT> ;
         friend class OctreeBreadthFirstIterator<OctreeT> ;
-        friend class OctreeLeafNodeIterator<OctreeT> ;
-        friend class OctreeLeafNodeBreadthIterator<OctreeT> ;
+        friend class OctreeLeafNodeDepthFirstIterator<OctreeT> ;
+        friend class OctreeLeafNodeBreadthFirstIterator<OctreeT> ;
 
         typedef BufferedBranchNode<BranchContainerT> BranchNode;
         typedef OctreeLeafNode<LeafContainerT> LeafNode;
@@ -249,10 +249,36 @@ namespace pcl
         const Iterator end() {return Iterator();};
 
         // Octree leaf node iterators
-        typedef OctreeLeafNodeIterator<OctreeT> LeafNodeIterator;
-        typedef const OctreeLeafNodeIterator<OctreeT> ConstLeafNodeIterator;
-        LeafNodeIterator leaf_begin(unsigned int max_depth_arg = 0) {return LeafNodeIterator(this, max_depth_arg);};
-        const LeafNodeIterator leaf_end() {return LeafNodeIterator();};
+        // The previous deprecated names
+        // LeafNodeIterator and ConstLeafNodeIterator are deprecated.
+        // Please use LeafNodeDepthFirstIterator and ConstLeafNodeDepthFirstIterator instead.
+        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeIterator;
+        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeIterator;
+
+        PCL_DEPRECATED ("Please use leaf_depth_begin () instead.")
+        LeafNodeIterator leaf_begin (unsigned int max_depth_arg = 0)
+        {
+          return LeafNodeIterator (this, max_depth_arg);
+        };
+
+        PCL_DEPRECATED ("Please use leaf_depth_end () instead.")
+        const LeafNodeIterator leaf_end ()
+        {
+          return LeafNodeIterator ();
+        };
+
+        // The currently valide names
+        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeDepthFirstIterator;
+        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeDepthFirstIterator;
+        LeafNodeDepthFirstIterator leaf_depth_begin (unsigned int max_depth_arg = 0)
+        {
+          return LeafNodeDepthFirstIterator (this, max_depth_arg);
+        };
+
+        const LeafNodeDepthFirstIterator leaf_depth_end ()
+        {
+          return LeafNodeDepthFirstIterator();
+        };
 
         // Octree depth-first iterators
         typedef OctreeDepthFirstIterator<OctreeT> DepthFirstIterator;
@@ -267,8 +293,8 @@ namespace pcl
         const BreadthFirstIterator breadth_end() {return BreadthFirstIterator();};
 
         // Octree leaf node iterators
-        typedef OctreeLeafNodeBreadthIterator<OctreeT> LeafNodeBreadthIterator;
-        typedef const OctreeLeafNodeBreadthIterator<OctreeT> ConstLeafNodeBreadthIterator;
+        typedef OctreeLeafNodeBreadthFirstIterator<OctreeT> LeafNodeBreadthIterator;
+        typedef const OctreeLeafNodeBreadthFirstIterator<OctreeT> ConstLeafNodeBreadthIterator;
 
         LeafNodeBreadthIterator leaf_breadth_begin (unsigned int max_depth_arg = 0u)
         {

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -234,6 +234,7 @@ namespace pcl
         friend class OctreeDepthFirstIterator<OctreeT> ;
         friend class OctreeBreadthFirstIterator<OctreeT> ;
         friend class OctreeLeafNodeIterator<OctreeT> ;
+        friend class OctreeLeafNodeBreadthIterator<OctreeT> ;
 
         typedef BufferedBranchNode<BranchContainerT> BranchNode;
         typedef OctreeLeafNode<LeafContainerT> LeafNode;
@@ -264,6 +265,20 @@ namespace pcl
         typedef const OctreeBreadthFirstIterator<OctreeT> ConstBreadthFirstIterator;
         BreadthFirstIterator breadth_begin(unsigned int max_depth_arg = 0) {return BreadthFirstIterator(this, max_depth_arg);};
         const BreadthFirstIterator breadth_end() {return BreadthFirstIterator();};
+
+        // Octree leaf node iterators
+        typedef OctreeLeafNodeBreadthIterator<OctreeT> LeafNodeBreadthIterator;
+        typedef const OctreeLeafNodeBreadthIterator<OctreeT> ConstLeafNodeBreadthIterator;
+
+        LeafNodeBreadthIterator leaf_breadth_begin (unsigned int max_depth_arg = 0u)
+        {
+          return LeafNodeBreadthIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
+        };
+
+        const LeafNodeBreadthIterator leaf_breadth_end ()
+        {
+          return LeafNodeBreadthIterator (this, 0, NULL);
+        };
 
         /** \brief Empty constructor. */
         Octree2BufBase ();

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -105,8 +105,8 @@ namespace pcl
         friend class OctreeDepthFirstIterator<OctreeT> ;
         friend class OctreeBreadthFirstIterator<OctreeT> ;
         friend class OctreeFixedDepthIterator<OctreeT> ;
-        friend class OctreeLeafNodeIterator<OctreeT> ;
-        friend class OctreeLeafNodeBreadthIterator<OctreeT> ;
+        friend class OctreeLeafNodeDepthFirstIterator<OctreeT> ;
+        friend class OctreeLeafNodeBreadthFirstIterator<OctreeT> ;
 
         // Octree default iterators
         typedef OctreeDepthFirstIterator<OctreeT> Iterator;
@@ -123,17 +123,36 @@ namespace pcl
         };
 
         // Octree leaf node iterators
-        typedef OctreeLeafNodeIterator<OctreeT> LeafNodeIterator;
-        typedef const OctreeLeafNodeIterator<OctreeT> ConstLeafNodeIterator;
+        // The previous deprecated names
+        // LeafNodeIterator and ConstLeafNodeIterator are deprecated.
+        // Please use LeafNodeDepthFirstIterator and ConstLeafNodeDepthFirstIterator instead.
+        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeIterator;
+        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeIterator;
 
+        PCL_DEPRECATED ("Please use leaf_depth_begin () instead.")
         LeafNodeIterator leaf_begin (unsigned int max_depth_arg = 0u)
         {
           return LeafNodeIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
         };
 
+        PCL_DEPRECATED ("Please use leaf_depth_end () instead.")
         const LeafNodeIterator leaf_end ()
         {
           return LeafNodeIterator (this, 0, NULL);
+        };
+
+        // The currently valide names
+        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeDepthFirstIterator;
+        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeDepthFirstIterator;
+
+        LeafNodeDepthFirstIterator leaf_depth_begin (unsigned int max_depth_arg = 0u)
+        {
+          return LeafNodeDepthFirstIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
+        };
+
+        const LeafNodeDepthFirstIterator leaf_depth_end ()
+        {
+          return LeafNodeDepthFirstIterator (this, 0, NULL);
         };
 
         // Octree depth-first iterators
@@ -179,17 +198,17 @@ namespace pcl
         };
 
         // Octree leaf node iterators
-        typedef OctreeLeafNodeBreadthIterator<OctreeT> LeafNodeBreadthIterator;
-        typedef const OctreeLeafNodeBreadthIterator<OctreeT> ConstLeafNodeBreadthIterator;
+        typedef OctreeLeafNodeBreadthFirstIterator<OctreeT> LeafNodeBreadthFirstIterator;
+        typedef const OctreeLeafNodeBreadthFirstIterator<OctreeT> ConstLeafNodeBreadthFirstIterator;
 
-        LeafNodeBreadthIterator leaf_breadth_begin (unsigned int max_depth_arg = 0u)
+        LeafNodeBreadthFirstIterator leaf_breadth_begin (unsigned int max_depth_arg = 0u)
         {
-          return LeafNodeBreadthIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
+          return LeafNodeBreadthFirstIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
         };
 
-        const LeafNodeBreadthIterator leaf_breadth_end ()
+        const LeafNodeBreadthFirstIterator leaf_breadth_end ()
         {
-          return LeafNodeBreadthIterator (this, 0, NULL);
+          return LeafNodeBreadthFirstIterator (this, 0, NULL);
         };
 
         /** \brief Empty constructor. */

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -106,6 +106,7 @@ namespace pcl
         friend class OctreeBreadthFirstIterator<OctreeT> ;
         friend class OctreeFixedDepthIterator<OctreeT> ;
         friend class OctreeLeafNodeIterator<OctreeT> ;
+        friend class OctreeLeafNodeBreadthIterator<OctreeT> ;
 
         // Octree default iterators
         typedef OctreeDepthFirstIterator<OctreeT> Iterator;
@@ -175,6 +176,20 @@ namespace pcl
         const FixedDepthIterator fixed_depth_end ()
         {
           return FixedDepthIterator (this, 0, NULL);
+        };
+
+        // Octree leaf node iterators
+        typedef OctreeLeafNodeBreadthIterator<OctreeT> LeafNodeBreadthIterator;
+        typedef const OctreeLeafNodeBreadthIterator<OctreeT> ConstLeafNodeBreadthIterator;
+
+        LeafNodeBreadthIterator leaf_breadth_begin (unsigned int max_depth_arg = 0u)
+        {
+          return LeafNodeBreadthIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
+        };
+
+        const LeafNodeBreadthIterator leaf_breadth_end ()
+        {
+          return LeafNodeBreadthIterator (this, 0, NULL);
         };
 
         /** \brief Empty constructor. */

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -662,7 +662,7 @@ namespace pcl
      */
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-      class OctreeLeafNodeIterator : public OctreeDepthFirstIterator<OctreeT>
+      class OctreeLeafNodeDepthFirstIterator : public OctreeDepthFirstIterator<OctreeT>
       {
         typedef typename OctreeDepthFirstIterator<OctreeT>::BranchNode BranchNode;
         typedef typename OctreeDepthFirstIterator<OctreeT>::LeafNode LeafNode;
@@ -672,7 +672,7 @@ namespace pcl
          * \param[in] max_depth_arg Depth limitation during traversal
          */
         explicit
-        OctreeLeafNodeIterator (unsigned int max_depth_arg = 0) :
+        OctreeLeafNodeDepthFirstIterator (unsigned int max_depth_arg = 0) :
             OctreeDepthFirstIterator<OctreeT> (max_depth_arg)
         {
           reset ();
@@ -683,7 +683,7 @@ namespace pcl
          * \param[in] max_depth_arg Depth limitation during traversal
          */
         explicit
-        OctreeLeafNodeIterator (OctreeT* octree_arg, unsigned int max_depth_arg = 0) :
+        OctreeLeafNodeDepthFirstIterator (OctreeT* octree_arg, unsigned int max_depth_arg = 0) :
             OctreeDepthFirstIterator<OctreeT> (octree_arg, max_depth_arg)
         {
           reset ();
@@ -697,7 +697,7 @@ namespace pcl
           *  \warning For advanced users only.
           */
         explicit
-        OctreeLeafNodeIterator (OctreeT* octree_arg,
+        OctreeLeafNodeDepthFirstIterator (OctreeT* octree_arg,
                                 unsigned int max_depth_arg,
                                 IteratorState* current_state,
                                 const std::vector<IteratorState>& stack = std::vector<IteratorState> ())
@@ -719,7 +719,7 @@ namespace pcl
         /** \brief Preincrement operator.
          * \note recursively step to next octree leaf node
          */
-        inline OctreeLeafNodeIterator&
+        inline OctreeLeafNodeDepthFirstIterator&
         operator++ ()
         {
           do
@@ -733,10 +733,10 @@ namespace pcl
         /** \brief postincrement operator.
          * \note step to next octree node
          */
-        inline OctreeLeafNodeIterator
+        inline OctreeLeafNodeDepthFirstIterator
         operator++ (int)
         {
-          OctreeLeafNodeIterator _Tmp = *this;
+          OctreeLeafNodeDepthFirstIterator _Tmp = *this;
           ++*this;
           return (_Tmp);
         }
@@ -765,7 +765,7 @@ namespace pcl
      */
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     template<typename OctreeT>
-      class OctreeLeafNodeBreadthIterator : public OctreeBreadthFirstIterator<OctreeT>
+      class OctreeLeafNodeBreadthFirstIterator : public OctreeBreadthFirstIterator<OctreeT>
       {
         typedef typename OctreeBreadthFirstIterator<OctreeT>::BranchNode BranchNode;
         typedef typename OctreeBreadthFirstIterator<OctreeT>::LeafNode LeafNode;
@@ -775,14 +775,14 @@ namespace pcl
          * \param[in] max_depth_arg Depth limitation during traversal
          */
         explicit
-        OctreeLeafNodeBreadthIterator (unsigned int max_depth_arg = 0);
+        OctreeLeafNodeBreadthFirstIterator (unsigned int max_depth_arg = 0);
 
         /** \brief Constructor.
          * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its root node.
          * \param[in] max_depth_arg Depth limitation during traversal
          */
         explicit
-        OctreeLeafNodeBreadthIterator (OctreeT* octree_arg, unsigned int max_depth_arg = 0);
+        OctreeLeafNodeBreadthFirstIterator (OctreeT* octree_arg, unsigned int max_depth_arg = 0);
 
         /** \brief Copy constructor.
           * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its root node.
@@ -793,7 +793,7 @@ namespace pcl
           *  \warning For advanced users only.
           */
         explicit
-        OctreeLeafNodeBreadthIterator (OctreeT* octree_arg,
+        OctreeLeafNodeBreadthFirstIterator (OctreeT* octree_arg,
                                        unsigned int max_depth_arg,
                                        IteratorState* current_state,
                                        const std::deque<IteratorState>& fifo = std::deque<IteratorState> ());
@@ -806,14 +806,14 @@ namespace pcl
         /** \brief Preincrement operator.
          * \note recursively step to next octree leaf node
          */
-        inline OctreeLeafNodeBreadthIterator&
+        inline OctreeLeafNodeBreadthFirstIterator&
         operator++ ();
 
 
         /** \brief Postincrement operator.
          * \note step to next octree node
          */
-        inline OctreeLeafNodeBreadthIterator
+        inline OctreeLeafNodeBreadthFirstIterator
         operator++ (int);
       };
 

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -756,6 +756,67 @@ namespace pcl
         }
       };
 
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    /** \brief Octree leaf node iterator class
+     * \note This class implements a forward iterator for traversing the leaf nodes of an octree data structure
+     * in the breadth first way.
+     * \ingroup octree
+     * \author Fabien Rozar (fabien.rozar@gmail.com)
+     */
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    template<typename OctreeT>
+      class OctreeLeafNodeBreadthIterator : public OctreeBreadthFirstIterator<OctreeT>
+      {
+        typedef typename OctreeBreadthFirstIterator<OctreeT>::BranchNode BranchNode;
+        typedef typename OctreeBreadthFirstIterator<OctreeT>::LeafNode LeafNode;
+
+      public:
+        /** \brief Empty constructor.
+         * \param[in] max_depth_arg Depth limitation during traversal
+         */
+        explicit
+        OctreeLeafNodeBreadthIterator (unsigned int max_depth_arg = 0);
+
+        /** \brief Constructor.
+         * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its root node.
+         * \param[in] max_depth_arg Depth limitation during traversal
+         */
+        explicit
+        OctreeLeafNodeBreadthIterator (OctreeT* octree_arg, unsigned int max_depth_arg = 0);
+
+        /** \brief Copy constructor.
+          * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its root node.
+          * \param[in] max_depth_arg Depth limitation during traversal
+          * \param[in] current_state A pointer to the current iterator state
+          * \param[in] fifo Internal container of octree node to go through
+          *
+          *  \warning For advanced users only.
+          */
+        explicit
+        OctreeLeafNodeBreadthIterator (OctreeT* octree_arg,
+                                       unsigned int max_depth_arg,
+                                       IteratorState* current_state,
+                                       const std::deque<IteratorState>& fifo = std::deque<IteratorState> ());
+
+        /** \brief Reset the iterator to the first leaf in the breadth first way.
+         */
+        inline void
+        reset ();
+
+        /** \brief Preincrement operator.
+         * \note recursively step to next octree leaf node
+         */
+        inline OctreeLeafNodeBreadthIterator&
+        operator++ ();
+
+
+        /** \brief Postincrement operator.
+         * \note step to next octree node
+         */
+        inline OctreeLeafNodeBreadthIterator
+        operator++ (int);
+      };
+
   }
 }
 

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -295,9 +295,9 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
 
     unsigned int leaf_node_counter = 0;
     // iterate over tree
-    OctreePointCloudPointVector<PointXYZ>::LeafNodeIterator it2;
-    const OctreePointCloudPointVector<PointXYZ>::LeafNodeIterator it2_end = octree.leaf_end();
-    for (it2 = octree.leaf_begin(); it2 != it2_end; ++it2)
+    OctreePointCloudPointVector<PointXYZ>::LeafNodeDepthFirstIterator it2;
+    const OctreePointCloudPointVector<PointXYZ>::LeafNodeDepthFirstIterator it2_end = octree.leaf_depth_end();
+    for (it2 = octree.leaf_depth_begin(); it2 != it2_end; ++it2)
     {
       ++leaf_node_counter;
       unsigned int depth = it2.getCurrentOctreeDepth ();
@@ -326,14 +326,14 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
     octree.addPointsFromInputCloud ();
 
     //  test iterator
-    OctreePointCloudPointVector<PointXYZ>::LeafNodeIterator it;
-    const OctreePointCloudPointVector<PointXYZ>::LeafNodeIterator it_end = octree.leaf_end();
+    OctreePointCloudPointVector<PointXYZ>::LeafNodeDepthFirstIterator it;
+    const OctreePointCloudPointVector<PointXYZ>::LeafNodeDepthFirstIterator it_end = octree.leaf_depth_end();
     unsigned int leaf_count = 0;
 
     std::vector<int> indexVector;
 
     // iterate over tree
-    for (it = octree.leaf_begin(); it != it_end; ++it)
+    for (it = octree.leaf_depth_begin(); it != it_end; ++it)
     {
       OctreeNode* node = it.getCurrentOctreeNode ();
 
@@ -902,13 +902,13 @@ TEST (PCL, Octree_Pointcloud_Iterator_Test)
   octreeA.addPointsFromInputCloud ();
 
   // instantiate iterator for octreeA
-  OctreePointCloud<PointXYZ>::LeafNodeIterator it1;
-  OctreePointCloud<PointXYZ>::LeafNodeIterator it1_end = octreeA.leaf_end();
+  OctreePointCloud<PointXYZ>::LeafNodeDepthFirstIterator it1;
+  OctreePointCloud<PointXYZ>::LeafNodeDepthFirstIterator it1_end = octreeA.leaf_depth_end();
 
   std::vector<int> indexVector;
   unsigned int leafNodeCounter = 0;
 
-  for (it1 = octreeA.leaf_begin(); it1 != it1_end; ++it1)
+  for (it1 = octreeA.leaf_depth_begin(); it1 != it1_end; ++it1)
   {
     it1.getLeafContainer().getPointIndices(indexVector);
     leafNodeCounter++;

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -144,15 +144,15 @@ struct OctreeIteratorTest : public OctreeIteratorBaseTest
 
 using pcl::octree::OctreeDepthFirstIterator;
 using pcl::octree::OctreeBreadthFirstIterator;
-using pcl::octree::OctreeLeafNodeIterator;
+using pcl::octree::OctreeLeafNodeDepthFirstIterator;
 using pcl::octree::OctreeFixedDepthIterator;
-using pcl::octree::OctreeLeafNodeBreadthIterator;
+using pcl::octree::OctreeLeafNodeBreadthFirstIterator;
 
 typedef testing::Types<OctreeDepthFirstIterator<OctreeBase<int> >,
                        OctreeBreadthFirstIterator<OctreeBase<int> >,
-                       OctreeLeafNodeIterator<OctreeBase<int> >,
+                       OctreeLeafNodeDepthFirstIterator<OctreeBase<int> >,
                        OctreeFixedDepthIterator<OctreeBase<int> >,
-                       OctreeLeafNodeBreadthIterator<OctreeBase<int> > > OctreeIteratorTypes;
+                       OctreeLeafNodeBreadthFirstIterator<OctreeBase<int> > > OctreeIteratorTypes;
 TYPED_TEST_CASE (OctreeIteratorTest, OctreeIteratorTypes);
 
 TYPED_TEST (OctreeIteratorTest, CopyConstructor)
@@ -278,22 +278,22 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, End)
 TEST_F (OctreeBaseBeginEndIteratorsTest, LeafBegin)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeIterator IteratorT;
+  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Default initialization
-  IteratorT it_a_1 = oct_a_.leaf_begin ();
-  IteratorT it_a_2 = oct_a_.leaf_begin ();
-  IteratorT it_b = oct_b_.leaf_begin ();
+  IteratorT it_a_1 = oct_a_.leaf_depth_begin ();
+  IteratorT it_a_2 = oct_a_.leaf_depth_begin ();
+  IteratorT it_b = oct_b_.leaf_depth_begin ();
 
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
 
   // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.leaf_begin ();
-  IteratorT it_m_1 = oct_a_.leaf_begin (1);
-  IteratorT it_m_2 = oct_a_.leaf_begin (2);
-  IteratorT it_m_b_1 = oct_b_.leaf_begin (1);
+  IteratorT it_m = oct_a_.leaf_depth_begin ();
+  IteratorT it_m_1 = oct_a_.leaf_depth_begin (1);
+  IteratorT it_m_2 = oct_a_.leaf_depth_begin (2);
+  IteratorT it_m_b_1 = oct_b_.leaf_depth_begin (1);
 
   EXPECT_NE (it_m_1, it_m_2);
   EXPECT_EQ (it_m_2, it_m); // tree depth is 2
@@ -303,12 +303,12 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, LeafBegin)
 TEST_F (OctreeBaseBeginEndIteratorsTest, LeafEnd)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeIterator IteratorT;
+  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Default initialization
-  IteratorT it_a_1 = oct_a_.leaf_end ();
-  IteratorT it_a_2 = oct_a_.leaf_end ();
-  IteratorT it_b = oct_b_.leaf_end ();
+  IteratorT it_a_1 = oct_a_.leaf_depth_end ();
+  IteratorT it_a_2 = oct_a_.leaf_depth_end ();
+  IteratorT it_b = oct_b_.leaf_depth_end ();
 
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
@@ -398,7 +398,7 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, BreadthEnd)
 TEST_F (OctreeBaseBeginEndIteratorsTest, LeafBreadthBegin)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthIterator IteratorT;
+  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_1 = oct_a_.leaf_breadth_begin ();
@@ -423,7 +423,7 @@ TEST_F (OctreeBaseBeginEndIteratorsTest, LeafBreadthBegin)
 TEST_F (OctreeBaseBeginEndIteratorsTest, LeafBreadthEnd)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthIterator IteratorT;
+  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_1 = oct_a_.leaf_breadth_end ();
@@ -508,21 +508,21 @@ TEST_F (OctreeBaseIteratorsForLoopTest, DefaultIterator)
   ASSERT_EQ (oct_a_.getBranchCount (), branch_count);
 }
 
-TEST_F (OctreeBaseIteratorsForLoopTest, LeafNodeIterator)
+TEST_F (OctreeBaseIteratorsForLoopTest, LeafNodeDepthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeIterator IteratorT;
+  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a;
-  IteratorT it_a_end = oct_a_.leaf_end ();
+  IteratorT it_a_end = oct_a_.leaf_depth_end ();
 
   unsigned int node_count = 0;
   unsigned int branch_count = 0;
   unsigned int leaf_count = 0;
 
   // Iterate over every node of the octree oct_a_.
-  for (it_a = oct_a_.leaf_begin (); it_a != it_a_end; ++it_a)
+  for (it_a = oct_a_.leaf_depth_begin (); it_a != it_a_end; ++it_a)
   {
     // store node, branch and leaf count
     const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
@@ -549,7 +549,7 @@ TEST_F (OctreeBaseIteratorsForLoopTest, LeafNodeIterator)
   branch_count = 0;
   leaf_count = 0;
   unsigned int max_depth = 1;
-  for (it_a = oct_a_.leaf_begin (max_depth); it_a != it_a_end; ++it_a)
+  for (it_a = oct_a_.leaf_depth_begin (max_depth); it_a != it_a_end; ++it_a)
   {
     // store node, branch and leaf count
     const pcl::octree::OctreeNode* node = it_a.getCurrentOctreeNode ();
@@ -767,10 +767,10 @@ TEST_F (OctreeBaseIteratorsForLoopTest, FixedDepthIterator)
   ASSERT_EQ ((oct_a_.getBranchCount () - 1), branch_count);
 }
 
-TEST_F (OctreeBaseIteratorsForLoopTest, LeafNodeBreadthIterator)
+TEST_F (OctreeBaseIteratorsForLoopTest, LeafNodeBreadthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthIterator IteratorT;
+  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a;
@@ -858,18 +858,18 @@ TEST_F (OctreeBaseIteratorsPrePostTest, DefaultIterator)
   EXPECT_EQ (it_a_post, it_a_end);
 }
 
-TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeIterator)
+TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeDepthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeIterator IteratorT;
+  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;
   IteratorT it_a_post;
-  IteratorT it_a_end = oct_a_.leaf_end ();
+  IteratorT it_a_end = oct_a_.leaf_depth_end ();
 
   // Iterate over every node of the octree oct_a_.
-  for (it_a_pre = oct_a_.leaf_begin (), it_a_post = oct_a_.leaf_begin ();
+  for (it_a_pre = oct_a_.leaf_depth_begin (), it_a_post = oct_a_.leaf_depth_begin ();
        ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
   {
     EXPECT_EQ (it_a_pre, it_a_post++);
@@ -953,10 +953,10 @@ TEST_F (OctreeBaseIteratorsPrePostTest, FixedDepthIterator)
   }
 }
 
-TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeBreadthIterator)
+TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeBreadthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthIterator IteratorT;
+  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1021,40 +1021,40 @@ struct OctreePointCloudAdjacencyBeginEndIteratorsTest
   OctreeT oct_a_, oct_b_;
 };
 
-TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafBegin)
+TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafDepthBegin)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeIterator IteratorT;
+  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Default initialization
-  IteratorT it_a_1 = oct_a_.leaf_begin ();
-  IteratorT it_a_2 = oct_a_.leaf_begin ();
-  IteratorT it_b = oct_b_.leaf_begin ();
+  IteratorT it_a_1 = oct_a_.leaf_depth_begin ();
+  IteratorT it_a_2 = oct_a_.leaf_depth_begin ();
+  IteratorT it_b = oct_b_.leaf_depth_begin ();
 
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
   EXPECT_NE (it_a_2, it_b);
 
   // Different max depths are not the same iterators
-  IteratorT it_m = oct_a_.leaf_begin ();
-  IteratorT it_m_1 = oct_a_.leaf_begin (1);
-  IteratorT it_m_md = oct_a_.leaf_begin (oct_a_.getTreeDepth ());
-  IteratorT it_m_b_1 = oct_b_.leaf_begin (1);
+  IteratorT it_m = oct_a_.leaf_depth_begin ();
+  IteratorT it_m_1 = oct_a_.leaf_depth_begin (1);
+  IteratorT it_m_md = oct_a_.leaf_depth_begin (oct_a_.getTreeDepth ());
+  IteratorT it_m_b_1 = oct_b_.leaf_depth_begin (1);
 
   EXPECT_NE (it_m_1, it_m_md);
   EXPECT_EQ (it_m_md, it_m); // should default to tree depth
   EXPECT_NE (it_m_1, it_m_b_1);
 }
 
-TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafEnd)
+TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafDepthEnd)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeIterator IteratorT;
+  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Default initialization
-  IteratorT it_a_1 = oct_a_.leaf_end ();
-  IteratorT it_a_2 = oct_a_.leaf_end ();
-  IteratorT it_b = oct_b_.leaf_end ();
+  IteratorT it_a_1 = oct_a_.leaf_depth_end ();
+  IteratorT it_a_2 = oct_a_.leaf_depth_end ();
+  IteratorT it_b = oct_b_.leaf_depth_end ();
 
   EXPECT_EQ (it_a_1, it_a_2);
   EXPECT_NE (it_a_1, it_b);
@@ -1186,7 +1186,7 @@ TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, FixedDepthEnd)
 TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafBreadthBegin)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthIterator IteratorT;
+  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_1 = oct_a_.leaf_breadth_begin ();
@@ -1211,7 +1211,7 @@ TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafBreadthBegin)
 TEST_F (OctreePointCloudAdjacencyBeginEndIteratorsTest, LeafBreadthEnd)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthIterator IteratorT;
+  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_1 = oct_a_.leaf_breadth_end ();
@@ -1425,24 +1425,24 @@ TEST_F (OctreePointCloudSierpinskiTest, DefaultIterator)
   }
 }
 
-TEST_F (OctreePointCloudSierpinskiTest, LeafNodeIterator)
+TEST_F (OctreePointCloudSierpinskiTest, LeafNodeDepthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeIterator IteratorT;
+  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Check the number of branch and leaf nodes
   ASSERT_EQ (oct_.getLeafCount (), pow (4, depth_));
   ASSERT_EQ (oct_.getBranchCount (), computeTotalParentNodeCount (depth_));
 
   IteratorT it;
-  IteratorT it_end = oct_.leaf_end ();
+  IteratorT it_end = oct_.leaf_depth_end ();
 
   // Check the number of leaf and branch nodes
   unsigned int node_count = 0;
   unsigned int branch_count = 0;
   unsigned int leaf_count = 0;
 
-  for (it = oct_.leaf_begin (); it != it_end; ++it)
+  for (it = oct_.leaf_depth_begin (); it != it_end; ++it)
   {
     // store node, branch and leaf count
     const pcl::octree::OctreeNode* node = it.getCurrentOctreeNode ();
@@ -1462,7 +1462,7 @@ TEST_F (OctreePointCloudSierpinskiTest, LeafNodeIterator)
   EXPECT_EQ (node_count, pow (4, depth_));
 
   // Check the specific key/child_idx value for this octree
-  for (it = oct_.leaf_begin (); it != it_end; ++it)
+  for (it = oct_.leaf_depth_begin (); it != it_end; ++it)
   {
     for (unsigned int i = 0; i < depth_; ++i)
     {
@@ -1607,10 +1607,10 @@ TEST_F (OctreePointCloudSierpinskiTest, FixedDepthIterator)
   }
 }
 
-TEST_F (OctreePointCloudSierpinskiTest, LeafNodeBreadthIterator)
+TEST_F (OctreePointCloudSierpinskiTest, LeafNodeBreadthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthIterator IteratorT;
+  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Check the number of branch and leaf nodes
   ASSERT_EQ (oct_.getLeafCount (), pow (4, depth_));


### PR DESCRIPTION
**Warning:** this PR relies on #1983 

The purpose of this PR is to add a new iterator over leaf nodes of an octree. The existant leaf node iterator walks through an octree in the depth first way. The iterator I propose here walks through an octree in the breadth first way.

Technically, the implementation of `OctreeLeafNodeBreadthIterator` is really similar to `OctreeLeafNodeIterator` but it inherites from `OctreeBreadthFirstIterator`. So internally it uses a FIFO data structure.

The implementation is tested with the tests introduced in the PR #1983.