### PR TITLE
Transform classic loops to range-based for loops in module outofcore

### DIFF
--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -164,19 +164,19 @@ class OutofcoreCloud : public Object
     }
 
     int
-    getDisplayDepth ()
+    getDisplayDepth () const
     {
       return display_depth_;
     }
 
     uint64_t
-    getPointsLoaded ()
+    getPointsLoaded () const
     {
       return points_loaded_;
     }
 
     uint64_t
-    getDataLoaded ()
+    getDataLoaded () const
     {
       return data_loaded_;
     }

--- a/outofcore/src/visualization/camera.cpp
+++ b/outofcore/src/visualization/camera.cpp
@@ -33,8 +33,8 @@ Camera::Camera (std::string name) :
   camera_actor_->GetProperty ()->SetLighting (false);
   camera_actor_->GetProperty ()->SetLineStipplePattern (1010101010);
 
-  for (int i = 0; i < 24; i++)
-    frustum_[i] = 0;
+  for (double &f : frustum_)
+    f = 0;
 
   hull_actor_ = vtkSmartPointer<vtkActor>::New ();
   vtkSmartPointer<vtkPolyDataMapper> hull_mapper = vtkSmartPointer<vtkPolyDataMapper>::New ();
@@ -55,8 +55,8 @@ Camera::Camera (std::string name, vtkSmartPointer<vtkCamera> camera) :
   camera_actor_->SetCamera (camera_);
   camera_actor_->GetProperty ()->SetLighting (false);
 
-  for (int i = 0; i < 24; i++)
-    frustum_[i] = 0;
+  for (double &f : frustum_)
+    f = 0;
 
   hull_actor_ = vtkSmartPointer<vtkActor>::New ();
   vtkSmartPointer<vtkPolyDataMapper> hull_mapper = vtkSmartPointer<vtkPolyDataMapper>::New ();

--- a/outofcore/src/visualization/outofcore_cloud.cpp
+++ b/outofcore/src/visualization/outofcore_cloud.cpp
@@ -157,11 +157,11 @@ OutofcoreCloud::updateVoxelData ()
   double voxel_side_length = octree_->getVoxelSideLength (display_depth_);
 
   double s = voxel_side_length / 2;
-  for (size_t i = 0; i < voxel_centers.size (); i++)
+  for (const auto &voxel_center : voxel_centers)
   {
-    double x = voxel_centers[i].x;
-    double y = voxel_centers[i].y;
-    double z = voxel_centers[i].z;
+    double x = voxel_center.x;
+    double y = voxel_center.y;
+    double z = voxel_center.z;
 
     voxel_data->AddInputData (getVtkCube (x - s, x + s, y - s, y + s, z - s, z + s));
   }

--- a/outofcore/src/visualization/scene.cpp
+++ b/outofcore/src/visualization/scene.cpp
@@ -28,11 +28,11 @@ Scene::getCameras ()
 Camera*
 Scene::getCamera (vtkCamera *camera)
 {
-  for (size_t i = 0; i < cameras_.size (); i++)
+  for (const auto &c : cameras_)
   {
-    if (cameras_[i]->getCamera ().GetPointer () == camera)
+    if (c->getCamera ().GetPointer () == camera)
     {
-      return cameras_[i];
+      return c;
     }
   }
 
@@ -42,9 +42,9 @@ Scene::getCamera (vtkCamera *camera)
 Camera*
 Scene::getCamera (std::string name)
 {
-  for (size_t i = 0; i < cameras_.size (); i++)
-    if (cameras_[i]->getName () == name)
-      return cameras_[i];
+  for (const auto &camera : cameras_)
+    if (camera->getName () == name)
+      return camera;
 
   return NULL;
 }
@@ -60,9 +60,9 @@ Scene::addObject (Object *object)
 Object*
 Scene::getObjectByName (std::string name)
 {
-  for (size_t i = 0; i < objects_.size (); i++)
-    if (objects_[i]->getName () == name)
-      return objects_[i];
+  for (const auto &object : objects_)
+    if (object->getName () == name)
+      return object;
 
   return NULL;
 }

--- a/outofcore/src/visualization/viewport.cpp
+++ b/outofcore/src/visualization/viewport.cpp
@@ -20,17 +20,6 @@
 #include <vtkRenderWindowInteractor.h>
 #include <vtkSmartPointer.h>
 
-//void CallbackFunction (vtkObject* caller, long unsigned int vtkNotUsed (eventId), void* clientData, void* vtkNotUsed (callData) )
-//{
-//  vtkRenderer* renderer = static_cast<vtkRenderer*> (caller);
-//
-//  double timeInSeconds = renderer->GetLastRenderTimeInSeconds ();
-//  double fps = 1.0/timeInSeconds;
-//  std::cout << "FPS: " << fps << std::endl;
-//
-//  std::cout << "Callback" << std::endl;
-//}
-
 // Operators
 // -----------------------------------------------------------------------------
 Viewport::Viewport (vtkSmartPointer<vtkRenderWindow> window, double xmin/*=0.0*/, double ymin/*=0.0*/,
@@ -144,24 +133,15 @@ Viewport::viewportActorUpdate ()
 
   std::vector<Camera*> cameras = scene->getCameras ();
 
-  for (size_t i = 0; i < cameras.size (); i++)
+  for (auto &camera : cameras)
   {
-    cameras[i]->render (renderer_);
-//    if (cameras[i]->getCamera () != renderer_->GetActiveCamera ())
-//    {
-//      renderer_->AddActor (cameras[i]->getCameraActor ());
-//      if (cameras[i]->getName () == "octree")
-//      {
-//        renderer_->AddActor (cameras[i]->getHullActor ());
-//      }
-//    }
+    camera->render (renderer_);
   }
 
   std::vector<Object*> objects = scene->getObjects ();
-  for (size_t i = 0; i < objects.size (); i++)
+  for (auto &object : objects)
   {
-    //std::cout << objects[i]->getName () << std::endl;
-    objects[i]->render (renderer_);
+    object->render (renderer_);
   }
 }
 
@@ -189,10 +169,9 @@ Viewport::viewportHudUpdate ()
 
   uint64_t points_loaded = 0;
   uint64_t data_loaded = 0;
-  for (size_t i = 0; i < objects.size (); i++)
+  for (const auto &object : objects)
   {
-    //TYPE& dynamic_cast<TYPE&> (object);
-    OutofcoreCloud* cloud = dynamic_cast<OutofcoreCloud*> (objects[i]);
+    const auto cloud = dynamic_cast<const OutofcoreCloud*> (object);
     if (cloud != NULL)
     {
       points_loaded += cloud->getPointsLoaded ();

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -303,7 +303,7 @@ main (int argc, char* argv[])
   std::vector<int> file_arg_indices = parse_file_extension_argument (argc, argv, ".pcd");
 
   std::vector<boost::filesystem::path> pcd_paths;
-  for (const int file_arg_index : file_arg_indices)
+  for (const int &file_arg_index : file_arg_indices)
   {
     boost::filesystem::path pcd_path (argv[file_arg_index]);
     if (!boost::filesystem::exists (pcd_path))

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -179,10 +179,10 @@ outofcoreProcess (std::vector<boost::filesystem::path> pcd_paths, boost::filesys
   uint64_t total_pts = 0;
 
   // Iterate over all pcd files adding points to the octree
-  for (size_t i = 0; i < pcd_paths.size (); i++)
+  for (const auto &pcd_path : pcd_paths)
   {
 
-    PCLPointCloud2::Ptr cloud = getCloudFromFile (pcd_paths[i]);
+    PCLPointCloud2::Ptr cloud = getCloudFromFile (pcd_path);
 
     boost::uint64_t pts = 0;
     
@@ -303,9 +303,9 @@ main (int argc, char* argv[])
   std::vector<int> file_arg_indices = parse_file_extension_argument (argc, argv, ".pcd");
 
   std::vector<boost::filesystem::path> pcd_paths;
-  for (size_t i = 0; i < file_arg_indices.size (); i++)
+  for (const int file_arg_index : file_arg_indices)
   {
-    boost::filesystem::path pcd_path (argv[file_arg_indices[i]]);
+    boost::filesystem::path pcd_path (argv[file_arg_index]);
     if (!boost::filesystem::exists (pcd_path))
     {
       PCL_WARN ("File %s doesn't exist", pcd_path.string ().c_str ());


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix