### PR TITLE
Fix broken failure_after_max_iter_

### DIFF
--- a/registration/include/pcl/registration/default_convergence_criteria.h
+++ b/registration/include/pcl/registration/default_convergence_criteria.h
@@ -76,7 +76,8 @@ namespace pcl
           CONVERGENCE_CRITERIA_TRANSFORM,
           CONVERGENCE_CRITERIA_ABS_MSE,
           CONVERGENCE_CRITERIA_REL_MSE,
-          CONVERGENCE_CRITERIA_NO_CORRESPONDENCES
+          CONVERGENCE_CRITERIA_NO_CORRESPONDENCES,
+          CONVERGENCE_CRITERIA_FAILURE_AFTER_MAX_ITERATIONS
         };
 
         /** \brief Empty constructor.
@@ -111,14 +112,14 @@ namespace pcl
         /** \brief Empty destructor */
         ~DefaultConvergenceCriteria () {}
 
-        /** \brief Set the maximum number of iterations that the internal rotation, 
+        /** \brief Set the maximum number of consecutive iterations that the internal rotation, 
           * translation, and MSE differences are allowed to be similar. 
           * \param[in] nr_iterations the maximum number of iterations 
           */
         inline void
         setMaximumIterationsSimilarTransforms (const int nr_iterations) { max_iterations_similar_transforms_ = nr_iterations; }
 
-        /** \brief Get the maximum number of iterations that the internal rotation, 
+        /** \brief Get the maximum number of consecutive iterations that the internal rotation, 
           * translation, and MSE differences are allowed to be similar, as set by the user.
           */
         inline int

--- a/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
+++ b/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
@@ -59,14 +59,13 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   // 1. Number of iterations has reached the maximum user imposed number of iterations
   if (iterations_ >= max_iterations_)
   {
-    if (failure_after_max_iter_)
-      convergence_state_ = CONVERGENCE_CRITERIA_FAILURE_AFTER_MAX_ITERATIONS;
-    else
+    if (!failure_after_max_iter_)
     {
       iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_ITERATIONS;
       return (true);
     }
+    convergence_state_ = CONVERGENCE_CRITERIA_FAILURE_AFTER_MAX_ITERATIONS;
   }
 
   // 2. The epsilon (difference) between the previous transformation and the current estimated transformation
@@ -78,14 +77,13 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
 
   if (cos_angle >= rotation_threshold_ && translation_sqr <= translation_threshold_)
   {
-    if (iterations_similar_transforms_ < max_iterations_similar_transforms_)
-      is_similar = true;
-    else
+    if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {
       iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_TRANSFORM;
       return (true);
     }
+    is_similar = true;
   }
 
   correspondences_cur_mse_ = calculateMSE (correspondences_);
@@ -95,27 +93,25 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   // Absolute
   if (fabs (correspondences_cur_mse_ - correspondences_prev_mse_) < mse_threshold_absolute_)
   {
-    if (iterations_similar_transforms_ < max_iterations_similar_transforms_)
-      is_similar = true;
-    else
+    if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {
       iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_ABS_MSE;
       return (true);
     }
+    is_similar = true;
   }
   
   // Relative
   if (fabs (correspondences_cur_mse_ - correspondences_prev_mse_) / correspondences_prev_mse_ < mse_threshold_relative_)
   {
-    if (iterations_similar_transforms_ < max_iterations_similar_transforms_)
-      is_similar = true;
-    else
+    if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {
       iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_REL_MSE;
       return (true);
     }
+    is_similar = true;
   }
 
   if (is_similar)

--- a/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
+++ b/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
@@ -61,7 +61,6 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   {
     if (!failure_after_max_iter_)
     {
-      iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_ITERATIONS;
       return (true);
     }
@@ -79,7 +78,6 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   {
     if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {
-      iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_TRANSFORM;
       return (true);
     }
@@ -95,7 +93,6 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   {
     if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {
-      iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_ABS_MSE;
       return (true);
     }
@@ -107,7 +104,6 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   {
     if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {
-      iterations_similar_transforms_ = 0;
       convergence_state_ = CONVERGENCE_CRITERIA_REL_MSE;
       return (true);
     }

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -235,7 +235,7 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
 
     converged_ = static_cast<bool> ((*convergence_criteria_));
   }
-  while (!converged_);
+  while (convergence_criteria_->getConvergenceState() == pcl::registration::DefaultConvergenceCriteria<Scalar>::CONVERGENCE_CRITERIA_NOT_CONVERGED);
 
   // Transform the input cloud using the final transformation
   PCL_DEBUG ("Transformation is:\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n", 


### PR DESCRIPTION
Executive summary:

This updates `ICP` and `DefaultConvergenceCriteria` classes to fix misbehavior in the "failure after maximum iterations" mode. (Prior to this change the registration loop would hang in an infinite loop #1598). It also refines "maximum iterations similar transforms" option to mean **consequtive** transforms.

If you use `DefaultConvergenceCriteria` in your registration code, you need to make an adjustment similar to what this PR does in "icp.hpp".

---

It follows #1598. I try to implement as possible as i can. But I didn't understand what taketwo said about reset similar transforms, so I implement my solution.

- Exit loop with convergence state instead of `converged_` in icp.
- Add new convergence state `CONVERGENCE_CRITERIA_FAILURE_AFTER_MAX_
ITERATIONS`.
- When `failure_after_max_iter_` is set true, `hasConverged()` checks all similarity before returning a failure.
- Even though one iteration has several similar conditions, counts `iterations_similar_transforms_` up only 1.
- If transform becomes large, `iterations_similar_transforms_` reset to 0. Only consecutive similar iterations are allowed to converge.
- Edit a description about the change above in API docs.
- When new alignment restarts after a convergence or a failure, `iterations_similar_transforms_` also reset to 0.