### PR TITLE
Transform classic loops to range-based for loops in module filters

### DIFF
--- a/filters/include/pcl/filters/impl/box_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/box_clipper3D.hpp
@@ -208,7 +208,7 @@ pcl::BoxClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& clou
   }
   else
   {
-    for (const int index : indices)
+    for (const int &index : indices)
       if (clipPoint3D (cloud_in[index]))
         clipped.push_back (index);
   }

--- a/filters/include/pcl/filters/impl/box_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/box_clipper3D.hpp
@@ -208,9 +208,9 @@ pcl::BoxClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& clou
   }
   else
   {
-    for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
-      if (clipPoint3D (cloud_in[*iIt]))
-        clipped.push_back (*iIt);
+    for (const int index : indices)
+      if (clipPoint3D (cloud_in[index]))
+        clipped.push_back (index);
   }
 }
 #endif //PCL_FILTERS_IMPL_BOX_CLIPPER3D_HPP

--- a/filters/include/pcl/filters/impl/covariance_sampling.hpp
+++ b/filters/include/pcl/filters/impl/covariance_sampling.hpp
@@ -202,8 +202,8 @@ pcl::CovarianceSampling<PointT, PointNT>::applyFilter (std::vector<int> &sampled
   }
 
   // Remap the sampled_indices to the input_ cloud
-  for (size_t i = 0; i < sampled_indices.size (); ++i)
-    sampled_indices[i] = (*indices_)[candidate_indices[sampled_indices[i]]];
+  for (int &sampled_index : sampled_indices)
+    sampled_index = (*indices_)[candidate_indices[sampled_index]];
 }
 
 

--- a/filters/include/pcl/filters/impl/extract_indices.hpp
+++ b/filters/include/pcl/filters/impl/extract_indices.hpp
@@ -67,8 +67,8 @@ pcl::ExtractIndices<PointT>::filterDirectly (PointCloudPtr &cloud)
       return;
     }
     uint8_t* pt_data = reinterpret_cast<uint8_t*> (&cloud->points[pt_index]);
-    for (int fi = 0; fi < static_cast<int> (fields.size ()); ++fi)  // fi = field iterator
-      memcpy (pt_data + fields[fi].offset, &user_filter_value_, sizeof (float));
+    for (const auto &field : fields)
+      memcpy (pt_data + field.offset, &user_filter_value_, sizeof (float));
   }
   if (!std::isfinite (user_filter_value_))
     cloud->is_dense = false;
@@ -100,8 +100,8 @@ pcl::ExtractIndices<PointT>::applyFilter (PointCloud &output)
         return;
       }
       uint8_t* pt_data = reinterpret_cast<uint8_t*> (&output.points[pt_index]);
-      for (int fi = 0; fi < static_cast<int> (fields.size ()); ++fi)  // fi = field iterator
-        memcpy (pt_data + fields[fi].offset, &user_filter_value_, sizeof (float));
+      for (const auto &field : fields)
+        memcpy (pt_data + field.offset, &user_filter_value_, sizeof (float));
     }
     if (!std::isfinite (user_filter_value_))
       output.is_dense = false;

--- a/filters/include/pcl/filters/impl/grid_minimum.hpp
+++ b/filters/include/pcl/filters/impl/grid_minimum.hpp
@@ -165,10 +165,10 @@ pcl::GridMinimum<PointT>::applyFilterIndices (std::vector<int> &indices)
 
   index = 0;
 
