### PR TITLE
fix link order issue with boost

### DIFF
--- a/cmake/pcl_find_boost.cmake
+++ b/cmake/pcl_find_boost.cmake
@@ -37,10 +37,10 @@ endif(Boost_SERIALIZATION_FOUND)
 
 # Required boost modules
 if(WITH_OPENNI2)
-set(BOOST_REQUIRED_MODULES system filesystem thread date_time iostreams chrono)
+set(BOOST_REQUIRED_MODULES filesystem thread date_time iostreams chrono system)
 find_package(Boost 1.47.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_MODULES})
 else()
-set(BOOST_REQUIRED_MODULES system filesystem thread date_time iostreams)
+set(BOOST_REQUIRED_MODULES filesystem thread date_time iostreams system)
 find_package(Boost 1.40.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_MODULES})
 endif()
 


### PR DESCRIPTION
This could happen with any boost that was compiled
with -DBOOST_SYSTEM_NO_DEPRECATED.  As of boost-1.66.0
that's the effective default, so the issue is more apparent.
In this case one get an undefined reference to
boost::system::system_category() as the 'system' module
is first in the link order, which will cause that as yet unused
symbol to be discarded by the linker.

Instead move the 'system' module to be the last in the link order
so that all references are resolved.

This was tested with cmake 3.5.2