### PR TITLE
Transform classic loops to range-based for loops in module recognition

### DIFF
--- a/recognition/include/pcl/recognition/crh_alignment.h
+++ b/recognition/include/pcl/recognition/crh_alignment.h
@@ -153,10 +153,10 @@ namespace pcl
 
         //if the number of peaks is too big, we should try to reduce using siluette matching
 
-        for (size_t i = 0; i < peaks.size(); i++)
+        for (const float peak : peaks)
         {
           Eigen::Affine3f rollToRot;
-          computeRollTransform (centroid_input_, centroid_target_, peaks[i], rollToRot);
+          computeRollTransform (centroid_input_, centroid_target_, peak, rollToRot);
 
           Eigen::Matrix4f rollHomMatrix = Eigen::Matrix4f ();
           rollHomMatrix.setIdentity (4, 4);
@@ -245,11 +245,10 @@ namespace pcl
           {
             bool insert = true;
 
-            for (size_t j = 0; j < peaks_indices.size (); j++)
+            for (int peaks_index : peaks_indices)
             { //check inserted peaks, first pick always inserted
-              if (std::abs (peaks_indices[j] - scored_peaks[i].second) <= peak_distance || std::abs (
-                                                                                             peaks_indices[j] - (scored_peaks[i].second
-                                                                                                 - nr_bins_after_padding)) <= peak_distance)
+              if ((std::abs (peaks_index - scored_peaks[i].second) <= peak_distance) ||
+                  (std::abs (peaks_index - (scored_peaks[i].second - nr_bins_after_padding)) <= peak_distance))
               {
                 insert = false;
                 break;

--- a/recognition/include/pcl/recognition/crh_alignment.h
+++ b/recognition/include/pcl/recognition/crh_alignment.h
@@ -153,7 +153,7 @@ namespace pcl
 
         //if the number of peaks is too big, we should try to reduce using siluette matching
 
-        for (const float peak : peaks)
+        for (const float &peak : peaks)
         {
           Eigen::Affine3f rollToRot;
           computeRollTransform (centroid_input_, centroid_target_, peak, rollToRot);
@@ -245,7 +245,7 @@ namespace pcl
           {
             bool insert = true;
 
-            for (int peaks_index : peaks_indices)
+            for (const int &peaks_index : peaks_indices)
             { //check inserted peaks, first pick always inserted
               if ((std::abs (peaks_index - scored_peaks[i].second) <= peak_distance) ||
                   (std::abs (peaks_index - (scored_peaks[i].second - nr_bins_after_padding)) <= peak_distance))

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -295,21 +295,21 @@ namespace pcl
             }
           }
 
-          for (size_t i = 0; i < explained.size (); i++)
+          for (const int i : explained)
           {
             if (val < 0)
             {
               //the hypothesis is being removed, check that there are no points that become unexplained and have clutter unexplained hypotheses
-              if ((explained_by_RM[explained[i]] == 0) && (unexplained_by_RM[explained[i]] > 0))
+              if ((explained_by_RM[i] == 0) && (unexplained_by_RM[i] > 0))
               {
-                add_to_unexplained += unexplained_by_RM[explained[i]]; //the points become unexplained
+                add_to_unexplained += unexplained_by_RM[i]; //the points become unexplained
               }
             } else
             {
               //std::cout << "being added..." << add_to_unexplained << " " << unexplained_by_RM[explained[i]] << std::endl;
-              if ((explained_by_RM[explained[i]] == 1) && (unexplained_by_RM[explained[i]] > 0))
+              if ((explained_by_RM[i] == 1) && (unexplained_by_RM[i] > 0))
               { //the only hypothesis explaining that point
-                add_to_unexplained -= unexplained_by_RM[explained[i]]; //the points are not unexplained any longer because this hypothesis explains them
+                add_to_unexplained -= unexplained_by_RM[i]; //the points are not unexplained any longer because this hypothesis explains them
               }
             }
           }
@@ -353,17 +353,17 @@ namespace pcl
 
       void updateCMDuplicity(std::vector<int> & vec, std::vector<int> & occupancy_vec, float sign) {
         int add_to_duplicity_ = 0;
-        for (size_t i = 0; i < vec.size (); i++)
+        for (const int i : vec)
         {
-          bool prev_dup = occupancy_vec[vec[i]] > 1;
-          occupancy_vec[vec[i]] += static_cast<int> (sign);
-          if ((occupancy_vec[vec[i]] > 1) && prev_dup)
+          bool prev_dup = occupancy_vec[i] > 1;
+          occupancy_vec[i] += static_cast<int> (sign);
+          if ((occupancy_vec[i] > 1) && prev_dup)
           { //its still a duplicate, we are adding
             add_to_duplicity_ += static_cast<int> (sign); //so, just add or remove one
-          } else if ((occupancy_vec[vec[i]] == 1) && prev_dup)
+          } else if ((occupancy_vec[i] == 1) && prev_dup)
           { //if was duplicate before, now its not, remove 2, we are removing the hypothesis
             add_to_duplicity_ -= 2;
-          } else if ((occupancy_vec[vec[i]] > 1) && !prev_dup)
+          } else if ((occupancy_vec[i] > 1) && !prev_dup)
           { //it was not a duplicate but it is now, add 2, we are adding a conflicting hypothesis for the point
             add_to_duplicity_ += 2;
           }

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -295,7 +295,7 @@ namespace pcl
             }
           }
 
-          for (const int i : explained)
+          for (const int &i : explained)
           {
             if (val < 0)
             {
@@ -353,7 +353,7 @@ namespace pcl
 
       void updateCMDuplicity(std::vector<int> & vec, std::vector<int> & occupancy_vec, float sign) {
         int add_to_duplicity_ = 0;
-        for (const int i : vec)
+        for (const int &i : vec)
         {
           bool prev_dup = occupancy_vec[i] > 1;
           occupancy_vec[i] += static_cast<int> (sign);

--- a/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
@@ -101,7 +101,7 @@ pcl::GeometricConsistencyGrouping<PointModelT, PointSceneT>::clusterCorresponden
       {
         //Let's check if j fits into the current consensus set
         bool is_a_good_candidate = true;
-        for (const int k : consensus_set)
+        for (const int &k : consensus_set)
         {
           int scene_index_k = model_scene_corrs_->at (k).index_match;
           int model_index_k = model_scene_corrs_->at (k).index_query;
@@ -133,7 +133,7 @@ pcl::GeometricConsistencyGrouping<PointModelT, PointSceneT>::clusterCorresponden
     if (static_cast<int> (consensus_set.size ()) > gc_threshold_)
     {
       Correspondences temp_corrs, filtered_corrs;
-      for (const int j : consensus_set)
+      for (const int &j : consensus_set)
       {
         temp_corrs.push_back (model_scene_corrs_->at (j));
         taken_corresps[ j ] = true;

--- a/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
@@ -101,10 +101,10 @@ pcl::GeometricConsistencyGrouping<PointModelT, PointSceneT>::clusterCorresponden
       {
         //Let's check if j fits into the current consensus set
         bool is_a_good_candidate = true;
-        for (size_t k = 0; k < consensus_set.size (); ++k)
+        for (const int k : consensus_set)
         {
-          int scene_index_k = model_scene_corrs_->at (consensus_set[k]).index_match;
-          int model_index_k = model_scene_corrs_->at (consensus_set[k]).index_query;
+          int scene_index_k = model_scene_corrs_->at (k).index_match;
+          int model_index_k = model_scene_corrs_->at (k).index_query;
           int scene_index_j = model_scene_corrs_->at (j).index_match;
           int model_index_j = model_scene_corrs_->at (j).index_query;
           
@@ -133,10 +133,10 @@ pcl::GeometricConsistencyGrouping<PointModelT, PointSceneT>::clusterCorresponden
     if (static_cast<int> (consensus_set.size ()) > gc_threshold_)
     {
       Correspondences temp_corrs, filtered_corrs;
-      for (size_t j = 0; j < consensus_set.size (); j++)
+      for (const int j : consensus_set)
       {
-        temp_corrs.push_back (model_scene_corrs_->at (consensus_set[j]));
-        taken_corresps[ consensus_set[j] ] = true;
+        temp_corrs.push_back (model_scene_corrs_->at (j));
+        taken_corresps[ j ] = true;
       }
       //ransac filtering
       corr_rejector.getRemainingCorrespondences (temp_corrs, filtered_corrs);

--- a/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
@@ -285,7 +285,7 @@ pcl::Hough3DGrouping<PointModelT, PointSceneT, PointModelRfT, PointSceneRfT>::cl
   for (size_t j = 0; j < max_values.size (); ++j)
   {
     Correspondences temp_corrs, filtered_corrs;
-    for (const int i : max_ids[j])
+    for (const int &i : max_ids[j])
     {
       temp_corrs.push_back (model_scene_corrs_->at (i));
     }

--- a/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
@@ -285,9 +285,9 @@ pcl::Hough3DGrouping<PointModelT, PointSceneT, PointModelRfT, PointSceneRfT>::cl
   for (size_t j = 0; j < max_values.size (); ++j)
   {
     Correspondences temp_corrs, filtered_corrs;
-    for (size_t i = 0; i < max_ids[j].size (); ++i)
+    for (const int i : max_ids[j])
     {
-      temp_corrs.push_back (model_scene_corrs_->at (max_ids[j][i]));
+      temp_corrs.push_back (model_scene_corrs_->at (i));
     }
     // RANSAC filtering
     corr_rejector.getRemainingCorrespondences (temp_corrs, filtered_corrs);

--- a/recognition/include/pcl/recognition/impl/hv/greedy_verification.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/greedy_verification.hpp
@@ -97,9 +97,9 @@ template<typename ModelT, typename SceneT>
 
       recognition_models_.push_back (recog_model);
 
-      for (size_t i = 0; i < explained_indices.size (); i++)
+      for (const int explained_index : explained_indices)
       {
-        points_explained_by_rm_[explained_indices[i]].push_back (recog_model);
+        points_explained_by_rm_[explained_index].push_back (recog_model);
       }
     }
 

--- a/recognition/include/pcl/recognition/impl/hv/greedy_verification.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/greedy_verification.hpp
@@ -97,7 +97,7 @@ template<typename ModelT, typename SceneT>
 
       recognition_models_.push_back (recog_model);
 
-      for (const int explained_index : explained_indices)
+      for (const int &explained_index : explained_indices)
       {
         points_explained_by_rm_[explained_index].push_back (recog_model);
       }

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -171,7 +171,7 @@ mets::gol_type pcl::GlobalHypothesesVerification<ModelT, SceneT>::evaluateSoluti
   setPreviousBadInfo (bad_info);
 
   int n_active_hyp = 0;
-  for(const bool i : active) {
+  for(const bool &i : active) {
     if(i)
       n_active_hyp++;
   }
@@ -381,9 +381,9 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::SAOptimize(std::vector<i
 
   recognition_models_.clear ();
 
-  for (const int cc_indice : cc_indices)
+  for (const int &cc_index : cc_indices)
   {
-    recognition_models_.push_back (recognition_models_copy[cc_indice]);
+    recognition_models_.push_back (recognition_models_copy[cc_index]);
   }
 
   for (size_t j = 0; j < recognition_models_.size (); j++)

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -171,8 +171,8 @@ mets::gol_type pcl::GlobalHypothesesVerification<ModelT, SceneT>::evaluateSoluti
   setPreviousBadInfo (bad_info);
 
   int n_active_hyp = 0;
-  for(size_t i=0; i < active.size(); i++) {
-    if(active[i])
+  for(const bool i : active) {
+    if(i)
       n_active_hyp++;
   }
 
@@ -267,11 +267,11 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::initialize()
 
     float intens_incr = 100.f / static_cast<float> (clusters.size ());
     float intens = intens_incr;
-    for (size_t i = 0; i < clusters.size (); i++)
+    for (const auto &cluster : clusters)
     {
-      for (size_t j = 0; j < clusters[i].indices.size (); j++)
+      for (const auto &vertex : cluster.indices)
       {
-        clusters_cloud_->points[clusters[i].indices[j]].intensity = intens;
+        clusters_cloud_->points[vertex].intensity = intens;
       }
 
       intens += intens_incr;
@@ -381,9 +381,9 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::SAOptimize(std::vector<i
 
   recognition_models_.clear ();
 
-  for (size_t j = 0; j < cc_indices.size (); j++)
+  for (const int cc_indice : cc_indices)
   {
-    recognition_models_.push_back (recognition_models_copy[cc_indices[j]]);
+    recognition_models_.push_back (recognition_models_copy[cc_indice]);
   }
 
   for (size_t j = 0; j < recognition_models_.size (); j++)
@@ -692,9 +692,9 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::computeClutterCue(boost:
 
     size_t p = 0;
     size_t j = 0;
-    for (size_t i = 0; i < neighborhood_indices.size (); i++)
+    for (const auto &neighborhood_index : neighborhood_indices)
     {
-      if ((j < exp_idces.size ()) && (neighborhood_indices[i].first == exp_idces[j]))
+      if ((j < exp_idces.size ()) && (neighborhood_index.first == exp_idces[j]))
       {
         //this index is explained by the hypothesis so ignore it, advance j
         j++;
@@ -702,11 +702,11 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::computeClutterCue(boost:
       {
         //indices_in_nb[i] < exp_idces[j]
         //recog_model->unexplained_in_neighborhood.push_back(neighborhood_indices[i]);
-        recog_model->unexplained_in_neighborhood[p] = neighborhood_indices[i].first;
+        recog_model->unexplained_in_neighborhood[p] = neighborhood_index.first;
 
-        if (clusters_cloud_->points[recog_model->explained_[neighborhood_indices[i].second]].intensity != 0.f
-            && (clusters_cloud_->points[recog_model->explained_[neighborhood_indices[i].second]].intensity
-                == clusters_cloud_->points[neighborhood_indices[i].first].intensity))
+        if (clusters_cloud_->points[recog_model->explained_[neighborhood_index.second]].intensity != 0.f
+            && (clusters_cloud_->points[recog_model->explained_[neighborhood_index.second]].intensity
+                == clusters_cloud_->points[neighborhood_index.first].intensity))
         {
 
           recog_model->unexplained_in_neighborhood_weights[p] = clutter_regularizer_;
@@ -716,13 +716,13 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::computeClutterCue(boost:
           //neighborhood_indices[i].first gives the index to the scene point and second to the explained scene point by the model causing this...
           //calculate weight of this clutter point based on the distance of the scene point and the model point causing it
           float d = static_cast<float> (pow (
-              (scene_cloud_downsampled_->points[recog_model->explained_[neighborhood_indices[i].second]].getVector3fMap ()
-                  - scene_cloud_downsampled_->points[neighborhood_indices[i].first].getVector3fMap ()).norm (), 2));
+              (scene_cloud_downsampled_->points[recog_model->explained_[neighborhood_index.second]].getVector3fMap ()
+                  - scene_cloud_downsampled_->points[neighborhood_index.first].getVector3fMap ()).norm (), 2));
           float d_weight = -(d / rn_sqr) + 1; //points that are close have a strong weight*/
 
           //using normals to weight clutter points
-          Eigen::Vector3f scene_p_normal = scene_normals_->points[neighborhood_indices[i].first].getNormalVector3fMap ();
-          Eigen::Vector3f model_p_normal = scene_normals_->points[recog_model->explained_[neighborhood_indices[i].second]].getNormalVector3fMap ();
+          Eigen::Vector3f scene_p_normal = scene_normals_->points[neighborhood_index.first].getNormalVector3fMap ();
+          Eigen::Vector3f model_p_normal = scene_normals_->points[recog_model->explained_[neighborhood_index.second]].getNormalVector3fMap ();
           float dotp = scene_p_normal.dot (model_p_normal); //[-1,1] from antiparallel trough perpendicular to parallel
 
           if (dotp < 0)

--- a/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
@@ -112,10 +112,10 @@ template<typename ModelT, typename SceneT>
         recognition_models_.push_back (recog_model);
 
         // update explained_by_RM_, add 1
-        for (size_t i = 0; i < explained_indices.size (); i++)
+        for (const int explained_index : explained_indices)
         {
-          explained_by_RM_[explained_indices[i]]++;
-          points_explained_by_rm_[explained_indices[i]].push_back (recog_model);
+          explained_by_RM_[explained_index]++;
+          points_explained_by_rm_[explained_index].push_back (recog_model);
         }
       }
       else

--- a/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
@@ -112,7 +112,7 @@ template<typename ModelT, typename SceneT>
         recognition_models_.push_back (recog_model);
 
         // update explained_by_RM_, add 1
-        for (const int explained_index : explained_indices)
+        for (const int &explained_index : explained_indices)
         {
           explained_by_RM_[explained_index]++;
           points_explained_by_rm_[explained_index].push_back (recog_model);

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -404,7 +404,7 @@ pcl::features::ISMModel::saveModelToFile (std::string& file_name)
   for (unsigned int i_cluster = 0; i_cluster < number_of_clusters_; i_cluster++)
   {
     output_file << static_cast<unsigned int> (clusters_[i_cluster].size ()) << " ";
-    for (const unsigned int i_visual_word : clusters_[i_cluster])
+    for (const unsigned int &i_visual_word : clusters_[i_cluster])
       output_file << i_visual_word << " ";
   }
 

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -404,8 +404,8 @@ pcl::features::ISMModel::saveModelToFile (std::string& file_name)
   for (unsigned int i_cluster = 0; i_cluster < number_of_clusters_; i_cluster++)
   {
     output_file << static_cast<unsigned int> (clusters_[i_cluster].size ()) << " ";
-    for (const unsigned int &i_visual_word : clusters_[i_cluster])
-      output_file << i_visual_word << " ";
+    for (const unsigned int &visual_word : clusters_[i_cluster])
+      output_file << visual_word << " ";
   }
 
   output_file.close ();

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -107,11 +107,11 @@ pcl::features::ISMVoteList<PointT>::getColoredCloud (typename pcl::PointCloud<Po
   point.r = 0;
   point.g = 0;
   point.b = 255;
-  for (size_t i_vote = 0; i_vote < votes_->points.size (); i_vote++)
+  for (const auto &i_vote : votes_->points)
   {
-    point.x = votes_->points[i_vote].x;
-    point.y = votes_->points[i_vote].y;
-    point.z = votes_->points[i_vote].z;
+    point.x = i_vote.x;
+    point.y = i_vote.y;
+    point.z = i_vote.z;
     colored_cloud->points.push_back (point);
   }
   colored_cloud->height += static_cast<uint32_t> (votes_->points.size ());
@@ -404,8 +404,8 @@ pcl::features::ISMModel::saveModelToFile (std::string& file_name)
   for (unsigned int i_cluster = 0; i_cluster < number_of_clusters_; i_cluster++)
   {
     output_file << static_cast<unsigned int> (clusters_[i_cluster].size ()) << " ";
-    for (unsigned int i_visual_word = 0; i_visual_word < static_cast<unsigned int> (clusters_[i_cluster].size ()); i_visual_word++)
-      output_file << clusters_[i_cluster][i_visual_word] << " ";
+    for (const unsigned int i_visual_word : clusters_[i_cluster])
+      output_file << i_visual_word << " ";
   }
 
   output_file.close ();

--- a/recognition/include/pcl/recognition/linemod.h
+++ b/recognition/include/pcl/recognition/linemod.h
@@ -100,11 +100,11 @@ namespace pcl
 
         const size_t mapsSize = width*height;
 
-        for (size_t map_index = 0; map_index < maps_.size (); ++map_index)
+        for (auto &map : maps_)
         {
           //maps_[map_index] = new unsigned char[mapsSize];
-          maps_[map_index] = reinterpret_cast<unsigned char*> (aligned_malloc (mapsSize));
-          memset (maps_[map_index], 0, mapsSize);
+          map = reinterpret_cast<unsigned char*> (aligned_malloc (mapsSize));
+          memset (map, 0, mapsSize);
         }
       }
 
@@ -112,9 +112,9 @@ namespace pcl
       void 
       releaseAll ()
       {
-        for (size_t map_index = 0; map_index < maps_.size (); ++map_index)
+        for (auto &map : maps_)
           //if (maps_[map_index] != NULL) delete[] maps_[map_index];
-          if (maps_[map_index] != NULL) aligned_free (maps_[map_index]);
+          if (map != NULL) aligned_free (map);
 
         maps_.clear ();
         width_ = 0;
@@ -242,11 +242,11 @@ namespace pcl
 
         const size_t mapsSize = mem_width_ * mem_height_;
 
-        for (size_t map_index = 0; map_index < maps_.size (); ++map_index)
+        for (auto &map : maps_)
         {
           //maps_[map_index] = new unsigned char[2*mapsSize];
-          maps_[map_index] = reinterpret_cast<unsigned char*> (aligned_malloc (2*mapsSize));
-          memset (maps_[map_index], 0, 2*mapsSize);
+          map = reinterpret_cast<unsigned char*> (aligned_malloc (2*mapsSize));
+          memset (map, 0, 2*mapsSize);
         }
       }
 
@@ -254,9 +254,9 @@ namespace pcl
       void 
       releaseAll ()
       {
-        for (size_t map_index = 0; map_index < maps_.size (); ++map_index)
+        for (auto &map : maps_)
           //if (maps_[map_index] != NULL) delete[] maps_[map_index];
-          if (maps_[map_index] != NULL) aligned_free (maps_[map_index]);
+          if (map != NULL) aligned_free (map);
 
         maps_.clear ();
         width_ = 0;

--- a/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
+++ b/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
@@ -229,15 +229,15 @@ namespace pcl
           int max_num_transforms = 0;
 
           // For each full leaf
-          for (const auto &full_leave : full_leaves)
+          for (const auto &full_leaf : full_leaves)
           {
             // Is there an entry for 'model' in the current cell
-            const RotationSpaceCell::Entry *entry = full_leave->getData ().getEntry (model);
+            const RotationSpaceCell::Entry *entry = full_leaf->getData ().getEntry (model);
             if ( !entry )
               continue;
 
             int num_transforms = entry->getNumberOfTransforms ();
-            const std::set<CellOctree::Node*>& neighs = full_leave->getNeighbors ();
+            const std::set<CellOctree::Node*>& neighs = full_leaf->getNeighbors ();
 
             // For each neighbor
             for (const auto &neigh : neighs)

--- a/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
+++ b/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
@@ -229,20 +229,20 @@ namespace pcl
           int max_num_transforms = 0;
 
           // For each full leaf
-          for ( std::vector<CellOctree::Node*>::const_iterator leaf = full_leaves.begin () ; leaf != full_leaves.end () ; ++leaf )
+          for (const auto full_leave : full_leaves)
           {
             // Is there an entry for 'model' in the current cell
-            const RotationSpaceCell::Entry *entry = (*leaf)->getData ().getEntry (model);
+            const RotationSpaceCell::Entry *entry = full_leave->getData ().getEntry (model);
             if ( !entry )
               continue;
 
             int num_transforms = entry->getNumberOfTransforms ();
-            const std::set<CellOctree::Node*>& neighs = (*leaf)->getNeighbors ();
+            const std::set<CellOctree::Node*>& neighs = full_leave->getNeighbors ();
 
             // For each neighbor
-            for ( std::set<CellOctree::Node*>::const_iterator neigh = neighs.begin () ; neigh != neighs.end () ; ++neigh )
+            for (const auto neigh : neighs)
             {
-              const RotationSpaceCell::Entry *neigh_entry = (*neigh)->getData ().getEntry (model);
+              const RotationSpaceCell::Entry *neigh_entry = neigh->getData ().getEntry (model);
               if ( !neigh_entry )
                 continue;
 

--- a/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
+++ b/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
@@ -229,7 +229,7 @@ namespace pcl
           int max_num_transforms = 0;
 
           // For each full leaf
-          for (const auto full_leave : full_leaves)
+          for (const auto &full_leave : full_leaves)
           {
             // Is there an entry for 'model' in the current cell
             const RotationSpaceCell::Entry *entry = full_leave->getData ().getEntry (model);
@@ -240,7 +240,7 @@ namespace pcl
             const std::set<CellOctree::Node*>& neighs = full_leave->getNeighbors ();
 
             // For each neighbor
-            for (const auto neigh : neighs)
+            for (const auto &neigh : neighs)
             {
               const RotationSpaceCell::Entry *neigh_entry = neigh->getData ().getEntry (model);
               if ( !neigh_entry )

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -980,8 +980,8 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
   //}
 
   MaskMap mask_maps[8];
-  for (size_t map_index = 0; map_index < 8; ++map_index)
-    mask_maps[map_index].resize (width, height);
+  for (auto &mask_map : mask_maps)
+    mask_map.resize (width, height);
 
   unsigned char map[255];
   memset(map, 0, 255);
@@ -1251,8 +1251,8 @@ pcl::SurfaceNormalModality<PointInT>::extractAllFeatures (
   //}
 
   MaskMap mask_maps[8];
-  for (size_t map_index = 0; map_index < 8; ++map_index)
-    mask_maps[map_index].resize (width, height);
+  for (auto &mask_map : mask_maps)
+    mask_map.resize (width, height);
 
   unsigned char map[255];
   memset(map, 0, 255);

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -76,24 +76,19 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
     }
   }
 
-  for (size_t i = 0; i < files.size (); i++)
+  for (const auto &filename : files)
   {
-    std::stringstream filestream;
-    filestream << data_dir << "/" << files[i];
-    std::string file = filestream.str ();
+    std::string file = data_dir + "/" + filename;
 
-    std::string pose_file (files[i]);
+    std::string pose_file (filename);
     boost::replace_all (pose_file, ".pcd", "_pose.txt");
 
     Eigen::Matrix4f pose_mat;
     pose_mat.setIdentity (4, 4);
 
-    std::stringstream filestream_pose;
-    filestream_pose << data_dir << "/" << pose_file;
-    pose_file = filestream_pose.str ();
+    pose_file = data_dir + "/" + pose_file;
 
-    bool result = readMatrixFromFile (pose_file, pose_mat);
-    if (result)
+    if (readMatrixFromFile (pose_file, pose_mat))
     {
       Eigen::Vector3f ea = pose_mat.block<3, 3> (0, 0).eulerAngles (0, 1, 2);
       ea *= 57.2957795f; //transform it to degrees to do the binning
@@ -152,9 +147,9 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
           yaw_pitch_bins[i][j] = min_images_per_bin_;
         }
 
-        for (size_t ii = 0; ii < image_files_per_bin[i][j].size (); ii++)
+        for (const auto &ii : image_files_per_bin[i][j])
         {
-          image_files_.push_back (image_files_per_bin[i][j][ii]);
+          image_files_.push_back (ii);
         }
       }
     }
@@ -405,11 +400,10 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
       negative_p.resize (N_patches);
 
       //extract positive patch
-      for (size_t p = 0; p < positive_p.size (); p++)
+      for (const auto &p : positive_p)
       {
-        int col, row;
-        col = positive_p[p].first;
-        row = positive_p[p].second;
+        int col = p.first;
+        int row = p.second;
 
         pcl::PointXYZ patch_center_point;
         patch_center_point.x = cloud->at (col + w_size_2, row + w_size_2).x;
@@ -465,11 +459,10 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
       sleep(2);
 #endif
 
-      for (size_t p = 0; p < negative_p.size (); p++)
+      for (const auto &p : negative_p)
       {
-        int col, row;
-        col = negative_p[p].first;
-        row = negative_p[p].second;
+        int col = p.first;
+        int row = p.second;
 
         TrainingExample te;
         te.iimages_.push_back (integral_image_depth);

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -78,7 +78,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
 
   for (const auto &filename : files)
   {
-    std::string file = data_dir + "/" + filename;
+    std::string file = data_dir + '/' + filename;
 
     std::string pose_file (filename);
     boost::replace_all (pose_file, ".pcd", "_pose.txt");
@@ -86,7 +86,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
     Eigen::Matrix4f pose_mat;
     pose_mat.setIdentity (4, 4);
 
-    pose_file = data_dir + "/" + pose_file;
+    pose_file = data_dir + '/' + pose_file;
 
     if (readMatrixFromFile (pose_file, pose_mat))
     {

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -369,16 +369,16 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
           std::vector<NodeType> leaves;
           dfe.evaluate (forest_, fhda, rse, eval_examples, 0, leaves);
 
-          for (const auto &leave : leaves)
+          for (const auto &leaf : leaves)
           {
-            if (leave.value >= thres_face_)
+            if (leaf.value >= thres_face_)
             {
-              if ((leave.covariance_trans_.trace () + leave.covariance_rot_.trace ()) > trans_max_variance_)
+              if ((leaf.covariance_trans_.trace () + leaf.covariance_rot_.trace ()) > trans_max_variance_)
                 continue;
 
-              Eigen::Vector3f head_center = Eigen::Vector3f (static_cast<float>(leave.trans_mean_[0]),
-                                                             static_cast<float>(leave.trans_mean_[1]),
-                                                             static_cast<float>(leave.trans_mean_[2]));
+              Eigen::Vector3f head_center = Eigen::Vector3f (static_cast<float>(leaf.trans_mean_[0]),
+                                                             static_cast<float>(leaf.trans_mean_[1]),
+                                                             static_cast<float>(leaf.trans_mean_[2]));
               head_center *= 0.001f;
 
               pcl::PointXYZ patch_center_point;
@@ -393,7 +393,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
               if (!pcl::isFinite (ppp))
                 continue;
 
-              //this is a good leave
+              //this is a good leaf
               for (int j = te.col_; j < (te.col_ + w_size_); j++)
               {
                 for (int k = te.row_; k < (te.row_ + w_size_); k++)
@@ -402,10 +402,10 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
               head_center_votes_.push_back (head_center);
               float mult_fact = 0.0174532925f;
-              angle_votes_.emplace_back(static_cast<float>(leave.rot_mean_[0]) * mult_fact,
-                                   static_cast<float>(leave.rot_mean_[1]) * mult_fact,
-                                   static_cast<float>(leave.rot_mean_[2]) * mult_fact);
-              uncertainties_.push_back (static_cast<float>(leave.covariance_trans_.trace () + leave.covariance_rot_.trace ()));
+              angle_votes_.emplace_back(static_cast<float>(leaf.rot_mean_[0]) * mult_fact,
+                                   static_cast<float>(leaf.rot_mean_[1]) * mult_fact,
+                                   static_cast<float>(leaf.rot_mean_[2]) * mult_fact);
+              uncertainties_.push_back (static_cast<float>(leaf.covariance_trans_.trace () + leaf.covariance_rot_.trace ()));
             }
           }
         }

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -191,9 +191,9 @@ void pcl::RFFaceDetectorTrainer::faceVotesClustering()
     {
       //compute rotation using the first less uncertain votes
       std::vector < std::pair<int, float> > uncertainty;
-      for (size_t j = 0; j < votes_indices[i].size (); j++)
+      for (const int index : votes_indices[i])
       {
-        uncertainty.emplace_back (votes_indices[i][j], uncertainties_[votes_indices[i][j]]);
+        uncertainty.emplace_back (index, uncertainties_[index]);
       }
 
       std::sort (uncertainty.begin (), uncertainty.end (), boost::bind (&std::pair<int, float>::second, _1) < boost::bind (&std::pair<int, float>::second, _2));
@@ -369,16 +369,16 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
           std::vector<NodeType> leaves;
           dfe.evaluate (forest_, fhda, rse, eval_examples, 0, leaves);
 
-          for (size_t l = 0; l < leaves.size (); l++)
+          for (const auto &leave : leaves)
           {
-            if (leaves[l].value >= thres_face_)
+            if (leave.value >= thres_face_)
             {
-              if ((leaves[l].covariance_trans_.trace () + leaves[l].covariance_rot_.trace ()) > trans_max_variance_)
+              if ((leave.covariance_trans_.trace () + leave.covariance_rot_.trace ()) > trans_max_variance_)
                 continue;
 
-              Eigen::Vector3f head_center = Eigen::Vector3f (static_cast<float>(leaves[l].trans_mean_[0]),
-                                                             static_cast<float>(leaves[l].trans_mean_[1]),
-                                                             static_cast<float>(leaves[l].trans_mean_[2]));
+              Eigen::Vector3f head_center = Eigen::Vector3f (static_cast<float>(leave.trans_mean_[0]),
+                                                             static_cast<float>(leave.trans_mean_[1]),
+                                                             static_cast<float>(leave.trans_mean_[2]));
               head_center *= 0.001f;
 
               pcl::PointXYZ patch_center_point;
@@ -402,10 +402,10 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
               head_center_votes_.push_back (head_center);
               float mult_fact = 0.0174532925f;
-              angle_votes_.emplace_back(static_cast<float>(leaves[l].rot_mean_[0]) * mult_fact,
-                                   static_cast<float>(leaves[l].rot_mean_[1]) * mult_fact,
-                                   static_cast<float>(leaves[l].rot_mean_[2]) * mult_fact);
-              uncertainties_.push_back (static_cast<float>(leaves[l].covariance_trans_.trace () + leaves[l].covariance_rot_.trace ()));
+              angle_votes_.emplace_back(static_cast<float>(leave.rot_mean_[0]) * mult_fact,
+                                   static_cast<float>(leave.rot_mean_[1]) * mult_fact,
+                                   static_cast<float>(leave.rot_mean_[2]) * mult_fact);
+              uncertainties_.push_back (static_cast<float>(leave.covariance_trans_.trace () + leave.covariance_rot_.trace ()));
             }
           }
         }

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -191,7 +191,7 @@ void pcl::RFFaceDetectorTrainer::faceVotesClustering()
     {
       //compute rotation using the first less uncertain votes
       std::vector < std::pair<int, float> > uncertainty;
-      for (const int index : votes_indices[i])
+      for (const int &index : votes_indices[i])
       {
         uncertainty.emplace_back (index, uncertainties_[index]);
       }

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -1336,7 +1336,7 @@ pcl::LINEMOD::loadTemplates (std::vector<std::string> & file_names)
 {
   templates_.clear ();
 
-  for(auto &filename : file_names)
+  for(const auto &filename : file_names)
   {
     std::ifstream file_stream;
     file_stream.open (filename.c_str (), std::ofstream::in | std::ofstream::binary);

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -234,10 +234,8 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
 
     size_t max_score = 0;
     size_t copy_back_counter = 0;
-    for (size_t feature_index = 0; feature_index < templates_[template_index].features.size (); ++feature_index)
+    for (const auto &feature : templates_[template_index].features)
     {
-      const QuantizedMultiModFeature & feature = templates_[template_index].features[feature_index];
-
       for (size_t bin_index = 0; bin_index < 8; ++bin_index)
       {
         if ((feature.quantized_value & (0x1<<bin_index)) != 0)
@@ -366,8 +364,8 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
   for (size_t modality_index = 0; modality_index < modality_linearized_maps.size (); ++modality_index)
   {
     modality_energy_maps[modality_index].releaseAll ();
-    for (size_t bin_index = 0; bin_index < modality_linearized_maps[modality_index].size (); ++bin_index)
-      modality_linearized_maps[modality_index][bin_index].releaseAll ();
+    for (auto &bin_index : modality_linearized_maps[modality_index])
+      bin_index.releaseAll ();
   }
 }
 
@@ -555,10 +553,8 @@ pcl::LINEMOD::detectTemplates (const std::vector<QuantizableModality*> & modalit
 
     int max_score = 0;
     size_t copy_back_counter = 0;
-    for (size_t feature_index = 0; feature_index < templates_[template_index].features.size (); ++feature_index)
+    for (const auto &feature : templates_[template_index].features)
     {
-      const QuantizedMultiModFeature & feature = templates_[template_index].features[feature_index];
-
       for (size_t bin_index = 0; bin_index < 8; ++bin_index)
       {
         if ((feature.quantized_value & (0x1<<bin_index)) != 0)
@@ -825,9 +821,9 @@ pcl::LINEMOD::detectTemplates (const std::vector<QuantizableModality*> & modalit
     modality_energy_maps_2[modality_index].releaseAll ();
     modality_energy_maps_3[modality_index].releaseAll ();
 #endif
-    for (size_t bin_index = 0; bin_index < modality_linearized_maps[modality_index].size (); ++bin_index)
+    for (auto &bin_index : modality_linearized_maps[modality_index])
     {
-      modality_linearized_maps[modality_index][bin_index].releaseAll ();
+      bin_index.releaseAll ();
 #ifdef LINEMOD_USE_SEPARATE_ENERGY_MAPS
       modality_linearized_maps_1[modality_index][bin_index].releaseAll ();
       modality_linearized_maps_2[modality_index][bin_index].releaseAll ();
@@ -1028,10 +1024,8 @@ pcl::LINEMOD::detectTemplatesSemiScaleInvariant (
 
       int max_score = 0;
       size_t copy_back_counter = 0;
-      for (size_t feature_index = 0; feature_index < templates_[template_index].features.size (); ++feature_index)
+      for (const auto &feature : templates_[template_index].features)
       {
-        const QuantizedMultiModFeature & feature = templates_[template_index].features[feature_index];
-
         for (size_t bin_index = 0; bin_index < 8; ++bin_index)
         {
           if ((feature.quantized_value & (0x1<<bin_index)) != 0)
@@ -1301,9 +1295,9 @@ pcl::LINEMOD::detectTemplatesSemiScaleInvariant (
     modality_energy_maps_2[modality_index].releaseAll ();
     modality_energy_maps_3[modality_index].releaseAll ();
 #endif
-    for (size_t bin_index = 0; bin_index < modality_linearized_maps[modality_index].size (); ++bin_index)
+    for (auto &bin_index : modality_linearized_maps[modality_index])
     {
-      modality_linearized_maps[modality_index][bin_index].releaseAll ();
+      bin_index.releaseAll ();
 #ifdef LINEMOD_USE_SEPARATE_ENERGY_MAPS
       modality_linearized_maps_1[modality_index][bin_index].releaseAll ();
       modality_linearized_maps_2[modality_index][bin_index].releaseAll ();
@@ -1342,10 +1336,10 @@ pcl::LINEMOD::loadTemplates (std::vector<std::string> & file_names)
 {
   templates_.clear ();
 
-  for(size_t i=0; i < file_names.size (); i++)
+  for(auto &filename : file_names)
   {
     std::ifstream file_stream;
-    file_stream.open (file_names[i].c_str (), std::ofstream::in | std::ofstream::binary);
+    file_stream.open (filename.c_str (), std::ofstream::in | std::ofstream::binary);
 
     int nr_templates;
     read (file_stream, nr_templates);

--- a/recognition/src/ransac_based/model_library.cpp
+++ b/recognition/src/ransac_based/model_library.cpp
@@ -130,7 +130,7 @@ ModelLibrary::addModel (const PointCloudIn& points, const PointCloudN& normals, 
   int num_of_pairs = 0;
 
   // Run through all full leaves
-  for (const auto full_leave : full_leaves)
+  for (const auto &full_leave : full_leaves)
   {
     const ORROctree::Node::Data* node_data1 = full_leave->getData ();
 

--- a/recognition/src/ransac_based/model_library.cpp
+++ b/recognition/src/ransac_based/model_library.cpp
@@ -87,8 +87,8 @@ void
 ModelLibrary::removeAllModels ()
 {
   // Delete the model entries
-  for ( map<string,Model*>::iterator it = models_.begin() ; it != models_.end() ; ++it )
-    delete it->second;
+  for (auto &model : models_)
+    delete model.second;
   models_.clear();
 
   // Clear the hash table
@@ -130,18 +130,18 @@ ModelLibrary::addModel (const PointCloudIn& points, const PointCloudN& normals, 
   int num_of_pairs = 0;
 
   // Run through all full leaves
-  for ( vector<ORROctree::Node*>::const_iterator leaf1 = full_leaves.begin () ; leaf1 != full_leaves.end () ; ++leaf1 )
+  for (const auto full_leave : full_leaves)
   {
-    const ORROctree::Node::Data* node_data1 = (*leaf1)->getData ();
+    const ORROctree::Node::Data* node_data1 = full_leave->getData ();
 
     // Get all full leaves at the right distance to the current leaf
     inter_leaves.clear ();
     octree.getFullLeavesIntersectedBySphere (node_data1->getPoint (), pair_width_, inter_leaves);
 
-    for ( list<ORROctree::Node*>::iterator leaf2 = inter_leaves.begin () ; leaf2 != inter_leaves.end () ; ++leaf2 )
+    for (const auto &inter_leave : inter_leaves)
     {
       // Compute the hash table key
-      if ( this->addToHashTable(new_model, node_data1, (*leaf2)->getData ()) )
+      if ( this->addToHashTable(new_model, node_data1, inter_leave->getData ()) )
         ++num_of_pairs;
     }
   }

--- a/recognition/src/ransac_based/model_library.cpp
+++ b/recognition/src/ransac_based/model_library.cpp
@@ -130,18 +130,18 @@ ModelLibrary::addModel (const PointCloudIn& points, const PointCloudN& normals, 
   int num_of_pairs = 0;
 
   // Run through all full leaves
-  for (const auto &full_leave : full_leaves)
+  for (const auto &full_leaf : full_leaves)
   {
-    const ORROctree::Node::Data* node_data1 = full_leave->getData ();
+    const ORROctree::Node::Data* node_data1 = full_leaf->getData ();
 
     // Get all full leaves at the right distance to the current leaf
     inter_leaves.clear ();
     octree.getFullLeavesIntersectedBySphere (node_data1->getPoint (), pair_width_, inter_leaves);
 
-    for (const auto &inter_leave : inter_leaves)
+    for (const auto &inter_leaf : inter_leaves)
     {
       // Compute the hash table key
-      if ( this->addToHashTable(new_model, node_data1, inter_leave->getData ()) )
+      if ( this->addToHashTable(new_model, node_data1, inter_leaf->getData ()) )
         ++num_of_pairs;
     }
   }

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -321,13 +321,13 @@ pcl::recognition::ObjRecRANSAC::groupHypotheses(list<HypothesisBase>& hypotheses
   float transformed_point[3];
 
   // Add all rigid transforms to the discrete rigid transform space
-  for (const auto &hypothese : hypotheses)
+  for (const auto &hypothesis : hypotheses)
   {
     // Transform the center of mass of the model
-    aux::transform (hypothese.rigid_transform_, hypothese.obj_model_->getOctreeCenterOfMass (), transformed_point);
+    aux::transform (hypothesis.rigid_transform_, hypothesis.obj_model_->getOctreeCenterOfMass (), transformed_point);
 
     // Now add the rigid transform at the right place
-    transform_space.addRigidTransform (hypothese.obj_model_, transformed_point, hypothese.rigid_transform_);
+    transform_space.addRigidTransform (hypothesis.obj_model_, transformed_point, hypothesis.rigid_transform_);
   }
 
   list<RotationSpace*>& rotation_spaces = transform_space.getRotationSpaces ();
@@ -584,8 +584,8 @@ pcl::recognition::ObjRecRANSAC::filterGraphOfConflictingHypotheses (ORRGraph<Hyp
     size_t num_of_explained = 0;
 
     // Accumulate the number of pixels the neighbors are explaining
-    for ( set<ORRGraph<Hypothesis*>::Node*>::const_iterator neigh = node->getNeighbors ().begin () ; neigh != node->getNeighbors ().end () ; ++neigh )
-      num_of_explained += (*neigh)->getData ()->explained_pixels_.size ();
+    for (const auto &neigh : node->getNeighbors ())
+      num_of_explained += neigh->getData ()->explained_pixels_.size ();
 
     // Now compute the fitness for the node
     node->setFitness (static_cast<int> (node->getData ()->explained_pixels_.size ()) - static_cast<int> (num_of_explained));
@@ -624,10 +624,10 @@ pcl::recognition::ObjRecRANSAC::testHypothesis (Hypothesis* hypothesis, int& mat
   float transformed_point[3];
 
   // The match/penalty loop
-  for (const auto &full_model_leave : full_model_leaves)
+  for (const auto &full_model_leaf : full_model_leaves)
   {
     // Transform the model point with the current rigid transform
-    aux::transform (rigid_transform, full_model_leave->getData ()->getPoint (), transformed_point);
+    aux::transform (rigid_transform, full_model_leaf->getData ()->getPoint (), transformed_point);
 
     // Get the pixel 'transformed_point' lies in
     const ORROctreeZProjection::Pixel* pixel = scene_octree_proj_.getPixel (transformed_point);
@@ -661,10 +661,10 @@ pcl::recognition::ObjRecRANSAC::testHypothesisNormalBased (Hypothesis* hypothesi
   float transformed_point[3];
 
   // The match/penalty loop
-  for (const auto &full_model_leave : full_model_leaves)
+  for (const auto &full_model_leaf : full_model_leaves)
   {
     // Transform the model point with the current rigid transform
-    aux::transform (rigid_transform, full_model_leave->getData ()->getPoint (), transformed_point);
+    aux::transform (rigid_transform, full_model_leaf->getData ()->getPoint (), transformed_point);
 
     // Get the pixel 'transformed_point' lies in
     const ORROctreeZProjection::Pixel* pixel = scene_octree_proj_.getPixel (transformed_point);
@@ -698,7 +698,7 @@ pcl::recognition::ObjRecRANSAC::testHypothesisNormalBased (Hypothesis* hypothesi
       float rotated_normal[3];
       aux::mult3x3 (rigid_transform, closest_node->getData ()->getNormal (), rotated_normal);
 
-      match += aux::dot3 (rotated_normal, full_model_leave->getData ()->getNormal ());
+      match += aux::dot3 (rotated_normal, full_model_leaf->getData ()->getNormal ());
     }
   }
 

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -247,13 +247,13 @@ pcl::recognition::ObjRecRANSAC::generateHypotheses (const list<OrientedPointPair
   float hash_table_key[3];
   int num_hypotheses = 0;
 
-  for ( list<OrientedPointPair>::const_iterator pair = pairs.begin () ; pair != pairs.end () ; ++pair )
+  for (const auto &pair : pairs)
   {
     // Just to make the code more readable
-    const float *scene_p1 = (*pair).p1_;
-    const float *scene_n1 = (*pair).n1_;
-    const float *scene_p2 = (*pair).p2_;
-    const float *scene_n2 = (*pair).n2_;
+    const float *scene_p1 = pair.p1_;
+    const float *scene_n1 = pair.n1_;
+    const float *scene_p2 = pair.p2_;
+    const float *scene_n2 = pair.n2_;
 
     // Use normals and points to compute a hash table key
     compute_oriented_point_pair_signature (scene_p1, scene_n1, scene_p2, scene_n2, hash_table_key);
@@ -263,20 +263,20 @@ pcl::recognition::ObjRecRANSAC::generateHypotheses (const list<OrientedPointPair
     for ( int i = 0 ; i < num_neigh_cells ; ++i )
     {
       // Check for all models in the current cell
-      for ( ModelLibrary::HashTableCell::iterator cell_it = neigh_cells[i]->begin () ; cell_it != neigh_cells[i]->end () ; ++cell_it )
+      for (const auto &cell : *neigh_cells[i])
       {
         // For better code readability
-        const ModelLibrary::Model *obj_model = (*cell_it).first;
-        ModelLibrary::node_data_pair_list& model_pairs = (*cell_it).second;
+        const ModelLibrary::Model *obj_model = cell.first;
+        const ModelLibrary::node_data_pair_list& model_pairs = cell.second;
 
         // Check for all pairs which belong to the current model
-        for ( ModelLibrary::node_data_pair_list::iterator model_pair_it = model_pairs.begin () ; model_pair_it != model_pairs.end () ; ++model_pair_it )
+        for (const auto &model_pair : model_pairs)
         {
           // Get the points and normals
-          const float *model_p1 = (*model_pair_it).first->getPoint ();
-          const float *model_n1 = (*model_pair_it).first->getNormal ();
-          const float *model_p2 = (*model_pair_it).second->getPoint ();
-          const float *model_n2 = (*model_pair_it).second->getNormal ();
+          const float *model_p1 = model_pair.first->getPoint ();
+          const float *model_n1 = model_pair.first->getNormal ();
+          const float *model_p2 = model_pair.second->getPoint ();
+          const float *model_n2 = model_pair.second->getNormal ();
 
           HypothesisBase hypothesis(obj_model);
           // Get the rigid transform from model to scene
@@ -321,13 +321,13 @@ pcl::recognition::ObjRecRANSAC::groupHypotheses(list<HypothesisBase>& hypotheses
   float transformed_point[3];
 
   // Add all rigid transforms to the discrete rigid transform space
-  for ( list<HypothesisBase>::iterator hypo_it = hypotheses.begin () ; hypo_it != hypotheses.end () ; ++hypo_it )
+  for (const auto &hypothese : hypotheses)
   {
     // Transform the center of mass of the model
-    aux::transform (hypo_it->rigid_transform_, hypo_it->obj_model_->getOctreeCenterOfMass (), transformed_point);
+    aux::transform (hypothese.rigid_transform_, hypothese.obj_model_->getOctreeCenterOfMass (), transformed_point);
 
     // Now add the rigid transform at the right place
-    transform_space.addRigidTransform (hypo_it->obj_model_, transformed_point, hypo_it->rigid_transform_);
+    transform_space.addRigidTransform (hypothese.obj_model_, transformed_point, hypothese.rigid_transform_);
   }
 
   list<RotationSpace*>& rotation_spaces = transform_space.getRotationSpaces ();
@@ -341,19 +341,19 @@ pcl::recognition::ObjRecRANSAC::groupHypotheses(list<HypothesisBase>& hypotheses
 #endif
 
   // Now take the best hypothesis from each rotation space
-  for ( list<RotationSpace*>::iterator rs_it = rotation_spaces.begin () ; rs_it != rotation_spaces.end () ; ++rs_it )
+  for (const auto &rotation_space : rotation_spaces)
   {
     const map<string, ModelLibrary::Model*>& models = model_library_.getModels ();
     Hypothesis best_hypothesis;
     best_hypothesis.match_confidence_ = 0.0f;
 
     // For each model in the library
-    for ( map<string, ModelLibrary::Model*>::const_iterator model = models.begin () ; model != models.end () ; ++model )
+    for (const auto &model : models)
     {
       // Build a hypothesis based on the entry with most votes
-      Hypothesis hypothesis (model->second);
+      Hypothesis hypothesis (model.second);
 
-      if ( !(*rs_it)->getTransformWithMostVotes (model->second, hypothesis.rigid_transform_) )
+      if ( !rotation_space->getTransformWithMostVotes (model.second, hypothesis.rigid_transform_) )
         continue;
 
       int int_match;
@@ -390,7 +390,7 @@ pcl::recognition::ObjRecRANSAC::groupHypotheses(list<HypothesisBase>& hypotheses
 
     if ( best_hypothesis.match_confidence_ > 0.0f )
     {
-      const float *c = (*rs_it)->getCenter ();
+      const float *c = rotation_space->getCenter ();
       HypothesisOctree::Node* node = grouped_hypotheses.createLeaf (c[0], c[1], c[2]);
 
       node->setData (best_hypothesis);
@@ -439,8 +439,8 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfCloseHypotheses (HypothesisOctree& h
     // Get the neighbors of the current rotation space
     const set<HypothesisOctree::Node*>& neighbors = (*hypo)->getNeighbors ();
 
-    for ( set<HypothesisOctree::Node*>::const_iterator n = neighbors.begin() ; n != neighbors.end() ; ++n )
-      graph.insertDirectedEdge ((*hypo)->getData ().getLinearId (), (*n)->getData ().getLinearId ());
+    for (const auto neighbor : neighbors)
+      graph.insertDirectedEdge ((*hypo)->getData ().getLinearId (), neighbor->getData ().getLinearId ());
   }
 
 #ifdef OBJ_REC_RANSAC_VERBOSE
@@ -461,8 +461,8 @@ pcl::recognition::ObjRecRANSAC::filterGraphOfCloseHypotheses (ORRGraph<Hypothesi
   graph.computeMaximalOnOffPartition (on_nodes, off_nodes);
 
   // Copy the data from the on_nodes to the list 'out'
-  for ( list<ORRGraph<Hypothesis>::Node*>::iterator it = on_nodes.begin () ; it != on_nodes.end () ; ++it )
-    out.push_back ((*it)->getData ());
+  for (const auto &on_node : on_nodes)
+    out.push_back (on_node->getData ());
 
 #ifdef OBJ_REC_RANSAC_VERBOSE
   printf ("done [%i remaining hypotheses]\n", static_cast<int> (out.size ()));
@@ -505,10 +505,10 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
   set<ordered_int_pair, bool(*)(const ordered_int_pair&, const ordered_int_pair&)> ordered_hypotheses_ids (aux::compareOrderedPairs<int>);
 
   // Project the hypotheses onto the "range image" and store in each pixel the corresponding hypothesis id
-  for ( vector<BVHH::BoundedObject*>::const_iterator obj = bounded_objects->begin () ; obj != bounded_objects->end () ; ++obj )
+  for (const auto bounded_object : *bounded_objects)
   {
     // For better code readability
-    Hypothesis *hypo1 = (*obj)->getData ();
+    Hypothesis *hypo1 = bounded_object->getData ();
 
     // Get the bounds of the current hypothesis
     float bounds[6];
@@ -518,10 +518,10 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
     list<BVHH::BoundedObject*> intersected_objects;
     bvh.intersect (bounds, intersected_objects);
 
-    for ( list<BVHH::BoundedObject*>::iterator it = intersected_objects.begin () ; it != intersected_objects.end () ; ++it )
+    for (const auto &intersected_object : intersected_objects)
     {
       // For better code readability
-      Hypothesis *hypo2 = (*it)->getData ();
+      Hypothesis *hypo2 = intersected_object->getData ();
 
       // Build an ordered int pair out of the hypotheses ids
       pair<int,int> id_pair;
@@ -579,16 +579,16 @@ pcl::recognition::ObjRecRANSAC::filterGraphOfConflictingHypotheses (ORRGraph<Hyp
   vector<ORRGraph<Hypothesis*>::Node*> &nodes = graph.getNodes ();
 
   // Compute the penalty for each graph node
-  for ( vector<ORRGraph<Hypothesis*>::Node*>::iterator it = nodes.begin () ; it != nodes.end () ; ++it )
+  for (auto &node : nodes)
   {
     size_t num_of_explained = 0;
 
     // Accumulate the number of pixels the neighbors are explaining
-    for ( set<ORRGraph<Hypothesis*>::Node*>::const_iterator neigh = (*it)->getNeighbors ().begin () ; neigh != (*it)->getNeighbors ().end () ; ++neigh )
+    for ( set<ORRGraph<Hypothesis*>::Node*>::const_iterator neigh = node->getNeighbors ().begin () ; neigh != node->getNeighbors ().end () ; ++neigh )
       num_of_explained += (*neigh)->getData ()->explained_pixels_.size ();
 
     // Now compute the fitness for the node
-    (*it)->setFitness (static_cast<int> ((*it)->getData ()->explained_pixels_.size ()) - static_cast<int> (num_of_explained));
+    node->setFitness (static_cast<int> (node->getData ()->explained_pixels_.size ()) - static_cast<int> (num_of_explained));
   }
 
   // Leave the fitest leaves on, such that there are no neighboring ON nodes
@@ -596,12 +596,12 @@ pcl::recognition::ObjRecRANSAC::filterGraphOfConflictingHypotheses (ORRGraph<Hyp
   graph.computeMaximalOnOffPartition (on_nodes, off_nodes);
 
   // The ON nodes correspond to accepted solutions
-  for ( list<ORRGraph<Hypothesis*>::Node*>::iterator it = on_nodes.begin () ; it != on_nodes.end () ; ++it )
+  for (const auto &on_node : on_nodes)
   {
-    recognized_objects.emplace_back((*it)->getData ()->obj_model_->getObjectName (),
-                            (*it)->getData ()->rigid_transform_,
-                            (*it)->getData ()->match_confidence_,
-                            (*it)->getData ()->obj_model_->getUserData ()
+    recognized_objects.emplace_back(on_node->getData ()->obj_model_->getObjectName (),
+                                    on_node->getData ()->rigid_transform_,
+                                    on_node->getData ()->match_confidence_,
+                                    on_node->getData ()->obj_model_->getUserData ()
     );
   }
 
@@ -624,10 +624,10 @@ pcl::recognition::ObjRecRANSAC::testHypothesis (Hypothesis* hypothesis, int& mat
   float transformed_point[3];
 
   // The match/penalty loop
-  for ( std::vector<ORROctree::Node*>::const_iterator leaf_it = full_model_leaves.begin () ; leaf_it != full_model_leaves.end () ; ++leaf_it )
+  for (const auto full_model_leave : full_model_leaves)
   {
     // Transform the model point with the current rigid transform
-    aux::transform (rigid_transform, (*leaf_it)->getData ()->getPoint (), transformed_point);
+    aux::transform (rigid_transform, full_model_leave->getData ()->getPoint (), transformed_point);
 
     // Get the pixel 'transformed_point' lies in
     const ORROctreeZProjection::Pixel* pixel = scene_octree_proj_.getPixel (transformed_point);
@@ -661,10 +661,10 @@ pcl::recognition::ObjRecRANSAC::testHypothesisNormalBased (Hypothesis* hypothesi
   float transformed_point[3];
 
   // The match/penalty loop
-  for ( std::vector<ORROctree::Node*>::const_iterator leaf_it = full_model_leaves.begin () ; leaf_it != full_model_leaves.end () ; ++leaf_it )
+  for (const auto full_model_leave : full_model_leaves)
   {
     // Transform the model point with the current rigid transform
-    aux::transform (rigid_transform, (*leaf_it)->getData ()->getPoint (), transformed_point);
+    aux::transform (rigid_transform, full_model_leave->getData ()->getPoint (), transformed_point);
 
     // Get the pixel 'transformed_point' lies in
     const ORROctreeZProjection::Pixel* pixel = scene_octree_proj_.getPixel (transformed_point);
@@ -698,7 +698,7 @@ pcl::recognition::ObjRecRANSAC::testHypothesisNormalBased (Hypothesis* hypothesi
       float rotated_normal[3];
       aux::mult3x3 (rigid_transform, closest_node->getData ()->getNormal (), rotated_normal);
 
-      match += aux::dot3 (rotated_normal, (*leaf_it)->getData ()->getNormal ());
+      match += aux::dot3 (rotated_normal, full_model_leave->getData ()->getNormal ());
     }
   }
 

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -439,7 +439,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfCloseHypotheses (HypothesisOctree& h
     // Get the neighbors of the current rotation space
     const set<HypothesisOctree::Node*>& neighbors = (*hypo)->getNeighbors ();
 
-    for (const auto neighbor : neighbors)
+    for (const auto &neighbor : neighbors)
       graph.insertDirectedEdge ((*hypo)->getData ().getLinearId (), neighbor->getData ().getLinearId ());
   }
 
@@ -505,7 +505,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
   set<ordered_int_pair, bool(*)(const ordered_int_pair&, const ordered_int_pair&)> ordered_hypotheses_ids (aux::compareOrderedPairs<int>);
 
   // Project the hypotheses onto the "range image" and store in each pixel the corresponding hypothesis id
-  for (const auto bounded_object : *bounded_objects)
+  for (const auto &bounded_object : *bounded_objects)
   {
     // For better code readability
     Hypothesis *hypo1 = bounded_object->getData ();
@@ -624,7 +624,7 @@ pcl::recognition::ObjRecRANSAC::testHypothesis (Hypothesis* hypothesis, int& mat
   float transformed_point[3];
 
   // The match/penalty loop
-  for (const auto full_model_leave : full_model_leaves)
+  for (const auto &full_model_leave : full_model_leaves)
   {
     // Transform the model point with the current rigid transform
     aux::transform (rigid_transform, full_model_leave->getData ()->getPoint (), transformed_point);
@@ -661,7 +661,7 @@ pcl::recognition::ObjRecRANSAC::testHypothesisNormalBased (Hypothesis* hypothesi
   float transformed_point[3];
 
   // The match/penalty loop
-  for (const auto full_model_leave : full_model_leaves)
+  for (const auto &full_model_leave : full_model_leaves)
   {
     // Transform the model point with the current rigid transform
     aux::transform (rigid_transform, full_model_leave->getData ()->getPoint (), transformed_point);

--- a/recognition/src/ransac_based/orr_octree.cpp
+++ b/recognition/src/ransac_based/orr_octree.cpp
@@ -187,8 +187,8 @@ pcl::recognition::ORROctree::build (const PointCloudIn& points, float voxel_size
   else
   {
     // Iterate over all full leaves and average points
-    for ( vector<ORROctree::Node*>::iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it )
-      (*it)->getData ()->computeAveragePoint ();
+    for (const auto &full_leave : full_leaves_)
+      full_leave->getData ()->computeAveragePoint ();
   }
 
 #ifdef PCL_REC_ORR_OCTREE_VERBOSE

--- a/recognition/src/ransac_based/orr_octree.cpp
+++ b/recognition/src/ransac_based/orr_octree.cpp
@@ -162,7 +162,7 @@ pcl::recognition::ORROctree::build (const PointCloudIn& points, float voxel_size
   // Compute the normals and average points for each full octree node
   if ( normals )
   {
-    for ( vector<ORROctree::Node*>::iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; )
+    for ( auto it = full_leaves_.begin() ; it != full_leaves_.end() ; )
     {
       // Compute the average point in the current octree leaf
       (*it)->getData ()->computeAveragePoint ();
@@ -187,8 +187,8 @@ pcl::recognition::ORROctree::build (const PointCloudIn& points, float voxel_size
   else
   {
     // Iterate over all full leaves and average points
-    for (const auto &full_leave : full_leaves_)
-      full_leave->getData ()->computeAveragePoint ();
+    for (const auto &full_leaf : full_leaves_)
+      full_leaf->getData ()->computeAveragePoint ();
   }
 
 #ifdef PCL_REC_ORR_OCTREE_VERBOSE

--- a/recognition/src/ransac_based/orr_octree_zprojection.cpp
+++ b/recognition/src/ransac_based/orr_octree_zprojection.cpp
@@ -110,9 +110,9 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   full_leaves_bounds[2] = std::numeric_limits<float>::infinity();
   full_leaves_bounds[3] = -std::numeric_limits<float>::infinity();
 
-  for (const auto &leave : full_leaves)
+  for (const auto &leaf : full_leaves)
   {
-    const auto bounds = leave->getBounds ();
+    const auto bounds = leaf->getBounds ();
     if ( bounds[0] < full_leaves_bounds[0] ) full_leaves_bounds[0] = bounds[0];
     if ( bounds[1] > full_leaves_bounds[1] ) full_leaves_bounds[1] = bounds[1];
     if ( bounds[2] < full_leaves_bounds[2] ) full_leaves_bounds[2] = bounds[2];
@@ -152,9 +152,9 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   int pixel_id = 0;
 
   // Project the octree full leaves onto the xy-plane
-  for (const auto &full_leave : full_leaves)
+  for (const auto &full_leaf : full_leaves)
   {
-    this->getPixelCoordinates (full_leave->getCenter(), num_pixels_x_, num_pixels_y_);
+    this->getPixelCoordinates (full_leaf->getCenter(), num_pixels_x_, num_pixels_y_);
     // If there is no set/pixel and at this position -> create one
     if ( sets_[num_pixels_x_][num_pixels_y_] == NULL )
     {
@@ -165,7 +165,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
     }
 
     // Insert the full octree leaf at the right position in the set
-    sets_[num_pixels_x_][num_pixels_y_]->insert (full_leave);
+    sets_[num_pixels_x_][num_pixels_y_]->insert (full_leaf);
   }
 
   // Now, at each occupied (i, j) position, get the longest connected component consisting of neighboring full leaves

--- a/recognition/src/ransac_based/orr_octree_zprojection.cpp
+++ b/recognition/src/ransac_based/orr_octree_zprojection.cpp
@@ -110,7 +110,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   full_leaves_bounds[2] = std::numeric_limits<float>::infinity();
   full_leaves_bounds[3] = -std::numeric_limits<float>::infinity();
 
-  for (const auto& leave : full_leaves)
+  for (const auto leave : full_leaves)
   {
     const auto bounds = leave->getBounds ();
     if ( bounds[0] < full_leaves_bounds[0] ) full_leaves_bounds[0] = bounds[0];
@@ -152,9 +152,9 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   int pixel_id = 0;
 
   // Project the octree full leaves onto the xy-plane
-  for (auto fl_it = full_leaves.cbegin () ; fl_it != full_leaves.cend () ; ++fl_it )
+  for (const auto full_leave : full_leaves)
   {
-    this->getPixelCoordinates ((*fl_it)->getCenter(), num_pixels_x_, num_pixels_y_);
+    this->getPixelCoordinates (full_leave->getCenter(), num_pixels_x_, num_pixels_y_);
     // If there is no set/pixel and at this position -> create one
     if ( sets_[num_pixels_x_][num_pixels_y_] == NULL )
     {
@@ -165,14 +165,14 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
     }
 
     // Insert the full octree leaf at the right position in the set
-    sets_[num_pixels_x_][num_pixels_y_]->insert (*fl_it);
+    sets_[num_pixels_x_][num_pixels_y_]->insert (full_leave);
   }
 
   // Now, at each occupied (i, j) position, get the longest connected component consisting of neighboring full leaves
-  for ( list<Set*>::iterator current_set = full_sets_.begin () ; current_set != full_sets_.end () ; ++current_set )
+  for (const auto &full_set : full_sets_)
   {
     // Get the first node in the set
-    set<ORROctree::Node*, bool(*)(ORROctree::Node*,ORROctree::Node*)>::iterator node = (*current_set)->get_nodes ().begin ();
+    set<ORROctree::Node*, bool(*)(ORROctree::Node*,ORROctree::Node*)>::iterator node = full_set->get_nodes ().begin ();
     // Initialize
     float best_min = (*node)->getBounds ()[4];
     float best_max = (*node)->getBounds ()[5];
@@ -183,7 +183,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
     int len = 1;
 
     // Find the longest 1D "connected component" at the current (i, j) position
-    for ( ++node ; node != (*current_set)->get_nodes ().end () ; ++node )
+    for ( ++node ; node != full_set->get_nodes ().end () ; ++node )
     {
       int id_z2 = (*node)->getData ()->get3dIdZ ();
       cur_max = (*node)->getBounds()[5];
@@ -208,8 +208,8 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
       id_z1 = id_z2;
     }
 
-    int i = (*current_set)->get_x ();
-    int j = (*current_set)->get_y ();
+    int i = full_set->get_x ();
+    int j = full_set->get_y ();
 
     pixels_[i][j]->set_z1 (best_min - eps_front);
     pixels_[i][j]->set_z2 (best_max  + eps_back);

--- a/recognition/src/ransac_based/orr_octree_zprojection.cpp
+++ b/recognition/src/ransac_based/orr_octree_zprojection.cpp
@@ -110,7 +110,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   full_leaves_bounds[2] = std::numeric_limits<float>::infinity();
   full_leaves_bounds[3] = -std::numeric_limits<float>::infinity();
 
-  for (const auto leave : full_leaves)
+  for (const auto &leave : full_leaves)
   {
     const auto bounds = leave->getBounds ();
     if ( bounds[0] < full_leaves_bounds[0] ) full_leaves_bounds[0] = bounds[0];
@@ -152,7 +152,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   int pixel_id = 0;
 
   // Project the octree full leaves onto the xy-plane
-  for (const auto full_leave : full_leaves)
+  for (const auto &full_leave : full_leaves)
   {
     this->getPixelCoordinates (full_leave->getCenter(), num_pixels_x_, num_pixels_y_);
     // If there is no set/pixel and at this position -> create one


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix