### PR TITLE
fix comment

### DIFF
--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -46,10 +46,10 @@
 
 namespace pcl
 {
-  // r,g,b, i values are from 0 to 1
+  // r,g,b, i values are from 0 to 255
   // h = [0,360]
   // s, v values are from 0 to 1
-  // if s = 0 > h = -1 (undefined)
+  // if s = 0 => h = 0
 
   /** \brief Convert a XYZRGB point type to a XYZI
     * \param[in] in the input XYZRGB point 
@@ -153,7 +153,7 @@ namespace pcl
     if (max == 0) // division by zero
     {
       out.s = 0.f;
-      out.h = 0.f; // h = -1.f;
+      out.h = 0.f;
       return;
     }
 


### PR DESCRIPTION
resolve #2473 

Fixes the description for `rgb` and `i` range value. It also fix the description for the value of `h` when `s` is `0`