-  for (size_t cp = 0; cp < first_and_last_indices_vector.size (); ++cp)
+  for (const auto &cp : first_and_last_indices_vector)
   {
-    unsigned int first_index = first_and_last_indices_vector[cp].first;
-    unsigned int last_index = first_and_last_indices_vector[cp].second;
+    unsigned int first_index = cp.first;
+    unsigned int last_index = cp.second;
     unsigned int min_index = index_vector[first_index].cloud_point_index;
     float min_z = input_->points[index_vector[first_index].cloud_point_index].z;
 

--- a/filters/include/pcl/filters/impl/random_sample.hpp
+++ b/filters/include/pcl/filters/impl/random_sample.hpp
@@ -71,7 +71,7 @@ pcl::RandomSample<PointT>::applyFilter (PointCloud &output)
     for (size_t rii = 0; rii < removed_indices_->size (); ++rii)
     {
       uint8_t* pt_data = reinterpret_cast<uint8_t*> (&output[(*removed_indices_)[rii]]);
-      for (const unsigned long offset : offsets)
+      for (const unsigned long &offset : offsets)
       {
         memcpy (pt_data + offset, &user_filter_value, sizeof (float));
       }

--- a/filters/include/pcl/filters/impl/random_sample.hpp
+++ b/filters/include/pcl/filters/impl/random_sample.hpp
@@ -59,21 +59,21 @@ pcl::RandomSample<PointT>::applyFilter (PointCloud &output)
     std::vector<pcl::PCLPointField> fields;
     pcl::getFields (*input_, fields);
     std::vector<size_t> offsets;
-    for (size_t i = 0; i < fields.size (); ++i)
+    for (const auto &field : fields)
     {
-      if (fields[i].name == "x" ||
-          fields[i].name == "y" ||
-          fields[i].name == "z")
-        offsets.push_back (fields[i].offset);
+      if (field.name == "x" ||
+          field.name == "y" ||
+          field.name == "z")
+        offsets.push_back (field.offset);
     }
     // For every "removed" point, set the x,y,z fields to user_filter_value_
     const static float user_filter_value = user_filter_value_;
     for (size_t rii = 0; rii < removed_indices_->size (); ++rii)
     {
       uint8_t* pt_data = reinterpret_cast<uint8_t*> (&output[(*removed_indices_)[rii]]);
-      for (size_t i = 0; i < offsets.size (); ++i)
+      for (const unsigned long offset : offsets)
       {
-        memcpy (pt_data + offsets[i], &user_filter_value, sizeof (float));
+        memcpy (pt_data + offset, &user_filter_value, sizeof (float));
       }
       if (!std::isfinite (user_filter_value_))
         output.is_dense = false;

--- a/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
@@ -120,10 +120,10 @@ pcl::StatisticalOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &in
 
   // Estimate the mean and the standard deviation of the distance vector
   double sum = 0, sq_sum = 0;
-  for (size_t i = 0; i < distances.size (); ++i)
+  for (const float distance : distances)
   {
-    sum += distances[i];
-    sq_sum += distances[i] * distances[i];
+    sum += distance;
+    sq_sum += distance * distance;
   }
   double mean = sum / static_cast<double>(valid_distances);
   double variance = (sq_sum - sum * sum / static_cast<double>(valid_distances)) / (static_cast<double>(valid_distances) - 1);

--- a/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
@@ -120,7 +120,7 @@ pcl::StatisticalOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &in
 
   // Estimate the mean and the standard deviation of the distance vector
   double sum = 0, sq_sum = 0;
-  for (const float distance : distances)
+  for (const float &distance : distances)
   {
     sum += distance;
     sq_sum += distance * distance;

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -140,10 +140,10 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
   // If dense, no need to check for NaNs
   if (cloud->is_dense)
   {
-    for (std::vector<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+    for (const int index : indices)
     {
       // Get the distance value
-      const uint8_t* pt_data = reinterpret_cast<const uint8_t*> (&cloud->points[*it]);
+      const uint8_t* pt_data = reinterpret_cast<const uint8_t*> (&cloud->points[index]);
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
       if (limit_negative)
@@ -159,17 +159,17 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
           continue;
       }
       // Create the point structure and get the min/max
-      pcl::Array4fMapConst pt = cloud->points[*it].getArray4fMap ();
+      pcl::Array4fMapConst pt = cloud->points[index].getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }
   }
   else
   {
-    for (std::vector<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+    for (const int index : indices)
     {
       // Get the distance value
-      const uint8_t* pt_data = reinterpret_cast<const uint8_t*> (&cloud->points[*it]);
+      const uint8_t* pt_data = reinterpret_cast<const uint8_t*> (&cloud->points[index]);
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
       if (limit_negative)
@@ -186,12 +186,12 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
       }
 
       // Check if the point is invalid
-      if (!std::isfinite (cloud->points[*it].x) || 
-          !std::isfinite (cloud->points[*it].y) || 
-          !std::isfinite (cloud->points[*it].z))
+      if (!std::isfinite (cloud->points[index].x) || 
+          !std::isfinite (cloud->points[index].y) || 
+          !std::isfinite (cloud->points[index].z))
         continue;
       // Create the point structure and get the min/max
-      pcl::Array4fMapConst pt = cloud->points[*it].getArray4fMap ();
+      pcl::Array4fMapConst pt = cloud->points[index].getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }
@@ -393,11 +393,11 @@ pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
   }
   
   index = 0;
-  for (size_t cp = 0; cp < first_and_last_indices_vector.size (); ++cp)
+  for (const auto &cp : first_and_last_indices_vector)
   {
     // calculate centroid - sum values from all input points, that have the same idx value in index_vector array
-  	unsigned int first_index = first_and_last_indices_vector[cp].first;
-  	unsigned int last_index = first_and_last_indices_vector[cp].second;
+  	unsigned int first_index = cp.first;
+  	unsigned int last_index = cp.second;
 
     // index is centroid final position in resulting PointCloud
     if (save_leaf_layout_)

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -140,7 +140,7 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
   // If dense, no need to check for NaNs
   if (cloud->is_dense)
   {
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       // Get the distance value
       const uint8_t* pt_data = reinterpret_cast<const uint8_t*> (&cloud->points[index]);
@@ -166,7 +166,7 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
   }
   else
   {
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       // Get the distance value
       const uint8_t* pt_data = reinterpret_cast<const uint8_t*> (&cloud->points[index]);

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -694,8 +694,8 @@ namespace pcl
         Eigen::Vector4i ijk (static_cast<int> (floorf (x * inverse_leaf_size_[0])), static_cast<int> (floorf (y * inverse_leaf_size_[1])), static_cast<int> (floorf (z * inverse_leaf_size_[2])), 0);
         std::vector<int> neighbors;
         neighbors.reserve (relative_coordinates.size ());
-        for (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> >::const_iterator it = relative_coordinates.begin (); it != relative_coordinates.end (); it++)
-          neighbors.push_back (leaf_layout_[(ijk + (Eigen::Vector4i() << *it, 0).finished() - min_b_).dot (divb_mul_)]);
+        for (const auto &relative_coordinate : relative_coordinates)
+          neighbors.push_back (leaf_layout_[(ijk + (Eigen::Vector4i() << relative_coordinate, 0).finished() - min_b_).dot (divb_mul_)]);
         return (neighbors);
       }
 

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -428,7 +428,7 @@ namespace pcl
 
         // Find leaves corresponding to neighbors
         k_leaves.reserve (k);
-        for (const int k_index : k_indices)
+        for (const int &k_index : k_indices)
         {
           k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[k_index]]);
         }

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -428,9 +428,9 @@ namespace pcl
 
         // Find leaves corresponding to neighbors
         k_leaves.reserve (k);
-        for (std::vector<int>::iterator iter = k_indices.begin (); iter != k_indices.end (); iter++)
+        for (const int k_index : k_indices)
         {
-          k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[*iter]]);
+          k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[k_index]]);
         }
         return k;
       }
@@ -482,9 +482,9 @@ namespace pcl
 
         // Find leaves corresponding to neighbors
         k_leaves.reserve (k);
-        for (std::vector<int>::iterator iter = k_indices.begin (); iter != k_indices.end (); iter++)
+        for (const int &k_index : k_indices)
         {
-          k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[*iter]]);
+          k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[k_index]]);
         }
         return k;
       }

--- a/filters/src/extract_indices.cpp
+++ b/filters/src/extract_indices.cpp
@@ -71,7 +71,7 @@ pcl::ExtractIndices<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
                       inserter (remaining_indices, remaining_indices.begin ()));
 
       // Prepare the output and copy the data
-      for (const int remaining_index : remaining_indices)
+      for (const int &remaining_index : remaining_indices)
         for (size_t j = 0; j < output.fields.size(); ++j)
           memcpy (&output.data[remaining_index * output.point_step + output.fields[j].offset],
                   &user_filter_value_, sizeof(float));

--- a/filters/src/extract_indices.cpp
+++ b/filters/src/extract_indices.cpp
@@ -71,9 +71,9 @@ pcl::ExtractIndices<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
                       inserter (remaining_indices, remaining_indices.begin ()));
 
       // Prepare the output and copy the data
-      for (size_t i = 0; i < remaining_indices.size (); ++i)
+      for (const int remaining_index : remaining_indices)
         for (size_t j = 0; j < output.fields.size(); ++j)
-          memcpy (&output.data[remaining_indices[i] * output.point_step + output.fields[j].offset],
+          memcpy (&output.data[remaining_index * output.point_step + output.fields[j].offset],
                   &user_filter_value_, sizeof(float));
     }
     if (!std::isfinite (user_filter_value_))

--- a/filters/src/statistical_outlier_removal.cpp
+++ b/filters/src/statistical_outlier_removal.cpp
@@ -239,7 +239,7 @@ pcl::StatisticalOutlierRemoval<pcl::PCLPointCloud2>::generateStatistics (double&
 
   // Estimate the mean and the standard deviation of the distance vector
   double sum = 0, sq_sum = 0;
-  for (const float distance : distances)
+  for (const float &distance : distances)
   {
     sum += distance;
     sq_sum += distance * distance;

--- a/filters/src/statistical_outlier_removal.cpp
+++ b/filters/src/statistical_outlier_removal.cpp
@@ -239,10 +239,10 @@ pcl::StatisticalOutlierRemoval<pcl::PCLPointCloud2>::generateStatistics (double&
 
   // Estimate the mean and the standard deviation of the distance vector
   double sum = 0, sq_sum = 0;
-  for (size_t i = 0; i < distances.size (); ++i)
+  for (const float distance : distances)
   {
-    sum += distances[i];
-    sq_sum += distances[i] * distances[i];
+    sum += distance;
+    sq_sum += distance * distance;
   }
 
   mean = sum / static_cast<double>(valid_distances);

--- a/filters/src/voxel_grid_label.cpp
+++ b/filters/src/voxel_grid_label.cpp
@@ -333,16 +333,16 @@ pcl::VoxelGridLabel::applyFilter (PointCloud &output)
       {
         // find the label with the highest occurrence
         int n_occurrence = labels.begin()->second;
-        int label = labels.begin()->first;
-        for (auto it = labels.cbegin (); it != labels.cend (); ++it)
+        int best_label = labels.begin()->first;
+        for (const auto &label : labels)
         {
-          if (n_occurrence < it->second)
+          if (n_occurrence < label.second)
           {
-            n_occurrence = it->second;
-            label = it->first;
+            n_occurrence = label.second;
+            best_label = label.first;
           }
         }
-        output.points[index].label = label;
+        output.points[index].label = best_label;
       }
     }
     cp = i;


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix