### PR TITLE
Bugfix miscalculation of quantile of KLD

### DIFF
--- a/tracking/include/pcl/tracking/kld_adaptive_particle_filter.h
+++ b/tracking/include/pcl/tracking/kld_adaptive_particle_filter.h
@@ -139,9 +139,9 @@ namespace pcl
         if (u == 0.)
           return (0.5);
         y = u / 2.0;
-        if (y < -6.)
+        if (y < -3.)
           return (0.0);
-        if (y > 6.)
+        if (y > 3.)
           return (1.0);
         if (y < 0.0)
           y = - y;


### PR DESCRIPTION
Before bugfix, normalQuantile function return following this.
I think original author forgot that u is halved.
```
(input, output)
-20, 0
-19, 0
-18, 0
-17, 0
-16, 0
-15, 0
-14, 0
-13, 0
-12, 1944.33
-11, 243.061
-10, 20.8074
-9, 1.02105
-8, 0.0201278
-7, 6.16628e-05
-6, 1.1355e-09
-5, 2.86862e-07
-4, 3.16712e-05
-3, 0.0013499
-2, 0.0227501
-1, 0.158655
0, 0.5
1, 0.841345
2, 0.97725
3, 0.99865
4, 0.999968
5, 1
6, 1
7, 0.999938
8, 0.979872
9, -0.0210484
10, -19.8074
11, -242.061
12, -1943.33
13, 1
14, 1
15, 1
16, 1
17, 1
18, 1
19, 1
20, 1
```
after
```
(input, output)
-20, 0
-19, 0
-18, 0
-17, 0
-16, 0
-15, 0
-14, 0
-13, 0
-12, 0
-11, 0
-10, 0
-9, 0
-8, 0
-7, 0
-6, 1.1355e-09
-5, 2.86862e-07
-4, 3.16712e-05
-3, 0.0013499
-2, 0.0227501
-1, 0.158655
0, 0.5
1, 0.841345
2, 0.97725
3, 0.99865
4, 0.999968
5, 1
6, 1
7, 1
8, 1
9, 1
10, 1
11, 1
12, 1
13, 1
14, 1
15, 1
16, 1
17, 1
18, 1
19, 1
20, 1
```