### PR TITLE
Switch to standard `[[deprecated]]` attribute

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -306,65 +306,9 @@ log2f (float x)
   #define PCL_PRAGMA_WARNING
 #endif
 
-
-// Macro to deprecate old functions
-//
-// Usage:
-// don't use me any more
-// PCL_DEPRECATED(void OldFunc(int a, float b), "Use newFunc instead, this functions will be gone in the next major release");
-// use me instead
-// void NewFunc(int a, double b);
-
 //for clang cf. http://clang.llvm.org/docs/LanguageExtensions.html
 #ifndef __has_extension
   #define __has_extension(x) 0 // Compatibility with pre-3.0 compilers.
-#endif
-
-// check Intel compiler first since it usually also defines __GNUC__, __clang__, etc.
-#if defined(__INTEL_COMPILER)
-  #define PCL_DEPRECATED(message) __attribute((deprecated))
-#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < PCL_LINEAR_VERSION(4,5,0) && ! defined(__clang__)) || defined(__INTEL_COMPILER)
-  #define PCL_DEPRECATED(message) __attribute__ ((deprecated))
-// gcc supports this starting from 4.5 : http://gcc.gnu.org/bugzilla/show_bug.cgi?id=43666
-#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) >= PCL_LINEAR_VERSION(4,5,0)) || (defined(__clang__) && __has_extension(attribute_deprecated_with_message))
-  #define PCL_DEPRECATED(message) __attribute__ ((deprecated(message)))
-#elif defined(_MSC_VER)
-  #define PCL_DEPRECATED(message) __declspec(deprecated(message))
-#else
-  #pragma message("WARNING: You need to implement PCL_DEPRECATED for this compiler")
-  #define PCL_DEPRECATED(message)
-#endif
-
-
-// Macro to deprecate old classes/structs
-//
-// Usage:
-// don't use me any more
-// class PCL_DEPRECATED_CLASS(OldClass, "Use newClass instead, this class will be gone in the next major release")
-// {
-//   public:
-//     OldClass() {}
-// };
-// use me instead
-// class NewFunc
-// {
-//   public:
-//     NewClass() {}
-// };
-
-// check Intel compiler first since it usually also defines __GNUC__, __clang__, etc.
-#if defined(__INTEL_COMPILER)
-  #define PCL_DEPRECATED_CLASS(func, message) __attribute((deprecated)) func
-#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) < PCL_LINEAR_VERSION(4,5,0) && ! defined(__clang__)) || defined(__INTEL_COMPILER)
-  #define PCL_DEPRECATED_CLASS(func, message) __attribute__ ((deprecated)) func
-// gcc supports this starting from 4.5 : http://gcc.gnu.org/bugzilla/show_bug.cgi?id=43666
-#elif (defined(__GNUC__) && PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) >= PCL_LINEAR_VERSION(4,5,0)) || (defined(__clang__) && __has_extension(attribute_deprecated_with_message))
-  #define PCL_DEPRECATED_CLASS(func, message) __attribute__ ((deprecated(message))) func
-#elif defined(_MSC_VER)
-  #define PCL_DEPRECATED_CLASS(func, message) __declspec(deprecated(message)) func
-#else
-  #pragma message("WARNING: You need to implement PCL_DEPRECATED_CLASS for this compiler")
-  #define PCL_DEPRECATED_CLASS(func) func
 #endif
 
 #if defined (__GNUC__) || defined (__PGI) || defined (__IBMCPP__) || defined (__SUNPRO_CC)

--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -279,8 +279,7 @@ PREDEFINED =           = "HAVE_QHULL=1" \
                          "HAVE_ENSENSO=1" \
                          "HAVE_DAVIDSDK=1" \
                          "HAVE_DSSDK=1" \
-                         "HAVE_RSSDK=1" \
-                         "PCL_DEPRECATED(x)="
+                         "HAVE_RSSDK=1"
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 

--- a/io/include/pcl/io/ascii_io.h
+++ b/io/include/pcl/io/ascii_io.h
@@ -116,7 +116,7 @@ namespace pcl
         * \param[in] p  a point type
         */
       template<typename PointT>
-      PCL_DEPRECATED ("Use setInputFields<PointT> () instead")
+      [[deprecated("use parameterless setInputFields<PointT>() instead")]]
       inline void setInputFields (const PointT p)
       {
         (void) p;

--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -75,8 +75,8 @@ namespace pcl
                                                       float,
                                                       float);
 
-      typedef PCL_DEPRECATED ("Use 'sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba' instead")
-      sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb;
+      [[deprecated("use sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba instead")]]
+      typedef sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb;
 
       /** \brief Signal used for a single sector
        *         Represents 1 corrected packet from the HDL Velodyne with the returned intensity.
@@ -107,8 +107,8 @@ namespace pcl
       typedef void
       (sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> >&);
 
-      typedef PCL_DEPRECATED ("Use 'sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba' instead")
-      sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb;
+      [[deprecated("use sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba instead")]]
+      typedef sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb;
 
       /** \brief Constructor taking an optional path to an HDL corrections file.  The Grabber will listen on the default IP/port for data packets [192.168.3.255/2368]
        * \param[in] correctionsFile Path to a file which contains the correction parameters for the HDL.  This parameter is mandatory for the HDL-64, optional for the HDL-32

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -254,13 +254,13 @@ namespace pcl
         typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeIterator;
         typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeIterator;
 
-        PCL_DEPRECATED ("Please use leaf_depth_begin () instead.")
+        [[deprecated("use leaf_depth_begin() instead")]]
         LeafNodeIterator leaf_begin (unsigned int max_depth_arg = 0)
         {
           return LeafNodeIterator (this, max_depth_arg);
         };
 
-        PCL_DEPRECATED ("Please use leaf_depth_end () instead.")
+        [[deprecated("use leaf_depth_end() instead")]]
         const LeafNodeIterator leaf_end ()
         {
           return LeafNodeIterator ();

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -128,13 +128,13 @@ namespace pcl
         typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeIterator;
         typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeIterator;
 
-        PCL_DEPRECATED ("Please use leaf_depth_begin () instead.")
+        [[deprecated("use leaf_depth_begin() instead")]]
         LeafNodeIterator leaf_begin (unsigned int max_depth_arg = 0u)
         {
           return LeafNodeIterator (this, max_depth_arg? max_depth_arg : this->octree_depth_);
         };
 
-        PCL_DEPRECATED ("Please use leaf_depth_end () instead.")
+        [[deprecated("use leaf_depth_end() instead")]]
         const LeafNodeIterator leaf_end ()
         {
           return LeafNodeIterator (this, 0, NULL);

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -211,7 +211,7 @@ namespace pcl
       using experimental::EuclideanClusterComparator<PointT, PointLT>::setExcludeLabels;
 
       /** \brief Default constructor for EuclideanClusterComparator. */
-      PCL_DEPRECATED ("Remove PointNT from template parameters.")
+      [[deprecated("remove PointNT from template parameters")]]
       EuclideanClusterComparator ()
         : normals_ ()
         , angular_threshold_ (0.0f)
@@ -220,43 +220,35 @@ namespace pcl
       /** \brief Provide a pointer to the input normals.
        * \param[in] normals the input normal cloud
        */
+      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
       inline void
-      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
-                      "this function has no effect on the behavior of the comparator. Therefore it is "
-                      "deprecated and will be removed in future releases.")
       setInputNormals (const PointCloudNConstPtr& normals) { normals_ = normals; }
 
       /** \brief Get the input normals. */
+      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
       inline PointCloudNConstPtr
-      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
-                      "this function has no effect on the behavior of the comparator. Therefore it is "
-                      "deprecated and will be removed in future releases.")
       getInputNormals () const { return (normals_); }
 
       /** \brief Set the tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane.
         * \param[in] angular_threshold the tolerance in radians
         */
+      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
       inline void
-      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
-                      "this function has no effect on the behavior of the comparator. Therefore it is "
-                      "deprecated and will be removed in future releases.")
       setAngularThreshold (float angular_threshold)
       {
         angular_threshold_ = std::cos (angular_threshold);
       }
 
       /** \brief Get the angular threshold in radians for difference in normal direction between neighboring points, to be considered part of the same plane. */
+      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
       inline float
-      PCL_DEPRECATED ("EuclideadClusterComparator never actually used normals and angular threshold, "
-                      "this function has no effect on the behavior of the comparator. Therefore it is "
-                      "deprecated and will be removed in future releases.")
       getAngularThreshold () const { return (std::acos (angular_threshold_) ); }
 
       /** \brief Set labels in the label cloud to exclude.
         * \param[in] exclude_labels a vector of bools corresponding to whether or not a given label should be considered
         */
