### PR TITLE
Add header with low level I/O helpers.

### DIFF
--- a/io/include/pcl/io/low_level_io.h
+++ b/io/include/pcl/io/low_level_io.h
@@ -1,0 +1,165 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *  Copyright (c) 2018 Fizyr BV. - https://fizyr.com
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This file defines compatibility wrappers for low level I/O functions.
+ * Implemented as inlinable functions to prevent any performance overhead.
+ */
+
+#ifndef __PCL_IO_LOW_LEVEL_IO__
+#define __PCL_IO_LOW_LEVEL_IO__
+
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
+# include <io.h>
+# include <windows.h>
+# include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+# include <unistd.h>
+# include <sys/mman.h>
+# include <sys/types.h>
+# include <sys/stat.h>
+# include <sys/fcntl.h>
+#endif
+
+namespace pcl
+{
+  namespace io
+  {
+#ifdef _WIN32
+    inline int raw_open(const char * pathname, int flags, int mode)
+    {
+      return ::_open(pathname, flags, mode);
+    }
+
+    inline int raw_open(const char * pathname, int flags)
+    {
+      return ::_open(pathname, flags);
+    }
+
+    inline int raw_close(int fd)
+    {
+      return ::_close(fd);
+    }
+
+    inline int raw_lseek(int fd, long offset, int whence)
+    {
+      return ::_lseek(fd, offset, whence);
+    }
+
+    inline int raw_read(int fd, void * buffer, size_t count)
+    {
+      return ::_read(fd, buffer, count);
+    }
+
+    inline int raw_write(int fd, const void * buffer, size_t count)
+    {
+      return ::_write(fd, buffer, count);
+    }
+
+    inline int raw_fallocate(int fd, long len)
+    {
+      return ::_chsize(fd, len);
+    }
+#else
+    inline int raw_open(const char * pathname, int flags, int mode)
+    {
+      return ::open(pathname, flags, mode);
+    }
+
+    inline int raw_open(const char * pathname, int flags)
+    {
+      return ::open(pathname, flags);
+    }
+
+    inline int raw_close(int fd)
+    {
+      return ::close(fd);
+    }
+
+    inline off_t raw_lseek(int fd, off_t offset, int whence)
+    {
+      return ::lseek(fd, offset, whence);
+    }
+
+    inline ssize_t raw_read(int fd, void * buffer, size_t count)
+    {
+      return ::read(fd, buffer, count);
+    }
+
+    inline ssize_t raw_write(int fd, const void * buffer, size_t count)
+    {
+      return ::write(fd, buffer, count);
+    }
+
+# ifndef __APPLE__
+    inline int raw_fallocate(int fd, off_t len)
+    {
+      return ::posix_fallocate(fd, 0, len);
+    }
+# else
+    inline int raw_fallocate(int fd, off_t len)
+    {
+      // Try to allocate contiguous space first.
+      ::fstore_t store = {F_ALLOCATEALL | F_ALLOCATECONTIG, F_PEOFPOSMODE, 0, len};
+      if (::fcntl(fd, F_PREALLOCATE, &store) < 0)
+      {
+        // Try fragmented if that failed.
+        store.fst_flags = F_ALLOCATEALL;
+        int ret = ::fcntl(fd, F_PREALLOCATE, &store);
+
+        // Bail if it still failed.
+        if (ret < 0) {
+          return ret;
+        }
+      }
+
+      // File could be larger than requested, so truncate.
+      return ::ftruncate(fd, len);
+    }
+# endif // __APPLE__
+#endif // _WIN32
+
+  }
+}
+#endif // __PCL_IO_LOW_LEVEL_IO__

--- a/io/src/lzf_image_io.cpp
+++ b/io/src/lzf_image_io.cpp
@@ -35,6 +35,7 @@
  *
  */
 #include <pcl/console/time.h>
+#include <pcl/io/low_level_io.h>
 #include <pcl/io/lzf_image_io.h>
 #include <pcl/io/lzf.h>
 #include <pcl/console/print.h>
@@ -43,19 +44,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
-
-#ifdef _WIN32
-# include <io.h>
-# include <windows.h>
-# define pcl_open                    _open
-# define pcl_close(fd)               _close(fd)
-# define pcl_lseek(fd,offset,origin) _lseek(fd,offset,origin)
-#else
-# include <sys/mman.h>
-# define pcl_open                    open
-# define pcl_close(fd)               close(fd)
-# define pcl_lseek(fd,offset,origin) lseek(fd,offset,origin)
-#endif
 
 #define LZF_HEADER_SIZE 37
 
