### PR TITLE
Use always const reference in for-ranged loops, instead of just const

### DIFF
--- a/geometry/include/pcl/geometry/mesh_conversion.h
+++ b/geometry/include/pcl/geometry/mesh_conversion.h
@@ -113,7 +113,7 @@ namespace pcl
       for (const auto &polygon : face_vertex_mesh.polygons)
       {
         vi.clear ();
-        for (const unsigned int vertex : polygon.vertices)
+        for (const unsigned int &vertex : polygon.vertices)
         {
           vi.emplace_back (vertex);
         }

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -120,7 +120,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::calculateNormalCovar (const
 
   float zz = 0;
 
-  for (const int neighbor : neighbors)
+  for (const int &neighbor : neighbors)
   {
     if (std::isfinite (normals_->points[neighbor].normal_x))
     {

--- a/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
@@ -77,7 +77,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::calculateCombinedCovar (con
 {
   memset (coefficients, 0, sizeof (float) * 21);
   unsigned count = 0;
-  for (const int neighbor : neighbors)
+  for (const int &neighbor : neighbors)
   {
     if (std::isfinite (normals_->points[neighbor].normal_x) && std::isfinite (intensity_gradients_->points[neighbor].gradient [0]))
     {

--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -314,7 +314,7 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
 
       this->searchForNeighbors (static_cast<int> (index), border_radius_, nn_indices, nn_distances);
 
-      for (const int nn_index : nn_indices)
+      for (const int &nn_index : nn_indices)
       {
         if (edge_points_[nn_index])
         {

--- a/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
@@ -191,7 +191,7 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::detectKeypointsForOctave (
   else
   {
     // Add keypoints to output
-    for (const int keypoint_index : extrema_indices)
+    for (const int &keypoint_index : extrema_indices)
     {
       PointOutT keypoint;
       keypoint.x = input.points[keypoint_index].x;

--- a/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
@@ -103,7 +103,7 @@ pcl::SmoothedSurfacesKeypoint<PointT, PointNT>::detectKeypoints (PointCloudT &ou
     input_tree->radiusSearch (point_i, input_scale_ * neighborhood_constant_, nn_indices, nn_distances);
 
     bool is_min = true, is_max = true;
-    for (const int nn_index : nn_indices)
+    for (const int &nn_index : nn_indices)
       if (nn_index != point_i)
       {
         if (diffs[input_index_][point_i] < diffs[input_index_][nn_index])
@@ -127,7 +127,7 @@ pcl::SmoothedSurfacesKeypoint<PointT, PointNT>::detectKeypoints (PointCloudT &ou
         cloud_trees_[cloud_i]->radiusSearch (point_i, scales_[scale_i].first * neighborhood_constant_, nn_indices, nn_distances);
 
         bool is_min_other_scale = true, is_max_other_scale = true;
-        for (const int nn_index : nn_indices)
+        for (const int &nn_index : nn_indices)
           if (nn_index != point_i)
           {
             if (diffs[input_index_][point_i] < diffs[cloud_i][nn_index])

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -372,7 +372,7 @@ NarfKeypoint::calculateCompleteInterestImage ()
       }
       
       // Reset was_touched to false
-      for (const int neighbors_to_check_idx : neighbors_to_check)
+      for (const int &neighbors_to_check_idx : neighbors_to_check)
         was_touched[neighbors_to_check_idx] = false;
       
       float angle_change_value = 0.0f;
@@ -552,7 +552,7 @@ NarfKeypoint::calculateSparseInterestImage ()
     }
     
     // Reset was_touched to false
-    for (const int neighbors_to_check_idx : neighbors_to_check)
+    for (const int &neighbors_to_check_idx : neighbors_to_check)
       was_touched[neighbors_to_check_idx] = false;
     
     float angle_change_value = 0.0f;
@@ -586,7 +586,7 @@ NarfKeypoint::calculateSparseInterestImage ()
     // Every point in distance search_radius cannot have a higher value
     // Therefore: if too low, set all to zero. Else calculate properly
     if (maximum_interest_value < parameters_.min_interest_value)
-      for (const int neighbors_idx : neighbors_within_radius_overhead)
+      for (const int &neighbors_idx : neighbors_within_radius_overhead)
         interest_image_[neighbors_idx] = 0.0f;
     else
     {
@@ -624,7 +624,7 @@ NarfKeypoint::calculateSparseInterestImage ()
       }
 
       // Caclulate interest values for neighbors
-      for (const int index2 : neighbors_within_radius_overhead)
+      for (const int &index2 : neighbors_within_radius_overhead)
       {
         int y2 = index2/range_image.width,
             x2 = index2 - y2*range_image.width;

--- a/ml/src/svm_wrapper.cpp
+++ b/ml/src/svm_wrapper.cpp
@@ -901,7 +901,7 @@ pcl::SVMClassify::saveClassificationResult (const char *filename)
 
   for (const auto &prediction : prediction_)
   {
-    for (const double value : prediction)
+    for (const double &value : prediction)
       output << value << " ";
 
     output << "\n";

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -606,7 +606,7 @@ pcl::visualization::PCLPlotter::computeHistogram (
   }
 
   //fill the freq for each data
-  for (const double value : data)
+  for (const double &value : data)
   {
     if (std::isfinite (value))
     {

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -4625,7 +4625,7 @@ pcl::visualization::PCLVisualizer::getUniqueCameraFile (int argc, char **argv)
     bool valid = false;
 
     // Calculate sha1 using canonical paths
-    for (int p_file_index : p_file_indices)
+    for (const int &p_file_index : p_file_indices)
     {
       boost::filesystem::path path (argv[p_file_index]);
       if (boost::filesystem::exists (path))


### PR DESCRIPTION
Use always const reference in for-ranged loops, even reference is not necessary, to match latest style guide discussion