### PR TITLE
Remove useless size check in PLYReader::endHeaderCallback()

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -96,7 +96,7 @@ bool
 pcl::PLYReader::endHeaderCallback ()
 {
   cloud_->data.resize (static_cast<size_t>(cloud_->point_step) * cloud_->width * cloud_->height);
-  return (cloud_->data.size () == cloud_->point_step * cloud_->width * cloud_->height);
+  return (true);
 }
 
 template<typename Scalar> void


### PR DESCRIPTION
In the case that vector resize fails, an exception is thrown, so the size check is not performed anyway.

Supersedes and closes #2243.