### PR TITLE
Remove CMake policy CMP0054 setting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 ### ---[ PCL global CMake
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 OLD) # Silent warnings about quoted variables
-endif()
-
 if(POLICY CMP0074)
   # TODO:
   # 1. Find*.cmake modules need to be individually verified.


### PR DESCRIPTION
I compiled, ran tests and linked against a downstream target. It seems our code was already compliant and it didn't cause any issues.

At some point the PCLConfig was reporting "duplicate targets" again. After deleting and rebuilding I could no longer replicate this situation. I would still suggest other @PointCloudLibrary/maintainers to actually give it a try on their local platforms before merging. 
