### PR TITLE
Add PointNormal to ExtractIndices Instantiate Types

### DIFF
--- a/filters/src/extract_indices.cpp
+++ b/filters/src/extract_indices.cpp
@@ -186,7 +186,7 @@ pcl::ExtractIndices<pcl::PCLPointCloud2>::applyFilter (std::vector<int> &indices
 #include <pcl/point_types.h>
 
 #ifdef PCL_ONLY_CORE_POINT_TYPES
-  PCL_INSTANTIATE(ExtractIndices, (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGB)(pcl::PointXYZRGBA)(pcl::Normal)(pcl::PointXYZRGBNormal))
+  PCL_INSTANTIATE(ExtractIndices, (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGB)(pcl::PointXYZRGBA)(pcl::Normal)(pcl::PointNormal)(pcl::PointXYZRGBNormal))
 #else
   PCL_INSTANTIATE(ExtractIndices, PCL_POINT_TYPES)
 #endif


### PR DESCRIPTION
This pull request will add <code>pcl::PointNormal</code> to instantiate types of <code>pcl::ExtractIndices</code>, because this type is missing even though there are <code>pcl::Normal</code> and <code>pcl::PointXYZRGBNormal</code>.
It is no longer necessary to separate point cloud to <code>pcl::PointXYZ</code> and <code>pcl::Normal</code> when want to use <code>pcl::ExtractIndices</code> with <code>pcl::PointNormal</code>. You can use <code>pcl::ExtractIndices\<pcl::PointNormal\></code> directly.
