### PR TITLE
[WIP] Moving to C++ 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,7 @@
 ### ---[ PCL global CMake
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-if(POLICY CMP0017)
-  # Do not include files in CMAKE_MODULE_PATH from files
-  # in CMake module directory. Fix MXE build
-  cmake_policy(SET CMP0017 NEW)
-endif()
-
-if(POLICY CMP0020 AND (WIN32 AND NOT MINGW))
-  cmake_policy(SET CMP0020 NEW) # Automatically link Qt executables to qtmain target on Windows
-endif()
-
-if(POLICY CMP0048)
-  cmake_policy(SET CMP0048 OLD) # do not use VERSION option in project() command
-endif()
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 OLD) # Silent warnings about quoted variables
-endif()
+set(CMAKE_CXX_STANDARD 14)
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "possible configurations" FORCE)
 

--- a/apps/src/dinast_grabber_example.cpp
+++ b/apps/src/dinast_grabber_example.cpp
@@ -79,7 +79,7 @@ class DinastProcessor
       
       while (!viewer.wasStopped())
       {
-        boost::this_thread::sleep (boost::posix_time::seconds (1));
+        std::this_thread::sleep_for (std::chrono::seconds (1));
       }
       
       interface.stop ();

--- a/apps/src/ni_agast.cpp
+++ b/apps/src/ni_agast.cpp
@@ -311,7 +311,7 @@ class AGASTDemo
 
         cloud_viewer_.spinOnce ();
         image_viewer_.spinOnce ();
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       grabber_.stop ();

--- a/apps/src/ni_brisk.cpp
+++ b/apps/src/ni_brisk.cpp
@@ -268,7 +268,7 @@ class BRISKDemo
 
         cloud_viewer_.spinOnce ();
         image_viewer_.spinOnce ();
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       grabber_.stop ();

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -527,7 +527,7 @@ class NILinemod
         cloud_viewer_.spinOnce ();
 
         image_viewer_.spinOnce ();
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       grabber_.stop ();

--- a/apps/src/ni_susan.cpp
+++ b/apps/src/ni_susan.cpp
@@ -172,7 +172,7 @@ class SUSANDemo
 
         cloud_viewer_.spinOnce ();
         image_viewer_.spinOnce ();
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       grabber_.stop ();

--- a/apps/src/ni_trajkovic.cpp
+++ b/apps/src/ni_trajkovic.cpp
@@ -195,7 +195,7 @@ class TrajkovicDemo
 
         cloud_viewer_.spinOnce ();
         image_viewer_.spinOnce ();
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       grabber_.stop ();

