### PR TITLE
Bump Eigen minimum version to 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ else()
 endif()
 
 # Eigen (required)
-find_package(Eigen REQUIRED)
+find_package(Eigen 3.1 REQUIRED)
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
 
 # FLANN (required)

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -124,7 +124,7 @@ macro(find_eigen)
   elseif(NOT EIGEN_ROOT)
     get_filename_component(EIGEN_ROOT "@EIGEN_INCLUDE_DIRS@" ABSOLUTE)
   endif()
-  find_package(Eigen)
+  find_package(Eigen 3.1)
   set(EIGEN_DEFINITIONS ${EIGEN_DEFINITIONS})
 endmacro()
 

--- a/segmentation/CMakeLists.txt
+++ b/segmentation/CMakeLists.txt
@@ -61,6 +61,7 @@ set(incs
   "include/pcl/${SUBSYS_NAME}/ground_plane_comparator.h"
   "include/pcl/${SUBSYS_NAME}/organized_connected_component_segmentation.h"
   "include/pcl/${SUBSYS_NAME}/organized_multi_plane_segmentation.h"
+  "include/pcl/${SUBSYS_NAME}/random_walker.h"
   "include/pcl/${SUBSYS_NAME}/region_3d.h"
   "include/pcl/${SUBSYS_NAME}/planar_region.h"
   "include/pcl/${SUBSYS_NAME}/planar_polygon_fusion.h"
@@ -82,12 +83,6 @@ if(Boost_MAJOR_VERSION GREATER 1 OR Boost_MINOR_VERSION GREATER 43)
     "include/pcl/${SUBSYS_NAME}/min_cut_segmentation.h"
   )
 endif()
-# Random walker requires Eigen::Sparse module that is available since 3.1.0
-if(NOT ("${EIGEN_VERSION}" VERSION_LESS 3.1.0))
-  list(APPEND incs
-    "include/pcl/${SUBSYS_NAME}/random_walker.h"
-  )
-endif()
 
 set(impl_incs
   "include/pcl/${SUBSYS_NAME}/impl/extract_clusters.hpp"
@@ -96,6 +91,7 @@ set(impl_incs
   "include/pcl/${SUBSYS_NAME}/impl/sac_segmentation.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/seeded_hue_segmentation.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/segment_differences.hpp"
+  "include/pcl/${SUBSYS_NAME}/impl/random_walker.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/region_growing.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/region_growing_rgb.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/organized_connected_component_segmentation.hpp"
@@ -117,12 +113,6 @@ set(impl_incs
 if(Boost_MAJOR_VERSION GREATER 1 OR Boost_MINOR_VERSION GREATER 43)
   list(APPEND impl_incs
     "include/pcl/${SUBSYS_NAME}/impl/min_cut_segmentation.hpp"
-  )
-endif()
-# Random walker requires Eigen::Sparse module that is available since 3.1.0
-if(NOT ("${EIGEN_VERSION}" VERSION_LESS 3.1.0))
-  list(APPEND impl_incs
-    "include/pcl/${SUBSYS_NAME}/impl/random_walker.hpp"
   )
 endif()
 

--- a/test/segmentation/CMakeLists.txt
+++ b/test/segmentation/CMakeLists.txt
@@ -12,13 +12,10 @@ if(NOT build)
   return()
 endif()
 
-# Random walker requires Eigen::Sparse module that is available since 3.1.0
-if(NOT ("${EIGEN_VERSION}" VERSION_LESS 3.1.0))
-  PCL_ADD_TEST(random_walker test_random_walker
-               FILES test_random_walker.cpp
-               LINK_WITH pcl_gtest
-               ARGUMENTS "${PCL_SOURCE_DIR}/test/segmentation/data")
-endif()
+PCL_ADD_TEST(random_walker test_random_walker
+             FILES test_random_walker.cpp
+             LINK_WITH pcl_gtest
+             ARGUMENTS "${PCL_SOURCE_DIR}/test/segmentation/data")
 
 PCL_ADD_TEST(a_segmentation_test test_segmentation
              FILES test_segmentation.cpp


### PR DESCRIPTION
[Eigen 3.1](http://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.1.0) is from 2012. Even Ubuntu 14.04 ships already Eigen 3.2, so there is no reason to support older versions.