### PR TITLE
Update Azure Pipelines script

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -166,11 +166,15 @@ jobs:
           echo.set(VCPKG_BUILD_TYPE release)>> %VCPKG_DIR%\triplets\%PLATFORM%-windows.cmake
           %VCPKG_DIR%\bootstrap-vcpkg.bat
           %VCPKG_DIR%\vcpkg.exe version
-        displayName: Bootstrap vcpkg
+        displayName: 'Bootstrap vcpkg'
       - script: |
           %VCPKG_DIR%\vcpkg.exe install boost-system boost-filesystem boost-thread boost-date-time boost-iostreams boost-chrono boost-asio boost-dynamic-bitset boost-foreach boost-graph boost-interprocess boost-multi-array boost-ptr-container boost-random boost-signals2 eigen3 flann gtest qhull --triplet %PLATFORM%-windows
           %VCPKG_DIR%\vcpkg.exe list
-        displayName: Install Dependencies
+        displayName: 'Install Dependencies'
+      - script: |
+          rmdir %VCPKG_DIR%\downloads /S /Q
+          rmdir %VCPKG_DIR%\packages /S /Q
+        displayName: 'Free up space'
       - script: |
           call "%VCVARSALL%" %ARCHITECTURE%
           set PATH=%VCPKG_DIR%\installed\%PLATFORM%-windows\bin;%PATH%


### PR DESCRIPTION
Free up space on Windows machines by deleting vcpkg downloads and packages folders.

Possible upgrade if we still need extra space is to also add
```
rmdir %VCPKG_DIR%\buildtrees /S /Q
```

I apologize I can't test this on my fork, but I have som authorization problem that I'm not able to sort out and the pipline fails to start.

Closes #2654