### PR TITLE
Replace boost::lexical_cast conversion from integer types to std::string by std::to_string

### DIFF
--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/screenshot_manager.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/screenshot_manager.h
@@ -48,7 +48,6 @@
 #include <pcl/gpu/containers/device_array.h>
 #include <pcl/gpu/containers/kernel_containers.h>
 #include <pcl/gpu/kinfu_large_scale/pixel_rgb.h> 
-#include <boost/lexical_cast.hpp>
 #include <boost/filesystem.hpp> 
 //#include <boost/graph/buffer_concepts.hpp>
 

--- a/gpu/kinfu_large_scale/src/screenshot_manager.cpp
+++ b/gpu/kinfu_large_scale/src/screenshot_manager.cpp
@@ -72,8 +72,8 @@ namespace pcl
                     Eigen::Vector3f teVecs = camPose.translation ();
 
                     // Create filenames
-                    filename_pose = filename_pose + boost::lexical_cast<std::string> (screenshot_counter) + file_extension_pose;
-                    filename_image = filename_image + boost::lexical_cast<std::string> (screenshot_counter) + file_extension_image;
+                    filename_pose = filename_pose + std::to_string(screenshot_counter) + file_extension_pose;
+                    filename_image = filename_image + std::to_string(screenshot_counter) + file_extension_image;
 
                     // Write files
                     writePose (filename_pose, teVecs, erreMats);

--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -47,7 +47,6 @@
 #include <Eigen/StdVector>
 #include <pcl/io/boost.h>
 #include <boost/thread.hpp>
-#include <boost/lexical_cast.hpp> // TODO: Remove when setExtrinsicCalibration is fixed
 
 #include <pcl/io/grabber.h>
 #include <pcl/common/synchronizer.h>

--- a/io/src/ascii_io.cpp
+++ b/io/src/ascii_io.cpp
@@ -39,7 +39,6 @@
 #include <istream>
 #include <fstream>
 #include <boost/filesystem.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/cstdint.hpp>
 
 //////////////////////////////////////////////////////////////////////////////

--- a/io/src/depth_sense/depth_sense_grabber_impl.cpp
+++ b/io/src/depth_sense/depth_sense_grabber_impl.cpp
@@ -35,8 +35,6 @@
  *
  */
 
-#include <boost/lexical_cast.hpp>
-
 #include <pcl/common/io.h>
 #include <pcl/io/depth_sense_grabber.h>
 #include <pcl/io/depth_sense/depth_sense_grabber_impl.h>

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -40,7 +40,6 @@
 #include <iostream>
 #include <pcl/common/io.h>
 #include <pcl/io/boost.h>
-#include <boost/lexical_cast.hpp>
 #include <pcl/console/time.h>
 
 pcl::MTLReader::MTLReader ()

--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -34,7 +34,6 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/chrono.hpp>
 

--- a/io/src/real_sense_grabber.cpp
+++ b/io/src/real_sense_grabber.cpp
@@ -35,8 +35,6 @@
  *
  */
 
-#include <boost/lexical_cast.hpp>
-
 #include <pxcimage.h>
 #include <pxccapture.h>
 #include <pxcprojection.h>

--- a/outofcore/include/pcl/outofcore/boost.h
+++ b/outofcore/include/pcl/outofcore/boost.h
@@ -52,4 +52,3 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -271,7 +271,7 @@ namespace pcl
       
       for(size_t i=0; i<8; i++)
       {
-        boost::filesystem::path child_path = this->node_metadata_->getDirectoryPathname () / boost::filesystem::path (boost::lexical_cast<std::string> (i));
+        boost::filesystem::path child_path = this->node_metadata_->getDirectoryPathname () / boost::filesystem::path (std::to_string(i));
         if (boost::filesystem::exists (child_path))
           child_count++;
       }
@@ -316,7 +316,7 @@ namespace pcl
         //check all 8 possible child directories
         for (int i = 0; i < 8; i++)
         {
-          boost::filesystem::path child_dir = node_metadata_->getDirectoryPathname () / boost::filesystem::path (boost::lexical_cast<std::string> (i));
+          boost::filesystem::path child_dir = node_metadata_->getDirectoryPathname () / boost::filesystem::path (std::to_string(i));
           //if the directory exists and the child hasn't been created (set to 0 by this node's constructor)
           if (boost::filesystem::exists (child_dir) && this->children_[i] == 0)
           {
@@ -915,7 +915,7 @@ namespace pcl
       childbb_min[0] = start[0] + static_cast<double> (x) * step[0];
       childbb_max[0] = start[0] + static_cast<double> (x + 1) * step[0];
 
-      boost::filesystem::path childdir = node_metadata_->getDirectoryPathname () / boost::filesystem::path (boost::lexical_cast<std::string> (idx));
+      boost::filesystem::path childdir = node_metadata_->getDirectoryPathname () / boost::filesystem::path (std::to_string(idx));
       children_[idx] = new OutofcoreOctreeBaseNode<ContainerT, PointT> (childbb_min, childbb_max, childdir.string ().c_str (), this);
 
       num_children_++;

--- a/tools/boost.h
+++ b/tools/boost.h
@@ -49,7 +49,6 @@
 #include <boost/random.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/date_time/gregorian/gregorian_types.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/tools/cluster_extraction.cpp
+++ b/tools/cluster_extraction.cpp
@@ -136,7 +136,7 @@ saveCloud (const std::string &filename, const std::vector<pcl::PCLPointCloud2::P
 
   for (size_t i = 0; i < output.size (); i++)
   {
-    std::string clustername = basename + boost::lexical_cast<std::string>(i) + ".pcd";
+    std::string clustername = basename + std::to_string(i) + ".pcd";
     print_highlight ("Saving "); print_value ("%s ", clustername.c_str ());
 
     pcl::io::savePCDFile (clustername, *(output[i]), translation, orientation, false);

--- a/tools/pcd2png.cpp
+++ b/tools/pcd2png.cpp
@@ -43,8 +43,6 @@
  *
  */
 
-#include <boost/lexical_cast.hpp>
-
 #include <pcl/console/time.h>
 #include <pcl/console/print.h>
 #include <pcl/console/parse.h>

--- a/tools/train_unary_classifier.cpp
+++ b/tools/train_unary_classifier.cpp
@@ -180,7 +180,7 @@ saveCloud (const std::string &filename, std::vector<FeatureT, Eigen::aligned_all
     for (size_t i = 0; i < output.size (); i++)
     {
       std::string fname (filename);
-      std::string s = boost::lexical_cast<std::string>( static_cast<int> (i) );
+      std::string s = std::to_string(static_cast<int> (i) );
       fname = fname + "_" + s + ".pcd";
 
       print_highlight ("Saving "); print_value ("%s ", fname.c_str ());


### PR DESCRIPTION
Changes are done by: run-clang-tidy -header-filter='.' -checks='-,boost-use-to-string' -fix
Additionally removed not needed #include <boost/lexical_cast.hpp>

There are still some lexical_cast left, but only for floating point values.