### PR TITLE
Fix too small loop variables

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
@@ -150,7 +150,7 @@ namespace pcl
       cloud_out.height = 1;
       cloud_out.is_dense = false;
 
-      for (int i = 0; i < points->GetNumberOfPoints (); i++)
+      for (vtkIdType i = 0; i < points->GetNumberOfPoints (); i++)
       {
         double p[3];
         points->GetPoint (i, p);

--- a/apps/cloud_composer/src/point_selectors/selection_event.cpp
+++ b/apps/cloud_composer/src/point_selectors/selection_event.cpp
@@ -52,7 +52,7 @@ pcl::cloud_composer::SelectionEvent::findIndicesInItem (CloudItem* cloud_item, p
     vtkIdTypeArray* point_ids  = vtkIdTypeArray::SafeDownCast(points_in_item->GetPointData ()->GetArray ("vtkIdFilter_Ids"));
   
     indices->indices.resize (point_ids->GetNumberOfTuples ());
-    for(int i =0; i < point_ids->GetNumberOfTuples (); ++i)
+    for(vtkIdType i =0; i < point_ids->GetNumberOfTuples (); ++i)
     {
     //qDebug () << "id="<<point_ids->GetValue (i);
       indices->indices[i] = point_ids->GetValue (i);

--- a/apps/in_hand_scanner/src/integration.cpp
+++ b/apps/in_hand_scanner/src/integration.cpp
@@ -213,7 +213,7 @@ pcl::ihs::Integration::merge (const CloudXYZRGBNormalConstPtr& cloud_data,
   // Nearest neighbor search
   CloudXYZPtr xyz_model (new CloudXYZ ());
   xyz_model->reserve (mesh_model->sizeVertices ());
-  for (unsigned int i=0; i<mesh_model->sizeVertices (); ++i)
+  for (size_t i=0; i<mesh_model->sizeVertices (); ++i)
   {
     const PointIHS& pt = mesh_model->getVertexDataCloud () [i];
     xyz_model->push_back (PointXYZ (pt.x, pt.y, pt.z));
@@ -388,7 +388,7 @@ pcl::ihs::Integration::merge (const CloudXYZRGBNormalConstPtr& cloud_data,
 void
 pcl::ihs::Integration::age (const MeshPtr& mesh, const bool cleanup) const
 {
-  for (unsigned int i=0; i<mesh->sizeVertices (); ++i)
+  for (size_t i=0; i<mesh->sizeVertices (); ++i)
   {
     PointIHS& pt = mesh->getVertexDataCloud () [i];
     if (pt.age < max_age_)
@@ -422,7 +422,7 @@ pcl::ihs::Integration::age (const MeshPtr& mesh, const bool cleanup) const
 void
 pcl::ihs::Integration::removeUnfitVertices (const MeshPtr& mesh, const bool cleanup) const
 {
-  for (unsigned int i=0; i<mesh->sizeVertices (); ++i)
+  for (size_t i=0; i<mesh->sizeVertices (); ++i)
   {
     if (pcl::ihs::countDirections (mesh->getVertexDataCloud () [i].directions) < min_directions_)
     {

--- a/apps/in_hand_scanner/src/offline_integration.cpp
+++ b/apps/in_hand_scanner/src/offline_integration.cpp
@@ -146,7 +146,7 @@ pcl::ihs::OfflineIntegration::computationThread ()
     return;
   }
 
-  for (unsigned int i=1; i<filenames.size (); ++i)
+  for (size_t i=1; i<filenames.size (); ++i)
   {
     std::cerr << "Processing file " << std::setw (5) << i+1 << " / " << filenames.size () << std::endl;
 

--- a/apps/in_hand_scanner/src/opengl_viewer.cpp
+++ b/apps/in_hand_scanner/src/opengl_viewer.cpp
@@ -91,7 +91,7 @@ pcl::ihs::detail::FaceVertexMesh::FaceVertexMesh (const Mesh& mesh, const Eigen:
   triangles.reserve (mesh.sizeFaces ());
   pcl::ihs::detail::FaceVertexMesh::Triangle triangle;
 
-  for (unsigned int i=0; i<mesh.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh.sizeFaces (); ++i)
   {
     Mesh::VertexAroundFaceCirculator circ = mesh.getVertexAroundFaceCirculator (Mesh::FaceIndex (i));
     triangle.first  = (circ++).getTargetIndex ().get ();
@@ -932,7 +932,7 @@ pcl::ihs::OpenGLViewer::drawMeshes ()
         }
         case COL_VISCONF:
         {
-          for (unsigned int i=0; i<mesh.vertices.size (); ++i)
+          for (size_t i=0; i<mesh.vertices.size (); ++i)
           {
             const unsigned int n = pcl::ihs::countDirections (mesh.vertices [i].directions);
             const unsigned int index = static_cast <unsigned int> (

--- a/apps/in_hand_scanner/src/visibility_confidence.cpp
+++ b/apps/in_hand_scanner/src/visibility_confidence.cpp
@@ -74,7 +74,7 @@ pcl::ihs::Dome::Dome ()
   vertices_.col (29) = Eigen::Vector4f (-0.187592626f, -0.577350378f, 0.794654489f, 0.f);
   vertices_.col (30) = Eigen::Vector4f ( 0.491123348f, -0.356822133f, 0.794654548f, 0.f);
 
-  for (unsigned int i=0; i<vertices_.cols (); ++i)
+  for (Eigen::Index i=0; i < vertices_.cols (); ++i)
   {
     vertices_.col (i).head <3> ().normalize ();
   }

--- a/apps/point_cloud_editor/src/cloud.cpp
+++ b/apps/point_cloud_editor/src/cloud.cpp
@@ -418,7 +418,7 @@ Cloud::getDisplaySpacePoint (unsigned int index) const
 void
 Cloud::getDisplaySpacePoints (Point3DVector& pts) const
 {
-  for(unsigned int i = 0; i < cloud_.size(); ++i)
+  for(size_t i = 0; i < cloud_.size(); ++i)
     pts.push_back(getDisplaySpacePoint(i));
 }
 
@@ -464,7 +464,7 @@ Cloud::updateCloudMembers ()
   float *pt = &(cloud_.points[0].data[X]);
   std::copy(pt, pt+XYZ_SIZE, max_xyz_);
   std::copy(max_xyz_, max_xyz_+XYZ_SIZE, min_xyz_);
-  for (unsigned int i = 1; i < cloud_.size(); ++i)
+  for (size_t i = 1; i < cloud_.size(); ++i)
   {
     for (unsigned int j = 0; j < XYZ_SIZE; ++j)
     {

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -573,7 +573,7 @@ CloudEditorWidget::isColored (const std::string &fileName) const
   pcl::PCDReader reader;
   reader.readHeader(fileName, cloud2);
   std::vector< pcl::PCLPointField > fs = cloud2.fields;
-  for(unsigned int i = 0; i < fs.size(); ++i)
+  for(size_t i = 0; i < fs.size(); ++i)
   {
     std::string name(fs[i].name);
     stringToLower(name);

--- a/apps/point_cloud_editor/src/select2DTool.cpp
+++ b/apps/point_cloud_editor/src/select2DTool.cpp
@@ -96,7 +96,7 @@ Select2DTool::end (int x, int y, BitMask modifiers, BitMask)
 
   Point3DVector ptsvec;
   cloud_ptr_->getDisplaySpacePoints(ptsvec);
-  for(unsigned int i = 0; i < ptsvec.size(); ++i)
+  for(size_t i = 0; i < ptsvec.size(); ++i)
   {
     Point3D pt = ptsvec[i];
     if (isInSelectBox(pt, project, viewport))

--- a/apps/src/convolve.cpp
+++ b/apps/src/convolve.cpp
@@ -71,7 +71,7 @@ main (int argc, char ** argv)
   Eigen::ArrayXf gaussian_kernel(5);
   gaussian_kernel << 1.f/16, 1.f/4, 3.f/8, 1.f/4, 1.f/16;
   pcl::console::print_info ("convolution kernel:");
-  for (int i = 0; i < gaussian_kernel.size (); ++i)
+  for (Eigen::Index i = 0; i < gaussian_kernel.size (); ++i)
     pcl::console::print_info (" %f", gaussian_kernel[i]);
   pcl::console::print_info ("\n");
 

--- a/apps/src/feature_matching.cpp
+++ b/apps/src/feature_matching.cpp
@@ -298,12 +298,12 @@ void ICCVTutorial<FeatureType>::filterCorrespondences ()
 {
   cout << "correspondence rejection..." << std::flush;
   std::vector<std::pair<unsigned, unsigned> > correspondences;
-  for (unsigned cIdx = 0; cIdx < source2target_.size (); ++cIdx)
+  for (size_t cIdx = 0; cIdx < source2target_.size (); ++cIdx)
     if (target2source_[source2target_[cIdx]] == static_cast<int> (cIdx))
       correspondences.push_back(std::make_pair(cIdx, source2target_[cIdx]));
 
   correspondences_->resize (correspondences.size());
-  for (unsigned cIdx = 0; cIdx < correspondences.size(); ++cIdx)
+  for (size_t cIdx = 0; cIdx < correspondences.size(); ++cIdx)
   {
     (*correspondences_)[cIdx].index_query = correspondences[cIdx].first;
     (*correspondences_)[cIdx].index_match = correspondences[cIdx].second;

--- a/apps/src/nn_classification_example.cpp
+++ b/apps/src/nn_classification_example.cpp
@@ -80,7 +80,7 @@ main (int, char* argv[])
   }
 
   // Print results
-  for (unsigned i = 0; i < result->first.size(); ++i)
+  for (size_t i = 0; i < result->first.size(); ++i)
     std::cerr << result->first.at (i) << ": " << result->second.at (i) << std::endl;
 
   return 0;

--- a/apps/src/pcd_organized_multi_plane_segmentation.cpp
+++ b/apps/src/pcd_organized_multi_plane_segmentation.cpp
@@ -186,7 +186,7 @@ class PCDOrganizedMultiPlaneSegmentation
         
 //        sprintf (name, "approx_plane_%02d", int (i));
 //        viewer.addPolygon<PointT> (approx_contour_const, 0.5 * red[i], 0.5 * grn[i], 0.5 * blu[i], name);
-        for (unsigned idx = 0; idx < approx_contour->points.size (); ++idx)
+        for (size_t idx = 0; idx < approx_contour->points.size (); ++idx)
         {
           sprintf (name, "approx_plane_%02d_%03d", int (i), int(idx));
           viewer.addLine (approx_contour->points [idx], approx_contour->points [(idx+1)%approx_contour->points.size ()], 0.5 * red[i], 0.5 * grn[i], 0.5 * blu[i], name);

--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -134,7 +134,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
   else
   {
     cam_positions.resize (sphere->GetNumberOfPoints ());
-    for (int i = 0; i < sphere->GetNumberOfPoints (); i++)
+    for (vtkIdType i = 0; i < sphere->GetNumberOfPoints (); i++)
     {
       double cam_pos[3];
       sphere->GetPoint (i, cam_pos);
@@ -382,7 +382,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
       vtkSmartPointer<vtkIdTypeArray> ids = vtkSmartPointer<vtkIdTypeArray>::New ();
       ids = vtkIdTypeArray::SafeDownCast(hdw_selection->GetNode(0)->GetSelectionList());
       double visible_area = 0;
-      for (int sel_id = 0; sel_id < (ids->GetNumberOfTuples ()); sel_id++)
+      for (vtkIdType sel_id = 0; sel_id < (ids->GetNumberOfTuples ()); sel_id++)
       {
         int id_mesh = int (ids->GetValue (sel_id));
         if(id_mesh >= polydata->GetNumberOfPolys())

--- a/apps/src/test_search.cpp
+++ b/apps/src/test_search.cpp
@@ -44,7 +44,7 @@ main (int argc, char ** argv)
   else
   {
     cloud->resize (1000000);
-    for (unsigned idx = 0; idx < cloud->size (); ++idx)
+    for (size_t idx = 0; idx < cloud->size (); ++idx)
     {
       (*cloud)[idx].x = static_cast<float> (rand () / RAND_MAX);
       (*cloud)[idx].y = static_cast<float> (rand () / RAND_MAX);
@@ -125,7 +125,7 @@ main (int argc, char ** argv)
   else
   {
     cerr << "size of result: " <<kd_indices.size () << endl;
-    for (unsigned idx = 0; idx < kd_indices.size (); ++idx)
+    for (size_t idx = 0; idx < kd_indices.size (); ++idx)
     {
       if (kd_indices[idx] != bf_indices[idx] && kd_distances[idx] != bf_distances[idx])
       {

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -345,7 +345,7 @@ RangeImage::getIntegralImage (float*& integral_image, int*& valid_points_num_ima
 void 
 RangeImage::setUnseenToMaxRange ()
 {
-  for (unsigned int i=0; i<points.size (); ++i)
+  for (size_t i=0; i < points.size (); ++i)
     if (std::isinf (points[i].range))
       points[i].range = std::numeric_limits<float>::infinity ();
 }
@@ -443,7 +443,7 @@ RangeImage::getMinMaxRanges (float& min_range, float& max_range) const
 {
   min_range = std::numeric_limits<float>::infinity ();
   max_range = -std::numeric_limits<float>::infinity ();
-  for (unsigned int i=0; i<points.size (); ++i)
+  for (size_t i=0; i < points.size (); ++i)
   {
     float range = points[i].range;
     if (!std::isfinite (range))

--- a/examples/geometry/example_half_edge_mesh.cpp
+++ b/examples/geometry/example_half_edge_mesh.cpp
@@ -97,7 +97,7 @@ void
 printVertices (const Mesh& mesh)
 {
   std::cout << "Vertices:\n   ";
-  for (unsigned int i=0; i<mesh.sizeVertices (); ++i)
+  for (size_t i=0; i<mesh.sizeVertices (); ++i)
   {
     std::cout << mesh.getVertexDataCloud () [i] << " ";
   }
@@ -132,7 +132,7 @@ void
 printFaces (const Mesh& mesh)
 {
   std::cout << "Faces:\n";
-  for (unsigned int i=0; i<mesh.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh.sizeFaces (); ++i)
   {
     printFace (mesh, FaceIndex (i));
   }

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -501,7 +501,7 @@ addSupervoxelConnectionsToViewer (PointT &supervoxel_center,
   // Add the points to the dataset
   polyData->SetPoints (points);
   polyLine->GetPointIds  ()->SetNumberOfIds(points->GetNumberOfPoints ());
-  for(unsigned int i = 0; i < points->GetNumberOfPoints (); i++)
+  for(vtkIdType i = 0; i < points->GetNumberOfPoints (); i++)
     polyLine->GetPointIds ()->SetId (i,i);
   cells->InsertNextCell (polyLine);
   // Add the lines to the dataset

--- a/examples/surface/example_nurbs_fitting_closed_curve.cpp
+++ b/examples/surface/example_nurbs_fitting_closed_curve.cpp
@@ -14,7 +14,7 @@ pcl::visualization::PCLVisualizer viewer ("Curve Fitting PDM (red), SDM (green),
 void
 PointCloud2Vector2d (pcl::PointCloud<pcl::PointXYZ>::Ptr cloud, pcl::on_nurbs::vector_vec2d &data)
 {
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     pcl::PointXYZ &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y))

--- a/examples/surface/example_nurbs_fitting_closed_curve3d.cpp
+++ b/examples/surface/example_nurbs_fitting_closed_curve3d.cpp
@@ -12,7 +12,7 @@ pcl::visualization::PCLVisualizer viewer ("Curve Fitting 3D");
 void
 PointCloud2Vector2d (pcl::PointCloud<pcl::PointXYZ>::Ptr cloud, pcl::on_nurbs::vector_vec3d &data)
 {
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     pcl::PointXYZ &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y) && !std::isnan (p.z))

--- a/examples/surface/example_nurbs_fitting_curve2d.cpp
+++ b/examples/surface/example_nurbs_fitting_curve2d.cpp
@@ -12,7 +12,7 @@ pcl::visualization::PCLVisualizer viewer ("Curve Fitting 2D");
 void
 PointCloud2Vector2d (pcl::PointCloud<pcl::PointXYZ>::Ptr cloud, pcl::on_nurbs::vector_vec2d &data)
 {
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     pcl::PointXYZ &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y))
@@ -26,7 +26,7 @@ VisualizeCurve (ON_NurbsCurve &curve, double r, double g, double b, bool show_cp
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
   pcl::on_nurbs::Triangulation::convertCurve2PointCloud (curve, cloud, 8);
 
-  for (std::size_t i = 0; i < cloud->size () - 1; i++)
+  for (size_t i = 0; i < cloud->size () - 1; i++)
   {
     pcl::PointXYZRGB &p1 = cloud->at (i);
     pcl::PointXYZRGB &p2 = cloud->at (i + 1);

--- a/examples/surface/example_nurbs_fitting_surface.cpp
+++ b/examples/surface/example_nurbs_fitting_surface.cpp
@@ -171,7 +171,7 @@ main (int argc, char *argv[])
 void
 PointCloud2Vector3d (pcl::PointCloud<Point>::Ptr cloud, pcl::on_nurbs::vector_vec3d &data)
 {
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     Point &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y) && !std::isnan (p.z))

--- a/features/include/pcl/features/impl/fpfh.hpp
+++ b/features/include/pcl/features/impl/fpfh.hpp
@@ -250,7 +250,7 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
     {
       if (this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
       {
-        for (int d = 0; d < fpfh_histogram_.size (); ++d)
+        for (size_t d = 0; d < fpfh_histogram_.size (); ++d)
           output.points[idx].histogram[d] = std::numeric_limits<float>::quiet_NaN ();
     
         output.is_dense = false;
@@ -266,7 +266,7 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
       weightPointSPFHSignature (hist_f1_, hist_f2_, hist_f3_, nn_indices, nn_dists, fpfh_histogram_);
 
       // ...and copy it into the output cloud
-      for (int d = 0; d < fpfh_histogram_.size (); ++d)
+      for (size_t d = 0; d < fpfh_histogram_.size (); ++d)
         output.points[idx].histogram[d] = fpfh_histogram_[d];
     }
   }
@@ -278,7 +278,7 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
       if (!isFinite ((*input_)[(*indices_)[idx]]) ||
           this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
       {
-        for (int d = 0; d < fpfh_histogram_.size (); ++d)
+        for (size_t d = 0; d < fpfh_histogram_.size (); ++d)
           output.points[idx].histogram[d] = std::numeric_limits<float>::quiet_NaN ();
     
         output.is_dense = false;
@@ -294,7 +294,7 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
       weightPointSPFHSignature (hist_f1_, hist_f2_, hist_f3_, nn_indices, nn_dists, fpfh_histogram_);
 
       // ...and copy it into the output cloud
-      for (int d = 0; d < fpfh_histogram_.size (); ++d)
+      for (size_t d = 0; d < fpfh_histogram_.size (); ++d)
         output.points[idx].histogram[d] = fpfh_histogram_[d];
     }
   }

--- a/features/include/pcl/features/impl/grsd.hpp
+++ b/features/include/pcl/features/impl/grsd.hpp
@@ -102,7 +102,7 @@ pcl::GRSDEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
   {
     int source_type = types[idx];
     std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud_downsampled->points[idx], relative_coordinates_all_);
-    for (unsigned id_n = 0; id_n < neighbors.size (); id_n++)
+    for (size_t id_n = 0; id_n < neighbors.size (); id_n++)
     {
       int neighbor_type;
       if (neighbors[id_n] == -1) // empty

--- a/features/include/pcl/features/impl/intensity_spin.hpp
+++ b/features/include/pcl/features/impl/intensity_spin.hpp
@@ -161,9 +161,9 @@ pcl::IntensitySpinEstimation<PointInT, PointOutT>::computeFeature (PointCloudOut
     computeIntensitySpinImage (*surface_, static_cast<float> (search_radius_), sigma_, k, nn_indices, nn_dist_sqr, intensity_spin_image);
 
     // Copy into the resultant cloud
-    int bin = 0;
-    for (int bin_j = 0; bin_j < intensity_spin_image.cols (); ++bin_j)
-      for (int bin_i = 0; bin_i < intensity_spin_image.rows (); ++bin_i)
+    size_t bin = 0;
+    for (Eigen::Index bin_j = 0; bin_j < intensity_spin_image.cols (); ++bin_j)
+      for (Eigen::Index bin_i = 0; bin_i < intensity_spin_image.rows (); ++bin_i)
         output.points[idx].histogram[bin++] = intensity_spin_image (bin_i, bin_j);
   }
 }

--- a/features/include/pcl/features/impl/normal_based_signature.hpp
+++ b/features/include/pcl/features/impl/normal_based_signature.hpp
@@ -143,10 +143,10 @@ pcl::NormalBasedSignatureEstimation<PointT, PointNT, PointFeature>::computeFeatu
 
       // do DCT on the s_matrix row-wise
       Eigen::VectorXf dct_row (M_);
-      for (int m = 0; m < s_row.size (); ++m)
+      for (Eigen::Index m = 0; m < s_row.size (); ++m)
       {
         float Xk = 0.0f;
-        for (int n = 0; n < s_row.size (); ++n)
+        for (Eigen::Index n = 0; n < s_row.size (); ++n)
           Xk += static_cast<float> (s_row[n] * cos (M_PI / (static_cast<double> (M_ * n) + 0.5) * static_cast<double> (k)));
         dct_row[m] = Xk;
       }

--- a/features/include/pcl/features/impl/organized_edge_detection.hpp
+++ b/features/include/pcl/features/impl/organized_edge_detection.hpp
@@ -70,7 +70,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::assignLabelIndices (pcl::PointCloud<Poi
 {
   const unsigned invalid_label = unsigned (0);
   label_indices.resize (num_of_edgetype_);
-  for (unsigned idx = 0; idx < input_->points.size (); idx++)
+  for (size_t idx = 0; idx < input_->points.size (); idx++)
   {
     if (labels[idx].label != invalid_label)
     {

--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -184,7 +184,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
     {
       if (this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
       {
-        for (int d = 0; d < pfh_histogram_.size (); ++d)
+        for (Eigen::Index d = 0; d < pfh_histogram_.size (); ++d)
           output.points[idx].histogram[d] = std::numeric_limits<float>::quiet_NaN ();
 
         output.is_dense = false;
@@ -195,7 +195,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
       computePointPFHSignature (*surface_, *normals_, nn_indices, nr_subdiv_, pfh_histogram_);
 
       // Copy into the resultant cloud
-      for (int d = 0; d < pfh_histogram_.size (); ++d)
+      for (Eigen::Index d = 0; d < pfh_histogram_.size (); ++d)
         output.points[idx].histogram[d] = pfh_histogram_[d];
     }
   }
@@ -207,7 +207,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
       if (!isFinite ((*input_)[(*indices_)[idx]]) ||
           this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
       {
-        for (int d = 0; d < pfh_histogram_.size (); ++d)
+        for (Eigen::Index d = 0; d < pfh_histogram_.size (); ++d)
           output.points[idx].histogram[d] = std::numeric_limits<float>::quiet_NaN ();
 
         output.is_dense = false;
@@ -218,7 +218,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
       computePointPFHSignature (*surface_, *normals_, nn_indices, nr_subdiv_, pfh_histogram_);
 
       // Copy into the resultant cloud
-      for (int d = 0; d < pfh_histogram_.size (); ++d)
+      for (Eigen::Index d = 0; d < pfh_histogram_.size (); ++d)
         output.points[idx].histogram[d] = pfh_histogram_[d];
     }
   }

--- a/features/include/pcl/features/impl/pfhrgb.hpp
+++ b/features/include/pcl/features/impl/pfhrgb.hpp
@@ -160,7 +160,7 @@ pcl::PFHRGBEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudO
     computePointPFHRGBSignature (*surface_, *normals_, nn_indices, nr_subdiv_, pfhrgb_histogram_);
 
     // Copy into the resultant cloud
-    for (int d = 0; d < pfhrgb_histogram_.size (); ++d) {
+    for (Eigen::Index d = 0; d < pfhrgb_histogram_.size (); ++d) {
       output.points[idx].histogram[d] = pfhrgb_histogram_[d];
 //      PCL_INFO ("%f ", pfhrgb_histogram_[d]);
     }

--- a/features/include/pcl/features/impl/rift.hpp
+++ b/features/include/pcl/features/impl/rift.hpp
@@ -171,9 +171,9 @@ pcl::RIFTEstimation<PointInT, GradientT, PointOutT>::computeFeature (PointCloudO
     computeRIFT (*surface_, *gradient_, (*indices_)[idx], static_cast<float> (search_radius_), nn_indices, nn_dist_sqr, rift_descriptor);
 
     // Copy into the resultant cloud
-    int bin = 0;
-    for (int g_bin = 0; g_bin < rift_descriptor.cols (); ++g_bin)
-      for (int d_bin = 0; d_bin < rift_descriptor.rows (); ++d_bin)
+    size_t bin = 0;
+    for (Eigen::Index g_bin = 0; g_bin < rift_descriptor.cols (); ++g_bin)
+      for (Eigen::Index d_bin = 0; d_bin < rift_descriptor.rows (); ++d_bin)
         output.points[idx].histogram[bin++] = rift_descriptor (d_bin, g_bin);
   }
 }

--- a/features/include/pcl/features/impl/shot_omp.hpp
+++ b/features/include/pcl/features/impl/shot_omp.hpp
@@ -179,7 +179,7 @@ pcl::SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::computeFeature (
                                                                                            nn_dists) == 0)
     {
       // Copy into the resultant cloud
-      for (int d = 0; d < shot.size (); ++d)
+      for (Eigen::Index d = 0; d < shot.size (); ++d)
         output.points[idx].descriptor[d] = std::numeric_limits<float>::quiet_NaN ();
       for (int d = 0; d < 9; ++d)
         output.points[idx].rf[d] = std::numeric_limits<float>::quiet_NaN ();
@@ -192,7 +192,7 @@ pcl::SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::computeFeature (
     this->computePointSHOT (idx, nn_indices, nn_dists, shot);
 
     // Copy into the resultant cloud
-    for (int d = 0; d < shot.size (); ++d)
+    for (Eigen::Index d = 0; d < shot.size (); ++d)
       output.points[idx].descriptor[d] = shot[d];
     for (int d = 0; d < 3; ++d)
     {
@@ -267,7 +267,7 @@ pcl::SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::computeFeat
         this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
     {
       // Copy into the resultant cloud
-      for (int d = 0; d < shot.size (); ++d)
+      for (Eigen::Index d = 0; d < shot.size (); ++d)
         output.points[idx].descriptor[d] = std::numeric_limits<float>::quiet_NaN ();
       for (int d = 0; d < 9; ++d)
         output.points[idx].rf[d] = std::numeric_limits<float>::quiet_NaN ();
@@ -280,7 +280,7 @@ pcl::SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::computeFeat
     this->computePointSHOT (idx, nn_indices, nn_dists, shot);
 
     // Copy into the resultant cloud
-    for (int d = 0; d < shot.size (); ++d)
+    for (Eigen::Index d = 0; d < shot.size (); ++d)
       output.points[idx].descriptor[d] = shot[d];
     for (int d = 0; d < 3; ++d)
     {

--- a/features/include/pcl/features/impl/spin_image.hpp
+++ b/features/include/pcl/features/impl/spin_image.hpp
@@ -328,9 +328,9 @@ pcl::SpinImageEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointClo
     Eigen::ArrayXXd res = computeSiForPoint (indices_->at (i_input));
 
     // Copy into the resultant cloud
-    for (int iRow = 0; iRow < res.rows () ; iRow++)
+    for (Eigen::Index iRow = 0; iRow < res.rows () ; iRow++)
     {
-      for (int iCol = 0; iCol < res.cols () ; iCol++)
+      for (Eigen::Index iCol = 0; iCol < res.cols () ; iCol++)
       {
         output.points[i_input].histogram[ iRow*res.cols () + iCol ] = static_cast<float> (res (iRow, iCol));
       }

--- a/features/include/pcl/features/impl/vfh.hpp
+++ b/features/include/pcl/features/impl/vfh.hpp
@@ -238,19 +238,19 @@ pcl::VFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
   output.height = 1;
 
   // Estimate the FPFH at nn_indices[0] using the entire cloud and copy the resultant signature
-  for (int d = 0; d < hist_f1_.size (); ++d)
+  for (Eigen::Index d = 0; d < hist_f1_.size (); ++d)
     output.points[0].histogram[d + 0] = hist_f1_[d];
 
   size_t data_size = hist_f1_.size ();
-  for (int d = 0; d < hist_f2_.size (); ++d)
+  for (Eigen::Index d = 0; d < hist_f2_.size (); ++d)
     output.points[0].histogram[d + data_size] = hist_f2_[d];
 
   data_size += hist_f2_.size ();
-  for (int d = 0; d < hist_f3_.size (); ++d)
+  for (Eigen::Index d = 0; d < hist_f3_.size (); ++d)
     output.points[0].histogram[d + data_size] = hist_f3_[d];
 
   data_size += hist_f3_.size ();
-  for (int d = 0; d < hist_f4_.size (); ++d)
+  for (Eigen::Index d = 0; d < hist_f4_.size (); ++d)
     output.points[0].histogram[d + data_size] = hist_f4_[d];
 
   // ---[ Step 2 : obtain the viewpoint component
@@ -279,7 +279,7 @@ pcl::VFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
   }
   data_size += hist_f4_.size ();
   // Copy the resultant signature
-  for (int d = 0; d < hist_vp_.size (); ++d)
+  for (Eigen::Index d = 0; d < hist_vp_.size (); ++d)
     output.points[0].histogram[d + data_size] = hist_vp_[d];
 }
 

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -261,7 +261,7 @@ Narf::extractFromRangeImageWithBestRotation (const RangeImage& range_image, cons
   if (rotations.empty())
     return false;
   float best_rotation=rotations[0], best_strength=strengths[0];
-  for (unsigned int i=1; i<rotations.size(); ++i)
+  for (size_t i = 1; i < rotations.size(); ++i)
   {
     if (strengths[i] > best_strength)
     {
@@ -401,7 +401,7 @@ Narf::extractForInterestPoints (const RangeImage& range_image, const PointCloud<
         feature->getRotations(rotations, strengths);
         {
           //feature->getRotatedVersions(range_image, rotations, feature_list);
-          for (unsigned int i=0; i<rotations.size(); ++i)
+          for (size_t i = 0; i < rotations.size(); ++i)
           {
             float rotation = rotations[i];
             Narf* feature2 = new Narf(*feature);  // Call copy constructor
@@ -498,7 +498,7 @@ Narf::getRotations (std::vector<float>& rotations, std::vector<float>& strengths
 void 
 Narf::getRotatedVersions (const RangeImage&, const std::vector<float>& rotations, std::vector<Narf*>& features) const
 {
-  for (unsigned int i=0; i<rotations.size(); ++i)
+  for (size_t i = 0; i < rotations.size(); ++i)
   {
     float rotation = rotations[i];
     
@@ -680,7 +680,7 @@ NarfDescriptor::computeFeature(NarfDescriptor::PointCloudOut& output)
   
   // Copy to NARF36 struct
   output.points.resize(feature_list.size());
-  for (unsigned int i=0; i<feature_list.size(); ++i)
+  for (size_t i = 0; i < feature_list.size(); ++i)
   {
     feature_list[i]->copyToNarf36(output.points[i]);
   }

--- a/filters/include/pcl/filters/impl/box_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/box_clipper3D.hpp
@@ -202,7 +202,7 @@ pcl::BoxClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& clou
   if (indices.empty ())
   {
     clipped.reserve (cloud_in.size ());
-    for (unsigned pIdx = 0; pIdx < cloud_in.size (); ++pIdx)
+    for (size_t pIdx = 0; pIdx < cloud_in.size (); ++pIdx)
       if (clipPoint3D (cloud_in[pIdx]))
         clipped.push_back (pIdx);
   }

--- a/filters/include/pcl/filters/impl/grid_minimum.hpp
+++ b/filters/include/pcl/filters/impl/grid_minimum.hpp
@@ -165,7 +165,7 @@ pcl::GridMinimum<PointT>::applyFilterIndices (std::vector<int> &indices)
 
   index = 0;
 
-  for (unsigned int cp = 0; cp < first_and_last_indices_vector.size (); ++cp)
+  for (size_t cp = 0; cp < first_and_last_indices_vector.size (); ++cp)
   {
     unsigned int first_index = first_and_last_indices_vector[cp].first;
     unsigned int last_index = first_and_last_indices_vector[cp].second;

--- a/filters/include/pcl/filters/impl/normal_space.hpp
+++ b/filters/include/pcl/filters/impl/normal_space.hpp
@@ -206,21 +206,21 @@ pcl::NormalSpaceSampling<PointT, NormalT>::applyFilter (std::vector<int> &indice
   // Setting up random access for the list created above. Maintaining the iterators to individual elements of the list
   // in a vector. Using vector now as the size of the list is known.
   std::vector<std::vector<std::list<int>::iterator> > random_access (normals_hg.size ());
-  for (unsigned int i = 0; i < normals_hg.size (); i++)
+  for (size_t i = 0; i < normals_hg.size (); i++)
   {
     random_access.emplace_back();
     random_access[i].resize (normals_hg[i].size ());
 
-    unsigned int j = 0;
+    size_t j = 0;
     for (std::list<int>::iterator itr = normals_hg[i].begin (); itr != normals_hg[i].end (); itr++, j++)
       random_access[i][j] = itr;
   }
-  std::vector<unsigned int> start_index (normals_hg.size ());
+  std::vector<size_t> start_index (normals_hg.size ());
   start_index[0] = 0;
-  unsigned int prev_index = start_index[0];
-  for (unsigned int i = 1; i < normals_hg.size (); i++)
+  size_t prev_index = 0;
+  for (size_t i = 1; i < normals_hg.size (); i++)
   {
-    start_index[i] = prev_index + static_cast<unsigned int> (normals_hg[i-1].size ());
+    start_index[i] = prev_index + normals_hg[i-1].size ();
     prev_index = start_index[i];
   }
 
@@ -232,7 +232,7 @@ pcl::NormalSpaceSampling<PointT, NormalT>::applyFilter (std::vector<int> &indice
   while (i < sample_)
   {
     // Iterating through every bin and picking one point at random, until the required number of points are sampled.
-    for (unsigned int j = 0; j < normals_hg.size (); j++)
+    for (size_t j = 0; j < normals_hg.size (); j++)
     {
       unsigned int M = static_cast<unsigned int> (normals_hg[j].size ());
       if (M == 0 || bin_empty_flag.test (j)) // bin_empty_flag(i) is set if all points in that bin are sampled..

--- a/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
+++ b/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
@@ -49,7 +49,7 @@ pcl::SamplingSurfaceNormal<PointT>::applyFilter (PointCloud &output)
 {
   std::vector <int> indices;
   size_t npts = input_->points.size ();
-  for (unsigned int i = 0; i < npts; i++)
+  for (size_t i = 0; i < npts; i++)
     indices.push_back (i);
 
   Vector max_vec (3, 1);
@@ -68,7 +68,7 @@ pcl::SamplingSurfaceNormal<PointT>::findXYZMaxMin (const PointCloud& cloud, Vect
   float maxval = cloud.points[0].x;
   float minval = cloud.points[0].x;
 
-  for (unsigned int i = 0; i < cloud.points.size (); i++)
+  for (size_t i = 0; i < cloud.points.size (); i++)
   {
     if (cloud.points[i].x > maxval)
     {
@@ -85,7 +85,7 @@ pcl::SamplingSurfaceNormal<PointT>::findXYZMaxMin (const PointCloud& cloud, Vect
   maxval = cloud.points[0].y;
   minval = cloud.points[0].y;
 
-  for (unsigned int i = 0; i < cloud.points.size (); i++)
+  for (size_t i = 0; i < cloud.points.size (); i++)
   {
     if (cloud.points[i].y > maxval)
     {
@@ -102,7 +102,7 @@ pcl::SamplingSurfaceNormal<PointT>::findXYZMaxMin (const PointCloud& cloud, Vect
   maxval = cloud.points[0].z;
   minval = cloud.points[0].z;
 
-  for (unsigned int i = 0; i < cloud.points.size (); i++)
+  for (size_t i = 0; i < cloud.points.size (); i++)
   {
     if (cloud.points[i].z > maxval)
     {
@@ -181,7 +181,7 @@ pcl::SamplingSurfaceNormal<PointT>::samplePartition (
 
   computeNormal (cloud, normal, curvature);
 
-  for (unsigned int i = 0; i < cloud.points.size (); i++)
+  for (size_t i = 0; i < cloud.points.size (); i++)
   {
     // TODO: change to Boost random number generators!
     const float r = float (std::rand ()) / float (RAND_MAX);
@@ -234,8 +234,8 @@ pcl::SamplingSurfaceNormal<PointT>::computeMeanAndCovarianceMatrix (const pcl::P
 {
   // create the buffer on the stack which is much faster than using cloud.points[indices[i]] and centroid as a buffer
   Eigen::Matrix<float, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<float, 1, 9, Eigen::RowMajor>::Zero ();
-  unsigned int point_count = 0;
-  for (unsigned int i = 0; i < cloud.points.size (); i++)
+  size_t point_count = 0;
+  for (size_t i = 0; i < cloud.points.size (); i++)
   {
     if (!isFinite (cloud[i]))
     {

--- a/filters/include/pcl/filters/impl/shadowpoints.hpp
+++ b/filters/include/pcl/filters/impl/shadowpoints.hpp
@@ -51,13 +51,13 @@ pcl::ShadowPoints<PointT, NormalT>::applyFilter (PointCloud &output)
   if (extract_removed_indices_)
     removed_indices_->resize (input_->points.size ());
 
-  unsigned int cp = 0;
-  unsigned int ri = 0;
-  for (unsigned int i = 0; i < input_->points.size (); i++)
+  size_t cp = 0;
+  size_t ri = 0;
+  for (size_t i = 0; i < input_->points.size (); i++)
   {
     const NormalT &normal = input_normals_->points[i];
     const PointT &pt = input_->points[i];
-    float val = fabsf (normal.normal_x * pt.x + normal.normal_y * pt.y + normal.normal_z * pt.z);
+    const float val = fabsf (normal.normal_x * pt.x + normal.normal_y * pt.y + normal.normal_z * pt.z);
 
     if ( (val >= threshold_) ^ negative_)
       output.points[cp++] = pt;

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -393,7 +393,7 @@ pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
   }
   
   index = 0;
-  for (unsigned int cp = 0; cp < first_and_last_indices_vector.size (); ++cp)
+  for (size_t cp = 0; cp < first_and_last_indices_vector.size (); ++cp)
   {
     // calculate centroid - sum values from all input points, that have the same idx value in index_vector array
   	unsigned int first_index = first_and_last_indices_vector[cp].first;

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -386,7 +386,7 @@ pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const PointT& referenc
 
   // Check each neighbor to see if it is occupied and contains sufficient points
   // Slower than radius search because needs to check 26 indices
-  for (int ni = 0; ni < relative_coordinates.cols (); ni++)
+  for (Eigen::Index ni = 0; ni < relative_coordinates.cols (); ni++)
   {
     Eigen::Vector4i displacement = (Eigen::Vector4i () << relative_coordinates.col (ni), 0).finished ();
     // Checking if the specified cell is in the grid

--- a/filters/include/pcl/filters/model_outlier_removal.h
+++ b/filters/include/pcl/filters/model_outlier_removal.h
@@ -95,7 +95,7 @@ namespace pcl
       setModelCoefficients (const pcl::ModelCoefficients model_coefficients)
       {
         model_coefficients_.resize (model_coefficients.values.size ());
-        for (unsigned int i = 0; i < model_coefficients.values.size (); i++)
+        for (size_t i = 0; i < model_coefficients.values.size (); i++)
         {
           model_coefficients_[i] = model_coefficients.values[i];
         }
@@ -108,7 +108,7 @@ namespace pcl
       {
         pcl::ModelCoefficients mc;
         mc.values.resize (model_coefficients_.size ());
-        for (unsigned int i = 0; i < mc.values.size (); i++)
+        for (size_t i = 0; i < mc.values.size (); i++)
           mc.values[i] = model_coefficients_[i];
         return (mc);
       }

--- a/filters/include/pcl/filters/normal_refinement.h
+++ b/filters/include/pcl/filters/normal_refinement.h
@@ -102,7 +102,7 @@ namespace pcl
     float nx = 0.0f;
     float ny = 0.0f;
     float nz = 0.0f;
-    for (unsigned int i = 0; i < k_indices.size (); ++i) {
+    for (size_t i = 0; i < k_indices.size (); ++i) {
       // Neighbor
       const NormalT& pointi = cloud[k_indices[i]];
       

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -338,7 +338,7 @@ namespace pcl
         Eigen::Array4i diff2min = min_b_ - ijk;
         Eigen::Array4i diff2max = max_b_ - ijk;
         std::vector<int> neighbors (relative_coordinates.cols());
-        for (int ni = 0; ni < relative_coordinates.cols (); ni++)
+        for (Eigen::Index ni = 0; ni < relative_coordinates.cols (); ni++)
         {
           Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
           // checking if the specified cell is in the grid
@@ -668,7 +668,7 @@ namespace pcl
         Eigen::Array4i diff2min = min_b_ - ijk;
         Eigen::Array4i diff2max = max_b_ - ijk;
         std::vector<int> neighbors (relative_coordinates.cols());
-        for (int ni = 0; ni < relative_coordinates.cols (); ni++)
+        for (Eigen::Index ni = 0; ni < relative_coordinates.cols (); ni++)
         {
           Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
           // checking if the specified cell is in the grid

--- a/geometry/include/pcl/geometry/impl/polygon_operations.hpp
+++ b/geometry/include/pcl/geometry/impl/polygon_operations.hpp
@@ -52,7 +52,7 @@ pcl::approximatePolygon (const PlanarPolygon<PointT>& polygon, PlanarPolygon<Poi
   Eigen::Affine3f transformation = Eigen::Translation3f (0, 0, coefficients [3]) * Eigen::AngleAxisf (rotation_angle, rotation_axis);
 
   typename pcl::PointCloud<PointT>::VectorType polygon2D (contour.size ());
-  for (unsigned pIdx = 0; pIdx < polygon2D.size (); ++pIdx)
+  for (size_t pIdx = 0; pIdx < polygon2D.size (); ++pIdx)
     polygon2D [pIdx].getVector3fMap () = transformation * contour [pIdx].getVector3fMap ();
 
   typename pcl::PointCloud<PointT>::VectorType approx_polygon2D;
@@ -62,7 +62,7 @@ pcl::approximatePolygon (const PlanarPolygon<PointT>& polygon, PlanarPolygon<Poi
   approx_contour.resize (approx_polygon2D.size ());
   
   Eigen::Affine3f inv_transformation = transformation.inverse ();
-  for (unsigned pIdx = 0; pIdx < approx_polygon2D.size (); ++pIdx)
+  for (size_t pIdx = 0; pIdx < approx_polygon2D.size (); ++pIdx)
     approx_contour [pIdx].getVector3fMap () = inv_transformation * approx_polygon2D [pIdx].getVector3fMap ();
 }
 
@@ -82,7 +82,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
   if (closed)
   {
     float max_distance = .0f;
-    for (unsigned idx = 1; idx < polygon.size (); ++idx)
+    for (size_t idx = 1; idx < polygon.size (); ++idx)
     {
       float distance = (polygon [0].x - polygon [idx].x) * (polygon [0].x - polygon [idx].x) + 
                        (polygon [0].y - polygon [idx].y) * (polygon [0].y - polygon [idx].y);
@@ -94,7 +94,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
       }
     }
 
-    for (unsigned idx = 1; idx < polygon.size (); ++idx)
+    for (size_t idx = 1; idx < polygon.size (); ++idx)
     {
       float distance = (polygon [interval.second].x - polygon [idx].x) * (polygon [interval.second].x - polygon [idx].x) + 
                        (polygon [interval.second].y - polygon [idx].y) * (polygon [interval.second].y - polygon [idx].y);
@@ -142,7 +142,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
     // => 0-crossing
     if (currentInterval.first > currentInterval.second)
     {
-      for (unsigned idx = first_index; idx < polygon.size(); idx++)
+      for (size_t idx = first_index; idx < polygon.size(); idx++)
       {
         float distance = fabsf (line_x * polygon[idx].x + line_y * polygon[idx].y + line_d);
         if (distance > max_distance)
@@ -182,15 +182,15 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
   {
     std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > lines (result.size ());
     std::reverse (result.begin (), result.end ());
-    for (unsigned rIdx = 0; rIdx < result.size (); ++rIdx)
+    for (size_t rIdx = 0; rIdx < result.size (); ++rIdx)
     {
-      unsigned nIdx = rIdx + 1;
+      size_t nIdx = rIdx + 1;
       if (nIdx == result.size ())
         nIdx = 0;
       
       Eigen::Vector2f centroid = Eigen::Vector2f::Zero ();
       Eigen::Matrix2f covariance = Eigen::Matrix2f::Zero ();
-      unsigned pIdx = result[rIdx];
+      size_t pIdx = result[rIdx];
       unsigned num_points = 0;
       if (pIdx > result[nIdx])
       {
@@ -250,9 +250,9 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
     }
     
     float threshold2 = threshold * threshold;
-    for (unsigned rIdx = 0; rIdx < lines.size (); ++rIdx)
+    for (size_t rIdx = 0; rIdx < lines.size (); ++rIdx)
     {
-      unsigned nIdx = rIdx + 1;
+      size_t nIdx = rIdx + 1;
       if (nIdx == result.size ())
         nIdx = 0;      
       

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -571,13 +571,13 @@ namespace pcl
           if (this->sizeHalfEdges () != other.sizeHalfEdges ()) return (false);
           if (this->sizeFaces     () != other.sizeFaces     ()) return (false);
 
-          for (unsigned int i=0; i<this->sizeVertices (); ++i)
+          for (size_t i=0; i<this->sizeVertices (); ++i)
           {
             if (this->getOutgoingHalfEdgeIndex (VertexIndex (i)) !=
                 other.getOutgoingHalfEdgeIndex (VertexIndex (i))) return (false);
           }
 
-          for (unsigned int i=0; i<this->sizeHalfEdges (); ++i)
+          for (size_t i=0; i<this->sizeHalfEdges (); ++i)
           {
             if (this->getTerminatingVertexIndex (HalfEdgeIndex (i)) !=
                 other.getTerminatingVertexIndex (HalfEdgeIndex (i))) return (false);
@@ -592,7 +592,7 @@ namespace pcl
                 other.getFaceIndex (HalfEdgeIndex (i))) return (false);
           }
 
-          for (unsigned int i=0; i<this->sizeFaces (); ++i)
+          for (size_t i=0; i<this->sizeFaces (); ++i)
           {
             if (this->getInnerHalfEdgeIndex (FaceIndex (i)) !=
                 other.getInnerHalfEdgeIndex (FaceIndex (i))) return (false);
@@ -1953,7 +1953,7 @@ namespace pcl
         bool
         isManifold (boost::false_type /*is_manifold*/) const
         {
-          for (unsigned int i=0; i<this->sizeVertices (); ++i)
+          for (size_t i=0; i<this->sizeVertices (); ++i)
           {
             if (!this->isManifold (VertexIndex (i))) return (false);
           }

--- a/gpu/kinfu_large_scale/src/cyclical_buffer.cpp
+++ b/gpu/kinfu_large_scale/src/cyclical_buffer.cpp
@@ -111,7 +111,7 @@ pcl::gpu::kinfuLS::CyclicalBuffer::performShift (const TsdfVolume::Ptr volume, c
   std::vector<float , Eigen::aligned_allocator<float> > intensities_vector;
   intensities.download (intensities_vector);
   current_slice_intensities->points.resize (current_slice_xyz->points.size ());
-  for(int i = 0 ; i < current_slice_intensities->points.size () ; ++i)
+  for(size_t i = 0 ; i < current_slice_intensities->points.size () ; ++i)
     current_slice_intensities->points[i].intensity = intensities_vector[i];
 
   current_slice_intensities->width = (int) current_slice_intensities->points.size ();

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -277,7 +277,7 @@ void showCameras (pcl::texture_mapping::CameraVector cams, pcl::PointCloud<pcl::
   pcl::visualization::PCLVisualizer visu ("cameras");
 
   // add a visual for each camera at the correct pose
-  for(int i = 0 ; i < cams.size () ; ++i)
+  for(size_t i = 0 ; i < cams.size () ; ++i)
   {
     // read current camera
     pcl::TextureMapping<pcl::PointXYZ>::Camera cam = cams[i];
@@ -351,7 +351,7 @@ void showCameras (pcl::texture_mapping::CameraVector cams, pcl::PointCloud<pcl::
 std::ifstream& GotoLine(std::ifstream& file, unsigned int num)
 {
   file.seekg (std::ios::beg);
-  for(int i=0; i < num - 1; ++i)
+  for(unsigned int i=0; i < num - 1; ++i)
   {
     file.ignore (std::numeric_limits<std::streamsize>::max (),'\n');
   }
@@ -464,7 +464,7 @@ main (int argc, char** argv)
 
   // Create materials for each texture (and one extra for occluded faces)
   mesh.tex_materials.resize (my_cams.size () + 1);
-  for(int i = 0 ; i <= my_cams.size() ; ++i)
+  for(size_t i = 0 ; i <= my_cams.size() ; ++i)
   {
     pcl::TexMaterial mesh_material;
     mesh_material.tex_Ka.r = 0.2f;
@@ -503,7 +503,7 @@ main (int argc, char** argv)
   
   
   PCL_INFO ("Sorting faces by cameras done.\n");
-  for(int i = 0 ; i <= my_cams.size() ; ++i)
+  for(size_t i = 0 ; i <= my_cams.size() ; ++i)
   {
     PCL_INFO ("\tSub mesh %d contains %d faces and %d UV coordinates.\n", i, mesh.tex_polygons[i].size (), mesh.tex_coordinates[i].size ());
   }

--- a/gpu/people/src/face_detector.cpp
+++ b/gpu/people/src/face_detector.cpp
@@ -327,7 +327,7 @@ pcl::gpu::people::FaceDetector::loadFromXML2(const std::string                  
   //merge root and leaf nodes in one classifiers array, leaf nodes are sorted behind the root nodes
   Ncv32u offset_root = haarClassifierNodes.size();
 
-  for (Ncv32u i=0; i<haarClassifierNodes.size(); i++)
+  for (size_t i = 0; i < haarClassifierNodes.size(); i++)
   {
       HaarClassifierNodeDescriptor32 node_left = haarClassifierNodes[i].getLeftNodeDesc();
       if (!node_left.isLeaf())
@@ -346,7 +346,7 @@ pcl::gpu::people::FaceDetector::loadFromXML2(const std::string                  
       haarClassifierNodes[i].setRightNodeDesc(node_right);
   }
 
-  for (Ncv32u i=0; i<host_temp_classifier_not_root_nodes.size(); i++)
+  for (size_t i = 0; i < host_temp_classifier_not_root_nodes.size(); i++)
   {
       HaarClassifierNodeDescriptor32 node_left = host_temp_classifier_not_root_nodes[i].getLeftNodeDesc();
       if (!node_left.isLeaf())
@@ -583,7 +583,7 @@ pcl::gpu::people::FaceDetector::NCVprocess(pcl::PointCloud<pcl::RGB>&           
 
   NCV_SKIP_COND_BEGIN
 
-  for(int i=0; i<input_gray.points.size(); i++)
+  for(size_t i = 0; i < input_gray.points.size(); i++)
   {
     memcpy(h_src.ptr(), &input_gray.points[i].intensity, sizeof(input_gray.points[i].intensity));
   }
@@ -628,7 +628,7 @@ pcl::gpu::people::FaceDetector::NCVprocess(pcl::PointCloud<pcl::RGB>&           
   PCL_ASSERT_CUDA_RETURN(cudaStreamSynchronize(0), NCV_CUDA_ERROR);
 
   // Copy result back into output cloud
-  for(int i=0; i<cloud_out.points.size(); i++)
+  for(size_t i = 0; i < cloud_out.points.size(); i++)
   {
     memcpy(&cloud_out.points[i].intensity, h_src.ptr() /* + i * ??? */, sizeof(cloud_out.points[i].intensity));
   }

--- a/gpu/people/src/organized_plane_detector.cpp
+++ b/gpu/people/src/organized_plane_detector.cpp
@@ -108,9 +108,9 @@ pcl::gpu::people::OrganizedPlaneDetector::process(const PointCloud<PointTC>::Con
   }
 
   // Fill in the probabilities
-  for(int plane = 0; plane < inlier_indices.size(); plane++)                                            // iterate over all found planes
+  for(size_t plane = 0; plane < inlier_indices.size(); plane++)                                            // iterate over all found planes
   {
-    for(int idx = 0; idx < inlier_indices[plane].indices.size(); idx++)                               // iterate over all the indices in that plane
+    for(size_t idx = 0; idx < inlier_indices[plane].indices.size(); idx++)                               // iterate over all the indices in that plane
     {
       P_l_host_.points[inlier_indices[plane].indices[idx]].probs[pcl::gpu::people::Background] = 1.f;   // set background at max
     }
@@ -140,7 +140,7 @@ pcl::gpu::people::OrganizedPlaneDetector::allocate_buffers(int rows, int cols)
 void
 pcl::gpu::people::OrganizedPlaneDetector::emptyHostLabelProbability(HostLabelProbability& histogram)
 {
-  for(int hist = 0; hist < histogram.points.size(); hist++)
+  for(size_t hist = 0; hist < histogram.points.size(); hist++)
   {
     for(int label = 0; label < pcl::gpu::people::NUM_LABELS; label++)
     {
@@ -158,7 +158,7 @@ pcl::gpu::people::OrganizedPlaneDetector::copyHostLabelProbability(HostLabelProb
     PCL_ERROR("[pcl::gpu::people::OrganizedPlaneDetector::copyHostLabelProbability] : (E) : Sizes don't match\n");
     return -1;
   }
-  for(int hist = 0; hist < src.points.size(); hist++)
+  for(size_t hist = 0; hist < src.points.size(); hist++)
   {
     for(int label = 0; label < pcl::gpu::people::NUM_LABELS; label++)
     {
@@ -177,7 +177,7 @@ pcl::gpu::people::OrganizedPlaneDetector::copyAndClearHostLabelProbability(HostL
     PCL_ERROR("[pcl::gpu::people::OrganizedPlaneDetector::copyHostLabelProbability] : (E) : Sizes don't match\n");
     return -1;
   }
-  for(int hist = 0; hist < src.points.size(); hist++)
+  for(size_t hist = 0; hist < src.points.size(); hist++)
   {
     for(int label = 0; label < pcl::gpu::people::NUM_LABELS; label++)
     {

--- a/gpu/people/tools/people_app.cpp
+++ b/gpu/people/tools/people_app.cpp
@@ -256,7 +256,7 @@ class PeoplePCDApp
         rgba_host_.points.resize(w * h);
         rgba_host_.width = w;
         rgba_host_.height = h;
-        for(int i = 0; i < rgba_host_.size(); ++i)
+        for(size_t i = 0; i < rgba_host_.size(); ++i)
         {
           const unsigned char *pixel = &rgb_host_[i * 3];
           RGB& rgba = rgba_host_.points[i];         

--- a/io/include/pcl/compression/impl/entropy_range_coder.hpp
+++ b/io/include/pcl/compression/impl/entropy_range_coder.hpp
@@ -273,7 +273,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
   frequencyTableSize++;
 
   // convert to cumulative frequency table
-  for (unsigned int f = 1; f < frequencyTableSize; f++)
+  for (uint64_t f = 1; f < frequencyTableSize; f++)
   {
     cFreqTable_[f] = cFreqTable_[f - 1] + cFreqTable_[f];
     if (cFreqTable_[f] <= cFreqTable_[f - 1])
@@ -283,7 +283,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
   // rescale if numerical limits are reached
   while (cFreqTable_[static_cast<std::size_t> (frequencyTableSize - 1)] >= maxRange)
   {
-    for (unsigned int f = 1; f < cFreqTable_.size (); f++)
+    for (size_t f = 1; f < cFreqTable_.size (); f++)
     {
       cFreqTable_[f] /= 2;
       ;
@@ -303,7 +303,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
   unsigned long streamByteCount = sizeof(frequencyTableSize) + sizeof(frequencyTableByteSize);
 
   // write cumulative  frequency table to output stream
-  for (unsigned int f = 1; f < frequencyTableSize; f++)
+  for (uint64_t f = 1; f < frequencyTableSize; f++)
   {
     outputByteStream_arg.write (reinterpret_cast<const char*> (&cFreqTable_[f]), frequencyTableByteSize);
     streamByteCount += frequencyTableByteSize;
@@ -364,7 +364,7 @@ pcl::StaticRangeCoder::decodeStreamToIntVector (std::istream& inputByteStream_ar
   unsigned char frequencyTableByteSize;
 
   unsigned int outputBufPos = 0;
-  unsigned long output_size = static_cast<unsigned long> (outputIntVector_arg.size ());
+  size_t output_size = outputIntVector_arg.size ();
 
   // read size of cumulative frequency table from stream
   inputByteStream_arg.read (reinterpret_cast<char*> (&frequencyTableSize), sizeof(frequencyTableSize));
@@ -382,7 +382,7 @@ pcl::StaticRangeCoder::decodeStreamToIntVector (std::istream& inputByteStream_ar
   memset (&cFreqTable_[0], 0, sizeof(uint64_t) * static_cast<std::size_t> (frequencyTableSize));
 
   // read cumulative frequency table
-  for (unsigned int f = 1; f < frequencyTableSize; f++)
+  for (uint64_t f = 1; f < frequencyTableSize; f++)
   {
     inputByteStream_arg.read (reinterpret_cast<char *> (&cFreqTable_[f]), frequencyTableByteSize);
     streamByteCount += frequencyTableByteSize;
@@ -403,7 +403,7 @@ pcl::StaticRangeCoder::decodeStreamToIntVector (std::istream& inputByteStream_ar
   }
 
   // decoding
-  for (unsigned int i = 0; i < output_size; i++)
+  for (size_t i = 0; i < output_size; i++)
   {
     uint64_t count = (code - low) / (range /= cFreqTable_[static_cast<std::size_t> (frequencyTableSize - 1)]);
 

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -560,10 +560,10 @@ pcl::io::OpenNI2Grabber::convertToXYZPointCloud (const DepthImage::Ptr& depth_im
     depth_map = depth_resize_buffer_.data();
   }
 
-  int depth_idx = 0;
-  for (int v = 0; v < depth_height_; ++v)
+  unsigned depth_idx = 0;
+  for (unsigned v = 0; v < depth_height_; ++v)
   {
-    for (int u = 0; u < depth_width_; ++u, ++depth_idx)
+    for (unsigned u = 0; u < depth_width_; ++u, ++depth_idx)
     {
       pcl::PointXYZ& pt = cloud->points[depth_idx];
       // Check for invalid measurements
@@ -662,11 +662,11 @@ pcl::io::OpenNI2Grabber::convertToXYZRGBPointCloud (const Image::Ptr &image, con
   unsigned step = cloud->width / depth_width_;
   unsigned skip = cloud->width - (depth_width_ * step);
 
-  int value_idx = 0;
-  int point_idx = 0;
-  for (int v = 0; v < depth_height_; ++v, point_idx += skip)
+  unsigned value_idx = 0;
+  unsigned point_idx = 0;
+  for (unsigned v = 0; v < depth_height_; ++v, point_idx += skip)
   {
-    for (int u = 0; u < depth_width_; ++u, ++value_idx, point_idx += step)
+    for (unsigned u = 0; u < depth_width_; ++u, ++value_idx, point_idx += step)
     {
       PointT& pt = cloud->points[point_idx];
       /// @todo Different values for these cases
@@ -773,12 +773,12 @@ pcl::io::OpenNI2Grabber::convertToXYZIPointCloud (const IRImage::Ptr &ir_image, 
   }
 
 
-  int depth_idx = 0;
+  size_t depth_idx = 0;
   float bad_point = std::numeric_limits<float>::quiet_NaN ();
 
-  for (int v = 0; v < depth_height_; ++v)
+  for (unsigned v = 0; v < depth_height_; ++v)
   {
-    for (int u = 0; u < depth_width_; ++u, ++depth_idx)
+    for (unsigned u = 0; u < depth_width_; ++u, ++depth_idx)
     {
       pcl::PointXYZI& pt = cloud->points[depth_idx];
       /// @todo Different values for these cases

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -166,7 +166,7 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
 
 #ifndef _WIN32
   // add context object for each found device
-  for (unsigned deviceIdx = 0; deviceIdx < device_context_.size (); ++deviceIdx)
+  for (size_t deviceIdx = 0; deviceIdx < device_context_.size (); ++deviceIdx)
   {
     // register bus@address to the corresponding context object
     unsigned short vendor_id;
@@ -181,7 +181,7 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
   getDeviceInfos ();
 #endif
   // build serial number -> device index map
-  for (unsigned deviceIdx = 0; deviceIdx < device_context_.size (); ++deviceIdx)
+  for (size_t deviceIdx = 0; deviceIdx < device_context_.size (); ++deviceIdx)
   {
     std::string serial_number = getSerialNumber (deviceIdx);
     if (!serial_number.empty ())
@@ -190,7 +190,7 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
 
 
   // redundant, but needed for Windows right now and also for Xtion
-  for (unsigned deviceIdx = 0; deviceIdx < device_context_.size (); ++deviceIdx)
+  for (size_t deviceIdx = 0; deviceIdx < device_context_.size (); ++deviceIdx)
   {
     unsigned short product_id;
     unsigned short vendor_id;

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -357,7 +357,7 @@ pcl::io::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::PolygonMe
   while (mesh_polygons->GetNextCell (nr_cell_points, cell_points))
   {
     mesh.polygons[id_poly].vertices.resize (nr_cell_points);
-    for (int i = 0; i < nr_cell_points; ++i)
+    for (vtkIdType i = 0; i < nr_cell_points; ++i)
       mesh.polygons[id_poly].vertices[i] = static_cast<int> (cell_points[i]);
     ++id_poly;
   }

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -437,7 +437,7 @@ template <typename PointInT, typename PointOutT, typename NormalT> void
 pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseCurvature (PointCloudOut &output) const
 {
   PointOutT point;
-  for (unsigned idx = 0; idx < input_->points.size(); ++idx)
+  for (size_t idx = 0; idx < input_->points.size(); ++idx)
   {
     point.x = input_->points[idx].x;
     point.y = input_->points[idx].y;

--- a/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
@@ -187,7 +187,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
 #ifdef _OPENMP
   #pragma omp parallel for num_threads(threads_) default (shared)
 #endif    
-  for (unsigned idx = 0; idx < intensity_gradients_->size (); ++idx)
+  for (size_t idx = 0; idx < intensity_gradients_->size (); ++idx)
   {
     float len = intensity_gradients_->points [idx].gradient_x * intensity_gradients_->points [idx].gradient_x +
                 intensity_gradients_->points [idx].gradient_y * intensity_gradients_->points [idx].gradient_y +

--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -381,7 +381,7 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
       omp_mem[tid][2] = e3c;
     }
 
-    for (int d = 0; d < omp_mem[tid].size (); d++)
+    for (Eigen::Index d = 0; d < omp_mem[tid].size (); d++)
         prg_mem[index][d] = omp_mem[tid][d];
   }
 

--- a/ml/src/densecrf.cpp
+++ b/ml/src/densecrf.cpp
@@ -294,7 +294,7 @@ pcl::DenseCrf::runInference (float relax)
     next_[i] = -unary_[i];
 
   // Add up all pairwise potentials
-	for( unsigned int i = 0; i < pairwise_potential_.size(); i++ )
+	for( size_t i = 0; i < pairwise_potential_.size(); i++ )
     pairwise_potential_[i]->compute( next_, current_, tmp_, M_ );
 
 	// Exponentiate and normalize

--- a/people/apps/main_ground_based_people_detection.cpp
+++ b/people/apps/main_ground_based_people_detection.cpp
@@ -173,7 +173,7 @@ int main (int argc, char** argv)
   Eigen::VectorXf ground_coeffs;
   ground_coeffs.resize(4);
   std::vector<int> clicked_points_indices;
-  for (unsigned int i = 0; i < clicked_points_3d->points.size(); i++)
+  for (size_t i = 0; i < clicked_points_3d->points.size(); i++)
     clicked_points_indices.push_back(i);
   pcl::SampleConsensusModelPlane<PointT> model_plane(clicked_points_3d);
   model_plane.computeModelCoefficients(clicked_points_indices,ground_coeffs);

--- a/people/include/pcl/people/impl/head_based_subcluster.hpp
+++ b/people/include/pcl/people/impl/head_based_subcluster.hpp
@@ -141,12 +141,12 @@ pcl::people::HeadBasedSubclustering<PointT>::mergeClustersCloseInFloorCoordinate
   connected_clusters.resize(input_clusters.size());
   std::vector<bool> used_clusters;          // 0 in correspondence of clusters remained to process, 1 for already used clusters
   used_clusters.resize(input_clusters.size());
-  for(unsigned int i = 0; i < input_clusters.size(); i++)             // for every cluster
+  for(size_t i = 0; i < input_clusters.size(); i++)             // for every cluster
   {
     Eigen::Vector3f theoretical_center = input_clusters[i].getTCenter();
     float t = theoretical_center.dot(head_ground_coeffs) / normalize_factor;    // height from the ground
     Eigen::Vector3f current_cluster_center_projection = theoretical_center - head_ground_coeffs * t;    // projection of the point on the groundplane
-    for(unsigned int j = i+1; j < input_clusters.size(); j++)         // for every remaining cluster
+    for(size_t j = i+1; j < input_clusters.size(); j++)         // for every remaining cluster
     {
       theoretical_center = input_clusters[j].getTCenter();
       float t = theoretical_center.dot(head_ground_coeffs) / normalize_factor;    // height from the ground
@@ -158,7 +158,7 @@ pcl::people::HeadBasedSubclustering<PointT>::mergeClustersCloseInFloorCoordinate
     }
   }
 
-  for(unsigned int i = 0; i < connected_clusters.size(); i++)   // for every cluster
+  for(size_t i = 0; i < connected_clusters.size(); i++)   // for every cluster
   {
     if (!used_clusters[i])                                      // if this cluster has not been used yet
     {
@@ -172,7 +172,7 @@ pcl::people::HeadBasedSubclustering<PointT>::mergeClustersCloseInFloorCoordinate
         // Copy cluster points into new cluster:
         pcl::PointIndices point_indices;
         point_indices = input_clusters[i].getIndices();
-        for(unsigned int j = 0; j < connected_clusters[i].size(); j++)
+        for(size_t j = 0; j < connected_clusters[i].size(); j++)
         {
           if (!used_clusters[connected_clusters[i][j]])         // if this cluster has not been used yet
           {
@@ -280,7 +280,7 @@ pcl::people::HeadBasedSubclustering<PointT>::subcluster (std::vector<pcl::people
 
   // Remove clusters with too high height from the ground plane:
   std::vector<pcl::people::PersonCluster<PointT> > new_clusters;
-  for(unsigned int i = 0; i < clusters.size(); i++)   // for every cluster
+  for(size_t i = 0; i < clusters.size(); i++)   // for every cluster
   {
     if (clusters[i].getHeight() <= max_height_)
       new_clusters.push_back(clusters[i]);

--- a/people/include/pcl/people/impl/person_classifier.hpp
+++ b/people/include/pcl/people/impl/person_classifier.hpp
@@ -260,7 +260,7 @@ pcl::people::PersonClassifier<PointT>::evaluate (float height_person,
  
     // Calculate confidence value by dot product:
     confidence = 0.0;
-    for(unsigned int i = 0; i < SVM_weights_.size(); i++)
+    for(size_t i = 0; i < SVM_weights_.size(); i++)
     { 
       confidence += SVM_weights_[i] * descriptor[i];
     }

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -917,7 +917,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::clusterDes
 {
   Eigen::MatrixXf points_to_cluster (histograms.size (), FeatureSize);
 
-  for (unsigned int i_feature = 0; i_feature < histograms.size (); i_feature++)
+  for (size_t i_feature = 0; i_feature < histograms.size (); i_feature++)
     for (int i_dim = 0; i_dim < FeatureSize; i_dim++)
       points_to_cluster (i_feature, i_dim) = histograms[i_feature].histogram[i_dim];
 
@@ -941,7 +941,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::calculateS
   if (training_sigmas_.size () != 0)
   {
     sigmas.resize (training_sigmas_.size (), 0.0f);
-    for (unsigned int i_sigma = 0; i_sigma < training_sigmas_.size (); i_sigma++)
+    for (size_t i_sigma = 0; i_sigma < training_sigmas_.size (); i_sigma++)
       sigmas[i_sigma] = training_sigmas_[i_sigma];
     return;
   }
@@ -1311,7 +1311,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeKMe
   for (int i_dim = 0; i_dim < feature_dimension; i_dim++)
     box[i_dim] = Eigen::Vector2f (points_to_cluster (0, i_dim), points_to_cluster (0, i_dim));
 
-  for (unsigned int i_point = 0; i_point < number_of_points; i_point++)
+  for (size_t i_point = 0; i_point < number_of_points; i_point++)
     for (int i_dim = 0; i_dim < feature_dimension; i_dim++)
     {
       float v = points_to_cluster (i_point, i_dim);
@@ -1349,7 +1349,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeKMe
         centers.setZero ();
         for (int i_cluster = 0; i_cluster < number_of_clusters; i_cluster++)
           counters[i_cluster] = 0;
-        for (unsigned int i_point = 0; i_point < number_of_points; i_point++)
+        for (size_t i_point = 0; i_point < number_of_points; i_point++)
         {
           int i_label = labels (i_point, 0);
           for (int i_dim = 0; i_dim < feature_dimension; i_dim++)
@@ -1387,7 +1387,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeKMe
         }
       }
       compactness = 0.0f;
-      for (unsigned int i_point = 0; i_point < number_of_points; i_point++)
+      for (size_t i_point = 0; i_point < number_of_points; i_point++)
       {
         Eigen::VectorXf sample (feature_dimension);
         sample = points_to_cluster.row (i_point);
@@ -1494,7 +1494,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::generateCe
   }
 
   for (int i_cluster = 0; i_cluster < number_of_clusters; i_cluster++)
-    for (unsigned int i_dim = 0; i_dim < dimension; i_dim++)
+    for (size_t i_dim = 0; i_dim < dimension; i_dim++)
       out_centers (i_cluster, i_dim) = data (centers[i_cluster], i_dim);
 }
 
@@ -1506,7 +1506,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::generateRa
   size_t dimension = boxes.size ();
   float margin = 1.0f / static_cast<float> (dimension);
 
-  for (unsigned int i_dim = 0; i_dim < dimension; i_dim++)
+  for (size_t i_dim = 0; i_dim < dimension; i_dim++)
   {
     unsigned int random_integer = rand () - 1;
     float random_float = static_cast<float> (random_integer) / static_cast<float> (std::numeric_limits<unsigned int>::max ());
@@ -1520,7 +1520,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeDis
 {
   size_t dimension = vec_1.rows () > 1 ? vec_1.rows () : vec_1.cols ();
   float distance = 0.0f;
-  for(unsigned int i_dim = 0; i_dim < dimension; i_dim++)
+  for(size_t i_dim = 0; i_dim < dimension; i_dim++)
   {
     float diff = vec_1 (i_dim) - vec_2 (i_dim);
     distance += diff * diff;

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -385,7 +385,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (
 
     if (compute_hessian)
     {
-      for (int j = 0; j < hessian.cols (); j++)
+      for (Eigen::Index j = 0; j < hessian.cols (); j++)
       {
         // Update hessian, Equation 6.13 [Magnusson 2009]
         hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_gradient_.col (j)) +
@@ -470,7 +470,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eige
     // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
     cov_dxd_pi = c_inv * point_gradient_.col (i);
 
-    for (int j = 0; j < hessian.cols (); j++)
+    for (Eigen::Index j = 0; j < hessian.cols (); j++)
     {
       // Update hessian, Equation 6.13 [Magnusson 2009]
       hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_gradient_.col (j)) +

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -278,7 +278,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::optimizeModelCoefficients (
   Eigen::LevenbergMarquardt<Eigen::NumericalDiff<OptimizationFunctor>, double> lm (num_diff);
   Eigen::VectorXd coeff;
   int info = lm.minimize (coeff);
-  for (int i = 0; i < coeff.size (); ++i)
+  for (Eigen::Index i = 0; i < coeff.size (); ++i)
     optimized_coefficients[i] = static_cast<float> (coeff[i]);
 
   // Compute the L2 norm of the residuals

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -455,7 +455,7 @@ namespace pcl
       {
         size_t sample_size = sample.size ();
         size_t index_size = shuffled_indices_.size ();
-        for (unsigned int i = 0; i < sample_size; ++i)
+        for (size_t i = 0; i < sample_size; ++i)
           // The 1/(RAND_MAX+1.0) trick is when the random numbers are not uniformly distributed and for small modulo
           // elements, that does not matter (and nowadays, random number generators are good)
           //std::swap (shuffled_indices_[i], shuffled_indices_[i + (rand () % (index_size - i))]);
@@ -490,14 +490,14 @@ namespace pcl
         if (indices.size () < sample_size - 1)
         {
           // radius search failed, make an invalid model
-          for(unsigned int i = 1; i < sample_size; ++i)
+          for(size_t i = 1; i < sample_size; ++i)
             shuffled_indices_[i] = shuffled_indices_[0];
         }
         else
         {
-          for (unsigned int i = 0; i < sample_size-1; ++i)
+          for (size_t i = 0; i < sample_size-1; ++i)
             std::swap (indices[i], indices[i + (rnd () % (indices.size () - i))]);
-          for (unsigned int i = 1; i < sample_size; ++i)
+          for (size_t i = 1; i < sample_size; ++i)
             shuffled_indices_[i] = indices[i-1];
         }
 

--- a/search/include/pcl/search/impl/brute_force.hpp
+++ b/search/include/pcl/search/impl/brute_force.hpp
@@ -250,7 +250,7 @@ pcl::search::BruteForce<PointT>::denseRadiusSearch (
   }
   else
   {
-    for (unsigned index = 0; index < input_->size (); ++index)
+    for (size_t index = 0; index < input_->size (); ++index)
     {
       distance = getDistSqr (input_->points[index], point);
       if (distance <= radius)
@@ -309,7 +309,7 @@ pcl::search::BruteForce<PointT>::sparseRadiusSearch (
   }
   else
   {
-    for (unsigned index = 0; index < input_->size (); ++index)
+    for (size_t index = 0; index < input_->size (); ++index)
     {
       if (!std::isfinite (input_->points[index].x))
         continue;

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -252,7 +252,7 @@ namespace pcl
       setExcludeLabels (const std::vector<bool>& exclude_labels)
       {
         exclude_labels_ = boost::make_shared<std::set<uint32_t> > ();
-        for (uint32_t i = 0; i < exclude_labels.size (); ++i)
+        for (size_t i = 0; i < exclude_labels.size (); ++i)
           if (exclude_labels[i])
             exclude_labels_->insert (i);
       }

--- a/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
@@ -125,7 +125,7 @@ pcl::OrganizedConnectedComponentSegmentation<PointT, PointLT>::segment (pcl::Poi
   labels.points.resize (input_->points.size (), invalid_pt);
   labels.width = input_->width;
   labels.height = input_->height;
-  unsigned int clust_id = 0;
+  size_t clust_id = 0;
   
   //First pixel
   if (std::isfinite (input_->points[0].x))
@@ -205,8 +205,8 @@ pcl::OrganizedConnectedComponentSegmentation<PointT, PointLT>::segment (pcl::Poi
   }
   
   std::vector<unsigned> map (clust_id);
-  unsigned max_id = 0;
-  for (unsigned runIdx = 0; runIdx < run_ids.size (); ++runIdx)
+  size_t max_id = 0;
+  for (size_t runIdx = 0; runIdx < run_ids.size (); ++runIdx)
   {
     // if it is its own root -> new region
     if (run_ids[runIdx] == runIdx)
@@ -216,7 +216,7 @@ pcl::OrganizedConnectedComponentSegmentation<PointT, PointLT>::segment (pcl::Poi
   }
 
   label_indices.resize (max_id + 1);
-  for (unsigned idx = 0; idx < input_->points.size (); idx++)
+  for (size_t idx = 0; idx < input_->points.size (); idx++)
   {
     if (labels[idx].label != invalid_label)
     {

--- a/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
@@ -111,7 +111,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segment (std::ve
   // Calculate range part of planes' hessian normal form
   std::vector<float> plane_d (input_->points.size ());
   
-  for (unsigned int i = 0; i < input_->size (); ++i)
+  for (size_t i = 0; i < input_->size (); ++i)
     plane_d[i] = input_->points[i].getVector3fMap ().dot (normals_->points[i].getNormalVector3fMap ());
   
   // Make a comparator
@@ -204,7 +204,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segment (std::ve
     boundary_cloud.resize (0);
     pcl::OrganizedConnectedComponentSegmentation<PointT,PointLT>::findLabeledRegionBoundary (inlier_indices[i].indices[0], labels, boundary_indices[i]);
     boundary_cloud.points.resize (boundary_indices[i].indices.size ());
-    for (unsigned j = 0; j < boundary_indices[i].indices.size (); j++)
+    for (size_t j = 0; j < boundary_indices[i].indices.size (); j++)
       boundary_cloud.points[j] = input_->points[boundary_indices[i].indices[j]];
     
     Eigen::Vector3f centroid = Eigen::Vector3f (centroids[i][0],centroids[i][1],centroids[i][2]);
@@ -243,7 +243,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segmentAndRefine
     int max_inlier_idx = static_cast<int> (inlier_indices[i].indices.size ()) - 1;
     pcl::OrganizedConnectedComponentSegmentation<PointT,PointLT>::findLabeledRegionBoundary (inlier_indices[i].indices[max_inlier_idx], labels, boundary_indices[i]);
     boundary_cloud.points.resize (boundary_indices[i].indices.size ());
-    for (unsigned j = 0; j < boundary_indices[i].indices.size (); j++)
+    for (size_t j = 0; j < boundary_indices[i].indices.size (); j++)
       boundary_cloud.points[j] = input_->points[boundary_indices[i].indices[j]];
     
     Eigen::Vector3f centroid = Eigen::Vector3f (centroids[i][0],centroids[i][1],centroids[i][2]);
@@ -287,7 +287,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segmentAndRefine
     int max_inlier_idx = static_cast<int> (inlier_indices[i].indices.size ()) - 1;
     pcl::OrganizedConnectedComponentSegmentation<PointT,PointLT>::findLabeledRegionBoundary (inlier_indices[i].indices[max_inlier_idx], labels, boundary_indices[i]);
     boundary_cloud.points.resize (boundary_indices[i].indices.size ());
-    for (unsigned j = 0; j < boundary_indices[i].indices.size (); j++)
+    for (size_t j = 0; j < boundary_indices[i].indices.size (); j++)
       boundary_cloud.points[j] = input_->points[boundary_indices[i].indices[j]];
 
     Eigen::Vector3f centroid = Eigen::Vector3f (centroids[i][0],centroids[i][1],centroids[i][2]);

--- a/segmentation/include/pcl/segmentation/impl/random_walker.hpp
+++ b/segmentation/include/pcl/segmentation/impl/random_walker.hpp
@@ -193,7 +193,7 @@ namespace pcl
             Eigen::SimplicialCholesky<SparseMatrix, Eigen::Lower> cg;
             cg.compute (L);
             bool succeeded = true;
-            for (int i = 0; i < B.cols (); ++i)
+            for (Eigen::Index i = 0; i < B.cols (); ++i)
             {
               Vector b = B.col (i);
               X.col (i) = cg.solve (b);
@@ -210,7 +210,7 @@ namespace pcl
           {
             using namespace boost;
             if (X.cols ())
-              for (int i = 0; i < X.rows (); ++i)
+              for (Eigen::Index i = 0; i < X.rows (); ++i)
               {
                 size_t max_column;
                 X.row (i).maxCoeff (&max_column);
@@ -226,7 +226,7 @@ namespace pcl
             using namespace boost;
             potentials = Matrix::Zero (num_vertices (g_), colors_.size ());
             // Copy over rows from X
-            for (int i = 0; i < X.rows (); ++i)
+            for (Eigen::Index i = 0; i < X.rows (); ++i)
               potentials.row (L_vertex_bimap.left.at (i)).head (X.cols ()) = X.row (i);
             // In rows that correspond to seeds put ones in proper columns
             for (size_t i = 0; i < seeds_.size (); ++i)
@@ -237,7 +237,7 @@ namespace pcl
             }
             // Fill in a map that associates colors with columns in potentials matrix
             color_to_column_map.clear ();
-            for (int i = 0; i < potentials.cols (); ++i)
+            for (Eigen::Index i = 0; i < potentials.cols (); ++i)
               color_to_column_map[B_color_bimap.left.at (i)] = i;
           }
 

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -276,7 +276,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
     }
 
     is_free = NONE;
-    for (unsigned temp = 0; temp < indices_->size (); temp++)
+    for (size_t temp = 0; temp < indices_->size (); temp++)
     {
       if (state_[temp] == FREE)
       {

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -148,7 +148,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::process (PointCloudOut &output)
     normals_->height = 1;
     normals_->width = static_cast<uint32_t> (normals_->size ());
 
-    for (unsigned int i = 0; i < output.size (); ++i)
+    for (size_t i = 0; i < output.size (); ++i)
     {
       typedef typename pcl::traits::fieldList<PointOutT>::type FieldList;
       pcl::for_each_type<FieldList> (SetIfFieldExists<PointOutT, float> (output.points[i], "normal_x", normals_->points[i].normal_x));
@@ -846,7 +846,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::MLSVoxelGrid::MLSVoxelGrid (PointC
   const double max_size = (std::max) ((std::max)(bounding_box_size.x (), bounding_box_size.y ()), bounding_box_size.z ());
   // Put initial cloud in voxel grid
   data_size_ = static_cast<uint64_t> (1.5 * max_size / voxel_size_);
-  for (unsigned int i = 0; i < indices->size (); ++i)
+  for (size_t i = 0; i < indices->size (); ++i)
     if (std::isfinite (cloud->points[(*indices)[i]].x))
     {
       Eigen::Vector3i pos;

--- a/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
+++ b/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
@@ -59,7 +59,7 @@ pcl::OrganizedFastMesh<PointInT>::performReconstruction (pcl::PolygonMesh &outpu
   // (running over complete image since some rows and columns are left out
   // depending on triangle_pixel_size)
   // avoid to do that here (only needed for ASCII mesh file output, e.g., in vtk files
-  for (unsigned int i = 0; i < input_->points.size (); ++i)
+  for (size_t i = 0; i < input_->points.size (); ++i)
     if (!isFinite (input_->points[i]))
       resetPointData (i, output, 0.0f, x_idx, y_idx, z_idx);
 }

--- a/surface/src/on_nurbs/closing_boundary.cpp
+++ b/surface/src/on_nurbs/closing_boundary.cpp
@@ -330,11 +330,11 @@ void
 ClosingBoundary::optimizeBoundary (std::vector<ON_NurbsSurface> &nurbs_list, std::vector<NurbsDataSurface> &data_list,
                                    Parameter param)
 {
-  for (unsigned n1 = 0; n1 < nurbs_list.size (); n1++)
+  for (size_t n1 = 0; n1 < nurbs_list.size (); n1++)
     data_list[n1].clear_boundary ();
 
   // for each nurbs
-  for (unsigned n1 = 0; n1 < nurbs_list.size (); n1++)
+  for (size_t n1 = 0; n1 < nurbs_list.size (); n1++)
   {
     //  for (unsigned n1 = 0; n1 < 1; n1++) {
     ON_NurbsSurface *nurbs1 = &nurbs_list[n1];
@@ -345,12 +345,12 @@ ClosingBoundary::optimizeBoundary (std::vector<ON_NurbsSurface> &nurbs_list, std
     sampleFromBoundary (nurbs1, boundary1, params1, param.samples);
 
     // for each other nurbs
-    for (unsigned n2 = (n1 + 1); n2 < nurbs_list.size (); n2++)
+    for (size_t n2 = (n1 + 1); n2 < nurbs_list.size (); n2++)
     {
       ON_NurbsSurface *nurbs2 = &nurbs_list[n2];
 
       // for all points in the point list
-      for (unsigned i = 0; i < boundary1.size (); i++)
+      for (size_t i = 0; i < boundary1.size (); i++)
       {
         double error;
         Eigen::Vector3d p, tu, tv;
@@ -392,12 +392,12 @@ ClosingBoundary::optimizeBoundary (std::vector<ON_NurbsSurface> &nurbs_list, std
     FittingSurface::Parameter paramFP (1.0, param.smoothness, 0.0, 1.0, param.smoothness, 0.0);
 
     std::vector<double> wBnd, wInt;
-    for (unsigned i = 0; i < data_list[n1].boundary.size (); i++)
+    for (size_t i = 0; i < data_list[n1].boundary.size (); i++)
       data_list[n1].boundary_weight.push_back (param.boundary_weight);
-    for (unsigned i = 0; i < data_list[n1].interior.size (); i++)
+    for (size_t i = 0; i < data_list[n1].interior.size (); i++)
       data_list[n1].interior_weight.push_back (param.interior_weight);
 
-    for (unsigned i = 0; i < param.fit_iter; i++)
+    for (size_t i = 0; i < param.fit_iter; i++)
     {
       fit.assemble (paramFP);
       fit.solve ();

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -74,7 +74,7 @@ FittingCurve2d::findElement (double xi, const std::vector<double> &elements)
   if (xi >= elements.back ())
     return (int (elements.size ()) - 2);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     if (xi >= elements[i] && xi < elements[i + 1])
     {
@@ -94,7 +94,7 @@ FittingCurve2d::refine ()
 
   std::vector<double> elements = getElementVector (m_nurbs);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
   for (size_t i = 0; i < xi.size (); i++)
@@ -516,7 +516,7 @@ FittingCurve2d::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::Vecto
   error = DBL_MAX;
   int is_corner (-1);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     Eigen::Vector2d p1;
     nurbs.Evaluate (elements[i], 0, 2, &p1 (0));
@@ -674,7 +674,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
   std::vector<double> elements = pcl::on_nurbs::FittingCurve2d::getElementVector (nurbs);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];
@@ -717,7 +717,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
   double d_shortest (DBL_MAX);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -74,7 +74,7 @@ FittingCurve2d::findElement (double xi, const std::vector<double> &elements)
   if (xi >= elements.back ())
     return (int (elements.size ()) - 2);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     if (xi >= elements[i] && xi < elements[i + 1])
     {
@@ -94,10 +94,10 @@ FittingCurve2d::refine ()
 
   std::vector<double> elements = getElementVector (m_nurbs);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
     m_nurbs.InsertKnot (xi[i], 1);
 }
 
@@ -160,7 +160,7 @@ FittingCurve2d::addControlPointConstraint (int i, const Eigen::Vector2d &f, doub
   // add constraint for control point
   m_solver.f (row, 0, f (0) * weight);
   m_solver.f (row, 1, f (1) * weight);
-  for (int j = 0; j < cols; j++)
+  for (unsigned j = 0; j < cols; j++)
     m_solver.K (row, j, 0.0);
   m_solver.K (row, i, weight);
 }
@@ -516,7 +516,7 @@ FittingCurve2d::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::Vecto
   error = DBL_MAX;
   int is_corner (-1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     Eigen::Vector2d p1;
     nurbs.Evaluate (elements[i], 0, 2, &p1 (0));
@@ -674,7 +674,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
   std::vector<double> elements = pcl::on_nurbs::FittingCurve2d::getElementVector (nurbs);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];
@@ -717,7 +717,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
   double d_shortest (DBL_MAX);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -75,7 +75,7 @@ FittingCurve2dAPDM::findElement (double xi, const std::vector<double> &elements)
   if (xi >= elements.back ())
     return (int (elements.size ()) - 2);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     if (xi >= elements[i] && xi < elements[i + 1])
     {
@@ -95,10 +95,10 @@ FittingCurve2dAPDM::refine ()
 
   std::vector<double> elements = getElementVector (m_nurbs);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
     m_nurbs.InsertKnot (xi[i], 1);
 }
 
@@ -241,7 +241,7 @@ FittingCurve2dAPDM::addCPsOnClosestPointViolation (double max_error)
 
   //int nknots (0);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
 
     bool inserted (false);
@@ -333,7 +333,7 @@ FittingCurve2dAPDM::removeCPsOnLine (const ON_NurbsCurve &nurbs, double min_curv
   nurbs_opt.m_knot[cp_red] = 0.0;
   nurbs_opt.m_knot[nurbs_opt.m_knot_capacity - cp_red - 1] = 1.0;
 
-  for (unsigned j = 0; j < cps.size (); j++)
+  for (size_t j = 0; j < cps.size (); j++)
     nurbs_opt.SetCV (j + cp_red, cps[j]);
 
   for (int j = 0; j < cp_red; j++)
@@ -514,7 +514,7 @@ FittingCurve2dAPDM::initCPsNurbsCurve2D (int order, const vector_vec2d &cps)
   nurbs = ON_NurbsCurve (2, false, order, ncps);
   nurbs.MakePeriodicUniformKnotVector (1.0 / (ncps - order + 1));
 
-  for (int j = 0; j < cps.size (); j++)
+  for (size_t j = 0; j < cps.size (); j++)
     nurbs.SetCV (cp_red + j, ON_3dPoint (cps[j] (0), cps[j] (1), 0.0));
 
   // close nurbs
@@ -747,9 +747,9 @@ FittingCurve2dAPDM::assembleClosestPoints (const std::vector<double> &elements, 
   double ds = 1.0 / (2.0 * sigma2);
   double seg = 1.0 / (samples_per_element + 1);
 
-  for (unsigned i = 0; i < elements.size (); i++)
+  for (size_t i = 0; i < elements.size (); i++)
   {
-    int k = i % int (elements.size ());
+    size_t k = i % elements.size ();
     double xi0 = elements[i];
     double dxi = elements[k] - xi0;
 
@@ -889,7 +889,7 @@ FittingCurve2dAPDM::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::V
   error = DBL_MAX;
   int is_corner (-1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     Eigen::Vector2d p1;
     nurbs.Evaluate (elements[i], 0, 2, &p1 (0));
@@ -1047,7 +1047,7 @@ FittingCurve2dAPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, cons
   std::vector<double> elements = pcl::on_nurbs::FittingCurve2dAPDM::getElementVector (nurbs);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];
@@ -1090,13 +1090,13 @@ FittingCurve2dAPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, cons
   double d_shortest (DBL_MAX);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < nurbs.Order (); j++)
+    for (size_t j = 0; j < nurbs.Order (); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 

--- a/surface/src/on_nurbs/fitting_curve_2d_asdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_asdm.cpp
@@ -406,7 +406,7 @@ FittingCurve2dASDM::assembleClosestPoints (const std::vector<double> &elements, 
 
   double ds = 1.0 / (2.0 * sigma2);
 
-  for (unsigned i = 0; i < elements.size (); i++)
+  for (size_t i = 0; i < elements.size (); i++)
   {
 
     int j = (i + 1) % int (elements.size ());

--- a/surface/src/on_nurbs/fitting_curve_2d_atdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_atdm.cpp
@@ -321,7 +321,7 @@ FittingCurve2dATDM::assembleClosestPoints (const std::vector<double> &elements, 
 
   double ds = 1.0 / (2.0 * sigma2);
 
-  for (unsigned i = 0; i < elements.size (); i++)
+  for (size_t i = 0; i < elements.size (); i++)
   {
 
     int j = i % int (elements.size ());

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -75,7 +75,7 @@ FittingCurve2dPDM::findElement (double xi, const std::vector<double> &elements)
   if (xi >= elements.back ())
     return (int (elements.size ()) - 2);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     if (xi >= elements[i] && xi < elements[i + 1])
     {
@@ -95,10 +95,10 @@ FittingCurve2dPDM::refine ()
 
   std::vector<double> elements = getElementVector (m_nurbs);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
     m_nurbs.InsertKnot (xi[i], 1);
 }
 
@@ -208,7 +208,7 @@ FittingCurve2dPDM::addCPsOnClosestPointViolation (double max_error)
 
   //int nknots (0);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
 
     bool inserted (false);
@@ -300,7 +300,7 @@ FittingCurve2dPDM::removeCPsOnLine (const ON_NurbsCurve &nurbs, double min_curve
   nurbs_opt.m_knot[cp_red] = 0.0;
   nurbs_opt.m_knot[nurbs_opt.m_knot_capacity - cp_red - 1] = 1.0;
 
-  for (unsigned j = 0; j < cps.size (); j++)
+  for (size_t j = 0; j < cps.size (); j++)
     nurbs_opt.SetCV (j + cp_red, cps[j]);
 
   for (int j = 0; j < cp_red; j++)
@@ -375,7 +375,7 @@ FittingCurve2dPDM::initCPsNurbsCurve2D (int order, const vector_vec2d &cps)
   nurbs = ON_NurbsCurve (2, false, order, ncps);
   nurbs.MakePeriodicUniformKnotVector (1.0 / (ncps - order + 1));
 
-  for (int j = 0; j < cps.size (); j++)
+  for (size_t j = 0; j < cps.size (); j++)
     nurbs.SetCV (cp_red + j, ON_3dPoint (cps[j] (0), cps[j] (1), 0.0));
 
   // close nurbs
@@ -646,7 +646,7 @@ FittingCurve2dPDM::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::Ve
   error = DBL_MAX;
   int is_corner (-1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     Eigen::Vector2d p1;
     nurbs.Evaluate (elements[i], 0, 2, &p1 (0));
@@ -804,7 +804,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
   std::vector<double> elements = pcl::on_nurbs::FittingCurve2dPDM::getElementVector (nurbs);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];
@@ -847,7 +847,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
   double d_shortest (DBL_MAX);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -75,7 +75,7 @@ FittingCurve2dPDM::findElement (double xi, const std::vector<double> &elements)
   if (xi >= elements.back ())
     return (int (elements.size ()) - 2);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     if (xi >= elements[i] && xi < elements[i + 1])
     {
@@ -95,7 +95,7 @@ FittingCurve2dPDM::refine ()
 
   std::vector<double> elements = getElementVector (m_nurbs);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
   for (size_t i = 0; i < xi.size (); i++)
@@ -208,7 +208,7 @@ FittingCurve2dPDM::addCPsOnClosestPointViolation (double max_error)
 
   //int nknots (0);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
 
     bool inserted (false);
@@ -646,7 +646,7 @@ FittingCurve2dPDM::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::Ve
   error = DBL_MAX;
   int is_corner (-1);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     Eigen::Vector2d p1;
     nurbs.Evaluate (elements[i], 0, 2, &p1 (0));
@@ -804,7 +804,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
   std::vector<double> elements = pcl::on_nurbs::FittingCurve2dPDM::getElementVector (nurbs);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];
@@ -847,7 +847,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
   double d_shortest (DBL_MAX);
   double seg = 1.0 / (nurbs.Order () - 1);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     double &xi0 = elements[i];
     double &xi1 = elements[i + 1];

--- a/surface/src/on_nurbs/fitting_curve_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_pdm.cpp
@@ -75,7 +75,7 @@ FittingCurve::findElement (double xi, const std::vector<double> &elements)
   if (xi >= elements.back ())
     return (int (elements.size ()) - 2);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     if (xi >= elements[i] && xi < elements[i + 1])
     {
@@ -95,10 +95,10 @@ FittingCurve::refine ()
 
   std::vector<double> elements = getElementVector (m_nurbs);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
     m_nurbs.InsertKnot (xi[i], 1);
 }
 
@@ -422,7 +422,7 @@ FittingCurve::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Eige
 
   double d_shortest (DBL_MAX);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (unsigned long i = 0; i < elements.size () - 1; i++)
   {
     double xi = elements[i] + 0.5 * (elements[i + 1] - elements[i]);
 

--- a/surface/src/on_nurbs/fitting_curve_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_pdm.cpp
@@ -75,7 +75,7 @@ FittingCurve::findElement (double xi, const std::vector<double> &elements)
   if (xi >= elements.back ())
     return (int (elements.size ()) - 2);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     if (xi >= elements[i] && xi < elements[i + 1])
     {
@@ -95,7 +95,7 @@ FittingCurve::refine ()
 
   std::vector<double> elements = getElementVector (m_nurbs);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
   for (size_t i = 0; i < xi.size (); i++)
@@ -422,7 +422,7 @@ FittingCurve::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Eige
 
   double d_shortest (DBL_MAX);
 
-  for (unsigned long i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     double xi = elements[i] + 0.5 * (elements[i + 1] - elements[i]);
 

--- a/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
@@ -81,10 +81,10 @@ FittingCylinder::refine (int dim)
   std::vector<double> xi;
   std::vector<double> elements = getElementVector (m_nurbs, dim);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
     m_nurbs.InsertKnot (dim, xi[i], 1);
 }
 
@@ -95,13 +95,13 @@ FittingCylinder::refine (int dim, double param)
 
   if (param == elements[elements.size () - 1])
   {
-    int i = int (elements.size ()) - 2;
+    size_t i = elements.size () - 2;
     double xi = elements[i] + 0.5 * (elements[i + 1] - elements[i]);
     m_nurbs.InsertKnot (dim, xi);
     return;
   }
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
   {
     if (param >= elements[i] && param < elements[i + 1])
     {
@@ -614,9 +614,9 @@ FittingCylinder::findClosestElementMidPoint (const ON_NurbsSurface &nurbs, const
   std::vector<double> elementsV = getElementVector (nurbs, 1);
 
   double d_shortest = std::numeric_limits<double>::max ();
-  for (unsigned i = 0; i < elementsU.size () - 1; i++)
+  for (size_t i = 0; i < elementsU.size () - 1; i++)
   {
-    for (unsigned j = 0; j < elementsV.size () - 1; j++)
+    for (size_t j = 0; j < elementsV.size () - 1; j++)
     {
       double points[3];
 

--- a/surface/src/on_nurbs/fitting_sphere_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_sphere_pdm.cpp
@@ -168,7 +168,7 @@ FittingSphere::initNurbsSphere (int order, NurbsDataSurface *data, Eigen::Vector
 
   Eigen::Vector3d _min (DBL_MAX, DBL_MAX, DBL_MAX);
   Eigen::Vector3d _max (-DBL_MAX, -DBL_MAX, -DBL_MAX);
-  for (int i = 0; i < data->interior.size (); i++)
+  for (size_t i = 0; i < data->interior.size (); i++)
   {
     Eigen::Vector3d p = data->interior[i] - mean;
 
@@ -515,9 +515,9 @@ FittingSphere::findClosestElementMidPoint (const ON_NurbsSurface &nurbs, const V
   std::vector<double> elementsV = getElementVector (nurbs, 1);
 
   double d_shortest = std::numeric_limits<double>::max ();
-  for (unsigned i = 0; i < elementsU.size () - 1; i++)
+  for (size_t i = 0; i < elementsU.size () - 1; i++)
   {
-    for (unsigned j = 0; j < elementsV.size () - 1; j++)
+    for (size_t j = 0; j < elementsV.size () - 1; j++)
     {
       double points[3];
 

--- a/surface/src/on_nurbs/fitting_surface_im.cpp
+++ b/surface/src/on_nurbs/fitting_surface_im.cpp
@@ -157,7 +157,7 @@ FittingSurfaceIM::refine ()
   {
     int dim = 0;
     std::vector<double> elements = getElementVector (m_nurbs, dim);
-    for (unsigned i = 0; i < elements.size () - 1; i++)
+    for (size_t i = 0; i < elements.size () - 1; i++)
     {
       double xi = elements[i] + 0.5 * (elements[i + 1] - elements[i]);
       m_nurbs.InsertKnot (dim, xi, 1);
@@ -166,7 +166,7 @@ FittingSurfaceIM::refine ()
   {
     int dim = 1;
     std::vector<double> elements = getElementVector (m_nurbs, dim);
-    for (unsigned i = 0; i < elements.size () - 1; i++)
+    for (size_t i = 0; i < elements.size () - 1; i++)
     {
       double xi = elements[i] + 0.5 * (elements[i + 1] - elements[i]);
       m_nurbs.InsertKnot (dim, xi, 1);
@@ -521,9 +521,9 @@ FittingSurfaceIM::findClosestElementMidPoint (const ON_NurbsSurface &nurbs, cons
   std::vector<double> elementsV = getElementVector (nurbs, 1);
 
   double d_shortest (DBL_MAX);
-  for (unsigned i = 0; i < elementsU.size () - 1; i++)
+  for (size_t i = 0; i < elementsU.size () - 1; i++)
   {
-    for (unsigned j = 0; j < elementsV.size () - 1; j++)
+    for (size_t j = 0; j < elementsV.size () - 1; j++)
     {
       double points[3];
       double d;

--- a/surface/src/on_nurbs/fitting_surface_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_surface_pdm.cpp
@@ -86,10 +86,10 @@ FittingSurface::refine (int dim)
   std::vector<double> xi;
   std::vector<double> elements = getElementVector (m_nurbs, dim);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
     m_nurbs.InsertKnot (dim, xi[i], 1);
 
   m_elementsU = getElementVector (m_nurbs, 0);
@@ -106,10 +106,10 @@ FittingSurface::refine (ON_NurbsSurface &nurbs, int dim)
   std::vector<double> xi;
   std::vector<double> elements = getElementVector (nurbs, dim);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
     nurbs.InsertKnot (dim, xi[i], 1);
 }
 
@@ -1120,9 +1120,9 @@ FittingSurface::findClosestElementMidPoint (const ON_NurbsSurface &nurbs, const 
   std::vector<double> elementsV = getElementVector (nurbs, 1);
 
   double d_shortest (DBL_MAX);
-  for (unsigned i = 0; i < elementsU.size () - 1; i++)
+  for (size_t i = 0; i < elementsU.size () - 1; i++)
   {
-    for (unsigned j = 0; j < elementsV.size () - 1; j++)
+    for (size_t j = 0; j < elementsV.size () - 1; j++)
     {
       double points[3];
       double d;
@@ -1164,20 +1164,20 @@ FittingSurface::inverseMappingBoundary (const ON_NurbsSurface &nurbs, const Vect
   std::vector<double> elementsV = getElementVector (nurbs, 1);
 
   // NORTH - SOUTH
-  for (unsigned i = 0; i < (elementsV.size () - 1); i++)
+  for (size_t i = 0; i < (elementsV.size () - 1); i++)
   {
     ini_points.emplace_back(WEST, elementsV[i] + 0.5 * (elementsV[i + 1] - elementsV[i]));
     ini_points.emplace_back(EAST, elementsV[i] + 0.5 * (elementsV[i + 1] - elementsV[i]));
   }
 
   // WEST - EAST
-  for (unsigned i = 0; i < (elementsU.size () - 1); i++)
+  for (size_t i = 0; i < (elementsU.size () - 1); i++)
   {
     ini_points.emplace_back(NORTH, elementsU[i] + 0.5 * (elementsU[i + 1] - elementsU[i]));
     ini_points.emplace_back(SOUTH, elementsU[i] + 0.5 * (elementsU[i + 1] - elementsU[i]));
   }
 
-  for (unsigned i = 0; i < ini_points.size (); i++)
+  for (size_t i = 0; i < ini_points.size (); i++)
   {
 
     Vector2d params = inverseMappingBoundary (nurbs, pt, ini_points[i].side, ini_points[i].hint, err_tmp, p_tmp,

--- a/surface/src/on_nurbs/global_optimization_pdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_pdm.cpp
@@ -115,7 +115,7 @@ GlobalOptimization::assemble (Parameter params)
 
   m_solver.assign (m_nrows, m_ncols, 3);
 
-  for (unsigned i = 0; i < m_data.size (); i++)
+  for (size_t i = 0; i < m_data.size (); i++)
     m_data[i]->common_boundary_param.clear ();
 
   // assemble matrix
@@ -159,7 +159,7 @@ GlobalOptimization::updateSurf (double damp)
 {
   int ncps (0);
 
-  for (unsigned i = 0; i < m_nurbs.size (); i++)
+  for (size_t i = 0; i < m_nurbs.size (); i++)
   {
     ON_NurbsSurface* nurbs = m_nurbs[i];
 
@@ -199,10 +199,10 @@ GlobalOptimization::refine (unsigned id, int dim)
   std::vector<double> xi;
   std::vector<double> elements = FittingSurface::getElementVector (*m_nurbs[id], dim);
 
-  for (unsigned i = 0; i < elements.size () - 1; i++)
+  for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (unsigned i = 0; i < xi.size (); i++)
+  for (size_t i = 0; i < xi.size (); i++)
   {
     m_nurbs[id]->InsertKnot (dim, xi[i], 1);
   }
@@ -234,7 +234,7 @@ GlobalOptimization::assembleCommonBoundaries (unsigned id1, double weight, unsig
   if (nurbs1->Order (0) != nurbs1->Order (1))
     printf ("[GlobalOptimization::assembleCommonBoundaries] Warning, order in u and v direction differ (nurbs1).\n");
 
-  for (unsigned i = 0; i < data1->common_boundary_point.size (); i++)
+  for (size_t i = 0; i < data1->common_boundary_point.size (); i++)
   {
     Eigen::Vector3d p1, tu1, tv1, p2, tu2, tv2, t1, t2;
     Eigen::Vector2d params1, params2;
@@ -325,12 +325,12 @@ GlobalOptimization::assembleClosingBoundaries (unsigned id, unsigned samples, do
   ClosingBoundary::sampleFromBoundary (nurbs1, boundary1, params1, samples);
 
   // for each other nurbs
-  for (unsigned n2 = (id + 1); n2 < m_nurbs.size (); n2++)
+  for (size_t n2 = (id + 1); n2 < m_nurbs.size (); n2++)
   {
     ON_NurbsSurface *nurbs2 = m_nurbs[n2];
 
     // find closest point to boundary
-    for (unsigned i = 0; i < boundary1.size (); i++)
+    for (size_t i = 0; i < boundary1.size (); i++)
     {
       double error;
       Eigen::Vector3d p, tu, tv;
@@ -359,7 +359,7 @@ GlobalOptimization::assembleInteriorPoints (unsigned id, int ncps, double weight
 
   ON_NurbsSurface *nurbs = m_nurbs[id];
   NurbsDataSurface *data = m_data[id];
-  unsigned nInt = static_cast<unsigned> (m_data[id]->interior.size ());
+  size_t interiorSize = m_data[id]->interior.size ();
 
   // interior points should lie on surface
   data->interior_line_start.clear ();
@@ -368,7 +368,7 @@ GlobalOptimization::assembleInteriorPoints (unsigned id, int ncps, double weight
   data->interior_normals.clear ();
   //  data->interior_param.clear();
 
-  for (unsigned p = 0; p < nInt; p++)
+  for (size_t p = 0; p < interiorSize; p++)
   {
     Vector3d pcp;
     pcp (0) = data->interior[p] (0);

--- a/surface/src/on_nurbs/global_optimization_tdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_tdm.cpp
@@ -90,7 +90,7 @@ GlobalOptimizationTDM::assemble (Parameter params)
 
   m_solver.assign (m_nrows, m_ncols, 1);
 
-  for (unsigned i = 0; i < m_data.size (); i++)
+  for (size_t i = 0; i < m_data.size (); i++)
     m_data[i]->common_boundary_param.clear ();
 
   // assemble matrix
@@ -208,7 +208,7 @@ GlobalOptimizationTDM::updateSurf (double damp)
 {
   int ncps (0);
 
-  for (unsigned i = 0; i < m_nurbs.size (); i++)
+  for (size_t i = 0; i < m_nurbs.size (); i++)
   {
     ON_NurbsSurface* nurbs = m_nurbs[i];
 
@@ -276,7 +276,7 @@ GlobalOptimizationTDM::assembleCommonBoundaries (unsigned id1, double weight, un
   if (nurbs1->m_order[0] != nurbs1->m_order[1])
     printf ("[GlobalOptimizationTDM::assembleCommonBoundaries] Warning, order in u and v direction differ (nurbs1).\n");
 
-  for (unsigned i = 0; i < data1->common_boundary_point.size (); i++)
+  for (size_t i = 0; i < data1->common_boundary_point.size (); i++)
   {
     Eigen::Vector3d p0 = data1->common_boundary_point[i];
     Eigen::Vector2i id (id1, data1->common_boundary_idx[i]);
@@ -368,12 +368,12 @@ GlobalOptimizationTDM::assembleClosingBoundaries (unsigned id, unsigned samples,
   ClosingBoundary::sampleFromBoundary (nurbs1, boundary1, params1, samples);
 
   // for each other nurbs
-  for (unsigned n2 = (id + 1); n2 < m_nurbs.size (); n2++)
+  for (size_t n2 = (id + 1); n2 < m_nurbs.size (); n2++)
   {
     ON_NurbsSurface *nurbs2 = m_nurbs[n2];
 
     // find closest point to boundary
-    for (unsigned i = 0; i < boundary1.size (); i++)
+    for (size_t i = 0; i < boundary1.size (); i++)
     {
       double error;
       Eigen::Vector3d p, tu, tv;
@@ -412,14 +412,14 @@ GlobalOptimizationTDM::assembleClosingBoundariesTD (unsigned id, unsigned sample
 
   // for each other nurbs
   //  for (unsigned n2 = (id + 1); n2 < m_nurbs.size(); n2++) {
-  for (unsigned n2 = 0; n2 < m_nurbs.size (); n2++)
+  for (size_t n2 = 0; n2 < m_nurbs.size (); n2++)
   {
     if (id == n2)
       continue;
     ON_NurbsSurface *nurbs2 = m_nurbs[n2];
 
     // find closest point to boundary
-    for (unsigned i = 0; i < boundary1.size (); i++)
+    for (size_t i = 0; i < boundary1.size (); i++)
     {
       double error;
       Eigen::Vector3d p, n, tu, tv;

--- a/surface/src/on_nurbs/nurbs_solve_eigen.cpp
+++ b/surface/src/on_nurbs/nurbs_solve_eigen.cpp
@@ -94,9 +94,9 @@ NurbsSolve::resize (unsigned rows)
 void
 NurbsSolve::printK ()
 {
-  for (unsigned r = 0; r < m_Keig.rows (); r++)
+  for (Eigen::Index r = 0; r < m_Keig.rows (); r++)
   {
-    for (unsigned c = 0; c < m_Keig.cols (); c++)
+    for (Eigen::Index c = 0; c < m_Keig.cols (); c++)
     {
       printf (" %f", m_Keig (r, c));
     }
@@ -107,9 +107,9 @@ NurbsSolve::printK ()
 void
 NurbsSolve::printX ()
 {
-  for (unsigned r = 0; r < m_xeig.rows (); r++)
+  for (Eigen::Index r = 0; r < m_xeig.rows (); r++)
   {
-    for (unsigned c = 0; c < m_xeig.cols (); c++)
+    for (Eigen::Index c = 0; c < m_xeig.cols (); c++)
     {
       printf (" %f", m_xeig (r, c));
     }
@@ -120,9 +120,9 @@ NurbsSolve::printX ()
 void
 NurbsSolve::printF ()
 {
-  for (unsigned r = 0; r < m_feig.rows (); r++)
+  for (Eigen::Index r = 0; r < m_feig.rows (); r++)
   {
-    for (unsigned c = 0; c < m_feig.cols (); c++)
+    for (Eigen::Index c = 0; c < m_feig.cols (); c++)
     {
       printf (" %f", m_feig (r, c));
     }

--- a/surface/src/on_nurbs/nurbs_tools.cpp
+++ b/surface/src/on_nurbs/nurbs_tools.cpp
@@ -89,9 +89,9 @@ NurbsTools::getClosestPoint (const Eigen::Vector2d &p, const vector_vec2d &data)
   if (data.empty ())
     throw std::runtime_error ("[NurbsTools::getClosestPoint(2d)] Data empty.\n");
 
-  unsigned idx (0);
+  size_t idx = 0;
   double dist2 (DBL_MAX);
-  for (unsigned i = 0; i < data.size (); i++)
+  for (size_t i = 0; i < data.size (); i++)
   {
     double d2 = (data[i] - p).squaredNorm ();
     if (d2 < dist2)
@@ -109,9 +109,9 @@ NurbsTools::getClosestPoint (const Eigen::Vector3d &p, const vector_vec3d &data)
   if (data.empty ())
     throw std::runtime_error ("[NurbsTools::getClosestPoint(2d)] Data empty.\n");
 
-  unsigned idx (0);
+  size_t idx = 0;
   double dist2 (DBL_MAX);
-  for (unsigned i = 0; i < data.size (); i++)
+  for (size_t i = 0; i < data.size (); i++)
   {
     double d2 = (data[i] - p).squaredNorm ();
     if (d2 < dist2)
@@ -130,11 +130,11 @@ NurbsTools::getClosestPoint (const Eigen::Vector2d &p, const Eigen::Vector2d &di
   if (data.empty ())
     throw std::runtime_error ("[NurbsTools::getClosestPoint(2d)] Data empty.\n");
 
-  unsigned idx (0);
+  size_t idx = 0;
   idxcp = 0;
   double dist2 (0.0);
   double dist2cp (DBL_MAX);
-  for (unsigned i = 0; i < data.size (); i++)
+  for (size_t i = 0; i < data.size (); i++)
   {
     Eigen::Vector2d v = (data[i] - p);
     double d2 = v.squaredNorm ();

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -593,7 +593,7 @@ SequentialFitter::grow (float max_dist, float max_angle, unsigned min_length, un
 
   double int_err (0.0);
   double div_err = 1.0 / double (m_data.interior_error.size ());
-  for (unsigned i = 0; i < m_data.interior_error.size (); i++)
+  for (size_t i = 0; i < m_data.interior_error.size (); i++)
   {
     int_err += (m_data.interior_error[i] * div_err);
   }
@@ -608,9 +608,9 @@ unsigned
 SequentialFitter::PCL2ON (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_cloud, const std::vector<int> &indices,
                           vector_vec3d &on_cloud)
 {
-  unsigned numPoints (0);
+  size_t numPoints = 0;
 
-  for (unsigned i = 0; i < indices.size (); i++)
+  for (size_t i = 0; i < indices.size (); i++)
   {
 
     pcl::PointXYZRGB &pt = pcl_cloud->at (indices[i]);

--- a/surface/src/on_nurbs/triangulation.cpp
+++ b/surface/src/on_nurbs/triangulation.cpp
@@ -182,7 +182,7 @@ Triangulation::convertSurface2PolygonMesh (const ON_NurbsSurface &nurbs, Polygon
   createVertices (cloud, float (x0), float (y0), 0.0f, float (w), float (h), resolution, resolution);
   createIndices (mesh.polygons, 0, resolution, resolution);
 
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     pcl::PointXYZ &v = cloud->at (i);
 
@@ -232,7 +232,7 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
   std::vector<uint32_t> out_idx;
   pcl::on_nurbs::vector_vec2d out_pc;
 
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     double err;
     Eigen::Vector2d pc, tc;
@@ -255,7 +255,7 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     pt_is_in[i] = (z (2) >= 0.0);
   }
 
-  for (unsigned i = 0; i < polygons.size (); i++)
+  for (size_t i = 0; i < polygons.size (); i++)
   {
     unsigned in (0);
     pcl::Vertices &poly = polygons[i];
@@ -358,7 +358,7 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
   pcl::on_nurbs::NurbsTools::computeBoundingBox (curve, a0, a1);
   double rScale = 1.0 / pcl::on_nurbs::NurbsTools::computeRScale (a0, a1);
 
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     double err, param;
     Eigen::Vector2d pc, tc;
@@ -385,7 +385,7 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     start.push_back (Eigen::Vector3d (vp (0), vp (1), 0.0));
   }
 
-  for (unsigned i = 0; i < polygons.size (); i++)
+  for (size_t i = 0; i < polygons.size (); i++)
   {
     unsigned in (0);
     pcl::Vertices &poly = polygons[i];
@@ -483,7 +483,7 @@ Triangulation::convertSurface2Vertices (const ON_NurbsSurface &nurbs, pcl::Point
   createVertices (cloud, float (x0), float (y0), 0.0f, float (w), float (h), resolution, resolution);
   createIndices (vertices, 0, resolution, resolution);
 
-  for (unsigned i = 0; i < cloud->size (); i++)
+  for (size_t i = 0; i < cloud->size (); i++)
   {
     pcl::PointXYZ &v = cloud->at (i);
 

--- a/surface/src/vtk_smoothing/vtk_utils.cpp
+++ b/surface/src/vtk_smoothing/vtk_utils.cpp
@@ -162,7 +162,7 @@ pcl::VTKUtils::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::Pol
   while (mesh_polygons->GetNextCell (nr_cell_points, cell_points))
   {
     mesh.polygons[id_poly].vertices.resize (nr_cell_points);
-    for (int i = 0; i < nr_cell_points; ++i)
+    for (vtkIdType i = 0; i < nr_cell_points; ++i)
       mesh.polygons[id_poly].vertices[i] = static_cast<unsigned int> (cell_points[i]);
     ++id_poly;
   }

--- a/test/common/test_gaussian.cpp
+++ b/test/common/test_gaussian.cpp
@@ -51,16 +51,16 @@ TEST(PCL, GaussianKernel)
   // Test kernel only version
   gk.compute(5, computed_kernel);
   EXPECT_EQ(kernel.size (), computed_kernel.size ());
-  for(int i = 0; i < kernel.size (); i++)
+  for(Eigen::Index i = 0; i < kernel.size (); i++)
     EXPECT_NEAR(kernel[i], computed_kernel[i], 1e-4);
 
   // Test kernel and derivative version
   gk.compute(5, computed_kernel, computed_derivative);
   EXPECT_EQ(kernel.size (), computed_kernel.size ());
-  for(int i = 0; i < kernel.size (); i++)
+  for(Eigen::Index i = 0; i < kernel.size (); i++)
     EXPECT_NEAR(kernel[i], computed_kernel[i], 1e-4);
   EXPECT_EQ(derivative.size (), computed_derivative.size ());
-  for(int i = 0; i < derivative.size (); i++)
+  for(Eigen::Index i = 0; i < derivative.size (); i++)
     EXPECT_NEAR(derivative[i], computed_derivative[i], 1e-4);
 }
 

--- a/test/common/test_vector_average.cpp
+++ b/test/common/test_vector_average.cpp
@@ -56,7 +56,7 @@ TEST (PCL, VectorAverage_mean)
   
   Eigen::Vector3f correct_mean (0.0f, 0.0f, 0.0f);
   float weigth_sum = 0.0f;
-  for (unsigned int i = 0; i < points.size (); ++i)
+  for (size_t i = 0; i < points.size (); ++i)
   {
     correct_mean += weights[i]*points[i];
     weigth_sum += weights[i];
@@ -64,7 +64,7 @@ TEST (PCL, VectorAverage_mean)
   correct_mean /= weigth_sum;
   
   pcl::VectorAverage<float, 3> va;
-  for (unsigned int i=0; i<points.size(); ++i)
+  for (size_t i = 0; i < points.size(); ++i)
     va.add(points[i], weights[i]);
   Eigen::Vector3f mean = va.getMean();
   //std::cout << "Correct: "<<correct_mean <<"\n"<< "Result: "<<mean<<"\n";

--- a/test/features/test_gasd_estimation.cpp
+++ b/test/features/test_gasd_estimation.cpp
@@ -74,9 +74,9 @@ TEST(PCL, GASDTransformEstimation)
   -0.035592, -0.369596, -0.928511, 0.0622551,
   0, 0, 0, 1;
 
-  for (int i = 0; i < trans.rows(); ++i)
+  for (Eigen::Index i = 0; i < trans.rows(); ++i)
   {
-    for (int j = 0; j < trans.cols (); ++j)
+    for (Eigen::Index j = 0; j < trans.cols (); ++j)
     {
       EXPECT_NEAR (trans (i, j), ref_trans (i, j), 1e-5);
     }

--- a/test/features/test_narf.cpp
+++ b/test/features/test_narf.cpp
@@ -64,7 +64,7 @@ TEST (PCL, Narf_save_load)
   //  EXPECT_EQ (narf.getTransformation().matrix(), narf2.getTransformation().matrix());
   // The above generates http://msdn.microsoft.com/en-us/library/sxe76d9e.aspx in VS2010
   // Therefore we use this:
-  for (int i=0; i<narf.getTransformation().matrix().size(); ++i)
+  for (Eigen::Index i = 0; i < narf.getTransformation().matrix().size(); ++i)
     EXPECT_EQ (narf.getTransformation().data()[i], narf2.getTransformation().data()[i]);
   EXPECT_EQ (narf.getPosition(), narf2.getPosition());
   EXPECT_EQ (narf.getSurfacePatchPixelSize(), narf2.getSurfacePatchPixelSize());

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -1788,7 +1788,7 @@ TEST (SamplingSurfaceNormal, Filters)
   ssn_filter.filter (outcloud);
 
   // All the sampled points should have normals along the direction of Z axis
-  for (unsigned int i = 0; i < outcloud.points.size (); i++)
+  for (size_t i = 0; i < outcloud.points.size (); i++)
   {
     EXPECT_NEAR (outcloud.points[i].normal[0], 0, 1e-3);
     EXPECT_NEAR (outcloud.points[i].normal[1], 0, 1e-3);
@@ -2186,7 +2186,7 @@ TEST (NormalRefinement, Filters)
   // Run estimation
   pcl::NormalEstimation<pcl::PointXYZRGB, pcl::PointXYZRGBNormal> ne;
   cloud_organized_normal.reserve (cloud_organized_nonan.size ());
-  for (unsigned int i = 0; i < cloud_organized_nonan.size (); ++i)
+  for (size_t i = 0; i < cloud_organized_nonan.size (); ++i)
   {
     // Output point
     pcl::PointXYZRGBNormal normali;
@@ -2257,7 +2257,7 @@ TEST (NormalRefinement, Filters)
   int num_nans = 0;
 
   // Loop
-  for (unsigned int i = 0; i < idx_table.size (); ++i)
+  for (size_t i = 0; i < idx_table.size (); ++i)
   {
     float tmp;
 
@@ -2301,13 +2301,13 @@ TEST (NormalRefinement, Filters)
 
   // Error variance of estimated
   float err_est_var = 0.0f;
-  for (unsigned int i = 0; i < errs_est.size (); ++i)
+  for (size_t i = 0; i < errs_est.size (); ++i)
     err_est_var = (errs_est[i] - err_est_mean) * (errs_est[i] - err_est_mean);
   err_est_var /= static_cast<float> (errs_est.size () - 1);
 
   // Error variance of refined
   float err_refined_var = 0.0f;
-  for (unsigned int i = 0; i < errs_refined.size (); ++i)
+  for (size_t i = 0; i < errs_refined.size (); ++i)
     err_refined_var = (errs_refined[i] - err_refined_mean) * (errs_refined[i] - err_refined_mean);
   err_refined_var /= static_cast<float> (errs_refined.size () - 1);
 

--- a/test/geometry/test_mesh.cpp
+++ b/test/geometry/test_mesh.cpp
@@ -92,7 +92,7 @@ TEST (TestAddDeleteFace, NonManifold1)
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear (); // 0
   vi.push_back (VI (2)); vi.push_back (VI (1)); vi.push_back (VI (4)); faces.push_back (vi); vi.clear (); // 1
   vi.push_back (VI (0)); vi.push_back (VI (2)); vi.push_back (VI (5)); faces.push_back (vi); vi.clear (); // 2
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i=0; i < faces.size (); ++i)
   {
     ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
   }
@@ -154,7 +154,7 @@ TEST (TestAddDeleteFace, NonManifold2)
   // 3 - 4 //
   vi.push_back (VI (0)); vi.push_back (VI (1)); vi.push_back (VI (2)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (4)); faces.push_back (vi); vi.clear ();
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i=0; i < faces.size (); ++i)
   {
     ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
   }
@@ -291,7 +291,7 @@ TEST (TestAddDeleteFace, NonManifold2)
   vi.push_back (VI (0)); vi.push_back (VI (8)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (0)); vi.push_back (VI (2)); vi.push_back (VI (3)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (0)); vi.push_back (VI (6)); vi.push_back (VI (7)); faces.push_back (vi); vi.clear ();
-  for (unsigned int i=4; i<faces.size (); ++i)
+  for (size_t i = 4; i < faces.size (); ++i)
   {
     EXPECT_TRUE (mesh.addFace (faces [i]).isValid ());
   }
@@ -307,10 +307,10 @@ TEST (TestAddDeleteFace, NonManifold2)
 
   // Copy vertex indices to data
   std::vector <std::vector <int> > expected (faces.size ());
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i = 0; i < faces.size (); ++i)
   {
     std::vector <int> tmp (faces [i].size ());
-    for (unsigned int j=0; j<faces [i].size (); ++j)
+    for (size_t j = 0; j < faces [i].size (); ++j)
     {
       tmp [j] = faces [i][j].get ();
     }
@@ -353,10 +353,10 @@ TEST (TestAddDeleteFace, Manifold1)
   vi.push_back (VI (0)); vi.push_back (VI (5)); vi.push_back (VI (6)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (0)); vi.push_back (VI (6)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear ();
 
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i = 0; i < faces.size (); ++i)
   {
     std::vector <int> tmp (faces [i].size ());
-    for (unsigned int j=0; j<faces [i].size (); ++j)
+    for (size_t j = 0; j < faces [i].size (); ++j)
     {
       tmp [j] = faces [i][j].get ();
     }
@@ -391,7 +391,7 @@ TEST (TestAddDeleteFace, Manifold1)
   vi.push_back (VI ( 8)); vi.push_back (VI (2)); vi.push_back (VI (9)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (10)); vi.push_back (VI (9)); vi.push_back (VI (2)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (10)); vi.push_back (VI (2)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear ();
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i = 0; i < faces.size (); ++i)
   {
     ASSERT_TRUE (mesh.addFace (faces [i]).isValid ()) << "Face " << i;
   }
@@ -518,10 +518,10 @@ TEST (TestDelete, VertexAndEdge)
   vi.push_back (VI (0)); vi.push_back (VI (5)); vi.push_back (VI (6)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (0)); vi.push_back (VI (6)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear ();
 
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i = 0; i < faces.size (); ++i)
   {
     std::vector <int> tmp (faces [i].size ());
-    for (unsigned int j=0; j<faces [i].size (); ++j)
+    for (size_t j = 0; j < faces [i].size (); ++j)
     {
       tmp [j] = faces [i][j].get ();
     }
@@ -584,7 +584,7 @@ TEST (TestMesh, IsBoundaryIsManifold)
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear (); // 0
   vi.push_back (VI (2)); vi.push_back (VI (1)); vi.push_back (VI (4)); faces.push_back (vi); vi.clear (); // 1
   vi.push_back (VI (0)); vi.push_back (VI (2)); vi.push_back (VI (5)); faces.push_back (vi); vi.clear (); // 2
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i = 0; i < faces.size (); ++i)
   {
     ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
   }
@@ -609,7 +609,7 @@ TEST (TestMesh, IsBoundaryIsManifold)
   EXPECT_TRUE  (mesh.isManifold (VI (5)));
   ASSERT_FALSE (mesh.isManifold ());
 
-  for (unsigned int i=0; i<mesh.sizeEdges (); ++i)
+  for (size_t i = 0; i < mesh.sizeEdges (); ++i)
   {
     ASSERT_TRUE (mesh.isBoundary (EdgeIndex (i)));
   }

--- a/test/geometry/test_mesh_circulators.cpp
+++ b/test/geometry/test_mesh_circulators.cpp
@@ -309,7 +309,7 @@ TEST_F (TestMeshCirculators, FaceAroundVertexDecrement)
 TEST_F (TestMeshCirculators, VertexAroundFaceIncrement)
 {
   VertexIndices actual;
-  for (unsigned int i=0; i<mesh_.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh_.sizeFaces (); ++i)
   {
     VAFC       circ     = mesh_.getVertexAroundFaceCirculator (FaceIndex (i));
     const VAFC circ_end = circ;
@@ -331,7 +331,7 @@ TEST_F (TestMeshCirculators, VertexAroundFaceIncrement)
 TEST_F (TestMeshCirculators, VertexAroundFaceDecrement)
 {
   VertexIndices actual;
-  for (unsigned int i=0; i<mesh_.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh_.sizeFaces (); ++i)
   {
     VAFC       circ     = mesh_.getVertexAroundFaceCirculator (FaceIndex (i));
     const VAFC circ_end = circ;
@@ -353,7 +353,7 @@ TEST_F (TestMeshCirculators, VertexAroundFaceDecrement)
 TEST_F (TestMeshCirculators, InnerHalfEdgeAroundFaceForAllFacesIncrement)
 {
   VertexIndices actual;
-  for (unsigned int i=0; i<mesh_.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh_.sizeFaces (); ++i)
   {
     IHEAFC       circ     = mesh_.getInnerHalfEdgeAroundFaceCirculator (FaceIndex (i));
     const IHEAFC circ_end = circ;
@@ -376,7 +376,7 @@ TEST_F (TestMeshCirculators, InnerHalfEdgeAroundFaceForAllFacesIncrement)
 TEST_F (TestMeshCirculators, InnerHalfEdgeAroundFaceForAllFacesDecrement)
 {
   VertexIndices actual;
-  for (unsigned int i=0; i<mesh_.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh_.sizeFaces (); ++i)
   {
     IHEAFC       circ     = mesh_.getInnerHalfEdgeAroundFaceCirculator (FaceIndex (i));
     const IHEAFC circ_end = circ;
@@ -437,7 +437,7 @@ TEST_F (TestMeshCirculators, InnerHalfEdgeAroundFaceForBoundaryDecrement)
 TEST_F (TestMeshCirculators, OuterHalfEdgeAroundFaceIncrement)
 {
   VertexIndices actual;
-  for (unsigned int i=0; i<mesh_.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh_.sizeFaces (); ++i)
   {
     OHEAFC       circ     = mesh_.getOuterHalfEdgeAroundFaceCirculator (FaceIndex (i));
     const OHEAFC circ_end = circ;
@@ -464,7 +464,7 @@ TEST_F (TestMeshCirculators, OuterHalfEdgeAroundFaceIncrement)
 TEST_F (TestMeshCirculators, OuterHalfEdgeAroundFaceDecrement)
 {
   VertexIndices actual;
-  for (unsigned int i=0; i<mesh_.sizeFaces (); ++i)
+  for (size_t i=0; i<mesh_.sizeFaces (); ++i)
   {
     OHEAFC       circ     = mesh_.getOuterHalfEdgeAroundFaceCirculator (FaceIndex (i));
     const OHEAFC circ_end = circ;

--- a/test/geometry/test_mesh_common_functions.h
+++ b/test/geometry/test_mesh_common_functions.h
@@ -69,7 +69,7 @@ hasFaces (const MeshT& mesh, const std::vector <typename MeshT::VertexIndices> &
   }
 
   VertexIndices vi;
-  for (unsigned int i=0; i<mesh.sizeFaces (); ++i)
+  for (size_t i = 0; i < mesh.sizeFaces (); ++i)
   {
     if (verbose) std::cerr << "Face " << std::setw (2) << i << ": ";
     VAFC       circ     = mesh.getVertexAroundFaceCirculator (FaceIndex (i));
@@ -95,7 +95,7 @@ hasFaces (const MeshT& mesh, const std::vector <typename MeshT::VertexIndices> &
       return (false);
     }
     if (verbose) std::cerr << "\texpected: ";
-    for (unsigned int j=0; j<vi.size (); ++j)
+    for (size_t j = 0; j < vi.size (); ++j)
     {
       if (verbose) std::cerr << std::setw (2) << faces [i][j] << " ";
       if (vi [j] != faces [i][j])
@@ -131,7 +131,7 @@ hasFaces (const MeshT& mesh, const std::vector <std::vector <int> > &faces, cons
 
   const VertexDataCloud& vdc = mesh.getVertexDataCloud ();
   std::vector <int> vv;
-  for (unsigned int i=0; i<mesh.sizeFaces (); ++i)
+  for (size_t i = 0; i < mesh.sizeFaces (); ++i)
   {
     if (verbose) std::cerr << "Face " << std::setw (2) << i << ": ";
     VAFC       circ     = mesh.getVertexAroundFaceCirculator (FaceIndex (i));
@@ -157,7 +157,7 @@ hasFaces (const MeshT& mesh, const std::vector <std::vector <int> > &faces, cons
       return (false);
     }
     if (verbose) std::cerr << "\texpected: ";
-    for (unsigned int j=0; j<vv.size (); ++j)
+    for (size_t j=0; j<vv.size (); ++j)
     {
       if (verbose) std::cerr << std::setw (2) << faces [i][j] << " ";
       if (vv [j] != faces [i][j])

--- a/test/geometry/test_mesh_data.cpp
+++ b/test/geometry/test_mesh_data.cpp
@@ -406,10 +406,10 @@ TEST (TestMesh, MeshData)
     EXPECT_EQ (edc.size () , edc_new.size ());
     EXPECT_EQ (fdc.size () , fdc_new.size ());
 
-    for (unsigned int i=0; i<vdc_new.size  (); ++i) EXPECT_EQ (vdc  [i], vdc_new  [i]) << "Index " << i;
-    for (unsigned int i=0; i<hedc_new.size (); ++i) EXPECT_EQ (hedc [i], hedc_new [i]) << "Index " << i;
-    for (unsigned int i=0; i<edc_new.size  (); ++i) EXPECT_EQ (edc  [i], edc_new  [i]) << "Index " << i;
-    for (unsigned int i=0; i<fdc_new.size  (); ++i) EXPECT_EQ (fdc  [i], fdc_new  [i]) << "Index " << i;
+    for (size_t i = 0; i < vdc_new.size  (); ++i) EXPECT_EQ (vdc  [i], vdc_new  [i]) << "Index " << i;
+    for (size_t i = 0; i < hedc_new.size (); ++i) EXPECT_EQ (hedc [i], hedc_new [i]) << "Index " << i;
+    for (size_t i = 0; i < edc_new.size  (); ++i) EXPECT_EQ (edc  [i], edc_new  [i]) << "Index " << i;
+    for (size_t i = 0; i < fdc_new.size  (); ++i) EXPECT_EQ (fdc  [i], fdc_new  [i]) << "Index " << i;
 
     vdc_new  [0] = 0;
     hedc_new [0] = 1;

--- a/test/geometry/test_polygon_mesh.cpp
+++ b/test/geometry/test_polygon_mesh.cpp
@@ -178,7 +178,7 @@ TYPED_TEST (TestPolygonMesh, ThreePolygons)
   faces.push_back (vi);
   vi.clear ();
 
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i=0; i < faces.size (); ++i)
   {
     ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
   }

--- a/test/geometry/test_quad_mesh.cpp
+++ b/test/geometry/test_quad_mesh.cpp
@@ -344,7 +344,7 @@ TYPED_TEST (TestQuadMesh, NineQuads)
 
   ASSERT_EQ (order_vec.size (), non_manifold.size ());
   ASSERT_EQ (9, faces.size ());
-  for (unsigned int i=0; i<order_vec.size (); ++i)
+  for (size_t i=0; i<order_vec.size (); ++i)
   {
     std::stringstream ss;
     ss << "Configuration " << i;
@@ -356,16 +356,16 @@ TYPED_TEST (TestQuadMesh, NineQuads)
     if (9 != order.size ()) continue;
 
     Mesh mesh;
-    for (unsigned int j=0; j<16; ++j) mesh.addVertex (j);
+    for (size_t j=0; j<16; ++j) mesh.addVertex (j);
 
     std::vector <VertexIndices> ordered_faces;
 
-    for (unsigned int j=0; j<faces.size (); ++j)
+    for (size_t j=0; j<faces.size (); ++j)
     {
       ordered_faces.push_back (faces [order [j]]);
     }
     bool check_has_faces = true;
-    for (unsigned int j=0; j<faces.size (); ++j)
+    for (size_t j=0; j<faces.size (); ++j)
     {
       const FaceIndex index = mesh.addFace (ordered_faces [j]);
 

--- a/test/geometry/test_triangle_mesh.cpp
+++ b/test/geometry/test_triangle_mesh.cpp
@@ -541,7 +541,7 @@ TEST (TestManifoldTriangleMesh, addTrianglePair)
   tmp.push_back (vi [ 6]); tmp.push_back (vi [10]); tmp.push_back (vi [11]); tmp.push_back (vi [ 7]); faces.push_back (tmp); tmp.clear ();
   tmp.push_back (vi [ 5]); tmp.push_back (vi [ 9]); tmp.push_back (vi [10]); tmp.push_back (vi [ 6]); faces.push_back (tmp); tmp.clear ();
 
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i=0; i < faces.size (); ++i)
   {
     std::pair <FaceIndex, FaceIndex> fip;
     fip = mesh.addTrianglePair (faces [i]);
@@ -549,7 +549,7 @@ TEST (TestManifoldTriangleMesh, addTrianglePair)
     ASSERT_TRUE (fip.second.isValid ());
   }
 
-  for (unsigned int i=0; i<faces.size (); ++i)
+  for (size_t i=0; i < faces.size (); ++i)
   {
     VertexIndices actual_1, actual_2;
 

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -96,7 +96,7 @@ TEST (PCL, PLYReaderWriter)
   EXPECT_EQ (cloud.is_dense, cloud2.is_dense);   // test for fromPCLPointCloud2 ()
   EXPECT_EQ (cloud.size (), cloud2.size ());         // test for fromPCLPointCloud2 ()
 
-  for (uint32_t counter = 0; counter < cloud.size (); ++counter)
+  for (size_t counter = 0; counter < cloud.size (); ++counter)
   {
     EXPECT_FLOAT_EQ (cloud[counter].x, cloud2[counter].x);     // test for fromPCLPointCloud2 ()
     EXPECT_FLOAT_EQ (cloud[counter].y, cloud2[counter].y);     // test for fromPCLPointCloud2 ()

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -96,7 +96,7 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
   MyPoint test_point(0.0f, 0.0f, 0.0f);
   double max_dist = 0.15;
   set<int> brute_force_result;
-  for (unsigned int i=0; i<cloud.points.size(); ++i)
+  for (size_t i=0; i < cloud.points.size(); ++i)
     if (euclideanDistance(cloud.points[i], test_point) < max_dist)
       brute_force_result.insert(i);
   vector<int> k_indices;

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -207,7 +207,7 @@ TEST (PCL, Octree_Test)
   ASSERT_EQ (leafVectorB.size (), octreeB.getLeafCount ());
   ASSERT_EQ (leafVectorA.size (), leafVectorB.size ());
 
-  for (unsigned int i = 0; i < leafVectorB.size (); i++)
+  for (size_t i = 0; i < leafVectorB.size (); i++)
   {
     ASSERT_EQ (*leafVectorA[i], *leafVectorB[i]);
   }
@@ -523,7 +523,7 @@ TEST (PCL, Octree2Buf_Test)
   ASSERT_EQ (leafVectorB.size (), octreeB.getLeafCount ());
   ASSERT_EQ (leafVectorA.size (), leafVectorB.size ());
 
-  for (unsigned int i = 0; i < leafVectorB.size (); i++)
+  for (size_t i = 0; i < leafVectorB.size (); i++)
   {
     ASSERT_EQ (*leafVectorA[i], *leafVectorB[i]);
   }
@@ -603,7 +603,7 @@ TEST (PCL, Octree2Buf_Base_Double_Buffering_Test)
     ASSERT_EQ (leafVectorA.size (), leafVectorB.size ());
 
     // check if octree octree structure is consistent.
-    for (unsigned int i = 0; i < leafVectorB.size (); i++)
+    for (size_t i = 0; i < leafVectorB.size (); i++)
     {
       ASSERT_EQ (*leafVectorA[i], *leafVectorB[i]);
     }
@@ -671,7 +671,7 @@ TEST (PCL, Octree2Buf_Base_Double_Buffering_XOR_Test)
     ASSERT_EQ (treeBinaryA.size (), treeBinaryB.size ());
 
     // check if octree octree structure is consistent.
-    for (unsigned int i = 0; i < leafVectorB.size (); i++)
+    for (size_t i = 0; i < leafVectorB.size (); i++)
     {
       ASSERT_EQ (*leafVectorA[i], *leafVectorB[i]);
     }

--- a/test/registration/test_correspondence_estimation.cpp
+++ b/test/registration/test_correspondence_estimation.cpp
@@ -76,7 +76,7 @@ TEST (CorrespondenceEstimation, CorrespondenceEstimationNormalShooting)
   ce.determineCorrespondences (*corr);
 
   // Based on the data defined, the correspondence indices should be 1 <-> 1 , 2 <-> 2 , 3 <-> 3 etc.
-  for (unsigned int i = 0; i < corr->size (); i++)
+  for (size_t i = 0; i < corr->size (); i++)
   {
     EXPECT_EQ ((*corr)[i].index_query, (*corr)[i].index_match);
   }

--- a/test/registration/test_correspondence_rejectors.cpp
+++ b/test/registration/test_correspondence_rejectors.cpp
@@ -138,11 +138,11 @@ TEST (CorrespondenceRejectors, CorrespondenceRejectionPoly)
    * Test criterion 2: expect high precision/recall. The true positives are the unscrambled correspondences
    * where the query/match index are equal.
    */
-  unsigned int true_positives = 0;
-  for (unsigned int i = 0; i < result.size(); ++i)
+  size_t true_positives = 0;
+  for (size_t i = 0; i < result.size(); ++i)
     if (result[i].index_query == result[i].index_match)
       ++true_positives;
-  const unsigned int false_positives = static_cast<unsigned int> (result.size()) - true_positives;
+  const size_t false_positives = result.size() - true_positives;
 
   const double precision = double(true_positives) / double(true_positives+false_positives);
   const double recall = double(true_positives) / double(size-last);

--- a/test/sample_consensus/test_sample_consensus_plane_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_plane_models.cpp
@@ -250,7 +250,7 @@ TEST (SampleConsensusModelNormalParallelPlane, RANSAC)
   cloud.points.resize (10);
   normals.resize (10);
 
-  for (unsigned idx = 0; idx < cloud.size (); ++idx)
+  for (size_t idx = 0; idx < cloud.size (); ++idx)
   {
     cloud.points[idx].x = static_cast<float> ((rand () % 200) - 100);
     cloud.points[idx].y = static_cast<float> ((rand () % 200) - 100);

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -164,7 +164,7 @@ bool testUniqueness (const vector<int>& indices, const string& name)
 bool testOrder (const vector<float>& distances, const string& name)
 {
   bool ordered = true;
-  for (unsigned idx1 = 1; idx1 < distances.size (); ++idx1)
+  for (size_t idx1 = 1; idx1 < distances.size (); ++idx1)
   {
     if (distances [idx1-1] > distances [idx1])
     {
@@ -254,7 +254,7 @@ bool compareResults (const std::vector<int>& indices1, const::vector<float>& dis
   }
   else
   {
-    for (unsigned idx = 0; idx < indices1.size (); ++idx)
+    for (size_t idx = 0; idx < indices1.size (); ++idx)
     {
       if (indices1[idx] != indices2[idx] && fabs (distances1[idx] - distances2[idx]) > eps)
       {
@@ -406,7 +406,7 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
       }
     }
   }
-  for (unsigned sIdx = 0; sIdx < search_methods.size (); ++sIdx)
+  for (size_t sIdx = 0; sIdx < search_methods.size (); ++sIdx)
   {
     cout << search_methods [sIdx]->getName () << ": " << (passed[sIdx]?"passed":"failed") << endl;
     EXPECT_TRUE (passed [sIdx]);

--- a/test/segmentation/test_random_walker.cpp
+++ b/test/segmentation/test_random_walker.cpp
@@ -173,7 +173,7 @@ TEST_P (RandomWalkerTest, BuildLinearSystem)
   std::vector<Weight> degrees (g.rows, 0.0);
   std::vector<Weight> L_sums (g.rows, 0.0);
   std::vector<Weight> B_sums (g.rows, 0.0);
-  for (int k = 0; k < rw.L.outerSize (); ++k)
+  for (Eigen::Index k = 0; k < rw.L.outerSize (); ++k)
   {
     for (SparseMatrix::InnerIterator it (rw.L, k); it; ++it)
     {
@@ -189,7 +189,7 @@ TEST_P (RandomWalkerTest, BuildLinearSystem)
       }
     }
   }
-  for (int k = 0; k < rw.B.outerSize (); ++k)
+  for (Eigen::Index k = 0; k < rw.B.outerSize (); ++k)
   {
     for (SparseMatrix::InnerIterator it (rw.B, k); it; ++it)
     {

--- a/tools/tiff2pcd.cpp
+++ b/tools/tiff2pcd.cpp
@@ -324,7 +324,7 @@ int main(int argc, char ** argv)
   sort (tiff_depth_files.begin (), tiff_depth_files.end ());
   sort (tiff_depth_paths.begin (), tiff_depth_paths.end ());
 
-  for(unsigned int i=0; i<tiff_rgb_paths.size(); i++)
+  for(size_t i = 0; i < tiff_rgb_paths.size(); i++)
   {
     // Load the input file
     vtkSmartPointer<vtkImageData> rgb_data;

--- a/visualization/src/common/io.cpp
+++ b/visualization/src/common/io.cpp
@@ -56,7 +56,7 @@ pcl::visualization::getCorrespondingPointCloud (vtkPolyData *src,
   cloud.height = 1; cloud.width = static_cast<uint32_t> (src->GetNumberOfPoints ());
   cloud.is_dense = false;
   cloud.points.resize (cloud.width * cloud.height);
-  for (int i = 0; i < src->GetNumberOfPoints (); i++)
+  for (vtkIdType i = 0; i < src->GetNumberOfPoints (); i++)
   {
     double p[3];
     src->GetPoint (i, p);

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -386,7 +386,7 @@ pcl::visualization::ImageViewer::spinOnce (int time, bool force_redraw)
     interactor_->Start ();
     interactor_->DestroyTimer (exit_main_loop_timer_callback_->right_timer_id);
   );
-  for(unsigned int i = 0; i < image_data_.size(); i++)
+  for(size_t i = 0; i < image_data_.size(); i++)
 	  delete [] image_data_[i];
   image_data_.clear ();
 }
@@ -871,7 +871,7 @@ void
 pcl::visualization::ImageViewer::render ()
 {
   win_->Render ();
-  for(unsigned int i = 0; i < image_data_.size(); i++)
+  for(size_t i = 0; i < image_data_.size(); i++)
 	  delete [] image_data_[i];
   image_data_.clear ();
 }

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -158,7 +158,7 @@ pcl::visualization::PCLPlotter::addPlotData (
   double *array_x = new double[plot_data.size ()];
   double *array_y = new double[plot_data.size ()];
 
-  for (unsigned int i = 0; i < plot_data.size (); i++)
+  for (size_t i = 0; i < plot_data.size (); i++)
   {
     array_x[i] = plot_data[i].first;
     array_y[i] = plot_data[i].second;

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3276,7 +3276,7 @@ pcl::visualization::PCLVisualizer::addPolylineFromPolygonMesh (
   {
     vtkSmartPointer<vtkPolyLine> polyLine = vtkSmartPointer<vtkPolyLine>::New();
     polyLine->GetPointIds()->SetNumberOfIds(polymesh.polygons[i].vertices.size());
-    for(unsigned int k = 0; k < polymesh.polygons[i].vertices.size(); k++)
+    for(size_t k = 0; k < polymesh.polygons[i].vertices.size(); k++)
     {
       polyLine->GetPointIds ()->SetId (k, polymesh.polygons[i].vertices[k]);
     }
@@ -3713,7 +3713,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
   else
   {
     cam_positions.resize (sphere->GetNumberOfPoints ());
-    for (int i = 0; i < sphere->GetNumberOfPoints (); i++)
+    for (vtkIdType i = 0; i < sphere->GetNumberOfPoints (); i++)
     {
       double cam_pos[3];
       sphere->GetPoint (i, cam_pos);
@@ -3918,7 +3918,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
     if (!ids)
       return;
     double visible_area = 0;
-    for (int sel_id = 0; sel_id < (ids->GetNumberOfTuples ()); sel_id++)
+    for (vtkIdType sel_id = 0; sel_id < (ids->GetNumberOfTuples ()); sel_id++)
     {
       int id_mesh = static_cast<int> (ids->GetValue (sel_id));
       vtkCell * cell = polydata->GetCell (id_mesh);

--- a/visualization/src/range_image_visualizer.cpp
+++ b/visualization/src/range_image_visualizer.cpp
@@ -139,7 +139,7 @@ pcl::visualization::RangeImageVisualizer::getInterestPointsWidget (
   RangeImageVisualizer* widget = new RangeImageVisualizer;
   widget->showFloatImage (interest_image, range_image.width, range_image.height, min_value, max_value);
   widget->setWindowTitle (name);
-  for (unsigned int i=0; i<interest_points.points.size(); ++i)
+  for (size_t i=0; i<interest_points.points.size(); ++i)
   {
     const pcl::InterestPoint& interest_point = interest_points.points[i];
     float image_x, image_y;

--- a/visualization/tools/openni2_viewer.cpp
+++ b/visualization/tools/openni2_viewer.cpp
@@ -317,7 +317,7 @@ main (int argc, char** argv)
         boost::shared_ptr<pcl::io::openni2::OpenNI2DeviceManager> deviceManager = pcl::io::openni2::OpenNI2DeviceManager::getInstance ();
         if (deviceManager->getNumOfConnectedDevices () > 0)
         {
-          for (unsigned deviceIdx = 0; deviceIdx < deviceManager->getNumOfConnectedDevices (); ++deviceIdx)
+          for (size_t deviceIdx = 0; deviceIdx < deviceManager->getNumOfConnectedDevices (); ++deviceIdx)
           {
             boost::shared_ptr<pcl::io::openni2::OpenNI2Device> device = deviceManager->getDeviceByIndex (deviceIdx);
             cout << "Device " << device->getStringID () << "connected." << endl;


### PR DESCRIPTION
Fix issues reported by `run-clang-tidy -header-filter='.*' -checks='-*,bugprone-too-small-loop-variable'`