### PR TITLE
Fix warnings from GCC 7.3.0

### DIFF
--- a/test/common/test_eigen.cpp
+++ b/test/common/test_eigen.cpp
@@ -745,7 +745,6 @@ TEST (PCL, eigen33f)
   const unsigned iterations = 1000000;
   bool r_failed;
   unsigned r_fail_count = 0;
-  unsigned c_fail_count = 0;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -340,7 +340,10 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
 
       OctreeContainerPointIndices& container = it.getLeafContainer();
       if (it.getCurrentOctreeDepth () < octree.getTreeDepth ())
+      {
         ASSERT_LE (container.getSize (), leafAggSize);
+      }
+
 
       // add points from leaf node to indexVector
       container.getPointIndices (indexVector);

--- a/test/segmentation/test_random_walker.cpp
+++ b/test/segmentation/test_random_walker.cpp
@@ -230,7 +230,9 @@ TEST_P (RandomWalkerTest, GetPotentials)
   for (std::set<Color>::iterator it = g.colors.begin (); it != g.colors.end (); ++it)
     for (size_t i = 0; i < g.size; ++i)
       if (g.potentials.count (*it))
+      {
         EXPECT_NEAR (g.potentials[*it] (i), p (i, map[*it]), 0.01);
+      }
 }
 
 INSTANTIATE_TEST_CASE_P (VariousGraphs,


### PR DESCRIPTION
This fixes a few warnings from GCC 7.3.0 in test sources.

```
../test/common/test_eigen.cpp:748:12: warning: unused variable ‘c_fail_count’ [-Wunused-variable]
../test/octree/test_octree.cpp:342:10: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
../test/segmentation/test_random_walker.cpp:232:10: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
```