### PR TITLE
Transform classic loops to range-based for loops in module geometry

### DIFF
--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -1381,9 +1381,9 @@ namespace pcl
 
           const FaceIndex idx_face (static_cast <int> (this->sizeFaces () - 1));
 
-          for (HalfEdgeIndices::const_iterator it=inner_he.begin (); it!=inner_he.end (); ++it)
+          for (const auto &idx_half_edge : inner_he)
           {
-            this->setFaceIndex (*it, idx_face);
+            this->setFaceIndex (idx_half_edge, idx_face);
           }
 
           return (idx_face);

--- a/geometry/include/pcl/geometry/mesh_conversion.h
+++ b/geometry/include/pcl/geometry/mesh_conversion.h
@@ -89,7 +89,6 @@ namespace pcl
     {
       typedef HalfEdgeMeshT                          HalfEdgeMesh;
       typedef typename HalfEdgeMesh::VertexDataCloud VertexDataCloud;
-      typedef typename HalfEdgeMesh::VertexIndex     VertexIndex;
       typedef typename HalfEdgeMesh::VertexIndices   VertexIndices;
 
       BOOST_STATIC_ASSERT (HalfEdgeMesh::HasVertexData::value); // Output mesh must have data associated with the vertices!
@@ -101,9 +100,9 @@ namespace pcl
       half_edge_mesh.reserveEdges (3 * face_vertex_mesh.polygons.size ());
       half_edge_mesh.reserveFaces (    face_vertex_mesh.polygons.size ());
 
-      for (typename VertexDataCloud::const_iterator it=vertices.begin (); it!=vertices.end (); ++it)
+      for (const auto &vertex : vertices)
       {
-        half_edge_mesh.addVertex (*it);
+        half_edge_mesh.addVertex (vertex);
       }
 
       assert (half_edge_mesh.sizeVertices () == vertices.size ());
@@ -111,12 +110,12 @@ namespace pcl
       int count_not_added = 0;
       VertexIndices vi;
       vi.reserve (3); // Minimum number (triangle)
-      for (size_t i=0; i<face_vertex_mesh.polygons.size (); ++i)
+      for (const auto &polygon : face_vertex_mesh.polygons)
       {
         vi.clear ();
-        for (size_t j=0; j<face_vertex_mesh.polygons [i].vertices.size (); ++j)
+        for (const unsigned int vertex : polygon.vertices)
         {
-          vi.push_back (VertexIndex (face_vertex_mesh.polygons [i].vertices [j]));
+          vi.emplace_back (vertex);
         }
 
         if (!half_edge_mesh.addFace (vi).isValid ())


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix