### PR TITLE
[CMAKE] Fix apps compilation

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SUBSYS_NAME apps)
 set(SUBSYS_DESC "Application examples/samples that show how PCL works")
-set(SUBSYS_DEPS common geometry io filters sample_consensus segmentation visualization kdtree features surface octree registration keypoints tracking search recognition ml stereo)
+set(SUBSYS_DEPS common geometry io filters sample_consensus segmentation visualization kdtree features surface octree registration keypoints tracking search recognition ml stereo 2d)
 
 set(DEFAULT FALSE)
 PCL_SUBSYS_OPTION(build "${SUBSYS_NAME}" "${SUBSYS_DESC}" ${DEFAULT} "${REASON}")


### PR DESCRIPTION
Add the 2d library as a dependance in application directory.

I really would like to see the different existing application of PCL but most of them are obsolete/doesn't compile, etc...

I tried to compile `pcl_apps_point_cloud_editor` with the following command:
```sh
cmake -DBUILD_apps=ON -DBUILD_apps_point_cloud_editor=ON && make
```

Unfortunately, the file `apps/CMakeFiles/pcl_pcd_organized_edge_detection.dir/src/pcd_organized_edge_detection.cpp.o` didn't compile because of missing include directory `2d/include`.

This PR fixes it.