### PR TITLE
Make test conditions consistent with `OctreePointCloudSearch::boxSearch()` implementation.

### DIFF
--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -1335,9 +1335,9 @@ TEST (PCL, Octree_Pointcloud_Box_Search)
       bool idxInResults;
       const PointXYZ& pt = cloudIn->points[i];
 
-      inBox = (pt.x > lowerBoxCorner (0)) && (pt.x < upperBoxCorner (0)) &&
-              (pt.y > lowerBoxCorner (1)) && (pt.y < upperBoxCorner (1)) &&
-              (pt.z > lowerBoxCorner (2)) && (pt.z < upperBoxCorner (2));
+      inBox = (pt.x >= lowerBoxCorner (0)) && (pt.x <= upperBoxCorner (0)) &&
+              (pt.y >= lowerBoxCorner (1)) && (pt.y <= upperBoxCorner (1)) &&
+              (pt.z >= lowerBoxCorner (2)) && (pt.z <= upperBoxCorner (2));
 
       idxInResults = false;
       for (j = 0; (j < k_indices.size ()) && (!idxInResults); ++j)


### PR DESCRIPTION
Fixes #2440. 

The check conditions in the test are now consistent with the implementation.
https://github.com/PointCloudLibrary/pcl/blob/9467b944ee3e30bb4cf8445d861c280f0fba1020/octree/include/pcl/octree/impl/octree_search.hpp#L563-L574
