### PR TITLE
Make pcl::MovingLeastSquares thread-safe

### DIFF
--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -283,8 +283,6 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performProcessing (PointCloudOut &
   // Compute the number of coefficients
   nr_coeff_ = (order_ + 1) * (order_ + 2) / 2;
 
-  size_t mls_result_index = 0;
-
 #ifdef _OPENMP
   // (Maximum) number of threads
   const unsigned int threads = threads_ == 0 ? 1 : threads_;
@@ -324,6 +322,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performProcessing (PointCloudOut &
         // Get a plane approximating the local surface's tangent and project point onto it
         const int index = (*indices_)[cp];
 
+        size_t mls_result_index = 0;
         if (cache_mls_results_)
           mls_result_index = index; // otherwise we give it a dummy location.
 


### PR DESCRIPTION
Problem:
Running `pcl::MovingLeastSquares` with multiple threads may lead to an out-of-bounds exception in `pcl::MLSResult::computeMLSSurface` because the member `MLSResult::num_neighbors` is overwritten by another thread.
I'm afraid I have introduced this bug myself on refactoring the function for #2324 when I left the local variable `mls_result_index` at the top of the function (like in the non-OpenMP version) instead of moving it inside the parallel region (like in the OpenMP version).

Proposed solution:
Move the local variable `mls_result_index` inside the OpenMP parallel region, so that each thread has its private copy.