### PR TITLE
Docstring typos' corrections.

### DIFF
--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -352,7 +352,7 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeCanny (pcl::PointCloud<PointOutT> &out
   convolution_.filter (*smoothed_cloud);
   //PCL_ERROR ("Gaussian blur: %g\n", tt.toc ()); tt.tic ();
   
-  // Edge detection usign Sobel
+  // Edge detection using Sobel
   pcl::PointCloud<PointXYZIEdge>::Ptr edges (new pcl::PointCloud<PointXYZIEdge>);
   setInputCloud (smoothed_cloud);
   detectEdgeSobel (*edges);
@@ -431,7 +431,7 @@ pcl::Edge<PointInT, PointOutT>::canny (
   convolution_.filter (smoothed_cloud_y);
 
 
-  // Edge detection usign Sobel
+  // Edge detection using Sobel
   pcl::PointCloud<PointXYZIEdge>::Ptr edges (new pcl::PointCloud<PointXYZIEdge>);
   sobelMagnitudeDirection (smoothed_cloud_x, smoothed_cloud_y, *edges.get ());
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1917,7 +1917,7 @@ pcl::OrganizedDataIndex -> pcl::search::OrganizedNeighbor
 * Update: remove ciminpack dependency and rely on eigen for LM
 * Fixed a bug in ICP-NL by modifying `WarpPointRigid` to preserve the value of the 4th coordinate when warping; Re-enabled missing unit tests for ICP and ICP-NL
 * Added point-to-plane ICP
-* added nr_iterations_ and max_iterations_ to the initializer list (were mising)
+* added nr_iterations_ and max_iterations_ to the initializer list (were missing)
 * Fixed bugs in `WarpPointRigid3D` and `TransformationEstimationLM`
 * fixed a problem where if no correspondences would be found via `nearestKSearch`, the RANSAC-based rejection scheme would fail (thanks to James for reporting this)
 * changed the default LM implementation to use L2 instead of L2SQR

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
@@ -123,7 +123,7 @@ class CloudEditorWidget : public QGLWidget
     void
     cut ();
 
-    /// @brief Enters the mode where users are able to translate the selecte
+    /// @brief Enters the mode where users are able to translate the selected
     /// points.
     void
     transform ();

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
@@ -76,7 +76,7 @@ class CommandQueue
     void
     execute (CommandPtr);
 
-    /// @brief Undoes the last command by poping the tail of the queue, invoke
+    /// @brief Undoes the last command by popping the tail of the queue, invoke
     /// the undo function of the command.
     void
     undo ();

--- a/cmake/Modules/NSIS.template.in
+++ b/cmake/Modules/NSIS.template.in
@@ -861,7 +861,7 @@ Section "Uninstall"
 @CPACK_NSIS_DELETE_ICONS@
 @CPACK_NSIS_DELETE_ICONS_EXTRA@
   
-  ;Delete empty start menu parent diretories
+  ;Delete empty start menu parent directories
   StrCpy $MUI_TEMP "$SMPROGRAMS\$MUI_TEMP"
  
   startMenuDeleteLoop:
@@ -880,7 +880,7 @@ Section "Uninstall"
   Delete "$SMPROGRAMS\$MUI_TEMP\Uninstall.lnk"
 @CPACK_NSIS_DELETE_ICONS_EXTRA@
   
-  ;Delete empty start menu parent diretories
+  ;Delete empty start menu parent directories
   StrCpy $MUI_TEMP "$SMPROGRAMS\$MUI_TEMP"
  
   secondStartMenuDeleteLoop:

--- a/common/include/pcl/common/eigen.h
+++ b/common/include/pcl/common/eigen.h
@@ -238,10 +238,10 @@ namespace pcl
     * \ingroup common
     */
   inline Eigen::Affine3f
-  getTransformationFromTwoUnitVectors (const Eigen::Vector3f& y_direction, 
+  getTransformationFromTwoUnitVectors (const Eigen::Vector3f& y_direction,
                                        const Eigen::Vector3f& z_axis);
 
-  /** \brief Get the transformation that will translate \a orign to (0,0,0) and rotate \a z_axis into (0,0,1)
+  /** \brief Get the transformation that will translate \a origin to (0,0,0) and rotate \a z_axis into (0,0,1)
     * and \a y_direction into a vector with x=0 (or into (0,1,0) should \a y_direction be orthogonal to \a z_axis)
     * \param[in] y_direction the y direction
     * \param[in] z_axis the z-axis

--- a/common/include/pcl/common/generate.h
+++ b/common/include/pcl/common/generate.h
@@ -65,7 +65,7 @@ namespace pcl
       CloudGenerator ();
 
       /** Constructor with single generator to ensure all X, Y and Z values are within same range
-        * \param params paramteres for X, Y and Z values generation. Uniqueness is ensured through
+        * \param params parameters for X, Y and Z values generation. Uniqueness is ensured through
         * seed incrementation
         */
       CloudGenerator (const GeneratorParameters& params);

--- a/common/include/pcl/pcl_exports.h
+++ b/common/include/pcl/pcl_exports.h
@@ -36,7 +36,7 @@
 #define PCL_EXPORTS_H_
 
 // This header is created to include to NVCC compiled sources.
-// Header 'pcl_macros' is not suitable since it inludes <Eigen/Core>,
+// Header 'pcl_macros' is not suitable since it includes <Eigen/Core>,
 // which can't be eaten by nvcc (it's too weak)
 
 #if defined WIN32 || defined _WIN32 || defined WINCE || defined __MINGW32__

--- a/cuda/common/include/pcl/cuda/cutil.h
+++ b/cuda/common/include/pcl/cuda/cutil.h
@@ -849,7 +849,7 @@ extern "C" {
         exit(EXIT_FAILURE);                                                  \
     } } while(0);
 
-    //! Check if conditon is true (flexible assert)
+    //! Check if condition is true (flexible assert)
 #  define CUT_CONDITION( val)                                                \
     if( CUTFalse == cutCheckCondition( val, __FILE__, __LINE__)) {           \
         exit(EXIT_FAILURE);                                                  \

--- a/doc/tutorials/content/pcl_visualizer.rst
+++ b/doc/tutorials/content/pcl_visualizer.rst
@@ -439,7 +439,7 @@ window. We must store the view port ID number that is passed back in the
 fifth parameter and use it in all other calls where we only want to
 affect that viewport.
 
-We also set the background colour of this viewport, give it a lable
+We also set the background colour of this viewport, give it a label
 based on what we are using the viewport to distinguish, and add our
 point cloud to it, using an RGB colour handler.
 

--- a/doc/tutorials/content/remove_outliers.rst
+++ b/doc/tutorials/content/remove_outliers.rst
@@ -62,7 +62,7 @@ For the *ConditionalRemoval* class, the user must specify '-c' as the command li
    :language: cpp
    :lines: 38-53
 
-Basically, we create the condition which a given point must satisfy for it to remain in our PointCloud.  In this example, we use add two comparisons to the conditon: greater than (GT) 0.0 and less than (LT) 0.8.  This condition is then used to build the filter. 
+Basically, we create the condition which a given point must satisfy for it to remain in our PointCloud.  In this example, we use add two comparisons to the condition: greater than (GT) 0.0 and less than (LT) 0.8.  This condition is then used to build the filter. 
 
 In both cases the code above creates the filter object that we are going to use and sets certain parameters that are necessary for the filtering to take place.
 

--- a/doc/tutorials/content/sources/narf_feature_extraction/narf_feature_extraction.cpp
+++ b/doc/tutorials/content/sources/narf_feature_extraction/narf_feature_extraction.cpp
@@ -115,7 +115,7 @@ main (int argc, char** argv)
   else
   {
     setUnseenToMaxRange = true;
-    cout << "\nNo *.pcd file given => Genarating example point cloud.\n\n";
+    cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
     for (float x=-0.5f; x<=0.5f; x+=0.01f)
     {
       for (float y=-0.5f; y<=0.5f; y+=0.01f)

--- a/doc/tutorials/content/sources/narf_keypoint_extraction/narf_keypoint_extraction.cpp
+++ b/doc/tutorials/content/sources/narf_keypoint_extraction/narf_keypoint_extraction.cpp
@@ -109,7 +109,7 @@ main (int argc, char** argv)
   else
   {
     setUnseenToMaxRange = true;
-    cout << "\nNo *.pcd file given => Genarating example point cloud.\n\n";
+    cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
     for (float x=-0.5f; x<=0.5f; x+=0.01f)
     {
       for (float y=-0.5f; y<=0.5f; y+=0.01f)

--- a/doc/tutorials/content/sources/pcl_visualizer/pcl_visualizer_demo.cpp
+++ b/doc/tutorials/content/sources/pcl_visualizer/pcl_visualizer_demo.cpp
@@ -282,7 +282,7 @@ main (int argc, char** argv)
   // ------------------------------------
   pcl::PointCloud<pcl::PointXYZ>::Ptr basic_cloud_ptr (new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr point_cloud_ptr (new pcl::PointCloud<pcl::PointXYZRGB>);
-  std::cout << "Genarating example point clouds.\n\n";
+  std::cout << "Generating example point clouds.\n\n";
   // We're going to make an ellipse extruded along the z-axis. The colour for
   // the XYZRGB cloud will gradually go from red to green to blue.
   uint8_t r(255), g(15), b(15);

--- a/doc/tutorials/content/sources/random_sample_consensus/random_sample_consensus.cpp
+++ b/doc/tutorials/content/sources/random_sample_consensus/random_sample_consensus.cpp
@@ -87,7 +87,7 @@ main(int argc, char** argv)
   // copies all inliers of the model computed to another PointCloud
   pcl::copyPointCloud<pcl::PointXYZ>(*cloud, inliers, *final);
 
-  // creates the visualization object and adds either our orignial cloud or all of the inliers
+  // creates the visualization object and adds either our original cloud or all of the inliers
   // depending on the command line arguments specified.
   boost::shared_ptr<pcl::visualization::PCLVisualizer> viewer;
   if (pcl::console::find_argument (argc, argv, "-f") >= 0 || pcl::console::find_argument (argc, argv, "-sf") >= 0)

--- a/doc/tutorials/content/sources/range_image_border_extraction/range_image_border_extraction.cpp
+++ b/doc/tutorials/content/sources/range_image_border_extraction/range_image_border_extraction.cpp
@@ -92,7 +92,7 @@ main (int argc, char** argv)
   }
   else
   {
-    cout << "\nNo *.pcd file given => Genarating example point cloud.\n\n";
+    cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
     for (float x=-0.5f; x<=0.5f; x+=0.01f)
     {
       for (float y=-0.5f; y<=0.5f; y+=0.01f)

--- a/doc/tutorials/content/sources/range_image_visualization/range_image_visualization.cpp
+++ b/doc/tutorials/content/sources/range_image_visualization/range_image_visualization.cpp
@@ -102,7 +102,7 @@ main (int argc, char** argv)
   }
   else
   {
-    std::cout << "\nNo *.pcd file given => Genarating example point cloud.\n\n";
+    std::cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
     for (float x=-0.5f; x<=0.5f; x+=0.01f)
     {
       for (float y=-0.5f; y<=0.5f; y+=0.01f)

--- a/examples/features/example_rift_estimation.cpp
+++ b/examples/features/example_rift_estimation.cpp
@@ -86,7 +86,7 @@ main (int, char** argv)
   gradient_est.setSearchMethod(treept2);
   gradient_est.setRadiusSearch(0.25);
   gradient_est.compute(*cloud_ig);
-  std::cout<<" Intesity Gradient estimated";
+  std::cout<<" Intensity Gradient estimated";
   std::cout<<" with size "<< cloud_ig->points.size() <<std::endl;
 
 

--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -159,7 +159,7 @@ if(build)
        )
 	
     if(MSVC)
-      # Workaround to aviod hitting the MSVC 4GB linker memory limit when building pcl_features.
+      # Workaround to avoid hitting the MSVC 4GB linker memory limit when building pcl_features.
       # Disable whole program optimization (/GL) and link-time code generation (/LTCG).
       string(REPLACE "/GL" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
       string(REPLACE "/LTCG" "" CMAKE_SHARED_LINKER_FLAGS_RELEASE ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}) 

--- a/features/include/pcl/features/rops_estimation.h
+++ b/features/include/pcl/features/rops_estimation.h
@@ -110,7 +110,7 @@ namespace pcl
       setTriangles (const std::vector <pcl::Vertices>& triangles);
 
       /** \brief Returns the triangles of the mesh.
-        * \param[out] triangles triangles of tthe mesh
+        * \param[out] triangles triangles of the mesh
         */
       void
       getTriangles (std::vector <pcl::Vertices>& triangles) const;

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -83,7 +83,7 @@ pcl::FrustumCulling<PointT>::applyFilter (std::vector<int> &indices)
   Eigen::Vector4f pl_l; // left plane
 
   Eigen::Vector3f view = camera_pose_.block (0, 0, 3, 1);    // view vector for the camera  - first column of the rotation matrix
-  Eigen::Vector3f up = camera_pose_.block (0, 1, 3, 1);      // up vector for the camera    - second column of the rotation matix
+  Eigen::Vector3f up = camera_pose_.block (0, 1, 3, 1);      // up vector for the camera    - second column of the rotation matrix
   Eigen::Vector3f right = camera_pose_.block (0, 2, 3, 1);   // right vector for the camera - third column of the rotation matrix
   Eigen::Vector3f T = camera_pose_.block (0, 3, 3, 1);       // The (X, Y, Z) position of the camera w.r.t origin
 

--- a/filters/include/pcl/filters/sampling_surface_normal.h
+++ b/filters/include/pcl/filters/sampling_surface_normal.h
@@ -144,7 +144,7 @@ namespace pcl
 
     private:
 
-      /** \brief @b CompareDim is a comparator object for sorting across a specific dimenstion (i,.e X, Y or Z)
+      /** \brief @b CompareDim is a comparator object for sorting across a specific dimension (i,.e X, Y or Z)
        */
       struct CompareDim
       {

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -520,7 +520,7 @@ namespace pcl
       /** \brief Flag to determine if voxel structure is searchable. */
       bool searchable_;
 
-      /** \brief Minimum points contained with in a voxel to allow it to be useable. */
+      /** \brief Minimum points contained with in a voxel to allow it to be usable. */
       int min_points_per_voxel_;
 
       /** \brief Minimum allowable ratio between eigenvalues to prevent singular covariance matrices. */

--- a/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
+++ b/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
@@ -113,7 +113,7 @@ namespace pcl
                            const Eigen::Vector3i& in_target_voxel);
 
       /** \brief Computes the voxel coordinates (i, j, k) of all occluded
-        * voxels in the voxel gird.
+        * voxels in the voxel grid.
         * \param[out] occluded_voxels the coordinates (i, j, k) of all occluded voxels
         * \return 0 upon success and -1 if an error occurs
         */

--- a/gpu/kinfu/src/internal.h
+++ b/gpu/kinfu/src/internal.h
@@ -341,7 +341,7 @@ namespace pcl
     PCL_EXPORTS size_t 
     extractCloud (const PtrStep<short2>& volume, const float3& volume_size, PtrSz<PointType> output);
 
-    /** \brief Performs normals computation for given poins using tsdf volume
+    /** \brief Performs normals computation for given points using tsdf volume
       * \param[in] volume tsdf volume
       * \param[in] volume_size volume size
       * \param[in] input points where normals are computed

--- a/gpu/kinfu/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu/tools/record_tsdfvolume.cpp
@@ -375,7 +375,7 @@ main (int argc, char* argv[])
   // parse input cloud file
   pc::parse_argument (argc, argv, "-cf", cloud_file);
 
-  // pase output volume file
+  // parse output volume file
   pc::parse_argument (argc, argv, "-vf", volume_file);
 
   // parse options to extract and save cloud from volume

--- a/gpu/kinfu/tools/tsdf_volume.h
+++ b/gpu/kinfu/tools/tsdf_volume.h
@@ -241,11 +241,11 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   //   template <typename PointT> void
   //   createFromCloud (const typename pcl::PointCloud<PointT>::ConstPtr &cloud, const Intr &intr);
 
-    /** \brief Retunrs the 3D voxel coordinate */
+    /** \brief Returns the 3D voxel coordinate */
     template <typename PointT> void
     getVoxelCoord (const PointT &point, Eigen::Vector3i &voxel_coord)  const;
 
-    /** \brief Retunrs the 3D voxel coordinate and point offset wrt. to the voxel center (in mm) */
+    /** \brief Returns the 3D voxel coordinate and point offset wrt. to the voxel center (in mm) */
     template <typename PointT> void
     getVoxelCoordAndOffset (const PointT &point, Eigen::Vector3i &voxel_coord, Eigen::Vector3f &offset) const;
 

--- a/gpu/kinfu/tools/tsdf_volume.hpp
+++ b/gpu/kinfu/tools/tsdf_volume.hpp
@@ -204,7 +204,7 @@ pcl::TSDFVolume<VoxelT, WeightT>::getVoxelCoord (const PointT &point, Eigen::Vec
 }
 
 
-/** \brief Retunrs the 3D voxel coordinate and point offset wrt. to the voxel center (in mm) */
+/** \brief Returns the 3D voxel coordinate and point offset wrt. to the voxel center (in mm) */
 template <typename VoxelT, typename WeightT> template <typename PointT> void
 pcl::TSDFVolume<VoxelT, WeightT>::getVoxelCoordAndOffset (const PointT &point,
                                                                           Eigen::Vector3i &coord, Eigen::Vector3f &offset) const

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
@@ -300,7 +300,7 @@ namespace pcl
                                          pcl::device::kinfuLS::Mat33& transform_out, float3& translation_out);
           
           /** \brief helper function that pre-process a raw detph map the kinect fusion algorithm.
-            * The raw depth map is first blured, eventually truncated, and downsampled for each pyramid level.
+            * The raw depth map is first blurred, eventually truncated, and downsampled for each pyramid level.
             * Then, vertex and normal maps are computed for each pyramid level.
             * \param[in] depth_raw the raw depth map to process
             * \param[in] cam_intrinsics intrinsics of the camera used to acquire the depth map

--- a/gpu/kinfu_large_scale/src/internal.h
+++ b/gpu/kinfu_large_scale/src/internal.h
@@ -357,7 +357,7 @@ namespace pcl
       PCL_EXPORTS size_t
       extractSliceAsCloud (const PtrStep<short2>& volume, const float3& volume_size, const pcl::gpu::kinfuLS::tsdf_buffer* buffer, const int shiftX, const int shiftY, const int shiftZ, PtrSz<PointType> output_xyz, PtrSz<float> output_intensities);
 
-      /** \brief Performs normals computation for given poins using tsdf volume
+      /** \brief Performs normals computation for given points using tsdf volume
         * \param[in] volume tsdf volume
         * \param[in] volume_size volume size
         * \param[in] input points where normals are computed

--- a/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
@@ -373,7 +373,7 @@ main (int argc, char* argv[])
   // parse input cloud file
   pc::parse_argument (argc, argv, "-cf", cloud_file);
 
-  // pase output volume file
+  // parse output volume file
   pc::parse_argument (argc, argv, "-vf", volume_file);
 
   // parse options to extract and save cloud from volume

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -239,7 +239,7 @@ saveOBJFile (const std::string &file_name,
   PCL_INFO ("Closing obj file\n");
   fs.close ();
 
-  /* Write material defination for OBJ file*/
+  /* Write material definition for OBJ file*/
   // Open file
   PCL_INFO ("Writing material files\n");
   //don't do it if no material to write
@@ -363,7 +363,7 @@ std::ifstream& GotoLine(std::ifstream& file, unsigned int num)
   return (file);
 }
 
-/** \brief Helper function that reads a camera file outputed by Kinfu */
+/** \brief Helper function that reads a camera file outputted by Kinfu */
 bool readCamPoseFile(std::string filename, pcl::TextureMapping<pcl::PointXYZ>::Camera &cam)
 {
   ifstream myReadFile;

--- a/gpu/octree/test/test_host_radius_search.cpp
+++ b/gpu/octree/test/test_host_radius_search.cpp
@@ -110,7 +110,7 @@ TEST(PCL_OctreeGPU, hostRadiusSearch)
              
     for(size_t i = 0; i < data.tests_num; ++i)
     {
-        //search host on octree tha was built on device
+        //search host on octree that was built on device
         vector<int> results_host_gpu; //host search
         octree_device.radiusSearchHost(data.queries[i], data.radiuses[i], results_host_gpu);                        
         

--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -118,7 +118,7 @@ namespace pcl
       HDLGrabber (const std::string& correctionsFile = "",
                   const std::string& pcapFile = "");
 
-      /** \brief Constructor taking a pecified IP/port and an optional path to an HDL corrections file.
+      /** \brief Constructor taking a specified IP/port and an optional path to an HDL corrections file.
        * \param[in] ipAddress IP Address that should be used to listen for HDL packets
        * \param[in] port UDP Port that should be used to listen for HDL packets
        * \param[in] correctionsFile Path to a file which contains the correction parameters for the HDL.  This field is mandatory for the HDL-64, optional for the HDL-32

--- a/io/include/pcl/io/openni2/openni2_device_manager.h
+++ b/io/include/pcl/io/openni2/openni2_device_manager.h
@@ -59,7 +59,7 @@ namespace pcl
         OpenNI2DeviceManager ();
         virtual ~OpenNI2DeviceManager ();
 
-        // This may not actually be a sigleton yet. Need to work out cross-dll incerface.
+        // This may not actually be a singleton yet. Need to work out cross-dll incerface.
         // Based on http://stackoverflow.com/a/13431981/1789618
         static boost::shared_ptr<OpenNI2DeviceManager> getInstance ()
         {

--- a/io/include/pcl/io/png_io.h
+++ b/io/include/pcl/io/png_io.h
@@ -100,7 +100,7 @@ namespace pcl
     PCL_EXPORTS void
     savePNGFile (const std::string& file_name, const pcl::PointCloud<unsigned short>& cloud);
 
-    /** \brief Saves a PCLImage (formely ROS sensor_msgs::Image) to PNG file.
+    /** \brief Saves a PCLImage (formerly ROS sensor_msgs::Image) to PNG file.
       * \param[in] file_name the name of the file to write to disk
       * \param[in] image image to save
       * \ingroup io

--- a/io/include/pcl/io/vtk_io.h
+++ b/io/include/pcl/io/vtk_io.h
@@ -45,7 +45,7 @@
 #include <pcl/PCLPointCloud2.h>
 #include <pcl/PolygonMesh.h>
 
-// Please do not add any functions tha depend on VTK structures to this file!
+// Please do not add any functions that depend on VTK structures to this file!
 // Use vtk_io_lib.h instead.
 
 namespace pcl

--- a/io/src/dinast_grabber.cpp
+++ b/io/src/dinast_grabber.cpp
@@ -313,7 +313,7 @@ pcl::DinastGrabber::getXYZIPointCloud ()
     {
       double pixel = image_[x + image_width_ * y];
 
-      // Correcting distortion, data emprically got in a calibration test
+      // Correcting distortion, data empirically got in a calibration test
       double xc = static_cast<double> (x - image_width_ / 2);
       double yc = static_cast<double> (y - image_height_ / 2);
       double r1 = sqrt (xc * xc + yc * yc);

--- a/io/src/ensenso_grabber.cpp
+++ b/io/src/ensenso_grabber.cpp
@@ -323,7 +323,7 @@ pcl::EnsensoGrabber::grabSingleCloud (pcl::PointCloud<pcl::PointXYZ> &cloud)
     cloud.height = height;
     cloud.is_dense = false;
 
-    // Copy data in point cloud (and convert milimeters in meters)
+    // Copy data in point cloud (and convert millimeters in meters)
     for (size_t i = 0; i < pointMap.size (); i += 3)
     {
       cloud.points[i / 3].x = pointMap[i] / 1000.0;
@@ -433,7 +433,7 @@ pcl::EnsensoGrabber::estimateCalibrationPatternPose (Eigen::Affine3d &pattern_po
     // Convert tf into a matrix
     if (!jsonTransformationToMatrix (tf.asJson (), pattern_pose))
       return (false);
-    pattern_pose.translation () /= 1000.0;  // Convert translation in meters (Ensenso API returns milimeters)
+    pattern_pose.translation () /= 1000.0;  // Convert translation in meters (Ensenso API returns millimeters)
     return (true);
   }
   catch (NxLibException &ex)
@@ -1043,7 +1043,7 @@ pcl::EnsensoGrabber::processGrabbing ()
           cloud->height = height;
           cloud->is_dense = false;
 
-          // Copy data in point cloud (and convert milimeters in meters)
+          // Copy data in point cloud (and convert millimeters in meters)
           for (size_t i = 0; i < pointMap.size (); i += 3)
           {
             cloud->points[i / 3].x = pointMap[i] / 1000.0;

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -1129,7 +1129,7 @@ pcl::io::saveOBJFile (const std::string &file_name,
   // Close obj file
   fs.close ();
 
-  /* Write material defination for OBJ file*/
+  /* Write material definition for OBJ file*/
   // Open file
 
   std::ofstream m_fs;

--- a/keypoints/include/pcl/keypoints/agast_2d.h
+++ b/keypoints/include/pcl/keypoints/agast_2d.h
@@ -159,7 +159,7 @@ namespace pcl
             nr_max_keypoints_ = nr_max_keypoints;
           }
 
-          /** \brief Get the maximum nuber of keypoints to return, as set by the user. */
+          /** \brief Get the maximum number of keypoints to return, as set by the user. */
           inline unsigned int 
           getMaxKeypoints ()
           {
@@ -641,7 +641,7 @@ namespace pcl
         nr_max_keypoints_ = nr_max_keypoints;
       }
 
-      /** \brief Get the maximum nuber of keypoints to return, as set by the user. */
+      /** \brief Get the maximum number of keypoints to return, as set by the user. */
       inline unsigned int 
       getMaxKeypoints ()
       {

--- a/keypoints/include/pcl/keypoints/susan.h
+++ b/keypoints/include/pcl/keypoints/susan.h
@@ -44,7 +44,7 @@
 
 namespace pcl
 {
-  /** \brief SUSANKeypoint implements a RGB-D extension of the SUSAN detector inluding normal 
+  /** \brief SUSANKeypoint implements a RGB-D extension of the SUSAN detector including normal 
     * directions variation in top of intensity variation. 
     * It is different from Harris in that it exploits normals directly so it is faster.  
     * Original paper "SUSAN — A New Approach to Low Level Image Processing", Smith,

--- a/ml/include/pcl/ml/feature_handler.h
+++ b/ml/include/pcl/ml/feature_handler.h
@@ -96,7 +96,7 @@ namespace pcl
 
       /** \brief Generates evaluation code for the specified feature and writes it to the specified stream.
         * \param[in] feature The feature for which code is generated.
-        * \param[out] stream The destionation for the code.
+        * \param[out] stream The destination for the code.
         */
       virtual void 
       generateCodeForEvaluation (const FeatureType & feature,

--- a/ml/include/pcl/ml/stats_estimator.h
+++ b/ml/include/pcl/ml/stats_estimator.h
@@ -124,7 +124,7 @@ namespace pcl
 
       /** \brief Generates code for computing the branch indices for the specified node and writes it to the specified stream.
         * \param[in] node The node for which the branch index estimation code is generated.
-        * \param[out] stream The destionation for the code.
+        * \param[out] stream The destination for the code.
         */
       virtual void 
       generateCodeForBranchIndexComputation (NodeType & node,
@@ -132,7 +132,7 @@ namespace pcl
 
       /** \brief Generates code for computing the output for the specified node and writes it to the specified stream.
         * \param[in] node The node for which the output estimation code is generated.
-        * \param[out] stream The destionation for the code.
+        * \param[out] stream The destination for the code.
         */
       virtual void 
       generateCodeForOutput (NodeType & node,

--- a/ml/include/pcl/ml/svm_wrapper.h
+++ b/ml/include/pcl/ml/svm_wrapper.h
@@ -87,7 +87,7 @@ namespace pcl
     }
   };
 
-  /** \brief The structure initialize a model crated by the SVM (Support Vector Machines) classifier (pcl::SVMTrain)
+  /** \brief The structure initialize a model created by the SVM (Support Vector Machines) classifier (pcl::SVMTrain)
    */
   struct SVMModel: svm_model
   {

--- a/ml/src/kmeans.cpp
+++ b/ml/src/kmeans.cpp
@@ -106,13 +106,13 @@ pcl::Kmeans::computeCentroids()
   {
     num_points_in_cluster = 0;
 
-    // For earch PointId in this set
+    // For each PointId in this set
     BOOST_FOREACH(SetPoints::value_type pid, clusters_to_points_[cid])
     {
       Point p = data_[pid];
       //Point p = ps__.getPoint(pid);
       for (i=0; i<num_dimensions_; i++)
-        centroid[i] += p[i];	
+        centroid[i] += p[i];
       num_points_in_cluster++;
     }
     // if no point in the clusters, this goes to inf (correct!)

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -845,8 +845,8 @@ namespace pcl
          *  \param key_arg: reference to an octree key
          *  \param binary_tree_in_it_arg iterator of binary input data
          *  \param binary_tree_in_it_end_arg
-         *  \param leaf_container_vector_it_arg: iterator pointing to leaf containter pointers to be added to a leaf node
-         *  \param leaf_container_vector_it_end_arg: iterator pointing to leaf containter pointers pointing to last object in input container.
+         *  \param leaf_container_vector_it_arg: iterator pointing to leaf container pointers to be added to a leaf node
+         *  \param leaf_container_vector_it_end_arg: iterator pointing to leaf container pointers pointing to last object in input container.
          *  \param branch_reset_arg: Reset pointer array of current branch
          *  \param do_XOR_decoding_arg: select if binary tree structure is based on current octree (false) of based on a XOR comparison between current and previous octree
          **/

--- a/outofcore/include/pcl/outofcore/octree_disk_container.h
+++ b/outofcore/include/pcl/outofcore/octree_disk_container.h
@@ -258,7 +258,7 @@ namespace pcl
 
         /** \brief Generate a universally unique identifier (UUID)
          *
-         * A mutex lock happens to ensure uniquness
+         * A mutex lock happens to ensure uniqueness
          *
          */
         static void

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -431,7 +431,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
         te.wsize_ = w_size_;
 
         te.trans_ = center_point.getVector3fMap () - patch_center_point.getVector3fMap ();
-        te.trans_ *= 1000.f; //transform it to milimiters
+        te.trans_ *= 1000.f; //transform it to millimeters
         te.rot_ = ea;
         te.rot_ *= 57.2957795f; //transform it to degrees
 

--- a/registration/include/pcl/registration/graph_handler.h
+++ b/registration/include/pcl/registration/graph_handler.h
@@ -51,7 +51,7 @@ namespace pcl
   namespace registration
   {
     /** \brief @b GraphHandler class is a wrapper for a general SLAM graph
-      * The actual graph class must fulfil the following boost::graph concepts:
+      * The actual graph class must fulfill the following boost::graph concepts:
       * - BidirectionalGraph
       * - AdjacencyGraph
       * - VertexAndEdgeListGraph

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -298,7 +298,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     delta_ *= mean_dist;
   }
 
-  // heuristic determination of number of trials to have high probabilty of finding a good solution
+  // heuristic determination of number of trials to have high probability of finding a good solution
   if (max_iterations_ == 0)
   {
     float first_est = std::log (small_error_) / std::log (1.0 - std::pow ((double) approx_overlap_, (double) min_iterations));

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -193,7 +193,7 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
   for (it_curr = it->begin (), it_curr_e = it->end (); it_curr != it_curr_e; it_curr++)
     candidates_.push_back (*it_curr);
 
-  // sort acoording to score value
+  // sort according to score value
   std::sort (candidates_.begin (), candidates_.end (), by_score ());
 
   // return here if no score was valid, i.e. all scores are FLT_MAX

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -233,7 +233,7 @@ namespace pcl
       using Registration<PointSource, PointTarget>::update_visualizer_;
 
       /** \brief Estimate the transformation and returns the transformed source (input) as output.
-        * \param[out] output the resultant input transfomed point cloud dataset
+        * \param[out] output the resultant input transformed point cloud dataset
         */
       virtual void
       computeTransformation (PointCloudSource &output)
@@ -242,7 +242,7 @@ namespace pcl
       }
 
       /** \brief Estimate the transformation and returns the transformed source (input) as output.
-        * \param[out] output the resultant input transfomed point cloud dataset
+        * \param[out] output the resultant input transformed point cloud dataset
         * \param[in] guess the initial gross estimation of the transformation
         */
       virtual void

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -404,14 +404,14 @@ namespace pcl
 
       /** \brief Call the registration algorithm which estimates the transformation and returns the transformed source 
         * (input) as \a output.
-        * \param[out] output the resultant input transfomed point cloud dataset
+        * \param[out] output the resultant input transformed point cloud dataset
         */
       inline void
       align (PointCloudSource &output);
 
       /** \brief Call the registration algorithm which estimates the transformation and returns the transformed source 
         * (input) as \a output.
-        * \param[out] output the resultant input transfomed point cloud dataset
+        * \param[out] output the resultant input transformed point cloud dataset
         * \param[in] guess the initial gross estimation of the transformation
         */
       inline void 

--- a/sample_consensus/include/pcl/sample_consensus/sac.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac.h
@@ -90,7 +90,7 @@ namespace pcl
 
       /** \brief Constructor for base SAC.
         * \param[in] model a Sample Consensus model
-        * \param[in] threshold distance to model threshol
+        * \param[in] threshold distance to model threshold
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensus (const SampleConsensusModelPtr &model, 

--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -319,7 +319,7 @@ namespace pcl
         {
           point_representation_ = point_representation;
           dim_ = point_representation->getNumberOfDimensions ();
-          if (input_) // re-create the tree, since point_represenation might change things such as the scaling of the point clouds.
+          if (input_) // re-create the tree, since point_representation might change things such as the scaling of the point clouds.
             setInputCloud (input_, indices_);
         }
 

--- a/segmentation/include/pcl/segmentation/grabcut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/grabcut_segmentation.h
@@ -53,7 +53,7 @@ namespace pcl
     namespace grabcut
     {
       /** boost implementation of Boykov and Kolmogorov's maxflow algorithm doesn't support
-        * negative flows which makes it inappropriate for this conext.
+        * negative flows which makes it inappropriate for this context.
         * This implementation of Boykov and Kolmogorov's maxflow algorithm by Stephen Gould
         * <stephen.gould@anu.edu.au> in DARWIN under BSD does the trick however solwer than original
         * implementation.

--- a/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
@@ -182,7 +182,7 @@ pcl::CPCSegmentation<PointT>::applyCuttingPlane (uint32_t depth_levels_left)
     {
       Eigen::Vector3f plane_normal (model_coefficients[0], model_coefficients[1], model_coefficients[2]);
       // Cut the connections.
-      // We only interate through the points which are within the support (when we are local, otherwise all points in the segment).
+      // We only iterate through the points which are within the support (when we are local, otherwise all points in the segment).
       // We also just actually cut when the edge goes through the plane. This is why we check the planedistance
       std::vector<pcl::PointIndices> cluster_indices;
       pcl::EuclideanClusterExtraction<WeightSACPointType> euclidean_clusterer;

--- a/surface/include/pcl/surface/poisson.h
+++ b/surface/include/pcl/surface/poisson.h
@@ -138,7 +138,7 @@ namespace pcl
       inline void
       setSolverDivide (int solver_divide) { solver_divide_ = solver_divide; }
 
-      /** \brief Get the the depth at which a block Gauss-Seidel solver is used to solve the Laplacian equation */
+      /** \brief Get the depth at which a block Gauss-Seidel solver is used to solve the Laplacian equation */
       inline int
       getSolverDivide () { return solver_divide_; }
 

--- a/test/filters/test_clipper.cpp
+++ b/test/filters/test_clipper.cpp
@@ -138,7 +138,7 @@ TEST (CropBox, Filters)
   Eigen::Vector4f min_pt (-1.0f, -1.0f, -1.0f, 1.0f);
   Eigen::Vector4f max_pt (1.0f, 1.0f, 1.0f, 1.0f);
 
-  // Cropbox slighlty bigger then bounding box of points
+  // Cropbox slightly bigger then bounding box of points
   cropBoxFilter.setMin (min_pt);
   cropBoxFilter.setMax (max_pt);
 
@@ -298,7 +298,7 @@ TEST (CropBox, Filters)
   CropBox<PCLPointCloud2> cropBoxFilter2(true);
   cropBoxFilter2.setInputCloud (input2);
 
-  // Cropbox slighlty bigger then bounding box of points
+  // Cropbox slightly bigger then bounding box of points
   cropBoxFilter2.setMin (min_pt);
   cropBoxFilter2.setMax (max_pt);
 


### PR DESCRIPTION
Found via `codespell -q 3 -I ../pcl-word-whitelist.txt --skip="./surface/include/pcl/surface/3rdparty,./surface/src/3rdparty,./recognition/include/pcl/recognition/3rdparty` where whitelist consists of:  
```
ang
childs
currect
currenty
everytime
iff
indeces
isnt
ith
lod
metre
metres
mitre
nd
normaly
opps
ot
resizeable
te
vertexes
uint
```