### PR TITLE
Fix data race in NormalEstimationOMP

### DIFF
--- a/features/include/pcl/features/impl/normal_3d_omp.hpp
+++ b/features/include/pcl/features/impl/normal_3d_omp.hpp
@@ -78,7 +78,7 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
     {
       Eigen::Vector4f n;
       if (this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0 ||
-          !computePointNormal (*surface_, nn_indices, n, output.points[idx].curvature))
+          !pcl::computePointNormal (*surface_, nn_indices, n, output.points[idx].curvature))
       {
         output.points[idx].normal[0] = output.points[idx].normal[1] = output.points[idx].normal[2] = output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN ();
 
@@ -106,7 +106,7 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
       Eigen::Vector4f n;
       if (!isFinite ((*input_)[(*indices_)[idx]]) ||
           this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0 ||
-          !computePointNormal (*surface_, nn_indices, n, output.points[idx].curvature))
+          !pcl::computePointNormal (*surface_, nn_indices, n, output.points[idx].curvature))
       {
         output.points[idx].normal[0] = output.points[idx].normal[1] = output.points[idx].normal[2] = output.points[idx].curvature = std::numeric_limits<float>::quiet_NaN ();
 


### PR DESCRIPTION
# Problem
The function `computeFeature` of the class `pcl::NormalEstimationOMP` calls the member function `computePointNormal`. And this `computePointNormal` accesses the member variable `xyz_centroid_` and `covariance_matrix_`.
These variables are written at the same time in using OpenMP, so they will be destroyed.

# Solution
Replace with the non-member version.