--- a/apps/src/openni_3d_concave_hull.cpp
+++ b/apps/src/openni_3d_concave_hull.cpp
@@ -106,7 +106,7 @@ class OpenNI3DConcaveHull
     {
       if (!cloud_ || !new_cloud_)
       {
-        boost::this_thread::sleep (boost::posix_time::milliseconds (1));
+        std::this_thread::sleep_for (std::chrono::milliseconds (1));
         return;
       }
 
@@ -145,7 +145,7 @@ class OpenNI3DConcaveHull
       
       while (!viewer.wasStopped ())
       {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
 
       interface->stop ();

--- a/apps/src/openni_3d_convex_hull.cpp
+++ b/apps/src/openni_3d_convex_hull.cpp
@@ -104,7 +104,7 @@ class OpenNI3DConvexHull
     {
       if (!cloud_ || !new_cloud_)
       {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         return;
       }
 
@@ -143,7 +143,7 @@ class OpenNI3DConvexHull
       
       while (!viewer.wasStopped ())
       {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
 
       interface->stop ();

--- a/apps/src/openni_boundary_estimation.cpp
+++ b/apps/src/openni_boundary_estimation.cpp
@@ -123,7 +123,7 @@ class OpenNIIntegralImageNormalEstimation
       boost::mutex::scoped_lock lock (mtx_);
       if (!cloud_)
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         return;
       }
 
@@ -163,7 +163,7 @@ class OpenNIIntegralImageNormalEstimation
       
       while (!viewer.wasStopped ())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 
       interface->stop ();

--- a/apps/src/openni_change_viewer.cpp
+++ b/apps/src/openni_change_viewer.cpp
@@ -128,7 +128,7 @@ class OpenNIChangeViewer
       
       while (!viewer.wasStopped())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 
       interface->stop ();

--- a/apps/src/openni_fast_mesh.cpp
+++ b/apps/src/openni_fast_mesh.cpp
@@ -122,10 +122,10 @@ class OpenNIFastMesh
       while (!view->wasStopped ())
       //while (!viewer.wasStopped ())
       {
-        //boost::this_thread::sleep (boost::posix_time::milliseconds (1));
+        //std::this_thread::sleep_for (std::chrono::milliseconds (1));
         if (!cloud_ || !mtx_.try_lock ())
         {
-          boost::this_thread::sleep (boost::posix_time::milliseconds (1));
+          std::this_thread::sleep_for (std::chrono::milliseconds (1));
           continue;
         }
 

--- a/apps/src/openni_feature_persistence.cpp
+++ b/apps/src/openni_feature_persistence.cpp
@@ -158,7 +158,7 @@ class OpenNIFeaturePersistence
       boost::mutex::scoped_lock lock (mtx_);
       if (!cloud_)
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         return;
       }
 
@@ -196,7 +196,7 @@ class OpenNIFeaturePersistence
 
       while (!viewer.wasStopped ())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 
       interface->stop ();

--- a/apps/src/openni_grab_frame.cpp
+++ b/apps/src/openni_grab_frame.cpp
@@ -194,7 +194,7 @@ class OpenNIGrabFrame
       // wait until user quits program with Ctrl-C, but no busy-waiting -> sleep (1);
       while (!visualizer_->wasStopped())
       {
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
 
         visualizer_->spinOnce ();
         
@@ -213,7 +213,7 @@ class OpenNIGrabFrame
       }
       
       //while (!quit_)
-        //boost::this_thread::sleep (boost::posix_time::seconds (1));
+        //std::this_thread::sleep_for (std::chrono::seconds (1));
    
       // stop the grabber
       grabber_.stop ();

--- a/apps/src/openni_grab_images.cpp
+++ b/apps/src/openni_grab_images.cpp
@@ -278,7 +278,7 @@ class OpenNIGrabFrame
         trigger_ = false;
         image_viewer_.spinOnce ();
         depth_image_viewer_.spinOnce ();
-        //boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        //std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
       
       image_mutex_.lock ();

--- a/apps/src/openni_ii_normal_estimation.cpp
+++ b/apps/src/openni_ii_normal_estimation.cpp
@@ -104,7 +104,7 @@ class OpenNIIntegralImageNormalEstimation
       mtx_.lock ();
       if (!cloud_ || !normals_)
       {
-        //boost::this_thread::sleep(boost::posix_time::seconds(1));
+        //std::this_thread::sleep_for(std::chrono::seconds(1));
         mtx_.unlock ();
         return;
       }
@@ -168,7 +168,7 @@ class OpenNIIntegralImageNormalEstimation
 
       while (!viewer.wasStopped ())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 
       interface->stop ();

--- a/apps/src/openni_mobile_server.cpp
+++ b/apps/src/openni_mobile_server.cpp
@@ -161,7 +161,7 @@ class PCLMobileServer
 
       // wait for first cloud
       while (!getLatestPointCloud ())
-        boost::this_thread::sleep (boost::posix_time::milliseconds (10));
+        std::this_thread::sleep_for (std::chrono::milliseconds (10));
 
       viewer_.showCloud (getLatestPointCloud ());
 

--- a/apps/src/openni_octree_compression.cpp
+++ b/apps/src/openni_octree_compression.cpp
@@ -168,7 +168,7 @@ class SimpleOpenNIViewer
 
       while (!outputFile_.fail())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 
       interface->stop ();
@@ -222,7 +222,7 @@ struct EventHelper
 
     while (!outputFile_.fail ())
     {
-      boost::this_thread::sleep(boost::posix_time::seconds(1));
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
     interface->stop ();
@@ -466,7 +466,7 @@ main (int argc, char **argv)
 
         std::cout << "Disconnected!" << std::endl;
 
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
 
       }
       catch (std::exception& e)

--- a/apps/src/openni_organized_compression.cpp
+++ b/apps/src/openni_organized_compression.cpp
@@ -165,7 +165,7 @@ class SimpleOpenNIViewer
 
         while (!outputFile_.fail())
         {
-          boost::this_thread::sleep(boost::posix_time::seconds(1));
+          std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
         interface->stop ();
@@ -255,7 +255,7 @@ struct EventHelper
 
       while (!outputFile_.fail ())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 
       interface->stop ();
@@ -275,7 +275,7 @@ struct EventHelper
       grabber.start ();
       while (!outputFile_.fail())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
       grabber.stop ();
 
@@ -450,7 +450,7 @@ main (int argc, char **argv)
 
         std::cout << "Disconnected!" << std::endl;
 
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
 
       }
       catch (std::exception& e)

--- a/apps/src/openni_passthrough.cpp
+++ b/apps/src/openni_passthrough.cpp
@@ -105,7 +105,7 @@ OpenNIPassthrough::timeoutSlot ()
 {
   if (!cloud_pass_)
   {
-    boost::this_thread::sleep (boost::posix_time::milliseconds (1));
+    std::this_thread::sleep_for (std::chrono::milliseconds (1));
     return;
   }
 

--- a/apps/src/openni_shift_to_depth_conversion.cpp
+++ b/apps/src/openni_shift_to_depth_conversion.cpp
@@ -141,7 +141,7 @@ class SimpleOpenNIViewer
       grabber_->start ();
       while (true)
       {
-        boost::this_thread::sleep (boost::posix_time::seconds (1));
+        std::this_thread::sleep_for (std::chrono::seconds (1));
       }
       grabber_->stop ();
 

--- a/apps/src/openni_tracking.cpp
+++ b/apps/src/openni_tracking.cpp
@@ -271,7 +271,7 @@ public:
     
     if (!cloud_pass_)
     {
-      boost::this_thread::sleep (boost::posix_time::seconds (1));
+      std::this_thread::sleep_for (std::chrono::seconds (1));
       return;
     }
     
@@ -662,7 +662,7 @@ public:
     interface->start ();
       
     while (!viewer_.wasStopped ())
-      boost::this_thread::sleep(boost::posix_time::seconds(1));
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     interface->stop ();
   }
   

--- a/apps/src/openni_uniform_sampling.cpp
+++ b/apps/src/openni_uniform_sampling.cpp
@@ -96,7 +96,7 @@ class OpenNIUniformSampling
       boost::mutex::scoped_lock lock (mtx_);
       if (!keypoints_ && !cloud_)
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         return;
       }
 
@@ -126,7 +126,7 @@ class OpenNIUniformSampling
       
       while (!viewer.wasStopped ())
       {
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 
       interface->stop ();

--- a/apps/src/pcd_organized_edge_detection.cpp
+++ b/apps/src/pcd_organized_edge_detection.cpp
@@ -213,7 +213,7 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
   while (!viewer.wasStopped ())
   {
     viewer.spinOnce ();
-    boost::this_thread::sleep (boost::posix_time::microseconds (100));
+    std::this_thread::sleep_for (std::chrono::microseconds (100));
   }
 
   // Combine point clouds and edge labels

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -517,7 +517,7 @@ class ObjectSelection
           if (image_viewer_->wasStopped ())
             break;
         }
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
     }
     

--- a/apps/src/ppf_object_recognition.cpp
+++ b/apps/src/ppf_object_recognition.cpp
@@ -166,7 +166,7 @@ main (int argc, char** argv)
   while (!viewer.wasStopped ())
   {
     viewer.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 
   return 0;

--- a/common/include/pcl/common/boost.h
+++ b/common/include/pcl/common/boost.h
@@ -52,11 +52,12 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/function.hpp>
 //#include <boost/timer.hpp>
-#include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/signals2.hpp>
 #include <boost/signals2/slot.hpp>
 #include <boost/algorithm/string.hpp>
+
+#include <thread>
 #endif
 
 #endif    // PCL_COMMON_BOOST_H_

--- a/common/include/pcl/common/time_trigger.h
+++ b/common/include/pcl/common/time_trigger.h
@@ -42,8 +42,10 @@
 #include <pcl/pcl_macros.h>
 #ifndef Q_MOC_RUN
 #include <boost/function.hpp>
-#include <boost/thread.hpp>
 #include <boost/signals2.hpp>
+#include <boost/thread.hpp>
+
+#include <thread>
 #endif
 
 namespace pcl
@@ -99,7 +101,7 @@ namespace pcl
       bool quit_;
       bool running_;
 
-      boost::thread timer_thread_;
+      std::thread timer_thread_;
       boost::condition_variable condition_;
       boost::mutex condition_mutex_;
   };

--- a/common/src/time_trigger.cpp
+++ b/common/src/time_trigger.cpp
@@ -49,7 +49,7 @@ pcl::TimeTrigger::TimeTrigger (double interval, const callback_type& callback)
 , condition_ ()
 , condition_mutex_ ()
 {
-  timer_thread_ = boost::thread (boost::bind (&TimeTrigger::thread_function, this));
+  timer_thread_ = std::thread (boost::bind (&TimeTrigger::thread_function, this));
   registerCallback (callback);
 }
 
@@ -63,7 +63,7 @@ pcl::TimeTrigger::TimeTrigger (double interval)
 , condition_ ()
 , condition_mutex_ ()
 {
-  timer_thread_ = boost::thread (boost::bind (&TimeTrigger::thread_function, this));
+  timer_thread_ = std::thread (boost::bind (&TimeTrigger::thread_function, this));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/doc/tutorials/content/dinast_grabber.rst
+++ b/doc/tutorials/content/dinast_grabber.rst
@@ -84,7 +84,7 @@ The code from *apps/src/dinast_grabber_example.cpp* will be used for this tutori
         
         while (!viewer.wasStopped())
         {
-          boost::this_thread::sleep (boost::posix_time::seconds (1));
+          std::this_thread::sleep_for (std::chrono::seconds (1));
         }
         
         interface.stop ();

--- a/doc/tutorials/content/hdl_grabber.rst
+++ b/doc/tutorials/content/hdl_grabber.rst
@@ -155,7 +155,7 @@ So let's look at the code. The following represents a simplified version of *vis
            if (!grabber_.isRunning ())
              cloud_viewer_->spin ();
 
-           boost::this_thread::sleep (boost::posix_time::microseconds (100));
+           std::this_thread::sleep_for (std::chrono::microseconds (100));
          }
 
          grabber_.stop ();

--- a/doc/tutorials/content/openni_grabber.rst
+++ b/doc/tutorials/content/openni_grabber.rst
@@ -68,7 +68,7 @@ So let's look at the code. From *visualization/tools/openni_viewer_simple.cpp*
               
           while (!viewer.wasStopped())
           {   
-            boost::this_thread::sleep (boost::posix_time::seconds (1));
+            std::this_thread::sleep_for (std::chrono::seconds (1));
           }   
 
           interface->stop (); 

--- a/doc/tutorials/content/pcl_visualizer.rst
+++ b/doc/tutorials/content/pcl_visualizer.rst
@@ -145,7 +145,7 @@ found at the bottom of the sample:
     while (!viewer->wasStopped ())
     {
       viewer->spinOnce (100);
-      boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+      std::this_thread::sleep_for (std::chrono::microseconds (100000));
     }
     ...
 

--- a/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
+++ b/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
@@ -137,7 +137,7 @@ main (void)
   while (!viewer_ptr->wasStopped ())
   {
     PCL_INFO("FPS: %f\n", ensenso_ptr->getFramesPerSecond ());
-    boost::this_thread::sleep (boost::posix_time::milliseconds (500));
+    std::this_thread::sleep_for (std::chrono::milliseconds (500));
   }
 
   ensenso_ptr->stop ();

--- a/doc/tutorials/content/sources/ground_based_rgbd_people_detection/src/main_ground_based_people_detection.cpp
+++ b/doc/tutorials/content/sources/ground_based_rgbd_people_detection/src/main_ground_based_people_detection.cpp
@@ -139,7 +139,7 @@ int main (int argc, char** argv)
 
   // Wait for the first frame:
   while(!new_cloud_available_flag) 
-    boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   new_cloud_available_flag = false;
 
   cloud_mutex.lock ();    // for not overwriting the point cloud

--- a/doc/tutorials/content/sources/moment_of_inertia/moment_of_inertia.cpp
+++ b/doc/tutorials/content/sources/moment_of_inertia/moment_of_inertia.cpp
@@ -100,7 +100,7 @@ int main (int argc, char** argv)
   while(!viewer->wasStopped())
   {
     viewer->spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 
   return (0);

--- a/doc/tutorials/content/sources/normal_distributions_transform/normal_distributions_transform.cpp
+++ b/doc/tutorials/content/sources/normal_distributions_transform/normal_distributions_transform.cpp
@@ -102,7 +102,7 @@ main (int argc, char** argv)
   while (!viewer_final->wasStopped ())
   {
     viewer_final->spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 
   return (0);

--- a/doc/tutorials/content/sources/openni_grabber/openni_grabber.cpp
+++ b/doc/tutorials/content/sources/openni_grabber/openni_grabber.cpp
@@ -36,7 +36,7 @@ public:
 
     // wait until user quits program with Ctrl-C, but no busy-waiting -> sleep (1);
     while (true)
-      boost::this_thread::sleep (boost::posix_time::seconds (1));
+      std::this_thread::sleep_for (std::chrono::seconds (1));
 
     // stop the grabber
     interface->stop ();

--- a/doc/tutorials/content/sources/pcl_visualizer/pcl_visualizer_demo.cpp
+++ b/doc/tutorials/content/sources/pcl_visualizer/pcl_visualizer_demo.cpp
@@ -375,6 +375,6 @@ main (int argc, char** argv)
   while (!viewer->wasStopped ())
   {
     viewer->spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }

--- a/doc/tutorials/content/sources/random_sample_consensus/random_sample_consensus.cpp
+++ b/doc/tutorials/content/sources/random_sample_consensus/random_sample_consensus.cpp
@@ -97,7 +97,7 @@ main(int argc, char** argv)
   while (!viewer->wasStopped ())
   {
     viewer->spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
   return 0;
  }

--- a/doc/tutorials/content/sources/region_growing_rgb_segmentation/region_growing_rgb_segmentation.cpp
+++ b/doc/tutorials/content/sources/region_growing_rgb_segmentation/region_growing_rgb_segmentation.cpp
@@ -44,7 +44,7 @@ main (int argc, char** argv)
   viewer.showCloud (colored_cloud);
   while (!viewer.wasStopped ())
   {
-    boost::this_thread::sleep (boost::posix_time::microseconds (100));
+    std::this_thread::sleep_for (std::chrono::microseconds (100));
   }
 
   return (0);

--- a/doc/tutorials/content/sources/tracking/tracking_sample.cpp
+++ b/doc/tutorials/content/sources/tracking/tracking_sample.cpp
@@ -135,7 +135,7 @@ viz_cb (pcl::visualization::PCLVisualizer& viz)
     
   if (!cloud_pass_)
     {
-      boost::this_thread::sleep (boost::posix_time::seconds (1));
+      std::this_thread::sleep_for (std::chrono::seconds (1));
       return;
    }
 
@@ -280,6 +280,6 @@ main (int argc, char** argv)
   //Start viewer and object tracking
   interface->start();
   while (!viewer_->wasStopped ())
-    boost::this_thread::sleep(boost::posix_time::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
   interface->stop();
 }

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -594,7 +594,7 @@ CPCSegmentation Parameters: \n\
           viewer->addText ("Press d to show help", 5, 10, 12, textcolor, textcolor, textcolor, "help_text");
       }
 
-      boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+      std::this_thread::sleep_for (std::chrono::microseconds (100000));
     }
   }  /// END if (show_visualization)
 

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -492,7 +492,7 @@ LCCPSegmentation Parameters: \n\
           viewer->addText ("Press d to show help", 5, 10, 12, 1.0, 1.0, 1.0, "help_text");
       }
 
