### PR TITLE
Transform classic loops to range-based for loops in module io

### DIFF
--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -141,8 +141,8 @@ namespace pcl
 
   Grabber::~Grabber () throw ()
   {
-    for (std::map<std::string, boost::signals2::signal_base*>::iterator signal_it = signals_.begin (); signal_it != signals_.end (); ++signal_it)
-      delete signal_it->second;
+    for (auto &signal : signals_)
+      delete signal.second;
   }
 
   template<typename T> boost::signals2::signal<T>*
@@ -173,32 +173,32 @@ namespace pcl
   Grabber::block_signal ()
   {
     if (connections_.find (typeid (T).name ()) != connections_.end ())
-      for (std::vector<boost::signals2::shared_connection_block>::iterator cIt = shared_connections_[typeid (T).name ()].begin (); cIt != shared_connections_[typeid (T).name ()].end (); ++cIt)
-        cIt->block ();
+      for (auto &connection : shared_connections_[typeid (T).name ()])
+        connection.block ();
   }
 
   template<typename T> void
   Grabber::unblock_signal ()
   {
     if (connections_.find (typeid (T).name ()) != connections_.end ())
-      for (std::vector<boost::signals2::shared_connection_block>::iterator cIt = shared_connections_[typeid (T).name ()].begin (); cIt != shared_connections_[typeid (T).name ()].end (); ++cIt)
-        cIt->unblock ();
+      for (auto &connection : shared_connections_[typeid (T).name ()])
+        connection.unblock ();
   }
 
   void
   Grabber::block_signals ()
   {
-    for (std::map<std::string, boost::signals2::signal_base*>::iterator signal_it = signals_.begin (); signal_it != signals_.end (); ++signal_it)
-      for (std::vector<boost::signals2::shared_connection_block>::iterator cIt = shared_connections_[signal_it->first].begin (); cIt != shared_connections_[signal_it->first].end (); ++cIt)
-        cIt->block ();
+    for (const auto &signal : signals_)
+      for (auto &connection : shared_connections_[signal.first])
+        connection.block ();
   }
 
   void
   Grabber::unblock_signals ()
   {
-    for (std::map<std::string, boost::signals2::signal_base*>::iterator signal_it = signals_.begin (); signal_it != signals_.end (); ++signal_it)
-      for (std::vector<boost::signals2::shared_connection_block>::iterator cIt = shared_connections_[signal_it->first].begin (); cIt != shared_connections_[signal_it->first].end (); ++cIt)
-        cIt->unblock ();
+    for (const auto &signal : signals_)
+      for (auto &connection : shared_connections_[signal.first])
+        connection.unblock ();
   }
 
   template<typename T> int
@@ -239,13 +239,6 @@ namespace pcl
       std::stringstream sstream;
 
       sstream << "no callback for type:" << typeid (T).name ();
-      /*
-      sstream << "registered Callbacks are:" << std::endl;
-      for( std::map<std::string, boost::signals2::signal_base*>::const_iterator cIt = signals_.begin ();
-           cIt != signals_.end (); ++cIt)
-      {
-        sstream << cIt->first << std::endl;
-      }*/
 
       PCL_THROW_EXCEPTION (pcl::IOException, "[" << getName () << "] " << sstream.str ());
       //return (boost::signals2::connection ());

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -66,18 +66,18 @@ pcl::PCDWriter::generateHeader (const pcl::PointCloud<PointT> &cloud, const int 
   pcl::getFields (cloud, fields);
  
   std::stringstream field_names, field_types, field_sizes, field_counts;
-  for (size_t i = 0; i < fields.size (); ++i)
+  for (const auto &field : fields)
   {
-    if (fields[i].name == "_")
+    if (field.name == "_")
       continue;
     // Add the regular dimension
-    field_names << " " << fields[i].name;
-    field_sizes << " " << pcl::getFieldSize (fields[i].datatype);
-    if ("rgb" == fields[i].name)
+    field_names << " " << field.name;
+    field_sizes << " " << pcl::getFieldSize (field.datatype);
+    if ("rgb" == field.name)
       field_types << " " << "U";
     else
-      field_types << " " << pcl::getFieldType (fields[i].datatype);
-    int count = abs (static_cast<int> (fields[i].count));
+      field_types << " " << pcl::getFieldType (field.datatype);
+    int count = abs (static_cast<int> (field.count));
     if (count == 0) count = 1;  // check for 0 counts (coming from older converter code)
     field_counts << " " << count;
   }
@@ -148,15 +148,15 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   size_t nri = 0;
   pcl::getFields (cloud, fields);
   // Compute the total size of the fields
-  for (size_t i = 0; i < fields.size (); ++i)
+  for (const auto &field : fields)
   {
-    if (fields[i].name == "_")
+    if (field.name == "_")
       continue;
     
-    int fs = fields[i].count * getFieldSize (fields[i].datatype);
+    int fs = field.count * getFieldSize (field.datatype);
     fsize += fs;
     fields_sizes.push_back (fs);
-    fields[nri++] = fields[i];
+    fields[nri++] = field;
   }
   fields.resize (nri);
   
@@ -203,9 +203,9 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   for (size_t i = 0; i < cloud.points.size (); ++i)
   {
     int nrj = 0;
-    for (size_t j = 0; j < fields.size (); ++j)
+    for (const auto &field : fields)
     {
-      memcpy (out, reinterpret_cast<const char*> (&cloud.points[i]) + fields[j].offset, fields_sizes[nrj]);
+      memcpy (out, reinterpret_cast<const char*> (&cloud.points[i]) + field.offset, fields_sizes[nrj]);
       out += fields_sizes[nrj++];
     }
   }
@@ -281,14 +281,14 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   pcl::getFields (cloud, fields);
   std::vector<int> fields_sizes (fields.size ());
   // Compute the total size of the fields
-  for (size_t i = 0; i < fields.size (); ++i)
+  for (const auto &field : fields)
   {
-    if (fields[i].name == "_")
+    if (field.name == "_")
       continue;
     
-    fields_sizes[nri] = fields[i].count * pcl::getFieldSize (fields[i].datatype);
+    fields_sizes[nri] = field.count * pcl::getFieldSize (field.datatype);
     fsize += fields_sizes[nri];
-    fields[nri] = fields[i];
+    fields[nri] = field;
     ++nri;
   }
   fields_sizes.resize (nri);
@@ -631,15 +631,15 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   size_t nri = 0;
   pcl::getFields (cloud, fields);
   // Compute the total size of the fields
-  for (size_t i = 0; i < fields.size (); ++i)
+  for (const auto &field : fields)
   {
-    if (fields[i].name == "_")
+    if (field.name == "_")
       continue;
     
-    int fs = fields[i].count * getFieldSize (fields[i].datatype);
+    int fs = field.count * getFieldSize (field.datatype);
     fsize += fs;
     fields_sizes.push_back (fs);
-    fields[nri++] = fields[i];
+    fields[nri++] = field;
   }
   fields.resize (nri);
   
@@ -678,12 +678,12 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
 
   char *out = &map[0] + data_idx;
   // Copy the data
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (int index : indices)
   {
     int nrj = 0;
-    for (size_t j = 0; j < fields.size (); ++j)
+    for (const auto &field : fields)
     {
-      memcpy (out, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[j].offset, fields_sizes[nrj]);
+      memcpy (out, reinterpret_cast<const char*> (&cloud.points[index]) + field.offset, fields_sizes[nrj]);
       out += fields_sizes[nrj++];
     }
   }
@@ -762,7 +762,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
   stream.imbue (std::locale::classic ());
 
   // Iterate through the points
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (const int index : indices)
   {
     for (size_t d = 0; d < fields.size (); ++d)
     {
@@ -781,42 +781,42 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
           case pcl::PCLPointField::INT8:
           {
             int8_t value;
-            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (int8_t), sizeof (int8_t));
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (int8_t), sizeof (int8_t));
             stream << boost::numeric_cast<int32_t>(value);
             break;
           }
           case pcl::PCLPointField::UINT8:
           {
             uint8_t value;
-            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (uint8_t), sizeof (uint8_t));
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (uint8_t), sizeof (uint8_t));
             stream << boost::numeric_cast<uint32_t>(value);
             break;
           }
           case pcl::PCLPointField::INT16:
           {
             int16_t value;
-            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (int16_t), sizeof (int16_t));
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (int16_t), sizeof (int16_t));
             stream << boost::numeric_cast<int16_t>(value);
             break;
           }
           case pcl::PCLPointField::UINT16:
           {
             uint16_t value;
-            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (uint16_t), sizeof (uint16_t));
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (uint16_t), sizeof (uint16_t));
             stream << boost::numeric_cast<uint16_t>(value);
             break;
           }
           case pcl::PCLPointField::INT32:
           {
             int32_t value;
-            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (int32_t), sizeof (int32_t));
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (int32_t), sizeof (int32_t));
             stream << boost::numeric_cast<int32_t>(value);
             break;
           }
           case pcl::PCLPointField::UINT32:
           {
             uint32_t value;
-            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (uint32_t), sizeof (uint32_t));
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (uint32_t), sizeof (uint32_t));
             stream << boost::numeric_cast<uint32_t>(value);
             break;
           }
@@ -830,13 +830,13 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
             if ("rgb" == fields[d].name)
             {
               uint32_t value;
-              memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (float), sizeof (float));
+              memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (float), sizeof (float));
               stream << boost::numeric_cast<uint32_t>(value);
             }
             else
             {
               float value;
-              memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (float), sizeof (float));
+              memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (float), sizeof (float));
               if (std::isnan (value))
                 stream << "nan";
               else
@@ -847,7 +847,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
           case pcl::PCLPointField::FLOAT64:
           {
             double value;
-            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[indices[i]]) + fields[d].offset + c * sizeof (double), sizeof (double));
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[index]) + fields[d].offset + c * sizeof (double), sizeof (double));
             if (std::isnan (value))
               stream << "nan";
             else

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -678,7 +678,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
 
   char *out = &map[0] + data_idx;
   // Copy the data
-  for (int index : indices)
+  for (const int &index : indices)
   {
     int nrj = 0;
     for (const auto &field : fields)
@@ -762,7 +762,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
   stream.imbue (std::locale::classic ());
 
   // Iterate through the points
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     for (size_t d = 0; d < fields.size (); ++d)
     {

--- a/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
+++ b/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
@@ -218,9 +218,9 @@ pcl::io::PointCloudImageExtractorFromLabelField<PointT>::extractImpl (const Poin
       // Note: the color LUT has a finite size (256 colors), therefore when
       // there are more labels the colors will repeat
       size_t color = 0;
-      for (std::set<uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter)
+      for (const unsigned int label : labels)
       {
-        colormap[*iter] = color % GlasbeyLUT::size ();
+        colormap[label] = color % GlasbeyLUT::size ();
         ++color;
       }
 

--- a/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
+++ b/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
@@ -218,7 +218,7 @@ pcl::io::PointCloudImageExtractorFromLabelField<PointT>::extractImpl (const Poin
       // Note: the color LUT has a finite size (256 colors), therefore when
       // there are more labels the colors will repeat
       size_t color = 0;
-      for (const unsigned int label : labels)
+      for (const uint32_t &label : labels)
       {
         colormap[label] = color % GlasbeyLUT::size ();
         ++color;

--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -149,11 +149,11 @@ pcl::HDLGrabber::initialize (const std::string& correctionsFile)
 
   loadCorrectionsFile (correctionsFile);
 
-  for (uint8_t i = 0; i < HDL_MAX_NUM_LASERS; i++)
+  for (auto &laser_correction : laser_corrections_)
   {
-    HDLLaserCorrection correction = laser_corrections_[i];
-    laser_corrections_[i].sinVertOffsetCorrection = correction.verticalOffsetCorrection * correction.sinVertCorrection;
-    laser_corrections_[i].cosVertOffsetCorrection = correction.verticalOffsetCorrection * correction.cosVertCorrection;
+    HDLLaserCorrection correction = laser_correction;
+    laser_correction.sinVertOffsetCorrection = correction.verticalOffsetCorrection * correction.sinVertCorrection;
+    laser_correction.cosVertOffsetCorrection = correction.verticalOffsetCorrection * correction.cosVertCorrection;
   }
   sweep_xyz_signal_ = createSignal<sig_cb_velodyne_hdl_sweep_point_cloud_xyz> ();
   sweep_xyzrgba_signal_ = createSignal<sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba> ();
@@ -167,8 +167,8 @@ pcl::HDLGrabber::initialize (const std::string& correctionsFile)
   current_sweep_xyz_.reset (new pcl::PointCloud<pcl::PointXYZ>);
   current_sweep_xyzi_.reset (new pcl::PointCloud<pcl::PointXYZI>);
 
-  for (uint8_t i = 0; i < HDL_MAX_NUM_LASERS; i++)
-    laser_rgb_mapping_[i].r = laser_rgb_mapping_[i].g = laser_rgb_mapping_[i].b = 0;
+  for (auto &rgb : laser_rgb_mapping_)
+    rgb.r = rgb.g = rgb.b = 0;
 
   if (laser_corrections_[32].distanceCorrection == 0.0)
   {
@@ -335,9 +335,8 @@ pcl::HDLGrabber::toPointClouds (HDLDataPacket *dataPacket)
   current_scan_xyzi_->header.seq = scan_counter;
   scan_counter++;
 
-  for (uint8_t i = 0; i < HDL_FIRING_PER_PKT; ++i)
+  for (const auto &firing_data : dataPacket->firingData)
   {
-    HDLFiringData firing_data = dataPacket->firingData[i];
     uint8_t offset = (firing_data.blockIdentifier == BLOCK_0_TO_31) ? 0 : 32;
 
     for (uint8_t j = 0; j < HDL_LASER_PER_FIRING; j++)

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -467,12 +467,12 @@ pcl::OBJReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
 
   if (material_files.size () > 0)
   {
-    for (std::size_t i = 0; i < material_files.size (); ++i)
+    for (const auto &material_file : material_files)
     {
       MTLReader companion;
-      if (companion.read (file_name, material_files[i]))
+      if (companion.read (file_name, material_file))
         PCL_WARN ("[pcl::OBJReader::readHeader] Problem reading material file %s\n",
-                  material_files[i].c_str ());
+                  material_file.c_str ());
       companions_.push_back (companion);
     }
   }
@@ -772,10 +772,10 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
       {
         mesh.tex_polygons.emplace_back();
         mesh.tex_materials.emplace_back();
-        for (std::size_t i = 0; i < companions_.size (); ++i)
+        for (auto &companion : companions_)
         {
-          std::vector<pcl::TexMaterial>::const_iterator mat_it = companions_[i].getMaterial (st[1]);
-          if (mat_it != companions_[i].materials_.end ())
+          std::vector<pcl::TexMaterial>::const_iterator mat_it = companion.getMaterial (st[1]);
+          if (mat_it != companion.materials_.end ())
           {
             mesh.tex_materials.back () = *mat_it;
             break;
@@ -1094,10 +1094,10 @@ pcl::io::saveOBJFile (const std::string &file_name,
   for (unsigned m = 0; m < nr_meshes; ++m)
   {
     fs << "# " << tex_mesh.tex_coordinates[m].size() << " vertex textures in submesh " << m <<  '\n';
-    for (size_t i = 0; i < tex_mesh.tex_coordinates[m].size (); ++i)
+    for (const auto &coordinate : tex_mesh.tex_coordinates[m])
     {
       fs << "vt ";
-      fs <<  tex_mesh.tex_coordinates[m][i][0] << " " << tex_mesh.tex_coordinates[m][i][1] << '\n';
+      fs <<  coordinate[0] << " " << coordinate[1] << '\n';
     }
   }
 

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -772,9 +772,9 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
       {
         mesh.tex_polygons.emplace_back();
         mesh.tex_materials.emplace_back();
-        for (auto &companion : companions_)
+        for (const auto &companion : companions_)
         {
-          std::vector<pcl::TexMaterial>::const_iterator mat_it = companion.getMaterial (st[1]);
+          auto mat_it = companion.getMaterial (st[1]);
           if (mat_it != companion.materials_.end ())
           {
             mesh.tex_materials.back () = *mat_it;

--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -544,9 +544,8 @@ pcl::io::openni2::OpenNI2Device::getDefaultIRMode () const
 {
   // Search for and return VGA@30 Hz mode
   vector<OpenNI2VideoMode> modeList = getSupportedIRVideoModes ();
-  for (vector<OpenNI2VideoMode>::iterator modeItr = modeList.begin (); modeItr != modeList.end (); ++modeItr)
+  for (const auto &mode : modeList)
   {
-    OpenNI2VideoMode mode = *modeItr;
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
       return mode;
   }
@@ -558,9 +557,8 @@ pcl::io::openni2::OpenNI2Device::getDefaultColorMode () const
 {
   // Search for and return VGA@30 Hz mode
   vector<OpenNI2VideoMode> modeList = getSupportedColorVideoModes ();
-  for (vector<OpenNI2VideoMode>::iterator modeItr = modeList.begin (); modeItr != modeList.end (); ++modeItr)
+  for (const auto &mode : modeList)
   {
-    OpenNI2VideoMode mode = *modeItr;
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
       return mode;
   }
@@ -572,9 +570,8 @@ pcl::io::openni2::OpenNI2Device::getDefaultDepthMode () const
 {
   // Search for and return VGA@30 Hz mode
   vector<OpenNI2VideoMode> modeList = getSupportedDepthVideoModes ();
-  for (vector<OpenNI2VideoMode>::iterator modeItr = modeList.begin (); modeItr != modeList.end (); ++modeItr)
+  for (const auto &mode : modeList)
   {
-    OpenNI2VideoMode mode = *modeItr;
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
       return mode;
   }
@@ -687,19 +684,19 @@ bool
 pcl::io::openni2::OpenNI2Device::findCompatibleVideoMode (const std::vector<OpenNI2VideoMode> supportedModes, const OpenNI2VideoMode& requested_mode, OpenNI2VideoMode& actual_mode) const
 {
   bool found = false;
-  for (std::vector<OpenNI2VideoMode>::const_iterator modeIt = supportedModes.begin (); modeIt != supportedModes.end (); ++modeIt)
+  for (const auto &supportedMode : supportedModes)
   {
-    if (modeIt->frame_rate_ == requested_mode.frame_rate_
-      && resizingSupported (modeIt->x_resolution_, modeIt->y_resolution_, requested_mode.x_resolution_, requested_mode.y_resolution_))
+    if (supportedMode.frame_rate_ == requested_mode.frame_rate_
+      && resizingSupported (supportedMode.x_resolution_, supportedMode.y_resolution_, requested_mode.x_resolution_, requested_mode.y_resolution_))
     {
       if (found)
       { // check whether the new mode is better -> smaller than the current one.
-        if (actual_mode.x_resolution_ * actual_mode.x_resolution_ > modeIt->x_resolution_ * modeIt->y_resolution_ )
-          actual_mode = *modeIt;
+        if (actual_mode.x_resolution_ * actual_mode.x_resolution_ > supportedMode.x_resolution_ * supportedMode.y_resolution_ )
+          actual_mode = supportedMode;
       }
       else
       {
-        actual_mode = *modeIt;
+        actual_mode = supportedMode;
         found = true;
       }
     }
@@ -880,8 +877,8 @@ std::ostream& pcl::io::openni2::operator<< (std::ostream& stream, const OpenNI2D
     stream << "IR sensor video modes:" << std::endl;
     const std::vector<OpenNI2VideoMode>& video_modes = device.getSupportedIRVideoModes ();
 
-    for (auto it = video_modes.cbegin (), it_end = video_modes.cend (); it != it_end; ++it)
-      stream << "   - " << *it << std::endl;
+    for (const auto &video_mode : video_modes)
+      stream << "   - " << video_mode << std::endl;
   }
   else
   {
@@ -893,8 +890,8 @@ std::ostream& pcl::io::openni2::operator<< (std::ostream& stream, const OpenNI2D
     stream << "Color sensor video modes:" << std::endl;
     const std::vector<OpenNI2VideoMode>& video_modes = device.getSupportedColorVideoModes ();
 
-    for (auto it = video_modes.cbegin (), it_end = video_modes.cend (); it != it_end; ++it)
-      stream << "   - " << *it << std::endl;
+    for (const auto &video_mode : video_modes)
+      stream << "   - " << video_mode << std::endl;
   }
   else
   {
@@ -906,8 +903,8 @@ std::ostream& pcl::io::openni2::operator<< (std::ostream& stream, const OpenNI2D
     stream << "Depth sensor video modes:" << std::endl;
     const std::vector<OpenNI2VideoMode>& video_modes = device.getSupportedDepthVideoModes ();
 
-    for (auto it = video_modes.cbegin (), it_end = video_modes.cend (); it != it_end; ++it)
-      stream << "   - " << *it << std::endl;
+    for (const auto &video_mode : video_modes)
+      stream << "   - " << video_mode << std::endl;
   }
   else
   {

--- a/io/src/openni2/openni2_device_manager.cpp
+++ b/io/src/openni2/openni2_device_manager.cpp
@@ -157,8 +157,8 @@ namespace pcl
 
             result->reserve (device_set_.size ());
 
-            for (auto it = device_set_.cbegin (), it_end = device_set_.cend (); it != it_end; ++it)
-              result->push_back (*it);
+            for (const auto &device : device_set_)
+              result->push_back (device);
 
             return result;
           }
@@ -246,12 +246,12 @@ operator<< (std::ostream& stream, const OpenNI2DeviceManager& device_manager)
 {
   auto device_info = device_manager.getConnectedDeviceInfos ();
 
-  for (auto it = device_info->cbegin (), it_end = device_info->cend (); it != it_end; ++it)
+  for (const auto &device : *device_info)
   {
-    stream << "Uri: " << it->uri_ << " (Vendor: " << it->vendor_ <<
-      ", Name: " << it->name_ <<
-      ", Vendor ID: " << it->vendor_id_ <<
-      ", Product ID: " << it->product_id_ <<
+    stream << "Uri: " << device.uri_ << " (Vendor: " << device.vendor_ <<
+      ", Name: " << device.name_ <<
+      ", Vendor ID: " << device.vendor_id_ <<
+      ", Product ID: " << device.product_id_ <<
       ")" << std::endl;
   }
 

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -849,10 +849,10 @@ pcl::io::OpenNI2Grabber::getAvailableDepthModes () const
 {
 pcl::io::openni2::OpenNI2VideoMode dummy;
   std::vector<std::pair<int, pcl::io::openni2::OpenNI2VideoMode> > result;
-  for (std::map<int, pcl::io::openni2::OpenNI2VideoMode>::const_iterator it = config2oni_map_.begin (); it != config2oni_map_.end (); ++it)
+  for (const auto &config2oni : config2oni_map_)
   {
-    if (device_->findCompatibleDepthMode (it->second, dummy))
-      result.emplace_back(*it);
+    if (device_->findCompatibleDepthMode (config2oni.second, dummy))
+      result.emplace_back(config2oni);
   }
 
   return (result);
@@ -864,10 +864,10 @@ pcl::io::OpenNI2Grabber::getAvailableImageModes () const
 {
 pcl::io::openni2::OpenNI2VideoMode dummy;
   std::vector<std::pair<int, pcl::io::openni2::OpenNI2VideoMode> > result;
-  for (std::map<int, pcl::io::openni2::OpenNI2VideoMode>::const_iterator it = config2oni_map_.begin (); it != config2oni_map_.end (); ++it)
+  for (const auto &config2oni : config2oni_map_)
   {
-    if (device_->findCompatibleColorMode (it->second, dummy))
-      result.emplace_back(*it);
+    if (device_->findCompatibleColorMode (config2oni.second, dummy))
+      result.emplace_back(config2oni);
   }
 
   return (result);

--- a/io/src/openni_camera/openni_device.cpp
+++ b/io/src/openni_camera/openni_device.cpp
@@ -873,9 +873,9 @@ openni_wrapper::OpenNIDevice::ImageDataThreadFunction ()
     image_lock.unlock ();
     
     boost::shared_ptr<Image> image = getCurrentImage (image_data);
-    for (std::map< OpenNIDevice::CallbackHandle, ActualImageCallbackFunction >::iterator callbackIt = image_callback_.begin (); callbackIt != image_callback_.end (); ++callbackIt)
+    for (const auto &callback : image_callback_)
     {
-      callbackIt->second.operator()(image);
+      callback.second.operator()(image);
     }
   }
 }
@@ -903,10 +903,9 @@ openni_wrapper::OpenNIDevice::DepthDataThreadFunction ()
 
     boost::shared_ptr<DepthImage> depth_image ( new DepthImage (depth_data, baseline_, getDepthFocalLength (), shadow_value_, no_sample_value_) );
 
-    for (std::map< OpenNIDevice::CallbackHandle, ActualDepthImageCallbackFunction >::iterator callbackIt = depth_callback_.begin ();
-         callbackIt != depth_callback_.end (); ++callbackIt)
+    for (const auto &callback : depth_callback_)
     {
-      callbackIt->second.operator()(depth_image);
+      callback.second.operator()(depth_image);
     }
   }
 }
@@ -934,10 +933,9 @@ openni_wrapper::OpenNIDevice::IRDataThreadFunction ()
 
     boost::shared_ptr<IRImage> ir_image ( new IRImage (ir_data) );
 
-    for (std::map< OpenNIDevice::CallbackHandle, ActualIRImageCallbackFunction >::iterator callbackIt = ir_callback_.begin ();
-         callbackIt != ir_callback_.end (); ++callbackIt)
+    for (const auto &callback : ir_callback_)
     {
-      callbackIt->second.operator()(ir_image);
+      callback.second.operator()(ir_image);
     }
   }
 }
@@ -1117,18 +1115,18 @@ openni_wrapper::OpenNIDevice::findCompatibleImageMode (const XnMapOutputMode& ou
   else
   {
     bool found = false;
-    for (std::vector<XnMapOutputMode>::const_iterator modeIt = available_image_modes_.begin (); modeIt != available_image_modes_.end (); ++modeIt)
+    for (const auto &available_image_mode : available_image_modes_)
     {
-      if (modeIt->nFPS == output_mode.nFPS && isImageResizeSupported (modeIt->nXRes, modeIt->nYRes, output_mode.nXRes, output_mode.nYRes))
+      if (available_image_mode.nFPS == output_mode.nFPS && isImageResizeSupported (available_image_mode.nXRes, available_image_mode.nYRes, output_mode.nXRes, output_mode.nYRes))
       {
         if (found)
         { // check whether the new mode is better -> smaller than the current one.
-          if (mode.nXRes * mode.nYRes > modeIt->nXRes * modeIt->nYRes )
-            mode = *modeIt;
+          if (mode.nXRes * mode.nYRes > available_image_mode.nXRes * available_image_mode.nYRes )
+            mode = available_image_mode;
         }
         else
         {
-          mode = *modeIt;
+          mode = available_image_mode;
           found = true;
         }
       }
@@ -1149,18 +1147,18 @@ openni_wrapper::OpenNIDevice::findCompatibleDepthMode (const XnMapOutputMode& ou
   else
   {
     bool found = false;
-    for (std::vector<XnMapOutputMode>::const_iterator modeIt = available_depth_modes_.begin (); modeIt != available_depth_modes_.end (); ++modeIt)
+    for (const auto &available_depth_mode : available_depth_modes_)
     {
-      if (modeIt->nFPS == output_mode.nFPS && isImageResizeSupported (modeIt->nXRes, modeIt->nYRes, output_mode.nXRes, output_mode.nYRes))
+      if (available_depth_mode.nFPS == output_mode.nFPS && isImageResizeSupported (available_depth_mode.nXRes, available_depth_mode.nYRes, output_mode.nXRes, output_mode.nYRes))
       {
         if (found)
         { // check whether the new mode is better -> smaller than the current one.
-          if (mode.nXRes * mode.nYRes > modeIt->nXRes * modeIt->nYRes )
-            mode = *modeIt;
+          if (mode.nXRes * mode.nYRes > available_depth_mode.nXRes * available_depth_mode.nYRes )
+            mode = available_depth_mode;
         }
         else
         {
-          mode = *modeIt;
+          mode = available_depth_mode;
           found = true;
         }
       }
@@ -1173,9 +1171,9 @@ openni_wrapper::OpenNIDevice::findCompatibleDepthMode (const XnMapOutputMode& ou
 bool 
 openni_wrapper::OpenNIDevice::isImageModeSupported (const XnMapOutputMode& output_mode) const throw ()
 {
-  for (std::vector<XnMapOutputMode>::const_iterator modeIt = available_image_modes_.begin (); modeIt != available_image_modes_.end (); ++modeIt)
+  for (const auto &available_image_mode : available_image_modes_)
   {
-    if (modeIt->nFPS == output_mode.nFPS && modeIt->nXRes == output_mode.nXRes && modeIt->nYRes == output_mode.nYRes)
+    if (available_image_mode.nFPS == output_mode.nFPS && available_image_mode.nXRes == output_mode.nXRes && available_image_mode.nYRes == output_mode.nYRes)
       return (true);
   }
   return (false);
@@ -1185,9 +1183,9 @@ openni_wrapper::OpenNIDevice::isImageModeSupported (const XnMapOutputMode& outpu
 bool 
 openni_wrapper::OpenNIDevice::isDepthModeSupported (const XnMapOutputMode& output_mode) const throw ()
 {
-  for (std::vector<XnMapOutputMode>::const_iterator modeIt = available_depth_modes_.begin (); modeIt != available_depth_modes_.end (); ++modeIt)
+  for (const auto &available_depth_mode : available_depth_modes_)
   {
-    if (modeIt->nFPS == output_mode.nFPS && modeIt->nXRes == output_mode.nXRes && modeIt->nYRes == output_mode.nYRes)
+    if (available_depth_mode.nFPS == output_mode.nFPS && available_depth_mode.nXRes == output_mode.nXRes && available_depth_mode.nYRes == output_mode.nYRes)
       return (true);
   }
   return (false);

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -190,25 +190,25 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
 
 
   // redundant, but needed for Windows right now and also for Xtion
-  for (const auto &deviceIdx : device_context_)
+  for (const auto &device : device_context_)
   {
     unsigned short product_id;
     unsigned short vendor_id;
 
-    getDeviceType(deviceIdx.device_node.GetCreationInfo (), vendor_id, product_id );
+    getDeviceType(device.device_node.GetCreationInfo (), vendor_id, product_id );
 
 #if _WIN32
     if (vendor_id == 0x45e)
     {
-      strcpy (const_cast<char*> (device_context_[deviceIdx].device_node.GetDescription ().strVendor), "Microsoft");
-      strcpy (const_cast<char*> (device_context_[deviceIdx].device_node.GetDescription ().strName), "Xbox NUI Camera");
+      strcpy (const_cast<char*> (device_context_[device].device_node.GetDescription ().strVendor), "Microsoft");
+      strcpy (const_cast<char*> (device_context_[device].device_node.GetDescription ().strName), "Xbox NUI Camera");
     }
     else
 #endif
-    if (vendor_id == 0x1d27 && deviceIdx.image_node.get () == 0)
+    if (vendor_id == 0x1d27 && device.image_node.get () == 0)
     {
-      strcpy (const_cast<char*> (deviceIdx.device_node.GetDescription ().strVendor), "ASUS");
-      strcpy (const_cast<char*> (deviceIdx.device_node.GetDescription ().strName), "Xtion Pro");
+      strcpy (const_cast<char*> (device.device_node.GetDescription ().strVendor), "ASUS");
+      strcpy (const_cast<char*> (device.device_node.GetDescription ().strName), "Xtion Pro");
     }
   }
   return (static_cast<unsigned int> (device_context_.size ()));

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -190,12 +190,12 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
 
 
   // redundant, but needed for Windows right now and also for Xtion
-  for (size_t deviceIdx = 0; deviceIdx < device_context_.size (); ++deviceIdx)
+  for (const auto &deviceIdx : device_context_)
   {
     unsigned short product_id;
     unsigned short vendor_id;
 
-    getDeviceType(device_context_[deviceIdx].device_node.GetCreationInfo (), vendor_id, product_id );
+    getDeviceType(deviceIdx.device_node.GetCreationInfo (), vendor_id, product_id );
 
 #if _WIN32
     if (vendor_id == 0x45e)
@@ -205,10 +205,10 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
     }
     else
 #endif
-    if (vendor_id == 0x1d27 && device_context_[deviceIdx].image_node.get () == 0)
+    if (vendor_id == 0x1d27 && deviceIdx.image_node.get () == 0)
     {
-      strcpy (const_cast<char*> (device_context_[deviceIdx].device_node.GetDescription ().strVendor), "ASUS");
-      strcpy (const_cast<char*> (device_context_[deviceIdx].device_node.GetDescription ().strName), "Xtion Pro");
+      strcpy (const_cast<char*> (deviceIdx.device_node.GetDescription ().strVendor), "ASUS");
+      strcpy (const_cast<char*> (deviceIdx.device_node.GetDescription ().strName), "Xtion Pro");
     }
   }
   return (static_cast<unsigned int> (device_context_.size ()));

--- a/io/src/openni_grabber.cpp
+++ b/io/src/openni_grabber.cpp
@@ -857,10 +857,10 @@ pcl::OpenNIGrabber::getAvailableDepthModes () const
 {
   XnMapOutputMode dummy;
   std::vector<std::pair<int, XnMapOutputMode> > result;
-  for (std::map<int, XnMapOutputMode>::const_iterator it = config2xn_map_.begin (); it != config2xn_map_.end (); ++it)
+  for (const auto &config2xn : config2xn_map_)
   {
-    if (device_->findCompatibleDepthMode (it->second, dummy))
-      result.emplace_back(*it);
+    if (device_->findCompatibleDepthMode (config2xn.second, dummy))
+      result.emplace_back(config2xn);
   }
 
   return (result);
@@ -872,10 +872,10 @@ pcl::OpenNIGrabber::getAvailableImageModes () const
 {
   XnMapOutputMode dummy;
   std::vector<std::pair<int, XnMapOutputMode> > result;
-  for (std::map<int, XnMapOutputMode>::const_iterator it = config2xn_map_.begin (); it != config2xn_map_.end (); ++it)
+  for (const auto &config2xn : config2xn_map_)
   {
-    if (device_->findCompatibleImageMode (it->second, dummy))
-      result.emplace_back(*it);
+    if (device_->findCompatibleImageMode (config2xn.second, dummy))
+      result.emplace_back(config2xn);
   }
 
   return (result);

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -580,13 +580,13 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
     std::vector<pcl::PCLPointField> fields (cloud.fields.size ());
     std::vector<int> fields_sizes (cloud.fields.size ());
     int nri = 0, fsize = 0;
-    for (size_t i = 0; i < cloud.fields.size (); ++i)
+    for (const auto &field : cloud.fields)
     {
-      if (cloud.fields[i].name == "_")
+      if (field.name == "_")
         continue;
-      fields_sizes[nri] = cloud.fields[i].count * pcl::getFieldSize (cloud.fields[i].datatype);
+      fields_sizes[nri] = field.count * pcl::getFieldSize (field.datatype);
       fsize += fields_sizes[nri];
-      fields[nri] = cloud.fields[i];
+      fields[nri] = field;
       ++nri;
     }
     fields.resize (nri);
@@ -972,8 +972,8 @@ pcl::PCDWriter::generateHeaderBinary (const pcl::PCLPointCloud2 &cloud,
 
   // Compute the total size of the fields
   unsigned int fsize = 0;
-  for (size_t i = 0; i < cloud.fields.size (); ++i)
-    fsize += cloud.fields[i].count * getFieldSize (cloud.fields[i].datatype);
+  for (const auto &field : cloud.fields)
+    fsize += field.count * getFieldSize (field.datatype);
 
   // The size of the fields cannot be larger than point_step
   if (fsize > cloud.point_step)
@@ -1054,8 +1054,8 @@ pcl::PCDWriter::generateHeaderBinaryCompressed (std::ostream &os,
 
   // Compute the total size of the fields
   unsigned int fsize = 0;
-  for (size_t i = 0; i < cloud.fields.size (); ++i)
-    fsize += cloud.fields[i].count * getFieldSize (cloud.fields[i].datatype);
+  for (const auto &field : cloud.fields)
+    fsize += field.count * getFieldSize (field.datatype);
 
   // The size of the fields cannot be larger than point_step
   if (fsize > cloud.point_step)
@@ -1066,15 +1066,15 @@ pcl::PCDWriter::generateHeaderBinaryCompressed (std::ostream &os,
 
   std::stringstream field_names, field_types, field_sizes, field_counts;
   // Check if the size of the fields is smaller than the size of the point step
-  for (size_t i = 0; i < cloud.fields.size (); ++i)
+  for (const auto &field : cloud.fields)
   {
-    if (cloud.fields[i].name == "_")
+    if (field.name == "_")
       continue;
     // Add the regular dimension
-    field_names << " " << cloud.fields[i].name;
-    field_sizes << " " << pcl::getFieldSize (cloud.fields[i].datatype);
-    field_types << " " << pcl::getFieldType (cloud.fields[i].datatype);
-    int count = abs (static_cast<int> (cloud.fields[i].count));
+    field_names << " " << field.name;
+    field_sizes << " " << pcl::getFieldSize (field.datatype);
+    field_types << " " << pcl::getFieldType (field.datatype);
+    int count = abs (static_cast<int> (field.count));
     if (count == 0) count = 1;  // check for 0 counts (coming from older converter code)
     field_counts << " " << count;
   }
@@ -1356,14 +1356,14 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
   std::vector<pcl::PCLPointField> fields (cloud.fields.size ());
   std::vector<int> fields_sizes (cloud.fields.size ());
   // Compute the total size of the fields
-  for (size_t i = 0; i < cloud.fields.size (); ++i)
+  for (const auto &field : cloud.fields)
   {
-    if (cloud.fields[i].name == "_")
+    if (field.name == "_")
       continue;
 
-    fields_sizes[nri] = cloud.fields[i].count * pcl::getFieldSize (cloud.fields[i].datatype);
+    fields_sizes[nri] = field.count * pcl::getFieldSize (field.datatype);
     fsize += fields_sizes[nri];
-    fields[nri] = cloud.fields[i];
+    fields[nri] = field;
     ++nri;
   }
   fields_sizes.resize (nri);

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -620,16 +620,16 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
     {
       if ((*range_grid_)[r].size () == 0)
       {
-        for (size_t f = 0; f < cloud_->fields.size (); ++f)
-          if (cloud_->fields[f].datatype == ::pcl::PCLPointField::FLOAT32)
-            memcpy (&data[r * cloud_->point_step + cloud_->fields[f].offset],
+        for (const auto &field : cloud_->fields)
+          if (field.datatype == ::pcl::PCLPointField::FLOAT32)
+            memcpy (&data[r * cloud_->point_step + field.offset],
                     reinterpret_cast<const char*> (&f_nan), sizeof (float));
-          else if (cloud_->fields[f].datatype == ::pcl::PCLPointField::FLOAT64)
-            memcpy (&data[r * cloud_->point_step + cloud_->fields[f].offset],
+          else if (field.datatype == ::pcl::PCLPointField::FLOAT64)
+            memcpy (&data[r * cloud_->point_step + field.offset],
                     reinterpret_cast<const char*> (&d_nan), sizeof (double));
           else
-            memset (&data[r * cloud_->point_step + cloud_->fields[f].offset], 0,
-                    pcl::getFieldSize (cloud_->fields[f].datatype) * cloud_->fields[f].count);
+            memset (&data[r * cloud_->point_step + field.offset], 0,
+                    pcl::getFieldSize (field.datatype) * field.count);
       }
       else
         memcpy (&data[r* cloud_->point_step], &cloud_->data[(*range_grid_)[r][0] * cloud_->point_step], cloud_->point_step);
@@ -640,14 +640,14 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
   orientation_ = Eigen::Quaternionf (orientation);
   origin_ = origin;
 
-  for (size_t i = 0; i < cloud_->fields.size (); ++i)
+  for (auto &field : cloud_->fields)
   {
-    if (cloud_->fields[i].name == "nx")
-      cloud_->fields[i].name = "normal_x";
-    if (cloud_->fields[i].name == "ny")
-      cloud_->fields[i].name = "normal_y";
-    if (cloud_->fields[i].name == "nz")
-      cloud_->fields[i].name = "normal_z";
+    if (field.name == "nx")
+      field.name = "normal_x";
+    if (field.name == "ny")
+      field.name = "normal_y";
+    if (field.name == "nz")
+      field.name = "normal_z";
   }
   return (0);
 }
@@ -680,16 +680,16 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
     {
       if ((*range_grid_)[r].size () == 0)
       {
-        for (size_t f = 0; f < cloud_->fields.size (); ++f)
-          if (cloud_->fields[f].datatype == ::pcl::PCLPointField::FLOAT32)
-            memcpy (&data[r * cloud_->point_step + cloud_->fields[f].offset],
+        for (const auto &field : cloud_->fields)
+          if (field.datatype == ::pcl::PCLPointField::FLOAT32)
+            memcpy (&data[r * cloud_->point_step + field.offset],
                     reinterpret_cast<const char*> (&f_nan), sizeof (float));
-          else if (cloud_->fields[f].datatype == ::pcl::PCLPointField::FLOAT64)
-            memcpy (&data[r * cloud_->point_step + cloud_->fields[f].offset],
+          else if (field.datatype == ::pcl::PCLPointField::FLOAT64)
+            memcpy (&data[r * cloud_->point_step + field.offset],
                     reinterpret_cast<const char*> (&d_nan), sizeof (double));
           else
-            memset (&data[r * cloud_->point_step + cloud_->fields[f].offset], 0,
-                    pcl::getFieldSize (cloud_->fields[f].datatype) * cloud_->fields[f].count);
+            memset (&data[r * cloud_->point_step + field.offset], 0,
+                    pcl::getFieldSize (field.datatype) * field.count);
       }
       else
         memcpy (&data[r* cloud_->point_step], &cloud_->data[(*range_grid_)[r][0] * cloud_->point_step], cloud_->point_step);
@@ -700,14 +700,14 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
   orientation_ = Eigen::Quaternionf (orientation);
   origin_ = origin;
 
-  for (size_t i = 0; i < cloud_->fields.size (); ++i)
+  for (auto &field : cloud_->fields)
   {
-    if (cloud_->fields[i].name == "nx")
-      cloud_->fields[i].name = "normal_x";
-    if (cloud_->fields[i].name == "ny")
-      cloud_->fields[i].name = "normal_y";
-    if (cloud_->fields[i].name == "nz")
-      cloud_->fields[i].name = "normal_z";
+    if (field.name == "nx")
+      field.name = "normal_x";
+    if (field.name == "ny")
+      field.name = "normal_y";
+    if (field.name == "nz")
+      field.name = "normal_z";
   }
   return (0);
 }
@@ -766,27 +766,27 @@ pcl::PLYWriter::generateHeader (const pcl::PCLPointCloud2 &cloud,
 
   oss << "\nelement vertex "<< valid_points;
 
-  for (std::size_t i = 0; i < cloud.fields.size (); ++i)
+  for (const auto &field : cloud.fields)
   {
-    if (cloud.fields[i].name == "normal_x")
+    if (field.name == "normal_x")
     {
       oss << "\nproperty float nx";
     }
-    else if (cloud.fields[i].name == "normal_y")
+    else if (field.name == "normal_y")
     {
       oss << "\nproperty float ny";
     }
-    else if (cloud.fields[i].name == "normal_z")
+    else if (field.name == "normal_z")
     {
       oss << "\nproperty float nz";
     }
-    else if (cloud.fields[i].name == "rgb")
+    else if (field.name == "rgb")
     {
       oss << "\nproperty uchar red"
         "\nproperty uchar green"
         "\nproperty uchar blue";
     }
-    else if (cloud.fields[i].name == "rgba")
+    else if (field.name == "rgba")
     {
       oss << "\nproperty uchar red"
         "\nproperty uchar green"
@@ -796,9 +796,9 @@ pcl::PLYWriter::generateHeader (const pcl::PCLPointCloud2 &cloud,
     else
     {
       oss << "\nproperty";
-      if (cloud.fields[i].count != 1)
+      if (field.count != 1)
         oss << " list uint";
-      switch (cloud.fields[i].datatype)
+      switch (field.datatype)
       {
         case pcl::PCLPointField::INT8 : oss << " char "; break;
         case pcl::PCLPointField::UINT8 : oss << " uchar "; break;
@@ -814,7 +814,7 @@ pcl::PLYWriter::generateHeader (const pcl::PCLPointCloud2 &cloud,
           return ("");
         }
       }
-      oss << cloud.fields[i].name;
+      oss << field.name;
     }
   }
 
@@ -1767,10 +1767,9 @@ pcl::io::savePLYFileBinary (const std::string &file_name, const pcl::PolygonMesh
   {
     unsigned char value = static_cast<unsigned char> (mesh.polygons[i].vertices.size ());
     fpout.write (reinterpret_cast<const char*> (&value), sizeof (unsigned char));
-    for (size_t j = 0; j < mesh.polygons[i].vertices.size (); ++j)
+    for (const int value : mesh.polygons[i].vertices)
     {
       //fs << mesh.polygons[i].vertices[j] << " ";
-      int value = mesh.polygons[i].vertices[j];
       fpout.write (reinterpret_cast<const char*> (&value), sizeof (int));
     }
   }

--- a/io/tools/converter.cpp
+++ b/io/tools/converter.cpp
@@ -218,8 +218,8 @@ main (int argc,
   supported_extensions.emplace_back("vtk");
   std::vector<int> file_args;
   for (int i = 1; i < argc; ++i)
-    for (size_t j = 0; j < supported_extensions.size(); ++j)
-      if (boost::algorithm::ends_with(argv[i], supported_extensions[j]))
+    for (const auto &supported_extension : supported_extensions)
+      if (boost::algorithm::ends_with(argv[i], supported_extension))
       {
         file_args.push_back(i);
         break;

--- a/io/tools/pcd_introduce_nan.cpp
+++ b/io/tools/pcd_introduce_nan.cpp
@@ -63,7 +63,7 @@ main (int argc,
   if (pcl::io::loadPCDFile (argv[1], *cloud) != 0)
     return (-1);
 
-  for (PointCloudT::iterator cloud_it (cloud->begin ()); cloud_it != cloud->end (); ++cloud_it)
+  for (auto &point : *cloud)
   {
     int random = 1 + (rand () % (int) (100));
     int random_xyz = 1 + (rand () % (int) (3 - 1 + 1));
@@ -71,11 +71,11 @@ main (int argc,
     if (random < percentage_of_NaN)
     {
       if (random_xyz == 1)
-        cloud_it->x = std::numeric_limits<double>::quiet_NaN ();
+        point.x = std::numeric_limits<double>::quiet_NaN ();
       else if (random_xyz == 2)
-        cloud_it->y = std::numeric_limits<double>::quiet_NaN ();
+        point.y = std::numeric_limits<double>::quiet_NaN ();
       else
-        cloud_it->z = std::numeric_limits<double>::quiet_NaN ();
+        point.z = std::numeric_limits<double>::quiet_NaN ();
     }
   }
 


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix