### PR TITLE
Second round replacing #ifndef guards by #pragma once include guards

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/crh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/crh_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_CRH_ESTIMATOR_H_
-#define REC_FRAMEWORK_CRH_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -90,5 +89,3 @@ namespace pcl
     };
   }
 }
-
-#endif /* REC_FRAMEWORK_CVFH_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/cvfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/cvfh_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_CVFH_ESTIMATOR_H_
-#define REC_FRAMEWORK_CVFH_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -162,5 +161,3 @@ namespace pcl
     };
   }
 }
-
-#endif /* REC_FRAMEWORK_CVFH_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/esf_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/esf_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_ESF_ESTIMATOR_H_
-#define REC_FRAMEWORK_ESF_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h>
 #include <pcl/features/esf.h>
@@ -56,5 +55,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_ESF_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_GLOBAL_ESTIMATOR_H_
-#define REC_FRAMEWORK_GLOBAL_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
 
@@ -43,6 +42,3 @@ namespace pcl
     };
   }
 }
-
-
-#endif /* REC_FRAMEWORK_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/ourcvfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/ourcvfh_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_OURCVFH_ESTIMATOR_H_
-#define REC_FRAMEWORK_OURCVFH_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -197,5 +196,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_OURCVFH_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/vfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/vfh_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_VFH_ESTIMATOR_H_
-#define REC_FRAMEWORK_VFH_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -71,5 +70,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_VFH_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/colorshot_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/colorshot_local_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_COLORSHOT_LOCAL_ESTIMATOR_H_
-#define REC_FRAMEWORK_COLORSHOT_LOCAL_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -90,5 +89,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_COLORSHOT_LOCAL_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_FPFH_LOCAL_ESTIMATOR_H_
-#define REC_FRAMEWORK_FPFH_LOCAL_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -89,5 +88,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_FPFH_LOCAL_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator_omp.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator_omp.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_FPFH_LOCAL_ESTIMATOR_OMP_H_
-#define REC_FRAMEWORK_FPFH_LOCAL_ESTIMATOR_OMP_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -91,5 +90,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_FPFH_LOCAL_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_LOCAL_ESTIMATOR_H_
-#define REC_FRAMEWORK_LOCAL_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
 #include <pcl/filters/uniform_sampling.h>
@@ -522,5 +521,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_LOCAL_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_SHOT_LOCAL_ESTIMATOR_H_
-#define REC_FRAMEWORK_SHOT_LOCAL_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -140,5 +139,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_SHOT_LOCAL_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator_omp.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator_omp.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_SHOT_LOCAL_ESTIMATOR_OMP_H_
-#define REC_FRAMEWORK_SHOT_LOCAL_ESTIMATOR_OMP_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h>
@@ -152,5 +151,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_SHOT_LOCAL_ESTIMATOR_OMP_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_NORMAL_ESTIMATOR_H_
-#define REC_FRAMEWORK_NORMAL_ESTIMATOR_H_
+#pragma once
 
 #include <pcl/filters/radius_outlier_removal.h>
 #include <pcl/filters/voxel_grid.h>
@@ -296,5 +295,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_NORMAL_ESTIMATOR_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_MESH_SOURCE_H_
-#define REC_FRAMEWORK_MESH_SOURCE_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/pc_source/source.h>
 #include <pcl/apps/render_views_tesselated_sphere.h>
@@ -290,5 +289,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_MESH_SOURCE_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/registered_views_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/registered_views_source.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_MESH_SOURCE_H_
-#define REC_FRAMEWORK_MESH_SOURCE_H_
+#pragma once
 
 #include <pcl/apps/3d_rec_framework/pc_source/source.h>
 #include <pcl/io/io.h>
@@ -384,5 +383,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_MESH_SOURCE_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_VIEWS_SOURCE_H_
-#define REC_FRAMEWORK_VIEWS_SOURCE_H_
+#pragma once
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
@@ -297,5 +296,3 @@ namespace pcl
     };
   }
 }
-
-#endif /* REC_FRAMEWORK_VIEWS_SOURCE_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_classifier.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_classifier.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_GLOBAL_PIPELINE_H_
-#define REC_FRAMEWORK_GLOBAL_PIPELINE_H_
+#pragma once
 
 #include <flann/flann.h>
 #include <pcl/common/common.h>
@@ -220,4 +219,3 @@ namespace pcl
       };
   }
 }
-#endif /* REC_FRAMEWORK_GLOBAL_PIPELINE_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_crh.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_crh.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_GLOBAL_RECOGNIZER_CRH_H_
-#define REC_FRAMEWORK_GLOBAL_RECOGNIZER_CRH_H_
+#pragma once
 
 #include <flann/flann.h>
 #include <pcl/common/common.h>
@@ -269,4 +268,3 @@ namespace pcl
     };
   }
 }
-#endif /* REC_FRAMEWORK_GLOBAL_PIPELINE_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_GLOBAL_RECOGNIZER_CVFH_H_
-#define REC_FRAMEWORK_GLOBAL_RECOGNIZER_CVFH_H_
+#pragma once
 
 #include <flann/flann.h>
 #include <pcl/common/common.h>
@@ -353,4 +352,3 @@ namespace pcl
       };
   }
 }
-#endif /* REC_FRAMEWORK_GLOBAL_PIPELINE_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/local_recognizer.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/local_recognizer.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_LOCAL_RECOGNIZER_H_
-#define REC_FRAMEWORK_LOCAL_RECOGNIZER_H_
+#pragma once
 
 //#include <opencv2/opencv.hpp>
 #include <flann/flann.h>
@@ -350,5 +349,3 @@ namespace pcl
       };
   }
 }
-
-#endif /* REC_FRAMEWORK_LOCAL_RECOGNIZER_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/tools/openni_frame_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/tools/openni_frame_source.h
@@ -1,5 +1,4 @@
-#ifndef OPENNI_CAPTURE_H
-#define OPENNI_CAPTURE_H
+#pragma once
 
 #include <pcl/io/openni_grabber.h>
 #include <pcl/visualization/pcl_visualizer.h>
@@ -38,5 +37,3 @@ namespace OpenNIFrameSource
   };
 
 }
-
-#endif

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/metrics.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/metrics.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_METRICS_H_
-#define REC_FRAMEWORK_METRICS_H_
+#pragma once
 
 #include <cmath>
 #include <cstdlib>
@@ -133,5 +132,3 @@ namespace Metrics
         }
     };
 }
-
-#endif /* REC_FRAMEWORK_METRICS_H_ */

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef REC_FRAMEWORK_UNIFORM_SAMPLING_H_
-#define REC_FRAMEWORK_UNIFORM_SAMPLING_H_
+#pragma once
 
 #include <vtkPolyData.h>
 #include <vtkTriangle.h>
@@ -162,5 +161,3 @@ namespace pcl
     }
   }
 }
-
-#endif /* REC_FRAMEWORK_UNIFORM_SAMPLING_H_ */

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_browser.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_browser.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef CLOUD_BROWSER_H_
-#define CLOUD_BROWSER_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 
@@ -79,21 +78,3 @@ namespace pcl
     
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#endif

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_composer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_composer.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef CLOUD_COMPOSER_H_
-#define CLOUD_COMPOSER_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 
@@ -169,8 +168,3 @@ namespace pcl
     
   }
 }
-
-
-
-
-#endif // CLOUD_COMPOSER_H

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef CLOUD_VIEW_H_
-#define CLOUD_VIEW_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 #include <pcl/visualization/pcl_visualizer.h>
@@ -151,5 +150,3 @@ namespace pcl
 }
 
 Q_DECLARE_METATYPE (pcl::cloud_composer::CloudView);
-#endif
-

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_viewer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_viewer.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef CLOUD_VIEWER_H_
-#define CLOUD_VIEWER_H_
+#pragma once
 
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/apps/cloud_composer/project_model.h>
@@ -83,4 +82,3 @@ namespace pcl
     };
   }
 }
-#endif

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef COMMANDS_H_
-#define COMMANDS_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 #include <pcl/pcl_exports.h>
@@ -219,4 +218,3 @@ namespace pcl
 } 
 
 Q_DECLARE_METATYPE (ConstItemList);
-#endif //COMMANDS_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef ITEM_INSPECTOR_H_
-#define ITEM_INSPECTOR_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 #include <pcl/apps/cloud_composer/project_model.h>
@@ -98,21 +97,3 @@ namespace pcl
     
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#endif

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
@@ -35,9 +35,7 @@
  *
  */
 
-#ifndef CLOUD_COMPOSER_ITEM_H_
-#define CLOUD_COMPOSER_ITEM_H_
-
+#pragma once
 
 #include <pcl/point_types.h>
 #include <pcl/visualization/pcl_visualizer.h>
@@ -168,14 +166,3 @@ namespace pcl
 typedef QList<const pcl::cloud_composer::CloudComposerItem*> ConstItemList;
 
 Q_DECLARE_METATYPE (pcl::cloud_composer::CloudComposerItem);
-
-
-
-
-
-
-
-
-
-
-#endif //CLOUD_COMPOSER_ITEM_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef CLOUD_ITEM_H_
-#define CLOUD_ITEM_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/items/cloud_composer_item.h>
 #include <pcl/visualization/pcl_visualizer.h>
@@ -187,5 +186,3 @@ Q_DECLARE_METATYPE (pcl::search::KdTree<pcl::PointXYZRGBA>::Ptr);
 Q_DECLARE_METATYPE (pcl::PointCloud <pcl::PointXYZ>::Ptr);
 Q_DECLARE_METATYPE (pcl::PointCloud <pcl::PointXYZRGB>::Ptr);
 Q_DECLARE_METATYPE (pcl::PointCloud <pcl::PointXYZRGBA>::Ptr);
-
-#endif //CLOUD_ITEM_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/fpfh_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/fpfh_item.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef FPFH_ITEM_H_
-#define FPFH_ITEM_H_
+#pragma once
 
 #include <pcl/point_types.h>
 #include <pcl/features/fpfh.h>
@@ -85,5 +84,3 @@ namespace pcl
 
 Q_DECLARE_METATYPE (pcl::PointCloud<pcl::FPFHSignature33>::Ptr);
 Q_DECLARE_METATYPE (pcl::PointCloud<pcl::FPFHSignature33>::ConstPtr);
-
-#endif //NORMALS_ITEM_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/normals_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/normals_item.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NORMALS_ITEM_H_
-#define NORMALS_ITEM_H_
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/point_types.h>
@@ -84,5 +83,3 @@ namespace pcl
 
 Q_DECLARE_METATYPE (pcl::PointCloud<pcl::Normal>::Ptr);
 Q_DECLARE_METATYPE (pcl::PointCloud<pcl::Normal>::ConstPtr);
-
-#endif //NORMALS_ITEM_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/merge_selection.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/merge_selection.h
@@ -35,11 +35,9 @@
  *
  */
 
-#ifndef MERGE_SELECTION_H_
-#define MERGE_SELECTION_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
-
 
 namespace pcl
 {
@@ -70,5 +68,3 @@ namespace pcl
 
   }
 }
-
-#endif

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/click_trackball_interactor_style.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/click_trackball_interactor_style.h
@@ -35,14 +35,10 @@
  *
  */
 
-#ifndef CLICK_TRACKBALL_STYLE_INTERACTOR_H_
-#define CLICK_TRACKBALL_STYLE_INTERACTOR_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h>
 #include <pcl/apps/cloud_composer/qt.h>
-
-
-
 
 namespace pcl
 {
@@ -116,7 +112,3 @@ namespace pcl
   }
   
 }
-
-#endif // CLICK_TRACKBALL_STYLE_INTERACTOR_H_
-        
-        

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef INTERACTOR_STYLE_SWITCH_H_
-#define INTERACTOR_STYLE_SWITCH_H_
+#pragma once
 
 #include <pcl/visualization/vtk.h>
 #include <pcl/visualization/interactor_style.h>
@@ -149,7 +148,3 @@ namespace pcl
   }
   
 }
-
-#endif // INTERACTOR_STYLE_SWITCH_H_
-        
-        

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/manipulation_event.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/manipulation_event.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef MANIPULATION_EVENT_H_
-#define MANIPULATION_EVENT_H_
+#pragma once
 
 #include <pcl/visualization/vtk.h>
 #include <pcl/apps/cloud_composer/items/cloud_item.h>
@@ -76,7 +75,3 @@ namespace pcl
   }
   
 }
-
-#endif // MANIPULATION_EVENT_H_
-        
-        

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/rectangular_frustum_selector.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/rectangular_frustum_selector.h
@@ -35,14 +35,10 @@
  *
  */
 
-#ifndef RECTANGULAR_FRUSTRUM_SELECTOR_H_
-#define RECTANGULAR_FRUSTRUM_SELECTOR_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h>
 #include <pcl/apps/cloud_composer/qt.h>
-
-
-
 
 namespace pcl
 {
@@ -94,7 +90,3 @@ namespace pcl
   }
   
 }
-
-#endif // RECTANGULAR_FRUSTRUM_SELECTOR_H_
-        
-        

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selected_trackball_interactor_style.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selected_trackball_interactor_style.h
@@ -35,14 +35,8 @@
  *
  */
 
-#ifndef SELECTED_TRACKBALL_STYLE_INTERACTOR_H_
-#define SELECTED_TRACKBALL_STYLE_INTERACTOR_H_
-
 #include <pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h>
 #include <pcl/apps/cloud_composer/qt.h>
-
-
-
 
 namespace pcl
 {
@@ -125,7 +119,3 @@ namespace pcl
   }
   
 }
-
-#endif // SELECTED_TRACKBALL_STYLE_INTERACTOR_H_
-        
-        

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selection_event.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selection_event.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef SELECTION_EVENT_H_
-#define SELECTION_EVENT_H_
+#pragma once
 
 #include <pcl/visualization/vtk.h>
 #include <pcl/apps/cloud_composer/items/cloud_item.h>
@@ -90,7 +89,3 @@ namespace pcl
   }
   
 }
-
-#endif // SELECTION_EVENT_H_
-        
-        

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
@@ -35,9 +35,7 @@
  *
  */
 
-#ifndef PROJECT_MODEL_H_
-#define PROJECT_MODEL_H_
-
+#pragma once
 
 #include <vtkSmartPointer.h>
 #include <vtkCamera.h>
@@ -209,6 +207,3 @@ namespace pcl
 
 Q_DECLARE_METATYPE (pcl::cloud_composer::ProjectModel);
 Q_DECLARE_METATYPE (pcl::cloud_composer::interactor_styles::INTERACTOR_STYLES);
-
-#endif //PROJECT_MODEL_H
-

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
@@ -35,12 +35,10 @@
  *
  */
 
-#ifndef PROPERTIES_MODEL_H_
-#define PROPERTIES_MODEL_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 #include <pcl/common/boost.h> 
-
 
 namespace pcl
 {
@@ -92,5 +90,3 @@ namespace pcl
 
 Q_DECLARE_METATYPE (pcl::cloud_composer::PropertiesModel);
 Q_DECLARE_METATYPE (pcl::cloud_composer::PropertiesModel*);
-
-#endif //PROPERTIES_MODEL_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/qt.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/qt.h
@@ -36,8 +36,7 @@
  *
  */
 
-#ifndef CLOUD_COMPOSER_QT_H_
-#define CLOUD_COMPOSER_QT_H_
+#pragma once
 
 #ifdef __GNUC__
 #pragma GCC system_header
@@ -70,6 +69,3 @@
 #include <QFileDialog>
 #include <QAction>
 #include <QGridLayout>
-
-
-#endif // CLOUD_COMPOSER_QT_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/signal_multiplexer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/signal_multiplexer.h
@@ -40,8 +40,7 @@
  *
  */
 
-#ifndef SIGNAL_MULTIPLEXER_H_
-#define SIGNAL_MULTIPLEXER_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 
@@ -148,21 +147,3 @@ namespace pcl
     };
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#endif // SIGNAL_MULTIPLEXER_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/abstract_tool.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/abstract_tool.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef ABSTRACT_TOOL_H_
-#define ABSTRACT_TOOL_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 #include <pcl/apps/cloud_composer/commands.h>
@@ -185,6 +184,3 @@ namespace pcl
 
   }
 }
-
-
-#endif //ABSTRACT_TOOL_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/tool_factory.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/tool_factory.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef TOOL_FACTORY_H_
-#define TOOL_FACTORY_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 #include <pcl/apps/cloud_composer/items/cloud_composer_item.h>
@@ -95,5 +94,3 @@ Q_DECLARE_METATYPE (pcl::cloud_composer::ToolFactory*);
 
 Q_DECLARE_INTERFACE(pcl::cloud_composer::ToolFactory,
                     "cloud_composer.ToolFactory/1.0")
-
-#endif //TOOL_FACTORY_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef TOOLBOX_MODEL_H_
-#define TOOLBOX_MODEL_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/qt.h>
 
@@ -119,6 +118,3 @@ namespace pcl
 
 Q_DECLARE_METATYPE (pcl::cloud_composer::ToolBoxModel);
 Q_DECLARE_METATYPE (QStandardItemModel*);
-
-#endif //TOOLBOX_MODEL_H_
-

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/euclidean_clustering.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/euclidean_clustering.h
@@ -35,12 +35,10 @@
  *
  */
 
-#ifndef EUCLIDEAN_CLUSTERING_H_
-#define EUCLIDEAN_CLUSTERING_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
 #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
-
 
 namespace pcl
 {
@@ -104,10 +102,3 @@ namespace pcl
 
   }
 }
-
-
-
-
-
-
-#endif //EUCLIDEAN_CLUSTERING_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/fpfh_estimation.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/fpfh_estimation.h
@@ -35,13 +35,10 @@
  *
  */
 
-#ifndef FPFH_ESTIMATION_H_
-#define FPFH_ESTIMATION_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
 #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
-
-
 
 namespace pcl
 {
@@ -107,10 +104,3 @@ namespace pcl
 
   }
 }
-
-
-
-
-
-
-#endif //FPFH_ESTIMATION_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/normal_estimation.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/normal_estimation.h
@@ -35,12 +35,10 @@
  *
  */
 
-#ifndef NORMAL_ESTIMATION_H_
-#define NORMAL_ESTIMATION_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
 #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
-
 
 namespace pcl
 {
@@ -104,10 +102,3 @@ namespace pcl
 
   }
 }
-
-
-
-
-
-
-#endif //NORMAL_ESTIMATION_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/organized_segmentation.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/organized_segmentation.h
@@ -35,8 +35,7 @@
   *
   */
  
- #ifndef ORGANIZED_SEGMENTATION_H_
- #define ORGANIZED_SEGMENTATION_H_
+#pragma once
  
  #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
  #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
@@ -108,10 +107,3 @@
      
    }
  }
- 
- 
- 
- 
- 
- 
- #endif //ORGANIZED_SEGMENTATION_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/sanitize_cloud.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/sanitize_cloud.h
@@ -35,12 +35,10 @@
  *
  */
 
-#ifndef SANITIZE_CLOUD_H_
-#define SANITIZE_CLOUD_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
 #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
-
 
 namespace pcl
 {
@@ -104,10 +102,3 @@ namespace pcl
       
     }
   }
-  
-  
-  
-  
-  
-  
-  #endif //SANITIZE_CLOUD_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/statistical_outlier_removal.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/statistical_outlier_removal.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef STATISTICAL_OUTLIER_REMOVAL_H_
-#define STATISTICAL_OUTLIER_REMOVAL_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
 #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
@@ -104,10 +103,3 @@ namespace pcl
 
   }
 }
-
-
-
-
-
-
-#endif //STATISTICAL_OUTLIER_REMOVAL_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/supervoxels.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/supervoxels.h
@@ -35,8 +35,7 @@
   *
   */
  
- #ifndef SUPERVOXELS_H_
- #define SUPERVOXELS_H_
+#pragma once
  
  #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
  #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
@@ -110,10 +109,3 @@
      
    }
  }
- 
- 
- 
- 
- 
- 
- #endif //SUPERVOXELS_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/voxel_grid_downsample.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/voxel_grid_downsample.h
@@ -35,12 +35,10 @@
  *
  */
 
-#ifndef VOXEL_GRID_DOWNSAMPLE_H_
-#define VOXEL_GRID_DOWNSAMPLE_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
 #include <pcl/apps/cloud_composer/tool_interface/tool_factory.h>
-
 
 namespace pcl
 {
@@ -104,10 +102,3 @@ namespace pcl
 
   }
 }
-
-
-
-
-
-
-#endif //VOXEL_GRID_DOWNSAMPLE_H_

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/transform_clouds.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/transform_clouds.h
@@ -35,11 +35,9 @@
  *
  */
 
-#ifndef TRANSFORM_CLOUDS_H_
-#define TRANSFORM_CLOUDS_H_
+#pragma once
 
 #include <pcl/apps/cloud_composer/tool_interface/abstract_tool.h>
-
 
 namespace pcl
 {
@@ -67,5 +65,3 @@ namespace pcl
 
   }
 }
-
-#endif

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/work_queue.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/work_queue.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef WORK_QUEUE_H_
-#define WORK_QUEUE_H_
+#pragma once
 
 #include "qt.h"
 
@@ -83,5 +82,3 @@ namespace pcl
     };
   }
 }
-
-#endif //WORK_QUEUE_H_

--- a/apps/include/pcl/apps/dominant_plane_segmentation.h
+++ b/apps/include/pcl/apps/dominant_plane_segmentation.h
@@ -33,8 +33,7 @@
  *
  */
 
-#ifndef DOMINANT_PLANE_SEGMENTATION_H_
-#define DOMINANT_PLANE_SEGMENTATION_H_
+#pragma once
 
 #include <pcl/common/common.h>
 #include <pcl/point_cloud.h>
@@ -286,5 +285,3 @@ namespace pcl
 #ifdef PCL_NO_PRECOMPILE
 #include <pcl/apps/impl/dominant_plane_segmentation.hpp>
 #endif
-
-#endif /* DOMINANT_PLANE_SEGMENTATION_H_ */

--- a/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
+++ b/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
@@ -5,8 +5,7 @@
  *      Author: ari
  */
 
-#ifndef FACE_DETECTION_APPS_UTILS_H_
-#define FACE_DETECTION_APPS_UTILS_H_
+#pragma once
 
 namespace face_detection_apps_utils
 {
@@ -145,5 +144,3 @@ namespace face_detection_apps_utils
     }
   }
 }
-
-#endif /* FACE_DETECTION_APPS_UTILS_H_ */

--- a/apps/include/pcl/apps/face_detection/openni_frame_source.h
+++ b/apps/include/pcl/apps/face_detection/openni_frame_source.h
@@ -1,5 +1,4 @@
-#ifndef OPENNI_CAPTURE_H
-#define OPENNI_CAPTURE_H
+#pragma once
 
 #include <pcl/io/openni_grabber.h>
 #include <pcl/visualization/pcl_visualizer.h>
@@ -38,5 +37,3 @@ namespace OpenNIFrameSource
   };
 
 }
-
-#endif

--- a/apps/include/pcl/apps/nn_classification.h
+++ b/apps/include/pcl/apps/nn_classification.h
@@ -37,8 +37,7 @@
  *
  */
 
-#ifndef NNCLASSIFICATION_H_
-#define NNCLASSIFICATION_H_
+#pragma once
 
 #include <cstdlib>
 #include <cfloat>
@@ -299,5 +298,3 @@ namespace pcl
       }
   };
 }
-
-#endif /* NNCLASSIFICATION_H_ */

--- a/apps/include/pcl/apps/render_views_tesselated_sphere.h
+++ b/apps/include/pcl/apps/render_views_tesselated_sphere.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef RENDER_VIEWS_TESSELATED_SPHERE_H_
-#define RENDER_VIEWS_TESSELATED_SPHERE_H_
+#pragma once
 
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
@@ -178,5 +177,3 @@ namespace pcl
 
   }
 }
-
-#endif /* RENDER_VIEWS_TESSELATED_SPHERE_H_ */

--- a/apps/include/pcl/apps/vfh_nn_classifier.h
+++ b/apps/include/pcl/apps/vfh_nn_classifier.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef VFHCLASSIFICATION_H_
-#define VFHCLASSIFICATION_H_
+#pragma once
 
 #include <fstream>
 #include <pcl/point_types.h>
@@ -265,5 +264,3 @@ namespace pcl
       }
   };
 }
-
-#endif /* VFHCLASSIFICATION_H_ */

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
@@ -39,8 +39,7 @@
 /// display.
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef CLOUD_H_
-#define CLOUD_H_
+#pragma once
 
 #include <QtGui/QColor>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -472,8 +471,3 @@ class Cloud : public Statistics
     /// The translations on x, y, and z axis on the selected points.
     float select_translate_x_, select_translate_y_, select_translate_z_;
 };
-#endif // CLOUD_H_
-
-
-
-

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
@@ -38,8 +38,7 @@
 /// which are used for viewing and editing point clouds
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef CLOUD_EDITOR_WIDGET_H_
-#define CLOUD_EDITOR_WIDGET_H_
+#pragma once
 
 #include <QGLWidget>
 #include <boost/function.hpp>
@@ -311,4 +310,3 @@ class CloudEditorWidget : public QGLWidget
 
 
 };
-#endif // CLOUD_EDITOR_WIDGET_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudTransformTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudTransformTool.h
@@ -38,8 +38,7 @@
 /// transformation matrix using inputs from the mouse.
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef CLOUD_TRANSFORM_TOOL_H_
-#define CLOUD_TRANSFORM_TOOL_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/toolInterface.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -146,4 +145,3 @@ class CloudTransformTool : public ToolInterface
     /// default translation factor
     static const float DEFAULT_TRANSLATE_FACTOR_;
 };
-#endif  //CLOUD_TRANSFORM_TOOL_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/command.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/command.h
@@ -39,8 +39,7 @@
 /// CommandQueue.
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef COMMAND_H_
-#define COMMAND_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 
@@ -101,4 +100,3 @@ class Command
       assert(false); return (*this);
     }
 };
-#endif //COMMAND_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
@@ -39,8 +39,7 @@
 /// in order to both execute them and undo them in the proper order.
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef COMMAND_QUEUE_H_
-#define COMMAND_QUEUE_H_
+#pragma once
 
 #include <deque>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -119,4 +118,3 @@ class CommandQueue
     /// The depth limit of the command queue.
     unsigned int depth_limit_;
 };
-#endif // COMMAND_QUEUE_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/common.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/common.h
@@ -37,8 +37,7 @@
 /// @details The set of simple common operations used throughout the project.
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef COMMON_H_
-#define COMMON_H_
+#pragma once
 
 #include <sstream>
 
@@ -83,5 +82,3 @@ toString(T input, std::string &result)
 /// @param s The string to be made lower.
 void
 stringToLower(std::string &s);
-
-#endif // COMMON_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyBuffer.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyBuffer.h
@@ -38,8 +38,7 @@
 /// copied from the cloud.
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef COPY_BUFFER_H_
-#define COPY_BUFFER_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 #include <pcl/apps/point_cloud_editor/cloud.h>
@@ -114,4 +113,3 @@ class CopyBuffer : public Statistics
     /// a cloud object holding all the copied points.
     Cloud buffer_; 
 };
-#endif // COPY_BUFFER_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyCommand.h
@@ -38,8 +38,7 @@
 /// buffer with the current selection.  The
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef COPY_COMMAND_H_
-#define COPY_COMMAND_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/command.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -114,4 +113,3 @@ class CopyCommand : public Command
     /// a shared pointer pointing to the cloud
     ConstCloudPtr cloud_ptr_;
 };
-#endif //COPY_COMMAND_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cutCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cutCommand.h
@@ -38,8 +38,7 @@
 /// points from the cloud and filling the copy buffer.
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef CUT_COMMAND_H_
-#define CUT_COMMAND_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/command.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -110,5 +109,3 @@ class CutCommand : public Command
     CopyBuffer cut_cloud_buffer_;
 
 };
-
-#endif // CUT_COMMAND_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/deleteCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/deleteCommand.h
@@ -38,8 +38,7 @@
 /// from the cloud as well as the ability to undo the removal.
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef DELETE_COMMAND_H_
-#define DELETE_COMMAND_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/command.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -102,5 +101,3 @@ class DeleteCommand : public Command
     /// a copy buffer which backs up the points deleted from the cloud.
     CopyBuffer deleted_cloud_buffer_;
 };
-
-#endif // DELETE_COMMAND_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseCommand.h
@@ -40,8 +40,7 @@
 /// http://pointclouds.org/documentation/tutorials/statistical_outlier.php
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef DENOISE_COMMAND_H_
-#define DENOISE_COMMAND_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/command.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -115,5 +114,3 @@ private:
   /// A selection object which backs up the indices of the noisy points removed.
   Selection removed_indices_;
 };
-
-#endif // DENOISE_COMMAND_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseParameterForm.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseParameterForm.h
@@ -38,9 +38,7 @@
 /// to PCL's denoising filter.
 /// @author  Yue Li and Matthew Hielsberg
 
-
-#ifndef DENOISE_PARAMETER_FORM_H_
-#define DENOISE_PARAMETER_FORM_H_
+#pragma once
 
 #include <QLineEdit>
 #include <QDialog>
@@ -112,5 +110,3 @@ class DenoiseParameterForm : public QDialog
     /// The flag indicating whether the OK button was pressed
     bool ok_;
 };
-
-#endif // DENOISE_PARAMETER_FORM_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/localTypes.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/localTypes.h
@@ -37,9 +37,7 @@
 /// @details A set of useful typedefs, forward declarations and constants.
 /// @author  Yue Li and Matthew Hielsberg
 
-
-#ifndef LOCAL_TYPES_H_
-#define LOCAL_TYPES_H_
+#pragma once
 
 #include <vector>
 #include <boost/shared_ptr.hpp>
@@ -191,7 +189,3 @@ const float DISPLAY_Z_TRANSLATION = -2.0f;
 
 /// The radius of the trackball given as a percentage of the screen width
 const float TRACKBALL_RADIUS_SCALE = 0.4f;
-
-
-
-#endif // LOCAL_TYPES_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
@@ -40,8 +40,7 @@
 /// @author  Yue Li and Matthew Hielsberg
 ///
 
-#ifndef MAIN_WINDOW_H_
-#define MAIN_WINDOW_H_
+#pragma once
 
 #include <QtGui>
 #include <QMainWindow>
@@ -241,4 +240,3 @@ class MainWindow : public QMainWindow
     /// the slider used for adjusting moving speed.
      QSlider *move_speed_slider_;
 };
-#endif //MAIN_WINDOW_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/pasteCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/pasteCommand.h
@@ -38,9 +38,7 @@
 /// points in a cloud object as well as undo.
 /// @author  Yue Li and Matthew Hielsberg
 
-
-#ifndef PASTE_COMMAND_H_
-#define PASTE_COMMAND_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/command.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -106,4 +104,3 @@ class PasteCommand : public Command
     /// support undo, one only has to resize the cloud using this value.
     unsigned int prev_cloud_size_;
 };
-#endif // PASTE_COMMAND_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select1DTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select1DTool.h
@@ -37,8 +37,7 @@
 /// @details Tool for selecting and deselecting individual points in the cloud.
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef SELECT_1D_TOOL_H
-#define SELECT_1D_TOOL_H
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/toolInterface.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -107,4 +106,3 @@ class Select1DTool : public ToolInterface
     /// a shared pointer pointing to the cloud object
     CloudPtr cloud_ptr_;
 };
-#endif // SELECT_1D_TOOL_H

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
@@ -38,8 +38,7 @@
 /// functionalities to enable 2D selection.
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef SELECT_2D_TOOL_H_
-#define SELECT_2D_TOOL_H_
+#pragma once
 
 #include <qgl.h>
 #include <pcl/apps/point_cloud_editor/toolInterface.h>
@@ -149,4 +148,3 @@ class Select2DTool : public ToolInterface
     bool display_box_;
 
 };
-#endif // SELECT_2D_TOOL_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selection.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selection.h
@@ -38,9 +38,7 @@
 /// point cloud that have been identifed by the selection tools.
 /// @author  Yue Li and Matthew Hielsberg
 
-
-#ifndef SELECTION_H_
-#define SELECTION_H_
+#pragma once
 
 #include <set>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -202,5 +200,3 @@ class Selection : public Statistics
     /// A set of unique indices that have been selected in the cloud.
     std::set<unsigned int> selected_indices_;
 };
-
-#endif // SELECTION_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selectionTransformTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selectionTransformTool.h
@@ -37,8 +37,7 @@
 /// @details This tool provides the ability to transform the current selection.
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef SELECTION_TRANSFORM_TOOL_H_
-#define SELECTION_TRANSFORM_TOOL_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/toolInterface.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -162,4 +161,3 @@ class SelectionTransformTool : public ToolInterface
     BitMask modifiers_;
 
 };
-#endif // SELECTION_TRANSFORMER_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statistics.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statistics.h
@@ -38,8 +38,7 @@
 /// displayed in a pop-up dialog.
 /// @author Yue Li and Matthew Hielsberg
 
-#ifndef STATISTICS_H_
-#define STATISTICS_H_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -94,5 +93,3 @@ class Statistics
   private:
     static std::vector<Statistics*> stat_vec_;
 };
-
-#endif // STATISTICS_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
@@ -38,8 +38,7 @@
 /// to PCL's denoising filter.
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef STATISTICS_DIALOG_H_
-#define STATISTICS_DIALOG_H_
+#pragma once
 
 #include <QLineEdit>
 #include <QDialog>
@@ -77,5 +76,3 @@ class StatisticsDialog : public QDialog
     /// A timer used for periodically update the statistics in the dialog.
     QTimer timer_;
 };
-
-#endif // STATISTICS_DIALOG_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/toolInterface.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/toolInterface.h
@@ -39,8 +39,7 @@
 /// Note that the CTRL key may be evaluated as the Command key in OSX.
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef TOOL_INTERFACE_H_
-#define TOOL_INTERFACE_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 
@@ -120,4 +119,3 @@ class ToolInterface
       assert(false); return (*this);
     }
 };
-#endif // TOOL_INTERFACE_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/trackball.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/trackball.h
@@ -38,8 +38,7 @@
 /// class has been based on 
 /// @author Matthew Hielsberg
 
-#ifndef TRACKBALL_H_
-#define TRACKBALL_H_
+#pragma once
 
 #include <boost/math/quaternion.hpp>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
@@ -75,5 +74,3 @@ class TrackBall
     float radius_sqr_;
         
 }; // class TrackBall
-
-#endif // TRACKBALL_H_

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/transformCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/transformCommand.h
@@ -38,13 +38,11 @@
 /// functionalities.  // XXX - transformation of what?
 /// @author  Yue Li and Matthew Hielsberg
 
-#ifndef TRANSFORM_COMMAND_H_
-#define TRANSFORM_COMMAND_H_
+#pragma once
 
 #include <pcl/apps/point_cloud_editor/command.h>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 #include <pcl/apps/point_cloud_editor/cloud.h>
-
 
 class TransformCommand : public Command
 {
@@ -115,5 +113,3 @@ class TransformCommand : public Command
     /// The center of the cloud used by this command
     float cloud_center_[XYZ_SIZE];
 };
-
-#endif // TRANSFORM_COMMAND_H_

--- a/common/include/pcl/common/bivariate_polynomial.h
+++ b/common/include/pcl/common/bivariate_polynomial.h
@@ -36,8 +36,8 @@
  * $Id$
  *
  */
-#ifndef BIVARIATE_POLYNOMIAL_H
-#define BIVARIATE_POLYNOMIAL_H
+
+#pragma once
 
 #include <fstream>
 #include <iostream>
@@ -139,5 +139,3 @@ namespace pcl
 }  // end namespace
 
 #include <pcl/common/impl/bivariate_polynomial.hpp>
-
-#endif

--- a/common/include/pcl/common/fft/kiss_fft.h
+++ b/common/include/pcl/common/fft/kiss_fft.h
@@ -1,5 +1,4 @@
-#ifndef KISS_FFT_H
-#define KISS_FFT_H
+#pragma once
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -125,6 +124,4 @@ kiss_fft_next_fast_size(int n);
 
 #ifdef __cplusplus
 } 
-#endif
-
 #endif

--- a/common/include/pcl/common/fft/kiss_fftr.h
+++ b/common/include/pcl/common/fft/kiss_fftr.h
@@ -1,5 +1,4 @@
-#ifndef KISS_FTR_H
-#define KISS_FTR_H
+#pragma once
 
 #include "kiss_fft.h"
 #ifdef __cplusplus
@@ -42,5 +41,4 @@ void PCL_EXPORTS kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_
 
 #ifdef __cplusplus
 }
-#endif
 #endif

--- a/common/include/pcl/common/projection_matrix.h
+++ b/common/include/pcl/common/projection_matrix.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef __PCL_ORGANIZED_PROJECTION_MATRIX_H__
-#define __PCL_ORGANIZED_PROJECTION_MATRIX_H__
+#pragma once
 
 #include <pcl/common/eigen.h>
 #include <pcl/console/print.h>
@@ -76,5 +75,3 @@ namespace pcl
 }
 
 #include <pcl/common/impl/projection_matrix.hpp>
-
-#endif // __PCL_ORGANIZED_PROJECTION_MATRIX_H__

--- a/common/include/pcl/common/synchronizer.h
+++ b/common/include/pcl/common/synchronizer.h
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *  Author: Nico Blodow (blodow@in.tum.de), Suat Gedikli (gedikli@willowgarage.com)
  */
-#ifndef __PCL_SYNCHRONIZER__
-#define __PCL_SYNCHRONIZER__
+
+#pragma once
 
 namespace pcl
 {
@@ -173,6 +173,3 @@ namespace pcl
     }
   } ;
 } // namespace
-
-#endif // __PCL_SYNCHRONIZER__
-

--- a/common/include/pcl/console/print.h
+++ b/common/include/pcl/console/print.h
@@ -34,8 +34,8 @@
  * $Id$
  *
  */
-#ifndef TERMINAL_TOOLS_PRINT_H_
-#define TERMINAL_TOOLS_PRINT_H_
+
+#pragma once
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -247,5 +247,3 @@ namespace pcl
     print (VERBOSITY_LEVEL level, const char *format, ...);
   }
 } 
-
-#endif // TERMINAL_TOOLS_PRINT_H_

--- a/common/include/pcl/console/time.h
+++ b/common/include/pcl/console/time.h
@@ -35,8 +35,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
-#ifndef TERMINAL_TOOLS_TIME_H_
-#define TERMINAL_TOOLS_TIME_H_
+
+#pragma once
 
 #ifdef __GNUC__
 #pragma GCC system_header 
@@ -91,5 +91,3 @@ namespace pcl
     };
   } 
 }
-
-#endif

--- a/cuda/common/include/pcl/cuda/cutil.h
+++ b/cuda/common/include/pcl/cuda/cutil.h
@@ -23,8 +23,7 @@
 
 /* CUda UTility Library */
 
-#ifndef _CUTIL_H_
-#define _CUTIL_H_
+#pragma once
 
 #ifdef _WIN32
 #   pragma warning( disable : 4996 ) // disable deprecated warning 
@@ -951,5 +950,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif  // #ifdef _DEBUG (else branch)
-
-#endif  // #ifndef _CUTIL_H_

--- a/cuda/common/include/pcl/cuda/cutil_inline.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline.h
@@ -9,8 +9,7 @@
  *
  */
  
-#ifndef _CUTIL_INLINE_H_
-#define _CUTIL_INLINE_H_
+#pragma once
 
 #include <cuda.h>
 #include <pcl/cuda/cutil.h>
@@ -29,6 +28,3 @@ inline void print_NVCC_min_spec(const char *sSDKsample, const char *sNVCCReq, co
 }
 
 #define ALIGN_OFFSET(offset, alignment) offset = (offset + (alignment-1)) & ~((alignment-1))
-
-
-#endif // _CUTIL_INLINE_H_

--- a/cuda/common/include/pcl/cuda/cutil_inline_bankchecker.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_bankchecker.h
@@ -9,8 +9,7 @@
  *
  */
  
- #ifndef _CUTIL_INLINE_BANKCHECKER_H_
-#define _CUTIL_INLINE_BANKCHECKER_H_
+#pragma once
 
 #ifdef _DEBUG
    #if __DEVICE_EMULATION__
@@ -33,5 +32,3 @@ inline void __cutilBankChecker(unsigned int tidx, unsigned int tidy, unsigned in
 {
     cutCheckBankAccess( tidx, tidy, tidz, bdimx, bdimy, bdimz, file, line, aname, index);
 }
-
-#endif // _CUTIL_INLINE_BANKCHECKER_H_

--- a/cuda/common/include/pcl/cuda/cutil_inline_drvapi.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_drvapi.h
@@ -9,8 +9,7 @@
  *
  */
  
-#ifndef _CUTIL_INLINE_FUNCTIONS_DRVAPI_H_
-#define _CUTIL_INLINE_FUNCTIONS_DRVAPI_H_
+#pragma once
 
 #include <stdio.h>
 #include <string.h>
@@ -379,6 +378,3 @@ inline bool cutilDrvCudaCapabilities(int major_version, int minor_version, int a
 {
 	return cutilDrvCudaDevCapabilities(major_version, minor_version, 0, argc, argv);
 }
-
-
-#endif // _CUTIL_INLINE_FUNCTIONS_DRVAPI_H_

--- a/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
@@ -9,8 +9,7 @@
  *
  */
  
-#ifndef _CUTIL_INLINE_FUNCTIONS_RUNTIME_H_
-#define _CUTIL_INLINE_FUNCTIONS_RUNTIME_H_
+#pragma once
 
 #ifdef _WIN32
 #ifdef _DEBUG // Do this only in debug mode...
@@ -484,5 +483,3 @@ inline bool cutilCudaCapabilities(int major_version, int minor_version, int argc
         return false;
     }
 }
-
-#endif // _CUTIL_INLINE_FUNCTIONS_RUNTIME_H_

--- a/cuda/common/include/pcl/cuda/cutil_math.h
+++ b/cuda/common/include/pcl/cuda/cutil_math.h
@@ -20,8 +20,7 @@
     Thanks to Linh Hah for additions and fixes.
 */
 
-#ifndef CUTIL_MATH_H
-#define CUTIL_MATH_H
+#pragma once
 
 #include "cuda_runtime.h"
 
@@ -1324,5 +1323,3 @@ inline __device__ __host__ float4 smoothstep(float4 a, float4 b, float4 x)
 	float4 y = clamp((x - a) / (b - a), 0.0f, 1.0f);
 	return (y*y*(make_float4(3.0f) - (make_float4(2.0f)*y)));
 }
-
-#endif

--- a/cuda/nn/organized_neighbor_search.h
+++ b/cuda/nn/organized_neighbor_search.h
@@ -34,8 +34,7 @@
  * Author: Julius Kammerl (julius@kammerl.de)
  */
 
-#ifndef POINTCLOUD_DEPTH_NEIGHBOR_SEARCH_H
-#define POINTCLOUD_DEPTH_NEIGHBOR_SEARCH_H
+#pragma once
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -339,6 +338,3 @@ namespace pcl
 }
 
 //#include "organized_neighbor_search.hpp"
-
-#endif
-

--- a/doc/tutorials/content/qt_colorize_cloud.rst
+++ b/doc/tutorials/content/qt_colorize_cloud.rst
@@ -60,13 +60,13 @@ pclviewer.h
 
 .. literalinclude:: sources/qt_colorize_cloud/pclviewer.h
    :language: cpp
-   :lines: 42-57
+   :lines: 41-56
 
 These are the public slots triggered by the buttons in the UI.
 
 .. literalinclude:: sources/qt_colorize_cloud/pclviewer.h
    :language: cpp
-   :lines: 59-86
+   :lines: 58-85
 
 These are the protected members of our class;
   * ``viewer_`` is the visualizer object

--- a/doc/tutorials/content/qt_visualizer.rst
+++ b/doc/tutorials/content/qt_visualizer.rst
@@ -101,7 +101,7 @@ pclviewer.h
 
 .. literalinclude:: sources/qt_visualizer/pclviewer.h
    :language: cpp
-   :lines: 1-18
+   :lines: 1-17
 
 This file is the header for the class PCLViewer; we include ``QMainWindow`` because this class contains UI elements, we include the PCL headers we will 
 be using and the VTK header for the ``qvtkWidget``. We also define typedefs of the point types and point clouds, this improves readabily.
@@ -109,32 +109,32 @@ be using and the VTK header for the ``qvtkWidget``. We also define typedefs of t
 
 .. literalinclude:: sources/qt_visualizer/pclviewer.h
    :language: cpp
-   :lines: 20-23
+   :lines: 19-22
 
 We declare the namespace ``Ui`` and the class PCLViewer inside it.
 
 .. literalinclude:: sources/qt_visualizer/pclviewer.h
    :language: cpp
-   :lines: 25-27
+   :lines: 24-26
 
 This is the definition of the PCLViewer class; the macro ``Q_OBJECT`` tells the compiler that this object contains UI elements;
 this imply that this file will be processed through `the Meta-Object Compiler (moc) <http://qt-project.org/doc/qt-4.8/moc.html>`_.
 
 .. literalinclude:: sources/qt_visualizer/pclviewer.h
    :language: cpp
-   :lines: 29-31
+   :lines: 28-30
 
 The constructor and destructor of the PCLViewer class.
 
 .. literalinclude:: sources/qt_visualizer/pclviewer.h
    :language: cpp
-   :lines: 33-50
+   :lines: 32-49
 
 These are the public slots; these functions will be linked with UI elements actions.
 
 .. literalinclude:: sources/qt_visualizer/pclviewer.h
    :language: cpp
-   :lines: 52-58
+   :lines: 51-57
 
 | A boost shared pointer to a PCLVisualier and a pointer to a point cloud are defined here.
 | The integers ``red``, ``green``, ``blue`` will help us store the value of the sliders.

--- a/doc/tutorials/content/sources/iccv2011/include/feature_estimation.h
+++ b/doc/tutorials/content/sources/iccv2011/include/feature_estimation.h
@@ -1,5 +1,4 @@
-#ifndef FEATURE_ESTIMATION_H
-#define FEATURE_ESTIMATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -137,5 +136,3 @@ computeFeatures (const PointCloudPtr & input)
 
   return (features);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/filters.h
+++ b/doc/tutorials/content/sources/iccv2011/include/filters.h
@@ -1,5 +1,4 @@
-#ifndef FILTERS_H
-#define FILTERS_H
+#pragma once
 
 #include <pcl/filters/passthrough.h>
 #include <pcl/filters/voxel_grid.h>
@@ -60,5 +59,3 @@ applyFilters (const PointCloudPtr & input, float min_depth, float max_depth, flo
 
   return (filtered);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/load_clouds.h
+++ b/doc/tutorials/content/sources/iccv2011/include/load_clouds.h
@@ -1,5 +1,4 @@
-#ifndef IO_H_
-#define IO_H_
+#pragma once
 
 #include "typedefs.h"
 
@@ -65,6 +64,3 @@ loadGlobalDescriptors (std::string filename)
   pcl::console::print_info ("Loaded %s (%lu points)\n", filename.c_str (), output->size ());
   return (output);
 }
-
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/object_recognition.h
+++ b/doc/tutorials/content/sources/iccv2011/include/object_recognition.h
@@ -1,5 +1,4 @@
-#ifndef OBJECT_RECOGNITION_H_
-#define OBJECT_RECOGNITION_H_
+#pragma once
 
 #include "typedefs.h"
 #include "load_clouds.h"
@@ -198,5 +197,3 @@ class ObjectRecognition
     GlobalDescriptorsPtr descriptors_;
     pcl::KdTreeFLANN<GlobalDescriptorT>::Ptr kdtree_;
 };
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/openni_capture.h
+++ b/doc/tutorials/content/sources/iccv2011/include/openni_capture.h
@@ -1,5 +1,4 @@
-#ifndef OPENNI_CAPTURE_H
-#define OPENNI_CAPTURE_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -30,5 +29,3 @@ class OpenNICapture
     bool use_trigger_, trigger_;
     boost::mutex mutex_;
 };
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/registration.h
+++ b/doc/tutorials/content/sources/iccv2011/include/registration.h
@@ -1,5 +1,4 @@
-#ifndef REGISTRATION_H
-#define REGISTRATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -90,5 +89,3 @@ refineAlignment (const PointCloudPtr & source_points, const PointCloudPtr & targ
 
   return (icp.getFinalTransformation () * initial_alignment);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/segmentation.h
+++ b/doc/tutorials/content/sources/iccv2011/include/segmentation.h
@@ -1,5 +1,4 @@
-#ifndef SEGMENTATION_H
-#define SEGMENTATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -102,5 +101,3 @@ clusterObjects (const PointCloudPtr & input,
   ec.setInputCloud (input);
   ec.extract (cluster_indices_out);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/surface.h
+++ b/doc/tutorials/content/sources/iccv2011/include/surface.h
@@ -1,5 +1,4 @@
-#ifndef SURFACE_H_
-#define SURFACE_H_
+#pragma once
 
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/surface/mls.h>
@@ -126,5 +125,3 @@ marchingCubesTriangulation (const SurfaceElementsPtr & surfels, float leaf_size,
   
   return (output);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iccv2011/include/typedefs.h
+++ b/doc/tutorials/content/sources/iccv2011/include/typedefs.h
@@ -1,5 +1,4 @@
-#ifndef TYPEDEFS_H
-#define TYPEDEFS_H
+#pragma once
 
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -29,5 +28,3 @@ typedef pcl::VFHSignature308 GlobalDescriptorT;
 typedef pcl::PointCloud<GlobalDescriptorT> GlobalDescriptors;
 typedef pcl::PointCloud<GlobalDescriptorT>::Ptr GlobalDescriptorsPtr;
 typedef pcl::PointCloud<GlobalDescriptorT>::ConstPtr GlobalDescriptorsConstPtr;
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/feature_estimation.h
+++ b/doc/tutorials/content/sources/iros2011/include/feature_estimation.h
@@ -1,5 +1,4 @@
-#ifndef FEATURE_ESTIMATION_H
-#define FEATURE_ESTIMATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -108,5 +107,3 @@ computeFeatures (const PointCloudPtr & input)
 
   return (features);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/filters.h
+++ b/doc/tutorials/content/sources/iros2011/include/filters.h
@@ -1,5 +1,4 @@
-#ifndef FILTERS_H
-#define FILTERS_H
+#pragma once
 
 #include <pcl/filters/passthrough.h>
 #include <pcl/filters/voxel_grid.h>
@@ -30,5 +29,3 @@ removeOutliers (const PointCloudPtr & input, float radius, int min_neighbors)
   PointCloudPtr inliers;
   return (inliers);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/load_clouds.h
+++ b/doc/tutorials/content/sources/iros2011/include/load_clouds.h
@@ -1,5 +1,4 @@
-#ifndef IO_H_
-#define IO_H_
+#pragma once
 
 #include "typedefs.h"
 
@@ -65,6 +64,3 @@ loadGlobalDescriptors (std::string filename)
   pcl::console::print_info ("Loaded %s (%lu points)\n", filename.c_str (), output->size ());
   return (output);
 }
-
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/object_recognition.h
+++ b/doc/tutorials/content/sources/iros2011/include/object_recognition.h
@@ -1,5 +1,4 @@
-#ifndef OBJECT_RECOGNITION_H_
-#define OBJECT_RECOGNITION_H_
+#pragma once
 
 #include "typedefs.h"
 
@@ -10,7 +9,6 @@
 
 #include <pcl/io/pcd_io.h>
 #include <pcl/kdtree/kdtree_flann.h>
-
 
 struct ObjectRecognitionParameters
 {
@@ -155,5 +153,3 @@ protected:
   GlobalDescriptorsPtr descriptors_;
   pcl::KdTreeFLANN<GlobalDescriptorT>::Ptr kdtree_;
 };
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/openni_capture.h
+++ b/doc/tutorials/content/sources/iros2011/include/openni_capture.h
@@ -1,5 +1,4 @@
-#ifndef OPENNI_CAPTURE_H
-#define OPENNI_CAPTURE_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -30,5 +29,3 @@ protected:
   bool use_trigger_, trigger_;
   boost::mutex mutex_;
 };
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/registration.h
+++ b/doc/tutorials/content/sources/iros2011/include/registration.h
@@ -1,6 +1,4 @@
-#ifndef REGISTRATION_H
-#define REGISTRATION_H
-
+#pragma once
 #include "typedefs.h"
 
 #include <pcl/registration/ia_ransac.h>
@@ -61,5 +59,3 @@ refineAlignment (const PointCloudPtr & source_points, const PointCloudPtr & targ
 {
   return (Eigen::Matrix4f::Identity ());
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/segmentation.h
+++ b/doc/tutorials/content/sources/iros2011/include/segmentation.h
@@ -1,5 +1,4 @@
-#ifndef SEGMENTATION_H
-#define SEGMENTATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -64,5 +63,3 @@ clusterObjects (const PointCloudPtr & input,
                 std::vector<pcl::PointIndices> & cluster_indices_out)
 {  
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/feature_estimation.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/feature_estimation.h
@@ -1,5 +1,4 @@
-#ifndef FEATURE_ESTIMATION_H
-#define FEATURE_ESTIMATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -138,5 +137,3 @@ computeFeatures (const PointCloudPtr & input)
 
   return (features);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/filters.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/filters.h
@@ -1,5 +1,4 @@
-#ifndef FILTERS_H
-#define FILTERS_H
+#pragma once
 
 #include <pcl/filters/passthrough.h>
 #include <pcl/filters/voxel_grid.h>
@@ -60,5 +59,3 @@ applyFilters (const PointCloudPtr & input, float min_depth, float max_depth, flo
 
   return (filtered);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/object_recognition.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/object_recognition.h
@@ -1,5 +1,4 @@
-#ifndef OBJECT_RECOGNITION_H_
-#define OBJECT_RECOGNITION_H_
+#pragma once
 
 #include "typedefs.h"
 #include "load_clouds.h"
@@ -10,7 +9,6 @@
 
 #include <pcl/io/pcd_io.h>
 #include <pcl/kdtree/kdtree_flann.h>
-
 
 struct ObjectRecognitionParameters
 {
@@ -198,5 +196,3 @@ class ObjectRecognition
     GlobalDescriptorsPtr descriptors_;
     pcl::KdTreeFLANN<GlobalDescriptorT>::Ptr kdtree_;
 };
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/openni_capture.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/openni_capture.h
@@ -1,5 +1,4 @@
-#ifndef OPENNI_CAPTURE_H
-#define OPENNI_CAPTURE_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -30,5 +29,3 @@ class OpenNICapture
     bool use_trigger_, trigger_;
     boost::mutex mutex_;
 };
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/registration.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/registration.h
@@ -1,5 +1,4 @@
-#ifndef REGISTRATION_H
-#define REGISTRATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -90,5 +89,3 @@ refineAlignment (const PointCloudPtr & source_points, const PointCloudPtr & targ
 
   return (icp.getFinalTransformation () * initial_alignment);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/segmentation.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/segmentation.h
@@ -1,5 +1,4 @@
-#ifndef SEGMENTATION_H
-#define SEGMENTATION_H
+#pragma once
 
 #include "typedefs.h"
 
@@ -102,5 +101,3 @@ clusterObjects (const PointCloudPtr & input,
   ec.setInputCloud (input);
   ec.extract (cluster_indices_out);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/surface.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/surface.h
@@ -1,5 +1,4 @@
-#ifndef SURFACE_H_
-#define SURFACE_H_
+#pragma once
 
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/surface/mls.h>
@@ -126,5 +125,3 @@ marchingCubesTriangulation (const SurfaceElementsPtr & surfels, float leaf_size,
   
   return (output);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/solution/typedefs.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/typedefs.h
@@ -1,5 +1,4 @@
-#ifndef TYPEDEFS_H
-#define TYPEDEFS_H
+#pragma once
 
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -29,5 +28,3 @@ typedef pcl::VFHSignature308 GlobalDescriptorT;
 typedef pcl::PointCloud<GlobalDescriptorT> GlobalDescriptors;
 typedef pcl::PointCloud<GlobalDescriptorT>::Ptr GlobalDescriptorsPtr;
 typedef pcl::PointCloud<GlobalDescriptorT>::ConstPtr GlobalDescriptorsConstPtr;
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/surface.h
+++ b/doc/tutorials/content/sources/iros2011/include/surface.h
@@ -1,5 +1,4 @@
-#ifndef SURFACE_H_
-#define SURFACE_H_
+#pragma once
 
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/surface/mls.h>
@@ -66,5 +65,3 @@ marchingCubesTriangulation (const SurfaceElementsPtr & surfels, float leaf_size,
   pcl::PolygonMesh::Ptr output (new pcl::PolygonMesh);
   return (output);
 }
-
-#endif

--- a/doc/tutorials/content/sources/iros2011/include/typedefs.h
+++ b/doc/tutorials/content/sources/iros2011/include/typedefs.h
@@ -1,5 +1,4 @@
-#ifndef TYPEDEFS_H
-#define TYPEDEFS_H
+#pragma once
 
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -36,5 +35,3 @@ typedef pcl::VFHSignature308 GlobalDescriptorT;
 typedef pcl::PointCloud<GlobalDescriptorT> GlobalDescriptors;
 typedef pcl::PointCloud<GlobalDescriptorT>::Ptr GlobalDescriptorsPtr;
 typedef pcl::PointCloud<GlobalDescriptorT>::ConstPtr GlobalDescriptorsConstPtr;
-
-#endif

--- a/doc/tutorials/content/sources/qt_colorize_cloud/pclviewer.h
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/pclviewer.h
@@ -1,5 +1,4 @@
-#ifndef PCLVIEWER_H
-#define PCLVIEWER_H
+#pragma once
 
 // Qt
 #include <QMainWindow>
@@ -89,5 +88,3 @@ class PCLViewer : public QMainWindow
     /** @brief ui pointer */
     Ui::PCLViewer *ui;
 };
-
-#endif // PCLVIEWER_H

--- a/doc/tutorials/content/sources/qt_visualizer/pclviewer.h
+++ b/doc/tutorials/content/sources/qt_visualizer/pclviewer.h
@@ -1,5 +1,4 @@
-#ifndef PCLVIEWER_H
-#define PCLVIEWER_H
+#pragma once
 
 #include <iostream>
 
@@ -61,5 +60,3 @@ private:
   Ui::PCLViewer *ui;
 
 };
-
-#endif // PCLVIEWER_H

--- a/features/include/pcl/features/statistical_multiscale_interest_region_extraction.h
+++ b/features/include/pcl/features/statistical_multiscale_interest_region_extraction.h
@@ -37,8 +37,7 @@
  *  $Id$
  */
 
-#ifndef STATISTICAL_MULTISCALE_INTEREST_REGION_EXTRACTION_H_
-#define STATISTICAL_MULTISCALE_INTEREST_REGION_EXTRACTION_H_
+#pragma once
 
 #include <pcl/pcl_base.h>
 #include <list>
@@ -126,5 +125,3 @@ namespace pcl
 #ifdef PCL_NO_PRECOMPILE
 #include <pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp>
 #endif
-
-#endif /* STATISTICAL_MULTISCALE_INTEREST_REGION_EXTRACTION_H_ */

--- a/geometry/include/pcl/geometry/line_iterator.h
+++ b/geometry/include/pcl/geometry/line_iterator.h
@@ -33,8 +33,8 @@
  *
  */
 
-#ifndef __PCL_LINE_ITERATOR__
-#define __PCL_LINE_ITERATOR__
+#pragma once
+
 #include "organized_index_iterator.h"
 
 namespace pcl
@@ -271,5 +271,3 @@ LineIterator::reset ()
 }
 
 } // namespace pcl
-
-#endif // __PCL_LINE_ITERATOR__

--- a/geometry/include/pcl/geometry/organized_index_iterator.h
+++ b/geometry/include/pcl/geometry/organized_index_iterator.h
@@ -33,8 +33,7 @@
  *
  */
 
-#ifndef __PCL_ORGANIZED_INDEX_ITERATOR__
-#define __PCL_ORGANIZED_INDEX_ITERATOR__
+#pragma once
 
 namespace pcl
 {
@@ -149,5 +148,3 @@ pcl::OrganizedIndexIterator::getColumnIndex () const
   return index_ % width_;
 }
 } // namespace pcl
-
-#endif // __PCL_ORGANIZED_INDEX_ITERATOR__

--- a/gpu/kinfu/tools/tsdf_volume.h
+++ b/gpu/kinfu/tools/tsdf_volume.h
@@ -34,9 +34,7 @@
  *  $Id: tsdf_volume.h 6459 2012-07-18 07:50:37Z dpb $
  */
 
-
-#ifndef TSDF_VOLUME_H_
-#define TSDF_VOLUME_H_
+#pragma once
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -296,5 +294,3 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 }
-
-#endif /* TSDF_VOLUME_H_ */

--- a/gpu/kinfu_large_scale/tools/color_handler.h
+++ b/gpu/kinfu_large_scale/tools/color_handler.h
@@ -34,8 +34,7 @@
 *  Author: Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
 */
 
-#ifndef COLOR_HANDLER_H_
-#define COLOR_HANDLER_H_
+#pragma once
 
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -99,6 +98,3 @@ namespace pcl
     };
   }
 }
-
-
-#endif /* COLOR_HANDLER_H_ */

--- a/gpu/people/include/pcl/gpu/people/person_attribs.h
+++ b/gpu/people/include/pcl/gpu/people/person_attribs.h
@@ -1,5 +1,4 @@
-#ifndef PLC_GPU_PEOPLE_PERSON_ATTRIBS_H_
-#define PLC_GPU_PEOPLE_PERSON_ATTRIBS_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -46,5 +45,3 @@ namespace pcl
     }
   }
 }
-
-#endif /* PLC_GPU_PEOPLE_PERSON_ATTRIBS_H_ */

--- a/gpu/utils/include/pcl/gpu/utils/device/cutil_math.h
+++ b/gpu/utils/include/pcl/gpu/utils/device/cutil_math.h
@@ -20,8 +20,7 @@
     Thanks to Linh Hah for additions and fixes.
 */
 
-#ifndef CUTIL_MATH_H
-#define CUTIL_MATH_H
+#pragma once
 
 #include "cuda_runtime.h"
 
@@ -1324,5 +1323,3 @@ inline __device__ __host__ float4 smoothstep(float4 a, float4 b, float4 x)
 	float4 y = clamp((x - a) / (b - a), 0.0f, 1.0f);
 	return (y*y*(make_float4(3.0f) - (make_float4(2.0f)*y)));
 }
-
-#endif

--- a/io/include/pcl/compression/color_coding.h
+++ b/io/include/pcl/compression/color_coding.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef COLOR_COMPRESSION_H
-#define COLOR_COMPRESSION_H
+#pragma once
 
 #include <iterator>
 #include <iostream>
@@ -416,5 +415,3 @@ namespace pcl
 }
 
 #define PCL_INSTANTIATE_ColorCoding(T) template class PCL_EXPORTS pcl::octree::ColorCoding<T>;
-
-#endif

--- a/io/include/pcl/compression/compression_profiles.h
+++ b/io/include/pcl/compression/compression_profiles.h
@@ -34,8 +34,7 @@
  * Author: Julius Kammerl (julius@kammerl.de)
  */
 
-#ifndef OCTREE_COMPRESSION_PROFILES_H
-#define OCTREE_COMPRESSION_PROFILES_H
+#pragma once
 
 namespace pcl
 {
@@ -179,7 +178,3 @@ namespace pcl
 
   }
 }
-
-
-#endif
-

--- a/io/include/pcl/compression/entropy_range_coder.h
+++ b/io/include/pcl/compression/entropy_range_coder.h
@@ -38,8 +38,7 @@
  * Author: Julius Kammerl (julius@kammerl.de)
  */
 
-#ifndef __PCL_IO_RANGECODING__
-#define __PCL_IO_RANGECODING__
+#pragma once
 
 #include <map>
 #include <iostream>
@@ -187,6 +186,3 @@ namespace pcl
 
 
 //#include "impl/entropy_range_coder.hpp"
-
-#endif
-

--- a/io/include/pcl/compression/libpng_wrapper.h
+++ b/io/include/pcl/compression/libpng_wrapper.h
@@ -34,8 +34,7 @@
  * Author: Julius Kammerl (julius@kammerl.de)
  */
 
-#ifndef __PCL_IO_LIBPNG_WRAPPER__
-#define __PCL_IO_LIBPNG_WRAPPER__
+#pragma once
 
 #include <vector>
 #include <pcl/common/common.h>
@@ -136,7 +135,3 @@ namespace pcl
                       unsigned int& channels_arg);
   }
 }
-
-
-#endif
-

--- a/io/include/pcl/compression/octree_pointcloud_compression.h
+++ b/io/include/pcl/compression/octree_pointcloud_compression.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef OCTREE_COMPRESSION_H
-#define OCTREE_COMPRESSION_H
+#pragma once
 
 #include <pcl/common/common.h>
 #include <pcl/common/io.h>
@@ -318,7 +317,3 @@ namespace pcl
   }
 
 }
-
-
-#endif
-

--- a/io/include/pcl/compression/point_coding.h
+++ b/io/include/pcl/compression/point_coding.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef POINT_COMPRESSION_H
-#define POINT_COMPRESSION_H
+#pragma once
 
 #include <iterator>
 #include <iostream>
@@ -211,5 +210,3 @@ namespace pcl
 }
 
 #define PCL_INSTANTIATE_ColorCoding(T) template class PCL_EXPORTS pcl::octree::ColorCoding<T>;
-
-#endif

--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -35,8 +35,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _PCL_IO_BOOST_H_
-#define _PCL_IO_BOOST_H_
+#pragma once
 
 #if defined __GNUC__
 #  pragma GCC system_header 
@@ -81,5 +80,3 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #endif
-#endif    // _PCL_IO_BOOST_H_
-

--- a/io/include/pcl/io/davidsdk_grabber.h
+++ b/io/include/pcl/io/davidsdk_grabber.h
@@ -36,10 +36,9 @@
  *  Author: Victor Lamoine (victor.lamoine@gmail.com)
  */
 
-#include <pcl/pcl_config.h>
+#pragma once
 
-#ifndef __PCL_IO_DAVIDSDK_GRABBER__
-#define __PCL_IO_DAVIDSDK_GRABBER__
+#include <pcl/pcl_config.h>
 
 #include <pcl/common/time.h>
 #include <pcl/common/io.h>
@@ -265,5 +264,3 @@ namespace pcl
       processGrabbing ();
   };
 }  // namespace pcl
-
-#endif // __PCL_IO_DAVIDSDK_GRABBER__

--- a/io/include/pcl/io/eigen.h
+++ b/io/include/pcl/io/eigen.h
@@ -35,14 +35,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _PCL_IO_EIGEN_H_
-#define _PCL_IO_EIGEN_H_
+#pragma once
 
 #if defined __GNUC__
 #  pragma GCC system_header 
 #endif
 
 #include <Eigen/Core>
-
-#endif    // _PCL_IO_EIGEN_H_
-

--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -36,10 +36,9 @@
  *  Author: Victor Lamoine (victor.lamoine@gmail.com)
  */
 
-#include <pcl/pcl_config.h>
+#pragma once
 
-#ifndef __PCL_IO_ENSENSO_GRABBER__
-#define __PCL_IO_ENSENSO_GRABBER__
+#include <pcl/pcl_config.h>
 
 #include <pcl/common/time.h>
 #include <pcl/common/io.h>
@@ -490,6 +489,3 @@ namespace pcl
       processGrabbing ();
   };
 }  // namespace pcl
-
-#endif // __PCL_IO_ENSENSO_GRABBER__
-

--- a/io/include/pcl/io/fotonic_grabber.h
+++ b/io/include/pcl/io/fotonic_grabber.h
@@ -35,11 +35,10 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_FZAPI
-
-#ifndef __PCL_IO_FOTONIC_GRABBER__
-#define __PCL_IO_FOTONIC_GRABBER__
 
 #include <pcl/io/eigen.h>
 #include <pcl/io/boost.h>
@@ -156,5 +155,4 @@ namespace pcl
   };
 
 } // namespace pcl
-#endif // __PCL_IO_FOTONIC_GRABBER__
 #endif // HAVE_FOTONIC

--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -31,11 +31,10 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+ 
+#pragma once
 
 #include <pcl/pcl_config.h>
-
-#ifndef __PCL_IO_GRABBER__
-#define __PCL_IO_GRABBER__
 
 // needed for the grabber interface / observers
 #include <map>
@@ -269,5 +268,3 @@ namespace pcl
   }
 
 } // namespace
-
-#endif

--- a/io/include/pcl/io/image_grabber.h
+++ b/io/include/pcl/io/image_grabber.h
@@ -39,8 +39,6 @@
  */
 
 #pragma once
-#ifndef __PCL_IO_IMAGE_GRABBER__
-#define __PCL_IO_IMAGE_GRABBER__
 
 #include "pcl/pcl_config.h"
 #include <pcl/io/grabber.h>
@@ -315,4 +313,3 @@ namespace pcl
     signal_->operator () (cloud);
   }
 }
-#endif

--- a/io/include/pcl/io/low_level_io.h
+++ b/io/include/pcl/io/low_level_io.h
@@ -40,8 +40,7 @@
  * Implemented as inlinable functions to prevent any performance overhead.
  */
 
-#ifndef __PCL_IO_LOW_LEVEL_IO__
-#define __PCL_IO_LOW_LEVEL_IO__
+#pragma once
 
 #ifdef _WIN32
 # ifndef WIN32_LEAN_AND_MEAN
@@ -212,4 +211,3 @@ namespace pcl
 
   }
 }
-#endif // __PCL_IO_LOW_LEVEL_IO__

--- a/io/include/pcl/io/obj_io.h
+++ b/io/include/pcl/io/obj_io.h
@@ -34,8 +34,8 @@
  *
  */
 
-#ifndef OBJ_IO_H_
-#define OBJ_IO_H_
+#pragma once
+
 #include <pcl/pcl_macros.h>
 #include <pcl/TextureMesh.h>
 #include <pcl/PolygonMesh.h>
@@ -343,5 +343,3 @@ namespace pcl
 
   }
 }
-
-#endif /* OBJ_IO_H_ */

--- a/io/include/pcl/io/oni_grabber.h
+++ b/io/include/pcl/io/oni_grabber.h
@@ -35,11 +35,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __PCL_IO_ONI_PLAYER__
-#define __PCL_IO_ONI_PLAYER__
 
 #include <pcl/io/eigen.h>
 #include <pcl/io/boost.h>
@@ -204,7 +203,4 @@ namespace pcl
   };
 
 } // namespace
-
-#endif // __PCL_IO_ONI_PLAYER__
 #endif // HAVE_OPENNI
-

--- a/io/include/pcl/io/openni2/openni_shift_to_depth_conversion.h
+++ b/io/include/pcl/io/openni2/openni_shift_to_depth_conversion.h
@@ -35,11 +35,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI2
-
-#ifndef __OPENNI_SHIFT_TO_DEPTH_CONVERSION
-#define __OPENNI_SHIFT_TO_DEPTH_CONVERSION
 
 #include <vector>
 #include <limits>
@@ -119,6 +119,4 @@ namespace openni_wrapper
       bool init_;
   } ;
 }
-
 #endif
-#endif //__OPENNI_SHIFT_TO_DEPTH_CONVERSION

--- a/io/include/pcl/io/openni_camera/openni.h
+++ b/io/include/pcl/io/openni_camera/openni.h
@@ -34,11 +34,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef _PCL_OPENNI_OPENNI_H_
-#define _PCL_OPENNI_OPENNI_H_
 
 #if defined __GNUC__
 #  pragma GCC system_header 
@@ -52,4 +52,3 @@
 #include <XnVersion.h>
 
 #endif
-#endif    // _PCL_OPENNI_OPENNI_H_

--- a/io/include/pcl/io/openni_camera/openni_depth_image.h
+++ b/io/include/pcl/io/openni_camera/openni_depth_image.h
@@ -35,11 +35,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_DEPTH_IMAGE__
-#define __OPENNI_DEPTH_IMAGE__
 
 #include "openni.h"
 
@@ -226,4 +226,3 @@ namespace openni_wrapper
   }
 } // namespace
 #endif
-#endif //__OPENNI_DEPTH_IMAGE

--- a/io/include/pcl/io/openni_camera/openni_device.h
+++ b/io/include/pcl/io/openni_camera/openni_device.h
@@ -35,11 +35,11 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
 
-#ifndef __OPENNI_IDEVICE_H__
-#define __OPENNI_IDEVICE_H__
 #include <map>
 #include <vector>
 #include <utility>
@@ -610,5 +610,4 @@ namespace openni_wrapper
   }
 
 }
-#endif // __OPENNI_IDEVICE_H__
 #endif // HAVE_OPENNI

--- a/io/include/pcl/io/openni_camera/openni_device_kinect.h
+++ b/io/include/pcl/io/openni_camera/openni_device_kinect.h
@@ -34,11 +34,10 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_DEVICE_KINECT__
-#define __OPENNI_DEVICE_KINECT__
 
 #include "openni_device.h"
 #include "openni_driver.h"
@@ -86,4 +85,3 @@ namespace openni_wrapper
 } // namespace
 
 #endif
-#endif // __OPENNI_DEVICE_KINECT__

--- a/io/include/pcl/io/openni_camera/openni_device_oni.h
+++ b/io/include/pcl/io/openni_camera/openni_device_oni.h
@@ -34,11 +34,10 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_DEVICE_ONI__
-#define __OPENNI_DEVICE_ONI__
 
 #include "openni_device.h"
 #include "openni_driver.h"
@@ -107,6 +106,4 @@ namespace openni_wrapper
     bool ir_stream_running_;
   };
 } //namespace openni_wrapper
-#endif //__OPENNI_DEVICE_ONI__
 #endif //HAVE_OPENNI
-

--- a/io/include/pcl/io/openni_camera/openni_device_primesense.h
+++ b/io/include/pcl/io/openni_camera/openni_device_primesense.h
@@ -34,11 +34,10 @@
  *
  */
 
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_DEVICE_PRIMESENSE__
-#define __OPENNI_DEVICE_PRIMESENSE__
 
 #include "openni_device.h"
 #include "openni_driver.h"
@@ -70,4 +69,3 @@ protected:
 } // namespace
 
 #endif
-#endif // __OPENNI_DEVICE_PRIMESENSE__

--- a/io/include/pcl/io/openni_camera/openni_device_xtion.h
+++ b/io/include/pcl/io/openni_camera/openni_device_xtion.h
@@ -34,11 +34,10 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_DEVICE_XTION_PRO__
-#define __OPENNI_DEVICE_XTION_PRO__
 
 #include "openni_device.h"
 #include "openni_driver.h"
@@ -71,4 +70,3 @@ namespace openni_wrapper
 } // namespace
 
 #endif
-#endif // __OPENNI_DEVICE_PRIMESENSE__

--- a/io/include/pcl/io/openni_camera/openni_driver.h
+++ b/io/include/pcl/io/openni_camera/openni_driver.h
@@ -34,11 +34,11 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
 
-#ifndef OPENNI_OPENNI_H_
-#define OPENNI_OPENNI_H_
 #include <string>
 #include <vector>
 #include <map>
@@ -247,5 +247,4 @@ namespace openni_wrapper
     return static_cast<unsigned> (device_context_.size ());
   }
 } // namespace
-#endif
 #endif

