### PR TITLE
Transform classic loops to range-based for loops in module octree

### DIFF
--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -66,14 +66,14 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 {
   if (indices_)
   {
-    for (std::vector<int>::const_iterator current = indices_->begin (); current != indices_->end (); ++current)
+    for (const int index : *indices_)
     {
-      assert( (*current>=0) && (*current < static_cast<int> (input_->points.size ())));
+      assert( (index >= 0) && (index < static_cast<int> (input_->points.size ())));
       
-      if (isFinite (input_->points[*current]))
+      if (isFinite (input_->points[index]))
       {
         // add points to octree
-        this->addPointIdx (*current);
+        this->addPointIdx (index);
       }
     }
   }
@@ -539,10 +539,10 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     // add data to new branch
     OctreeKey new_index_key;
 
-    for (auto it = leafIndices.cbegin(), it_end = leafIndices.cend(); it!=it_end; ++it)
+    for (const int leafIndex : leafIndices)
     {
 
-      const PointT& point_from_index = input_->points[*it];
+      const PointT& point_from_index = input_->points[leafIndex];
       // generate key
       genOctreeKeyforPoint (point_from_index, new_index_key);
 
@@ -550,7 +550,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
       BranchNode* newBranchParent;
       this->createLeafRecursive (new_index_key, depth_mask, childBranch, newLeaf, newBranchParent);
 
-      (*newLeaf)->addPointIndex(*it);
+      (*newLeaf)->addPointIndex(leafIndex);
     }
   }
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -66,7 +66,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 {
   if (indices_)
   {
-    for (const int index : *indices_)
+    for (const int &index : *indices_)
     {
       assert( (index >= 0) && (index < static_cast<int> (input_->points.size ())));
       
@@ -539,7 +539,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     // add data to new branch
     OctreeKey new_index_key;
 
-    for (const int leafIndex : leafIndices)
+    for (const int &leafIndex : leafIndices)
     {
 
       const PointT& point_from_index = input_->points[leafIndex];

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -361,9 +361,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
         (*child_leaf)->getPointIndices (decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (int &i : decoded_point_vector)
+        for (const int &index : decoded_point_vector)
         {
-          const PointT& candidate_point = this->getPointByIndex (i);
+          const PointT& candidate_point = this->getPointByIndex (index);
 
           // calculate point distance to search point
           squared_dist = pointSquaredDist (candidate_point, point);
@@ -373,7 +373,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
             continue;
 
           // add point to result vector
-          k_indices.push_back (i);
+          k_indices.push_back (index);
           k_sqr_distances.push_back (squared_dist);
 
           if (max_nn != 0 && k_indices.size () == static_cast<unsigned int> (max_nn))
@@ -454,9 +454,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::a
     (**child_leaf).getPointIndices (decoded_point_vector);
 
     // Linearly iterate over all decoded (unsorted) points
-    for (int &i : decoded_point_vector)
+    for (const int &index : decoded_point_vector)
     {
-      const PointT& candidate_point = this->getPointByIndex (i);
+      const PointT& candidate_point = this->getPointByIndex (index);
 
       // calculate point distance to search point
       double squared_dist = pointSquaredDist (candidate_point, point);
@@ -465,7 +465,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::a
       if (squared_dist >= smallest_squared_dist)
         continue;
 
-      result_index = i;
+      result_index = index;
       smallest_squared_dist = squared_dist;
       sqr_distance = static_cast<float> (squared_dist);
     }
@@ -535,9 +535,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::b
         (**child_leaf).getPointIndices (decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (int &i : decoded_point_vector)
+        for (const int &index : decoded_point_vector)
         {
-          const PointT& candidate_point = this->getPointByIndex (i);
+          const PointT& candidate_point = this->getPointByIndex (index);
 
           // check if point falls within search box
           bInBox = ( (candidate_point.x >= min_pt (0)) && (candidate_point.x <= max_pt (0)) &&
@@ -546,7 +546,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::b
 
           if (bInBox)
             // add to result vector
-            k_indices.push_back (i);
+            k_indices.push_back (index);
         }
       }
     }

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -270,7 +270,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
       (*child_leaf)->getPointIndices (decoded_point_vector);
 
       // Linearly iterate over all decoded (unsorted) points
-      for (const int point_index : decoded_point_vector)
+      for (const int &point_index : decoded_point_vector)
       {
 
         const PointT& candidate_point = this->getPointByIndex (point_index);
@@ -361,7 +361,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
         (*child_leaf)->getPointIndices (decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (int & i : decoded_point_vector)
+        for (int &i : decoded_point_vector)
         {
           const PointT& candidate_point = this->getPointByIndex (i);
 
@@ -454,7 +454,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::a
     (**child_leaf).getPointIndices (decoded_point_vector);
 
     // Linearly iterate over all decoded (unsorted) points
-    for (int & i : decoded_point_vector)
+    for (int &i : decoded_point_vector)
     {
       const PointT& candidate_point = this->getPointByIndex (i);
 
@@ -535,7 +535,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::b
         (**child_leaf).getPointIndices (decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (int & i : decoded_point_vector)
+        for (int &i : decoded_point_vector)
         {
           const PointT& candidate_point = this->getPointByIndex (i);
 

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -270,10 +270,10 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
       (*child_leaf)->getPointIndices (decoded_point_vector);
 
       // Linearly iterate over all decoded (unsorted) points
-      for (size_t i = 0; i < decoded_point_vector.size (); i++)
+      for (const int point_index : decoded_point_vector)
       {
 
-        const PointT& candidate_point = this->getPointByIndex (decoded_point_vector[i]);
+        const PointT& candidate_point = this->getPointByIndex (point_index);
 
         // calculate point distance to search point
         float squared_dist = pointSquaredDist (candidate_point, point);
@@ -284,7 +284,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
           prioPointQueueEntry point_entry;
 
           point_entry.point_distance_ = squared_dist;
-          point_entry.point_idx_ = decoded_point_vector[i];
+          point_entry.point_idx_ = point_index;
           point_candidates.push_back (point_entry);
         }
       }
@@ -361,9 +361,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
         (*child_leaf)->getPointIndices (decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (size_t i = 0; i < decoded_point_vector.size (); i++)
+        for (int & i : decoded_point_vector)
         {
-          const PointT& candidate_point = this->getPointByIndex (decoded_point_vector[i]);
+          const PointT& candidate_point = this->getPointByIndex (i);
 
           // calculate point distance to search point
           squared_dist = pointSquaredDist (candidate_point, point);
@@ -373,7 +373,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::g
             continue;
 
           // add point to result vector
-          k_indices.push_back (decoded_point_vector[i]);
+          k_indices.push_back (i);
           k_sqr_distances.push_back (squared_dist);
 
           if (max_nn != 0 && k_indices.size () == static_cast<unsigned int> (max_nn))
@@ -454,9 +454,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::a
     (**child_leaf).getPointIndices (decoded_point_vector);
 
     // Linearly iterate over all decoded (unsorted) points
-    for (size_t i = 0; i < decoded_point_vector.size (); i++)
+    for (int & i : decoded_point_vector)
     {
-      const PointT& candidate_point = this->getPointByIndex (decoded_point_vector[i]);
+      const PointT& candidate_point = this->getPointByIndex (i);
 
       // calculate point distance to search point
       double squared_dist = pointSquaredDist (candidate_point, point);
@@ -465,7 +465,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::a
       if (squared_dist >= smallest_squared_dist)
         continue;
 
-      result_index = decoded_point_vector[i];
+      result_index = i;
       smallest_squared_dist = squared_dist;
       sqr_distance = static_cast<float> (squared_dist);
     }
@@ -535,9 +535,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::b
         (**child_leaf).getPointIndices (decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (size_t i = 0; i < decoded_point_vector.size (); i++)
+        for (int & i : decoded_point_vector)
         {
-          const PointT& candidate_point = this->getPointByIndex (decoded_point_vector[i]);
+          const PointT& candidate_point = this->getPointByIndex (i);
 
           // check if point falls within search box
           bInBox = ( (candidate_point.x >= min_pt (0)) && (candidate_point.x <= max_pt (0)) &&
@@ -546,7 +546,7 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::b
 
           if (bInBox)
             // add to result vector
-            k_indices.push_back (decoded_point_vector[i]);
+            k_indices.push_back (i);
         }
       }
     }

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -93,7 +93,7 @@ namespace pcl
           std::vector<OctreeContainerPointIndices*> leaf_containers;
           this->serializeNewLeafs (leaf_containers);
 
-          for (const auto leaf_container : leaf_containers)
+          for (const auto &leaf_container : leaf_containers)
           {
             if (static_cast<int> (leaf_container->getSize ()) >= minPointsPerLeaf_arg)
               leaf_container->getPointIndices(indicesVector_arg);

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -93,10 +93,10 @@ namespace pcl
           std::vector<OctreeContainerPointIndices*> leaf_containers;
           this->serializeNewLeafs (leaf_containers);
 
-          for (auto it = leaf_containers.cbegin(), it_end = leaf_containers.cend(); it != it_end; ++it)
+          for (const auto leaf_container : leaf_containers)
           {
-            if (static_cast<int> ((*it)->getSize ()) >= minPointsPerLeaf_arg)
-              (*it)->getPointIndices(indicesVector_arg);
+            if (static_cast<int> (leaf_container->getSize ()) >= minPointsPerLeaf_arg)
+              leaf_container->getPointIndices(indicesVector_arg);
           }
 
           return (indicesVector_arg.size ());


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix