### PR TITLE
Use range-based loop in ORROctreeZProjection::build

### DIFF
--- a/recognition/src/ransac_based/orr_octree_zprojection.cpp
+++ b/recognition/src/ransac_based/orr_octree_zprojection.cpp
@@ -44,6 +44,7 @@
  */
 
 #include <pcl/recognition/ransac_based/orr_octree_zprojection.h>
+#include <array>
 #include <vector>
 
 using namespace std;
@@ -99,23 +100,24 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   // Compute the bounding box of the full leaves
   const vector<ORROctree::Node*>& full_leaves = input.getFullLeaves ();
   vector<ORROctree::Node*>::const_iterator fl_it = full_leaves.begin ();
-  float full_leaves_bounds[4];
+  std::array<float, 4> full_leaves_bounds;
 
   if ( full_leaves.empty() )
     return;
 
   // The initialization run
-  full_leaves_bounds[0] = (*fl_it)->getBounds ()[0];
-  full_leaves_bounds[1] = (*fl_it)->getBounds ()[1];
-  full_leaves_bounds[2] = (*fl_it)->getBounds ()[2];
-  full_leaves_bounds[3] = (*fl_it)->getBounds ()[3];
+  full_leaves_bounds[0] = std::numeric_limits<float>::infinity();
+  full_leaves_bounds[1] = -std::numeric_limits<float>::infinity();
+  full_leaves_bounds[2] = std::numeric_limits<float>::infinity();
+  full_leaves_bounds[3] = -std::numeric_limits<float>::infinity();
 
-  for ( ++fl_it ; fl_it != full_leaves.end () ; ++fl_it )
+  for (const auto& leave : full_leaves)
   {
-    if ( (*fl_it)->getBounds ()[0] < full_leaves_bounds[0] ) full_leaves_bounds[0] = (*fl_it)->getBounds ()[0];
-    if ( (*fl_it)->getBounds ()[1] > full_leaves_bounds[1] ) full_leaves_bounds[1] = (*fl_it)->getBounds ()[1];
-    if ( (*fl_it)->getBounds ()[2] < full_leaves_bounds[2] ) full_leaves_bounds[2] = (*fl_it)->getBounds ()[2];
-    if ( (*fl_it)->getBounds ()[3] > full_leaves_bounds[3] ) full_leaves_bounds[3] = (*fl_it)->getBounds ()[3];
+    const auto bounds = leave->getBounds ();
+    if ( bounds[0] < full_leaves_bounds[0] ) full_leaves_bounds[0] = bounds[0];
+    if ( bounds[1] > full_leaves_bounds[1] ) full_leaves_bounds[1] = bounds[1];
+    if ( bounds[2] < full_leaves_bounds[2] ) full_leaves_bounds[2] = bounds[2];
+    if ( bounds[3] > full_leaves_bounds[3] ) full_leaves_bounds[3] = bounds[3];
   }
 
   // Make some initializations


### PR DESCRIPTION
Short explanation: `full_leaves_bounds` will be initialized to values, so during first loop run these values will be always overridden by value of first leave. This are 4 additional assignments of double, but it increases readability due to range-based for loop