### PR TITLE
Transform classic loops to range-based for loops in module visualization

### DIFF
--- a/visualization/include/pcl/visualization/impl/image_viewer.hpp
+++ b/visualization/include/pcl/visualization/impl/image_viewer.hpp
@@ -253,12 +253,12 @@ pcl::visualization::ImageViewer::addRectangle (
   min_pt_2d.x = min_pt_2d.y = std::numeric_limits<float>::max ();
   max_pt_2d.x = max_pt_2d.y = -std::numeric_limits<float>::max ();
   // Search for the two extrema
-  for (size_t i = 0; i < pp_2d.size (); ++i)
+  for (const auto &point : pp_2d)
   {
-    if (pp_2d[i].x < min_pt_2d.x) min_pt_2d.x = pp_2d[i].x;
-    if (pp_2d[i].y < min_pt_2d.y) min_pt_2d.y = pp_2d[i].y;
-    if (pp_2d[i].x > max_pt_2d.x) max_pt_2d.x = pp_2d[i].x;
-    if (pp_2d[i].y > max_pt_2d.y) max_pt_2d.y = pp_2d[i].y;
+    if (point.x < min_pt_2d.x) min_pt_2d.x = point.x;
+    if (point.y < min_pt_2d.y) min_pt_2d.y = point.y;
+    if (point.x > max_pt_2d.x) max_pt_2d.x = point.x;
+    if (point.y > max_pt_2d.y) max_pt_2d.y = point.y;
   }
   min_pt_2d.y = float (image->height) - min_pt_2d.y;
   max_pt_2d.y = float (image->height) - max_pt_2d.y;
@@ -316,12 +316,12 @@ pcl::visualization::ImageViewer::addRectangle (
   min_pt_2d.x = min_pt_2d.y = std::numeric_limits<float>::max ();
   max_pt_2d.x = max_pt_2d.y = -std::numeric_limits<float>::max ();
   // Search for the two extrema
-  for (size_t i = 0; i < pp_2d.size (); ++i)
+  for (const auto &point : pp_2d)
   {
-    if (pp_2d[i].x < min_pt_2d.x) min_pt_2d.x = pp_2d[i].x;
-    if (pp_2d[i].y < min_pt_2d.y) min_pt_2d.y = pp_2d[i].y;
-    if (pp_2d[i].x > max_pt_2d.x) max_pt_2d.x = pp_2d[i].x;
-    if (pp_2d[i].y > max_pt_2d.y) max_pt_2d.y = pp_2d[i].y;
+    if (point.x < min_pt_2d.x) min_pt_2d.x = point.x;
+    if (point.y < min_pt_2d.y) min_pt_2d.y = point.y;
+    if (point.x > max_pt_2d.x) max_pt_2d.x = point.x;
+    if (point.y > max_pt_2d.y) max_pt_2d.y = point.y;
   }
   min_pt_2d.y = float (image->height) - min_pt_2d.y;
   max_pt_2d.y = float (image->height) - max_pt_2d.y;

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1122,10 +1122,10 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   corrs.resize (correspondences.size ());
 
   size_t index = 0;
-  for (pcl::Correspondences::iterator corrs_it (corrs.begin ()); corrs_it != corrs.end (); ++corrs_it)
+  for (auto &corr : corrs)
   {
-    corrs_it->index_query = index;
-    corrs_it->index_match = correspondences[index];
+    corr.index_query = index;
+    corr.index_match = correspondences[index];
     index++;
   }
 
@@ -1691,9 +1691,9 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (
 
   // Get the maximum size of a polygon
   int max_size_of_polygon = -1;
-  for (size_t i = 0; i < vertices.size (); ++i)
-    if (max_size_of_polygon < static_cast<int> (vertices[i].vertices.size ()))
-      max_size_of_polygon = static_cast<int> (vertices[i].vertices.size ());
+  for (const auto &vertex : vertices)
+    if (max_size_of_polygon < static_cast<int> (vertex.vertices.size ()))
+      max_size_of_polygon = static_cast<int> (vertex.vertices.size ());
 
   if (vertices.size () > 1)
   {
@@ -1870,9 +1870,9 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
 
   // Get the maximum size of a polygon
   int max_size_of_polygon = -1;
-  for (size_t i = 0; i < verts.size (); ++i)
-    if (max_size_of_polygon < static_cast<int> (verts[i].vertices.size ()))
-      max_size_of_polygon = static_cast<int> (verts[i].vertices.size ());
+  for (const auto &vertex : verts)
+    if (max_size_of_polygon < static_cast<int> (vertex.vertices.size ()))
+      max_size_of_polygon = static_cast<int> (vertex.vertices.size ());
 
   // Update the cells
   cells = vtkSmartPointer<vtkCellArray>::New ();

--- a/visualization/src/common/io.cpp
+++ b/visualization/src/common/io.cpp
@@ -73,9 +73,9 @@ pcl::visualization::getCorrespondingPointCloud (vtkPolyData *src,
   std::vector<int> nn_indices (1);
   std::vector<float> nn_dists (1);
   // For each point on screen, find its correspondent in the target
-  for (size_t i = 0; i < cloud.points.size (); ++i)
+  for (const auto &point : cloud.points)
   {
-    kdtree.nearestKSearch (cloud.points[i], 1, nn_indices, nn_dists);
+    kdtree.nearestKSearch (point, 1, nn_indices, nn_dists);
     indices.push_back (nn_indices[0]);
   }
   // Sort and remove duplicate indices
@@ -106,9 +106,9 @@ pcl::visualization::savePointData (vtkPolyData* data, const std::string &out_fil
 
   // Attempting to load all Point Cloud data input files (using the actor name)...
   int i = 1;
-  for (auto it = actors->cbegin (); it != actors->cend (); ++it)
+  for (const auto &actor : *actors)
   {
-    std::string file_name = (*it).first;
+    std::string file_name = actor.first;
 
     // Is there a ".pcd" in the name? If no, then do not attempt to load this actor
     std::string::size_type position;

--- a/visualization/src/histogram_visualizer.cpp
+++ b/visualization/src/histogram_visualizer.cpp
@@ -66,16 +66,16 @@ pcl::visualization::PCLHistogramVisualizer::PCLHistogramVisualizer () :
 void
 pcl::visualization::PCLHistogramVisualizer::spinOnce (int time)
 {
-  for (RenWinInteractMap::iterator am_it = wins_.begin (); am_it != wins_.end (); ++am_it)
+  for (auto &win : wins_)
   {
-    DO_EVERY(1.0/(*am_it).second.interactor_->GetDesiredUpdateRate (),
-      (*am_it).second.interactor_->Render ();
-      exit_main_loop_timer_callback_->right_timer_id = (*am_it).second.interactor_->CreateRepeatingTimer (time);
+    DO_EVERY(1.0/win.second.interactor_->GetDesiredUpdateRate (),
+      win.second.interactor_->Render ();
+      exit_main_loop_timer_callback_->right_timer_id = win.second.interactor_->CreateRepeatingTimer (time);
 
       // Set the correct interactor for callbacks
-      exit_main_loop_timer_callback_->interact = (*am_it).second.interactor_;
-      (*am_it).second.interactor_->Start ();
-      (*am_it).second.interactor_->DestroyTimer (exit_main_loop_timer_callback_->right_timer_id);
+      exit_main_loop_timer_callback_->interact = win.second.interactor_;
+      win.second.interactor_->Start ();
+      win.second.interactor_->DestroyTimer (exit_main_loop_timer_callback_->right_timer_id);
     );
   }
 }
@@ -119,10 +119,10 @@ pcl::visualization::PCLHistogramVisualizer::setBackgroundColor (const double &r,
     ++i;
   }
   */
-  for (RenWinInteractMap::iterator am_it = wins_.begin (); am_it != wins_.end (); ++am_it)
+  for (auto &win : wins_)
   {
-    (*am_it).second.ren_->SetBackground (r, g, b);
-    (*am_it).second.ren_->Render ();
+    win.second.ren_->SetBackground (r, g, b);
+    win.second.ren_->Render ();
   }
 }
 
@@ -130,10 +130,10 @@ pcl::visualization::PCLHistogramVisualizer::setBackgroundColor (const double &r,
 void 
 pcl::visualization::PCLHistogramVisualizer::setGlobalYRange (float minp, float maxp)
 {
-  for (RenWinInteractMap::iterator am_it = wins_.begin (); am_it != wins_.end (); ++am_it)
+  for (auto &win : wins_)
   {
-    (*am_it).second.xy_plot_->SetYRange (minp, maxp);
-    (*am_it).second.xy_plot_->Modified ();
+    win.second.xy_plot_->SetYRange (minp, maxp);
+    win.second.xy_plot_->Modified ();
   }
 }
 
@@ -142,15 +142,15 @@ void
 pcl::visualization::PCLHistogramVisualizer::updateWindowPositions ()
 {
   int posx = 0, posy = 0;
-  for (RenWinInteractMap::iterator am_it = wins_.begin (); am_it != wins_.end (); ++am_it)
+  for (auto &win : wins_)
   {
     // Get the screen size
-    int *scr_size = (*am_it).second.win_->GetScreenSize ();
-    int *win_size = (*am_it).second.win_->GetActualSize ();
+    int *scr_size = win.second.win_->GetScreenSize ();
+    int *win_size = win.second.win_->GetActualSize ();
 
     // Update the position of the current window
-    (*am_it).second.win_->SetPosition (posx, posy);
-    (*am_it).second.win_->Modified ();
+    win.second.win_->SetPosition (posx, posy);
+    win.second.win_->Modified ();
     // If there is space on Y, go on Y first
     if ((posy + win_size[1]) <= scr_size[1]) 
       posy += win_size[1];
@@ -353,8 +353,8 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
 
   // Compute the total size of the fields
   unsigned int fsize = 0;
-  for (size_t i = 0; i < cloud.fields.size (); ++i)
-    fsize += cloud.fields[i].count * pcl::getFieldSize (cloud.fields[i].datatype);
+  for (const auto &field : cloud.fields)
+    fsize += field.count * pcl::getFieldSize (field.datatype);
 
   // Parse the cloud data and store it in the array
   double xy[2];
@@ -448,8 +448,8 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
   
   // Compute the total size of the fields
   unsigned int fsize = 0;
-  for (size_t i = 0; i < cloud.fields.size (); ++i)
-    fsize += cloud.fields[i].count * pcl::getFieldSize (cloud.fields[i].datatype);
+  for (const auto &field : cloud.fields)
+    fsize += field.count * pcl::getFieldSize (field.datatype);
 
   // Parse the cloud data and store it in the array
   double xy[2];

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -386,8 +386,8 @@ pcl::visualization::ImageViewer::spinOnce (int time, bool force_redraw)
     interactor_->Start ();
     interactor_->DestroyTimer (exit_main_loop_timer_callback_->right_timer_id);
   );
-  for(size_t i = 0; i < image_data_.size(); i++)
-	  delete [] image_data_[i];
+  for(auto &i : image_data_)
+    delete [] i;
   image_data_.clear ();
 }
 
@@ -871,8 +871,8 @@ void
 pcl::visualization::ImageViewer::render ()
 {
   win_->Render ();
-  for(size_t i = 0; i < image_data_.size(); i++)
-	  delete [] image_data_[i];
+  for(auto &i : image_data_)
+    delete [] i;
   image_data_.clear ();
 }
 
@@ -883,9 +883,9 @@ pcl::visualization::ImageViewer::convertIntensityCloudToUChar (
     boost::shared_array<unsigned char> data)
 {
   int j = 0;
-  for (size_t i = 0; i < cloud.points.size (); ++i)
+  for (const auto &point : cloud.points)
   {
-    data[j++] = static_cast <unsigned char> (cloud.points[i].intensity * 255);
+    data[j++] = static_cast <unsigned char> (point.intensity * 255);
   }
 }
 
@@ -896,8 +896,8 @@ pcl::visualization::ImageViewer::convertIntensityCloud8uToUChar (
     boost::shared_array<unsigned char> data)
 {
   int j = 0;
-  for (size_t i = 0; i < cloud.points.size (); ++i)
-    data[j++] = static_cast<unsigned char> (cloud.points[i].intensity);
+  for (const auto &point : cloud.points)
+    data[j++] = static_cast<unsigned char> (point.intensity);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -639,17 +639,17 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
     // Geometry ?
     if (keymod)
     {
-      for (auto it = cloud_actors_->begin (); it != cloud_actors_->end (); ++it)
+      for (auto &actor : *cloud_actors_)
       {
-        CloudActor *act = &(*it).second;
-        if (index >= static_cast<int> (act->geometry_handlers.size ()))
+        CloudActor &act = actor.second;
+        if (index >= static_cast<int> (act.geometry_handlers.size ()))
           continue;
 
         // Save the geometry handler index for later usage
-        act->geometry_handler_index_ = index;
+        act.geometry_handler_index_ = index;
 
         // Create the new geometry
-        PointCloudGeometryHandler<pcl::PCLPointCloud2>::ConstPtr geometry_handler = act->geometry_handlers[index];
+        PointCloudGeometryHandler<pcl::PCLPointCloud2>::ConstPtr geometry_handler = act.geometry_handlers[index];
 
         // Use the handler to obtain the geometry
         vtkSmartPointer<vtkPoints> points;
@@ -668,66 +668,66 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
 #if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2
         if (use_vbos_)
         {
-          vtkVertexBufferObjectMapper* mapper = static_cast<vtkVertexBufferObjectMapper*>(act->actor->GetMapper ());
+          vtkVertexBufferObjectMapper* mapper = static_cast<vtkVertexBufferObjectMapper*>(act.actor->GetMapper ());
           mapper->SetInput (data);
           // Modify the actor
-          act->actor->SetMapper (mapper);
+          act.actor->SetMapper (mapper);
         }
         else
 #endif
         {
-          vtkPolyDataMapper* mapper = static_cast<vtkPolyDataMapper*>(act->actor->GetMapper ());
+          vtkPolyDataMapper* mapper = static_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
           mapper->SetInputData (data);
           // Modify the actor
-          act->actor->SetMapper (mapper);
+          act.actor->SetMapper (mapper);
         }
-        act->actor->Modified ();
+        act.actor->Modified ();
       }
     }
     else
     {
-      for (auto it = cloud_actors_->begin (); it != cloud_actors_->end (); ++it)
+      for (auto &actor : *cloud_actors_)
       {
-        CloudActor *act = &(*it).second;
+        CloudActor &act = actor.second;
         // Check for out of bounds
-        if (index >= static_cast<int> (act->color_handlers.size ()))
+        if (index >= static_cast<int> (act.color_handlers.size ()))
           continue;
 
         // Save the color handler index for later usage
-        act->color_handler_index_ = index;
+        act.color_handler_index_ = index;
 
         // Get the new color
-        PointCloudColorHandler<pcl::PCLPointCloud2>::ConstPtr color_handler = act->color_handlers[index];
+        PointCloudColorHandler<pcl::PCLPointCloud2>::ConstPtr color_handler = act.color_handlers[index];
 
         vtkSmartPointer<vtkDataArray> scalars;
         color_handler->getColor (scalars);
         double minmax[2];
         scalars->GetRange (minmax);
         // Update the data
-        vtkPolyData *data = static_cast<vtkPolyData*>(act->actor->GetMapper ()->GetInput ());
+        vtkPolyData *data = static_cast<vtkPolyData*>(act.actor->GetMapper ()->GetInput ());
         data->GetPointData ()->SetScalars (scalars);
         // Modify the mapper
 #if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2
         if (use_vbos_)
         {
-          vtkVertexBufferObjectMapper* mapper = static_cast<vtkVertexBufferObjectMapper*>(act->actor->GetMapper ());
+          vtkVertexBufferObjectMapper* mapper = static_cast<vtkVertexBufferObjectMapper*>(act.actor->GetMapper ());
           mapper->SetScalarRange (minmax);
           mapper->SetScalarModeToUsePointData ();
           mapper->SetInput (data);
           // Modify the actor
-          act->actor->SetMapper (mapper);
+          act.actor->SetMapper (mapper);
         }
         else
 #endif
         {
-          vtkPolyDataMapper* mapper = static_cast<vtkPolyDataMapper*>(act->actor->GetMapper ());
+          vtkPolyDataMapper* mapper = static_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
           mapper->SetScalarRange (minmax);
           mapper->SetScalarModeToUsePointData ();
           mapper->SetInputData (data);
           // Modify the actor
-          act->actor->SetMapper (mapper);
+          act.actor->SetMapper (mapper);
         }
-        act->actor->Modified ();
+        act.actor->Modified ();
       }
     }
 
@@ -787,29 +787,29 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
     case 'l': case 'L':
     {
       // Iterate over the entire actors list and extract the geomotry/color handlers list
-      for (CloudActorMap::iterator it = cloud_actors_->begin (); it != cloud_actors_->end (); ++it)
+      for (auto &actor : *cloud_actors_)
       {
         std::list<std::string> geometry_handlers_list, color_handlers_list;
-        CloudActor *act = &(*it).second;
-        for (size_t i = 0; i < act->geometry_handlers.size (); ++i)
-          geometry_handlers_list.push_back (act->geometry_handlers[i]->getFieldName ());
-        for (size_t i = 0; i < act->color_handlers.size (); ++i)
-          color_handlers_list.push_back (act->color_handlers[i]->getFieldName ());
+        CloudActor *act = &actor.second;
+        for (auto &geometry_handler : act->geometry_handlers)
+          geometry_handlers_list.push_back (geometry_handler->getFieldName ());
+        for (auto &color_handler : act->color_handlers)
+          color_handlers_list.push_back (color_handler->getFieldName ());
 
         if (!geometry_handlers_list.empty ())
         {
           int i = 0;
-          pcl::console::print_info ("List of available geometry handlers for actor "); pcl::console::print_value ("%s: ", (*it).first.c_str ());
-          for (std::list<std::string>::iterator git = geometry_handlers_list.begin (); git != geometry_handlers_list.end (); ++git)
-            pcl::console::print_value ("%s(%d) ", (*git).c_str (), ++i);
+          pcl::console::print_info ("List of available geometry handlers for actor "); pcl::console::print_value ("%s: ", actor.first.c_str ());
+          for (auto &git : geometry_handlers_list)
+            pcl::console::print_value ("%s(%d) ", git.c_str (), ++i);
           pcl::console::print_info ("\n");
         }
         if (!color_handlers_list.empty ())
         {
           int i = 0;
-          pcl::console::print_info ("List of available color handlers for actor "); pcl::console::print_value ("%s: ", (*it).first.c_str ());
-          for (std::list<std::string>::iterator cit = color_handlers_list.begin (); cit != color_handlers_list.end (); ++cit)
-            pcl::console::print_value ("%s(%d) ", (*cit).c_str (), ++i);
+          pcl::console::print_info ("List of available color handlers for actor "); pcl::console::print_value ("%s: ", actor.first.c_str ());
+          for (auto &cit : color_handlers_list)
+            pcl::console::print_value ("%s(%d) ", cit.c_str (), ++i);
           pcl::console::print_info ("\n");
         }
       }
@@ -1237,16 +1237,16 @@ pcl::visualization::PCLVisualizerInteractorStyle::updateLookUpTableDisplay (bool
   else  // lut_actor_id_ == "", the user did not specify which cloud/shape LUT should be displayed
   // Circling through all clouds/shapes and displaying first LUT found
   {
-    for (auto am_it = cloud_actors_->cbegin (); am_it != cloud_actors_->cend (); ++am_it)
+    for (const auto &actor : *cloud_actors_)
     {
-      const CloudActor *act = & (*am_it).second;
-      if (!act->actor->GetMapper ()->GetLookupTable ())
+      const auto &act = actor.second;
+      if (!act.actor->GetMapper ()->GetLookupTable ())
         continue;
 
-      if (!act->actor->GetMapper ()->GetInput ()->GetPointData ()->GetScalars ())
+      if (!act.actor->GetMapper ()->GetInput ()->GetPointData ()->GetScalars ())
         continue;
 
-      vtkScalarsToColors* lut = act->actor->GetMapper ()->GetLookupTable ();
+      vtkScalarsToColors* lut = act.actor->GetMapper ()->GetLookupTable ();
       lut_actor_->SetLookupTable (lut);
       lut_actor_->Modified ();
       actor_found = true;
@@ -1255,9 +1255,9 @@ pcl::visualization::PCLVisualizerInteractorStyle::updateLookUpTableDisplay (bool
 
     if (!actor_found)
     {
-      for (auto sm_it = shape_actors_->cbegin (); sm_it != shape_actors_->cend (); ++sm_it)
+      for (const auto &shape_actor : *shape_actors_)
       {
-        const vtkSmartPointer<vtkProp> *act = & (*sm_it).second;
+        const vtkSmartPointer<vtkProp> *act = &shape_actor.second;
         const vtkSmartPointer<vtkActor> actor = vtkActor::SafeDownCast (*act);
         if (!actor)
           continue;
@@ -1538,8 +1538,8 @@ pcl::visualization::PCLHistogramVisualizerInteractorStyle::OnTimer ()
     return;
   }
 
-  for (RenWinInteractMap::iterator am_it = wins_.begin (); am_it != wins_.end (); ++am_it)
-    (*am_it).second.ren_->Render ();
+  for (auto &win : wins_)
+    win.second.ren_->Render ();
 }
 
 namespace pcl

--- a/visualization/src/pcl_painter2D.cpp
+++ b/visualization/src/pcl_painter2D.cpp
@@ -360,14 +360,12 @@ pcl::visualization::PCLPainter2D::getWindowSize ()
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 bool 
 pcl::visualization::PCLPainter2D::Paint (vtkContext2D *painter)
-{  
+{
   //draw every figures
-  for (size_t i = 0; i < figures_.size (); i++)
+  for (auto &figure : figures_)
   {
-    figures_[i]->draw (painter); 	//that's it ;-)
+    figure->draw (painter); //that's it ;-)
   }
-  
+
   return true;
 }
-
-

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -352,8 +352,8 @@ pcl::visualization::PCLPlotter::addFeatureHistogram (
 
   // Compute the total size of the fields
   unsigned int fsize = 0;
-  for (size_t i = 0; i < cloud.fields.size (); ++i)
-    fsize += cloud.fields[i].count * pcl::getFieldSize (cloud.fields[i].datatype);
+  for (const auto &field : cloud.fields)
+    fsize += field.count * pcl::getFieldSize (field.datatype);
   
   int hsize = cloud.fields[field_idx].count;
   std::vector<double> array_x (hsize), array_y (hsize);
@@ -606,11 +606,11 @@ pcl::visualization::PCLPlotter::computeHistogram (
   }
 
   //fill the freq for each data
-  for (size_t i = 0; i < data.size (); i++)
+  for (const double value : data)
   {
-    if (std::isfinite (data[i]))
+    if (std::isfinite (value))
     {
-      unsigned int index = (unsigned int) (floor ((data[i] - min) / size));
+      unsigned int index = (unsigned int) (floor ((value - min) / size));
       if (index == (unsigned int) nbins) index = nbins - 1; //including right boundary
       histogram[index].second++;
     }

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3058,9 +3058,9 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (const pcl::PolygonMesh &poly_
     colors->SetName ("Colors");
     pcl::PointCloud<pcl::PointXYZRGB> cloud;
     pcl::fromPCLPointCloud2 (poly_mesh.cloud, cloud);
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (const auto &point : cloud.points)
     {
-      const unsigned char color[3] = { cloud.points[i].r, cloud.points[i].g, cloud.points[i].b };
+      const unsigned char color[3] = { point.r, point.g, point.b };
       colors->InsertNextTupleValue (color);
     }
   }
@@ -3071,9 +3071,9 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (const pcl::PolygonMesh &poly_
     colors->SetName ("Colors");
     pcl::PointCloud<pcl::PointXYZRGBA> cloud;
     pcl::fromPCLPointCloud2 (poly_mesh.cloud, cloud);
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (const auto &point : cloud.points)
     {
-      const unsigned char color[3] = { cloud.points[i].r, cloud.points[i].g, cloud.points[i].b };
+      const unsigned char color[3] = { point.r, point.g, point.b };
       colors->InsertNextTupleValue (color);
     }
   }
@@ -3084,12 +3084,11 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (const pcl::PolygonMesh &poly_
     //create polys from polyMesh.polygons
     vtkSmartPointer<vtkCellArray> cell_array = vtkSmartPointer<vtkCellArray>::New ();
 
-    for (size_t i = 0; i < poly_mesh.polygons.size (); i++)
+    for (const auto &polygon : poly_mesh.polygons)
     {
-      size_t n_points (poly_mesh.polygons[i].vertices.size ());
-      cell_array->InsertNextCell (int (n_points));
-      for (size_t j = 0; j < n_points; j++)
-        cell_array->InsertCellPoint (poly_mesh.polygons[i].vertices[j]);
+      cell_array->InsertNextCell (static_cast<int> (polygon.vertices.size ()));
+      for (const auto &vertex : polygon.vertices)
+        cell_array->InsertCellPoint (vertex);
     }
 
     vtkSmartPointer<vtkPolyData> polydata = vtkSmartPointer<vtkPolyData>::New ();
@@ -3207,9 +3206,9 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
 
   // Get the maximum size of a polygon
   int max_size_of_polygon = -1;
-  for (size_t i = 0; i < verts.size (); ++i)
-    if (max_size_of_polygon < static_cast<int> (verts[i].vertices.size ()))
-      max_size_of_polygon = static_cast<int> (verts[i].vertices.size ());
+  for (const auto &vertex : verts)
+    if (max_size_of_polygon < static_cast<int> (vertex.vertices.size ()))
+      max_size_of_polygon = static_cast<int> (vertex.vertices.size ());
 
   // Update the cells
   cells = vtkSmartPointer<vtkCellArray>::New ();
@@ -3272,13 +3271,13 @@ pcl::visualization::PCLVisualizer::addPolylineFromPolygonMesh (
   vtkSmartPointer <vtkPolyData> polyData;
   allocVtkPolyData (polyData);
 
-  for (size_t i = 0; i < polymesh.polygons.size (); i++)
+  for (const auto &polygon : polymesh.polygons)
   {
     vtkSmartPointer<vtkPolyLine> polyLine = vtkSmartPointer<vtkPolyLine>::New();
-    polyLine->GetPointIds()->SetNumberOfIds(polymesh.polygons[i].vertices.size());
-    for(size_t k = 0; k < polymesh.polygons[i].vertices.size(); k++)
+    polyLine->GetPointIds()->SetNumberOfIds(polygon.vertices.size());
+    for(size_t v = 0; v < polygon.vertices.size(); v++)
     {
-      polyLine->GetPointIds ()->SetId (k, polymesh.polygons[i].vertices[k]);
+      polyLine->GetPointIds ()->SetId (v, polygon.vertices[v]);
     }
 
     cells->InsertNextCell (polyLine);
@@ -3342,8 +3341,8 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
   }
   // total number of vertices
   std::size_t nb_vertices = 0;
-  for (std::size_t i = 0; i < mesh.tex_polygons.size (); ++i)
-    nb_vertices += mesh.tex_polygons[i].size ();
+  for (const auto &tex_polygon : mesh.tex_polygons)
+    nb_vertices += tex_polygon.size ();
   // no vertices --> exit
   if (nb_vertices == 0)
   {
@@ -3352,8 +3351,8 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
   }
   // total number of coordinates
   std::size_t nb_coordinates = 0;
-  for (std::size_t i = 0; i < mesh.tex_coordinates.size (); ++i)
-    nb_coordinates += mesh.tex_coordinates[i].size ();
+  for (const auto &tex_coordinate : mesh.tex_coordinates)
+    nb_coordinates += tex_coordinate.size ();
   // no texture coordinates --> exit
   if (nb_coordinates == 0)
   {
@@ -3410,14 +3409,13 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
 
   //create polys from polyMesh.tex_polygons
   vtkSmartPointer<vtkCellArray> polys = vtkSmartPointer<vtkCellArray>::New ();
-  for (std::size_t i = 0; i < mesh.tex_polygons.size (); i++)
+  for (const auto &tex_polygon : mesh.tex_polygons)
   {
-    for (std::size_t j = 0; j < mesh.tex_polygons[i].size (); j++)
+    for (const auto &vertex : tex_polygon)
     {
-      std::size_t n_points = mesh.tex_polygons[i][j].vertices.size ();
-      polys->InsertNextCell (int (n_points));
-      for (std::size_t k = 0; k < n_points; k++)
-        polys->InsertCellPoint (mesh.tex_polygons[i][j].vertices[k]);
+      polys->InsertNextCell (static_cast<int> (vertex.vertices.size ()));
+      for (const auto &point : vertex.vertices)
+        polys->InsertCellPoint (point);
     }
   }
 
@@ -3470,9 +3468,8 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
 
     for (std::size_t t = 0; t < mesh.tex_coordinates.size (); ++t)
       if (t == tex_id)
-        for (std::size_t tc = 0; tc < mesh.tex_coordinates[t].size (); ++tc)
-          coordinates->InsertNextTuple2 (mesh.tex_coordinates[t][tc][0],
-                                         mesh.tex_coordinates[t][tc][1]);
+        for (const auto &tc : mesh.tex_coordinates[t])
+          coordinates->InsertNextTuple2 (tc[0], tc[1]);
       else
         for (std::size_t tc = 0; tc < mesh.tex_coordinates[t].size (); ++tc)
           coordinates->InsertNextTuple2 (-1.0, -1.0);
@@ -3752,11 +3749,11 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
   cam->Modified ();
 
   //For each camera position, transform the object and render view
-  for (size_t i = 0; i < cam_positions.size (); i++)
+  for (const auto &cam_position : cam_positions)
   {
-    cam_pos[0] = cam_positions[i][0];
-    cam_pos[1] = cam_positions[i][1];
-    cam_pos[2] = cam_positions[i][2];
+    cam_pos[0] = cam_position[0];
+    cam_pos[1] = cam_position[1];
+    cam_pos[2] = cam_position[2];
 
     //create temporal virtual camera
     vtkSmartPointer<vtkCamera> cam_tmp = vtkSmartPointer<vtkCamera>::New ();
@@ -3777,9 +3774,9 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
 
     cam_tmp->SetViewUp (test[0], test[1], test[2]);
 
-    for (int k = 0; k < 3; k++)
+    for (double &c_pos : cam_pos)
     {
-      cam_pos[k] = cam_pos[k] * camera_radius;
+      c_pos *= camera_radius;
     }
 
     cam_tmp->SetPosition (cam_pos);
@@ -3955,11 +3952,11 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
 
     //NOTE: vtk view coordinate system is different than the standard camera coordinates (z forward, y down, x right)
     //thus, the fliping in y and z
-    for (size_t i = 0; i < cloud->points.size (); i++)
+    for (auto &point : cloud->points)
     {
-      cloud->points[i].getVector4fMap () = trans_view * cloud->points[i].getVector4fMap ();
-      cloud->points[i].y *= -1.0f;
-      cloud->points[i].z *= -1.0f;
+      point.getVector4fMap () = trans_view * point.getVector4fMap ();
+      point.y *= -1.0f;
+      point.z *= -1.0f;
     }
 
     renderer->RemoveActor (actor_view);
@@ -4628,9 +4625,9 @@ pcl::visualization::PCLVisualizer::getUniqueCameraFile (int argc, char **argv)
     bool valid = false;
 
     // Calculate sha1 using canonical paths
-    for (size_t i = 0; i < p_file_indices.size (); ++i)
+    for (int p_file_index : p_file_indices)
     {
-      boost::filesystem::path path (argv[p_file_indices[i]]);
+      boost::filesystem::path path (argv[p_file_index]);
       if (boost::filesystem::exists (path))
       {
         path = boost::filesystem::canonical (path);

--- a/visualization/src/range_image_visualizer.cpp
+++ b/visualization/src/range_image_visualizer.cpp
@@ -139,9 +139,8 @@ pcl::visualization::RangeImageVisualizer::getInterestPointsWidget (
   RangeImageVisualizer* widget = new RangeImageVisualizer;
   widget->showFloatImage (interest_image, range_image.width, range_image.height, min_value, max_value);
   widget->setWindowTitle (name);
-  for (size_t i=0; i<interest_points.points.size(); ++i)
+  for (const auto &interest_point : interest_points.points)
   {
-    const pcl::InterestPoint& interest_point = interest_points.points[i];
     float image_x, image_y;
     range_image.getImagePoint (interest_point.x, interest_point.y, interest_point.z, image_x, image_y);
     widget->markPoint (static_cast<size_t> (image_x), static_cast<size_t> (image_y), green_color, red_color);

--- a/visualization/tools/pcd_viewer.cpp
+++ b/visualization/tools/pcd_viewer.cpp
@@ -712,14 +712,14 @@ main (int argc, char** argv)
     {
       if (ph) ph->spinOnce ();
 
-      for (int i = 0; i < int (imgs.size ()); ++i)
+      for (auto &img : imgs)
       {
-        if (imgs[i]->wasStopped ())
+        if (img->wasStopped ())
         {
           stopped = true;
           break;
         }
-        imgs[i]->spinOnce ();
+        img->spinOnce ();
       }
         
       if (p)


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix