### PR TITLE
Misc. typos (cont. 2)

### DIFF
--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -76,7 +76,7 @@ namespace pcl
       /** \brief This function suppresses the edges which don't form a local maximum 
         * in the edge direction.
         * \param[in] edges point cloud containing all the edges
-        * \param[out] maxima point cloud containing the non-max supressed edges
+        * \param[out] maxima point cloud containing the non-max suppressed edges
         * \param[in] tLow
         */
       void

--- a/2d/include/pcl/2d/impl/morphology.hpp
+++ b/2d/include/pcl/2d/impl/morphology.hpp
@@ -277,7 +277,7 @@ pcl::Morphology<PointT>::subtractionBinary (
     const pcl::PointCloud<PointT> &input1, 
     const pcl::PointCloud<PointT> &input2)
 {
-  const int height = (input1.height < input2.hieght) ? input1.height : input2.height;
+  const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
   output.width = width;
   output.height = height;
@@ -299,7 +299,7 @@ pcl::Morphology<PointT>::unionBinary (
     const pcl::PointCloud<PointT> &input1, 
     const pcl::PointCloud<PointT> &input2)
 {
-  const int height = (input1.height < input2.hieght) ? input1.height : input2.height;
+  const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
   output.width = width;
   output.height = height;

--- a/2d/include/pcl/2d/impl/morphology.hpp
+++ b/2d/include/pcl/2d/impl/morphology.hpp
@@ -77,7 +77,7 @@ pcl::Morphology<PointT>::erosionBinary (pcl::PointCloud<PointT> &output)
           {
             continue;
           }
-          // If one of the elements of the kernel and image dont match, 
+          // If one of the elements of the kernel and image don't match, 
           // the output image is 0. So, move to the next point.
           if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity != 1)
           {
@@ -192,7 +192,7 @@ pcl::Morphology<PointT>::erosionGray (pcl::PointCloud<PointT> &output)
           {
             continue;
           }
-          // If one of the elements of the kernel and image dont match, 
+          // If one of the elements of the kernel and image don't match, 
           // the output image is 0. So, move to the next point.
           if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity < min || min == -1)
           {
@@ -236,7 +236,7 @@ pcl::Morphology<PointT>::dilationGray (pcl::PointCloud<PointT> &output)
           {
             continue;
           }
-          // If one of the elements of the kernel and image dont match, 
+          // If one of the elements of the kernel and image don't match, 
           // the output image is 0. So, move to the next point.
           if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity > max || max == -1)
           {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -384,7 +384,7 @@
 * Removed unnecessary mutex locking in `TimeTrigger::registerCallback`
   [[#1087]](https://github.com/PointCloudLibrary/pcl/pull/1087)
 * Updated PCL exception types to have nothrow copy constructor and copy
-  assigment operator
+  assignment operator
   [[#1119]](https://github.com/PointCloudLibrary/pcl/pull/1119)
 * Fixed a bug with `PCA` not triggering recomputation when input indices are
   changed
@@ -625,7 +625,7 @@
 * Added a new `MetaRegistration` class that allows to register a stream of
   clouds where each cloud is aligned to the conglomerate of all previous clouds
   [[#1426]](https://github.com/PointCloudLibrary/pcl/pull/1426)
-* Fixed segmentation fault occuring in `CorrespondenceRejectorSurfaceNormal`
+* Fixed segmentation fault occurring in `CorrespondenceRejectorSurfaceNormal`
   [[#1536]](https://github.com/PointCloudLibrary/pcl/pull/1536)
 * Use aligned allocator in vectors of MatchingCandidate
   [[#1552]](https://github.com/PointCloudLibrary/pcl/pull/1552)
@@ -1381,13 +1381,13 @@ The most notable overall changes are:
 * Added a setDimension function to concave hull, so users can specify desired dimensionality of the resulting hull. If no dimension is specified, one will be automatically determined.
 * Fixed bug #692 - MovingLeastSquares indices issues
 * Added curve fitting and trimming of surfaces to examples/surface/example_nurbs_fitting_surface.cpp
-* Added iterative fitting routines for curve fitting surface::on_nurbs::Triangulation - added convertion functions for nurbs curve to line-polygon - added convertion functions for nurbs surface and curve to PolyMesh 
+* Added iterative fitting routines for curve fitting surface::on_nurbs::Triangulation - added conversion functions for nurbs curve to line-polygon - added conversion functions for nurbs surface and curve to PolyMesh 
 * Added flag to enable/disable usage of UmfPack for fast solving of sparse systems of equations - added triangulation functions to convert ON_NurbsSurface to pcl::PolygonMesh 
 * Added bug fix in ConcaveHull, thanks to summer.icecream
 * Added marching cubes using RBF and Hoppe SDF
 * Pushed new functions that perform texture-mapping on meshes.
 * Fix: issue #646 (vtk_smoothing not copied)
-* Added new functionalities to TextureMapping: Find occlusions based on raytracing in octrees, UV mapping based on Texture resolution and camera focal lenght.
+* Added new functionalities to TextureMapping: Find occlusions based on raytracing in octrees, UV mapping based on Texture resolution and camera focal length.
 * Relaxing dimensionality check threshold on concave_hull, so that 3D hulls should no longer be calculated on 2D input. 
 * Added poisson filter
 
@@ -1629,7 +1629,7 @@ The most notable overall changes are:
 * added a normal space sampling filter
 * fixed bug #433: `pcl::CropBox` doesn't update `width` and `height` member of output point cloud
 * fixed bug #423 `CropBox` + `VoxelGrid` filters, order changes behaviour (using openni grabber)
-* add `CropHull` filter for filtering points based on a 2D or 3D convex or concave hull. The ray-polygon intersection test is used, which relys on closed polygons/surfaces
+* add `CropHull` filter for filtering points based on a 2D or 3D convex or concave hull. The ray-polygon intersection test is used, which relies on closed polygons/surfaces
 * added clipper3D interface and a draft plane_clipper3D implementation
 * removed spurious old `ColorFilter` class (obsolete, and it was never implemented - the skeleton was just lurking around)
 * better Doxygen documentation to `PassThrough`, `VoxelGrid` and `Filter`
@@ -1683,7 +1683,7 @@ The most notable overall changes are:
 ### `lipcl_keypoints`
 
 * added refine method for `Harris3D` corner detector
-* rewrote big parts of the NARF keypoint extraction. Hopfully fixing some stability issues. Unfortunately still pretty slow for high resolution point clouds.
+* rewrote big parts of the NARF keypoint extraction. Hopefully fixing some stability issues. Unfortunately still pretty slow for high resolution point clouds.
 * fixed bug #461 (SIFT Keypoint result cloud fields not complete); cleaned up the line-wrapping in the error/warning messages
 
 ### `libpcl_surface`
@@ -1827,7 +1827,7 @@ pcl::OrganizedDataIndex -> pcl::search::OrganizedNeighbor
 * fixed a bug in `getRejectedQueryIndices`, wrong output when order of correspondences have been changed
 * moved `getRejectedQueryIndices` to pcl/common/correspondence.h
 * added more doxygen documentation to the registration components
-* marked all `getRemainingCorrespondences`-functions as DEPRECATED, we sould replace them with purely stateless version outside the class body
+* marked all `getRemainingCorrespondences`-functions as DEPRECATED, we should replace them with purely stateless version outside the class body
 * fixed a const missing in `PolynomialCalculationsT` (#388 - thanks Julian!)
 * add `PCL_DEPRECATED` macro, closes #354.
 * added `PointXYZHSV` type and the conversions for it
@@ -1913,7 +1913,7 @@ pcl::OrganizedDataIndex -> pcl::search::OrganizedNeighbor
   * fixed bug in getRejectedQueryIndices, wrong output when order of correspondences have been changed
   * moved getRejectedQueryIndices to pcl/common/correspondence.h
   * added more doxygen documentation to the registration components
-  * marked all "getRemainingCorrespondences"-functions as DEPRECATED, we sould replace them with purely stateless version outside the class body
+  * marked all "getRemainingCorrespondences"-functions as DEPRECATED, we should replace them with purely stateless version outside the class body
 * Update: remove ciminpack dependency and rely on eigen for LM
 * Fixed a bug in ICP-NL by modifying `WarpPointRigid` to preserve the value of the 4th coordinate when warping; Re-enabled missing unit tests for ICP and ICP-NL
 * Added point-to-plane ICP
@@ -2306,7 +2306,7 @@ The version numbers below belong to the *perception_pcl* stack in ROS, which coo
  * added a new generalized field value filter (_pcl::ConditionalRemoval_)
  * cleaned up normal estimation through integral images
  * PCL rift.hpp and point_types.hpp fixed for Windows/VS2010
- * fixed all _is_dense_ occurances
+ * fixed all _is_dense_ occurrences
  * *unmanged all _Eigen3::_ calls to _Eigen::_*
  * changed all _!isnan_ checks to _isfinite_ in order to catch INF/-INF values
  * added vtk_io tools for saving VTK data from _PolygonMesh_ structures
@@ -2341,7 +2341,7 @@ The version numbers below belong to the *perception_pcl* stack in ROS, which coo
  * Added Correspondence as a structure representing correspondences/matches (similar to OpenCV's DMatch) containing query and match indices as well as the distance between them respective points.
  * Added _CorrespondenceEstimation_ for determining closest point correspondence, feature correspondences and reciprocal point correspondences.
  * Added _CorrespondenceRejection_ and derivations for rejecting correspondences, e.g., based on distance, removing 1-to-n correspondences, RANSAC-based outlier removal (+transformation estimation).
- * Further splitted up registration.h and added transformation estimation classes, e.g., for estimating rigid transformation using SVD.
+ * Further split up registration.h and added transformation estimation classes, e.g., for estimating rigid transformation using SVD.
  * Added ```sensor_msgs::Image image;  pcl::toROSMsg (cloud, image);```See tools/convert_pcd_image.cpp for a sample.
  * Added a new point type, _PointWithScale_, to store the output of _SIFTKeypoint_ detection.
  * Fixed a minor bug in the error-checking in _SIFTKeypoint::setScales(...)_
@@ -2395,7 +2395,7 @@ The version numbers below belong to the *perception_pcl* stack in ROS, which coo
  * Added RSD (Radius Signature Descriptor) feature.
  * Updated the entire PCL tree to use FLANN as a default _KdTree_
  * Optimized the _KdTreeFLANN::radiusSearch_ so it doesn't do any memory allocation if the indices and distances vectors passed in are pre-allocated to the point cloud size.
- * Changed _KdTree::radiusSearch_ method signature to return int (number of neighbors found) intead of bool
+ * Changed _KdTree::radiusSearch_ method signature to return int (number of neighbors found) instead of bool
  * added new _pcl::View<T>_ class that holds a _PointCloud_, an _Image_, and a _CameraInfo_ message (r34575)
  * Moving the _Surface_ reconstruction framework to the new structure (r34547)
  * Moving the _Segmentation_ framework to the new structure (r34546)

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -265,7 +265,7 @@ endmacro(find_glew)
 #                   |--> _lib is optional ==> disable it (thanks to the guardians) 
 #                   |                         and warn
 #                   `--> _lib is required
-#                                       |--> component is required explicitely ==> error
+#                                       |--> component is required explicitly ==> error
 #                                       `--> component is induced ==> warn and remove it
 #                                                                     from the list
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
@@ -140,7 +140,7 @@ namespace pcl
 
           if (out->points.size () == 0)
           {
-            PCL_WARN("NORMAL estimator: Cloud has no points after voxel grid, wont be able to compute normals!\n");
+            PCL_WARN("NORMAL estimator: Cloud has no points after voxel grid, won't be able to compute normals!\n");
             return;
           }
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/local_recognizer.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/local_recognizer.h
@@ -334,7 +334,7 @@ namespace pcl
 
         /**
          * \brief Initializes the FLANN structure from the provided source
-         * It does training for the models that havent been trained yet
+         * It does training for the models that haven't been trained yet
          */
 
         void

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
@@ -74,7 +74,7 @@ namespace pcl
         /** \brief Stores the state of the current tree view in item_treestate_map_  */
         void 
         storeTreeState ();
-        /** \brief Retores the state of \param model 's view from item_treestate_map_  */
+        /** \brief Restores the state of \param model 's view from item_treestate_map_  */
         void
         restoreTreeState ();
         /** \brief Removes the extra tabs the item might have */

--- a/apps/cloud_composer/src/commands.cpp
+++ b/apps/cloud_composer/src/commands.cpp
@@ -582,7 +582,7 @@ pcl::cloud_composer::MergeCloudCommand::redo ()
 {
   qDebug () << "Redo in MergeCloudCommand ";
   last_was_undo_ = false;
-  //There is only one output_pair, but thats ok
+  //There is only one output_pair, but that's ok
   foreach (OutputPair output_pair, output_data_)
   {
     //Replace the input with the output for this pair

--- a/apps/cloud_composer/src/items/cloud_item.cpp
+++ b/apps/cloud_composer/src/items/cloud_item.cpp
@@ -90,7 +90,7 @@ pcl::cloud_composer::CloudItem::removeFromView (boost::shared_ptr<pcl::visualiza
 QVariant
 pcl::cloud_composer::CloudItem::data (int role) const
 {
-  // Check if we're trying to get something which is template dependant, if so, create the template if it hasn't been set
+  // Check if we're trying to get something which is template dependent, if so, create the template if it hasn't been set
   if ( (role == ItemDataRole::CLOUD_TEMPLATED || role == ItemDataRole::KD_TREE_SEARCH) && !template_cloud_set_)
   {
     qCritical () << "Attempted to access templated types which are not set!!";

--- a/apps/cloud_composer/src/items/fpfh_item.cpp
+++ b/apps/cloud_composer/src/items/fpfh_item.cpp
@@ -39,7 +39,7 @@ pcl::cloud_composer::FPFHItem::getInspectorTabs ()
 {
  
   
-  //Create the plotter and QVTKWidget if it doesnt exist
+  //Create the plotter and QVTKWidget if it doesn't exist
   if (!plot_)
   {
     plot_ = boost::shared_ptr<pcl::visualization::PCLPlotter> (new pcl::visualization::PCLPlotter);

--- a/apps/cloud_composer/src/point_selectors/selection_event.cpp
+++ b/apps/cloud_composer/src/point_selectors/selection_event.cpp
@@ -11,7 +11,7 @@ pcl::cloud_composer::SelectionEvent::~SelectionEvent ()
 void
 pcl::cloud_composer::SelectionEvent::findIndicesInItem (CloudItem* cloud_item, pcl::PointIndices::Ptr indices)
 {
-  // WE DONT NEED TO DO THIS SEARCH BECAUSE WE HAVE A 1-1 CORRESPONDENCE VTK TO PCL
+  // WE DON'T NEED TO DO THIS SEARCH BECAUSE WE HAVE A 1-1 CORRESPONDENCE VTK TO PCL
   // THIS IS ONLY THE CASE FOR CLOUDS WITH NO NANs
  //Go through every point in the selected data set and find the matching index in this cloud
  //pcl::search::KdTree<pcl::PointXYZ>::Ptr search = cloud_item->data (KD_TREE_SEARCH).value <pcl::search::Search<pcl::PointXYZ>::Ptr> ();

--- a/apps/include/pcl/apps/dominant_plane_segmentation.h
+++ b/apps/include/pcl/apps/dominant_plane_segmentation.h
@@ -230,7 +230,7 @@ namespace pcl
             return 1;
           else
           {
-            //compute distance and check aginst max_dist
+            //compute distance and check against max_dist
             if ((p1.getVector3fMap () - p2.getVector3fMap ()).norm () <= max_dist)
             {
               p2.intensity = p1.intensity;

--- a/apps/include/pcl/apps/pcd_video_player.h
+++ b/apps/include/pcl/apps/pcd_video_player.h
@@ -128,7 +128,7 @@ class PCDVideoPlayer : public QMainWindow
     /** \brief Indicate that the timeoutSlot needs to reload the pointcloud */
     bool cloud_modified_;
 
-    /** \brief Indicate that files should play continiously */
+    /** \brief Indicate that files should play continuously */
     bool play_mode_;
     /** \brief In play mode only update if speed_counter_ == speed_value */
     unsigned int speed_counter_;

--- a/apps/include/pcl/apps/render_views_tesselated_sphere.h
+++ b/apps/include/pcl/apps/render_views_tesselated_sphere.h
@@ -17,7 +17,7 @@ namespace pcl
 {
   namespace apps
   {
-    /** \brief @b Class to render synthetic views of a 3D mesh using a tesselated sphere
+    /** \brief @b Class to render synthetic views of a 3D mesh using a tessellated sphere
      * NOTE: This class should replace renderViewTesselatedSphere from pcl::visualization.
      * Some extensions are planned in the near future to this class like removal of duplicated views for
      * symmetrical objects, generation of RGB synthetic clouds when RGB available on mesh, etc.
@@ -70,7 +70,7 @@ namespace pcl
         campos_constraints_func_ = bb;
       }
 
-      /* \brief Indicates wether to generate organized or unorganized data
+      /* \brief Indicates whether to generate organized or unorganized data
        * \param b organized/unorganized
        */
       void
@@ -88,7 +88,7 @@ namespace pcl
         resolution_ = res;
       }
 
-      /* \brief Wether to use the vertices or triangle centers of the tesselated sphere
+      /* \brief Whether to use the vertices or triangle centers of the tessellated sphere
        * \param use true indicates to use vertices, false triangle centers
        */
 
@@ -107,7 +107,7 @@ namespace pcl
         radius_sphere_ = radius;
       }
 
-      /* \brief Wether to compute the entropies (level of occlusions for each view)
+      /* \brief Whether to compute the entropies (level of occlusions for each view)
        * \param compute true to compute entropies, false otherwise
        */
       void
@@ -116,8 +116,8 @@ namespace pcl
         compute_entropy_ = compute;
       }
 
-      /* \brief How many times the icosahedron should be tesselated. Results in more or less camera positions and generated views.
-       * \param level amount of tesselation
+      /* \brief How many times the icosahedron should be tessellated. Results in more or less camera positions and generated views.
+       * \param level amount of tessellation
        */
       void
       setTesselationLevel (int level)

--- a/apps/optronic_viewer/include/pcl/apps/optronic_viewer/filter_window.h
+++ b/apps/optronic_viewer/include/pcl/apps/optronic_viewer/filter_window.h
@@ -81,7 +81,7 @@ namespace pcl
         virtual void next ();
 
       Q_SIGNALS:
-        /** \brief Ommitted when a filter is created. */
+        /** \brief Omitted when a filter is created. */
         void filterCreated ();
 
       protected:

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
@@ -409,7 +409,7 @@ class Cloud : public Statistics
     /// The internal representation of the cloud
     Cloud3D cloud_;
 
-    /// @breif A weak pointer pointing to the selection object.
+    /// @brief A weak pointer pointing to the selection object.
     /// @details This implementation uses the weak pointer to allow for a lazy
     /// update of the cloud if the selection object is destroyed.
     boost::weak_ptr<Selection> selection_wk_ptr_;

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
@@ -53,7 +53,7 @@
 class CommandQueue
 {
   public:
-    /// @brief Defaut Constructor
+    /// @brief Default Constructor
     /// @details Creates a command queue object and makes its depth limit
     /// be the default value.
     CommandQueue ();
@@ -81,7 +81,7 @@ class CommandQueue
     void
     undo ();
 
-    /// @breif Changes the command history limit.
+    /// @brief Changes the command history limit.
     /// @details If the passed size is smaller than the current size then the
     /// oldest commands are removed (their undo functions are not called).
     /// @param size The new maximum number of commands that may exist in this

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/transformCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/transformCommand.h
@@ -34,7 +34,7 @@
 ///
 
 /// @file   transformCommand.h
-/// @details a TransfromCommand object provides transformation and undo
+/// @details a TransformCommand object provides transformation and undo
 /// functionalities.  // XXX - transformation of what?
 /// @author  Yue Li and Matthew Hielsberg
 

--- a/apps/point_cloud_editor/src/common.cpp
+++ b/apps/point_cloud_editor/src/common.cpp
@@ -70,7 +70,7 @@ multMatrix(const float* left, const float* right, float* result)
 
 // This code was found on:
 // http://stackoverflow.com/questions/1148309/inverting-a-4x4-matrix
-// and is listed as being part of an open soure project (the MESA project)
+// and is listed as being part of an open source project (the MESA project)
 //
 // The original code in MESA comes from __gluInvertMatrixd() in project.c
 //

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -113,7 +113,7 @@ PCDVideoPlayer::PCDVideoPlayer ()
 void 
 PCDVideoPlayer::backButtonPressed ()
 {
-  if(current_frame_ == 0) // Allready in the beginning
+  if(current_frame_ == 0) // Already in the beginning
   {
     PCL_DEBUG ("[PCDVideoPlayer::nextButtonPressed] : reached the end\n");
     current_frame_ = nr_of_frames_ - 1; // reset to end
@@ -295,7 +295,7 @@ print_usage ()
   PCL_INFO ("\t  Up/Down move a vertical slider by one single step.\n");
   PCL_INFO ("\t  PageUp moves up one page.\n");
   PCL_INFO ("\t  PageDown moves down one page.\n");
-  PCL_INFO ("\t  Home moves to the start (mininum).\n");
+  PCL_INFO ("\t  Home moves to the start (minimum).\n");
   PCL_INFO ("\t  End moves to the end (maximum).\n");
 }
 

--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -113,7 +113,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
   ico->SetSolidTypeToIcosahedron ();
   ico->Update ();
 
-  //tesselate cells from icosahedron
+  //tessellate cells from icosahedron
   vtkSmartPointer<vtkLoopSubdivisionFilter> subdivide = vtkSmartPointer<vtkLoopSubdivisionFilter>::New ();
   subdivide->SetNumberOfSubdivisions (tesselation_level_);
   subdivide->SetInputConnection (ico->GetOutputPort ());

--- a/cmake/CMakeParseArguments.cmake
+++ b/cmake/CMakeParseArguments.cmake
@@ -58,7 +58,7 @@
 # the new option.
 # E.g. my_install(TARGETS foo DESTINATION OPTIONAL) would result in
 # MY_INSTALL_DESTINATION set to "OPTIONAL", but MY_INSTALL_DESTINATION would
-# be empty and MY_INSTALL_OPTIONAL would be set to TRUE therefor.
+# be empty and MY_INSTALL_OPTIONAL would be set to TRUE therefore.
 
 #=============================================================================
 # Copyright 2010 Alexander Neundorf <neundorf@kde.org>

--- a/cmake/pcl_cpack.cmake
+++ b/cmake/pcl_cpack.cmake
@@ -78,7 +78,7 @@ set(PCL_CPACK_CFG_FILE "${PCL_BINARY_DIR}/cpack_options.cmake")
 # Make the CPack input file.
 macro(PCL_MAKE_CPACK_INPUT)
     set(_cpack_cfg_in "${PCL_SOURCE_DIR}/cmake/cpack_options.cmake.in")
-    set(${_var} "${${_var}}\nset(CPACK_COMPONENT_GROUP_PCL_DESCRIPTION \"PCL headers and librairies\")\n")
+    set(${_var} "${${_var}}\nset(CPACK_COMPONENT_GROUP_PCL_DESCRIPTION \"PCL headers and libraries\")\n")
 
     # Prepare the components list
     set(PCL_CPACK_COMPONENTS)

--- a/cmake/pcl_targets.cmake
+++ b/cmake/pcl_targets.cmake
@@ -450,7 +450,7 @@ endmacro(PCL_ADD_LINKFLAGS)
 
 ###############################################################################
 # Make a pkg-config file for a library. Do not include general PCL stuff in the
-# arguments; they will be added automaticaly.
+# arguments; they will be added automatically.
 # _name The library name. "pcl_" will be preprended to this.
 # _component The part of PCL that this pkg-config file belongs to.
 # _desc Description of the library.
@@ -487,7 +487,7 @@ endmacro(PCL_MAKE_PKGCONFIG)
 # Essentially a duplicate of PCL_MAKE_PKGCONFIG, but 
 # ensures that no -L or l flags will be created
 # Do not include general PCL stuff in the
-# arguments; they will be added automaticaly.
+# arguments; they will be added automatically.
 # _name The library name. "pcl_" will be preprended to this.
 # _component The part of PCL that this pkg-config file belongs to.
 # _desc Description of the library.
@@ -623,7 +623,7 @@ endmacro(PCL_GET_SUBSUBSYS_STATUS)
 ###############################################################################
 # Set the hyperstatus of a subsystem and its dependee
 # _name Subsystem name.
-# _dependee Dependant subsystem.
+# _dependee Dependent subsystem.
 # _status AUTO_OFF to disable AUTO_ON to enable
 # ARGN[0] Reason for not building.
 macro(PCL_SET_SUBSYS_HYPERSTATUS _name _dependee _status) 
@@ -636,7 +636,7 @@ endmacro(PCL_SET_SUBSYS_HYPERSTATUS)
 ###############################################################################
 # Get the hyperstatus of a subsystem and its dependee
 # _name IN subsystem name.
-# _dependee IN dependant subsystem.
+# _dependee IN dependent subsystem.
 # _var OUT hyperstatus
 # ARGN[0] Reason for not building.
 macro(PCL_GET_SUBSYS_HYPERSTATUS _var _name)
@@ -852,7 +852,7 @@ endmacro(PCL_ADD_DOC)
 # This macro adds on option named "WITH_NAME", where NAME is the capitalized
 # dependency name. The user may use this option to control whether the
 # corresponding grabber should be built or not. Also an attempt to find a
-# package with the given name is made. If it is not successfull, then the
+# package with the given name is made. If it is not successful, then the
 # "WITH_NAME" option is coerced to FALSE.
 macro(PCL_ADD_GRABBER_DEPENDENCY _name _description)
     string(TOUPPER ${_name} _name_capitalized)

--- a/cmake/pcl_utils.cmake
+++ b/cmake/pcl_utils.cmake
@@ -405,7 +405,7 @@ macro(sort_relative _list _sorted_list _to_sort_relative)
   if(NOT (list_length EQUAL to_sort_list_length))
     message(FATAL_ERROR "size mismatch between ${_to_sort_relative} ${to_sort_list_length} and ${_list} ${list_length}")
   endif(NOT (list_length EQUAL to_sort_list_length))
-  # unset the temporary list to avoid suprises (I had some them and were hard to find)
+  # unset the temporary list to avoid surprises (I had some them and were hard to find)
   unset(tmp_list)
   # fill it with a dummy value
   fill_list(tmp_list list_length "#")

--- a/common/include/pcl/common/bivariate_polynomial.h
+++ b/common/include/pcl/common/bivariate_polynomial.h
@@ -70,7 +70,7 @@ namespace pcl
       void
       setDegree (int new_degree);
 
-      /** How many parametes has a bivariate polynomial with this degree */
+      /** How many parameters has a bivariate polynomial with this degree */
       unsigned int
       getNoOfParameters () const { return getNoOfParametersFromDegree (degree);}
 
@@ -108,7 +108,7 @@ namespace pcl
       void
       readBinary (const char* filename);
       
-      /** How many parametes has a bivariate polynomial of the given degree */
+      /** How many parameters has a bivariate polynomial of the given degree */
       static unsigned int
       getNoOfParametersFromDegree (int n) { return ((n+2)* (n+1))/2;}
 

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -204,7 +204,7 @@ namespace pcl
   /** \brief Compute normalized the 3x3 covariance matrix of a given set of points.
     * The result is returned as a Eigen::Matrix3f.
     * Normalized means that every entry has been divided by the number of points in the point cloud.
-    * For small number of points, or if you want explicitely the sample-variance, use computeCovarianceMatrix
+    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
     * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
     * the covariance matrix and is returned by the computeCovarianceMatrix function.
     * \param[in] cloud the input point cloud
@@ -313,7 +313,7 @@ namespace pcl
     * their indices.
     * The result is returned as a Eigen::Matrix3f.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, use computeCovarianceMatrix
+    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
     * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
     * the covariance matrix and is returned by the computeCovarianceMatrix function.
     * \param[in] cloud the input point cloud
@@ -351,7 +351,7 @@ namespace pcl
   /** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
     * their indices. The result is returned as a Eigen::Matrix3f.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, use computeCovarianceMatrix
+    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
     * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
     * the covariance matrix and is returned by the computeCovarianceMatrix function.
     * \param[in] cloud the input point cloud
@@ -388,7 +388,7 @@ namespace pcl
 
   /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, scale the covariance matrix
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
     * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
     * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
     * \param[in] cloud the input point cloud
@@ -421,7 +421,7 @@ namespace pcl
 
   /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, scale the covariance matrix
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
     * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
     * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
     * \param[in] cloud the input point cloud
@@ -458,7 +458,7 @@ namespace pcl
 
   /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, scale the covariance matrix
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
     * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
     * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
     * \param[in] cloud the input point cloud
@@ -495,7 +495,7 @@ namespace pcl
 
   /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, scale the covariance matrix
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
     * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
     * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
     * \param[in] cloud the input point cloud
@@ -524,7 +524,7 @@ namespace pcl
 
   /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, scale the covariance matrix
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
     * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
     * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
     * \param[in] cloud the input point cloud
@@ -557,7 +557,7 @@ namespace pcl
 
   /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
     * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitely the sample-variance, scale the covariance matrix
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
     * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
     * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
     * \param[in] cloud the input point cloud

--- a/common/include/pcl/common/generate.h
+++ b/common/include/pcl/common/generate.h
@@ -64,13 +64,13 @@ namespace pcl
       /// Default constructor
       CloudGenerator ();
 
-      /** Consttructor with single generator to ensure all X, Y and Z values are within same range
+      /** Constructor with single generator to ensure all X, Y and Z values are within same range
         * \param params paramteres for X, Y and Z values generation. Uniqueness is ensured through
         * seed incrementation
         */
       CloudGenerator (const GeneratorParameters& params);
 
-      /** Constructor with independant generators per axis
+      /** Constructor with independent generators per axis
         * \param x_params parameters for x values generation
         * \param y_params parameters for y values generation
         * \param z_params parameters for z values generation
@@ -86,19 +86,19 @@ namespace pcl
       setParameters (const GeneratorParameters& params);
       
       /** Set parameters for x values generation
-        * \param x_params paramters for x values generation
+        * \param x_params parameters for x values generation
         */
       void
       setParametersForX (const GeneratorParameters& x_params);
 
       /** Set parameters for y values generation
-        * \param y_params paramters for y values generation
+        * \param y_params parameters for y values generation
         */
       void
       setParametersForY (const GeneratorParameters& y_params);
       
       /** Set parameters for z values generation
-        * \param z_params paramters for z values generation
+        * \param z_params parameters for z values generation
         */
       void
       setParametersForZ (const GeneratorParameters& z_params);

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -116,7 +116,7 @@ pcl::computeRoots (const Matrix& m, Roots& roots)
         std::swap (roots (0), roots (1));
     }
 
-    if (roots (0) <= 0)  // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+    if (roots (0) <= 0)  // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
       computeRoots2 (c2, c1, roots);
   }
 }

--- a/common/include/pcl/common/impl/intersections.hpp
+++ b/common/include/pcl/common/impl/intersections.hpp
@@ -145,7 +145,7 @@ pcl::threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
   if (fabs (determinant) < determinant_tolerance)
   {
     // det ~= 0
-    PCL_DEBUG ("At least two planes are parralel.\n");
+    PCL_DEBUG ("At least two planes are parallel.\n");
     return (false);
   }
 

--- a/common/include/pcl/common/intersections.h
+++ b/common/include/pcl/common/intersections.h
@@ -112,7 +112,7 @@ namespace pcl
   }
 
   /** \brief Determine the point of intersection of three non-parallel planes by solving the equations.
-    * \note If using nearly parralel planes you can lower the determinant_tolerance value. This can
+    * \note If using nearly parallel planes you can lower the determinant_tolerance value. This can
     * lead to inconsistent results.
     * If the three planes intersects in a line the point will be anywhere on the line.
     * \param[in] plane_a are the coefficients of the first plane in the form ax + by + cz + d = 0

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -416,7 +416,7 @@ namespace pcl
     *  BORDER_REFLECT_101:   gfedcb|abcdefgh|gfedcba
     *  BORDER_WRAP:          cdefgh|abcdefgh|abcdefg
     *  BORDER_CONSTANT:      iiiiii|abcdefgh|iiiiiii  with some specified 'i'
-    *  BORDER_TRANSPARENT:   mnopqr|abcdefgh|tuvwxyz  where m-r and t-z are orignal values of cloud_out
+    *  BORDER_TRANSPARENT:   mnopqr|abcdefgh|tuvwxyz  where m-r and t-z are original values of cloud_out
     * \param value
     * \throw pcl::BadArgumentException if any of top, bottom, left or right is negative.
     * \ingroup common

--- a/common/include/pcl/common/spring.h
+++ b/common/include/pcl/common/spring.h
@@ -51,7 +51,7 @@ namespace pcl
      * custom values.
      * \param[in] input the input point cloud
      * \param[out] output the output point cloud
-     * \param[in] val the point value to be insterted
+     * \param[in] val the point value to be inserted
      * \param[in] amount the amount of rows to be added
      */
     template <typename PointT> void
@@ -63,7 +63,7 @@ namespace pcl
       * custom values.
       * \param[in] input the input point cloud
       * \param[out] output the output point cloud
-      * \param[in] val the point value to be insterted
+      * \param[in] val the point value to be inserted
       * \param[in] amount the amount of columns to be added
       */
     template <typename PointT> void

--- a/common/include/pcl/common/time.h
+++ b/common/include/pcl/common/time.h
@@ -163,7 +163,7 @@ namespace pcl
         stop_watch_.reset ();
       }
 
-      /** \brief Notifies the class that the event occured. */
+      /** \brief Notifies the class that the event occurred. */
       void event ()
       {
         event_time_queue_.push (stop_watch_.getTimeSeconds ());

--- a/common/include/pcl/common/time_trigger.h
+++ b/common/include/pcl/common/time_trigger.h
@@ -70,7 +70,7 @@ namespace pcl
       /** \brief Destructor. */
       ~TimeTrigger ();
 
-      /** \brief registeres a callback
+      /** \brief registers a callback
         * \param[in] callback callback function to the list of callbacks. signature has to be boost::function<void()>
         * \return connection the connection, which can be used to disable/enable and remove callback from list
         */

--- a/common/include/pcl/console/parse.h
+++ b/common/include/pcl/console/parse.h
@@ -274,7 +274,7 @@ namespace pcl
     PCL_EXPORTS int
     parse_x_arguments (int argc, char** argv, const char* str, std::vector<int>& v);
 
-    /** \brief Parse for specific given command line arguments (multiple occurences
+    /** \brief Parse for specific given command line arguments (multiple occurrences
       * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
@@ -285,7 +285,7 @@ namespace pcl
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<int> &values);
 
-    /** \brief Parse for specific given command line arguments (multiple occurences
+    /** \brief Parse for specific given command line arguments (multiple occurrences
       * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
@@ -296,7 +296,7 @@ namespace pcl
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<float> &values);
 
-    /** \brief Parse for specific given command line arguments (multiple occurences
+    /** \brief Parse for specific given command line arguments (multiple occurrences
       * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
@@ -307,7 +307,7 @@ namespace pcl
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<double> &values);
 
-    /** \brief Parse for a specific given command line argument (multiple occurences
+    /** \brief Parse for a specific given command line argument (multiple occurrences
       * of the same command line parameter).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
@@ -318,7 +318,7 @@ namespace pcl
     PCL_EXPORTS bool
     parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<std::string> &values);
 
-    /** \brief Parse command line arguments for file names with given extension (multiple occurences
+    /** \brief Parse command line arguments for file names with given extension (multiple occurrences
       * of 2x argument groups, separated by commas).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments
@@ -332,7 +332,7 @@ namespace pcl
                                  std::vector<double> &values_f, 
                                  std::vector<double> &values_s);
 
-    /** \brief Parse command line arguments for file names with given extension (multiple occurences
+    /** \brief Parse command line arguments for file names with given extension (multiple occurrences
       * of 3x argument groups, separated by commas).
       * \param[in] argc the number of command line arguments
       * \param[in] argv the command line arguments

--- a/common/include/pcl/exceptions.h
+++ b/common/include/pcl/exceptions.h
@@ -145,7 +145,7 @@ namespace pcl
   } ;
 
   /** \class IsNotDenseException
-    * \brief An exception that is thrown when a PointCloud is not dense but is attemped to be used as dense
+    * \brief An exception that is thrown when a PointCloud is not dense but is attempted to be used as dense
     */
   class IsNotDenseException : public PCLException
   {
@@ -251,7 +251,7 @@ namespace pcl
   };
 
   /** \class BadArgumentException
-    * \brief An exception that is thrown when the argments number or type is wrong/unhandled.
+    * \brief An exception that is thrown when the arguments number or type is wrong/unhandled.
     */
   class BadArgumentException : public PCLException
   {

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -1519,7 +1519,7 @@ namespace pcl
 
     union
     {
-      /** \brief Diameter of the meaningfull keypoint neighborhood. */
+      /** \brief Diameter of the meaningful keypoint neighborhood. */
       float scale;
       float size;
     };

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -48,7 +48,7 @@ namespace pcl
   /** \brief @b PointRepresentation provides a set of methods for converting a point structs/object into an
     * n-dimensional vector.
     * \note This is an abstract class.  Subclasses must set nr_dimensions_ to the appropriate value in the constructor
-    * and provide an implemention of the pure virtual copyToFloatArray method.
+    * and provide an implementation of the pure virtual copyToFloatArray method.
     * \author Michael Dixon
     */
   template <typename PointT>
@@ -80,7 +80,7 @@ namespace pcl
       /** \brief Empty destructor */
       virtual ~PointRepresentation () {}
 
-      /** \brief Copy point data from input point to a float array. This method must be overriden in all subclasses.
+      /** \brief Copy point data from input point to a float array. This method must be overridden in all subclasses.
        *  \param[in] p The input point
        *  \param[out] out A pointer to a float array.
        */

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -344,7 +344,7 @@ namespace pcl
   /** \brief Get the value at a specified field in a point
     * \param[in] pt the point to get the value from
     * \param[in] field_offset the offset of the field
-    * \param[out] value the value to retreive
+    * \param[out] value the value to retrieve
     */
   template <typename PointT, typename ValT> inline void
   getFieldValue (const PointT &pt, size_t field_offset, ValT &value)

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -349,7 +349,7 @@ namespace pcl
       getTransformationToWorldSystem () const { return to_world_system_;}
       
       /** Getter for the angular resolution of the range image in x direction in radians per pixel.
-       *  Provided for downwards compatability */
+       *  Provided for downwards compatibility */
       inline float
       getAngularResolution () const { return angular_resolution_x_;}
       
@@ -746,7 +746,7 @@ namespace pcl
       getViewingDirection (const Eigen::Vector3f& point, Eigen::Vector3f& viewing_direction) const;
       
       /** Return a newly created Range image.
-       *  Can be reimplmented in derived classes like RangeImagePlanar to return an image of the same type. */
+       *  Can be reimplemented in derived classes like RangeImagePlanar to return an image of the same type. */
       PCL_EXPORTS virtual RangeImage* 
       getNew () const { return new RangeImage; }
 
@@ -771,9 +771,9 @@ namespace pcl
       Eigen::Affine3f to_world_system_;        /**< Inverse of to_range_image_system_ */
       float angular_resolution_x_;             /**< Angular resolution of the range image in x direction in radians per pixel */
       float angular_resolution_y_;             /**< Angular resolution of the range image in y direction in radians per pixel */
-      float angular_resolution_x_reciprocal_;  /**< 1.0/angular_resolution_x_ - provided for better performace of
+      float angular_resolution_x_reciprocal_;  /**< 1.0/angular_resolution_x_ - provided for better performance of
                                                 *   multiplication compared to division */
-      float angular_resolution_y_reciprocal_;  /**< 1.0/angular_resolution_y_ - provided for better performace of
+      float angular_resolution_y_reciprocal_;  /**< 1.0/angular_resolution_y_ - provided for better performance of
                                                 *   multiplication compared to division */
       int image_offset_x_, image_offset_y_;    /**< Position of the top left corner of the range image compared to
                                                 *   an image of full size (360x180 degrees) */

--- a/common/include/pcl/range_image/range_image_planar.h
+++ b/common/include/pcl/range_image/range_image_planar.h
@@ -64,11 +64,11 @@ namespace pcl
       PCL_EXPORTS virtual ~RangeImagePlanar ();
 
       /** Return a newly created RangeImagePlanar.
-       *  Reimplmentation to return an image of the same type. */
+       *  Reimplementation to return an image of the same type. */
       virtual RangeImage* 
       getNew () const { return new RangeImagePlanar; }
 
-      /** Copy *this to other. Derived version - also copying additonal RangeImagePlanar members */
+      /** Copy *this to other. Derived version - also copying additional RangeImagePlanar members */
       PCL_EXPORTS virtual void
       copyTo (RangeImage& other) const;
       

--- a/common/include/pcl/range_image/range_image_spherical.h
+++ b/common/include/pcl/range_image/range_image_spherical.h
@@ -63,7 +63,7 @@ namespace pcl
       PCL_EXPORTS virtual ~RangeImageSpherical () {}
 
       /** Return a newly created RangeImagePlanar.
-       *  Reimplmentation to return an image of the same type. */
+       *  Reimplementation to return an image of the same type. */
       virtual RangeImage*
       getNew () const { return new RangeImageSpherical; }
 

--- a/common/src/fft/kiss_fft.c
+++ b/common/src/fft/kiss_fft.c
@@ -15,7 +15,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 #include "pcl/common/fft/_kiss_fft_guts.h"
 /* The guts header contains all the multiplication and addition macros that are defined for
- fixed or floating point complex numbers.  It also delares the kf_ internal functions.
+ fixed or floating point complex numbers.  It also declares the kf_ internal functions.
  */
 
 static void kf_bfly2(

--- a/common/src/poses_from_matches.cpp
+++ b/common/src/poses_from_matches.cpp
@@ -95,7 +95,7 @@ pcl::PosesFromMatches::estimatePosesUsing2Correspondences (const pcl::PointCorre
   pcl::TransformationFromCorrespondences transformation_from_correspondeces;
   
   // The following loop structure goes through the pairs in the order 12, 13, 23, 14, 24, 34, ...,
-  // testing the best correspondences pairs first, without beeing stuck too long with one specific
+  // testing the best correspondences pairs first, without being stuck too long with one specific
   // (possibly wrong) correspondence.
   bool done = false;
   for (int correspondence2_idx = 0; correspondence2_idx < max_correspondence_idx && !done; ++correspondence2_idx)
@@ -209,7 +209,7 @@ pcl::PosesFromMatches::estimatePosesUsing3Correspondences (const PointCorrespond
   pcl::TransformationFromCorrespondences transformation_from_correspondeces;
   
   // The following loop structure goes through the triples in the order 123, 124, 134, 234, 125, 135, 235, ...,
-  // testing the best correspondences triples first, without beeing stuck too long with one specific
+  // testing the best correspondences triples first, without being stuck too long with one specific
   // (possibly wrong) correspondence.
   bool done = false;
   for (int correspondence3_idx = 0; correspondence3_idx < max_correspondence_idx && !done; ++correspondence3_idx)

--- a/cuda/common/include/pcl/cuda/common/eigen.h
+++ b/cuda/common/include/pcl/cuda/common/eigen.h
@@ -218,7 +218,7 @@ namespace pcl
   		      swap (roots.x, roots.y);
   		  }
   		  
-  		  if (roots.x <= 0.0f) // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+  		  if (roots.x <= 0.0f) // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
   			  computeRoots2 (c2, c1, roots);
   		}
     }

--- a/cuda/common/include/pcl/cuda/cutil.h
+++ b/cuda/common/include/pcl/cuda/cutil.h
@@ -340,7 +340,7 @@ extern "C" {
     //! @param w     width of the image
     //! @param h     height of the image
     //! @note If a NULL pointer is passed to this function and it is 
-    //!       initialized  withing Cutil then cutFree() has to be used to
+    //!       initialized within Cutil then cutFree() has to be used to
     //!       deallocate the memory
     ////////////////////////////////////////////////////////////////////////////
     DLL_MAPPING
@@ -355,7 +355,7 @@ extern "C" {
     //! @param w     width of the image
     //! @param h     height of the image
     //! @note If a NULL pointer is passed to this function and it is 
-    //!       initialized withing Cutil then cutFree() has to be used to 
+    //!       initialized within Cutil then cutFree() has to be used to 
     //!       deallocate the memory
     ////////////////////////////////////////////////////////////////////////////
     DLL_MAPPING
@@ -439,7 +439,7 @@ extern "C" {
     ////////////////////////////////////////////////////////////////////////////
     // Command line arguments: General notes
     // * All command line arguments begin with '--' followed by the token; 
-    //   token and value are seperated by '='; example --samples=50
+    //   token and value are separated by '='; example --samples=50
     // * Arrays have the form --model=[one.obj,two.obj,three.obj] 
     //   (without whitespaces)
     ////////////////////////////////////////////////////////////////////////////

--- a/cuda/common/include/pcl/cuda/cutil_inline_drvapi.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_drvapi.h
@@ -57,7 +57,7 @@ inline int _ConvertSMVer2CoresDrvApi(int major, int minor)
 {
 	// Defines for GPU Architecture types (using the SM version to determine the # of cores per SM
 	typedef struct {
-		int SM; // 0xMm (hexidecimal notation), M = SM Major version, and m = SM minor version
+		int SM; // 0xMm (hexadecimal notation), M = SM Major version, and m = SM minor version
 		int Cores;
 	} sSMtoCores;
 
@@ -195,7 +195,7 @@ inline int cutilDrvGetMaxGflopsGraphicsDeviceId()
 		    sm_per_multiproc = _ConvertSMVer2CoresDrvApi(major, minor);
 		}
 
-		// If this is a Tesla based GPU and SM 2.0, and TCC is disabled, this is a contendor
+		// If this is a Tesla based GPU and SM 2.0, and TCC is disabled, this is a contender
 		if (!bTCC) // Is this GPU running the TCC driver?  If so we pass on this
 		{
 			int compute_perf  = multiProcessorCount * sm_per_multiproc * clockRate;

--- a/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
@@ -85,7 +85,7 @@ inline int _ConvertSMVer2Cores(int major, int minor)
 {
 	// Defines for GPU Architecture types (using the SM version to determine the # of cores per SM
 	typedef struct {
-		int SM; // 0xMm (hexidecimal notation), M = SM Major version, and m = SM minor version
+		int SM; // 0xMm (hexadecimal notation), M = SM Major version, and m = SM minor version
 		int Cores;
 	} sSMtoCores;
 
@@ -226,7 +226,7 @@ inline int cutGetMaxGflopsGraphicsDeviceId()
 	return max_perf_device;
 }
 
-// Give a little more for Windows : the console window often disapears before we can read the message
+// Give a little more for Windows : the console window often disappears before we can read the message
 #ifdef _WIN32
 # if 1//ndef UNICODE
 #  ifdef _DEBUG // Do this only in debug mode...

--- a/cuda/nn/organized_neighbor_search.hpp
+++ b/cuda/nn/organized_neighbor_search.hpp
@@ -190,7 +190,7 @@ namespace pcl
       // vector for nearest neighbor candidates
       std::vector<nearestNeighborCandidate> nearestNeighbors;
 
-      // iterator for radius seach lookup table
+      // iterator for radius search lookup table
       typename std::vector<radiusSearchLoopkupEntry>::const_iterator radiusSearchLookup_Iterator;
       radiusSearchLookup_Iterator = radiusSearchLookup_.begin ();
 

--- a/cuda/segmentation/src/mssegmentation.cpp
+++ b/cuda/segmentation/src/mssegmentation.cpp
@@ -162,7 +162,7 @@ void meanShiftSegmentation(const GpuMat& src, Mat& dst, int sp, int sr, int mins
     vector<SegmLink> edges;
     edges.reserve(g.numv);
 
-    // Prepare edges connecting differnet components
+    // Prepare edges connecting different components
     for (int v = 0; v < g.numv; ++v)
     {
         int c1 = comps.find(v);
@@ -174,7 +174,7 @@ void meanShiftSegmentation(const GpuMat& src, Mat& dst, int sp, int sr, int mins
         }
     }
 
-    // Sort all graph's edges connecting differnet components (in asceding order)
+    // Sort all graph's edges connecting different components (in ascending order)
     sort(edges.begin(), edges.end());
 
     // Exclude small components (starting from the nearest couple)

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -163,7 +163,7 @@ int main (int argc, char *argv[])
   don.setNormalScaleSmall(normals_small_scale);
 
   if(!don.initCompute ()){
-    std::cerr << "Error: Could not intialize DoN feature operator" << std::endl;
+    std::cerr << "Error: Could not initialize DoN feature operator" << std::endl;
     exit(EXIT_FAILURE);
   }
 

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -189,8 +189,8 @@ LCCPSegmentation Parameters: \n\
 CPCSegmentation Parameters: \n\
   -cut <max_cuts>,<cutting_min_segments>,<min_cut_score> - Plane cutting parameters for splitting of segments\n\
        <max_cuts> - Perform cuts up to this recursion level. Cuts are performed in each segment separately (default 25)\n\
-       <cutting_min_segments> - Minumum number of supervoxels in the segment to perform cutting (default 400).\n\
-       <min_cut_score> - Minumum score a proposed cut needs to have for being cut (default 0.16)\n\
+       <cutting_min_segments> - Minimum number of supervoxels in the segment to perform cutting (default 400).\n\
+       <min_cut_score> - Minimum score a proposed cut needs to have for being cut (default 0.16)\n\
   -clocal - Use locally constrained cuts (recommended flag)\n\
   -cdir - Use directed weigths (recommended flag) \n\
   -cclean - Use clean cuts. \n\
@@ -255,7 +255,7 @@ CPCSegmentation Parameters: \n\
   {
     pcl::console::parse (argc, argv, "-o", outputname);
 
-    // If no filename is given, get output filename from inputname (strip seperators and file extension)
+    // If no filename is given, get output filename from inputname (strip separators and file extension)
     if (outputname.empty () || (outputname.at (0) == '-'))
     {
       outputname = pcd_filename;
@@ -348,7 +348,7 @@ CPCSegmentation Parameters: \n\
   textcolor = bg_white?0:1;
 
   pcl::console::print_info ("Maximum cuts: %d\n", max_cuts);
-  pcl::console::print_info ("Minumum segment siz: %d\n", cutting_min_segments);
+  pcl::console::print_info ("Minimum segment size: %d\n", cutting_min_segments);
   pcl::console::print_info ("Use local constrain: %d\n", use_local_constrain);
   pcl::console::print_info ("Use directed weights: %d\n", use_directed_cutting);
   pcl::console::print_info ("Use clean cuts: %d\n", use_clean_cutting);
@@ -386,7 +386,7 @@ CPCSegmentation Parameters: \n\
   /// Get the cloud of supervoxel centroid with normals and the colored cloud with supervoxel coloring (this is used for visulization)
   pcl::PointCloud<pcl::PointNormal>::Ptr sv_centroid_normal_cloud = pcl::SupervoxelClustering<PointT>::makeSupervoxelNormalCloud (supervoxel_clusters);
 
-  /// Set paramters for LCCP preprocessing and CPC (CPC inherits from LCCP, thus it includes LCCP's functionality)
+  /// Set parameters for LCCP preprocessing and CPC (CPC inherits from LCCP, thus it includes LCCP's functionality)
 
   PCL_INFO ("Starting Segmentation\n");
   pcl::CPCSegmentation<PointT> cpc;

--- a/examples/segmentation/example_extract_clusters_normals.cpp
+++ b/examples/segmentation/example_extract_clusters_normals.cpp
@@ -90,7 +90,7 @@ main (int, char **argv)
 
   std::cout << "No of clusters formed are " << cluster_indices.size () << std::endl;
 
-  // Saving the clusters in seperate pcd files
+  // Saving the clusters in separate pcd files
   int j = 0;
   for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin (); it != cluster_indices.end (); ++it)
   {

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -226,7 +226,7 @@ LCCPSegmentation Parameters: \n\
   {
     pcl::console::parse (argc, argv, "-o", outputname);
 
-    // If no filename is given, get output filename from inputname (strip seperators and file extension)
+    // If no filename is given, get output filename from inputname (strip separators and file extension)
     if (outputname.empty () || (outputname.at (0) == '-'))
     {
       outputname = pcd_filename;

--- a/features/include/pcl/features/rops_estimation.h
+++ b/features/include/pcl/features/rops_estimation.h
@@ -125,7 +125,7 @@ namespace pcl
 
       /** \brief This method simply builds the list of triangles for every point.
         * The list of triangles for each point consists of indices of triangles it belongs to.
-        * The only purpose of this method is to improve perfomance of the algorithm.
+        * The only purpose of this method is to improve performance of the algorithm.
         */
       void
       buildListOfPointsTriangles ();
@@ -215,10 +215,10 @@ namespace pcl
       /** \brief Stores the angle step. Step is calculated with respect to number of rotations. */
       float step_;
 
-      /** \brief Stores the set of triangles reprsenting the mesh. */
+      /** \brief Stores the set of triangles representing the mesh. */
       std::vector <pcl::Vertices> triangles_;
 
-      /** \brief Stores the set of triangles for each point. Its purpose is to improve perfomance. */
+      /** \brief Stores the set of triangles for each point. Its purpose is to improve performance. */
       std::vector <std::vector <unsigned int> > triangles_of_the_point_;
 
     public:

--- a/features/src/range_image_border_extractor.cpp
+++ b/features/src/range_image_border_extractor.cpp
@@ -504,7 +504,7 @@ RangeImageBorderExtractor::calculateBorderDirections ()
           if (neighbor_border_direction==NULL || index2==index)
             continue;
           
-          // Oposite directions?
+          // Opposite directions?
           float cos_angle = neighbor_border_direction->dot(*border_direction);
           if (cos_angle<min_cos_angle)
           {

--- a/filters/include/pcl/filters/convolution.h
+++ b/filters/include/pcl/filters/convolution.h
@@ -65,8 +65,8 @@ namespace pcl
       * policies:
       * - Ignoring: elements at special locations are filled with zero
       * (default behaviour)
-      * - Mirroring: the missing rows or columns are obtained throug mirroring
-      * - Duplicating: the missing rows or columns are obtained throug
+      * - Mirroring: the missing rows or columns are obtained through mirroring
+      * - Duplicating: the missing rows or columns are obtained through
       * duplicating
       *
       * \author Nizar Sallem

--- a/filters/include/pcl/filters/convolution_3d.h
+++ b/filters/include/pcl/filters/convolution_3d.h
@@ -80,7 +80,7 @@ namespace pcl
         virtual PointOutT
         operator() (const std::vector<int>& indices, const std::vector<float>& distances) = 0;
 
-        /** \brief Must call this methode before doing any computation
+        /** \brief Must call this method before doing any computation
           * \note make sure to override this with at least
           * \code
           * bool initCompute ()
@@ -150,7 +150,7 @@ namespace pcl
         inline void
         setThreshold (float threshold) { threshold_ = threshold; }
 
-        /** Must call this methode before doing any computation */
+        /** Must call this method before doing any computation */
         bool initCompute ();
 
         virtual PointOutT

--- a/filters/include/pcl/filters/model_outlier_removal.h
+++ b/filters/include/pcl/filters/model_outlier_removal.h
@@ -228,7 +228,7 @@ namespace pcl
       /** \brief The model used to calculate distances */
       SampleConsensusModelPtr model_;
 
-      /** \brief The threshold used to seperate outliers (removed_indices) from inliers (indices) */
+      /** \brief The threshold used to separate outliers (removed_indices) from inliers (indices) */
       float thresh_;
 
       /** \brief The model coefficients */

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -367,7 +367,7 @@ namespace pcl
 
       }
 
-      /** \brief Get the voxels surrounding point p, not including the voxel contating point p.
+      /** \brief Get the voxels surrounding point p, not including the voxel containing point p.
        * \note Only voxels containing a sufficient number of points are used (slower than radius search in practice).
        * \param[in] reference_point the point to get the leaf structure at
        * \param[out] neighbors

--- a/filters/src/passthrough.cpp
+++ b/filters/src/passthrough.cpp
@@ -86,7 +86,7 @@ pcl::PassThrough<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
   {
     // Copy the header (and thus the frame_id) + allocate enough space for points
     output.height = 1; // filtering breaks the organized structure
-    // Because we're doing explit checks for isfinite, is_dense = true
+    // Because we're doing explicit checks for isfinite, is_dense = true
     output.is_dense = true;
   }
   output.row_step = input_->row_step;

--- a/geometry/include/pcl/geometry/mesh_traits.h
+++ b/geometry/include/pcl/geometry/mesh_traits.h
@@ -77,7 +77,7 @@ namespace pcl
       typedef EdgeDataT     EdgeData;
       typedef FaceDataT     FaceData;
 
-      /** \brief Specifies wether the mesh is manifold or not (only non-manifold vertices can be represented). */
+      /** \brief Specifies whether the mesh is manifold or not (only non-manifold vertices can be represented). */
       typedef boost::false_type IsManifold;
     };
   } // End namespace geometry

--- a/gpu/containers/include/pcl/gpu/containers/device_array.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_array.h
@@ -73,18 +73,18 @@ namespace pcl
             
             /** \brief Initializes with user allocated buffer. Reference counting is disabled in this case.
               * \param ptr pointer to buffer
-              * \param size elemens number
+              * \param size elements number
               * */
             DeviceArray(T *ptr, size_t size);
 
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceArray(const DeviceArray& other);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceArray& operator = (const DeviceArray& other);
 
             /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.               
-              * \param size elemens number
+              * \param size elements number
               * */
             void create(size_t size);
 
@@ -98,7 +98,7 @@ namespace pcl
 
             /** \brief Uploads data to internal buffer in GPU memory. It calls create() inside to ensure that intenal buffer size is enough.
               * \param host_ptr pointer to buffer to upload               
-              * \param size elemens number
+              * \param size elements number
               * */
             void upload(const T *host_ptr, size_t size);
 
@@ -180,7 +180,7 @@ namespace pcl
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceArray2D(const DeviceArray2D& other);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceArray2D& operator = (const DeviceArray2D& other);
 
             /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.
@@ -205,7 +205,7 @@ namespace pcl
               * */
             void upload(const void *host_ptr, size_t host_step, int rows, int cols);
 
-            /** \brief Downloads data from internal buffer to CPU memory. User is resposible for correct host buffer size.
+            /** \brief Downloads data from internal buffer to CPU memory. User is responsible for correct host buffer size.
               * \param host_ptr pointer to host buffer to download               
               * \param host_step stride between two consecutive rows in bytes for host buffer             
               * */

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -75,7 +75,7 @@ namespace pcl
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceMemory(const DeviceMemory& other_arg);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceMemory& operator=(const DeviceMemory& other_arg);
 
              /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.               
@@ -167,7 +167,7 @@ namespace pcl
             /** \brief Copy constructor. Just increments reference counter. */
             DeviceMemory2D(const DeviceMemory2D& other_arg);
 
-            /** \brief Assigment operator. Just increments reference counter. */
+            /** \brief Assignment operator. Just increments reference counter. */
             DeviceMemory2D& operator=(const DeviceMemory2D& other_arg);
 
             /** \brief Allocates internal buffer in GPU memory. If internal buffer was created before the function recreates it with new size. If new and old sizes are equal it does nothing.
@@ -192,7 +192,7 @@ namespace pcl
               * */
             void upload(const void *host_ptr_arg, size_t host_step_arg, int rows_arg, int colsBytes_arg);
 
-            /** \brief Downloads data from internal buffer to CPU memory. User is resposible for correct host buffer size.
+            /** \brief Downloads data from internal buffer to CPU memory. User is responsible for correct host buffer size.
               * \param host_ptr_arg pointer to host buffer to download               
               * \param host_step_arg stride between two consecutive rows in bytes for host buffer             
               * */

--- a/gpu/containers/include/pcl/gpu/containers/initialization.h
+++ b/gpu/containers/include/pcl/gpu/containers/initialization.h
@@ -50,20 +50,20 @@ namespace pcl
         /** \brief Sets active device to work with. */
         PCL_EXPORTS void setDevice(int device);
 
-        /** \brief Return devuce name for gived device. */
+        /** \brief Return device name for given device. */
         PCL_EXPORTS std::string getDeviceName(int device);
 
-        /** \brief Prints infromatoin about given cuda deivce or about all deivces
-         *  \param device: if < 0 prints info for all devices, otherwise the function interpets is as device id.
+        /** \brief Prints information about given cuda device or about all devices
+         *  \param device: if < 0 prints info for all devices, otherwise the function interprets it as device id.
          */
         void PCL_EXPORTS printCudaDeviceInfo(int device = -1);
 
-        /** \brief Prints infromatoin about given cuda deivce or about all deivces
-         *  \param device: if < 0 prints info for all devices, otherwise the function interpets is as device id.
+        /** \brief Prints information about given cuda device or about all devices
+         *  \param device: if < 0 prints info for all devices, otherwise the function interprets it as device id.
          */
         void PCL_EXPORTS printShortCudaDeviceInfo(int device = -1);
 
-        /** \brief Returns true if pre-Fermi generaton GPU. 
+        /** \brief Returns true if pre-Fermi generator GPU. 
           * \param device: device id to check, if < 0 checks current device.
           */
         bool PCL_EXPORTS checkIfPreFermiGPU(int device = -1);

--- a/gpu/containers/src/initialization.cpp
+++ b/gpu/containers/src/initialization.cpp
@@ -50,7 +50,7 @@ void throw_nogpu() { throw "PCL 2.0 exception"; }
 int  pcl::gpu::getCudaEnabledDeviceCount() { return 0; }
 void pcl::gpu::setDevice(int /*device*/) { throw_nogpu(); }
 std::string pcl::gpu::getDeviceName(int /*device*/) { throw_nogpu(); }
-void pcl::gpu::printCudaDeviceInfo(int /*deivce*/){ throw_nogpu(); }
+void pcl::gpu::printCudaDeviceInfo(int /*device*/){ throw_nogpu(); }
 void pcl::gpu::printShortCudaDeviceInfo(int /*device*/) { throw_nogpu(); }
 
 #else
@@ -111,7 +111,7 @@ namespace
     {
         // Defines for GPU Architecture types (using the SM version to determine the # of cores per SM
         typedef struct {
-            int SM; // 0xMm (hexidecimal notation), M = SM Major version, and m = SM minor version
+            int SM; // 0xMm (hexadecimal notation), M = SM Major version, and m = SM minor version
             int Cores;
         } SMtoCores;
 

--- a/gpu/features/include/pcl/gpu/features/device/eigen.hpp
+++ b/gpu/features/include/pcl/gpu/features/device/eigen.hpp
@@ -154,7 +154,7 @@ namespace pcl
                     if (roots.x >= roots.y)
                         swap (roots.x, roots.y);
                 }
-                if (roots.x <= 0) // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+                if (roots.x <= 0) // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
                     computeRoots2 (c2, c1, roots);
             }
         }

--- a/gpu/features/src/spinimages.cu
+++ b/gpu/features/src/spinimages.cu
@@ -240,12 +240,12 @@ namespace pcl
 				if (angular)
 				{					
 					//transform sum to average dividing angle/spinimage element-wize.
-					const float *amgles_beg = simage_angles + FSize;
-					const float *amgles_end = amgles_beg + FSize;
+					const float *angles_beg = simage_angles + FSize;
+					const float *angles_end = angles_beg + FSize;
 					const float *images_beg = simage_angles;
 
-					Block::transform(amgles_beg, amgles_end, images_beg, output.ptr(i_input), Div12eps());
-					////Block::copy(amgles_beg, amgles_end, output.ptr(i_input));
+					Block::transform(angles_beg, angles_end, images_beg, output.ptr(i_input), Div12eps());
+					////Block::copy(angles_beg, angles_end, output.ptr(i_input));
 					//Block::copy(images_beg, images_beg + FSize, output.ptr(i_input));
 				}
 				else

--- a/gpu/features/src/spinimages.cu
+++ b/gpu/features/src/spinimages.cu
@@ -244,7 +244,7 @@ namespace pcl
 					const float *amgles_end = amgles_beg + FSize;
 					const float *images_beg = simage_angles;
 
-					Block::transfrom(amgles_beg, amgles_end, images_beg, output.ptr(i_input), Div12eps());
+					Block::transform(amgles_beg, amgles_end, images_beg, output.ptr(i_input), Div12eps());
 					////Block::copy(amgles_beg, amgles_end, output.ptr(i_input));
 					//Block::copy(images_beg, images_beg + FSize, output.ptr(i_input));
 				}
@@ -259,7 +259,7 @@ namespace pcl
 					__syncthreads();
 
 					float sum = simage_angles[FSize];
-					Block::transfrom(simage_angles, simage_angles + FSize, output.ptr(i_input), DivValIfNonZero(sum));
+					Block::transform(simage_angles, simage_angles + FSize, output.ptr(i_input), DivValIfNonZero(sum));
 				}		
 			}
 

--- a/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
@@ -65,7 +65,7 @@ namespace pcl
         */
       ColorVolume(const TsdfVolume& tsdf, int max_weight = -1);
 
-      /** \brief Desctructor */
+      /** \brief Destructor */
       ~ColorVolume();
 
       /** \brief Resets color volume to uninitialized state */

--- a/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
@@ -101,7 +101,7 @@ namespace pcl
         getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy);
         
 
-        /** \brief Sets initial camera pose relative to volume coordiante space
+        /** \brief Sets initial camera pose relative to volume coordinate space
           * \param[in] pose Initial camera pose
           */
         void

--- a/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
@@ -82,7 +82,7 @@ namespace pcl
       void
       setIntrinsics(float fx = 525.f, float fy = 525.f, float cx = -1, float cy = -1);
       
-      /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal fiels.
+      /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal files.
         * \param[in] volume tsdf volume container
         * \param[in] camera_pose camera pose
         */ 

--- a/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
@@ -69,7 +69,7 @@ namespace pcl
         */
       TsdfVolume(const Eigen::Vector3i& resolution);           
             
-      /** \brief Sets Tsdf volume size for each dimention
+      /** \brief Sets Tsdf volume size for each dimension
         * \param[in] size size of tsdf volume in meters
         */
       void
@@ -81,7 +81,7 @@ namespace pcl
       void
       setTsdfTruncDist (float distance);
 
-      /** \brief Returns tsdf volume container that point to data in GPU memroy */
+      /** \brief Returns tsdf volume container that point to data in GPU memory */
       DeviceArray2D<int> 
       data() const;
 

--- a/gpu/kinfu/src/cuda/tsdf_volume.cu
+++ b/gpu/kinfu/src/cuda/tsdf_volume.cu
@@ -130,7 +130,7 @@ namespace pcl
         {
           float3 v_g = getVoxelGCoo (x, y, z);            //3 // p
 
-          //tranform to curr cam coo space
+          //transform to curr cam coo space
           float3 v = Rcurr_inv * (v_g - tcurr);           //4
 
           int2 coo;           //project to current cam

--- a/gpu/kinfu/src/cuda/utils.hpp
+++ b/gpu/kinfu/src/cuda/utils.hpp
@@ -182,7 +182,7 @@ namespace pcl
            if (roots.x >= roots.y)
              swap (roots.x, roots.y);
          }
-         if (roots.x <= 0) // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+         if (roots.x <= 0) // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
            computeRoots2 (c2, c1, roots);
        }
      }

--- a/gpu/kinfu/src/internal.h
+++ b/gpu/kinfu/src/internal.h
@@ -95,7 +95,7 @@ namespace pcl
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Maps
   
-    /** \brief Perfoms bilateral filtering of disparity map
+    /** \brief Performs bilateral filtering of disparity map
       * \param[in] src soruce map
       * \param[out] dst output map
       */
@@ -131,7 +131,7 @@ namespace pcl
     void 
     computeNormalsEigen (const MapArr& vmap, MapArr& nmap);
 
-    /** \brief Performs affine tranform of vertex and normal maps
+    /** \brief Performs affine transform of vertex and normal maps
       * \param[in] vmap_src source vertex map
       * \param[in] nmap_src source vertex map
       * \param[in] Rmat Rotation mat
@@ -335,7 +335,7 @@ namespace pcl
     /** \brief Perform point cloud extraction from tsdf volume
       * \param[in] volume tsdf volume 
       * \param[in] volume_size size of the volume
-      * \param[out] output buffer large enought to store point cloud
+      * \param[out] output buffer large enough to store point cloud
       * \return number of point stored to passed buffer
       */ 
     PCL_EXPORTS size_t 

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -222,7 +222,7 @@ pcl::gpu::KinfuTracker::allocateBufffers (int rows, int cols)
     coresps_[i].create (pyr_rows, pyr_cols);
   }  
   depthRawScaled_.create (rows, cols);
-  // see estimate tranform for the magic numbers
+  // see estimate transform for the magic numbers
   gbuf_.create (27, 20*60);
   sumbuf_.create (27);
 }
@@ -297,7 +297,7 @@ pcl::gpu::KinfuTracker::operator() (const DepthMap& depth_raw,
       }
       else
       {
-        Rcurr = Rprev; // tranform to global coo for ith camera pose
+        Rcurr = Rprev; // transform to global coo for ith camera pose
         tcurr = tprev;
       }
       {
@@ -365,7 +365,7 @@ pcl::gpu::KinfuTracker::operator() (const DepthMap& depth_raw,
           }
         }
       }
-      //save tranform
+      //save transform
       rmats_.push_back (Rcurr);
       tvecs_.push_back (tcurr);
   } 

--- a/gpu/kinfu/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu/tools/kinfu_app_sim.cpp
@@ -396,7 +396,7 @@ display_tic_toc (vector<double> &tic_toc,const string &fun_name)
 void
 capture (Eigen::Isometry3d pose_in,unsigned short* depth_buffer_mm,const uint8_t* color_buffer)//, string point_cloud_fname)
 {
-  // No reference image - but this is kept for compatability with range_test_v2:
+  // No reference image - but this is kept for compatibility with range_test_v2:
   float* reference = new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   //const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.
@@ -1078,7 +1078,7 @@ struct KinFuApp
       PtrStepSz<const KinfuTracker::PixelRGB> rgb24_sim = PtrStepSz<const KinfuTracker::PixelRGB>(height, width, color_buf_, width);
       tic_toc.push_back (getTime ());
       
-      if (1==0){ // live capture - probably doesnt work anymore, left in here for comparison:
+      if (1==0){ // live capture - probably doesn't work anymore, left in here for comparison:
 	bool has_frame = evaluation_ptr_ ? evaluation_ptr_->grab(i, depth) : capture_.grab (depth, rgb24);      
 	if (!has_frame)
 	{
@@ -1382,7 +1382,7 @@ print_cli_help ()
   cout << "    --registration, -r              : enable registration mode" << endl; 
   cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << endl;   
   cout << "    -volume_suze <size_in_meters>   : define integration volume size" << endl;   
-  cout << "    -dev <deivce>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
+  cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
   cout << "";
   cout << " For RGBD benchmark (Requires OpenCV):" << endl; 
   cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
@@ -68,7 +68,7 @@ namespace pcl
           */
         ColorVolume(const TsdfVolume& tsdf, int max_weight = -1);
 
-        /** \brief Desctructor */
+        /** \brief Destructor */
         ~ColorVolume();
 
         /** \brief Resets color volume to uninitialized state */

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
@@ -228,7 +228,7 @@ pcl::kinfuLS::WorldModel<PointT>::getWorldAsCubes (const double size, std::vecto
 		}
 		else
 		{
-		  PCL_INFO ("Extracted cube was empty, skiping this one.\n");
+		  PCL_INFO ("Extracted cube was empty, skipping this one.\n");
 		}
 		origin.z += cubeSide * step_increment;
 	  }

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
@@ -105,7 +105,7 @@ namespace pcl
           void
           setDepthIntrinsics (float fx, float fy, float cx = -1, float cy = -1);
 
-          /** \brief Sets initial camera pose relative to volume coordiante space
+          /** \brief Sets initial camera pose relative to volume coordinate space
             * \param[in] pose Initial camera pose
             */
           void

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
@@ -88,7 +88,7 @@ namespace pcl
         void
         setIntrinsics(float fx = 525.f, float fy = 525.f, float cx = -1, float cy = -1);
         
-        /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal fiels.
+        /** \brief Runs raycasting algorithm from given camera pose. It writes results to internal files.
           * \param[in] volume tsdf volume container
           * \param[in] camera_pose camera pose
           * \param buffer

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
@@ -112,7 +112,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
           */
         TsdfVolume (const Eigen::Vector3i& resolution);           
               
-        /** \brief Sets Tsdf volume size for each dimention
+        /** \brief Sets Tsdf volume size for each dimension
           * \param[in] size size of tsdf volume in meters
           */
         void
@@ -124,7 +124,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         void
         setTsdfTruncDist (float distance);
 
-        /** \brief Returns tsdf volume container that point to data in GPU memroy */
+        /** \brief Returns tsdf volume container that point to data in GPU memory */
         DeviceArray2D<int> 
         data () const;
 

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
@@ -57,7 +57,7 @@ namespace pcl
     /** \brief WorldModel maintains a 3D point cloud that can be queried and updated via helper functions.\n
       * The world is represented as a point cloud.\n
       * When new points are added to the world, we replace old ones by the newest ones.
-      * This is acheived by setting old points to nan (for speed)
+      * This is achieved by setting old points to nan (for speed)
       * \author Raphael Favier
       */
     template <typename PointT>
@@ -103,7 +103,7 @@ namespace pcl
         void addSlice (const PointCloudPtr new_cloud);
 
 
-        /** \brief Retreive existing data from the world model, after a shift
+        /** \brief Retrieve existing data from the world model, after a shift
           * \param[in] previous_origin_x global origin of the cube on X axis, before the shift
           * \param[in] previous_origin_y global origin of the cube on Y axis, before the shift
           * \param[in] previous_origin_z global origin of the cube on Z axis, before the shift
@@ -161,7 +161,7 @@ namespace pcl
           * \param[in] size the size of a 3D cube.
           * \param[out] cubes a vector of point clouds representing each cube (in their original world coordinates). 
           * \param[out] transforms a vector containing the xyz position of each cube in world coordinates.
-          * \param[in] overlap optional overlap (in percent) between each cube (usefull to create overlapped meshes).
+          * \param[in] overlap optional overlap (in percent) between each cube (useful to create overlapped meshes).
           */
         void getWorldAsCubes (double size, std::vector<PointCloudPtr> &cubes, std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &transforms, double overlap = 0.0);
         

--- a/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
+++ b/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
@@ -103,7 +103,7 @@ namespace pcl
       #pragma unroll
                 for(int z = 0; z < buffer.voxels_size.z; ++z, pos+=z_step)
                 {
-                  ///If we went outside of the memory, make sure we go back to the begining of it
+                  ///If we went outside of the memory, make sure we go back to the beginning of it
                   if(pos > buffer.tsdf_memory_end)
                     pos = pos - size;
                   
@@ -141,7 +141,7 @@ namespace pcl
             #pragma unroll				
                 for(int z = 0; z < nbSteps; ++z, pos+=z_step)
                 {
-                  ///If we went outside of the memory, make sure we go back to the begining of it
+                  ///If we went outside of the memory, make sure we go back to the beginning of it
                   if(pos > buffer.tsdf_memory_end)
                     pos = pos - size;
                   
@@ -224,7 +224,7 @@ namespace pcl
           {
             float3 v_g = getVoxelGCoo (x, y, z);            //3 // p
 
-            //tranform to curr cam coo space
+            //transform to curr cam coo space
             float3 v = Rcurr_inv * (v_g - tcurr);           //4
 
             int2 coo;           //project to current cam

--- a/gpu/kinfu_large_scale/src/cuda/utils.hpp
+++ b/gpu/kinfu_large_scale/src/cuda/utils.hpp
@@ -185,7 +185,7 @@ namespace pcl
             if (roots.x >= roots.y)
               swap (roots.x, roots.y);
           }
-          if (roots.x <= 0) // eigenval for symetric positive semi-definite matrix can not be negative! Set it to 0
+          if (roots.x <= 0) // eigenval for symmetric positive semi-definite matrix can not be negative! Set it to 0
             computeRoots2 (c2, c1, roots);
         }
       }

--- a/gpu/kinfu_large_scale/src/internal.h
+++ b/gpu/kinfu_large_scale/src/internal.h
@@ -60,7 +60,7 @@ namespace pcl
       ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       // Maps
     
-      /** \brief Perfoms bilateral filtering of disparity map
+      /** \brief Performs bilateral filtering of disparity map
         * \param[in] src soruce map
         * \param[out] dst output map
         */
@@ -96,7 +96,7 @@ namespace pcl
       void 
       computeNormalsEigen (const MapArr& vmap, MapArr& nmap);
 
-      /** \brief Performs affine tranform of vertex and normal maps
+      /** \brief Performs affine transform of vertex and normal maps
         * \param[in] vmap_src source vertex map
         * \param[in] nmap_src source vertex map
         * \param[in] Rmat Rotation mat
@@ -337,7 +337,7 @@ namespace pcl
       /** \brief Perform point cloud extraction from tsdf volume
         * \param[in] volume tsdf volume 
         * \param[in] volume_size size of the volume
-        * \param[out] output buffer large enought to store point cloud
+        * \param[out] output buffer large enough to store point cloud
         * \return number of point stored to passed buffer
         */ 
       PCL_EXPORTS size_t 
@@ -350,8 +350,8 @@ namespace pcl
         * \param[in] shiftX Offset in indices that will be cleared from the TSDF volume. The clearing start from buffer.OriginX and stops in OriginX + shiftX
         * \param[in] shiftY Offset in indices that will be cleared from the TSDF volume. The clearing start from buffer.OriginY and stops in OriginY + shiftY
         * \param[in] shiftZ Offset in indices that will be cleared from the TSDF volume. The clearing start from buffer.OriginZ and stops in OriginZ + shiftZ
-        * \param[out] output_xyz buffer large enought to store point cloud xyz values
-        * \param[out] output_intensities buffer large enought to store point cloud intensity values
+        * \param[out] output_xyz buffer large enough to store point cloud xyz values
+        * \param[out] output_intensities buffer large enough to store point cloud intensity values
         * \return number of point stored to passed buffer
         */ 
       PCL_EXPORTS size_t

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -295,7 +295,7 @@ pcl::gpu::kinfuLS::KinfuTracker::allocateBufffers (int rows, int cols)
     coresps_[i].create (pyr_rows, pyr_cols);
   }  
   depthRawScaled_.create (rows, cols);
-  // see estimate tranform for the magic numbers
+  // see estimate transform for the magic numbers
   int r = (int)ceil ( ((float)rows) / ESTIMATE_COMBINED_CUDA_GRID_Y );
   int c = (int)ceil ( ((float)cols) / ESTIMATE_COMBINED_CUDA_GRID_X );
   gbuf_.create (27, r * c);
@@ -545,7 +545,7 @@ pcl::gpu::kinfuLS::KinfuTracker::performPairWiseICP(const Intr cam_intrinsics, M
   }
   
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  // since raw depthmaps are quite noisy, we make sure the estimated transform is big enought to be taken into account
+  // since raw depthmaps are quite noisy, we make sure the estimated transform is big enough to be taken into account
   float rnorm = rodrigues2(current_rotation).norm();
   float tnorm = (current_translation).norm();    
   const float alpha = 1.f;
@@ -582,7 +582,7 @@ pcl::gpu::kinfuLS::KinfuTracker::operator() (const DepthMap& depth_raw)
   
   ///////////////////////////////////////////////////////////////////////////////////////////
   // Initialization at first frame
-  if (global_time_ == 0) // this is the frist frame, the tsdf volume needs to be initialized
+  if (global_time_ == 0) // this is the first frame, the tsdf volume needs to be initialized
   {  
     // Initial rotation
     Matrix3frm initial_cam_rot = rmats_[0]; //  [Ri|ti] - pos of camera
@@ -667,7 +667,7 @@ pcl::gpu::kinfuLS::KinfuTracker::operator() (const DepthMap& depth_raw)
   device_current_translation_local -= getCyclicalBufferStructure()->origin_metric;   // translation (local translation = global translation - origin of cube)
   
   ///////////////////////////////////////////////////////////////////////////////////////////
-  // Integration check - We do not integrate volume if camera does not move far enought.  
+  // Integration check - We do not integrate volume if camera does not move far enough.  
   {
     float rnorm = rodrigues2(current_global_rotation.inverse() * last_known_global_rotation).norm();
     float tnorm = (current_global_translation - last_known_global_translation).norm();    

--- a/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
@@ -394,7 +394,7 @@ display_tic_toc (vector<double> &tic_toc,const string &fun_name)
 void
 capture (Eigen::Isometry3d pose_in,unsigned short* depth_buffer_mm,const uint8_t* color_buffer)//, string point_cloud_fname)
 {
-  // No reference image - but this is kept for compatability with range_test_v2:
+  // No reference image - but this is kept for compatibility with range_test_v2:
   float* reference = new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   //const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.
@@ -1076,7 +1076,7 @@ struct KinFuApp
       PtrStepSz<const KinfuTracker::PixelRGB> rgb24_sim = PtrStepSz<const KinfuTracker::PixelRGB>(height, width, color_buf_, width);
       tic_toc.push_back (getTime ());
       
-      if (1==0){ // live capture - probably doesnt work anymore, left in here for comparison:
+      if (1==0){ // live capture - probably doesn't work anymore, left in here for comparison:
 	bool has_frame = evaluation_ptr_ ? evaluation_ptr_->grab(i, depth) : capture_.grab (depth, rgb24);      
 	if (!has_frame)
 	{
@@ -1386,7 +1386,7 @@ print_cli_help ()
   cout << "    --registration, -r              : enable registration mode" << endl; 
   cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << endl;   
   cout << "    -volume_suze <size_in_meters>   : define integration volume size" << endl;   
-  cout << "    -dev <deivce>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
+  cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
   cout << "";
   cout << " For RGBD benchmark (Requires OpenCV):" << endl; 
   cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl;

--- a/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
+++ b/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
@@ -284,7 +284,7 @@ receiveAndProcess ()
 
   {
     boost::mutex::scoped_lock io_lock (io_mutex);
-    PCL_INFO ("Writing remaing %d maps in the buffer to disk...\n", buff.getSize ());
+    PCL_INFO ("Writing remaining %d maps in the buffer to disk...\n", buff.getSize ());
   }
   while (!buff.isEmpty ())
   {

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -201,7 +201,7 @@ saveOBJFile (const std::string &file_name,
   int f_idx = 0;
 
   // int idx_vt =0;
-  PCL_INFO ("Writting faces...\n");
+  PCL_INFO ("Writing faces...\n");
   for (int m = 0; m < nr_meshes; ++m)
   {
     if (m > 0) 
@@ -242,7 +242,7 @@ saveOBJFile (const std::string &file_name,
   /* Write material defination for OBJ file*/
   // Open file
   PCL_INFO ("Writing material files\n");
-  //dont do it if no material to write
+  //don't do it if no material to write
   if(tex_mesh.tex_materials.size() ==0)
     return (0);
 

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -49,7 +49,7 @@ namespace pcl
     namespace gpu
     {   
         /**
-         * \brief   Octree implementation on GPU. It suppors parallel building and paralel batch search as well .       
+         * \brief   Octree implementation on GPU. It suppors parallel building and parallel batch search as well .       
          * \author  Anaoly Baksheev, Itseez, myname.mysurname@mycompany.com
          */
 
@@ -95,10 +95,10 @@ namespace pcl
             /** \brief Returns true if tree has been built */
             bool isBuilt();
 
-            /** \brief Downloads Octree from GPU to search using CPU fucntion. It use usefull for signle (not-batch) search */
+            /** \brief Downloads Octree from GPU to search using CPU function. It use useful for single (not-batch) search */
             void internalDownload();
 
-            /** \brief Performs search of all points wihtin given radius on CPU. It call \a internalDownload if nessesary
+            /** \brief Performs search of all points within given radius on CPU. It call \a internalDownload if necessary
               * \param[in] center center of sphere
               * \param[in] radius radious of sphere
               * \param[out] out indeces of points within give sphere
@@ -106,7 +106,7 @@ namespace pcl
               */
             void radiusSearchHost(const PointType& center, float radius, std::vector<int>& out, int max_nn = INT_MAX);
 
-            /** \brief Performs approximate neares neighbor search on CPU. It call \a internalDownload if nessesary
+            /** \brief Performs approximate nearest neighbor search on CPU. It call \a internalDownload if necessary
               * \param[in]  query 3D point for which neighbour is be fetched             
               * \param[out] out_index neighbour index
               * \param[out] sqr_dist square distance to the neighbour returned
@@ -117,7 +117,7 @@ namespace pcl
               * \param[in] centers array of centers 
               * \param[in] radius radius for all queries
               * \param[in] max_results max number of returned points for each querey
-              * \param[out] result results packed to signle array
+              * \param[out] result results packed to single array
               */
             void radiusSearch(const Queries& centers, float radius, int max_results, NeighborIndices& result) const;
 
@@ -125,7 +125,7 @@ namespace pcl
               * \param[in] centers array of centers 
               * \param[in] radiuses array of radiuses
               * \param[in] max_results max number of returned points for each querey
-              * \param[out] result results packed to signle array
+              * \param[out] result results packed to single array
               */
             void radiusSearch(const Queries& centers, const Radiuses& radiuses, int max_results, NeighborIndices& result) const;
 
@@ -134,7 +134,7 @@ namespace pcl
               * \param[in] indices indices for centers array (only for these points search is performed)
               * \param[in] radius radius for all queries
               * \param[in] max_results max number of returned points for each querey
-              * \param[out] result results packed to signle array
+              * \param[out] result results packed to single array
               */
             void radiusSearch(const Queries& centers, const Indices& indices, float radius, int max_results, NeighborIndices& result) const;
 
@@ -146,7 +146,7 @@ namespace pcl
 
             /** \brief Batch exact k-nearest search on GPU for k == 1 only!
               * \param[in] queries array of centers
-              * \param[in] k nubmer of neighbors (only k == 1 is supported)
+              * \param[in] k number of neighbors (only k == 1 is supported)
               * \param[out] results array of results
               */
             void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const;

--- a/gpu/octree/src/cuda/octree_builder.cu
+++ b/gpu/octree/src/cuda/octree_builder.cu
@@ -186,7 +186,7 @@ namespace pcl
 
             __device__  __forceinline__ void operator()() const
             {             
-                //32 is a perfomance penalty step for search
+                //32 is a performance penalty step for search
                 Static<(max_points_per_leaf % 32) == 0>::check();                 
 
                 if (threadIdx.x == 0)

--- a/gpu/octree/src/cuda/octree_host.cu
+++ b/gpu/octree/src/cuda/octree_host.cu
@@ -89,14 +89,14 @@ void pcl::device::OctreeImpl::internalDownload()
 
 namespace 
 {
-    int getBitsNum(int interger)
+    int getBitsNum(int integer)
     {
         int count = 0;
-        while(interger > 0)
+        while(integer > 0)
         {
-            if (interger & 1)
+            if (integer & 1)
                 ++count;
-            interger>>=1;
+            integer>>=1;
         }
         return count;
     } 

--- a/gpu/octree/src/cuda/octree_iterator.hpp
+++ b/gpu/octree/src/cuda/octree_iterator.hpp
@@ -89,20 +89,20 @@ namespace pcl
         {       
             int level;
             int node_idx;
-            int lenght;
+            int length;
             const OctreeGlobalWithBox& octree;
 
             __device__ __forceinline__ OctreeIteratorDeviceNS(const OctreeGlobalWithBox& octree_arg) : octree(octree_arg)
             {
                 node_idx = 0;
                 level = 0;
-                lenght = 1;
+                length = 1;
             }
 
             __device__ __forceinline__ void gotoNextLevel(int first, int len) 
             {  
                 node_idx = first;
-                lenght = len;
+                length = len;
                 ++level;
             }       
 
@@ -116,7 +116,7 @@ namespace pcl
 #if 1
                 while(level >= 0)
                 {                
-                    if (lenght > 1)
+                    if (length > 1)
                     {
                         lenght--;
                         node_idx++;                      
@@ -143,7 +143,7 @@ namespace pcl
 
                     int pos = node_idx - parent_first;
 
-                    lenght = parent_len - pos;
+                    length = parent_len - pos;
                 }
 #endif
             }

--- a/gpu/octree/src/utils/priority_octree_iterator.hpp
+++ b/gpu/octree/src/utils/priority_octree_iterator.hpp
@@ -45,20 +45,20 @@ namespace pcl
         {       
             int level;
             int node_idx;
-            int lenght;
+            int length;
             const OctreeGlobalWithBox& octree;
 
             __device__ __forceinline__ OctreePriorityIteratorDevice(const OctreeGlobalWithBox& octree_arg) : octree(octree_arg)
             {
                 node_idx = 0;
                 level = 0;
-                lenght = 1;
+                length = 1;
             }
 
             __device__ __forceinline__ void gotoNextLevel(int first, int len) 
             {  
                 node_idx = first;
-                lenght = len;
+                length = len;
                 ++level;
             }       
 
@@ -72,7 +72,7 @@ namespace pcl
 #if 1
                 while(level >= 0)
                 {                
-                    if (lenght > 1)
+                    if (length > 1)
                     {
                         lenght--;
                         node_idx++;                      
@@ -99,7 +99,7 @@ namespace pcl
 
                     int pos = node_idx - parent_first;
 
-                    lenght = parent_len - pos;
+                    length = parent_len - pos;
                 }
 #endif
             }

--- a/gpu/octree/test/perfomance.cpp
+++ b/gpu/octree/test/perfomance.cpp
@@ -69,8 +69,8 @@ using pcl::ScopeTime;
     #include "opencv2/contrib/contrib.hpp"
 #endif
 
-//TEST(PCL_OctreeGPU, DISABLED_perfomance)
-TEST(PCL_OctreeGPU, perfomance)
+//TEST(PCL_OctreeGPU, DISABLED_performance)
+TEST(PCL_OctreeGPU, performance)
 {
     DataGenerator data;
     data.data_size = 871000;

--- a/gpu/octree/test/perfomance.cpp
+++ b/gpu/octree/test/perfomance.cpp
@@ -108,7 +108,7 @@ TEST(PCL_OctreeGPU, perfomance)
     
     cout << "[!] Host octree resolution: " << host_octree_resolution << endl << endl;    
 
-    cout << "======  Build perfomance =====" << endl;
+    cout << "======  Build performance =====" << endl;
     // build device octree
     pcl::gpu::Octree octree_device;                
     octree_device.setCloud(cloud_device);	    
@@ -142,7 +142,7 @@ TEST(PCL_OctreeGPU, perfomance)
     }
 #endif
     
-    //// Radius search perfomance ///
+    //// Radius search performance ///
 
     const int max_answers = 500;
     float dist;

--- a/gpu/people/include/pcl/gpu/people/label_blob2.h
+++ b/gpu/people/include/pcl/gpu/people/label_blob2.h
@@ -52,7 +52,7 @@ namespace pcl
     namespace people
     {      
       /**
-       * @brief This structure containts all parameters to describe blobs and their parent/child relations
+       * @brief This structure contains all parameters to describe blobs and their parent/child relations
        * @todo: clean this out in the end, perhaps place the children in a separate struct
        */
       struct Blob2 

--- a/gpu/people/include/pcl/gpu/people/label_common.h
+++ b/gpu/people/include/pcl/gpu/people/label_common.h
@@ -151,7 +151,7 @@ namespace pcl
       };
 
       /**
-       *  @brief This LUT contains the ideal lenght between this part and his children
+       *  @brief This LUT contains the ideal length between this part and his children
        **/
       static const float LUT_ideal_length[][4] = 
       {
@@ -183,7 +183,7 @@ namespace pcl
       };
 
       /**
-       * @brief This LUT contains the max lenght between this part and his children
+       * @brief This LUT contains the max length between this part and his children
        **/
       static const float LUT_max_length_offset[][4] = 
       {

--- a/gpu/people/include/pcl/gpu/people/label_segment.h
+++ b/gpu/people/include/pcl/gpu/people/label_segment.h
@@ -77,7 +77,7 @@ namespace pcl
          * \param[in] dmap the cvMat with the depths, must be CV_16U in mm
          * \param[out] lmap_out the smoothed output labelmap as cvMat
          * \param[in] patch_size make the patch size for smoothing
-         * \param[in] depthThres the z-distance thresshold
+         * \param[in] depthThres the z-distance threshold
          * \todo add a Gaussian contribution function to depth and vote
          **/
         //inline void smoothLabelImage ( cv::Mat&      lmap_in,

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -70,7 +70,7 @@ namespace pcl
     namespace people    
     {           
      /**
-       * @brief This structure containts all parameters to describe the segmented tree
+       * @brief This structure contains all parameters to describe the segmented tree
        */
       struct Tree2 
       {
@@ -222,7 +222,7 @@ namespace pcl
        * @param[in] parent_label this is the part label that indicates the row
        * @param[in] child_label  this is the part label that indicates the childs needed to be investigated
        * @param[in] child_number the number of this child in the parent, some parents have multiple childs
-       * @return zero if successfull
+       * @return zero if successful
        * @todo once we have good evaluation function reconsider best_value
        **/
       inline int
@@ -281,7 +281,7 @@ namespace pcl
        * @param[in] child_label  this is the part label that indicates the childs needed to be investigated
        * @param[in] child_number the number of this child in the parent, some parents have multiple childs
        * @param person_attribs
-       * @return zero if successfull
+       * @return zero if successful
        * @todo once we have good evaluation function reconsider best_value
        **/
       inline int

--- a/gpu/people/include/pcl/gpu/people/person_attribs.h
+++ b/gpu/people/include/pcl/gpu/people/person_attribs.h
@@ -25,7 +25,7 @@ namespace pcl
           /**
            * \brief Read XML configuration file for a specific person
            * \param[in] is input stream of file
-           * \return 0 when successfull, -1 when an error occured, datastructure might become corrupted in the process
+           * \return 0 when successful, -1 when an error occurred, datastructure might become corrupted in the process
            **/
           int
           readPersonXMLConfig (std::istream& is);

--- a/gpu/people/src/cuda/smooth.cu
+++ b/gpu/people/src/cuda/smooth.cu
@@ -142,7 +142,7 @@ void pcl::device::smoothLabelImage(const Labels& src, const Depth& depth, Labels
   if (num_parts <= 32)
     pcl::device::smoothKernel<32><<<grid, block>>>(src, depth, dst, patch_size, depthThres, num_parts);
   else
-    throw std::exception(); //should instanciate another smoothKernel<N>
+    throw std::exception(); //should instantiate another smoothKernel<N>
 
   cudaSafeCall( cudaGetLastError() );
   cudaSafeCall( cudaDeviceSynchronize() );

--- a/gpu/surface/src/internal.h
+++ b/gpu/surface/src/internal.h
@@ -66,7 +66,7 @@ namespace pcl
 	  public:
 		  FacetStream(size_t buffer_size);
 
-          // indeces: in each col indeces of vertexes for sigle facet
+          // indeces: in each col indeces of vertexes for single facet
 		  DeviceArray2D<int>  verts_inds;		  
 
 		  DeviceArray<int> head_points;		  

--- a/gpu/utils/include/pcl/gpu/utils/device/block.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/block.hpp
@@ -96,7 +96,7 @@ namespace pcl
 			}
 
 			template<typename InIt, typename OutIt, class UnOp>
-			static __device__ __forceinline__ void transfrom(InIt beg, InIt end, OutIt out, UnOp op)
+			static __device__ __forceinline__ void transform(InIt beg, InIt end, OutIt out, UnOp op)
 			{
 				int STRIDE = stride();
 				InIt  t = beg + flattenedThreadId();
@@ -107,7 +107,7 @@ namespace pcl
 			}
 
 			template<typename InIt1, typename InIt2, typename OutIt, class BinOp>
-			static __device__ __forceinline__ void transfrom(InIt1 beg1, InIt1 end1, InIt2 beg2, OutIt out, BinOp op)
+			static __device__ __forceinline__ void transform(InIt1 beg1, InIt1 end1, InIt2 beg2, OutIt out, BinOp op)
 			{
 				int STRIDE = stride();
 				InIt1 t1 = beg1 + flattenedThreadId();

--- a/gpu/utils/include/pcl/gpu/utils/device/reduce.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/reduce.hpp
@@ -34,8 +34,8 @@
 *  Author: Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
 */
 
-#ifndef PCL_GPU_DEVUCE_REDUCE_HPP_
-#define PCL_GPU_DEVUCE_REDUCE_HPP_
+#ifndef PCL_GPU_DEVICE_REDUCE_HPP_
+#define PCL_GPU_DEVICE_REDUCE_HPP_
 
 namespace pcl
 {

--- a/io/include/pcl/compression/color_coding.h
+++ b/io/include/pcl/compression/color_coding.h
@@ -294,8 +294,8 @@ namespace pcl
 
         /** \brief Decode color information
           * \param outputCloud_arg output point cloud
-          * \param beginIdx_arg index indicating first point to be assiged with color information
-          * \param endIdx_arg index indicating last point to be assiged with color information
+          * \param beginIdx_arg index indicating first point to be assigned with color information
+          * \param endIdx_arg index indicating last point to be assigned with color information
           * \param rgba_offset_arg offset to color information
           */
         void
@@ -355,8 +355,8 @@ namespace pcl
 
         /** \brief Set default color to points
          * \param outputCloud_arg output point cloud
-         * \param beginIdx_arg index indicating first point to be assiged with color information
-         * \param endIdx_arg index indicating last point to be assiged with color information
+         * \param beginIdx_arg index indicating first point to be assigned with color information
+         * \param endIdx_arg index indicating last point to be assigned with color information
          * \param rgba_offset_arg offset to color information
          * */
         void

--- a/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
@@ -88,7 +88,7 @@ namespace pcl
       compressedDataOut_arg.write (reinterpret_cast<const char*> (&cloud_height), sizeof (cloud_height));
       // encode frame max depth
       compressedDataOut_arg.write (reinterpret_cast<const char*> (&maxDepth), sizeof (maxDepth));
-      // encode frame focal lenght
+      // encode frame focal length
       compressedDataOut_arg.write (reinterpret_cast<const char*> (&focalLength), sizeof (focalLength));
       // encode frame disparity scale
       compressedDataOut_arg.write (reinterpret_cast<const char*> (&disparityScale), sizeof (disparityScale));
@@ -186,7 +186,7 @@ namespace pcl
        compressedDataOut_arg.write (reinterpret_cast<const char*> (&height_arg), sizeof (height_arg));
        // encode frame max depth
        compressedDataOut_arg.write (reinterpret_cast<const char*> (&maxDepth), sizeof (maxDepth));
-       // encode frame focal lenght
+       // encode frame focal length
        compressedDataOut_arg.write (reinterpret_cast<const char*> (&focalLength_arg), sizeof (focalLength_arg));
        // encode frame disparity scale
        compressedDataOut_arg.write (reinterpret_cast<const char*> (&disparityScale_arg), sizeof (disparityScale_arg));

--- a/io/include/pcl/compression/octree_pointcloud_compression.h
+++ b/io/include/pcl/compression/octree_pointcloud_compression.h
@@ -265,13 +265,13 @@ namespace pcl
         /** \brief Vector for storing binary tree structure */
         std::vector<char> binary_tree_data_vector_;
 
-        /** \brief Interator on binary tree structure vector */
+        /** \brief Iterator on binary tree structure vector */
         std::vector<char> binary_color_tree_vector_;
 
         /** \brief Vector for storing points per voxel information  */
         std::vector<unsigned int> point_count_data_vector_;
 
-        /** \brief Interator on points per voxel vector */
+        /** \brief Iterator on points per voxel vector */
         std::vector<unsigned int>::const_iterator point_count_data_vector_iterator_;
 
         /** \brief Color coding instance */

--- a/io/include/pcl/compression/organized_pointcloud_compression.h
+++ b/io/include/pcl/compression/organized_pointcloud_compression.h
@@ -122,7 +122,7 @@ namespace pcl
          * \param[in] compressedDataIn_arg: binary input stream containing compressed data
          * \param[out] cloud_arg: reference to decoded point cloud
          * \param[in] bShowStatistics_arg: show compression statistics during decoding
-         * \return false if an I/O error occured.
+         * \return false if an I/O error occurred.
          */
         bool decodePointCloud (std::istream& compressedDataIn_arg,
                                PointCloudPtr &cloud_arg,

--- a/io/include/pcl/compression/point_coding.h
+++ b/io/include/pcl/compression/point_coding.h
@@ -162,8 +162,8 @@ namespace pcl
         /** \brief Decode differential point information
           * \param outputCloud_arg output point cloud
           * \param referencePoint_arg coordinates of reference point
-          * \param beginIdx_arg index indicating first point to be assiged with color information
-          * \param endIdx_arg index indicating last point to be assiged with color information
+          * \param beginIdx_arg index indicating first point to be assigned with color information
+          * \param endIdx_arg index indicating last point to be assigned with color information
           */
         void
         decodePoints (PointCloudPtr outputCloud_arg, const double* referencePoint_arg, std::size_t beginIdx_arg,

--- a/io/include/pcl/io/ascii_io.h
+++ b/io/include/pcl/io/ascii_io.h
@@ -125,7 +125,7 @@ namespace pcl
       }
 
 
-      /** \brief Set the Separting characters for the ascii point fields 2.
+      /** \brief Set the Separating characters for the ascii point fields 2.
         * \param[in] chars string of separating characters
         *  Sets the separating characters for the point fields.  The
         *  default separating characters are " \n\t,"

--- a/io/include/pcl/io/fotonic_grabber.h
+++ b/io/include/pcl/io/fotonic_grabber.h
@@ -135,7 +135,7 @@ namespace pcl
       void
       setupDevice (const FZ_DEVICE_INFO& device_info, const Mode& depth_mode, const Mode& image_mode);
 
-      /** \brief Continously asks for data from the device and publishes it if available. */
+      /** \brief Continuously asks for data from the device and publishes it if available. */
       void
       processGrabbing ();
 

--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -62,7 +62,7 @@ namespace pcl
       /** \brief Constructor. */
       Grabber () : signals_ (), connections_ (), shared_connections_ () {}
 
-      /** \brief virtual desctructor. */
+      /** \brief virtual destructor. */
       virtual inline ~Grabber () throw ();
 
       /** \brief registers a callback function/method to a signal with the corresponding signature

--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -147,7 +147,7 @@ pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename,
 #ifdef _OPENMP
 #pragma omp parallel for num_threads (num_threads)
 #else
-  (void) num_threads; // supress warning if OMP is not present
+  (void) num_threads; // suppress warning if OMP is not present
 #endif
   for (int i = 0; i < static_cast< int> (cloud.size ()); ++i)
   {
@@ -278,7 +278,7 @@ pcl::io::LZFRGB24ImageReader::readOMP (
 #ifdef _OPENMP
 #pragma omp parallel for num_threads (num_threads)
 #else
-  (void) num_threads; // supress warning if OMP is not present
+  (void) num_threads; // suppress warning if OMP is not present
 #endif//_OPENMP
   for (long int i = 0; i < cloud.size (); ++i)
   {

--- a/io/include/pcl/io/oni_grabber.h
+++ b/io/include/pcl/io/oni_grabber.h
@@ -84,7 +84,7 @@ namespace pcl
       typedef void (sig_cb_openni_point_cloud_rgba) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> >&);
       typedef void (sig_cb_openni_point_cloud_i) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&);
 
-      /** \brief constuctor
+      /** \brief constructor
         * \param[in] file_name the path to the ONI file
         * \param[in] repeat whether the play back should be in an infinite loop or not
         * \param[in] stream whether the playback should be in streaming mode or in triggered mode.

--- a/io/include/pcl/io/openni2/openni2_device.h
+++ b/io/include/pcl/io/openni2/openni2_device.h
@@ -230,21 +230,21 @@ namespace pcl
           void
           setUseDeviceTimer (bool enable);
 
-          /** \brief Get absolut number of depth frames in the current stream.
+          /** \brief Get absolute number of depth frames in the current stream.
           * This function returns 0 if the current device is not a file stream or
           * if the current mode has no depth stream.
           */
           int
           getDepthFrameCount ();
 
-          /** \brief Get absolut number of color frames in the current stream.
+          /** \brief Get absolute number of color frames in the current stream.
           * This function returns 0 if the current device is not a file stream or
           * if the current mode has no color stream.
           */
           int
           getColorFrameCount ();
 
-          /** \brief Get absolut number of ir frames in the current stream.
+          /** \brief Get absolute number of ir frames in the current stream.
           * This function returns 0 if the current device is not a file stream or
           * if the current mode has no ir stream.
           */

--- a/io/include/pcl/io/openni_camera/openni_driver.h
+++ b/io/include/pcl/io/openni_camera/openni_driver.h
@@ -198,7 +198,7 @@ namespace openni_wrapper
     /**
      * @author Suat Gedikli
      * @brief decomposes the connection string into vendor id and product id.
-     * @param[in] connection_string the string containing teh connection information
+     * @param[in] connection_string the string containing the connection information
      * @param[out] vendorId the vendor id
      * @param[out] productId the product id
      */

--- a/io/include/pcl/io/pcd_io.h
+++ b/io/include/pcl/io/pcd_io.h
@@ -70,7 +70,7 @@ namespace pcl
         *   - POINTS ...
         *   - DATA ascii/binary
         * 
-        * Everything that follows \b DATA is intepreted as data points and
+        * Everything that follows \b DATA is interpreted as data points and
         * will be read accordingly.
         *
         * PCD_V7 represents PCD files with version 0.7 and has an important

--- a/io/include/pcl/io/ply/byte_order.h
+++ b/io/include/pcl/io/ply/byte_order.h
@@ -49,7 +49,7 @@ namespace pcl
     namespace ply
     {
       /** \file byte_order.h
-        * defines byte shift operations and endianess.
+        * defines byte shift operations and endianness.
         * \author Ares Lagae as part of libply, Nizar Sallem
         * \ingroup io
         */

--- a/io/include/pcl/io/ply_io.h
+++ b/io/include/pcl/io/ply_io.h
@@ -742,7 +742,7 @@ namespace pcl
   {
     /** \brief Load a PLY v.6 file into a templated PointCloud type.
       *
-      * Any PLY files containg sensor data will generate a warning as a
+      * Any PLY files containing sensor data will generate a warning as a
       * pcl/PCLPointCloud2 message cannot hold the sensor origin.
       *
       * \param[in] file_name the name of the file to load
@@ -760,7 +760,7 @@ namespace pcl
       * \param[in] file_name the name of the file to load
       * \param[in] cloud the resultant templated point cloud
       * \param[in] origin the sensor acquisition origin (only for > PLY_V7 - null if not present)
-      * \param[in] orientation the sensor acquisition orientation if availble, 
+      * \param[in] orientation the sensor acquisition orientation if available, 
       * identity if not present
       * \ingroup io
       */
@@ -787,7 +787,7 @@ namespace pcl
 
     /** \brief Load a PLY file into a PolygonMesh type.
       *
-      * Any PLY files containg sensor data will generate a warning as a
+      * Any PLY files containing sensor data will generate a warning as a
       * pcl/PolygonMesh message cannot hold the sensor origin.
       *
       * \param[in] file_name the name of the file to load

--- a/io/include/pcl/io/real_sense_grabber.h
+++ b/io/include/pcl/io/real_sense_grabber.h
@@ -137,7 +137,7 @@ namespace pcl
         * If the default is supplied, then the mode closest to VGA at 30 Hz
         * will be chosen.
         * \param[in] strict if set to \c true, an exception will be thrown if
-        * device does not support exactly the mode requsted. Otherwise the
+        * device does not support exactly the mode requested. Otherwise the
         * closest available mode is selected. */
       RealSenseGrabber (const std::string& device_id = "", const Mode& mode = Mode (), bool strict = false);
 

--- a/io/src/ifs_io.cpp
+++ b/io/src/ifs_io.cpp
@@ -329,7 +329,7 @@ pcl::IFSWriter::write (const std::string &file_name, const pcl::PCLPointCloud2 &
 
   if (!cloud.is_dense)
   {
-    PCL_ERROR ("[pcl::IFSWriter::write] Non dense cloud are not alowed by IFS format!\n");
+    PCL_ERROR ("[pcl::IFSWriter::write] Non dense cloud are not allowed by IFS format!\n");
     return (-1);
   }
 

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -347,7 +347,7 @@ pcl::io::OpenNI2Grabber::setupDevice (const std::string& device_id, const Mode& 
   }
   catch (...)
   {
-    PCL_THROW_EXCEPTION (pcl::IOException, "unknown error occured");
+    PCL_THROW_EXCEPTION (pcl::IOException, "unknown error occurred");
   }
 
   typedef pcl::io::openni2::OpenNI2VideoMode VideoMode;

--- a/io/src/openni_grabber.cpp
+++ b/io/src/openni_grabber.cpp
@@ -366,7 +366,7 @@ pcl::OpenNIGrabber::setupDevice (const std::string& device_id, const Mode& depth
   }
   catch (...)
   {
-    PCL_THROW_EXCEPTION (pcl::IOException, "unknown error occured");
+    PCL_THROW_EXCEPTION (pcl::IOException, "unknown error occurred");
   }
 
   XnMapOutputMode depth_md;

--- a/io/src/pcd_grabber.cpp
+++ b/io/src/pcd_grabber.cpp
@@ -199,7 +199,7 @@ pcl::PCDGrabberBase::PCDGrabberImpl::readAhead ()
       // Try to read in the file as a PCD first
       valid_ = (reader.read (*pcd_iterator_, next_cloud_, origin_, orientation_, pcd_version) == 0);
 
-      // Has an error occured? Check if we can interpret the file as a TAR file first before going onto the next
+      // Has an error occurred? Check if we can interpret the file as a TAR file first before going onto the next
       if (!valid_ && openTARFile (*pcd_iterator_) >= 0 && readTARHeader ())
       {
         tar_file_ = *pcd_iterator_;
@@ -241,7 +241,7 @@ pcl::PCDGrabberBase::PCDGrabberImpl::readTARHeader ()
   }
 
   // We only support regular files for now. 
-  // Addional file types in TAR include: hard links, symbolic links, device/special files, block devices, 
+  // Additional file types in TAR include: hard links, symbolic links, device/special files, block devices, 
   // directories, and named pipes.
   if (tar_header_.file_type[0] != '0' && tar_header_.file_type[0] != '\0')
   {

--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -380,7 +380,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
             {
               if (error_callback_)
               {
-                error_callback_ (line_number_, "parse error: unkonwn scalar type");
+                error_callback_ (line_number_, "parse error: unknown scalar type");
               }
               return false;
             }

--- a/io/src/real_sense_grabber.cpp
+++ b/io/src/real_sense_grabber.cpp
@@ -323,7 +323,7 @@ pcl::RealSenseGrabber::run ()
       frequency_.event ();
       fps_mutex_.unlock ();
 
-      /* We preform the following steps to convert received data into point clouds:
+      /* We perform the following steps to convert received data into point clouds:
        *
        *   1. Push depth image to the depth buffer
        *   2. Pull filtered depth image from the depth buffer

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -298,7 +298,7 @@ class Consumer
 
       {
         boost::mutex::scoped_lock io_lock (io_mutex);
-        print_info ("Writing remaing %ld clouds in the buffer to disk...\n", buf_.getSize ());
+        print_info ("Writing remaining %ld clouds in the buffer to disk...\n", buf_.getSize ());
       }
       while (!buf_.isEmpty ())
         writeToDisk (buf_.getFront ());

--- a/ml/include/pcl/ml/impl/kmeans.hpp
+++ b/ml/include/pcl/ml/impl/kmeans.hpp
@@ -132,7 +132,7 @@ pcl::Kmeans<PointT>::cluster (std::vector<PointIndices> &clusters)
     
     
   }
-  // if cluster field name is set, check if field name is valied
+  // if cluster field name is set, check if field name is valid
   else
   {
     user_index = pcl::getFieldIndex (point, cluster_field_name_.c_str (), fields);

--- a/ml/include/pcl/ml/regression_variance_stats_estimator.h
+++ b/ml/include/pcl/ml/regression_variance_stats_estimator.h
@@ -156,7 +156,7 @@ namespace pcl
         * \param[in] data_set The data set corresponding to the supplied result data.
         * \param[in] examples The examples used for extracting the supplied result data.
         * \param[in] label_data The label data corresponding to the specified examples.
-        * \param[in] results The results computed using the specifed examples.
+        * \param[in] results The results computed using the specified examples.
         * \param[in] flags The flags corresponding to the results.
         * \param[in] threshold The threshold for which the information gain is computed.
         */

--- a/ml/src/kmeans.cpp
+++ b/ml/src/kmeans.cpp
@@ -258,7 +258,7 @@ pcl::Kmeans::cluster (std::vector<PointIndices> &clusters)
     
     /*    
   }
-  // if cluster field name is set, check if field name is valied
+  // if cluster field name is set, check if field name is valid
   else
   {
     user_index = pcl::getFieldIndex (point, cluster_field_name_.c_str (), fields);

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -1981,7 +1981,7 @@ static decision_function svm_train_one (
   return f;
 }
 
-// Platt's binary SVM Probablistic Output: an improvement from Lin et al.
+// Platt's binary SVM Probabilistic Output: an improvement from Lin et al.
 static void sigmoid_train (
   int l, const double *dec_values, const double *labels,
   double& A, double& B)

--- a/octree/include/pcl/octree/impl/octree2buf_base.hpp
+++ b/octree/include/pcl/octree/impl/octree2buf_base.hpp
@@ -364,7 +364,7 @@ namespace pcl
               child_branch = static_cast<BranchNode*> (child_node);
               branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
             } else {
-              // depth has changed.. child in preceeding buffer is a leaf node.
+              // depth has changed.. child in preceding buffer is a leaf node.
               deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
               child_branch = createBranchChild (*branch_arg, child_idx);
             }
@@ -406,7 +406,7 @@ namespace pcl
               child_leaf = static_cast<LeafNode*> (child_node);
               branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
             } else {
-              // depth has changed.. child in preceeding buffer is a leaf node.
+              // depth has changed.. child in preceding buffer is a leaf node.
               deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
               child_leaf = createLeafChild (*branch_arg, child_idx);
             }
@@ -697,7 +697,7 @@ namespace pcl
                     child_branch = static_cast<BranchNode*> (child_node);
                     branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
                   } else {
-                    // depth has changed.. child in preceeding buffer is a leaf node.
+                    // depth has changed.. child in preceding buffer is a leaf node.
                     deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
                     child_branch = createBranchChild (*branch_arg, child_idx);
                   }
@@ -741,7 +741,7 @@ namespace pcl
                   child_leaf = static_cast<LeafNode*> (child_node);
                   branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
                 } else {
-                  // depth has changed.. child in preceeding buffer is a leaf node.
+                  // depth has changed.. child in preceding buffer is a leaf node.
                   deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
                   child_leaf = createLeafChild (*branch_arg, child_idx);
                 }

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -97,7 +97,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::n
   OctreeKey key;
   key.x = key.y = key.z = 0;
 
-  // initalize smallest point distance in search with high value
+  // initialize smallest point distance in search with high value
   double smallest_dist = std::numeric_limits<double>::max ();
 
   getKNearestNeighborRecursive (p_q, k, this->root_node_, key, 1, smallest_dist, point_candidates);

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -489,7 +489,7 @@ namespace pcl
           return ret;
         }
 
-        /** \brief Check for leaf not existance in the octree
+        /** \brief Check if leaf doesn't exist in the octree
          *  \param key_arg: octree key addressing a leaf node.
          *  \return "true" if leaf node is found; "false" otherwise
          * */

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -344,7 +344,7 @@ namespace pcl
           return result;
         }
 
-        /** \brief Check for existance of a leaf node in the octree
+        /** \brief Check for existence of a leaf node in the octree
          *  \param key_arg: octree key addressing a leaf node.
          *  \return "true" if leaf node is found; "false" otherwise
          * */

--- a/outofcore/include/pcl/outofcore/cJSON.h
+++ b/outofcore/include/pcl/outofcore/cJSON.h
@@ -113,7 +113,7 @@ PCLAPI(void) cJSON_AddItemToObject(cJSON *object,const char *string,cJSON *item)
 PCLAPI(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
 PCLAPI(void) cJSON_AddItemReferenceToObject(cJSON *object,const char *string,cJSON *item);
 
-/* Remove/Detatch items from Arrays/Objects. */
+/* Remove/Detach items from Arrays/Objects. */
 PCLAPI(cJSON *) cJSON_DetachItemFromArray(cJSON *array,int which);
 PCLAPI(void)    cJSON_DeleteItemFromArray(cJSON *array,int which);
 PCLAPI(cJSON *) cJSON_DetachItemFromObject(cJSON *object,const char *string);

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -245,7 +245,7 @@ namespace pcl
 
       if ((start + count) > size ())
       {
-        PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeDiskContainer::%s] Indicies out of range; start + count exceeds the size of the stored points\n", __FUNCTION__);
+        PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeDiskContainer::%s] Indices out of range; start + count exceeds the size of the stored points\n", __FUNCTION__);
         PCL_THROW_EXCEPTION (PCLException, "[pcl::outofcore::OutofcoreOctreeDiskContainer] Outofcore Octree Exception: Read indices exceed range");
       }
 

--- a/outofcore/include/pcl/outofcore/octree_base_node.h
+++ b/outofcore/include/pcl/outofcore/octree_base_node.h
@@ -328,7 +328,7 @@ namespace pcl
          *
          * \param bb_min triple of x,y,z minima for bounding box
          * \param bb_max triple of x,y,z maxima for bounding box
-         * \param tree adress of the tree data structure that will hold this initial root node
+         * \param tree address of the tree data structure that will hold this initial root node
          * \param rootname Root directory for location of on-disk octree storage; if directory 
          * doesn't exist, it is created; if "rootname" is an existing file, 
          * 

--- a/outofcore/include/pcl/outofcore/octree_ram_container.h
+++ b/outofcore/include/pcl/outofcore/octree_ram_container.h
@@ -65,7 +65,7 @@ namespace pcl
       public:
         typedef typename OutofcoreAbstractNodeContainer<PointT>::AlignedPointTVector AlignedPointTVector;
 
-        /** \brief empty contructor (with a path parameter?)
+        /** \brief empty constructor (with a path parameter?)
           */
         OutofcoreOctreeRamContainer (const boost::filesystem::path&) : container_ () { }
         

--- a/outofcore/tools/outofcore_print.cpp
+++ b/outofcore/tools/outofcore_print.cpp
@@ -237,7 +237,7 @@ outofcorePrint (boost::filesystem::path tree_root, size_t print_depth, bool boun
 void
 printHelp (int, char **argv)
 {
-  print_info ("This program is used to process pcd fiels into an outofcore data structure viewable by the");
+  print_info ("This program is used to process pcd files into an outofcore data structure viewable by the");
   print_info ("pcl_outofcore_viewer\n\n");
   print_info ("%s <options> <input_tree_dir> \n", argv[0]);
   print_info ("\n");

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -229,7 +229,7 @@ outofcoreProcess (std::vector<boost::filesystem::path> pcd_paths, boost::filesys
 void
 printHelp (int, char **argv)
 {
-  print_info ("This program is used to process pcd fiels into an outofcore data structure viewable by the");
+  print_info ("This program is used to process pcd files into an outofcore data structure viewable by the");
   print_info ("pcl_outofcore_viewer\n\n");
   print_info ("%s <options> <input>.pcd <output_tree_dir>\n", argv[0]);
   print_info ("\n");

--- a/people/include/pcl/people/ground_based_people_detection_app.h
+++ b/people/include/pcl/people/ground_based_people_detection_app.h
@@ -150,7 +150,7 @@ namespace pcl
       /**
        * \brief Set sensor orientation (vertical = true means portrait mode, vertical = false means landscape mode).
        *
-       * \param[in] vertical Set landscape/portait camera orientation (default = false).
+       * \param[in] vertical Set landscape/portrait camera orientation (default = false).
        */
       void
       setSensorPortraitOrientation (bool vertical);

--- a/people/include/pcl/people/impl/head_based_subcluster.hpp
+++ b/people/include/pcl/people/impl/head_based_subcluster.hpp
@@ -210,7 +210,7 @@ pcl::people::HeadBasedSubclustering<PointT>::createSubClusters (pcl::people::Per
     Eigen::Vector3f p_current_eigen(current_point->x, current_point->y, current_point->z);  // conversion to eigen
     float t = p_current_eigen.dot(head_ground_coeffs) / normalize_factor;       // height from the ground
     maxima_projected.col(i).matrix () = p_current_eigen - head_ground_coeffs * t;         // projection of the point on the groundplane
-    subclusters_number_of_points(i) = 0;                              // intialize number of points
+    subclusters_number_of_points(i) = 0;                              // initialize number of points
   }
 
   // Associate cluster points to one of the maximum:

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -149,7 +149,7 @@ namespace pcl
         return (filtered_quantized_color_gradients_);
       }
   
-      /** \brief Returns a reference to the internally computed spreaded quantized map. */
+      /** \brief Returns a reference to the internally computed spread quantized map. */
       inline QuantizedMap &
       getSpreadedQuantizedMap () 
       { 
@@ -243,7 +243,7 @@ namespace pcl
       /** \brief Determines whether variable numbers of features are extracted or not. */
       bool variable_feature_nr_;
 
-      /** \brief Stores a smoothed verion of the input cloud. */
+      /** \brief Stores a smoothed version of the input cloud. */
 	    pcl::PointCloud<pcl::RGB>::Ptr smoothed_input_;
 
       /** \brief Defines which feature selection method is used. */
@@ -264,7 +264,7 @@ namespace pcl
       pcl::QuantizedMap quantized_color_gradients_;
       /** \brief The map which holds the filtered quantized data. */
       pcl::QuantizedMap filtered_quantized_color_gradients_;
-      /** \brief The map which holds the spreaded quantized data. */
+      /** \brief The map which holds the spread quantized data. */
       pcl::QuantizedMap spreaded_filtered_quantized_color_gradients_;
   
   };

--- a/recognition/include/pcl/recognition/crh_alignment.h
+++ b/recognition/include/pcl/recognition/crh_alignment.h
@@ -176,7 +176,7 @@ namespace pcl
 
       }
 
-      /** \brief Computes the roll angle that aligns input to modle.
+      /** \brief Computes the roll angle that aligns input to model.
        * \param[in] input_ftt CRH histogram of the input cloud
        * \param[in] target_ftt CRH histogram of the target cloud
        * \param[out] peaks Vector containing angles where the histograms correlate

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -94,7 +94,7 @@ namespace pcl
           {
             solution_[index] = val;
             //update optimizer solution
-            cost_ = opt_->evaluateSolution (solution_, index); //this will udpate the cost function in opt_
+            cost_ = opt_->evaluateSolution (solution_, index); //this will update the cost function in opt_
           }
           void setSolution(std::vector<bool> & sol)
           {

--- a/recognition/include/pcl/recognition/impl/hv/greedy_verification.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/greedy_verification.hpp
@@ -53,7 +53,7 @@ template<typename ModelT, typename SceneT>
     // initialize explained_by_RM
     points_explained_by_rm_.resize (scene_cloud_downsampled_->points.size ());
 
-    // initalize model
+    // initialize model
     for (size_t m = 0; m < visible_models_.size (); m++)
     {
       boost::shared_ptr < RecognitionModel > recog_model (new RecognitionModel);

--- a/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
@@ -59,7 +59,7 @@ template<typename ModelT, typename SceneT>
     explained_by_RM_.resize (scene_cloud_downsampled_->points.size ());
     points_explained_by_rm_.resize (scene_cloud_downsampled_->points.size ());
 
-    // initalize model
+    // initialize model
     for (size_t m = 0; m < complete_models_.size (); m++)
     {
       boost::shared_ptr < RecognitionModel > recog_model (new RecognitionModel);
@@ -120,7 +120,7 @@ template<typename ModelT, typename SceneT>
       }
       else
       {
-        mask_[m] = false; // the model didnt survive the sequential check...
+        mask_[m] = false; // the model didn't survive the sequential check...
       }
     }
   }

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -67,7 +67,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::readLTMHeader (int fd, pcl::io::TARHeader &
     return (false);
 
   // We only support regular files for now. 
-  // Addional file types in TAR include: hard links, symbolic links, device/special files, block devices, 
+  // Additional file types in TAR include: hard links, symbolic links, device/special files, block devices, 
   // directories, and named pipes.
   if (header.file_type[0] != '0' && header.file_type[0] != '\0')
     return (false);

--- a/recognition/include/pcl/recognition/implicit_shape_model.h
+++ b/recognition/include/pcl/recognition/implicit_shape_model.h
@@ -357,7 +357,7 @@ namespace pcl
         void
         setTrainingClasses (const std::vector<unsigned int>& training_classes);
 
-        /** \brief This method returns the coresponding cloud of normals for every training point cloud. */
+        /** \brief This method returns the corresponding cloud of normals for every training point cloud. */
         std::vector<typename pcl::PointCloud<NormalT>::Ptr>
         getTrainingNormals ();
 
@@ -405,7 +405,7 @@ namespace pcl
         /** \brief This method allows to set the value of sigma used for calculating the learned weights for every single class.
           * \param[in] training_sigmas new sigmas for every class. If you want these values to be computed automatically,
           * just pass the empty array. The automatic regime calculates the maximum distance between the objects points and takes 10% of
-          * this value as recomended in the article. If there are several objects of the same class,
+          * this value as recommended in the article. If there are several objects of the same class,
           * then it computes the average maximum distance and takes 10%. Note that each class has its own sigma value.
           */
         void
@@ -435,7 +435,7 @@ namespace pcl
           * and returns the list of votes.
           * \param[in] model trained model which will be used for searching the objects
           * \param[in] in_cloud input cloud that need to be investigated
-          * \param[in] in_normals cloud of normals coresponding to the input cloud
+          * \param[in] in_normals cloud of normals corresponding to the input cloud
           * \param[in] in_class_of_interest class which we are looking for
           */
         boost::shared_ptr<pcl::features::ISMVoteList<PointT> >
@@ -567,7 +567,7 @@ namespace pcl
         void
         generateRandomCenter (const std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >& boxes, Eigen::VectorXf& center);
 
-        /** \brief Computes the square distance beetween two vectors.
+        /** \brief Computes the square distance between two vectors.
           * \param[in] vec_1 first vector
           * \param[in] vec_2 second vector
           */

--- a/recognition/include/pcl/recognition/linemod/line_rgbd.h
+++ b/recognition/include/pcl/recognition/linemod/line_rgbd.h
@@ -209,7 +209,7 @@ namespace pcl
       void 
       detect (std::vector<typename pcl::LineRGBD<PointXYZT, PointRGBT>::Detection> & detections);
 
-      /** \brief Applies the detection process in a semi-scale-invariant manner. This is done by acutally
+      /** \brief Applies the detection process in a semi-scale-invariant manner. This is done by actually
         *        scaling the template to different sizes.
         */
       void
@@ -304,7 +304,7 @@ namespace pcl
 
       /** \brief Point clouds corresponding to the templates. */
       pcl::PointCloud<pcl::PointXYZRGBA>::CloudVectorType template_point_clouds_;
-      /** \brief Bounding boxes corresonding to the templates. */
+      /** \brief Bounding boxes corresponding to the templates. */
       std::vector<pcl::BoundingBoxXYZ> bounding_boxes_;
       /** \brief Object IDs corresponding to the templates. */
       std::vector<size_t> object_ids_;

--- a/recognition/include/pcl/recognition/quantizable_modality.h
+++ b/recognition/include/pcl/recognition/quantizable_modality.h
@@ -62,7 +62,7 @@ namespace pcl
       virtual QuantizedMap &
       getQuantizedMap () = 0;
 
-      /** \brief Returns a reference to the internally computed spreaded quantized map. */
+      /** \brief Returns a reference to the internally computed spread quantized map. */
       virtual QuantizedMap &
       getSpreadedQuantizedMap () = 0;
 

--- a/recognition/include/pcl/recognition/ransac_based/voxel_structure.h
+++ b/recognition/include/pcl/recognition/ransac_based/voxel_structure.h
@@ -160,7 +160,7 @@ namespace pcl
       T *voxels_;
       int num_of_voxels_[3], num_of_voxels_xy_plane_, total_num_of_voxels_;
       REAL bounds_[6];
-      REAL spacing_[3]; // spacing betwen the voxel in x, y and z direction = voxel size in x, y and z direction
+      REAL spacing_[3]; // spacing between the voxel in x, y and z direction = voxel size in x, y and z direction
       REAL min_center_[3]; // the center of the voxel with integer coordinates (0, 0, 0)
     };
   } // namespace recognition

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -372,7 +372,7 @@ namespace pcl
         return (filtered_quantized_surface_normals_); 
       }
 
-      /** \brief Returns a reference to the internal spreaded quantized map. */
+      /** \brief Returns a reference to the internal spread quantized map. */
       inline QuantizedMap &
       getSpreadedQuantizedMap () 
       { 
@@ -476,7 +476,7 @@ namespace pcl
       pcl::QuantizedMap quantized_surface_normals_;
       /** \brief Filtered quantized surface normals. */
       pcl::QuantizedMap filtered_quantized_surface_normals_;
-      /** \brief Spreaded quantized surface normals. */
+      /** \brief Spread quantized surface normals. */
       pcl::QuantizedMap spreaded_quantized_surface_normals_;
 
       /** \brief Map containing surface normal orientations. */

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -313,11 +313,11 @@ namespace pcl
         inline const std::string& 
         getClassName () const { return (corr_name_); }
 
-        /** \brief Internal computation initalization. */
+        /** \brief Internal computation initialization. */
         bool
         initCompute ();
         
-        /** \brief Internal computation initalization for reciprocal correspondences. */
+        /** \brief Internal computation initialization for reciprocal correspondences. */
         bool
         initComputeReciprocal ();
 

--- a/registration/include/pcl/registration/correspondence_estimation_backprojection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_backprojection.h
@@ -202,7 +202,7 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::tree_reciprocal_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_;
 
-        /** \brief Internal computation initalization. */
+        /** \brief Internal computation initialization. */
         bool
         initCompute ();
 

--- a/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
+++ b/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
@@ -198,7 +198,7 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::tree_reciprocal_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_;
 
-        /** \brief Internal computation initalization. */
+        /** \brief Internal computation initialization. */
         bool
         initCompute ();
 

--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -346,7 +346,7 @@ namespace pcl
         }
         
         /** \brief Get the correspondence score for a given pair of correspondent points based on 
-          * the angle betweeen the normals. The normmals for the in put and target clouds must be 
+          * the angle between the normals. The normmals for the in put and target clouds must be 
           * set before using this function
           * \param[in] corr Correspondent points
           */

--- a/registration/include/pcl/registration/correspondence_types.h
+++ b/registration/include/pcl/registration/correspondence_types.h
@@ -50,7 +50,7 @@ namespace pcl
       * \param[in] correspondences list of correspondences
       * \param[out] mean the mean descriptor distance of correspondences
       * \param[out] stddev the standard deviation of descriptor distances.
-      * \note The sample varaiance is used to determine the standard deviation
+      * \note The sample variance is used to determine the standard deviation
       */
     inline void 
     getCorDistMeanStd (const pcl::Correspondences& correspondences, double &mean, double &stddev);

--- a/registration/include/pcl/registration/exceptions.h
+++ b/registration/include/pcl/registration/exceptions.h
@@ -59,7 +59,7 @@ namespace pcl
   } ;
 
  /** \class NotEnoughPointsException
-    * \brief An exception that is thrown when the number of correspondants is not equal
+    * \brief An exception that is thrown when the number of correspondents is not equal
     * to the minimum required
     */
   class PCL_EXPORTS NotEnoughPointsException : public PCLException

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -179,7 +179,7 @@ namespace pcl
         * \param[in] cloud_src the source point cloud dataset
         * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
         * \param[in] cloud_tgt the target point cloud dataset
-        * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+        * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
         * \param[out] transformation_matrix the resultant transformation matrix
         */
       void
@@ -253,7 +253,7 @@ namespace pcl
       int k_correspondences_;
 
       /** \brief The epsilon constant for gicp paper; this is NOT the convergence 
-        * tolerence 
+        * tolerance 
         * default: 0.001
         */
       double gicp_epsilon_;
@@ -293,7 +293,7 @@ namespace pcl
       int max_inner_iterations_;
 
       /** \brief compute points covariances matrices according to the K nearest 
-        * neighbors. K is set via setCorrespondenceRandomness() methode.
+        * neighbors. K is set via setCorrespondenceRandomness() method.
         * \param cloud pointer to point cloud
         * \param tree KD tree performer for nearest neighbors search
         * \param[out] cloud_covariances covariances matrices for each point in the cloud

--- a/registration/include/pcl/registration/ia_fpcs.h
+++ b/registration/include/pcl/registration/ia_fpcs.h
@@ -515,7 +515,7 @@ namespace pcl
       /** \brief Estimated squared metric overlap between source and target.
         * \note Internally calculated using the estimated overlap and the extent of the source cloud.
         * It is used to derive the minimum sampling distance of the base points as well as to calculated
-        * the number of trys to reliable find a correct mach.
+        * the number of tries to reliably find a correct match.
         */
       float max_base_diameter_sqr_;
 

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -258,7 +258,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
     Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap ();
     Eigen::Vector4f pp (transformation_matrix * p_src);
     // Estimate the distance (cost function)
-    // The last coordiante is still guaranteed to be set to 1.0
+    // The last coordinate is still guaranteed to be set to 1.0
     Eigen::Vector3d res(pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     Eigen::Vector3d temp (gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]) * res);
     //increment= res'*temp/num_matches = temp'*M*temp/num_matches (we postpone 1/num_matches after the loop closes)
@@ -286,7 +286,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
     Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap ();
 
     Eigen::Vector4f pp (transformation_matrix * p_src);
-    // The last coordiante is still guaranteed to be set to 1.0
+    // The last coordinate is still guaranteed to be set to 1.0
     Eigen::Vector3d res (pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     // temp = M*res
     Eigen::Vector3d temp (gicp_->mahalanobis ((*gicp_->tmp_idx_src_)[i]) * res);
@@ -320,7 +320,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
     // The last coordinate, p_tgt[3] is guaranteed to be set to 1.0 in registration.hpp
     Vector4fMapConst p_tgt = gicp_->tmp_tgt_->points[(*gicp_->tmp_idx_tgt_)[i]].getVector4fMap ();
     Eigen::Vector4f pp (transformation_matrix * p_src);
-    // The last coordiante is still guaranteed to be set to 1.0
+    // The last coordinate is still guaranteed to be set to 1.0
     Eigen::Vector3d res (pp[0] - p_tgt[0], pp[1] - p_tgt[1], pp[2] - p_tgt[2]);
     // temp = M*res
     Eigen::Vector3d temp (gicp_->mahalanobis((*gicp_->tmp_idx_src_)[i]) * res);

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -187,7 +187,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
         // select four coplanar point base
         if (selectBase (base_indices, ratio) == 0)
         {
-          // calculate candidate pair correspondences using diagonal lenghts of base
+          // calculate candidate pair correspondences using diagonal lengths of base
           pcl::Correspondences pairs_a, pairs_b;
           if (bruteForceCorrespondences (base_indices[0], base_indices[1], pairs_a) == 0 &&
             bruteForceCorrespondences (base_indices[2], base_indices[3], pairs_b) == 0)
@@ -217,7 +217,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   }
   
 
-  // determine best match over all trys
+  // determine best match over all tries
   finalCompute (all_candidates);
 
   // apply the final transformation
@@ -343,7 +343,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   Eigen::Vector4f centre_pt;
   float nearest_to_plane = FLT_MAX;
 
-  // repeat base search until valid quadruple was found or ransac_iterations_ number of trys were unsuccessfull
+  // repeat base search until valid quadruple was found or ransac_iterations_ number of tries were unsuccessful
   for (int i = 0; i < ransac_iterations_; i++)
   {
     // random select an appropriate point triple
@@ -382,7 +382,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
       }
     }
 
-    // check if at least one point fullfilled the conditions
+    // check if at least one point fulfilled the conditions
     if (nearest_to_plane != FLT_MAX)
     {
       // order points to build largest quadrangle and calcuate intersection ratios of diagonals
@@ -391,7 +391,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     }
   }
 
-  // return unsuccessfull if no quadruple was selected
+  // return unsuccessful if no quadruple was selected
   return (-1);
 }
 
@@ -697,7 +697,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     }
   }
 
-  // return unsuccessfull if no match was found
+  // return unsuccessful if no match was found
   return (matches.size () > 0 ? 0 : -1);
 }
 
@@ -868,7 +868,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
       break;
   }
 
-  // check current costs and return unsuccessfull if larger than previous ones
+  // check current costs and return unsuccessful if larger than previous ones
   inlier_score_temp /= static_cast <float> (nr_points);
   float fitness_score_temp = 1.f - inlier_score_temp;
 
@@ -885,7 +885,7 @@ template <typename PointSource, typename PointTarget, typename NormalT, typename
 pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::finalCompute (
   const std::vector <MatchingCandidates > &candidates)
 {
-  // get best fitness_score over all trys
+  // get best fitness_score over all tries
   int nr_candidates = static_cast <int> (candidates.size ());
   int best_index = -1;
   float best_score = FLT_MAX;

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -164,7 +164,7 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
     scale += lambda_;
   }
 
-  // calculate the fitness and return unsuccessfull if smaller than previous ones
+  // calculate the fitness and return unsuccessful if smaller than previous ones
   float fitness_score_temp = (score_a + lambda_ * score_b) / scale;
   if (fitness_score_temp > fitness_score)
     return (-1);

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -235,7 +235,7 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
     // Estimate the transform from the samples to their corresponding points
     transformation_estimation_->estimateRigidTransformation (*input_, sample_indices, *target_, corresponding_indices, transformation_);
 
-    // Tranform the data and compute the error
+    // Transform the data and compute the error
     transformPointCloud (*input_, input_transformed, transformation_);
     error = computeErrorMetric (input_transformed, static_cast<float> (corr_dist_threshold_));
 

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -221,7 +221,7 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
     // Estimate the transform
     transformation_estimation_->estimateRigidTransformation (*input_transformed, *target_, *correspondences_, transformation_);
 
-    // Tranform the data
+    // Transform the data
     transformCloud (*input_transformed, *input_transformed, transformation_);
 
     // Obtain the final transformation    

--- a/registration/include/pcl/registration/impl/joint_icp.hpp
+++ b/registration/include/pcl/registration/impl/joint_icp.hpp
@@ -236,7 +236,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
     // Estimate the transform jointly, on a combined correspondence set
     transformation_estimation_->estimateRigidTransformation (*inputs_transformed_combined, *targets_combined, *correspondences_, transformation_);
 
-    // Tranform the combined data
+    // Transform the combined data
     this->transformCloud (*inputs_transformed_combined, *inputs_transformed_combined, transformation_);
     // And all its components
     for (size_t i = 0; i < sources_.size (); i++)

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -61,7 +61,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributions
 
   double gauss_c1, gauss_c2, gauss_d3;
 
-  // Initializes the guassian fitting parameters (eq. 6.8) [Magnusson 2009]
+  // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10.0 * (1 - outlier_ratio_);
   gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
   gauss_d3 = -log (gauss_c2);
@@ -81,7 +81,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformati
 
   double gauss_c1, gauss_c2, gauss_d3;
 
-  // Initializes the guassian fitting parameters (eq. 6.8) [Magnusson 2009]
+  // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   gauss_c1 = 10 * (1 - outlier_ratio_);
   gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
   gauss_d3 = -log (gauss_c2);
@@ -362,7 +362,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
   double e_x_cov_x = exp (-gauss_d2_ * x_trans.dot (c_inv * x_trans) / 2);
-  // Calculate probability of transtormed points existance, Equation 6.9 [Magnusson 2009]
+  // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
   double score_inc = -gauss_d1_ * e_x_cov_x;
 
   e_x_cov_x = gauss_d2_ * e_x_cov_x;
@@ -686,7 +686,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT
   // Iterate until max number of iterations, interval convergance or a value satisfies the sufficient decrease, Equation 1.1, and curvature condition, Equation 1.2 [More, Thuente 1994]
   while (!interval_converged && step_iterations < max_step_iterations && !(psi_t <= 0 /*Sufficient Decrease*/ && d_phi_t <= -nu * d_phi_0 /*Curvature Condition*/))
   {
-    // Use auxilary function if interval I is not closed
+    // Use auxiliary function if interval I is not closed
     if (open_interval)
     {
       a_t = trialValueSelectionMT (a_l, f_l, g_l,

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -348,7 +348,7 @@ namespace pcl
                            PointCloudSource &trans_cloud);
 
       /** \brief Update interval of possible step lengths for More-Thuente method, \f$ I \f$ in More-Thuente (1994)
-        * \note Updating Algorithm until some value satifies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+        * \note Updating Algorithm until some value satisfies \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
         * and Modified Updating Algorithm from then on [More, Thuente 1994].
         * \param[in,out] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
         * \param[in,out] f_l value at first endpoint, \f$ f_l \f$ in Moore-Thuente (1994), \f$ \psi(\alpha_l) \f$ for Update Algorithm and \f$ \phi(\alpha_l) \f$ for Modified Update Algorithm
@@ -368,7 +368,7 @@ namespace pcl
 
       /** \brief Select new trial value for More-Thuente method.
         * \note Trial Value Selection [More, Thuente 1994], \f$ \psi(\alpha_k) \f$ is used for \f$ f_k \f$ and \f$ g_k \f$
-        * until some value satifies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
+        * until some value satisfies the test \f$ \psi(\alpha_k) \leq 0 \f$ and \f$ \phi'(\alpha_k) \geq 0 \f$
         * then \f$ \phi(\alpha_k) \f$ is used from then on.
         * \note Interpolation Minimizer equations from Optimization Theory and Methods: Nonlinear Programming By Wenyu Sun, Ya-xiang Yuan (89-100).
         * \param[in] a_l first endpoint of interval \f$ I \f$, \f$ \alpha_l \f$ in Moore-Thuente (1994)
@@ -387,14 +387,14 @@ namespace pcl
                              double a_u, double f_u, double g_u,
                              double a_t, double f_t, double g_t);
 
-      /** \brief Auxilary function used to determin endpoints of More-Thuente interval.
+      /** \brief Auxiliary function used to determine endpoints of More-Thuente interval.
         * \note \f$ \psi(\alpha) \f$ in Equation 1.6 (Moore, Thuente 1994)
         * \param[in] a the step length, \f$ \alpha \f$ in More-Thuente (1994)
         * \param[in] f_a function value at step length a, \f$ \phi(\alpha) \f$ in More-Thuente (1994)
         * \param[in] f_0 initial function value, \f$ \phi(0) \f$ in Moore-Thuente (1994)
         * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
         * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-        * \return sufficent decrease value
+        * \return sufficient decrease value
         */
       inline double
       auxilaryFunction_PsiMT (double a, double f_a, double f_0, double g_0, double mu = 1.e-4)
@@ -402,12 +402,12 @@ namespace pcl
         return (f_a - f_0 - mu * g_0 * a);
       }
 
-      /** \brief Auxilary function derivative used to determin endpoints of More-Thuente interval.
+      /** \brief Auxiliary function derivative used to determine endpoints of More-Thuente interval.
         * \note \f$ \psi'(\alpha) \f$, derivative of Equation 1.6 (Moore, Thuente 1994)
         * \param[in] g_a function gradient at step length a, \f$ \phi'(\alpha) \f$ in More-Thuente (1994)
         * \param[in] g_0 initial function gradiant, \f$ \phi'(0) \f$ in More-Thuente (1994)
         * \param[in] mu the step length, constant \f$ \mu \f$ in Equation 1.1 [More, Thuente 1994]
-        * \return sufficent decrease derivative
+        * \return sufficient decrease derivative
         */
       inline double
       auxilaryFunction_dPsiMT (double g_a, double g_0, double mu = 1.e-4)

--- a/registration/include/pcl/registration/pyramid_feature_matching.h
+++ b/registration/include/pcl/registration/pyramid_feature_matching.h
@@ -119,7 +119,7 @@ namespace pcl
       isComputed () { return is_computed_; }
 
       /** \brief Static method for comparing two pyramid histograms that returns a floating point value between 0 and 1,
-       * representing the similiarity between the feature sets on which the two pyramid histograms are based.
+       * representing the similarity between the feature sets on which the two pyramid histograms are based.
        * \param pyramid_a Pointer to the first pyramid to be compared (needs to be computed already).
        * \param pyramid_b Pointer to the second pyramid to be compared (needs to be computed already).
        */

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -422,7 +422,7 @@ namespace pcl
       inline const std::string&
       getClassName () const { return (reg_name_); }
         
-      /** \brief Internal computation initalization. */
+      /** \brief Internal computation initialization. */
       bool
       initCompute ();
 
@@ -528,7 +528,7 @@ namespace pcl
       double euclidean_fitness_epsilon_;
 
       /** \brief The maximum distance threshold between two correspondent points in source <-> target. If the 
-        * distance is larger than this threshold, the points will be ignored in the alignement process.
+        * distance is larger than this threshold, the points will be ignored in the alignment process.
         */
       double corr_dist_threshold_;
 

--- a/registration/include/pcl/registration/transformation_estimation.h
+++ b/registration/include/pcl/registration/transformation_estimation.h
@@ -95,7 +95,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         virtual void

--- a/registration/include/pcl/registration/transformation_estimation_2D.h
+++ b/registration/include/pcl/registration/transformation_estimation_2D.h
@@ -95,7 +95,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         virtual void

--- a/registration/include/pcl/registration/transformation_estimation_3point.h
+++ b/registration/include/pcl/registration/transformation_estimation_3point.h
@@ -101,7 +101,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         virtual void

--- a/registration/include/pcl/registration/transformation_estimation_dq.h
+++ b/registration/include/pcl/registration/transformation_estimation_dq.h
@@ -96,7 +96,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void

--- a/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
+++ b/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
@@ -96,7 +96,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void

--- a/registration/include/pcl/registration/transformation_estimation_lm.h
+++ b/registration/include/pcl/registration/transformation_estimation_lm.h
@@ -219,7 +219,7 @@ namespace pcl
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
-          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the chosen _Scalar
+          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) depending on the chosen _Scalar
           */
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor

--- a/registration/include/pcl/registration/transformation_estimation_lm.h
+++ b/registration/include/pcl/registration/transformation_estimation_lm.h
@@ -133,7 +133,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from 
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from 
           * \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
@@ -219,7 +219,7 @@ namespace pcl
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
-          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the choosen _Scalar
+          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the chosen _Scalar
           */
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor
@@ -234,7 +234,7 @@ namespace pcl
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,1> ValueType;
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
 
-          /** \brief Empty Construtor. */
+          /** \brief Empty Constructor. */
           Functor () : m_data_points_ (ValuesAtCompileTime) {}
 
           /** \brief Constructor

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
@@ -99,7 +99,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void
@@ -135,7 +135,7 @@ namespace pcl
                                      ConstCloudIterator<PointTarget>& target_it, 
                                      Matrix4 &transformation_matrix) const;
 
-        /** \brief Construct a 4 by 4 tranformation matrix from the provided rotation and translation.
+        /** \brief Construct a 4 by 4 transformation matrix from the provided rotation and translation.
           * \param[in] alpha the rotation about the x-axis
           * \param[in] beta the rotation about the y-axis
           * \param[in] gamma the rotation about the z-axis

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
@@ -99,7 +99,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void
@@ -145,7 +145,7 @@ namespace pcl
                                      typename std::vector<Scalar>::const_iterator& weights_it,
                                      Matrix4 &transformation_matrix) const;
 
-        /** \brief Construct a 4 by 4 tranformation matrix from the provided rotation and translation.
+        /** \brief Construct a 4 by 4 transformation matrix from the provided rotation and translation.
           * \param[in] alpha the rotation about the x-axis
           * \param[in] beta the rotation about the y-axis
           * \param[in] gamma the rotation about the z-axis

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -204,7 +204,7 @@ namespace pcl
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
-          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the chosen _Scalar
+          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) depending on the chosen _Scalar
           */
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -139,7 +139,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from 
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from 
           * \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           * \note Uses the weights given by setWeights.
@@ -204,7 +204,7 @@ namespace pcl
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
-          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the choosen _Scalar
+          * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the chosen _Scalar
           */
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor
@@ -219,7 +219,7 @@ namespace pcl
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,1> ValueType;
           typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
 
-          /** \brief Empty Construtor. */
+          /** \brief Empty Constructor. */
           Functor () : m_data_points_ (ValuesAtCompileTime) {}
 
           /** \brief Constructor

--- a/registration/include/pcl/registration/transformation_estimation_svd.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd.h
@@ -99,7 +99,7 @@ namespace pcl
           * \param[in] cloud_src the source point cloud dataset
           * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
           * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interst points from \a indices_src
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
           * \param[out] transformation_matrix the resultant transformation matrix
           */
         inline void

--- a/registration/include/pcl/registration/transformation_validation.h
+++ b/registration/include/pcl/registration/transformation_validation.h
@@ -101,7 +101,7 @@ namespace pcl
         /** \brief Comparator function for deciding which score is better after running the 
           * validation on multiple transforms. Pure virtual.
           *
-          * \note For example, for Euclidean distances smaller is better, for inliers the oposite.
+          * \note For example, for Euclidean distances smaller is better, for inliers the opposite.
           *
           * \param[in] score1 the first value
           * \param[in] score2 the second value

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -311,7 +311,7 @@ namespace pcl
         PCL_DEBUG("[pcl::%s::computeTransformation] Convergence failed\n",
             getClassName ().c_str ());
     }
-    //for some reason the static equivalent methode raises an error
+    //for some reason the static equivalent method raises an error
     // final_transformation_.block<3,3> (0,0) = (transformation_.block<3,3> (0,0)) * (guess.block<3,3> (0,0));
     // final_transformation_.block <3, 1> (0, 3) = transformation_.block <3, 1> (0, 3) + guess.rightCols<1>.block <3, 1> (0, 3);
     final_transformation_.topLeftCorner (3, 3) =

--- a/sample_consensus/include/pcl/sample_consensus/impl/lmeds.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/lmeds.hpp
@@ -65,7 +65,7 @@ pcl::LeastMedianSquares<PointT>::computeModel (int debug_verbosity_level)
   int n_inliers_count = 0;
 
   unsigned skipped_count = 0;
-  // supress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
+  // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
   const unsigned max_skip = max_iterations_ * 10;
   
   // Iterate

--- a/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
@@ -78,7 +78,7 @@ pcl::MaximumLikelihoodSampleConsensus<PointT>::computeModel (int debug_verbosity
   int n_inliers_count = 0;
   size_t indices_size;
   unsigned skipped_count = 0;
-  // supress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
+  // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
   const unsigned max_skip = max_iterations_ * 10;
   
   // Iterate

--- a/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
@@ -65,7 +65,7 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
 
   int n_inliers_count = 0;
   unsigned skipped_count = 0;
-  // supress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
+  // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
   const unsigned max_skip = max_iterations_ * 10;
   
   // Iterate

--- a/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
@@ -66,7 +66,7 @@ pcl::RandomSampleConsensus<PointT>::computeModel (int)
 
   int n_inliers_count = 0;
   unsigned skipped_count = 0;
-  // supress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
+  // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
   const unsigned max_skip = max_iterations_ * 10;
   
   // Iterate

--- a/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
@@ -66,7 +66,7 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
 
   int n_inliers_count = 0;
   unsigned skipped_count = 0;
-  // supress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
+  // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
   const unsigned max_skip = max_iterations_ * 10;
   
   // Number of samples to try randomly

--- a/sample_consensus/include/pcl/sample_consensus/impl/rransac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rransac.hpp
@@ -64,7 +64,7 @@ pcl::RandomizedRandomSampleConsensus<PointT>::computeModel (int debug_verbosity_
 
   int n_inliers_count = 0;
   unsigned skipped_count = 0;
-  // supress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
+  // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
   const unsigned max_skip = max_iterations_ * 10;
 
   // Number of samples to try randomly

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -172,7 +172,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::getDistancesToModel (
     // Calculate the cones perfect normals
     Eigen::Vector4f cone_normal = sinf (opening_angle) * height + cosf (opening_angle) * dir;
 
-    // Aproximate the distance from the point to the cone as the difference between
+    // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
     double d_euclid = fabs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
 
@@ -228,7 +228,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::selectWithinDistance (
     // Calculate the cones perfect normals
     Eigen::Vector4f cone_normal = sinf (opening_angle) * height + cosf (opening_angle) * pp_pt_dir;
 
-    // Aproximate the distance from the point to the cone as the difference between
+    // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
     double d_euclid = fabs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
 
@@ -290,7 +290,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::countWithinDistance (
     // Calculate the cones perfect normals
     Eigen::Vector4f cone_normal = sinf (opening_angle) * height + cosf (opening_angle) * pp_pt_dir;
 
-    // Aproximate the distance from the point to the cone as the difference between
+    // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
     double d_euclid = fabs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
 
@@ -473,7 +473,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::doSamplesVerifyModel (
     Eigen::Vector4f height = apex - pt_proj;
     double actual_cone_radius = tan (openning_angle) * height.norm ();
 
-    // Aproximate the distance from the point to the cone as the difference between
+    // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
     if (fabs (static_cast<double>(pointToAxisDistance (pt, model_coefficients) - actual_cone_radius)) > threshold)
       return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -147,7 +147,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::getDistancesToModel (
   // Iterate through the 3d points and calculate the distances from them to the sphere
   for (size_t i = 0; i < indices_->size (); ++i)
   {
-    // Aproximate the distance from the point to the cylinder as the difference between
+    // Approximate the distance from the point to the cylinder as the difference between
     // dist(point,cylinder_axis) and cylinder radius
     // @note need to revise this.
     Eigen::Vector4f pt (input_->points[(*indices_)[i]].x, input_->points[(*indices_)[i]].y, input_->points[(*indices_)[i]].z, 0);
@@ -192,7 +192,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::selectWithinDistance (
   // Iterate through the 3d points and calculate the distances from them to the sphere
   for (size_t i = 0; i < indices_->size (); ++i)
   {
-    // Aproximate the distance from the point to the cylinder as the difference between
+    // Approximate the distance from the point to the cylinder as the difference between
     // dist(point,cylinder_axis) and cylinder radius
     Eigen::Vector4f pt (input_->points[(*indices_)[i]].x, input_->points[(*indices_)[i]].y, input_->points[(*indices_)[i]].z, 0);
     Eigen::Vector4f n  (normals_->points[(*indices_)[i]].normal[0], normals_->points[(*indices_)[i]].normal[1], normals_->points[(*indices_)[i]].normal[2], 0);
@@ -239,7 +239,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::countWithinDistance (
   // Iterate through the 3d points and calculate the distances from them to the sphere
   for (size_t i = 0; i < indices_->size (); ++i)
   {
-    // Aproximate the distance from the point to the cylinder as the difference between
+    // Approximate the distance from the point to the cylinder as the difference between
     // dist(point,cylinder_axis) and cylinder radius
     Eigen::Vector4f pt (input_->points[(*indices_)[i]].x, input_->points[(*indices_)[i]].y, input_->points[(*indices_)[i]].z, 0);
     Eigen::Vector4f n  (normals_->points[(*indices_)[i]].normal[0], normals_->points[(*indices_)[i]].normal[1], normals_->points[(*indices_)[i]].normal[2], 0);
@@ -400,7 +400,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::doSamplesVerifyModel (
 
   for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
   {
-    // Aproximate the distance from the point to the cylinder as the difference between
+    // Approximate the distance from the point to the cylinder as the difference between
     // dist(point,cylinder_axis) and cylinder radius
     // @note need to revise this.
     Eigen::Vector4f pt (input_->points[*it].x, input_->points[*it].y, input_->points[*it].z, 0);

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -647,7 +647,7 @@ namespace pcl
 
   /** Base functor all the models that need non linear optimization must
     * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
-    * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) dependening on the choosen _Scalar
+    * or operator() (const Eigen::VectorXf& x, Eigen::VectorXf& fvec) depending on the chosen _Scalar
     */
   template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
   struct Functor

--- a/segmentation/include/pcl/segmentation/cpc_segmentation.h
+++ b/segmentation/include/pcl/segmentation/cpc_segmentation.h
@@ -157,7 +157,7 @@ namespace pcl
       /** \brief Use clean cutting */
       bool use_clean_cutting_;
       
-      /** \brief Interations for RANSAC */
+      /** \brief Iterations for RANSAC */
       uint32_t ransac_itrs_;
      
       

--- a/segmentation/include/pcl/segmentation/grabcut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/grabcut_segmentation.h
@@ -195,7 +195,7 @@ namespace pcl
       colorDistance (const Color& c1, const Color& c2);
       /// User supplied Trimap values
       enum TrimapValue { TrimapUnknown = -1, TrimapForeground, TrimapBackground };
-      /// Grabcut derived hard segementation values
+      /// Grabcut derived hard segmentation values
       enum SegmentationValue { SegmentationForeground = 0, SegmentationBackground };
       /// Gaussian structure
       struct Gaussian
@@ -211,9 +211,9 @@ namespace pcl
         Eigen::Matrix3f inverse;
         /// weighting of this gaussian in the GMM.
         float pi;
-        /// heighest eigenvalue of covariance matrix
+        /// highest eigenvalue of covariance matrix
         float eigenvalue;
-        /// eigenvector corresponding to the heighest eigenvector
+        /// eigenvector corresponding to the highest eigenvector
         Eigen::Vector3f eigenvector;
       };
 
@@ -332,7 +332,7 @@ namespace pcl
         , nb_neighbours_ (9)
         , initialized_ (false)
       {}
-      /// Desctructor
+      /// Destructor
       virtual ~GrabCut () {};
       // /// Set input cloud
       void

--- a/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
@@ -68,7 +68,7 @@ pcl::CPCSegmentation<PointT>::segment ()
     // Correct edge relations using extended convexity definition if k>0
     applyKconvexity (k_factor_);
 
-    // Determine wether to use cutting planes
+    // Determine whether to use cutting planes
     doGrouping ();
 
     grouping_data_valid_ = true;
@@ -98,7 +98,7 @@ pcl::CPCSegmentation<PointT>::applyCuttingPlane (uint32_t depth_levels_left)
   boost::tie (edge_itr, edge_itr_end) = boost::edges (sv_adjacency_list_);
   for (next_edge = edge_itr; edge_itr != edge_itr_end; edge_itr = next_edge)
   {
-    next_edge++;  // next_edge iterator is neccessary, because removing an edge invalidates the iterator to the current edge
+    next_edge++;  // next_edge iterator is necessary, because removing an edge invalidates the iterator to the current edge
     uint32_t source_sv_label = sv_adjacency_list_[boost::source (*edge_itr, sv_adjacency_list_)];
     uint32_t target_sv_label = sv_adjacency_list_[boost::target (*edge_itr, sv_adjacency_list_)];
 
@@ -183,7 +183,7 @@ pcl::CPCSegmentation<PointT>::applyCuttingPlane (uint32_t depth_levels_left)
       Eigen::Vector3f plane_normal (model_coefficients[0], model_coefficients[1], model_coefficients[2]);
       // Cut the connections.
       // We only interate through the points which are within the support (when we are local, otherwise all points in the segment).
-      // We also just acutally cut when the edge goes through the plane. This is why we check the planedistance
+      // We also just actually cut when the edge goes through the plane. This is why we check the planedistance
       std::vector<pcl::PointIndices> cluster_indices;
       pcl::EuclideanClusterExtraction<WeightSACPointType> euclidean_clusterer;
       pcl::search::KdTree<WeightSACPointType>::Ptr tree (new pcl::search::KdTree<WeightSACPointType>);
@@ -225,7 +225,7 @@ pcl::CPCSegmentation<PointT>::applyCuttingPlane (uint32_t depth_levels_left)
       }
       if (cut_support_indices.size () == 0)
       {
-//         std::cout << "Could not find planes which exceed required minumum score (threshold " << min_cut_score_ << "), not cutting" << std::endl;
+//         std::cout << "Could not find planes which exceed required minimum score (threshold " << min_cut_score_ << "), not cutting" << std::endl;
         continue;
       }
     }
@@ -303,7 +303,7 @@ pcl::CPCSegmentation<PointT>::WeightedRandomSampleConsensus::computeModel (int)
   Eigen::VectorXf model_coefficients;
 
   unsigned skipped_count = 0;
-  // supress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
+  // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
   const unsigned max_skip = max_iterations_ * 10;
 
   // Iterate

--- a/segmentation/include/pcl/segmentation/impl/lccp_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/lccp_segmentation.hpp
@@ -248,7 +248,7 @@ pcl::LCCPSegmentation<PointT>::mergeSmallSegments ()
 
     // After filtered Segments are deleted, compute completely new adjacency map
     // NOTE Recomputing the adjacency of every segment in every iteration is an easy but inefficient solution.
-    // Because the number of segments in an average scene is usually well below 1000, the time spend for noise filtering is still neglible in most cases
+    // Because the number of segments in an average scene is usually well below 1000, the time spend for noise filtering is still negligible in most cases
     computeSegmentAdjacency ();
   }  // End while (Filtering)
 }
@@ -349,7 +349,7 @@ pcl::LCCPSegmentation<PointT>::recursiveSegmentGrowing (const VertexID &query_po
   sv_label_to_seg_label_map_[sv_label] = segment_label;
   seg_label_to_sv_list_map_[segment_label].insert (sv_label);
 
-  // Iterate through all neighbors of this supervoxel and check wether they should be merged with the current supervoxel
+  // Iterate through all neighbors of this supervoxel and check whether they should be merged with the current supervoxel
   std::pair<OutEdgeIterator, OutEdgeIterator> out_edge_iterator_range;
   out_edge_iterator_range = boost::out_edges (query_point_id, sv_adjacency_list_);  // adjacent vertices to node (*itr) in graph sv_adjacency_list_
   for (OutEdgeIterator out_Edge_itr = out_edge_iterator_range.first; out_Edge_itr != out_edge_iterator_range.second; ++out_Edge_itr)
@@ -385,7 +385,7 @@ pcl::LCCPSegmentation<PointT>::applyKconvexity (const unsigned int k_arg)
   // Check all edges in the graph for k-convexity
   for (next_edge = edge_itr; edge_itr != edge_itr_end; edge_itr = next_edge)
   {
-    next_edge++;  // next_edge iterator is neccessary, because removing an edge invalidates the iterator to the current edge
+    next_edge++;  // next_edge iterator is necessary, because removing an edge invalidates the iterator to the current edge
 
     is_convex = sv_adjacency_list_[*edge_itr].is_convex;
 
@@ -443,7 +443,7 @@ pcl::LCCPSegmentation<PointT>::calculateConvexConnections (SupervoxelAdjacencyLi
 
   for (next_edge = edge_itr; edge_itr != edge_itr_end; edge_itr = next_edge)
   {
-    next_edge++;  // next_edge iterator is neccessary, because removing an edge invalidates the iterator to the current edge
+    next_edge++;  // next_edge iterator is necessary, because removing an edge invalidates the iterator to the current edge
 
     uint32_t source_sv_label = adjacency_list_arg[boost::source (*edge_itr, adjacency_list_arg)];
     uint32_t target_sv_label = adjacency_list_arg[boost::target (*edge_itr, adjacency_list_arg)];

--- a/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
@@ -68,7 +68,7 @@ pcl::OrganizedConnectedComponentSegmentation<PointT, PointLT>::findLabeledRegion
                              Neighbor( 0,  1,  labels->width    ),
                              Neighbor(-1,  1,  labels->width - 1)};
   
-  // find one pixel with other label in the neighborhood -> assume thats the one we came from
+  // find one pixel with other label in the neighborhood -> assume that's the one we came from
   int direction = -1;
   int x;
   int y;

--- a/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
@@ -317,7 +317,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::refine (std::vec
                                                                         PointCloudLPtr& labels,
                                                                         std::vector<pcl::PointIndices>& label_indices)
 {
-  //List of lables to grow, and index of model corresponding to each label
+  //List of labels to grow, and index of model corresponding to each label
   std::vector<bool> grow_labels;
   std::vector<int> label_to_model;
   grow_labels.resize (label_indices.size (), false);

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -317,12 +317,12 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findRegionsKNN (int index, int nghbr_num
   distances.resize (clusters_.size (), max_dist);
 
   int number_of_points = num_pts_in_segment_[index];
-  //loop throug every point in this segment and check neighbours
+  //loop through every point in this segment and check neighbours
   for (int i_point = 0; i_point < number_of_points; i_point++)
   {
     int point_index = clusters_[index].indices[i_point];
     int number_of_neighbours = static_cast<int> (point_neighbours_[point_index].size ());
-    //loop throug every neighbour of the current point, find out to which segment it belongs
+    //loop through every neighbour of the current point, find out to which segment it belongs
     //and if it belongs to neighbouring segment and is close enough then remember segment and its distance
     for (int i_nghbr = 0; i_nghbr < number_of_neighbours; i_nghbr++)
     {

--- a/segmentation/include/pcl/segmentation/lccp_segmentation.h
+++ b/segmentation/include/pcl/segmentation/lccp_segmentation.h
@@ -61,10 +61,10 @@ namespace pcl
     /** \brief Edge Properties stored in the adjacency graph.*/
     struct EdgeProperties
     {
-      /** \brief Desribes the difference of normals of the two supervoxels being connected*/
+      /** \brief Describes the difference of normals of the two supervoxels being connected*/
       float normal_difference;
       
-      /** \brief Desribes if a connection is convex or concave*/
+      /** \brief Describes if a connection is convex or concave*/
       bool is_convex;
       
       /** \brief Describes if a connection is valid for the segment growing. Usually convex connections are and concave connection are not. Due to k-concavity a convex connection can be invalidated*/
@@ -301,7 +301,7 @@ namespace pcl
       /** \brief Normal Threshold in degrees [0,180] used for merging */
       float concavity_tolerance_threshold_;
 
-      /** \brief Marks if valid grouping data (\ref sv_adjacency_list_, \ref sv_label_to_seg_label_map_, \ref processed_) is avaiable */
+      /** \brief Marks if valid grouping data (\ref sv_adjacency_list_, \ref sv_label_to_seg_label_map_, \ref processed_) is available */
       bool grouping_data_valid_;
       
       /** \brief Marks if supervoxels have been set by calling \ref setInputSupervoxels */

--- a/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
@@ -111,7 +111,7 @@ namespace pcl
       segment (pcl::PointCloud<PointLT>& labels, std::vector<pcl::PointIndices>& label_indices) const;
       
       /** \brief Find the boundary points / contour of a connected component
-        * \param[in] start_idx the first (lowest) index of the connected component for which a boundary shoudl be returned
+        * \param[in] start_idx the first (lowest) index of the connected component for which a boundary should be returned
         * \param[in] labels the Label cloud produced by segmentation
         * \param[out] boundary_indices the indices of the boundary points for the label corresponding to start_idx
         */

--- a/segmentation/include/pcl/segmentation/sac_segmentation.h
+++ b/segmentation/include/pcl/segmentation/sac_segmentation.h
@@ -370,7 +370,7 @@ namespace pcl
       getNormalDistanceWeight () const { return (distance_weight_); }
 
       /** \brief Set the minimum opning angle for a cone model.
-        * \param min_angle the opening angle which we need minumum to validate a cone model.
+        * \param min_angle the opening angle which we need minimum to validate a cone model.
         * \param max_angle the opening angle which we need maximum to validate a cone model.
         */
       inline void
@@ -380,7 +380,7 @@ namespace pcl
         max_angle_ = max_angle;
       }
  
-      /** \brief Get the opening angle which we need minumum to validate a cone model. */
+      /** \brief Get the opening angle which we need minimum to validate a cone model. */
       inline void
       getMinMaxOpeningAngle (double &min_angle, double &max_angle)
       {

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -272,7 +272,7 @@ namespace pcl
         * Points that belong to the same supervoxel have the same color.
         * But this function doesn't guarantee that different segments will have different
         * color(it's random). Points that are unlabeled will be black
-        * \note This will expand the label_colors_ vector so that it can accomodate all labels
+        * \note This will expand the label_colors_ vector so that it can accommodate all labels
         */
       PCL_DEPRECATED ("SupervoxelClustering::getColoredCloud is deprecated. Use the getLabeledCloud function instead. examples/segmentation/example_supervoxels.cpp shows how to use this to display and save with colorized labels.")
       typename pcl::PointCloud<PointXYZRGBA>::Ptr
@@ -297,7 +297,7 @@ namespace pcl
        * Points that belong to the same supervoxel have the same color.
        * But this function doesn't guarantee that different segments will have different
        * color(it's random). Points that are unlabeled will be black
-       * \note This will expand the label_colors_ vector so that it can accomodate all labels
+       * \note This will expand the label_colors_ vector so that it can accommodate all labels
        */
       PCL_DEPRECATED ("SupervoxelClustering::getColoredVoxelCloud is deprecated. Use the getLabeledVoxelCloud function instead. examples/segmentation/example_supervoxels.cpp shows how to use this to display and save with colorized labels.")
       pcl::PointCloud<pcl::PointXYZRGBA>::Ptr

--- a/segmentation/src/supervoxel_clustering.cpp
+++ b/segmentation/src/supervoxel_clustering.cpp
@@ -63,7 +63,7 @@ namespace pcl
       data_.xyz_[0] += new_point.x;
       data_.xyz_[1] += new_point.y;
       data_.xyz_[2] += new_point.z;
-      //Separate sums for r,g,b since we cant sum in uchars
+      //Separate sums for r,g,b since we can't sum in uchars
       data_.rgb_[0] += static_cast<float> (new_point.r); 
       data_.rgb_[1] += static_cast<float> (new_point.g); 
       data_.rgb_[2] += static_cast<float> (new_point.b); 
@@ -78,7 +78,7 @@ namespace pcl
       data_.xyz_[0] += new_point.x;
       data_.xyz_[1] += new_point.y;
       data_.xyz_[2] += new_point.z;
-      //Separate sums for r,g,b since we cant sum in uchars
+      //Separate sums for r,g,b since we can't sum in uchars
       data_.rgb_[0] += static_cast<float> (new_point.r); 
       data_.rgb_[1] += static_cast<float> (new_point.g); 
       data_.rgb_[2] += static_cast<float> (new_point.b); 

--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -144,7 +144,7 @@ pcl::simulation::PolygonMeshModel::PolygonMeshModel (GLenum mode, pcl::PolygonMe
 	apoly.colors_[4*j + 0] = newcloud.points[pt].r/255.0f; // Red
 	apoly.colors_[4*j + 1] = newcloud.points[pt].g/255.0f; // Green
 	apoly.colors_[4*j + 2] = newcloud.points[pt].b/255.0f; // Blue
-	apoly.colors_[4*j + 3] = 1.0f; // transparancy? unnecessary?
+	apoly.colors_[4*j + 3] = 1.0f; // transparency? unnecessary?
       }
       polygons.push_back (apoly);
     }

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -505,7 +505,7 @@ costFunction3 (float ref_val,float depth_val)
   { // working range
     float min_dist = abs (ref_val - 0.7253f/(1.0360f - (depth_val)));
 
-    int lup = static_cast<int> (ceil (min_dist*100)); // has resulution of 0.01m
+    int lup = static_cast<int> (ceil (min_dist*100)); // has resolution of 0.01m
     if (lup > 300)
     { // implicitly this caps the cost if there is a hole in the model
       lup = 300;
@@ -520,7 +520,7 @@ costFunction4(float ref_val,float depth_val)
 {
   float disparity_diff = abs( ( -0.7253f/ref_val +1.0360f ) -  depth_val );
 
-  int top_lup = static_cast<int> (ceil (disparity_diff*300)); // has resulution of 0.001m
+  int top_lup = static_cast<int> (ceil (disparity_diff*300)); // has resolution of 0.001m
   if (top_lup > 300)
   {
     top_lup =300;
@@ -529,7 +529,7 @@ costFunction4(float ref_val,float depth_val)
 
   // bottom:
   //bottom = bottom_lookup(   round(mu*1000+1));
-  int bottom_lup = static_cast<int> (ceil( (depth_val) * 300)); // has resulution of 0.001m
+  int bottom_lup = static_cast<int> (ceil( (depth_val) * 300)); // has resolution of 0.001m
   if (bottom_lup > 300)
   {
     bottom_lup =300;

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -539,7 +539,7 @@ costFunction4(float ref_val,float depth_val)
   float proportion = 0.999f;
   float lhood = proportion + (1-proportion)*(top/bottom);
 
-  // safety fix thats seems to be required due to opengl ayschronizate
+  // safety fix that seems to be required due to opengl asyschronizate
   // ask hordur about this
   if (bottom == 0)
   {

--- a/simulation/tools/README_about_tools
+++ b/simulation/tools/README_about_tools
@@ -4,7 +4,7 @@ mfallon and hordurj march 2012
 1. sim_viewer.cpp
 purpose: simulate in viewer which is almost the same as pcl_viewer
 status : use the mouse to drive around, and 'v' to capture a cloud. reads vtk and obj. 
-         visualizes vtk and makes pcd of obj. conflict between RL and VTK means doesnt visualize/simulate properly
+         visualizes vtk and makes pcd of obj. conflict between RL and VTK means doesn't visualize/simulate properly
 was    : range_pcd_viewer.cpp
 
 2. sim_terminal_demo.cpp

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -416,14 +416,14 @@ void display ()
     boost::this_thread::sleep (boost::posix_time::microseconds (100000));
   }    
   
-  // doesnt work:
+  // doesn't work:
 //    viewer->~PCLVisualizer();
 //    viewer.reset();
     
     
     cout << "done\n";
-    // Problem: vtk and opengl dont seem to play very well together
-    // vtk seems to misbehave after a little while and wont keep the window on the screen
+    // Problem: vtk and opengl don't seem to play very well together
+    // vtk seems to misbehave after a little while and won't keep the window on the screen
 
     // method1: kill with [x] - but eventually it crashes:
     //while (!viewer.wasStopped ()){

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -392,7 +392,7 @@ boost::shared_ptr<pcl::visualization::PCLVisualizer> simpleVis (pcl::PointCloud<
 
 void capture (Eigen::Isometry3d pose_in, string point_cloud_fname)
 {
-  // No reference image - but this is kept for compatability with range_test_v2:
+  // No reference image - but this is kept for compatibility with range_test_v2:
   float* reference = new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.
@@ -471,7 +471,7 @@ void capture (Eigen::Isometry3d pose_in, string point_cloud_fname)
     writer.writeBinary (point_cloud_fname, *pc_out);
     //cout << "finished writing file\n";
   }
-  // Disabled all OpenCV stuff for now: dont want the dependency
+  // Disabled all OpenCV stuff for now: don't want the dependency
   /*
   bool demo_other_stuff = false;
   if (demo_other_stuff && write_cloud)

--- a/simulation/tools/simulation_io.cpp
+++ b/simulation/tools/simulation_io.cpp
@@ -97,7 +97,7 @@ pcl::simulation::SimExample::initializeGL (int argc, char** argv)
 void
 pcl::simulation::SimExample::doSim (Eigen::Isometry3d pose_in)
 {
-  // No reference image - but this is kept for compatability with range_test_v2:
+  // No reference image - but this is kept for compatibility with range_test_v2:
   float* reference = new float[rl_->getRowHeight() * rl_->getColWidth()];
   const float* depth_buffer = rl_->getDepthBuffer();
   // Copy one image from our last as a reference.

--- a/stereo/include/pcl/stereo/stereo_matching.h
+++ b/stereo/include/pcl/stereo/stereo_matching.h
@@ -458,8 +458,8 @@ namespace pcl
         radius_ = radius;
       };
 
-      /** \brief setter for the spatial bandwith used for cost aggregation based on adaptive weights
-        * \param[in] gamma_s spatial bandwith used for cost aggregation based on adaptive weights
+      /** \brief setter for the spatial bandwidth used for cost aggregation based on adaptive weights
+        * \param[in] gamma_s spatial bandwidth used for cost aggregation based on adaptive weights
         */
       void 
       setGammaS (int gamma_s)
@@ -467,8 +467,8 @@ namespace pcl
         gamma_s_ = gamma_s;
       };
 
-      /** \brief setter for the color bandwith used for cost aggregation based on adaptive weights
-        * \param[in] gamma_c color bandwith used for cost aggregation based on adaptive weights
+      /** \brief setter for the color bandwidth used for cost aggregation based on adaptive weights
+        * \param[in] gamma_c color bandwidth used for cost aggregation based on adaptive weights
         */
       void 
       setGammaC (int gamma_c)

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_bezier.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_bezier.h
@@ -1416,7 +1416,7 @@ public:
     order1 - [in]
     order2 - [in]
   Returns:
-    True if input was valid and creation succeded.
+    True if input was valid and creation succeeded.
   */
   bool Create(
     int dim,

--- a/surface/include/pcl/surface/bilateral_upsampling.h
+++ b/surface/include/pcl/surface/bilateral_upsampling.h
@@ -48,7 +48,7 @@ namespace pcl
 
   /** \brief Bilateral filtering implementation, based on the following paper:
     *   * Kopf, Johannes and Cohen, Michael F. and Lischinski, Dani and Uyttendaele, Matt - Joint Bilateral Upsampling,
-    *   * ACM Transations in Graphics, July 2007
+    *   * ACM Transactions in Graphics, July 2007
     *
     * Takes in a colored organized point cloud (i.e. PointXYZRGB or PointXYZRGBA), that might contain nan values for the
     * depth information, and it will return an upsampled version of this cloud, based on the formula:

--- a/surface/include/pcl/surface/grid_projection.h
+++ b/surface/include/pcl/surface/grid_projection.h
@@ -125,7 +125,7 @@ namespace pcl
         *  points within the padding area,and do a weighted average. Say if the padding
         *  size is 1, when we process cell (x,y,z), we will find union of input data points
         *  from (x-1) to (x+1), (y-1) to (y+1), (z-1) to (z+1)(in total, 27 cells). In this
-        *  way, even the cells itself doesnt contain any data points, we will stil process it
+        *  way, even the cells itself doesn't contain any data points, we will still process it
         *  because there are data points in the padding area. This can help us fix holes which 
         *  is smaller than the padding size.
         * \param padding_size The num of padding cells we want to create 

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -175,7 +175,7 @@ namespace pcl
      * \brief Project a point using the specified method.
      * \param[in] pt The point to be project.
      * \param[in] method The projection method to be used.
-     * \param[in] required_neighbors The minimun number of neighbors required.
+     * \param[in] required_neighbors The minimum number of neighbors required.
      * \note If required_neighbors then any number of neighbors is allowed.
      * \note If required_neighbors is not satisfied it projects to the mls plane.
      * \return The MLSProjectionResults for the input data.
@@ -186,7 +186,7 @@ namespace pcl
     /**
      * \brief Project the query point used to generate the mls surface about using the specified method.
      * \param[in] method The projection method to be used.
-     * \param[in] required_neighbors The minimun number of neighbors required.
+     * \param[in] required_neighbors The minimum number of neighbors required.
      * \note If required_neighbors then any number of neighbors is allowed.
      * \note If required_neighbors is not satisfied it projects to the mls plane.
      * \return The MLSProjectionResults for the input data.
@@ -479,7 +479,7 @@ namespace pcl
       inline int
       getDilationIterations () const { return (dilation_iteration_num_); }
 
-      /** \brief Set wether the mls results should be stored for each point in the input cloud
+      /** \brief Set whether the mls results should be stored for each point in the input cloud
         * \param[in] True if the mls results should be stored, otherwise false.
         * \note The cache_mls_results_ is forced to true when using upsampling method VOXEL_GRID_DILATION or DISTINCT_CLOUD.
         * \note If memory consumption is a concern set to false when not using upsampling method VOXEL_GRID_DILATION or DISTINCT_CLOUD.
@@ -505,7 +505,7 @@ namespace pcl
 
       /** \brief Get the MLSResults for input cloud
         * \note The results are only stored if setCacheMLSResults(true) was called or when using the upsampling method DISTINCT_CLOUD or VOXEL_GRID_DILATION.
-        * \note This vector is align with the input cloud indicies, so use getCorrespondingIndices to get the correct results when using output cloud indicies.
+        * \note This vector is align with the input cloud indices, so use getCorrespondingIndices to get the correct results when using output cloud indices.
         */
       inline const std::vector<MLSResult>&
       getMLSResults () const { return (mls_results_); }

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -3839,7 +3839,7 @@ bool ON_BinaryArchive::WriteObjectUserData( const ON_Object& object )
           {
             // 22 January 2004 Dale Lear
             //   Disable crc checking when writing the
-            //   unknow user data block.
+            //   unknown user data block.
             //   This has to be done so we don't get an extra
             //   32 bit CRC calculated on the block that
             //   ON_UnknownUserData::Write() writes.  The

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -235,10 +235,10 @@ SequentialFitter::setCorners (pcl::PointIndices::Ptr &corners, bool flip_on_dema
     throw std::runtime_error ("[SequentialFitter::setCorners] Error: Empty or invalid pcl-point-cloud.\n");
 
   if (corners->indices.size () < 4)
-    throw std::runtime_error ("[SequentialFitter::setCorners] Error: to few corners (<4)\n");
+    throw std::runtime_error ("[SequentialFitter::setCorners] Error: too few corners (<4)\n");
 
   if (corners->indices.size () > 4)
-    printf ("[SequentialFitter::setCorners] Warning: to many corners (>4)\n");
+    printf ("[SequentialFitter::setCorners] Warning: too many corners (>4)\n");
 
   bool flip = false;
   pcl::PointXYZRGB &pt0 = m_cloud->at (corners->indices[0]);

--- a/test/common/test_eigen.cpp
+++ b/test/common/test_eigen.cpp
@@ -607,7 +607,7 @@ inline void generateSymPosMatrix3x3 (Matrix& matrix)
     val2 = val1;
     val3 = val1;
   }
-  // 1%: 2 values are equal but none is set explicitely to 0
+  // 1%: 2 values are equal but none is set explicitly to 0
   else if (test_case == 1)
   {
     val2 = val3;

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -1294,7 +1294,7 @@ TEST (VoxelGridCovariance, Filters)
   EXPECT_LE (fabs (output.points[neighbors.at (0)].y - output.points[centroidIdx].y), 0.02);
   EXPECT_LE (output.points[neighbors.at (0)].z - output.points[centroidIdx].z, 0.02 * 2);
 
-  // testing seach functions
+  // testing search functions
   grid.setSaveLeafLayout (false);
   grid.filter (output, true);
 

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -941,7 +941,7 @@ TEST_F (PLYTest, LoadPLYFileColoredASCIIIntoBlob)
   EXPECT_EQ (cloud_blob.point_step, 16);
   EXPECT_EQ (cloud_blob.row_step, 16 * 4);
   EXPECT_EQ (cloud_blob.data.size(), 16 * 4);
-  // EXPECT_TRUE (cloud_blob.is_dense);   // this is failing and it shouldnt?
+  // EXPECT_TRUE (cloud_blob.is_dense);   // this is failing and it shouldn't?
 
   // scope blob data
   ps = cloud_blob.point_step;
@@ -989,7 +989,7 @@ TEST_F (PLYTest, LoadPLYFileColoredASCIIIntoPolygonMesh)
   EXPECT_EQ (mesh.cloud.point_step, 16);
   EXPECT_EQ (mesh.cloud.row_step, 16 * 4);
   EXPECT_EQ (mesh.cloud.data.size(), 16 * 4);
-  // EXPECT_TRUE (mesh.cloud.is_dense);   // this is failing and it shouldnt?
+  // EXPECT_TRUE (mesh.cloud.is_dense);   // this is failing and it shouldn't?
 
   // scope blob data
   ps = mesh.cloud.point_step;
@@ -1033,7 +1033,7 @@ TYPED_TEST (PLYPointCloudTest, LoadPLYFileColoredASCIIIntoPointCloud)
   EXPECT_EQ (cloud_rgb.height, 1);
   EXPECT_EQ (cloud_rgb.width, 4);
   EXPECT_EQ (cloud_rgb.points.size(), 4);
-  // EXPECT_TRUE (cloud_rgb.is_dense); // this is failing and it shouldnt?
+  // EXPECT_TRUE (cloud_rgb.is_dense); // this is failing and it shouldn't?
 
   // scope cloud data
   ASSERT_EQ (cloud_rgb[0].rgba, PLYTest::rgba_1_);

--- a/test/io/test_octree_compression.cpp
+++ b/test/io/test_octree_compression.cpp
@@ -167,7 +167,7 @@ TEST(PCL, OctreeDeCompressionFile)
 
     EXPECT_EQ(rv, 0) << " loadPCDFile " << pcd_file;
     EXPECT_GT((int) input_cloud_ptr->width , 0) << "invalid point cloud width from " << pcd_file;
-    EXPECT_GT((int) input_cloud_ptr->height, 0) << "invalid point cloud heigth from " << pcd_file;
+    EXPECT_GT((int) input_cloud_ptr->height, 0) << "invalid point cloud height from " << pcd_file;
 
     // iterate over compression profiles
     for (int compression_profile = pcl::io::LOW_RES_ONLINE_COMPRESSION_WITHOUT_COLOR;

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -64,7 +64,7 @@ struct MyPoint : public PointXYZ
 
 PointCloud<MyPoint> cloud, cloud_big;
 
-// Includ the implementation so that KdTree<MyPoint> works
+// Include the implementation so that KdTree<MyPoint> works
 #include <pcl/kdtree/impl/kdtree_flann.hpp>
 
 void 

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -61,7 +61,7 @@
 #include <pcl/registration/ppf_registration.h>
 #include <pcl/registration/ndt.h>
 #include <pcl/registration/sample_consensus_prerejective.h>
-// We need Histogram<2> to function, so we'll explicitely add kdtree_flann.hpp here
+// We need Histogram<2> to function, so we'll explicitly add kdtree_flann.hpp here
 #include <pcl/kdtree/impl/kdtree_flann.hpp>
 //(pcl::Histogram<2>)
 

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -128,7 +128,7 @@ vector<int> unorganized_dense_cloud_query_indices;
 vector<int> unorganized_sparse_cloud_query_indices;
 vector<int> organized_sparse_query_indices;
 
-/** \briet test whether the result of a search containes unique point ids or not
+/** \briet test whether the result of a search contains unique point ids or not
   * @param indices resulting indices from a search
   * @param name name of the search method that returned these distances
   * @return true if indices are unique, false otherwise

--- a/test/surface/test_gp3.cpp
+++ b/test/surface/test_gp3.cpp
@@ -226,7 +226,7 @@ TEST (PCL, UpdateMesh_With_TextureMapping)
     //tex_material.tex_Ns = 0.0f;
     //tex_material.tex_illum = 2;
 
-    //// set texture material paramaters
+    //// set texture material parameters
     //tm.setTextureMaterials(tex_material);
 
     //// set texture files

--- a/tools/mesh2pcd.cpp
+++ b/tools/mesh2pcd.cpp
@@ -58,7 +58,7 @@ printHelp (int, char **argv)
 {
   print_error ("Syntax is: %s input.{ply,obj} output.pcd <options>\n", argv[0]);
   print_info ("  where options are:\n");
-  print_info ("                     -level X      = tesselated sphere level (default: ");
+  print_info ("                     -level X      = tessellated sphere level (default: ");
   print_value ("%d", default_tesselated_sphere_level);
   print_info (")\n");
   print_info ("                     -resolution X = the sphere resolution in angle increments (default: ");

--- a/tools/pcl_video.cpp
+++ b/tools/pcl_video.cpp
@@ -160,7 +160,7 @@ class Recorder
             tide::TrackEntry::Ptr track(new tide::TrackEntry(1, 1, "pointcloud2"));
             track->name("3D video");
             track->codec_name("pcl::PCLPointCloud2");
-            // Adding each level 1 element (only the first occurance, in the case of
+            // Adding each level 1 element (only the first occurrence, in the case of
             // clusters) to the index makes opening the file later much faster.
             segment.index.insert(std::make_pair(tracks.id(),
                         segment.to_segment_offset(stream_.tellp())));
@@ -287,7 +287,7 @@ class Player
             tide::Segment segment;
             segment.read(stream);
             // The segment's date is stored as the number of nanoseconds since the
-            // start of the millenium. Boost::Date_Time is invaluable here.
+            // start of the millennium. Boost::Date_Time is invaluable here.
             bpt::ptime basis(boost::gregorian::date(2001, 1, 1));
             bpt::time_duration sd(bpt::microseconds(segment.info.date() / 1000));
             bpt::ptime seg_start(basis + sd);

--- a/tools/png2pcd.cpp
+++ b/tools/png2pcd.cpp
@@ -216,7 +216,7 @@ main (int argc, char** argv)
       }
       else
       {
-        print_error ("Unknow depth unit defined.\n");
+        print_error ("Unknown depth unit defined.\n");
         exit (-1);
       }
     }

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -108,7 +108,7 @@ main (int argc, char** argv)
               "         -view_point <x,y,z>       : set the camera viewpoint from where the acquisition will take place\n"
               "         -target_point <x,y,z>     : the target point that the camera should look at (default: 0, 0, 0)\n"
               "         -organized <0|1>          : create an organized, grid-like point cloud of width x height (1), or keep it unorganized with height = 1 (0)\n"
-              "         -noise <0|1>              : add gausian noise (1) or keep the model noiseless (0)\n"
+              "         -noise <0|1>              : add gaussian noise (1) or keep the model noiseless (0)\n"
               "         -noise_std <x>            : use X times the standard deviation\n"
               "");
     return (-1);

--- a/tracking/include/pcl/tracking/pyramidal_klt.h
+++ b/tracking/include/pcl/tracking/pyramidal_klt.h
@@ -48,7 +48,7 @@ namespace pcl
   namespace tracking
   {
     /** Pyramidal Kanade Lucas Tomasi tracker.
-      * This is an implemntation of the Pyramidal Kanade Lucas Tomasi tracker that operates on
+      * This is an implementation of the Pyramidal Kanade Lucas Tomasi tracker that operates on
       * organized 3D keypoints with color/intensity information (this is the default behaviour but you
       * can alterate it by providing another operator as second template argument). It is an affine
       * tracker that iteratively computes the optical flow to find the best guess for a point p at t
@@ -196,12 +196,12 @@ namespace pcl
         inline void
         setPointsToTrack (const pcl::PointCloud<pcl::PointUV>::ConstPtr& points);
 
-        /// \brief \return a pointer to the points succesfully tracked.
+        /// \brief \return a pointer to the points successfully tracked.
         inline pcl::PointCloud<pcl::PointUV>::ConstPtr
         getTrackedPoints () const { return (keypoints_); };
 
         /** \brief \return the status of points to track.
-          * Status == 0  --> points succesfully tracked;
+          * Status == 0  --> points successfully tracked;
           * Status < 0   --> point is lost;
           * Status == -1 --> point is out of bond;
           * Status == -2 --> optical flow can not be computed for this point.
@@ -209,7 +209,7 @@ namespace pcl
         inline pcl::PointIndicesConstPtr
         getPointsToTrackStatus () const { return (keypoints_status_); }
 
-        /** \brief Return the computed transfromation from tracked points. */
+        /** \brief Return the computed transformation from tracked points. */
         Eigen::Affine3f
         getResult () const { return (motion_); }
 
@@ -279,7 +279,7 @@ namespace pcl
           * \param[out] win patch with interpolated intensity values
           * \param[out] grad_x_win patch with interpolated gradient along X values
           * \param[out] grad_y_win patch with interpolated gradient along Y values
-          * \param[out] covariance covariance matrix coefficents
+          * \param[out] covariance covariance matrix coefficients
           */
         virtual void
         spatialGradient (const FloatImage& img,

--- a/visualization/include/pcl/visualization/interactor_style.h
+++ b/visualization/include/pcl/visualization/interactor_style.h
@@ -355,7 +355,7 @@ namespace pcl
         /** \brief Get camera parameters from a string vector.
           * \param[in] camera A string vector:
           * Clipping Range, Focal Point, Position, ViewUp, Distance, Field of View Y, Window Size, Window Pos.
-          * Values in each string are seperated by a ','
+          * Values in each string are separated by a ','
           */
         bool
         getCameraParameters (const std::vector<std::string> &camera);

--- a/visualization/include/pcl/visualization/pcl_plotter.h
+++ b/visualization/include/pcl/visualization/pcl_plotter.h
@@ -188,7 +188,7 @@ namespace pcl
                      std::vector<char> const &color = std::vector<char>());
         
         /** \brief Adds a plot based on a space/tab delimited table provided in a file
-          * \param[in] filename name of the file containing the table. 1st column represents the values of X-Axis. Rest of the columns represent the corresponding values in Y-Axes. First row of the file is concidered for naming/labling of the plot. The plot-names should not contain any space in between.
+          * \param[in] filename name of the file containing the table. 1st column represents the values of X-Axis. Rest of the columns represent the corresponding values in Y-Axes. First row of the file is considered for naming/labeling of the plot. The plot-names should not contain any space in between.
           * \param[in] type type of the graph plotted. vtkChart::LINE for line plot, vtkChart::BAR for bar plot, and vtkChart::POINTS for a scattered point plot
           */
         void

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -2311,7 +2311,7 @@ namespace pcl
                                 vtkTexture* vtk_tex) const;
 
         /** \brief Get camera file for camera parameter saving/restoring from command line.
-          * Camera filename is calculated using sha1 value of all pathes of input .pcd files
+          * Camera filename is calculated using sha1 value of all paths of input .pcd files
           * \return empty string if failed.
           */
         std::string

--- a/visualization/include/pcl/visualization/point_cloud_geometry_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_geometry_handlers.h
@@ -179,7 +179,7 @@ namespace pcl
     //////////////////////////////////////////////////////////////////////////////////////
     /** \brief Surface normal handler class for PointCloud geometry. Given an input
       * dataset, all data present in fields "normal_x", "normal_y", and "normal_z" is
-      * extracted and dislayed on screen as XYZ data.
+      * extracted and displayed on screen as XYZ data.
       * \author Radu B. Rusu 
       * \ingroup visualization
       */
@@ -428,7 +428,7 @@ namespace pcl
     //////////////////////////////////////////////////////////////////////////////////////
     /** \brief Surface normal handler class for PointCloud geometry. Given an input
       * dataset, all data present in fields "normal_x", "normal_y", and "normal_z" is
-      * extracted and dislayed on screen as XYZ data.
+      * extracted and displayed on screen as XYZ data.
       * \author Radu B. Rusu 
       * \ingroup visualization
       */

--- a/visualization/include/pcl/visualization/point_picking_event.h
+++ b/visualization/include/pcl/visualization/point_picking_event.h
@@ -118,7 +118,7 @@ namespace pcl
         /** \brief For situations when multiple points are selected in a sequence, return the point coordinates.
           * \param[out] x1 the x coordinate of the first point that got selected by the user
           * \param[out] y1 the y coordinate of the first point that got selected by the user
-          * \param[out] z1 the z coordinate of the firts point that got selected by the user
+          * \param[out] z1 the z coordinate of the first point that got selected by the user
           * \param[out] x2 the x coordinate of the second point that got selected by the user
           * \param[out] y2 the y coordinate of the second point that got selected by the user
           * \param[out] z2 the z coordinate of the second point that got selected by the user

--- a/visualization/include/pcl/visualization/simple_buffer_visualizer.h
+++ b/visualization/include/pcl/visualization/simple_buffer_visualizer.h
@@ -63,7 +63,7 @@ namespace pcl
           // load values into cloud
           updateValuesToDisplay();
                 
-          // check if we need to automatically handle the backgroud color
+          // check if we need to automatically handle the background color
           if(control_background_color_)
           {
             if(values_.back() < lowest_threshold_)
@@ -155,7 +155,7 @@ namespace pcl
         }
     
       private:
-        /** \brief initialize ther buffer that stores the values to zero. 
+        /** \brief initialize the buffer that stores the values to zero. 
           * \note The size is set by private member nb_values_ which is in the range [2-308].
           */
         void
@@ -210,13 +210,13 @@ namespace pcl
           */
         int nb_values_;
     
-        /** \brief boolean used to know if we need to change the backgroud color in case of low values. */
+        /** \brief boolean used to know if we need to change the background color in case of low values. */
         bool control_background_color_;
     
         /** \brief threshold to turn the background orange if latest value is lower. */
         float lowest_threshold_;
 
-        /** \brief boolean used to know if we need to change the backgroud color in case of low values. True means we do it ourselves. */
+        /** \brief boolean used to know if we need to change the background color in case of low values. True means we do it ourselves. */
         bool handle_y_scale_;
     
         /** \brief float tracking the minimal and maximal values ever observed. */

--- a/visualization/include/pcl/visualization/vtk/vtkRenderWindowInteractorFix.mm
+++ b/visualization/include/pcl/visualization/vtk/vtkRenderWindowInteractorFix.mm
@@ -144,7 +144,7 @@
     {
       [self breakEventLoop];
       
-      // The NSWindow is closing, so prevent anyone from accidently using it
+      // The NSWindow is closing, so prevent anyone from accidentally using it
       renWin->SetRootWindow(NULL);
     }
   }

--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
@@ -84,7 +84,7 @@ public:
   // - StreamRead specified once by R, queried a few times by A
   // - StreamCopy specified once by R, used a few times S
   // - StaticDraw specified once by A, used many times S
-  // - StaticRead specificed once by R, queried many times by A
+  // - StaticRead specified once by R, queried many times by A
   // - StaticCopy specified once by R, used many times S
   // - DynamicDraw respecified repeatedly by A, used many times S
   // - DynamicRead respecified repeatedly by R, queried many times by A

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -236,7 +236,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::setCameraParameters (const Eig
   window_size[0] = 2 * static_cast<int> (intrinsics (0, 2));
   window_size[1] = 2 * static_cast<int> (intrinsics (1, 2));
 
-  // Compute the vertical field of view based on the focal length and image heigh
+  // Compute the vertical field of view based on the focal length and image height
   double fovy = 2 * atan (window_size[1] / (2. * intrinsics (1, 1))) * 180.0 / M_PI;
 
 

--- a/visualization/src/pcl_painter2D.cpp
+++ b/visualization/src/pcl_painter2D.cpp
@@ -364,7 +364,7 @@ pcl::visualization::PCLPainter2D::Paint (vtkContext2D *painter)
   //draw every figures
   for (size_t i = 0; i < figures_.size (); i++)
   {
-    figures_[i]->draw (painter); 	//thats it ;-)
+    figures_[i]->draw (painter); 	//that's it ;-)
   }
   
   return true;

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3789,7 +3789,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
   ico->SetSolidTypeToIcosahedron ();
   ico->Update ();
 
-  //tesselate cells from icosahedron
+  //tessellate cells from icosahedron
   vtkSmartPointer<vtkLoopSubdivisionFilter> subdivide = vtkSmartPointer<vtkLoopSubdivisionFilter>::New ();
   subdivide->SetNumberOfSubdivisions (tesselation_level);
   subdivide->SetInputConnection (ico->GetOutputPort ());

--- a/visualization/tools/openni_image.cpp
+++ b/visualization/tools/openni_image.cpp
@@ -330,7 +330,7 @@ class Writer
       {
         {
           boost::mutex::scoped_lock io_lock (io_mutex);
-          print_info ("Writing remaing %ld clouds in the buffer to disk...\n", buf_.getSize ());
+          print_info ("Writing remaining %ld clouds in the buffer to disk...\n", buf_.getSize ());
         }
         while (!buf_.isEmpty ())
         {


### PR DESCRIPTION
Found via `codespell -q 3 -I ../pcl-whitelist.txt --skip="./surface/include/pcl/surface/3rdparty,./surface/src/3rdparty,./recognition/include/pcl/recognition/3rdparty"`  
Whitelist:
```
ang
childs
everytime
iff
indeces
isnt
ith
lod
metre
metres
mitre
nd
normaly
ot
resizeable
te
vertexes
```