### PR TITLE
Misc. typos (cont.)

### DIFF
--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -163,7 +163,7 @@ int main (int argc, char *argv[])
   don.setNormalScaleSmall(normals_small_scale);
 
   if(!don.initCompute ()){
-    std::cerr << "Error: Could not intialize DoN feature operator" << std::endl;
+    std::cerr << "Error: Could not initialize DoN feature operator" << std::endl;
     exit(EXIT_FAILURE);
   }
 

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -189,8 +189,8 @@ LCCPSegmentation Parameters: \n\
 CPCSegmentation Parameters: \n\
   -cut <max_cuts>,<cutting_min_segments>,<min_cut_score> - Plane cutting parameters for splitting of segments\n\
        <max_cuts> - Perform cuts up to this recursion level. Cuts are performed in each segment separately (default 25)\n\
-       <cutting_min_segments> - Minumum number of supervoxels in the segment to perform cutting (default 400).\n\
-       <min_cut_score> - Minumum score a proposed cut needs to have for being cut (default 0.16)\n\
+       <cutting_min_segments> - Minimum number of supervoxels in the segment to perform cutting (default 400).\n\
+       <min_cut_score> - Minimum score a proposed cut needs to have for being cut (default 0.16)\n\
   -clocal - Use locally constrained cuts (recommended flag)\n\
   -cdir - Use directed weigths (recommended flag) \n\
   -cclean - Use clean cuts. \n\
@@ -255,7 +255,7 @@ CPCSegmentation Parameters: \n\
   {
     pcl::console::parse (argc, argv, "-o", outputname);
 
-    // If no filename is given, get output filename from inputname (strip seperators and file extension)
+    // If no filename is given, get output filename from inputname (strip separators and file extension)
     if (outputname.empty () || (outputname.at (0) == '-'))
     {
       outputname = pcd_filename;
@@ -348,7 +348,7 @@ CPCSegmentation Parameters: \n\
   textcolor = bg_white?0:1;
 
   pcl::console::print_info ("Maximum cuts: %d\n", max_cuts);
-  pcl::console::print_info ("Minumum segment siz: %d\n", cutting_min_segments);
+  pcl::console::print_info ("Minimum segment size: %d\n", cutting_min_segments);
   pcl::console::print_info ("Use local constrain: %d\n", use_local_constrain);
   pcl::console::print_info ("Use directed weights: %d\n", use_directed_cutting);
   pcl::console::print_info ("Use clean cuts: %d\n", use_clean_cutting);
@@ -386,7 +386,7 @@ CPCSegmentation Parameters: \n\
   /// Get the cloud of supervoxel centroid with normals and the colored cloud with supervoxel coloring (this is used for visulization)
   pcl::PointCloud<pcl::PointNormal>::Ptr sv_centroid_normal_cloud = pcl::SupervoxelClustering<PointT>::makeSupervoxelNormalCloud (supervoxel_clusters);
 
-  /// Set paramters for LCCP preprocessing and CPC (CPC inherits from LCCP, thus it includes LCCP's functionality)
+  /// Set parameters for LCCP preprocessing and CPC (CPC inherits from LCCP, thus it includes LCCP's functionality)
 
   PCL_INFO ("Starting Segmentation\n");
   pcl::CPCSegmentation<PointT> cpc;

--- a/examples/segmentation/example_extract_clusters_normals.cpp
+++ b/examples/segmentation/example_extract_clusters_normals.cpp
@@ -90,7 +90,7 @@ main (int, char **argv)
 
   std::cout << "No of clusters formed are " << cluster_indices.size () << std::endl;
 
-  // Saving the clusters in seperate pcd files
+  // Saving the clusters in separate pcd files
   int j = 0;
   for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin (); it != cluster_indices.end (); ++it)
   {

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -226,7 +226,7 @@ LCCPSegmentation Parameters: \n\
   {
     pcl::console::parse (argc, argv, "-o", outputname);
 
-    // If no filename is given, get output filename from inputname (strip seperators and file extension)
+    // If no filename is given, get output filename from inputname (strip separators and file extension)
     if (outputname.empty () || (outputname.at (0) == '-'))
     {
       outputname = pcd_filename;

--- a/features/include/pcl/features/rops_estimation.h
+++ b/features/include/pcl/features/rops_estimation.h
@@ -125,7 +125,7 @@ namespace pcl
 
       /** \brief This method simply builds the list of triangles for every point.
         * The list of triangles for each point consists of indices of triangles it belongs to.
-        * The only purpose of this method is to improve perfomance of the algorithm.
+        * The only purpose of this method is to improve performance of the algorithm.
         */
       void
       buildListOfPointsTriangles ();
@@ -215,10 +215,10 @@ namespace pcl
       /** \brief Stores the angle step. Step is calculated with respect to number of rotations. */
       float step_;
 
-      /** \brief Stores the set of triangles reprsenting the mesh. */
+      /** \brief Stores the set of triangles representing the mesh. */
       std::vector <pcl::Vertices> triangles_;
 
-      /** \brief Stores the set of triangles for each point. Its purpose is to improve perfomance. */
+      /** \brief Stores the set of triangles for each point. Its purpose is to improve performance. */
       std::vector <std::vector <unsigned int> > triangles_of_the_point_;
 
     public:

--- a/geometry/include/pcl/geometry/mesh_traits.h
+++ b/geometry/include/pcl/geometry/mesh_traits.h
@@ -77,7 +77,7 @@ namespace pcl
       typedef EdgeDataT     EdgeData;
       typedef FaceDataT     FaceData;
 
-      /** \brief Specifies wether the mesh is manifold or not (only non-manifold vertices can be represented). */
+      /** \brief Specifies whether the mesh is manifold or not (only non-manifold vertices can be represented). */
       typedef boost::false_type IsManifold;
     };
   } // End namespace geometry

--- a/gpu/containers/include/pcl/gpu/containers/device_array.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_array.h
@@ -73,18 +73,18 @@ namespace pcl
             
             /** \brief Initializes with user allocated buffer. Reference counting is disabled in this case.
               * \param ptr pointer to buffer
-              * \param size elemens number
+              * \param size elements number
               * */
             DeviceArray(T *ptr, size_t size);
 
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceArray(const DeviceArray& other);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceArray& operator = (const DeviceArray& other);
 
             /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.               
-              * \param size elemens number
+              * \param size elements number
               * */
             void create(size_t size);
 
@@ -98,7 +98,7 @@ namespace pcl
 
             /** \brief Uploads data to internal buffer in GPU memory. It calls create() inside to ensure that intenal buffer size is enough.
               * \param host_ptr pointer to buffer to upload               
-              * \param size elemens number
+              * \param size elements number
               * */
             void upload(const T *host_ptr, size_t size);
 
@@ -180,7 +180,7 @@ namespace pcl
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceArray2D(const DeviceArray2D& other);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceArray2D& operator = (const DeviceArray2D& other);
 
             /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.
@@ -205,7 +205,7 @@ namespace pcl
               * */
             void upload(const void *host_ptr, size_t host_step, int rows, int cols);
 
-            /** \brief Downloads data from internal buffer to CPU memory. User is resposible for correct host buffer size.
+            /** \brief Downloads data from internal buffer to CPU memory. User is responsible for correct host buffer size.
               * \param host_ptr pointer to host buffer to download               
               * \param host_step stride between two consecutive rows in bytes for host buffer             
               * */

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -75,7 +75,7 @@ namespace pcl
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceMemory(const DeviceMemory& other_arg);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceMemory& operator=(const DeviceMemory& other_arg);
 
              /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.               
@@ -167,7 +167,7 @@ namespace pcl
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceMemory2D(const DeviceMemory2D& other_arg);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceMemory2D& operator=(const DeviceMemory2D& other_arg);
 
             /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.
@@ -192,7 +192,7 @@ namespace pcl
               * */
             void upload(const void *host_ptr_arg, size_t host_step_arg, int rows_arg, int colsBytes_arg);
 
-            /** \brief Downloads data from internal buffer to CPU memory. User is resposible for correct host buffer size.
+            /** \brief Downloads data from internal buffer to CPU memory. User is responsible for correct host buffer size.
               * \param host_ptr_arg pointer to host buffer to download               
               * \param host_step_arg stride between two consecutive rows in bytes for host buffer             
               * */

--- a/gpu/containers/include/pcl/gpu/containers/initialization.h
+++ b/gpu/containers/include/pcl/gpu/containers/initialization.h
@@ -50,20 +50,20 @@ namespace pcl
         /** \brief Sets active device to work with. */
         PCL_EXPORTS void setDevice(int device);
 
-        /** \brief Return devuce name for gived device. */
+        /** \brief Return device name for given device. */
         PCL_EXPORTS std::string getDeviceName(int device);
 
-        /** \brief Prints infromatoin about given cuda deivce or about all deivces
-         *  \param device: if < 0 prints info for all devices, otherwise the function interpets is as device id.
+        /** \brief Prints information about given cuda device or about all devices
+         *  \param device: if < 0 prints info for all devices, otherwise the function interprets it as device id.
          */
         void PCL_EXPORTS printCudaDeviceInfo(int device = -1);
 
-        /** \brief Prints infromatoin about given cuda deivce or about all deivces
-         *  \param device: if < 0 prints info for all devices, otherwise the function interpets is as device id.
+        /** \brief Prints information about given cuda device or about all devices
+         *  \param device: if < 0 prints info for all devices, otherwise the function interprets it as device id.
          */
         void PCL_EXPORTS printShortCudaDeviceInfo(int device = -1);
 
-        /** \brief Returns true if pre-Fermi generaton GPU. 
+        /** \brief Returns true if pre-Fermi generator GPU. 
           * \param device: device id to check, if < 0 checks current device.
           */
         bool PCL_EXPORTS checkIfPreFermiGPU(int device = -1);

--- a/gpu/containers/src/initialization.cpp
+++ b/gpu/containers/src/initialization.cpp
@@ -50,7 +50,7 @@ void throw_nogpu() { throw "PCL 2.0 exception"; }
 int  pcl::gpu::getCudaEnabledDeviceCount() { return 0; }
 void pcl::gpu::setDevice(int /*device*/) { throw_nogpu(); }
 std::string pcl::gpu::getDeviceName(int /*device*/) { throw_nogpu(); }
-void pcl::gpu::printCudaDeviceInfo(int /*deivce*/){ throw_nogpu(); }
+void pcl::gpu::printCudaDeviceInfo(int /*device*/){ throw_nogpu(); }
 void pcl::gpu::printShortCudaDeviceInfo(int /*device*/) { throw_nogpu(); }
 
 #else
@@ -111,7 +111,7 @@ namespace
     {
         // Defines for GPU Architecture types (using the SM version to determine the # of cores per SM
         typedef struct {
-            int SM; // 0xMm (hexidecimal notation), M = SM Major version, and m = SM minor version
+            int SM; // 0xMm (hexadecimal notation), M = SM Major version, and m = SM minor version
             int Cores;
         } SMtoCores;
 

--- a/gpu/features/include/pcl/gpu/features/device/eigen.hpp
+++ b/gpu/features/include/pcl/gpu/features/device/eigen.hpp
@@ -154,7 +154,7 @@ namespace pcl
                     if (roots.x >= roots.y)
                         swap (roots.x, roots.y);
                 }
-                if (roots.x <= 0) // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+                if (roots.x <= 0) // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
                     computeRoots2 (c2, c1, roots);
             }
         }

--- a/gpu/features/src/spinimages.cu
+++ b/gpu/features/src/spinimages.cu
@@ -240,12 +240,12 @@ namespace pcl
 				if (angular)
 				{					
 					//transform sum to average dividing angle/spinimage element-wize.
-					const float *amgles_beg = simage_angles + FSize;
-					const float *amgles_end = amgles_beg + FSize;
+					const float *angles_beg = simage_angles + FSize;
+					const float *angles_end = angles_beg + FSize;
 					const float *images_beg = simage_angles;
 
-					Block::transform(amgles_beg, amgles_end, images_beg, output.ptr(i_input), Div12eps());
-					////Block::copy(amgles_beg, amgles_end, output.ptr(i_input));
+					Block::transform(angles_beg, angles_end, images_beg, output.ptr(i_input), Div12eps());
+					////Block::copy(angles_beg, angles_end, output.ptr(i_input));
 					//Block::copy(images_beg, images_beg + FSize, output.ptr(i_input));
 				}
 				else

--- a/gpu/features/src/spinimages.cu
+++ b/gpu/features/src/spinimages.cu
@@ -244,7 +244,7 @@ namespace pcl
 					const float *amgles_end = amgles_beg + FSize;
 					const float *images_beg = simage_angles;
 
-					Block::transfrom(amgles_beg, amgles_end, images_beg, output.ptr(i_input), Div12eps());
+					Block::transform(amgles_beg, amgles_end, images_beg, output.ptr(i_input), Div12eps());
 					////Block::copy(amgles_beg, amgles_end, output.ptr(i_input));
 					//Block::copy(images_beg, images_beg + FSize, output.ptr(i_input));
 				}
@@ -259,7 +259,7 @@ namespace pcl
 					__syncthreads();
 
 					float sum = simage_angles[FSize];
-					Block::transfrom(simage_angles, simage_angles + FSize, output.ptr(i_input), DivValIfNonZero(sum));
+					Block::transform(simage_angles, simage_angles + FSize, output.ptr(i_input), DivValIfNonZero(sum));
 				}		
 			}
 

--- a/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
@@ -65,7 +65,7 @@ namespace pcl
         */
       ColorVolume(const TsdfVolume& tsdf, int max_weight = -1);
 
-      /** \brief Desctructor */
+      /** \brief Destructor */
       ~ColorVolume();
 
       /** \brief Resets color volume to uninitialized state */

--- a/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
@@ -101,7 +101,7 @@ namespace pcl
         getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy);
         
 
-        /** \brief Sets initial camera pose relative to volume coordiante space
+        /** \brief Sets initial camera pose relative to volume coordinate space
           * \param[in] pose Initial camera pose
           */
         void

--- a/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
@@ -82,7 +82,7 @@ namespace pcl
       void
       setIntrinsics(float fx = 525.f, float fy = 525.f, float cx = -1, float cy = -1);
       
-      /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal fiels.
+      /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal files.
         * \param[in] volume tsdf volume container
         * \param[in] camera_pose camera pose
         */ 

--- a/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
@@ -69,7 +69,7 @@ namespace pcl
         */
       TsdfVolume(const Eigen::Vector3i& resolution);           
             
-      /** \brief Sets Tsdf volume size for each dimention
+      /** \brief Sets Tsdf volume size for each dimension
         * \param[in] size size of tsdf volume in meters
         */
       void
@@ -81,7 +81,7 @@ namespace pcl
       void
       setTsdfTruncDist (float distance);
 
-      /** \brief Returns tsdf volume container that point to data in GPU memroy */
+      /** \brief Returns tsdf volume container that point to data in GPU memory */
       DeviceArray2D<int> 
       data() const;
 

--- a/gpu/kinfu/src/cuda/tsdf_volume.cu
+++ b/gpu/kinfu/src/cuda/tsdf_volume.cu
@@ -130,7 +130,7 @@ namespace pcl
         {
           float3 v_g = getVoxelGCoo (x, y, z);            //3 // p
 
-          //tranform to curr cam coo space
+          //transform to curr cam coo space
           float3 v = Rcurr_inv * (v_g - tcurr);           //4
 
           int2 coo;           //project to current cam

--- a/gpu/kinfu/src/cuda/utils.hpp
+++ b/gpu/kinfu/src/cuda/utils.hpp
@@ -182,7 +182,7 @@ namespace pcl
            if (roots.x >= roots.y)
              swap (roots.x, roots.y);
          }
-         if (roots.x <= 0) // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+         if (roots.x <= 0) // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
            computeRoots2 (c2, c1, roots);
        }
      }

--- a/gpu/kinfu/src/internal.h
+++ b/gpu/kinfu/src/internal.h
@@ -95,7 +95,7 @@ namespace pcl
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Maps
   
-    /** \brief Perfoms bilateral filtering of disparity map
+    /** \brief Performs bilateral filtering of disparity map
       * \param[in] src soruce map
       * \param[out] dst output map
       */
@@ -131,7 +131,7 @@ namespace pcl
     void 
     computeNormalsEigen (const MapArr& vmap, MapArr& nmap);
 
-    /** \brief Performs affine tranform of vertex and normal maps
+    /** \brief Performs affine transform of vertex and normal maps
       * \param[in] vmap_src source vertex map
       * \param[in] nmap_src source vertex map
       * \param[in] Rmat Rotation mat
@@ -335,7 +335,7 @@ namespace pcl
     /** \brief Perform point cloud extraction from tsdf volume
       * \param[in] volume tsdf volume 
       * \param[in] volume_size size of the volume
-      * \param[out] output buffer large enought to store point cloud
+      * \param[out] output buffer large enough to store point cloud
       * \return number of point stored to passed buffer
       */ 
     PCL_EXPORTS size_t 

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -222,7 +222,7 @@ pcl::gpu::KinfuTracker::allocateBufffers (int rows, int cols)
     coresps_[i].create (pyr_rows, pyr_cols);
   }  
   depthRawScaled_.create (rows, cols);
-  // see estimate tranform for the magic numbers
+  // see estimate transform for the magic numbers
   gbuf_.create (27, 20*60);
   sumbuf_.create (27);
 }
