### PR TITLE
Tiny fixes: Typo + function type

### DIFF
--- a/common/include/pcl/common/colors.h
+++ b/common/include/pcl/common/colors.h
@@ -59,7 +59,7 @@ namespace pcl
       /** Get a color from the lookup table with a given id.
         *
         * The id should be less than the size of the LUT (see size()). */
-      static RGB at (unsigned int color_id);
+      static RGB at (size_t color_id);
 
       /** Get the number of colors in the lookup table.
         *

--- a/common/src/colors.cpp
+++ b/common/src/colors.cpp
@@ -300,10 +300,10 @@ static const unsigned char GLASBEY_LUT[] =
 };
 
 /// Number of colors in Glasbey lookup table
-static const unsigned int GLASBEY_LUT_SIZE = sizeof (GLASBEY_LUT) / (sizeof (GLASBEY_LUT[0]) * 3);
+static const size_t GLASBEY_LUT_SIZE = sizeof (GLASBEY_LUT) / (sizeof (GLASBEY_LUT[0]) * 3);
 
 pcl::RGB
-pcl::GlasbeyLUT::at (unsigned int color_id)
+pcl::GlasbeyLUT::at (size_t color_id)
 {
   assert (color_id < GLASBEY_LUT_SIZE);
   pcl::RGB color;

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3858,7 +3858,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
   cam->SetViewAngle (view_angle);
   cam->Modified ();
 
-  //For each camera position, traposesnsform the object and render view
+  //For each camera position, transform the object and render view
   for (size_t i = 0; i < cam_positions.size (); i++)
   {
     cam_pos[0] = cam_positions[i][0];


### PR DESCRIPTION
Changes:

* 1febf00

   pcl_visualizer: Fix typo in comment

* fe04456

   Make GlasbeyLUT at() and size() consistent

   Without this, code such as this:

       size_t i = 10000;
      pcl::RGB color = pcl::GlasbeyLUT::at(i % pcl::GlasbeyLUT::size());

   ... produces the warning `Parameter type mismatch: Values of type 'size_t' may not fit into the receiver type 'unsigned int'`.