### PR TITLE
Properly deprecated HDLGrabber members.

### DIFF
--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -263,12 +263,33 @@ namespace pcl
       uint16_t last_azimuth_;
       boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> > current_scan_xyz_, current_sweep_xyz_;
       boost::shared_ptr<pcl::PointCloud<pcl::PointXYZI> > current_scan_xyzi_, current_sweep_xyzi_;
-      boost::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBA> > current_scan_xyzrgba_, current_sweep_xyzrgba_;
+      union
+      {
+        PCL_DEPRECATED ("Use 'current_scan_xyzrgba_' instead")
+        boost::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBA> > current_scan_xyzrgb_;
+        boost::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBA> > current_scan_xyzrgba_;
+      };
+      union
+      {
+        PCL_DEPRECATED ("Use 'current_sweep_xyzrgba_' instead")
+        boost::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBA> > current_sweep_xyzrgb_;
+        boost::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBA> > current_sweep_xyzrgba_;
+      };
       boost::signals2::signal<sig_cb_velodyne_hdl_sweep_point_cloud_xyz>* sweep_xyz_signal_;
-      boost::signals2::signal<sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba>* sweep_xyzrgba_signal_;
+      union
+      {
+        PCL_DEPRECATED ("Use 'sweep_xyzrgba_signal_' instead")
+        boost::signals2::signal<sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba>* sweep_xyzrgb_signal_;
+        boost::signals2::signal<sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba>* sweep_xyzrgba_signal_;
+      };
       boost::signals2::signal<sig_cb_velodyne_hdl_sweep_point_cloud_xyzi>* sweep_xyzi_signal_;
       boost::signals2::signal<sig_cb_velodyne_hdl_scan_point_cloud_xyz>* scan_xyz_signal_;
-      boost::signals2::signal<sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba>* scan_xyzrgba_signal_;
+      union
+      {
+        PCL_DEPRECATED ("Use 'scan_xyzrgba_signal_' instead")
+        boost::signals2::signal<sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba>* scan_xyzrgb_signal_;
+        boost::signals2::signal<sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba>* scan_xyzrgba_signal_;
+      };
       boost::signals2::signal<sig_cb_velodyne_hdl_scan_point_cloud_xyzi>* scan_xyzi_signal_;
 
       void

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -395,7 +395,8 @@ pcl::OBJReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
       if (line[0] == 'v')
       {
         // Vertex (v)
-        if ((line[1] == ' ')) {
+        if (line[1] == ' ')
+        {
           ++nr_point;
           continue;
         }


### PR DESCRIPTION
Closes #2493.

Upon merge downgrade changes in #2102 to ABI breakage simply.