### PR TITLE
Setting the resolution of the occupancy grid

### DIFF
--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -447,6 +447,11 @@ namespace pcl
 
       void
       verify();
+      
+      void setResolutionOccupancyGrid(float r)
+      {
+        res_occupancy_grid_ = r;
+      }
 
       void setRadiusNormals(float r)
       {


### PR DESCRIPTION
If the resolution of a point cloud is in millimeter instead of meter, the resolution of the occupancy grid must be set to ~10. Otherwise, the index at line 348 in hv_go.hpp (int idx = pos_z * size_x * size_y + pos_y * size_x + pos_x;) would overflow and produce a segmentation fault. Nevertheless, the occupancy grid would have way too many entries.