### PR TITLE
Bump CMake minimum version to 3.1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,5 @@
 ### ---[ PCL global CMake
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
-
-if(POLICY CMP0017)
-  # Do not include files in CMAKE_MODULE_PATH from files
-  # in CMake module directory. Fix MXE build
-  cmake_policy(SET CMP0017 NEW)
-endif()
-
-if(POLICY CMP0020 AND (WIN32 AND NOT MINGW))
-  cmake_policy(SET CMP0020 NEW) # Automatically link Qt executables to qtmain target on Windows
-endif()
-
-if(POLICY CMP0042)
-  # Uses Mac OS X @rpath in the target's install name
-  cmake_policy(SET CMP0042 NEW)
-endif()
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 OLD) # do not use VERSION option in project() command


### PR DESCRIPTION
I know this is already being addressed in #2382, but I want to start dealing with the policies and it might take some time until that other one is merged. Activating the C++14 flags will still be the responsibility of the original PR.

Cheers