### PR TITLE
Transform classic loops to range-based for loops in module keypoints

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -120,15 +120,15 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::calculateNormalCovar (const
 
   float zz = 0;
 
-  for (std::vector<int>::const_iterator iIt = neighbors.begin(); iIt != neighbors.end(); ++iIt)
+  for (const int neighbor : neighbors)
   {
-    if (std::isfinite (normals_->points[*iIt].normal_x))
+    if (std::isfinite (normals_->points[neighbor].normal_x))
     {
       // nx, ny, nz, h
-      norm1 = _mm_load_ps (&(normals_->points[*iIt].normal_x));
+      norm1 = _mm_load_ps (&(normals_->points[neighbor].normal_x));
 
       // nx, nx, nx, nx
-      norm2 = _mm_set1_ps (normals_->points[*iIt].normal_x);
+      norm2 = _mm_set1_ps (normals_->points[neighbor].normal_x);
 
       // nx * nx, nx * ny, nx * nz, nx * h
       norm2 = _mm_mul_ps (norm1, norm2);
@@ -137,7 +137,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::calculateNormalCovar (const
       vec1 = _mm_add_ps (vec1, norm2);
 
       // ny, ny, ny, ny
-      norm2 = _mm_set1_ps (normals_->points[*iIt].normal_y);
+      norm2 = _mm_set1_ps (normals_->points[neighbor].normal_y);
 
       // ny * nx, ny * ny, ny * nz, ny * h
       norm2 = _mm_mul_ps (norm1, norm2);
@@ -145,7 +145,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::calculateNormalCovar (const
       // accumulate
       vec2 = _mm_add_ps (vec2, norm2);
 
-      zz += normals_->points[*iIt].normal_z * normals_->points[*iIt].normal_z;
+      zz += normals_->points[neighbor].normal_z * normals_->points[neighbor].normal_z;
       ++count;
     }
   }

--- a/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
@@ -77,36 +77,36 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::calculateCombinedCovar (con
 {
   memset (coefficients, 0, sizeof (float) * 21);
   unsigned count = 0;
-  for (std::vector<int>::const_iterator iIt = neighbors.begin(); iIt != neighbors.end(); ++iIt)
+  for (const int neighbor : neighbors)
   {
-    if (std::isfinite (normals_->points[*iIt].normal_x) && std::isfinite (intensity_gradients_->points[*iIt].gradient [0]))
+    if (std::isfinite (normals_->points[neighbor].normal_x) && std::isfinite (intensity_gradients_->points[neighbor].gradient [0]))
     {
-      coefficients[ 0] += normals_->points[*iIt].normal_x * normals_->points[*iIt].normal_x;
-      coefficients[ 1] += normals_->points[*iIt].normal_x * normals_->points[*iIt].normal_y;
-      coefficients[ 2] += normals_->points[*iIt].normal_x * normals_->points[*iIt].normal_z;
-      coefficients[ 3] += normals_->points[*iIt].normal_x * intensity_gradients_->points[*iIt].gradient [0];
-      coefficients[ 4] += normals_->points[*iIt].normal_x * intensity_gradients_->points[*iIt].gradient [1];
-      coefficients[ 5] += normals_->points[*iIt].normal_x * intensity_gradients_->points[*iIt].gradient [2];
+      coefficients[ 0] += normals_->points[neighbor].normal_x * normals_->points[neighbor].normal_x;
+      coefficients[ 1] += normals_->points[neighbor].normal_x * normals_->points[neighbor].normal_y;
+      coefficients[ 2] += normals_->points[neighbor].normal_x * normals_->points[neighbor].normal_z;
+      coefficients[ 3] += normals_->points[neighbor].normal_x * intensity_gradients_->points[neighbor].gradient [0];
+      coefficients[ 4] += normals_->points[neighbor].normal_x * intensity_gradients_->points[neighbor].gradient [1];
+      coefficients[ 5] += normals_->points[neighbor].normal_x * intensity_gradients_->points[neighbor].gradient [2];
 
-      coefficients[ 6] += normals_->points[*iIt].normal_y * normals_->points[*iIt].normal_y;
-      coefficients[ 7] += normals_->points[*iIt].normal_y * normals_->points[*iIt].normal_z;
-      coefficients[ 8] += normals_->points[*iIt].normal_y * intensity_gradients_->points[*iIt].gradient [0];
-      coefficients[ 9] += normals_->points[*iIt].normal_y * intensity_gradients_->points[*iIt].gradient [1];
-      coefficients[10] += normals_->points[*iIt].normal_y * intensity_gradients_->points[*iIt].gradient [2];
+      coefficients[ 6] += normals_->points[neighbor].normal_y * normals_->points[neighbor].normal_y;
+      coefficients[ 7] += normals_->points[neighbor].normal_y * normals_->points[neighbor].normal_z;
+      coefficients[ 8] += normals_->points[neighbor].normal_y * intensity_gradients_->points[neighbor].gradient [0];
+      coefficients[ 9] += normals_->points[neighbor].normal_y * intensity_gradients_->points[neighbor].gradient [1];
+      coefficients[10] += normals_->points[neighbor].normal_y * intensity_gradients_->points[neighbor].gradient [2];
 
-      coefficients[11] += normals_->points[*iIt].normal_z * normals_->points[*iIt].normal_z;
-      coefficients[12] += normals_->points[*iIt].normal_z * intensity_gradients_->points[*iIt].gradient [0];
-      coefficients[13] += normals_->points[*iIt].normal_z * intensity_gradients_->points[*iIt].gradient [1];
-      coefficients[14] += normals_->points[*iIt].normal_z * intensity_gradients_->points[*iIt].gradient [2];
+      coefficients[11] += normals_->points[neighbor].normal_z * normals_->points[neighbor].normal_z;
+      coefficients[12] += normals_->points[neighbor].normal_z * intensity_gradients_->points[neighbor].gradient [0];
+      coefficients[13] += normals_->points[neighbor].normal_z * intensity_gradients_->points[neighbor].gradient [1];
+      coefficients[14] += normals_->points[neighbor].normal_z * intensity_gradients_->points[neighbor].gradient [2];
 
-      coefficients[15] += intensity_gradients_->points[*iIt].gradient [0] * intensity_gradients_->points[*iIt].gradient [0];
-      coefficients[16] += intensity_gradients_->points[*iIt].gradient [0] * intensity_gradients_->points[*iIt].gradient [1];
-      coefficients[17] += intensity_gradients_->points[*iIt].gradient [0] * intensity_gradients_->points[*iIt].gradient [2];
+      coefficients[15] += intensity_gradients_->points[neighbor].gradient [0] * intensity_gradients_->points[neighbor].gradient [0];
+      coefficients[16] += intensity_gradients_->points[neighbor].gradient [0] * intensity_gradients_->points[neighbor].gradient [1];
+      coefficients[17] += intensity_gradients_->points[neighbor].gradient [0] * intensity_gradients_->points[neighbor].gradient [2];
 
-      coefficients[18] += intensity_gradients_->points[*iIt].gradient [1] * intensity_gradients_->points[*iIt].gradient [1];
-      coefficients[19] += intensity_gradients_->points[*iIt].gradient [1] * intensity_gradients_->points[*iIt].gradient [2];
+      coefficients[18] += intensity_gradients_->points[neighbor].gradient [1] * intensity_gradients_->points[neighbor].gradient [1];
+      coefficients[19] += intensity_gradients_->points[neighbor].gradient [1] * intensity_gradients_->points[neighbor].gradient [2];
 
-      coefficients[20] += intensity_gradients_->points[*iIt].gradient [2] * intensity_gradients_->points[*iIt].gradient [2];
+      coefficients[20] += intensity_gradients_->points[neighbor].gradient [2] * intensity_gradients_->points[neighbor].gradient [2];
 
       ++count;
     }

--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -314,9 +314,9 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
 
       this->searchForNeighbors (static_cast<int> (index), border_radius_, nn_indices, nn_distances);
 
-      for (size_t j = 0 ; j < nn_indices.size (); j++)
+      for (const int nn_index : nn_indices)
       {
-        if (edge_points_[nn_indices[j]])
+        if (edge_points_[nn_index])
         {
           borders[index] = true;
           break;

--- a/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
@@ -191,11 +191,9 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::detectKeypointsForOctave (
   else
   {
     // Add keypoints to output
-    for (size_t i_keypoint = 0; i_keypoint < extrema_indices.size (); ++i_keypoint)
+    for (const int keypoint_index : extrema_indices)
     {
       PointOutT keypoint;
-      const int &keypoint_index = extrema_indices[i_keypoint];
-   
       keypoint.x = input.points[keypoint_index].x;
       keypoint.y = input.points[keypoint_index].y;
       keypoint.z = input.points[keypoint_index].z;

--- a/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
@@ -103,12 +103,12 @@ pcl::SmoothedSurfacesKeypoint<PointT, PointNT>::detectKeypoints (PointCloudT &ou
     input_tree->radiusSearch (point_i, input_scale_ * neighborhood_constant_, nn_indices, nn_distances);
 
     bool is_min = true, is_max = true;
-    for (std::vector<int>::iterator nn_it = nn_indices.begin (); nn_it != nn_indices.end (); ++nn_it)
-      if (*nn_it != point_i)
+    for (const int nn_index : nn_indices)
+      if (nn_index != point_i)
       {
-        if (diffs[input_index_][point_i] < diffs[input_index_][*nn_it])
+        if (diffs[input_index_][point_i] < diffs[input_index_][nn_index])
           is_max = false;
-        else if (diffs[input_index_][point_i] > diffs[input_index_][*nn_it])
+        else if (diffs[input_index_][point_i] > diffs[input_index_][nn_index])
           is_min = false;
       }
 
@@ -127,12 +127,12 @@ pcl::SmoothedSurfacesKeypoint<PointT, PointNT>::detectKeypoints (PointCloudT &ou
         cloud_trees_[cloud_i]->radiusSearch (point_i, scales_[scale_i].first * neighborhood_constant_, nn_indices, nn_distances);
 
         bool is_min_other_scale = true, is_max_other_scale = true;
-        for (std::vector<int>::iterator nn_it = nn_indices.begin (); nn_it != nn_indices.end (); ++nn_it)
-          if (*nn_it != point_i)
+        for (const int nn_index : nn_indices)
+          if (nn_index != point_i)
           {
-            if (diffs[input_index_][point_i] < diffs[cloud_i][*nn_it])
+            if (diffs[input_index_][point_i] < diffs[cloud_i][nn_index])
               is_max_other_scale = false;
-            else if (diffs[input_index_][point_i] > diffs[cloud_i][*nn_it])
+            else if (diffs[input_index_][point_i] > diffs[cloud_i][nn_index])
               is_min_other_scale = false;
           }
 

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -372,8 +372,8 @@ NarfKeypoint::calculateCompleteInterestImage ()
       }
       
       // Reset was_touched to false
-      for (size_t neighbors_to_check_idx=0; neighbors_to_check_idx<neighbors_to_check.size (); ++neighbors_to_check_idx)
-        was_touched[neighbors_to_check[neighbors_to_check_idx]] = false;
+      for (const int neighbors_to_check_idx : neighbors_to_check)
+        was_touched[neighbors_to_check_idx] = false;
       
       float angle_change_value = 0.0f;
       for (int histogram_cell1=0; histogram_cell1<angle_histogram_size-1; ++histogram_cell1)
@@ -552,8 +552,8 @@ NarfKeypoint::calculateSparseInterestImage ()
     }
     
     // Reset was_touched to false
-    for (size_t neighbors_to_check_idx=0; neighbors_to_check_idx<neighbors_to_check.size (); ++neighbors_to_check_idx)
-      was_touched[neighbors_to_check[neighbors_to_check_idx]] = false;
+    for (const int neighbors_to_check_idx : neighbors_to_check)
+      was_touched[neighbors_to_check_idx] = false;
     
     float angle_change_value = 0.0f;
     for (int histogram_cell1=0; histogram_cell1<angle_histogram_size-1; ++histogram_cell1)
@@ -586,8 +586,8 @@ NarfKeypoint::calculateSparseInterestImage ()
     // Every point in distance search_radius cannot have a higher value
     // Therefore: if too low, set all to zero. Else calculate properly
     if (maximum_interest_value < parameters_.min_interest_value)
-      for (size_t neighbors_idx=0; neighbors_idx<neighbors_within_radius_overhead.size (); ++neighbors_idx)
-        interest_image_[neighbors_within_radius_overhead[neighbors_idx]] = 0.0f;
+      for (const int neighbors_idx : neighbors_within_radius_overhead)
+        interest_image_[neighbors_idx] = 0.0f;
     else
     {
       // Reduce number of neighbors to go through by filtering close by points with the same angle
@@ -624,9 +624,8 @@ NarfKeypoint::calculateSparseInterestImage ()
       }
 
       // Caclulate interest values for neighbors
-      for (size_t neighbors_idx=0; neighbors_idx<neighbors_within_radius_overhead.size (); ++neighbors_idx)
+      for (const int index2 : neighbors_within_radius_overhead)
       {
-        int index2 = neighbors_within_radius_overhead[neighbors_idx];
         int y2 = index2/range_image.width,
             x2 = index2 - y2*range_image.width;
         const PointWithRange& point2 = range_image.getPoint (index2);
@@ -640,13 +639,13 @@ NarfKeypoint::calculateSparseInterestImage ()
           float& histogram_value = angle_histogram[angle_histogram_idx];
           histogram_value = 0;
           const std::vector<std::pair<int,float> >& relevent_point_indices = angle_elements[angle_histogram_idx];
-          for (size_t rpi_idx=0; rpi_idx<relevent_point_indices.size (); ++rpi_idx)
+          for (const auto &relevent_point_index : relevent_point_indices)
           {
-            int index3 = relevent_point_indices[rpi_idx].first;
+            int index3 = relevent_point_index.first;
             int y3 = index3/range_image.width,
                 x3 = index3 - y3*range_image.width;
             const PointWithRange& point3 = range_image.getPoint (index3);
-            float surface_change_score = relevent_point_indices[rpi_idx].second;
+            float surface_change_score = relevent_point_index.second;
             
             float pixelDistance = static_cast<float> (std::max (abs (x3-x2), abs (y3-y2)));
             float distance = (point3.getVector3fMap ()-point2.getVector3fMap ()).norm ();
@@ -832,16 +831,13 @@ NarfKeypoint::calculateInterestPoints ()
   std::sort (tmp_interest_points.begin (), tmp_interest_points.end (), isBetterInterestPoint);
   
   float min_distance_squared = powf (parameters_.min_distance_between_interest_points*parameters_.support_size, 2);
-  for (size_t int_point_idx=0; int_point_idx<tmp_interest_points.size (); ++int_point_idx)
+  for (const auto &interest_point : tmp_interest_points)
   {
     if (parameters_.max_no_of_interest_points > 0  &&  int (interest_points_->size ()) >= parameters_.max_no_of_interest_points)
       break;
-    const InterestPoint& interest_point = tmp_interest_points[int_point_idx];
-    
     bool better_point_too_close = false;
-    for (size_t int_point_idx2=0; int_point_idx2<interest_points_->points.size (); ++int_point_idx2)
+    for (const auto &interest_point2 : interest_points_->points)
     {
-      const InterestPoint& interest_point2 = interest_points_->points[int_point_idx2];
       float distance_squared = (interest_point.getVector3fMap ()-interest_point2.getVector3fMap ()).squaredNorm ();
       if (distance_squared < min_distance_squared)
       {


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix