### PR TITLE
CMake: Do not include test targets in PCLConfig.cmake

### DIFF
--- a/cmake/pcl_pclconfig.cmake
+++ b/cmake/pcl_pclconfig.cmake
@@ -16,7 +16,11 @@ set(PCLCONFIG_SSE_COMPILE_OPTIONS ${SSE_FLAGS})
 
 foreach(_ss ${PCL_SUBSYSTEMS_MODULES})
     PCL_GET_SUBSYS_STATUS(_status ${_ss})
-    if(_status)
+
+    # do not include test targets
+    string(REGEX MATCH "^tests_" _is_test ${_ss})
+
+    if(_status AND NOT _is_test)
         set(PCLCONFIG_AVAILABLE_COMPONENTS "${PCLCONFIG_AVAILABLE_COMPONENTS} ${_ss}")
         set(PCLCONFIG_AVAILABLE_COMPONENTS_LIST "${PCLCONFIG_AVAILABLE_COMPONENTS_LIST}\n# - ${_ss}")
         GET_IN_MAP(_deps PCL_SUBSYS_DEPS ${_ss})
@@ -68,7 +72,7 @@ foreach(_ss ${PCL_SUBSYSTEMS_MODULES})
 	    endif (_sub_status)
 	  endforeach(_sub)
 	endif (${PCL_SUBSYS_SUBSYS})
-    endif(_status)
+    endif()
 endforeach(_ss)
 
 #Boost modules


### PR DESCRIPTION
Fixes #2429.

PCLConfig.cmake before the change
```
# ------------------------------------------------------------------------------------
# Helper to use PCL from outside project
#
# target_link_libraries(my_fabulous_target PCL_XXX_LIBRARIES) where XXX is the
# upper cased xxx from :
# 
# - common
# - kdtree
# - octree
# - search
# - tests_common
# - tests_kdtree
# - tests_octree
# - tests_search
#
# PCL_INCLUDE_DIRS is filled with PCL and available 3rdparty headers
# PCL_LIBRARY_DIRS is filled with PCL components libraries install directory and
# 3rdparty libraries paths
#
#                                   www.pointclouds.org
#------------------------------------------------------------------------------------
```

After the proposed patch
```
# ------------------------------------------------------------------------------------
# Helper to use PCL from outside project
#
# target_link_libraries(my_fabulous_target PCL_XXX_LIBRARIES) where XXX is the
# upper cased xxx from :
# 
# - common
# - kdtree
# - octree
# - search
#
# PCL_INCLUDE_DIRS is filled with PCL and available 3rdparty headers
# PCL_LIBRARY_DIRS is filled with PCL components libraries install directory and
# 3rdparty libraries paths
#
#                                   www.pointclouds.org
#------------------------------------------------------------------------------------
```