@@ -297,7 +297,7 @@ pcl::gpu::KinfuTracker::operator() (const DepthMap& depth_raw,
       }
       else
       {
-        Rcurr = Rprev; // tranform to global coo for ith camera pose
+        Rcurr = Rprev; // transform to global coo for ith camera pose
         tcurr = tprev;
       }
       {
@@ -365,7 +365,7 @@ pcl::gpu::KinfuTracker::operator() (const DepthMap& depth_raw,
           }
         }
       }
-      //save tranform
+      //save transform
       rmats_.push_back (Rcurr);
       tvecs_.push_back (tcurr);
   } 

--- a/gpu/kinfu/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu/tools/kinfu_app_sim.cpp
@@ -396,7 +396,7 @@ display_tic_toc (vector<double> &tic_toc,const string &fun_name)
 void
 capture (Eigen::Isometry3d pose_in,unsigned short* depth_buffer_mm,const uint8_t* color_buffer)//, string point_cloud_fname)
 {
-  // No reference image - but this is kept for compatability with range_test_v2:
+  // No reference image - but this is kept for compatibility with range_test_v2:
   float* reference = new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   //const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.
@@ -1078,7 +1078,7 @@ struct KinFuApp
       PtrStepSz<const KinfuTracker::PixelRGB> rgb24_sim = PtrStepSz<const KinfuTracker::PixelRGB>(height, width, color_buf_, width);
       tic_toc.push_back (getTime ());
       
-      if (1==0){ // live capture - probably doesnt work anymore, left in here for comparison:
+      if (1==0){ // live capture - probably doesn't work anymore, left in here for comparison:
 	bool has_frame = evaluation_ptr_ ? evaluation_ptr_->grab(i, depth) : capture_.grab (depth, rgb24);      
 	if (!has_frame)
 	{
@@ -1382,7 +1382,7 @@ print_cli_help ()
   cout << "    --registration, -r              : enable registration mode" << endl; 
   cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << endl;   
   cout << "    -volume_suze <size_in_meters>   : define integration volume size" << endl;   
-  cout << "    -dev <deivce>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
+  cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
   cout << "";
   cout << " For RGBD benchmark (Requires OpenCV):" << endl; 
   cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
@@ -68,7 +68,7 @@ namespace pcl
           */
         ColorVolume(const TsdfVolume& tsdf, int max_weight = -1);
 
-        /** \brief Desctructor */
+        /** \brief Destructor */
         ~ColorVolume();
 
         /** \brief Resets color volume to uninitialized state */

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
@@ -228,7 +228,7 @@ pcl::kinfuLS::WorldModel<PointT>::getWorldAsCubes (const double size, std::vecto
 		}
 		else
 		{
-		  PCL_INFO ("Extracted cube was empty, skiping this one.\n");
+		  PCL_INFO ("Extracted cube was empty, skipping this one.\n");
 		}
 		origin.z += cubeSide * step_increment;
 	  }

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
@@ -105,7 +105,7 @@ namespace pcl
           void
           setDepthIntrinsics (float fx, float fy, float cx = -1, float cy = -1);
 
-          /** \brief Sets initial camera pose relative to volume coordiante space
+          /** \brief Sets initial camera pose relative to volume coordinate space
             * \param[in] pose Initial camera pose
             */
           void

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
@@ -88,7 +88,7 @@ namespace pcl
         void
         setIntrinsics(float fx = 525.f, float fy = 525.f, float cx = -1, float cy = -1);
         
-        /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal fiels.
+        /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal files.
           * \param[in] volume tsdf volume container
           * \param[in] camera_pose camera pose
           * \param buffer

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
@@ -112,7 +112,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
           */
         TsdfVolume (const Eigen::Vector3i& resolution);           
               
-        /** \brief Sets Tsdf volume size for each dimention
+        /** \brief Sets Tsdf volume size for each dimension
           * \param[in] size size of tsdf volume in meters
           */
         void
@@ -124,7 +124,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         void
         setTsdfTruncDist (float distance);
 
-        /** \brief Returns tsdf volume container that point to data in GPU memroy */
+        /** \brief Returns tsdf volume container that point to data in GPU memory */
         DeviceArray2D<int> 
         data () const;
 

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
@@ -57,7 +57,7 @@ namespace pcl
     /** \brief WorldModel maintains a 3D point cloud that can be queried and updated via helper functions.\n
       * The world is represented as a point cloud.\n
       * When new points are added to the world, we replace old ones by the newest ones.
-      * This is acheived by setting old points to nan (for speed)
+      * This is achieved by setting old points to nan (for speed)
       * \author Raphael Favier
       */
     template <typename PointT>
@@ -103,7 +103,7 @@ namespace pcl
         void addSlice (const PointCloudPtr new_cloud);
 
 
-        /** \brief Retreive existing data from the world model, after a shift
+        /** \brief Retrieve existing data from the world model, after a shift
           * \param[in] previous_origin_x global origin of the cube on X axis, before the shift
           * \param[in] previous_origin_y global origin of the cube on Y axis, before the shift
           * \param[in] previous_origin_z global origin of the cube on Z axis, before the shift
@@ -161,7 +161,7 @@ namespace pcl
           * \param[in] size the size of a 3D cube.
           * \param[out] cubes a vector of point clouds representing each cube (in their original world coordinates). 
           * \param[out] transforms a vector containing the xyz position of each cube in world coordinates.
-          * \param[in] overlap optional overlap (in percent) between each cube (usefull to create overlapped meshes).
+          * \param[in] overlap optional overlap (in percent) between each cube (useful to create overlapped meshes).
           */
         void getWorldAsCubes (double size, std::vector<PointCloudPtr> &cubes, std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &transforms, double overlap = 0.0);
         

--- a/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
+++ b/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
@@ -103,7 +103,7 @@ namespace pcl
       #pragma unroll
                 for(int z = 0; z < buffer.voxels_size.z; ++z, pos+=z_step)
                 {
-                  ///If we went outside of the memory, make sure we go back to the begining of it
+                  ///If we went outside of the memory, make sure we go back to the beginning of it
                   if(pos > buffer.tsdf_memory_end)
                     pos = pos - size;
                   
@@ -141,7 +141,7 @@ namespace pcl
             #pragma unroll				
                 for(int z = 0; z < nbSteps; ++z, pos+=z_step)
                 {
-                  ///If we went outside of the memory, make sure we go back to the begining of it
+                  ///If we went outside of the memory, make sure we go back to the beginning of it
                   if(pos > buffer.tsdf_memory_end)
                     pos = pos - size;
                   
@@ -224,7 +224,7 @@ namespace pcl
           {
             float3 v_g = getVoxelGCoo (x, y, z);            //3 // p
 
-            //tranform to curr cam coo space
+            //transform to curr cam coo space
             float3 v = Rcurr_inv * (v_g - tcurr);           //4
 
             int2 coo;           //project to current cam

--- a/gpu/kinfu_large_scale/src/cuda/utils.hpp
+++ b/gpu/kinfu_large_scale/src/cuda/utils.hpp
@@ -185,7 +185,7 @@ namespace pcl
             if (roots.x >= roots.y)
               swap (roots.x, roots.y);
           }
-          if (roots.x <= 0) // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+          if (roots.x <= 0) // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
             computeRoots2 (c2, c1, roots);
         }
       }

--- a/gpu/kinfu_large_scale/src/internal.h
+++ b/gpu/kinfu_large_scale/src/internal.h
@@ -60,7 +60,7 @@ namespace pcl
       ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       // Maps
     
-      /** \brief Perfoms bilateral filtering of disparity map
+      /** \brief Performs bilateral filtering of disparity map
         * \param[in] src soruce map
         * \param[out] dst output map
         */
@@ -96,7 +96,7 @@ namespace pcl
       void 
       computeNormalsEigen (const MapArr& vmap, MapArr& nmap);
 
-      /** \brief Performs affine tranform of vertex and normal maps
+      /** \brief Performs affine transform of vertex and normal maps
         * \param[in] vmap_src source vertex map
         * \param[in] nmap_src source vertex map
         * \param[in] Rmat Rotation mat
@@ -337,7 +337,7 @@ namespace pcl
       /** \brief Perform point cloud extraction from tsdf volume
         * \param[in] volume tsdf volume 
         * \param[in] volume_size size of the volume
-        * \param[out] output buffer large enought to store point cloud
+        * \param[out] output buffer large enough to store point cloud
         * \return number of point stored to passed buffer
         */ 
       PCL_EXPORTS size_t 
@@ -350,8 +350,8 @@ namespace pcl
         * \param[in] shiftX Offset in indices that will be cleared from the TSDF volume. The clearing start from buffer.OriginX and stops in OriginX + shiftX
         * \param[in] shiftY Offset in indices that will be cleared from the TSDF volume. The clearing start from buffer.OriginY and stops in OriginY + shiftY
         * \param[in] shiftZ Offset in indices that will be cleared from the TSDF volume. The clearing start from buffer.OriginZ and stops in OriginZ + shiftZ
-        * \param[out] output_xyz buffer large enought to store point cloud xyz values
-        * \param[out] output_intensities buffer large enought to store point cloud intensity values
+        * \param[out] output_xyz buffer large enough to store point cloud xyz values
+        * \param[out] output_intensities buffer large enough to store point cloud intensity values
         * \return number of point stored to passed buffer
         */ 
       PCL_EXPORTS size_t

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -295,7 +295,7 @@ pcl::gpu::kinfuLS::KinfuTracker::allocateBufffers (int rows, int cols)
     coresps_[i].create (pyr_rows, pyr_cols);
   }  
   depthRawScaled_.create (rows, cols);
-  // see estimate tranform for the magic numbers
+  // see estimate transform for the magic numbers
   int r = (int)ceil ( ((float)rows) / ESTIMATE_COMBINED_CUDA_GRID_Y );
   int c = (int)ceil ( ((float)cols) / ESTIMATE_COMBINED_CUDA_GRID_X );
   gbuf_.create (27, r * c);
@@ -545,7 +545,7 @@ pcl::gpu::kinfuLS::KinfuTracker::performPairWiseICP(const Intr cam_intrinsics, M
   }
   
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  // since raw depthmaps are quite noisy, we make sure the estimated transform is big enought to be taken into account
+  // since raw depthmaps are quite noisy, we make sure the estimated transform is big enough to be taken into account
   float rnorm = rodrigues2(current_rotation).norm();
   float tnorm = (current_translation).norm();    
   const float alpha = 1.f;
@@ -582,7 +582,7 @@ pcl::gpu::kinfuLS::KinfuTracker::operator() (const DepthMap& depth_raw)
   
   ///////////////////////////////////////////////////////////////////////////////////////////
   // Initialization at first frame
-  if (global_time_ == 0) // this is the frist frame, the tsdf volume needs to be initialized
+  if (global_time_ == 0) // this is the first frame, the tsdf volume needs to be initialized
   {  
     // Initial rotation
     Matrix3frm initial_cam_rot = rmats_[0]; //  [Ri|ti] - pos of camera
@@ -667,7 +667,7 @@ pcl::gpu::kinfuLS::KinfuTracker::operator() (const DepthMap& depth_raw)
   device_current_translation_local -= getCyclicalBufferStructure()->origin_metric;   // translation (local translation = global translation - origin of cube)
   
   ///////////////////////////////////////////////////////////////////////////////////////////
-  // Integration check - We do not integrate volume if camera does not move far enought.  
+  // Integration check - We do not integrate volume if camera does not move far enough.  
   {
     float rnorm = rodrigues2(current_global_rotation.inverse() * last_known_global_rotation).norm();
     float tnorm = (current_global_translation - last_known_global_translation).norm();    

--- a/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
@@ -394,7 +394,7 @@ display_tic_toc (vector<double> &tic_toc,const string &fun_name)
 void
 capture (Eigen::Isometry3d pose_in,unsigned short* depth_buffer_mm,const uint8_t* color_buffer)//, string point_cloud_fname)
 {
-  // No reference image - but this is kept for compatability with range_test_v2:
+  // No reference image - but this is kept for compatibility with range_test_v2:
   float* reference = new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   //const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.
@@ -1076,7 +1076,7 @@ struct KinFuApp
       PtrStepSz<const KinfuTracker::PixelRGB> rgb24_sim = PtrStepSz<const KinfuTracker::PixelRGB>(height, width, color_buf_, width);
       tic_toc.push_back (getTime ());
       
-      if (1==0){ // live capture - probably doesnt work anymore, left in here for comparison:
+      if (1==0){ // live capture - probably doesn't work anymore, left in here for comparison:
 	bool has_frame = evaluation_ptr_ ? evaluation_ptr_->grab(i, depth) : capture_.grab (depth, rgb24);      
 	if (!has_frame)
 	{
@@ -1386,7 +1386,7 @@ print_cli_help ()
   cout << "    --registration, -r              : enable registration mode" << endl; 
   cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << endl;   
   cout << "    -volume_suze <size_in_meters>   : define integration volume size" << endl;   
-  cout << "    -dev <deivce>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
+  cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
   cout << "";
   cout << " For RGBD benchmark (Requires OpenCV):" << endl; 
   cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl;

--- a/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
+++ b/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
@@ -284,7 +284,7 @@ receiveAndProcess ()
 
   {
     boost::mutex::scoped_lock io_lock (io_mutex);
-    PCL_INFO ("Writing remaing %d maps in the buffer to disk...\n", buff.getSize ());
+    PCL_INFO ("Writing remaining %d maps in the buffer to disk...\n", buff.getSize ());
   }
   while (!buff.isEmpty ())
   {

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -201,7 +201,7 @@ saveOBJFile (const std::string &file_name,
   int f_idx = 0;
 
   // int idx_vt =0;
-  PCL_INFO ("Writting faces...\n");
+  PCL_INFO ("Writing faces...\n");
   for (int m = 0; m < nr_meshes; ++m)
   {
     if (m > 0) 
@@ -242,7 +242,7 @@ saveOBJFile (const std::string &file_name,
   /* Write material defination for OBJ file*/
   // Open file
   PCL_INFO ("Writing material files\n");
-  //dont do it if no material to write
+  //don't do it if no material to write
   if(tex_mesh.tex_materials.size() ==0)
     return (0);
 

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -49,7 +49,7 @@ namespace pcl
     namespace gpu
     {   
         /**
-         * \brief   Octree implementation on GPU. It suppors parallel building and paralel batch search as well .       
+         * \brief   Octree implementation on GPU. It suppors parallel building and parallel batch search as well .       
          * \author  Anaoly Baksheev, Itseez, myname.mysurname@mycompany.com
          */
 
@@ -95,10 +95,10 @@ namespace pcl
             /** \brief Returns true if tree has been built */
             bool isBuilt();
 
-            /** \brief Downloads Octree from GPU to search using CPU fucntion. It use usefull for signle (not-batch) search */
+            /** \brief Downloads Octree from GPU to search using CPU function. It use useful for single (not-batch) search */
             void internalDownload();
 
-            /** \brief Performs search of all points wihtin given radius on CPU. It call \a internalDownload if nessesary
+            /** \brief Performs search of all points within given radius on CPU. It call \a internalDownload if necessary
               * \param[in] center center of sphere
               * \param[in] radius radious of sphere
               * \param[out] out indeces of points within give sphere
@@ -106,7 +106,7 @@ namespace pcl
               */
             void radiusSearchHost(const PointType& center, float radius, std::vector<int>& out, int max_nn = INT_MAX);
 
-            /** \brief Performs approximate neares neighbor search on CPU. It call \a internalDownload if nessesary
+            /** \brief Performs approximate nearest neighbor search on CPU. It call \a internalDownload if necessary
               * \param[in]  query 3D point for which neighbour is be fetched             
               * \param[out] out_index neighbour index
               * \param[out] sqr_dist square distance to the neighbour returned
@@ -117,7 +117,7 @@ namespace pcl
               * \param[in] centers array of centers 
               * \param[in] radius radius for all queries
               * \param[in] max_results max number of returned points for each querey
-              * \param[out] result results packed to signle array
+              * \param[out] result results packed to single array
               */
             void radiusSearch(const Queries& centers, float radius, int max_results, NeighborIndices& result) const;
 
@@ -125,7 +125,7 @@ namespace pcl
               * \param[in] centers array of centers 
               * \param[in] radiuses array of radiuses
               * \param[in] max_results max number of returned points for each querey
-              * \param[out] result results packed to signle array
+              * \param[out] result results packed to single array
               */
             void radiusSearch(const Queries& centers, const Radiuses& radiuses, int max_results, NeighborIndices& result) const;
 
@@ -134,7 +134,7 @@ namespace pcl
               * \param[in] indices indices for centers array (only for these points search is performed)
               * \param[in] radius radius for all queries
               * \param[in] max_results max number of returned points for each querey
-              * \param[out] result results packed to signle array
+              * \param[out] result results packed to single array
               */
             void radiusSearch(const Queries& centers, const Indices& indices, float radius, int max_results, NeighborIndices& result) const;
 
@@ -146,7 +146,7 @@ namespace pcl
 
             /** \brief Batch exact k-nearest search on GPU for k == 1 only!
               * \param[in] queries array of centers
-              * \param[in] k nubmer of neighbors (only k == 1 is supported)
+              * \param[in] k number of neighbors (only k == 1 is supported)
               * \param[out] results array of results
               */
             void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const;

--- a/gpu/octree/src/cuda/octree_builder.cu
+++ b/gpu/octree/src/cuda/octree_builder.cu
@@ -186,7 +186,7 @@ namespace pcl
 
             __device__  __forceinline__ void operator()() const
             {             
-                //32 is a perfomance penalty step for search
+                //32 is a performance penalty step for search
                 Static<(max_points_per_leaf % 32) == 0>::check();                 
 
                 if (threadIdx.x == 0)

--- a/gpu/octree/src/cuda/octree_host.cu
+++ b/gpu/octree/src/cuda/octree_host.cu
@@ -89,14 +89,14 @@ void pcl::device::OctreeImpl::internalDownload()
 
 namespace 
 {
-    int getBitsNum(int interger)
+    int getBitsNum(int integer)
     {
         int count = 0;
-        while(interger > 0)
+        while(integer > 0)
         {
-            if (interger & 1)
+            if (integer & 1)
                 ++count;
-            interger>>=1;
+            integer>>=1;
         }
         return count;
     } 

--- a/gpu/octree/src/cuda/octree_iterator.hpp
+++ b/gpu/octree/src/cuda/octree_iterator.hpp
@@ -89,20 +89,20 @@ namespace pcl
         {       
             int level;
             int node_idx;
-            int lenght;
+            int length;
             const OctreeGlobalWithBox& octree;
 
             __device__ __forceinline__ OctreeIteratorDeviceNS(const OctreeGlobalWithBox& octree_arg) : octree(octree_arg)
             {
                 node_idx = 0;
                 level = 0;
-                lenght = 1;
+                length = 1;
             }
 
             __device__ __forceinline__ void gotoNextLevel(int first, int len) 
             {  
                 node_idx = first;
-                lenght = len;
+                length = len;
                 ++level;
             }       
 
@@ -116,7 +116,7 @@ namespace pcl
 #if 1
                 while(level >= 0)
                 {                
-                    if (lenght > 1)
+                    if (length > 1)
                     {
                         lenght--;
                         node_idx++;                      
@@ -143,7 +143,7 @@ namespace pcl
 
                     int pos = node_idx - parent_first;
 
-                    lenght = parent_len - pos;
+                    length = parent_len - pos;
                 }
 #endif
             }

--- a/gpu/octree/src/utils/priority_octree_iterator.hpp
+++ b/gpu/octree/src/utils/priority_octree_iterator.hpp
@@ -45,20 +45,20 @@ namespace pcl
         {       
             int level;
             int node_idx;
-            int lenght;
+            int length;
             const OctreeGlobalWithBox& octree;
 
             __device__ __forceinline__ OctreePriorityIteratorDevice(const OctreeGlobalWithBox& octree_arg) : octree(octree_arg)
             {
                 node_idx = 0;
                 level = 0;
-                lenght = 1;
+                length = 1;
             }
 
             __device__ __forceinline__ void gotoNextLevel(int first, int len) 
             {  
                 node_idx = first;
-                lenght = len;
+                length = len;
                 ++level;
             }       
 
@@ -72,7 +72,7 @@ namespace pcl
 #if 1
                 while(level >= 0)
                 {                
-                    if (lenght > 1)
+                    if (length > 1)
                     {
                         lenght--;
                         node_idx++;                      
@@ -99,7 +99,7 @@ namespace pcl
 
                     int pos = node_idx - parent_first;
 
-                    lenght = parent_len - pos;
+                    length = parent_len - pos;
                 }
 #endif
             }

--- a/gpu/octree/test/perfomance.cpp
+++ b/gpu/octree/test/perfomance.cpp
@@ -69,8 +69,8 @@ using pcl::ScopeTime;
     #include "opencv2/contrib/contrib.hpp"
 #endif
 
-//TEST(PCL_OctreeGPU, DISABLED_perfomance)
-TEST(PCL_OctreeGPU, perfomance)
+//TEST(PCL_OctreeGPU, DISABLED_performance)
+TEST(PCL_OctreeGPU, performance)
 {
     DataGenerator data;
     data.data_size = 871000;

--- a/gpu/octree/test/perfomance.cpp
+++ b/gpu/octree/test/perfomance.cpp
@@ -108,7 +108,7 @@ TEST(PCL_OctreeGPU, perfomance)
     
     cout << "[!] Host octree resolution: " << host_octree_resolution << endl << endl;    
 
-    cout << "======  Build perfomance =====" << endl;
+    cout << "======  Build performance =====" << endl;
     // build device octree
     pcl::gpu::Octree octree_device;                
     octree_device.setCloud(cloud_device);	    
@@ -142,7 +142,7 @@ TEST(PCL_OctreeGPU, perfomance)
     }
 #endif
     
-    //// Radius search perfomance ///
+    //// Radius search performance ///
 
     const int max_answers = 500;
     float dist;

--- a/gpu/people/include/pcl/gpu/people/label_blob2.h
+++ b/gpu/people/include/pcl/gpu/people/label_blob2.h
@@ -52,7 +52,7 @@ namespace pcl
     namespace people
     {      
       /**
-       * @brief This structure containts all parameters to describe blobs and their parent/child relations
+       * @brief This structure contains all parameters to describe blobs and their parent/child relations
        * @todo: clean this out in the end, perhaps place the children in a separate struct
        */
       struct Blob2 

--- a/gpu/people/include/pcl/gpu/people/label_common.h
+++ b/gpu/people/include/pcl/gpu/people/label_common.h
@@ -151,7 +151,7 @@ namespace pcl
       };
 
       /**
-       *  @brief This LUT contains the ideal lenght between this part and his children
+       *  @brief This LUT contains the ideal length between this part and his children
        **/
       static const float LUT_ideal_length[][4] = 
       {
@@ -183,7 +183,7 @@ namespace pcl
       };
 
       /**
-       * @brief This LUT contains the max lenght between this part and his children
+       * @brief This LUT contains the max length between this part and his children
        **/
       static const float LUT_max_length_offset[][4] = 
       {

--- a/gpu/people/include/pcl/gpu/people/label_segment.h
+++ b/gpu/people/include/pcl/gpu/people/label_segment.h
@@ -77,7 +77,7 @@ namespace pcl
          * \param[in] dmap the cvMat with the depths, must be CV_16U in mm
          * \param[out] lmap_out the smoothed output labelmap as cvMat
          * \param[in] patch_size make the patch size for smoothing
-         * \param[in] depthThres the z-distance thresshold
+         * \param[in] depthThres the z-distance threshold
          * \todo add a Gaussian contribution function to depth and vote
          **/
         //inline void smoothLabelImage ( cv::Mat&      lmap_in,

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -70,7 +70,7 @@ namespace pcl
     namespace people    
     {           
      /**
-       * @brief This structure containts all parameters to describe the segmented tree
+       * @brief This structure contains all parameters to describe the segmented tree
        */
       struct Tree2 
       {
@@ -222,7 +222,7 @@ namespace pcl
        * @param[in] parent_label this is the part label that indicates the row
        * @param[in] child_label  this is the part label that indicates the childs needed to be investigated
        * @param[in] child_number the number of this child in the parent, some parents have multiple childs
-       * @return zero if successfull
+       * @return zero if successful
        * @todo once we have good evaluation function reconsider best_value
        **/
       inline int
@@ -281,7 +281,7 @@ namespace pcl
        * @param[in] child_label  this is the part label that indicates the childs needed to be investigated
        * @param[in] child_number the number of this child in the parent, some parents have multiple childs
        * @param person_attribs
-       * @return zero if successfull
+       * @return zero if successful
        * @todo once we have good evaluation function reconsider best_value
        **/
       inline int

--- a/gpu/people/include/pcl/gpu/people/person_attribs.h
+++ b/gpu/people/include/pcl/gpu/people/person_attribs.h
@@ -25,7 +25,7 @@ namespace pcl
           /**
            * \brief Read XML configuration file for a specific person
            * \param[in] is input stream of file
-           * \return 0 when successfull, -1 when an error occured, datastructure might become corrupted in the process
+           * \return 0 when successful, -1 when an error occurred, datastructure might become corrupted in the process
            **/
           int
           readPersonXMLConfig (std::istream& is);

--- a/gpu/people/src/cuda/smooth.cu
+++ b/gpu/people/src/cuda/smooth.cu
@@ -142,7 +142,7 @@ void pcl::device::smoothLabelImage(const Labels& src, const Depth& depth, Labels
   if (num_parts <= 32)
     pcl::device::smoothKernel<32><<<grid, block>>>(src, depth, dst, patch_size, depthThres, num_parts);
   else
-    throw std::exception(); //should instanciate another smoothKernel<N>
+    throw std::exception(); //should instantiate another smoothKernel<N>
 
   cudaSafeCall( cudaGetLastError() );
   cudaSafeCall( cudaDeviceSynchronize() );

--- a/gpu/utils/include/pcl/gpu/utils/device/block.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/block.hpp
@@ -96,7 +96,7 @@ namespace pcl
 			}
 
 			template<typename InIt, typename OutIt, class UnOp>
-			static __device__ __forceinline__ void transfrom(InIt beg, InIt end, OutIt out, UnOp op)
+			static __device__ __forceinline__ void transform(InIt beg, InIt end, OutIt out, UnOp op)
 			{
 				int STRIDE = stride();
 				InIt  t = beg + flattenedThreadId();
@@ -107,7 +107,7 @@ namespace pcl
 			}
 
 			template<typename InIt1, typename InIt2, typename OutIt, class BinOp>
-			static __device__ __forceinline__ void transfrom(InIt1 beg1, InIt1 end1, InIt2 beg2, OutIt out, BinOp op)
+			static __device__ __forceinline__ void transform(InIt1 beg1, InIt1 end1, InIt2 beg2, OutIt out, BinOp op)
 			{
 				int STRIDE = stride();
 				InIt1 t1 = beg1 + flattenedThreadId();

--- a/gpu/utils/include/pcl/gpu/utils/device/reduce.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/reduce.hpp
@@ -34,8 +34,8 @@
 *  Author: Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
 */
 
-#ifndef PCL_GPU_DEVUCE_REDUCE_HPP_
-#define PCL_GPU_DEVUCE_REDUCE_HPP_
+#ifndef PCL_GPU_DEVICE_REDUCE_HPP_
+#define PCL_GPU_DEVICE_REDUCE_HPP_
 
 namespace pcl
 {

--- a/octree/include/pcl/octree/impl/octree2buf_base.hpp
+++ b/octree/include/pcl/octree/impl/octree2buf_base.hpp
@@ -364,7 +364,7 @@ namespace pcl
               child_branch = static_cast<BranchNode*> (child_node);
               branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
             } else {
-              // depth has changed.. child in preceeding buffer is a leaf node.
+              // depth has changed.. child in preceding buffer is a leaf node.
               deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
               child_branch = createBranchChild (*branch_arg, child_idx);
             }
@@ -406,7 +406,7 @@ namespace pcl
               child_leaf = static_cast<LeafNode*> (child_node);
               branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
             } else {
-              // depth has changed.. child in preceeding buffer is a leaf node.
+              // depth has changed.. child in preceding buffer is a leaf node.
               deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
               child_leaf = createLeafChild (*branch_arg, child_idx);
             }
@@ -697,7 +697,7 @@ namespace pcl
                     child_branch = static_cast<BranchNode*> (child_node);
                     branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
                   } else {
-                    // depth has changed.. child in preceeding buffer is a leaf node.
+                    // depth has changed.. child in preceding buffer is a leaf node.
                     deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
                     child_branch = createBranchChild (*branch_arg, child_idx);
                   }
@@ -741,7 +741,7 @@ namespace pcl
                   child_leaf = static_cast<LeafNode*> (child_node);
                   branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
                 } else {
-                  // depth has changed.. child in preceeding buffer is a leaf node.
+                  // depth has changed.. child in preceding buffer is a leaf node.
                   deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
                   child_leaf = createLeafChild (*branch_arg, child_idx);
                 }

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -97,7 +97,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::n
   OctreeKey key;
   key.x = key.y = key.z = 0;
 
-  // initalize smallest point distance in search with high value
+  // initialize smallest point distance in search with high value
   double smallest_dist = std::numeric_limits<double>::max ();
 
   getKNearestNeighborRecursive (p_q, k, this->root_node_, key, 1, smallest_dist, point_candidates);

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -489,7 +489,7 @@ namespace pcl
           return ret;
         }
 
-        /** \brief Check for leaf not existance in the octree
+        /** \brief Check if leaf doesn't exist in the octree
          *  \param key_arg: octree key addressing a leaf node.
          *  \return "true" if leaf node is found; "false" otherwise
          * */

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -344,7 +344,7 @@ namespace pcl
           return result;
         }
 
-        /** \brief Check for existance of a leaf node in the octree
+        /** \brief Check for existence of a leaf node in the octree
          *  \param key_arg: octree key addressing a leaf node.
          *  \return "true" if leaf node is found; "false" otherwise
          * */

--- a/outofcore/include/pcl/outofcore/cJSON.h
+++ b/outofcore/include/pcl/outofcore/cJSON.h
@@ -113,7 +113,7 @@ PCLAPI(void) cJSON_AddItemToObject(cJSON *object,const char *string,cJSON *item)
 PCLAPI(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
 PCLAPI(void) cJSON_AddItemReferenceToObject(cJSON *object,const char *string,cJSON *item);
 
-/* Remove/Detatch items from Arrays/Objects. */
+/* Remove/Detach items from Arrays/Objects. */
 PCLAPI(cJSON *) cJSON_DetachItemFromArray(cJSON *array,int which);
 PCLAPI(void)    cJSON_DeleteItemFromArray(cJSON *array,int which);
 PCLAPI(cJSON *) cJSON_DetachItemFromObject(cJSON *object,const char *string);

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -245,7 +245,7 @@ namespace pcl
 
       if ((start + count) > size ())
       {
-        PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeDiskContainer::%s] Indicies out of range; start + count exceeds the size of the stored points\n", __FUNCTION__);
+        PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeDiskContainer::%s] Indices out of range; start + count exceeds the size of the stored points\n", __FUNCTION__);
         PCL_THROW_EXCEPTION (PCLException, "[pcl::outofcore::OutofcoreOctreeDiskContainer] Outofcore Octree Exception: Read indices exceed range");
       }
 

--- a/outofcore/include/pcl/outofcore/octree_base_node.h
+++ b/outofcore/include/pcl/outofcore/octree_base_node.h
@@ -328,7 +328,7 @@ namespace pcl
          *
          * \param bb_min triple of x,y,z minima for bounding box
          * \param bb_max triple of x,y,z maxima for bounding box
-         * \param tree adress of the tree data structure that will hold this initial root node
+         * \param tree address of the tree data structure that will hold this initial root node
          * \param rootname Root directory for location of on-disk octree storage; if directory 
          * doesn't exist, it is created; if "rootname" is an existing file, 
          * 

--- a/outofcore/include/pcl/outofcore/octree_ram_container.h
+++ b/outofcore/include/pcl/outofcore/octree_ram_container.h
@@ -65,7 +65,7 @@ namespace pcl
       public:
         typedef typename OutofcoreAbstractNodeContainer<PointT>::AlignedPointTVector AlignedPointTVector;
 
-        /** \brief empty contructor (with a path parameter?)
+        /** \brief empty constructor (with a path parameter?)
           */
         OutofcoreOctreeRamContainer (const boost::filesystem::path&) : container_ () { }
         

--- a/outofcore/tools/outofcore_print.cpp
+++ b/outofcore/tools/outofcore_print.cpp
@@ -237,7 +237,7 @@ outofcorePrint (boost::filesystem::path tree_root, size_t print_depth, bool boun
 void
 printHelp (int, char **argv)
 {
-  print_info ("This program is used to process pcd fiels into an outofcore data structure viewable by the");
+  print_info ("This program is used to process pcd files into an outofcore data structure viewable by the");
   print_info ("pcl_outofcore_viewer\n\n");
   print_info ("%s <options> <input_tree_dir> \n", argv[0]);
   print_info ("\n");

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -229,7 +229,7 @@ outofcoreProcess (std::vector<boost::filesystem::path> pcd_paths, boost::filesys
 void
 printHelp (int, char **argv)
 {
-  print_info ("This program is used to process pcd fiels into an outofcore data structure viewable by the");
+  print_info ("This program is used to process pcd files into an outofcore data structure viewable by the");
   print_info ("pcl_outofcore_viewer\n\n");
   print_info ("%s <options> <input>.pcd <output_tree_dir>\n", argv[0]);
   print_info ("\n");

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -313,11 +313,11 @@ namespace pcl
         inline const std::string& 
         getClassName () const { return (corr_name_); }
 
-        /** \brief Internal computation initalization. */
+        /** \brief Internal computation initialization. */
         bool
         initCompute ();
         
-        /** \brief Internal computation initalization for reciprocal correspondences. */
+        /** \brief Internal computation initialization for reciprocal correspondences. */
         bool
         initComputeReciprocal ();
 

--- a/registration/include/pcl/registration/correspondence_estimation_backprojection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_backprojection.h
@@ -202,7 +202,7 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::tree_reciprocal_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_;
 
-        /** \brief Internal computation initalization. */
+        /** \brief Internal computation initialization. */
         bool
         initCompute ();
 

--- a/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
+++ b/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
@@ -198,7 +198,7 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::tree_reciprocal_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_;
 
-        /** \brief Internal computation initalization. */
+        /** \brief Internal computation initialization. */
         bool
         initCompute ();
 

--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -346,7 +346,7 @@ namespace pcl
         }
         
         /** \brief Get the correspondence score for a given pair of correspondent points based on 
-          * the angle betweeen the normals. The normmals for the in put and target clouds must be 
+          * the angle between the normals. The normmals for the in put and target clouds must be 
           * set before using this function
           * \param[in] corr Correspondent points
           */

--- a/registration/include/pcl/registration/correspondence_types.h
+++ b/registration/include/pcl/registration/correspondence_types.h
@@ -50,7 +50,7 @@ namespace pcl
       * \param[in] correspondences list of correspondences
       * \param[out] mean the mean descriptor distance of correspondences
       * \param[out] stddev the standard deviation of descriptor distances.
-      * \note The sample varaiance is used to determine the standard deviation
+      * \note The sample variance is used to determine the standard deviation
       */
     inline void 
     getCorDistMeanStd (const pcl::Correspondences& correspondences, double &mean, double &stddev);

--- a/registration/include/pcl/registration/exceptions.h
+++ b/registration/include/pcl/registration/exceptions.h
@@ -59,7 +59,7 @@ namespace pcl
   } ;
 
  /** \class NotEnoughPointsException
-    * \brief An exception that is thrown when the number of correspondants is not equal
+    * \brief An exception that is thrown when the number of correspondents is not equal
     * to the minimum required
     */
   class PCL_EXPORTS NotEnoughPointsException : public PCLException

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -179,7 +179,7 @@ namespace pcl
         * \param[in] cloud_src the source point cloud dataset
         * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
         * \param[in] cloud_tgt the target point cloud dataset
-        * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+        * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
         * \param[out] transformation_matrix the resultant transformation matrix
         */
       void
@@ -253,7 +253,7 @@ namespace pcl
       int k_correspondences_;
 
       /** \brief The epsilon constant for gicp paper; this is NOT the convergence 
-        * tolerence 
+        * tolerance 
         * default: 0.001
         */
       double gicp_epsilon_;
@@ -293,7 +293,7 @@ namespace pcl
       int max_inner_iterations_;
 
       /** \brief compute points covariances matrices according to the K nearest 
-        * neighbors. K is set via setCorrespondenceRandomness() methode.
+        * neighbors. K is set via setCorrespondenceRandomness() method.
         * \param cloud pointer to point cloud
         * \param tree KD tree performer for nearest neighbors search
         * \param[out] cloud_covariances covariances matrices for each point in the cloud

--- a/registration/include/pcl/registration/ia_fpcs.h
+++ b/registration/include/pcl/registration/ia_fpcs.h
@@ -515,7 +515,7 @@ namespace pcl
       /** \brief Estimated squared metric overlap between source and target.
         * \note Internally calculated using the estimated overlap and the extent of the source cloud.
         * It is used to derive the minimum sampling distance of the base points as well as to calculated
-        * the number of trys to reliable find a correct mach.
+        * the number of tries to reliably find a correct match.
         */
       float max_base_diameter_sqr_;
 

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -258,7 +258,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
     Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap ();
     Eigen::Vector4f pp (transformation_matrix * p_src);
     // Estimate the distance (cost function)
-    // The last coordiante is still guaranteed to be set to 1.0
+    // The last coordinate is still guaranteed to be set to 1.0
     Eigen::Vector3d res(pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     Eigen::Vector3d temp (gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]) * res);
     //increment= res'*temp/num_matches = temp'*M*temp/num_matches (we postpone 1/num_matches after the loop closes)
@@ -286,7 +286,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
     Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap ();
 
     Eigen::Vector4f pp (transformation_matrix * p_src);
-    // The last coordiante is still guaranteed to be set to 1.0
+    // The last coordinate is still guaranteed to be set to 1.0
     Eigen::Vector3d res (pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     // temp = M*res
     Eigen::Vector3d temp (gicp_->mahalanobis ((*gicp_->tmp_idx_src_)[i]) * res);
@@ -320,7 +320,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
     Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap ();
     Eigen::Vector4f pp (transformation_matrix * p_src);
-    // The last coordiante is still guaranteed to be set to 1.0
+    // The last coordinate is still guaranteed to be set to 1.0
     Eigen::Vector3d res (pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     // temp = M*res
     Eigen::Vector3d temp (gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]) * res);

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -187,7 +187,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
         // select four coplanar point base
         if (selectBase (base_indices, ratio) == 0)
         {
-          // calculate candidate pair correspondences using diagonal lenghts of base
+          // calculate candidate pair correspondences using diagonal lengths of base
           pcl::Correspondences pairs_a, pairs_b;
           if (bruteForceCorrespondences (base_indices[0], base_indices[1], pairs_a) == 0 &&
             bruteForceCorrespondences (base_indices[2], base_indices[3], pairs_b) == 0)
@@ -217,7 +217,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   }
   
 
-  // determine best match over all trys
+  // determine best match over all tries
   finalCompute (all_candidates);
 
   // apply the final transformation
@@ -343,7 +343,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   Eigen::Vector4f centre_pt;
   float nearest_to_plane = FLT_MAX;
 
-  // repeat base search until valid quadruple was found or ransac_iterations_ number of trys were unsuccessfull
+  // repeat base search until valid quadruple was found or ransac_iterations_ number of tries were unsuccessful
   for (int i = 0; i < ransac_iterations_; i++)
   {
     // random select an appropriate point triple
@@ -382,7 +382,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
       }
     }
 
-    // check if at least one point fullfilled the conditions
+    // check if at least one point fulfilled the conditions
     if (nearest_to_plane != FLT_MAX)
     {
       // order points to build largest quadrangle and calcuate intersection ratios of diagonals
@@ -391,7 +391,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     }
   }
 
-  // return unsuccessfull if no quadruple was selected
+  // return unsuccessful if no quadruple was selected
   return (-1);
 }
 
@@ -697,7 +697,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     }
   }
 
-  // return unsuccessfull if no match was found
+  // return unsuccessful if no match was found
   return (matches.size () > 0 ? 0 : -1);
 }
 
@@ -868,7 +868,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
       break;
   }
 
-  // check current costs and return unsuccessfull if larger than previous ones
+  // check current costs and return unsuccessful if larger than previous ones
   inlier_score_temp /= static_cast <float> (nr_points);
   float fitness_score_temp = 1.f - inlier_score_temp;
 
@@ -885,7 +885,7 @@ template <typename PointSource, typename PointTarget, typename NormalT, typename
 pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::finalCompute (
   const std::vector <MatchingCandidates > &candidates)
 {
-  // get best fitness_score over all trys
+  // get best fitness_score over all tries
   int nr_candidates = static_cast <int> (candidates.size ());
   int best_index = -1;
   float best_score = FLT_MAX;

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -164,7 +164,7 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
     scale += lambda_;
   }
 
-  // calculate the fitness and return unsuccessfull if smaller than previous ones
+  // calculate the fitness and return unsuccessful if smaller than previous ones
   float fitness_score_temp = (score_a + lambda_ * score_b) / scale;
   if (fitness_score_temp > fitness_score)
     return (-1);

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -235,7 +235,7 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
     // Estimate the transform from the samples to their corresponding points
     transformation_estimation_->estimateRigidTransformation (*input_, sample_indices, *target_, corresponding_indices, transformation_);
 
-    // Tranform the data and compute the error
+    // Transform the data and compute the error
     transformPointCloud (*input_, input_transformed, transformation_);
     error = computeErrorMetric (input_transformed, static_cast<float> (corr_dist_threshold_));
 

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -221,7 +221,7 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
     // Estimate the transform
     transformation_estimation_->estimateRigidTransformation (*input_transformed, *target_, *correspondences_, transformation_);
 
-    // Tranform the data
+    // Transform the data
     transformCloud (*input_transformed, *input_transformed, transformation_);
 
     // Obtain the final transformation    

--- a/registration/include/pcl/registration/impl/joint_icp.hpp
+++ b/registration/include/pcl/registration/impl/joint_icp.hpp
@@ -236,7 +236,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
     // Estimate the transform jointly, on a combined correspondence set
     transformation_estimation_->estimateRigidTransformation (*inputs_transformed_combined, *targets_combined, *correspondences_, transformation_);
 
-    // Tranform the combined data
+    // Transform the combined data
     this->transformCloud (*inputs_transformed_combined, *inputs_transformed_combined, transformation_);
     // And all its components
     for (size_t i = 0; i < sources_.size (); i++)

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -61,7 +61,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributions
 
   double gauss_c1, gauss_c2, gauss_d3;
 
-  // Initializes the guassian fitting parameters (eq. 6.8) [Magnusson 2009]
+  // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
   gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
   gauss_d3 = -log (gauss_c2);
@@ -81,7 +81,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformati
 
   double gauss_c1, gauss_c2, gauss_d3;
 
-  // Initializes the guassian fitting parameters (eq. 6.8) [Magnusson 2009]
+  // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
   gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
   gauss_d3 = -log (gauss_c2);
@@ -362,7 +362,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
   double e_x_cov_x = exp (-gauss_d2_ * x_trans.dot (c_inv * x_trans) / 2);
-  // Calculate probability of transtormed points existance, Equation 6.9 [Magnusson 2009]
+  // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
   double score_inc = -gauss_d1_ * e_x_cov_x;
 
   e_x_cov_x = gauss_d2_ * e_x_cov_x;
@@ -686,7 +686,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT
   // Iterate until max number of iterations, interval convergance or a value satisfies the sufficient decrease, Equation 1.1, and curvature condition, Equation 1.2 [More, Thuente 1994]
   while (!interval_converged && step_iterations < max_step_iterations && !(psi_t <= 0 /*Sufficient Decrease*/ && d_phi_t <= -nu * d_phi_0 /*Curvature Condition*/))
   {
-    // Use auxilary function if interval I is not closed
+    // Use auxiliary function if interval I is not closed
     if (open_interval)
     {
       a_t = trialValueSelectionMT (a_l, f_l, g_l,

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -348,7 +348,7 @@ namespace pcl
                            PointCloudSource &trans_cloud);
 
       /** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in More-Thuente (1994)
-        * \note Updating Algorithm until some value satifies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+        * \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
         * and Modified Updating Algorithm from then on [More, Thuente 1994].
         * \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
         * \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified Update Algorithm
@@ -368,7 +368,7 @@ namespace pcl
 
       /** \brief Select new trial value for More-Thuente method.
         * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k \f$ and \f$ g_k \f$
-        * until some value satifies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+        * until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
         * then \f$ \phi(\alpha_k) \f$ is used from then on.
         * \note Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming By Wenyu Sun, Ya-xiang Yuan (89-100).
         * \param[in] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
@@ -387,14 +387,14 @@ namespace pcl
                              double a_u, double f_u, double g_u,
                              double a_t, double f_t, double g_t);
 
-      /** \brief Auxilary function used to determin endpoints of More-Thuente interval.
+      /** \brief Auxiliary function used to determine endpoints of More-Thuente interval.
         * \note \f$ \psi(\alpha) \f$ in Equation 1.6 (Moore, Thuente 1994)
         * \param[in] a the step length, \f$ \alpha \f$ in More-Thuente (1994)
         * \param[in] f_a function value at step length a, \f$ \phi(\alpha) \f$ in More-Thuente (1994)
         * \param[in] f_0 initial function value, \f$ \phi(0) \f$ in Moore-Thuente (1994)
         * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
         * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-        * \return sufficent decrease value
+        * \return sufficient decrease value
         */
       inline double
       auxilaryFunction_PsiMT (double a, double f_a, double f_0, double g_0, double mu = 1.e-4)
@@ -402,12 +402,12 @@ namespace pcl
         return (f_a - f_0 - mu * g_0 * a);
       }
 
-      /** \brief Auxilary function derivative used to determin endpoints of More-Thuente interval.
+      /** \brief Auxiliary function derivative used to determine endpoints of More-Thuente interval.
         * \note \f$ \psi'(\alpha) \f$, derivative of Equation 1.6 (Moore, Thuente 1994)
         * \param[in] g_a function gradient at step length a, \f$ \phi'(\alpha) \f$ in More-Thuente (1994)
         * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
         * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-        * \return sufficent decrease derivative
+        * \return sufficient decrease derivative
         */
       inline double
       auxilaryFunction_dPsiMT (double g_a, double g_0, double mu = 1.e-4)

--- a/registration/include/pcl/registration/pyramid_feature_matching.h
+++ b/registration/include/pcl/registration/pyramid_feature_matching.h
@@ -119,7 +119,7 @@ namespace pcl
       isComputed () { return is_computed_; }
 
       /** \brief Static method for comparing two pyramid histograms that returns a floating point value between 0 and 1,
-       * representing the similiarity between the feature sets on which the two pyramid histograms are based.
+       * representing the similarity between the feature sets on which the two pyramid histograms are based.
        * \param pyramid_a Pointer to the first pyramid to be compared (needs to be computed already).
        * \param pyramid_b Pointer to the second pyramid to be compared (needs to be computed already).
        */

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -422,7 +422,7 @@ namespace pcl
       inline const std::string&
       getClassName () const { return (reg_name_); }
         
-      /** \brief Internal computation initalization. */
+      /** \brief Internal computation initialization. */
       bool
       initCompute ();
 
@@ -528,7 +528,7 @@ namespace pcl
       double euclidean_fitness_epsilon_;
 
       /** \brief The maximum distance threshold between two correspondent points in source <-> target. If the 
-        * distance is larger than this threshold, the points will be ignored in the alignement process.
+        * distance is larger than this threshold, the points will be ignored in the alignment process.
         */
       double corr_dist_threshold_;
 

--- a/registration/include/pcl/registration/transformation_estimation.h
+++ b/registration/include/pcl/registration/transformation_estimation.h
@@ -95,7 +95,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         virtual void

--- a/registration/include/pcl/registration/transformation_estimation_2D.h
+++ b/registration/include/pcl/registration/transformation_estimation_2D.h
@@ -95,7 +95,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         virtual void

--- a/registration/include/pcl/registration/transformation_estimation_3point.h
+++ b/registration/include/pcl/registration/transformation_estimation_3point.h
@@ -101,7 +101,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         virtual void

--- a/registration/include/pcl/registration/transformation_estimation_dq.h
+++ b/registration/include/pcl/registration/transformation_estimation_dq.h
@@ -96,7 +96,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void

--- a/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
+++ b/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
@@ -96,7 +96,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void

--- a/registration/include/pcl/registration/transformation_estimation_lm.h
+++ b/registration/include/pcl/registration/transformation_estimation_lm.h
@@ -133,7 +133,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from 
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from 
           * \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
@@ -219,7 +219,7 @@ namespace pcl
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
-          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the choosen _Scalar
+          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the chosen _Scalar
           */
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor
@@ -234,7 +234,7 @@ namespace pcl
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,1> ValueType;
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
 
-          /** \brief Empty Construtor. */
+          /** \brief Empty Constructor. */
           Functor () : m_data_points_ (ValuesAtCompileTime) {}
 
           /** \brief Constructor

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
@@ -99,7 +99,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void
@@ -135,7 +135,7 @@ namespace pcl
                                      ConstCloudIterator<PointTarget>& target_it, 
                                      Matrix4 &transformation_matrix) const;
 
-        /** \brief Construct a 4 by 4 tranformation matrix from the provided rotation and translation.
+        /** \brief Construct a 4 by 4 transformation matrix from the provided rotation and translation.
           * \param[in] alpha the rotation about the x-axis
           * \param[in] beta the rotation about the y-axis
           * \param[in] gamma the rotation about the z-axis

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
@@ -99,7 +99,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void
@@ -145,7 +145,7 @@ namespace pcl
                                      typename std::vector<Scalar>::const_iterator& weights_it,
                                      Matrix4 &transformation_matrix) const;
 
-        /** \brief Construct a 4 by 4 tranformation matrix from the provided rotation and translation.
+        /** \brief Construct a 4 by 4 transformation matrix from the provided rotation and translation.
           * \param[in] alpha the rotation about the x-axis
           * \param[in] beta the rotation about the y-axis
           * \param[in] gamma the rotation about the z-axis

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -139,7 +139,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from 
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from 
           * \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           * \note Uses the weights given by setWeights.
@@ -204,7 +204,7 @@ namespace pcl
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
-          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the choosen _Scalar
+          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the chosen _Scalar
           */
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor
@@ -219,7 +219,7 @@ namespace pcl
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,1> ValueType;
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
 
-          /** \brief Empty Construtor. */
+          /** \brief Empty Constructor. */
           Functor () : m_data_points_ (ValuesAtCompileTime) {}
 
           /** \brief Constructor

--- a/registration/include/pcl/registration/transformation_estimation_svd.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd.h
@@ -99,7 +99,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void

--- a/registration/include/pcl/registration/transformation_validation.h
+++ b/registration/include/pcl/registration/transformation_validation.h
@@ -101,7 +101,7 @@ namespace pcl
         /** \brief Comparator function for deciding which score is better after running the 
           * validation on multiple transforms. Pure virtual.
           *
-          * \note For example, for Euclidean distances smaller is better, for inliers the oposite.
+          * \note For example, for Euclidean distances smaller is better, for inliers the opposite.
           *
           * \param[in] score1 the first value
           * \param[in] score2 the second value

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -311,7 +311,7 @@ namespace pcl
         PCL_DEBUG("[pcl::%s::computeTransformation] Convergence failed\n",
             getClassName ().c_str ());
     }
-    //for some reason the static equivalent methode raises an error
+    //for some reason the static equivalent method raises an error
     // final_transformation_.block<3,3> (0,0) = (transformation_.block<3,3> (0,0)) * (guess.block<3,3> (0,0));
     // final_transformation_.block <3, 1> (0, 3) = transformation_.block <3, 1> (0, 3) + guess.rightCols<1>.block <3, 1> (0, 3);
     final_transformation_.topLeftCorner (3, 3) =


### PR DESCRIPTION
Found via `codespell -q 3 -I ../pcl-whitelist.txt`

Whitelist:
```
ang
childs
indeces
ith
lod
metre
metres
nd
ot
te
vertexes
```