### PR TITLE
Fix a bug in `CentroidPoint`

### DIFF
--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -1038,22 +1038,14 @@ namespace pcl
 
     public:
 
-      CentroidPoint ()
-      : num_points_ (0)
-      {
-      }
+      CentroidPoint () = default;
 
       /** Add a new point to the centroid computation.
         *
         * In this function only the accumulators and point counter are updated,
         * actual centroid computation does not happen until get() is called. */
       void
-      add (const PointT& point)
-      {
-        // Invoke add point on each accumulator
-        boost::fusion::for_each (accumulators_, detail::AddPoint<PointT> (point));
-        ++num_points_;
-      }
+      add (const PointT& point);
 
       /** Retrieve the current centroid.
         *
@@ -1065,20 +1057,10 @@ namespace pcl
         * If the number of accumulated points is zero, then the point will be
         * left untouched. */
       template <typename PointOutT> void
-      get (PointOutT& point) const
-      {
-        if (num_points_ != 0)
-        {
-          // Filter accumulators so that only those that are compatible with
-          // both PointT and requested point type remain
-          typename pcl::detail::Accumulators<PointT, PointOutT>::type ca (accumulators_);
-          // Invoke get point on each accumulator in filtered list
-          boost::fusion::for_each (ca, detail::GetPoint<PointOutT> (point, num_points_));
-        }
-      }
+      get (PointOutT& point) const;
 
       /** Get the total number of points that were added. */
-      size_t
+      inline size_t
       getSize () const
       {
         return (num_points_);
@@ -1088,7 +1070,7 @@ namespace pcl
 
     private:
 
-      size_t num_points_;
+      size_t num_points_ = 0;
       typename pcl::detail::Accumulators<PointT>::type accumulators_;
 
   };

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -970,30 +970,14 @@ namespace pcl
     * taking into account the meaning of the data inside fields. Currently the
     * following fields are supported:
     *
-    * - XYZ (\c x, \c y, \c z)
-    *
-    *   Separate average for each field.
-    *
-    * - Normal (\c normal_x, \c normal_y, \c normal_z)
-    *
-    *   Separate average for each field, and the resulting vector is normalized.
-    *
-    * - Curvature (\c curvature)
-    *
-    *   Average.
-    *
-    * - RGB/RGBA (\c rgb or \c rgba)
-    *
-    *   Separate average for R, G, B, and alpha channels.
-    *
-    * - Intensity (\c intensity)
-    *
-    *   Average.
-    *
-    * - Label (\c label)
-    *
-    *   Majority vote. If several labels have the same largest support then the
-    *   smaller label wins.
+    *  Data      | Point fields                          | Algorithm
+    *  --------- | ------------------------------------- | -------------------------------------------------------------------------------------------
+    *  XYZ       | \c x, \c y, \c z                      | Average (separate for each field)
+    *  Normal    | \c normal_x, \c normal_y, \c normal_z | Average (separate for each field), resulting vector is normalized
+    *  Curvature | \c curvature                          | Average
+    *  Color     | \c rgb or \c rgba                     | Average (separate for R, G, B, and alpha channels)
+    *  Intensity | \c intensity                          | Average
+    *  Label     | \c label                              | Majority vote; if several labels have the same largest support then the  smaller label wins
     *
     * The template parameter defines the type of points that may be accumulated
     * with this class. This may be an arbitrary PCL point type, and centroid

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -874,7 +874,7 @@ pcl::CentroidPoint<PointT>::get (PointOutT& point) const
   {
     // Filter accumulators so that only those that are compatible with
     // both PointT and requested point type remain
-    typename pcl::detail::Accumulators<PointT, PointOutT>::type ca (accumulators_);
+    auto ca = boost::fusion::filter_if<detail::IsAccumulatorCompatible<PointT, PointOutT>> (accumulators_);
     // Invoke get point on each accumulator in filtered list
     boost::fusion::for_each (ca, detail::GetPoint<PointOutT> (point, num_points_));
   }

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -858,7 +858,28 @@ pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
   return (pcl::computeNDCentroid (cloud, indices.indices, centroid));
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointT> void
+pcl::CentroidPoint<PointT>::add (const PointT& point)
+{
+  // Invoke add point on each accumulator
+  boost::fusion::for_each (accumulators_, detail::AddPoint<PointT> (point));
+  ++num_points_;
+}
+
+template <typename PointT>
+template <typename PointOutT> void
+pcl::CentroidPoint<PointT>::get (PointOutT& point) const
+{
+  if (num_points_ != 0)
+  {
+    // Filter accumulators so that only those that are compatible with
+    // both PointT and requested point type remain
+    typename pcl::detail::Accumulators<PointT, PointOutT>::type ca (accumulators_);
+    // Invoke get point on each accumulator in filtered list
+    boost::fusion::for_each (ca, detail::GetPoint<PointOutT> (point, num_points_));
+  }
+}
+
 template <typename PointInT, typename PointOutT> size_t
 pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                       PointOutT& centroid)
