### PR TITLE
Improve speed of transformPointCloud/WithNormals() functions

### DIFF
--- a/common/include/pcl/common/impl/transforms.hpp
+++ b/common/include/pcl/common/impl/transforms.hpp
@@ -37,6 +37,179 @@
  *
  */
 
+#if defined(__SSE2__)
+#include <xmmintrin.h>
+#endif
+
+#if defined(__AVX__)
+#include <immintrin.h>
+#endif
+
+namespace pcl
+{
+
+  namespace detail
+  {
+
+    /** A helper struct to apply an SO3 or SE3 transform to a 3D point.
+      * Supports single and double precision transform matrices. */
+    template<typename Scalar>
+    struct Transformer
+    {
+      const Eigen::Matrix<Scalar, 4, 4>& tf;
+
+      /** Construct a transformer object.
+        * The transform matrix is captured by const reference. Make sure that it does not go out of scope before this
+        * object does. */
+      Transformer (const Eigen::Matrix<Scalar, 4, 4>& transform) : tf (transform) { };
+
+      /** Apply SO3 transform (top-left corner of the transform matrix).
+        * \param[in] src input 3D point (pointer to 3 floats)
+        * \param[out] tgt output 3D point (pointer to 4 floats), can be the same as input. The fourth element is set to 0. */
+      void so3 (const float* src, float* tgt) const
+      {
+        const Scalar p[3] = { src[0], src[1], src[2] };  // need this when src == tgt
+        tgt[0] = static_cast<float> (tf (0, 0) * p[0] + tf (0, 1) * p[1] + tf (0, 2) * p[2]);
+        tgt[1] = static_cast<float> (tf (1, 0) * p[0] + tf (1, 1) * p[1] + tf (1, 2) * p[2]);
+        tgt[2] = static_cast<float> (tf (2, 0) * p[0] + tf (2, 1) * p[1] + tf (2, 2) * p[2]);
+        tgt[3] = 0;
+      }
+
+      /** Apply SE3 transform.
+        * \param[in] src input 3D point (pointer to 3 floats)
+        * \param[out] tgt output 3D point (pointer to 4 floats), can be the same as input. The fourth element is set to 1. */
+      void se3 (const float* src, float* tgt) const
+      {
+        const Scalar p[3] = { src[0], src[1], src[2] };  // need this when src == tgt
+        tgt[0] = static_cast<float> (tf (0, 0) * p[0] + tf (0, 1) * p[1] + tf (0, 2) * p[2] + tf (0, 3));
+        tgt[1] = static_cast<float> (tf (1, 0) * p[0] + tf (1, 1) * p[1] + tf (1, 2) * p[2] + tf (1, 3));
+        tgt[2] = static_cast<float> (tf (2, 0) * p[0] + tf (2, 1) * p[1] + tf (2, 2) * p[2] + tf (2, 3));
+        tgt[3] = 1;
+      }
+    };
+
+#if defined(__SSE2__)
+
+    /** Optimized version for single-precision transforms using SSE2 intrinsics. */
+    template<>
+    struct Transformer<float>
+    {
+      /// Columns of the transform matrix stored in XMM registers.
+      __m128 c[4];
+
+      Transformer(const Eigen::Matrix4f& tf)
+      {
+        for (size_t i = 0; i < 4; ++i)
+          c[i] = _mm_load_ps (tf.col (i).data ());
+      }
+
+      void so3 (const float* src, float* tgt) const
+      {
+        __m128 p0 = _mm_mul_ps (_mm_load_ps1 (&src[0]), c[0]);
+        __m128 p1 = _mm_mul_ps (_mm_load_ps1 (&src[1]), c[1]);
+        __m128 p2 = _mm_mul_ps (_mm_load_ps1 (&src[2]), c[2]);
+        _mm_store_ps (tgt, _mm_add_ps(p0, _mm_add_ps(p1, p2)));
+      }
+
+      void se3 (const float* src, float* tgt) const
+      {
+        __m128 p0 = _mm_mul_ps (_mm_load_ps1 (&src[0]), c[0]);
+        __m128 p1 = _mm_mul_ps (_mm_load_ps1 (&src[1]), c[1]);
+        __m128 p2 = _mm_mul_ps (_mm_load_ps1 (&src[2]), c[2]);
+        _mm_store_ps (tgt, _mm_add_ps(p0, _mm_add_ps(p1, _mm_add_ps(p2, c[3]))));
+      }
+    };
+
+#if not defined(__AVX__)
+
+    /** Optimized version for double-precision transform using SSE2 intrinsics. */
+    template<>
+    struct Transformer<double>
+    {
+      /// Columns of the transform matrix stored in XMM registers.
+      __m128d c[4][2];
+
+      Transformer(const Eigen::Matrix4d& tf)
+      {
+        for (size_t i = 0; i < 4; ++i)
+        {
+          c[i][0] = _mm_load_pd (tf.col (i).data () + 0);
+          c[i][1] = _mm_load_pd (tf.col (i).data () + 2);
+        }
+      }
+
+      void so3 (const float* src, float* tgt) const
+      {
+        __m128d xx = _mm_cvtps_pd (_mm_load_ps1 (&src[0]));
+        __m128d p0 = _mm_mul_pd (xx, c[0][0]);
+        __m128d p1 = _mm_mul_pd (xx, c[0][1]);
+
+        for (size_t i = 1; i < 3; ++i)
+        {
+          __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
+          p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
+          p1 = _mm_add_pd (_mm_mul_pd (vv, c[i][1]), p1);
+        }
+
+        _mm_store_ps (tgt, _mm_movelh_ps (_mm_cvtpd_ps (p0), _mm_cvtpd_ps (p1)));
+      }
+
+      void se3 (const float* src, float* tgt) const
+      {
+        __m128d p0 = c[3][0];
+        __m128d p1 = c[3][1];
+
+        for (size_t i = 0; i < 3; ++i)
+        {
+          __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
+          p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
+          p1 = _mm_add_pd (_mm_mul_pd (vv, c[i][1]), p1);
+        }
+
+        _mm_store_ps (tgt, _mm_movelh_ps (_mm_cvtpd_ps (p0), _mm_cvtpd_ps (p1)));
+      }
+
+    };
+
+#else
+
+  /** Optimized version for double-precision transform using AVX intrinsics. */
+  template<>
+  struct Transformer<double>
+  {
+    __m256d c[4];
+
+    Transformer(const Eigen::Matrix4d& tf)
+    {
+      for (size_t i = 0; i < 4; ++i)
+        c[i] = _mm256_load_pd (tf.col (i).data ());
+    }
+
+    void so3 (const float* src, float* tgt) const
+    {
+      __m256d p0 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[0])), c[0]);
+      __m256d p1 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[1])), c[1]);
+      __m256d p2 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[2])), c[2]);
+      _mm_store_ps (tgt, _mm256_cvtpd_ps (_mm256_add_pd(p0, _mm256_add_pd(p1, p2))));
+    }
+
+    void se3 (const float* src, float* tgt) const
+    {
+      __m256d p0 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[0])), c[0]);
+      __m256d p1 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[1])), c[1]);
+      __m256d p2 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[2])), c[2]);
+      _mm_store_ps (tgt, _mm256_cvtpd_ps (_mm256_add_pd(p0, _mm256_add_pd(p1, _mm256_add_pd(p2, c[3])))));
+    }
+
+  };
+
+#endif
+#endif
+
+  }
+
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename Scalar> void
 pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
@@ -59,17 +232,12 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
     cloud_out.sensor_origin_      = cloud_in.sensor_origin_;
   }
 
+  pcl::detail::Transformer<Scalar> tf (transform.matrix ());
   if (cloud_in.is_dense)
   {
     // If the dataset is dense, simply transform it!
     for (size_t i = 0; i < cloud_out.points.size (); ++i)
-    {
-      //cloud_out.points[i].getVector3fMap () = transform * cloud_in.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[i].x, cloud_in[i].y, cloud_in[i].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
-    }
+      tf.se3 (cloud_in[i].data, cloud_out[i].data);
   }
   else
   {
@@ -81,11 +249,7 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
           !pcl_isfinite (cloud_in.points[i].y) || 
           !pcl_isfinite (cloud_in.points[i].z))
         continue;
-      //cloud_out.points[i].getVector3fMap () = transform * cloud_in.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[i].x, cloud_in[i].y, cloud_in[i].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
+      tf.se3 (cloud_in[i].data, cloud_out[i].data);
     }
   }
 }
@@ -108,6 +272,7 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out.sensor_orientation_ = cloud_in.sensor_orientation_;
   cloud_out.sensor_origin_      = cloud_in.sensor_origin_;
 
+  pcl::detail::Transformer<Scalar> tf (transform.matrix ());
   if (cloud_in.is_dense)
   {
     // If the dataset is dense, simply transform it!
@@ -116,11 +281,7 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
       // Copy fields first, then transform xyz data
       if (copy_all_fields)
         cloud_out.points[i] = cloud_in.points[indices[i]];
-      //cloud_out.points[i].getVector3fMap () = transform*cloud_out.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[indices[i]].x, cloud_in[indices[i]].y, cloud_in[indices[i]].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
+      tf.se3 (cloud_in[indices[i]].data, cloud_out[i].data);
     }
   }
   else
@@ -135,11 +296,7 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
           !pcl_isfinite (cloud_in.points[indices[i]].y) || 
           !pcl_isfinite (cloud_in.points[indices[i]].z))
         continue;
-      //cloud_out.points[i].getVector3fMap () = transform*cloud_out.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[indices[i]].x, cloud_in[indices[i]].y, cloud_in[indices[i]].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
+      tf.se3 (cloud_in[indices[i]].data, cloud_out[i].data);
     }
   }
 }
@@ -167,23 +324,14 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
     cloud_out.sensor_origin_      = cloud_in.sensor_origin_;
   }
 
+  pcl::detail::Transformer<Scalar> tf (transform.matrix ());
   // If the data is dense, we don't need to check for NaN
   if (cloud_in.is_dense)
   {
     for (size_t i = 0; i < cloud_out.points.size (); ++i)
     {
-      //cloud_out.points[i].getVector3fMap() = transform * cloud_in.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[i].x, cloud_in[i].y, cloud_in[i].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
-
-      // Rotate normals (WARNING: transform.rotation () uses SVD internally!)
-      //cloud_out.points[i].getNormalVector3fMap() = transform.rotation () * cloud_in.points[i].getNormalVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> nt (cloud_in[i].normal_x, cloud_in[i].normal_y, cloud_in[i].normal_z);
-      cloud_out[i].normal_x = static_cast<float> (transform (0, 0) * nt.coeffRef (0) + transform (0, 1) * nt.coeffRef (1) + transform (0, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_y = static_cast<float> (transform (1, 0) * nt.coeffRef (0) + transform (1, 1) * nt.coeffRef (1) + transform (1, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_z = static_cast<float> (transform (2, 0) * nt.coeffRef (0) + transform (2, 1) * nt.coeffRef (1) + transform (2, 2) * nt.coeffRef (2));
+      tf.se3 (cloud_in[i].data, cloud_out[i].data);
+      tf.so3 (cloud_in[i].data_n, cloud_out[i].data_n);
     }
   }
   // Dataset might contain NaNs and Infs, so check for them first.
@@ -195,19 +343,8 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
           !pcl_isfinite (cloud_in.points[i].y) || 
           !pcl_isfinite (cloud_in.points[i].z))
         continue;
-
-      //cloud_out.points[i].getVector3fMap() = transform * cloud_in.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[i].x, cloud_in[i].y, cloud_in[i].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
-
-      // Rotate normals
-      //cloud_out.points[i].getNormalVector3fMap() = transform.rotation () * cloud_in.points[i].getNormalVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> nt (cloud_in[i].normal_x, cloud_in[i].normal_y, cloud_in[i].normal_z);
-      cloud_out[i].normal_x = static_cast<float> (transform (0, 0) * nt.coeffRef (0) + transform (0, 1) * nt.coeffRef (1) + transform (0, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_y = static_cast<float> (transform (1, 0) * nt.coeffRef (0) + transform (1, 1) * nt.coeffRef (1) + transform (1, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_z = static_cast<float> (transform (2, 0) * nt.coeffRef (0) + transform (2, 1) * nt.coeffRef (1) + transform (2, 2) * nt.coeffRef (2));
+      tf.se3 (cloud_in[i].data, cloud_out[i].data);
+      tf.so3 (cloud_in[i].data_n, cloud_out[i].data_n);
     }
   }
 }
@@ -230,6 +367,7 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out.sensor_orientation_ = cloud_in.sensor_orientation_;
   cloud_out.sensor_origin_      = cloud_in.sensor_origin_;
 
+  pcl::detail::Transformer<Scalar> tf (transform.matrix ());
   // If the data is dense, we don't need to check for NaN
   if (cloud_in.is_dense)
   {
@@ -238,18 +376,8 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
       // Copy fields first, then transform
       if (copy_all_fields)
         cloud_out.points[i] = cloud_in.points[indices[i]];
-      //cloud_out.points[i].getVector3fMap() = transform * cloud_in.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[indices[i]].x, cloud_in[indices[i]].y, cloud_in[indices[i]].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
-
-      // Rotate normals
-      //cloud_out.points[i].getNormalVector3fMap() = transform.rotation () * cloud_in.points[i].getNormalVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> nt (cloud_in[indices[i]].normal_x, cloud_in[indices[i]].normal_y, cloud_in[indices[i]].normal_z);
-      cloud_out[i].normal_x = static_cast<float> (transform (0, 0) * nt.coeffRef (0) + transform (0, 1) * nt.coeffRef (1) + transform (0, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_y = static_cast<float> (transform (1, 0) * nt.coeffRef (0) + transform (1, 1) * nt.coeffRef (1) + transform (1, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_z = static_cast<float> (transform (2, 0) * nt.coeffRef (0) + transform (2, 1) * nt.coeffRef (1) + transform (2, 2) * nt.coeffRef (2));
+      tf.se3 (cloud_in[indices[i]].data, cloud_out[i].data);
+      tf.so3 (cloud_in[indices[i]].data_n, cloud_out[i].data_n);
     }
   }
   // Dataset might contain NaNs and Infs, so check for them first.
@@ -266,18 +394,8 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
           !pcl_isfinite (cloud_in.points[indices[i]].z))
         continue;
 
-      //cloud_out.points[i].getVector3fMap() = transform * cloud_in.points[i].getVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> pt (cloud_in[indices[i]].x, cloud_in[indices[i]].y, cloud_in[indices[i]].z);
-      cloud_out[i].x = static_cast<float> (transform (0, 0) * pt.coeffRef (0) + transform (0, 1) * pt.coeffRef (1) + transform (0, 2) * pt.coeffRef (2) + transform (0, 3));
-      cloud_out[i].y = static_cast<float> (transform (1, 0) * pt.coeffRef (0) + transform (1, 1) * pt.coeffRef (1) + transform (1, 2) * pt.coeffRef (2) + transform (1, 3));
-      cloud_out[i].z = static_cast<float> (transform (2, 0) * pt.coeffRef (0) + transform (2, 1) * pt.coeffRef (1) + transform (2, 2) * pt.coeffRef (2) + transform (2, 3));
-
-      // Rotate normals
-      //cloud_out.points[i].getNormalVector3fMap() = transform.rotation () * cloud_in.points[i].getNormalVector3fMap ();
-      Eigen::Matrix<Scalar, 3, 1> nt (cloud_in[indices[i]].normal_x, cloud_in[indices[i]].normal_y, cloud_in[indices[i]].normal_z);
-      cloud_out[i].normal_x = static_cast<float> (transform (0, 0) * nt.coeffRef (0) + transform (0, 1) * nt.coeffRef (1) + transform (0, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_y = static_cast<float> (transform (1, 0) * nt.coeffRef (0) + transform (1, 1) * nt.coeffRef (1) + transform (1, 2) * nt.coeffRef (2));
-      cloud_out[i].normal_z = static_cast<float> (transform (2, 0) * nt.coeffRef (0) + transform (2, 1) * nt.coeffRef (1) + transform (2, 2) * nt.coeffRef (2));
+      tf.se3 (cloud_in[indices[i]].data, cloud_out[i].data);
+      tf.so3 (cloud_in[indices[i]].data_n, cloud_out[i].data_n);
     }
   }
 }
@@ -316,8 +434,8 @@ pcl::transformPoint (const PointT &point,
                      const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
 {
   PointT ret = point;
-  ret.getVector3fMap () = transform * point.getVector3fMap ();
-
+  pcl::detail::Transformer<Scalar> tf (transform.matrix ());
+  tf.se3 (point.data, ret.data);
   return (ret);
 }
 
@@ -327,9 +445,9 @@ pcl::transformPointWithNormal (const PointT &point,
                      const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
 {
   PointT ret = point;
-  ret.getVector3fMap () = transform * point.getVector3fMap ();
-  ret.getNormalVector3fMap () = transform.rotation () * point.getNormalVector3fMap ();
-
+  pcl::detail::Transformer<Scalar> tf (transform.matrix ());
+  tf.se3 (point.data, ret.data);
+  tf.so3 (point.data_n, ret.data_n);
   return (ret);
 }
 


### PR DESCRIPTION
# tl;dr;

This adds an implementation of point cloud transform functions using SSE2 intrinsics. Depending on the transform scalar precision, compiler flags, compiler version, point type, and point cloud properties this may lead to up to 35% faster transforms of VGA-sized point clouds.

The old, non-optimized implementation is retained as a fallback for machines without SSE2 instructions.

# Long version

Recently I was wondering if I can improve performance of `transformPointCloud()` family of functions. This is how they transform every point internally:

https://github.com/PointCloudLibrary/pcl/blob/c78482bacb515c3880386c6ab4566ca964c2ebe2/common/include/pcl/common/impl/transforms.hpp#L67-L71

This manually spelled out vector-matrix product looks strange, especially since Eigen should properly align points and provide vectorized matrix operations. In fact, this already seemed strange to me nearly four years ago. So I asked why and the [answer](https://github.com/PointCloudLibrary/pcl/commit/0266f79136d8c214628ba8d86a02bb2a08a431d8#r7772811) was:

> You wouldn't believe it, but we had a look a long time ago at the generated assembly code and it was faster. Things might have change since then.

I decided to check myself. My development environment is Ubuntu 16.04 with Eigen 3.3 and GCC 5.4. When I switched to use Eigen's vector-matrix multiplication operator, I observed 2x slowdown, indeed. Same with GCC 6.3. However, GCC 7.2 gave nearly 2x speeedup! Clearly, older compilers were not vectorizing properly.

Looking at the disassembly, I found that indeed they are not using vectorized SSE2 instructions. Funny enough, when I compiled with GCC 5.4 and `-msse2` flag (instead of `-march=native`), I got vectorized code. Turns out, in native mode in addition to SSE2 extensions, FMA (fuse-multiply-add) instructions become enabled and compiler starts to abuse them.

So simply switching to vector-matrix product is not an option because depending on the compiler version and compiler flags this introduces either speedups or slowdowns. An alternative was to implement everything directly with SSE2 intrinsics such that compiler can not screw up and is guaranteed to emit optimal SSE2 assembly.

Since PCL does not have a built-in benchmarking framework, I have a separate [repository](https://github.com/taketwo/pcl-transforms) with the proposed implementation and benchmarks. Here are my results with VGA-sized point clouds on i7 from 2015:
 
![benchmark](https://user-images.githubusercontent.com/1241736/37096344-a292a0f6-2218-11e8-9d74-31b5104213e4.png)

For every cell two tests are run: baseline PCL transform and proposed transform. The reported number is the runtime (in microseconds) for the proposed transform and the fraction of the baseline time. Thus numbers less than 1.0 represent improved performance.

I am lazy to provide complete discussion of the results and let anyone interested study this table or even run tests himself. Just couple of points:

 1. The "-no-sse2" people are obviously not affected by this change;
 2. Dense `XYZ` point clouds are transformed 24% to 35% faster;
 3. For double-precision transform matrices there is a performance gain only with old GCC. There are a couple of red cells also, but I tend to think these are measurement noise;
 4. Transformation of `XYZRGBNormal` point clouds is nearly 3 times slower than `XYZ` clouds, although it involves only double the number of operations. I conclude that memory access is the real bottleneck here.

Closes #1255.

<strike>One last note: double-precision transforms can be made faster with AVX instructions. But I leave this as an exercise for the future generations.</strike> (This PR now contains AVX optimizations as well.)
