### PR TITLE
Public access to VoxelGrid boost pointer.

### DIFF
--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -186,11 +186,12 @@ namespace pcl
       typedef typename Filter<PointT>::PointCloud PointCloud;
       typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      
+    public:
+    
       typedef boost::shared_ptr< VoxelGrid<PointT> > Ptr;
       typedef boost::shared_ptr< const VoxelGrid<PointT> > ConstPtr;
- 
-
-    public:
+    
       /** \brief Empty constructor. */
       VoxelGrid () : 
         leaf_size_ (Eigen::Vector4f::Zero ()),


### PR DESCRIPTION
It was not possible to declare boost pointers of VoxelGrid as its rights were protected. Moved them to public scope as it is done with other objects in PCL.