### PR TITLE
Fix error in SampleConsensusModelLine::isSampleGood

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -57,7 +57,7 @@ pcl::SampleConsensusModelLine<PointT>::isSampleGood (const std::vector<int> &sam
       (input_->points[samples[0]].z != input_->points[samples[1]].z))
     return (true);
 
-  return (true);
+  return (false);
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`pcl::SampleConsensusModelLine<PointT>::isSampleGood` always returned true ignoring the actual result of the test.