-      boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+      std::this_thread::sleep_for (std::chrono::microseconds (100000));
     }
   }  /// END if (show_visualization)
 

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -478,7 +478,7 @@ main (int argc, char ** argv)
       
     
     viewer->spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
     
   }
   return (0);

--- a/examples/stereo/example_stereo_baseline.cpp
+++ b/examples/stereo/example_stereo_baseline.cpp
@@ -96,6 +96,6 @@ main(int argc, char **argv)
   {
     viewer->spinOnce (100);
     iv.spinOnce (100); // press 'q' to exit
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -1018,7 +1018,7 @@ struct KinFuLSApp
         //~ cout << "In main loop" << endl;                  
       } 
       exit_ = true;
-      boost::this_thread::sleep (boost::posix_time::millisec (100));
+      std::this_thread::sleep_for (std::chrono::milliseconds (100));
 
       if (!triggered_capture)     
         capture_.stop (); // Stop stream

--- a/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
+++ b/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
@@ -264,7 +264,7 @@ grabAndSend ()
   {
     if (is_done)
       break;
-    boost::this_thread::sleep (boost::posix_time::seconds (1));
+    std::this_thread::sleep_for (std::chrono::seconds (1));
   }
   interface->stop ();
 }
@@ -320,7 +320,7 @@ main (int argc, char** argv)
   std::cout << "Starting the producer and consumer threads..." << std::endl;
   std::cout << "Press Ctrl-C to end" << std::endl;
   std::thread producer (grabAndSend);
-  boost::this_thread::sleep (boost::posix_time::seconds (2));
+  std::this_thread::sleep_for (std::chrono::seconds (2));
   std::thread consumer (receiveAndProcess);
   std::thread consumer2 (receiveAndProcess);
   std::thread consumer3 (receiveAndProcess);

--- a/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
+++ b/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
@@ -319,11 +319,11 @@ main (int argc, char** argv)
   buff.setCapacity (buff_size);
   std::cout << "Starting the producer and consumer threads..." << std::endl;
   std::cout << "Press Ctrl-C to end" << std::endl;
-  boost::thread producer (grabAndSend);
+  std::thread producer (grabAndSend);
   boost::this_thread::sleep (boost::posix_time::seconds (2));
-  boost::thread consumer (receiveAndProcess);
-  boost::thread consumer2 (receiveAndProcess);
-  boost::thread consumer3 (receiveAndProcess);
+  std::thread consumer (receiveAndProcess);
+  std::thread consumer2 (receiveAndProcess);
+  std::thread consumer3 (receiveAndProcess);
   signal (SIGINT, ctrlC);
   producer.join ();
   {

--- a/gpu/people/tools/people_tracking.cpp
+++ b/gpu/people/tools/people_tracking.cpp
@@ -63,7 +63,7 @@ class PeopleTrackingApp
 
       while (!viewer.wasStopped())
       {
-        boost::this_thread::sleep (boost::posix_time::seconds (1));
+        std::this_thread::sleep_for (std::chrono::seconds (1));
       }
       interface->stop ();
     }

--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -48,7 +48,6 @@
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>
-#include <boost/thread.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/bind.hpp>
@@ -81,5 +80,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #endif
+#include <thread>
 #endif    // _PCL_IO_BOOST_H_
 

--- a/io/include/pcl/io/davidsdk_grabber.h
+++ b/io/include/pcl/io/davidsdk_grabber.h
@@ -43,10 +43,10 @@
 
 #include <pcl/common/time.h>
 #include <pcl/common/io.h>
-#include <boost/thread.hpp>
 #include <pcl/PolygonMesh.h>
 #include <pcl/io/grabber.h>
 
+#include <thread>
 #include <david.h>
 
 namespace pcl
@@ -219,7 +219,7 @@ namespace pcl
 
     protected:
       /** @brief Grabber thread */
-      boost::thread grabber_thread_;
+      std::thread grabber_thread_;
 
       /** @brief Boost point cloud signal */
       boost::signals2::signal<sig_cb_davidsdk_point_cloud>* point_cloud_signal_;

--- a/io/include/pcl/io/depth_sense/depth_sense_device_manager.h
+++ b/io/include/pcl/io/depth_sense/depth_sense_device_manager.h
@@ -41,7 +41,7 @@
 #include <boost/utility.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/thread.hpp>
+#include <thread>
 
 #include <pcl/pcl_exports.h>
 
@@ -138,7 +138,7 @@ namespace pcl
           static boost::mutex mutex_;
 
           /// Thread where the grabbing takes place.
-          boost::thread depth_sense_thread_;
+          std::thread depth_sense_thread_;
 
           struct CapturedDevice
           {

--- a/io/include/pcl/io/dinast_grabber.h
+++ b/io/include/pcl/io/dinast_grabber.h
@@ -207,7 +207,7 @@ namespace pcl
       
       bool running_;
       
-      boost::thread capture_thread_;
+      std::thread capture_thread_;
       
       mutable boost::mutex capture_mutex_;
       boost::signals2::signal<sig_cb_dinast_point_cloud>* point_cloud_signal_;

--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -47,8 +47,9 @@
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
 #include <pcl/io/boost.h>
-#include <boost/thread.hpp>
 #include <boost/lexical_cast.hpp> // TODO: Remove when setExtrinsicCalibration is fixed
+
+#include <thread>
 
 #include <pcl/io/grabber.h>
 #include <pcl/common/synchronizer.h>
@@ -437,7 +438,7 @@ namespace pcl
 
     protected:
       /** @brief Grabber thread */
-      boost::thread grabber_thread_;
+      std::thread grabber_thread_;
 
       /** @brief Boost point cloud signal */
       boost::signals2::signal<sig_cb_ensenso_point_cloud>* point_cloud_signal_;

--- a/io/include/pcl/io/fotonic_grabber.h
+++ b/io/include/pcl/io/fotonic_grabber.h
@@ -46,7 +46,7 @@
 #include <pcl/io/grabber.h>
 #include <pcl/common/synchronizer.h>
 
-#include <boost/thread.hpp>  
+#include <thread>
 
 #include <fz_api.h>
 
@@ -149,7 +149,7 @@ namespace pcl
 
       FZ_Device_Handle_t * fotonic_device_handle_;
 
-      boost::thread grabber_thread_;
+      std::thread grabber_thread_;
 
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -294,8 +294,8 @@ namespace pcl
       boost::asio::io_service hdl_read_socket_service_;
       boost::asio::ip::udp::socket *hdl_read_socket_;
       std::string pcap_file_name_;
-      boost::thread *queue_consumer_thread_;
-      boost::thread *hdl_read_packet_thread_;
+      std::thread *queue_consumer_thread_;
+      std::thread *hdl_read_packet_thread_;
       bool terminate_read_packet_thread_;
       pcl::RGB laser_rgb_mapping_[HDL_MAX_NUM_LASERS];
       float min_distance_threshold_;

--- a/io/include/pcl/io/openni_camera/openni_device.h
+++ b/io/include/pcl/io/openni_camera/openni_device.h
@@ -548,9 +548,9 @@ namespace openni_wrapper
       boost::condition_variable image_condition_;
       boost::condition_variable depth_condition_;
       boost::condition_variable ir_condition_;
-      boost::thread image_thread_;
-      boost::thread depth_thread_;
-      boost::thread ir_thread_;
+      std::thread image_thread_;
+      std::thread depth_thread_;
+      std::thread ir_thread_;
   };
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/include/pcl/io/openni_camera/openni_device_oni.h
+++ b/io/include/pcl/io/openni_camera/openni_device_oni.h
@@ -98,7 +98,7 @@ namespace openni_wrapper
     static void __stdcall NewONIIRDataAvailable (xn::ProductionNode& node, void* cookie) throw ();
 
     xn::Player player_;
-    boost::thread player_thread_;
+    std::thread player_thread_;
     mutable boost::mutex player_mutex_;
     boost::condition_variable player_condition_;
     bool streaming_;

--- a/io/include/pcl/io/real_sense/real_sense_device_manager.h
+++ b/io/include/pcl/io/real_sense/real_sense_device_manager.h
@@ -38,11 +38,12 @@
 #ifndef PCL_IO_REAL_SENSE_DEVICE_MANAGER_H
 #define PCL_IO_REAL_SENSE_DEVICE_MANAGER_H
 
-#include <boost/thread.hpp>
 #include <boost/utility.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
+
+#include <thread>
 
 #include <pcl/pcl_exports.h>
 

--- a/io/include/pcl/io/real_sense_grabber.h
+++ b/io/include/pcl/io/real_sense_grabber.h
@@ -267,7 +267,7 @@ namespace pcl
       EventFrequency frequency_;
       mutable boost::mutex fps_mutex_;
 
-      boost::thread thread_;
+      std::thread thread_;
 
       /// Depth buffer to perform temporal filtering of the depth images
       boost::shared_ptr<pcl::io::Buffer<unsigned short> > depth_buffer_;

--- a/io/include/pcl/io/robot_eye_grabber.h
+++ b/io/include/pcl/io/robot_eye_grabber.h
@@ -131,8 +131,8 @@ namespace pcl
       boost::asio::ip::udp::endpoint sender_endpoint_;
       boost::asio::io_service io_service_;
       boost::shared_ptr<boost::asio::ip::udp::socket> socket_;
-      boost::shared_ptr<boost::thread> socket_thread_;
-      boost::shared_ptr<boost::thread> consumer_thread_;
+      boost::shared_ptr<std::thread> socket_thread_;
+      boost::shared_ptr<std::thread> consumer_thread_;
 
       pcl::SynchronizedQueue<boost::shared_array<unsigned char> > packet_queue_;
       boost::shared_ptr<pcl::PointCloud<pcl::PointXYZI> > point_cloud_xyzi_;

--- a/io/src/davidsdk_grabber.cpp
+++ b/io/src/davidsdk_grabber.cpp
@@ -137,7 +137,7 @@ pcl::DavidSDKGrabber::start ()
 
   frequency_.reset ();
   running_ = true;
-  grabber_thread_ = boost::thread (&pcl::DavidSDKGrabber::processGrabbing, this);
+  grabber_thread_ = std::thread (&pcl::DavidSDKGrabber::processGrabbing, this);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/depth_sense/depth_sense_device_manager.cpp
+++ b/io/src/depth_sense/depth_sense_device_manager.cpp
@@ -47,7 +47,7 @@ pcl::io::depth_sense::DepthSenseDeviceManager::DepthSenseDeviceManager ()
   try
   {
     context_ = DepthSense::Context::create ("localhost");
-    depth_sense_thread_ = boost::thread (&DepthSense::Context::run, &context_);
+    depth_sense_thread_ = std::thread (&DepthSense::Context::run, &context_);
   }
   catch (...)
   {

--- a/io/src/dinast_grabber.cpp
+++ b/io/src/dinast_grabber.cpp
@@ -107,7 +107,7 @@ void
 pcl::DinastGrabber::onInit (const int device_position)
 {
   setupDevice (device_position);
-  capture_thread_ = boost::thread (&DinastGrabber::captureThreadFunction, this);
+  capture_thread_ = std::thread (&DinastGrabber::captureThreadFunction, this);
   image_ = new unsigned char [image_size_];
 }
 

--- a/io/src/ensenso_grabber.cpp
+++ b/io/src/ensenso_grabber.cpp
@@ -205,7 +205,7 @@ pcl::EnsensoGrabber::start ()
 
   frequency_.reset ();
   running_ = true;
-  grabber_thread_ = boost::thread (&pcl::EnsensoGrabber::processGrabbing, this);
+  grabber_thread_ = std::thread (&pcl::EnsensoGrabber::processGrabbing, this);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/fotonic_grabber.cpp
+++ b/io/src/fotonic_grabber.cpp
@@ -48,7 +48,7 @@
 #include <pcl/io/boost.h>
 #include <pcl/exceptions.h>
 
-#include <boost/thread.hpp>
+#include <thread>
 
 #include <iostream>
 
@@ -123,7 +123,7 @@ pcl::FotonicGrabber::start ()
 
   running_ = true;
 
-  grabber_thread_ = boost::thread(&pcl::FotonicGrabber::processGrabbing, this); 
+  grabber_thread_ = std::thread(&pcl::FotonicGrabber::processGrabbing, this); 
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/fotonic_grabber.cpp
+++ b/io/src/fotonic_grabber.cpp
@@ -341,7 +341,7 @@ pcl::FotonicGrabber::processGrabbing ()
       }
     }
     else
-      boost::this_thread::sleep (boost::posix_time::milliseconds(1));
+      std::this_thread::sleep_for (std::chrono::milliseconds(1));
 
     continue_grabbing = running_;
   }

--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -721,7 +721,7 @@ pcl::HDLGrabber::readPacketsFromPcap ()
     usec_delay = ((header->ts.tv_sec - lasttime.tv_sec) * 1000000) +
     (header->ts.tv_usec - lasttime.tv_usec);
 
