### PR TITLE
Fix app/CMakeLists to enable Apps under Windows

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -205,7 +205,9 @@ if(build)
 
   # OpenGL and GLUT
   if(OPENGL_FOUND AND GLUT_FOUND)
-    include_directories("${OPENGL_INCLUDE_DIR}")
+    if(NOT WIN32)
+        include_directories("${OPENGL_INCLUDE_DIR}")
+    endif()
     include_directories("${GLUT_INCLUDE_DIR}")
     PCL_ADD_EXECUTABLE_OPT_BUNDLE(pcl_grabcut_2d "${SUBSYS_NAME}" src/grabcut_2d.cpp)
     target_link_libraries (pcl_grabcut_2d pcl_common pcl_io pcl_segmentation pcl_search ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})


### PR DESCRIPTION
Configuration was failing at [apps/CMakeLists.txt L208](https://github.com/PointCloudLibrary/pcl/blob/ce416739f44156828aee8b41ee89bac4aa5f5987/apps/CMakeLists.txt#L208) because `OPENGL_INCLUDE_DIR` is not defined on Windows. See [here](https://cmake.org/pipermail/cmake/2004-September/005508.html) for a possible reference on the topic.

This PR adds a control statment to ignore that line under Windows.

Fixes #2539