### PR TITLE
Transform classic loops to range-based for loops in tools

### DIFF
--- a/tools/compute_hausdorff.cpp
+++ b/tools/compute_hausdorff.cpp
@@ -88,12 +88,12 @@ compute (Cloud &cloud_a, Cloud &cloud_b)
   pcl::search::KdTree<PointType> tree_b;
   tree_b.setInputCloud (cloud_b.makeShared ());
   float max_dist_a = -std::numeric_limits<float>::max ();
-  for (size_t i = 0; i < cloud_a.points.size (); ++i)
+  for (const auto &point : cloud_a.points)
   {
     std::vector<int> indices (1);
     std::vector<float> sqr_distances (1);
 
-    tree_b.nearestKSearch (cloud_a.points[i], 1, indices, sqr_distances);
+    tree_b.nearestKSearch (point, 1, indices, sqr_distances);
     if (sqr_distances[0] > max_dist_a)
       max_dist_a = sqr_distances[0];
   }
@@ -102,12 +102,12 @@ compute (Cloud &cloud_a, Cloud &cloud_b)
   pcl::search::KdTree<PointType> tree_a;
   tree_a.setInputCloud (cloud_a.makeShared ());
   float max_dist_b = -std::numeric_limits<float>::max ();
-  for (size_t i = 0; i < cloud_b.points.size (); ++i)
+  for (const auto &point : cloud_b.points)
   {
     std::vector<int> indices (1);
     std::vector<float> sqr_distances (1);
 
-    tree_a.nearestKSearch (cloud_b.points[i], 1, indices, sqr_distances);
+    tree_a.nearestKSearch (point, 1, indices, sqr_distances);
     if (sqr_distances[0] > max_dist_b)
       max_dist_b = sqr_distances[0];
   }

--- a/tools/concatenate_points_pcd.cpp
+++ b/tools/concatenate_points_pcd.cpp
@@ -134,7 +134,7 @@ main (int argc, char** argv)
 
   //pcl::PointCloud<pcl::PointXYZ> cloud_all;
   pcl::PCLPointCloud2 cloud_all;
-  for (const int file_index : file_indices)
+  for (const int &file_index : file_indices)
   {
     // Load the Point Cloud
     pcl::PCLPointCloud2 cloud;

--- a/tools/concatenate_points_pcd.cpp
+++ b/tools/concatenate_points_pcd.cpp
@@ -134,11 +134,11 @@ main (int argc, char** argv)
 
   //pcl::PointCloud<pcl::PointXYZ> cloud_all;
   pcl::PCLPointCloud2 cloud_all;
-  for (size_t i = 0; i < file_indices.size (); ++i)
+  for (const int file_index : file_indices)
   {
     // Load the Point Cloud
     pcl::PCLPointCloud2 cloud;
-    loadCloud (argv[file_indices[i]], cloud);
+    loadCloud (argv[file_index], cloud);
     //pcl::PointCloud<pcl::PointXYZ> cloud;
     //pcl::io::loadPCDFile (argv[file_indices[i]], cloud);
     //cloud_all += cloud;

--- a/tools/elch.cpp
+++ b/tools/elch.cpp
@@ -146,11 +146,11 @@ main (int argc, char **argv)
     }
   }
 
-  for (size_t i = 0; i < clouds.size (); i++)
+  for (const auto &cloud : clouds)
   {
-    std::string result_filename (clouds[i].first);
+    std::string result_filename (cloud.first);
     result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-    pcl::io::savePCDFileBinary (result_filename.c_str (), *(clouds[i].second));
+    pcl::io::savePCDFileBinary (result_filename.c_str (), *(cloud.second));
     std::cout << "saving result to " << result_filename << std::endl;
   }
 

