### PR TITLE
Transition to standard smart pointers, part 3

### DIFF
--- a/doc/tutorials/content/dinast_grabber.rst
+++ b/doc/tutorials/content/dinast_grabber.rst
@@ -30,7 +30,7 @@ And this is a video of the PCL Cloud Viewer showing the point cloud data corresp
   
 Dinast Grabber currently offer this data type, as is the one currently available from Dinast devices:
 
-* `void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&)`
+* `void (const pcl::PointCloud<pcl::PointXYZI>::ConstPtr&)`
   
 The code
 --------

--- a/doc/tutorials/content/gpu_people.rst
+++ b/doc/tutorials/content/gpu_people.rst
@@ -39,7 +39,7 @@ Now, let's break down the code piece by piece. Starting from the main routine.
 
 .. literalinclude:: sources/gpu/people_detect/src/people_detect.cpp
    :language: cpp
-   :lines: 317-368
+   :lines: 317-367
 
 First the GPU device is set, by default this is the first GPU found in the bus, but if you have multiple GPU's in
 your system, this allows you to select a specific one.
@@ -47,7 +47,7 @@ Then a OpenNI Capture is made, see the OpenNI Grabber tutorial for more info on 
 
 .. literalinclude:: sources/gpu/people_detect/src/people_detect.cpp
    :language: cpp
-   :lines: 330-339
+   :lines: 329-338
 
 The implementation is based on a similar approach as Shotton et al. and thus needs off-line learned random
 decision forests for labeling. The current implementation allows up to 4 decision trees to be loaded into
@@ -55,19 +55,19 @@ the forest. This is done by giving it the names of the text files to load.
 
 .. literalinclude:: sources/gpu/people_detect/src/people_detect.cpp
    :language: cpp
-   :lines: 341-342
+   :lines: 340-341
 
 An additional parameter allows you to configure the number of trees to be loaded. 
 
 .. literalinclude:: sources/gpu/people_detect/src/people_detect.cpp
    :language: cpp
-   :lines: 351-353
+   :lines: 350-352
 
 Then the RDF object is created, loading the trees upon creation.
 
 .. literalinclude:: sources/gpu/people_detect/src/people_detect.cpp
    :language: cpp
-   :lines: 355-360
+   :lines: 354-359
 
 Now we create the application object, give it the pointer to the RDF object and start the loop.
 Now we'll have a look at the main loop.

--- a/doc/tutorials/content/hdl_grabber.rst
+++ b/doc/tutorials/content/hdl_grabber.rst
@@ -197,7 +197,7 @@ the *Grabber* interface so generic, leading to the relatively complicated
 *boost::bind* line. In fact, we can register the following callback types as of
 this writing:
 
-* `void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> >&)`
+* `void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)`
 
 Compiling and running the program
 ---------------------------------

--- a/doc/tutorials/content/openni_grabber.rst
+++ b/doc/tutorials/content/openni_grabber.rst
@@ -106,19 +106,19 @@ the *Grabber* interface so generic, leading to the relatively complicated
 *boost::bind* line. In fact, we can register the following callback types as of
 this writing:
 
-* `void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> >&)`
+* `void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)`
 
-* `void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&)`
+* `void (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&)`
 
-* `void (const boost::shared_ptr<openni_wrapper::Image>&)`
+* `void (const openni_wrapper::Image::Ptr&)`
 
   This provides just the RGB image from the built-in camera.
 
-* `void (const boost::shared_ptr<openni_wrapper::DepthImage>&)`
+* `void (const openni_wrapper::DepthImage::Ptr&)`
 
   This provides the depth image, without any color or intensity information
 
-* `void (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant)`
+* `void (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float constant)`
     
   When a callback of this type is registered, the grabber sends both RGB
   image and depth image and the constant (*1 / focal length*), which you need

--- a/doc/tutorials/content/sources/davidsdk/davidsdk_images_viewer.cpp
+++ b/doc/tutorials/content/sources/davidsdk/davidsdk_images_viewer.cpp
@@ -64,7 +64,7 @@ getOpenCVType (const std::string &type)
 /** @brief Process and/or display DavidSDKGrabber image
  * @param[in] image davidSDK image */
 void
