### PR TITLE
Transform classic loops to range-based for loops in module simulation

### DIFF
--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -7,8 +7,8 @@ pcl::simulation::TriangleMeshModel::TriangleMeshModel (pcl::PolygonMesh::Ptr plg
   Indices indices;
 
   bool found_rgb = false;
-  for (size_t i=0; i < plg->cloud.fields.size () ; ++i)
-    if (plg->cloud.fields[i].name.compare ("rgb") == 0)
+  for (const auto &field : plg->cloud.fields)
+    if (field.name == "rgb")
       found_rgb = true;
 
   if (found_rgb)
@@ -21,17 +21,15 @@ pcl::simulation::TriangleMeshModel::TriangleMeshModel (pcl::PolygonMesh::Ptr plg
     PCL_DEBUG("Mesh points: %ld", newcloud.points.size ());
 
     Eigen::Vector4f tmp;
-    for(size_t i=0; i< plg->polygons.size (); ++i)
-    { // each triangle/polygon
-      pcl::Vertices apoly_in = plg->polygons[i];
-      for(size_t j = 0; j < apoly_in.vertices.size (); ++j)
-      { // each point
-        uint32_t pt = apoly_in.vertices[j];
-        tmp = newcloud.points[pt].getVector4fMap();
+    for(const auto &polygon : plg->polygons)
+    {
+      for(const unsigned int point : polygon.vertices)
+      {
+        tmp = newcloud.points[point].getVector4fMap();
         vertices.push_back (Vertex (Eigen::Vector3f (tmp (0), tmp (1), tmp (2)),
-                                    Eigen::Vector3f (newcloud.points[pt].r/255.0f,
-                                                     newcloud.points[pt].g/255.0f,
-                                                     newcloud.points[pt].b/255.0f)));
+                                    Eigen::Vector3f (newcloud.points[point].r/255.0f,
+                                                     newcloud.points[point].g/255.0f,
+                                                     newcloud.points[point].b/255.0f)));
         indices.push_back (indices.size ());
       }
     }
@@ -41,13 +39,11 @@ pcl::simulation::TriangleMeshModel::TriangleMeshModel (pcl::PolygonMesh::Ptr plg
     pcl::PointCloud<pcl::PointXYZ> newcloud;
     pcl::fromPCLPointCloud2 (plg->cloud, newcloud);
     Eigen::Vector4f tmp;
-    for(size_t i=0; i< plg->polygons.size (); i++)
-    { // each triangle/polygon
-      pcl::Vertices apoly_in = plg->polygons[i];
-      for(size_t j=0; j< apoly_in.vertices.size (); j++)
-      { // each point
-        uint32_t pt = apoly_in.vertices[j];
-        tmp = newcloud.points[pt].getVector4fMap();
+    for(const auto &polygon : plg->polygons)
+    {
+      for(const unsigned int point : polygon.vertices)
+      {
+        tmp = newcloud.points[point].getVector4fMap();
         vertices.push_back (Vertex (Eigen::Vector3f (tmp (0), tmp (1), tmp (2)),
                                     Eigen::Vector3f (1.0, 1.0, 1.0)));
         indices.push_back (indices.size ());
@@ -115,18 +111,20 @@ pcl::simulation::TriangleMeshModel::~TriangleMeshModel ()
 pcl::simulation::PolygonMeshModel::PolygonMeshModel (GLenum mode, pcl::PolygonMesh::Ptr plg) : mode_ (mode)
 {
   bool found_rgb=false;
-  for (size_t i=0; i<plg->cloud.fields.size () ;i++)
-    if (plg->cloud.fields[i].name.compare ("rgb") == 0 || plg->cloud.fields[i].name.compare ("rgba") == 0)
+  for (auto &field : plg->cloud.fields)
+    if ((field.name =="rgb") || (field.name == "rgba"))
+    {
       found_rgb = true;
-  
+      break;
+    }
+
   if (found_rgb)
   {
     pcl::PointCloud<pcl::PointXYZRGB> newcloud;  
     pcl::fromPCLPointCloud2 (plg->cloud, newcloud);
     Eigen::Vector4f tmp;
-    for(size_t i = 0; i< plg->polygons.size (); i++)
+    for(const auto &apoly_in : plg->polygons)
     { // each triangle/polygon
-      pcl::Vertices apoly_in = plg->polygons[i];
       SinglePoly apoly;
       apoly.nvertices_ = apoly_in.vertices.size ();
       apoly.vertices_ = new float[3*apoly_in.vertices.size ()];
@@ -154,9 +152,8 @@ pcl::simulation::PolygonMeshModel::PolygonMeshModel (GLenum mode, pcl::PolygonMe
     pcl::PointCloud<pcl::PointXYZ> newcloud;  
     pcl::fromPCLPointCloud2 (plg->cloud, newcloud);
     Eigen::Vector4f tmp;
-    for(size_t i=0; i< plg->polygons.size (); i++)
+    for(const auto &apoly_in : plg->polygons)
     { // each triangle/polygon
-      pcl::Vertices apoly_in = plg->polygons[i];
       SinglePoly apoly;
       apoly.nvertices_ = apoly_in.vertices.size ();
       apoly.vertices_ = new float [3*apoly_in.vertices.size ()];
@@ -184,10 +181,10 @@ pcl::simulation::PolygonMeshModel::PolygonMeshModel (GLenum mode, pcl::PolygonMe
 pcl::simulation::PolygonMeshModel::~PolygonMeshModel ()
 {
   // TODO: memory management!
-  for (size_t i = 0; i < polygons.size (); ++i)
+  for (auto &polygon : polygons)
   {
-    delete [] polygons[i].vertices_;
-    delete [] polygons[i].colors_;
+    delete [] polygon.vertices_;
+    delete [] polygon.colors_;
   }
 }
 
@@ -200,11 +197,11 @@ pcl::simulation::PolygonMeshModel::draw ()
   glEnableClientState (GL_VERTEX_ARRAY);
   glEnableClientState (GL_COLOR_ARRAY);
 
-  for (size_t i = 0; i < polygons.size (); i++)
+  for (const auto &polygon : polygons)
   {
-    glVertexPointer (3, GL_FLOAT, 0, polygons[i].vertices_);
-    glColorPointer (4, GL_FLOAT, 0, polygons[i].colors_);
-    glDrawArrays (mode_, 0, polygons[i].nvertices_);
+    glVertexPointer (3, GL_FLOAT, 0, polygon.vertices_);
+    glColorPointer (4, GL_FLOAT, 0, polygon.colors_);
+    glDrawArrays (mode_, 0, polygon.nvertices_);
   }
   glDisableClientState (GL_COLOR_ARRAY);
   glDisableClientState (GL_VERTEX_ARRAY);

--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -23,7 +23,7 @@ pcl::simulation::TriangleMeshModel::TriangleMeshModel (pcl::PolygonMesh::Ptr plg
     Eigen::Vector4f tmp;
     for(const auto &polygon : plg->polygons)
     {
-      for(const unsigned int point : polygon.vertices)
+      for(const unsigned int &point : polygon.vertices)
       {
         tmp = newcloud.points[point].getVector4fMap();
         vertices.push_back (Vertex (Eigen::Vector3f (tmp (0), tmp (1), tmp (2)),
@@ -41,7 +41,7 @@ pcl::simulation::TriangleMeshModel::TriangleMeshModel (pcl::PolygonMesh::Ptr plg
     Eigen::Vector4f tmp;
     for(const auto &polygon : plg->polygons)
     {
-      for(const unsigned int point : polygon.vertices)
+      for(const unsigned int &point : polygon.vertices)
       {
         tmp = newcloud.points[point].getVector4fMap();
         vertices.push_back (Vertex (Eigen::Vector3f (tmp (0), tmp (1), tmp (2)),

--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -112,7 +112,7 @@ pcl::simulation::PolygonMeshModel::PolygonMeshModel (GLenum mode, pcl::PolygonMe
 {
   bool found_rgb=false;
   for (const auto &field : plg->cloud.fields)
-    if ((field.name =="rgb") || (field.name == "rgba"))
+    if ((field.name == "rgb") || (field.name == "rgba"))
     {
       found_rgb = true;
       break;

--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -111,7 +111,7 @@ pcl::simulation::TriangleMeshModel::~TriangleMeshModel ()
 pcl::simulation::PolygonMeshModel::PolygonMeshModel (GLenum mode, pcl::PolygonMesh::Ptr plg) : mode_ (mode)
 {
   bool found_rgb=false;
-  for (auto &field : plg->cloud.fields)
+  for (const auto &field : plg->cloud.fields)
     if ((field.name =="rgb") || (field.name == "rgba"))
     {
       found_rgb = true;

--- a/simulation/src/scene.cpp
+++ b/simulation/src/scene.cpp
@@ -28,8 +28,8 @@ Scene::addCompleteModel (std::vector<Model::Ptr> model)
 void
 Scene::draw ()
 {
-  for (std::vector<Model::Ptr>::iterator model = models_.begin (); model != models_.end (); ++model)
-    (*model)->draw ();
+  for (auto &model : models_)
+    model->draw ();
 }
 
 void

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -325,7 +325,7 @@ void display ()
   
   range_likelihood_->computeLikelihoods (reference, poses, scores);
   std::cout << "score: ";
-  for (const float score : scores)
+  for (const float &score : scores)
   {
     std::cout << " " << score;
   }

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -325,9 +325,9 @@ void display ()
   
   range_likelihood_->computeLikelihoods (reference, poses, scores);
   std::cout << "score: ";
-  for (size_t i = 0; i<scores.size (); ++i)
+  for (const float score : scores)
   {
-    std::cout << " " << scores[i];
+    std::cout << " " << score;
   }
   std::cout << std::endl;
 

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -245,9 +245,9 @@ void capture (Eigen::Isometry3d pose_in)
 
   range_likelihood_->computeLikelihoods (reference, poses, scores);
   std::cout << "score: ";
-  for (size_t i = 0; i<scores.size (); ++i)
+  for (const float score : scores)
   {
-    std::cout << " " << scores[i];
+    std::cout << " " << score;
   }
   std::cout << std::endl;
 

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -245,7 +245,7 @@ void capture (Eigen::Isometry3d pose_in)
 
   range_likelihood_->computeLikelihoods (reference, poses, scores);
   std::cout << "score: ";
-  for (const float score : scores)
+  for (const float &score : scores)
   {
     std::cout << " " << score;
   }


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix