### PR TITLE
Switch to using client-based search in Doxygen

### DIFF
--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -205,7 +205,7 @@ USE_MATHJAX            = NO
 MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
 MATHJAX_EXTENSIONS     =
 SEARCHENGINE           = @DOCUMENTATION_SEARCHENGINE@
-SERVER_BASED_SEARCH    = YES
+SERVER_BASED_SEARCH    = NO
 
 #---------------------------------------------------------------------------
 # configuration options related to the LaTeX output


### PR DESCRIPTION
As reported in https://github.com/PointCloudLibrary/documentation/issues/1, documentation search does not work. It looks like execution of PHP scripts (which power server-side search) was disabled, which I suspect has happened while solving #2381.

This commit enables client-side JavaScript-based search.