### PR TITLE
Transform classic loops to range-based for loops in examples

### DIFF
--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -221,7 +221,7 @@ int main (int argc, char *argv[])
   for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin (); it != cluster_indices.end (); ++it, j++)
   {
     pcl::PointCloud<PointOutT>::Ptr cloud_cluster_don (new pcl::PointCloud<PointOutT>);
-    for (const int index : it->indices){
+    for (const int &index : it->indices){
       cloud_cluster_don->points.push_back (doncloud->points[index]);
     }
 

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -221,8 +221,8 @@ int main (int argc, char *argv[])
   for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin (); it != cluster_indices.end (); ++it, j++)
   {
     pcl::PointCloud<PointOutT>::Ptr cloud_cluster_don (new pcl::PointCloud<PointOutT>);
-    for (std::vector<int>::const_iterator pit = it->indices.begin (); pit != it->indices.end (); ++pit){
-      cloud_cluster_don->points.push_back (doncloud->points[*pit]);
+    for (const int index : it->indices){
+      cloud_cluster_don->points.push_back (doncloud->points[index]);
     }
 
     cloud_cluster_don->width = int (cloud_cluster_don->points.size ());

--- a/examples/segmentation/example_extract_clusters_normals.cpp
+++ b/examples/segmentation/example_extract_clusters_normals.cpp
@@ -95,8 +95,8 @@ main (int, char **argv)
   for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin (); it != cluster_indices.end (); ++it)
   {
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_cluster (new pcl::PointCloud<pcl::PointXYZ>);
-    for (std::vector<int>::const_iterator pit = it->indices.begin (); pit != it->indices.end (); ++pit)
-      cloud_cluster->points.push_back (cloud_ptr->points[*pit]); 
+    for (const int index : it->indices)
+      cloud_cluster->points.push_back (cloud_ptr->points[index]); 
     cloud_cluster->width = static_cast<uint32_t> (cloud_cluster->points.size ());
     cloud_cluster->height = 1;
     cloud_cluster->is_dense = true;

--- a/examples/segmentation/example_extract_clusters_normals.cpp
+++ b/examples/segmentation/example_extract_clusters_normals.cpp
@@ -95,7 +95,7 @@ main (int, char **argv)
   for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin (); it != cluster_indices.end (); ++it)
   {
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_cluster (new pcl::PointCloud<pcl::PointXYZ>);
-    for (const int index : it->indices)
+    for (const int &index : it->indices)
       cloud_cluster->points.push_back (cloud_ptr->points[index]); 
     cloud_cluster->width = static_cast<uint32_t> (cloud_cluster->points.size ());
     cloud_cluster->height = 1;

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -270,8 +270,8 @@ main (int argc, char ** argv)
   // check that there are no negative z values, since we use log(z)
   if (cloud->isOrganized () && !disable_transform)
   {
-    for (PointCloudT::iterator cloud_itr = cloud->begin (); cloud_itr != cloud->end (); ++cloud_itr)
-      if (cloud_itr->z < 0)
+    for (const auto &point : *cloud)
+      if (point.z < 0)
       {
         PCL_ERROR ("Points found with negative Z values, this is not compatible with the single camera transform!\n");
         PCL_ERROR ("Set the --NT option to disable the single camera transform!\n");
@@ -453,9 +453,9 @@ main (int argc, char ** argv)
     }
     else if (!show_graph && graph_added)
     {
-      for (std::vector<std::string>::iterator name_itr = poly_names.begin (); name_itr != poly_names.end (); ++name_itr)
+      for (const auto &poly_name : poly_names)
       {
-        viewer->removeShape (*name_itr);
+        viewer->removeShape (poly_name);
       }
       graph_added = false;
     }
@@ -491,10 +491,10 @@ addSupervoxelConnectionsToViewer (PointT &supervoxel_center,
   vtkSmartPointer<vtkPolyLine> polyLine = vtkSmartPointer<vtkPolyLine>::New ();
   
   //Iterate through all adjacent points, and add a center point to adjacent point pair
-  for (auto adjacent_itr = adjacent_supervoxel_centers.begin (); adjacent_itr != adjacent_supervoxel_centers.end (); ++adjacent_itr)
+  for (const auto &adjacent_supervoxel_center : adjacent_supervoxel_centers)
   {
     points->InsertNextPoint (supervoxel_center.data);
-    points->InsertNextPoint (adjacent_itr->data); 
+    points->InsertNextPoint (adjacent_supervoxel_center.data); 
   } 
   // Create a polydata to store everything in
   vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New ();
@@ -556,8 +556,8 @@ void removeText (pcl::visualization::PCLVisualizer::Ptr viewer)
 bool
 hasField (const pcl::PCLPointCloud2 &pc2, const std::string &field_name)
 {
-  for (size_t cf = 0; cf < pc2.fields.size (); ++cf)
-    if (pc2.fields[cf].name == field_name)
+  for (const auto &field : pc2.fields)
+    if (field.name == field_name)
       return true;
-    return false;
+  return false;
 }

--- a/examples/surface/example_nurbs_fitting_closed_curve.cpp
+++ b/examples/surface/example_nurbs_fitting_closed_curve.cpp
@@ -14,11 +14,10 @@ pcl::visualization::PCLVisualizer viewer ("Curve Fitting PDM (red), SDM (green),
 void
 PointCloud2Vector2d (pcl::PointCloud<pcl::PointXYZ>::Ptr cloud, pcl::on_nurbs::vector_vec2d &data)
 {
-  for (size_t i = 0; i < cloud->size (); i++)
+  for (const auto &p : *cloud)
   {
-    pcl::PointXYZ &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y))
-      data.push_back (Eigen::Vector2d (p.x, p.y));
+      data.emplace_back (p.x, p.y);
   }
 }
 

--- a/examples/surface/example_nurbs_fitting_closed_curve3d.cpp
+++ b/examples/surface/example_nurbs_fitting_closed_curve3d.cpp
@@ -12,11 +12,10 @@ pcl::visualization::PCLVisualizer viewer ("Curve Fitting 3D");
 void
 PointCloud2Vector2d (pcl::PointCloud<pcl::PointXYZ>::Ptr cloud, pcl::on_nurbs::vector_vec3d &data)
 {
-  for (size_t i = 0; i < cloud->size (); i++)
+  for (const auto &p : *cloud)
   {
-    pcl::PointXYZ &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y) && !std::isnan (p.z))
-      data.push_back (Eigen::Vector3d (p.x, p.y, p.z));
+      data.emplace_back (p.x, p.y, p.z);
   }
 }
 

--- a/examples/surface/example_nurbs_fitting_curve2d.cpp
+++ b/examples/surface/example_nurbs_fitting_curve2d.cpp
@@ -12,11 +12,10 @@ pcl::visualization::PCLVisualizer viewer ("Curve Fitting 2D");
 void
 PointCloud2Vector2d (pcl::PointCloud<pcl::PointXYZ>::Ptr cloud, pcl::on_nurbs::vector_vec2d &data)
 {
-  for (size_t i = 0; i < cloud->size (); i++)
+  for (const auto &p : *cloud)
   {
-    pcl::PointXYZ &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y))
-      data.push_back (Eigen::Vector2d (p.x, p.y));
+      data.emplace_back (p.x, p.y);
   }
 }
 

--- a/examples/surface/example_nurbs_fitting_surface.cpp
+++ b/examples/surface/example_nurbs_fitting_surface.cpp
@@ -171,7 +171,7 @@ main (int argc, char *argv[])
 void
 PointCloud2Vector3d (pcl::PointCloud<Point>::Ptr cloud, pcl::on_nurbs::vector_vec3d &data)
 {
-  for (auto &p : *cloud)
+  for (const auto &p : *cloud)
   {
     if (!std::isnan (p.x) && !std::isnan (p.y) && !std::isnan (p.z))
       data.emplace_back (p.x, p.y, p.z);

--- a/examples/surface/example_nurbs_fitting_surface.cpp
+++ b/examples/surface/example_nurbs_fitting_surface.cpp
@@ -171,11 +171,10 @@ main (int argc, char *argv[])
 void
 PointCloud2Vector3d (pcl::PointCloud<Point>::Ptr cloud, pcl::on_nurbs::vector_vec3d &data)
 {
-  for (size_t i = 0; i < cloud->size (); i++)
+  for (auto &p : *cloud)
   {
-    Point &p = cloud->at (i);
     if (!std::isnan (p.x) && !std::isnan (p.y) && !std::isnan (p.z))
-      data.push_back (Eigen::Vector3d (p.x, p.y, p.z));
+      data.emplace_back (p.x, p.y, p.z);
   }
 }
 


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix