### PR TITLE
Transform classic loops to range-based for loops in module features

### DIFF
--- a/features/include/pcl/features/impl/3dsc.hpp
+++ b/features/include/pcl/features/impl/3dsc.hpp
@@ -141,8 +141,8 @@ pcl::ShapeContext3DEstimation<PointInT, PointNT, PointOutT>::computePoint (
   const size_t neighb_cnt = searchForNeighbors ((*indices_)[index], search_radius_, nn_indices, nn_dists);
   if (neighb_cnt == 0)
   {
-    for (size_t i = 0; i < desc.size (); ++i)
-      desc[i] = std::numeric_limits<float>::quiet_NaN ();
+    for (float &descriptor : desc)
+      descriptor = std::numeric_limits<float>::quiet_NaN ();
 
     memset (rf, 0, sizeof (rf[0]) * 9);
     return (false);

--- a/features/include/pcl/features/impl/board.hpp
+++ b/features/include/pcl/features/impl/board.hpp
@@ -177,7 +177,7 @@ pcl::BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT>::normalDis
   Eigen::Vector3f normal_mean;
   normal_mean.setZero ();
 
-  for (const int normal_index : normal_indices)
+  for (const int &normal_index : normal_indices)
   {
     const PointNT& curPt = normal_cloud[normal_index];
 

--- a/features/include/pcl/features/impl/board.hpp
+++ b/features/include/pcl/features/impl/board.hpp
@@ -177,9 +177,9 @@ pcl::BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT>::normalDis
   Eigen::Vector3f normal_mean;
   normal_mean.setZero ();
 
-  for (size_t i = 0; i < normal_indices.size (); ++i)
+  for (const int normal_index : normal_indices)
   {
-    const PointNT& curPt = normal_cloud[normal_indices[i]];
+    const PointNT& curPt = normal_cloud[normal_index];
 
     normal_mean += curPt.getNormalVector3fMap ();
   }

--- a/features/include/pcl/features/impl/boundary.hpp
+++ b/features/include/pcl/features/impl/boundary.hpp
@@ -74,7 +74,7 @@ pcl::BoundaryEstimation<PointInT, PointNT, PointOutT>::isBoundaryPoint (
   float max_dif = FLT_MIN, dif;
   int cp = 0;
 
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     if (!std::isfinite (cloud.points[index].x) || 
         !std::isfinite (cloud.points[index].y) || 

--- a/features/include/pcl/features/impl/boundary.hpp
+++ b/features/include/pcl/features/impl/boundary.hpp
@@ -74,14 +74,14 @@ pcl::BoundaryEstimation<PointInT, PointNT, PointOutT>::isBoundaryPoint (
   float max_dif = FLT_MIN, dif;
   int cp = 0;
 
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (const int index : indices)
   {
-    if (!std::isfinite (cloud.points[indices[i]].x) || 
-        !std::isfinite (cloud.points[indices[i]].y) || 
-        !std::isfinite (cloud.points[indices[i]].z))
+    if (!std::isfinite (cloud.points[index].x) || 
+        !std::isfinite (cloud.points[index].y) || 
+        !std::isfinite (cloud.points[index].z))
       continue;
 
-    Eigen::Vector4f delta = cloud.points[indices[i]].getVector4fMap () - q_point.getVector4fMap ();
+    Eigen::Vector4f delta = cloud.points[index].getVector4fMap () - q_point.getVector4fMap ();
     if (delta == Eigen::Vector4f::Zero())
       continue;
 

--- a/features/include/pcl/features/impl/crh.hpp
+++ b/features/include/pcl/features/impl/crh.hpp
@@ -101,10 +101,10 @@ pcl::CRHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
 
   float sum_w = 0, w = 0;
   int bin = 0;
-  for (size_t i = 0; i < grid.points.size (); ++i)
+  for (const auto &point : grid.points)
   {
-    bin = static_cast<int> ((((atan2 (grid.points[i].normal_y, grid.points[i].normal_x) + M_PI) * 180 / M_PI) / bin_angle)) % nbins;
-    w = std::sqrt (grid.points[i].normal_y * grid.points[i].normal_y + grid.points[i].normal_x * grid.points[i].normal_x);
+    bin = static_cast<int> ((((atan2 (point.normal_y, point.normal_x) + M_PI) * 180 / M_PI) / bin_angle)) % nbins;
+    w = std::sqrt (point.normal_y * point.normal_y + point.normal_x * point.normal_x);
     sum_w += w;
     spatial_data[bin] += w;
   }

--- a/features/include/pcl/features/impl/cvfh.hpp
+++ b/features/include/pcl/features/impl/cvfh.hpp
@@ -172,16 +172,16 @@ pcl::CVFHEstimation<PointInT, PointNT, PointOutT>::filterNormalsWithHighCurvatur
   size_t in, out;
   in = out = 0;
 
-  for (int i = 0; i < static_cast<int> (indices_to_use.size ()); i++)
+  for (const int index : indices_to_use)
   {
-    if (cloud.points[indices_to_use[i]].curvature > threshold)
+    if (cloud.points[index].curvature > threshold)
     {
-      indices_out[out] = indices_to_use[i];
+      indices_out[out] = index;
       out++;
     }
     else
     {
-      indices_in[in] = indices_to_use[i];
+      indices_in[in] = index;
       in++;
     }
   }
@@ -273,19 +273,19 @@ pcl::CVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
   if (clusters.size () > 0)
   { // ---[ Step 1b.1 : If yes, compute CVFH using the cluster information
 
-    for (size_t i = 0; i < clusters.size (); ++i) //for each cluster
+    for (const auto &cluster : clusters) //for each cluster
     {
       Eigen::Vector4f avg_normal = Eigen::Vector4f::Zero ();
       Eigen::Vector4f avg_centroid = Eigen::Vector4f::Zero ();
 
-      for (size_t j = 0; j < clusters[i].indices.size (); j++)
+      for (const auto &index : cluster.indices)
       {
-        avg_normal += normals_filtered_cloud->points[clusters[i].indices[j]].getNormalVector4fMap ();
-        avg_centroid += normals_filtered_cloud->points[clusters[i].indices[j]].getVector4fMap ();
+        avg_normal += normals_filtered_cloud->points[index].getNormalVector4fMap ();
+        avg_centroid += normals_filtered_cloud->points[index].getVector4fMap ();
       }
 
-      avg_normal /= static_cast<float> (clusters[i].indices.size ());
-      avg_centroid /= static_cast<float> (clusters[i].indices.size ());
+      avg_normal /= static_cast<float> (cluster.indices.size ());
+      avg_centroid /= static_cast<float> (cluster.indices.size ());
 
       Eigen::Vector4f centroid_test;
       pcl::compute3DCentroid (*normals_filtered_cloud, centroid_test);

--- a/features/include/pcl/features/impl/cvfh.hpp
+++ b/features/include/pcl/features/impl/cvfh.hpp
@@ -172,7 +172,7 @@ pcl::CVFHEstimation<PointInT, PointNT, PointOutT>::filterNormalsWithHighCurvatur
   size_t in, out;
   in = out = 0;
 
-  for (const int index : indices_to_use)
+  for (const int &index : indices_to_use)
   {
     if (cloud.points[index].curvature > threshold)
     {

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -270,31 +270,31 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
   float weights[10] = {0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 1.0f,  1.0f, 2.0f, 2.0f, 2.0f};
 
   hist.reserve (binsize * 10);
-  for (const float i : h_a3_in)
+  for (const float &i : h_a3_in)
     hist.push_back (i * weights[0]);
-  for (const float i : h_a3_out)
+  for (const float &i : h_a3_out)
     hist.push_back (i * weights[1]);
-  for (const float i : h_a3_mix)
+  for (const float &i : h_a3_mix)
     hist.push_back (i * weights[2]);
 
-  for (const float i : h_d3_in)
+  for (const float &i : h_d3_in)
     hist.push_back (i * weights[3]);
-  for (const float i : h_d3_out)
+  for (const float &i : h_d3_out)
     hist.push_back (i * weights[4]);
-  for (const float i : h_d3_mix)
+  for (const float &i : h_d3_mix)
     hist.push_back (i * weights[5]);
 
-  for (const float i : h_in)
+  for (const float &i : h_in)
     hist.push_back (i*0.5f * weights[6]);
-  for (const float i : h_out)
+  for (const float &i : h_out)
     hist.push_back (i * weights[7]);
-  for (const float i : h_mix)
+  for (const float &i : h_mix)
     hist.push_back (i * weights[8]);
-  for (const float i : h_mix_ratio)
+  for (const float &i : h_mix_ratio)
     hist.push_back (i*0.5f * weights[9]);
 
   float sm = 0;
-  for (const float i : hist)
+  for (const float &i : hist)
     sm += i;
 
   for (float &i : hist)

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -270,35 +270,35 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
   float weights[10] = {0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 1.0f,  1.0f, 2.0f, 2.0f, 2.0f};
 
   hist.reserve (binsize * 10);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_a3_in[i] * weights[0]);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_a3_out[i] * weights[1]);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_a3_mix[i] * weights[2]);
+  for (const float i : h_a3_in)
+    hist.push_back (i * weights[0]);
+  for (const float i : h_a3_out)
+    hist.push_back (i * weights[1]);
+  for (const float i : h_a3_mix)
+    hist.push_back (i * weights[2]);
 
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_d3_in[i] * weights[3]);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_d3_out[i] * weights[4]);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_d3_mix[i] * weights[5]);
+  for (const float i : h_d3_in)
+    hist.push_back (i * weights[3]);
+  for (const float i : h_d3_out)
+    hist.push_back (i * weights[4]);
+  for (const float i : h_d3_mix)
+    hist.push_back (i * weights[5]);
 
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_in[i]*0.5f * weights[6]);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_out[i] * weights[7]);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_mix[i] * weights[8]);
-  for (int i = 0; i < binsize; i++)
-    hist.push_back (h_mix_ratio[i]*0.5f * weights[9]);
+  for (const float i : h_in)
+    hist.push_back (i*0.5f * weights[6]);
+  for (const float i : h_out)
+    hist.push_back (i * weights[7]);
+  for (const float i : h_mix)
+    hist.push_back (i * weights[8]);
+  for (const float i : h_mix_ratio)
+    hist.push_back (i*0.5f * weights[9]);
 
   float sm = 0;
-  for (size_t i = 0; i < hist.size (); i++)
-    sm += hist[i];
+  for (const float i : hist)
+    sm += i;
 
-  for (size_t i = 0; i < hist.size (); i++)
-    hist[i] /= sm;
+  for (float &i : hist)
+    i /= sm;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/features/include/pcl/features/impl/fpfh.hpp
+++ b/features/include/pcl/features/impl/fpfh.hpp
@@ -73,7 +73,7 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computePointSPFHSignature (
   float hist_incr = 100.0f / static_cast<float>(indices.size () - 1);
 
   // Iterate over all the points in the neighborhood
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     // Avoid unnecessary returns
     if (p_idx == index)

--- a/features/include/pcl/features/impl/fpfh.hpp
+++ b/features/include/pcl/features/impl/fpfh.hpp
@@ -73,14 +73,14 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computePointSPFHSignature (
   float hist_incr = 100.0f / static_cast<float>(indices.size () - 1);
 
   // Iterate over all the points in the neighborhood
-  for (size_t idx = 0; idx < indices.size (); ++idx)
+  for (const int index : indices)
   {
     // Avoid unnecessary returns
-    if (p_idx == indices[idx])
+    if (p_idx == index)
         continue;
 
     // Compute the pair P to NNi
-    if (!computePairFeatures (cloud, normals, p_idx, indices[idx], pfh_tuple[0], pfh_tuple[1], pfh_tuple[2], pfh_tuple[3]))
+    if (!computePairFeatures (cloud, normals, p_idx, index, pfh_tuple[0], pfh_tuple[1], pfh_tuple[2], pfh_tuple[3]))
         continue;
 
     // Normalize the f1, f2, f3 features and push them in the histogram
@@ -259,8 +259,8 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
 
       // ... and remap the nn_indices values so that they represent row indices in the spfh_hist_* matrices 
       // instead of indices into surface_->points
-      for (size_t i = 0; i < nn_indices.size (); ++i)
-        nn_indices[i] = spfh_hist_lookup[nn_indices[i]];
+      for (int &nn_index : nn_indices)
+        nn_index = spfh_hist_lookup[nn_index];
 
       // Compute the FPFH signature (i.e. compute a weighted combination of local SPFH signatures) ...
       weightPointSPFHSignature (hist_f1_, hist_f2_, hist_f3_, nn_indices, nn_dists, fpfh_histogram_);
@@ -287,8 +287,8 @@ pcl::FPFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
 
       // ... and remap the nn_indices values so that they represent row indices in the spfh_hist_* matrices 
       // instead of indices into surface_->points
-      for (size_t i = 0; i < nn_indices.size (); ++i)
-        nn_indices[i] = spfh_hist_lookup[nn_indices[i]];
+      for (int &nn_index : nn_indices)
+        nn_index = spfh_hist_lookup[nn_index];
 
       // Compute the FPFH signature (i.e. compute a weighted combination of local SPFH signatures) ...
       weightPointSPFHSignature (hist_f1_, hist_f2_, hist_f3_, nn_indices, nn_dists, fpfh_histogram_);

--- a/features/include/pcl/features/impl/fpfh_omp.hpp
+++ b/features/include/pcl/features/impl/fpfh_omp.hpp
@@ -150,8 +150,8 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
 
     // ... and remap the nn_indices values so that they represent row indices in the spfh_hist_* matrices 
     // instead of indices into surface_->points
-    for (size_t i = 0; i < nn_indices.size (); ++i)
-      nn_indices[i] = spfh_hist_lookup[nn_indices[i]];
+    for (int &nn_index : nn_indices)
+      nn_index = spfh_hist_lookup[nn_index];
 
     // Compute the FPFH signature (i.e. compute a weighted combination of local SPFH signatures) ...
     Eigen::VectorXf fpfh_histogram = Eigen::VectorXf::Zero (nr_bins);

--- a/features/include/pcl/features/impl/gfpfh.hpp
+++ b/features/include/pcl/features/impl/gfpfh.hpp
@@ -145,9 +145,9 @@ pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::computeTransitionHistograms 
     transition_histograms[i].resize ((getNumberOfClasses () + 2) * (getNumberOfClasses () + 1) / 2, 0);
 
     std::vector< std::vector <int> > transitions (getNumberOfClasses () + 1);
-    for (size_t k = 0; k < transitions.size (); ++k)
+    for (auto &transition : transitions)
     {
-      transitions[k].resize (getNumberOfClasses () + 1, 0);
+      transition.resize (getNumberOfClasses () + 1, 0);
     }
 
     for (size_t k = 1; k < label_histograms[i].size (); ++k)
@@ -208,9 +208,9 @@ pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::computeDistanceHistogram (co
 
   const float range = max_value - min_value;
   const int max_bin = descriptorSize () - 1;
-  for (size_t i = 0; i < distances.size (); ++i)
+  for (const float distance : distances)
   {
-    const float raw_bin = static_cast<float> (descriptorSize ()) * (distances[i] - min_value) / range;
+    const float raw_bin = static_cast<float> (descriptorSize ()) * (distance - min_value) / range;
     int bin = std::min (max_bin, static_cast<int> (floor (raw_bin)));
     histogram[bin] += 1;
   }
@@ -224,12 +224,12 @@ pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::computeMeanHistogram (const 
   assert (histograms.size () > 0);
 
   mean_histogram.resize (histograms[0].size (), 0);
-  for (size_t i = 0; i < histograms.size (); ++i)
-    for (size_t j = 0; j < histograms[i].size (); ++j)
-      mean_histogram[j] += static_cast<float> (histograms[i][j]);
+  for (const auto &histogram : histograms)
+    for (size_t j = 0; j < histogram.size (); ++j)
+      mean_histogram[j] += static_cast<float> (histogram[j]);
 
-  for (size_t i = 0; i < mean_histogram.size (); ++i)
-    mean_histogram[i] /= static_cast<float> (histograms.size ());
+  for (float &i : mean_histogram)
+    i /= static_cast<float> (histograms.size ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -252,9 +252,9 @@ template <typename PointInT, typename PointNT, typename PointOutT> boost::uint32
 pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::getDominantLabel (const std::vector<int>& indices)
 {
   std::vector<uint32_t> counts (getNumberOfClasses () + 1, 0);
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (const int nn_index : indices)
   {
-    uint32_t label = labels_->points[indices[i]].label;
+    uint32_t label = labels_->points[nn_index].label;
     counts[label] += 1;
   }
 

--- a/features/include/pcl/features/impl/gfpfh.hpp
+++ b/features/include/pcl/features/impl/gfpfh.hpp
@@ -208,7 +208,7 @@ pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::computeDistanceHistogram (co
 
   const float range = max_value - min_value;
   const int max_bin = descriptorSize () - 1;
-  for (const float distance : distances)
+  for (const float &distance : distances)
   {
     const float raw_bin = static_cast<float> (descriptorSize ()) * (distance - min_value) / range;
     int bin = std::min (max_bin, static_cast<int> (floor (raw_bin)));
@@ -252,7 +252,7 @@ template <typename PointInT, typename PointNT, typename PointOutT> boost::uint32
 pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::getDominantLabel (const std::vector<int>& indices)
 {
   std::vector<uint32_t> counts (getNumberOfClasses () + 1, 0);
-  for (const int nn_index : indices)
+  for (const int &nn_index : indices)
   {
     uint32_t label = labels_->points[nn_index].label;
     counts[label] += 1;

--- a/features/include/pcl/features/impl/grsd.hpp
+++ b/features/include/pcl/features/impl/grsd.hpp
@@ -102,13 +102,13 @@ pcl::GRSDEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
   {
     int source_type = types[idx];
     std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud_downsampled->points[idx], relative_coordinates_all_);
-    for (size_t id_n = 0; id_n < neighbors.size (); id_n++)
+    for (const int neighbor : neighbors)
     {
       int neighbor_type;
-      if (neighbors[id_n] == -1) // empty
+      if (neighbor == -1) // empty
         neighbor_type = NR_CLASS;
       else
-        neighbor_type = types[neighbors[id_n]];
+        neighbor_type = types[neighbor];
       transition_matrix (source_type, neighbor_type)++;
     }
   }

--- a/features/include/pcl/features/impl/grsd.hpp
+++ b/features/include/pcl/features/impl/grsd.hpp
@@ -102,7 +102,7 @@ pcl::GRSDEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
   {
     int source_type = types[idx];
     std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud_downsampled->points[idx], relative_coordinates_all_);
-    for (const int neighbor : neighbors)
+    for (const int &neighbor : neighbors)
     {
       int neighbor_type;
       if (neighbor == -1) // empty

--- a/features/include/pcl/features/impl/intensity_gradient.hpp
+++ b/features/include/pcl/features/impl/intensity_gradient.hpp
@@ -58,9 +58,9 @@ pcl::IntensityGradientEstimation <PointInT, PointNT, PointOutT, IntensitySelecto
   Eigen::Matrix3f A = Eigen::Matrix3f::Zero ();
   Eigen::Vector3f b = Eigen::Vector3f::Zero ();
 
-  for (size_t i_point = 0; i_point < indices.size (); ++i_point)
+  for (const int nn_index : indices)
   {
-    PointInT p = cloud.points[indices[i_point]];
+    PointInT p = cloud.points[nn_index];
     if (!std::isfinite (p.x) ||
         !std::isfinite (p.y) ||
         !std::isfinite (p.z) ||
@@ -171,10 +171,10 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
       float mean_intensity = 0;
       // Initialize to 0
       centroid.setZero ();
-      for (size_t i = 0; i < nn_indices.size (); ++i)
+      for (const int nn_index : nn_indices)
       {
-        centroid += surface_->points[nn_indices[i]].getVector3fMap ();
-        mean_intensity += intensity_ (surface_->points[nn_indices[i]]);
+        centroid += surface_->points[nn_index].getVector3fMap ();
+        mean_intensity += intensity_ (surface_->points[nn_index]);
       }
       centroid /= static_cast<float> (nn_indices.size ());
       mean_intensity /= static_cast<float> (nn_indices.size ());
@@ -209,14 +209,14 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
       // Initialize to 0
       centroid.setZero ();
       unsigned cp = 0;
-      for (size_t i = 0; i < nn_indices.size (); ++i)
+      for (const int nn_index : nn_indices)
       {
         // Check if the point is invalid
-        if (!isFinite ((*surface_) [nn_indices[i]]))
+        if (!isFinite ((*surface_) [nn_index]))
           continue;
 
-        centroid += surface_->points [nn_indices[i]].getVector3fMap ();
-        mean_intensity += intensity_ (surface_->points [nn_indices[i]]);
+        centroid += surface_->points [nn_index].getVector3fMap ();
+        mean_intensity += intensity_ (surface_->points [nn_index]);
         ++cp;
       }
       centroid /= static_cast<float> (cp);

--- a/features/include/pcl/features/impl/intensity_gradient.hpp
+++ b/features/include/pcl/features/impl/intensity_gradient.hpp
@@ -58,7 +58,7 @@ pcl::IntensityGradientEstimation <PointInT, PointNT, PointOutT, IntensitySelecto
   Eigen::Matrix3f A = Eigen::Matrix3f::Zero ();
   Eigen::Vector3f b = Eigen::Vector3f::Zero ();
 
-  for (const int nn_index : indices)
+  for (const int &nn_index : indices)
   {
     PointInT p = cloud.points[nn_index];
     if (!std::isfinite (p.x) ||
@@ -171,7 +171,7 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
       float mean_intensity = 0;
       // Initialize to 0
       centroid.setZero ();
-      for (const int nn_index : nn_indices)
+      for (const int &nn_index : nn_indices)
       {
         centroid += surface_->points[nn_index].getVector3fMap ();
         mean_intensity += intensity_ (surface_->points[nn_index]);
@@ -209,7 +209,7 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
       // Initialize to 0
       centroid.setZero ();
       unsigned cp = 0;
-      for (const int nn_index : nn_indices)
+      for (const int &nn_index : nn_indices)
       {
         // Check if the point is invalid
         if (!isFinite ((*surface_) [nn_index]))

--- a/features/include/pcl/features/impl/moment_invariants.hpp
+++ b/features/include/pcl/features/impl/moment_invariants.hpp
@@ -57,7 +57,7 @@ pcl::MomentInvariantsEstimation<PointInT, PointOutT>::computePointMomentInvarian
   float mu200 = 0, mu020 = 0, mu002 = 0, mu110 = 0, mu101 = 0, mu011  = 0;
 
   // Iterate over the nearest neighbors set
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     // Demean the points
     temp_pt_[0] = cloud.points[index].x - xyz_centroid_[0];

--- a/features/include/pcl/features/impl/moment_invariants.hpp
+++ b/features/include/pcl/features/impl/moment_invariants.hpp
@@ -57,12 +57,12 @@ pcl::MomentInvariantsEstimation<PointInT, PointOutT>::computePointMomentInvarian
   float mu200 = 0, mu020 = 0, mu002 = 0, mu110 = 0, mu101 = 0, mu011  = 0;
 
   // Iterate over the nearest neighbors set
-  for (size_t nn_idx = 0; nn_idx < indices.size (); ++nn_idx)
+  for (const int index : indices)
   {
     // Demean the points
-    temp_pt_[0] = cloud.points[indices[nn_idx]].x - xyz_centroid_[0];
-    temp_pt_[1] = cloud.points[indices[nn_idx]].y - xyz_centroid_[1];
-    temp_pt_[2] = cloud.points[indices[nn_idx]].z - xyz_centroid_[2];
+    temp_pt_[0] = cloud.points[index].x - xyz_centroid_[0];
+    temp_pt_[1] = cloud.points[index].y - xyz_centroid_[1];
+    temp_pt_[2] = cloud.points[index].z - xyz_centroid_[2];
 
     mu200 += temp_pt_[0] * temp_pt_[0];
     mu020 += temp_pt_[1] * temp_pt_[1];

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -143,9 +143,9 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::calculateMeanFeatu
   float normalization_factor = 0.0f;
   for (std::vector<std::vector<std::vector<float> > >::iterator scale_it = features_at_scale_vectorized_.begin (); scale_it != features_at_scale_vectorized_.end(); ++scale_it) {
     normalization_factor += static_cast<float> (scale_it->size ());
-    for (std::vector<std::vector<float> >::iterator feature_it = scale_it->begin (); feature_it != scale_it->end (); ++feature_it)
+    for (const auto &feature : *scale_it)
       for (int dim_i = 0; dim_i < feature_representation_->getNumberOfDimensions (); ++dim_i)
-        mean_feature_[dim_i] += (*feature_it)[dim_i];
+        mean_feature_[dim_i] += feature[dim_i];
   }
 
   for (int dim_i = 0; dim_i < feature_representation_->getNumberOfDimensions (); ++dim_i)

--- a/features/include/pcl/features/impl/organized_edge_detection.hpp
+++ b/features/include/pcl/features/impl/organized_edge_detection.hpp
@@ -157,14 +157,14 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
           int dx = 0;
           int dy = 0;
           int num_of_invalid_pt = 0;
-          for (int d_idx = 0; d_idx < num_of_ngbr; d_idx++)
+          for (const auto &direction : directions)
           {
-            int nghr_idx = curr_idx + directions[d_idx].d_index;
+            int nghr_idx = curr_idx + direction.d_index;
             assert (nghr_idx >= 0 && nghr_idx < input_->points.size ());
             if (!std::isfinite (input_->points[nghr_idx].z))
             {
-              dx += directions[d_idx].d_x;
-              dy += directions[d_idx].d_y;
+              dx += direction.d_x;
+              dy += direction.d_y;
               num_of_invalid_pt++;
             }
           }

--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -169,16 +169,16 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::filterNormalsWithHighCurva
   size_t in, out;
   in = out = 0;
 
-  for (int i = 0; i < static_cast<int> (indices_to_use.size ()); i++)
+  for (const int index : indices_to_use)
   {
-    if (cloud.points[indices_to_use[i]].curvature > threshold)
+    if (cloud.points[index].curvature > threshold)
     {
-      indices_out[out] = indices_to_use[i];
+      indices_out[out] = index;
       out++;
     }
     else
     {
-      indices_in[in] = indices_to_use[i];
+      indices_in[in] = index;
       in++;
     }
   }
@@ -238,9 +238,9 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::sgurf (Eigen::Vector3f & c
   float sum_w = 0.f;
 
   //for (int k = 0; k < static_cast<intgrid->points[k].getVector3fMap ();> (grid->points.size ()); k++)
-  for (int k = 0; k < static_cast<int> (indices.indices.size ()); k++)
+  for (const int index : indices.indices)
   {
-    Eigen::Vector3f pvector = grid->points[indices.indices[k]].getVector3fMap ();
+    Eigen::Vector3f pvector = grid->points[index].getVector3fMap ();
     float d_k = (pvector).norm ();
     float w = (max_dist - d_k);
     Eigen::Vector3f diff = (pvector);
@@ -390,11 +390,11 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeRFAndShapeDistribut
     // Make a note of how many transformations correspond to each cluster
     cluster_axes_[i] = transformations.size ();
     
-    for (size_t t = 0; t < transformations.size (); t++)
+    for (const auto &transformation : transformations)
     {
 
-      pcl::transformPointCloud (*processed, *grid, transformations[t]);
-      transforms_.push_back (transformations[t]);
+      pcl::transformPointCloud (*processed, *grid, transformation);
+      transforms_.push_back (transformation);
       valid_transforms_.push_back (true);
 
       std::vector < Eigen::VectorXf > quadrants (8);
@@ -611,7 +611,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
 
     std::vector<pcl::PointIndices> clusters_filtered;
     int cluster_filtered_idx = 0;
-    for (size_t i = 0; i < clusters.size (); i++)
+    for (const auto &cluster : clusters)
     {
 
       pcl::PointIndices pi;
@@ -624,27 +624,27 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
       Eigen::Vector4f avg_normal = Eigen::Vector4f::Zero ();
       Eigen::Vector4f avg_centroid = Eigen::Vector4f::Zero ();
 
-      for (size_t j = 0; j < clusters[i].indices.size (); j++)
+      for (const auto &index : cluster.indices)
       {
-        avg_normal += normals_filtered_cloud->points[clusters[i].indices[j]].getNormalVector4fMap ();
-        avg_centroid += normals_filtered_cloud->points[clusters[i].indices[j]].getVector4fMap ();
+        avg_normal += normals_filtered_cloud->points[index].getNormalVector4fMap ();
+        avg_centroid += normals_filtered_cloud->points[index].getVector4fMap ();
       }
 
-      avg_normal /= static_cast<float> (clusters[i].indices.size ());
-      avg_centroid /= static_cast<float> (clusters[i].indices.size ());
+      avg_normal /= static_cast<float> (cluster.indices.size ());
+      avg_centroid /= static_cast<float> (cluster.indices.size ());
       avg_normal.normalize ();
 
       Eigen::Vector3f avg_norm (avg_normal[0], avg_normal[1], avg_normal[2]);
       Eigen::Vector3f avg_dominant_centroid (avg_centroid[0], avg_centroid[1], avg_centroid[2]);
 
-      for (size_t j = 0; j < clusters[i].indices.size (); j++)
+      for (const auto &index : cluster.indices)
       {
         //decide if normal should be added
-        double dot_p = avg_normal.dot (normals_filtered_cloud->points[clusters[i].indices[j]].getNormalVector4fMap ());
+        double dot_p = avg_normal.dot (normals_filtered_cloud->points[index].getNormalVector4fMap ());
         if (fabs (acos (dot_p)) < (eps_angle_threshold_ * refine_clusters_))
         {
-          clusters_[cluster_filtered_idx].indices.push_back (indices_from_nfc_to_indices[clusters[i].indices[j]]);
-          clusters_filtered[cluster_filtered_idx].indices.push_back (clusters[i].indices[j]);
+          clusters_[cluster_filtered_idx].indices.push_back (indices_from_nfc_to_indices[index]);
+          clusters_filtered[cluster_filtered_idx].indices.push_back (index);
         }
       }
 
@@ -675,21 +675,19 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
   // ---[ Step 1b : check if any dominant cluster was found
   if (clusters.size () > 0)
   { // ---[ Step 1b.1 : If yes, compute CVFH using the cluster information
-
-    for (size_t i = 0; i < clusters.size (); ++i) //for each cluster
-
+    for (auto &cluster : clusters) //for each cluster
     {
       Eigen::Vector4f avg_normal = Eigen::Vector4f::Zero ();
       Eigen::Vector4f avg_centroid = Eigen::Vector4f::Zero ();
 
-      for (size_t j = 0; j < clusters[i].indices.size (); j++)
+      for (const auto &index : cluster.indices)
       {
-        avg_normal += normals_filtered_cloud->points[clusters[i].indices[j]].getNormalVector4fMap ();
-        avg_centroid += normals_filtered_cloud->points[clusters[i].indices[j]].getVector4fMap ();
+        avg_normal += normals_filtered_cloud->points[index].getNormalVector4fMap ();
+        avg_centroid += normals_filtered_cloud->points[index].getVector4fMap ();
       }
 
-      avg_normal /= static_cast<float> (clusters[i].indices.size ());
-      avg_centroid /= static_cast<float> (clusters[i].indices.size ());
+      avg_normal /= static_cast<float> (cluster.indices.size ());
+      avg_centroid /= static_cast<float> (cluster.indices.size ());
       avg_normal.normalize ();
 
       Eigen::Vector3f avg_norm (avg_normal[0], avg_normal[1], avg_normal[2]);

--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -169,7 +169,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::filterNormalsWithHighCurva
   size_t in, out;
   in = out = 0;
 
-  for (const int index : indices_to_use)
+  for (const int &index : indices_to_use)
   {
     if (cloud.points[index].curvature > threshold)
     {
@@ -238,7 +238,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::sgurf (Eigen::Vector3f & c
   float sum_w = 0.f;
 
   //for (int k = 0; k < static_cast<intgrid->points[k].getVector3fMap ();> (grid->points.size ()); k++)
-  for (const int index : indices.indices)
+  for (const int &index : indices.indices)
   {
     Eigen::Vector3f pvector = grid->points[index].getVector3fMap ();
     float d_k = (pvector).norm ();

--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -675,7 +675,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
   // ---[ Step 1b : check if any dominant cluster was found
   if (clusters.size () > 0)
   { // ---[ Step 1b.1 : If yes, compute CVFH using the cluster information
-    for (auto &cluster : clusters) //for each cluster
+    for (const auto &cluster : clusters) //for each cluster
     {
       Eigen::Vector4f avg_normal = Eigen::Vector4f::Zero ();
       Eigen::Vector4f avg_centroid = Eigen::Vector4f::Zero ();
@@ -690,12 +690,9 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
       avg_centroid /= static_cast<float> (cluster.indices.size ());
       avg_normal.normalize ();
 
-      Eigen::Vector3f avg_norm (avg_normal[0], avg_normal[1], avg_normal[2]);
-      Eigen::Vector3f avg_dominant_centroid (avg_centroid[0], avg_centroid[1], avg_centroid[2]);
-
       //append normal and centroid for the clusters
-      dominant_normals_.push_back (avg_norm);
-      centroids_dominant_orientations_.push_back (avg_dominant_centroid);
+      dominant_normals_.emplace_back (avg_normal[0], avg_normal[1], avg_normal[2]);
+      centroids_dominant_orientations_.emplace_back (avg_centroid[0], avg_centroid[1], avg_centroid[2]);
     }
 
     //compute modified VFH for all dominant clusters and add them to the list!

--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -133,7 +133,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computePointPFHSignature (
       // Copy into the histogram
       h_index = 0;
       h_p     = 1;
-      for (const int d : f_index_)
+      for (const int &d : f_index_)
       {
         h_index += h_p * d;
         h_p     *= nr_split;

--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -133,9 +133,9 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computePointPFHSignature (
       // Copy into the histogram
       h_index = 0;
       h_p     = 1;
-      for (int d = 0; d < 3; ++d)
+      for (const int d : f_index_)
       {
-        h_index += h_p * f_index_[d];
+        h_index += h_p * d;
         h_p     *= nr_split;
       }
       pfh_histogram[h_index] += hist_incr;

--- a/features/include/pcl/features/impl/ppfrgb.hpp
+++ b/features/include/pcl/features/impl/ppfrgb.hpp
@@ -123,7 +123,7 @@ pcl::PPFRGBRegionEstimation<PointInT, PointNT, PointOutT>::computeFeature (Point
 {
   PCL_INFO ("before computing output size: %u\n", output.size ());
   output.resize (indices_->size ());
-  for (int index_i = 0; index_i < static_cast<int> (indices_->size ()); ++index_i)
+  for (size_t index_i = 0; index_i < indices_->size (); ++index_i)
   {
     int i = (*indices_)[index_i];
     std::vector<int> nn_indices;
@@ -135,9 +135,8 @@ pcl::PPFRGBRegionEstimation<PointInT, PointNT, PointOutT>::computeFeature (Point
     average_feature_nn.f1 = average_feature_nn.f2 = average_feature_nn.f3 = average_feature_nn.f4 =
         average_feature_nn.r_ratio = average_feature_nn.g_ratio = average_feature_nn.b_ratio = 0.0f;
 
-    for (std::vector<int>::iterator nn_it = nn_indices.begin (); nn_it != nn_indices.end (); ++nn_it)
+    for (const int j : nn_indices)
     {
-      int j = *nn_it;
       if (i != j)
       {
         float f1, f2, f3, f4, r_ratio, g_ratio, b_ratio;

--- a/features/include/pcl/features/impl/ppfrgb.hpp
+++ b/features/include/pcl/features/impl/ppfrgb.hpp
@@ -135,7 +135,7 @@ pcl::PPFRGBRegionEstimation<PointInT, PointNT, PointOutT>::computeFeature (Point
     average_feature_nn.f1 = average_feature_nn.f2 = average_feature_nn.f3 = average_feature_nn.f4 =
         average_feature_nn.r_ratio = average_feature_nn.g_ratio = average_feature_nn.b_ratio = 0.0f;
 
-    for (const int j : nn_indices)
+    for (const int &j : nn_indices)
     {
       if (i != j)
       {

--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -42,6 +42,8 @@
 
 #include <pcl/features/rops_estimation.h>
 
+#include <array>
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 pcl::ROPSEstimation <PointInT, PointOutT>::ROPSEstimation () :
@@ -157,12 +159,12 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeFeature (PointCloudOut &output
     PointCloudIn transformed_cloud;
     transformCloud (input_->points[(*indices_)[i_point]], lrf_matrix, local_points, transformed_cloud);
 
-    PointInT axis[3];
-    axis[0].x = 1.0f; axis[0].y = 0.0f; axis[0].z = 0.0f;
-    axis[1].x = 0.0f; axis[1].y = 1.0f; axis[1].z = 0.0f;
-    axis[2].x = 0.0f; axis[2].y = 0.0f; axis[2].z = 1.0f;
+    std::array<PointInT, 3> axes;
+    axes[0].x = 1.0f; axes[0].y = 0.0f; axes[0].z = 0.0f;
+    axes[1].x = 0.0f; axes[1].y = 1.0f; axes[1].z = 0.0f;
+    axes[2].x = 0.0f; axes[2].y = 0.0f; axes[2].z = 1.0f;
     std::vector <float> feature;
-    for (unsigned int i_axis = 0; i_axis < 3; i_axis++)
+    for (const auto &axis : axes)
     {
       float theta = step_;
       do
@@ -170,7 +172,7 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeFeature (PointCloudOut &output
         //rotate local surface and get bounding box
         PointCloudIn rotated_cloud;
         Eigen::Vector3f min, max;
-        rotateCloud (axis[i_axis], theta, transformed_cloud, rotated_cloud, min, max);
+        rotateCloud (axis, theta, transformed_cloud, rotated_cloud, min, max);
 
         //for each projection (XY, XZ and YZ) compute distribution matrix and central moments
         for (unsigned int i_proj = 0; i_proj < 3; i_proj++)
@@ -267,12 +269,12 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeLRF (const PointInT& point, co
 
     Eigen::Matrix3f curr_scatter_matrix;
     curr_scatter_matrix.setZero ();
-    for (unsigned int i_pt = 0; i_pt < 3; i_pt++)
+    for (const auto &i_pt : pt)
     {
-      Eigen::Vector3f vec = pt[i_pt] - feature_point;
+      Eigen::Vector3f vec = i_pt - feature_point;
       curr_scatter_matrix += vec * (vec.transpose ());
-      for (unsigned int j_pt = 0; j_pt < 3; j_pt++)
-        curr_scatter_matrix += vec * ((pt[j_pt] - feature_point).transpose ());
+      for (const auto &j_pt : pt)
+        curr_scatter_matrix += vec * ((j_pt - feature_point).transpose ());
     }
     scatter_matrices[i_triangle] = coeff * curr_scatter_matrix;
   }
@@ -312,9 +314,9 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeLRF (const PointInT& point, co
 
     float factor1 = 0.0f;
     float factor3 = 0.0f;
-    for (unsigned int i_pt = 0; i_pt < 3; i_pt++)
+    for (const auto &i_pt : pt)
     {
-      Eigen::Vector3f vec = pt[i_pt] - feature_point;
+      Eigen::Vector3f vec = i_pt - feature_point;
       factor1 += vec.dot (v1);
       factor3 += vec.dot (v3);
     }

--- a/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
+++ b/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
@@ -212,8 +212,8 @@ pcl::StatisticalMultiscaleInterestRegionExtraction<PointT>::extractExtrema (std:
       std::vector<int> nn_indices;
       geodesicFixedRadiusSearch (point_i, scale_values_[scale_i], nn_indices);
       bool is_max_point = true, is_min_point = true;
-      for (std::vector<int>::iterator nn_it = nn_indices.begin (); nn_it != nn_indices.end (); ++nn_it)
-        if (F_scales_[scale_i][point_i] < F_scales_[scale_i][*nn_it])
+      for (const int nn_index : nn_indices)
+        if (F_scales_[scale_i][point_i] < F_scales_[scale_i][nn_index])
           is_max_point = false;
         else
           is_min_point = false;

--- a/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
+++ b/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
@@ -212,7 +212,7 @@ pcl::StatisticalMultiscaleInterestRegionExtraction<PointT>::extractExtrema (std:
       std::vector<int> nn_indices;
       geodesicFixedRadiusSearch (point_i, scale_values_[scale_i], nn_indices);
       bool is_max_point = true, is_min_point = true;
-      for (const int nn_index : nn_indices)
+      for (const int &nn_index : nn_indices)
         if (F_scales_[scale_i][point_i] < F_scales_[scale_i][nn_index])
           is_max_point = false;
         else

--- a/features/include/pcl/features/impl/vfh.hpp
+++ b/features/include/pcl/features/impl/vfh.hpp
@@ -134,11 +134,11 @@ pcl::VFHEstimation<PointInT, PointNT, PointOutT>::computePointSPFHSignature (con
     hist_incr_size_component = 0.0;
 
   // Iterate over all the points in the neighborhood
-  for (size_t idx = 0; idx < indices.size (); ++idx)
+  for (const int index : indices)
   {
     // Compute the pair P to NNi
-    if (!computePairFeatures (centroid_p, centroid_n, cloud.points[indices[idx]].getVector4fMap (),
-                              normals.points[indices[idx]].getNormalVector4fMap (), pfh_tuple[0], pfh_tuple[1],
+    if (!computePairFeatures (centroid_p, centroid_n, cloud.points[index].getVector4fMap (),
+                              normals.points[index].getNormalVector4fMap (), pfh_tuple[0], pfh_tuple[1],
                               pfh_tuple[2], pfh_tuple[3]))
       continue;
 

--- a/features/include/pcl/features/impl/vfh.hpp
+++ b/features/include/pcl/features/impl/vfh.hpp
@@ -134,7 +134,7 @@ pcl::VFHEstimation<PointInT, PointNT, PointOutT>::computePointSPFHSignature (con
     hist_incr_size_component = 0.0;
 
   // Iterate over all the points in the neighborhood
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     // Compute the pair P to NNi
     if (!computePairFeatures (centroid_p, centroid_n, cloud.points[index].getVector4fMap (),

--- a/features/include/pcl/features/normal_3d.h
+++ b/features/include/pcl/features/normal_3d.h
@@ -205,9 +205,9 @@ namespace pcl
   {
     Eigen::Vector3f normal_mean = Eigen::Vector3f::Zero ();
 
-    for (size_t i = 0; i < normal_indices.size (); ++i)
+    for (const int normal_index : normal_indices)
     {
-      const PointNT& cur_pt = normal_cloud[normal_indices[i]];
+      const PointNT& cur_pt = normal_cloud[normal_index];
 
       if (pcl::isFinite (cur_pt))
       {

--- a/features/include/pcl/features/normal_3d.h
+++ b/features/include/pcl/features/normal_3d.h
@@ -205,7 +205,7 @@ namespace pcl
   {
     Eigen::Vector3f normal_mean = Eigen::Vector3f::Zero ();
 
-    for (const int normal_index : normal_indices)
+    for (const int &normal_index : normal_indices)
     {
       const PointNT& cur_pt = normal_cloud[normal_index];
 

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -401,7 +401,7 @@ Narf::extractForInterestPoints (const RangeImage& range_image, const PointCloud<
         feature->getRotations(rotations, strengths);
         {
           //feature->getRotatedVersions(range_image, rotations, feature_list);
-          for (const float rotation : rotations)
+          for (const float &rotation : rotations)
           {
             Narf* feature2 = new Narf(*feature);  // Call copy constructor
             feature2->transformation_ = Eigen::AngleAxisf(-rotation, Eigen::Vector3f(0.0f, 0.0f, 1.0f))*feature2->transformation_;
@@ -497,7 +497,7 @@ Narf::getRotations (std::vector<float>& rotations, std::vector<float>& strengths
 void 
 Narf::getRotatedVersions (const RangeImage&, const std::vector<float>& rotations, std::vector<Narf*>& features) const
 {
-  for (const float rotation : rotations)
+  for (const float &rotation : rotations)
   {
     Narf* feature = new Narf(*this);  // Call copy constructor
     feature->transformation_ = Eigen::AngleAxisf(-rotation, Eigen::Vector3f(0.0f, 0.0f, 1.0f))*feature->transformation_;

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -401,9 +401,8 @@ Narf::extractForInterestPoints (const RangeImage& range_image, const PointCloud<
         feature->getRotations(rotations, strengths);
         {
           //feature->getRotatedVersions(range_image, rotations, feature_list);
-          for (size_t i = 0; i < rotations.size(); ++i)
+          for (const float rotation : rotations)
           {
-            float rotation = rotations[i];
             Narf* feature2 = new Narf(*feature);  // Call copy constructor
             feature2->transformation_ = Eigen::AngleAxisf(-rotation, Eigen::Vector3f(0.0f, 0.0f, 1.0f))*feature2->transformation_;
             feature2->surface_patch_rotation_ = rotation;
@@ -498,10 +497,8 @@ Narf::getRotations (std::vector<float>& rotations, std::vector<float>& strengths
 void 
 Narf::getRotatedVersions (const RangeImage&, const std::vector<float>& rotations, std::vector<Narf*>& features) const
 {
-  for (size_t i = 0; i < rotations.size(); ++i)
+  for (const float rotation : rotations)
   {
-    float rotation = rotations[i];
-    
     Narf* feature = new Narf(*this);  // Call copy constructor
     feature->transformation_ = Eigen::AngleAxisf(-rotation, Eigen::Vector3f(0.0f, 0.0f, 1.0f))*feature->transformation_;
     feature->surface_patch_rotation_ = rotation;
@@ -686,8 +683,8 @@ NarfDescriptor::computeFeature(NarfDescriptor::PointCloudOut& output)
   }
   
   // Cleanup
-  for (size_t i=0; i<feature_list.size(); ++i)
-    delete feature_list[i];
+  for (auto &i : feature_list)
+    delete i;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix