### PR TITLE
Fix access specifier in PointCloudColorHandlerRGBAField

### DIFF
--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -488,6 +488,7 @@ namespace pcl
         virtual std::string
         getName () const { return ("PointCloudColorHandlerRGBAField"); }
 
+      private:
         // Members derived from the base class
         using PointCloudColorHandler<PointT>::cloud_;
         using PointCloudColorHandler<PointT>::capable_;


### PR DESCRIPTION
Fix access specifier in <code>PointCloudColorHandlerRGBAField<PointT></code>.
I think that members derived from the base class should be private in this class. 
(See [PointCloudColorHandlerRGBField](https://github.com/PointCloudLibrary/pcl/blob/master/visualization/include/pcl/visualization/point_cloud_color_handlers.h#L306) a similar class.)

* PointCloudColorHandlerRGBField
https://github.com/PointCloudLibrary/pcl/blob/377a5bdb0a5f726f2a00b75fde0106114a67c187/visualization/include/pcl/visualization/point_cloud_color_handlers.h#L301-L312

* PointCloudColorHandlerRGBAField
https://github.com/PointCloudLibrary/pcl/blob/377a5bdb0a5f726f2a00b75fde0106114a67c187/visualization/include/pcl/visualization/point_cloud_color_handlers.h#L486-L496