+      [[deprecated("use setExcludeLabels(const ExcludeLabelSetConstPtr &) instead")]]
       void
-      PCL_DEPRECATED ("Use setExcludeLabels (const ExcludeLabelSetConstPtr &) instead")
       setExcludeLabels (const std::vector<bool>& exclude_labels)
       {
         exclude_labels_ = boost::make_shared<std::set<uint32_t> > ();

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -59,7 +59,7 @@ namespace pcl
       pcl::PointCloud<PointT> &output);
 
   template <typename PointT>
-  PCL_DEPRECATED("getPointCloudDifference() does not use the tgt parameter, thus it is deprecated and will be removed in future releases.")
+  [[deprecated("tgt parameter is not used; it is deprecated and will be removed in future releases")]]
   inline void getPointCloudDifference (
       const pcl::PointCloud<PointT> &src,
       const pcl::PointCloud<PointT> & /* tgt */,

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -189,7 +189,7 @@ namespace pcl
        */
       SupervoxelClustering (float voxel_resolution, float seed_resolution);
 
-      PCL_DEPRECATED ("SupervoxelClustering constructor with flag for using the single camera transform is deprecated. Default behavior is now to use the transform for organized clouds, and not use it for unorganized. To force use/disuse of the transform, use the setUseSingleCameraTransform(bool) function.")
+      [[deprecated("constructor with flag for using the single camera transform is deprecated. Default behavior is now to use the transform for organized clouds, and not use it for unorganized. Use setUseSingleCameraTransform() to override the defaults.")]]
       SupervoxelClustering (float voxel_resolution, float seed_resolution, bool);
 
       /** \brief This destructor destroys the cloud, normals and search method used for
@@ -273,7 +273,7 @@ namespace pcl
         * color(it's random). Points that are unlabeled will be black
         * \note This will expand the label_colors_ vector so that it can accommodate all labels
         */
-      PCL_DEPRECATED ("SupervoxelClustering::getColoredCloud is deprecated. Use the getLabeledCloud function instead. examples/segmentation/example_supervoxels.cpp shows how to use this to display and save with colorized labels.")
+      [[deprecated("use getLabeledCloud() instead. An example of how to display and save with colorized labels can be found in examples/segmentation/example_supervoxels.cpp")]]
       typename pcl::PointCloud<PointXYZRGBA>::Ptr
       getColoredCloud () const
       { 
@@ -298,7 +298,7 @@ namespace pcl
        * color(it's random). Points that are unlabeled will be black
        * \note This will expand the label_colors_ vector so that it can accommodate all labels
        */
-      PCL_DEPRECATED ("SupervoxelClustering::getColoredVoxelCloud is deprecated. Use the getLabeledVoxelCloud function instead. examples/segmentation/example_supervoxels.cpp shows how to use this to display and save with colorized labels.")
+      [[deprecated("use getLabeledVoxelCloud() instead. An example of how to display and save with colorized labels can be found in examples/segmentation/example_supervoxels.cpp")]]
       pcl::PointCloud<pcl::PointXYZRGBA>::Ptr
       getColoredVoxelCloud () const
       {

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -356,7 +356,7 @@ namespace pcl
       /** \brief Sets whether the surface and normal are approximated using a polynomial, or only via tangent estimation.
         * \param[in] polynomial_fit set to true for polynomial fit
         */
-      PCL_DEPRECATED ("[pcl::surface::MovingLeastSquares::setPolynomialFit] setPolynomialFit is deprecated. Please use setPolynomialOrder instead.")
+      [[deprecated("use setPolynomialOrder() instead")]]
       inline void
       setPolynomialFit (bool polynomial_fit)
       {
@@ -374,7 +374,7 @@ namespace pcl
       }
 
       /** \brief Get the polynomial_fit value (true if the surface and normal are approximated using a polynomial). */
-      PCL_DEPRECATED ("[pcl::surface::MovingLeastSquares::getPolynomialFit] getPolynomialFit is deprecated. Please use getPolynomialOrder instead.")
+      [[deprecated("use getPolynomialOrder() instead")]]
       inline bool
       getPolynomialFit () const { return (order_ > 1); }
 


### PR DESCRIPTION
The `[[deprecated]]` attribute is part of the standard; no workarounds for different compilers is needed anymore. Thus `PCL_DEPRECATED` macro is removed.