### PR TITLE
swap the header in pcl::PointCloud::swap

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -562,6 +562,7 @@ namespace pcl
       inline void
       swap (PointCloud<PointT> &rhs)
       {
+        std::swap (header, rhs.header);
         this->points.swap (rhs.points);
         std::swap (width, rhs.width);
         std::swap (height, rhs.height);


### PR DESCRIPTION
Fix issue #2470.

Swap the missing header.
Since the mapping_ is not used in the project it is not swapped.