### PR TITLE
Improve QHull finder script

### DIFF
--- a/cmake/Modules/FindQhull.cmake
+++ b/cmake/Modules/FindQhull.cmake
@@ -6,7 +6,7 @@
 # QHULL_INCLUDE_DIRS - Directories containing the QHULL include files.
 # QHULL_LIBRARIES - Libraries needed to use QHULL.
 # QHULL_DEFINITIONS - Compiler flags for QHULL.
-# If QHULL_USE_STATIC is specified then look for static libraries ONLY else 
+# If QHULL_USE_STATIC is specified then look for static libraries ONLY else
 # look for shared ones
 
 set(QHULL_MAJOR_VERSION 6)
@@ -22,7 +22,7 @@ endif(QHULL_USE_STATIC)
 find_file(QHULL_HEADER
           NAMES libqhull/libqhull.h qhull.h
           HINTS "${QHULL_ROOT}" "$ENV{QHULL_ROOT}" "${QHULL_INCLUDE_DIR}"
-          PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull" 
+          PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull"
           PATH_SUFFIXES qhull src/libqhull libqhull include)
 
 set(QHULL_HEADER "${QHULL_HEADER}" CACHE INTERNAL "QHull header" FORCE )
@@ -41,20 +41,18 @@ else(QHULL_HEADER)
   set(QHULL_INCLUDE_DIR "QHULL_INCLUDE_DIR-NOTFOUND")
 endif(QHULL_HEADER)
 
-set(QHULL_INCLUDE_DIR "${QHULL_INCLUDE_DIR}" CACHE PATH "QHull include dir." FORCE)
-
-find_library(QHULL_LIBRARY 
+find_library(QHULL_LIBRARY
              NAMES ${QHULL_RELEASE_NAME}
              HINTS "${QHULL_ROOT}" "$ENV{QHULL_ROOT}"
-             PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull" 
+             PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull"
              PATH_SUFFIXES project build bin lib)
 
 get_filename_component(QHULL_LIBRARY_NAME "${QHULL_LIBRARY}" NAME)
 
-find_library(QHULL_LIBRARY_DEBUG 
+find_library(QHULL_LIBRARY_DEBUG
              NAMES ${QHULL_DEBUG_NAME} ${QHULL_RELEASE_NAME}
              HINTS "${QHULL_ROOT}" "$ENV{QHULL_ROOT}"
-             PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull" 
+             PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull"
              PATH_SUFFIXES project build bin lib debug/lib)
 
 if(NOT QHULL_LIBRARY_DEBUG)
@@ -63,13 +61,26 @@ endif(NOT QHULL_LIBRARY_DEBUG)
 
 get_filename_component(QHULL_LIBRARY_DEBUG_NAME "${QHULL_LIBRARY_DEBUG}" NAME)
 
-set(QHULL_INCLUDE_DIRS ${QHULL_INCLUDE_DIR})
-set(QHULL_LIBRARIES optimized ${QHULL_LIBRARY} debug ${QHULL_LIBRARY_DEBUG})
+if(QHULL_INCLUDE_DIR AND QHULL_LIBRARY)
+
+  # Include directories
+  set(QHULL_INCLUDE_DIRS ${QHULL_INCLUDE_DIR})
+  unset(QHULL_INCLUDE_DIR)
+  mark_as_advanced(QHULL_INCLUDE_DIRS)
+
+  # Libraries
+  set(QHULL_LIBRARIES optimized ${QHULL_LIBRARY} debug ${QHULL_LIBRARY_DEBUG})
+  unset(QHULL_LIBRARY)
+  unset(QHULL_LIBRARY_DEBUG)
+  mark_as_advanced(QHULL_LIBRARIES)
+
+endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Qhull DEFAULT_MSG QHULL_LIBRARY QHULL_INCLUDE_DIR)
-
-mark_as_advanced(QHULL_LIBRARY QHULL_LIBRARY_DEBUG QHULL_INCLUDE_DIR)
+find_package_handle_standard_args(Qhull
+  FOUND_VAR QHULL_FOUND
+  REQUIRED_VARS QHULL_LIBRARIES QHULL_INCLUDE_DIRS
+)
 
 if(QHULL_FOUND)
   set(HAVE_QHULL ON)


### PR DESCRIPTION
* Make sure `QHULL_LIBRARIES` and `QHULL_INCLUDE_DIRS` variables are not defined if QHull is not found
* Make `QHULL_LIBRARIES` and `QHULL_INCLUDE_DIRS` advanced options
* Some reformatting

Fixes #2343; similar to #2061.

@kgreenek please confirm that this works for you.