### PR TITLE
Transform classic loops to range-based for loops in tests.

### DIFF
--- a/people/include/pcl/people/impl/person_cluster.hpp
+++ b/people/include/pcl/people/impl/person_cluster.hpp
@@ -258,7 +258,7 @@ pcl::people::PersonCluster<PointT>::getIndices ()
 }
 
 template <typename PointT> float
-pcl::people::PersonCluster<PointT>::getHeight ()
+pcl::people::PersonCluster<PointT>::getHeight () const
 {
   return (height_);
 }
@@ -286,7 +286,7 @@ pcl::people::PersonCluster<PointT>::updateHeight (const Eigen::VectorXf& ground_
 }
 
 template <typename PointT> float
-pcl::people::PersonCluster<PointT>::getDistance ()
+pcl::people::PersonCluster<PointT>::getDistance () const
 {
   return (distance_);
 }
@@ -340,31 +340,31 @@ pcl::people::PersonCluster<PointT>::getMax ()
 }
 
 template <typename PointT> float
-pcl::people::PersonCluster<PointT>::getAngle ()
+pcl::people::PersonCluster<PointT>::getAngle () const
 {
   return (angle_);
 }
 
 template <typename PointT>
-float pcl::people::PersonCluster<PointT>::getAngleMax ()
+float pcl::people::PersonCluster<PointT>::getAngleMax () const
 {
   return (angle_max_);
 }
 
 template <typename PointT>
-float pcl::people::PersonCluster<PointT>::getAngleMin ()
+float pcl::people::PersonCluster<PointT>::getAngleMin () const
 {
   return (angle_min_);
 }
 
 template <typename PointT>
-int pcl::people::PersonCluster<PointT>::getNumberPoints ()
+int pcl::people::PersonCluster<PointT>::getNumberPoints () const
 {
   return (n_);
 }
 
 template <typename PointT>
-float pcl::people::PersonCluster<PointT>::getPersonConfidence ()
+float pcl::people::PersonCluster<PointT>::getPersonConfidence () const
 {
   return (person_confidence_);
 }

--- a/people/include/pcl/people/person_cluster.h
+++ b/people/include/pcl/people/person_cluster.h
@@ -155,7 +155,7 @@ namespace pcl
        * \return the height of the cluster.
        */
       float
-      getHeight ();
+      getHeight () const;
 
       /**
        * \brief Update the height of the cluster.
@@ -181,28 +181,28 @@ namespace pcl
        * y dimension.
        */
       float
-      getDistance ();
+      getDistance () const;
 
       /**
        * \brief Returns the angle formed by the cluster's centroid with respect to the sensor (in radians).
        * \return the angle formed by the cluster's centroid with respect to the sensor (in radians).
        */
       float
-      getAngle ();
+      getAngle () const;
 
       /**
        * \brief Returns the minimum angle formed by the cluster with respect to the sensor (in radians).
        * \return the minimum angle formed by the cluster with respect to the sensor (in radians).
        */
       float
-      getAngleMin ();
+      getAngleMin () const;
 
       /**
        * \brief Returns the maximum angle formed by the cluster with respect to the sensor (in radians).
        * \return the maximum angle formed by the cluster with respect to the sensor (in radians).
        */
       float
-      getAngleMax ();
+      getAngleMax () const;
 
       /**
        * \brief Returns the indices of the point cloud points corresponding to the cluster.
@@ -274,14 +274,14 @@ namespace pcl
        * \return the HOG confidence.
        */
       float
-      getPersonConfidence ();
+      getPersonConfidence () const;
 
       /**
        * \brief Returns the number of points of the cluster.
        * \return the number of points of the cluster.
        */
       int
-      getNumberPoints ();
+      getNumberPoints () const;
 
       /**
        * \brief Sets the cluster height.

--- a/test/common/test_pca.cpp
+++ b/test/common/test_pca.cpp
@@ -49,11 +49,11 @@ pcl::PCA<pcl::PointXYZ> pca;
 TEST(PCA, projection)
 {
   pcl::PointXYZ projected, reconstructed;
-  for(size_t i = 0; i < cloud.size(); i++)
+  for(const auto &point : cloud)
   {
-    pca.project (cloud[i], projected);
+    pca.project (point, projected);
     pca.reconstruct (projected, reconstructed);
-    EXPECT_NEAR_VECTORS (reconstructed.getVector3fMap (), cloud[i].getVector3fMap (), 2.5e-4);
+    EXPECT_NEAR_VECTORS (reconstructed.getVector3fMap (), point.getVector3fMap (), 2.5e-4);
   }
 }
 

--- a/test/features/test_boundary_estimation.cpp
+++ b/test/features/test_boundary_estimation.cpp
@@ -76,10 +76,10 @@ TEST (PCL, BoundaryEstimation)
   EXPECT_EQ (b.getInputNormals (), normals);
 
   // getCoordinateSystemOnPlane
-  for (size_t i = 0; i < normals->points.size (); ++i)
+  for (const auto &point : normals->points)
   {
-    b.getCoordinateSystemOnPlane (normals->points[i], u, v);
-    Vector4fMap n4uv = normals->points[i].getNormalVector4fMap ();
+    b.getCoordinateSystemOnPlane (point, u, v);
+    Vector4fMapConst n4uv = point.getNormalVector4fMap ();
     EXPECT_NEAR (n4uv.dot(u), 0, 1e-4);
     EXPECT_NEAR (n4uv.dot(v), 0, 1e-4);
     EXPECT_NEAR (u.dot(v), 0, 1e-4);

--- a/test/features/test_invariants_estimation.cpp
+++ b/test/features/test_invariants_estimation.cpp
@@ -85,11 +85,11 @@ TEST (PCL, MomentInvariantsEstimation)
   mi.compute (*moments);
   EXPECT_EQ (moments->points.size (), indices.size ());
 
-  for (size_t i = 0; i < moments->points.size (); ++i)
+  for (const auto &point : moments->points)
   {
-    EXPECT_NEAR (moments->points[i].j1, 1.59244, 1e-4);
-    EXPECT_NEAR (moments->points[i].j2, 0.652063, 1e-4);
-    EXPECT_NEAR (moments->points[i].j3, 0.053917, 1e-4);
+    EXPECT_NEAR (point.j1, 1.59244, 1e-4);
+    EXPECT_NEAR (point.j2, 0.652063, 1e-4);
+    EXPECT_NEAR (point.j3, 0.053917, 1e-4);
   }
 }
 

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -153,12 +153,12 @@ TEST (PCL, NormalEstimation)
   n.compute (*normals);
   EXPECT_EQ (normals->points.size (), indices.size ());
 
-  for (size_t i = 0; i < normals->points.size (); ++i)
+  for (const auto &point : normals->points)
   {
-    EXPECT_NEAR (normals->points[i].normal[0], -0.035592, 1e-4);
-    EXPECT_NEAR (normals->points[i].normal[1], -0.369596, 1e-4);
-    EXPECT_NEAR (normals->points[i].normal[2], -0.928511, 1e-4);
-    EXPECT_NEAR (normals->points[i].curvature, 0.0693136, 1e-4);
+    EXPECT_NEAR (point.normal[0], -0.035592, 1e-4);
+    EXPECT_NEAR (point.normal[1], -0.369596, 1e-4);
+    EXPECT_NEAR (point.normal[2], -0.928511, 1e-4);
+    EXPECT_NEAR (point.curvature, 0.0693136, 1e-4);
   }
 
   PointCloud<PointXYZ>::Ptr surfaceptr = cloudptr;
@@ -204,12 +204,12 @@ TEST (PCL, NormalEstimationOpenMP)
   n.compute (*normals);
   EXPECT_EQ (normals->points.size (), indices.size ());
 
-  for (size_t i = 0; i < normals->points.size (); ++i)
+  for (const auto &point : normals->points)
   {
-    EXPECT_NEAR (normals->points[i].normal[0], -0.035592, 1e-4);
-    EXPECT_NEAR (normals->points[i].normal[1], -0.369596, 1e-4);
-    EXPECT_NEAR (normals->points[i].normal[2], -0.928511, 1e-4);
-    EXPECT_NEAR (normals->points[i].curvature, 0.0693136, 1e-4);
+    EXPECT_NEAR (point.normal[0], -0.035592, 1e-4);
+    EXPECT_NEAR (point.normal[1], -0.369596, 1e-4);
+    EXPECT_NEAR (point.normal[2], -0.928511, 1e-4);
+    EXPECT_NEAR (point.curvature, 0.0693136, 1e-4);
   }
 }
 

--- a/test/features/test_pfh_estimation.cpp
+++ b/test/features/test_pfh_estimation.cpp
@@ -216,35 +216,35 @@ TEST (PCL, PFHEstimation)
   pfh.compute (*pfhs);
   EXPECT_EQ (pfhs->points.size (), indices.size ());
 
-  for (size_t i = 0; i < pfhs->points.size (); ++i)
+  for (const auto &point : pfhs->points)
   {
-    EXPECT_NEAR (pfhs->points[i].histogram[0],  0.156477  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[1],  0.539396  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[2],  0.410907  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[3],  0.184465  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[4],  0.115767  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[5],  0.0572475 , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[6],  0.206092  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[7],  0.339667  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[8],  0.265883  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[9],  0.0038165 , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[10], 0.103046  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[11], 0.214997  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[12], 0.398186  , 3e-2); // larger error w.r.t. considering all point pairs (feature bins=0,2,2 where 2 is middle, so angle of 0)
-    EXPECT_NEAR (pfhs->points[i].histogram[13], 0.298959  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[14], 0.00127217, 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[15], 0.11704   , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[16], 0.255706  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[17], 0.356205  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[18], 0.265883  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[19], 0.00127217, 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[20], 0.148844  , 1e-4);
-    //EXPECT_NEAR (pfhs->points[i].histogram[21], 0.721316  , 1e-3);
-    //EXPECT_NEAR (pfhs->points[i].histogram[22], 0.438899  , 1e-2);
-    EXPECT_NEAR (pfhs->points[i].histogram[23], 0.22263   , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[24], 0.0216269 , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[25], 0.223902  , 1e-4);
-    EXPECT_NEAR (pfhs->points[i].histogram[26], 0.07633   , 1e-4);
+    EXPECT_NEAR (point.histogram[0],  0.156477  , 1e-4);
+    EXPECT_NEAR (point.histogram[1],  0.539396  , 1e-4);
+    EXPECT_NEAR (point.histogram[2],  0.410907  , 1e-4);
+    EXPECT_NEAR (point.histogram[3],  0.184465  , 1e-4);
+    EXPECT_NEAR (point.histogram[4],  0.115767  , 1e-4);
+    EXPECT_NEAR (point.histogram[5],  0.0572475 , 1e-4);
+    EXPECT_NEAR (point.histogram[6],  0.206092  , 1e-4);
+    EXPECT_NEAR (point.histogram[7],  0.339667  , 1e-4);
+    EXPECT_NEAR (point.histogram[8],  0.265883  , 1e-4);
+    EXPECT_NEAR (point.histogram[9],  0.0038165 , 1e-4);
+    EXPECT_NEAR (point.histogram[10], 0.103046  , 1e-4);
+    EXPECT_NEAR (point.histogram[11], 0.214997  , 1e-4);
+    EXPECT_NEAR (point.histogram[12], 0.398186  , 3e-2); // larger error w.r.t. considering all point pairs (feature bins=0,2,2 where 2 is middle, so angle of 0)
+    EXPECT_NEAR (point.histogram[13], 0.298959  , 1e-4);
+    EXPECT_NEAR (point.histogram[14], 0.00127217, 1e-4);
+    EXPECT_NEAR (point.histogram[15], 0.11704   , 1e-4);
+    EXPECT_NEAR (point.histogram[16], 0.255706  , 1e-4);
+    EXPECT_NEAR (point.histogram[17], 0.356205  , 1e-4);
+    EXPECT_NEAR (point.histogram[18], 0.265883  , 1e-4);
+    EXPECT_NEAR (point.histogram[19], 0.00127217, 1e-4);
+    EXPECT_NEAR (point.histogram[20], 0.148844  , 1e-4);
+    //EXPECT_NEAR (point.histogram[21], 0.721316  , 1e-3);
+    //EXPECT_NEAR (point.histogram[22], 0.438899  , 1e-2);
+    EXPECT_NEAR (point.histogram[23], 0.22263   , 1e-4);
+    EXPECT_NEAR (point.histogram[24], 0.0216269 , 1e-4);
+    EXPECT_NEAR (point.histogram[25], 0.223902  , 1e-4);
+    EXPECT_NEAR (point.histogram[26], 0.07633   , 1e-4);
   }
   //Eigen::Map<Eigen::VectorXf> h (&(pfhs->points[0].histogram[0]), 125);
   //std::cerr << h.head<27> () << std::endl;

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -2257,7 +2257,7 @@ TEST (NormalRefinement, Filters)
   int num_nans = 0;
 
   // Loop
-  for (const int idx : idx_table)
+  for (const int &idx : idx_table)
   {
     float tmp;
 
@@ -2301,13 +2301,13 @@ TEST (NormalRefinement, Filters)
 
   // Error variance of estimated
   float err_est_var = 0.0f;
-  for (const float err : errs_est)
+  for (const float &err : errs_est)
     err_est_var = (err - err_est_mean) * (err - err_est_mean);
   err_est_var /= static_cast<float> (errs_est.size () - 1);
 
   // Error variance of refined
   float err_refined_var = 0.0f;
-  for (const float err : errs_refined)
+  for (const float &err : errs_refined)
     err_refined_var = (err - err_refined_mean) * (err - err_refined_mean);
   err_refined_var /= static_cast<float> (errs_refined.size () - 1);
 

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -1345,24 +1345,24 @@ TEST (ProjectInliers, Filters)
   proj.setModelCoefficients (coefficients);
   proj.filter (output);
 
-  for (size_t i = 0; i < output.points.size (); ++i)
-    EXPECT_NEAR (output.points[i].z, 0.0, 1e-4);
+  for (const auto &point : output.points)
+    EXPECT_NEAR (point.z, 0.0, 1e-4);
 
-    // Test the pcl::PCLPointCloud2 method
-    ProjectInliers<PCLPointCloud2> proj2;
+  // Test the pcl::PCLPointCloud2 method
+  ProjectInliers<PCLPointCloud2> proj2;
 
-    PCLPointCloud2 output_blob;
+  PCLPointCloud2 output_blob;
 
-    proj2.setModelType (SACMODEL_PLANE);
-    proj2.setInputCloud (cloud_blob);
-    proj2.setModelCoefficients (coefficients);
-    proj2.filter (output_blob);
+  proj2.setModelType (SACMODEL_PLANE);
+  proj2.setInputCloud (cloud_blob);
+  proj2.setModelCoefficients (coefficients);
+  proj2.filter (output_blob);
 
-    fromPCLPointCloud2 (output_blob, output);
+  fromPCLPointCloud2 (output_blob, output);
 
-    for (size_t i = 0; i < output.points.size (); ++i)
-    EXPECT_NEAR (output.points[i].z, 0.0, 1e-4);
-  }
+  for (const auto &point : output.points)
+    EXPECT_NEAR (point.z, 0.0, 1e-4);
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (RadiusOutlierRemoval, Filters)
@@ -1590,11 +1590,11 @@ TEST (ConditionalRemoval, Filters)
   condrem.filter (output);
 
   int num_not_nan = 0;
-  for (size_t i = 0; i < output.points.size (); i++)
+  for (const auto &point : output.points)
   {
-    if (std::isfinite (output.points[i].x) &&
-        std::isfinite (output.points[i].y) &&
-        std::isfinite (output.points[i].z))
+    if (std::isfinite (point.x) &&
+        std::isfinite (point.y) &&
+        std::isfinite (point.z))
     num_not_nan++;
   }
 
@@ -1627,11 +1627,11 @@ TEST (ConditionalRemoval, Filters)
   condrem_.filter (output);
 
   num_not_nan = 0;
-  for (size_t i = 0; i < output.points.size (); i++)
+  for (const auto &point : output.points)
   {
-    if (std::isfinite (output.points[i].x) &&
-        std::isfinite (output.points[i].y) &&
-        std::isfinite (output.points[i].z))
+    if (std::isfinite (point.x) &&
+        std::isfinite (point.y) &&
+        std::isfinite (point.z))
     num_not_nan++;
   }
 
@@ -1695,11 +1695,11 @@ TEST (ConditionalRemovalSetIndices, Filters)
   EXPECT_EQ (cloud->points[cloud->points.size () - 1].z, output.points[output.points.size () - 1].z);
 
   int num_not_nan = 0;
-  for (size_t i = 0; i < output.points.size (); i++)
+  for (const auto &point : output.points)
   {
-    if (std::isfinite (output.points[i].x) &&
-        std::isfinite (output.points[i].y) &&
-        std::isfinite (output.points[i].z))
+    if (std::isfinite (point.x) &&
+        std::isfinite (point.y) &&
+        std::isfinite (point.z))
       num_not_nan++;
   }
 
@@ -1745,11 +1745,11 @@ TEST (ConditionalRemovalSetIndices, Filters)
   EXPECT_EQ (cloud->points[cloud->points.size () - 1].z, output.points[output.points.size () - 1].z);
 
   num_not_nan = 0;
-  for (size_t i = 0; i < output.points.size (); i++)
+  for (const auto &point : output.points)
   {
-    if (std::isfinite (output.points[i].x) &&
-        std::isfinite (output.points[i].y) &&
-        std::isfinite (output.points[i].z))
+    if (std::isfinite (point.x) &&
+        std::isfinite (point.y) &&
+        std::isfinite (point.z))
       num_not_nan++;
   }
 
@@ -1788,11 +1788,11 @@ TEST (SamplingSurfaceNormal, Filters)
   ssn_filter.filter (outcloud);
 
   // All the sampled points should have normals along the direction of Z axis
-  for (size_t i = 0; i < outcloud.points.size (); i++)
+  for (const auto &point : outcloud.points)
   {
-    EXPECT_NEAR (outcloud.points[i].normal[0], 0, 1e-3);
-    EXPECT_NEAR (outcloud.points[i].normal[1], 0, 1e-3);
-    EXPECT_NEAR (outcloud.points[i].normal[2], 1, 1e-3);
+    EXPECT_NEAR (point.normal[0], 0, 1e-3);
+    EXPECT_NEAR (point.normal[1], 0, 1e-3);
+    EXPECT_NEAR (point.normal[2], 1, 1e-3);
   }
 }
 
@@ -1925,11 +1925,11 @@ TEST (FrustumCulling, Filters)
   fc.setKeepOrganized (true);
   fc.filter (*output);
   EXPECT_EQ (output->size (), input->size ());
-  for (size_t i = 0; i < output->size (); i++)
+  for (const auto &point : *output)
   {
-    EXPECT_TRUE (std::isnan (output->at (i).x));
-    EXPECT_TRUE (std::isnan (output->at (i).y));
-    EXPECT_TRUE (std::isnan (output->at (i).z));
+    EXPECT_TRUE (std::isnan (point.x));
+    EXPECT_TRUE (std::isnan (point.y));
+    EXPECT_TRUE (std::isnan (point.z));
   }
   removed = fc.getRemovedIndices ();
   EXPECT_EQ (removed->size (), input->size ());
@@ -2257,12 +2257,12 @@ TEST (NormalRefinement, Filters)
   int num_nans = 0;
 
   // Loop
-  for (size_t i = 0; i < idx_table.size (); ++i)
+  for (const int idx : idx_table)
   {
     float tmp;
 
     // Estimated (need to avoid zeros and NaNs)
-    const pcl::PointXYZRGBNormal& calci = cloud_organized_normal[idx_table[i]];
+    const pcl::PointXYZRGBNormal& calci = cloud_organized_normal[idx];
     if ((fabsf (calci.normal_x) + fabsf (calci.normal_y) + fabsf (calci.normal_z)) > 0.0f)
     {
       tmp = 1.0f - (calci.normal_x * a + calci.normal_y * b + calci.normal_z * c);
@@ -2274,7 +2274,7 @@ TEST (NormalRefinement, Filters)
     }
 
     // Refined
-    const pcl::PointXYZRGBNormal& refinedi = cloud_organized_normal_refined[idx_table[i]];
+    const pcl::PointXYZRGBNormal& refinedi = cloud_organized_normal_refined[idx];
     if ((fabsf (refinedi.normal_x) + fabsf (refinedi.normal_y) + fabsf (refinedi.normal_z)) > 0.0f)
     {
       tmp = 1.0f - (refinedi.normal_x * a + refinedi.normal_y * b + refinedi.normal_z * c);
@@ -2301,14 +2301,14 @@ TEST (NormalRefinement, Filters)
 
   // Error variance of estimated
   float err_est_var = 0.0f;
-  for (size_t i = 0; i < errs_est.size (); ++i)
-    err_est_var = (errs_est[i] - err_est_mean) * (errs_est[i] - err_est_mean);
+  for (const float err : errs_est)
+    err_est_var = (err - err_est_mean) * (err - err_est_mean);
   err_est_var /= static_cast<float> (errs_est.size () - 1);
 
   // Error variance of refined
   float err_refined_var = 0.0f;
-  for (size_t i = 0; i < errs_refined.size (); ++i)
-    err_refined_var = (errs_refined[i] - err_refined_mean) * (errs_refined[i] - err_refined_mean);
+  for (const float err : errs_refined)
+    err_refined_var = (err - err_refined_mean) * (err - err_refined_mean);
   err_refined_var /= static_cast<float> (errs_refined.size () - 1);
 
   // Refinement should not produce any zeros and NaNs

--- a/test/geometry/test_mesh.cpp
+++ b/test/geometry/test_mesh.cpp
@@ -92,9 +92,9 @@ TEST (TestAddDeleteFace, NonManifold1)
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear (); // 0
   vi.push_back (VI (2)); vi.push_back (VI (1)); vi.push_back (VI (4)); faces.push_back (vi); vi.clear (); // 1
   vi.push_back (VI (0)); vi.push_back (VI (2)); vi.push_back (VI (5)); faces.push_back (vi); vi.clear (); // 2
-  for (size_t i=0; i < faces.size (); ++i)
+  for (const auto &face : faces)
   {
-    ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
+    ASSERT_TRUE (mesh.addFace (face).isValid ());
   }
   EXPECT_TRUE (hasFaces (mesh, faces));
 
@@ -154,9 +154,9 @@ TEST (TestAddDeleteFace, NonManifold2)
   // 3 - 4 //
   vi.push_back (VI (0)); vi.push_back (VI (1)); vi.push_back (VI (2)); faces.push_back (vi); vi.clear ();
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (4)); faces.push_back (vi); vi.clear ();
-  for (size_t i=0; i < faces.size (); ++i)
+  for (const auto &face : faces)
   {
-    ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
+    ASSERT_TRUE (mesh.addFace (face).isValid ());
   }
   EXPECT_TRUE (hasFaces (mesh, faces));
 
@@ -584,9 +584,9 @@ TEST (TestMesh, IsBoundaryIsManifold)
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear (); // 0
   vi.push_back (VI (2)); vi.push_back (VI (1)); vi.push_back (VI (4)); faces.push_back (vi); vi.clear (); // 1
   vi.push_back (VI (0)); vi.push_back (VI (2)); vi.push_back (VI (5)); faces.push_back (vi); vi.clear (); // 2
-  for (size_t i = 0; i < faces.size (); ++i)
+  for (const auto &face : faces)
   {
-    ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
+    ASSERT_TRUE (mesh.addFace (face).isValid ());
   }
   EXPECT_TRUE (hasFaces (mesh, faces));
 

--- a/test/geometry/test_mesh_conversion.cpp
+++ b/test/geometry/test_mesh_conversion.cpp
@@ -176,7 +176,7 @@ TYPED_TEST (TestMeshConversion, HalfEdgeMeshToFaceVertexMesh)
   for (size_t i=0; i<faces.size (); ++i)
   {
     vi.clear ();
-    for (const unsigned int j : faces [i])
+    for (const unsigned int &j : faces [i])
     {
       vi.push_back (VertexIndex (static_cast <int> (j)));
     }

--- a/test/geometry/test_mesh_conversion.cpp
+++ b/test/geometry/test_mesh_conversion.cpp
@@ -176,9 +176,9 @@ TYPED_TEST (TestMeshConversion, HalfEdgeMeshToFaceVertexMesh)
   for (size_t i=0; i<faces.size (); ++i)
   {
     vi.clear ();
-    for (size_t j=0; j<faces [i].size (); ++j)
+    for (const unsigned int j : faces [i])
     {
-      vi.push_back (VertexIndex (static_cast <int> (faces [i][j])));
+      vi.push_back (VertexIndex (static_cast <int> (j)));
     }
 
     ASSERT_TRUE (half_edge_mesh.addFace (vi).isValid ()) << "Face number " << i;

--- a/test/geometry/test_polygon_mesh.cpp
+++ b/test/geometry/test_polygon_mesh.cpp
@@ -178,9 +178,9 @@ TYPED_TEST (TestPolygonMesh, ThreePolygons)
   faces.push_back (vi);
   vi.clear ();
 
-  for (size_t i=0; i < faces.size (); ++i)
+  for (const auto &face : faces)
   {
-    ASSERT_TRUE (mesh.addFace (faces [i]).isValid ());
+    ASSERT_TRUE (mesh.addFace (face).isValid ());
   }
 
   ASSERT_TRUE (hasFaces (mesh, faces));

--- a/test/geometry/test_triangle_mesh.cpp
+++ b/test/geometry/test_triangle_mesh.cpp
@@ -541,10 +541,10 @@ TEST (TestManifoldTriangleMesh, addTrianglePair)
   tmp.push_back (vi [ 6]); tmp.push_back (vi [10]); tmp.push_back (vi [11]); tmp.push_back (vi [ 7]); faces.push_back (tmp); tmp.clear ();
   tmp.push_back (vi [ 5]); tmp.push_back (vi [ 9]); tmp.push_back (vi [10]); tmp.push_back (vi [ 6]); faces.push_back (tmp); tmp.clear ();
 
-  for (size_t i=0; i < faces.size (); ++i)
+  for (const auto &face : faces)
   {
     std::pair <FaceIndex, FaceIndex> fip;
-    fip = mesh.addTrianglePair (faces [i]);
+    fip = mesh.addTrianglePair (face);
     ASSERT_TRUE (fip.first.isValid ());
     ASSERT_TRUE (fip.second.isValid ());
   }

--- a/test/io/test_grabbers.cpp
+++ b/test/io/test_grabbers.cpp
@@ -546,10 +546,10 @@ int
   }
   sort (pcd_files_.begin (), pcd_files_.end ());
   // And load them
-  for (size_t i = 0; i < pcd_files_.size (); i++)
+  for (const auto &pcd_file : pcd_files_)
   {
     CloudT::Ptr cloud (new CloudT);
-    pcl::io::loadPCDFile (pcd_files_[i], *cloud); 
+    pcl::io::loadPCDFile (pcd_file, *cloud); 
     pcds_.emplace_back(cloud);
   }
 

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -274,18 +274,18 @@ TEST (PCL, ConcatenatePoints)
   cloud_a.points.resize (cloud_a.width * cloud_a.height);
   cloud_b.points.resize (cloud_b.width * cloud_b.height);
 
-  for (size_t i = 0; i < cloud_a.points.size (); ++i)
+  for (auto &point : cloud_a.points)
   {
-    cloud_a.points[i].x = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
-    cloud_a.points[i].y = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
-    cloud_a.points[i].z = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
+    point.x = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
+    point.y = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
+    point.z = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
   }
 
-  for (size_t i = 0; i < cloud_b.points.size (); ++i)
+  for (auto &point : cloud_b.points)
   {
-    cloud_b.points[i].x = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
-    cloud_b.points[i].y = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
-    cloud_b.points[i].z = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
+    point.x = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
+    point.y = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
+    point.z = static_cast<float> (1024 * rand () / (RAND_MAX + 1.0));
   }
 
   // Copy the point cloud data

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -214,9 +214,9 @@ TEST_F (PLYColorTest, LoadPLYFileColoredASCIIIntoBlob)
 
   // scope blob data
   ps = cloud_blob.point_step;
-  for (size_t i = 0; i < cloud_blob.fields.size (); ++i)
-    if (cloud_blob.fields[i].name == std::string("rgba"))
-      offset = static_cast<int32_t> (cloud_blob.fields[i].offset);
+  for (const auto &field : cloud_blob.fields)
+    if (field.name == std::string("rgba"))
+      offset = static_cast<int32_t> (field.offset);
 
   ASSERT_GE (offset, 0);
 
@@ -262,9 +262,9 @@ TEST_F (PLYColorTest, LoadPLYFileColoredASCIIIntoPolygonMesh)
 
   // scope blob data
   ps = mesh.cloud.point_step;
-  for (size_t i = 0; i < mesh.cloud.fields.size (); ++i)
-    if (mesh.cloud.fields[i].name == std::string("rgba"))
-      offset = static_cast<int32_t> (mesh.cloud.fields[i].offset);
+  for (const auto &field : mesh.cloud.fields)
+    if (field.name == std::string("rgba"))
+      offset = static_cast<int32_t> (field.offset);
 
   ASSERT_GE (offset, 0);
 

--- a/test/io/test_point_cloud_image_extractors.cpp
+++ b/test/io/test_point_cloud_image_extractors.cpp
@@ -55,11 +55,11 @@ TEST (PCL, PointCloudImageExtractorFromNormalField)
   cloud.height = 2;
   cloud.is_dense = true;
   cloud.points.resize (cloud.width * cloud.height);
-  for (size_t i = 0; i < cloud.points.size (); i++)
+  for (auto &point : cloud.points)
   {
-    cloud.points[i].normal_x = -1.0;
-    cloud.points[i].normal_y =  0.0;
-    cloud.points[i].normal_z =  1.0;
+    point.normal_x = -1.0;
+    point.normal_y =  0.0;
+    point.normal_z =  1.0;
   }
   pcl::PCLImage image;
   PointCloudImageExtractorFromNormalField<PointT> pcie;
@@ -93,11 +93,11 @@ TEST (PCL, PointCloudImageExtractorFromRGBField)
   cloud.height = 2;
   cloud.is_dense = true;
   cloud.points.resize (cloud.width * cloud.height);
-  for (size_t i = 0; i < cloud.points.size (); i++)
+  for (auto &point : cloud.points)
   {
-    cloud.points[i].r =   0;
-    cloud.points[i].g = 127;
-    cloud.points[i].b = 254;
+    point.r =   0;
+    point.g = 127;
+    point.b = 254;
   }
   pcl::PCLImage image;
   PointCloudImageExtractorFromRGBField<PointT> pcie;
@@ -131,12 +131,12 @@ TEST (PCL, PointCloudImageExtractorFromRGBAField)
   cloud.height = 2;
   cloud.is_dense = true;
   cloud.points.resize (cloud.width * cloud.height);
-  for (size_t i = 0; i < cloud.points.size (); i++)
+  for (auto &point : cloud.points)
   {
-    cloud.points[i].r =   0;
-    cloud.points[i].g = 127;
-    cloud.points[i].b = 254;
-    cloud.points[i].a = 100;
+    point.r =   0;
+    point.g = 127;
+    point.b = 254;
+    point.a = 100;
   }
   pcl::PCLImage image;
   PointCloudImageExtractorFromRGBField<PointT> pcie;

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -105,7 +105,7 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
   
   //cout << k_indices.size()<<"=="<<brute_force_result.size()<<"?\n";
   
-  for (const int k_index : k_indices)
+  for (const int &k_index : k_indices)
   {
     set<int>::iterator brute_force_result_it = brute_force_result.find (k_index);
     bool ok = brute_force_result_it != brute_force_result.end ();
@@ -187,7 +187,7 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
-  for (const int k_index : k_indices)
+  for (const int &k_index : k_indices)
   {
     const MyPoint& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -105,9 +105,9 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
   
   //cout << k_indices.size()<<"=="<<brute_force_result.size()<<"?\n";
   
-  for (size_t i = 0; i < k_indices.size (); ++i)
+  for (const int k_index : k_indices)
   {
-    set<int>::iterator brute_force_result_it = brute_force_result.find (k_indices[i]);
+    set<int>::iterator brute_force_result_it = brute_force_result.find (k_index);
     bool ok = brute_force_result_it != brute_force_result.end ();
     //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
     //else      cerr << k_indices[i] << " is correct...\n";
@@ -128,8 +128,8 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
 
     ScopeTime scopeTime ("FLANN radiusSearch");
     {
-      for (size_t i = 0; i < cloud_big.points.size (); ++i)
-        kdtree.radiusSearch (cloud_big.points[i], 0.1, k_indices, k_distances);
+      for (const auto &point : cloud_big.points)
+        kdtree.radiusSearch (point, 0.1, k_indices, k_distances);
     }
   }
   
@@ -139,8 +139,8 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
 
     ScopeTime scopeTime ("FLANN radiusSearch (max neighbors in radius)");
     {
-      for (size_t i = 0; i < cloud_big.points.size (); ++i)
-        kdtree.radiusSearch (cloud_big.points[i], 0.1, k_indices, k_distances, 10);
+      for (const auto &point : cloud_big.points)
+        kdtree.radiusSearch (point, 0.1, k_indices, k_distances, 10);
     }
   }
   
@@ -151,8 +151,8 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
 
     ScopeTime scopeTime ("FLANN radiusSearch (unsorted results)");
     {
-      for (size_t i = 0; i < cloud_big.points.size (); ++i)
-        kdtree.radiusSearch (cloud_big.points[i], 0.1, k_indices, k_distances);
+      for (const auto &point : cloud_big.points)
+        kdtree.radiusSearch (point, 0.1, k_indices, k_distances);
     }
   }
 }
@@ -187,14 +187,14 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
-  for (size_t i = 0; i < k_indices.size (); ++i)
+  for (const int k_index : k_indices)
   {
-    const MyPoint& point = cloud.points[k_indices[i]];
+    const MyPoint& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
       ok = (fabs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
-    //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
-    //else      cerr << k_indices[i] << " is correct...\n";
+    //if (!ok)  cerr << k_index << " is not correct...\n";
+    //else      cerr << k_index << " is correct...\n";
     EXPECT_EQ (ok, true);
   }
 
@@ -202,8 +202,8 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
   {
     KdTreeFLANN<MyPoint> kdtree;
     kdtree.setInputCloud (cloud_big.makeShared ());
-    for (size_t i = 0; i < cloud_big.points.size (); ++i)
-      kdtree.nearestKSearch (cloud_big.points[i], no_of_neighbors, k_indices, k_distances);
+    for (const auto &point : cloud_big.points)
+      kdtree.nearestKSearch (point, no_of_neighbors, k_indices, k_distances);
   }
 }
 

--- a/test/keypoints/test_keypoints.cpp
+++ b/test/keypoints/test_keypoints.cpp
@@ -159,7 +159,7 @@ TEST (PCL, SIFTKeypoint_radiusSearch)
 
   // Are they all unique?
   set<int> unique_indices;
-  for (const int nn_index : nn_indices)
+  for (const int &nn_index : nn_indices)
   {
     unique_indices.insert (nn_index);
   }

--- a/test/keypoints/test_keypoints.cpp
+++ b/test/keypoints/test_keypoints.cpp
@@ -159,9 +159,9 @@ TEST (PCL, SIFTKeypoint_radiusSearch)
 
   // Are they all unique?
   set<int> unique_indices;
-  for (size_t i_neighbor = 0; i_neighbor < nn_indices.size (); ++i_neighbor)
+  for (const int nn_index : nn_indices)
   {
-    unique_indices.insert (nn_indices[i_neighbor]);
+    unique_indices.insert (nn_index);
   }
 
   EXPECT_EQ (nn_indices.size (), unique_indices.size ());

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -164,8 +164,8 @@ TEST (PCL, Octree_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (unsigned int j = 0; j < 256; j++)
-      if (data[j] == leafInt)
+    for (const int value : data)
+      if (value == leafInt)
       {
         bFound = true;
         break;
@@ -183,8 +183,8 @@ TEST (PCL, Octree_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (unsigned int j = 0; j < 256; j++)
-      if (data[j] == leafInt)
+    for (const int value : data)
+      if (value == leafInt)
       {
         bFound = true;
         break;
@@ -339,14 +339,14 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
       Eigen::Vector3f min_pt, max_pt;
       octree.getVoxelBounds (it, min_pt, max_pt);
 
-      for (size_t i=0; i < tmpVector.size(); ++i)
+      for (int i : tmpVector)
       {
-        ASSERT_GE (cloud->points[tmpVector[i]].x, min_pt(0));
-        ASSERT_GE (cloud->points[tmpVector[i]].y, min_pt(1));
-        ASSERT_GE (cloud->points[tmpVector[i]].z, min_pt(2));
-        ASSERT_LE (cloud->points[tmpVector[i]].x, max_pt(0));
-        ASSERT_LE (cloud->points[tmpVector[i]].y, max_pt(1));
-        ASSERT_LE (cloud->points[tmpVector[i]].z, max_pt(2));
+        ASSERT_GE (cloud->points[i].x, min_pt(0));
+        ASSERT_GE (cloud->points[i].y, min_pt(1));
+        ASSERT_GE (cloud->points[i].z, min_pt(2));
+        ASSERT_LE (cloud->points[i].x, max_pt(0));
+        ASSERT_LE (cloud->points[i].y, max_pt(1));
+        ASSERT_LE (cloud->points[i].z, max_pt(2));
       }
 
       leaf_count++;
@@ -481,8 +481,8 @@ TEST (PCL, Octree2Buf_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (unsigned int j = 0; j < 256; j++)
-      if (data[j] == leafInt)
+    for (const int value : data)
+      if (value == leafInt)
       {
         bFound = true;
         break;
@@ -500,8 +500,8 @@ TEST (PCL, Octree2Buf_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (unsigned int j = 0; j < 256; j++)
-      if (data[j] == leafInt)
+    for (const int value : data)
+      if (value == leafInt)
       {
         bFound = true;
         break;
@@ -735,11 +735,11 @@ TEST (PCL, Octree_Pointcloud_Test)
     ASSERT_EQ (cloudA->points.size (), octreeA.getLeafCount ());
 
     // checks for getVoxelDataAtPoint() and isVoxelOccupiedAtPoint() functionality
-    for (size_t i = 0; i < cloudA->points.size (); i++)
+    for (const auto &point : cloudA->points)
     {
-      ASSERT_TRUE (octreeA.isVoxelOccupiedAtPoint (cloudA->points[i]));
-      octreeA.deleteVoxelAtPoint (cloudA->points[i]);
-      ASSERT_FALSE (octreeA.isVoxelOccupiedAtPoint (cloudA->points[i]));
+      ASSERT_TRUE (octreeA.isVoxelOccupiedAtPoint (point));
+      octreeA.deleteVoxelAtPoint (point);
+      ASSERT_FALSE (octreeA.isVoxelOccupiedAtPoint (point));
     }
 
     ASSERT_EQ (static_cast<unsigned int> (0), octreeA.getLeafCount ());
@@ -1245,11 +1245,11 @@ TEST (PCL, Octree_Pointcloud_Box_Search)
     cloudIn->width = 300;
     cloudIn->height = 1;
     cloudIn->points.resize (cloudIn->width * cloudIn->height);
-    for (size_t i = 0; i < cloudIn->points.size(); i++)
+    for (auto &point : cloudIn->points)
     {
-      cloudIn->points[i] = PointXYZ (static_cast<float> (10.0 * rand () / RAND_MAX),
-                                     static_cast<float> (10.0 * rand () / RAND_MAX),
-                                     static_cast<float> (10.0 * rand () / RAND_MAX));
+      point = PointXYZ (static_cast<float> (10.0 * rand () / RAND_MAX),
+                        static_cast<float> (10.0 * rand () / RAND_MAX),
+                        static_cast<float> (10.0 * rand () / RAND_MAX));
     }
 
 

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -164,7 +164,7 @@ TEST (PCL, Octree_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (const int value : data)
+    for (const int &value : data)
       if (value == leafInt)
       {
         bFound = true;
@@ -183,7 +183,7 @@ TEST (PCL, Octree_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (const int value : data)
+    for (const int &value : data)
       if (value == leafInt)
       {
         bFound = true;
@@ -339,7 +339,7 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
       Eigen::Vector3f min_pt, max_pt;
       octree.getVoxelBounds (it, min_pt, max_pt);
 
-      for (int i : tmpVector)
+      for (const int &i : tmpVector)
       {
         ASSERT_GE (cloud->points[i].x, min_pt(0));
         ASSERT_GE (cloud->points[i].y, min_pt(1));
@@ -481,7 +481,7 @@ TEST (PCL, Octree2Buf_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (const int value : data)
+    for (const int &value : data)
       if (value == leafInt)
       {
         bFound = true;
@@ -500,7 +500,7 @@ TEST (PCL, Octree2Buf_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (const int value : data)
+    for (const int &value : data)
       if (value == leafInt)
       {
         bFound = true;

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -124,8 +124,8 @@ struct OctreeIteratorTest : public OctreeIteratorBaseTest
     keys_[7] = OctreeKeyT (0b1u, 0b1u, 0b1u);
 
     // Create the leaves
-    for (uint8_t i = 0; i < 8; ++i)
-      octree_.createLeaf (keys_[i].x, keys_[i].y, keys_[i].z);
+    for (const auto &key : keys_)
+      octree_.createLeaf (key.x, key.y, key.z);
 
     // reset the iterator state
     it_.reset ();
@@ -1439,12 +1439,10 @@ struct OctreePointCloudSierpinskiTest
   {
     std::vector<std::pair<Eigen::Vector3f, Eigen::Vector3f> > voxels_out;
 
-    for (std::vector<std::pair<Eigen::Vector3f, Eigen::Vector3f> >::const_iterator it = voxels_in.begin ();
-        it != voxels_in.end ();
-        ++it)
+    for (const auto &voxel : voxels_in)
       {
-        Eigen::Vector3f v_min = it->first;
-        Eigen::Vector3f v_max = it->second;
+        Eigen::Vector3f v_min = voxel.first;
+        Eigen::Vector3f v_max = voxel.second;
         Eigen::Vector3f v_mid = 0.5 * (v_min + v_max);
 
         std::pair<Eigen::Vector3f, Eigen::Vector3f> voxel_0;

--- a/test/outofcore/test_outofcore.cpp
+++ b/test/outofcore/test_outofcore.cpp
@@ -274,11 +274,11 @@ point_test (octree_disk& t)
     //query the list
     AlignedPointTVector pointsinregion;
 
-    for (AlignedPointTVector::iterator pointit = points.begin (); pointit != points.end (); ++pointit)
+    for (const auto &point : points)
     {
-      if ((query_box_min[0] <= pointit->x) && (pointit->x < qboxmax[0]) && (query_box_min[1] < pointit->y) && (pointit->y < qboxmax[1]) && (query_box_min[2] <= pointit->z) && (pointit->z < qboxmax[2]))
+      if ((query_box_min[0] <= point.x) && (point.x < qboxmax[0]) && (query_box_min[1] < point.y) && (point.y < qboxmax[1]) && (query_box_min[2] <= point.z) && (point.z < qboxmax[2]))
       {
-        pointsinregion.push_back (*pointit);
+        pointsinregion.push_back (point);
       }
     }
 

--- a/test/people/test_people_groundBasedPeopleDetectionApp.cpp
+++ b/test/people/test_people_groundBasedPeopleDetectionApp.cpp
@@ -90,9 +90,9 @@ TEST (PCL, GroundBasedPeopleDetectionApp)
   EXPECT_TRUE (people_detector.compute(clusters));             // perform people detection
 
   unsigned int k = 0;
-  for(std::vector<pcl::people::PersonCluster<PointT> >::iterator it = clusters.begin(); it != clusters.end(); ++it)
+  for(auto &cluster : clusters)
   {
-    if(it->getPersonConfidence() > min_confidence)             // draw only people with confidence above a threshold
+    if(cluster.getPersonConfidence() > min_confidence)             // draw only people with confidence above a threshold
       k++;
   }
   EXPECT_EQ (k, 5);		// verify number of people found (should be five)

--- a/test/people/test_people_groundBasedPeopleDetectionApp.cpp
+++ b/test/people/test_people_groundBasedPeopleDetectionApp.cpp
@@ -90,7 +90,7 @@ TEST (PCL, GroundBasedPeopleDetectionApp)
   EXPECT_TRUE (people_detector.compute(clusters));             // perform people detection
 
   unsigned int k = 0;
-  for(auto &cluster : clusters)
+  for(const auto &cluster : clusters)
   {
     if(cluster.getPersonConfidence() > min_confidence)             // draw only people with confidence above a threshold
       k++;

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -84,10 +84,10 @@ computeRmsE (const PointCloud<PointType>::ConstPtr &model, const PointCloud<Poin
 
   vector<int> neigh_indices (1);
   vector<float> neigh_sqr_dists (1);
-  for (size_t i = 0; i < transformed_model.size (); ++i)
+  for (const auto &model : transformed_model)
   {
 
-    int found_neighs = tree.nearestKSearch (transformed_model.at (i), 1, neigh_indices, neigh_sqr_dists);
+    int found_neighs = tree.nearestKSearch (model, 1, neigh_indices, neigh_sqr_dists);
     if(found_neighs == 1)
     {
       ++found_points;
@@ -138,8 +138,8 @@ TEST (PCL, Hough3DGrouping)
 
   // Pick transformation with lowest error
   double min_rms_e = std::numeric_limits<double>::max ();
-  for (size_t i = 0; i < rototranslations.size (); ++i)
-    min_rms_e = std::min (min_rms_e, computeRmsE (model_, scene_, rototranslations[i]));
+  for (const auto &rototranslation : rototranslations)
+    min_rms_e = std::min (min_rms_e, computeRmsE (model_, scene_, rototranslation));
   EXPECT_LT (min_rms_e, 1E-2);
 }
 

--- a/test/registration/test_correspondence_rejectors.cpp
+++ b/test/registration/test_correspondence_rejectors.cpp
@@ -101,11 +101,11 @@ TEST (CorrespondenceRejectors, CorrespondenceRejectionPoly)
   rng.seed (1e6);
   boost::normal_distribution<> nd (0, 0.005);
   boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > var_nor (rng, nd);
-  for (pcl::PointCloud<pcl::PointXYZ>::iterator it = target.begin (); it != target.end (); ++it)
+  for (auto &point : target)
   {
-    it->x += static_cast<float> (var_nor ());
-    it->y += static_cast<float> (var_nor ());
-    it->z += static_cast<float> (var_nor ());
+    point.x += static_cast<float> (var_nor ());
+    point.y += static_cast<float> (var_nor ());
+    point.z += static_cast<float> (var_nor ());
   }
   
   // Ensure deterministic sampling inside the rejector
@@ -139,8 +139,8 @@ TEST (CorrespondenceRejectors, CorrespondenceRejectionPoly)
    * where the query/match index are equal.
    */
   size_t true_positives = 0;
