### PR TITLE
Second change VTK version check in addTextureMesh

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3524,7 +3524,7 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
   std::size_t tex_id = 0;
   while (tex_id < last_tex_id)
   {
-#if VTK_MAJOR_VERSION < 8
+#if VTK_MAJOR_VERSION < 9
     int tu = vtkProperty::VTK_TEXTURE_UNIT_0 + tex_id;
 #else
     const char *tu = mesh.tex_materials[tex_id].tex_name.c_str ();


### PR DESCRIPTION
Fixes an issue introduced by #2291 and not completely fixed with  #2311.

The changes in the VTK API adressed in #2291 did not make it into the VTK releases 8.x, they were directly applied on the master branch with VTK version 9.0.0. As a result, the visualization module of the current pcl master does not compile against the pcl releases with version 8.x . This PR resolves the issue.