### PR TITLE
fix missing include for compiling with CUDA 10.1

### DIFF
--- a/cuda/common/include/pcl/cuda/thrust.h
+++ b/cuda/common/include/pcl/cuda/thrust.h
@@ -41,6 +41,7 @@
 
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
+#include <thrust/device_malloc.h>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/sequence.h>


### PR DESCRIPTION
Without this change

git clone https://github.com/PointCloudLibrary/pcl
cd pcl && mkdir build & cd build
cmake -DBUILD_CUDA=ON  ..
make -j

will result in compilation error when the CUDA version is 10.1, this PR solves it