### PR TITLE
Fix warning: 'register' storage class specifier is deprecated

### DIFF
--- a/filters/include/pcl/filters/impl/box_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/box_clipper3D.hpp
@@ -202,7 +202,7 @@ pcl::BoxClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& clou
   if (indices.empty ())
   {
     clipped.reserve (cloud_in.size ());
-    for (register unsigned pIdx = 0; pIdx < cloud_in.size (); ++pIdx)
+    for (unsigned pIdx = 0; pIdx < cloud_in.size (); ++pIdx)
       if (clipPoint3D (cloud_in[pIdx]))
         clipped.push_back (pIdx);
   }

--- a/filters/include/pcl/filters/impl/plane_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/plane_clipper3D.hpp
@@ -186,14 +186,14 @@ pcl::PlaneClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& cl
 #if 0
     Eigen::MatrixXf points = cloud_in.getMatrixXfMap (4, sizeof (PointT) / sizeof (float), offsetof(PointT,x) / sizeof (float));
     Eigen::VectorXf distances = plane_params_.transpose () * points;
-    for (register unsigned rIdx = 0; rIdx < cloud_in.size (); ++ rIdx)
+    for (unsigned rIdx = 0; rIdx < cloud_in.size (); ++ rIdx)
     {
       if (distances (rIdx, 0) >= -plane_params_[3])
         clipped.push_back (rIdx);
     }
 #else
     Eigen::Matrix4Xf points (4, cloud_in.size ());
-    for (register unsigned rIdx = 0; rIdx < cloud_in.size (); ++ rIdx)
+    for (unsigned rIdx = 0; rIdx < cloud_in.size (); ++ rIdx)
     {
       points (0, rIdx) = cloud_in[rIdx].x;
       points (1, rIdx) = cloud_in[rIdx].y;
@@ -201,7 +201,7 @@ pcl::PlaneClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& cl
       points (3, rIdx) = 1;
     }
     Eigen::VectorXf distances = plane_params_.transpose () * points;
