### PR TITLE
Added missing 8 bytes to compressed binary pcd length.

### DIFF
--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -781,6 +781,8 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
         return (-1);
       }
       mmap_size += compressed_size;
+      // Add the 8 bytes used to store the compressed and uncompressed size
+      mmap_size += 8;
 
       // Reset position
       pcl_lseek (fd, 0, SEEK_SET);


### PR DESCRIPTION
When compressed binary pcd files are read the size passed to mmap for memory mapping the file is 8 bytes to small, as the size of the two four byte unsigned integers used to store the uncompressed and compressed size of the data in the pcd file are not added to the total size. This can lead to a segfault, when the size of a pcd file is at most 8 bytes smaller than the next multiple of the page size of the virtual address space and if the next page after the last page used by mmap is not owned by the process.