-    boost::this_thread::sleep (boost::posix_time::microseconds (usec_delay));
+    std::this_thread::sleep_for (std::chrono::microseconds (usec_delay));
 
     lasttime.tv_sec = header->ts.tv_sec;
     lasttime.tv_usec = header->ts.tv_usec;

--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -493,7 +493,7 @@ pcl::HDLGrabber::start ()
   if (isRunning ())
     return;
 
-  queue_consumer_thread_ = new boost::thread (boost::bind (&HDLGrabber::processVelodynePackets, this));
+  queue_consumer_thread_ = new std::thread (boost::bind (&HDLGrabber::processVelodynePackets, this));
 
   if (pcap_file_name_.empty ())
   {
@@ -523,12 +523,12 @@ pcl::HDLGrabber::start ()
       PCL_ERROR("[pcl::HDLGrabber::start] Unable to bind to socket! %s\n", e.what ());
       return;
     }
-    hdl_read_packet_thread_ = new boost::thread (boost::bind (&HDLGrabber::readPacketsFromSocket, this));
+    hdl_read_packet_thread_ = new std::thread (boost::bind (&HDLGrabber::readPacketsFromSocket, this));
   }
   else
   {
 #ifdef HAVE_PCAP
-    hdl_read_packet_thread_ = new boost::thread (boost::bind (&HDLGrabber::readPacketsFromPcap, this));
+    hdl_read_packet_thread_ = new std::thread (boost::bind (&HDLGrabber::readPacketsFromPcap, this));
 #endif // #ifdef HAVE_PCAP
   }
 }
@@ -542,7 +542,6 @@ pcl::HDLGrabber::stop ()
 
   if (hdl_read_packet_thread_ != NULL)
   {
-    hdl_read_packet_thread_->interrupt ();
     hdl_read_packet_thread_->join ();
     delete hdl_read_packet_thread_;
     hdl_read_packet_thread_ = NULL;
@@ -565,7 +564,7 @@ pcl::HDLGrabber::stop ()
 bool
 pcl::HDLGrabber::isRunning () const
 {
-  return (!hdl_data_.isEmpty () || (hdl_read_packet_thread_ != NULL && !hdl_read_packet_thread_->timed_join (boost::posix_time::milliseconds (10))));
+  return (!hdl_data_.isEmpty () || (hdl_read_packet_thread_ != NULL));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -250,7 +250,7 @@ pcl::io::OpenNI2Grabber::start ()
   }
 
   // workaround, since the first frame is corrupted
-  //boost::this_thread::sleep (boost::posix_time::seconds (1));
+  //std::this_thread::sleep_for (std::chrono::seconds (1));
   unblock_signals ();
 }
 

--- a/io/src/openni_camera/openni_device.cpp
+++ b/io/src/openni_camera/openni_device.cpp
@@ -393,19 +393,19 @@ openni_wrapper::OpenNIDevice::Init ()
     //focal length from mm -> pixels (valid for 1280x1024)
     depth_focal_length_SXGA_ = static_cast<float> (static_cast<XnDouble> (depth_focal_length_SXGA) / pixel_size);
 
-    depth_thread_ = boost::thread (&OpenNIDevice::DepthDataThreadFunction, this);
+    depth_thread_ = std::thread (&OpenNIDevice::DepthDataThreadFunction, this);
   }
 
   if (hasImageStream ())
   {
     boost::lock_guard<boost::mutex> image_lock (image_mutex_);
-    image_thread_ = boost::thread (&OpenNIDevice::ImageDataThreadFunction, this);
+    image_thread_ = std::thread (&OpenNIDevice::ImageDataThreadFunction, this);
   }
 
   if (hasIRStream ())
   {
     boost::lock_guard<boost::mutex> ir_lock (ir_mutex_);
-    ir_thread_ = boost::thread (&OpenNIDevice::IRDataThreadFunction, this);
+    ir_thread_ = std::thread (&OpenNIDevice::IRDataThreadFunction, this);
   }
 }
 

--- a/io/src/openni_camera/openni_device_oni.cpp
+++ b/io/src/openni_camera/openni_device_oni.cpp
@@ -97,7 +97,7 @@ openni_wrapper::DeviceONI::DeviceONI (
 
   player_.SetRepeat (repeat);
   if (streaming_)
-    player_thread_ = boost::thread (&DeviceONI::PlayerThreadFunction, this);
+    player_thread_ = std::thread (&DeviceONI::PlayerThreadFunction, this);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/openni_grabber.cpp
+++ b/io/src/openni_grabber.cpp
@@ -241,7 +241,7 @@ pcl::OpenNIGrabber::start ()
     PCL_THROW_EXCEPTION (pcl::IOException, "Could not start streams. Reason: " << ex.what ());
   }
   // workaround, since the first frame is corrupted
-  boost::this_thread::sleep (boost::posix_time::seconds (1));
+  std::this_thread::sleep_for (std::chrono::seconds (1));
   unblock_signals ();
 }
 

--- a/io/src/pcd_grabber.cpp
+++ b/io/src/pcd_grabber.cpp
@@ -395,7 +395,7 @@ pcl::PCDGrabberBase::start ()
   }
   else // manual trigger
   {
-    boost::thread non_blocking_call (boost::bind (&PCDGrabberBase::PCDGrabberImpl::trigger, impl_));
+    std::thread non_blocking_call (boost::bind (&PCDGrabberBase::PCDGrabberImpl::trigger, impl_));
   }
 }
 
@@ -416,7 +416,7 @@ pcl::PCDGrabberBase::trigger ()
 {
   if (impl_->frames_per_second_ > 0)
     return;
-  boost::thread non_blocking_call (boost::bind (&PCDGrabberBase::PCDGrabberImpl::trigger, impl_));
+  std::thread non_blocking_call (boost::bind (&PCDGrabberBase::PCDGrabberImpl::trigger, impl_));
 
 //  impl_->trigger ();
 }

--- a/io/src/real_sense_grabber.cpp
+++ b/io/src/real_sense_grabber.cpp
@@ -172,7 +172,7 @@ pcl::RealSenseGrabber::start ()
         THROW_IO_EXCEPTION ("Invalid stream profile for PXC device");
       frequency_.reset ();
       is_running_ = true;
-      thread_ = boost::thread (&RealSenseGrabber::run, this);
+      thread_ = std::thread (&RealSenseGrabber::run, this);
     }
   }
 }

--- a/io/src/robot_eye_grabber.cpp
+++ b/io/src/robot_eye_grabber.cpp
@@ -326,8 +326,8 @@ pcl::RobotEyeGrabber::start ()
 
   terminate_thread_ = false;
   resetPointCloud ();
-  consumer_thread_.reset(new boost::thread (boost::bind (&RobotEyeGrabber::consumerThreadLoop, this)));
-  socket_thread_.reset(new boost::thread (boost::bind (&RobotEyeGrabber::socketThreadLoop, this)));
+  consumer_thread_.reset(new std::thread (boost::bind (&RobotEyeGrabber::consumerThreadLoop, this)));
+  socket_thread_.reset(new std::thread (boost::bind (&RobotEyeGrabber::socketThreadLoop, this)));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -239,7 +239,7 @@ class Producer
       {
         if (is_done)
           break;
-        boost::this_thread::sleep (boost::posix_time::seconds (1));
+        std::this_thread::sleep_for (std::chrono::seconds (1));
       }
       interface->stop ();
     }
@@ -459,7 +459,7 @@ main (int argc, char** argv)
     PCDBuffer<PointXYZRGBA> buf;
     buf.setCapacity (buff_size);
     Producer<PointXYZRGBA> producer (buf, depth_mode);
-    boost::this_thread::sleep (boost::posix_time::seconds (2));
+    std::this_thread::sleep_for (std::chrono::seconds (2));
     Consumer<PointXYZRGBA> consumer (buf);
 
     signal (SIGINT, ctrlC);
@@ -472,7 +472,7 @@ main (int argc, char** argv)
     PCDBuffer<PointXYZ> buf;
     buf.setCapacity (buff_size);
     Producer<PointXYZ> producer (buf, depth_mode);
