### PR TITLE
Do not terminate `openni_viewer`/`openni2_viewer` if image viewer was not instantiated

### DIFF
--- a/visualization/tools/openni2_viewer.cpp
+++ b/visualization/tools/openni2_viewer.cpp
@@ -200,7 +200,7 @@ public:
 
     grabber_.start ();
 
-    while (!cloud_viewer_->wasStopped () && (image_viewer_ && !image_viewer_->wasStopped ()))
+    while (!(cloud_viewer_->wasStopped () || (image_viewer_ && image_viewer_->wasStopped ())))
     {
       boost::shared_ptr<pcl::io::openni2::Image> image;
       CloudConstPtr cloud;

--- a/visualization/tools/openni_viewer.cpp
+++ b/visualization/tools/openni_viewer.cpp
@@ -192,7 +192,7 @@ class OpenNIViewer
       
       grabber_.start ();
 
-      while (!cloud_viewer_->wasStopped () && (image_viewer_ && !image_viewer_->wasStopped ()))
+      while (!(cloud_viewer_->wasStopped () || (image_viewer_ && image_viewer_->wasStopped ())))
       {
         boost::shared_ptr<openni_wrapper::Image> image;
         CloudConstPtr cloud;


### PR DESCRIPTION
It's possible that `image_viewer_` is unset. This fix allows the loop to run even if the image viewer was not instantiated.

Supersedes and closes #2582.