### PR TITLE
Fix SupervoxelClustering compilation problem in MSVC 2015.3

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -59,21 +59,6 @@ pcl::SupervoxelClustering<PointT>::SupervoxelClustering (float voxel_resolution,
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
-pcl::SupervoxelClustering<PointT>::SupervoxelClustering (float voxel_resolution, float seed_resolution, bool) :
-  resolution_ (voxel_resolution),
-  seed_resolution_ (seed_resolution),
-  adjacency_octree_ (),
-  voxel_centroid_cloud_ (),
-  color_importance_ (0.1f),
-  spatial_importance_ (0.4f),
-  normal_importance_ (1.0f),
-  use_default_transform_behaviour_ (true)
-{
-  adjacency_octree_.reset (new OctreeAdjacencyT (resolution_));
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT>
 pcl::SupervoxelClustering<PointT>::~SupervoxelClustering ()
 {
 

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -190,7 +190,7 @@ namespace pcl
       SupervoxelClustering (float voxel_resolution, float seed_resolution);
 
       [[deprecated("constructor with flag for using the single camera transform is deprecated. Default behavior is now to use the transform for organized clouds, and not use it for unorganized. Use setUseSingleCameraTransform() to override the defaults.")]]
-      SupervoxelClustering (float voxel_resolution, float seed_resolution, bool);
+      SupervoxelClustering (float voxel_resolution, float seed_resolution, bool) : SupervoxelClustering (voxel_resolution, seed_resolution) { }
 
       /** \brief This destructor destroys the cloud, normals and search method used for
         * finding neighbors. In other words it frees memory.


### PR DESCRIPTION
After #2699, MSVC 2015 Update 3 cannot build segmentation module due to [its bug](https://stackoverflow.com/questions/38378693/did-visual-studio-2015-update-3-break-constructor-attributes). To avoid this problem, change `SupervoxelClustering` constructor declaration and definition.
