### PR TITLE
Remove unnecessary VTK_INCLUDE_DIRECTORIES.

### DIFF
--- a/2d/CMakeLists.txt
+++ b/2d/CMakeLists.txt
@@ -33,7 +33,7 @@ if(build)
         set(VTK_IO_TARGET_LINK_LIBRARIES vtkCommon vtkWidgets vtkIO vtkImaging)
     endif()
 
-    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" ${VTK_INCLUDE_DIRECTORIES})
+    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 
     set(LIB_NAME "pcl_${SUBSYS_NAME}")
     PCL_MAKE_PKGCONFIG_HEADER_ONLY("${LIB_NAME}" "${SUBSYS_NAME}" "${SUBSYS_DESC}" "${SUBSYS_DEPS}" "" "" "" "")

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -329,7 +329,7 @@ if(build)
 
     add_definitions(${VTK_DEFINES})
     PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${incs} ${compression_incs} ${impl_incs} ${OPENNI_INCLUDES} ${OPENNI2_INCLUDES})
-    target_include_directories(${LIB_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" ${VTK_INCLUDE_DIRECTORIES})
+    target_include_directories(${LIB_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
     link_directories(${VTK_LINK_DIRECTORIES})
     target_link_libraries("${LIB_NAME}" pcl_common pcl_io_ply ${VTK_LIBRARIES})
     if(PNG_FOUND)


### PR DESCRIPTION
Since VTK 6 there are imported targets (as far as I read), so it explicit includes are not necessary anymore.