### PR TITLE
Correct setting of is_dense flag in SegmentDifferences

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/segment_differences.hpp
+++ b/segmentation/include/pcl/segmentation/impl/segment_differences.hpp
@@ -44,21 +44,22 @@
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::getPointCloudDifference (
-    const pcl::PointCloud<PointT> &src, 
-    const pcl::PointCloud<PointT> &, 
-    double threshold, const boost::shared_ptr<pcl::search::Search<PointT> > &tree,
+    const pcl::PointCloud<PointT> &src,
+    double threshold,
+    const boost::shared_ptr<pcl::search::Search<PointT> > &tree,
     pcl::PointCloud<PointT> &output)
 {
   // We're interested in a single nearest neighbor only
   std::vector<int> nn_indices (1);
   std::vector<float> nn_distances (1);
 
-  // The src indices that do not have a neighbor in tgt
+  // The input cloud indices that do not have a neighbor in the target cloud
   std::vector<int> src_indices;
 
   // Iterate through the source data set
   for (int i = 0; i < static_cast<int> (src.points.size ()); ++i)
   {
+    // Ignore invalid points in the inpout cloud
     if (!isFinite (src.points[i]))
       continue;
     // Search for the closest point in the target data set (number of neighbors to find = 1)
@@ -67,25 +68,16 @@ pcl::getPointCloudDifference (
       PCL_WARN ("No neighbor found for point %lu (%f %f %f)!\n", i, src.points[i].x, src.points[i].y, src.points[i].z);
       continue;
     }
-
+    // Add points without a corresponding point in the target cloud to the output cloud
     if (nn_distances[0] > threshold)
       src_indices.push_back (i);
   }
- 
-  // Allocate enough space and copy the basics
-  output.points.resize (src_indices.size ());
-  output.header   = src.header;
-  output.width    = static_cast<uint32_t> (src_indices.size ());
-  output.height   = 1;
-  //if (src.is_dense)
-    output.is_dense = true;
-  //else
-    // It's not necessarily true that is_dense is false if cloud_in.is_dense is false
-    // To verify this, we would need to iterate over all points and check for NaNs
-    //output.is_dense = false;
 
   // Copy all the data fields from the input cloud to the output one
   copyPointCloud (src, src_indices, output);
+
+  // Output is always dense, as invalid points in the input cloud are ignored
+  output.is_dense = true;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -121,13 +113,12 @@ pcl::SegmentDifferences<PointT>::segment (PointCloud &output)
   // Send the input dataset to the spatial locator
   tree_->setInputCloud (target_);
 
-  getPointCloudDifference (*input_, *target_, distance_threshold_, tree_, output);
+  getPointCloudDifference (*input_, distance_threshold_, tree_, output);
 
   deinitCompute ();
 }
 
 #define PCL_INSTANTIATE_SegmentDifferences(T) template class PCL_EXPORTS pcl::SegmentDifferences<T>;
-#define PCL_INSTANTIATE_getPointCloudDifference(T) template PCL_EXPORTS void pcl::getPointCloudDifference<T>(const pcl::PointCloud<T> &, const pcl::PointCloud<T> &, double, const boost::shared_ptr<pcl::search::Search<T> > &, pcl::PointCloud<T> &);
+#define PCL_INSTANTIATE_getPointCloudDifference(T) template PCL_EXPORTS void pcl::getPointCloudDifference<T>(const pcl::PointCloud<T> &, double, const boost::shared_ptr<pcl::search::Search<T> > &, pcl::PointCloud<T> &);
 
 #endif        // PCL_SEGMENTATION_IMPL_SEGMENT_DIFFERENCES_H_
-

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -59,6 +59,18 @@ namespace pcl
       const boost::shared_ptr<pcl::search::Search<PointT> > &tree,
       pcl::PointCloud<PointT> &output);
 
+  template <typename PointT>
+  PCL_DEPRECATED("getPointCloudDifference() does not use the tgt parameter, thus it is deprecated and will be removed in future releases.")
+  inline void getPointCloudDifference (
+      const pcl::PointCloud<PointT> &src,
+      const pcl::PointCloud<PointT> &tgt,
+      double threshold,
+      const boost::shared_ptr<pcl::search::Search<PointT> > &tree,
+      pcl::PointCloud<PointT> &output)
+  {
+    getPointCloudDifference<PointT> (src, pcl::PointCloud<PointT>(), threshold, tree, output);
+  }
+
   ////////////////////////////////////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////////////////////////////////////

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -46,17 +46,17 @@ namespace pcl
   ////////////////////////////////////////////////////////////////////////////////////////////
   /** \brief Obtain the difference between two aligned point clouds as another point cloud, given a distance threshold.
     * \param src the input point cloud source
-    * \param tgt the input point cloud target we need to obtain the difference against
     * \param threshold the distance threshold (tolerance) for point correspondences. (e.g., check if f a point p1 from 
     * src has a correspondence > threshold than a point p2 from tgt)
-    * \param tree the spatial locator (e.g., kd-tree) used for nearest neighbors searching built over \a tgt
+    * \param tree the spatial locator (e.g., kd-tree) used for nearest neighbors searching built over the target cloud
     * \param output the resultant output point cloud difference
     * \ingroup segmentation
     */
   template <typename PointT> 
   void getPointCloudDifference (
-      const pcl::PointCloud<PointT> &src, const pcl::PointCloud<PointT> &tgt, 
-      double threshold, const boost::shared_ptr<pcl::search::Search<PointT> > &tree,
+      const pcl::PointCloud<PointT> &src,
+      double threshold,
+      const boost::shared_ptr<pcl::search::Search<PointT> > &tree,
       pcl::PointCloud<PointT> &output);
 
   ////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- `is_dense` flag must be set after `copyPointCloud`, otherwise it will be overwritten.
- Correct argumentation why `is_dense` should be set to true (because it IS true, not because we don't want to check).
- Remove redundant copying of attributes, they will be copied in `copyPointCloud`.
- Remove unused parameter `tgt ` in `getPointCloudDifference`, it only needs the kd-tree.