### PR TITLE
Initialize curvature in `PointNormal` default ctor

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -882,6 +882,7 @@ namespace pcl
       x = y = z = 0.0f;
       data[3] = 1.0f;
       normal_x = normal_y = normal_z = data_n[3] = 0.0f;
+      curvature = 0.f;
     }
   
     friend std::ostream& operator << (std::ostream& os, const PointNormal& p);


### PR DESCRIPTION
Fixes #2658 