### PR TITLE
Fix Qt5 CMake issue

### DIFF
--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -28,7 +28,6 @@ jobs:
             -DQt5Concurrent_DIR=/usr/local/opt/qt5/lib/cmake/Qt5Concurrent \
             -DQt5OpenGL_DIR=/usr/local/opt/qt5/lib/cmake/Qt5OpenGL \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
-            -DPCL_QT_VERSION=5 \
             -DBUILD_simulation=ON \
             -DBUILD_surface_on_nurbs=ON \
             -DBUILD_global_tests=ON \

--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -22,11 +22,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
             -DGTEST_SRC_DIR="$GOOGLE_TEST_DIR/googletest" \
             -DGTEST_INCLUDE_DIR="$GOOGLE_TEST_DIR/googletest/include" \
-            -DQt5Core_DIR=/usr/local/opt/qt5/lib/cmake/Qt5Core \
-            -DQt5Gui_DIR=/usr/local/opt/qt5/lib/cmake/Qt5Gui \
-            -DQt5Widgets_DIR=/usr/local/opt/qt5/lib/cmake/Qt5Widgets \
-            -DQt5Concurrent_DIR=/usr/local/opt/qt5/lib/cmake/Qt5Concurrent \
-            -DQt5OpenGL_DIR=/usr/local/opt/qt5/lib/cmake/Qt5OpenGL \
+            -DQt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5 \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
             -DBUILD_simulation=ON \
             -DBUILD_surface_on_nurbs=ON \

--- a/.ci/azure-pipelines/build-ubuntu.yml
+++ b/.ci/azure-pipelines/build-ubuntu.yml
@@ -19,7 +19,6 @@ jobs:
           cmake $(Build.SourcesDirectory) \
             -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
-            -DPCL_QT_VERSION=5 \
             -DBUILD_simulation=ON \
             -DBUILD_surface_on_nurbs=ON \
             -DBUILD_global_tests=ON \

--- a/.ci/azure-pipelines/tutorials.yml
+++ b/.ci/azure-pipelines/tutorials.yml
@@ -23,7 +23,6 @@ jobs:
             -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
             -DPCL_NO_PRECOMPILE=ON \
-            -DPCL_QT_VERSION=5 \
             -DBUILD_surface_on_nurbs=ON \
             -DBUILD_global_tests=OFF \
             -DBUILD_tools=OFF \

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -75,7 +75,7 @@ if(build)
     PCL_ADD_EXECUTABLE(pcl_stereo_ground_segmentation "${SUBSYS_NAME}" src/stereo_ground_segmentation.cpp)
     target_link_libraries(pcl_stereo_ground_segmentation pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_features pcl_stereo)
 
-    if(QT5_FOUND AND VTK_USE_QVTK)
+    if(Qt5_FOUND AND VTK_USE_QVTK)
 
       # Manual registration demo
       QT5_WRAP_UI(manual_registration_ui src/manual_registration/manual_registration.ui)
@@ -149,7 +149,7 @@ if(build)
       PCL_ADD_EXECUTABLE_OPT_BUNDLE(pcl_openni_face_detector "${SUBSYS_NAME}" src/face_detection//openni_face_detection.cpp src/face_detection//openni_frame_source.cpp)
       target_link_libraries(pcl_openni_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree ${VTK_LIBRARIES})
 
-      if(QT5_FOUND AND VTK_USE_QVTK)
+      if(Qt5_FOUND AND VTK_USE_QVTK)
         # OpenNI Passthrough application demo
         QT5_WRAP_UI(openni_passthrough_ui src/openni_passthrough.ui)
         QT5_WRAP_CPP(openni_passthrough_moc include/pcl/apps/openni_passthrough.h OPTIONS -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED -DBOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)

--- a/apps/cloud_composer/CMakeLists.txt
+++ b/apps/cloud_composer/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # QT5 Found?
-if(NOT QT5_FOUND)
+if(NOT Qt5_FOUND)
   set(DEFAULT AUTO_OFF)
   set(REASON "Qt5 was not found.")
 elseif(NOT ${DEFAULT} STREQUAL "AUTO_OFF")

--- a/apps/in_hand_scanner/CMakeLists.txt
+++ b/apps/in_hand_scanner/CMakeLists.txt
@@ -116,7 +116,7 @@ if(build)
 
   set(EXE_NAME "pcl_${SUBSUBSYS_NAME}")
   pcl_add_executable_opt_bundle("${EXE_NAME}" "${SUBSUBSYS_NAME}" ${SRCS} ${INCS} ${IMPL_INCS})
-  target_link_libraries("${EXE_NAME}" ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt5::Widgets)
+  target_link_libraries("${EXE_NAME}" ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt5::Widgets Qt5::OpenGL)
 
   pcl_add_includes("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}" ${INCS})
   pcl_add_includes("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}/impl" ${IMPL_INCS})
@@ -128,7 +128,7 @@ if(build)
   list(APPEND OI_SRCS "${MOC_OPENGL_VIEWER_SRC}" "${MOC_OFFLINE_INTEGRATION_SRC}")
 
   pcl_add_executable_opt_bundle(pcl_offline_integration "${SUBSUBSYS_NAME}" ${OI_SRCS} ${OI_INCS})
-  target_link_libraries(pcl_offline_integration ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt5::Widgets)
+  target_link_libraries(pcl_offline_integration ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt5::Widgets Qt5::OpenGL)
 
   # Add to the compound apps target
   list(APPEND PCL_APPS_ALL_TARGETS ${PCL_IN_HAND_SCANNER_ALL_TARGETS})

--- a/apps/in_hand_scanner/CMakeLists.txt
+++ b/apps/in_hand_scanner/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SUBSUBSYS_LIBS pcl_common pcl_features pcl_io pcl_kdtree)
 
 ################################################################################
 # QT5 Found?
-if(NOT QT5_FOUND)
+if(NOT Qt5_FOUND)
   set(DEFAULT AUTO_OFF)
   set(REASON "Qt5 was not found.")
 elseif(NOT ${DEFAULT} STREQUAL "AUTO_OFF")

--- a/apps/modeler/CMakeLists.txt
+++ b/apps/modeler/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
 endif()
 
 # QT5 Found?
-if(NOT QT5_FOUND)
+if(NOT Qt5_FOUND)
   set(DEFAULT AUTO_OFF)
   set(REASON "Qt5 was not found.")
 elseif(NOT ${DEFAULT} STREQUAL "AUTO_OFF")

--- a/apps/optronic_viewer/CMakeLists.txt
+++ b/apps/optronic_viewer/CMakeLists.txt
@@ -17,7 +17,7 @@ elseif(NOT VTK_USE_QVTK)
 endif()
 
 # QT5 Found?
-if(NOT QT5_FOUND)
+if(NOT Qt5_FOUND)
   set(DEFAULT AUTO_OFF)
   set(REASON "Qt5 was not found.")
 elseif(NOT ${DEFAULT} STREQUAL "AUTO_OFF")

--- a/apps/point_cloud_editor/CMakeLists.txt
+++ b/apps/point_cloud_editor/CMakeLists.txt
@@ -57,7 +57,7 @@ set(SRCS src/main.cpp
   )
 
 # QT5 Found?
-if(NOT QT5_FOUND)
+if(NOT Qt5_FOUND)
   set(DEFAULT AUTO_OFF)
   set(REASON "Qt5 was not found.")
 elseif(NOT ${DEFAULT} STREQUAL "AUTO_OFF")


### PR DESCRIPTION
Fix: Qt5 was treated as not found, even it was found
Change: Remove PCL_QT_VERSION from Azure pipelines