### PR TITLE
Fix MSVC compile issues in CloudComposer

### DIFF
--- a/apps/cloud_composer/CMakeLists.txt
+++ b/apps/cloud_composer/CMakeLists.txt
@@ -1,6 +1,6 @@
 #Disable some warnings which are all over Qt headers and make finding error messages hell
 #if(${CMAKE_CXX_FLAGS} MATCHES "-Wconversion")
-#  string(REGEX REPLACE "-Wconversion(.+)" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+#    string(REGEX REPLACE "-Wconversion(.+)" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 #endif()
 
 set(SUBSUBSYS_NAME cloud_composer)
@@ -46,70 +46,95 @@ PCL_SUBSUBSYS_DEPEND(build "${SUBSYS_NAME}" "${SUBSUBSYS_NAME}" DEPS ${SUBSUBSYS
 PCL_ADD_DOC(${SUBSUBSYS_NAME})
 
 if(build)
-
     include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
+    #Create subdirectory for plugin libs
+    set(CLOUD_COMPOSER_PLUGIN_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cloud_composer_plugins")
+    make_directory("${CLOUD_COMPOSER_PLUGIN_DIR}")
+
+    set(INTERFACE_HEADERS
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/commands.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/properties_model.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/cloud_composer_item.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/cloud_item.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/fpfh_item.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/normals_item.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/click_trackball_interactor_style.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/interactor_style_switch.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/manipulation_event.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/rectangular_frustum_selector.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/selected_trackball_interactor_style.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/selection_event.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tool_interface/abstract_tool.h"
+    )
+
+    set(INTERFACE_SOURCES
+      src/commands.cpp
+      src/properties_model.cpp
+      src/items/cloud_composer_item.cpp
+      src/items/cloud_item.cpp
+      src/items/fpfh_item.cpp
+      src/items/normals_item.cpp
+      src/point_selectors/click_trackball_interactor_style.cpp
+      src/point_selectors/interactor_style_switch.cpp
+      src/point_selectors/manipulation_event.cpp
+      src/point_selectors/rectangular_frustum_selector.cpp
+      src/point_selectors/selected_trackball_interactor_style.cpp
+      src/point_selectors/selection_event.cpp
+      src/tool_interface/abstract_tool.cpp
+    )
+
+    # Build pcl_cc_tool_interface as static library, to fix issue mentioned in #2708
+    set(PCL_LIB_TYPE_ORIGIN ${PCL_LIB_TYPE})
+    set(PCL_LIB_TYPE STATIC)
+    QT4_WRAP_CPP(INTERFACE_HEADERS_MOC ${INTERFACE_HEADERS} OPTIONS -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED -DBOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
+    PCL_ADD_LIBRARY(pcl_cc_tool_interface "${SUBSUBSYS_NAME}" ${INTERFACE_HEADERS} ${INTERFACE_SOURCES} ${INTERFACE_HEADERS_MOC})
+    target_link_libraries(pcl_cc_tool_interface pcl_common pcl_filters pcl_search pcl_visualization ${VTK_LIBRARIES} ${QT_LIBRARIES})
+    set(PCL_LIB_TYPE ${PCL_LIB_TYPE_ORIGIN})
+
+    if(APPLE)
+      set_target_properties(pcl_cc_tool_interface PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
+
     #Sources & Headers for main application
-    set(incs "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/qt.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_composer.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/project_model.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_viewer.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_view.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_browser.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/item_inspector.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tool_interface/abstract_tool.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tool_interface/tool_factory.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/commands.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/work_queue.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/toolbox_model.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/properties_model.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/signal_multiplexer.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/merge_selection.h"
-             "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/transform_clouds.h")
+    set(incs
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_browser.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_composer.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_view.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/cloud_viewer.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/item_inspector.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/merge_selection.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/project_model.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/properties_model.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/qt.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/signal_multiplexer.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/toolbox_model.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/transform_clouds.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/work_queue.h"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tool_interface/tool_factory.h"
+    )
 
-    set(srcs src/main.cpp
-             src/cloud_composer.cpp
-             src/project_model.cpp
-             src/cloud_viewer.cpp
-             src/cloud_view.cpp
-             src/item_inspector.cpp
-             src/cloud_browser.cpp
-             src/commands.cpp
-             src/work_queue.cpp
-             src/toolbox_model.cpp
-             src/properties_model.cpp
-             src/signal_multiplexer.cpp
-             src/merge_selection.cpp
-             src/tool_interface/abstract_tool.cpp
-             src/transform_clouds.cpp)
+    set(srcs
+      src/cloud_browser.cpp
+      src/cloud_composer.cpp
+      src/cloud_view.cpp
+      src/cloud_viewer.cpp
+      src/item_inspector.cpp
+      src/main.cpp
+      src/merge_selection.cpp
+      src/project_model.cpp
+      src/properties_model.cpp
+      src/signal_multiplexer.cpp  
+      src/toolbox_model.cpp
+      src/transform_clouds.cpp
+      src/work_queue.cpp
+    )
 
-    set(impl_incs "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/impl/cloud_item.hpp"
-                  "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/impl/merge_selection.hpp"
-                  "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/impl/transform_clouds.hpp")
-
-    #Sources and headers for item types
-    set(item_incs "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/cloud_composer_item.h"
-                  "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/cloud_item.h"
-                  "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/normals_item.h"
-                  "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/items/fpfh_item.h")
-
-    set(item_srcs src/items/cloud_composer_item.cpp
-                  src/items/cloud_item.cpp
-                  src/items/normals_item.cpp
-                  src/items/fpfh_item.cpp)
-
-    #Sources and headers for point selectors
-    set(selector_incs "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/interactor_style_switch.h"
-                       "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/rectangular_frustum_selector.h"
-                       "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/selected_trackball_interactor_style.h"
-                       "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/point_selectors/click_trackball_interactor_style.h")
-
-    set(selector_srcs src/point_selectors/interactor_style_switch.cpp
-                       src/point_selectors/selection_event.cpp
-                       src/point_selectors/rectangular_frustum_selector.cpp
-                       src/point_selectors/selected_trackball_interactor_style.cpp
-                       src/point_selectors/click_trackball_interactor_style.cpp
-                       src/point_selectors/manipulation_event.cpp)
+    set(impl_incs
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/impl/cloud_item.hpp"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/impl/merge_selection.hpp"
+      "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/impl/transform_clouds.hpp"
+    )
 
     set(uis src/cloud_composer_main_window.ui)
     set(resources resources/resources.qrc)
@@ -119,8 +144,8 @@ if(build)
     QT4_ADD_RESOURCES(resource_srcs ${resources})
 
     set(EXE_NAME "pcl_${SUBSUBSYS_NAME}")
-    PCL_ADD_EXECUTABLE("${EXE_NAME}" "${SUBSUBSYS_NAME}" ${cloud_composer_ui} ${cloud_composer_moc} ${srcs} ${resource_srcs} ${item_srcs} ${selector_srcs} ${impl_incs})
-    target_link_libraries("${EXE_NAME}" pcl_common pcl_io pcl_visualization pcl_filters ${QVTK_LIBRARY} ${QT_LIBRARIES})
+    PCL_ADD_EXECUTABLE("${EXE_NAME}" "${SUBSUBSYS_NAME}" ${cloud_composer_ui} ${cloud_composer_moc} ${srcs} ${resource_srcs} ${impl_incs})
+    target_link_libraries("${EXE_NAME}" pcl_cc_tool_interface pcl_common pcl_io pcl_visualization pcl_filters ${QVTK_LIBRARY} ${QT_LIBRARIES})
 
     # Install include files
     PCL_ADD_INCLUDES("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}" ${incs} ${item_incs} ${selector_incs})
@@ -130,21 +155,6 @@ if(build)
 
 
     #TOOL buildING SCRIPTS
-    #Create subdirectory for plugin libs
-    set(CLOUD_COMPOSER_PLUGIN_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cloud_composer_plugins")
-    make_directory("${CLOUD_COMPOSER_PLUGIN_DIR}")
-
-    set(INTERFACE_HEADERS "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tool_interface/abstract_tool.h")
-    set(INTERFACE_SOURCES src/tool_interface/abstract_tool.cpp)
-
-    QT4_WRAP_CPP(INTERFACE_HEADERS_MOC ${INTERFACE_HEADERS} OPTIONS -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED -DBOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
-    PCL_ADD_LIBRARY(pcl_cc_tool_interface "${SUBSUBSYS_NAME}" ${INTERFACE_SOURCES} ${INTERFACE_HEADERS_MOC})
-    target_link_libraries(pcl_cc_tool_interface pcl_common ${QT_LIBRARIES})
-
-    if(APPLE)
-       SET_TARGET_PROPERTIES(pcl_cc_tool_interface PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-    endif()
-
     include(ComposerTool.cmake REQUIRED)
 
     #FPFH Tool
@@ -177,19 +187,19 @@ if(build)
     set(VOXDS_HEADERS "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tools/voxel_grid_downsample.h")
     define_composer_tool (voxel_grid_downsample "${VOXDS_SOURCES}" "${VOXDS_HEADERS}" "${VOXDS_DEPS}")
 
-     #Organized Segmentation
+    #Organized Segmentation
     set(OSEG_DEPS pcl_segmentation pcl_kdtree)
     set(OSEG_SOURCES tools/organized_segmentation.cpp "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tools/impl/organized_segmentation.hpp")
     set(OSEG_HEADERS "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tools/organized_segmentation.h")
     define_composer_tool (organized_segmentation "${OSEG_SOURCES}" "${OSEG_HEADERS}" "${OSEG_DEPS}")
 
-        #Sanitize Cloud Tool
+    #Sanitize Cloud Tool
     set(SAN_DEPS pcl_filters)
     set(SAN_SOURCES tools/sanitize_cloud.cpp)
     set(SAN_HEADERS "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tools/sanitize_cloud.h")
     define_composer_tool (sanitize_cloud "${SAN_SOURCES}" "${SAN_HEADERS}" "${SAN_DEPS}")
 
-     #Supervoxels
+    #Supervoxels
     set(VSP_DEPS pcl_octree pcl_segmentation)
     set(VSP_SOURCES tools/supervoxels.cpp "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tools/impl/supervoxels.hpp")
     set(VSP_HEADERS "include/pcl/${SUBSYS_NAME}/${SUBSUBSYS_NAME}/tools/supervoxels.h")

--- a/apps/cloud_composer/ComposerTool.cmake
+++ b/apps/cloud_composer/ComposerTool.cmake
@@ -19,11 +19,10 @@ function(define_composer_tool TOOL_NAME TOOL_SOURCES TOOL_HEADERS DEPS)
   add_definitions(-DQT_NO_DEBUG)
   add_definitions(-DQT_SHARED)
 
-  add_dependencies(${TOOL_TARGET} pcl_cc_tool_interface ${DEPS})
   target_link_libraries(${TOOL_TARGET} pcl_cc_tool_interface pcl_common pcl_io ${DEPS} ${QT_LIBRARIES})
 
   if(APPLE)
-    SET_TARGET_PROPERTIES(${TOOL_TARGET} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    set_target_properties(${TOOL_TARGET} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
   endif()
 
-endfunction(define_composer_tool TOOL_NAME TOOL_SOURCES TOOL_HEADERS DEPS)
+endfunction()

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
@@ -39,7 +39,6 @@
 #define COMMANDS_H_
 
 #include <pcl/apps/cloud_composer/qt.h>
-#include <pcl/pcl_exports.h>
 #include <pcl/apps/cloud_composer/items/cloud_item.h>
 
 namespace pcl
@@ -56,7 +55,7 @@ namespace pcl
 
 
     
-    class PCL_EXPORTS CloudCommand : public QUndoCommand
+    class CloudCommand : public QUndoCommand
     {
       public: 
         CloudCommand (ConstItemList input_data, QUndoCommand* parent = 0);
@@ -119,7 +118,7 @@ namespace pcl
         int template_type_;
     };
     
-    class PCL_EXPORTS ModifyItemCommand : public CloudCommand
+    class ModifyItemCommand : public CloudCommand
     {
       public: 
         ModifyItemCommand (ConstItemList input_data, QUndoCommand* parent = 0);
@@ -138,7 +137,7 @@ namespace pcl
       
     };
     
-    class PCL_EXPORTS NewItemCloudCommand : public CloudCommand
+    class NewItemCloudCommand : public CloudCommand
     {
       public: 
         NewItemCloudCommand (ConstItemList input_data, QUndoCommand* parent = 0);
@@ -155,7 +154,7 @@ namespace pcl
     };
     
 
-    class PCL_EXPORTS SplitCloudCommand : public CloudCommand
+    class SplitCloudCommand : public CloudCommand
     {
       public: 
         SplitCloudCommand (ConstItemList input_data, QUndoCommand* parent = 0);
@@ -172,7 +171,7 @@ namespace pcl
 
     };  
     
-    class PCL_EXPORTS DeleteItemCommand : public CloudCommand
+    class DeleteItemCommand : public CloudCommand
     {
       public: 
         DeleteItemCommand (ConstItemList input_data, QUndoCommand* parent = 0);
@@ -188,7 +187,7 @@ namespace pcl
       private:
     };
     
-    class PCL_EXPORTS MergeCloudCommand : public CloudCommand
+    class MergeCloudCommand : public CloudCommand
     {
       public: 
         /** \brief Construct for a merge command

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/cloud_item.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/cloud_item.hpp
@@ -76,8 +76,8 @@ pcl::cloud_composer::CloudItem::createCloudItemFromTemplate (const QString name,
 }
 
 
-#define PCL_INSTANTIATE_createCloudItemFromTemplate(T) template PCL_EXPORTS pcl::cloud_composer::CloudItem* pcl::cloud_composer::CloudItem::createCloudItemFromTemplate<T>(const QString, typename PointCloud<PointT>::Ptr);
+#define PCL_INSTANTIATE_createCloudItemFromTemplate(T) template pcl::cloud_composer::CloudItem* pcl::cloud_composer::CloudItem::createCloudItemFromTemplate<T>(const QString, typename PointCloud<PointT>::Ptr);
 
-#define PCL_INSTANTIATE_printNumPoints(T) template PCL_EXPORTS void pcl::cloud_composer::CloudItem::getNumPoints<T>();
+#define PCL_INSTANTIATE_printNumPoints(T) template void pcl::cloud_composer::CloudItem::getNumPoints<T>();
 
 #endif

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/merge_selection.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/merge_selection.hpp
@@ -111,7 +111,7 @@ pcl::cloud_composer::MergeSelection::performTemplatedAction (QList <const CloudC
 }
 
 
-#define PCL_INSTANTIATE_performTemplatedAction(T) template PCL_EXPORTS void pcl::cloud_composer::MergeSelection::performTemplatedAction<T> (QList <const CloudComposerItem*>);
+#define PCL_INSTANTIATE_performTemplatedAction(T) template void pcl::cloud_composer::MergeSelection::performTemplatedAction<T> (QList <const CloudComposerItem*>);
 
 
 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/transform_clouds.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/transform_clouds.hpp
@@ -91,7 +91,7 @@ pcl::cloud_composer::TransformClouds::performTemplatedAction (QList <const Cloud
 }
 
 
-#define PCL_INSTANTIATE_performTemplatedAction(T) template PCL_EXPORTS void pcl::cloud_composer::TransformClouds::performTemplatedAction<T> (QList <const CloudComposerItem*>);
+#define PCL_INSTANTIATE_performTemplatedAction(T) template void pcl::cloud_composer::TransformClouds::performTemplatedAction<T> (QList <const CloudComposerItem*>);
 
 
 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
@@ -74,7 +74,7 @@ namespace pcl
         KD_TREE_SEARCH
       };
     };
-    class PCL_EXPORTS CloudComposerItem : public QStandardItem
+    class CloudComposerItem : public QStandardItem
     {
       public:  
         

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
@@ -63,7 +63,7 @@ namespace pcl
         AXIS = (1 << 5), 
       };
     }
-    class PCL_EXPORTS CloudItem : public CloudComposerItem
+    class CloudItem : public CloudComposerItem
     {
       public:
         

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/normals_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/normals_item.h
@@ -38,7 +38,6 @@
 #ifndef NORMALS_ITEM_H_
 #define NORMALS_ITEM_H_
 
-#include <pcl/pcl_exports.h>
 #include <pcl/point_types.h>
 #include <pcl/features/normal_3d.h>
 
@@ -49,7 +48,7 @@ namespace pcl
   namespace cloud_composer
   {
     
-    class PCL_EXPORTS NormalsItem : public CloudComposerItem
+    class NormalsItem : public CloudComposerItem
     {
       public:
 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/click_trackball_interactor_style.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/click_trackball_interactor_style.h
@@ -49,7 +49,7 @@ namespace pcl
   namespace cloud_composer
   {
       
-    class PCL_EXPORTS ClickTrackballStyleInteractor : public vtkInteractorStyleTrackballActor
+    class ClickTrackballStyleInteractor : public vtkInteractorStyleTrackballActor
     {     
       public:
         static ClickTrackballStyleInteractor* New();

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h
@@ -78,7 +78,7 @@ namespace pcl
     class ClickTrackballStyleInteractor;
     class ProjectModel;
     
-    class PCL_EXPORTS InteractorStyleSwitch : public vtkInteractorStyle 
+    class InteractorStyleSwitch : public vtkInteractorStyle 
     {
       public:
         static InteractorStyleSwitch *New();

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/manipulation_event.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/manipulation_event.h
@@ -48,7 +48,7 @@ namespace pcl
   {
       
     
-    class PCL_EXPORTS ManipulationEvent
+    class ManipulationEvent
     {
       
       public:

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/rectangular_frustum_selector.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/rectangular_frustum_selector.h
@@ -49,7 +49,7 @@ namespace pcl
   namespace cloud_composer
   {
       
-    class PCL_EXPORTS RectangularFrustumSelector : public vtkInteractorStyleRubberBandPick
+    class RectangularFrustumSelector : public vtkInteractorStyleRubberBandPick
     {     
       public:
         static RectangularFrustumSelector* New();

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selected_trackball_interactor_style.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selected_trackball_interactor_style.h
@@ -49,7 +49,7 @@ namespace pcl
   namespace cloud_composer
   {
       
-    class PCL_EXPORTS SelectedTrackballStyleInteractor : public vtkInteractorStyleTrackballActor
+    class SelectedTrackballStyleInteractor : public vtkInteractorStyleTrackballActor
     {     
       public:
         static SelectedTrackballStyleInteractor* New();

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selection_event.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selection_event.h
@@ -48,7 +48,7 @@ namespace pcl
   {
     class RectangularFrustumSelector;  
     
-    class PCL_EXPORTS SelectionEvent
+    class SelectionEvent
     {
       
       public:

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
@@ -41,7 +41,6 @@
 #include <pcl/apps/cloud_composer/qt.h>
 #include <pcl/common/boost.h> 
 
-
 namespace pcl
 {
   namespace cloud_composer

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -175,7 +175,7 @@
  }
  
  
- #define PCL_INSTANTIATE_performTemplatedAction(T) template PCL_EXPORTS void pcl::cloud_composer::OrganizedSegmentationTool::performTemplatedAction<T> (QList <const CloudComposerItem*>);
+ #define PCL_INSTANTIATE_performTemplatedAction(T) template void pcl::cloud_composer::OrganizedSegmentationTool::performTemplatedAction<T> (QList <const CloudComposerItem*>);
  
  
  

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/supervoxels.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/supervoxels.hpp
@@ -115,7 +115,7 @@ pcl::cloud_composer::SupervoxelsTool::performTemplatedAction (QList <const Cloud
 
 
 
-#define PCL_INSTANTIATE_performTemplatedAction(T) template PCL_EXPORTS void pcl::cloud_composer::SupervoxelsTool::performTemplatedAction<T> (QList <const CloudComposerItem*>);
+#define PCL_INSTANTIATE_performTemplatedAction(T) template void pcl::cloud_composer::SupervoxelsTool::performTemplatedAction<T> (QList <const CloudComposerItem*>);
 
 
 


### PR DESCRIPTION
Fix MSVC compile issues in CloudComposer. This required to build pcl_cc_tool_interface as static library, because current PCL_EXPORTS macro doesn't work with classes using Q_OBJECT (see #2708).

cloud_composer is now using pcl_cc_tool_interface to prevent some cpps need to be compiled for both.