### PR TITLE
Transform classic loops to range-based for loops in module sample_consensus

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
@@ -147,8 +147,8 @@ pcl::MaximumLikelihoodSampleConsensus<PointT>::computeModel (int debug_verbosity
 
       n_inliers_count = 0;
       // Need to compute the number of inliers for this model to adapt k
-      for (size_t i = 0; i < distances.size (); ++i)
-        if (distances[i] <= 2 * sigma_)
+      for (const double distance : distances)
+        if (distance <= 2 * sigma_)
           n_inliers_count++;
 
       // Compute the k parameter (k=log(z)/log(1-w^n))

--- a/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
@@ -147,7 +147,7 @@ pcl::MaximumLikelihoodSampleConsensus<PointT>::computeModel (int debug_verbosity
 
       n_inliers_count = 0;
       // Need to compute the number of inliers for this model to adapt k
-      for (const double distance : distances)
+      for (const double &distance : distances)
         if (distance <= 2 * sigma_)
           n_inliers_count++;
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
@@ -91,7 +91,7 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
     if (distances.empty () && k > 1.0)
       continue;
 
-    for (const double distance : distances)
+    for (const double &distance : distances)
       d_cur_penalty += (std::min) (distance, threshold_);
 
     // Better match ?
@@ -105,7 +105,7 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
 
       n_inliers_count = 0;
       // Need to compute the number of inliers for this model to adapt k
-      for (const double distance : distances)
+      for (const double &distance : distances)
         if (distance <= threshold_)
           ++n_inliers_count;
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
@@ -91,8 +91,8 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
     if (distances.empty () && k > 1.0)
       continue;
 
-    for (size_t i = 0; i < distances.size (); ++i)
-      d_cur_penalty += (std::min) (distances[i], threshold_);
+    for (const double distance : distances)
+      d_cur_penalty += (std::min) (distance, threshold_);
 
     // Better match ?
     if (d_cur_penalty < d_best_penalty)
@@ -105,8 +105,8 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
 
       n_inliers_count = 0;
       // Need to compute the number of inliers for this model to adapt k
-      for (size_t i = 0; i < distances.size (); ++i)
-        if (distances[i] <= threshold_)
+      for (const double distance : distances)
+        if (distance <= threshold_)
           ++n_inliers_count;
 
       // Compute the k parameter (k=log(z)/log(1-w^n))

--- a/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
@@ -109,7 +109,7 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
     if (distances.empty () && k > 1.0)
       continue;
 
-    for (const double distance : distances)
+    for (const double &distance : distances)
       d_cur_penalty += std::min (distance, threshold_);
 
     // Better match ?
@@ -123,7 +123,7 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
 
       n_inliers_count = 0;
       // Need to compute the number of inliers for this model to adapt k
-      for (const double distance : distances)
+      for (const double &distance : distances)
         if (distance <= threshold_)
           n_inliers_count++;
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
@@ -109,8 +109,8 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
     if (distances.empty () && k > 1.0)
       continue;
 
-    for (size_t i = 0; i < distances.size (); ++i)
-      d_cur_penalty += (std::min) (distances[i], threshold_);
+    for (const double distance : distances)
+      d_cur_penalty += std::min (distance, threshold_);
 
     // Better match ?
     if (d_cur_penalty < d_best_penalty)
@@ -123,8 +123,8 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
 
       n_inliers_count = 0;
       // Need to compute the number of inliers for this model to adapt k
-      for (size_t i = 0; i < distances.size (); ++i)
-        if (distances[i] <= threshold_)
+      for (const double distance : distances)
+        if (distance <= threshold_)
           n_inliers_count++;
 
       // Compute the k parameter (k=log(z)/log(1-w^n))

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -255,7 +255,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the plane
-    for (const int inlier : inliers)
+    for (const int &inlier : inliers)
     {
       float dx = input_->points[inlier].x - model_coefficients[0];
       float dy = input_->points[inlier].y - model_coefficients[1];
@@ -303,7 +303,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int index : indices)
+  for (const int &index : indices)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
     if (fabsf (std::sqrt (

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -255,14 +255,14 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the plane
-    for (size_t i = 0; i < inliers.size (); ++i)
+    for (const int inlier : inliers)
     {
-      float dx = input_->points[inliers[i]].x - model_coefficients[0];
-      float dy = input_->points[inliers[i]].y - model_coefficients[1];
+      float dx = input_->points[inlier].x - model_coefficients[0];
+      float dy = input_->points[inlier].y - model_coefficients[1];
       float a = std::sqrt ( (model_coefficients[2] * model_coefficients[2]) / (dx * dx + dy * dy) );
 
-      projected_points.points[inliers[i]].x = a * dx + model_coefficients[0];
-      projected_points.points[inliers[i]].y = a * dy + model_coefficients[1];
+      projected_points.points[inlier].x = a * dx + model_coefficients[0];
+      projected_points.points[inlier].y = a * dy + model_coefficients[1];
     }
   }
   else
@@ -303,14 +303,14 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
     if (fabsf (std::sqrt (
-                         ( input_->points[*it].x - model_coefficients[0] ) *
-                         ( input_->points[*it].x - model_coefficients[0] ) +
-                         ( input_->points[*it].y - model_coefficients[1] ) *
-                         ( input_->points[*it].y - model_coefficients[1] )
+                         ( input_->points[index].x - model_coefficients[0] ) *
+                         ( input_->points[index].x - model_coefficients[0] ) +
+                         ( input_->points[index].y - model_coefficients[1] ) *
+                         ( input_->points[index].y - model_coefficients[1] )
                          ) - model_coefficients[2]) > threshold)
       return (false);
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -402,7 +402,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -402,14 +402,14 @@ pcl::SampleConsensusModelCircle3D<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
   {
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
 
     // what i have:
     // P : Sample Point
-    Eigen::Vector3d P (input_->points[*it].x, input_->points[*it].y, input_->points[*it].z);
+    Eigen::Vector3d P (input_->points[index].x, input_->points[index].y, input_->points[index].z);
     // C : Circle Center
     Eigen::Vector3d C (model_coefficients[0], model_coefficients[1], model_coefficients[2]);
     // N : Circle (Plane) Normal

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -378,16 +378,16 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the cone
-    for (size_t i = 0; i < inliers.size (); ++i)
+    for (const int inlier : inliers)
     {
-      Eigen::Vector4f pt (input_->points[inliers[i]].x, 
-                          input_->points[inliers[i]].y, 
-                          input_->points[inliers[i]].z, 
+      Eigen::Vector4f pt (input_->points[inlier].x, 
+                          input_->points[inlier].y, 
+                          input_->points[inlier].z, 
                           1);
 
       float k = (pt.dot (axis_dir) - apexdotdir) * dirdotdir;
 
-      pcl::Vector4fMap pp = projected_points.points[inliers[i]].getVector4fMap ();
+      pcl::Vector4fMap pp = projected_points.points[inlier].getVector4fMap ();
       pp.matrix () = apex + k * axis_dir;
 
       Eigen::Vector4f dir = pt - pp;
@@ -457,9 +457,9 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::doSamplesVerifyModel (
   float dirdotdir = 1.0f / axis_dir.dot (axis_dir);
 
   // Iterate through the 3d points and calculate the distances from them to the cone
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
   {
-    Eigen::Vector4f pt (input_->points[*it].x, input_->points[*it].y, input_->points[*it].z, 0);
+    Eigen::Vector4f pt (input_->points[index].x, input_->points[index].y, input_->points[index].z, 0);
 
     // Calculate the point's projection on the cone axis
     float k = (pt.dot (axis_dir) - apexdotdir) * dirdotdir;

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -378,7 +378,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the cone
-    for (const int inlier : inliers)
+    for (const int &inlier : inliers)
     {
       Eigen::Vector4f pt (input_->points[inlier].x, 
                           input_->points[inlier].y, 
@@ -457,7 +457,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::doSamplesVerifyModel (
   float dirdotdir = 1.0f / axis_dir.dot (axis_dir);
 
   // Iterate through the 3d points and calculate the distances from them to the cone
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     Eigen::Vector4f pt (input_->points[index].x, input_->points[index].y, input_->points[index].z, 0);
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -333,16 +333,16 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the cylinder
-    for (size_t i = 0; i < inliers.size (); ++i)
+    for (const int inlier : inliers)
     {
-      Eigen::Vector4f p (input_->points[inliers[i]].x,
-                         input_->points[inliers[i]].y,
-                         input_->points[inliers[i]].z,
+      Eigen::Vector4f p (input_->points[inlier].x,
+                         input_->points[inlier].y,
+                         input_->points[inlier].z,
                          1);
 
       float k = (p.dot (line_dir) - ptdotdir) * dirdotdir;
 
-      pcl::Vector4fMap pp = projected_points.points[inliers[i]].getVector4fMap ();
+      pcl::Vector4fMap pp = projected_points.points[inlier].getVector4fMap ();
       pp.matrix () = line_pt + k * line_dir;
 
       Eigen::Vector4f dir = p - pp;
@@ -396,12 +396,12 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
   {
     // Approximate the distance from the point to the cylinder as the difference between
     // dist(point,cylinder_axis) and cylinder radius
     // @note need to revise this.
-    Eigen::Vector4f pt (input_->points[*it].x, input_->points[*it].y, input_->points[*it].z, 0);
+    Eigen::Vector4f pt (input_->points[index].x, input_->points[index].y, input_->points[index].z, 0);
     if (fabs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]) > threshold)
       return (false);
   }

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -333,7 +333,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the cylinder
-    for (const int inlier : inliers)
+    for (const int &inlier : inliers)
     {
       Eigen::Vector4f p (input_->points[inlier].x,
                          input_->points[inlier].y,
@@ -396,7 +396,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     // Approximate the distance from the point to the cylinder as the difference between
     // dist(point,cylinder_axis) and cylinder radius

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -263,7 +263,7 @@ pcl::SampleConsensusModelLine<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the line
-    for (const int inlier : inliers)
+    for (const int &inlier : inliers)
     {
       Eigen::Vector4f pt (input_->points[inlier].x, input_->points[inlier].y, input_->points[inlier].z, 0);
       // double k = (DOT_PROD_3D (points[i], p21) - dotA_B) / dotB_B;
@@ -321,7 +321,7 @@ pcl::SampleConsensusModelLine<PointT>::doSamplesVerifyModel (
 
   double sqr_threshold = threshold * threshold;
   // Iterate through the 3d points and calculate the distances from them to the line
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -263,17 +263,17 @@ pcl::SampleConsensusModelLine<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the line
-    for (size_t i = 0; i < inliers.size (); ++i)
+    for (const int inlier : inliers)
     {
-      Eigen::Vector4f pt (input_->points[inliers[i]].x, input_->points[inliers[i]].y, input_->points[inliers[i]].z, 0);
+      Eigen::Vector4f pt (input_->points[inlier].x, input_->points[inlier].y, input_->points[inlier].z, 0);
       // double k = (DOT_PROD_3D (points[i], p21) - dotA_B) / dotB_B;
       float k = (pt.dot (line_dir) - line_pt.dot (line_dir)) / line_dir.dot (line_dir);
 
       Eigen::Vector4f pp = line_pt + k * line_dir;
       // Calculate the projection of the point on the line (pointProj = A + k * B)
-      projected_points.points[inliers[i]].x = pp[0];
-      projected_points.points[inliers[i]].y = pp[1];
-      projected_points.points[inliers[i]].z = pp[2];
+      projected_points.points[inlier].x = pp[0];
+      projected_points.points[inlier].y = pp[1];
+      projected_points.points[inlier].z = pp[2];
     }
   }
   else
@@ -321,11 +321,11 @@ pcl::SampleConsensusModelLine<PointT>::doSamplesVerifyModel (
 
   double sqr_threshold = threshold * threshold;
   // Iterate through the 3d points and calculate the distances from them to the line
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
-    if ((line_pt - input_->points[*it].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
+    if ((line_pt - input_->points[index].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
       return (false);
   }
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
@@ -296,7 +296,7 @@ pcl::SampleConsensusModelPlane<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the plane
-    for (const int inlier : inliers)
+    for (const int &inlier : inliers)
     {
       // Calculate the distance from the point to the plane
       Eigen::Vector4f p (input_->points[inlier].x,
@@ -352,7 +352,7 @@ pcl::SampleConsensusModelPlane<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     Eigen::Vector4f pt (input_->points[index].x,
                         input_->points[index].y,

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
@@ -296,17 +296,17 @@ pcl::SampleConsensusModelPlane<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the plane
-    for (size_t i = 0; i < inliers.size (); ++i)
+    for (const int inlier : inliers)
     {
       // Calculate the distance from the point to the plane
-      Eigen::Vector4f p (input_->points[inliers[i]].x,
-                         input_->points[inliers[i]].y,
-                         input_->points[inliers[i]].z,
+      Eigen::Vector4f p (input_->points[inlier].x,
+                         input_->points[inlier].y,
+                         input_->points[inlier].z,
                          1);
       // use normalized coefficients to calculate the scalar projection
       float distance_to_plane = tmp_mc.dot (p);
 
-      pcl::Vector4fMap pp = projected_points.points[inliers[i]].getVector4fMap ();
+      pcl::Vector4fMap pp = projected_points.points[inlier].getVector4fMap ();
       pp.matrix () = p - mc * distance_to_plane;        // mc[3] = 0, therefore the 3rd coordinate is safe
     }
   }
@@ -352,11 +352,11 @@ pcl::SampleConsensusModelPlane<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
   {
-    Eigen::Vector4f pt (input_->points[*it].x,
-                        input_->points[*it].y,
-                        input_->points[*it].z,
+    Eigen::Vector4f pt (input_->points[index].x,
+                        input_->points[index].y,
+                        input_->points[index].z,
                         1);
     if (fabs (model_coefficients.dot (pt)) > threshold)
       return (false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
@@ -286,16 +286,16 @@ pcl::SampleConsensusModelSphere<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
     if (fabs (sqrt (
-                    ( input_->points[*it].x - model_coefficients[0] ) *
-                    ( input_->points[*it].x - model_coefficients[0] ) +
-                    ( input_->points[*it].y - model_coefficients[1] ) *
-                    ( input_->points[*it].y - model_coefficients[1] ) +
-                    ( input_->points[*it].z - model_coefficients[2] ) *
-                    ( input_->points[*it].z - model_coefficients[2] )
+                    ( input_->points[index].x - model_coefficients[0] ) *
+                    ( input_->points[index].x - model_coefficients[0] ) +
+                    ( input_->points[index].y - model_coefficients[1] ) *
+                    ( input_->points[index].y - model_coefficients[1] ) +
+                    ( input_->points[index].z - model_coefficients[2] ) *
+                    ( input_->points[index].z - model_coefficients[2] )
                    ) - model_coefficients[3]) > threshold)
       return (false);
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
@@ -286,7 +286,7 @@ pcl::SampleConsensusModelSphere<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int index : indices)
+  for (const int &index : indices)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
     if (fabs (sqrt (

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
@@ -290,7 +290,7 @@ pcl::SampleConsensusModelStick<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the line
-    for (const int inlier : inliers)
+    for (const int &inlier : inliers)
     {
       Eigen::Vector4f pt (input_->points[inlier].x, input_->points[inlier].y, input_->points[inlier].z, 0);
       // double k = (DOT_PROD_3D (points[i], p21) - dotA_B) / dotB_B;
@@ -349,7 +349,7 @@ pcl::SampleConsensusModelStick<PointT>::doSamplesVerifyModel (
 
   float sqr_threshold = static_cast<float> (threshold * threshold);
   // Iterate through the 3d points and calculate the distances from them to the line
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
@@ -290,17 +290,17 @@ pcl::SampleConsensusModelStick<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the line
-    for (size_t i = 0; i < inliers.size (); ++i)
+    for (const int inlier : inliers)
     {
-      Eigen::Vector4f pt (input_->points[inliers[i]].x, input_->points[inliers[i]].y, input_->points[inliers[i]].z, 0);
+      Eigen::Vector4f pt (input_->points[inlier].x, input_->points[inlier].y, input_->points[inlier].z, 0);
       // double k = (DOT_PROD_3D (points[i], p21) - dotA_B) / dotB_B;
       float k = (pt.dot (line_dir) - line_pt.dot (line_dir)) / line_dir.dot (line_dir);
 
       Eigen::Vector4f pp = line_pt + k * line_dir;
       // Calculate the projection of the point on the line (pointProj = A + k * B)
-      projected_points.points[inliers[i]].x = pp[0];
-      projected_points.points[inliers[i]].y = pp[1];
-      projected_points.points[inliers[i]].z = pp[2];
+      projected_points.points[inlier].x = pp[0];
+      projected_points.points[inlier].y = pp[1];
+      projected_points.points[inlier].z = pp[2];
     }
   }
   else
@@ -349,11 +349,11 @@ pcl::SampleConsensusModelStick<PointT>::doSamplesVerifyModel (
 
   float sqr_threshold = static_cast<float> (threshold * threshold);
   // Iterate through the 3d points and calculate the distances from them to the line
-  for (std::set<int>::const_iterator it = indices.begin (); it != indices.end (); ++it)
+  for (const int index : indices)
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
-    if ((line_pt - input_->points[*it].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
+    if ((line_pt - input_->points[index].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
       return (false);
   }
 


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix