### PR TITLE
Provide `operator<<` for `Intensity32u` point type

### DIFF
--- a/common/src/point_types.cpp
+++ b/common/src/point_types.cpp
@@ -71,6 +71,13 @@ namespace pcl
   }
 
   std::ostream&
+  operator << (std::ostream& os, const Intensity32u& p)
+  {
+    os << "( " << p.intensity << " )";
+    return (os);
+  }
+
+  std::ostream&
   operator << (std::ostream& os, const PointXYZI& p)
   {
     os << "(" << p.x << "," << p.y << "," << p.z << " - " << p.intensity << ")";


### PR DESCRIPTION
Fix #2466.