### PR TITLE
image_viewer_ may not be set

### DIFF
--- a/visualization/tools/openni2_viewer.cpp
+++ b/visualization/tools/openni2_viewer.cpp
@@ -200,7 +200,7 @@ public:
 
     grabber_.start ();
 
-    while (!cloud_viewer_->wasStopped () && (image_viewer_ && !image_viewer_->wasStopped ()))
+    while (!cloud_viewer_->wasStopped () && (!image_viewer_ || !image_viewer_->wasStopped ()))
     {
       boost::shared_ptr<pcl::io::openni2::Image> image;
       CloudConstPtr cloud;


### PR DESCRIPTION
It's possible that `image_viewer_` is unset. This prevents the loop from running even if the grabber is grabbing point clouds.