### PR TITLE
Remove redundant string initialization with ""

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
@@ -262,7 +262,7 @@ namespace pcl
 
           //get models in directory
           std::vector < std::string > files;
-          std::string start = "";
+          std::string start;
           std::string ext = std::string ("ply");
           bf::path dir = path_;
           getModelsInDirectory (dir, start, files, ext);

--- a/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
+++ b/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
@@ -100,7 +100,7 @@ template<template<class > class DistT, typename PointT, typename FeatureT>
     //read mians scenes
     bf::path ply_files_dir = scenes_dir;
     std::vector < std::string > files;
-    std::string start = "";
+    std::string start;
     getScenesInDirectory (ply_files_dir, start, files);
 
     std::sort (files.begin (), files.end (), sortFiles);
@@ -314,10 +314,10 @@ float CG_THRESHOLD_ = 0.005f;
 int
 main (int argc, char ** argv)
 {
-  std::string path = "";
+  std::string path;
   std::string desc_name = "shot_omp";
   std::string training_dir = "trained_models/";
-  std::string mians_scenes = "";
+  std::string mians_scenes;
   int force_retrain = 0;
   int icp_iterations = 20;
   int use_cache = 1;
@@ -366,7 +366,7 @@ main (int argc, char ** argv)
   else
   {
     std::vector < std::string > files;
-    std::string start = "";
+    std::string start;
     std::string ext = std::string ("ply");
     bf::path dir = models_dir_path;
     getModelsInDirectory (dir, start, files, ext);

--- a/apps/point_cloud_editor/src/statistics.cpp
+++ b/apps/point_cloud_editor/src/statistics.cpp
@@ -44,7 +44,7 @@ std::vector<Statistics*> Statistics::stat_vec_;
 std::string
 Statistics::getStats()
 {
-  std::string result = "";
+  std::string result;
   std::vector<Statistics*>::const_iterator stat_vec_it;
   for(stat_vec_it = stat_vec_.begin(); stat_vec_it != stat_vec_.end(); ++stat_vec_it)
   {

--- a/apps/src/face_detection/face_trainer.cpp
+++ b/apps/src/face_detection/face_trainer.cpp
@@ -13,7 +13,7 @@ int main(int argc, char ** argv)
   int ntrees = 10;
   std::string forest_fn = "forest.txt";
   int n_features = 1000;
-  std::string directory = "";
+  std::string directory;
   int use_normals = 0;
   int num_images = 3000;
 

--- a/apps/src/face_detection/filesystem_face_detection.cpp
+++ b/apps/src/face_detection/filesystem_face_detection.cpp
@@ -217,7 +217,7 @@ int main(int argc, char ** argv)
   if (test_directory.compare ("") != 0)
   {
     //recognize all files in directory...
-    std::string start = "";
+    std::string start;
     std::string ext = std::string ("pcd");
     bf::path dir = test_directory;
 

--- a/apps/src/openni_klt.cpp
+++ b/apps/src/openni_klt.cpp
@@ -317,7 +317,7 @@ boost::shared_ptr<pcl::visualization::ImageViewer> img;
 int
 main (int argc, char** argv)
 {
-  std::string device_id("");
+  std::string device_id;
   pcl::OpenNIGrabber::Mode depth_mode = pcl::OpenNIGrabber::OpenNI_Default_Mode;
   pcl::OpenNIGrabber::Mode image_mode = pcl::OpenNIGrabber::OpenNI_Default_Mode;
   bool xyz = false;

--- a/apps/src/openni_mobile_server.cpp
+++ b/apps/src/openni_mobile_server.cpp
@@ -247,7 +247,7 @@ main (int argc, char ** argv)
 
   int port = 11111;
   float leaf_x = 0.01f, leaf_y = 0.01f, leaf_z = 0.01f;
-  std::string device_id = "";
+  std::string device_id;
 
   pcl::console::parse_argument (argc, argv, "-port", port);
   pcl::console::parse_3x_arguments (argc, argv, "-leaf", leaf_x, leaf_y, leaf_z, false);

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -211,7 +211,7 @@ CPCSegmentation Parameters: \n\
   bool save_binary_pcd = pcl::console::find_switch (argc, argv, "-bin");
 
   /// Create variables needed for preparations
-  std::string outputname ("");
+  std::string outputname;
   pcl::PointCloud<PointT>::Ptr input_cloud_ptr (new pcl::PointCloud<PointT>);
   pcl::PointCloud<pcl::Normal>::Ptr input_normals_ptr (new pcl::PointCloud<pcl::Normal>);
   bool has_normals = false;

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -182,7 +182,7 @@ LCCPSegmentation Parameters: \n\
   bool save_binary_pcd = pcl::console::find_switch (argc, argv, "-bin");
   
   /// Create variables needed for preparations
-  std::string outputname ("");
+  std::string outputname;
   pcl::PointCloud<PointT>::Ptr input_cloud_ptr (new pcl::PointCloud<PointT>);
   pcl::PointCloud<pcl::Normal>::Ptr input_normals_ptr (new pcl::PointCloud<pcl::Normal>);
   bool has_normals = false;

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -378,7 +378,7 @@ main (int argc, char** argv)
 {
   print_highlight ("PCL OpenNI Recorder for saving buffered PCD (binary compressed to disk). See %s -h for options.\n", argv[0]);
 
-  std::string device_id ("");
+  std::string device_id;
   int buff_size = BUFFER_SIZE;
 
   if (argc >= 2)

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -45,7 +45,7 @@ namespace pcl
 template<class FeatureType, class DataSet, class LabelType, class ExampleIndex, class NodeType>
 void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::initialize(std::string & data_dir)
 {
-  std::string start = "";
+  std::string start;
   std::string ext = std::string ("pcd");
   bf::path dir = data_dir;
 

--- a/tools/openni_save_image.cpp
+++ b/tools/openni_save_image.cpp
@@ -228,7 +228,7 @@ usage (char ** argv)
 int
 main(int argc, char ** argv)
 {
-  std::string device_id ("");
+  std::string device_id;
   pcl::OpenNIGrabber::Mode image_mode = pcl::OpenNIGrabber::OpenNI_Default_Mode;
   pcl::OpenNIGrabber::Mode depth_mode = pcl::OpenNIGrabber::OpenNI_Default_Mode;
   

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -4512,7 +4512,7 @@ pcl::visualization::PCLVisualizer::textureFromTexMaterial (const pcl::TexMateria
     boost::filesystem::path parent_dir = full_path.parent_path ();
     std::string upper_filename = tex_mat.tex_file;
     boost::to_upper (upper_filename);
-    std::string real_name = "";
+    std::string real_name;
 
     try
     {

--- a/visualization/tools/image_grabber_saver.cpp
+++ b/visualization/tools/image_grabber_saver.cpp
@@ -104,10 +104,10 @@ main (int argc, char** argv)
   float focal_length = 525.0;
   pcl::console::parse (argc, argv, "-focal", focal_length);
 
-  std::string depth_path = "";
+  std::string depth_path;
   pcl::console::parse_argument (argc, argv, "-depth_dir", depth_path);
 
-  std::string rgb_path = "";
+  std::string rgb_path;
   pcl::console::parse_argument (argc, argv, "-rgb_dir", rgb_path);
 
   pcl::console::parse_argument (argc, argv, "-out_dir", out_folder);

--- a/visualization/tools/image_grabber_viewer.cpp
+++ b/visualization/tools/image_grabber_viewer.cpp
@@ -190,7 +190,7 @@ main (int argc, char** argv)
   bool use_pclzf = (pcl::console::find_argument (argc, argv, "-pclzf") != -1);
 
   std::cout << "fps: " << frames_per_second << " , repeat: " << repeat << std::endl;
-  std::string path = "";
+  std::string path;
   pcl::console::parse_argument (argc, argv, "-dir", path);
   std::cout << "path: " << path << std::endl;
   if (path != "" && boost::filesystem::exists (path))

--- a/visualization/tools/oni_viewer_simple.cpp
+++ b/visualization/tools/oni_viewer_simple.cpp
@@ -158,7 +158,7 @@ usage(char ** argv)
 int
 main(int argc, char ** argv)
 {
-  std::string arg("");
+  std::string arg;
 
   unsigned frame_rate = 0;
   if (argc >= 2)

--- a/visualization/tools/openni2_viewer.cpp
+++ b/visualization/tools/openni2_viewer.cpp
@@ -291,7 +291,7 @@ boost::shared_ptr<pcl::visualization::ImageViewer> img;
 int
 main (int argc, char** argv)
 {
-  std::string device_id ("");
+  std::string device_id;
   pcl::io::OpenNI2Grabber::Mode depth_mode = pcl::io::OpenNI2Grabber::OpenNI_Default_Mode;
   pcl::io::OpenNI2Grabber::Mode image_mode = pcl::io::OpenNI2Grabber::OpenNI_Default_Mode;
   bool xyz = false;

--- a/visualization/tools/openni_image.cpp
+++ b/visualization/tools/openni_image.cpp
@@ -675,7 +675,7 @@ main (int argc, char ** argv)
   else
     print_highlight ("Using default buffer size of %d frames.\n", buff_size);
 
-  string device_id ("");
+  string device_id;
   OpenNIGrabber::Mode image_mode = OpenNIGrabber::OpenNI_Default_Mode;
   OpenNIGrabber::Mode depth_mode = OpenNIGrabber::OpenNI_Default_Mode;
   

--- a/visualization/tools/openni_viewer.cpp
+++ b/visualization/tools/openni_viewer.cpp
@@ -278,7 +278,7 @@ boost::shared_ptr<pcl::visualization::ImageViewer> img;
 int
 main (int argc, char** argv)
 {
-  std::string device_id("");
+  std::string device_id;
   pcl::OpenNIGrabber::Mode depth_mode = pcl::OpenNIGrabber::OpenNI_Default_Mode;
   pcl::OpenNIGrabber::Mode image_mode = pcl::OpenNIGrabber::OpenNI_Default_Mode;
   bool xyz = false;

--- a/visualization/tools/pcd_grabber_viewer.cpp
+++ b/visualization/tools/pcd_grabber_viewer.cpp
@@ -172,7 +172,7 @@ main (int argc, char** argv)
   bool repeat = (pcl::console::find_argument (argc, argv, "-repeat") != -1);
 
   std::cout << "fps: " << frames_per_second << " , repeat: " << repeat << std::endl;
-  std::string path = "";
+  std::string path;
   pcl::console::parse_argument (argc, argv, "-file", path);
   std::cout << "path: " << path << std::endl;
   if (path != "" && boost::filesystem::exists (path))


### PR DESCRIPTION
Changes are done by: run-clang-tidy -header-filter='.' -checks='-,readability-redundant-string-init' -fix