### PR TITLE
Create a clang-format config for PCL style.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,48 @@
+---
+Language: Cpp
+ColumnLimit: 160 # From Eclipse code style file
+
+# Namespaces
+# If multiple namespaces are declared within header files, always use 2 spaces to indent them
+CompactNamespaces: false
+NamespaceIndentation: All
+
+# Classes
+AlwaysBreakTemplateDeclarations: true # The template parameters of a class should be declared on a different line
+BreakConstructorInitializers:  AfterColon
+SpaceAfterTemplateKeyword: true
+SpacesInAngles: false
+
+# Functions/Methods
+AlignAfterOpenBracket: Align
+AlwaysBreakAfterReturnType: All # The return type of each function declaration must be placed on a different line
+BinPackArguments: true
+BinPackParameters: true
+IndentWrappedFunctionNames: false
+SpaceBeforeParens: Always
+SpaceInEmptyParentheses: false
+SpacesInParentheses: false
+
+# Braces
+# Braces, both open and close, go on their own lines
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Allman
+AllowShortCaseLabelsOnASingleLine: false
+
+# Spacing
+AccessModifierOffset: 0 # Access qualifiers (public, private and protected) are put at the indentation level of the class body
+IndentCaseLabels: true
+# The standard indentation for each block in PCL is 2 spaces
+ContinuationIndentWidth: 2
+IndentWidth: 2
+UseTab: Never
+
+# Miscellaneous
+BreakBeforeBinaryOperators: NonAssignment # When a long formula is broken across many lines, start each line with operator
+BreakBeforeTernaryOperators: true
+MaxEmptyLinesToKeep: 1
+SpaceBeforeAssignmentOperators: true
+SpacesInCStyleCastParentheses: false
+SpacesInSquareBrackets: false

--- a/.travis.sh
+++ b/.travis.sh
@@ -7,6 +7,8 @@ DOC_DIR=$BUILD_DIR/doc/doxygen/html
 TUTORIALS_DIR=$BUILD_DIR/doc/tutorials/html
 ADVANCED_DIR=$BUILD_DIR/doc/advanced/html
 
+RUN_CLANG_FORMAT_DIR=$PCL_DIR/run-clang-format
+
 CMAKE_C_FLAGS="-Wall -Wextra -Wabi -O2"
 CMAKE_CXX_FLAGS="-Wall -Wextra -Wabi -O2"
 
@@ -25,6 +27,19 @@ function before_install ()
       sudo ln -s ../../bin/ccache /usr/lib/ccache/clang++
     fi
   fi
+}
+
+function run_clang_format ()
+{
+  mkdir $RUN_CLANG_FORMAT_DIR
+  wget https://github.com/Sarcasm/run-clang-format/archive/master.zip  -O $RUN_CLANG_FORMAT_DIR/master.zip
+  unzip -d $RUN_CLANG_FORMAT_DIR $RUN_CLANG_FORMAT_DIR/master.zip run-clang-format-master/run-clang-format.py
+  result=python $RUN_CLANG_FORMAT_DIR/run-clang-format-master/run-clang-format.py -r \
+	  --clang-format-executable=clang-format-5.0 \
+	  --extensions='c,cpp,cu,cxx,h,hpp' \
+	  --exclude='**/3rdparty/*' \
+	  $PCL_DIR
+  exit $result
 }
 
 function build ()
@@ -302,6 +317,7 @@ function doc ()
 
 case $1 in
   before-install ) before_install;;
+  run-clang-format ) run_clang_format;;
   build ) build;;
   build-examples ) build_examples;;
   build-tools ) build_tools;;

--- a/.travis.sh
+++ b/.travis.sh
@@ -317,7 +317,7 @@ function doc ()
 
 case $1 in
   before-install ) before_install;;
-  run-clang-format ) run_clang_format;;
+  format-check ) run_clang_format;;
   build ) build;;
   build-examples ) build_examples;;
   build-tools ) build_tools;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ addons:
       - clang-format-5.0
 before_install:
   - bash .travis.sh before-install
-  - bash .travis.sh run-clang-format
 
 env:
   global:
@@ -62,6 +61,9 @@ env:
 
 jobs:
   include:
+    - stage: Format Check
+      env: TASK="format-check"
+      script:  bash .travis.sh $TASK
     - stage: Core Build
       env: TASK="build"
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ addons:
   apt:
     sources:
       - sourceline: 'ppa:v-launchpad-jochen-sprickerhof-de/pcl'
+      - sourceline: deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main
+        key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
       - cmake
       - libboost-filesystem1.54-dev
@@ -27,8 +29,10 @@ addons:
       - libglew-dev
       - libopenni-dev
       - python3-pip
+      - clang-format-5.0
 before_install:
   - bash .travis.sh before-install
+  - bash .travis.sh run-clang-format
 
 env:
   global:


### PR DESCRIPTION
The clang-format config enforces spacing and line-break guidelines from
the PCL style guide, but not guidelines such as all cap constants or
parenthesised return values etc.

Unfortunately, clang-format has limitations that mean a couple of the
style guidelines cannot be enforced, specifically:
1) Members affected by access qualifiers cannot be indented by one more level
2) Return type of functions will go on own separate line, not even the
   same line as template parameters as in one example from
   section 2.3 of the style guide

resolves #2106