### PR TITLE
Fix warning delete-non-virtual-dtor

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h
@@ -25,6 +25,9 @@ namespace pcl
         pcl::PointCloud<pcl::Normal>::Ptr normals_;
 
       public:
+        virtual
+        ~GlobalEstimator() = default;
+
         virtual void
         estimate (PointInTPtr & in, PointInTPtr & processed, std::vector<pcl::PointCloud<FeatureT>, Eigen::aligned_allocator<
             pcl::PointCloud<FeatureT> > > & signatures, std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids)=0;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h
@@ -42,6 +42,9 @@ namespace pcl
         float radius_;
 
       public:
+        virtual
+        ~KeypointExtractor() = default;
+
         void
         setInputCloud (PointInTPtr & input)
         {
@@ -417,6 +420,9 @@ namespace pcl
           keypoint_extractor_.clear ();
         }
 
+        virtual
+        ~LocalEstimator() = default;
+
         void
         setAdaptativeMLS (bool b)
         {
@@ -452,71 +458,6 @@ namespace pcl
         {
           support_radius_ = r;
         }
-
-        /*void
-         setFilterPlanar (bool b)
-         {
-         filter_planar_ = b;
-         }
-
-         void
-         filterPlanar (PointInTPtr & input, KeypointCloud & keypoints_cloud)
-         {
-         pcl::PointCloud<int> filtered_keypoints;
-         //create a search object
-         typename pcl::search::Search<PointInT>::Ptr tree;
-         if (input->isOrganized ())
-         tree.reset (new pcl::search::OrganizedNeighbor<PointInT> ());
-         else
-         tree.reset (new pcl::search::KdTree<PointInT> (false));
-         tree->setInputCloud (input);
-
-         //std::vector<int> nn_indices;
-         //std::vector<float> nn_distances;
-
-         neighborhood_indices_.reset (new std::vector<std::vector<int> >);
-         neighborhood_indices_->resize (keypoints_cloud.points.size ());
-         neighborhood_dist_.reset (new std::vector<std::vector<float> >);
-         neighborhood_dist_->resize (keypoints_cloud.points.size ());
-
-         filtered_keypoints.points.resize (keypoints_cloud.points.size ());
-         int good = 0;
-
-         //#pragma omp parallel for num_threads(8)
-         for (size_t i = 0; i < keypoints_cloud.points.size (); i++)
-         {
-
-         if (tree->radiusSearch (keypoints_cloud[i], support_radius_, (*neighborhood_indices_)[good], (*neighborhood_dist_)[good]))
-         {
-
-         EIGEN_ALIGN16 Eigen::Matrix3f covariance_matrix;
-         Eigen::Vector4f xyz_centroid;
-         EIGEN_ALIGN16 Eigen::Vector3f eigenValues;
-         EIGEN_ALIGN16 Eigen::Matrix3f eigenVectors;
-
-         //compute planarity of the region
-         computeMeanAndCovarianceMatrix (*input, (*neighborhood_indices_)[good], covariance_matrix, xyz_centroid);
-         pcl::eigen33 (covariance_matrix, eigenVectors, eigenValues);
-
-         float eigsum = eigenValues.sum ();
-         if (!pcl_isfinite(eigsum))
-         {
-         PCL_ERROR("Eigen sum is not finite\n");
-         }
-
-         if ((fabs (eigenValues[0] - eigenValues[1]) < 1.5e-4) || (eigsum != 0 && fabs (eigenValues[0] / eigsum) > 1.e-2))
-         {
-         //region is not planar, add to filtered keypoint
-         keypoints_cloud.points[good] = keypoints_cloud.points[i];
-         good++;
-         }
-         }
-         }
-
-         neighborhood_indices_->resize (good);
-         neighborhood_dist_->resize (good);
-         keypoints_cloud.points.resize (good);
-         }*/
 
       };
   }

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
@@ -145,6 +145,9 @@ namespace pcl
         load_views_ = true;
       }
 
+      virtual
+      ~Source() = default;
+
       float
       getScale ()
       {

--- a/io/include/pcl/io/image_metadata_wrapper.h
+++ b/io/include/pcl/io/image_metadata_wrapper.h
@@ -55,6 +55,9 @@ namespace pcl
       public:
         typedef boost::shared_ptr<FrameWrapper> Ptr;
 
+        virtual
+        ~FrameWrapper() = default;
+
         virtual const void*
         getData () const = 0;
 

--- a/recognition/include/pcl/recognition/hv/hypotheses_verification.h
+++ b/recognition/include/pcl/recognition/hv/hypotheses_verification.h
@@ -142,6 +142,9 @@ namespace pcl
       requires_normals_ = false;
     }
 
+    virtual
+    ~HypothesisVerification() = default;
+
     bool getRequiresNormals() {
       return requires_normals_;
     }

--- a/visualization/src/cloud_viewer.cpp
+++ b/visualization/src/cloud_viewer.cpp
@@ -43,6 +43,7 @@ namespace pcl
 {
   struct cloud_show_base
   {
+    virtual ~cloud_show_base() = default;
     virtual void pop () = 0;
     virtual bool popped () const = 0;
     typedef boost::shared_ptr<cloud_show_base> Ptr;


### PR DESCRIPTION
Fix warning: delete called on non-final '...' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]

I always added missing destructor. This could change behavior, because correct destructor should be now called.