### PR TITLE
Improve performance of finding single character in a string

### DIFF
--- a/apps/in_hand_scanner/src/offline_integration.cpp
+++ b/apps/in_hand_scanner/src/offline_integration.cpp
@@ -284,7 +284,7 @@ pcl::ihs::OfflineIntegration::load (const std::string&    filename,
   // Load the transformation.
   std::string fn_transform = filename;
 
-  size_t pos = fn_transform.find_last_of (".");
+  size_t pos = fn_transform.find_last_of ('.');
   if (pos == std::string::npos || pos == (fn_transform.size () - 1))
   {
     std::cerr << "ERROR in offline_integration.cpp: No file extension\n";

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -90,7 +90,7 @@ CloudEditorWidget::~CloudEditorWidget ()
 void
 CloudEditorWidget::loadFile(const std::string &filename)
 {
-  std::string ext = filename.substr(filename.find_last_of(".")+1);
+  std::string ext = filename.substr(filename.find_last_of('.')+1);
   FileLoadMap::iterator it = cloud_load_func_map_.find(ext);
   if (it != cloud_load_func_map_.end())
     (it->second)(this, filename);

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -75,7 +75,7 @@ saveOBJFile (const std::string &file_name,
   fs.open (file_name.c_str ());
 
   // Define material file
-  std::string mtl_file_name = file_name.substr (0, file_name.find_last_of (".")) + ".mtl";
+  std::string mtl_file_name = file_name.substr (0, file_name.find_last_of ('.')) + ".mtl";
   // Strip path for "mtllib" command
   std::string mtl_file_name_nopath = mtl_file_name;
   mtl_file_name_nopath.erase (0, mtl_file_name.find_last_of ('/') + 1);

--- a/gpu/people/src/face_detector.cpp
+++ b/gpu/people/src/face_detector.cpp
@@ -452,7 +452,7 @@ pcl::gpu::people::FaceDetector::ncvHaarLoadFromFile_host(const std::string &file
 
     NCVStatus ncv_return_status;
 
-    std::string fext = filename.substr(filename.find_last_of(".") + 1);
+    std::string fext = filename.substr(filename.find_last_of('.') + 1);
     std::transform(fext.begin(), fext.end(), fext.begin(), ::tolower);
 
     std::vector<HaarStage64> haar_stages;
@@ -497,7 +497,7 @@ pcl::gpu::people::FaceDetector::ncvHaarGetClassifierSize(const std::string &file
     size_t readCount;
     NCVStatus ncv_return_status;
 
-    std::string fext = filename.substr(filename.find_last_of(".") + 1);
+    std::string fext = filename.substr(filename.find_last_of('.') + 1);
     std::transform(fext.begin(), fext.end(), fext.begin(), ::tolower);
 
     if (fext == "nvbin")

--- a/io/src/ascii_io.cpp
+++ b/io/src/ascii_io.cpp
@@ -149,7 +149,7 @@ pcl::ASCIIReader::read (
   while (std::getline (ifile, line))
   {
     boost::algorithm::trim (line);
-    if (line.find_first_not_of ("#") != 0) 
+    if (line.find_first_not_of ('#') != 0) 
       continue;   //skip comment lines
 
    std::vector<std::string> tokens;

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -983,7 +983,7 @@ pcl::io::saveOBJFile (const std::string &file_name,
   fs.open (file_name.c_str ());
 
   // Define material file
-  std::string mtl_file_name = file_name.substr (0, file_name.find_last_of (".")) + ".mtl";
+  std::string mtl_file_name = file_name.substr (0, file_name.find_last_of ('.')) + ".mtl";
   // Strip path for "mtllib" command
   std::string mtl_file_name_nopath = mtl_file_name;
   mtl_file_name_nopath.erase (0, mtl_file_name.find_last_of ('/') + 1);

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -57,7 +57,7 @@
 int
 pcl::io::loadPolygonFile (const std::string &file_name, pcl::PolygonMesh& mesh)
 {
-  std::string extension = file_name.substr (file_name.find_last_of (".") + 1);
+  std::string extension = file_name.substr (file_name.find_last_of ('.') + 1);
 
   if (extension == "pcd") // no Polygon, but only a point cloud
   {
@@ -87,7 +87,7 @@ pcl::io::savePolygonFile (const std::string &file_name,
                           const bool binary_format)
 {
   // TODO: what about sensor position and orientation?!?!?!?
-  std::string extension = file_name.substr (file_name.find_last_of (".") + 1);
+  std::string extension = file_name.substr (file_name.find_last_of ('.') + 1);
   if (extension == "pcd")  // no Polygon, but only a point cloud
     return (pcl::io::savePCDFile (file_name, mesh.cloud, Eigen::Vector4f::Zero (), Eigen::Quaternionf::Identity (), binary_format) == 0);
   else if (extension == "vtk")

--- a/people/include/pcl/people/impl/person_classifier.hpp
+++ b/people/include/pcl/people/impl/person_classifier.hpp
@@ -57,25 +57,25 @@ pcl::people::PersonClassifier<PointT>::loadSVMFromFile (std::string svm_filename
   SVM_file.open(svm_filename.c_str());
 
   getline (SVM_file,line);      // read window_height line
-  size_t tok_pos = line.find_first_of(":", 0);  // search for token ":"
+  size_t tok_pos = line.find_first_of(':', 0);  // search for token ":"
   window_height_ = std::atoi(line.substr(tok_pos+1, std::string::npos - tok_pos-1).c_str());
 
   getline (SVM_file,line);      // read window_width line
-  tok_pos = line.find_first_of(":", 0);  // search for token ":"
+  tok_pos = line.find_first_of(':', 0);  // search for token ":"
   window_width_ = std::atoi(line.substr(tok_pos+1, std::string::npos - tok_pos-1).c_str());
 
   getline (SVM_file,line);      // read SVM_offset line
-  tok_pos = line.find_first_of(":", 0);  // search for token ":"
+  tok_pos = line.find_first_of(':', 0);  // search for token ":"
   SVM_offset_ = std::atof(line.substr(tok_pos+1, std::string::npos - tok_pos-1).c_str());
 
   getline (SVM_file,line);      // read SVM_weights line
-  tok_pos = line.find_first_of("[", 0);  // search for token "["
-  size_t tok_end_pos = line.find_first_of("]", 0);  // search for token "]" , end of SVM weights
+  tok_pos = line.find_first_of('[', 0);  // search for token "["
+  size_t tok_end_pos = line.find_first_of(']', 0);  // search for token "]" , end of SVM weights
   size_t prev_tok_pos;
   while (tok_pos < tok_end_pos) // while end of SVM_weights is not reached
   {
     prev_tok_pos = tok_pos;
-    tok_pos = line.find_first_of(",", prev_tok_pos+1);  // search for token ","
+    tok_pos = line.find_first_of(',', prev_tok_pos+1);  // search for token ","
     SVM_weights_.push_back(std::atof(line.substr(prev_tok_pos+1, tok_pos-prev_tok_pos-1).c_str()));
   }
   SVM_file.close();

--- a/tools/elch.cpp
+++ b/tools/elch.cpp
@@ -149,7 +149,7 @@ main (int argc, char **argv)
   for (size_t i = 0; i < clouds.size (); i++)
   {
     std::string result_filename (clouds[i].first);
-    result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+    result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
     pcl::io::savePCDFileBinary (result_filename.c_str (), *(clouds[i].second));
     std::cout << "saving result to " << result_filename << std::endl;
   }

--- a/tools/icp.cpp
+++ b/tools/icp.cpp
@@ -112,7 +112,7 @@ main (int argc, char **argv)
     std::cout << iicp.getAbsoluteTransform () << std::endl;
 
     std::string result_filename (argv[pcd_indices[i]]);
-    result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+    result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
     pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
     std::cout << "saving result to " << result_filename << std::endl;
   }

--- a/tools/icp2d.cpp
+++ b/tools/icp2d.cpp
@@ -79,7 +79,7 @@ main (int argc, char **argv)
   std::cout << argv[pcd_indices[0]] << " width: " << model->width << " height: " << model->height << std::endl;
 
   std::string result_filename (argv[pcd_indices[0]]);
-  result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+  result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
   pcl::io::savePCDFile (result_filename.c_str (), *model);
   std::cout << "saving first model to " << result_filename << std::endl;
 
@@ -127,7 +127,7 @@ main (int argc, char **argv)
     *model = *data;
 
     std::string result_filename (argv[pcd_indices[i]]);
-    result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+    result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
     pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
     std::cout << "saving result to " << result_filename << std::endl;
   }

--- a/tools/lum.cpp
+++ b/tools/lum.cpp
@@ -129,7 +129,7 @@ main (int argc, char **argv)
   for(size_t i = 0; i < lum.getNumVertices (); i++)
   {
     std::string result_filename (clouds[i].first);
-    result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+    result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
     pcl::io::savePCDFileBinary (result_filename.c_str (), *(clouds[i].second));
     //std::cout << "saving result to " << result_filename << std::endl;
   }

--- a/tools/ndt2d.cpp
+++ b/tools/ndt2d.cpp
@@ -115,7 +115,7 @@ main (int argc, char **argv)
   std::cout << argv[pcd_indices[0]] << " width: " << model->width << " height: " << model->height << std::endl;
 
   std::string result_filename (argv[pcd_indices[0]]);
-  result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+  result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
   try
   {
     pcl::io::savePCDFile (result_filename.c_str (), *model);
@@ -166,7 +166,7 @@ main (int argc, char **argv)
     try
     {
       std::string result_filename (argv[pcd_indices[i]]);
-      result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+      result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
       pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
       std::cout << "saving result to " << result_filename << std::endl;
     }

--- a/tools/ndt3d.cpp
+++ b/tools/ndt3d.cpp
@@ -99,7 +99,7 @@ main (int argc, char **argv)
   std::cout << argv[pcd_indices[0]] << " width: " << model->width << " height: " << model->height << std::endl;
 
   std::string result_filename (argv[pcd_indices[0]]);
-  result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+  result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
   pcl::io::savePCDFile (result_filename.c_str (), *model);
   std::cout << "saving first model to " << result_filename << std::endl;
 
@@ -145,7 +145,7 @@ main (int argc, char **argv)
     *model = *data;
 
     std::string result_filename (argv[pcd_indices[i]]);
-    result_filename = result_filename.substr (result_filename.rfind ("/") + 1);
+    result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
     pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
     std::cout << "saving result to " << result_filename << std::endl;
   }


### PR DESCRIPTION
Changes are done by: run-clang-tidy -header-filter='.' -checks='-,performance-faster-string-find' -fix