### PR TITLE
Added warnings when the input data is to large for compressed pcds

### DIFF
--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -340,6 +340,14 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   // Compute the size of data
   data_size = cloud.points.size () * fsize;
 
+  // If the data is to large the two 32 bit integers used to store the
+  // compressed and uncompressed size will overflow.
+  if (data_size * 3 / 2 > std::numeric_limits<uint32_t>::max ()) {
+    PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] The input data exceeds the maximum size for compressed version 0.7 pcds of %l bytes.\n",
+               static_cast<size_t>(std::numeric_limits<uint32_t>::max()) * 2 / 3);
+    return (-2);
+  }
+
   //////////////////////////////////////////////////////////////////////
   // Empty array holding only the valid data
   // data_size = nr_points * point_size 

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -342,9 +342,10 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
 
   // If the data is to large the two 32 bit integers used to store the
   // compressed and uncompressed size will overflow.
-  if (data_size * 3 / 2 > std::numeric_limits<uint32_t>::max ()) {
+  if (data_size * 3 / 2 > std::numeric_limits<uint32_t>::max ())
+  {
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] The input data exceeds the maximum size for compressed version 0.7 pcds of %l bytes.\n",
-               static_cast<size_t>(std::numeric_limits<uint32_t>::max()) * 2 / 3);
+               static_cast<size_t> (std::numeric_limits<uint32_t>::max ()) * 2 / 3);
     return (-2);
   }
 

--- a/io/include/pcl/io/pcd_io.h
+++ b/io/include/pcl/io/pcd_io.h
@@ -406,6 +406,10 @@ namespace pcl
         * \param[in] cloud the point cloud data message
         * \param[in] origin the sensor acquisition origin
         * \param[in] orientation the sensor acquisition orientation
+        * \return
+        * (-1) for a general error
+        * (-2) if the input cloud is too large for the file format
+        * 0 on success
         */
       int 
       writeBinaryCompressed (const std::string &file_name, const pcl::PCLPointCloud2 &cloud,
@@ -417,6 +421,10 @@ namespace pcl
         * \param[in] cloud the point cloud data message
         * \param[in] origin the sensor acquisition origin
         * \param[in] orientation the sensor acquisition orientation
+        * \return
+        * (-1) for a general error
+        * (-2) if the input cloud is too large for the file format
+        * 0 on success
         */
       int
       writeBinaryCompressed (std::ostream &os, const pcl::PCLPointCloud2 &cloud,
@@ -487,6 +495,10 @@ namespace pcl
       /** \brief Save point cloud data to a binary comprssed PCD file
         * \param[in] file_name the output file name
         * \param[in] cloud the point cloud data message
+        * \return
+        * (-1) for a general error
+        * (-2) if the input cloud is too large for the file format
+        * 0 on success
         */
       template <typename PointT> int 
       writeBinaryCompressed (const std::string &file_name, 

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -1389,9 +1389,10 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
 
   // If the data is too large the two 32 bit integers used to store the
   // compressed and uncompressed size will overflow.
-  if (data_size * 3 / 2 > std::numeric_limits<uint32_t>::max ()) {
+  if (data_size * 3 / 2 > std::numeric_limits<uint32_t>::max ())
+  {
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] The input data exceeds the maximum size for compressed version 0.7 pcds of %l bytes.\n",
-               static_cast<size_t>(std::numeric_limits<uint32_t>::max()) * 2 / 3);
+               static_cast<size_t> (std::numeric_limits<uint32_t>::max ()) * 2 / 3);
     return (-2);
   }
 

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -1387,6 +1387,14 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
   // Compute the size of data
   data_size = cloud.width * cloud.height * fsize;
 
+  // If the data is too large the two 32 bit integers used to store the
+  // compressed and uncompressed size will overflow.
+  if (data_size * 3 / 2 > std::numeric_limits<uint32_t>::max ()) {
+    PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] The input data exceeds the maximum size for compressed version 0.7 pcds of %l bytes.\n",
+               static_cast<size_t>(std::numeric_limits<uint32_t>::max()) * 2 / 3);
+    return (-2);
+  }
+
   //////////////////////////////////////////////////////////////////////
   // Empty array holding only the valid data
   // data_size = nr_points * point_size 
@@ -1452,10 +1460,11 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name, const pcl::
 {
   // Format output
   std::ostringstream oss;
-  if (writeBinaryCompressed (oss, cloud, origin, orientation))
+  int status = writeBinaryCompressed (oss, cloud, origin, orientation);
+  if (status)
   {
     throw pcl::IOException ("[pcl::PCDWriter::writeBinaryCompressed] Error during compression!");
-    return (-1);
+    return status;
   }
   std::string ostr = oss.str ();
 


### PR DESCRIPTION
This pr adds a warning if the input data to a binary compressed pcd is too large as suggested in #2152.