### PR TITLE
Tranform classic loops to range-based for loops in module 2d

### DIFF
--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -273,8 +273,8 @@ pcl::Edge<PointInT, PointOutT>::suppressNonMaxima (
   maxima.width = width;
   maxima.resize (height * width);
 
-  for (size_t i = 0; i < maxima.size (); ++i)
-    maxima[i].intensity = 0.0f;
+  for (auto &point : maxima)
+    point.intensity = 0.0f;
 
   // tHigh and non-maximal supression
   for (int i = 1; i < height - 1; i++)


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix