### PR TITLE
Throw an early exception to prevent divide by zero error (#2481)

### DIFF
--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -71,15 +71,15 @@ inline void
 pcl::getMeanStd (const std::vector<float> &values, double &mean, double &stddev)
 {
   // throw an exception when the input array is empty
-  if(values.size() == 0 )
+  if (values.empty ())
   {
-    PCL_THROW_EXCEPTION(BadArgumentException, "Error : Input array must have at least 1 element."); 
+    PCL_THROW_EXCEPTION (BadArgumentException, "Input array must have at least 1 element."); 
   }
   
   // when the array has only one element, mean is the number itself and standard dev is 0
-  if(values.size() == 1)
+  if (values.size () == 1)
   {
-    mean = static_cast<double>(values.at(0));
+    mean = values.at (0);
     stddev = 0;
     return;
   }

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -70,12 +70,18 @@ pcl::getAngle3D (const Eigen::Vector3f &v1, const Eigen::Vector3f &v2, const boo
 inline void
 pcl::getMeanStd (const std::vector<float> &values, double &mean, double &stddev)
 {
-  // throw an exception when there are less than two elements in vector `values` 
-  // to prevent divide by zero error. Then, let the program crash.
-  // Let the user explicity handle this exception as per his needs.
-  if(values.size() < 2 )
+  // throw an exception when the input array is empty
+  if(values.size() == 0 )
   {
-    throw std::length_error("Input array must have atleast 2 elements.");
+    PCL_THROW_EXCEPTION(BadArgumentException, "Error : Input array must have at least 1 element."); 
+  }
+  
+  // when the array has only one element, mean is the number itself and standard dev is 0
+  if(values.size() == 1)
+  {
+    mean = static_cast<double>(values.at(0));
+    stddev = 0;
+    return;
   }
   
   double sum = 0, sq_sum = 0;

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -70,6 +70,14 @@ pcl::getAngle3D (const Eigen::Vector3f &v1, const Eigen::Vector3f &v2, const boo
 inline void
 pcl::getMeanStd (const std::vector<float> &values, double &mean, double &stddev)
 {
+  // throw an exception when there are less than two elements in vector `values` 
+  // to prevent divide by zero error. Then, let the program crash.
+  // Let the user explicity handle this exception as per his needs.
+  if(values.size() < 2 )
+  {
+    throw std::length_error("Input array must have atleast 2 elements.");
+  }
+  
   double sum = 0, sq_sum = 0;
 
   for (size_t i = 0; i < values.size (); ++i)


### PR DESCRIPTION
Closes #2481 

Added a try catch block to throw a length error exception to report that at least 2 elements are required in array to perform the operation.