### PR TITLE
Transform classic loops to range-based for loops in module registration

### DIFF
--- a/registration/include/pcl/registration/default_convergence_criteria.h
+++ b/registration/include/pcl/registration/default_convergence_criteria.h
@@ -218,8 +218,8 @@ namespace pcl
         calculateMSE (const pcl::Correspondences &correspondences) const
         {
           double mse = 0;
-          for (size_t i = 0; i < correspondences.size (); ++i)
-            mse += correspondences[i].distance;
+          for (const auto &correspondence : correspondences)
+            mse += correspondence.distance;
           mse /= double (correspondences.size ());
           return (mse);
         }

--- a/registration/include/pcl/registration/icp.h
+++ b/registration/include/pcl/registration/icp.h
@@ -180,25 +180,25 @@ namespace pcl
         std::vector<pcl::PCLPointField> fields;
         pcl::getFields (*cloud, fields);
         source_has_normals_ = false;
-        for (size_t i = 0; i < fields.size (); ++i)
+        for (const auto &field : fields)
         {
-          if      (fields[i].name == "x") x_idx_offset_ = fields[i].offset;
-          else if (fields[i].name == "y") y_idx_offset_ = fields[i].offset;
-          else if (fields[i].name == "z") z_idx_offset_ = fields[i].offset;
-          else if (fields[i].name == "normal_x") 
+          if      (field.name == "x") x_idx_offset_ = field.offset;
+          else if (field.name == "y") y_idx_offset_ = field.offset;
+          else if (field.name == "z") z_idx_offset_ = field.offset;
+          else if (field.name == "normal_x") 
           {
             source_has_normals_ = true;
-            nx_idx_offset_ = fields[i].offset;
+            nx_idx_offset_ = field.offset;
           }
-          else if (fields[i].name == "normal_y") 
+          else if (field.name == "normal_y") 
           {
             source_has_normals_ = true;
-            ny_idx_offset_ = fields[i].offset;
+            ny_idx_offset_ = field.offset;
           }
-          else if (fields[i].name == "normal_z") 
+          else if (field.name == "normal_z") 
           {
             source_has_normals_ = true;
-            nz_idx_offset_ = fields[i].offset;
+            nz_idx_offset_ = field.offset;
           }
         }
       }
@@ -215,9 +215,9 @@ namespace pcl
         std::vector<pcl::PCLPointField> fields;
         pcl::getFields (*cloud, fields);
         target_has_normals_ = false;
