### PR TITLE
Unbreak build against Boost 1.68

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -104,7 +104,11 @@
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/visualization/common/common.h>
 #include <pcl/common/time.h>
+#if (BOOST_VERSION >= 106600)
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 #include <boost/filesystem.hpp>
 #include <pcl/console/parse.h>
 


### PR DESCRIPTION
After boostorg/uuid@33da3e2a5b87 (and boostorg/uuid@3d2f7758e9e1) build fails. See [error log](https://ptpb.pw/JLHZ)

CC @ilovezfs