### PR TITLE
Simplify boolean expressions

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
@@ -261,12 +261,7 @@ namespace pcl
         dir << base_dir << "/" << m.class_ << "/" << m.id_ << "/" << descr_name;
         bf::path desc_dir = dir.str ();
         std::cout << dir.str () << std::endl;
-        if (bf::exists (desc_dir))
-        {
-          return true;
-        }
-
-        return false;
+        return bf::exists (desc_dir);
       }
 
       std::string

--- a/apps/cloud_composer/src/items/cloud_item.cpp
+++ b/apps/cloud_composer/src/items/cloud_item.cpp
@@ -199,9 +199,6 @@ pcl::cloud_composer::CloudItem::checkIfFinite ()
   pass_filter.setKeepOrganized (false);
   pass_filter.filter (*cloud_filtered);
   
-  if (cloud_filtered->data.size() == cloud_blob_ptr_->data.size ())
-    return true;
-  
-  return false;
+  return cloud_filtered->data.size() == cloud_blob_ptr_->data.size ();
 
 }

--- a/apps/src/grabcut_2d.cpp
+++ b/apps/src/grabcut_2d.cpp
@@ -327,7 +327,7 @@ motion_callback (int x, int y)
 {
   y = height - y;
 
-  if (box == true)
+  if (box)
   {
     xend = x; yend = y;
     glutPostRedisplay ();

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -461,9 +461,7 @@ RangeImage::isValid (int index) const
 bool 
 RangeImage::isObserved (int x, int y) const
 {
-  if (!isInImage (x,y) || (pcl_isinf (getPoint (x,y).range)&&getPoint (x,y).range<0.0f))
-    return false;
-  return true;
+  return !(!isInImage (x,y) || (pcl_isinf (getPoint (x,y).range)&&getPoint (x,y).range<0.0f));
 }
 
 /////////////////////////////////////////////////////////////////////////

--- a/features/include/pcl/features/impl/range_image_border_extractor.hpp
+++ b/features/include/pcl/features/impl/range_image_border_extractor.hpp
@@ -395,10 +395,7 @@ bool RangeImageBorderExtractor::calculateMainPrincipalCurvature(int x, int y, in
         //angle1 = acosf(surface_structure_[y*range_image_->width+x-1]->normal.dot(local_surface->normal));
   //magnitude = angle2-angle1;
 
-  if (!pcl_isfinite(magnitude))
-    return false;
-  
-  return true;
+  return pcl_isfinite(magnitude);
 }
 
 }  // namespace end

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -437,7 +437,7 @@ pcl::gpu::kinfuLS::KinfuTracker::performICP(const Intr& cam_intrinsics, Matrix3f
         if ( fabs (det) < 100000 /*1e-15*/ || pcl_isnan (det) ) //TODO find a threshold that makes ICP track well, but prevents it from generating wrong transforms
         {
           if (pcl_isnan (det)) cout << "qnan" << endl;
-          if(lost_ == false)
+          if(!lost_)
             PCL_ERROR ("ICP LOST... PLEASE COME BACK TO THE LAST VALID POSE (green)\n");
           //reset (); //GUI will now show the user that ICP is lost. User needs to press "R" to reset the volume
           lost_ = true;

--- a/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
@@ -349,7 +349,7 @@ namespace pcl
         // reconstruct point cloud
         OrganizedConversion<PointT>::convert (disparityData,
                                               colorData,
-                                              static_cast<bool>(png_channels==1),
+                                              (png_channels == 1),
                                               cloud_width,
                                               cloud_height,
                                               focalLength,

--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -500,7 +500,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
       {
         if (end_header_callback_)
         {
-          if (end_header_callback_ () == false)
+          if (!end_header_callback_ ())
             return true;
         }
         break;
@@ -549,7 +549,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
              ++property_iterator)
         {
           struct property& property = *(property_iterator->get ());
-          if (property.parse (*this, format, stringstream) == false)
+          if (!property.parse (*this, format, stringstream))
             return false;
         }
         if (!stringstream.eof ())
@@ -595,7 +595,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
              ++property_iterator)
         {
           struct property& property = *(property_iterator->get ());
-          if (property.parse (*this, format, istream) == false)
+          if (!property.parse (*this, format, istream))
           {
             return false;
           }

--- a/io/tools/converter.cpp
+++ b/io/tools/converter.cpp
@@ -185,7 +185,7 @@ saveMesh (pcl::PolygonMesh& input,
     }
 
     PCL_INFO ("Saving file %s as %s.\n", output_file.c_str (), (output_type == ASCII) ? "ASCII" : "binary");
-    if (!pcl::io::savePolygonFile (output_file, input, (output_type == ASCII) ? false : true))
+    if (!pcl::io::savePolygonFile (output_file, input, output_type != ASCII))
       return (false);
   }
 

--- a/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
@@ -136,9 +136,9 @@ pcl::SmoothedSurfacesKeypoint<PointT, PointNT>::detectKeypoints (PointCloudT &ou
               is_min_other_scale = false;
           }
 
-        if (is_min == true && is_min_other_scale == false)
+        if (is_min && !is_min_other_scale)
           passed_min = false;
-        if (is_max == true && is_max_other_scale == false)
+        if (is_max && !is_max_other_scale)
           passed_max = false;
 
         if (!passed_min && !passed_max)

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -1595,10 +1595,7 @@ pcl::keypoints::brisk::Layer::halfsample (
   unsigned int row = 0;
   const unsigned int end = hsize / 2;
   bool half_end;
-  if (hsize % 2 == 0)
-    half_end = false;
-  else
-    half_end = true;
+  half_end = hsize % 2 != 0;
   while (p2 < p_end)
   {
     for (unsigned int i = 0; i < end; i++)

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -1132,7 +1132,7 @@ void Solver::do_shrinking()
     }
   }
 
-  if (unshrink == false && Gmax1 + Gmax2 <= eps*10)
+  if (!unshrink && Gmax1 + Gmax2 <= eps*10)
   {
     unshrink = true;
     reconstruct_gradient();
@@ -1407,7 +1407,7 @@ void Solver_NU::do_shrinking()
     }
   }
 
-  if (unshrink == false && max (Gmax1 + Gmax2, Gmax3 + Gmax4) <= eps*10)
+  if (!unshrink && max (Gmax1 + Gmax2, Gmax3 + Gmax4) <= eps*10)
   {
     unshrink = true;
     reconstruct_gradient();

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -375,7 +375,7 @@ namespace pcl
           assert(this->leaf_count_==0);
           max_objs_per_leaf_ = maxObjsPerLeaf;
 
-          this->dynamic_depth_enabled_ = static_cast<bool> (max_objs_per_leaf_>0);
+          this->dynamic_depth_enabled_ = max_objs_per_leaf_ > 0;
         }
 
 

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -519,7 +519,7 @@ namespace pcl
         if(hasUnloadedChildren ())
           loadChildren (false);
 
-      if( skip_bb_check == false )
+      if( !skip_bb_check )
       {
 
         //indices to store the points for each bin
@@ -666,7 +666,7 @@ namespace pcl
     OutofcoreOctreeBaseNode<ContainerT, PointT>::addDataAtMaxDepth (const pcl::PCLPointCloud2::Ptr input_cloud, const bool skip_bb_check)
     {
       //this assumes data is already in the correct bin
-      if(skip_bb_check == true)
+      if(skip_bb_check)
       {
         PCL_DEBUG ("[pcl::outofcore::OutofcoreOctreeBaseNode::%s] Adding %u points at max depth, %u\n",__FUNCTION__, input_cloud->width*input_cloud->height, this->depth_);
         

--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -71,11 +71,7 @@ class OutofcoreCloud : public Object
 
       bool operator< (const PcdQueueItem& rhs) const
       {
-       if (coverage < rhs.coverage)
-       {
-         return true;
-       }
-       return false;
+       return coverage < rhs.coverage;
       }
 
       std::string pcd_file;

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -102,10 +102,7 @@ namespace pcl
 
         bool check_inside(int col, int row, int min_col, int max_col, int min_row, int max_row)
         {
-          if (col >= min_col && col <= max_col && row >= min_row && row <= max_row)
-            return true;
-
-          return false;
+          return col >= min_col && col <= max_col && row >= min_row && row <= max_row;
         }
 
         template<class PointInT>

--- a/recognition/include/pcl/recognition/ransac_based/auxiliary.h
+++ b/recognition/include/pcl/recognition/ransac_based/auxiliary.h
@@ -56,9 +56,9 @@ namespace pcl
       compareOrderedPairs (const std::pair<T,T>& a, const std::pair<T,T>& b)
       {
         if ( a.first == b.first )
-          return static_cast<bool> (a.second < b.second);
+          return a.second < b.second;
 
-        return static_cast<bool> (a.first < b.first);
+        return a.first < b.first;
       }
 
       template<typename T> T

--- a/recognition/include/pcl/recognition/ransac_based/bvh.h
+++ b/recognition/include/pcl/recognition/ransac_based/bvh.h
@@ -192,11 +192,8 @@ namespace pcl
             inline bool
             intersect(const float box[6]) const
             {
-              if ( box[1] < bounds_[0] || box[3] < bounds_[2] || box[5] < bounds_[4] ||
-                   box[0] > bounds_[1] || box[2] > bounds_[3] || box[4] > bounds_[5] )
-                return false;
-
-              return true;
+              return !static_cast<bool>(box[1] < bounds_[0] || box[3] < bounds_[2] || box[5] < bounds_[4] ||
+                   box[0] > bounds_[1] || box[2] > bounds_[3] || box[4] > bounds_[5]);
             }
 
             /** \brief Computes and returns the volume of the bounding box of this node. */

--- a/recognition/include/pcl/recognition/ransac_based/bvh.h
+++ b/recognition/include/pcl/recognition/ransac_based/bvh.h
@@ -81,7 +81,7 @@ namespace pcl
             inline static bool
             compareCentroidsXCoordinates (const BoundedObject* a, const BoundedObject* b)
             {
-              return static_cast<bool> (a->getCentroid ()[0] < b->getCentroid ()[0]);
+              return a->getCentroid ()[0] < b->getCentroid ()[0];
             }
 
             float*
@@ -192,7 +192,7 @@ namespace pcl
             inline bool
             intersect(const float box[6]) const
             {
-              return !static_cast<bool>(box[1] < bounds_[0] || box[3] < bounds_[2] || box[5] < bounds_[4] ||
+              return !(box[1] < bounds_[0] || box[3] < bounds_[2] || box[5] < bounds_[4] ||
                    box[0] > bounds_[1] || box[2] > bounds_[3] || box[4] > bounds_[5]);
             }
 

--- a/recognition/include/pcl/recognition/ransac_based/orr_graph.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_graph.h
@@ -106,7 +106,7 @@ namespace pcl
             static inline bool
             compare (const Node* a, const Node* b)
             {
-              return (static_cast<bool> (a->fitness_ > b->fitness_));
+              return a->fitness_ > b->fitness_;
             }
 
             friend class ORRGraph;

--- a/recognition/include/pcl/recognition/ransac_based/orr_octree_zprojection.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_octree_zprojection.h
@@ -94,7 +94,7 @@ namespace pcl
             static inline bool
             compare_nodes_z (ORROctree::Node* node1, ORROctree::Node* node2)
             {
-              return static_cast<bool> (node1->getData ()->get3dIdZ () < node2->getData ()->get3dIdZ ());
+              return node1->getData()->get3dIdZ() < node2->getData()->get3dIdZ();
             }
 
             inline void

--- a/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
+++ b/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
@@ -171,7 +171,7 @@ namespace pcl
         static inline bool
         compareCorrespondences (const pcl::Correspondence& a, const pcl::Correspondence& b)
         {
-          return static_cast<bool> (a.distance < b.distance);
+          return a.distance < b.distance;
         }
 
       protected:

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -539,7 +539,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
       // Make sure that we do not compute the same set intersection twice
       pair<set<ordered_int_pair, bool(*)(const ordered_int_pair&, const ordered_int_pair&)>::iterator, bool> res = ordered_hypotheses_ids.insert (id_pair);
 
-      if ( res.second == false )
+      if ( !res.second )
         continue; // We've already computed that set intersection -> check the next pair
 
       // Do the more involved intersection test based on a set intersection of the range image pixels which explained by the hypotheses

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -213,7 +213,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::clusterPoses (typename pcl::PPFR
       }
     }
 
-    if (found_cluster == false)
+    if (!found_cluster)
     {
       // Create a new cluster with the current pose
       PoseWithVotesList new_cluster;

--- a/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
@@ -258,7 +258,7 @@ pcl::MinCutSegmentation<PointT>::extract (std::vector <pcl::PointIndices>& clust
   if ( !graph_is_valid_ )
   {
     success = buildGraph ();
-    if (success == false)
+    if (!success)
     {
       deinitCompute ();
       return;
@@ -271,7 +271,7 @@ pcl::MinCutSegmentation<PointT>::extract (std::vector <pcl::PointIndices>& clust
   if ( !unary_potentials_are_valid_ )
   {
     success = recalculateUnaryPotentials ();
-    if (success == false)
+    if (!success)
     {
       deinitCompute ();
       return;
@@ -282,7 +282,7 @@ pcl::MinCutSegmentation<PointT>::extract (std::vector <pcl::PointIndices>& clust
   if ( !binary_potentials_are_valid_ )
   {
     success = recalculateBinaryPotentials ();
-    if (success == false)
+    if (!success)
     {
       deinitCompute ();
       return;

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -468,7 +468,7 @@ pcl::RegionGrowing<PointT, NormalT>::growRegion (int initial_seed, int segment_n
       bool is_a_seed = false;
       bool belongs_to_segment = validatePoint (initial_seed, curr_seed, index, is_a_seed);
 
-      if (belongs_to_segment == false)
+      if (!belongs_to_segment)
       {
         i_nghbr++;
         continue;

--- a/simulation/src/glsl_shader.cpp
+++ b/simulation/src/glsl_shader.cpp
@@ -140,8 +140,7 @@ pcl::simulation::gllib::Program::link ()
   glLinkProgram (program_id_);
   printProgramInfoLog (program_id_);
 
-  if (getGLError () != GL_NO_ERROR) return false;
-  return true;
+  return getGLError () == GL_NO_ERROR;
 }
 
 void pcl::simulation::gllib::Program::use ()

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -469,13 +469,13 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
               int f = ffn_[nnIdx[doubleEdges[j].index]];
               if ((f != nnIdx[i]) && (f != R_))
                 visibility = isVisible(uvn_nn[i], uvn_nn[doubleEdges[j].index], doubleEdges[j].first, Eigen::Vector2f::Zero());
-              if (visibility == false)
+              if (!visibility)
                 break;
 
               int s = sfn_[nnIdx[doubleEdges[j].index]];
               if ((s != nnIdx[i]) && (s != R_))
                 visibility = isVisible(uvn_nn[i], uvn_nn[doubleEdges[j].index], doubleEdges[j].second, Eigen::Vector2f::Zero());
-              if (visibility == false)
+              if (!visibility)
                 break;
             }
           }

--- a/surface/include/pcl/surface/impl/surfel_smoothing.hpp
+++ b/surface/include/pcl/surface/impl/surfel_smoothing.hpp
@@ -305,7 +305,7 @@ pcl::SurfelSmoothing<PointT, PointNT>::extractSalientFeaturesBetweenScales (Poin
         smallest = false;
     }
 
-    if (largest == true || smallest == true)
+    if (largest || smallest)
       (*output_features)[point_i] = point_i;
   }
 }

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -187,10 +187,7 @@ SequentialFitter::is_back_facing (const Eigen::Vector3d &v0, const Eigen::Vector
   e2 = v2 - v0;
 
   Eigen::Vector3d z (m_extrinsic (0, 2), m_extrinsic (1, 2), m_extrinsic (2, 2));
-  if (z.dot (e1.cross (e2)) > 0.0)
-    return true;
-  else
-    return false;
+  return z.dot (e1.cross (e2)) > 0.0;
 }
 
 /********************************************************************************/

--- a/test/outofcore/test_outofcore.cpp
+++ b/test/outofcore/test_outofcore.cpp
@@ -103,10 +103,7 @@ AlignedPointTVector points;
 bool 
 compPt (const PointT &p1, const PointT &p2)
 {
-  if (p1.x != p2.x || p1.y != p2.y || p1.z != p2.z)
-    return false;
-  
-  return true;
+  return !(p1.x != p2.x || p1.y != p2.y || p1.z != p2.z);
 }
 
 TEST (PCL, Outofcore_Octree_Build)

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -209,7 +209,7 @@ showHypothesisAsCoordinateFrame (Hypothesis& hypo, CallbackParameters* parameter
 bool
 compareHypotheses (const Hypothesis& a, const Hypothesis& b)
 {
-  return (static_cast<bool> (a.match_confidence_ > b.match_confidence_));
+  return a.match_confidence_ > b.match_confidence_;
 }
 
 //===============================================================================================================================

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1151,11 +1151,11 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
   ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
-  if (am_it != shape_actor_map_->end () && overwrite == false)
+  if (am_it != shape_actor_map_->end () && !overwrite)
   {
     PCL_WARN ("[addCorrespondences] A set of correspondences with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
     return (false);
-  } else if (am_it == shape_actor_map_->end () && overwrite == true)
+  } else if (am_it == shape_actor_map_->end () && overwrite)
   {
     overwrite = false; // Correspondences doesn't exist, add them instead of updating them
   }


### PR DESCRIPTION
Changes are done by: run-clang-tidy -header-filter='.' -checks='-,readability-simplify-boolean-expr' -fix