-    boost::this_thread::sleep (boost::posix_time::seconds (2));
+    std::this_thread::sleep_for (std::chrono::seconds (2));
     Consumer<PointXYZ> consumer (buf);
 
     signal (SIGINT, ctrlC);

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -249,7 +249,7 @@ class Producer
       : buf_ (buf),
         depth_mode_ (depth_mode)
     {
-      thread_.reset (new boost::thread (boost::bind (&Producer::grabAndSend, this)));
+      thread_.reset (new std::thread (boost::bind (&Producer::grabAndSend, this)));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -264,7 +264,7 @@ class Producer
   private:
     PCDBuffer<PointT> &buf_;
     openni_wrapper::OpenNIDevice::DepthMode depth_mode_;
-    boost::shared_ptr<boost::thread> thread_;
+    boost::shared_ptr<std::thread> thread_;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -308,7 +308,7 @@ class Consumer
     Consumer (PCDBuffer<PointT> &buf)
       : buf_ (buf)
     {
-      thread_.reset (new boost::thread (boost::bind (&Consumer::receiveAndProcess, this)));
+      thread_.reset (new std::thread (boost::bind (&Consumer::receiveAndProcess, this)));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -322,7 +322,7 @@ class Consumer
 
   private:
     PCDBuffer<PointT> &buf_;
-    boost::shared_ptr<boost::thread> thread_;
+    boost::shared_ptr<std::thread> thread_;
     PCDWriter writer_;
 };
 

--- a/outofcore/include/pcl/outofcore/boost.h
+++ b/outofcore/include/pcl/outofcore/boost.h
@@ -44,7 +44,6 @@
 #endif
 
 #include <boost/filesystem.hpp>
-#include <boost/thread.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -54,5 +53,7 @@
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
+
+#include <thread>
 
 #endif //PCL_OUTOFCORE_BOOST_H_

--- a/outofcore/include/pcl/outofcore/visualization/object.h
+++ b/outofcore/include/pcl/outofcore/visualization/object.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <thread>
 
 // VTK
 #include <vtkActor.h>
@@ -13,8 +14,6 @@
 #include <vtkSmartPointer.h>
 
 // Boost
-//#include <boost/date_time.hpp>
-//#include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
 //Forward Declaration

--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -59,7 +59,7 @@ class OutofcoreCloud : public Object
 //    typedef std::map<std::string, vtkSmartPointer<vtkPolyData> >::iterator CloudDataCacheIterator;
 
 
-    static boost::shared_ptr<boost::thread> pcd_reader_thread;
+    static boost::shared_ptr<std::thread> pcd_reader_thread;
     //static MonitorQueue<std::string> pcd_queue;
 
     struct PcdQueueItem

--- a/outofcore/src/visualization/outofcore_cloud.cpp
+++ b/outofcore/src/visualization/outofcore_cloud.cpp
@@ -33,17 +33,15 @@
 #include <vtkProperty.h>
 #include <vtkSmartPointer.h>
 
-// Boost
-//#include <boost/date_time.hpp>
-//#include <boost/filesystem.hpp>
-#include <boost/thread.hpp>
+// C++
+#include <thread>
 
 // Forward Declarations
 
 boost::condition OutofcoreCloud::pcd_queue_ready;
 boost::mutex OutofcoreCloud::pcd_queue_mutex;
 
-boost::shared_ptr<boost::thread> OutofcoreCloud::pcd_reader_thread;
+boost::shared_ptr<std::thread> OutofcoreCloud::pcd_reader_thread;
 //MonitorQueue<std::string> OutofcoreCloud::pcd_queue;
 
 //std::map<std::string, vtkSmartPointer<vtkPolyData> > OutofcoreCloud::cloud_data_cache;
@@ -124,8 +122,8 @@ OutofcoreCloud::OutofcoreCloud (std::string name, boost::filesystem::path& tree_
   // Create the pcd reader thread once for all outofcore nodes
   if (OutofcoreCloud::pcd_reader_thread.get() == NULL)
   {
-//    OutofcoreCloud::pcd_reader_thread = boost::shared_ptr<boost::thread>(new boost::thread(&OutofcoreCloud::pcdReaderThread, this));
-    OutofcoreCloud::pcd_reader_thread = boost::shared_ptr<boost::thread>(new boost::thread(&OutofcoreCloud::pcdReaderThread));
+//    OutofcoreCloud::pcd_reader_thread = boost::shared_ptr<std::thread>(new std::thread(&OutofcoreCloud::pcdReaderThread, this));
+    OutofcoreCloud::pcd_reader_thread = boost::shared_ptr<std::thread>(new std::thread(&OutofcoreCloud::pcdReaderThread));
   }
 
 

--- a/outofcore/tools/outofcore_viewer.cpp
+++ b/outofcore/tools/outofcore_viewer.cpp
@@ -38,6 +38,7 @@
 // C++
 #include <iostream>
 #include <string>
+#include <thread>
 
 // PCL
 #include <pcl/common/time.h>
@@ -131,7 +132,6 @@ typedef Eigen::aligned_allocator<PointT> AlignedPointT;
 // Boost
 #include <boost/date_time.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/thread.hpp>
 
 // Globals
 vtkSmartPointer<vtkRenderWindow> window;

--- a/people/apps/main_ground_based_people_detection.cpp
+++ b/people/apps/main_ground_based_people_detection.cpp
@@ -145,7 +145,7 @@ int main (int argc, char** argv)
 
   // Wait for the first frame:
   while(!new_cloud_available_flag) 
-    boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   new_cloud_available_flag = false;
 
   cloud_mutex.lock ();    // for not overwriting the point cloud

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -413,7 +413,7 @@ void display ()
   while (!viewer->wasStopped ())
   {
     viewer->spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }    
   
   // doesn't work:

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -491,7 +491,7 @@ void capture (Eigen::Isometry3d pose_in, string point_cloud_fname)
     
       while (!viewer->wasStopped ()){
 	viewer->spinOnce (100);
-	boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+	std::this_thread::sleep_for (std::chrono::microseconds (100000));
       }
     }
   }

--- a/test/io/test_grabbers.cpp
+++ b/test/io/test_grabbers.cpp
@@ -49,7 +49,7 @@ TEST (PCL, PCDGrabber)
   grabber.registerCallback (fxn);
   grabber.start ();
   // 1 second should be /plenty/ of time
-  boost::this_thread::sleep (boost::posix_time::microseconds (1E6));
+  std::this_thread::sleep_for (std::chrono::microseconds (1E6));
   grabber.stop ();
 
   //// Make sure they match