@@ -877,7 +898,6 @@ pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
   return (cp.getSize ());
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT> size_t
 pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                       const std::vector<int>& indices,

--- a/test/common/test_centroid.cpp
+++ b/test/common/test_centroid.cpp
@@ -813,6 +813,7 @@ TEST (PCL, CentroidPoint)
     centroid.get (c);
     EXPECT_XYZ_EQ (PointXYZ (100, 100, 100), c);
   }
+
   // Single point
   {
     CentroidPoint<PointXYZ> centroid;
@@ -821,6 +822,7 @@ TEST (PCL, CentroidPoint)
     centroid.get (c);
     EXPECT_XYZ_EQ (p1, c);
   }
+
   // Multiple points
   {
     CentroidPoint<PointXYZ> centroid;
@@ -834,12 +836,36 @@ TEST (PCL, CentroidPoint)
 
   // Retrieve centroid into a different point type
   {
-    CentroidPoint<PointXYZ> centroid;
+    PointNormal p1; p1.getVector3fMap () << 1, 2, 3; p1.getNormalVector3fMap() << 0, 1, 0;
+    CentroidPoint<PointNormal> centroid;
     centroid.add (p1);
-    PointXYZRGB c; c.rgba = 0x00FFFFFF;
-    centroid.get (c);
-    EXPECT_XYZ_EQ (p1, c);
-    EXPECT_EQ (0x00FFFFFF, c.rgba);
+    // Retrieve into a point type that is a "superset" of the original
+    {
+      PointXYZRGBNormal c; c.rgba = 0x00FFFFFF;
+      centroid.get (c);
+      EXPECT_XYZ_EQ (p1, c);
+      EXPECT_NORMAL_EQ (p1, c);
+      EXPECT_EQ (0x00FFFFFF, c.rgba); // unchanged
+    }
+    // Retrieve into a point type that is a "subset" of the original
+    {
+      Normal c;
+      centroid.get (c);
+      EXPECT_NORMAL_EQ (p1, c);
+    }
+    // Retrieve into a point type that partially "overlaps" with the original
+    {
+      PointXYZRGB c; c.rgba = 0x00FFFFFF;
+      centroid.get (c);
+      EXPECT_XYZ_EQ (p1, c);
+      EXPECT_EQ (0x00FFFFFF, c.rgba); // unchanged
+    }
+    // Retrieve into a point type that does not "overlap" with the original
+    {
+      RGB c; c.rgba = 0x00FFFFFF;
+      centroid.get (c);
+      EXPECT_EQ (0x00FFFFFF, c.rgba); // unchanged
+    }
   }
 
   // Centroid with XYZ and RGB
@@ -857,7 +883,7 @@ TEST (PCL, CentroidPoint)
     EXPECT_EQ (0xFF111111, c.rgba);
   }
 
-  // Centroid with normal and curavture
+  // Centroid with normal and curvature
   {
     Normal np1; np1.getNormalVector4fMap () << 1, 0, 0, 0; np1.curvature = 0.2;
     Normal np2; np2.getNormalVector4fMap () << -1, 0, 0, 0; np2.curvature = 0.1;


### PR DESCRIPTION
Currently there is an issue with retrieving centroid into a point type whose fields are a subset of the fields of the accumulated type. E.g. the following would not compile:

```cpp
CentroidPoint<PointNormal> c;
Normal n;
c.get(n);
```

This PR fixes the bug and adds more unit tests. There are also a couple of cleanup commits.