-        for (size_t i = 0; i < fields.size (); ++i)
+        for (const auto &field : fields)
         {
-          if (fields[i].name == "normal_x" || fields[i].name == "normal_y" || fields[i].name == "normal_z") 
+          if (field.name == "normal_x" || field.name == "normal_y" || field.name == "normal_z") 
           {
             target_has_normals_ = true;
             break;

--- a/registration/include/pcl/registration/impl/correspondence_rejection_poly.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_poly.hpp
@@ -162,8 +162,8 @@ pcl::registration::CorrespondenceRejectorPoly<SourceT, TargetT>::computeHistogra
   const float idx_per_val = static_cast<float> (bins) / (upper - lower);
   
   // Accumulate
-  for (std::vector<float>::const_iterator it = data.begin (); it != data.end (); ++it)
-     ++result[ std::min (last_idx, int ((*it)*idx_per_val)) ];
+  for (const float value : data)
+     ++result[ std::min (last_idx, int (value*idx_per_val)) ];
   
   return (result);
 }

--- a/registration/include/pcl/registration/impl/correspondence_rejection_poly.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_poly.hpp
@@ -162,7 +162,7 @@ pcl::registration::CorrespondenceRejectorPoly<SourceT, TargetT>::computeHistogra
   const float idx_per_val = static_cast<float> (bins) / (upper - lower);
   
   // Accumulate
-  for (const float value : data)
+  for (const float &value : data)
      ++result[ std::min (last_idx, int (value*idx_per_val)) ];
   
   return (result);

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -124,8 +124,8 @@ pcl::registration::CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCo
        if (save_inliers_)
        {
          inlier_indices_.reserve (inliers.size ());
-         for (size_t i = 0; i < inliers.size (); ++i)
-           inlier_indices_.push_back (index_to_correspondence[inliers[i]]);
+         for (const int inlier : inliers)
+           inlier_indices_.push_back (index_to_correspondence[inlier]);
        }
 
        // get best transformation

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -124,7 +124,7 @@ pcl::registration::CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCo
        if (save_inliers_)
        {
          inlier_indices_.reserve (inliers.size ());
-         for (const int inlier : inliers)
+         for (const int &inlier : inliers)
            inlier_indices_.push_back (index_to_correspondence[inlier]);
        }
 

--- a/registration/include/pcl/registration/impl/correspondence_types.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_types.hpp
@@ -52,10 +52,10 @@ pcl::registration::getCorDistMeanStd (const pcl::Correspondences &correspondence
 
   double sum = 0, sq_sum = 0;
 
-  for (size_t i = 0; i < correspondences.size (); ++i)
+  for (const auto &correspondence : correspondences)
   {
-    sum += correspondences[i].distance;
-    sq_sum += correspondences[i].distance * correspondences[i].distance;
+    sum += correspondence.distance;
+    sq_sum += correspondence.distance * correspondence.distance;
   }
   mean = sum / static_cast<double> (correspondences.size ());
   double variance = (sq_sum - sum * sum / static_cast<double> (correspondences.size ())) / static_cast<double> (correspondences.size () - 1);

--- a/registration/include/pcl/registration/impl/elch.hpp
+++ b/registration/include/pcl/registration/impl/elch.hpp
@@ -227,8 +227,8 @@ pcl::registration::ELCH<PointT>::compute ()
   typename boost::graph_traits<LoopGraph>::edge_iterator edge_it, edge_it_end;
   for (boost::tuples::tie (edge_it, edge_it_end) = edges (*loop_graph_); edge_it != edge_it_end; edge_it++)
   {
-    for (int j = 0; j < 4; j++)
-      add_edge (source (*edge_it, *loop_graph_), target (*edge_it, *loop_graph_), 1, grb[j]);  //TODO add variance
+    for (auto &j : grb)
+      add_edge (source (*edge_it, *loop_graph_), target (*edge_it, *loop_graph_), 1, j);  //TODO add variance
   }
 
   double *weights[4];

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -359,7 +359,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     const PointTarget *pt2 = &(target_->points[base_indices[1]]);
     const PointTarget *pt3 = &(target_->points[base_indices[2]]);
 
-    for (const int target_index : *target_indices_)
+    for (const int &target_index : *target_indices_)
     {
       const PointTarget *pt4 = &(target_->points[target_index]);
 
@@ -670,7 +670,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     const PointTarget *pt2 = &(input_->points[pair.index_query]);
 
     // calculate intermediate points using both ratios from base (r1,r2)
-    for (const float r : ratio)
+    for (const float &r : ratio)
     {
       PointTarget pt_e;
       pt_e.x = pt1->x + r * (pt2->x - pt1->x);
@@ -679,7 +679,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
 
       // search for corresponding intermediate points
       tree_e->radiusSearch (pt_e, coincidation_limit_, ids, dists_sqr);
-      for (const int id : ids)
+      for (const int &id : ids)
       {
         std::vector <int> match_indices (4);
 
@@ -787,7 +787,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     float best_diff_sqr = FLT_MAX;
     int best_index = -1;
 
-    for (const int match_index : copy)
+    for (const int &match_index : copy)
     {
       // calculate difference of distances to centre point
       float dist_sqr_2 = pcl::squaredEuclideanDistance (input_->points[match_index], centre_pt_match);

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -248,8 +248,8 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   {
     target_indices_.reset (new std::vector <int> (static_cast <int> (target_->size ())));
     int index = 0;
-    for (std::vector <int>::iterator it = target_indices_->begin (), it_e = target_indices_->end (); it != it_e; it++)
-      *it = index++;
+    for (int &target_index : *target_indices_)
+      target_index = index++;
     target_cloud_updated_ = true;
   }
 
@@ -359,9 +359,9 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     const PointTarget *pt2 = &(target_->points[base_indices[1]]);
     const PointTarget *pt3 = &(target_->points[base_indices[2]]);
 
-    for (std::vector <int>::iterator it = target_indices_->begin (), it_e = target_indices_->end (); it != it_e; it++)
+    for (const int target_index : *target_indices_)
     {
-      const PointTarget *pt4 = &(target_->points[*it]);
+      const PointTarget *pt4 = &(target_->points[target_index]);
 
       float d1 = pcl::squaredEuclideanDistance (*pt4, *pt1);
       float d2 = pcl::squaredEuclideanDistance (*pt4, *pt2);
@@ -377,7 +377,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
       float dist_to_plane = pcl::pointToPlaneDistance (*pt4, coefficients);
       if (dist_to_plane < nearest_to_plane)
       {
-        base_indices[3] = *it;
+        base_indices[3] = target_index;
         nearest_to_plane = dist_to_plane;
       }
     }
@@ -642,10 +642,10 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   PointCloudSourcePtr cloud_e (new PointCloudSource);
   cloud_e->resize (pairs_a.size () * 2);
   PointCloudSourceIterator it_pt = cloud_e->begin ();
-  for (pcl::Correspondences::const_iterator it_pair = pairs_a.begin (), it_pair_e = pairs_a.end () ; it_pair != it_pair_e; it_pair++)
+  for (const auto &pair : pairs_a)
   {
-    const PointSource *pt1 = &(input_->points[it_pair->index_match]);
-    const PointSource *pt2 = &(input_->points[it_pair->index_query]);
+    const PointSource *pt1 = &(input_->points[pair.index_match]);
+    const PointSource *pt2 = &(input_->points[pair.index_query]);
 
     // calculate intermediate points using both ratios from base (r1,r2)
     for (int i = 0; i < 2; i++, it_pt++)
@@ -664,29 +664,29 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   std::vector <float> dists_sqr;
 
   // loop over second point pair correspondences
-  for (pcl::Correspondences::const_iterator it_pair = pairs_b.begin (), it_pair_e = pairs_b.end () ; it_pair != it_pair_e; it_pair++)
+  for (const auto &pair : pairs_b)
   {
-    const PointTarget *pt1 = &(input_->points[it_pair->index_match]);
-    const PointTarget *pt2 = &(input_->points[it_pair->index_query]);
+    const PointTarget *pt1 = &(input_->points[pair.index_match]);
+    const PointTarget *pt2 = &(input_->points[pair.index_query]);
 
     // calculate intermediate points using both ratios from base (r1,r2)
-    for (int i = 0; i < 2; i++)
+    for (const float r : ratio)
     {
       PointTarget pt_e;
-      pt_e.x = pt1->x + ratio[i] * (pt2->x - pt1->x);
-      pt_e.y = pt1->y + ratio[i] * (pt2->y - pt1->y);
-      pt_e.z = pt1->z + ratio[i] * (pt2->z - pt1->z);
+      pt_e.x = pt1->x + r * (pt2->x - pt1->x);
+      pt_e.y = pt1->y + r * (pt2->y - pt1->y);
+      pt_e.z = pt1->z + r * (pt2->z - pt1->z);
 
       // search for corresponding intermediate points
       tree_e->radiusSearch (pt_e, coincidation_limit_, ids, dists_sqr);
-      for (std::vector <int>::iterator it = ids.begin (), it_e = ids.end (); it != it_e; it++)
+      for (const int id : ids)
       {
         std::vector <int> match_indices (4);
 
-        match_indices[0] = pairs_a[static_cast <int> (std::floor ((float)(*it/2.f)))].index_match;
-        match_indices[1] = pairs_a[static_cast <int> (std::floor ((float)(*it/2.f)))].index_query;
-        match_indices[2] = it_pair->index_match;
-        match_indices[3] = it_pair->index_query;
+        match_indices[0] = pairs_a[static_cast <int> (std::floor ((float)(id/2.f)))].index_match;
+        match_indices[1] = pairs_a[static_cast <int> (std::floor ((float)(id/2.f)))].index_query;
+        match_indices[2] = pair.index_match;
+        match_indices[3] = pair.index_query;
 
         // EDITED: added coarse check of match based on edge length (due to rigid-body )
         if (checkBaseMatch (match_indices, dist_base) < 0)
@@ -730,16 +730,16 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   float fitness_score = FLT_MAX;
 
   // loop over all Candidate matches
-  for (std::vector <std::vector <int> >::iterator match_indices = matches.begin (), it_e = matches.end (); match_indices != it_e; match_indices++)
+  for (auto &match : matches)
   {
     Eigen::Matrix4f transformation_temp;
     pcl::Correspondences correspondences_temp;
 
     // determine corresondences between base and match according to their distance to centroid
-    linkMatchWithBase (base_indices, *match_indices, correspondences_temp);
+    linkMatchWithBase (base_indices, match, correspondences_temp);
 
     // check match based on residuals of the corresponding points after
-    if (validateMatch (base_indices, *match_indices, correspondences_temp, transformation_temp) < 0)
+    if (validateMatch (base_indices, match, correspondences_temp, transformation_temp) < 0)
       continue;
 
     // check resulting  using a sub sample of the source point cloud and compare to previous matches
@@ -787,16 +787,16 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     float best_diff_sqr = FLT_MAX;
     int best_index = -1;
 
-    for (auto it_match = copy.cbegin (), it_match_e = copy.cend (); it_match != it_match_e; it_match++)
+    for (const int match_index : copy)
     {
       // calculate difference of distances to centre point
-      float dist_sqr_2 = pcl::squaredEuclideanDistance (input_->points[*it_match], centre_pt_match);
+      float dist_sqr_2 = pcl::squaredEuclideanDistance (input_->points[match_index], centre_pt_match);
       float diff_sqr = std::abs(dist_sqr_1 - dist_sqr_2);
 
       if (diff_sqr < best_diff_sqr)
       {
         best_diff_sqr = diff_sqr;
-        best_index = *it_match;
+        best_index = match_index;
       }
     }
 

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -104,17 +104,17 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
   float fitness_score = FLT_MAX;
 
   // loop over all Candidate matches
-  for (std::vector <std::vector <int> >::iterator match_indices = matches.begin (), it_e = matches.end (); match_indices != it_e; match_indices++)
+  for (auto &match : matches)
   {
     Eigen::Matrix4f transformation_temp;
     pcl::Correspondences correspondences_temp;
     fitness_score = FLT_MAX; // reset to FLT_MAX to accept all candidates and not only best
 
     // determine corresondences between base and match according to their distance to centroid
-    linkMatchWithBase (base_indices, *match_indices, correspondences_temp);
+    linkMatchWithBase (base_indices, match, correspondences_temp);
 
     // check match based on residuals of the corresponding points after transformation
-    if (validateMatch (base_indices, *match_indices, correspondences_temp, transformation_temp) < 0)
+    if (validateMatch (base_indices, match, correspondences_temp, transformation_temp) < 0)
       continue;
 
     // check resulting transformation using a sub sample of the source point cloud
@@ -181,15 +181,15 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
 {
   // reorganize candidates into single vector
   size_t total_size = 0;
-  for (auto it = candidates.cbegin (), it_e = candidates.cend (); it != it_e; it++)
-    total_size += it->size ();
+  for (const auto &candidate : candidates)
+    total_size += candidate.size ();
 
   candidates_.clear ();
   candidates_.reserve (total_size);
 
-  for (auto it = candidates.cbegin (), it_e = candidates.cend (); it != it_e; it++)
-  for (auto it_curr = it->cbegin (), it_curr_e = it->cend (); it_curr != it_curr_e; it_curr++)
-    candidates_.push_back (*it_curr);
+  for (const auto &candidate : candidates)
+    for (const auto &match : candidate)
+      candidates_.push_back (match);
 
   // sort according to score value
   std::sort (candidates_.begin (), candidates_.end (), by_score ());

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -93,11 +93,11 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::select
 
     // Check to see if the sample is 1) unique and 2) far away from the other samples
     bool valid_sample = true;
-    for (size_t i = 0; i < sample_indices.size (); ++i)
+    for (const int sample_idx : sample_indices)
     {
-      float distance_between_samples = euclideanDistance (cloud.points[sample_index], cloud.points[sample_indices[i]]);
+      float distance_between_samples = euclideanDistance (cloud.points[sample_index], cloud.points[sample_idx]);
 
-      if (sample_index == sample_indices[i] || distance_between_samples < min_sample_distance)
+      if (sample_index == sample_idx || distance_between_samples < min_sample_distance)
       {
         valid_sample = false;
         break;

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -93,7 +93,7 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::select
 
     // Check to see if the sample is 1) unique and 2) far away from the other samples
     bool valid_sample = true;
-    for (const int sample_idx : sample_indices)
+    for (const int &sample_idx : sample_indices)
     {
       float distance_between_samples = euclideanDistance (cloud.points[sample_index], cloud.points[sample_idx]);
 

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -336,8 +336,8 @@ namespace pcl
         test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
         {
           ValueAndDerivatives<3,double> r = ValueAndDerivatives<3,double>::Zero ();
-          for (size_t i = 0; i < 4; i++)
-              r += single_grids_[i]->test (transformed_pt, cos_theta, sin_theta);
+          for (auto &single_grid : single_grids_)
+              r += single_grid->test (transformed_pt, cos_theta, sin_theta);
           return r;
         }
 

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -336,7 +336,7 @@ namespace pcl
         test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
         {
           ValueAndDerivatives<3,double> r = ValueAndDerivatives<3,double>::Zero ();
-          for (auto &single_grid : single_grids_)
+          for (const auto &single_grid : single_grids_)
               r += single_grid->test (transformed_pt, cos_theta, sin_theta);
           return r;
         }

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -105,7 +105,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
                                      search_method_->getModelDiameter () /2,
                                      indices,
                                      distances);
-    for(const size_t scene_point_index : indices)
+    for(const size_t &scene_point_index : indices)
 //    for(size_t i = 0; i < target_->points.size (); ++i)
     {
       //size_t scene_point_index = i;

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -105,11 +105,10 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
                                      search_method_->getModelDiameter () /2,
                                      indices,
                                      distances);
-    for(size_t i = 0; i < indices.size (); ++i)
+    for(const size_t scene_point_index : indices)
 //    for(size_t i = 0; i < target_->points.size (); ++i)
     {
       //size_t scene_point_index = i;
-      size_t scene_point_index = indices[i];
       if (scene_reference_index != scene_point_index)
       {
         if (/*pcl::computePPFPairFeature*/pcl::computePairFeatures (target_->points[scene_reference_index].getVector4fMap (),
@@ -131,10 +130,10 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
           alpha_s *= (-1);
 
           // Go through point pairs in the model with the same discretized feature
-          for (std::vector<std::pair<size_t, size_t> >::iterator v_it = nearest_indices.begin (); v_it != nearest_indices.end (); ++ v_it)
+          for (const auto &nearest_index : nearest_indices)
           {
-            size_t model_reference_index = v_it->first,
-                model_point_index = v_it->second;
+            size_t model_reference_index = nearest_index.first;
+            size_t model_point_index = nearest_index.second;
             // Calculate angle alpha = alpha_m - alpha_s
             float alpha = search_method_->alpha_m_[model_reference_index][model_point_index] - alpha_s;
             unsigned int alpha_discretized = static_cast<unsigned int> (floor (alpha) + floor (M_PI / search_method_->getAngleDiscretizationStep ()));

--- a/registration/src/correspondence_rejection_distance.cpp
+++ b/registration/src/correspondence_rejection_distance.cpp
@@ -47,21 +47,21 @@ pcl::registration::CorrespondenceRejectorDistance::getRemainingCorrespondences (
 {
   unsigned int number_valid_correspondences = 0;
   remaining_correspondences.resize (original_correspondences.size ());
-  for (size_t i = 0; i < original_correspondences.size (); ++i)
+  for (const auto &original_correspondence : original_correspondences)
   {
     if (data_container_)
     {
-      if (data_container_->getCorrespondenceScore (original_correspondences[i]) < max_distance_)
+      if (data_container_->getCorrespondenceScore (original_correspondence) < max_distance_)
       {
-        remaining_correspondences[number_valid_correspondences] = original_correspondences[i];
+        remaining_correspondences[number_valid_correspondences] = original_correspondence;
         ++number_valid_correspondences;
       }
     }
     else
     {
-      if (original_correspondences[i].distance < max_distance_)
+      if (original_correspondence.distance < max_distance_)
       {
-        remaining_correspondences[number_valid_correspondences] = original_correspondences[i];
+        remaining_correspondences[number_valid_correspondences] = original_correspondence;
         ++number_valid_correspondences;
       }
     }

--- a/registration/src/correspondence_rejection_features.cpp
+++ b/registration/src/correspondence_rejection_features.cpp
@@ -71,8 +71,8 @@ pcl::registration::CorrespondenceRejectorFeatures::hasValidFeatures ()
 {
   if (features_map_.empty ())
     return (false);
-  for (auto feature_itr = features_map_.cbegin (); feature_itr != features_map_.cend (); ++feature_itr)
-    if (!feature_itr->second->isValid ())
+  for (const auto &feature : features_map_)
+    if (!feature.second->isValid ())
       return (false);
   return (true);
 }

--- a/registration/src/correspondence_rejection_one_to_one.cpp
+++ b/registration/src/correspondence_rejection_one_to_one.cpp
@@ -53,14 +53,14 @@ pcl::registration::CorrespondenceRejectorOneToOne::getRemainingCorrespondences (
   remaining_correspondences.resize (input.size ());
   int index_last = -1;
   unsigned int number_valid_correspondences = 0;
-  for (size_t i = 0; i < input.size (); ++i)
+  for (const auto &i : input)
   {
-    if (input[i].index_match < 0)
+    if (i.index_match < 0)
       continue;
-    else if (input[i].index_match != index_last)
+    else if (i.index_match != index_last)
     {
-      remaining_correspondences[number_valid_correspondences] = input[i];
-      index_last = input[i].index_match;
+      remaining_correspondences[number_valid_correspondences] = i;
+      index_last = i.index_match;
       ++number_valid_correspondences;
     }
   }

--- a/registration/src/correspondence_rejection_organized_boundary.cpp
+++ b/registration/src/correspondence_rejection_organized_boundary.cpp
@@ -53,11 +53,11 @@ pcl::registration::CorrespondenceRejectionOrganizedBoundary::getRemainingCorresp
   }
 
   remaining_correspondences.reserve (original_correspondences.size ());
-  for (size_t c_i = 0; c_i < original_correspondences.size (); ++c_i)
+  for (const auto &original_correspondence : original_correspondences)
   {
     /// Count how many NaNs bound the target point
-    int x = original_correspondences[c_i].index_match % cloud->width;
-    int y = original_correspondences[c_i].index_match / cloud->width;
+    int x = original_correspondence.index_match % cloud->width;
+    int y = original_correspondence.index_match / cloud->width;
 
     int nan_count_tgt = 0;
     for (int x_d = -window_size_/2; x_d <= window_size_/2; ++x_d)
@@ -75,6 +75,6 @@ pcl::registration::CorrespondenceRejectionOrganizedBoundary::getRemainingCorresp
 
 
     /// The correspondence passes both tests, add it to the filtered set of correspondences
-    remaining_correspondences.push_back (original_correspondences[c_i]);
+    remaining_correspondences.push_back (original_correspondence);
   }
 }

--- a/registration/src/correspondence_rejection_surface_normal.cpp
+++ b/registration/src/correspondence_rejection_surface_normal.cpp
@@ -55,10 +55,10 @@ pcl::registration::CorrespondenceRejectorSurfaceNormal::getRemainingCorresponden
   remaining_correspondences.resize (original_correspondences.size ());
 
   // Test each correspondence
-  for (size_t i = 0; i < original_correspondences.size (); ++i)
+  for (const auto &original_correspondence : original_correspondences)
   {
-    if (data_container_->getCorrespondenceScoreFromNormals (original_correspondences[i]) > threshold_)
-      remaining_correspondences[number_valid_correspondences++] = original_correspondences[i];
+    if (data_container_->getCorrespondenceScoreFromNormals (original_correspondence) > threshold_)
+      remaining_correspondences[number_valid_correspondences++] = original_correspondence;
   }
   remaining_correspondences.resize (number_valid_correspondences);
 }


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix