### PR TITLE
Intel fixes

### DIFF
--- a/cmake/pcl_find_sse.cmake
+++ b/cmake/pcl_find_sse.cmake
@@ -12,18 +12,23 @@ macro(PCL_CHECK_FOR_SSE)
         endif()
     endif()
 
-    # Unfortunately we need to check for SSE to enable "-mfpmath=sse" alongside 
+    # Unfortunately we need to check for SSE to enable "-mfpmath=sse" alongside
     # "-march=native". The reason for this is that by default, 32bit architectures
     # tend to use the x87 FPU (which has 80 bit internal precision), thus leading
     # to different results than 64bit architectures which are using SSE2 (64 bit internal
-    # precision). One solution would be to use "-ffloat-store" on 32bit (see 
+    # precision). One solution would be to use "-ffloat-store" on 32bit (see
     # http://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html), but that slows code down,
     # so the preferred solution is to try "-mpfmath=sse" first.
     include(CheckCXXSourceRuns)
     set(CMAKE_REQUIRED_FLAGS)
 
     check_cxx_source_runs("
-        #include <mm_malloc.h>
+        // Intel compiler defines an incompatible _mm_malloc signature
+        #if defined(__INTEL_COMPILER)
+            #include <malloc.h>
+        #else
+            #include <mm_malloc.h>
+        #endif
         int main()
         {
           void* mem = _mm_malloc (100, 16);
@@ -122,7 +127,7 @@ macro(PCL_CHECK_FOR_SSE)
     elseif(MSVC AND NOT CMAKE_CL_64)
         set(CMAKE_REQUIRED_FLAGS "/arch:SSE2")
     endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
-    
+
     check_cxx_source_runs("
         #include <emmintrin.h>
         int main ()

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -321,22 +321,19 @@ log2f (float x)
   #define __has_extension(x) 0 // Compatibility with pre-3.0 compilers.
 #endif
 
-#if (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < PCL_LINEAR_VERSION(4,5,0) && ! defined(__clang__)) || defined(__INTEL_COMPILER)
-#define PCL_DEPRECATED(message) __attribute__ ((deprecated))
-#endif
-
+// check Intel compiler first since it usually also defines __GNUC__, __clang__, etc.
+#if defined(__INTEL_COMPILER)
+  #define PCL_DEPRECATED(message) __attribute((deprecated))
+#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < PCL_LINEAR_VERSION(4,5,0) && ! defined(__clang__)) || defined(__INTEL_COMPILER)
+  #define PCL_DEPRECATED(message) __attribute__ ((deprecated))
 // gcc supports this starting from 4.5 : http://gcc.gnu.org/bugzilla/show_bug.cgi?id=43666
-#if (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) >= PCL_LINEAR_VERSION(4,5,0)) || (defined(__clang__) && __has_extension(attribute_deprecated_with_message))
-#define PCL_DEPRECATED(message) __attribute__ ((deprecated(message)))
-#endif
-
-#ifdef _MSC_VER
-#define PCL_DEPRECATED(message) __declspec(deprecated(message))
-#endif
-
-#ifndef PCL_DEPRECATED
-#pragma message("WARNING: You need to implement PCL_DEPRECATED for this compiler")
-#define PCL_DEPRECATED(message)
+#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) >= PCL_LINEAR_VERSION(4,5,0)) || (defined(__clang__) && __has_extension(attribute_deprecated_with_message))
+  #define PCL_DEPRECATED(message) __attribute__ ((deprecated(message)))
+#elif defined(_MSC_VER)
+  #define PCL_DEPRECATED(message) __declspec(deprecated(message))
+#else
+  #pragma message("WARNING: You need to implement PCL_DEPRECATED for this compiler")
+  #define PCL_DEPRECATED(message)
 #endif
 
 
@@ -356,22 +353,19 @@ log2f (float x)
 //     NewClass() {}
 // };
 
-#if (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < PCL_LINEAR_VERSION(4,5,0) && ! defined(__clang__)) || defined(__INTEL_COMPILER)
-#define PCL_DEPRECATED_CLASS(func, message) __attribute__ ((deprecated)) func
-#endif
-
+// check Intel compiler first since it usually also defines __GNUC__, __clang__, etc.
+#if defined(__INTEL_COMPILER)
+  #define PCL_DEPRECATED_CLASS(func, message) __attribute((deprecated)) func
+#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < PCL_LINEAR_VERSION(4,5,0) && ! defined(__clang__)) || defined(__INTEL_COMPILER)
+  #define PCL_DEPRECATED_CLASS(func, message) __attribute__ ((deprecated)) func
 // gcc supports this starting from 4.5 : http://gcc.gnu.org/bugzilla/show_bug.cgi?id=43666
-#if (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) >= PCL_LINEAR_VERSION(4,5,0)) || (defined(__clang__) && __has_extension(attribute_deprecated_with_message))
-#define PCL_DEPRECATED_CLASS(func, message) __attribute__ ((deprecated(message))) func
-#endif
-
-#ifdef _MSC_VER
-#define PCL_DEPRECATED_CLASS(func, message) __declspec(deprecated(message)) func
-#endif
-
-#ifndef PCL_DEPRECATED_CLASS
-#pragma message("WARNING: You need to implement PCL_DEPRECATED_CLASS for this compiler")
-#define PCL_DEPRECATED_CLASS(func) func
+#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) >= PCL_LINEAR_VERSION(4,5,0)) || (defined(__clang__) && __has_extension(attribute_deprecated_with_message))
+  #define PCL_DEPRECATED_CLASS(func, message) __attribute__ ((deprecated(message))) func
+#elif defined(_MSC_VER)
+  #define PCL_DEPRECATED_CLASS(func, message) __declspec(deprecated(message)) func
+#else
+  #pragma message("WARNING: You need to implement PCL_DEPRECATED_CLASS for this compiler")
+  #define PCL_DEPRECATED_CLASS(func) func
 #endif
 
 #if defined (__GNUC__) || defined (__PGI) || defined (__IBMCPP__) || defined (__SUNPRO_CC)

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -393,7 +393,12 @@ log2f (float x)
 #endif
 
 #if defined (HAVE_MM_MALLOC)
-  #include <mm_malloc.h>
+  // Intel compiler defines an incompatible _mm_malloc signature
+  #if defined(__INTEL_COMPILER)
+    #include <malloc.h>
+  #else
+    #include <mm_malloc.h>
+  #endif
 #endif
 
 inline void*


### PR DESCRIPTION
Fixes `DEPRECATED` macros and `_mm_malloc` trauma with GCC.  See [this SO post](https://stackoverflow.com/a/18217566) for the `_mm_malloc` thing.  Only tested on Linux, but this should be OK for macOS and Windows, but I can't test those with the intel compilers.