### PR TITLE
fix missing vtkTexture.h, follow up on #2291

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -96,6 +96,10 @@
 #include <vtkLookupTable.h>
 #include <vtkTextureUnitManager.h>
 
+#if VTK_MAJOR_VERSION > 7
+#include <vtkTexture.h>
+#endif
+
 #include <pcl/visualization/common/shapes.h>
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/visualization/common/common.h>


### PR DESCRIPTION
This is a follow up on #2291. I forgot to include the header `vtkTexture.h`. We need this otherwise it won't compile. I discovered this after a fresh clone on a new computer. My bad on not realizing this earlier. 