@@ -126,7 +126,7 @@ TEST (PCL, ImageGrabberTIFF)
     size_t niter = 0;
     while (!signal_received)
     {
-      boost::this_thread::sleep (boost::posix_time::microseconds (10000));
+      std::this_thread::sleep_for (std::chrono::microseconds (10000));
       if (++niter > 100)
       {
         ASSERT_TRUE (false);
@@ -206,7 +206,7 @@ TEST (PCL, ImageGrabberPCLZF)
     size_t niter = 0;
     while (!signal_received)
     {
-      boost::this_thread::sleep (boost::posix_time::microseconds (10000));
+      std::this_thread::sleep_for (std::chrono::microseconds (10000));
       if (++niter > 100)
       {
         ASSERT_TRUE (false);
@@ -286,7 +286,7 @@ TEST (PCL, ImageGrabberOMP)
     size_t niter = 0;
     while (!signal_received)
     {
-      boost::this_thread::sleep (boost::posix_time::microseconds (10000));
+      std::this_thread::sleep_for (std::chrono::microseconds (10000));
       if (++niter > 100)
       {
         ASSERT_TRUE (false);
@@ -395,7 +395,7 @@ TEST (PCL, ImageGrabberSetIntrinsicsTIFF)
     size_t niter = 0;
     while (!signal_received)
     {
-      boost::this_thread::sleep (boost::posix_time::microseconds (10000));
+      std::this_thread::sleep_for (std::chrono::microseconds (10000));
       if (++niter > 100)
       {
         ASSERT_TRUE (false);
@@ -467,7 +467,7 @@ TEST (PCL, ImageGrabberSetIntrinsicsPCLZF)
     size_t niter = 0;
     while (!signal_received)
     {
-      boost::this_thread::sleep (boost::posix_time::microseconds (10000));
+      std::this_thread::sleep_for (std::chrono::microseconds (10000));
       if (++niter > 100)
       {
         ASSERT_TRUE (false);

--- a/test/sample_consensus/test_sample_consensus.cpp
+++ b/test/sample_consensus/test_sample_consensus.cpp
@@ -38,7 +38,7 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/thread.hpp>
+#include <thread>
 
 #include <pcl/sample_consensus/msac.h>
 #include <pcl/sample_consensus/lmeds.h>
@@ -96,37 +96,37 @@ TEST (SampleConsensus, InfiniteLoop)
   // Create the RANSAC object
   RandomSampleConsensus<PointXYZ> ransac (model, 0.03);
   sac_function = boost::bind (&RandomSampleConsensus<PointXYZ>::computeModel, &ransac, 0);
-  boost::thread thread1 (sac_function);
+  std::thread thread1 (sac_function);
   ASSERT_TRUE (thread1.timed_join (delay));
 
   // Create the LMSAC object
   LeastMedianSquares<PointXYZ> lmsac (model, 0.03);
   sac_function = boost::bind (&LeastMedianSquares<PointXYZ>::computeModel, &lmsac, 0);
-  boost::thread thread2 (sac_function);
+  std::thread thread2 (sac_function);
   ASSERT_TRUE (thread2.timed_join (delay));
 
   // Create the MSAC object
   MEstimatorSampleConsensus<PointXYZ> mesac (model, 0.03);
   sac_function = boost::bind (&MEstimatorSampleConsensus<PointXYZ>::computeModel, &mesac, 0);
-  boost::thread thread3 (sac_function);
+  std::thread thread3 (sac_function);
   ASSERT_TRUE (thread3.timed_join (delay));
 
   // Create the RRSAC object
   RandomizedRandomSampleConsensus<PointXYZ> rrsac (model, 0.03);
   sac_function = boost::bind (&RandomizedRandomSampleConsensus<PointXYZ>::computeModel, &rrsac, 0);
-  boost::thread thread4 (sac_function);
+  std::thread thread4 (sac_function);
   ASSERT_TRUE (thread4.timed_join (delay));
 
   // Create the RMSAC object
   RandomizedMEstimatorSampleConsensus<PointXYZ> rmsac (model, 0.03);
   sac_function = boost::bind (&RandomizedMEstimatorSampleConsensus<PointXYZ>::computeModel, &rmsac, 0);
-  boost::thread thread5 (sac_function);
+  std::thread thread5 (sac_function);
   ASSERT_TRUE (thread5.timed_join (delay));
 
   // Create the MLESAC object
   MaximumLikelihoodSampleConsensus<PointXYZ> mlesac (model, 0.03);
   sac_function = boost::bind (&MaximumLikelihoodSampleConsensus<PointXYZ>::computeModel, &mlesac, 0);
-  boost::thread thread6 (sac_function);
+  std::thread thread6 (sac_function);
   ASSERT_TRUE (thread6.timed_join (delay));
 }
 

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -465,7 +465,7 @@ run (float pair_width, float voxel_size, float max_coplanarity_angle, int num_hy
   {
     //main loop of the visualizer
     viz.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 
   vtk_model->Delete ();

--- a/tools/obj_rec_ransac_hash_table.cpp
+++ b/tools/obj_rec_ransac_hash_table.cpp
@@ -222,7 +222,7 @@ visualize (const ModelLibrary::HashTable& hash_table)
   while (!vis.wasStopped ())
   {
     vis.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }
 

--- a/tools/obj_rec_ransac_model_opps.cpp
+++ b/tools/obj_rec_ransac_model_opps.cpp
@@ -160,7 +160,7 @@ void run (float pair_width, float voxel_size, float max_coplanarity_angle)
   {
     //main loop of the visualizer
     viz.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }
 

--- a/tools/obj_rec_ransac_orr_octree.cpp
+++ b/tools/obj_rec_ransac_orr_octree.cpp
@@ -240,7 +240,7 @@ void run (const char* file_name, float voxel_size)
   {
     //main loop of the visualizer
     viz.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }
 

--- a/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+++ b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
@@ -145,7 +145,7 @@ void run (const char* file_name, float voxel_size)
   {
     //main loop of the visualizer
     viz.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }
 

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -221,7 +221,7 @@ run (float pair_width, float voxel_size, float max_coplanarity_angle)
   {
     //main loop of the visualizer
     viz.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }
 

--- a/tools/obj_rec_ransac_scene_opps.cpp
+++ b/tools/obj_rec_ransac_scene_opps.cpp
@@ -244,7 +244,7 @@ void run (float pair_width, float voxel_size, float max_coplanarity_angle)
   {
     //main loop of the visualizer
     viz.spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
   }
 }
 

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -191,7 +191,7 @@ private:
     {
       //main loop of the visualizer
       viz.spinOnce(100);
-      boost::this_thread::sleep(boost::posix_time::microseconds(100000));
+      std::this_thread::sleep_for(std::chrono::microseconds(100000));
     }
   }
 

--- a/tools/pcl_video.cpp
+++ b/tools/pcl_video.cpp
@@ -387,7 +387,7 @@ class Player
                 played_time = bpt::microsec_clock::local_time() - pb_start;
                 bpt::time_duration sleep_time(blk_offset - played_time);
                 std::cerr << "Will sleep " << sleep_time << " until displaying block\n";
-                boost::this_thread::sleep(sleep_time);
+                std::this_thread::sleep_for(sleep_time);
                 viewer_.showCloud(cloud);
                 //viewer_.removePointCloud("1");
                 //viewer_.addPointCloud(cloud, "1");

--- a/visualization/include/pcl/visualization/boost.h
+++ b/visualization/include/pcl/visualization/boost.h
@@ -60,10 +60,10 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/foreach.hpp>
-#ifndef Q_MOC_RUN
 #include <boost/date_time/posix_time/posix_time.hpp>
-#endif
 #include <boost/filesystem.hpp>
+
+#include <thread>
 #endif
 
 #endif    // PCL_VISUALIZATION_BOOST_H_

--- a/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
@@ -172,7 +172,7 @@ pcl::RegistrationVisualizer<PointSource, PointTarget>::runDisplay ()
 
     // Render visualizer updated buffers
     viewer_->spinOnce (100);
-    boost::this_thread::sleep (boost::posix_time::microseconds (100000));
+    std::this_thread::sleep_for (std::chrono::microseconds (100000));
 
   }
 }

--- a/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
@@ -41,7 +41,7 @@ template<typename PointSource, typename PointTarget> void
 pcl::RegistrationVisualizer<PointSource, PointTarget>::startDisplay ()
 {
   // Create and start the rendering thread. This will open the display window.
-  viewer_thread_ = boost::thread (&pcl::RegistrationVisualizer<PointSource, PointTarget>::runDisplay, this);
+  viewer_thread_ = std::thread (&pcl::RegistrationVisualizer<PointSource, PointTarget>::runDisplay, this);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/include/pcl/visualization/registration_visualizer.h
+++ b/visualization/include/pcl/visualization/registration_visualizer.h
@@ -168,7 +168,7 @@ namespace pcl
       boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer_;
 
       /** \brief The thread running the runDisplay() function. */
-      boost::thread viewer_thread_;
+      std::thread viewer_thread_;
 
       /** \brief The name of the registration method whose intermediate results are rendered. */
       std::string registration_method_name_;

--- a/visualization/src/cloud_viewer.cpp
+++ b/visualization/src/cloud_viewer.cpp
@@ -131,10 +131,10 @@ struct pcl::visualization::CloudViewer::CloudViewer_impl
   CloudViewer_impl (const std::string& window_name) :
     window_name_ (window_name), has_cloud_ (false), quit_ (false)
   {
-    viewer_thread_ = boost::thread (boost::ref (*this));
+    viewer_thread_ = std::thread (std::ref (*this));
     while (!viewer_)
     {
-      boost::thread::yield ();
+      std::this_thread::yield ();
     }
   }
 
@@ -153,7 +153,7 @@ struct pcl::visualization::CloudViewer::CloudViewer_impl
     }
     while (!cs->popped ())
     {
-      boost::thread::yield ();
+      std::this_thread::yield ();
     }
   }
 
@@ -249,7 +249,7 @@ struct pcl::visualization::CloudViewer::CloudViewer_impl
   std::string window_name_;
   boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer_;
   boost::mutex mtx_, spin_mtx_, c_mtx, once_mtx;
-  boost::thread viewer_thread_;
+  std::thread viewer_thread_;
   bool has_cloud_;
   bool quit_;
   std::list<boost::shared_ptr<cloud_show_base> > cloud_shows_;
@@ -335,7 +335,7 @@ pcl::visualization::CloudViewer::removeVisualizationCallable (const std::string 
 bool
 pcl::visualization::CloudViewer::wasStopped (int)
 {
-  boost::thread::yield (); //allow this to be called in a loop
+  std::this_thread::yield (); //allow this to be called in a loop
   return !impl_->viewer_;
 }
 

--- a/visualization/src/histogram_visualizer.cpp
+++ b/visualization/src/histogram_visualizer.cpp
@@ -142,7 +142,7 @@ pcl::visualization::PCLHistogramVisualizer::spin ()
       if ((*am_it).second.interactor_->stopped)
         return;
     }
-    boost::this_thread::sleep (boost::posix_time::seconds (1));
+    std::this_thread::sleep_for (std::chrono::seconds (1));
   }
   while (true);
 }
@@ -178,7 +178,7 @@ pcl::visualization::PCLHistogramVisualizer::spin ()
     spinOnce ();
     if (stopped_)
       break;
-    boost::this_thread::sleep (boost::posix_time::seconds (1));
+    std::this_thread::sleep_for (std::chrono::seconds (1));
   }
   while (true);
 }

--- a/visualization/tools/davidsdk_viewer.cpp
+++ b/visualization/tools/davidsdk_viewer.cpp
@@ -98,7 +98,7 @@ main (int argc,
 
   while (!viewer_ptr->wasStopped ())
   {
-    boost::this_thread::sleep (boost::posix_time::seconds (20));
+    std::this_thread::sleep_for (std::chrono::seconds (20));
     std::cout << "FPS: " << davidsdk_ptr->getFramesPerSecond () << std::endl;
   }
 

--- a/visualization/tools/ensenso_viewer.cpp
+++ b/visualization/tools/ensenso_viewer.cpp
@@ -78,7 +78,7 @@ main (void)
 
   while (!viewer_ptr->wasStopped ())
   {
-    boost::this_thread::sleep (boost::posix_time::milliseconds (1000));
+    std::this_thread::sleep_for (std::chrono::milliseconds (1000));
     std::cout << "FPS: " << ensenso_ptr->getFramesPerSecond () << std::endl;
   }
 

--- a/visualization/tools/hdl_viewer_simple.cpp
+++ b/visualization/tools/hdl_viewer_simple.cpp
@@ -177,7 +177,7 @@ class SimpleHDLViewer
         if (!grabber_.isRunning ())
           cloud_viewer_->spin ();
 
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       grabber_.stop ();

--- a/visualization/tools/image_grabber_viewer.cpp
+++ b/visualization/tools/image_grabber_viewer.cpp
@@ -254,7 +254,7 @@ main (int argc, char** argv)
 
     if (!cloud_)
     {
-      boost::this_thread::sleep(boost::posix_time::microseconds(10000));
+      std::this_thread::sleep_for(std::chrono::microseconds(10000));
       continue;
     }
     else if (mutex_.try_lock ())

--- a/visualization/tools/openni_image.cpp
+++ b/visualization/tools/openni_image.cpp
@@ -323,7 +323,7 @@ class Writer
         if (save_data || toggle_one_frame_capture)
           writeToDisk (buf_.popFront ());
         else
-          boost::this_thread::sleep (boost::posix_time::microseconds (100));
+          std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       if (save_data && buf_.getSize () > 0)
@@ -418,7 +418,7 @@ class Driver
       
       while (!is_done)
       {
-        boost::this_thread::sleep (boost::posix_time::seconds (1));
+        std::this_thread::sleep_for (std::chrono::seconds (1));
       }
       grabber_.stop ();
       image_connection.disconnect ();
@@ -477,7 +477,7 @@ class Viewer
              !depth_image_viewer_->wasStopped () && 
              !is_done)
       {
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
 
         if (!visualize)
         {

--- a/visualization/tools/openni_image.cpp
+++ b/visualization/tools/openni_image.cpp
@@ -347,7 +347,7 @@ class Writer
     Writer (Buffer &buf)
       : buf_ (buf)
     {
-      thread_.reset (new boost::thread (boost::bind (&Writer::receiveAndProcess, this)));
+      thread_.reset (new std::thread (boost::bind (&Writer::receiveAndProcess, this)));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -361,7 +361,7 @@ class Writer
 
   private:
     Buffer &buf_;
-    boost::shared_ptr<boost::thread> thread_;
+    boost::shared_ptr<std::thread> thread_;
 };
 
 
@@ -430,7 +430,7 @@ class Driver
       , buf_write_ (buf_write)
       , buf_vis_ (buf_vis)
     {
-      thread_.reset (new boost::thread (boost::bind (&Driver::grabAndSend, this)));
+      thread_.reset (new std::thread (boost::bind (&Driver::grabAndSend, this)));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -446,7 +446,7 @@ class Driver
     
     OpenNIGrabber& grabber_;
     Buffer &buf_write_, &buf_vis_;
-    boost::shared_ptr<boost::thread> thread_;
+    boost::shared_ptr<std::thread> thread_;
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/tools/pcd_grabber_viewer.cpp
+++ b/visualization/tools/pcd_grabber_viewer.cpp
@@ -248,7 +248,7 @@ main (int argc, char** argv)
 
     if (!cloud_)
     {
-      boost::this_thread::sleep(boost::posix_time::microseconds(10000));
+      std::this_thread::sleep_for(std::chrono::microseconds(10000));
       continue;
     }
     else if (mutex_.try_lock ())

--- a/visualization/tools/pcd_viewer.cpp
+++ b/visualization/tools/pcd_viewer.cpp
@@ -745,7 +745,7 @@ main (int argc, char** argv)
         }
         p->spinOnce ();
       }
-      boost::this_thread::sleep (boost::posix_time::microseconds (100));
+      std::this_thread::sleep_for (std::chrono::microseconds (100));
     }
     while (!stopped);
   }

--- a/visualization/tools/timed_trigger_test.cpp
+++ b/visualization/tools/timed_trigger_test.cpp
@@ -14,7 +14,7 @@ void callback ()
   double elapsed = pcl::getTime () - last_time;
   last_time = pcl::getTime ();
   cout << "global fn: " << pcl::getTime () - global_time << " :: " << elapsed << endl;
-  boost::this_thread::sleep(boost::posix_time::microseconds(1000));
+  std::this_thread::sleep_for(std::chrono::microseconds(1000));
 }
 
 class Dummy