@@ -87,34 +75,34 @@ pcl::io::LZFImageWriter::saveImageBlob (const char* data,
   UnmapViewOfFile (map);
   CloseHandle (h_native_file);
 #else
-  int fd = pcl_open (filename.c_str (), O_RDWR | O_CREAT | O_TRUNC, static_cast<mode_t> (0600));
+  int fd = raw_open (filename.c_str (), O_RDWR | O_CREAT | O_TRUNC, static_cast<mode_t> (0600));
   if (fd < 0)
     return (false);
 
   // Allocate disk space for the entire file to prevent bus errors.
   if (::posix_fallocate (fd, 0, data_size) != 0)
   {
-    pcl_close (fd);
+    raw_close (fd);
     throw pcl::IOException ("[pcl::PCDWriter::writeBinary] Error during posix_fallocate ()!");
     return (false);
   }
 
-  char *map = static_cast<char*> (mmap (0, data_size, PROT_WRITE, MAP_SHARED, fd, 0));
+  char *map = static_cast<char*> (::mmap (0, data_size, PROT_WRITE, MAP_SHARED, fd, 0));
   if (map == reinterpret_cast<char*> (-1))    // MAP_FAILED
   {
-    pcl_close (fd);
+    raw_close (fd);
     return (false);
   }
 
   // Copy the data
   memcpy (&map[0], data, data_size);
 
-  if (munmap (map, (data_size)) == -1)
+  if (::munmap (map, (data_size)) == -1)
   {
-    pcl_close (fd);
+    raw_close (fd);
     return (false);
   }
-  pcl_close (fd);
+  raw_close (fd);
 #endif
   return (true);
 }
@@ -379,7 +367,7 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
     return (false);
   }
   // Open for reading
-  int fd = pcl_open (filename.c_str (), O_RDONLY);
+  int fd = raw_open (filename.c_str (), O_RDONLY);
   if (fd == -1)
   {
     PCL_ERROR ("[pcl::io::LZFImageReader::loadImage] Failure to open file %s\n", filename.c_str () );
@@ -387,15 +375,15 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
   }
 
   // Seek to the end of file to get the filesize
-  off_t data_size = pcl_lseek (fd, 0, SEEK_END);
+  long data_size = raw_lseek (fd, 0, SEEK_END);
   if (data_size < 0)
   {
-    pcl_close (fd);
+    raw_close (fd);
     PCL_ERROR ("[pcl::io::LZFImageReader::loadImage] lseek errno: %d strerror: %s\n", errno, strerror (errno));
     PCL_ERROR ("[pcl::io::LZFImageReader::loadImage] Error during lseek ()!\n");
     return (false);
   }
-  pcl_lseek (fd, 0, SEEK_SET);
+  raw_lseek (fd, 0, SEEK_SET);
 
 #ifdef _WIN32
   // As we don't know the real size of data (compressed or not), 
@@ -407,15 +395,15 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
   if (map == NULL)
   {
     CloseHandle (fm);
-    pcl_close (fd);
+    raw_close (fd);
     PCL_ERROR ("[pcl::io::LZFImageReader::loadImage] Error mapping view of file, %s\n", filename.c_str ());
     return (false);
   }
 #else
-  char *map = static_cast<char*> (mmap (0, data_size, PROT_READ, MAP_SHARED, fd, 0));
+  char *map = static_cast<char*> (::mmap (0, data_size, PROT_READ, MAP_SHARED, fd, 0));
   if (map == reinterpret_cast<char*> (-1))    // MAP_FAILED
   {
-    pcl_close (fd);
+    raw_close (fd);
     PCL_ERROR ("[pcl::io::LZFImageReader::loadImage] Error preparing mmap for PCLZF file.\n");
     return (false);
   }
@@ -431,7 +419,7 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
   UnmapViewOfFile (map);
   CloseHandle (fm);
 #else
-    munmap (map, data_size);
+    ::munmap (map, data_size);
 #endif
     return (false);
   }
@@ -453,7 +441,7 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
   UnmapViewOfFile (map);
   CloseHandle (fm);
 #else
-    munmap (map, data_size);
+    ::munmap (map, data_size);
 #endif
     return (false);
   }
@@ -467,12 +455,12 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
   UnmapViewOfFile (map);
   CloseHandle (fm);
 #else
-  if (munmap (map, data_size) == -1)
+  if (::munmap (map, data_size) == -1)
     PCL_ERROR ("[pcl::io::LZFImageReader::loadImage] Munmap failure\n");
 #endif
-  pcl_close (fd);
+  raw_close (fd);
 
-  data_size = off_t (compressed_size);      // We only care about this from here on
+  data_size = compressed_size;      // We only care about this from here on
   return (true);
 }
 

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -43,25 +43,14 @@
 #include <stdlib.h>
 #include <pcl/io/boost.h>
 #include <pcl/common/io.h>
-#include <pcl/io/pcd_io.h>
+#include <pcl/io/low_level_io.h>
 #include <pcl/io/lzf.h>
