### PR TITLE
Fix preallocation of memory in ply loader 

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -359,7 +359,7 @@ namespace pcl
       current_field.name = property_name;
       current_field.offset = cloud_->point_step;
       current_field.datatype = pcl::traits::asEnum<ContentType>::value;
-      current_field.count = std::numeric_limits<SizeType>::max ();
+      current_field.count = 1u;
       if (current_field.count * sizeof (ContentType) + cloud_->point_step < std::numeric_limits<uint32_t>::max ())
         cloud_->point_step += static_cast<uint32_t> (current_field.count * sizeof (ContentType));
       else

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -330,7 +330,7 @@ namespace pcl
       current_field.name = property_name;
       current_field.offset = cloud_->point_step;
       current_field.datatype = pcl::traits::asEnum<pcl::io::ply::int32>::value;
-      current_field.count = std::numeric_limits<pcl::io::ply::uint8>::max ();
+      current_field.count = 1u;
       if (current_field.count * sizeof (pcl::io::ply::int32) + cloud_->point_step < std::numeric_limits<uint32_t>::max ())
           cloud_->point_step += static_cast<uint32_t> (current_field.count * sizeof (pcl::io::ply::int32));
       else

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -330,9 +330,9 @@ namespace pcl
       current_field.name = property_name;
       current_field.offset = cloud_->point_step;
       current_field.datatype = pcl::traits::asEnum<pcl::io::ply::int32>::value;
-      current_field.count = 1u;
-      if (current_field.count * sizeof (pcl::io::ply::int32) + cloud_->point_step < std::numeric_limits<uint32_t>::max ())
-          cloud_->point_step += static_cast<uint32_t> (current_field.count * sizeof (pcl::io::ply::int32));
+      current_field.count = 1u; // value will be updated once first vertex is read
+      if (sizeof (pcl::io::ply::int32) + cloud_->point_step < std::numeric_limits<uint32_t>::max ())
+          cloud_->point_step += static_cast<uint32_t> (sizeof (pcl::io::ply::int32));
       else
         cloud_->point_step = static_cast<uint32_t> (std::numeric_limits<uint32_t>::max ());
       do_resize_ = true;
@@ -359,9 +359,9 @@ namespace pcl
       current_field.name = property_name;
       current_field.offset = cloud_->point_step;
       current_field.datatype = pcl::traits::asEnum<ContentType>::value;
-      current_field.count = 1u;
-      if (current_field.count * sizeof (ContentType) + cloud_->point_step < std::numeric_limits<uint32_t>::max ())
-        cloud_->point_step += static_cast<uint32_t> (current_field.count * sizeof (ContentType));
+      current_field.count = 1u; // value will be updated once first vertex is read
+      if (sizeof (ContentType) + cloud_->point_step < std::numeric_limits<uint32_t>::max ())
+        cloud_->point_step += static_cast<uint32_t> (sizeof (ContentType));
       else
         cloud_->point_step = static_cast<uint32_t> (std::numeric_limits<uint32_t>::max ());
       do_resize_ = true;


### PR DESCRIPTION
Changed the default behaviour of the ply file loader such that it allocates only 1 element instead of std::numeric_limits<SizeType>::max() after reading the header that contains a list. The current implementation would allocate huge amounts of memory (and crash) if a ply file containing descriptors (e.g. FPFH) is loaded.

The reason for this is that if a ply file contains a property list, the default behaviour (https://github.com/PointCloudLibrary/pcl/blob/master/io/src/ply_io.cpp#L362-L366) always sets:
```
cloud_->point_step = static_cast<uint32_t> (std::numeric_limits<uint32_t>::max ());
```
if `SizeType` is equal or larger than uint32_t. This means that once end of the header is reached (https://github.com/PointCloudLibrary/pcl/blob/master/io/src/ply_io.cpp#L98), following memory is allocated:
```
static_cast<size_t>(cloud_->point_step) * cloud_->width * cloud_->height
 * 1 byte (std::vector<pcl::uint8_t>)
```
This in some cases can result in very large number. For example, if a single FPFH descriptor is stored in a ply file, the header would contain:
```
element vertex 1
property list uint float fpfh
```
this would be interpreted as:
SizeType is uint64_t
ContentType is float
cloud_->point_step = std::numeric_limits<uint32_t>::max () = 4294967295
cloud_->point_step * cloud_->width * cloud_->height = 4294967295
so 4294967295 * 1 bytes would be allocated, which is roughly 4 gb memory consumption (for single FPFH descriptor!).

Since the memory is anyway resized after the first vertex is read in, it is not necessary to preallocate this memory for max number of elements that a certain type can handle.

