### PR TITLE
Transform classic loops to range-based for loops in module tracking

### DIFF
--- a/tracking/include/pcl/tracking/impl/kld_adaptive_particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/kld_adaptive_particle_filter.hpp
@@ -34,14 +34,14 @@ pcl::tracking::KLDAdaptiveParticleFilterTracker<PointInT, StateT>::initCompute (
 
 template <typename PointInT, typename StateT> bool
 pcl::tracking::KLDAdaptiveParticleFilterTracker<PointInT, StateT>::insertIntoBins
-(std::vector<int> bin, std::vector<std::vector<int> > &B)
+(std::vector<int> &&new_bin, std::vector<std::vector<int> > &bins)
 {
-  for (size_t i = 0; i < B.size (); i++)
+  for (auto &existing_bin : bins)
   {
-    if (equalBin (bin, B[i]))
+    if (equalBin (new_bin, existing_bin))
       return false;
   }
-  B.push_back (bin);
+  bins.push_back (std::move(new_bin));
   return true;
 }
 
@@ -51,7 +51,7 @@ pcl::tracking::KLDAdaptiveParticleFilterTracker<PointInT, StateT>::resample ()
   unsigned int k = 0;
   unsigned int n = 0;
   PointCloudStatePtr S (new PointCloudState);
-  std::vector<std::vector<int> > B; // bins
+  std::vector<std::vector<int> > bins;
   
   // initializing for sampling without replacement
   std::vector<int> a (particles_->points.size ());
@@ -73,12 +73,12 @@ pcl::tracking::KLDAdaptiveParticleFilterTracker<PointInT, StateT>::resample ()
     
     S->points.push_back (x_t);
     // calc bin
-    std::vector<int> bin (StateT::stateDimension ());
+    std::vector<int> new_bin (StateT::stateDimension ());
     for (int i = 0; i < StateT::stateDimension (); i++)
-      bin[i] = static_cast<int> (x_t[i] / bin_size_[i]);
+      new_bin[i] = static_cast<int> (x_t[i] / bin_size_[i]);
     
     // calc bin index... how?
-    if (insertIntoBins (bin, B))
+    if (insertIntoBins (std::move(new_bin), bins))
       ++k;
     ++n;
   }

--- a/tracking/include/pcl/tracking/kld_adaptive_particle_filter.h
+++ b/tracking/include/pcl/tracking/kld_adaptive_particle_filter.h
@@ -109,7 +109,7 @@ namespace pcl
         * \param b index of the bin
         */
       virtual bool 
-      equalBin (std::vector<int> a, std::vector<int> b)
+      equalBin (const std::vector<int> &a, const std::vector<int> &b)
       {
         int dimension = StateT::stateDimension ();
         for (int i = 0; i < dimension; i++)
@@ -177,11 +177,11 @@ namespace pcl
 
       /** \brief insert a bin into the set of the bins. if that bin is already registered,
           return false. if not, return true.
-        * \param bin a bin to be inserted.
-        * \param B a set of the bins
+        * \param new_bin a bin to be inserted.
+        * \param bins a set of the bins
         */
       virtual bool 
-      insertIntoBins (std::vector<int> bin, std::vector<std::vector<int> > &B);
+      insertIntoBins (std::vector<int> &&new_bin, std::vector<std::vector<int> > &bins);
             
       /** \brief This method should get called before starting the actual computation. */
       bool 


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix