### PR TITLE
Fix access static members through instances

### DIFF
--- a/apps/cloud_composer/src/main.cpp
+++ b/apps/cloud_composer/src/main.cpp
@@ -9,5 +9,5 @@ main (int argc, char ** argv)
   
   pcl::cloud_composer::ComposerMainWindow cc;
   cc.show ();
-  return (app.exec ());
+  return (QApplication::exec ());
 }

--- a/apps/in_hand_scanner/src/main.cpp
+++ b/apps/in_hand_scanner/src/main.cpp
@@ -48,5 +48,5 @@ main (int argc, char** argv)
   QApplication app (argc, argv);
   pcl::ihs::MainWindow mw;
   mw.show ();
-  return (app.exec ());
+  return (QApplication::exec ());
 }

--- a/apps/in_hand_scanner/src/main_offline_integration.cpp
+++ b/apps/in_hand_scanner/src/main_offline_integration.cpp
@@ -50,5 +50,5 @@ main (int argc, char** argv)
   pcl::ihs::OfflineIntegration oi;
   QTimer::singleShot(0, &oi, SLOT (start ()));
   oi.show ();
-  return (app.exec ());
+  return (QApplication::exec ());
 }

--- a/apps/modeler/src/main.cpp
+++ b/apps/modeler/src/main.cpp
@@ -46,5 +46,5 @@ int main( int argc, char** argv )
 
   pcl::modeler::MainWindow::getInstance().show();
 
-  return app.exec();
+  return QApplication::exec();
 }

--- a/apps/point_cloud_editor/src/main.cpp
+++ b/apps/point_cloud_editor/src/main.cpp
@@ -60,5 +60,5 @@ main(int argc, char *argv[])
   //QApplication::setWindowIcon(QIcon(":/pceditor.icns"));
   MainWindow main_window(argc, argv);
   main_window.show();
-  return (app.exec());
+  return (QApplication::exec());
 }

--- a/apps/src/manual_registration/manual_registration.cpp
+++ b/apps/src/manual_registration/manual_registration.cpp
@@ -291,5 +291,5 @@ main (int argc, char** argv)
 
   man_reg.show();
 
-  return (app.exec());
+  return (QApplication::exec());
 }

--- a/apps/src/openni_passthrough.cpp
+++ b/apps/src/openni_passthrough.cpp
@@ -141,5 +141,5 @@ main (int argc, char ** argv)
 
   OpenNIPassthrough v (grabber);
   v.show ();
-  return (app.exec ());
+  return (QApplication::exec ());
 }

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -469,5 +469,5 @@ main (int argc, char ** argv)
   
   OrganizedSegmentationDemo seg_demo (grabber);
   seg_demo.show();
-  return (app.exec ());
+  return (QApplication::exec ());
 }

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -308,5 +308,5 @@ main (int argc, char** argv)
 
   VideoPlayer.show ();
 
-  return (app.exec ());
+  return (QApplication::exec ());
 }

--- a/common/src/point_types.cpp
+++ b/common/src/point_types.cpp
@@ -409,8 +409,8 @@ namespace pcl
   std::ostream& 
   operator << (std::ostream& os, const GFPFHSignature16& p)
   {
-    for (int i = 0; i < p.descriptorSize (); ++i)
-    os << (i == 0 ? "(" : "") << p.histogram[i] << (i < (p.descriptorSize () - 1) ? ", " : ")");
+    for (int i = 0; i < pcl::GFPFHSignature16::descriptorSize (); ++i)
+    os << (i == 0 ? "(" : "") << p.histogram[i] << (i < (pcl::GFPFHSignature16::descriptorSize () - 1) ? ", " : ")");
     return (os);
   }
 

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -299,7 +299,7 @@ main (int argc, char ** argv)
   std::cout << "Found " << supervoxel_clusters.size () << " Supervoxels!\n";
   PointLCloudT::Ptr labeled_voxel_cloud = super.getLabeledVoxelCloud ();
   PointCloudT::Ptr voxel_centroid_cloud = super.getVoxelCentroidCloud ();
-  PointNCloudT::Ptr sv_normal_cloud = super.makeSupervoxelNormalCloud (supervoxel_clusters);
+  PointNCloudT::Ptr sv_normal_cloud = pcl::SupervoxelClustering<PointT>::makeSupervoxelNormalCloud (supervoxel_clusters);
   PointLCloudT::Ptr full_labeled_cloud = super.getLabeledCloud ();
   
   std::cout << "Getting supervoxel adjacency\n";
@@ -311,7 +311,7 @@ main (int argc, char ** argv)
   super.refineSupervoxels (3, refined_supervoxel_clusters);
 
   PointLCloudT::Ptr refined_labeled_voxel_cloud = super.getLabeledVoxelCloud ();
-  PointNCloudT::Ptr refined_sv_normal_cloud = super.makeSupervoxelNormalCloud (refined_supervoxel_clusters);
+  PointNCloudT::Ptr refined_sv_normal_cloud = pcl::SupervoxelClustering<PointT>::makeSupervoxelNormalCloud (refined_supervoxel_clusters);
   PointLCloudT::Ptr refined_full_labeled_cloud = super.getLabeledCloud ();
   
   // THESE ONLY MAKE SENSE FOR ORGANIZED CLOUDS

--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -95,14 +95,14 @@ template<typename PointT> Eigen::Vector3f
 pcl::CropHull<PointT>::getHullCloudRange ()
 {
   Eigen::Vector3f cloud_min (
-    std::numeric_limits<float> ().max (),
-    std::numeric_limits<float> ().max (),
-    std::numeric_limits<float> ().max ()
+    std::numeric_limits<float>::max (),
+    std::numeric_limits<float>::max (),
+    std::numeric_limits<float>::max ()
   );
   Eigen::Vector3f cloud_max (
-    -std::numeric_limits<float> ().max (),
-    -std::numeric_limits<float> ().max (),
-    -std::numeric_limits<float> ().max ()
+    -std::numeric_limits<float>::max (),
+    -std::numeric_limits<float>::max (),
+    -std::numeric_limits<float>::max ()
   );
   for (size_t index = 0; index < indices_->size (); index++)
   {

--- a/io/src/image_grabber.cpp
+++ b/io/src/image_grabber.cpp
@@ -325,11 +325,11 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
     if (!boost::filesystem::is_directory (itr->status ()) 
         && isValidExtension (extension))
     {
-      if (basename.find ("rgb") < basename.npos)
+      if (basename.find ("rgb") < std::string::npos)
       {
         rgb_image_files_.push_back (pathname);
       }
-      else if (basename.find ("depth") < basename.npos)
+      else if (basename.find ("depth") < std::string::npos)
       {
         depth_image_files_.push_back (pathname);
       }
@@ -374,7 +374,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
     if (!boost::filesystem::is_directory (itr->status ())
         && isValidExtension (extension))
     {
-      if (basename.find ("depth") < basename.npos)
+      if (basename.find ("depth") < std::string::npos)
       {
         depth_image_files_.push_back (pathname);
       }
@@ -395,7 +395,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
     if (!boost::filesystem::is_directory (itr->status ())
         && isValidExtension (extension))
     {
-      if (basename.find ("rgb") < basename.npos)
+      if (basename.find ("rgb") < std::string::npos)
       {
         rgb_image_files_.push_back (pathname);
       }
@@ -442,9 +442,9 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadPCLZFFiles (const std::string &dir)
     if (!boost::filesystem::is_directory (itr->status ()) 
         && isValidExtension (extension))
     {
-      if (basename.find ("rgb") < basename.npos)
+      if (basename.find ("rgb") < std::string::npos)
         rgb_pclzf_files_.push_back (pathname);
-      else if (basename.find ("depth") < basename.npos)
+      else if (basename.find ("depth") < std::string::npos)
         depth_pclzf_files_.push_back (pathname);
       else
         xml_files_.push_back (pathname);
@@ -816,25 +816,25 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getVtkImage (
   // Check extension to generate the proper reader
   int retval;
   std::string upper = boost::algorithm::to_upper_copy (filename);
-  if (upper.find (".TIFF") < upper.npos)
+  if (upper.find (".TIFF") < std::string::npos)
   {
     vtkSmartPointer<vtkTIFFReader> tiff_reader = vtkSmartPointer<vtkTIFFReader>::New ();
     retval = tiff_reader->CanReadFile (filename.c_str ());
     reader = tiff_reader;
   }
-  else if (upper.find (".PNG") < upper.npos)
+  else if (upper.find (".PNG") < std::string::npos)
   {
     vtkSmartPointer<vtkPNGReader> png_reader = vtkSmartPointer<vtkPNGReader>::New ();
     retval = png_reader->CanReadFile (filename.c_str ());
     reader = png_reader;
   }
-  else if (upper.find (".JPG") < upper.npos || upper.find (".JPEG") < upper.npos)
+  else if (upper.find (".JPG") < std::string::npos || upper.find (".JPEG") < std::string::npos)
   {
     vtkSmartPointer<vtkJPEGReader> jpg_reader = vtkSmartPointer<vtkJPEGReader>::New ();
     retval = jpg_reader->CanReadFile (filename.c_str ());
     reader = jpg_reader;
   }
-  else if (upper.find (".PPM") < upper.npos)
+  else if (upper.find (".PPM") < std::string::npos)
   {
     vtkSmartPointer<vtkPNMReader> ppm_reader = vtkSmartPointer<vtkPNMReader>::New ();
     retval = ppm_reader->CanReadFile (filename.c_str ());

--- a/people/include/pcl/people/impl/person_classifier.hpp
+++ b/people/include/pcl/people/impl/person_classifier.hpp
@@ -58,15 +58,15 @@ pcl::people::PersonClassifier<PointT>::loadSVMFromFile (std::string svm_filename
 
   getline (SVM_file,line);      // read window_height line
   size_t tok_pos = line.find_first_of(":", 0);  // search for token ":"
-  window_height_ = std::atoi(line.substr(tok_pos+1, line.npos - tok_pos-1).c_str());
+  window_height_ = std::atoi(line.substr(tok_pos+1, std::string::npos - tok_pos-1).c_str());
 
   getline (SVM_file,line);      // read window_width line
   tok_pos = line.find_first_of(":", 0);  // search for token ":"
-  window_width_ = std::atoi(line.substr(tok_pos+1, line.npos - tok_pos-1).c_str());
+  window_width_ = std::atoi(line.substr(tok_pos+1, std::string::npos - tok_pos-1).c_str());
 
   getline (SVM_file,line);      // read SVM_offset line
   tok_pos = line.find_first_of(":", 0);  // search for token ":"
-  SVM_offset_ = std::atof(line.substr(tok_pos+1, line.npos - tok_pos-1).c_str());
+  SVM_offset_ = std::atof(line.substr(tok_pos+1, std::string::npos - tok_pos-1).c_str());
 
   getline (SVM_file,line);      // read SVM_weights line
   tok_pos = line.find_first_of("[", 0);  // search for token "["

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -256,7 +256,7 @@ pcl::recognition::ObjRecRANSAC::generateHypotheses (const list<OrientedPointPair
     const float *scene_n2 = (*pair).n2_;
 
     // Use normals and points to compute a hash table key
-    this->compute_oriented_point_pair_signature (scene_p1, scene_n1, scene_p2, scene_n2, hash_table_key);
+    pcl::recognition::ObjRecRANSAC::compute_oriented_point_pair_signature (scene_p1, scene_n1, scene_p2, scene_n2, hash_table_key);
     // Get the cell and its neighbors based on 'key'
     int num_neigh_cells = model_library_.getHashTable ().getNeighbors (hash_table_key, neigh_cells);
 

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -256,7 +256,7 @@ pcl::recognition::ObjRecRANSAC::generateHypotheses (const list<OrientedPointPair
     const float *scene_n2 = (*pair).n2_;
 
     // Use normals and points to compute a hash table key
-    pcl::recognition::ObjRecRANSAC::compute_oriented_point_pair_signature (scene_p1, scene_n1, scene_p2, scene_n2, hash_table_key);
+    compute_oriented_point_pair_signature (scene_p1, scene_n1, scene_p2, scene_n2, hash_table_key);
     // Get the cell and its neighbors based on 'key'
     int num_neigh_cells = model_library_.getHashTable ().getNeighbors (hash_table_key, neigh_cells);
 

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -92,7 +92,7 @@ FittingCurve2d::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = this->getElementVector (m_nurbs);
+  std::vector<double> elements = pcl::on_nurbs::FittingCurve2d::getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -92,7 +92,7 @@ FittingCurve2d::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = pcl::on_nurbs::FittingCurve2d::getElementVector (m_nurbs);
+  std::vector<double> elements = getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -93,7 +93,7 @@ FittingCurve2dAPDM::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = this->getElementVector (m_nurbs);
+  std::vector<double> elements = pcl::on_nurbs::FittingCurve2dAPDM::getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -93,7 +93,7 @@ FittingCurve2dAPDM::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = pcl::on_nurbs::FittingCurve2dAPDM::getElementVector (m_nurbs);
+  std::vector<double> elements = getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -93,7 +93,7 @@ FittingCurve2dPDM::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = pcl::on_nurbs::FittingCurve2dPDM::getElementVector (m_nurbs);
+  std::vector<double> elements = getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -93,7 +93,7 @@ FittingCurve2dPDM::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = this->getElementVector (m_nurbs);
+  std::vector<double> elements = pcl::on_nurbs::FittingCurve2dPDM::getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));

--- a/surface/src/on_nurbs/fitting_curve_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_pdm.cpp
@@ -93,7 +93,7 @@ FittingCurve::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = this->getElementVector (m_nurbs);
+  std::vector<double> elements = pcl::on_nurbs::FittingCurve::getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));

--- a/surface/src/on_nurbs/fitting_curve_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_pdm.cpp
@@ -93,7 +93,7 @@ FittingCurve::refine ()
 {
   std::vector<double> xi;
 
-  std::vector<double> elements = pcl::on_nurbs::FittingCurve::getElementVector (m_nurbs);
+  std::vector<double> elements = getElementVector (m_nurbs);
 
   for (unsigned i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));


### PR DESCRIPTION
Changes are done by: run-clang-tidy -header-filter='.' -checks='-,readability-static-accessed-through-instance' -fix

There are some changes I would revert, because they don't increase readability
* `QApplication::exec()` vs `app.exec()`
* `this->compute_oriented_point_pair_signature` => `pcl::recognition::ObjRecRANSAC::compute_oriented_point_pair_signature` (I believe `compute_oriented_point_pair_signature` without any prefix is enough)

 Whats your opinion? What keep, what revert?