+#include <pcl/io/pcd_io.h>
 #include <pcl/console/time.h>
 
 #include <cstring>
 #include <cerrno>
 
-#ifdef _WIN32
-# include <io.h>
-# include <windows.h>
-# define pcl_open                    _open
-# define pcl_close(fd)               _close(fd)
-# define pcl_lseek(fd,offset,origin) _lseek(fd,offset,origin)
-#else
-# include <sys/mman.h>
-# define pcl_open                    open
-# define pcl_close(fd)               close(fd)
-# define pcl_lseek(fd,offset,origin) lseek(fd,offset,origin)
-#endif
 #include <boost/version.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -750,7 +739,7 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
   /// We must re-open the file and read with mmap () for binary
   {
     // Open for reading
-    int fd = pcl_open (file_name.c_str (), O_RDONLY);
+    int fd = io::raw_open (file_name.c_str (), O_RDONLY);
     if (fd == -1)
     {
       PCL_ERROR ("[pcl::PCDReader::read] Failure to open file %s\n", file_name.c_str () );
@@ -758,17 +747,17 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
     }
 
     // Infer file size
-    const size_t file_size = pcl_lseek (fd, 0, SEEK_END);
-    pcl_lseek (fd, 0, SEEK_SET);
+    const size_t file_size = io::raw_lseek (fd, 0, SEEK_END);
+    io::raw_lseek (fd, 0, SEEK_SET);
     
     size_t mmap_size = offset + data_idx;   // ...because we mmap from the start of the file.
     if (data_type == 2)
     {
       // Seek to real start of data.
-      off_t result = pcl_lseek (fd, offset + data_idx, SEEK_SET);
+      long result = io::raw_lseek (fd, offset + data_idx, SEEK_SET);
       if (result < 0)
       {
-        pcl_close (fd);
+        io::raw_close (fd);
         PCL_ERROR ("[pcl::PCDReader::read] lseek errno: %d strerror: %s\n", errno, strerror (errno));
         PCL_ERROR ("[pcl::PCDReader::read] Error during lseek ()!\n");
         return (-1);
@@ -776,10 +765,10 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
     
       // Read compressed size to compute how much must be mapped
       unsigned int compressed_size = 0;
-      ssize_t num_read = pcl_read (fd, &compressed_size, 4);
+      ssize_t num_read = io::raw_read (fd, &compressed_size, 4);
       if (num_read < 0)
       {
-        pcl_close (fd);
+        io::raw_close (fd);
         PCL_ERROR ("[pcl::PCDReader::read] read errno: %d strerror: %s\n", errno, strerror (errno));
         PCL_ERROR ("[pcl::PCDReader::read] Error during read()!\n");
         return (-1);
@@ -789,7 +778,7 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
       mmap_size += 8;
 
       // Reset position
-      pcl_lseek (fd, 0, SEEK_SET);
+      io::raw_lseek (fd, 0, SEEK_SET);
     }
     else
     {
@@ -798,7 +787,7 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
 
     if (mmap_size > file_size)
     {
-      pcl_close (fd);
+      io::raw_close (fd);
       PCL_ERROR ("[pcl::PCDReader::read] Corrupted PCD file. The file is smaller than expected!\n");
       return (-1);
     }
@@ -814,15 +803,15 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
     if (map == NULL)
     {
       CloseHandle (fm);
-      pcl_close (fd);
+      io::raw_close (fd);
       PCL_ERROR ("[pcl::PCDReader::read] Error mapping view of file, %s\n", file_name.c_str ());
       return (-1);
     }
 #else
-    unsigned char *map = static_cast<unsigned char*> (mmap (0, mmap_size, PROT_READ, MAP_SHARED, fd, 0));
+    unsigned char *map = static_cast<unsigned char*> (::mmap (0, mmap_size, PROT_READ, MAP_SHARED, fd, 0));
     if (map == reinterpret_cast<unsigned char*> (-1))    // MAP_FAILED
     {
-      pcl_close (fd);
+      io::raw_close (fd);
       PCL_ERROR ("[pcl::PCDReader::read] Error preparing mmap for binary PCD file.\n");
       return (-1);
     }
@@ -835,14 +824,14 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
     UnmapViewOfFile (map);
     CloseHandle (fm);
 #else
-    if (munmap (map, mmap_size) == -1)
+    if (::munmap (map, mmap_size) == -1)
     {
-      pcl_close (fd);
+      io::raw_close (fd);
       PCL_ERROR ("[pcl::PCDReader::read] Munmap failure\n");
       return (-1);
     }
 #endif
-    pcl_close (fd);
+    io::raw_close (fd);
   }
   double total_time = tt.toc ();
   PCL_DEBUG ("[pcl::PCDReader::read] Loaded %s as a %s cloud in %g ms with %d points. Available dimensions: %s.\n", 
@@ -1272,7 +1261,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
   setLockingPermissions (file_name, file_lock);
 
 #else
-  int fd = pcl_open (file_name.c_str (), O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  int fd = io::raw_open (file_name.c_str (), O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
   if (fd < 0)
   {
     PCL_ERROR ("[pcl::PCDWriter::writeBinary] Error during open (%s)!\n", file_name.c_str());
@@ -1283,10 +1272,10 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
   setLockingPermissions (file_name, file_lock);
 
   // Stretch the file size to the size of the data
-  off_t result = pcl_lseek (fd, getpagesize () + cloud.data.size () - 1, SEEK_SET);
+  long result = io::raw_lseek (fd, getpagesize () + cloud.data.size () - 1, SEEK_SET);
   if (result < 0)
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinary] lseek errno: %d strerror: %s\n", errno, strerror (errno));
     PCL_ERROR ("[pcl::PCDWriter::writeBinary] Error during lseek ()!\n");
@@ -1296,7 +1285,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
   result = static_cast<int> (::write (fd, "", 1));
   if (result != 1)
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinary] Error during write ()!\n");
     return (-1);
@@ -1312,7 +1301,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
   char *map = static_cast<char*> (mmap (0, static_cast<size_t> (data_idx + cloud.data.size ()), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
   if (map == reinterpret_cast<char*> (-1))    // MAP_FAILED
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinary] Error during mmap ()!\n");
     return (-1);
@@ -1335,9 +1324,9 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
 #ifdef _WIN32
     UnmapViewOfFile (map);
 #else
-  if (munmap (map, static_cast<size_t> (data_idx + cloud.data.size ())) == -1)
+  if (::munmap (map, static_cast<size_t> (data_idx + cloud.data.size ())) == -1)
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinary] Error during munmap ()!\n");
     return (-1);
@@ -1347,7 +1336,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
 #ifdef _WIN32
   CloseHandle(h_native_file);
 #else
-  pcl_close (fd);
+  io::raw_close (fd);
 #endif
   resetLockingPermissions (file_name, file_lock);
   return (0);
@@ -1481,7 +1470,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name, const pcl::
     return (-1);
   }
 #else
-  int fd = pcl_open (file_name.c_str (), O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  int fd = io::raw_open (file_name.c_str (), O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
   if (fd < 0)
   {
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] Error during open (%s)!\n", file_name.c_str ());
@@ -1497,10 +1486,10 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name, const pcl::
   size_t page_size = getpagesize ();
   size_t size_pages = ostr.size () / page_size;
   size_t partial_pages = (size_pages * page_size < ostr.size ()) ? 1 : 0;
-  off_t result = pcl_lseek (fd, (size_pages + partial_pages) * page_size - 1, SEEK_SET);
+  long result = io::raw_lseek (fd, (size_pages + partial_pages) * page_size - 1, SEEK_SET);
   if (result < 0)
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] lseek errno: %d strerror: %s\n", errno, strerror (errno));
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] Error during lseek ()!\n");
@@ -1510,7 +1499,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name, const pcl::
   result = static_cast<int> (::write (fd, "", 1));
   if (result != 1)
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] Error during write ()!\n");
     return (-1);
@@ -1524,10 +1513,10 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name, const pcl::
   CloseHandle (fm);
 
 #else
-  char *map = static_cast<char*> (mmap (0, ostr.size (), PROT_WRITE, MAP_SHARED, fd, 0));
+  char *map = static_cast<char*> (::mmap (0, ostr.size (), PROT_WRITE, MAP_SHARED, fd, 0));
   if (map == reinterpret_cast<char*> (-1))    // MAP_FAILED
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] Error during mmap ()!\n");
     return (-1);
@@ -1547,9 +1536,9 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name, const pcl::
 #ifdef _WIN32
     UnmapViewOfFile (map);
 #else
-  if (munmap (map, ostr.size ()) == -1)
+  if (::munmap (map, ostr.size ()) == -1)
   {
-    pcl_close (fd);
+    io::raw_close (fd);
     resetLockingPermissions (file_name, file_lock);
     PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] Error during munmap ()!\n");
     return (-1);
@@ -1559,7 +1548,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name, const pcl::
 #ifdef _WIN32
   CloseHandle (h_native_file);
 #else
-  pcl_close (fd);
+  io::raw_close (fd);
 #endif
   resetLockingPermissions (file_name, file_lock);
 


### PR DESCRIPTION
This PR adds a header with some low level I/O wrappers for Windows, Unix and OSX compatibility, as discussed in #2325.

Most importantly, it should fix the use of `::posix_fallocate` for OSX.

I didn't compile yet, as compiling PCL takes quite some time. But feedback is already welcome.

Note that there are a few more modules that have some `#define pcl_open ...` and similar, but right now I added the header to the IO module. Maybe the header should move to the core module so all modules can use it?