### PR TITLE
Output Hessian matrix and points-distance for registration NDT

### DIFF
--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -175,6 +175,9 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformati
   // Store transformation probability.  The realtive differences within each scan registration are accurate
   // but the normalization constants need to be modified for it to be globally accurate
   trans_probability_ = score / static_cast<double> (input_->points.size ());
+
+  // get a copy of Hessian
+  hessian_ = hessian;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/registration/include/pcl/registration/impl/registration.hpp
+++ b/registration/include/pcl/registration/impl/registration.hpp
@@ -126,6 +126,10 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max
   std::vector<int> nn_indices (1);
   std::vector<float> nn_dists (1);
 
+  // will keep the distance to each matched point
+  tf_points_distance_.clear();
+  tf_points_distance_.resize(input_transformed.points.size ());
+  
   // For each point in the source dataset
   int nr = 0;
   for (size_t i = 0; i < input_transformed.points.size (); ++i)
@@ -140,6 +144,9 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max
       fitness_score += nn_dists[0];
       nr++;
     }
+        
+    // get the distance after registration
+    tf_points_distance_[i] = nn_dists[0];
   }
 
   if (nr > 0)

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -457,6 +457,16 @@ namespace pcl
       /** \brief The second order derivative of the transformation of a point w.r.t. the transform vector, \f$ H_E \f$ in Equation 6.20 [Magnusson 2009]. */
       Eigen::Matrix<double, 18, 6> point_hessian_;
 
+      /** \brief Will keep a copy of the Hessian \f$ H \f$ in Equation 6.13 [Magnusson 2009]. */
+      Eigen::Matrix<double, 6, 6> hessian_;
+
+    public:
+      /** \brief Return the hessian matrix */
+      Eigen::Matrix<double, 6, 6> getHessian()
+      {
+         return hessian_;
+      }
+
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -603,6 +603,17 @@ namespace pcl
     private:
       /** \brief The point representation used (internal). */
       PointRepresentationConstPtr point_representation_;
+      
+      
+      /** \brief Stores the distances between input pointcloud and matching points on registration */
+      std::vector<float> tf_points_distance_;
+    
+    public:
+      /** \brief returns the distances between input pointcloud and matching points on registration */
+      std::vector<float> getPointsDistance() {
+      	return tf_points_distance_;
+      }
+          
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
    };


### PR DESCRIPTION
Added functions to access the Hessian matrix computed during `computeTransformation` (on registration NDT), and to obtain the distances from each point in the input pointcloud to its corresponding matching point on `getFitnessScore` (registration).

With the Hessian available we can compute the covariance `covariance = ndt.getHessian().inverse();`, where `getHessian()` is introduced on this modification. 

Here is an example showing markers (covariance ellipses) for position/direction covariances (magenta/yellow) and the pointcloud is colored by the matching distance using `ndt.getPointsDistance()` also introduced on this modification (red: lower distance, purple longer distance). 

![error-ellipses--moriyama1](https://user-images.githubusercontent.com/16696954/53938845-cef6f600-40f4-11e9-8ff0-30fcf1e64885.png)