### PR TITLE
Replace boost::math::isnan by std::isnan

### DIFF
--- a/apps/in_hand_scanner/src/icp.cpp
+++ b/apps/in_hand_scanner/src/icp.cpp
@@ -407,7 +407,7 @@ pcl::ihs::ICP::selectDataPoints (const CloudXYZRGBNormalConstPtr& cloud_data) co
   CloudXYZRGBNormal::const_iterator it_in = cloud_data->begin ();
   for (; it_in!=cloud_data->end (); ++it_in)
   {
-    if (!boost::math::isnan (it_in->x))
+    if (!std::isnan (it_in->x))
     {
       PointNormal pt;
       pt.getVector4fMap ()       = it_in->getVector4fMap ();

--- a/apps/in_hand_scanner/src/input_data_processing.cpp
+++ b/apps/in_hand_scanner/src/input_data_processing.cpp
@@ -126,7 +126,7 @@ pcl::ihs::InputDataProcessing::segment (const CloudXYZRGBAConstPtr& cloud_in,
 
       xyz_mask (r, c) = hsv_mask (r, c) = false;
 
-      if (!boost::math::isnan (xyzrgb.x) && !boost::math::isnan (normal.normal_x) &&
+      if (!std::isnan (xyzrgb.x) && !std::isnan (normal.normal_x) &&
           xyzrgb.x  >= x_min             && xyzrgb.x  <= x_max                    &&
           xyzrgb.y  >= y_min             && xyzrgb.y  <= y_max                    &&
           xyzrgb.z  >= z_min             && xyzrgb.z  <= z_max)

--- a/apps/in_hand_scanner/src/input_data_processing.cpp
+++ b/apps/in_hand_scanner/src/input_data_processing.cpp
@@ -246,7 +246,7 @@ pcl::ihs::InputDataProcessing::calculateNormals (const CloudXYZRGBAConstPtr& clo
 
   for (; it_in!=cloud_in->end (); ++it_in, ++it_n, ++it_out)
   {
-    if (!boost::math::isnan (it_n->getNormalVector4fMap ()))
+    if (!it_n->getNormalVector4fMap (). hasNaN ())
     {
       // m -> cm
       it_out->getVector4fMap ()       = 100.f * it_in->getVector4fMap ();

--- a/apps/in_hand_scanner/src/integration.cpp
+++ b/apps/in_hand_scanner/src/integration.cpp
@@ -101,7 +101,7 @@ pcl::ihs::Integration::reconstructMesh (const CloudXYZRGBNormalConstPtr& cloud_d
     const PointXYZRGBNormal& pt_d = cloud_data->operator [] (c);
     const float weight = -pt_d.normal_z; // weight = -dot (normal, [0; 0; 1])
 
-    if (!boost::math::isnan (pt_d.x) && weight > min_weight_)
+    if (!std::isnan (pt_d.x) && weight > min_weight_)
     {
       cloud_model->operator [] (c) = PointIHS (pt_d, weight);
     }
@@ -113,7 +113,7 @@ pcl::ihs::Integration::reconstructMesh (const CloudXYZRGBNormalConstPtr& cloud_d
       const PointXYZRGBNormal& pt_d = cloud_data->operator [] (r*width + c);
       const float weight = -pt_d.normal_z; // weight = -dot (normal, [0; 0; 1])
 
-      if (!boost::math::isnan (pt_d.x) && weight > min_weight_)
+      if (!std::isnan (pt_d.x) && weight > min_weight_)
       {
         cloud_model->operator [] (r*width + c) = PointIHS (pt_d, weight);
       }
@@ -163,7 +163,7 @@ pcl::ihs::Integration::reconstructMesh (const CloudXYZRGBNormalConstPtr& cloud_d
 
       const float weight = -pt_d_0.normal_z; // weight = -dot (normal, [0; 0; 1])
 
-      if (!boost::math::isnan (pt_d_0.x) && weight > min_weight_)
+      if (!std::isnan (pt_d_0.x) && weight > min_weight_)
       {
         pt_m_0 = PointIHS (pt_d_0, weight);
       }
@@ -242,7 +242,7 @@ pcl::ihs::Integration::merge (const CloudXYZRGBNormalConstPtr& cloud_data,
     const PointXYZRGBNormal& pt_d = cloud_data->operator [] (c);
     const float weight = -pt_d.normal_z; // weight = -dot (normal, [0; 0; 1])
 
-    if (!boost::math::isnan (pt_d.x) && weight > min_weight_)
+    if (!std::isnan (pt_d.x) && weight > min_weight_)
     {
       PointIHS& pt_d_t = cloud_data_transformed->operator [] (c);
       pt_d_t = PointIHS (pt_d, weight);
@@ -257,7 +257,7 @@ pcl::ihs::Integration::merge (const CloudXYZRGBNormalConstPtr& cloud_data,
       const PointXYZRGBNormal& pt_d = cloud_data->operator [] (r*width + c);
       const float weight = -pt_d.normal_z; // weight = -dot (normal, [0; 0; 1])
 
-      if (!boost::math::isnan (pt_d.x) && weight > min_weight_)
+      if (!std::isnan (pt_d.x) && weight > min_weight_)
       {
         PointIHS& pt_d_t = cloud_data_transformed->operator [] (r*width + c);
         pt_d_t = PointIHS (pt_d, weight);
@@ -312,7 +312,7 @@ pcl::ihs::Integration::merge (const CloudXYZRGBNormalConstPtr& cloud_data,
 
       const float weight = -pt_d_0.normal_z; // weight = -dot (normal, [0; 0; 1])
 
-      if (!boost::math::isnan (pt_d_0.x) && weight > min_weight_)
+      if (!std::isnan (pt_d_0.x) && weight > min_weight_)
       {
         pt_d_t_0 = PointIHS (pt_d_0, weight);
         pt_d_t_0.getVector4fMap ()       = T * pt_d_t_0.getVector4fMap ();
@@ -519,10 +519,10 @@ pcl::ihs::Integration::addToMesh (const PointIHS& pt_0,
   // |   |
   // 3 - 0
   const unsigned char is_finite = static_cast <unsigned char> (
-                                    (1 * !boost::math::isnan (pt_0.x)) |
-                                    (2 * !boost::math::isnan (pt_1.x)) |
-                                    (4 * !boost::math::isnan (pt_2.x)) |
-                                    (8 * !boost::math::isnan (pt_3.x)));
+                                    (1 * !std::isnan (pt_0.x)) |
+                                    (2 * !std::isnan (pt_1.x)) |
+                                    (4 * !std::isnan (pt_2.x)) |
+                                    (8 * !std::isnan (pt_3.x)));
 
   switch (is_finite)
   {

--- a/apps/in_hand_scanner/src/opengl_viewer.cpp
+++ b/apps/in_hand_scanner/src/opengl_viewer.cpp
@@ -537,9 +537,9 @@ pcl::ihs::OpenGLViewer::addMesh (const CloudXYZRGBNormalConstPtr& cloud, const s
       const PointXYZRGBNormal& pt_2 = cloud->operator [] (ind_o_2);
       const PointXYZRGBNormal& pt_3 = cloud->operator [] (ind_o_3);
 
-      if (!boost::math::isnan (pt_1.x) && !boost::math::isnan (pt_3.x))
+      if (!std::isnan (pt_1.x) && !std::isnan (pt_3.x))
       {
-        if (!boost::math::isnan (pt_2.x)) // 1-2-3 is valid
+        if (!std::isnan (pt_2.x)) // 1-2-3 is valid
         {
           if (std::abs (pt_1.z - pt_2.z) < 1 &&
               std::abs (pt_1.z - pt_3.z) < 1 &&
@@ -552,7 +552,7 @@ pcl::ihs::OpenGLViewer::addMesh (const CloudXYZRGBNormalConstPtr& cloud, const s
             triangles.emplace_back(ind_v_1, ind_v_2, ind_v_3);
           }
         }
-        if (!boost::math::isnan (pt_0.x)) // 0-1-3 is valid
+        if (!std::isnan (pt_0.x)) // 0-1-3 is valid
         {
           if (std::abs (pt_0.z - pt_1.z) < 1 &&
               std::abs (pt_0.z - pt_3.z) < 1 &&

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -73,7 +73,6 @@ namespace pcl
 #endif
 #include <cmath>
 
-// MSCV doesn't have std::{isnan,isfinite}
 #if defined _WIN32 && defined _MSC_VER
 
 // If M_PI is not defined, then probably all of them are undefined


### PR DESCRIPTION

There is a single `boost::math::isnan` left, where I don't have an idea what boost returns
https://github.com/PointCloudLibrary/pcl/blob/ee3fe6fd0943c7e589dd4869615dab19fdecfef8/apps/in_hand_scanner/src/input_data_processing.cpp#L249

Error during compiling with Clang 6, if I replace this line:
```
/media/sf_pcl/apps/in_hand_scanner/src/input_data_processing.cpp:249:10: error: no matching function for call to 'isnan'
    if (!std::isnan (it_n->getNormalVector4fMap ()))
         ^~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/cmath:618:3: note: candidate function not viable: no known conversion from 'pcl::Vector4fMapConst' (aka 'const Map<const Matrix<float, 4, 1>, Eigen::Aligned>') to 'float' for 1st argument
  isnan(float __x)
  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/cmath:626:3: note: candidate function not viable: no known conversion from 'pcl::Vector4fMapConst' (aka 'const Map<const Matrix<float, 4, 1>, Eigen::Aligned>') to 'double' for 1st argument
  isnan(double __x)
  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/cmath:631:3: note: candidate function not viable: no known conversion from 'pcl::Vector4fMapConst' (aka 'const Map<const Matrix<float, 4, 1>, Eigen::Aligned>') to 'long double' for 1st argument
  isnan(long double __x)
  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/cmath:639:5: note: candidate template ignored: substitution failure [with _Tp = Eigen::Map<const Eigen::Matrix<float, 4, 1, 0, 4, 1>, 16, Eigen::Stride<0, 0> >]: no type named '__type' in '__gnu_cxx::__enable_if<false, bool>'
    isnan(_Tp __x)
    ^
1 error generated.
```
Any idea what do to with this line? (I have no OpenNI on my debug machine, so I cannot step into and see what the code is doing)