### PR TITLE
outofcore: Explictly use mt19937 random generator for boost 1.67.

### DIFF
--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -74,7 +74,7 @@ namespace pcl
     OutofcoreOctreeDiskContainer<PointT>::rand_gen_ (static_cast<unsigned int> (std::time(NULL)));
 
     template<typename PointT>
-    boost::uuids::random_generator OutofcoreOctreeDiskContainer<PointT>::uuid_gen_ (&rand_gen_);
+    boost::uuids::basic_random_generator<boost::mt19937> OutofcoreOctreeDiskContainer<PointT>::uuid_gen_ (&rand_gen_);
 
     template<typename PointT>
     const uint64_t OutofcoreOctreeDiskContainer<PointT>::READ_BLOCK_SIZE_ = static_cast<uint64_t> (2e12);

--- a/outofcore/include/pcl/outofcore/octree_disk_container.h
+++ b/outofcore/include/pcl/outofcore/octree_disk_container.h
@@ -296,7 +296,7 @@ namespace pcl
 
         static boost::mutex rng_mutex_;
         static boost::mt19937 rand_gen_;
-        static boost::uuids::random_generator uuid_gen_;
+        static boost::uuids::basic_random_generator<boost::mt19937> uuid_gen_;
 
     };
   } //namespace outofcore


### PR DESCRIPTION
This should fix #2284.

Boost 1.67 switched the default `boost::uuid::random_generator` from `boost::uuid::basic_random_generator<boost::mt19937>` to `boost::uuid::random_generator_pure` which uses OS provided randomness.

The new one doesn't accept a PRNG as constructor argument anymore. This PR switches back to the old behaviour explicitly.

It may actually be a good idea to switch to the new behaviour, but that would require some preprocessor checks to stay compatible with boost < 1.67. This PR doesn't change anything, it just chooses the old default explicitly.

Preprocessor checks can be added instead if that has the preference.