-grabberCallback (const boost::shared_ptr<pcl::PCLImage>& image)
+grabberCallback (const pcl::PCLImage::Ptr& image)
 {
   unsigned char *image_array = reinterpret_cast<unsigned char *> (&image->data[0]);
 
@@ -106,8 +106,7 @@ main (int argc,
     return (-1);
   PCL_WARN ("davidSDK connected\n");
 
-  boost::function<void
-  (const boost::shared_ptr<pcl::PCLImage> &)> f = boost::bind (&grabberCallback, _1);
+  boost::function<void (const pcl::PCLImage::Ptr &)> f = boost::bind (&grabberCallback, _1);
   davidsdk_ptr->registerCallback (f);
   davidsdk_ptr->start ();
   waitForUser ("Press enter to quit");

--- a/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
+++ b/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
@@ -26,6 +26,7 @@ typedef pcl::PointCloud<PointT> PointCloudT;
 
 /** @brief Convenience typdef for the Ensenso grabber callback */
 typedef std::pair<pcl::PCLImage, pcl::PCLImage> PairOfImages;
+typedef boost::shared_ptr<PairOfImages> PairOfImagesPtr;
 
 /** @brief CloudViewer pointer */
 pcl::visualization::CloudViewer::Ptr viewer_ptr;
@@ -92,8 +93,8 @@ getOpenCVType (const std::string &type)
  * @warning Image type changes if a calibration pattern is discovered/lost;
  * check @c images->first.encoding */
 void
-grabberCallback (const boost::shared_ptr<PointCloudT>& cloud,
-                 const boost::shared_ptr<PairOfImages>& images)
+grabberCallback (const PointCloudT::Ptr& cloud,
+                 const PairOfImagesPtr& images)
 {
   viewer_ptr->showCloud (cloud);
   unsigned char *l_image_array = reinterpret_cast<unsigned char *> (&images->first.data[0]);
@@ -126,9 +127,7 @@ main (void)
   //ensenso_ptr->initExtrinsicCalibration (5); // Disable projector if you want good looking images.
   // You won't be able to detect a calibration pattern with the projector enabled!
 
-  boost::function<void
-  (const boost::shared_ptr<PointCloudT>&,
-   const boost::shared_ptr<PairOfImages>&)> f = boost::bind (&grabberCallback, _1, _2);
+  boost::function<void (const PointCloudT::Ptr&, const PairOfImagesPtr&)> f = boost::bind (&grabberCallback, _1, _2);
   ensenso_ptr->registerCallback (f);
 
   cv::namedWindow ("Ensenso images", cv::WINDOW_AUTOSIZE);

--- a/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
+++ b/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
@@ -177,7 +177,7 @@ class PeoplePCDApp
       }
     }
 
-    void source_cb1(const boost::shared_ptr<const PointCloud<PointXYZRGBA> >& cloud)
+    void source_cb1(const PointCloud<PointXYZRGBA>::ConstPtr& cloud)
     {
       {
         boost::mutex::scoped_lock lock(data_ready_mutex_);
@@ -189,7 +189,7 @@ class PeoplePCDApp
       data_ready_cond_.notify_one();
     }
 
-    void source_cb2(const boost::shared_ptr<openni_wrapper::Image>& image_wrapper, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_wrapper, float)
+    void source_cb2(const openni_wrapper::Image::Ptr& image_wrapper, const openni_wrapper::DepthImage::Ptr& depth_wrapper, float)
     {
       {
         boost::mutex::scoped_try_lock lock(data_ready_mutex_);
@@ -244,11 +244,11 @@ class PeoplePCDApp
       if (ispcd)
         cloud_cb_= true;
 
-      typedef boost::shared_ptr<openni_wrapper::DepthImage> DepthImagePtr;
-      typedef boost::shared_ptr<openni_wrapper::Image> ImagePtr;
+      typedef openni_wrapper::DepthImage::Ptr DepthImagePtr;
+      typedef openni_wrapper::Image::Ptr ImagePtr;
 
-      boost::function<void (const boost::shared_ptr<const PointCloud<PointXYZRGBA> >&)> func1 = boost::bind (&PeoplePCDApp::source_cb1, this, _1);
-      boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func2 = boost::bind (&PeoplePCDApp::source_cb2, this, _1, _2, _3);                  
+      boost::function<void (const PointCloud<PointXYZRGBA>::ConstPtr&)> func1 = boost::bind (&PeoplePCDApp::source_cb1, this, _1);
+      boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func2 = boost::bind (&PeoplePCDApp::source_cb2, this, _1, _2, _3);
       boost::signals2::connection c = cloud_cb_ ? capture_.registerCallback (func1) : capture_.registerCallback (func2);
 
       {
@@ -323,8 +323,7 @@ int main(int argc, char** argv)
   pcl::gpu::printShortCudaDeviceInfo (device);
 
   // selecting data source
-  boost::shared_ptr<pcl::Grabber> capture;
-  capture.reset( new pcl::OpenNIGrabber() );
+  pcl::Grabber::Ptr capture (new pcl::OpenNIGrabber());
 
   //selecting tree files
   vector<string> tree_files;

--- a/doc/tutorials/content/sources/iccv2011/include/load_clouds.h
+++ b/doc/tutorials/content/sources/iccv2011/include/load_clouds.h
@@ -5,10 +5,10 @@
 #include <pcl/io/pcd_io.h>
   
 template <typename PointT>
-boost::shared_ptr<pcl::PointCloud<PointT> >
+typename pcl::PointCloud<PointT>::Ptr
 loadPointCloud (std::string filename, std::string suffix)
 {
-  boost::shared_ptr<pcl::PointCloud<PointT> > output (new pcl::PointCloud<PointT>);
+  typename pcl::PointCloud<PointT>::Ptr output (new pcl::PointCloud<PointT>);
   filename.append (suffix);
   pcl::io::loadPCDFile (filename, *output);
   pcl::console::print_info ("Loaded %s (%lu points)\n", filename.c_str (), output->size ());

--- a/doc/tutorials/content/sources/iccv2011/src/tutorial.cpp
+++ b/doc/tutorials/content/sources/iccv2011/src/tutorial.cpp
@@ -38,9 +38,9 @@ template<typename FeatureType>
 class ICCVTutorial
 {
   public:
-    ICCVTutorial (boost::shared_ptr<pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI> > keypoint_detector,
+    ICCVTutorial (pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI>::Ptr keypoint_detector,
                   typename pcl::Feature<pcl::PointXYZRGB, FeatureType>::Ptr feature_extractor,
-                  boost::shared_ptr<pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal> > surface_reconstructor,
+                  pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal>::Ptr surface_reconstructor,
                   typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr source,
                   typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr target);
     
@@ -110,9 +110,9 @@ class ICCVTutorial
     pcl::visualization::PCLVisualizer visualizer_;
     pcl::PointCloud<pcl::PointXYZI>::Ptr source_keypoints_;
     pcl::PointCloud<pcl::PointXYZI>::Ptr target_keypoints_;
-    boost::shared_ptr<pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI> > keypoint_detector_;
+    pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI>::Ptr keypoint_detector_;
     typename pcl::Feature<pcl::PointXYZRGB, FeatureType>::Ptr feature_extractor_;
-    boost::shared_ptr<pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal> > surface_reconstructor_;
+    pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal>::Ptr surface_reconstructor_;
     typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr source_;
     typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr target_;
     typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr source_segmented_;
@@ -133,9 +133,9 @@ class ICCVTutorial
 };
 
 template<typename FeatureType>
-ICCVTutorial<FeatureType>::ICCVTutorial(boost::shared_ptr<pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI> >keypoint_detector,
+ICCVTutorial<FeatureType>::ICCVTutorial(pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI>::Ptr keypoint_detector,
                                         typename pcl::Feature<pcl::PointXYZRGB, FeatureType>::Ptr feature_extractor,
-                                        boost::shared_ptr<pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal> > surface_reconstructor,
+                                        pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal>::Ptr surface_reconstructor,
                                         typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr source,
                                         typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr target)
 : source_keypoints_ (new pcl::PointCloud<pcl::PointXYZI> ())
@@ -540,7 +540,7 @@ main (int argc, char ** argv)
   int descriptor_type = atoi (argv[4]);
   int surface_type    = atoi (argv[5]);
   
-  boost::shared_ptr<pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI> > keypoint_detector;
+  pcl::Keypoint<pcl::PointXYZRGB, pcl::PointXYZI>::Ptr keypoint_detector;
   
   if (keypoint_type == 1)
   {
@@ -585,7 +585,7 @@ main (int argc, char ** argv)
     
   }
   
-  boost::shared_ptr<pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal> > surface_reconstruction;
+  pcl::PCLSurfaceBase<pcl::PointXYZRGBNormal>::Ptr surface_reconstruction;
   
   if (surface_type == 1)
   {

--- a/doc/tutorials/content/sources/iros2011/include/load_clouds.h
+++ b/doc/tutorials/content/sources/iros2011/include/load_clouds.h
@@ -3,12 +3,12 @@
 #include "typedefs.h"
 
 #include <pcl/io/pcd_io.h>
-  
+
 template <typename PointT>
-boost::shared_ptr<pcl::PointCloud<PointT> >
+typename pcl::PointCloud<PointT>::Ptr
 loadPointCloud (std::string filename, std::string suffix)
 {
-  boost::shared_ptr<pcl::PointCloud<PointT> > output (new pcl::PointCloud<PointT>);
+  typename pcl::PointCloud<PointT>::Ptr output (new pcl::PointCloud<PointT>);
   filename.append (suffix);
   pcl::io::loadPCDFile (filename, *output);
   pcl::console::print_info ("Loaded %s (%lu points)\n", filename.c_str (), output->size ());

--- a/doc/tutorials/content/sources/narf_descriptor_visualization/narf_descriptor_visualization.cpp
+++ b/doc/tutorials/content/sources/narf_descriptor_visualization/narf_descriptor_visualization.cpp
@@ -108,8 +108,8 @@ main (int argc, char** argv)
   float noise_level = 0.0;
   float min_range = 0.0f;
   int border_size = 1;
-  boost::shared_ptr<pcl::RangeImage> range_image_ptr (new pcl::RangeImage);
-  pcl::RangeImage& range_image = *range_image_ptr;   
+  pcl::RangeImage::Ptr range_image_ptr (new pcl::RangeImage);
+  pcl::RangeImage& range_image = *range_image_ptr;
   range_image.createFromPointCloud (point_cloud, angular_resolution, pcl::deg2rad (360.0f), pcl::deg2rad (180.0f),
                                    scene_sensor_pose, coordinate_frame, noise_level, min_range, border_size);
   range_image.integrateFarRanges (far_ranges);

--- a/doc/tutorials/content/sources/narf_feature_extraction/narf_feature_extraction.cpp
+++ b/doc/tutorials/content/sources/narf_feature_extraction/narf_feature_extraction.cpp
@@ -133,7 +133,7 @@ main (int argc, char** argv)
   float noise_level = 0.0;
   float min_range = 0.0f;
   int border_size = 1;
-  boost::shared_ptr<pcl::RangeImage> range_image_ptr (new pcl::RangeImage);
+  pcl::RangeImage::Ptr range_image_ptr (new pcl::RangeImage);
   pcl::RangeImage& range_image = *range_image_ptr;   
   range_image.createFromPointCloud (point_cloud, angular_resolution, pcl::deg2rad (360.0f), pcl::deg2rad (180.0f),
                                    scene_sensor_pose, coordinate_frame, noise_level, min_range, border_size);

--- a/doc/tutorials/content/sources/narf_keypoint_extraction/narf_keypoint_extraction.cpp
+++ b/doc/tutorials/content/sources/narf_keypoint_extraction/narf_keypoint_extraction.cpp
@@ -127,7 +127,7 @@ main (int argc, char** argv)
   float noise_level = 0.0;
   float min_range = 0.0f;
   int border_size = 1;
-  boost::shared_ptr<pcl::RangeImage> range_image_ptr (new pcl::RangeImage);
+  pcl::RangeImage::Ptr range_image_ptr (new pcl::RangeImage);
   pcl::RangeImage& range_image = *range_image_ptr;   
   range_image.createFromPointCloud (point_cloud, angular_resolution, pcl::deg2rad (360.0f), pcl::deg2rad (180.0f),
                                    scene_sensor_pose, coordinate_frame, noise_level, min_range, border_size);

--- a/doc/tutorials/content/sources/openni_narf_keypoint_extraction/openni_narf_keypoint_extraction.cpp
+++ b/doc/tutorials/content/sources/openni_narf_keypoint_extraction/openni_narf_keypoint_extraction.cpp
@@ -24,9 +24,9 @@ boost::mutex depth_image_mutex,
              ir_image_mutex,
              image_mutex;
 pcl::PointCloud<pcl::PointXYZ>::ConstPtr point_cloud_ptr;
-boost::shared_ptr<openni_wrapper::DepthImage> depth_image_ptr;
-boost::shared_ptr<openni_wrapper::IRImage> ir_image_ptr;
-boost::shared_ptr<openni_wrapper::Image> image_ptr;
+openni_wrapper::DepthImage::Ptr depth_image_ptr;
+openni_wrapper::IRImage::Ptr ir_image_ptr;
+openni_wrapper::Image::Ptr image_ptr;
 
 bool received_new_depth_data = false,
      received_new_ir_image   = false,
@@ -34,7 +34,7 @@ bool received_new_depth_data = false,
 struct EventHelper
 {
   void
-  depth_image_cb (const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image)
+  depth_image_cb (const openni_wrapper::DepthImage::Ptr& depth_image)
   {
     if (depth_image_mutex.try_lock ())
     {
@@ -115,7 +115,7 @@ int main (int argc, char** argv)
   pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id);
   EventHelper event_helper;
   
-  boost::function<void (const boost::shared_ptr<openni_wrapper::DepthImage>&) > f_depth_image =
+  boost::function<void (const openni_wrapper::DepthImage::Ptr&) > f_depth_image =
     boost::bind (&EventHelper::depth_image_cb, &event_helper, _1);
   boost::signals2::connection c_depth_image = interface->registerCallback (f_depth_image);
   
@@ -123,7 +123,7 @@ int main (int argc, char** argv)
   interface->start ();
   cout << "Done\n";
   
-  boost::shared_ptr<pcl::RangeImagePlanar> range_image_planar_ptr (new pcl::RangeImagePlanar);
+  pcl::RangeImagePlanar::Ptr range_image_planar_ptr (new pcl::RangeImagePlanar);
   pcl::RangeImagePlanar& range_image_planar = *range_image_planar_ptr;
   
   pcl::RangeImageBorderExtractor range_image_border_extractor;

--- a/doc/tutorials/content/sources/openni_range_image_visualization/openni_range_image_visualization.cpp
+++ b/doc/tutorials/content/sources/openni_range_image_visualization/openni_range_image_visualization.cpp
@@ -15,13 +15,13 @@ std::string device_id = "#1";
 float angular_resolution = -1.0f;
 
 boost::mutex depth_image_mutex;
-boost::shared_ptr<openni_wrapper::DepthImage> depth_image_ptr;
+openni_wrapper::DepthImage::Ptr depth_image_ptr;
 bool received_new_depth_data = false;
 
 struct EventHelper
 {
   void
-  depth_image_cb (const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image)
+  depth_image_cb (const openni_wrapper::DepthImage::Ptr& depth_image)
   {
     if (depth_image_mutex.try_lock ())
     {
@@ -92,7 +92,7 @@ int main (int argc, char** argv)
   pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id);
   EventHelper event_helper;
   
-  boost::function<void (const boost::shared_ptr<openni_wrapper::DepthImage>&) > f_depth_image =
+  boost::function<void (const openni_wrapper::DepthImage::Ptr&) > f_depth_image =
     boost::bind (&EventHelper::depth_image_cb, &event_helper, _1);
   boost::signals2::connection c_depth_image = interface->registerCallback (f_depth_image);
   
@@ -100,7 +100,7 @@ int main (int argc, char** argv)
   interface->start ();
   cout << "Done\n";
   
-  boost::shared_ptr<pcl::RangeImagePlanar> range_image_planar_ptr (new pcl::RangeImagePlanar);
+  pcl::RangeImagePlanar::Ptr range_image_planar_ptr (new pcl::RangeImagePlanar);
   pcl::RangeImagePlanar& range_image_planar = *range_image_planar_ptr;
   
   while (!viewer.wasStopped ())

--- a/doc/tutorials/content/sources/range_image_border_extraction/range_image_border_extraction.cpp
+++ b/doc/tutorials/content/sources/range_image_border_extraction/range_image_border_extraction.cpp
@@ -110,7 +110,7 @@ main (int argc, char** argv)
   float noise_level = 0.0;
   float min_range = 0.0f;
   int border_size = 1;
-  boost::shared_ptr<pcl::RangeImage> range_image_ptr (new pcl::RangeImage);
+  pcl::RangeImage::Ptr range_image_ptr (new pcl::RangeImage);
   pcl::RangeImage& range_image = *range_image_ptr;   
   range_image.createFromPointCloud (point_cloud, angular_resolution, pcl::deg2rad (360.0f), pcl::deg2rad (180.0f),
                                    scene_sensor_pose, coordinate_frame, noise_level, min_range, border_size);

--- a/doc/tutorials/content/sources/range_image_visualization/range_image_visualization.cpp
+++ b/doc/tutorials/content/sources/range_image_visualization/range_image_visualization.cpp
@@ -120,7 +120,7 @@ main (int argc, char** argv)
   float noise_level = 0.0;
   float min_range = 0.0f;
   int border_size = 1;
-  boost::shared_ptr<pcl::RangeImage> range_image_ptr(new pcl::RangeImage);
+  pcl::RangeImage::Ptr range_image_ptr(new pcl::RangeImage);
   pcl::RangeImage& range_image = *range_image_ptr;   
   range_image.createFromPointCloud (point_cloud, angular_resolution_x, angular_resolution_y,
                                     pcl::deg2rad (360.0f), pcl::deg2rad (180.0f),

--- a/doc/tutorials/content/sources/region_growing_rgb_segmentation/region_growing_rgb_segmentation.cpp
+++ b/doc/tutorials/content/sources/region_growing_rgb_segmentation/region_growing_rgb_segmentation.cpp
@@ -11,7 +11,7 @@
 int
 main (int argc, char** argv)
 {
-  pcl::search::Search <pcl::PointXYZRGB>::Ptr tree = boost::shared_ptr<pcl::search::Search<pcl::PointXYZRGB> > (new pcl::search::KdTree<pcl::PointXYZRGB>);
+  pcl::search::Search <pcl::PointXYZRGB>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZRGB>);
 
   pcl::PointCloud <pcl::PointXYZRGB>::Ptr cloud (new pcl::PointCloud <pcl::PointXYZRGB>);
   if ( pcl::io::loadPCDFile <pcl::PointXYZRGB> ("region_growing_rgb_tutorial.pcd", *cloud) == -1 )

--- a/doc/tutorials/content/sources/region_growing_segmentation/region_growing_segmentation.cpp
+++ b/doc/tutorials/content/sources/region_growing_segmentation/region_growing_segmentation.cpp
@@ -19,7 +19,7 @@ main (int argc, char** argv)
     return (-1);
   }
 
-  pcl::search::Search<pcl::PointXYZ>::Ptr tree = boost::shared_ptr<pcl::search::Search<pcl::PointXYZ> > (new pcl::search::KdTree<pcl::PointXYZ>);
+  pcl::search::Search<pcl::PointXYZ>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZ>);
   pcl::PointCloud <pcl::Normal>::Ptr normals (new pcl::PointCloud <pcl::Normal>);
   pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> normal_estimator;
   normal_estimator.setSearchMethod (tree);

--- a/doc/tutorials/content/sources/registration_api/example1.cpp
+++ b/doc/tutorials/content/sources/registration_api/example1.cpp
@@ -36,7 +36,7 @@ CloudPtr src, tgt;
 bool rejection = true;
 bool visualize = false;
 
-boost::shared_ptr<PCLVisualizer> vis;
+PCLVisualizer::Ptr vis;
 
 ////////////////////////////////////////////////////////////////////////////////
 void

--- a/doc/tutorials/content/sources/rops_feature/rops_feature.cpp
+++ b/doc/tutorials/content/sources/rops_feature/rops_feature.cpp
@@ -10,7 +10,7 @@ int main (int argc, char** argv)
   if (pcl::io::loadPCDFile (argv[1], *cloud) == -1)
     return (-1);
 
-  pcl::PointIndicesPtr indices = boost::shared_ptr <pcl::PointIndices> (new pcl::PointIndices ());
+  pcl::PointIndicesPtr indices (new pcl::PointIndices);
   std::ifstream indices_file;
   indices_file.open (argv[2], std::ifstream::in);
   for (std::string line; std::getline (indices_file, line);)

--- a/doc/tutorials/content/sources/supervoxel_clustering/supervoxel_clustering.cpp
+++ b/doc/tutorials/content/sources/supervoxel_clustering/supervoxel_clustering.cpp
@@ -36,7 +36,7 @@ main (int argc, char ** argv)
   }
 
 
-  PointCloudT::Ptr cloud = boost::shared_ptr <PointCloudT> (new PointCloudT ());
+  PointCloudT::Ptr cloud (new PointCloudT);
   pcl::console::print_highlight ("Loading point cloud...\n");
   if (pcl::io::loadPCDFile<PointT> (argv[1], *cloud))
   {

--- a/features/include/pcl/features/impl/shot_omp.hpp
+++ b/features/include/pcl/features/impl/shot_omp.hpp
@@ -63,7 +63,7 @@ pcl::SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::initCompute ()
   }
 
   // Default LRF estimation alg: SHOTLocalReferenceFrameEstimationOMP
-  typename boost::shared_ptr<SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT> > lrf_estimator(new SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT>());
+  typename SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT>::Ptr lrf_estimator(new SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT>);
   lrf_estimator->setRadiusSearch ((lrf_radius_ > 0 ? lrf_radius_ : search_radius_));
   lrf_estimator->setInputCloud (input_);
   lrf_estimator->setIndices (indices_);
@@ -101,7 +101,7 @@ pcl::SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::initCompute
   }
 
   // Default LRF estimation alg: SHOTLocalReferenceFrameEstimationOMP
-  typename boost::shared_ptr<SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT> > lrf_estimator(new SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT>());
+  typename SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT>::Ptr lrf_estimator(new SHOTLocalReferenceFrameEstimationOMP<PointInT, PointRFT>);
   lrf_estimator->setRadiusSearch ((lrf_radius_ > 0 ? lrf_radius_ : search_radius_));
   lrf_estimator->setInputCloud (input_);
   lrf_estimator->setIndices (indices_);

--- a/keypoints/include/pcl/keypoints/harris_2d.h
+++ b/keypoints/include/pcl/keypoints/harris_2d.h
@@ -168,7 +168,7 @@ namespace pcl
       Eigen::MatrixXf derivatives_rows_;
       Eigen::MatrixXf derivatives_cols_;
       /// intermediate holder for computed responses
-      boost::shared_ptr<pcl::PointCloud<PointOutT> > response_;
+      typename pcl::PointCloud<PointOutT>::Ptr response_;
       /// comparator for responses intensity
       bool 
       greaterIntensityAtIndices (int a, int b) const

--- a/keypoints/include/pcl/keypoints/harris_6d.h
+++ b/keypoints/include/pcl/keypoints/harris_6d.h
@@ -132,8 +132,8 @@ namespace pcl
       bool refine_;
       bool nonmax_;
       unsigned int threads_;    
-      boost::shared_ptr<pcl::PointCloud<NormalT> > normals_;
-      boost::shared_ptr<pcl::PointCloud<pcl::IntensityGradient> > intensity_gradients_;
+      typename pcl::PointCloud<NormalT>::Ptr normals_;
+      pcl::PointCloud<pcl::IntensityGradient>::Ptr intensity_gradients_;
   } ;
 }
 

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -240,7 +240,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::initCompute ()
 template <typename PointInT, typename PointOutT, typename NormalT> void
 pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut &output)
 {
-  boost::shared_ptr<pcl::PointCloud<PointOutT> > response (new pcl::PointCloud<PointOutT> ());
+  typename pcl::PointCloud<PointOutT>::Ptr response (new pcl::PointCloud<PointOutT>);
 
   response->points.reserve (input_->points.size());
 

--- a/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
@@ -209,7 +209,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
     }
   }
 
-  boost::shared_ptr<pcl::PointCloud<PointOutT> > response (new pcl::PointCloud<PointOutT> ());
+  typename pcl::PointCloud<PointOutT>::Ptr response (new pcl::PointCloud<PointOutT>);
   response->points.reserve (input_->points.size());
   responseTomasi(*response);
 

--- a/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
@@ -112,7 +112,7 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::detectKeypoints (PointCloudOut &output)
   output.points.clear ();
 
   // Create a local copy of the input cloud that will be resized for each octave
-  boost::shared_ptr<pcl::PointCloud<PointInT> > cloud (new pcl::PointCloud<PointInT> (*input_));
+  typename pcl::PointCloud<PointInT>::Ptr cloud (new pcl::PointCloud<PointInT> (*input_));
 
   VoxelGrid<PointInT> voxel_grid;
   // Search for keypoints at each octave
@@ -123,7 +123,7 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::detectKeypoints (PointCloudOut &output)
     const float s = 1.0f * scale; // note: this can be adjusted
     voxel_grid.setLeafSize (s, s, s);
     voxel_grid.setInputCloud (cloud);
-    boost::shared_ptr<pcl::PointCloud<PointInT> > temp (new pcl::PointCloud<PointInT>);    
+    typename pcl::PointCloud<PointInT>::Ptr temp (new pcl::PointCloud<PointInT>);
     voxel_grid.filter (*temp);
     cloud = temp;
 

--- a/keypoints/include/pcl/keypoints/impl/susan.hpp
+++ b/keypoints/include/pcl/keypoints/impl/susan.hpp
@@ -302,7 +302,7 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::isWithinNucleusCen
 template <typename PointInT, typename PointOutT, typename NormalT, typename IntensityT> void
 pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (PointCloudOut &output)
 {
-  boost::shared_ptr<pcl::PointCloud<PointOutT> > response (new pcl::PointCloud<PointOutT> ());
+  typename pcl::PointCloud<PointOutT>::Ptr response (new pcl::PointCloud<PointOutT>);
   response->reserve (surface_->size ());
 
   // Check if the output has a "label" field

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -279,7 +279,7 @@ namespace pcl
         }
 
         /** \brief Clone and cast to CorrespondenceEstimationBase */
-        virtual boost::shared_ptr< CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > clone () const = 0;
+        virtual typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::Ptr clone () const = 0;
 
       protected:
         /** \brief The correspondence estimation method name. */
@@ -424,7 +424,7 @@ namespace pcl
 
         
         /** \brief Clone and cast to CorrespondenceEstimationBase */
-        boost::shared_ptr< CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > 
+        typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::Ptr
         clone () const override
         {
           Ptr copy (new CorrespondenceEstimation<PointSource, PointTarget, Scalar> (*this));

--- a/registration/include/pcl/registration/correspondence_estimation_backprojection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_backprojection.h
@@ -187,7 +187,7 @@ namespace pcl
         getKSearch () const { return (k_); }
         
         /** \brief Clone and cast to CorrespondenceEstimationBase */
-        virtual boost::shared_ptr< CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > 
+        virtual typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::Ptr
         clone () const
         {
           Ptr copy (new CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> (*this));

--- a/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
+++ b/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
@@ -183,7 +183,7 @@ namespace pcl
         getKSearch () const { return (k_); }
 
         /** \brief Clone and cast to CorrespondenceEstimationBase */
-        boost::shared_ptr< CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > 
+        typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::Ptr
         clone () const override
         {
           Ptr copy (new CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> (*this));

--- a/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
@@ -177,7 +177,7 @@ namespace pcl
         determineReciprocalCorrespondences (Correspondences &correspondences, double max_distance);
         
         /** \brief Clone and cast to CorrespondenceEstimationBase */
-        virtual boost::shared_ptr< CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > 
+        virtual typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::Ptr
         clone () const
         {
           Ptr copy (new CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> (*this));

--- a/registration/include/pcl/registration/correspondence_rejection_distance.h
+++ b/registration/include/pcl/registration/correspondence_rejection_distance.h
@@ -172,8 +172,8 @@ namespace pcl
           * confident that the tree will be set correctly.
           */
         template <typename PointT> inline void
-        setSearchMethodTarget (const boost::shared_ptr<pcl::search::KdTree<PointT> > &tree, 
-                               bool force_no_recompute = false) 
+        setSearchMethodTarget (const typename pcl::search::KdTree<PointT>::Ptr &tree,
+                               bool force_no_recompute = false)
         { 
           boost::static_pointer_cast< DataContainer<PointT> > 
             (data_container_)->setSearchMethodTarget (tree, force_no_recompute );

--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -159,9 +159,11 @@ namespace pcl
             virtual bool isValid () = 0;
             virtual double getCorrespondenceScore (int index) = 0;
             virtual bool isCorrespondenceValid (int index) = 0;
+
+            typedef boost::shared_ptr<FeatureContainerInterface> Ptr;
         };
 
-        typedef boost::unordered_map<std::string, boost::shared_ptr<FeatureContainerInterface> > FeaturesMap;
+        typedef boost::unordered_map<std::string, FeatureContainerInterface::Ptr> FeaturesMap;
 
         /** \brief An STL map containing features to use when performing the correspondence search.*/
         FeaturesMap features_map_;

--- a/registration/include/pcl/registration/correspondence_rejection_median_distance.h
+++ b/registration/include/pcl/registration/correspondence_rejection_median_distance.h
@@ -162,8 +162,8 @@ namespace pcl
           * confident that the tree will be set correctly.
           */
         template <typename PointT> inline void
-        setSearchMethodTarget (const boost::shared_ptr<pcl::search::KdTree<PointT> > &tree, 
-                               bool force_no_recompute = false) 
+        setSearchMethodTarget (const typename pcl::search::KdTree<PointT>::Ptr &tree,
+                               bool force_no_recompute = false)
         { 
           boost::static_pointer_cast< DataContainer<PointT> > 
             (data_container_)->setSearchMethodTarget (tree, force_no_recompute );

--- a/registration/include/pcl/registration/correspondence_rejection_surface_normal.h
+++ b/registration/include/pcl/registration/correspondence_rejection_surface_normal.h
@@ -163,8 +163,8 @@ namespace pcl
           * confident that the tree will be set correctly.
           */
         template <typename PointT> inline void
-        setSearchMethodTarget (const boost::shared_ptr<pcl::search::KdTree<PointT> > &tree, 
-                               bool force_no_recompute = false) 
+        setSearchMethodTarget (const typename pcl::search::KdTree<PointT>::Ptr &tree,
+                               bool force_no_recompute = false)
         { 
           boost::static_pointer_cast< DataContainer<PointT> > 
             (data_container_)->setSearchMethodTarget (tree, force_no_recompute );

--- a/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
@@ -170,8 +170,8 @@ namespace pcl
           * confident that the tree will be set correctly.
           */
         template <typename PointT> inline void
-        setSearchMethodTarget (const boost::shared_ptr<pcl::search::KdTree<PointT> > &tree, 
-                               bool force_no_recompute = false) 
+        setSearchMethodTarget (const typename pcl::search::KdTree<PointT>::Ptr &tree,
+                               bool force_no_recompute = false)
         { 
           boost::static_pointer_cast< DataContainer<PointT> > 
             (data_container_)->setSearchMethodTarget (tree, force_no_recompute );

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -128,6 +128,8 @@ namespace pcl
           float threshold_;
       };
 
+      typedef typename boost::shared_ptr<ErrorFunctor> ErrorFunctorPtr;
+
       typedef typename KdTreeFLANN<FeatureT>::Ptr FeatureKdTreePtr; 
       /** \brief Constructor. */
       SampleConsensusInitialAlignment () : 
@@ -144,7 +146,7 @@ namespace pcl
         transformation_estimation_.reset (new pcl::registration::TransformationEstimationSVD<PointSource, PointTarget>);
       };
 
-      /** \brief Provide a boost shared pointer to the source point cloud's feature descriptors
+      /** \brief Provide a shared pointer to the source point cloud's feature descriptors
         * \param features the source point cloud's features
         */
       void 
@@ -154,7 +156,7 @@ namespace pcl
       inline FeatureCloudConstPtr const 
       getSourceFeatures () { return (input_features_); }
 
-      /** \brief Provide a boost shared pointer to the target point cloud's feature descriptors
+      /** \brief Provide a shared pointer to the target point cloud's feature descriptors
         * \param features the target point cloud's features
         */
       void 
@@ -200,12 +202,12 @@ namespace pcl
        * \param[in] error_functor a shared pointer to a subclass of SampleConsensusInitialAlignment::ErrorFunctor
        */
       void
-      setErrorFunction (const boost::shared_ptr<ErrorFunctor> & error_functor) { error_functor_ = error_functor; }
+      setErrorFunction (const ErrorFunctorPtr & error_functor) { error_functor_ = error_functor; }
 
       /** \brief Get a shared pointer to the ErrorFunctor that is to be minimized  
        * \return A shared pointer to a subclass of SampleConsensusInitialAlignment::ErrorFunctor
        */
-      boost::shared_ptr<ErrorFunctor>
+      ErrorFunctorPtr
       getErrorFunction () { return (error_functor_); }
 
     protected:
@@ -269,8 +271,7 @@ namespace pcl
       /** \brief The KdTree used to compare feature descriptors. */
       FeatureKdTreePtr feature_tree_;               
 
-      /** */
-      boost::shared_ptr<ErrorFunctor> error_functor_;
+      ErrorFunctorPtr error_functor_;
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };

--- a/registration/include/pcl/registration/impl/correspondence_rejection_features.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_features.hpp
@@ -55,7 +55,7 @@ template <typename FeatureT> inline typename pcl::PointCloud<FeatureT>::ConstPtr
 pcl::registration::CorrespondenceRejectorFeatures::getSourceFeature (const std::string &key)
 {
   if (features_map_.count (key) == 0)
-    return (boost::shared_ptr<pcl::PointCloud<const FeatureT> > ());
+    return (nullptr);
   else
     return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getSourceFeature ());
 }
@@ -75,7 +75,7 @@ template <typename FeatureT> inline typename pcl::PointCloud<FeatureT>::ConstPtr
 pcl::registration::CorrespondenceRejectorFeatures::getTargetFeature (const std::string &key)
 {
   if (features_map_.count (key) == 0)
-    return (boost::shared_ptr<const pcl::PointCloud<FeatureT> > ());
+    return (nullptr);
   else
     return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getTargetFeature ());
 }

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -321,10 +321,10 @@ namespace pcl
         {
           Eigen::Vector2f dx (step[0]/2, 0);
           Eigen::Vector2f dy (0, step[1]/2);
-          single_grids_[0] = boost::make_shared<SingleGrid> (cloud, about,        extent, step);
-          single_grids_[1] = boost::make_shared<SingleGrid> (cloud, about +dx,    extent, step);
-          single_grids_[2] = boost::make_shared<SingleGrid> (cloud, about +dy,    extent, step);
-          single_grids_[3] = boost::make_shared<SingleGrid> (cloud, about +dx+dy, extent, step);
+          single_grids_[0].reset(new SingleGrid (cloud, about,        extent, step));
+          single_grids_[1].reset(new SingleGrid (cloud, about +dx,    extent, step));
+          single_grids_[2].reset(new SingleGrid (cloud, about +dy,    extent, step));
+          single_grids_[3].reset(new SingleGrid (cloud, about +dx+dy, extent, step));
         }
         
         /** \brief Return the 'score' (denormalised likelihood) and derivatives of score of the point p given this distribution.

--- a/registration/include/pcl/registration/transformation_estimation_lm.h
+++ b/registration/include/pcl/registration/transformation_estimation_lm.h
@@ -162,7 +162,7 @@ namespace pcl
           * \param[in] warp_fcn a shared pointer to an object that warps points
           */
         void
-        setWarpFunction (const boost::shared_ptr<WarpPointRigid<PointSource, PointTarget, MatScalar> > &warp_fcn)
+        setWarpFunction (const typename WarpPointRigid<PointSource, PointTarget, MatScalar>::Ptr &warp_fcn)
         {
           warp_point_ = warp_fcn;
         }
@@ -215,7 +215,7 @@ namespace pcl
         mutable const std::vector<int> *tmp_idx_tgt_;
 
         /** \brief The parameterized function used to warp the source to the target. */
-        boost::shared_ptr<pcl::registration::WarpPointRigid<PointSource, PointTarget, MatScalar> > warp_point_;
+        typename pcl::registration::WarpPointRigid<PointSource, PointTarget, MatScalar>::Ptr warp_point_;
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -178,7 +178,7 @@ namespace pcl
           * \param[in] warp_fcn a shared pointer to an object that warps points
           */
         void
-        setWarpFunction (const boost::shared_ptr<WarpPointRigid<PointSource, PointTarget, MatScalar> > &warp_fcn)
+        setWarpFunction (const typename WarpPointRigid<PointSource, PointTarget, MatScalar>::Ptr &warp_fcn)
         { warp_point_ = warp_fcn; }
 
       protected:
@@ -198,7 +198,7 @@ namespace pcl
         mutable const std::vector<int> *tmp_idx_tgt_;
 
         /** \brief The parameterized function used to warp the source to the target. */
-        boost::shared_ptr<pcl::registration::WarpPointRigid<PointSource, PointTarget, MatScalar> > warp_point_;
+        typename pcl::registration::WarpPointRigid<PointSource, PointTarget, MatScalar>::Ptr warp_point_;
         
         /** Base functor all the models that need non linear optimization must
           * define their own one and implement operator() (const Eigen::VectorXd& x, Eigen::VectorXd& fvec)


### PR DESCRIPTION
Partially addresses #2792.

Note the deprecation in the second commit. The reason is that when the shared pointer is used through a `typedef`, compiler has difficulties determining the template type. Thus the template types should be explicitly specified when using `computeRSD`. But, this is not needed if there are no pointers at all.

@SergioRAgostinho if you prefer, I may put this commit in a separate PR so that we don't need to mark with whole thing with "deprecation" label.