### PR TITLE
Transform classic loops to range-based for loops in module surface

### DIFF
--- a/surface/include/pcl/surface/impl/concave_hull.hpp
+++ b/surface/include/pcl/surface/impl/concave_hull.hpp
@@ -487,7 +487,7 @@ pcl::ConcaveHull<PointInT>::performReconstruction (PointCloud &alpha_shape, std:
     {
       alpha_shape_sorted.points[sorted_idx] = alpha_shape.points[(*curr).first];
       // check where we can go from (*curr).first
-      for (const int i : (*curr).second)
+      for (const int &i : (*curr).second)
       {
         if (!used[i])
         {

--- a/surface/include/pcl/surface/impl/concave_hull.hpp
+++ b/surface/include/pcl/surface/impl/concave_hull.hpp
@@ -487,12 +487,12 @@ pcl::ConcaveHull<PointInT>::performReconstruction (PointCloud &alpha_shape, std:
     {
       alpha_shape_sorted.points[sorted_idx] = alpha_shape.points[(*curr).first];
       // check where we can go from (*curr).first
-      for (size_t i = 0; i < (*curr).second.size (); i++)
+      for (const int i : (*curr).second)
       {
-        if (!used[((*curr).second)[i]])
+        if (!used[i])
         {
           // we can go there
-          next = ((*curr).second)[i];
+          next = i;
           break;
         }
       }

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -883,10 +883,10 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
           else
             angle_so_far = 0;
         }
-        for (std::vector<int>::iterator it = to_erase.begin(); it != to_erase.end(); it++)
+        for (const int &it : to_erase)
         {
           for (std::vector<int>::iterator iter = angleIdx.begin(); iter != angleIdx.end(); iter++)
-            if (*it == *iter)
+            if (it == *iter)
             {
               angleIdx.erase(iter);
               break;

--- a/surface/include/pcl/surface/impl/surfel_smoothing.hpp
+++ b/surface/include/pcl/surface/impl/surfel_smoothing.hpp
@@ -297,7 +297,7 @@ pcl::SurfelSmoothing<PointT, PointNT>::extractSalientFeaturesBetweenScales (Poin
 
     bool largest = true;
     bool smallest = true;
-    for (const int nn_index : nn_indices)
+    for (const int &nn_index : nn_indices)
     {
       if (diffs[point_i] < diffs[nn_index])
         largest = false;

--- a/surface/include/pcl/surface/impl/surfel_smoothing.hpp
+++ b/surface/include/pcl/surface/impl/surfel_smoothing.hpp
@@ -297,9 +297,9 @@ pcl::SurfelSmoothing<PointT, PointNT>::extractSalientFeaturesBetweenScales (Poin
 
     bool largest = true;
     bool smallest = true;
-    for (std::vector<int>::iterator nn_index_it = nn_indices.begin (); nn_index_it != nn_indices.end (); ++nn_index_it)
+    for (const int nn_index : nn_indices)
     {
-      if (diffs[point_i] < diffs[*nn_index_it])
+      if (diffs[point_i] < diffs[nn_index])
         largest = false;
       else 
         smallest = false;

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -324,7 +324,7 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
     {
       Eigen::Vector2f tmp_VT;
       // for each point of this face
-      for (const unsigned int vertex : tex_polygon.vertices)
+      for (const unsigned int &vertex : tex_polygon.vertices)
       {
         // get point
         PointInT pt = camera_transformed_cloud->points[vertex];
@@ -385,7 +385,7 @@ pcl::TextureMapping<PointInT>::isPointOccluded (const PointInT &pt, OctreePtr oc
   octree->getIntersectedVoxelIndices(direction, -direction, indices);
 
   int nbocc = static_cast<int> (indices.size ());
-  for (const int index : indices)
+  for (const int &index : indices)
   {
    // if intersected point is on the over side of the camera
    if (pt.z * cloud->points[index].z < 0)
@@ -441,7 +441,7 @@ pcl::TextureMapping<PointInT>::removeOccludedPoints (const PointCloudPtr &input_
     octree->getIntersectedVoxelIndices (direction, -direction, indices);
 
     int nbocc = static_cast<int> (indices.size ());
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       // if intersected point is on the over side of the camera
       if (input_cloud->points[i].z * input_cloud->points[index].z < 0)
@@ -501,7 +501,7 @@ pcl::TextureMapping<PointInT>::removeOccludedPoints (const pcl::TextureMesh &tex
       std::vector<int>::iterator it;
 
       // iterate over face's vertex
-      for (const unsigned int vertex : tex_mesh.tex_polygons[polygons][faces].vertices)
+      for (const unsigned int &vertex : tex_mesh.tex_polygons[polygons][faces].vertices)
       {
         it = find (occluded.begin (), occluded.end (), vertex);
 
@@ -685,7 +685,7 @@ pcl::TextureMapping<PointInT>::showOcclusions (const PointCloudPtr &input_cloud,
     nbocc = static_cast<int> (indices.size ());
 
     // TODO need to clean this up and find tricks to get remove aliasaing effect on planes
-    for (const int index : indices)
+    for (const int &index : indices)
     {
       // if intersected point is on the over side of the camera
       if (pt.z * input_cloud->points[index].z < 0)
@@ -872,7 +872,7 @@ pcl::TextureMapping<PointInT>::textureMeshwithMultipleCameras (pcl::TextureMesh 
               if (kdtree.radiusSearch (center, radius, idxNeighbors, neighborsSquaredDistance) > 0 )
               {
                 // for each neighbor
-                for (const int idxNeighbor : idxNeighbors)
+                for (const int &idxNeighbor : idxNeighbors)
                 {
                   if (std::max (camera_cloud->points[mesh.tex_polygons[idx_pcam][idx_face].vertices[0]].z,
                                 std::max (camera_cloud->points[mesh.tex_polygons[idx_pcam][idx_face].vertices[1]].z, 

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -179,8 +179,8 @@ pcl::TextureMapping<PointInT>::mapTexture2Mesh (pcl::TextureMesh &tex_mesh)
 
       // get texture coordinates of each face
       std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > tex_coordinates = mapTexture2Face (facet[0], facet[1], facet[2]);
-      for (size_t n = 0; n < tex_coordinates.size (); ++n)
-        texture_map_tmp.push_back (tex_coordinates[n]);
+      for (const auto &tex_coordinate : tex_coordinates)
+        texture_map_tmp.push_back (tex_coordinate);
     }// end faces
 
     // texture materials
@@ -320,22 +320,18 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
     std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > texture_map_tmp;
 
     // processing each face visible by this camera
-    PointInT pt;
-    size_t idx;
-    for (size_t i = 0; i < tex_mesh.tex_polygons[m].size (); ++i)
+    for (const auto &tex_polygon : tex_mesh.tex_polygons[m])
     {
       Eigen::Vector2f tmp_VT;
       // for each point of this face
-      for (size_t j = 0; j < tex_mesh.tex_polygons[m][i].vertices.size (); ++j)
+      for (const unsigned int vertex : tex_polygon.vertices)
       {
         // get point
-        idx = tex_mesh.tex_polygons[m][i].vertices[j];
-        pt = camera_transformed_cloud->points[idx];
+        PointInT pt = camera_transformed_cloud->points[vertex];
 
         // compute UV coordinates for this point
         getPointUVCoordinates (pt, current_cam, tmp_VT);
         texture_map_tmp.push_back (tmp_VT);
-
       }// end points
     }// end faces
 
@@ -352,8 +348,8 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
 
   // push on extra empty UV map (for unseen faces) so that obj writer does not crash!
   std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > texture_map_tmp;
-  for (size_t i = 0; i < tex_mesh.tex_polygons[cams.size ()].size (); ++i)
-    for (size_t j = 0; j < tex_mesh.tex_polygons[cams.size ()][i].vertices.size (); ++j)
+  for (const auto &tex_polygon : tex_mesh.tex_polygons[cams.size ()])
+    for (size_t j = 0; j < tex_polygon.vertices.size (); ++j)
     {
       Eigen::Vector2f tmp_VT;
       tmp_VT[0] = -1;
@@ -364,12 +360,9 @@ pcl::TextureMapping<PointInT>::mapMultipleTexturesToMeshUV (pcl::TextureMesh &te
   tex_mesh.tex_coordinates.push_back (texture_map_tmp);
 
   // push on an extra dummy material for the same reason
-  std::stringstream tex_name;
-  tex_name << "material_" << cams.size ();
-  tex_name >> tex_material_.tex_name;
+  tex_material_.tex_name = "material_" + std::to_string(cams.size());
   tex_material_.tex_file = "occluded.jpg";
   tex_mesh.tex_materials.push_back (tex_material_);
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -392,16 +385,16 @@ pcl::TextureMapping<PointInT>::isPointOccluded (const PointInT &pt, OctreePtr oc
   octree->getIntersectedVoxelIndices(direction, -direction, indices);
 
   int nbocc = static_cast<int> (indices.size ());
-  for (size_t j = 0; j < indices.size (); j++)
+  for (const int index : indices)
   {
    // if intersected point is on the over side of the camera
-   if (pt.z * cloud->points[indices[j]].z < 0)
+   if (pt.z * cloud->points[index].z < 0)
    {
      nbocc--;
      continue;
    }
 
-   if (fabs (cloud->points[indices[j]].z - pt.z) <= distance_threshold)
+   if (fabs (cloud->points[index].z - pt.z) <= distance_threshold)
    {
      // points are very close to each-other, we do not consider the occlusion
      nbocc--;
@@ -448,16 +441,16 @@ pcl::TextureMapping<PointInT>::removeOccludedPoints (const PointCloudPtr &input_
     octree->getIntersectedVoxelIndices (direction, -direction, indices);
 
     int nbocc = static_cast<int> (indices.size ());
-    for (size_t j = 0; j < indices.size (); j++)
+    for (const int index : indices)
     {
       // if intersected point is on the over side of the camera
-      if (input_cloud->points[i].z * input_cloud->points[indices[j]].z < 0)
+      if (input_cloud->points[i].z * input_cloud->points[index].z < 0)
       {
         nbocc--;
         continue;
       }
 
-      if (fabs (input_cloud->points[indices[j]].z - input_cloud->points[i].z) <= maxDeltaZ)
+      if (fabs (input_cloud->points[index].z - input_cloud->points[i].z) <= maxDeltaZ)
       {
         // points are very close to each-other, we do not consider the occlusion
         nbocc--;
@@ -508,9 +501,9 @@ pcl::TextureMapping<PointInT>::removeOccludedPoints (const pcl::TextureMesh &tex
       std::vector<int>::iterator it;
 
       // iterate over face's vertex
-      for (size_t points = 0; points < tex_mesh.tex_polygons[polygons][faces].vertices.size (); ++points)
+      for (const unsigned int vertex : tex_mesh.tex_polygons[polygons][faces].vertices)
       {
-        it = find (occluded.begin (), occluded.end (), tex_mesh.tex_polygons[polygons][faces].vertices[points]);
+        it = find (occluded.begin (), occluded.end (), vertex);
 
         if (it == occluded.end ())
         {
@@ -580,10 +573,10 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
   pcl::fromPCLPointCloud2 (tex_mesh.cloud, *original_cloud);
 
   // for each camera
-  for (size_t cam = 0; cam < cameras.size (); ++cam)
+  for (const auto &camera : cameras)
   {
     // get camera pose as transform
-    Eigen::Affine3f cam_trans = cameras[cam].pose;
+    Eigen::Affine3f cam_trans = camera.pose;
 
     // transform original cloud in camera coordinates
     pcl::transformPointCloud (*original_cloud, *transformed_cloud, cam_trans.inverse ());
@@ -615,7 +608,7 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
           // does it land on the camera's image plane?
           PointInT pt = transformed_cloud->points[tex_mesh.tex_polygons[0][faces].vertices[current_pt_indice]];
           Eigen::Vector2f dummy_UV;
-          if (!getPointUVCoordinates (pt, cameras[cam], dummy_UV))
+          if (!getPointUVCoordinates (pt, camera, dummy_UV))
           {
             // point is not visible by the camera
             faceIsVisible = false;
@@ -692,22 +685,22 @@ pcl::TextureMapping<PointInT>::showOcclusions (const PointCloudPtr &input_cloud,
     nbocc = static_cast<int> (indices.size ());
 
     // TODO need to clean this up and find tricks to get remove aliasaing effect on planes
-    for (size_t j = 0; j < indices.size (); j++)
+    for (const int index : indices)
     {
       // if intersected point is on the over side of the camera
-      if (pt.z * input_cloud->points[indices[j]].z < 0)
+      if (pt.z * input_cloud->points[index].z < 0)
       {
         nbocc--;
       }
-      else if (fabs (input_cloud->points[indices[j]].z - pt.z) <= maxDeltaZ)
+      else if (fabs (input_cloud->points[index].z - pt.z) <= maxDeltaZ)
       {
         // points are very close to each-other, we do not consider the occlusion
         nbocc--;
       }
       else
       {
-        zDist.push_back (fabs (input_cloud->points[indices[j]].z - pt.z));
-        ptDist.push_back (pcl::euclideanDistance (input_cloud->points[indices[j]], pt));
+        zDist.push_back (fabs (input_cloud->points[index].z - pt.z));
+        ptDist.push_back (pcl::euclideanDistance (input_cloud->points[index], pt));
       }
     }
 
@@ -879,18 +872,18 @@ pcl::TextureMapping<PointInT>::textureMeshwithMultipleCameras (pcl::TextureMesh 
               if (kdtree.radiusSearch (center, radius, idxNeighbors, neighborsSquaredDistance) > 0 )
               {
                 // for each neighbor
-                for (size_t i = 0; i < idxNeighbors.size (); ++i)
+                for (const int idxNeighbor : idxNeighbors)
                 {
                   if (std::max (camera_cloud->points[mesh.tex_polygons[idx_pcam][idx_face].vertices[0]].z,
                                 std::max (camera_cloud->points[mesh.tex_polygons[idx_pcam][idx_face].vertices[1]].z, 
                                           camera_cloud->points[mesh.tex_polygons[idx_pcam][idx_face].vertices[2]].z))
-                     < camera_cloud->points[indexes_uv_to_points[idxNeighbors[i]].idx_cloud].z)
+                     < camera_cloud->points[indexes_uv_to_points[idxNeighbor].idx_cloud].z)
                   {
                     // neighbor is farther than all the face's points. Check if it falls into the triangle
-                    if (checkPointInsideTriangle(uv_coord1, uv_coord2, uv_coord3, projections->points[idxNeighbors[i]]))
+                    if (checkPointInsideTriangle(uv_coord1, uv_coord2, uv_coord3, projections->points[idxNeighbor]))
                     {
                       // current neighbor is inside triangle and is closer => the corresponding face
-                      visibility[indexes_uv_to_points[idxNeighbors[i]].idx_face] = false;
+                      visibility[indexes_uv_to_points[idxNeighbor].idx_face] = false;
                       cpt_invisible++;
                       //TODO we could remove the projections of this face from the kd-tree cloud, but I fond it slower, and I need the point to keep ordered to querry UV coordinates later
                     }
@@ -953,10 +946,6 @@ pcl::TextureMapping<PointInT>::textureMeshwithMultipleCameras (pcl::TextureMesh 
     visible_faces.resize (cpt_visible_faces);
     mesh.tex_polygons[current_cam].clear ();
     mesh.tex_polygons[current_cam] = visible_faces;
-
-    int nb_faces = 0;
-    for (int i = 0; i < static_cast<int> (mesh.tex_polygons.size ()); i++)
-      nb_faces += static_cast<int> (mesh.tex_polygons[i].size ());
   }
 
   // we have been through all the cameras.

--- a/surface/src/ear_clipping.cpp
+++ b/surface/src/ear_clipping.cpp
@@ -58,8 +58,8 @@ pcl::EarClipping::performProcessing (PolygonMesh& output)
 {
   output.polygons.clear ();
   output.cloud = input_mesh_->cloud;
-  for (int i = 0; i < static_cast<int> (input_mesh_->polygons.size ()); ++i)
-    triangulate (input_mesh_->polygons[i], output);
+  for (const auto &polygon : input_mesh_->polygons)
+    triangulate (polygon, output);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/surface/src/on_nurbs/closing_boundary.cpp
+++ b/surface/src/on_nurbs/closing_boundary.cpp
@@ -350,11 +350,10 @@ ClosingBoundary::optimizeBoundary (std::vector<ON_NurbsSurface> &nurbs_list, std
       ON_NurbsSurface *nurbs2 = &nurbs_list[n2];
 
       // for all points in the point list
-      for (size_t i = 0; i < boundary1.size (); i++)
+      for (const auto &p0 : boundary1)
       {
         double error;
         Eigen::Vector3d p, tu, tv;
-        Eigen::Vector3d p0 = boundary1[i];
         Eigen::Vector2d params1, params2;
 
         switch (param.type)

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -97,8 +97,8 @@ FittingCurve2d::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
-    m_nurbs.InsertKnot (xi[i], 1);
+  for (const double i : xi)
+    m_nurbs.InsertKnot (i, 1);
 }
 
 void

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -97,7 +97,7 @@ FittingCurve2d::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
     m_nurbs.InsertKnot (i, 1);
 }
 

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -98,8 +98,8 @@ FittingCurve2dAPDM::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
-    m_nurbs.InsertKnot (xi[i], 1);
+  for (const double i : xi)
+    m_nurbs.InsertKnot (i, 1);
 }
 
 void

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -98,7 +98,7 @@ FittingCurve2dAPDM::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
     m_nurbs.InsertKnot (i, 1);
 }
 

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -98,8 +98,8 @@ FittingCurve2dPDM::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
-    m_nurbs.InsertKnot (xi[i], 1);
+  for (const double i : xi)
+    m_nurbs.InsertKnot (i, 1);
 }
 
 void

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -98,7 +98,7 @@ FittingCurve2dPDM::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
     m_nurbs.InsertKnot (i, 1);
 }
 

--- a/surface/src/on_nurbs/fitting_curve_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_pdm.cpp
@@ -98,8 +98,8 @@ FittingCurve::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
-    m_nurbs.InsertKnot (xi[i], 1);
+  for (const double i : xi)
+    m_nurbs.InsertKnot (i, 1);
 }
 
 void

--- a/surface/src/on_nurbs/fitting_curve_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_pdm.cpp
@@ -98,7 +98,7 @@ FittingCurve::refine ()
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
     m_nurbs.InsertKnot (i, 1);
 }
 

--- a/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
@@ -84,8 +84,8 @@ FittingCylinder::refine (int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
-    m_nurbs.InsertKnot (dim, xi[i], 1);
+  for (const double i : xi)
+    m_nurbs.InsertKnot (dim, i, 1);
 }
 
 void

--- a/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
@@ -84,7 +84,7 @@ FittingCylinder::refine (int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
     m_nurbs.InsertKnot (dim, i, 1);
 }
 

--- a/surface/src/on_nurbs/fitting_sphere_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_sphere_pdm.cpp
@@ -168,9 +168,9 @@ FittingSphere::initNurbsSphere (int order, NurbsDataSurface *data, Eigen::Vector
 
   Eigen::Vector3d _min (DBL_MAX, DBL_MAX, DBL_MAX);
   Eigen::Vector3d _max (-DBL_MAX, -DBL_MAX, -DBL_MAX);
-  for (size_t i = 0; i < data->interior.size (); i++)
+  for (const auto &i : data->interior)
   {
-    Eigen::Vector3d p = data->interior[i] - mean;
+    Eigen::Vector3d p = i - mean;
 
     if (p (0) < _min (0))
       _min (0) = p (0);

--- a/surface/src/on_nurbs/fitting_surface_im.cpp
+++ b/surface/src/on_nurbs/fitting_surface_im.cpp
@@ -52,7 +52,7 @@ FittingSurfaceIM::computeMean () const
   double ds = 1.0 / double (m_indices.size ());
 
   const pcl::PointCloud<pcl::PointXYZRGB> &cloud_ref = *m_cloud;
-  for (const int index : m_indices)
+  for (const int &index : m_indices)
   {
     int i = index % cloud_ref.width;
     int j = index / cloud_ref.width;
@@ -76,7 +76,7 @@ FittingSurfaceIM::computeIndexBoundingBox (pcl::PointCloud<pcl::PointXYZRGB>::Pt
   Eigen::Vector4d bb = Eigen::Vector4d (DBL_MAX, 0, DBL_MAX, 0);
   const pcl::PointCloud<pcl::PointXYZRGB> &cloud_ref = *cloud;
 
-  for (const int index : indices)
+  for (const int &index : indices)
   {
     int i = index % cloud_ref.width;
     int j = index / cloud_ref.width;
@@ -273,7 +273,7 @@ FittingSurfaceIM::assemble (bool inverse_mapping)
 
   // assemble data points
   const pcl::PointCloud<pcl::PointXYZRGB> &cloud_ref = *m_cloud;
-  for (const int index : m_indices)
+  for (const int &index : m_indices)
   {
     int px = index % cloud_ref.width;
     int py = index / cloud_ref.width;

--- a/surface/src/on_nurbs/fitting_surface_im.cpp
+++ b/surface/src/on_nurbs/fitting_surface_im.cpp
@@ -52,10 +52,10 @@ FittingSurfaceIM::computeMean () const
   double ds = 1.0 / double (m_indices.size ());
 
   const pcl::PointCloud<pcl::PointXYZRGB> &cloud_ref = *m_cloud;
-  for (size_t idx = 0; idx < m_indices.size (); idx++)
+  for (const int index : m_indices)
   {
-    int i = m_indices[idx] % cloud_ref.width;
-    int j = m_indices[idx] / cloud_ref.width;
+    int i = index % cloud_ref.width;
+    int j = index / cloud_ref.width;
 
     const pcl::PointXYZRGB &point = cloud_ref (i, j);
     if (std::isnan (point.x) || std::isnan (point.y) || std::isnan (point.z))
@@ -76,10 +76,10 @@ FittingSurfaceIM::computeIndexBoundingBox (pcl::PointCloud<pcl::PointXYZRGB>::Pt
   Eigen::Vector4d bb = Eigen::Vector4d (DBL_MAX, 0, DBL_MAX, 0);
   const pcl::PointCloud<pcl::PointXYZRGB> &cloud_ref = *cloud;
 
-  for (size_t idx = 0; idx < indices.size (); idx++)
+  for (const int index : indices)
   {
-    int i = indices[idx] % cloud_ref.width;
-    int j = indices[idx] / cloud_ref.width;
+    int i = index % cloud_ref.width;
+    int j = index / cloud_ref.width;
 
     const pcl::PointXYZRGB &point = cloud_ref (i, j);
     if (std::isnan (point.x) || std::isnan (point.y) || std::isnan (point.z))
@@ -273,12 +273,12 @@ FittingSurfaceIM::assemble (bool inverse_mapping)
 
   // assemble data points
   const pcl::PointCloud<pcl::PointXYZRGB> &cloud_ref = *m_cloud;
-  for (size_t i = 0; i < m_indices.size (); i++)
+  for (const int index : m_indices)
   {
-    int px = m_indices[i] % cloud_ref.width;
-    int py = m_indices[i] / cloud_ref.width;
+    int px = index % cloud_ref.width;
+    int py = index / cloud_ref.width;
 
-    const pcl::PointXYZRGB &pt = cloud_ref.at (m_indices[i]);
+    const pcl::PointXYZRGB &pt = cloud_ref.at (index);
     Eigen::Vector2i params (px, py);
 
     if (std::isnan (pt.z) || pt.z == 0.0)

--- a/surface/src/on_nurbs/fitting_surface_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_surface_pdm.cpp
@@ -89,8 +89,8 @@ FittingSurface::refine (int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
-    m_nurbs.InsertKnot (dim, xi[i], 1);
+  for (const double i : xi)
+    m_nurbs.InsertKnot (dim, i, 1);
 
   m_elementsU = getElementVector (m_nurbs, 0);
   m_elementsV = getElementVector (m_nurbs, 1);
@@ -109,8 +109,8 @@ FittingSurface::refine (ON_NurbsSurface &nurbs, int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
-    nurbs.InsertKnot (dim, xi[i], 1);
+  for (const double i : xi)
+    nurbs.InsertKnot (dim, i, 1);
 }
 
 void

--- a/surface/src/on_nurbs/fitting_surface_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_surface_pdm.cpp
@@ -89,7 +89,7 @@ FittingSurface::refine (int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
     m_nurbs.InsertKnot (dim, i, 1);
 
   m_elementsU = getElementVector (m_nurbs, 0);
@@ -109,7 +109,7 @@ FittingSurface::refine (ON_NurbsSurface &nurbs, int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
     nurbs.InsertKnot (dim, i, 1);
 }
 

--- a/surface/src/on_nurbs/global_optimization_pdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_pdm.cpp
@@ -115,8 +115,8 @@ GlobalOptimization::assemble (Parameter params)
 
   m_solver.assign (m_nrows, m_ncols, 3);
 
-  for (size_t i = 0; i < m_data.size (); i++)
-    m_data[i]->common_boundary_param.clear ();
+  for (const auto &i : m_data)
+    i->common_boundary_param.clear ();
 
   // assemble matrix
   unsigned row (0);
@@ -159,10 +159,8 @@ GlobalOptimization::updateSurf (double damp)
 {
   int ncps (0);
 
-  for (size_t i = 0; i < m_nurbs.size (); i++)
+  for (const auto nurbs : m_nurbs)
   {
-    ON_NurbsSurface* nurbs = m_nurbs[i];
-
     int ncp = nurbs->CVCount ();
 
     for (int A = 0; A < ncp; A++)
@@ -202,9 +200,9 @@ GlobalOptimization::refine (unsigned id, int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (size_t i = 0; i < xi.size (); i++)
+  for (const double i : xi)
   {
-    m_nurbs[id]->InsertKnot (dim, xi[i], 1);
+    m_nurbs[id]->InsertKnot (dim, i, 1);
   }
 }
 

--- a/surface/src/on_nurbs/global_optimization_pdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_pdm.cpp
@@ -159,7 +159,7 @@ GlobalOptimization::updateSurf (double damp)
 {
   int ncps (0);
 
-  for (const auto nurbs : m_nurbs)
+  for (const auto &nurbs : m_nurbs)
   {
     int ncp = nurbs->CVCount ();
 
@@ -200,7 +200,7 @@ GlobalOptimization::refine (unsigned id, int dim)
   for (size_t i = 0; i < elements.size () - 1; i++)
     xi.push_back (elements[i] + 0.5 * (elements[i + 1] - elements[i]));
 
-  for (const double i : xi)
+  for (const double &i : xi)
   {
     m_nurbs[id]->InsertKnot (dim, i, 1);
   }

--- a/surface/src/on_nurbs/global_optimization_tdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_tdm.cpp
@@ -90,8 +90,8 @@ GlobalOptimizationTDM::assemble (Parameter params)
 
   m_solver.assign (m_nrows, m_ncols, 1);
 
-  for (size_t i = 0; i < m_data.size (); i++)
-    m_data[i]->common_boundary_param.clear ();
+  for (const auto &i : m_data)
+    i->common_boundary_param.clear ();
 
   // assemble matrix
   unsigned row (0);
@@ -208,10 +208,8 @@ GlobalOptimizationTDM::updateSurf (double damp)
 {
   int ncps (0);
 
-  for (size_t i = 0; i < m_nurbs.size (); i++)
+  for (const auto nurbs : m_nurbs)
   {
-    ON_NurbsSurface* nurbs = m_nurbs[i];
-
     int ncp = nurbs->CVCount ();
 
     for (int A = 0; A < ncp; A++)

--- a/surface/src/on_nurbs/global_optimization_tdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_tdm.cpp
@@ -208,7 +208,7 @@ GlobalOptimizationTDM::updateSurf (double damp)
 {
   int ncps (0);
 
-  for (const auto nurbs : m_nurbs)
+  for (const auto &nurbs : m_nurbs)
   {
     int ncp = nurbs->CVCount ();
 

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -593,9 +593,9 @@ SequentialFitter::grow (float max_dist, float max_angle, unsigned min_length, un
 
   double int_err (0.0);
   double div_err = 1.0 / double (m_data.interior_error.size ());
-  for (size_t i = 0; i < m_data.interior_error.size (); i++)
+  for (const double i : m_data.interior_error)
   {
-    int_err += (m_data.interior_error[i] * div_err);
+    int_err += (i * div_err);
   }
 
   printf ("[SequentialFitter::grow] average interior error: %e\n", int_err);
@@ -610,10 +610,10 @@ SequentialFitter::PCL2ON (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_cloud, con
 {
   size_t numPoints = 0;
 
-  for (size_t i = 0; i < indices.size (); i++)
+  for (const int index : indices)
   {
 
-    pcl::PointXYZRGB &pt = pcl_cloud->at (indices[i]);
+    pcl::PointXYZRGB &pt = pcl_cloud->at (index);
 
     if (!std::isnan (pt.x) && !std::isnan (pt.y) && !std::isnan (pt.z))
     {

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -593,7 +593,7 @@ SequentialFitter::grow (float max_dist, float max_angle, unsigned min_length, un
 
   double int_err (0.0);
   double div_err = 1.0 / double (m_data.interior_error.size ());
-  for (const double i : m_data.interior_error)
+  for (const double &i : m_data.interior_error)
   {
     int_err += (i * div_err);
   }
@@ -610,7 +610,7 @@ SequentialFitter::PCL2ON (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_cloud, con
 {
   size_t numPoints = 0;
 
-  for (const int index : indices)
+  for (const int &index : indices)
   {
 
     pcl::PointXYZRGB &pt = pcl_cloud->at (index);

--- a/surface/src/on_nurbs/triangulation.cpp
+++ b/surface/src/on_nurbs/triangulation.cpp
@@ -182,10 +182,8 @@ Triangulation::convertSurface2PolygonMesh (const ON_NurbsSurface &nurbs, Polygon
   createVertices (cloud, float (x0), float (y0), 0.0f, float (w), float (h), resolution, resolution);
   createIndices (mesh.polygons, 0, resolution, resolution);
 
-  for (size_t i = 0; i < cloud->size (); i++)
+  for (auto &v : *cloud)
   {
-    pcl::PointXYZ &v = cloud->at (i);
-
     double point[9];
     nurbs.Evaluate (v.x, v.y, 1, 3, point);
 
@@ -255,17 +253,14 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     pt_is_in[i] = (z (2) >= 0.0);
   }
 
-  for (size_t i = 0; i < polygons.size (); i++)
+  for (const auto &poly : polygons)
   {
     unsigned in (0);
-    pcl::Vertices &poly = polygons[i];
-
     std::vector<uint32_t> out_idx_tmp;
     pcl::on_nurbs::vector_vec2d out_pc_tmp;
 
-    for (std::size_t j = 0; j < poly.vertices.size (); j++)
+    for (const unsigned int vi : poly.vertices)
     {
-      uint32_t &vi = poly.vertices[j];
       if (pt_is_in[vi])
         in++;
       else
@@ -297,9 +292,8 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     v.y = float (pc (1));
   }
 
-  for (std::size_t i = 0; i < cloud->size (); i++)
+  for (auto &v : *cloud)
   {
-    pcl::PointXYZ &v = cloud->at (i);
     Eigen::Vector3d tu, tv;
 
     double point[3];
@@ -385,17 +379,14 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     start.push_back (Eigen::Vector3d (vp (0), vp (1), 0.0));
   }
 
-  for (size_t i = 0; i < polygons.size (); i++)
+  for (const auto &poly : polygons)
   {
     unsigned in (0);
-    pcl::Vertices &poly = polygons[i];
-
     std::vector<uint32_t> out_idx_tmp;
     pcl::on_nurbs::vector_vec2d out_pc_tmp;
 
-    for (std::size_t j = 0; j < poly.vertices.size (); j++)
+    for (const unsigned int vi : poly.vertices)
     {
-      uint32_t &vi = poly.vertices[j];
       if (pt_is_in[vi])
         in++;
       else
@@ -427,10 +418,8 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     v.y = float (pc (1));
   }
 
-  for (std::size_t i = 0; i < cloud->size (); i++)
+  for (auto &v : *cloud)
   {
-    pcl::PointXYZ &v = cloud->at (i);
-
     double point[3];
     nurbs.Evaluate (v.x, v.y, 0, 3, point);
 
@@ -483,10 +472,8 @@ Triangulation::convertSurface2Vertices (const ON_NurbsSurface &nurbs, pcl::Point
   createVertices (cloud, float (x0), float (y0), 0.0f, float (w), float (h), resolution, resolution);
   createIndices (vertices, 0, resolution, resolution);
 
-  for (size_t i = 0; i < cloud->size (); i++)
+  for (auto &v : *cloud)
   {
-    pcl::PointXYZ &v = cloud->at (i);
-
     double point[9];
     nurbs.Evaluate (v.x, v.y, 1, 3, point);
 

--- a/surface/src/on_nurbs/triangulation.cpp
+++ b/surface/src/on_nurbs/triangulation.cpp
@@ -259,7 +259,7 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     std::vector<uint32_t> out_idx_tmp;
     pcl::on_nurbs::vector_vec2d out_pc_tmp;
 
-    for (const unsigned int vi : poly.vertices)
+    for (const unsigned int &vi : poly.vertices)
     {
       if (pt_is_in[vi])
         in++;
@@ -385,7 +385,7 @@ Triangulation::convertTrimmedSurface2PolygonMesh (const ON_NurbsSurface &nurbs, 
     std::vector<uint32_t> out_idx_tmp;
     pcl::on_nurbs::vector_vec2d out_pc_tmp;
 
-    for (const unsigned int vi : poly.vertices)
+    for (const unsigned int &vi : poly.vertices)
     {
       if (pt_is_in[vi])
         in++;

--- a/surface/src/simplification_remove_unused_vertices.cpp
+++ b/surface/src/simplification_remove_unused_vertices.cpp
@@ -55,12 +55,12 @@ pcl::surface::SimplificationRemoveUnusedVertices::simplify(const pcl::PolygonMes
   indices.reserve (nr_points);
 
   // mark all points in triangles as being used
-  for (size_t polygon = 0; polygon < input.polygons.size (); ++polygon)
-    for (size_t point = 0; point < input.polygons[polygon].vertices.size (); ++point)
-      if (new_indices[ input.polygons[polygon].vertices[point] ] == -1 )
+  for (const auto &polygon : input.polygons)
+    for (size_t point = 0; point < polygon.vertices.size (); ++point)
+      if (new_indices[ polygon.vertices[point] ] == -1 )
       {
-        new_indices[input.polygons[polygon].vertices[point]] = static_cast<int> (indices.size ());
-        indices.push_back (input.polygons[polygon].vertices[point]);
+        new_indices[polygon.vertices[point]] = static_cast<int> (indices.size ());
+        indices.push_back (polygon.vertices[point]);
       }
 
   // in case all points are used , do nothing and return input mesh
@@ -91,12 +91,12 @@ pcl::surface::SimplificationRemoveUnusedVertices::simplify(const pcl::PolygonMes
 
   // copy mesh information (and update indices)
   output.polygons.reserve (input.polygons.size ());
-  for (size_t polygon = 0; polygon < input.polygons.size (); ++polygon)
+  for (const auto &polygon : input.polygons)
   {
     pcl::Vertices corrected_polygon;
-    corrected_polygon.vertices.resize (input.polygons[polygon].vertices.size ());
-    for (size_t point = 0; point < input.polygons[polygon].vertices.size(); ++point)
-      corrected_polygon.vertices[point] = new_indices[input.polygons[polygon].vertices[point]];
+    corrected_polygon.vertices.resize (polygon.vertices.size ());
+    for (size_t point = 0; point < polygon.vertices.size(); ++point)
+      corrected_polygon.vertices[point] = new_indices[polygon.vertices[point]];
     output.polygons.push_back (corrected_polygon);
   }
 }

--- a/surface/src/simplification_remove_unused_vertices.cpp
+++ b/surface/src/simplification_remove_unused_vertices.cpp
@@ -56,11 +56,11 @@ pcl::surface::SimplificationRemoveUnusedVertices::simplify(const pcl::PolygonMes
 
   // mark all points in triangles as being used
   for (const auto &polygon : input.polygons)
-    for (size_t point = 0; point < polygon.vertices.size (); ++point)
-      if (new_indices[ polygon.vertices[point] ] == -1 )
+    for (const auto &vertex : polygon.vertices)
+      if (new_indices[ vertex ] == -1 )
       {
-        new_indices[polygon.vertices[point]] = static_cast<int> (indices.size ());
-        indices.push_back (polygon.vertices[point]);
+        new_indices[vertex] = static_cast<int> (indices.size ());
+        indices.push_back (vertex);
       }
 
   // in case all points are used , do nothing and return input mesh


### PR DESCRIPTION
Changes are based on the result of run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix