### PR TITLE
Warn and skip adding normal cloud if it is empty

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -843,6 +843,13 @@ pcl::visualization::PCLVisualizer::addPointCloudNormals (
     PCL_ERROR ("[addPointCloudNormals] The number of points differs from the number of normals!\n");
     return (false);
   }
+
+  if (normals->empty ())
+  {
+    PCL_WARN ("[addPointCloudNormals] An empty normal cloud is given! Nothing to display.\n");
+    return (false);
+  }
+
   if (contains (id))
   {
     PCL_WARN ("[addPointCloudNormals] The id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());


### PR DESCRIPTION
Currently the `PCLVisualizer::addPointCloudNormals()` function does not check if the supplied normal cloud is empty. While perhaps logically it's okay to add an empty cloud, the implementation of the function can not deal with empty clouds (see [this line](https://github.com/PointCloudLibrary/pcl/blob/fc88d45bcc4f49904bcff1b4359f1310ab516292/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp#L895), `size_t` underflows and `nr_normals` becomes a ridiculously large number, bad alloc follows). This patch adds an a warning and an early return to avoid issues.