### PR TITLE
Use GLuint rather than size_t to represent OpenGL indices.

### DIFF
--- a/simulation/include/pcl/simulation/model.h
+++ b/simulation/include/pcl/simulation/model.h
@@ -58,7 +58,7 @@ namespace pcl
     };
 
     typedef std::vector<Vertex> Vertices;
-    typedef std::vector<size_t> Indices;
+    typedef std::vector<GLuint> Indices;
 
     class Model
     {


### PR DESCRIPTION
In the simulation model rendering, use GLuint rather than size_t to represent OpenGL indices.

size_t size in byte is dependent on the machine architecture.
In contrast, the OpenGL indices must be 32bits.

Specifically size_t being 64bits on a 64bits machine, it will be the wrong size for OpenGL .