-    for (register unsigned rIdx = 0; rIdx < cloud_in.size (); ++ rIdx)
+    for (unsigned rIdx = 0; rIdx < cloud_in.size (); ++ rIdx)
     {
       if (distances (rIdx, 0) >= 0)
         clipped.push_back (rIdx);
@@ -213,7 +213,7 @@ pcl::PlaneClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& cl
 
     //cout << "distances: " << distances.rows () << " x " << distances.cols () << endl;
     /*/
-    for (register unsigned pIdx = 0; pIdx < cloud_in.size (); ++pIdx)
+    for (unsigned pIdx = 0; pIdx < cloud_in.size (); ++pIdx)
       if (clipPoint3D (cloud_in[pIdx]))
         clipped.push_back (pIdx);
     //*/

--- a/io/src/oni_grabber.cpp
+++ b/io/src/oni_grabber.cpp
@@ -351,20 +351,20 @@ ONIGrabber::convertToXYZPointCloud(const boost::shared_ptr<openni_wrapper::Depth
 
   cloud->points.resize (cloud->height * cloud->width);
 
-  register float constant = 1.0f / device_->getDepthFocalLength (depth_width_);
+  float constant = 1.0f / device_->getDepthFocalLength (depth_width_);
 
   if (device_->isDepthRegistered ())
     cloud->header.frame_id = rgb_frame_id_;
   else
     cloud->header.frame_id = depth_frame_id_;
 
-  register int centerX = (cloud->width >> 1);
+  int centerX = (cloud->width >> 1);
   int centerY = (cloud->height >> 1);
 
   float bad_point = std::numeric_limits<float>::quiet_NaN ();
 
   // we have to use Data, since operator[] uses assert -> Debug-mode very slow!
-  register const unsigned short* depth_map = depth_image->getDepthMetaData ().Data ();
+  const unsigned short* depth_map = depth_image->getDepthMetaData ().Data ();
   if (depth_image->getWidth () != depth_width_ || depth_image->getHeight () != depth_height_)
   {
     static unsigned buffer_size = 0;
@@ -379,10 +379,10 @@ ONIGrabber::convertToXYZPointCloud(const boost::shared_ptr<openni_wrapper::Depth
     depth_map = depth_buffer.get ();
   }
 
-  register int depth_idx = 0;
+  int depth_idx = 0;
   for (int v = -centerY; v < centerY; ++v)
   {
-    for (register int u = -centerX; u < centerX; ++u, ++depth_idx)
+    for (int u = -centerX; u < centerX; ++u, ++depth_idx)
     {
       pcl::PointXYZ& pt = cloud->points[depth_idx];
       // Check for invalid measurements
@@ -421,10 +421,10 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr ONIGrabber::convertToXYZRGBPointCloud (
   cloud->points.resize(cloud->height * cloud->width);
 
   float constant = 1.0f / device_->getImageFocalLength(cloud->width);
-  register int centerX = (cloud->width >> 1);
+  int centerX = (cloud->width >> 1);
   int centerY = (cloud->height >> 1);
 
-  register const XnDepthPixel* depth_map = depth_image->getDepthMetaData().Data();
+  const XnDepthPixel* depth_map = depth_image->getDepthMetaData().Data();
   if (depth_image->getWidth() != depth_width_ || depth_image->getHeight() != depth_height_)
   {
     static unsigned buffer_size = 0;
@@ -450,7 +450,7 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr ONIGrabber::convertToXYZRGBPointCloud (
   image->fillRGB(image_width_, image_height_, rgb_buffer, image_width_ * 3);
 
   // depth_image already has the desired dimensions, but rgb_msg may be higher res.
-  register int color_idx = 0, depth_idx = 0;
+  int color_idx = 0, depth_idx = 0;
   RGBValue color;
   color.Alpha = 0;
 
@@ -458,7 +458,7 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr ONIGrabber::convertToXYZRGBPointCloud (
 
   for (int v = -centerY; v < centerY; ++v)
   {
-    for (register int u = -centerX; u < centerX; ++u, color_idx += 3, ++depth_idx)
+    for (int u = -centerX; u < centerX; ++u, color_idx += 3, ++depth_idx)
     {
       pcl::PointXYZRGB& pt = cloud->points[depth_idx];
       /// @todo Different values for these cases
@@ -505,10 +505,10 @@ pcl::PointCloud<pcl::PointXYZRGBA>::Ptr ONIGrabber::convertToXYZRGBAPointCloud (
   cloud->points.resize(cloud->height * cloud->width);
 
   float constant = 1.0f / device_->getImageFocalLength(cloud->width);
-  register int centerX = (cloud->width >> 1);
+  int centerX = (cloud->width >> 1);
   int centerY = (cloud->height >> 1);
 
-  register const XnDepthPixel* depth_map = depth_image->getDepthMetaData().Data();
+  const XnDepthPixel* depth_map = depth_image->getDepthMetaData().Data();
   if (depth_image->getWidth() != depth_width_ || depth_image->getHeight() != depth_height_)
   {
     static unsigned buffer_size = 0;
@@ -534,7 +534,7 @@ pcl::PointCloud<pcl::PointXYZRGBA>::Ptr ONIGrabber::convertToXYZRGBAPointCloud (
   image->fillRGB(image_width_, image_height_, rgb_buffer, image_width_ * 3);
 
   // depth_image already has the desired dimensions, but rgb_msg may be higher res.
-  register int color_idx = 0, depth_idx = 0;
+  int color_idx = 0, depth_idx = 0;
   RGBValue color;
   color.Alpha = 0;
 
@@ -542,7 +542,7 @@ pcl::PointCloud<pcl::PointXYZRGBA>::Ptr ONIGrabber::convertToXYZRGBAPointCloud (
 
   for (int v = -centerY; v < centerY; ++v)
   {
-    for (register int u = -centerX; u < centerX; ++u, color_idx += 3, ++depth_idx)
+    for (int u = -centerX; u < centerX; ++u, color_idx += 3, ++depth_idx)
     {
       pcl::PointXYZRGBA& pt = cloud->points[depth_idx];
       /// @todo Different values for these cases
@@ -584,11 +584,11 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr ONIGrabber::convertToXYZIPointCloud(const b
   cloud->points.resize(cloud->height * cloud->width);
 
   float constant = 1.0f / device_->getImageFocalLength(cloud->width);
-  register int centerX = (cloud->width >> 1);
+  int centerX = (cloud->width >> 1);
   int centerY = (cloud->height >> 1);
 
-  register const XnDepthPixel* depth_map = depth_image->getDepthMetaData().Data();
-  register const XnIRPixel* ir_map = ir_image->getMetaData().Data();
+  const XnDepthPixel* depth_map = depth_image->getDepthMetaData().Data();
+  const XnIRPixel* ir_map = ir_image->getMetaData().Data();
 
   if (depth_image->getWidth() != depth_width_ || depth_image->getHeight() != depth_height_)
   {
@@ -610,12 +610,12 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr ONIGrabber::convertToXYZIPointCloud(const b
     ir_map = ir_buffer.get ();
   }
 
-  register int depth_idx = 0;
+  int depth_idx = 0;
   float bad_point = std::numeric_limits<float>::quiet_NaN();
 
   for (int v = -centerY; v < centerY; ++v)
   {
-    for (register int u = -centerX; u < centerX; ++u, ++depth_idx)
+    for (int u = -centerX; u < centerX; ++u, ++depth_idx)
     {
       pcl::PointXYZI& pt = cloud->points[depth_idx];
       /// @todo Different values for these cases

--- a/io/src/openni_camera/openni_image_bayer_grbg.cpp
+++ b/io/src/openni_camera/openni_image_bayer_grbg.cpp
@@ -91,7 +91,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
     if (debayering_method_ == Bilinear)
     {
       // first line GRGRGR
-      for (register unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+      for (unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
       {
         gray_buffer[0] = bayer_pixel[0]; // green pixel
         gray_buffer[1] = AVG3 (bayer_pixel[0], bayer_pixel[2], bayer_pixel[1 + line_skip]); // interpolated green pixel
@@ -101,14 +101,14 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
       gray_buffer += 2 + gray_line_skip;
       bayer_pixel += 2;
 
-      for (register unsigned yIdx = 1; yIdx < height - 1; yIdx += 2)
+      for (unsigned yIdx = 1; yIdx < height - 1; yIdx += 2)
       {
         // blue line
         gray_buffer[0] = AVG3 (bayer_pixel[-line_skip], bayer_pixel[line_skip], bayer_pixel[1]);
         gray_buffer[1] = bayer_pixel[1];
         gray_buffer += 2;
         bayer_pixel += 2;
-        for (register unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+        for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
           gray_buffer[0] = AVG4 (bayer_pixel[-line_skip], bayer_pixel[line_skip], bayer_pixel[-1], bayer_pixel[1]);
           gray_buffer[1] = bayer_pixel[1];
@@ -116,7 +116,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
         gray_buffer += gray_line_skip;
 
         // red line
-        for (register unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+        for (unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
           gray_buffer[0] = bayer_pixel[0]; // green pixel
           gray_buffer[1] = AVG4 (bayer_pixel[0], bayer_pixel[2], bayer_pixel[-line_skip + 1], bayer_pixel[line_skip + 1]); // interpolated green pixel
@@ -132,7 +132,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
       gray_buffer[1] = bayer_pixel[1];
       gray_buffer += 2;
       bayer_pixel += 2;
-      for (register unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+      for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
       {
         gray_buffer[0] = AVG3 (bayer_pixel[-1], bayer_pixel[1], bayer_pixel[-line_skip]);
         gray_buffer[1] = bayer_pixel[1];
@@ -142,7 +142,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
     {
       int dv, dh;
       // first line GRGRGR
-      for (register unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+      for (unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
       {
         gray_buffer[0] = bayer_pixel[0]; // green pixel
         gray_buffer[1] = AVG3 (bayer_pixel[0], bayer_pixel[2], bayer_pixel[1 + line_skip]); // interpolated green pixel
@@ -152,14 +152,14 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
       gray_buffer += 2 + gray_line_skip;
       bayer_pixel += 2;
 
-      for (register unsigned yIdx = 1; yIdx < height - 1; yIdx += 2)
+      for (unsigned yIdx = 1; yIdx < height - 1; yIdx += 2)
       {
         // blue line
         gray_buffer[0] = AVG3 (bayer_pixel[-line_skip], bayer_pixel[line_skip], bayer_pixel[1]);
         gray_buffer[1] = bayer_pixel[1];
         gray_buffer += 2;
         bayer_pixel += 2;
-        for (register unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+        for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
           dv = abs (bayer_pixel[-line_skip] - bayer_pixel[line_skip]);
           dh = abs (bayer_pixel[-1] - bayer_pixel[1]);
@@ -175,7 +175,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
         gray_buffer += gray_line_skip;
 
         // red line
-        for (register unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+        for (unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
           gray_buffer[0] = bayer_pixel[0];
 
@@ -199,7 +199,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
       gray_buffer[1] = bayer_pixel[1];
       gray_buffer += 2;
       bayer_pixel += 2;
-      for (register unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+      for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
       {
         gray_buffer[0] = AVG3 (bayer_pixel[-1], bayer_pixel[1], bayer_pixel[-line_skip]);
         gray_buffer[1] = bayer_pixel[1];
@@ -209,7 +209,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
     {
       int dv, dh;
       // first line GRGRGR
-      for (register unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+      for (unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
       {
         gray_buffer[0] = bayer_pixel[0]; // green pixel
         gray_buffer[1] = AVG3 (bayer_pixel[0], bayer_pixel[2], bayer_pixel[1 + line_skip]); // interpolated green pixel
@@ -219,14 +219,14 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
       gray_buffer += 2 + gray_line_skip;
       bayer_pixel += 2;
 
-      for (register unsigned yIdx = 1; yIdx < height - 1; yIdx += 2)
+      for (unsigned yIdx = 1; yIdx < height - 1; yIdx += 2)
       {
         // blue line
         gray_buffer[0] = AVG3 (bayer_pixel[-line_skip], bayer_pixel[line_skip], bayer_pixel[1]);
         gray_buffer[1] = bayer_pixel[1];
         gray_buffer += 2;
         bayer_pixel += 2;
-        for (register unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+        for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
           dv = abs (bayer_pixel[-line_skip] - bayer_pixel[line_skip]);
           dh = abs (bayer_pixel[-1] - bayer_pixel[1]);
@@ -242,7 +242,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
         gray_buffer += gray_line_skip;
 
         // red line
-        for (register unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+        for (unsigned xIdx = 0; xIdx < width - 2; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
           gray_buffer[0] = bayer_pixel[0];
 
@@ -265,7 +265,7 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
       gray_buffer[1] = bayer_pixel[1];
       gray_buffer += 2;
       bayer_pixel += 2;
-      for (register unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
+      for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
       {
         gray_buffer[0] = AVG3 (bayer_pixel[-1], bayer_pixel[1], bayer_pixel[-line_skip]);
         gray_buffer[1] = bayer_pixel[1];
@@ -281,15 +281,15 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
       THROW_OPENNI_EXCEPTION ("Downsampling only possible for multiple of 2 in both dimensions. Request was %d x %d -> %d x %d.", image_md_->XRes (), image_md_->YRes (), width, height);
 
     // fast method -> simply takes each or each 2nd pixel-group to get gray values out
-    register unsigned bayerXStep = image_md_->XRes () / width;
-    register unsigned bayerYSkip = (image_md_->YRes () / height - 1) * image_md_->XRes ();
+    unsigned bayerXStep = image_md_->XRes () / width;
+    unsigned bayerYSkip = (image_md_->YRes () / height - 1) * image_md_->XRes ();
 
     // Downsampling and debayering at once
-    register const XnUInt8* bayer_buffer = image_md_->Data ();
+    const XnUInt8* bayer_buffer = image_md_->Data ();
 
-    for (register unsigned yIdx = 0; yIdx < height; ++yIdx, bayer_buffer += bayerYSkip, gray_buffer += gray_line_skip) // skip a line
+    for (unsigned yIdx = 0; yIdx < height; ++yIdx, bayer_buffer += bayerYSkip, gray_buffer += gray_line_skip) // skip a line
     {
-      for (register unsigned xIdx = 0; xIdx < width; ++xIdx, ++gray_buffer, bayer_buffer += bayerXStep)
+      for (unsigned xIdx = 0; xIdx < width; ++xIdx, ++gray_buffer, bayer_buffer += bayerXStep)
       {
         *gray_buffer = AVG (bayer_buffer[0], bayer_buffer[ image_md_->XRes () + 1]);
       }
@@ -314,7 +314,7 @@ openni_wrapper::ImageBayerGRBG::fillRGB (
 
   if (image_md_->XRes () == width && image_md_->YRes () == height)
   {
-    register const unsigned char* bayer_pixel = image_md_->Data ();
+    const unsigned char* bayer_pixel = image_md_->Data ();
 
     int bayer_line_step = image_md_->XRes ();
     int bayer_line_step2 = image_md_->XRes () << 1;
@@ -335,15 +335,15 @@ openni_wrapper::ImageBayerGRBG::fillRGB (
       THROW_OPENNI_EXCEPTION ("Downsampling only possible for integer scales in both dimensions. Request was %d x %d -> %d x %d.", image_md_->XRes (), image_md_->YRes (), width, height);
 
     // get each or each 2nd pixel group to find rgb values!
-    register unsigned bayerXStep = image_md_->XRes () / width;
-    register unsigned bayerYSkip = (image_md_->YRes () / height - 1) * image_md_->XRes ();
+    unsigned bayerXStep = image_md_->XRes () / width;
+    unsigned bayerYSkip = (image_md_->YRes () / height - 1) * image_md_->XRes ();
 
     // Downsampling and debayering at once
-    register const XnUInt8* bayer_buffer = image_md_->Data ();
+    const XnUInt8* bayer_buffer = image_md_->Data ();
 
-    for (register unsigned yIdx = 0; yIdx < height; ++yIdx, bayer_buffer += bayerYSkip, rgb_buffer += rgb_line_skip) // skip a line
+    for (unsigned yIdx = 0; yIdx < height; ++yIdx, bayer_buffer += bayerYSkip, rgb_buffer += rgb_line_skip) // skip a line
     {
-      for (register unsigned xIdx = 0; xIdx < width; ++xIdx, rgb_buffer += 3, bayer_buffer += bayerXStep)
+      for (unsigned xIdx = 0; xIdx < width; ++xIdx, rgb_buffer += 3, bayer_buffer += bayerXStep)
       {
         rgb_buffer[ 2 ] = bayer_buffer[ image_md_->XRes () ];
         rgb_buffer[ 1 ] = AVG (bayer_buffer[0], bayer_buffer[ image_md_->XRes () + 1]);

--- a/io/src/openni_camera/openni_image_yuv_422.cpp
+++ b/io/src/openni_camera/openni_image_yuv_422.cpp
@@ -76,7 +76,7 @@ void ImageYUV422::fillRGB (unsigned width, unsigned height, unsigned char* rgb_b
         THROW_OPENNI_EXCEPTION ("Downsampling only possible for power of two scale in both dimensions. Request was %d x %d -> %d x %d.", image_md_->XRes (), image_md_->YRes (), width, height);
   }
 
-  register const XnUInt8* yuv_buffer = image_md_->Data();
+  const XnUInt8* yuv_buffer = image_md_->Data();
 
   unsigned rgb_line_skip = 0;
   if (rgb_line_step != 0)
@@ -84,9 +84,9 @@ void ImageYUV422::fillRGB (unsigned width, unsigned height, unsigned char* rgb_b
 
   if (image_md_->XRes() == width && image_md_->YRes() == height)
   {
-    for( register unsigned yIdx = 0; yIdx < height; ++yIdx, rgb_buffer += rgb_line_skip )
+    for( unsigned yIdx = 0; yIdx < height; ++yIdx, rgb_buffer += rgb_line_skip )
     {
-      for( register unsigned xIdx = 0; xIdx < width; xIdx += 2, rgb_buffer += 6, yuv_buffer += 4 )
+      for( unsigned xIdx = 0; xIdx < width; xIdx += 2, rgb_buffer += 6, yuv_buffer += 4 )
       {
         int v = yuv_buffer[2] - 128;
         int u = yuv_buffer[0] - 128;
@@ -103,13 +103,13 @@ void ImageYUV422::fillRGB (unsigned width, unsigned height, unsigned char* rgb_b
   }
   else
   {
-    register unsigned yuv_step = image_md_->XRes() / width;
-    register unsigned yuv_x_step = yuv_step << 1;
-    register unsigned yuv_skip = (image_md_->YRes() / height - 1) * ( image_md_->XRes() << 1 );
+    unsigned yuv_step = image_md_->XRes() / width;
+    unsigned yuv_x_step = yuv_step << 1;
+    unsigned yuv_skip = (image_md_->YRes() / height - 1) * ( image_md_->XRes() << 1 );
 
-    for( register unsigned yIdx = 0; yIdx < image_md_->YRes(); yIdx += yuv_step, yuv_buffer += yuv_skip, rgb_buffer += rgb_line_skip )
+    for( unsigned yIdx = 0; yIdx < image_md_->YRes(); yIdx += yuv_step, yuv_buffer += yuv_skip, rgb_buffer += rgb_line_skip )
     {
-      for( register unsigned xIdx = 0; xIdx < image_md_->XRes(); xIdx += yuv_step, rgb_buffer += 3, yuv_buffer += yuv_x_step )
+      for( unsigned xIdx = 0; xIdx < image_md_->XRes(); xIdx += yuv_step, rgb_buffer += 3, yuv_buffer += yuv_x_step )
       {
         int v = yuv_buffer[2] - 128;
         int u = yuv_buffer[0] - 128;
@@ -135,14 +135,14 @@ void ImageYUV422::fillGrayscale (unsigned width, unsigned height, unsigned char*
   if (gray_line_step != 0)
     gray_line_skip = gray_line_step - width;
 
-  register unsigned yuv_step = image_md_->XRes() / width;
-  register unsigned yuv_x_step = yuv_step << 1;
-  register unsigned yuv_skip = (image_md_->YRes() / height - 1) * ( image_md_->XRes() << 1 );
-  register const XnUInt8* yuv_buffer = (image_md_->Data() + 1);
+  unsigned yuv_step = image_md_->XRes() / width;
+  unsigned yuv_x_step = yuv_step << 1;
+  unsigned yuv_skip = (image_md_->YRes() / height - 1) * ( image_md_->XRes() << 1 );
+  const XnUInt8* yuv_buffer = (image_md_->Data() + 1);
 
-  for( register unsigned yIdx = 0; yIdx < image_md_->YRes(); yIdx += yuv_step, yuv_buffer += yuv_skip, gray_buffer += gray_line_skip )
+  for( unsigned yIdx = 0; yIdx < image_md_->YRes(); yIdx += yuv_step, yuv_buffer += yuv_skip, gray_buffer += gray_line_skip )
   {
-    for( register unsigned xIdx = 0; xIdx < image_md_->XRes(); xIdx += yuv_step, ++gray_buffer, yuv_buffer += yuv_x_step )
+    for( unsigned xIdx = 0; xIdx < image_md_->XRes(); xIdx += yuv_step, ++gray_buffer, yuv_buffer += yuv_x_step )
     {
       *gray_buffer = *yuv_buffer;
     }

--- a/io/src/openni_grabber.cpp
+++ b/io/src/openni_grabber.cpp
@@ -539,10 +539,10 @@ pcl::OpenNIGrabber::convertToXYZPointCloud (const boost::shared_ptr<openni_wrapp
 
   cloud->points.resize (cloud->height * cloud->width);
 
-  register float constant_x = 1.0f / device_->getDepthFocalLength (depth_width_);
-  register float constant_y = 1.0f / device_->getDepthFocalLength (depth_width_);
-  register float centerX = ((float)cloud->width - 1.f) / 2.f;
-  register float centerY = ((float)cloud->height - 1.f) / 2.f;
+  float constant_x = 1.0f / device_->getDepthFocalLength (depth_width_);
+  float constant_y = 1.0f / device_->getDepthFocalLength (depth_width_);
+  float centerX = ((float)cloud->width - 1.f) / 2.f;
+  float centerY = ((float)cloud->height - 1.f) / 2.f;
 
   if (pcl_isfinite (depth_focal_length_x_))
     constant_x =  1.0f / static_cast<float> (depth_focal_length_x_);
@@ -565,7 +565,7 @@ pcl::OpenNIGrabber::convertToXYZPointCloud (const boost::shared_ptr<openni_wrapp
   float bad_point = std::numeric_limits<float>::quiet_NaN ();
 
   // we have to use Data, since operator[] uses assert -> Debug-mode very slow!
-  register const unsigned short* depth_map = depth_image->getDepthMetaData ().Data ();
+  const unsigned short* depth_map = depth_image->getDepthMetaData ().Data ();
   if (depth_image->getWidth() != depth_width_ || depth_image->getHeight () != depth_height_)
   {
     if (depth_buffer_size_ < depth_width_ * depth_height_)
@@ -577,10 +577,10 @@ pcl::OpenNIGrabber::convertToXYZPointCloud (const boost::shared_ptr<openni_wrapp
     depth_map = depth_buffer_.get ();
   }
 
-  register int depth_idx = 0;
+  int depth_idx = 0;
   for (unsigned int v = 0; v < depth_height_; ++v)
   {
-    for (register unsigned int u = 0; u < depth_width_; ++u, ++depth_idx)
+    for (unsigned int u = 0; u < depth_width_; ++u, ++depth_idx)
     {
       pcl::PointXYZ& pt = cloud->points[depth_idx];
       // Check for invalid measurements
@@ -616,10 +616,10 @@ pcl::OpenNIGrabber::convertToXYZRGBPointCloud (const boost::shared_ptr<openni_wr
   cloud->points.resize (cloud->height * cloud->width);
 
   //float constant = 1.0f / device_->getImageFocalLength (depth_width_);
-  register float constant_x = 1.0f / device_->getDepthFocalLength (depth_width_);
-  register float constant_y = 1.0f / device_->getDepthFocalLength (depth_width_);
-  register float centerX = ((float)cloud->width - 1.f) / 2.f;
-  register float centerY = ((float)cloud->height - 1.f) / 2.f;
+  float constant_x = 1.0f / device_->getDepthFocalLength (depth_width_);
+  float constant_y = 1.0f / device_->getDepthFocalLength (depth_width_);
+  float centerX = ((float)cloud->width - 1.f) / 2.f;
+  float centerY = ((float)cloud->height - 1.f) / 2.f;
 
   if (pcl_isfinite (depth_focal_length_x_))
     constant_x =  1.0f / static_cast<float> (depth_focal_length_x_);
@@ -633,7 +633,7 @@ pcl::OpenNIGrabber::convertToXYZRGBPointCloud (const boost::shared_ptr<openni_wr
   if (pcl_isfinite (depth_principal_point_y_))
     centerY =  static_cast<float> (depth_principal_point_y_);
 
-  register const XnDepthPixel* depth_map = depth_image->getDepthMetaData ().Data ();
+  const XnDepthPixel* depth_map = depth_image->getDepthMetaData ().Data ();
   if (depth_image->getWidth () != depth_width_ || depth_image->getHeight() != depth_height_)
   {
     if (depth_buffer_size_ < depth_width_ * depth_height_)
@@ -674,7 +674,7 @@ pcl::OpenNIGrabber::convertToXYZRGBPointCloud (const boost::shared_ptr<openni_wr
   int point_idx = 0;
   for (unsigned int v = 0; v < depth_height_; ++v, point_idx += skip)
   {
-    for (register unsigned int u = 0; u < depth_width_; ++u, ++value_idx, point_idx += step)
+    for (unsigned int u = 0; u < depth_width_; ++u, ++value_idx, point_idx += step)
     {
       PointT& pt = cloud->points[point_idx];
       /// @todo Different values for these cases
@@ -731,10 +731,10 @@ pcl::OpenNIGrabber::convertToXYZIPointCloud (const boost::shared_ptr<openni_wrap
   cloud->points.resize (cloud->height * cloud->width);
 
   //float constant = 1.0f / device_->getImageFocalLength (cloud->width);
-  register float constant_x = 1.0f / device_->getImageFocalLength (cloud->width);
-  register float constant_y = 1.0f / device_->getImageFocalLength (cloud->width);
-  register float centerX = ((float)cloud->width - 1.f) / 2.f;
-  register float centerY = ((float)cloud->height - 1.f) / 2.f;
+  float constant_x = 1.0f / device_->getImageFocalLength (cloud->width);
+  float constant_y = 1.0f / device_->getImageFocalLength (cloud->width);
+  float centerX = ((float)cloud->width - 1.f) / 2.f;
+  float centerY = ((float)cloud->height - 1.f) / 2.f;
 
   if (pcl_isfinite (rgb_focal_length_x_))
     constant_x =  1.0f / static_cast<float> (rgb_focal_length_x_);
@@ -748,8 +748,8 @@ pcl::OpenNIGrabber::convertToXYZIPointCloud (const boost::shared_ptr<openni_wrap
   if (pcl_isfinite (rgb_principal_point_y_))
     centerY = static_cast<float>(rgb_principal_point_y_);
 
-  register const XnDepthPixel* depth_map = depth_image->getDepthMetaData ().Data ();
-  register const XnIRPixel* ir_map = ir_image->getMetaData ().Data ();
+  const XnDepthPixel* depth_map = depth_image->getDepthMetaData ().Data ();
+  const XnIRPixel* ir_map = ir_image->getMetaData ().Data ();
 
   if (depth_image->getWidth () != depth_width_ || depth_image->getHeight () != depth_height_)
   {
@@ -767,12 +767,12 @@ pcl::OpenNIGrabber::convertToXYZIPointCloud (const boost::shared_ptr<openni_wrap
     ir_map = ir_buffer_.get ();
   }
 
-  register int depth_idx = 0;
+  int depth_idx = 0;
   float bad_point = std::numeric_limits<float>::quiet_NaN ();
 
   for (unsigned int v = 0; v < depth_height_; ++v)
   {
-    for (register unsigned int u = 0; u < depth_width_; ++u, ++depth_idx)
+    for (unsigned int u = 0; u < depth_width_; ++u, ++depth_idx)
     {
       pcl::PointXYZI& pt = cloud->points[depth_idx];
       /// @todo Different values for these cases

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -1578,9 +1578,9 @@ pcl::keypoints::brisk::Layer::halfsample (
   assert (floor (double (srcheight) / 2.0) == dstheight);
 
   // mask needed later:
-  register __m128i mask = _mm_set_epi32 (0x00FF00FF, 0x00FF00FF, 0x00FF00FF, 0x00FF00FF);
+  __m128i mask = _mm_set_epi32 (0x00FF00FF, 0x00FF00FF, 0x00FF00FF, 0x00FF00FF);
   // to be added in order to make successive averaging correct:
-  register __m128i ones = _mm_set_epi32 (0x11111111, 0x11111111, 0x11111111, 0x11111111);
+  __m128i ones = _mm_set_epi32 (0x11111111, 0x11111111, 0x11111111, 0x11111111);
 
   // data pointers:
   const __m128i* p1 = reinterpret_cast<const __m128i*> (&srcimg[0]);
@@ -1742,10 +1742,10 @@ pcl::keypoints::brisk::Layer::twothirdsample (
   assert (floor (double (srcheight) / 3.0 * 2.0) == dstheight);
 
   // masks:
-  register __m128i mask1 = _mm_set_epi8 (char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),12,char(0x80),10,char(0x80),7,char(0x80),4,char(0x80),1);
-  register __m128i mask2 = _mm_set_epi8 (char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),12,char(0x80),10,char(0x80),7,char(0x80),4,char(0x80),1,char(0x80));
-  register __m128i mask = _mm_set_epi8 (char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),14,12,11,9,8,6,5,3,2,0);
-  register __m128i store_mask = _mm_set_epi8 (0x0,0x0,0x0,0x0,0x0,0x0,char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80));
+  __m128i mask1 = _mm_set_epi8 (char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),12,char(0x80),10,char(0x80),7,char(0x80),4,char(0x80),1);
+  __m128i mask2 = _mm_set_epi8 (char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),12,char(0x80),10,char(0x80),7,char(0x80),4,char(0x80),1,char(0x80));
+  __m128i mask = _mm_set_epi8 (char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),14,12,11,9,8,6,5,3,2,0);
+  __m128i store_mask = _mm_set_epi8 (0x0,0x0,0x0,0x0,0x0,0x0,char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80),char(0x80));
 
   // data pointers:
   const unsigned char* p1 = &srcimg[0];


### PR DESCRIPTION
Fix warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]. It is deprecated since C++11, see [here](https://en.cppreference.com/w/cpp/keyword/register).