### PR TITLE
Fix regression in pcl::SACSegmentation line fitting

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -49,13 +49,16 @@
 template <typename PointT> bool
 pcl::SampleConsensusModelLine<PointT>::isSampleGood (const std::vector<int> &samples) const
 {
+  // Make sure that the two sample points are not identical
   if (
       (input_->points[samples[0]].x != input_->points[samples[1]].x)
-    &&
+    ||
       (input_->points[samples[0]].y != input_->points[samples[1]].y)
-    &&
+    ||
       (input_->points[samples[0]].z != input_->points[samples[1]].z))
+  {
     return (true);
+  }
 
   return (false);
 }


### PR DESCRIPTION
After updating from PCL 1.8.1 to 1.9.1 I realized that the `pcl::SACSegmentation` line fitting doesn't work anymore, if all points are in the ground plane (z=0), because `pcl::SampleConsensusModelLine<PointT>::isSampleGood` would always return false.

This problem was introduced with commit c529b5d81a58737e18a78fef1523399e11c958cd, which fixed another bug (return true in both branches) that previously concealed this bug here.

In my opinion `pcl::SampleConsensusModelLine<PointT>::isSampleGood` should only check if the two sample points differ in one coordinate, not in all of them.