### PR TITLE
Deprecate computeRSD() functions that take point clouds by pointer

### DIFF
--- a/features/include/pcl/features/impl/rsd.hpp
+++ b/features/include/pcl/features/impl/rsd.hpp
@@ -46,7 +46,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointNT, typename PointOutT> Eigen::MatrixXf
-pcl::computeRSD (boost::shared_ptr<const pcl::PointCloud<PointInT> > &surface, boost::shared_ptr<const pcl::PointCloud<PointNT> > &normals,
+pcl::computeRSD (const pcl::PointCloud<PointInT> &surface, const pcl::PointCloud<PointNT> &normals,
 		 const std::vector<int> &indices, double max_dist,
 		 int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram)
 {
@@ -79,18 +79,18 @@ pcl::computeRSD (boost::shared_ptr<const pcl::PointCloud<PointInT> > &surface, b
   for(i = begin+1; i != end; ++i)
   {
     // compute angle between the two lines going through normals (disregard orientation!)
-    double cosine = normals->points[*i].normal[0] * normals->points[*begin].normal[0] +
-                    normals->points[*i].normal[1] * normals->points[*begin].normal[1] +
-                    normals->points[*i].normal[2] * normals->points[*begin].normal[2];
+    double cosine = normals.points[*i].normal[0] * normals.points[*begin].normal[0] +
+                    normals.points[*i].normal[1] * normals.points[*begin].normal[1] +
+                    normals.points[*i].normal[2] * normals.points[*begin].normal[2];
     if (cosine > 1) cosine = 1;
     if (cosine < -1) cosine = -1;
     double angle  = acos (cosine);
     if (angle > M_PI/2) angle = M_PI - angle; /// \note: orientation is neglected!
 
     // Compute point to point distance
-    double dist = sqrt ((surface->points[*i].x - surface->points[*begin].x) * (surface->points[*i].x - surface->points[*begin].x) +
-                        (surface->points[*i].y - surface->points[*begin].y) * (surface->points[*i].y - surface->points[*begin].y) +
-                        (surface->points[*i].z - surface->points[*begin].z) * (surface->points[*i].z - surface->points[*begin].z));
+    double dist = sqrt ((surface.points[*i].x - surface.points[*begin].x) * (surface.points[*i].x - surface.points[*begin].x) +
+                        (surface.points[*i].y - surface.points[*begin].y) * (surface.points[*i].y - surface.points[*begin].y) +
+                        (surface.points[*i].z - surface.points[*begin].z) * (surface.points[*i].z - surface.points[*begin].z));
 
     if (dist > max_dist)
       continue; /// \note: we neglect points that are outside the specified interval!
@@ -147,7 +147,7 @@ pcl::computeRSD (boost::shared_ptr<const pcl::PointCloud<PointInT> > &surface, b
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT, typename PointOutT> Eigen::MatrixXf
-pcl::computeRSD (boost::shared_ptr<const pcl::PointCloud<PointNT> > &normals,
+pcl::computeRSD (const pcl::PointCloud<PointNT> &normals,
 		 const std::vector<int> &indices, const std::vector<float> &sqr_dists, double max_dist,
 		 int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram)
 {
@@ -180,9 +180,9 @@ pcl::computeRSD (boost::shared_ptr<const pcl::PointCloud<PointNT> > &normals,
   for(i = begin+1; i != end; ++i)
   {
     // compute angle between the two lines going through normals (disregard orientation!)
-    double cosine = normals->points[*i].normal[0] * normals->points[*begin].normal[0] +
-                    normals->points[*i].normal[1] * normals->points[*begin].normal[1] +
-                    normals->points[*i].normal[2] * normals->points[*begin].normal[2];
+    double cosine = normals.points[*i].normal[0] * normals.points[*begin].normal[0] +
+                    normals.points[*i].normal[1] * normals.points[*begin].normal[1] +
+                    normals.points[*i].normal[2] * normals.points[*begin].normal[2];
     if (cosine > 1) cosine = 1;
     if (cosine < -1) cosine = -1;
     double angle  = acos (cosine);
@@ -274,8 +274,8 @@ pcl::RSDEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
     {
       // Compute and store r_min and r_max in the output cloud
       this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_sqr_dists);
-      //histograms_->push_back (computeRSD (surface_, normals_, nn_indices, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], true));
-      histograms_->push_back (computeRSD (normals_, nn_indices, nn_sqr_dists, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], true));
+      //histograms_->push_back (computeRSD (*surface_, *normals_, nn_indices, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], true));
+      histograms_->push_back (computeRSD (*normals_, nn_indices, nn_sqr_dists, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], true));
     }
   }
   else
@@ -285,8 +285,8 @@ pcl::RSDEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
     {
       // Compute and store r_min and r_max in the output cloud
       this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_sqr_dists);
-      //computeRSD (surface_, normals_, nn_indices, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], false);
-      computeRSD (normals_, nn_indices, nn_sqr_dists, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], false);
+      //computeRSD (*surface_, *normals_, nn_indices, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], false);
+      computeRSD (*normals_, nn_indices, nn_sqr_dists, search_radius_, nr_subdiv_, plane_radius_, output.points[idx], false);
     }
   }
 }

--- a/features/include/pcl/features/rsd.h
+++ b/features/include/pcl/features/rsd.h
@@ -83,9 +83,19 @@ namespace pcl
     * \ingroup features
     */
   template <typename PointInT, typename PointNT, typename PointOutT> Eigen::MatrixXf
-  computeRSD (boost::shared_ptr<const pcl::PointCloud<PointInT> > &surface, boost::shared_ptr<const pcl::PointCloud<PointNT> > &normals,
-             const std::vector<int> &indices, double max_dist,
-             int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
+  computeRSD (const pcl::PointCloud<PointInT> &surface, const pcl::PointCloud<PointNT> &normals,
+              const std::vector<int> &indices, double max_dist,
+              int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
+
+  template <typename PointInT, typename PointNT, typename PointOutT>
+  [[deprecated("use computeRSD() overload that takes input point clouds by const reference")]]
+  Eigen::MatrixXf
+  computeRSD (typename pcl::PointCloud<PointInT>::ConstPtr &surface, typename pcl::PointCloud<PointNT>::ConstPtr &normals,
+              const std::vector<int> &indices, double max_dist,
+              int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false)
+  {
+    return computeRSD (*surface, *normals, indices, max_dist, nr_subdiv, plane_radius, radii, compute_histogram);
+  }
 
   /** \brief Estimate the Radius-based Surface Descriptor (RSD) for a given point based on its spatial neighborhood of 3D points with normals
     * \param[in] normals the dataset containing the surface normals at each point in the dataset
@@ -99,9 +109,19 @@ namespace pcl
     * \ingroup features
     */
   template <typename PointNT, typename PointOutT> Eigen::MatrixXf
-  computeRSD (boost::shared_ptr<const pcl::PointCloud<PointNT> > &normals,
-             const std::vector<int> &indices, const std::vector<float> &sqr_dists, double max_dist,
-             int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
+  computeRSD (const pcl::PointCloud<PointNT> &normals,
+              const std::vector<int> &indices, const std::vector<float> &sqr_dists, double max_dist,
+              int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
+
+  template <typename PointNT, typename PointOutT>
+  [[deprecated("use computeRSD() overload that takes input point cloud by const reference")]]
+  Eigen::MatrixXf
+  computeRSD (typename pcl::PointCloud<PointNT>::ConstPtr &normals,
+              const std::vector<int> &indices, const std::vector<float> &sqr_dists, double max_dist,
+              int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false)
+  {
+    return computeRSD (*normals, indices, sqr_dists, max_dist, nr_subdiv, plane_radius, radii, compute_histogram);
+  }
 
   /** \brief @b RSDEstimation estimates the Radius-based Surface Descriptor (minimal and maximal radius of the local surface's curves)
     * for a given point cloud dataset containing points and normals.


### PR DESCRIPTION
There is no reason to require the arguments to be pointers and not just objects. This commit adds overloads that take point clouds by reference and deprecates the old versions with pointers.

Extracted from #2823.