-  for (size_t i = 0; i < result.size(); ++i)
-    if (result[i].index_query == result[i].index_match)
+  for (auto &i : result)
+    if (i.index_query == i.index_match)
       ++true_positives;
   const size_t false_positives = result.size() - true_positives;
 

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -107,7 +107,7 @@ TEST (PCL, FlannSearch_nearestKSearch)
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
-  for (const int k_index : k_indices)
+  for (const int &k_index : k_indices)
   {
     const PointXYZ& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -107,9 +107,9 @@ TEST (PCL, FlannSearch_nearestKSearch)
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
-  for (size_t i = 0; i < k_indices.size (); ++i)
+  for (const int k_index : k_indices)
   {
-    const PointXYZ& point = cloud.points[k_indices[i]];
+    const PointXYZ& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
     ok = (fabs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
@@ -123,8 +123,8 @@ TEST (PCL, FlannSearch_nearestKSearch)
     pcl::search::Search<PointXYZ>* FlannSearch = new pcl::search::FlannSearch<PointXYZ>( new search::FlannSearch<PointXYZ>::KdTreeIndexCreator);
     //FlannSearch->initSearchDS ();
     FlannSearch->setInputCloud (cloud_big.makeShared ());
-    for (size_t i = 0; i < cloud_big.points.size (); ++i)
-      FlannSearch->nearestKSearch (cloud_big.points[i], no_of_neighbors, k_indices, k_distances);
+    for (const auto &point : cloud_big.points)
+      FlannSearch->nearestKSearch (point, no_of_neighbors, k_indices, k_distances);
   }
 }
 
@@ -282,13 +282,13 @@ TEST (PCL, FlannSearch_compareToKdTreeFlann)
 
   {
     ScopeTime scopeTime ("FLANN nearestKSearch");
-    for (size_t i = 0; i < cloud_big.points.size (); ++i)
-      flann_search->nearestKSearch (cloud_big.points[i], no_of_neighbors, k_indices, k_distances);
+    for (const auto &point : cloud_big.points)
+      flann_search->nearestKSearch (point, no_of_neighbors, k_indices, k_distances);
   }
   {
     ScopeTime scopeTime ("kd tree  nearestKSearch");
-    for (size_t i = 0; i < cloud_big.points.size (); ++i)
-      kdtree_search->nearestKSearch (cloud_big.points[i], no_of_neighbors, k_indices, k_distances);
+    for (const auto &point : cloud_big.points)
+      kdtree_search->nearestKSearch (point, no_of_neighbors, k_indices, k_distances);
   }
 
   vector<vector<int> > indices_flann;

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -101,9 +101,9 @@ init ()
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
-  for (size_t i = 0; i < k_indices.size (); ++i)
+  for (const int k_index : k_indices)
   {
-    const PointXYZ& point = cloud.points[k_indices[i]];
+    const PointXYZ& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
     ok = (fabs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
@@ -117,8 +117,8 @@ init ()
     pcl::search::Search<PointXYZ>* kdtree = new pcl::search::KdTree<PointXYZ>();
     //kdtree->initSearchDS ();
     kdtree->setInputCloud (cloud_big.makeShared ());
-    for (size_t i = 0; i < cloud_big.points.size (); ++i)
-    kdtree->nearestKSearch (cloud_big.points[i], no_of_neighbors, k_indices, k_distances);
+    for (const auto &point : cloud_big.points)
+    kdtree->nearestKSearch (point, no_of_neighbors, k_indices, k_distances);
   }
 }
 

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -101,7 +101,7 @@ init ()
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
-  for (const int k_index : k_indices)
+  for (const int &k_index : k_indices)
   {
     const PointXYZ& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -191,7 +191,7 @@ template<typename PointT> bool
 testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, const vector<bool>& indices_mask, const vector<bool>& nan_mask, const vector<int>& indices, const vector<int>& /*input_indices*/, const string& name)
 {
   bool validness = true;
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     if (!indices_mask [index])
     {
@@ -291,7 +291,7 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
   if (input_indices.size () != 0)
   {
     indices_mask.assign (point_cloud->size (), false);
-    for (const int input_index : input_indices)
+    for (const int &input_index : input_indices)
       indices_mask [input_index] = true;
   }
   
@@ -315,7 +315,7 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
   for (unsigned knn = 1; knn <= 512; knn <<= 3)
   {
     // find nn for each point in the cloud
-    for (const int query_index : query_indices)
+    for (const int &query_index : query_indices)
     {
       #pragma omp parallel for
       for (int sIdx = 0; sIdx < int (search_methods.size ()); ++sIdx)
@@ -361,7 +361,7 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
   if (input_indices.size () != 0)
   {
     indices_mask.assign (point_cloud->size (), false);
-    for (const int input_index : input_indices)
+    for (const int &input_index : input_indices)
       indices_mask [input_index] = true;
   }
   
@@ -386,7 +386,7 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
   {
     //cout << radius << endl;
     // find nn for each point in the cloud
-    for (const int query_index : query_indices)
+    for (const int &query_index : query_indices)
     {
       #pragma omp parallel for
       for (int sIdx = 0; sIdx < static_cast<int> (search_methods.size ()); ++sIdx)

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -191,12 +191,12 @@ template<typename PointT> bool
 testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, const vector<bool>& indices_mask, const vector<bool>& nan_mask, const vector<int>& indices, const vector<int>& /*input_indices*/, const string& name)
 {
   bool validness = true;
-  for (vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
+  for (const int index : indices)
   {
-    if (!indices_mask [*iIt])
+    if (!indices_mask [index])
     {
 #if DEBUG_OUT
-      cerr << name << ": result contains an invalid point: " << *iIt << " not in indices list.\n";
+      cerr << name << ": result contains an invalid point: " << index << " not in indices list.\n";
       
 //      for (vector<int>::const_iterator iIt2 = input_indices.begin (); iIt2 != input_indices.end (); ++iIt2)
 //        cout << *iIt2 << "  ";
@@ -205,12 +205,12 @@ testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, con
       validness = false;
       break;
     }
-    else if (!nan_mask [*iIt])
+    else if (!nan_mask [index])
     {
 #if DEBUG_OUT
-      cerr << name << ": result contains an invalid point: " << *iIt << " = NaN (" << point_cloud->points [*iIt].x << " , " 
-                                                                                   << point_cloud->points [*iIt].y << " , " 
-                                                                                   << point_cloud->points [*iIt].z << ")\n";
+      cerr << name << ": result contains an invalid point: " << index << " = NaN (" << point_cloud->points [index].x << " , " 
+                                                                                    << point_cloud->points [index].y << " , " 
+                                                                                    << point_cloud->points [index].z << ")\n";
 #endif
       validness = false;
       break;
@@ -291,8 +291,8 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
   if (input_indices.size () != 0)
   {
     indices_mask.assign (point_cloud->size (), false);
-    for (vector<int>::const_iterator iIt = input_indices.begin (); iIt != input_indices.end (); ++iIt)
-      indices_mask [*iIt] = true;
+    for (const int input_index : input_indices)
+      indices_mask [input_index] = true;
   }
   
   // remove also Nans
@@ -315,12 +315,12 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
   for (unsigned knn = 1; knn <= 512; knn <<= 3)
   {
     // find nn for each point in the cloud
-    for (vector<int>::const_iterator qIt = query_indices.begin (); qIt != query_indices.end (); ++qIt)
+    for (const int query_index : query_indices)
     {
       #pragma omp parallel for
       for (int sIdx = 0; sIdx < int (search_methods.size ()); ++sIdx)
       {
-        search_methods [sIdx]->nearestKSearch (point_cloud->points[*qIt], knn, indices [sIdx], distances [sIdx]);
+        search_methods [sIdx]->nearestKSearch (point_cloud->points[query_index], knn, indices [sIdx], distances [sIdx]);
         passed [sIdx] = passed [sIdx] && testUniqueness (indices [sIdx], search_methods [sIdx]->getName ());
         passed [sIdx] = passed [sIdx] && testOrder (distances [sIdx], search_methods [sIdx]->getName ());
         passed [sIdx] = passed [sIdx] && testResultValidity<PointT>(point_cloud, indices_mask, nan_mask, indices [sIdx], input_indices, search_methods [sIdx]->getName ());
@@ -361,8 +361,8 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
   if (input_indices.size () != 0)
   {
     indices_mask.assign (point_cloud->size (), false);
-    for (vector<int>::const_iterator iIt = input_indices.begin (); iIt != input_indices.end (); ++iIt)
-      indices_mask [*iIt] = true;
+    for (const int input_index : input_indices)
+      indices_mask [input_index] = true;
   }
   
   // remove also Nans
@@ -386,12 +386,12 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
   {
     //cout << radius << endl;
     // find nn for each point in the cloud
-    for (vector<int>::const_iterator qIt = query_indices.begin (); qIt != query_indices.end (); ++qIt)
+    for (const int query_index : query_indices)
     {
       #pragma omp parallel for
       for (int sIdx = 0; sIdx < static_cast<int> (search_methods.size ()); ++sIdx)
       {
-        search_methods [sIdx]->radiusSearch (point_cloud->points[*qIt], radius, indices [sIdx], distances [sIdx], 0);
+        search_methods [sIdx]->radiusSearch (point_cloud->points[query_index], radius, indices [sIdx], distances [sIdx], 0);
         passed [sIdx] = passed [sIdx] && testUniqueness (indices [sIdx], search_methods [sIdx]->getName ());
         passed [sIdx] = passed [sIdx] && testOrder (distances [sIdx], search_methods [sIdx]->getName ());
         passed [sIdx] = passed [sIdx] && testResultValidity<PointT>(point_cloud, indices_mask, nan_mask, indices [sIdx], input_indices, search_methods [sIdx]->getName ());

--- a/test/segmentation/test_random_walker.cpp
+++ b/test/segmentation/test_random_walker.cpp
@@ -227,7 +227,7 @@ TEST_P (RandomWalkerTest, GetPotentials)
   ASSERT_EQ (g.colors.size (), p.cols ());
   ASSERT_EQ (g.colors.size (), map.size ());
 
-  for (const unsigned int color : g.colors)
+  for (const unsigned int &color : g.colors)
     for (size_t i = 0; i < g.size; ++i)
       if (g.potentials.count (color))
       {

--- a/test/segmentation/test_random_walker.cpp
+++ b/test/segmentation/test_random_walker.cpp
@@ -227,11 +227,11 @@ TEST_P (RandomWalkerTest, GetPotentials)
   ASSERT_EQ (g.colors.size (), p.cols ());
   ASSERT_EQ (g.colors.size (), map.size ());
 
-  for (std::set<Color>::iterator it = g.colors.begin (); it != g.colors.end (); ++it)
+  for (const unsigned int color : g.colors)
     for (size_t i = 0; i < g.size; ++i)
-      if (g.potentials.count (*it))
+      if (g.potentials.count (color))
       {
-        EXPECT_NEAR (g.potentials[*it] (i), p (i, map[*it]), 0.01);
+        EXPECT_NEAR (g.potentials[color] (i), p (i, map[color]), 0.01);
       }
 }
 

--- a/test/surface/test_concave_hull.cpp
+++ b/test/surface/test_concave_hull.cpp
@@ -69,8 +69,8 @@ TEST (PCL, ConcaveHull_bunny)
 {
   //construct dataset
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud2D (new pcl::PointCloud<pcl::PointXYZ> (*cloud));
-  for (size_t i = 0; i < cloud2D->points.size (); i++)
-    cloud2D->points[i].z = 0;
+  for (auto &point : cloud2D->points)
+    point.z = 0;
 
   pcl::PointCloud<pcl::PointXYZ> alpha_shape;
   pcl::PointCloud<pcl::PointXYZ>::Ptr voronoi_centers (new pcl::PointCloud<pcl::PointXYZ>);

--- a/test/surface/test_convex_hull.cpp
+++ b/test/surface/test_convex_hull.cpp
@@ -325,11 +325,11 @@ TEST (PCL, ConvexHull_2dsquare)
   boost::uniform_01<boost::mt19937> rng (rng_alg);
   rng.base ().seed (12345u);
 
-  for (size_t i = 0; i < input_cloud->points.size (); i++)
+  for (auto &point : input_cloud->points)
   {
-    input_cloud->points[i].x = (2.0f * float (rng ()))-1.0f;
-    input_cloud->points[i].y = (2.0f * float (rng ()))-1.0f;
-    input_cloud->points[i].z = 1.0f;
+    point.x = (2.0f * float (rng ()))-1.0f;
+    point.y = (2.0f * float (rng ()))-1.0f;
+    point.z = 1.0f;
   }
 
   //Set up for creating a hull
@@ -354,15 +354,15 @@ TEST (PCL, ConvexHull_2dsquare)
   facets.emplace_back(0.0, -1.0, 0.0, -1.0);
 
   //Make sure they're in the plane
-  for (size_t i = 0; i < hull.points.size (); i++)
+  for (const auto &point : hull.points)
   {
-    float dist = fabs (hull.points[i].getVector4fMap ().dot (plane_normal));
+    float dist = fabs (point.getVector4fMap ().dot (plane_normal));
     EXPECT_NEAR (dist, 0.0, 1e-2);
 
     float min_dist = std::numeric_limits<float>::infinity ();
-    for (size_t j = 0; j < facets.size (); j++)
+    for (const auto &facet : facets)
     {
-      float d2 = fabs (hull.points[i].getVector4fMap ().dot (facets[j]));
+      float d2 = fabs (point.getVector4fMap ().dot (facet));
       
       if (d2 < min_dist)
         min_dist = d2;
@@ -385,11 +385,11 @@ TEST (PCL, ConvexHull_3dcube)
   boost::uniform_01<boost::mt19937> rng (rng_alg);
   rng.base ().seed (12345u);
 
-  for (size_t i = 0; i < input_cloud->points.size (); i++)
+  for (auto &point : input_cloud->points)
   {
-    input_cloud->points[i].x =  (2.0f * float (rng ()))-1.0f;
-    input_cloud->points[i].y =  (2.0f * float (rng ()))-1.0f;
-    input_cloud->points[i].z =  (2.0f * float (rng ()))-1.0f;
+    point.x =  (2.0f * float (rng ()))-1.0f;
+    point.y =  (2.0f * float (rng ()))-1.0f;
+    point.z =  (2.0f * float (rng ()))-1.0f;
   }
 
   //Set up for creating a hull
@@ -412,12 +412,12 @@ TEST (PCL, ConvexHull_3dcube)
   facets.emplace_back(0.0f, 0.0f, -1.0f, -1.0f);
 
   //Make sure they're near a facet
-  for (size_t i = 0; i < hull.points.size (); i++)
+  for (const auto &point : hull.points)
   {
     float min_dist = std::numeric_limits<float>::infinity ();
-    for (size_t j = 0; j < facets.size (); j++)
+    for (const auto &facet : facets)
     {
-      float dist = fabs (hull.points[i].getVector4fMap ().dot (facets[j]));
+      float dist = fabs (point.getVector4fMap ().dot (facet));
       
       if (dist < min_dist)
         min_dist = dist;

--- a/test/surface/test_ear_clipping.cpp
+++ b/test/surface/test_ear_clipping.cpp
@@ -91,8 +91,8 @@ TEST (PCL, EarClipping)
   clipper.process (triangulated_mesh);
 
   EXPECT_EQ (triangulated_mesh.polygons.size (), 4);
-  for (int i = 0; i < static_cast<int> (triangulated_mesh.polygons.size ()); ++i)
-    EXPECT_EQ (triangulated_mesh.polygons[i].vertices.size (), 3);
+  for (const auto &polygon : triangulated_mesh.polygons)
+    EXPECT_EQ (polygon.vertices.size (), 3);
 
   const int truth[][3] = { {5, 0, 1},
                            {2, 3, 4},
@@ -148,12 +148,12 @@ TEST (PCL, EarClippingCubeTest)
   PolygonMesh::Ptr mesh (new PolygonMesh);
   toPCLPointCloud2 (*cloud, mesh->cloud);
 
-  for (int i = 0; i < 6; ++i)
+  for (const auto &square : squares)
   {
-    vertices.vertices[0] = squares[i][0];
-    vertices.vertices[1] = squares[i][1];
-    vertices.vertices[2] = squares[i][2];
-    vertices.vertices[3] = squares[i][3];
+    vertices.vertices[0] = square[0];
+    vertices.vertices[1] = square[1];
+    vertices.vertices[2] = square[2];
+    vertices.vertices[3] = square[3];
     mesh->polygons.push_back (vertices);
   }
 
@@ -165,8 +165,8 @@ TEST (PCL, EarClippingCubeTest)
   clipper.process (triangulated_mesh);
 
   EXPECT_EQ (triangulated_mesh.polygons.size (), 12);
-  for (int i = 0; i < static_cast<int> (triangulated_mesh.polygons.size ()); ++i)
-    EXPECT_EQ (triangulated_mesh.polygons[i].vertices.size (), 3);
+  for (const auto &polygon : triangulated_mesh.polygons)
+    EXPECT_EQ (polygon.vertices.size (), 3);
 
   
 


### PR DESCRIPTION
Includes small changes to person_cluster (add const to some getter).

Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix