### PR TITLE
Transform classic loops to range-based for loops in module people

### DIFF
--- a/people/apps/main_ground_based_people_detection.cpp
+++ b/people/apps/main_ground_based_people_detection.cpp
@@ -221,12 +221,12 @@ int main (int argc, char** argv)
       pcl::visualization::PointCloudColorHandlerRGBField<PointT> rgb(cloud);
       viewer.addPointCloud<PointT> (cloud, rgb, "input_cloud");
       unsigned int k = 0;
-      for(std::vector<pcl::people::PersonCluster<PointT> >::iterator it = clusters.begin(); it != clusters.end(); ++it)
+      for(auto &cluster : clusters)
       {
-        if(it->getPersonConfidence() > min_confidence)             // draw only people with confidence above a threshold
+        if(cluster.getPersonConfidence() > min_confidence)             // draw only people with confidence above a threshold
         {
           // draw theoretical person bounding box in the PCL viewer:
-          it->drawTBoundingBox(viewer, k);
+          cluster.drawTBoundingBox(viewer, k);
           k++;
         }
       }

--- a/people/include/pcl/people/impl/head_based_subcluster.hpp
+++ b/people/include/pcl/people/impl/head_based_subcluster.hpp
@@ -172,7 +172,7 @@ pcl::people::HeadBasedSubclustering<PointT>::mergeClustersCloseInFloorCoordinate
         // Copy cluster points into new cluster:
         pcl::PointIndices point_indices;
         point_indices = input_clusters[i].getIndices();
-        for(const int cluster : connected_clusters[i])
+        for(const int &cluster : connected_clusters[i])
         {
           if (!used_clusters[cluster])         // if this cluster has not been used yet
           {

--- a/people/include/pcl/people/impl/head_based_subcluster.hpp
+++ b/people/include/pcl/people/impl/head_based_subcluster.hpp
@@ -172,13 +172,13 @@ pcl::people::HeadBasedSubclustering<PointT>::mergeClustersCloseInFloorCoordinate
         // Copy cluster points into new cluster:
         pcl::PointIndices point_indices;
         point_indices = input_clusters[i].getIndices();
-        for(size_t j = 0; j < connected_clusters[i].size(); j++)
+        for(const int cluster : connected_clusters[i])
         {
-          if (!used_clusters[connected_clusters[i][j]])         // if this cluster has not been used yet
+          if (!used_clusters[cluster])         // if this cluster has not been used yet
           {
-            used_clusters[connected_clusters[i][j]] = true;
-            for(std::vector<int>::const_iterator points_iterator = input_clusters[connected_clusters[i][j]].getIndices().indices.begin();
-                points_iterator != input_clusters[connected_clusters[i][j]].getIndices().indices.end(); points_iterator++)
+            used_clusters[cluster] = true;
+            for(std::vector<int>::const_iterator points_iterator = input_clusters[cluster].getIndices().indices.begin();
+                points_iterator != input_clusters[cluster].getIndices().indices.end(); points_iterator++)
             {
               point_indices.indices.push_back(*points_iterator);
             }


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix