### PR TITLE
Transform classic loops to range-based for loops in module common

### DIFF
--- a/common/include/pcl/common/impl/accumulators.hpp
+++ b/common/include/pcl/common/impl/accumulators.hpp
@@ -211,11 +211,11 @@ namespace pcl
       get (PointT& t, size_t) const
       {
         size_t max = 0;
-        for (auto itr = labels.cbegin (); itr != labels.cend (); ++itr)
-          if (itr->second > max)
+        for (const auto &label : labels)
+          if (label.second > max)
           {
-            max = itr->second;
-            t.label = itr->first;
+            max = label.second;
+            t.label = label.first;
           }
       }
 

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -135,11 +135,11 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (const int index : indices)
     {
-      centroid[0] += cloud[indices[i]].x;
-      centroid[1] += cloud[indices[i]].y;
-      centroid[2] += cloud[indices[i]].z;
+      centroid[0] += cloud[index].x;
+      centroid[1] += cloud[index].y;
+      centroid[2] += cloud[index].z;
     }
     centroid /= static_cast<Scalar> (indices.size ());
     centroid[3] = 1;
@@ -149,15 +149,15 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   else
   {
     unsigned cp = 0;
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (const int index : indices)
     {
       // Check if the point is invalid
-      if (!isFinite (cloud [indices[i]]))
+      if (!isFinite (cloud [index]))
         continue;
 
-      centroid[0] += cloud[indices[i]].x;
-      centroid[1] += cloud[indices[i]].y;
-      centroid[2] += cloud[indices[i]].z;
+      centroid[0] += cloud[index].x;
+      centroid[1] += cloud[index].y;
+      centroid[2] += cloud[index].z;
       ++cp;
     }
     centroid /= static_cast<Scalar> (cp);
@@ -300,16 +300,16 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = 0;
     // For each point in the cloud
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (const int index : indices)
     {
       // Check if the point is invalid
-      if (!isFinite (cloud[indices[i]]))
+      if (!isFinite (cloud[index]))
         continue;
 
       Eigen::Matrix<Scalar, 4, 1> pt;
-      pt[0] = cloud[indices[i]].x - centroid[0];
-      pt[1] = cloud[indices[i]].y - centroid[1];
-      pt[2] = cloud[indices[i]].z - centroid[2];
+      pt[0] = cloud[index].x - centroid[0];
+      pt[1] = cloud[index].y - centroid[1];
+      pt[2] = cloud[index].z - centroid[2];
 
       covariance_matrix (1, 1) += pt.y () * pt.y ();
       covariance_matrix (1, 2) += pt.y () * pt.z ();
@@ -434,32 +434,32 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   if (cloud.is_dense)
   {
     point_count = static_cast<unsigned int> (indices.size ());
-    for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
+    for (const int index : indices)
     {
       //const PointT& point = cloud[*iIt];
-      accu [0] += cloud[*iIt].x * cloud[*iIt].x;
-      accu [1] += cloud[*iIt].x * cloud[*iIt].y;
-      accu [2] += cloud[*iIt].x * cloud[*iIt].z;
-      accu [3] += cloud[*iIt].y * cloud[*iIt].y;
-      accu [4] += cloud[*iIt].y * cloud[*iIt].z;
-      accu [5] += cloud[*iIt].z * cloud[*iIt].z;
+      accu [0] += cloud[index].x * cloud[index].x;
+      accu [1] += cloud[index].x * cloud[index].y;
+      accu [2] += cloud[index].x * cloud[index].z;
+      accu [3] += cloud[index].y * cloud[index].y;
+      accu [4] += cloud[index].y * cloud[index].z;
+      accu [5] += cloud[index].z * cloud[index].z;
     }
   }
   else
   {
     point_count = 0;
-    for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
+    for (const int index : indices)
     {
-      if (!isFinite (cloud[*iIt]))
+      if (!isFinite (cloud[index]))
         continue;
 
       ++point_count;
-      accu [0] += cloud[*iIt].x * cloud[*iIt].x;
-      accu [1] += cloud[*iIt].x * cloud[*iIt].y;
-      accu [2] += cloud[*iIt].x * cloud[*iIt].z;
-      accu [3] += cloud[*iIt].y * cloud[*iIt].y;
-      accu [4] += cloud[*iIt].y * cloud[*iIt].z;
-      accu [5] += cloud[*iIt].z * cloud[*iIt].z;
+      accu [0] += cloud[index].x * cloud[index].x;
+      accu [1] += cloud[index].x * cloud[index].y;
+      accu [2] += cloud[index].x * cloud[index].z;
+      accu [3] += cloud[index].y * cloud[index].y;
+      accu [4] += cloud[index].y * cloud[index].z;
+      accu [5] += cloud[index].z * cloud[index].z;
     }
   }
   if (point_count != 0)
@@ -562,38 +562,38 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   if (cloud.is_dense)
   {
     point_count = indices.size ();
-    for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
+    for (const int index : indices)
     {
       //const PointT& point = cloud[*iIt];
-      accu [0] += cloud[*iIt].x * cloud[*iIt].x;
-      accu [1] += cloud[*iIt].x * cloud[*iIt].y;
-      accu [2] += cloud[*iIt].x * cloud[*iIt].z;
-      accu [3] += cloud[*iIt].y * cloud[*iIt].y;
-      accu [4] += cloud[*iIt].y * cloud[*iIt].z;
-      accu [5] += cloud[*iIt].z * cloud[*iIt].z;
-      accu [6] += cloud[*iIt].x;
-      accu [7] += cloud[*iIt].y;
-      accu [8] += cloud[*iIt].z;
+      accu [0] += cloud[index].x * cloud[index].x;
+      accu [1] += cloud[index].x * cloud[index].y;
+      accu [2] += cloud[index].x * cloud[index].z;
+      accu [3] += cloud[index].y * cloud[index].y;
+      accu [4] += cloud[index].y * cloud[index].z;
+      accu [5] += cloud[index].z * cloud[index].z;
+      accu [6] += cloud[index].x;
+      accu [7] += cloud[index].y;
+      accu [8] += cloud[index].z;
     }
   }
   else
   {
     point_count = 0;
-    for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
+    for (const int index : indices)
     {
-      if (!isFinite (cloud[*iIt]))
+      if (!isFinite (cloud[index]))
         continue;
 
       ++point_count;
-      accu [0] += cloud[*iIt].x * cloud[*iIt].x;
-      accu [1] += cloud[*iIt].x * cloud[*iIt].y;
-      accu [2] += cloud[*iIt].x * cloud[*iIt].z;
-      accu [3] += cloud[*iIt].y * cloud[*iIt].y; // 4
-      accu [4] += cloud[*iIt].y * cloud[*iIt].z; // 5
-      accu [5] += cloud[*iIt].z * cloud[*iIt].z; // 8
-      accu [6] += cloud[*iIt].x;
-      accu [7] += cloud[*iIt].y;
-      accu [8] += cloud[*iIt].z;
+      accu [0] += cloud[index].x * cloud[index].x;
+      accu [1] += cloud[index].x * cloud[index].y;
+      accu [2] += cloud[index].x * cloud[index].z;
+      accu [3] += cloud[index].y * cloud[index].y; // 4
+      accu [4] += cloud[index].y * cloud[index].z; // 5
+      accu [5] += cloud[index].z * cloud[index].z; // 8
+      accu [6] += cloud[index].x;
+      accu [7] += cloud[index].y;
+      accu [8] += cloud[index].z;
     }
   }
 
@@ -886,12 +886,12 @@ pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
   pcl::CentroidPoint<PointInT> cp;
 
   if (cloud.is_dense)
-    for (size_t i = 0; i < indices.size (); ++i)
-      cp.add (cloud[indices[i]]);
+    for (const int index : indices)
+      cp.add (cloud[index]);
   else
-    for (size_t i = 0; i < indices.size (); ++i)
-      if (pcl::isFinite (cloud[indices[i]]))
-        cp.add (cloud[indices[i]]);
+    for (const int index : indices)
+      if (pcl::isFinite (cloud[index]))
+        cp.add (cloud[index]);
 
   cp.get (centroid);
   return (cp.getSize ());

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -135,7 +135,7 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       centroid[0] += cloud[index].x;
       centroid[1] += cloud[index].y;
@@ -149,7 +149,7 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   else
   {
     unsigned cp = 0;
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       // Check if the point is invalid
       if (!isFinite (cloud [index]))
@@ -300,7 +300,7 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = 0;
     // For each point in the cloud
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       // Check if the point is invalid
       if (!isFinite (cloud[index]))
@@ -434,7 +434,7 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   if (cloud.is_dense)
   {
     point_count = static_cast<unsigned int> (indices.size ());
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       //const PointT& point = cloud[*iIt];
       accu [0] += cloud[index].x * cloud[index].x;
@@ -448,7 +448,7 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   else
   {
     point_count = 0;
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       if (!isFinite (cloud[index]))
         continue;
@@ -562,7 +562,7 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   if (cloud.is_dense)
   {
     point_count = indices.size ();
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       //const PointT& point = cloud[*iIt];
       accu [0] += cloud[index].x * cloud[index].x;
@@ -579,7 +579,7 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   else
   {
     point_count = 0;
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       if (!isFinite (cloud[index]))
         continue;
@@ -886,10 +886,10 @@ pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
   pcl::CentroidPoint<PointInT> cp;
 
   if (cloud.is_dense)
-    for (const int index : indices)
+    for (const int &index : indices)
       cp.add (cloud[index]);
   else
-    for (const int index : indices)
+    for (const int &index : indices)
       if (pcl::isFinite (cloud[index]))
         cp.add (cloud[index]);
 

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -86,7 +86,7 @@ pcl::getMeanStd (const std::vector<float> &values, double &mean, double &stddev)
   
   double sum = 0, sq_sum = 0;
 
-  for (const float value : values)
+  for (const float &value : values)
   {
     sum += value;
     sq_sum += value * value;
@@ -324,7 +324,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const pcl::PointIndices 
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (const int index : indices.indices)
+    for (const int &index : indices.indices)
     {
       pcl::Array4fMapConst pt = cloud.points[index].getArray4fMap ();
       min_p = min_p.min (pt);
@@ -334,7 +334,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const pcl::PointIndices 
   // NaN or Inf values could exist => check for them
   else
   {
-    for (const int index : indices.indices)
+    for (const int &index : indices.indices)
     {
       // Check if the point is invalid
       if (!std::isfinite (cloud.points[index].x) || 
@@ -361,7 +361,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const std::vector<int> &
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       pcl::Array4fMapConst pt = cloud.points[index].getArray4fMap ();
       min_pt = min_pt.array ().min (pt);
@@ -371,7 +371,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const std::vector<int> &
   // NaN or Inf values could exist => check for them
   else
   {
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       // Check if the point is invalid
       if (!std::isfinite (cloud.points[index].x) || 

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -86,10 +86,10 @@ pcl::getMeanStd (const std::vector<float> &values, double &mean, double &stddev)
   
   double sum = 0, sq_sum = 0;
 
-  for (size_t i = 0; i < values.size (); ++i)
+  for (const float value : values)
   {
-    sum += values[i];
-    sq_sum += values[i] * values[i];
+    sum += value;
+    sq_sum += value * value;
   }
   mean = sum / static_cast<double>(values.size ());
   double variance = (sq_sum - sum * sum / static_cast<double>(values.size ())) / (static_cast<double>(values.size ()) - 1);
@@ -324,9 +324,9 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const pcl::PointIndices 
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < indices.indices.size (); ++i)
+    for (const int index : indices.indices)
     {
-      pcl::Array4fMapConst pt = cloud.points[indices.indices[i]].getArray4fMap ();
+      pcl::Array4fMapConst pt = cloud.points[index].getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }
@@ -334,14 +334,14 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const pcl::PointIndices 
   // NaN or Inf values could exist => check for them
   else
   {
-    for (size_t i = 0; i < indices.indices.size (); ++i)
+    for (const int index : indices.indices)
     {
       // Check if the point is invalid
-      if (!std::isfinite (cloud.points[indices.indices[i]].x) || 
-          !std::isfinite (cloud.points[indices.indices[i]].y) || 
-          !std::isfinite (cloud.points[indices.indices[i]].z))
+      if (!std::isfinite (cloud.points[index].x) || 
+          !std::isfinite (cloud.points[index].y) || 
+          !std::isfinite (cloud.points[index].z))
         continue;
-      pcl::Array4fMapConst pt = cloud.points[indices.indices[i]].getArray4fMap ();
+      pcl::Array4fMapConst pt = cloud.points[index].getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }
@@ -361,9 +361,9 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const std::vector<int> &
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (const int index : indices)
     {
-      pcl::Array4fMapConst pt = cloud.points[indices[i]].getArray4fMap ();
+      pcl::Array4fMapConst pt = cloud.points[index].getArray4fMap ();
       min_pt = min_pt.array ().min (pt);
       max_pt = max_pt.array ().max (pt);
     }
@@ -371,14 +371,14 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, const std::vector<int> &
   // NaN or Inf values could exist => check for them
   else
   {
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (const int index : indices)
     {
       // Check if the point is invalid
-      if (!std::isfinite (cloud.points[indices[i]].x) || 
-          !std::isfinite (cloud.points[indices[i]].y) || 
-          !std::isfinite (cloud.points[indices[i]].z))
+      if (!std::isfinite (cloud.points[index].x) || 
+          !std::isfinite (cloud.points[index].y) || 
+          !std::isfinite (cloud.points[index].z))
         continue;
-      pcl::Array4fMapConst pt = cloud.points[indices[i]].getArray4fMap ();
+      pcl::Array4fMapConst pt = cloud.points[index].getArray4fMap ();
       min_pt = min_pt.array ().min (pt);
       max_pt = max_pt.array ().max (pt);
     }

--- a/common/include/pcl/common/impl/generate.hpp
+++ b/common/include/pcl/common/impl/generate.hpp
@@ -278,12 +278,10 @@ pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::fill (int width, int heig
   cloud.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
 
-  for (pcl::PointCloud<pcl::PointXY>::iterator points_it = cloud.begin ();
-       points_it != cloud.end ();
-       ++points_it)
+  for (auto &point : cloud)
   {
-    points_it->x = x_generator_.run ();
-    points_it->y = y_generator_.run ();
+    point.x = x_generator_.run ();
+    point.y = y_generator_.run ();
   }
   return (0);
 }

--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -269,8 +269,8 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
                      pcl::PointCloud<PointT> &cloud_out)
 {
   int nr_p = 0;
-  for (size_t i = 0; i < indices.size (); ++i)
-    nr_p += indices[i].indices.size ();
+  for (const auto &index : indices)
+    nr_p += index.indices.size ();
 
   // Do we want to copy everything? Remember we assume UNIQUE indices
   if (nr_p == cloud_in.points.size ())
@@ -290,13 +290,13 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
 
   // Iterate over each cluster
   int cp = 0;
-  for (size_t cc = 0; cc < indices.size (); ++cc)
+  for (const auto &cluster_index : indices)
   {
     // Iterate over each idx
-    for (size_t i = 0; i < indices[cc].indices.size (); ++i)
+    for (const auto &index : cluster_index.indices)
     {
       // Iterate over each dimension
-      cloud_out.points[cp] = cloud_in.points[indices[cc].indices[i]];
+      cloud_out.points[cp] = cloud_in.points[index];
       cp++;
     }
   }
@@ -309,8 +309,8 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
                      pcl::PointCloud<PointOutT> &cloud_out)
 {
   int nr_p = 0;
-  for (size_t i = 0; i < indices.size (); ++i)
-    nr_p += indices[i].indices.size ();
+  for (const auto &index : indices)
+    nr_p += index.indices.size ();
 
   // Do we want to copy everything? Remember we assume UNIQUE indices
   if (nr_p == cloud_in.points.size ())
@@ -330,12 +330,12 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
 
   // Iterate over each cluster
   int cp = 0;
-  for (size_t cc = 0; cc < indices.size (); ++cc)
+  for (const auto &cluster_index : indices)
   {
     // Iterate over each idx
-    for (size_t i = 0; i < indices[cc].indices.size (); ++i)
+    for (const auto &index : cluster_index.indices)
     {
-      copyPoint (cloud_in.points[indices[cc].indices[i]], cloud_out.points[cp]);
+      copyPoint (cloud_in.points[index], cloud_out.points[cp]);
       ++cp;
     }
   }

--- a/common/include/pcl/impl/cloud_iterator.hpp
+++ b/common/include/pcl/impl/cloud_iterator.hpp
@@ -358,13 +358,13 @@ pcl::CloudIterator<PointT>::CloudIterator (
   indices.reserve (corrs.size ());
   if (source)
   {
-    for (typename Correspondences::const_iterator indexIt = corrs.begin (); indexIt != corrs.end (); ++indexIt)
-      indices.push_back (indexIt->index_query);
+    for (const auto &corr : corrs)
+      indices.push_back (corr.index_query);
   }
   else
   {
-    for (typename Correspondences::const_iterator indexIt = corrs.begin (); indexIt != corrs.end (); ++indexIt)
-      indices.push_back (indexIt->index_match);
+    for (const auto &corr : corrs)
+      indices.push_back (corr.index_match);
   }
   iterator_ = new IteratorIdx<PointT> (cloud, indices);
 }
@@ -472,13 +472,13 @@ pcl::ConstCloudIterator<PointT>::ConstCloudIterator (
   indices.reserve (corrs.size ());
   if (source)
   {
-    for (typename Correspondences::const_iterator indexIt = corrs.begin (); indexIt != corrs.end (); ++indexIt)
-      indices.push_back (indexIt->index_query);
+    for (const auto &corr : corrs)
+      indices.push_back (corr.index_query);
   }
   else
   {
-    for (typename Correspondences::const_iterator indexIt = corrs.begin (); indexIt != corrs.end (); ++indexIt)
-      indices.push_back (indexIt->index_match);
+    for (const auto &corr : corrs)
+      indices.push_back (corr.index_match);
   }
   iterator_ = new typename pcl::ConstCloudIterator<PointT>::ConstIteratorIdx (cloud, indices);
 }

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -250,10 +250,10 @@ namespace pcl
   {
     out.width   = in.width;
     out.height  = in.height;
-    for (size_t i = 0; i < in.points.size (); i++)
+    for (const auto &point : in.points)
     {
       Intensity p;
-      PointRGBtoI (in.points[i], p);
+      PointRGBtoI (point, p);
       out.points.push_back (p);
     }
   }
@@ -268,10 +268,10 @@ namespace pcl
   {
     out.width   = in.width;
     out.height  = in.height;
-    for (size_t i = 0; i < in.points.size (); i++)
+    for (const auto &point : in.points)
     {
       Intensity8u p;
-      PointRGBtoI (in.points[i], p);
+      PointRGBtoI (point, p);
       out.points.push_back (p);
     }
   }
@@ -286,10 +286,10 @@ namespace pcl
   {
     out.width   = in.width;
     out.height  = in.height;
-    for (size_t i = 0; i < in.points.size (); i++)
+    for (const auto &point : in.points)
     {
       Intensity32u p;
-      PointRGBtoI (in.points[i], p);
+      PointRGBtoI (point, p);
       out.points.push_back (p);
     }
   }
@@ -304,10 +304,10 @@ namespace pcl
   {
     out.width   = in.width;
     out.height  = in.height;
-    for (size_t i = 0; i < in.points.size (); i++)
+    for (const auto &point : in.points)
     {
       PointXYZHSV p;
-      PointXYZRGBtoXYZHSV (in.points[i], p);
+      PointXYZRGBtoXYZHSV (point, p);
       out.points.push_back (p);
     }
   }
@@ -322,10 +322,10 @@ namespace pcl
   {
     out.width   = in.width;
     out.height  = in.height;
-    for (size_t i = 0; i < in.points.size (); i++)
+    for (const auto &point : in.points)
     {
       PointXYZHSV p;
-      PointXYZRGBAtoXYZHSV (in.points[i], p);
+      PointXYZRGBAtoXYZHSV (point, p);
       out.points.push_back (p);
     }
   }
@@ -340,10 +340,10 @@ namespace pcl
   {
     out.width   = in.width;
     out.height  = in.height;
-    for (size_t i = 0; i < in.points.size (); i++)
+    for (const auto &point : in.points)
     {
       PointXYZI p;
-      PointXYZRGBtoXYZI (in.points[i], p);
+      PointXYZRGBtoXYZI (point, p);
       out.points.push_back (p);
     }
   }

--- a/common/src/common.cpp
+++ b/common/src/common.cpp
@@ -74,7 +74,7 @@ pcl::getMeanStdDev (const std::vector<float> &values, double &mean, double &stdd
 {
   double sum = 0, sq_sum = 0;
 
-  for (const float value : values)
+  for (const float &value : values)
   {
     sum += value;
     sq_sum += value * value;

--- a/common/src/common.cpp
+++ b/common/src/common.cpp
@@ -74,10 +74,10 @@ pcl::getMeanStdDev (const std::vector<float> &values, double &mean, double &stdd
 {
   double sum = 0, sq_sum = 0;
 
-  for (size_t i = 0; i < values.size (); ++i)
+  for (const float value : values)
   {
-    sum += values[i];
-    sq_sum += values[i] * values[i];
+    sum += value;
+    sq_sum += value * value;
   }
   mean = sum / static_cast<double>(values.size ());
   double variance = (sq_sum - sum * sum / static_cast<double>(values.size ())) / (static_cast<double>(values.size ()) - 1);

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -106,17 +106,17 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
   //by offset so that we can compute sizes correctly. There is no
   //guarantee that the fields are in the correct order when they come in
   std::vector<const pcl::PCLPointField*> cloud1_fields_sorted;
-  for (size_t i = 0; i < cloud1.fields.size (); ++i)
-    cloud1_fields_sorted.push_back (&(cloud1.fields[i]));
+  for (const auto &field : cloud1.fields)
+    cloud1_fields_sorted.push_back (&field);
 
   std::sort (cloud1_fields_sorted.begin (), cloud1_fields_sorted.end (), fieldComp);
 
   for (size_t i = 0; i < cloud1_fields_sorted.size (); ++i)
   {
     bool match = false;
-    for (size_t j = 0; j < cloud2.fields.size (); ++j)
+    for (const auto &field : cloud2.fields)
     {
-      if (cloud1_fields_sorted[i]->name == cloud2.fields[j].name)
+      if (cloud1_fields_sorted[i]->name == field.name)
         match = true;
     }
 
@@ -233,12 +233,12 @@ pcl::concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
   }
 
   bool strip = false;
-  for (size_t i = 0; i < cloud1.fields.size (); ++i)
-    if (cloud1.fields[i].name == "_")
+  for (const auto &field : cloud1.fields)
+    if (field.name == "_")
       strip = true;
 
-  for (size_t i = 0; i < cloud2.fields.size (); ++i)
-    if (cloud2.fields[i].name == "_")
+  for (const auto &field : cloud2.fields)
+    if (field.name == "_")
       strip = true;
 
   if (!strip && cloud1.fields.size () != cloud2.fields.size ())
@@ -264,14 +264,14 @@ pcl::concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
     // Get the field sizes for the second cloud
     std::vector<pcl::PCLPointField> fields2;
     std::vector<int> fields2_sizes;
-    for (size_t j = 0; j < cloud2.fields.size (); ++j)
+    for (const auto &field : cloud2.fields)
     {
-      if (cloud2.fields[j].name == "_")
+      if (field.name == "_")
         continue;
 
-      fields2_sizes.push_back (cloud2.fields[j].count * 
-                               pcl::getFieldSize (cloud2.fields[j].datatype));
-      fields2.push_back (cloud2.fields[j]);
+      fields2_sizes.push_back (field.count * 
+                               pcl::getFieldSize (field.datatype));
+      fields2.push_back (field);
     }
 
     cloud_out.data.resize (nrpts + (cloud2.width * cloud2.height) * cloud_out.point_step);

--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -156,10 +156,8 @@ pcl::console::parse_file_extension_argument (int argc, const char * const * argv
   for (int i = 1; i < argc; ++i)
   {
     std::string fname = std::string (argv[i]);
-    for (size_t j = 0; j < extension.size (); ++j)
+    for (auto ext : extension)
     {
-      std::string ext = extension[j];
-
       // Needs to be at least 4: .ext
       if (fname.size () <= 4)
         continue;

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -345,9 +345,9 @@ RangeImage::getIntegralImage (float*& integral_image, int*& valid_points_num_ima
 void 
 RangeImage::setUnseenToMaxRange ()
 {
-  for (size_t i=0; i < points.size (); ++i)
-    if (std::isinf (points[i].range))
-      points[i].range = std::numeric_limits<float>::infinity ();
+  for (auto &point : points)
+    if (std::isinf (point.range))
+      point.range = std::numeric_limits<float>::infinity ();
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -443,9 +443,9 @@ RangeImage::getMinMaxRanges (float& min_range, float& max_range) const
 {
   min_range = std::numeric_limits<float>::infinity ();
   max_range = -std::numeric_limits<float>::infinity ();
-  for (size_t i=0; i < points.size (); ++i)
+  for (const auto &point : points)
   {
-    float range = points[i].range;
+    float range = point.range;
     if (!std::isfinite (range))
       continue;
     min_range = (std::min) (min_range, range);


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix