### PR TITLE
[PARSE] Constness of the API

### DIFF
--- a/common/include/pcl/console/parse.h
+++ b/common/include/pcl/console/parse.h
@@ -56,7 +56,7 @@ namespace pcl
       * \note find_switch is simply returning find_argument != -1.
       */
     PCL_EXPORTS bool
-    find_switch (int argc, char** argv, const char* argument_name);
+    find_switch (int argc, const char * const * argv, const char * argument_name);
 
     /** \brief Finds the position of the argument with name "argument_name" in the argument list "argv"
       * \param[in] argc the number of command line arguments
@@ -65,7 +65,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
      */
     PCL_EXPORTS int
-    find_argument (int argc, char** argv, const char* argument_name);
+    find_argument (int argc, const char * const * argv, const char * argument_name);
 
     /** \brief Template version for parsing arguments. Template parameter needs to have input stream operator overloaded!
       * \param[in] argc the number of command line arguments
@@ -75,7 +75,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
      */
     template<typename Type> int
-    parse (int argc, char** argv, const char* argument_name, Type& value)
+    parse (int argc, const char * const * argv, const char * argument_name, Type& value)
     {
       int index = find_argument (argc, argv, argument_name) + 1;
 
@@ -98,7 +98,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_argument (int argc, char** argv, const char* str, std::string &val);
+    parse_argument (int argc, const char * const * argv, const char * str, std::string &val);
 
     /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
@@ -108,7 +108,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_argument (int argc, char** argv, const char* str, bool &val);
+    parse_argument (int argc, const char * const * argv, const char * str, bool &val);
 
     /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
@@ -118,7 +118,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_argument (int argc, char** argv, const char* str, float &val);
+    parse_argument (int argc, const char * const * argv, const char * str, float &val);
     
     /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
@@ -128,7 +128,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_argument (int argc, char** argv, const char* str, double &val);
+    parse_argument (int argc, const char * const * argv, const char * str, double &val);
 
     /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
@@ -138,7 +138,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_argument (int argc, char** argv, const char* str, int &val);
+    parse_argument (int argc, const char * const * argv, const char * str, int &val);
 
     /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
@@ -148,7 +148,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_argument (int argc, char** argv, const char* str, unsigned int &val);
+    parse_argument (int argc, const char * const * argv, const char * str, unsigned int &val);
 
     /** \brief Parse for a specific given command line argument.
       * \param[in] argc the number of command line arguments
@@ -158,7 +158,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_argument (int argc, char** argv, const char* str, char &val);
+    parse_argument (int argc, const char * const * argv, const char * str, char &val);
 
     /** \brief Parse for specific given command line arguments (2x values comma
       * separated).
@@ -171,7 +171,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_2x_arguments (int argc, char** argv, const char* str, float &f, float &s, bool debug = true);
+    parse_2x_arguments (int argc, const char * const * argv, const char * str, float &f, float &s, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (2x values comma
       * separated).
@@ -184,7 +184,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_2x_arguments (int argc, char** argv, const char* str, double &f, double &s, bool debug = true);
+    parse_2x_arguments (int argc, const char * const * argv, const char * str, double &f, double &s, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (2x values comma
       * separated).
@@ -197,7 +197,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_2x_arguments (int argc, char** argv, const char* str, int &f, int &s, bool debug = true);
+    parse_2x_arguments (int argc, const char * const * argv, const char * str, int &f, int &s, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
       * separated).
@@ -211,7 +211,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_3x_arguments (int argc, char** argv, const char* str, float &f, float &s, float &t, bool debug = true);
+    parse_3x_arguments (int argc, const char * const * argv, const char * str, float &f, float &s, float &t, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
       * separated).
@@ -225,7 +225,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_3x_arguments (int argc, char** argv, const char* str, double &f, double &s, double &t, bool debug = true);
+    parse_3x_arguments (int argc, const char * const * argv, const char * str, double &f, double &s, double &t, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
       * separated).
@@ -239,7 +239,7 @@ namespace pcl
       * return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_3x_arguments (int argc, char** argv, const char* str, int &f, int &s, int &t, bool debug = true);
+    parse_3x_arguments (int argc, const char * const * argv, const char * str, int &f, int &s, int &t, bool debug = true);
 
     /** \brief Parse for specific given command line arguments (3x values comma
       * separated).
@@ -250,7 +250,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_x_arguments (int argc, char** argv, const char* str, std::vector<double>& v);
+    parse_x_arguments (int argc, const char * const * argv, const char * str, std::vector<double>& v);
 
     /** \brief Parse for specific given command line arguments (N values comma
       * separated).
@@ -261,7 +261,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_x_arguments (int argc, char** argv, const char* str, std::vector<float>& v);
+    parse_x_arguments (int argc, const char * const * argv, const char * str, std::vector<float>& v);
 
     /** \brief Parse for specific given command line arguments (N values comma
       * separated).
@@ -272,7 +272,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS int
-    parse_x_arguments (int argc, char** argv, const char* str, std::vector<int>& v);
+    parse_x_arguments (int argc, const char * const * argv, const char * str, std::vector<int>& v);
 
     /** \brief Parse for specific given command line arguments (multiple occurrences
       * of the same command line parameter).
@@ -283,7 +283,7 @@ namespace pcl
       * \return index of found argument or -1 if arguments do not appear in list
       */
     PCL_EXPORTS bool
-    parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<int> &values);
+    parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<int> &values);
 
     /** \brief Parse for specific given command line arguments (multiple occurrences
       * of the same command line parameter).
@@ -294,7 +294,7 @@ namespace pcl
       * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
-    parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<float> &values);
+    parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<float> &values);
 
     /** \brief Parse for specific given command line arguments (multiple occurrences
       * of the same command line parameter).
@@ -305,7 +305,7 @@ namespace pcl
       * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
-    parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<double> &values);
+    parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<double> &values);
 
     /** \brief Parse for a specific given command line argument (multiple occurrences
       * of the same command line parameter).
@@ -316,7 +316,7 @@ namespace pcl
       * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
-    parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<std::string> &values);
+    parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<std::string> &values);
 
     /** \brief Parse command line arguments for file names with given extension (multiple occurrences
       * of 2x argument groups, separated by commas).
@@ -328,7 +328,7 @@ namespace pcl
       * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
-    parse_multiple_2x_arguments (int argc, char** argv, const char* str, 
+    parse_multiple_2x_arguments (int argc, const char * const * argv, const char * str,
                                  std::vector<double> &values_f, 
                                  std::vector<double> &values_s);
 
@@ -343,7 +343,7 @@ namespace pcl
       * \return true if found, false otherwise
       */
     PCL_EXPORTS bool
-    parse_multiple_3x_arguments (int argc, char** argv, const char* str, 
+    parse_multiple_3x_arguments (int argc, const char * const * argv, const char * str,
                                  std::vector<double> &values_f, 
                                  std::vector<double> &values_s, 
                                  std::vector<double> &values_t);
@@ -355,7 +355,7 @@ namespace pcl
       * \return a vector with file names indices
       */
     PCL_EXPORTS std::vector<int>
-    parse_file_extension_argument (int argc, char** argv, const std::string &ext);
+    parse_file_extension_argument (int argc, const char * const * argv, const std::string &ext);
   }
 }
 

--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -44,14 +44,14 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::console::find_switch (int argc, char** argv, const char* argument_name)
+pcl::console::find_switch (int argc, const char * const * argv, const char * argument_name)
 {
   return (find_argument (argc, argv, argument_name) != -1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::find_argument (int argc, char** argv, const char* argument_name)
+pcl::console::find_argument (int argc, const char * const * argv, const char * argument_name)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -66,7 +66,7 @@ pcl::console::find_argument (int argc, char** argv, const char* argument_name)
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_argument (int argc, char** argv, const char* str, std::string &val)
+pcl::console::parse_argument (int argc, const char * const * argv, const char * str, std::string &val)
 {
   int index = find_argument (argc, argv, str) + 1;
   if (index > 0 && index < argc )
@@ -77,7 +77,7 @@ pcl::console::parse_argument (int argc, char** argv, const char* str, std::strin
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_argument (int argc, char** argv, const char* str, bool &val)
+pcl::console::parse_argument (int argc, const char * const * argv, const char * str, bool &val)
 {
   int index = find_argument (argc, argv, str) + 1;
 
@@ -89,7 +89,7 @@ pcl::console::parse_argument (int argc, char** argv, const char* str, bool &val)
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_argument (int argc, char** argv, const char* str, double &val)
+pcl::console::parse_argument (int argc, const char * const * argv, const char * str, double &val)
 {
   int index = find_argument (argc, argv, str) + 1;
 
@@ -101,7 +101,7 @@ pcl::console::parse_argument (int argc, char** argv, const char* str, double &va
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_argument (int argc, char** argv, const char* str, float &val)
+pcl::console::parse_argument (int argc, const char * const * argv, const char * str, float &val)
 {
   int index = find_argument (argc, argv, str) + 1;
 
@@ -113,7 +113,7 @@ pcl::console::parse_argument (int argc, char** argv, const char* str, float &val
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_argument (int argc, char** argv, const char* str, int &val)
+pcl::console::parse_argument (int argc, const char * const * argv, const char * str, int &val)
 {
   int index = find_argument (argc, argv, str) + 1;
 
@@ -125,7 +125,7 @@ pcl::console::parse_argument (int argc, char** argv, const char* str, int &val)
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_argument (int argc, char** argv, const char* str, unsigned int &val)
+pcl::console::parse_argument (int argc, const char * const * argv, const char * str, unsigned int &val)
 {
   int index = find_argument (argc, argv, str) + 1;
 
@@ -137,7 +137,7 @@ pcl::console::parse_argument (int argc, char** argv, const char* str, unsigned i
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_argument (int argc, char** argv, const char* str, char &val)
+pcl::console::parse_argument (int argc, const char * const * argv, const char * str, char &val)
 {
   int index = find_argument (argc, argv, str) + 1;
 
@@ -149,7 +149,7 @@ pcl::console::parse_argument (int argc, char** argv, const char* str, char &val)
 
 ////////////////////////////////////////////////////////////////////////////////
 std::vector<int>
-pcl::console::parse_file_extension_argument (int argc, char** argv, const std::string &extension)
+pcl::console::parse_file_extension_argument (int argc, const char * const * argv, const std::string &extension)
 {
   std::vector<int> indices;
   for (int i = 1; i < argc; ++i)
@@ -179,7 +179,7 @@ pcl::console::parse_file_extension_argument (int argc, char** argv, const std::s
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_2x_arguments (int argc, char** argv, const char* str, float &f, float &s, bool debug)
+pcl::console::parse_2x_arguments (int argc, const char * const * argv, const char * str, float &f, float &s, bool debug)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -204,7 +204,7 @@ pcl::console::parse_2x_arguments (int argc, char** argv, const char* str, float 
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_2x_arguments (int argc, char** argv, const char* str, double &f, double &s, bool debug)
+pcl::console::parse_2x_arguments (int argc, const char * const * argv, const char * str, double &f, double &s, bool debug)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -229,7 +229,7 @@ pcl::console::parse_2x_arguments (int argc, char** argv, const char* str, double
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_2x_arguments (int argc, char** argv, const char* str, int &f, int &s, bool debug)
+pcl::console::parse_2x_arguments (int argc, const char * const * argv, const char * str, int &f, int &s, bool debug)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -254,7 +254,7 @@ pcl::console::parse_2x_arguments (int argc, char** argv, const char* str, int &f
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_3x_arguments (int argc, char** argv, const char* str, float &f, float &s, float &t, bool debug)
+pcl::console::parse_3x_arguments (int argc, const char * const * argv, const char * str, float &f, float &s, float &t, bool debug)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -280,7 +280,7 @@ pcl::console::parse_3x_arguments (int argc, char** argv, const char* str, float 
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_3x_arguments (int argc, char** argv, const char* str, double &f, double &s, double &t, bool debug)
+pcl::console::parse_3x_arguments (int argc, const char * const * argv, const char * str, double &f, double &s, double &t, bool debug)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -306,7 +306,7 @@ pcl::console::parse_3x_arguments (int argc, char** argv, const char* str, double
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_3x_arguments (int argc, char** argv, const char* str, int &f, int &s, int &t, bool debug)
+pcl::console::parse_3x_arguments (int argc, const char * const * argv, const char * str, int &f, int &s, int &t, bool debug)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -332,7 +332,7 @@ pcl::console::parse_3x_arguments (int argc, char** argv, const char* str, int &f
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_x_arguments (int argc, char** argv, const char* str, std::vector<double>& v)
+pcl::console::parse_x_arguments (int argc, const char * const * argv, const char * str, std::vector<double>& v)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -355,7 +355,7 @@ pcl::console::parse_x_arguments (int argc, char** argv, const char* str, std::ve
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_x_arguments (int argc, char** argv, const char* str, std::vector<float>& v)
+pcl::console::parse_x_arguments (int argc, const char * const * argv, const char * str, std::vector<float>& v)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -378,7 +378,7 @@ pcl::console::parse_x_arguments (int argc, char** argv, const char* str, std::ve
 
 ////////////////////////////////////////////////////////////////////////////////
 int
-pcl::console::parse_x_arguments (int argc, char** argv, const char* str, std::vector<int>& v)
+pcl::console::parse_x_arguments (int argc, const char * const * argv, const char * str, std::vector<int>& v)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -401,7 +401,7 @@ pcl::console::parse_x_arguments (int argc, char** argv, const char* str, std::ve
 
 ////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<int> &values)
+pcl::console::parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<int> &values)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -420,7 +420,7 @@ pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, 
 
 ////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<double> &values)
+pcl::console::parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<double> &values)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -439,7 +439,7 @@ pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, 
 
 ////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<float> &values)
+pcl::console::parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<float> &values)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -458,7 +458,7 @@ pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, 
 
 ////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, std::vector<std::string> &values)
+pcl::console::parse_multiple_arguments (int argc, const char * const * argv, const char * str, std::vector<std::string> &values)
 {
   for (int i = 1; i < argc; ++i)
   {
@@ -476,7 +476,7 @@ pcl::console::parse_multiple_arguments (int argc, char** argv, const char* str, 
 
 ////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::console::parse_multiple_2x_arguments (int argc, char** argv, const char* str, std::vector<double> &values_f, std::vector<double> &values_s)
+pcl::console::parse_multiple_2x_arguments (int argc, const char * const * argv, const char * str, std::vector<double> &values_f, std::vector<double> &values_s)
 {
   double f, s;
   for (int i = 1; i < argc; ++i)
@@ -506,7 +506,7 @@ pcl::console::parse_multiple_2x_arguments (int argc, char** argv, const char* st
 
 ////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::console::parse_multiple_3x_arguments (int argc, char** argv, const char* str,
+pcl::console::parse_multiple_3x_arguments (int argc, const char * const * argv, const char * str,
                                              std::vector<double> &values_f,
                                              std::vector<double> &values_s,
                                              std::vector<double> &values_t)


### PR DESCRIPTION
Update the prototype of every parse functions to make them constness: where the `const` keyword should be, just put it.

When I write code, in the client side, I try to use const wherever it's possible. If in the library side, the const interface is not present, I have to remove the `const` keyword from the client side code (or use a temporary variable, or another trick) to be able to use the PCL functions. With the const API, from the client side you can use indifferently mutable or const variables.

Even if this PR changes the API, I don't think that it really breaks it. From the client side, every application should remain the same.

Also, I'm not able to say if this PR breaks ABI or not...