--- a/io/include/pcl/io/openni_camera/openni_exception.h
+++ b/io/include/pcl/io/openni_camera/openni_exception.h
@@ -34,11 +34,10 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_EXCEPTION__
-#define __OPENNI_EXCEPTION__
 
 #include <cstdarg>
 #include <cstdio>
@@ -136,5 +135,4 @@ namespace openni_wrapper
     throw OpenNIException (function_name, file_name, line_number, msg);
   }
 } // namespace openni_camera
-#endif
 #endif

--- a/io/include/pcl/io/openni_camera/openni_image.h
+++ b/io/include/pcl/io/openni_camera/openni_image.h
@@ -33,11 +33,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_IMAGE__
-#define __OPENNI_IMAGE__
 
 #include <pcl/pcl_exports.h>
 #include "openni.h"
@@ -206,4 +206,3 @@ namespace openni_wrapper
   }
 } // namespace
 #endif
-#endif //__OPENNI_IMAGE__

--- a/io/include/pcl/io/openni_camera/openni_image_bayer_grbg.h
+++ b/io/include/pcl/io/openni_camera/openni_image_bayer_grbg.h
@@ -35,11 +35,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
 
-#ifndef __OPENNI_IMAGE_BAYER_GRBG__
-#define __OPENNI_IMAGE_BAYER_GRBG__
 #include <pcl/pcl_macros.h>
 #include "openni_image.h"
 
@@ -100,4 +101,3 @@ namespace openni_wrapper
 } // namespace
 
 #endif
-#endif // __OPENNI_IMAGE__

--- a/io/include/pcl/io/openni_camera/openni_image_rgb24.h
+++ b/io/include/pcl/io/openni_camera/openni_image_rgb24.h
@@ -33,11 +33,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
 
-#ifndef __OPENNI_IMAGE_RGB__
-#define __OPENNI_IMAGE_RGB__
 #include "openni_image.h"
 #include <pcl/pcl_macros.h>
 
@@ -77,6 +78,4 @@ namespace openni_wrapper
 
 } // namespace openni_wrapper
 
-#endif // __OPENNI_IMAGE_RGB__
 #endif // HAVE_OPENNI
-

--- a/io/include/pcl/io/openni_camera/openni_image_yuv_422.h
+++ b/io/include/pcl/io/openni_camera/openni_image_yuv_422.h
@@ -33,11 +33,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
 
-#ifndef __OPENNI_IMAGE_YUV422__
-#define __OPENNI_IMAGE_YUV422__
 #include <pcl/pcl_macros.h>
 #include "openni_image.h"
 
@@ -76,4 +77,3 @@ namespace openni_wrapper
 } // namespace
 
 #endif
-#endif // __OPENNI_IMAGE__

--- a/io/include/pcl/io/openni_camera/openni_shift_to_depth_conversion.h
+++ b/io/include/pcl/io/openni_camera/openni_shift_to_depth_conversion.h
@@ -35,11 +35,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+#pragma once
+ 
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __OPENNI_SHIFT_TO_DEPTH_CONVERSION
-#define __OPENNI_SHIFT_TO_DEPTH_CONVERSION
 
 #include <stdint.h>
 #include <vector>
@@ -122,4 +122,3 @@ namespace openni_wrapper
 }
 
 #endif
-#endif //__OPENNI_SHIFT_TO_DEPTH_CONVERSION

--- a/io/include/pcl/io/openni_grabber.h
+++ b/io/include/pcl/io/openni_grabber.h
@@ -36,11 +36,10 @@
  *
  */
 
+#pragma once
+
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
-
-#ifndef __PCL_IO_OPENNI_GRABBER__
-#define __PCL_IO_OPENNI_GRABBER__
 
 #include <pcl/io/eigen.h>
 #include <pcl/io/boost.h>
@@ -503,5 +502,4 @@ namespace pcl
   }
 
 } // namespace pcl
-#endif // __PCL_IO_OPENNI_GRABBER__
 #endif // HAVE_OPENNI

--- a/io/include/pcl/io/ply/ply.h
+++ b/io/include/pcl/io/ply/ply.h
@@ -38,8 +38,7 @@
  *
  */
 
-#ifndef PLY_PLY_H
-#define PLY_PLY_H
+#pragma once
 
 #include <pcl/io/boost.h>
 #include <pcl/io/ply/byte_order.h>
@@ -100,4 +99,3 @@ namespace pcl
     } // namespace ply
   } // namespace io
 } // namespace pcl
-#endif // PCL_IO_PLY_PLY_H

--- a/ml/include/pcl/ml/dt/decision_tree_data_provider.h
+++ b/ml/include/pcl/ml/dt/decision_tree_data_provider.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef DECISION_TREE_DATA_PROVIDER_H_
-#define DECISION_TREE_DATA_PROVIDER_H_
+#pragma once
 
 #include <pcl/common/common.h>
 
@@ -70,5 +69,3 @@ namespace pcl
       getDatasetAndLabels(DataSet & data_set, std::vector<LabelType> & label_data, std::vector<ExampleIndex> & examples) = 0;
   };
 }
-
-#endif /* DECISION_TREE_DATA_PROVIDER_H_ */

--- a/ml/include/pcl/ml/svm.h
+++ b/ml/include/pcl/ml/svm.h
@@ -36,9 +36,7 @@
   *
   */
 
-
-#ifndef _LIBSVM_H_
-#define _LIBSVM_H_
+#pragma once
 
 #define LIBSVM_VERSION 311
 
@@ -161,5 +159,3 @@ extern "C"
 }
 
 #endif
-
-#endif /* _LIBSVM_H_ */

--- a/outofcore/include/pcl/outofcore/cJSON.h
+++ b/outofcore/include/pcl/outofcore/cJSON.h
@@ -20,8 +20,7 @@
   THE SOFTWARE.
 */
 
-#ifndef cJSON__h
-#define cJSON__h
+#pragma once
 
 #include <pcl/pcl_macros.h>
 
@@ -131,6 +130,4 @@ PCLAPI(void) cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *n
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/outofcore/include/pcl/outofcore/outofcore.h
+++ b/outofcore/include/pcl/outofcore/outofcore.h
@@ -37,8 +37,7 @@
  *  $Id$
  */
 
-#ifndef OUTOFCORE_H_
-#define OUTOFCORE_H_
+#pragma once
 
 #include <pcl/outofcore/octree_base.h>
 #include <pcl/outofcore/outofcore_base_data.h>
@@ -54,5 +53,3 @@
 #include <pcl/outofcore/outofcore_iterator_base.h>
 #include <pcl/outofcore/outofcore_breadth_first_iterator.h>
 #include <pcl/outofcore/outofcore_depth_first_iterator.h>
-
-#endif // OUTOFCORE_H_

--- a/outofcore/include/pcl/outofcore/outofcore_impl.h
+++ b/outofcore/include/pcl/outofcore/outofcore_impl.h
@@ -37,8 +37,7 @@
  *  $Id$
  */
 
-#ifndef OUTOFCORE_IMPL_H_
-#define OUTOFCORE_IMPL_H_
+#pragma once
 
 #include <pcl/outofcore/outofcore.h>
 
@@ -49,6 +48,3 @@
 
 #include <pcl/outofcore/impl/octree_disk_container.hpp>
 #include <pcl/outofcore/impl/octree_ram_container.hpp>
-
-
-#endif //OUTOFCORE_IMPL_H_

--- a/recognition/include/pcl/recognition/crh_alignment.h
+++ b/recognition/include/pcl/recognition/crh_alignment.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef CRH_ALIGNMENT_H_
-#define CRH_ALIGNMENT_H_
+#pragma once
 
 #include <pcl/common/common.h>
 #include <pcl/features/crh.h>
@@ -271,5 +270,3 @@ namespace pcl
       }
     };
 }
-
-#endif /* CRH_ALIGNMENT_H_ */

--- a/recognition/include/pcl/recognition/face_detection/face_common.h
+++ b/recognition/include/pcl/recognition/face_detection/face_common.h
@@ -1,5 +1,4 @@
-#ifndef FACE_DETECTOR_COMMON_H_
-#define FACE_DETECTOR_COMMON_H_
+#pragma once
 
 #include <pcl/features/integral_image2D.h>
 #include <Eigen/Core>
@@ -163,4 +162,3 @@ namespace pcl
     };
   }
 }
-#endif /* FACE_DETECTOR_COMMON_H_ */

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef FACE_DETECTOR_DATA_PROVIDER_H_
-#define FACE_DETECTOR_DATA_PROVIDER_H_
+#pragma once
 
 #include "pcl/common/common.h"
 #include "pcl/recognition/face_detection/face_common.h"
@@ -176,5 +175,3 @@ namespace pcl
     };
   }
 }
-
-#endif /* FACE_DETECTOR_DATA_PROVIDER_H_ */

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -5,8 +5,7 @@
  *      Author: aitor
  */
 
-#ifndef GO_H_
-#define GO_H_
+#pragma once
 
 #include <pcl/pcl_macros.h>
 #include <pcl/recognition/hv/hypotheses_verification.h>
@@ -493,5 +492,3 @@ namespace pcl
 #ifdef PCL_NO_PRECOMPILE
 #include <pcl/recognition/impl/hv/hv_go.hpp>
 #endif
-
-#endif /* GO_H_ */

--- a/recognition/include/pcl/recognition/ransac_based/orr_octree_zprojection.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_octree_zprojection.h
@@ -43,13 +43,11 @@
  *      Author: papazov
  */
 
-#ifndef ORR_OCTREE_ZPROJECTION_H_
-#define ORR_OCTREE_ZPROJECTION_H_
+#pragma once
 
 #include "orr_octree.h"
 #include <pcl/pcl_exports.h>
 #include <set>
-
 
 namespace pcl
 {
@@ -211,6 +209,3 @@ namespace pcl
     };
   } // namespace recognition
 } // namespace pcl
-
-
-#endif /* ORR_OCTREE_ZPROJECTION_H_ */

--- a/recognition/include/pcl/recognition/ransac_based/simple_octree.h
+++ b/recognition/include/pcl/recognition/ransac_based/simple_octree.h
@@ -43,8 +43,7 @@
  *      Author: papazov
  */
 
-#ifndef SIMPLE_OCTREE_H_
-#define SIMPLE_OCTREE_H_
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <set>
@@ -207,5 +206,3 @@ namespace pcl
 } // namespace pcl
 
 #include <pcl/recognition/impl/ransac_based/simple_octree.hpp>
-
-#endif /* SIMPLE_OCTREE_H_ */

--- a/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
+++ b/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
@@ -44,8 +44,7 @@
  *      Author: papazov
  */
 
-#ifndef TRIMMED_ICP_H_
-#define TRIMMED_ICP_H_
+#pragma once
 
 #include <pcl/registration/transformation_estimation_svd.h>
 #include <pcl/kdtree/kdtree_flann.h>
@@ -182,6 +181,3 @@ namespace pcl
     };
   } // namespace recognition
 } // namespace pcl
-
-
-#endif /* TRIMMED_ICP_H_ */

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -37,8 +37,8 @@
  * $Id$
  *
  */
-#ifndef IA_RANSAC_H_
-#define IA_RANSAC_H_
+
+#pragma once
 
 #include <pcl/registration/registration.h>
 #include <pcl/registration/transformation_estimation_svd.h>
@@ -277,5 +277,3 @@ namespace pcl
 }
 
 #include <pcl/registration/impl/ia_ransac.hpp>
-
-#endif  //#ifndef IA_RANSAC_H_

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_annotation2.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_annotation2.h
@@ -14,8 +14,7 @@
 ////////////////////////////////////////////////////////////////
 */
 
-#ifndef OPENNURBS_ANNOTATION2_H_INC
-#define OPENNURBS_ANNOTATION2_H_INC
+#pragma once
 
 #if defined(ON_OS_WINDOWS_GDI)
 
@@ -2338,9 +2337,3 @@ public:
   ON_wString m_fontface;
   int m_display;       // some future display flags - 
 };
-
-
-
-#endif
-
-

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_hatch.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_hatch.h
@@ -14,8 +14,7 @@
 ////////////////////////////////////////////////////////////////
 */
 
-#ifndef OPENNURBS_HATCH_H_INCLUDED
-#define OPENNURBS_HATCH_H_INCLUDED
+#pragma once
 
 /*
   class ON_HatchLoop
@@ -829,5 +828,3 @@ protected:
   class ON_HatchExtra* HatchExtension();
 
 };
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/closing_boundary.h
+++ b/surface/include/pcl/surface/on_nurbs/closing_boundary.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef CLOSING_BOUNDARY_H
-#define CLOSING_BOUNDARY_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/nurbs_data.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -141,5 +140,3 @@ namespace pcl
 
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_2D_H
-#define NURBS_FITTING_CURVE_2D_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -229,5 +228,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_apdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_apdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_2D_APDM_H
-#define NURBS_FITTING_CURVE_2D_APDM_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -240,5 +239,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_asdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_asdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_2D_ASDM_H
-#define NURBS_FITTING_CURVE_2D_ASDM_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -112,5 +111,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_atdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_atdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_2D_ATDM_H
-#define NURBS_FITTING_CURVE_2D_ATDM_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
 #include <pcl/surface/on_nurbs/nurbs_data.h>
@@ -109,5 +108,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_pdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_2D_PDM_H
-#define NURBS_FITTING_CURVE_2D_PDM_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -243,5 +242,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_sdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_sdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_2D_SDM_H
-#define NURBS_FITTING_CURVE_2D_SDM_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -104,5 +103,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_tdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_tdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_2D_TDM_H
-#define NURBS_FITTING_CURVE_2D_TDM_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -105,5 +104,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_pdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CURVE_PDM_H
-#define NURBS_FITTING_CURVE_PDM_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -189,5 +188,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_cylinder_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_cylinder_pdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_CYLINDER_H
-#define NURBS_FITTING_CYLINDER_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -212,5 +211,3 @@ namespace pcl
 
   }
 }
-
-#endif /* NURBS_FITTING_CYLINDER_H */

--- a/surface/include/pcl/surface/on_nurbs/fitting_sphere_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_sphere_pdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_SPHERE_H
-#define NURBS_FITTING_SPHERE_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
 #include <pcl/surface/on_nurbs/nurbs_data.h>
@@ -190,5 +189,3 @@ namespace pcl
 
   }
 }
-
-#endif /* NURBS_FITTING_SPHERE_H */

--- a/surface/include/pcl/surface/on_nurbs/fitting_surface_im.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_surface_im.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_SURFACE_IM_H
-#define NURBS_FITTING_SURFACE_IM_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
 #include <pcl/surface/on_nurbs/nurbs_data.h>
@@ -172,5 +171,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/fitting_surface_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_surface_pdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_PATCH_H
-#define NURBS_FITTING_PATCH_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
@@ -312,5 +311,3 @@ namespace pcl
 
   } // namespace on_nurbs
 } // namespace pcl
-
-#endif    // PATCHFITTING_H_

--- a/surface/include/pcl/surface/on_nurbs/fitting_surface_tdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_surface_tdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_FITTING_PATCH_TDM_H
-#define NURBS_FITTING_PATCH_TDM_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/fitting_surface_pdm.h>
 
@@ -134,5 +133,3 @@ namespace pcl
 
   }
 }
-
-#endif /* NURBS_FITTING_PATCH_TDM_H */

--- a/surface/include/pcl/surface/on_nurbs/global_optimization_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/global_optimization_pdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_OPTIMIZATION_H
-#define NURBS_OPTIMIZATION_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/nurbs_tools.h>
 #include <pcl/surface/on_nurbs/nurbs_data.h>
@@ -207,5 +206,3 @@ namespace pcl
 
   }
 }
-#endif
-

--- a/surface/include/pcl/surface/on_nurbs/global_optimization_tdm.h
+++ b/surface/include/pcl/surface/on_nurbs/global_optimization_tdm.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_OPTIMIZATION_TDM_H
-#define NURBS_OPTIMIZATION_TDM_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/global_optimization_pdm.h>
 
@@ -184,5 +183,3 @@ namespace pcl
 
   }
 }
-#endif
-

--- a/surface/include/pcl/surface/on_nurbs/nurbs_data.h
+++ b/surface/include/pcl/surface/on_nurbs/nurbs_data.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_DATA_H
-#define NURBS_DATA_H
+#pragma once
 
 #include <vector>
 #include <list>
@@ -209,6 +208,3 @@ namespace pcl
 
   }
 }
-
-#endif
-

--- a/surface/include/pcl/surface/on_nurbs/nurbs_solve.h
+++ b/surface/include/pcl/surface/on_nurbs/nurbs_solve.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef _NURBS_SOLVE_H_
-#define _NURBS_SOLVE_H_
+#pragma once
 
 #undef Success
 #include <Eigen/Dense>
@@ -135,5 +134,3 @@ namespace pcl
 
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/nurbs_tools.h
+++ b/surface/include/pcl/surface/on_nurbs/nurbs_tools.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_TOOLS_H
-#define NURBS_TOOLS_H
+#pragma once
 
 #include <pcl/surface/on_nurbs/nurbs_data.h>
 
@@ -147,5 +146,3 @@ namespace pcl
 
   }
 }
-
-#endif /* NTOOLS_H_ */

--- a/surface/include/pcl/surface/on_nurbs/sequential_fitter.h
+++ b/surface/include/pcl/surface/on_nurbs/sequential_fitter.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef SEQUENTIAL_FITTER_H
-#define SEQUENTIAL_FITTER_H
+#pragma once
 
 //#include <opencv2/core/core.hpp>
 //#include "v4r/TomGine/tgTomGine.h"
@@ -224,5 +223,3 @@ namespace pcl
 
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/on_nurbs/sparse_mat.h
+++ b/surface/include/pcl/surface/on_nurbs/sparse_mat.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef SPARSE_MAT_H
-#define SPARSE_MAT_H
+#pragma once
 
 #include <vector>
 #include <map>
@@ -109,5 +108,3 @@ namespace pcl
 
   }
 }
-
-#endif /* SPARSEMAT_H_ */

--- a/surface/include/pcl/surface/on_nurbs/triangulation.h
+++ b/surface/include/pcl/surface/on_nurbs/triangulation.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef NURBS_TRIANGULATION_H
-#define NURBS_TRIANGULATION_H
+#pragma once
 
 #include <pcl/pcl_exports.h>
 #include <pcl/point_cloud.h>
@@ -125,5 +124,3 @@ namespace pcl
     };
   }
 }
-
-#endif

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_quadric_decimation.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_quadric_decimation.h
@@ -36,8 +36,7 @@
  *
  */
 
-#ifndef VTK_MESH_QUADRIC_DECIMATION_H_
-#define VTK_MESH_QUADRIC_DECIMATION_H_
+#pragma once
 
 #include <pcl/surface/processing.h>
 #include <pcl/surface/vtk_smoothing/vtk.h>
@@ -81,4 +80,3 @@ namespace pcl
       vtkSmartPointer<vtkPolyData> vtk_polygons_;
   };
 }
-#endif /* VTK_MESH_QUADRIC_DECIMATION_H_ */

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_laplacian.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_laplacian.h
@@ -36,8 +36,7 @@
  *
  */
 
-#ifndef VTK_MESH_SMOOTHING_LAPLACIAN_H_
-#define VTK_MESH_SMOOTHING_LAPLACIAN_H_
+#pragma once
 
 #include <pcl/surface/processing.h>
 #include <pcl/surface/vtk_smoothing/vtk.h>
@@ -197,4 +196,3 @@ namespace pcl
       bool boundary_smoothing_;
   };
 }
-#endif /* VTK_MESH_SMOOTHING_LAPLACIAN_H_ */

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_windowed_sinc.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_windowed_sinc.h
@@ -36,8 +36,7 @@
  *
  */
 
-#ifndef VTK_MESH_SMOOTHING_WINDOWED_SINC_H_
-#define VTK_MESH_SMOOTHING_WINDOWED_SINC_H_
+#pragma once
 
 #include <pcl/surface/processing.h>
 #include <pcl/surface/vtk_smoothing/vtk.h>
@@ -196,4 +195,3 @@ namespace pcl
       bool normalize_coordinates_;
   };
 }
-#endif /* VTK_MESH_SMOOTHING_WINDOWED_SINC_H_ */

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_subdivision.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_subdivision.h
@@ -36,8 +36,7 @@
  *
  */
 
-#ifndef VTK_MESH_SUBDIVISION_H_
-#define VTK_MESH_SUBDIVISION_H_
+#pragma once
 
 #include <pcl/surface/processing.h>
 #include <pcl/surface/vtk_smoothing/vtk.h>
@@ -85,4 +84,3 @@ namespace pcl
       vtkSmartPointer<vtkPolyData> vtk_polygons_;
   };
 }
-#endif /* VTK_MESH_SUBDIVISION_H_ */

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_utils.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_utils.h
@@ -36,8 +36,7 @@
  *
  */
 
-#ifndef VTK_UTILS_H_
-#define VTK_UTILS_H_
+#pragma once
 
 #include <pcl/pcl_macros.h>
 #include <pcl/PolygonMesh.h>
@@ -79,5 +78,3 @@ namespace pcl
       mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyData> &poly_data);
   };
 }
-
-#endif /* VTK_UTILS_H_ */

--- a/test/registration/test_fpcs_ia_data.h
+++ b/test/registration/test_fpcs_ia_data.h
@@ -1,5 +1,4 @@
-#ifndef TEST_FPCS_DATA_H_
-#define TEST_FPCS_DATA_H_
+#pragma once
 
 const int nr_threads = 1;
 const float approx_overlap = 0.9f;
@@ -12,5 +11,3 @@ const float transform_from_fpcs [4][4] = {
   { -0.0139f, 0.5627f, 0.8265f, 0.0521f },
   { 0.f, 0.f, 0.f, 1.f }
 };
-
-#endif // TEST_FPCS_DATA_H_

--- a/test/registration/test_kfpcs_ia_data.h
+++ b/test/registration/test_kfpcs_ia_data.h
@@ -1,5 +1,4 @@
-#ifndef TEST_KFPCS_DATA_H_
-#define TEST_KFPCS_DATA_H_
+#pragma once
 
 const int nr_threads = 1;
 const float voxel_size = 0.1f;
@@ -12,5 +11,3 @@ const float transformation_office1_office2 [4][4] = {
   {  0.0037f, -0.0106f,  0.9999f,  0.7778f },
   {  0.0000f,  0.0000f,  0.0000f,  1.0000f }
 };
-
-#endif // TEST_KFPCS_DATA_H_

--- a/test/registration/test_registration_api_data.h
+++ b/test/registration/test_registration_api_data.h
@@ -1,6 +1,4 @@
-#ifndef REGISTRATION_API_DATA_H_
-
-#define REGISTRATION_API_DATA_H_
+#pragma once
 
 const int nr_original_correspondences = 397;
 const int correspondences_original[397][2] = {
@@ -1145,5 +1143,3 @@ const float transform_from_SAC[4][4] = {
 //  { 0.228091f, -0.107699f, 0.967665f, 0.0183277f },
 //  { 0.0f, 0.0f, 0.0f, 1.0f }
 //};
-
-#endif /* REGISTRATION_API_DATA_H_ */

--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
@@ -24,8 +24,7 @@
 // float and then uploaded.
 // DON'T PLAY WITH IT YET.
 
-#ifndef __vtkVertexBufferObject_h
-#define __vtkVertexBufferObject_h
+#pragma once
 
 #include <vector>
 
@@ -213,7 +212,3 @@ private:
   int GetDataTypeSize(int type);
   //ETX
 };
-
-#endif
-
-

--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
@@ -19,8 +19,7 @@
 // device-specific poly data mappers, that actually do the mapping to the
 // rendering/graphics hardware/software.
 
-#ifndef __vtkVertexBufferObjectMapper_h
-#define __vtkVertexBufferObjectMapper_h
+#pragma once
 
 #include <pcl/pcl_exports.h>
 
@@ -133,5 +132,3 @@ private:
   vtkVertexBufferObjectMapper(const vtkVertexBufferObjectMapper&);  // Not implemented.
   void operator=(const vtkVertexBufferObjectMapper&);  // Not implemented.
 };
-
-#endif


### PR DESCRIPTION
Continues #429/#2617. Last time I searched for `#include PCL`, now I searched just for `#ifndef`. I just skipped `3rdparty` directory (opennurbs/poisson4), because I'm not sure how you handle 3rdParty libraries.

There could be a compile issue, because some macros were multiple times used:
https://github.com/PointCloudLibrary/pcl/blob/5cef903b3be806105cfa9f8600e8bda9d3650a6b/doc/tutorials/content/sources/iros2011/include/object_recognition.h#L1-L2
https://github.com/PointCloudLibrary/pcl/blob/5cef903b3be806105cfa9f8600e8bda9d3650a6b/doc/tutorials/content/sources/iros2011/include/solution/object_recognition.h#L1-L2

https://github.com/PointCloudLibrary/pcl/blob/5cef903b3be806105cfa9f8600e8bda9d3650a6b/doc/tutorials/content/sources/iros2011/include/surface.h#L1-L2
https://github.com/PointCloudLibrary/pcl/blob/5cef903b3be806105cfa9f8600e8bda9d3650a6b/doc/tutorials/content/sources/iros2011/include/solution/surface.h#L1-L2

I didn't checked if we can remove solution directory or not, because it seems to be just a copy of parent directory.