### PR TITLE
Remove explicit initialization of `update_visualizer_` in `Registration` 

### DIFF
--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -124,7 +124,6 @@ namespace pcl
         , source_cloud_updated_ (true)
         , force_no_recompute_ (false)
         , force_no_recompute_reciprocal_ (false)
-        , update_visualizer_ (NULL)
         , point_representation_ ()
       {
       }


### PR DESCRIPTION
Fixes #2349. (Although I was not able to reproduce it with GCC 5.5.0 and Boost 1.67).