### PR TITLE
Update the OpenMP implementations of normal and FPFH estimation

### DIFF
--- a/features/include/pcl/features/impl/fpfh_omp.hpp
+++ b/features/include/pcl/features/impl/fpfh_omp.hpp
@@ -62,7 +62,8 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
     for (size_t idx = 0; idx < indices_->size (); ++idx)
     {
       int p_idx = (*indices_)[idx];
-      if (this->searchForNeighbors (p_idx, search_parameter_, nn_indices, nn_dists) == 0)
+      if (!isFinite ((*input_)[p_idx]) ||
+          this->searchForNeighbors (p_idx, search_parameter_, nn_indices, nn_dists) == 0)
         continue;
       
       spfh_indices_set.insert (nn_indices.begin (), nn_indices.end ());
@@ -98,7 +99,8 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
     int p_idx = spfh_indices_vec[i];
 
     // Find the neighborhood around p_idx
-    if (this->searchForNeighbors (*surface_, p_idx, search_parameter_, nn_indices, nn_dists) == 0)
+    if (!isFinite ((*input_)[p_idx]) ||
+        this->searchForNeighbors (*surface_, p_idx, search_parameter_, nn_indices, nn_dists) == 0)
       continue;
 
     // Estimate the SPFH signature around p_idx

--- a/features/include/pcl/features/impl/normal_3d_omp.hpp
+++ b/features/include/pcl/features/impl/normal_3d_omp.hpp
@@ -53,7 +53,6 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
   std::vector<float> nn_dists (k_);
 
   output.is_dense = true;
-
   // Save a few cycles by not checking every point for NaN/Inf values if the cloud is set to dense
   if (input_->is_dense)
   {
@@ -63,7 +62,9 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
     // Iterating over the entire index vector
     for (int idx = 0; idx < static_cast<int> (indices_->size ()); ++idx)
     {
-      if (this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
+      Eigen::Vector4f n;
+      if (this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0 ||
+          !computePointNormal (*surface_, nn_indices, n, output.points[idx].curvature))
       {
         output.points[idx].normal[0] = output.points[idx].normal[1] = output.points[idx].normal[2] = output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN ();
 
@@ -71,19 +72,13 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
         continue;
       }
 
-      Eigen::Vector4f n;
-      pcl::computePointNormal<PointInT> (*surface_, nn_indices,
-                                         n,
-                                         output.points[idx].curvature);
-                          
       output.points[idx].normal_x = n[0];
       output.points[idx].normal_y = n[1];
       output.points[idx].normal_z = n[2];
-  
+
       flipNormalTowardsViewpoint (input_->points[(*indices_)[idx]], vpx_, vpy_, vpz_,
-                                  output.points[idx].normal[0], 
-                                  output.points[idx].normal[1], 
-                                  output.points[idx].normal[2]);
+                                  output.points[idx].normal[0], output.points[idx].normal[1], output.points[idx].normal[2]);
+
     }
   }
   else
@@ -91,11 +86,13 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
 #ifdef _OPENMP
 #pragma omp parallel for shared (output) private (nn_indices, nn_dists) num_threads(threads_)
 #endif
-     // Iterating over the entire index vector
+    // Iterating over the entire index vector
     for (int idx = 0; idx < static_cast<int> (indices_->size ()); ++idx)
     {
+      Eigen::Vector4f n;
       if (!isFinite ((*input_)[(*indices_)[idx]]) ||
-          this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
+          this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0 ||
+          !computePointNormal (*surface_, nn_indices, n, output.points[idx].curvature))
       {
         output.points[idx].normal[0] = output.points[idx].normal[1] = output.points[idx].normal[2] = output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN ();
 
@@ -103,19 +100,15 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
         continue;
       }
 
-      Eigen::Vector4f n;
-      pcl::computePointNormal<PointInT> (*surface_, nn_indices,
-                                         n,
-                                         output.points[idx].curvature);
-                          
       output.points[idx].normal_x = n[0];
       output.points[idx].normal_y = n[1];
       output.points[idx].normal_z = n[2];
 
       flipNormalTowardsViewpoint (input_->points[(*indices_)[idx]], vpx_, vpy_, vpz_,
                                   output.points[idx].normal[0], output.points[idx].normal[1], output.points[idx].normal[2]);
+
     }
- }
+  }
 }
 
 #define PCL_INSTANTIATE_NormalEstimationOMP(T,NT) template class PCL_EXPORTS pcl::NormalEstimationOMP<T,NT>;


### PR DESCRIPTION
The OpenMP implementations in the "features" module are missing bug fixes which have already been applied to the standard implementations some time ago.

This PR fixes two issues:
- NormalEstimationOMP should set the normal-cloud to non-dense when the computation fails
- FPFHEstimationOMP must skip invalid points or the kdtree-search will assert