### PR TITLE
`PointXYZRGBL` `label` field is now default constructed to 0

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -425,7 +425,7 @@ namespace pcl
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const Intensity32u& p);
   /** \brief A point structure representing the grayscale intensity in single-channel images.
-    * Intensity is represented as a uint8_t value.
+    * Intensity is represented as a uint32_t value.
     * \ingroup common
     */
   struct Intensity32u: public _Intensity32u
@@ -662,7 +662,7 @@ namespace pcl
       data[3] = 1.0f;
       r = g = b = 0;
       a = 255;
-      label = 255;
+      label = 0;
     }
     inline PointXYZRGBL (uint8_t _r, uint8_t _g, uint8_t _b, uint32_t _label)
     {


### PR DESCRIPTION
Fix #2461.