### PR TITLE
Add cloexec option to fopen

### DIFF
--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -3087,7 +3087,7 @@ static const char *kernel_type_table[] =
 
 int svm_save_model (const char *model_file_name, const svm_model *model)
 {
-  FILE *fp = fopen (model_file_name, "w");
+  FILE *fp = fopen (model_file_name, "we");
 
   if (fp == NULL)
     return -1;
@@ -3233,7 +3233,7 @@ static char* readline (FILE *input)
 
 svm_model *svm_load_model (const char *model_file_name)
 {
-  FILE *fp = fopen (model_file_name, "rb");
+  FILE *fp = fopen (model_file_name, "rbe");
 
   if (fp == NULL)
     return NULL;

--- a/ml/src/svm_wrapper.cpp
+++ b/ml/src/svm_wrapper.cpp
@@ -294,7 +294,7 @@ bool
 pcl::SVM::loadProblem (const char *filename, svm_problem &prob)
 {
   int elements, max_index, inst_max_index, i, j;
-  FILE *fp = fopen (filename, "r");
+  FILE *fp = fopen (filename, "re");
   svm_node *x_space_;
   char *endptr;
   char *idx, *val, *label;

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -205,7 +205,7 @@ namespace pcl
 
         PointT temp;
         //open our file
-        FILE* f = fopen (disk_storage_filename_->c_str (), "rb");
+        FILE* f = fopen (disk_storage_filename_->c_str (), "rbe");
         assert (f != NULL);
 
         //seek the right length; 
@@ -331,7 +331,7 @@ namespace pcl
         }
         std::sort (offsets.begin (), offsets.end ());
 
-        FILE* f = fopen (disk_storage_filename_->c_str (), "rb");
+        FILE* f = fopen (disk_storage_filename_->c_str (), "rbe");
         assert (f != NULL);
         PointT p;
         char* loc = reinterpret_cast<char*> (&p);
@@ -430,7 +430,7 @@ namespace pcl
         }
         std::sort (offsets.begin (), offsets.end ());
 
-        FILE* f = fopen (disk_storage_filename_->c_str (), "rb");
+        FILE* f = fopen (disk_storage_filename_->c_str (), "rbe");
         assert (f != NULL);
         PointT p;
         char* loc = reinterpret_cast<char*> (&p);

--- a/outofcore/include/pcl/outofcore/impl/octree_ram_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_ram_container.hpp
@@ -62,7 +62,7 @@ namespace pcl
     {
       if (!container_.empty ())
       {
-        FILE* fxyz = fopen (path.string ().c_str (), "w");
+        FILE* fxyz = fopen (path.string ().c_str (), "we");
 
         boost::uint64_t num = size ();
         for (boost::uint64_t i = 0; i < num; i++)

--- a/outofcore/include/pcl/outofcore/octree_disk_container.h
+++ b/outofcore/include/pcl/outofcore/octree_disk_container.h
@@ -221,9 +221,9 @@ namespace pcl
         {
           if (boost::filesystem::exists (*disk_storage_filename_))
           {
-            FILE* fxyz = fopen (path.string ().c_str (), "w");
+            FILE* fxyz = fopen (path.string ().c_str (), "we");
 
-            FILE* f = fopen (disk_storage_filename_->c_str (), "rb");
+            FILE* f = fopen (disk_storage_filename_->c_str (), "rbe");
             assert (f != NULL);
 
             uint64_t num = size ();

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -87,7 +87,7 @@ template <typename PointXYZT, typename PointRGBT> bool
 pcl::LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name, const size_t object_id)
 {
   // Open the file
-  int ltm_fd = pcl_open (file_name.c_str (), O_RDONLY);
+  int ltm_fd = pcl_open (file_name.c_str (), O_RDONLY | O_CLOEXEC);
   if (ltm_fd == -1)
     return (false);
   


### PR DESCRIPTION
Changes are done by: run-clang-tidy -header-filter='.' -checks='-,android-*' -fix

Closes #2748.