### PR TITLE
Fix possible integer overflow while iterating Point Cloud fields

### DIFF
--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -1405,7 +1405,7 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
   //   pters[3] = &only_valid_data[offset_of_plane_RGB];
   //
   std::vector<char*> pters (fields.size ());
-  int toff = 0;
+  size_t toff = 0;
   for (size_t i = 0; i < pters.size (); ++i)
   {
     pters[i] = &only_valid_data[toff];

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -602,7 +602,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
 
     // Unpack the xxyyzz to xyz
     std::vector<char*> pters (fields.size ());
-    int toff = 0;
+    size_t toff = 0;
     for (size_t i = 0; i < pters.size (); ++i)
     {
       pters[i] = &buf[toff];

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -142,15 +142,15 @@ pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2>::getColo
   unsigned char* colors = new unsigned char[nr_points * 3];
 
   pcl::RGB rgb_data;
-  int point_offset = cloud_->fields[field_idx_].offset;
-  int j = 0;
+  size_t point_offset = cloud_->fields[field_idx_].offset;
+  size_t j = 0;
   
   // If XYZ present, check if the points are invalid
   int x_idx = pcl::getFieldIndex (*cloud_, "x");
   if (x_idx != -1)
   {
     float x_data, y_data, z_data;
-    int x_point_offset = cloud_->fields[x_idx].offset;
+    size_t x_point_offset = cloud_->fields[x_idx].offset;
     
     // Color every point
     for (vtkIdType cp = 0; cp < nr_points; ++cp, 


### PR DESCRIPTION
This caused a segfault on a cloud of 2Gb, which should not overflow uint32's.