@@ -35,10 +35,10 @@ int main ()
   Dummy dummy;
   global_time = pcl::getTime ();
   trigger.start ();
-  boost::this_thread::sleep(boost::posix_time::seconds(2));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   trigger.registerCallback ( boost::bind(&Dummy::myTimer, dummy));
-  boost::this_thread::sleep(boost::posix_time::seconds(3));
+  std::this_thread::sleep_for(std::chrono::seconds(3));
   trigger.setInterval (0.2);
-  boost::this_thread::sleep(boost::posix_time::seconds(2));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
   return 0;
 }

--- a/visualization/tools/vlp_viewer.cpp
+++ b/visualization/tools/vlp_viewer.cpp
@@ -185,7 +185,7 @@ class SimpleVLPViewer
         if (!grabber_.isRunning ())
           cloud_viewer_->spin ();
 
-        boost::this_thread::sleep (boost::posix_time::microseconds (100));
+        std::this_thread::sleep_for (std::chrono::microseconds (100));
       }
 
       grabber_.stop ();


### PR DESCRIPTION
This implements the tasks mentioned in #1638 and #2202 
The PR is currently still targeting C++ 17 until someone comes up with a replacement for shared_mutex, which was added in C++ 17. 

Tasks:
- [x] Replace boost thread dependency (thread, mutex, shared_mutex, condtion_variable)
- [x] Use chrono for thread timing
- [x] Update CMake to support C++ 14 (17)
- [ ] Use Lambdas instead of binds where appropiate (e.g. std::sort)
- [x] Replace boost functional (bind, function)
- [ ] Replace boost random generators
- [ ] Replace boost date time
- [x] Replace push_back with emplace_back (#2202)

Please check the changes for correctness