### PR TITLE
Use raw strings instead of escaped strings

### DIFF
--- a/io/tools/hdl_grabber_example.cpp
+++ b/io/tools/hdl_grabber_example.cpp
@@ -86,7 +86,7 @@ class SimpleHDLGrabber
       // start receiving point clouds
       interface.start ();
 
-      std::cout << "<Esc>, \'q\', \'Q\': quit the program" << std::endl;
+      std::cout << R"(<Esc>, 'q', 'Q': quit the program)" << std::endl;
       char key;
       do 
       {

--- a/io/tools/openni_grabber_depth_example.cpp
+++ b/io/tools/openni_grabber_depth_example.cpp
@@ -85,7 +85,7 @@ class SimpleOpenNIProcessor
       // start receiving point clouds
       interface.start ();
 
-      std::cout << "<Esc>, \'q\', \'Q\': quit the program" << std::endl;
+      std::cout << R"(<Esc>, 'q', 'Q': quit the program)" << std::endl;
       std::cout << "\' \': pause" << std::endl;
       char key;
       do

--- a/io/tools/openni_grabber_example.cpp
+++ b/io/tools/openni_grabber_example.cpp
@@ -115,7 +115,7 @@ class SimpleOpenNIProcessor
       // start receiving point clouds
       interface.start ();
 
-      std::cout << "<Esc>, \'q\', \'Q\': quit the program" << std::endl;
+      std::cout << R"(<Esc>, 'q', 'Q': quit the program)" << std::endl;
       std::cout << "\' \': pause" << std::endl;
       std::cout << "\'s\': save" << std::endl;
       char key;

--- a/io/tools/pcd_convert_NaN_nan.cpp
+++ b/io/tools/pcd_convert_NaN_nan.cpp
@@ -58,7 +58,7 @@ main (int argc, char **argv)
   ss << std::numeric_limits<float>::quiet_NaN ();
   std::string nanStr (ss.str ());
 
-  std::cout << "converting \"" << nanStr << "\" to \"nan\"" << std::endl;
+  std::cout << R"(converting ")" << nanStr << R"(" to "nan")" << std::endl;
 
   std::ifstream input (argv[1]);
   std::ofstream output (argv[2]);

--- a/visualization/tools/pcd_grabber_viewer.cpp
+++ b/visualization/tools/pcd_grabber_viewer.cpp
@@ -207,7 +207,7 @@ main (int argc, char** argv)
     }
     else
     {
-      std::cout << "Neither a pcd file given using the \"-file\" option, nor given a directory containing pcd files using the \"-dir\" option." << std::endl;
+      std::cout << R"(Neither a pcd file given using the "-file" option, nor given a directory containing pcd files using the "-dir" option.)" << std::endl;
     }
 
     // Sort the read files by name


### PR DESCRIPTION
Changes are done by: run-clang-tidy -header-filter='.' -checks='-,modernize-raw-string-literal' -fix