### PR TITLE
Update CMake policy 74

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,9 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 if(POLICY CMP0074)
-  # TODO:
-  # 1. Find*.cmake modules need to be individually verified.
-  # 2. PCLConfig.cmake needs to be changed.
-  cmake_policy(SET CMP0074 OLD)
+  # 1. Remove with 3.12.4.
+  # 2. Remove search paths with *_ROOT since they will be automatically checked
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "possible configurations" FORCE)

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -18,7 +18,7 @@ if(POLICY CMP0074)
   # this is a config file that will be consumed by parent projects with (likely)
   # NEW behavior, we need to push a policy stack.
   cmake_policy(PUSH)
-  cmake_policy(SET CMP0074 OLD)
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")


### PR DESCRIPTION
I reviewed things and I believe we're compliant. We only use `*_ROOT` variables to specify prefixes so it's totally ok, if CMake uses them to try and locate libraries by default.

Closes #2446 