### PR TITLE
Transform classic loops to range-based for loops in module gpu

### DIFF
--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
@@ -260,9 +260,9 @@ pcl::kinfuLS::WorldModel<PointT>::setIndicesAsNans (PointCloudPtr cloud, Indices
   
   for (int rii = 0; rii < static_cast<int> (indices->size ()); ++rii)  // rii = removed indices iterator
   {
-	uint8_t* pt_data = reinterpret_cast<uint8_t*> (&cloud->points[(*indices)[rii]]);
-	for (int fi = 0; fi < static_cast<int> (fields.size ()); ++fi)  // fi = field iterator
-	  memcpy (pt_data + fields[fi].offset, &my_nan, sizeof (float));
+    uint8_t* pt_data = reinterpret_cast<uint8_t*> (&cloud->points[(*indices)[rii]]);
+    for (const auto &field : fields)
+      memcpy (pt_data + field.offset, &my_nan, sizeof (float));
   }
 }
 

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -189,10 +189,10 @@ saveOBJFile (const std::string &file_name,
 
     PCL_INFO ("%d vertex textures in submesh %d\n", tex_mesh.tex_coordinates[m].size (), m);
     fs << "# " << tex_mesh.tex_coordinates[m].size() << " vertex textures in submesh " << m <<  std::endl;
-    for (size_t i = 0; i < tex_mesh.tex_coordinates[m].size (); ++i)
+    for (const auto &coordinate : tex_mesh.tex_coordinates[m])
     {
       fs << "vt ";
-      fs <<  tex_mesh.tex_coordinates[m][i][0] << " " << tex_mesh.tex_coordinates[m][i][1] << std::endl;
+      fs <<  coordinate[0] << " " << coordinate[1] << std::endl;
     }
   }
 

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -76,8 +76,8 @@ namespace pcl
         //Inline constructor
         Tree2() : id(NO_CHILD), lid(NO_CHILD), nr_parts(0)
         {
-          for(int i=0;i<NUM_PARTS;i++)
-            parts_lid[i] = NO_CHILD;
+          for(int &part : parts_lid)
+            part = NO_CHILD;
         }
        
         int     id;                     // specific identification number of this tree
@@ -124,10 +124,10 @@ namespace pcl
       {
         if(sorted[label].size() == 0)
           return 0;
-        for(size_t i = 0; i < sorted[label].size(); i++)
+        for(auto &i : sorted[label])
         {
           for(int j = 0; j < MAX_CHILD; j++)
-            sorted[label][i].child_id[j] = LEAF;
+            i.child_id[j] = LEAF;
         }
         return 0;
       }
@@ -146,8 +146,8 @@ namespace pcl
       {
         if(sorted[label].size() == 0)
           return 0;
-        for(size_t i = 0; i < sorted[label].size(); i++){
-          sorted[label][i].child_id[child_number] = NO_CHILD;
+        for(auto &i : sorted[label]){
+          i.child_id[child_number] = NO_CHILD;
         }
         return 0;
       }
@@ -163,8 +163,8 @@ namespace pcl
       {
         if(sorted[label].size() == 0)
           return false;
-        for(size_t i = 0; i < sorted[label].size(); i++)
-          if((sorted[label][i].child_id[child_number] != NO_CHILD) && (sorted[label][i].child_id[child_number] != LEAF))
+        for(const auto &i : sorted[label])
+          if((i.child_id[child_number] != NO_CHILD) && (i.child_id[child_number] != LEAF))
             return true;
         return false;
       }

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -124,10 +124,10 @@ namespace pcl
       {
         if(sorted[label].size() == 0)
           return 0;
-        for(auto &i : sorted[label])
+        for(auto &blob : sorted[label])
         {
           for(int j = 0; j < MAX_CHILD; j++)
-            i.child_id[j] = LEAF;
+            blob.child_id[j] = LEAF;
         }
         return 0;
       }
@@ -146,8 +146,8 @@ namespace pcl
       {
         if(sorted[label].size() == 0)
           return 0;
-        for(auto &i : sorted[label]){
-          i.child_id[child_number] = NO_CHILD;
+        for(auto &blob : sorted[label]){
+          blob.child_id[child_number] = NO_CHILD;
         }
         return 0;
       }
@@ -163,8 +163,8 @@ namespace pcl
       {
         if(sorted[label].size() == 0)
           return false;
-        for(const auto &i : sorted[label])
-          if((i.child_id[child_number] != NO_CHILD) && (i.child_id[child_number] != LEAF))
+        for(const auto &blob : sorted[label])
+          if((blob.child_id[child_number] != NO_CHILD) && (blob.child_id[child_number] != LEAF))
             return true;
         return false;
       }

--- a/gpu/people/src/bodyparts_detector.cpp
+++ b/gpu/people/src/bodyparts_detector.cpp
@@ -63,14 +63,14 @@ pcl::gpu::people::RDFBodyPartsDetector::RDFBodyPartsDetector( const vector<strin
 
   impl_.reset ( new device::MultiTreeLiveProc(rows, cols) );
 
-  for(size_t i = 0; i < tree_files.size(); ++i)
+  for(const auto &tree_file : tree_files)
   {
     // load the tree file
     vector<trees::Node>  nodes;
     vector<trees::Label> leaves;
 
     // this might throw but we haven't done any malloc yet
-    int height = loadTree (tree_files[i], nodes, leaves );
+    int height = loadTree (tree_file, nodes, leaves );
     impl_->trees.emplace_back(height, nodes, leaves);
   }
 
@@ -159,10 +159,10 @@ pcl::gpu::people::RDFBodyPartsDetector::allocate_buffers(int rows, int cols)
   means_storage_.resize((cols * rows + 1) * 3); // float3 * cols * rows and float3 for cc == -1.
 
   blob_matrix_.resize(NUM_PARTS);
-  for(size_t i = 0; i < blob_matrix_.size(); ++i)
+  for(auto &matrix : blob_matrix_)
   {
-    blob_matrix_[i].clear();
-    blob_matrix_[i].reserve(5000);
+    matrix.clear();
+    matrix.reserve(5000);
   }
 }
 
@@ -209,8 +209,8 @@ pcl::gpu::people::RDFBodyPartsDetector::process (const pcl::device::Depth& depth
     float3* means = (float3*) &means_storage_[3];
     int *rsizes = &region_sizes_[1];
 
-    for(size_t i = 0; i < blob_matrix_.size(); ++i)
-      blob_matrix_[i].clear();
+    for(auto &matrix : blob_matrix_)
+      matrix.clear();
 
     for(size_t k = 0; k < dst_labels_.size(); ++k)
     {
@@ -249,11 +249,11 @@ pcl::gpu::people::RDFBodyPartsDetector::process (const pcl::device::Depth& depth
     }
 
     int id = 0;
-    for(size_t label = 0; label < blob_matrix_.size(); ++label)
-      for(size_t b = 0; b < blob_matrix_[label].size(); ++b)
+    for(auto &matrix : blob_matrix_)
+      for(size_t b = 0; b < matrix.size(); ++b)
       {
-        blob_matrix_[label][b].id = id++;
-        blob_matrix_[label][b].lid = static_cast<int> (b);
+        matrix[b].id = id++;
+        matrix[b].lid = static_cast<int> (b);
       }
 
     buildRelations ( blob_matrix_ );
@@ -303,8 +303,8 @@ pcl::gpu::people::RDFBodyPartsDetector::processSmooth (const pcl::device::Depth&
     float3* means = (float3*) &means_storage_[3];
     int *rsizes = &region_sizes_[1];
 
-    for(size_t i = 0; i < blob_matrix_.size(); ++i)
-      blob_matrix_[i].clear();
+    for(auto &matrix : blob_matrix_)
+      matrix.clear();
 
     for(size_t k = 0; k < dst_labels_.size(); ++k)
     {
@@ -343,11 +343,11 @@ pcl::gpu::people::RDFBodyPartsDetector::processSmooth (const pcl::device::Depth&
     }
 
     int id = 0;
-    for(size_t label = 0; label < blob_matrix_.size(); ++label)
-      for(size_t b = 0; b < blob_matrix_[label].size(); ++b)
+    for(auto &matrix : blob_matrix_)
+      for(size_t b = 0; b < matrix.size(); ++b)
       {
-        blob_matrix_[label][b].id = id++;
-        blob_matrix_[label][b].lid = static_cast<int> (b);
+        matrix[b].id = id++;
+        matrix[b].lid = static_cast<int> (b);
       }
   }
 }

--- a/gpu/people/src/face_detector.cpp
+++ b/gpu/people/src/face_detector.cpp
@@ -327,44 +327,44 @@ pcl::gpu::people::FaceDetector::loadFromXML2(const std::string                  
   //merge root and leaf nodes in one classifiers array, leaf nodes are sorted behind the root nodes
   Ncv32u offset_root = haarClassifierNodes.size();
 
-  for (size_t i = 0; i < haarClassifierNodes.size(); i++)
+  for (auto &haarClassifierNode : haarClassifierNodes)
   {
-      HaarClassifierNodeDescriptor32 node_left = haarClassifierNodes[i].getLeftNodeDesc();
+      HaarClassifierNodeDescriptor32 node_left = haarClassifierNode.getLeftNodeDesc();
       if (!node_left.isLeaf())
       {
           Ncv32u new_offset = node_left.getNextNodeOffset() + offset_root;
           node_left.create(new_offset);
       }
-      haarClassifierNodes[i].setLeftNodeDesc(node_left);
+      haarClassifierNode.setLeftNodeDesc(node_left);
 
-      HaarClassifierNodeDescriptor32 node_right = haarClassifierNodes[i].getRightNodeDesc();
+      HaarClassifierNodeDescriptor32 node_right = haarClassifierNode.getRightNodeDesc();
       if (!node_right.isLeaf())
       {
           Ncv32u new_offset = node_right.getNextNodeOffset() + offset_root;
           node_right.create(new_offset);
       }
-      haarClassifierNodes[i].setRightNodeDesc(node_right);
+      haarClassifierNode.setRightNodeDesc(node_right);
   }
 
-  for (size_t i = 0; i < host_temp_classifier_not_root_nodes.size(); i++)
+  for (auto &host_temp_classifier_not_root_node : host_temp_classifier_not_root_nodes)
   {
-      HaarClassifierNodeDescriptor32 node_left = host_temp_classifier_not_root_nodes[i].getLeftNodeDesc();
+      HaarClassifierNodeDescriptor32 node_left = host_temp_classifier_not_root_node.getLeftNodeDesc();
       if (!node_left.isLeaf())
       {
           Ncv32u new_offset = node_left.getNextNodeOffset() + offset_root;
           node_left.create(new_offset);
       }
-      host_temp_classifier_not_root_nodes[i].setLeftNodeDesc(node_left);
+      host_temp_classifier_not_root_node.setLeftNodeDesc(node_left);
 
-      HaarClassifierNodeDescriptor32 node_right = host_temp_classifier_not_root_nodes[i].getRightNodeDesc();
+      HaarClassifierNodeDescriptor32 node_right = host_temp_classifier_not_root_node.getRightNodeDesc();
       if (!node_right.isLeaf())
       {
           Ncv32u new_offset = node_right.getNextNodeOffset() + offset_root;
           node_right.create(new_offset);
       }
-      host_temp_classifier_not_root_nodes[i].setRightNodeDesc(node_right);
+      host_temp_classifier_not_root_node.setRightNodeDesc(node_right);
 
-      haarClassifierNodes.push_back(host_temp_classifier_not_root_nodes[i]);
+      haarClassifierNodes.push_back(host_temp_classifier_not_root_node);
   }
   return (NCV_SUCCESS);
 }
@@ -583,9 +583,9 @@ pcl::gpu::people::FaceDetector::NCVprocess(pcl::PointCloud<pcl::RGB>&           
 
   NCV_SKIP_COND_BEGIN
 
-  for(size_t i = 0; i < input_gray.points.size(); i++)
+  for(const auto &point : input_gray.points)
   {
-    memcpy(h_src.ptr(), &input_gray.points[i].intensity, sizeof(input_gray.points[i].intensity));
+    memcpy(h_src.ptr(), &point.intensity, sizeof(point.intensity));
   }
 
   ncv_return_status = h_src.copySolid(d_src, 0);
@@ -628,9 +628,9 @@ pcl::gpu::people::FaceDetector::NCVprocess(pcl::PointCloud<pcl::RGB>&           
   PCL_ASSERT_CUDA_RETURN(cudaStreamSynchronize(0), NCV_CUDA_ERROR);
 
   // Copy result back into output cloud
-  for(size_t i = 0; i < cloud_out.points.size(); i++)
+  for(auto &point : cloud_out.points)
   {
-    memcpy(&cloud_out.points[i].intensity, h_src.ptr() /* + i * ??? */, sizeof(cloud_out.points[i].intensity));
+    memcpy(&point.intensity, h_src.ptr() /* + i * ??? */, sizeof(point.intensity));
   }
 
   NCV_SKIP_COND_END

--- a/gpu/people/src/organized_plane_detector.cpp
+++ b/gpu/people/src/organized_plane_detector.cpp
@@ -108,11 +108,11 @@ pcl::gpu::people::OrganizedPlaneDetector::process(const PointCloud<PointTC>::Con
   }
 
   // Fill in the probabilities
-  for(size_t plane = 0; plane < inlier_indices.size(); plane++)                                            // iterate over all found planes
+  for(const auto &inlier_index : inlier_indices)                           // iterate over all found planes
   {
-    for(size_t idx = 0; idx < inlier_indices[plane].indices.size(); idx++)                               // iterate over all the indices in that plane
+    for(const int index : inlier_index.indices)                            // iterate over all the indices in that plane
     {
-      P_l_host_.points[inlier_indices[plane].indices[idx]].probs[pcl::gpu::people::Background] = 1.f;   // set background at max
+      P_l_host_.points[index].probs[pcl::gpu::people::Background] = 1.f;   // set background at max
     }
   }
 }
@@ -140,11 +140,11 @@ pcl::gpu::people::OrganizedPlaneDetector::allocate_buffers(int rows, int cols)
 void
 pcl::gpu::people::OrganizedPlaneDetector::emptyHostLabelProbability(HostLabelProbability& histogram)
 {
-  for(size_t hist = 0; hist < histogram.points.size(); hist++)
+  for(auto &point : histogram.points)
   {
     for(int label = 0; label < pcl::gpu::people::NUM_LABELS; label++)
     {
-      histogram.points[hist].probs[label] = 0.f;
+      point.probs[label] = 0.f;
     }
   }
 }

--- a/gpu/people/src/organized_plane_detector.cpp
+++ b/gpu/people/src/organized_plane_detector.cpp
@@ -110,7 +110,7 @@ pcl::gpu::people::OrganizedPlaneDetector::process(const PointCloud<PointTC>::Con
   // Fill in the probabilities
   for(const auto &inlier_index : inlier_indices)                           // iterate over all found planes
   {
-    for(const int index : inlier_index.indices)                            // iterate over all the indices in that plane
+    for(const int &index : inlier_index.indices)                           // iterate over all the indices in that plane
     {
       P_l_host_.points[index].probs[pcl::gpu::people::Background] = 1.f;   // set background at max
     }

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -371,7 +371,7 @@ pcl::gpu::people::PeopleDetector::processProb ()
       Tree2 t2;
       buildTree(sorted2, cloud_host_, Neck, c, t2, person_attribs_);
       //int par = 0;
-      for(const int f : t2.parts_lid)
+      for(const int &f : t2.parts_lid)
       {
         if(f == NO_CHILD)
         {

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -371,9 +371,9 @@ pcl::gpu::people::PeopleDetector::processProb ()
       Tree2 t2;
       buildTree(sorted2, cloud_host_, Neck, c, t2, person_attribs_);
       //int par = 0;
-      for(const int &f : t2.parts_lid)
+      for(const int &node_type : t2.parts_lid)
       {
-        if(f == NO_CHILD)
+        if(node_type == NO_CHILD)
         {
           cerr << "1;";
           //par++;

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -371,9 +371,9 @@ pcl::gpu::people::PeopleDetector::processProb ()
       Tree2 t2;
       buildTree(sorted2, cloud_host_, Neck, c, t2, person_attribs_);
       //int par = 0;
-      for(int f = 0; f < NUM_PARTS; f++)
+      for(const int f : t2.parts_lid)
       {
-        if(t2.parts_lid[f] == NO_CHILD)
+        if(f == NO_CHILD)
         {
           cerr << "1;";
           //par++;

--- a/gpu/people/tools/people_pcd_prob.cpp
+++ b/gpu/people/tools/people_pcd_prob.cpp
@@ -187,9 +187,9 @@ class PeoplePCDApp
     void
     convertProbToRGB (pcl::PointCloud<pcl::device::prob_histogram>& histograms, int label, pcl::PointCloud<pcl::RGB>& rgb)
     {
-      for(size_t t = 0; t < histograms.points.size(); t++)
+      for(const auto &point : histograms.points)
       {
-        float value = histograms.points[t].probs[label];
+        float value = point.probs[label];
         float value8 = value * 255;
         char val = static_cast<char> (value8);
         pcl::RGB p;


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix