### PR TITLE
 Remove CMake config installation folder only when empty

### DIFF
--- a/cmake/uninstall_target.cmake.in
+++ b/cmake/uninstall_target.cmake.in
@@ -1,36 +1,34 @@
 if(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
-    message(FATAL_ERROR "Cannot find install manifest: \"@PROJECT_BINARY_DIR@/install_manifest.txt\"")
-endif(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: \"@PROJECT_BINARY_DIR@/install_manifest.txt\"")
+endif()
 
 file(READ "@PROJECT_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
-    message(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
-    if(EXISTS "$ENV{DESTDIR}${file}" OR IS_SYMLINK "$ENV{DESTDIR}${file}")
-        exec_program("@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
-            OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
-        if(NOT "${rm_retval}" STREQUAL 0)
-            message(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
-        endif(NOT "${rm_retval}" STREQUAL 0)
-    else(EXISTS "$ENV{DESTDIR}${file}" OR IS_SYMLINK "$ENV{DESTDIR}${file}")
-        message(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
-    endif(EXISTS "$ENV{DESTDIR}${file}" OR IS_SYMLINK "$ENV{DESTDIR}${file}")
-endforeach(file)
+  message(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
+  if(EXISTS "$ENV{DESTDIR}${file}" OR IS_SYMLINK "$ENV{DESTDIR}${file}")
+    exec_program("@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+                 OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+    endif()
+  else()
+    message(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
+  endif()
+endforeach()
 
 # remove pcl directory in include (removes all files in it!)
 message(STATUS "Uninstalling \"@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@\"")
 if(EXISTS "@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@")
-    exec_program("@CMAKE_COMMAND@"
-        ARGS "-E remove_directory \"@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@\""
-        OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
-    if(NOT "${rm_retval}" STREQUAL 0)
-        message(FATAL_ERROR
-            "Problem when removing \"@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@\"")
-    endif(NOT "${rm_retval}" STREQUAL 0)
-else(EXISTS "@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@")
-    message(STATUS
-        "Directory \"@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@\" does not exist.")
-endif(EXISTS "@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@")
+  exec_program("@CMAKE_COMMAND@"
+               ARGS "-E remove_directory \"@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@\""
+               OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
+  if(NOT "${rm_retval}" STREQUAL 0)
+    message(FATAL_ERROR "Problem when removing \"@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@\"")
+  endif()
+else()
+  message(STATUS "Directory \"@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@\" does not exist.")
+endif()
 
 # remove pcl directory in share (removes all files in it!)
 # created by CMakeLists.txt for PCLConfig.cmake
@@ -56,15 +54,13 @@ endif()
 if(@WITH_DOCS@)
   message(STATUS "Uninstalling \"@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@\"")
   if(EXISTS "@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@")
-      exec_program("@CMAKE_COMMAND@"
-          ARGS "-E remove_directory \"@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@\""
-          OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
-      if(NOT "${rm_retval}" STREQUAL 0)
-          message(FATAL_ERROR
-              "Problem when removing \"@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@\"")
-      endif(NOT "${rm_retval}" STREQUAL 0)
+    exec_program("@CMAKE_COMMAND@"
+                 ARGS "-E remove_directory \"@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@\""
+                 OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing \"@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@\"")
+    endif()
   else(EXISTS "@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@")
-      message(STATUS
-          "Directory \"@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@\" does not exist.")
-  endif(EXISTS "@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@")
+    message(STATUS "Directory \"@CMAKE_INSTALL_PREFIX@/@DOC_INSTALL_DIR@\" does not exist.")
+  endif()
 endif()

--- a/cmake/uninstall_target.cmake.in
+++ b/cmake/uninstall_target.cmake.in
@@ -34,19 +34,23 @@ endif(EXISTS "@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_ROOT@")
 
 # remove pcl directory in share (removes all files in it!)
 # created by CMakeLists.txt for PCLConfig.cmake
-message(STATUS "Uninstalling \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\"")
 if(EXISTS "@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@")
+  file(GLOB_RECURSE CMAKE_CONFIG_FOLDER_FILES FOLLOW_SYMLINKS
+       LIST_DIRECTORIES false
+       "@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@/*")
+  list(LENGTH CMAKE_CONFIG_FOLDER_FILES CMAKE_CONFIG_FOLDER_FILES_NUMBER)
+  if(CMAKE_CONFIG_FOLDER_FILES_NUMBER EQUAL 0)
+    message(STATUS "Uninstalling \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\"")
     exec_program("@CMAKE_COMMAND@"
-        ARGS "-E remove_directory \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\""
-        OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
+                 ARGS "-E remove_directory \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\""
+                 OUTPUT_VARIABLE rm_out RETURN_VALUE rm_retval)
     if(NOT "${rm_retval}" STREQUAL 0)
-        message(FATAL_ERROR
-            "Problem when removing \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\"")
-    endif(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\"")
+    endif()
+  endif()
 else(EXISTS "@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@")
-    message(STATUS
-        "Directory \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\" does not exist.")
-endif(EXISTS "@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@")
+  message(STATUS "Directory \"@CMAKE_INSTALL_PREFIX@/@PCLCONFIG_INSTALL_DIR@\" does not exist.")
+endif()
 
 # remove pcl directory in share/doc (removes all files in it!)
 if(@WITH_DOCS@)


### PR DESCRIPTION
With this PR we change, and fix under Windows, the behavior of the uninstall target when uninstalling the installed CMake configuration file folder.

The first commit, d05e0ed, is the proposed solution to the problem.
The second and last commit, e73d7d1, unifies the CMake style in `cmake/uninstall_target.cmake.in`.
We can drop the second commit if you feel it should not be applied.

A detailed discussion can be found in #2615.