### PR TITLE
Fix several unused variable/parameter warnings

### DIFF
--- a/io/include/pcl/io/file_io.h
+++ b/io/include/pcl/io/file_io.h
@@ -315,11 +315,11 @@ namespace pcl
 
   template <typename Type> inline
   std::enable_if_t<std::is_integral<Type>::value, bool>
-  isValueFinite (const pcl::PCLPointCloud2 &cloud,
-                 const unsigned int point_index, 
-                 const int point_size, 
-                 const unsigned int field_idx, 
-                 const unsigned int fields_count)
+  isValueFinite (const pcl::PCLPointCloud2& /* cloud */,
+                 const unsigned int /* point_index */,
+                 const int /* point_size */,
+                 const unsigned int /* field_idx */,
+                 const unsigned int /* fields_count */)
   {
     return true;
   }

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -275,7 +275,7 @@ namespace pcl
 
   template<typename T> inline
   std::enable_if_t<std::is_integral<T>::value>
-  unsetDenseFlagIfNotFinite(T value, PCLPointCloud2* cloud)
+  unsetDenseFlagIfNotFinite(T /* value */, PCLPointCloud2* /* cloud */)
   {
   }
 

--- a/test/io/test_range_coder.cpp
+++ b/test/io/test_range_coder.cpp
@@ -96,7 +96,6 @@ TEST (PCL, Adaptive_Range_Coder_Test)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, Static_Range_Coder_Test)
 {
-  size_t i;
   std::stringstream sstream;
   std::vector<char> inputCharData;
   std::vector<char> outputCharData;


### PR DESCRIPTION
These showed up after merging some of the recent PRs.