--- a/tools/grid_min.cpp
+++ b/tools/grid_min.cpp
@@ -117,11 +117,11 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
               float resolution)
 {
   vector<string> st;
-  for (size_t i = 0; i < pcd_files.size (); ++i)
+  for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
     Cloud::Ptr cloud (new Cloud);
-    if (!loadCloud (pcd_files[i], *cloud)) 
+    if (!loadCloud (pcd_file, *cloud)) 
       return (-1);
 
     // Perform the feature estimation
@@ -129,7 +129,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
     compute (cloud, output, resolution);
 
     // Prepare output file name
-    string filename = pcd_files[i];
+    string filename = pcd_file;
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     

--- a/tools/icp.cpp
+++ b/tools/icp.cpp
@@ -90,10 +90,10 @@ main (int argc, char **argv)
   pcl::registration::IncrementalRegistration<PointType> iicp;
   iicp.setRegistration (icp);
 
-  for (size_t i = 0; i < pcd_indices.size (); i++)
+  for (const int pcd_index : pcd_indices)
   {
     CloudPtr data (new Cloud);
-    if (pcl::io::loadPCDFile (argv[pcd_indices[i]], *data) == -1)
+    if (pcl::io::loadPCDFile (argv[pcd_index], *data) == -1)
     {
       std::cout << "Could not read file" << std::endl;
       return -1;
@@ -111,7 +111,7 @@ main (int argc, char **argv)
 
     std::cout << iicp.getAbsoluteTransform () << std::endl;
 
-    std::string result_filename (argv[pcd_indices[i]]);
+    std::string result_filename (argv[pcd_index]);
     result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
     pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
     std::cout << "saving result to " << result_filename << std::endl;

--- a/tools/icp.cpp
+++ b/tools/icp.cpp
@@ -90,7 +90,7 @@ main (int argc, char **argv)
   pcl::registration::IncrementalRegistration<PointType> iicp;
   iicp.setRegistration (icp);
 
-  for (const int pcd_index : pcd_indices)
+  for (const int &pcd_index : pcd_indices)
   {
     CloudPtr data (new Cloud);
     if (pcl::io::loadPCDFile (argv[pcd_index], *data) == -1)

--- a/tools/linemod_detection.cpp
+++ b/tools/linemod_detection.cpp
@@ -84,7 +84,7 @@ main (int argc, char** argv)
   line_rgbd.setDetectionThreshold (detect_thresh);
 
   // Load the template LMT and PCD files
-  for (const int lmt_file_index : lmt_file_indices)
+  for (const int &lmt_file_index : lmt_file_indices)
   {
     // Load the LMT file
     std::string lmt_filename = argv[lmt_file_index];

--- a/tools/linemod_detection.cpp
+++ b/tools/linemod_detection.cpp
@@ -84,10 +84,10 @@ main (int argc, char** argv)
   line_rgbd.setDetectionThreshold (detect_thresh);
 
   // Load the template LMT and PCD files
-  for (size_t i = 0; i < lmt_file_indices.size (); ++i)
+  for (const int lmt_file_index : lmt_file_indices)
   {
     // Load the LMT file
-    std::string lmt_filename = argv[lmt_file_indices[i]];
+    std::string lmt_filename = argv[lmt_file_index];
     line_rgbd.loadTemplates (lmt_filename);
   }
 
@@ -106,9 +106,8 @@ main (int argc, char** argv)
   std::vector<LineRGBD<PointXYZRGBA>::Detection> detections;
   line_rgbd.detect (detections);
 
-  for (size_t i = 0; i < detections.size (); ++i)
+  for (const auto &d : detections)
   {
-    const LineRGBD<PointXYZRGBA>::Detection & d = detections[i];
     const BoundingBoxXYZ & bb = d.bounding_box;
     print_info ("%lu %lu %f (%f %f %f) (%f %f %f)\n", 
                 d.detection_id, d.template_id, d.response,

--- a/tools/local_max.cpp
+++ b/tools/local_max.cpp
@@ -118,11 +118,11 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
               float radius)
 {
   vector<string> st;
-  for (size_t i = 0; i < pcd_files.size (); ++i)
+  for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
     Cloud::Ptr cloud (new Cloud);
-    if (!loadCloud (pcd_files[i], *cloud)) 
+    if (!loadCloud (pcd_file, *cloud)) 
       return (-1);
 
     // Perform the feature estimation
@@ -130,7 +130,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
     compute (cloud, output, radius);
 
     // Prepare output file name
-    string filename = pcd_files[i];
+    string filename = pcd_file;
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     

--- a/tools/mesh2pcd.cpp
+++ b/tools/mesh2pcd.cpp
@@ -148,8 +148,8 @@ main (int argc, char **argv)
 
   // Fuse clouds
   PointCloud<PointXYZ>::Ptr big_boy (new PointCloud<PointXYZ> ());
-  for (size_t i = 0; i < aligned_clouds.size (); i++)
-    *big_boy += *aligned_clouds[i];
+  for (const auto &aligned_cloud : aligned_clouds)
+    *big_boy += *aligned_cloud;
 
   if (vis_result)
   {

--- a/tools/morph.cpp
+++ b/tools/morph.cpp
@@ -139,11 +139,11 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
               float resolution, const std::string &method)
 {
   vector<string> st;
-  for (size_t i = 0; i < pcd_files.size (); ++i)
+  for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
     Cloud::Ptr cloud (new Cloud);
-    if (!loadCloud (pcd_files[i], *cloud))
+    if (!loadCloud (pcd_file, *cloud))
       return (-1);
 
     // Perform the feature estimation
@@ -151,7 +151,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
     compute (cloud, output, resolution, method);
 
     // Prepare output file name
-    string filename = pcd_files[i];
+    string filename = pcd_file;
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
 

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -237,12 +237,12 @@ update (CallbackParameters* params)
 
   // Clear the visualizer
   vtkRenderer *renderer = params->viz_.getRenderWindow ()->GetRenderers ()->GetFirstRenderer ();
-  for ( list<vtkActor*>::iterator it = params->actors_.begin () ; it != params->actors_.end () ; ++it )
-    renderer->RemoveActor (*it);
+  for (const auto &actor : params->actors_)
+    renderer->RemoveActor (actor);
   params->actors_.clear ();
 
-  for ( list<vtkActor*>::iterator it = params->model_actors_.begin () ; it != params->model_actors_.end () ; ++it )
-    renderer->RemoveActor (*it);
+  for (const auto &model_actor : params->model_actors_)
+    renderer->RemoveActor (model_actor);
   params->model_actors_.clear ();
 
   params->viz_.removeAllShapes ();

--- a/tools/obj_rec_ransac_model_opps.cpp
+++ b/tools/obj_rec_ransac_model_opps.cpp
@@ -195,16 +195,16 @@ void showModelOpps (PCLVisualizer& viz, const ModelLibrary::HashTable& hash_tabl
     // Get the opps in the current cell
     const ModelLibrary::node_data_pair_list& data_pairs = res->second;
 
-    for ( ModelLibrary::node_data_pair_list::const_iterator dp = data_pairs.begin () ; dp != data_pairs.end () ; ++dp )
+    for (const auto &data_pair : data_pairs)
     {
-      vtk_opps_points->InsertNextPoint (dp->first->getPoint ());
-      vtk_opps_points->InsertNextPoint (dp->second->getPoint ());
+      vtk_opps_points->InsertNextPoint (data_pair.first->getPoint ());
+      vtk_opps_points->InsertNextPoint (data_pair.second->getPoint ());
       vtk_opps_lines->InsertNextCell (2, ids);
       ids[0] += 2;
       ids[1] += 2;
 #ifndef _SHOW_MODEL_OCTREE_NORMALS_
-      vtk_normals->InsertNextTuple3 (dp->first->getNormal  ()[0], dp->first->getNormal  ()[1], dp->first->getNormal  ()[2]);
-      vtk_normals->InsertNextTuple3 (dp->second->getNormal ()[0], dp->second->getNormal ()[1], dp->second->getNormal ()[2]);
+      vtk_normals->InsertNextTuple3 (data_pair.first->getNormal  ()[0], data_pair.first->getNormal  ()[1], data_pair.first->getNormal  ()[2]);
+      vtk_normals->InsertNextTuple3 (data_pair.second->getNormal ()[0], data_pair.second->getNormal ()[1], data_pair.second->getNormal ()[2]);
 #endif
     }
   }

--- a/tools/obj_rec_ransac_orr_octree.cpp
+++ b/tools/obj_rec_ransac_orr_octree.cpp
@@ -157,10 +157,10 @@ void updateViewer (ORROctree& octree, PCLVisualizer& viz, std::vector<ORROctree:
   int i = 0;
 
   // Show the cubes
-  for ( std::list<ORROctree::Node*>::iterator it = intersected_leaves.begin () ; it != intersected_leaves.end () ; ++it )
+  for (const auto &intersected_leave : intersected_leaves)
   {
     sprintf(cube_id, "cube %i", ++i);
-    b = (*it)->getBounds ();
+    b = intersected_leave->getBounds ();
     viz.addCube (b[0], b[1], b[2], b[3], b[4], b[5], 1.0, 1.0, 0.0, cube_id);
   }
 
@@ -320,9 +320,9 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz, bool show_full_leaves_o
   if ( show_full_leaves_only )
   {
     std::vector<ORROctree::Node*>& full_leaves = octree->getFullLeaves ();
-    for ( std::vector<ORROctree::Node*>::iterator it = full_leaves.begin () ; it != full_leaves.end () ; ++it )
+    for (auto &full_leave : full_leaves)
       // Add it to the other cubes
-      node_to_cube (*it, append);
+      node_to_cube (full_leave, append);
   }
   else
   {

--- a/tools/obj_rec_ransac_orr_octree.cpp
+++ b/tools/obj_rec_ransac_orr_octree.cpp
@@ -75,7 +75,7 @@ using namespace pcl::io;
 void run (const char *file_name, float voxel_size);
 bool vtk_to_pointcloud (const char* file_name, PointCloud<PointXYZ>& pcl_points, PointCloud<Normal>* pcl_normals);
 void show_octree (ORROctree* octree, PCLVisualizer& viz, bool show_full_leaves_only);
-void node_to_cube (ORROctree::Node* node, vtkAppendPolyData* additive_octree);
+void node_to_cube (const ORROctree::Node* node, vtkAppendPolyData* additive_octree);
 void updateViewer (ORROctree& octree, PCLVisualizer& viz, std::vector<ORROctree::Node*>::iterator leaf);
 
 #define _SHOW_OCTREE_NORMALS_
@@ -157,10 +157,10 @@ void updateViewer (ORROctree& octree, PCLVisualizer& viz, std::vector<ORROctree:
   int i = 0;
 
   // Show the cubes
-  for (const auto &intersected_leave : intersected_leaves)
+  for (const auto &intersected_leaf : intersected_leaves)
   {
     sprintf(cube_id, "cube %i", ++i);
-    b = intersected_leave->getBounds ();
+    b = intersected_leaf->getBounds ();
     viz.addCube (b[0], b[1], b[2], b[3], b[4], b[5], 1.0, 1.0, 0.0, cube_id);
   }
 
@@ -297,7 +297,7 @@ bool vtk_to_pointcloud (const char* file_name, PointCloud<PointXYZ>& pcl_points,
 
 //===============================================================================================================================
 
-void node_to_cube (ORROctree::Node* node, vtkAppendPolyData* additive_octree)
+void node_to_cube (const ORROctree::Node* node, vtkAppendPolyData* additive_octree)
 {
   // Define the cube representing the leaf
   const float *b = node->getBounds ();
@@ -320,9 +320,9 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz, bool show_full_leaves_o
   if ( show_full_leaves_only )
   {
     std::vector<ORROctree::Node*>& full_leaves = octree->getFullLeaves ();
-    for (auto &full_leave : full_leaves)
+    for (const auto &full_leaf : full_leaves)
       // Add it to the other cubes
-      node_to_cube (full_leave, append);
+      node_to_cube (full_leaf, append);
   }
   else
   {

--- a/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+++ b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
@@ -195,9 +195,9 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz)
   cout << "There are " << octree->getFullLeaves ().size () << " full leaves.\n";
 
   std::vector<ORROctree::Node*>& full_leaves = octree->getFullLeaves ();
-  for ( std::vector<ORROctree::Node*>::iterator it = full_leaves.begin () ; it != full_leaves.end () ; ++it )
+  for (auto &full_leave : full_leaves)
     // Add it to the other cubes
-    node_to_cube (*it, append);
+    node_to_cube (full_leave, append);
 
   // Save the result
   append->Update();

--- a/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+++ b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
@@ -76,7 +76,7 @@ void run (const char *file_name, float voxel_size);
 bool vtk_to_pointcloud (const char* file_name, PointCloud<PointXYZ>& points);
 void show_octree (ORROctree* octree, PCLVisualizer& viz);
 void show_octree_zproj (ORROctreeZProjection* zproj, PCLVisualizer& viz);
-void node_to_cube (ORROctree::Node* node, vtkAppendPolyData* additive_octree);
+void node_to_cube (const ORROctree::Node* node, vtkAppendPolyData* additive_octree);
 void rectangle_to_vtk (float x1, float x2, float y1, float y2, float z, vtkAppendPolyData* additive_rectangle);
 
 //#define _SHOW_POINTS_
@@ -195,9 +195,9 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz)
   cout << "There are " << octree->getFullLeaves ().size () << " full leaves.\n";
 
   std::vector<ORROctree::Node*>& full_leaves = octree->getFullLeaves ();
-  for (auto &full_leave : full_leaves)
+  for (const auto &full_leaf : full_leaves)
     // Add it to the other cubes
-    node_to_cube (full_leave, append);
+    node_to_cube (full_leaf, append);
 
   // Save the result
   append->Update();
@@ -265,7 +265,7 @@ void show_octree_zproj (ORROctreeZProjection* zproj, PCLVisualizer& viz)
 
 //===============================================================================================================================
 
-void node_to_cube (ORROctree::Node* node, vtkAppendPolyData* additive_octree)
+void node_to_cube (const ORROctree::Node* node, vtkAppendPolyData* additive_octree)
 {
   // Define the cube representing the leaf
   const float *b = node->getBounds ();

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -151,7 +151,7 @@ run (float pair_width, float voxel_size, float max_coplanarity_angle)
   list<vtkSmartPointer<vtkPolyData> > vtk_models_list;
 
   // Load the models and add them to the recognizer
-  for ( list<string>::iterator it = model_names.begin () ; it != model_names.end () ; ++it )
+  for (auto &model_name : model_names)
   {
     PointCloud<PointXYZ>::Ptr model_points (new PointCloud<PointXYZ> ());
     model_points_list.push_back (model_points);
@@ -163,14 +163,14 @@ run (float pair_width, float voxel_size, float max_coplanarity_angle)
     vtk_models_list.push_back (vtk_model);
 
     // Compose the file
-    string file_name = string("../../test/") + *it + string (".vtk");
+    string file_name = string("../../test/") + model_name + string (".vtk");
 
     // Get the points and normals from the input model
     if ( !vtk2PointCloud (file_name.c_str (), *model_points, *model_normals, vtk_model) )
       continue;
 
     // Add the model
-    objrec.addModel (*model_points, *model_normals, *it, vtk_model);
+    objrec.addModel (*model_points, *model_normals, model_name, vtk_model);
   }
 
   // The scene in which the models are supposed to be recognized
@@ -241,8 +241,8 @@ update (CallbackParameters* params)
 {
   // Clear the visualizer from old object instances
   vtkRenderer *renderer = params->viz_.getRenderWindow ()->GetRenderers ()->GetFirstRenderer ();
-  for ( list<vtkActor*>::iterator it = params->actors_.begin () ; it != params->actors_.end () ; ++it )
-    renderer->RemoveActor (*it);
+  for (auto &actor : params->actors_)
+    renderer->RemoveActor (actor);
   params->actors_.clear ();
 
   // This will be the output of the recognition

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -151,7 +151,7 @@ run (float pair_width, float voxel_size, float max_coplanarity_angle)
   list<vtkSmartPointer<vtkPolyData> > vtk_models_list;
 
   // Load the models and add them to the recognizer
-  for (auto &model_name : model_names)
+  for (const auto &model_name : model_names)
   {
     PointCloud<PointXYZ>::Ptr model_points (new PointCloud<PointXYZ> ());
     model_points_list.push_back (model_points);

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -241,7 +241,7 @@ update (CallbackParameters* params)
 {
   // Clear the visualizer from old object instances
   vtkRenderer *renderer = params->viz_.getRenderWindow ()->GetRenderers ()->GetFirstRenderer ();
-  for (auto &actor : params->actors_)
+  for (const auto &actor : params->actors_)
     renderer->RemoveActor (actor);
   params->actors_.clear ();
 

--- a/tools/obj_rec_ransac_scene_opps.cpp
+++ b/tools/obj_rec_ransac_scene_opps.cpp
@@ -155,14 +155,14 @@ void update (CallbackParameters* params)
   vtkIdType ids[2] = {0, 1};
 
   // Insert the points and compute the lines
-  for ( list<ObjRecRANSAC::OrientedPointPair>::const_iterator it = opps.begin () ; it != opps.end () ; ++it )
+  for (const auto &opp : opps)
   {
-    vtk_opps_points->SetPoint (ids[0], it->p1_[0], it->p1_[1], it->p1_[2]);
-    vtk_opps_points->SetPoint (ids[1], it->p2_[0], it->p2_[1], it->p2_[2]);
+    vtk_opps_points->SetPoint (ids[0], opp.p1_[0], opp.p1_[1], opp.p1_[2]);
+    vtk_opps_points->SetPoint (ids[1], opp.p2_[0], opp.p2_[1], opp.p2_[2]);
     vtk_opps_lines->InsertNextCell (2, ids);
 
-    vtk_normals->SetTuple3 (ids[0], it->n1_[0], it->n1_[1], it->n1_[2]);
-    vtk_normals->SetTuple3 (ids[1], it->n2_[0], it->n2_[1], it->n2_[2]);
+    vtk_normals->SetTuple3 (ids[0], opp.n1_[0], opp.n1_[1], opp.n1_[2]);
+    vtk_normals->SetTuple3 (ids[1], opp.n2_[0], opp.n2_[1], opp.n2_[2]);
 
     ids[0] += 2;
     ids[1] += 2;

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -402,7 +402,7 @@ private:
 
         // Iterate over the leafs to compute the centroid of all of them
         pcl::CentroidPoint<pcl::PointXYZ> centroid;
-        for (auto voxelCentroid : voxelCentroids)
+        for (const auto &voxelCentroid : voxelCentroids)
         {
           centroid.add (voxelCentroid);
         }

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -308,11 +308,11 @@ private:
 
     // Create every cubes to be displayed
     double s = voxelSideLen / 2.0;
-    for (size_t i = 0; i < cloudVoxel->points.size (); i++)
+    for (const auto &point : cloudVoxel->points)
     {
-      double x = cloudVoxel->points[i].x;
-      double y = cloudVoxel->points[i].y;
-      double z = cloudVoxel->points[i].z;
+      double x = point.x;
+      double y = point.y;
+      double z = point.z;
 
       vtkSmartPointer<vtkCubeSource> wk_cubeSource = vtkSmartPointer<vtkCubeSource>::New ();
 
@@ -402,9 +402,9 @@ private:
 
         // Iterate over the leafs to compute the centroid of all of them
         pcl::CentroidPoint<pcl::PointXYZ> centroid;
-        for (size_t j = 0; j < voxelCentroids.size (); ++j)
+        for (auto voxelCentroid : voxelCentroids)
         {
-          centroid.add (voxelCentroids[j]);
+          centroid.add (voxelCentroid);
         }
         centroid.get (pt_centroid);
       }

--- a/tools/passthrough_filter.cpp
+++ b/tools/passthrough_filter.cpp
@@ -128,11 +128,11 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
               const std::string &field_name, float min, float max, bool inside, bool keep_organized)
 {
   vector<string> st;
-  for (size_t i = 0; i < pcd_files.size (); ++i)
+  for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
     pcl::PCLPointCloud2::Ptr cloud (new pcl::PCLPointCloud2);
-    if (!loadCloud (pcd_files[i], *cloud)) 
+    if (!loadCloud (pcd_file, *cloud)) 
       return (-1);
 
     // Perform the feature estimation
@@ -140,7 +140,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir,
     compute (cloud, output, field_name, min, max, inside, keep_organized);
 
     // Prepare output file name
-    string filename = pcd_files[i];
+    string filename = pcd_file;
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     

--- a/tools/progressive_morphological_filter.cpp
+++ b/tools/progressive_morphological_filter.cpp
@@ -176,11 +176,11 @@ int
 batchProcess (const vector<string> &pcd_files, string &output_dir, int max_window_size, float slope, float max_distance, float initial_distance, float cell_size, float base, bool exponential, bool approximate)
 {
   vector<string> st;
-  for (size_t i = 0; i < pcd_files.size (); ++i)
+  for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
     Cloud::Ptr cloud (new Cloud);
-    if (!loadCloud (pcd_files[i], *cloud))
+    if (!loadCloud (pcd_file, *cloud))
       return (-1);
 
     // Perform the feature estimation
@@ -188,7 +188,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir, int max_windo
     compute (cloud, output, max_window_size, slope, max_distance, initial_distance, cell_size, base, exponential, approximate);
 
     // Prepare output file name
-    string filename = pcd_files[i];
+    string filename = pcd_file;
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
 

--- a/tools/radius_filter.cpp
+++ b/tools/radius_filter.cpp
@@ -118,11 +118,11 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
               float radius, bool inside, bool keep_organized)
 {
   std::vector<std::string> st;
-  for (size_t i = 0; i < pcd_files.size (); ++i)
+  for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
     Cloud::Ptr cloud (new Cloud);
-    if (!loadCloud (pcd_files[i], cloud))
+    if (!loadCloud (pcd_file, cloud))
       return (-1);
 
     // Perform the feature estimation
@@ -130,7 +130,7 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, radius, inside, keep_organized);
 
     // Prepare output file name
-    std::string filename = pcd_files[i];
+    std::string filename = pcd_file;
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
 

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -179,11 +179,11 @@ int
 batchProcess (const vector<string> &pcd_files, string &output_dir, int max_it, double thresh, bool negative)
 {
   vector<string> st;
-  for (size_t i = 0; i < pcd_files.size (); ++i)
+  for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
     pcl::PCLPointCloud2::Ptr cloud (new pcl::PCLPointCloud2);
-    if (!loadCloud (pcd_files[i], *cloud)) 
+    if (!loadCloud (pcd_file, *cloud)) 
       return (-1);
 
     // Perform the feature estimation
@@ -191,7 +191,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir, int max_it, d
     compute (cloud, output, max_it, thresh, negative);
 
     // Prepare output file name
-    string filename = pcd_files[i];
+    string filename = pcd_file;
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -133,8 +133,8 @@ maskForegroundPoints (const PointCloudXYZRGBA::ConstPtr & input,
   seg.segment (*inliers, *coefficients);  
   
   // Mask off the plane inliers
-  for (size_t i = 0; i < inliers->indices.size (); ++i)
-    foreground_mask[inliers->indices[i]] = false;
+  for (const int index : inliers->indices)
+    foreground_mask[index] = false;
 
   // Mask off any foreground points that are too high above the detected plane
   const std::vector<float> & c = coefficients->values;
@@ -262,10 +262,10 @@ main (int argc, char** argv)
   parse_argument (argc, argv, "-max_height", max_height);
 
   // Segment and create templates for each input file
-  for (size_t i_file = 0; i_file < p_file_indices.size (); ++i_file)
+  for (int p_file_indice : p_file_indices)
   {
     // Load input file
-    const std::string input_filename = argv[p_file_indices[i_file]];
+    const std::string input_filename = argv[p_file_indice];
     PointCloudXYZRGBA::Ptr cloud (new PointCloudXYZRGBA);
     if (!loadCloud (input_filename, *cloud)) 
       return (-1);

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -133,7 +133,7 @@ maskForegroundPoints (const PointCloudXYZRGBA::ConstPtr & input,
   seg.segment (*inliers, *coefficients);  
   
   // Mask off the plane inliers
-  for (const int index : inliers->indices)
+  for (const int &index : inliers->indices)
     foreground_mask[index] = false;
 
   // Mask off any foreground points that are too high above the detected plane
@@ -262,10 +262,10 @@ main (int argc, char** argv)
   parse_argument (argc, argv, "-max_height", max_height);
 
   // Segment and create templates for each input file
-  for (int p_file_indice : p_file_indices)
+  for (const int &p_file_index : p_file_indices)
   {
     // Load input file
-    const std::string input_filename = argv[p_file_indice];
+    const std::string input_filename = argv[p_file_index];
     PointCloudXYZRGBA::Ptr cloud (new PointCloudXYZRGBA);
     if (!loadCloud (input_filename, *cloud)) 
       return (-1);

--- a/tools/transform_from_viewpoint.cpp
+++ b/tools/transform_from_viewpoint.cpp
@@ -78,8 +78,8 @@ transform (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &outp
 {
   // Check for 'normals'
   bool has_normals = false;
-  for (size_t i = 0; i < input->fields.size (); ++i)
-    if (input->fields[i].name == "normals")
+  for (const auto &field : input->fields)
+    if (field.name == "normals")
       has_normals = true;
 
   // Estimate

--- a/tools/transform_point_cloud.cpp
+++ b/tools/transform_point_cloud.cpp
@@ -135,11 +135,11 @@ transformPointCloud2 (const pcl::PCLPointCloud2 &input, pcl::PCLPointCloud2 &out
   // Check for 'rgb' and 'normals' fields
   bool has_rgb = false;
   bool has_normals = false;
-  for (size_t i = 0; i < input.fields.size (); ++i)
+  for (const auto &field : input.fields)
   {
-    if (input.fields[i].name.find("rgb") != std::string::npos)
+    if (field.name.find("rgb") != std::string::npos)
       has_rgb = true;
-    if (input.fields[i].name == "normal_x")
+    if (field.name == "normal_x")
       has_normals = true;
   }
 

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -382,13 +382,13 @@ main (int argc, char** argv)
 
     // Noisify each point in the dataset
     // \note: we might decide to noisify along the ray later
-    for (size_t cp = 0; cp < cloud.points.size (); ++cp)
+    for (auto &point : cloud.points)
     {
       // Add noise ?
       switch (noise_model)
       {
         // Gaussian
-        case 1: { cloud.points[cp].x += gaussian_rng (); cloud.points[cp].y += gaussian_rng (); cloud.points[cp].z += gaussian_rng (); break; }
+        case 1: { point.x += gaussian_rng (); point.y += gaussian_rng (); point.z += gaussian_rng (); break; }
       }
     }
 

--- a/tools/voxel_grid_occlusion_estimation.cpp
+++ b/tools/voxel_grid_occlusion_estimation.cpp
@@ -92,11 +92,11 @@ getVoxelActors (pcl::PointCloud<pcl::PointXYZ>& voxelCenters,
   
   double s = voxelSideLen/2.0;
   
-  for (size_t i = 0; i < voxelCenters.points.size (); i++)
+  for (const auto &point : voxelCenters.points)
   {
-    double x = voxelCenters.points[i].x;
-    double y = voxelCenters.points[i].y;
-    double z = voxelCenters.points[i].z;
+    double x = point.x;
+    double y = point.y;
+    double z = point.z;
     
     treeWireframe->AddInputData (getCuboid (x - s, x + s, y - s, y + s, z - s, z + s));
   }


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix