### PR TITLE
Remove redundant typenames

### DIFF
--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -47,7 +47,7 @@ namespace pcl
   class Edge
   {
     private:
-      typedef typename pcl::PointCloud<PointInT> PointCloudIn;
+      typedef pcl::PointCloud<PointInT> PointCloudIn;
       typedef typename PointCloudIn::Ptr PointCloudInPtr;
 
       PointCloudInPtr input_;

--- a/2d/include/pcl/2d/morphology.h
+++ b/2d/include/pcl/2d/morphology.h
@@ -45,7 +45,7 @@ namespace pcl
   class Morphology : public PCLBase<PointT>
   {
     private:
-      typedef typename pcl::PointCloud<PointT> PointCloudIn;
+      typedef pcl::PointCloud<PointT> PointCloudIn;
       typedef typename PointCloudIn::Ptr PointCloudInPtr;
 
       PointCloudInPtr structuring_element_;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/crh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/crh_estimator.h
@@ -62,7 +62,7 @@ namespace pcl
 
         crh_histograms_.resize(signatures.size());
 
-        typedef typename pcl::CRHEstimation<PointInT, pcl::Normal, pcl::Histogram<90> > CRHEstimation;
+        typedef pcl::CRHEstimation<PointInT, pcl::Normal, pcl::Histogram<90> > CRHEstimation;
         CRHEstimation crh;
         crh.setInputCloud(processed);
         crh.setInputNormals(normals_);

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/cvfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/cvfh_estimator.h
@@ -97,7 +97,7 @@ namespace pcl
         /*normals_.reset(new pcl::PointCloud<pcl::Normal>);
         normal_estimator_->estimate (in, processed, normals_);*/
 
-        typedef typename pcl::CVFHEstimation<PointInT, pcl::Normal, FeatureT> CVFHEstimation;
+        typedef pcl::CVFHEstimation<PointInT, pcl::Normal, FeatureT> CVFHEstimation;
         pcl::PointCloud<FeatureT> cvfh_signatures;
         typename pcl::search::KdTree<PointInT>::Ptr cvfh_tree (new pcl::search::KdTree<PointInT>);
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/esf_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/esf_estimator.h
@@ -27,7 +27,7 @@ namespace pcl
                   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > & centroids) override
         {
 
-          typedef typename pcl::ESFEstimation<PointInT, FeatureT> ESFEstimation;
+          typedef pcl::ESFEstimation<PointInT, FeatureT> ESFEstimation;
           pcl::PointCloud<FeatureT> ESF_signature;
 
           ESFEstimation esf;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/ourcvfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/ourcvfh_estimator.h
@@ -130,7 +130,7 @@ namespace pcl
           /*normals_.reset(new pcl::PointCloud<pcl::Normal>);
            normal_estimator_->estimate (in, processed, normals_);*/
 
-          typedef typename pcl::OURCVFHEstimation<PointInT, pcl::Normal, pcl::VFHSignature308> OURCVFHEstimation;
+          typedef pcl::OURCVFHEstimation<PointInT, pcl::Normal, pcl::VFHSignature308> OURCVFHEstimation;
           pcl::PointCloud<pcl::VFHSignature308> cvfh_signatures;
           typename pcl::search::KdTree<PointInT>::Ptr cvfh_tree (new pcl::search::KdTree<PointInT>);
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/vfh_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/global/vfh_estimator.h
@@ -39,7 +39,7 @@ namespace pcl
           normals_.reset(new pcl::PointCloud<pcl::Normal>);
           normal_estimator_->estimate (in, processed, normals_);
 
-          typedef typename pcl::VFHEstimation<PointInT, pcl::Normal, FeatureT> VFHEstimation;
+          typedef pcl::VFHEstimation<PointInT, pcl::Normal, FeatureT> VFHEstimation;
           pcl::PointCloud<FeatureT> vfh_signature;
 
           VFHEstimation vfh;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/colorshot_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/colorshot_local_estimator.h
@@ -61,7 +61,7 @@ namespace pcl
           }
 
           //compute signatures
-          typedef typename pcl::SHOTColorEstimation<PointInT, pcl::Normal, pcl::SHOT1344> SHOTEstimator;
+          typedef pcl::SHOTColorEstimation<PointInT, pcl::Normal, pcl::SHOT1344> SHOTEstimator;
           typename pcl::search::KdTree<PointInT>::Ptr tree (new pcl::search::KdTree<PointInT>);
 
           pcl::PointCloud<pcl::SHOT1344>::Ptr shots (new pcl::PointCloud<pcl::SHOT1344>);

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator.h
@@ -60,7 +60,7 @@ namespace pcl
           assert (processed->points.size () == normals->points.size ());
 
           //compute signatures
-          typedef typename pcl::FPFHEstimation<PointInT, pcl::Normal, pcl::FPFHSignature33> FPFHEstimator;
+          typedef pcl::FPFHEstimation<PointInT, pcl::Normal, pcl::FPFHSignature33> FPFHEstimator;
           typename pcl::search::KdTree<PointInT>::Ptr tree (new pcl::search::KdTree<PointInT>);
 
           pcl::PointCloud<pcl::FPFHSignature33>::Ptr fpfhs (new pcl::PointCloud<pcl::FPFHSignature33>);

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator_omp.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator_omp.h
@@ -61,7 +61,7 @@ namespace pcl
           assert (processed->points.size () == normals->points.size ());
 
           //compute signatures
-          typedef typename pcl::FPFHEstimationOMP<PointInT, pcl::Normal, pcl::FPFHSignature33> FPFHEstimator;
+          typedef pcl::FPFHEstimationOMP<PointInT, pcl::Normal, pcl::FPFHSignature33> FPFHEstimator;
           typename pcl::search::KdTree<PointInT>::Ptr tree (new pcl::search::KdTree<PointInT>);
 
           pcl::PointCloud<pcl::FPFHSignature33>::Ptr fpfhs (new pcl::PointCloud<pcl::FPFHSignature33>);

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator.h
@@ -107,7 +107,7 @@ namespace pcl
 
           std::cout << keypoints->points.size() << " " << normals->points.size() << " " << processed->points.size() << std::endl;
           //compute signatures
-          typedef typename pcl::SHOTEstimation<PointInT, pcl::Normal, pcl::SHOT352> SHOTEstimator;
+          typedef pcl::SHOTEstimation<PointInT, pcl::Normal, pcl::SHOT352> SHOTEstimator;
           typename pcl::search::KdTree<PointInT>::Ptr tree (new pcl::search::KdTree<PointInT>);
 
           pcl::PointCloud<pcl::SHOT352>::Ptr shots (new pcl::PointCloud<pcl::SHOT352>);

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator_omp.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator_omp.h
@@ -95,7 +95,7 @@ namespace pcl
           }
 
           //compute signatures
-          typedef typename pcl::SHOTEstimationOMP<PointInT, pcl::Normal, pcl::SHOT352> SHOTEstimator;
+          typedef pcl::SHOTEstimationOMP<PointInT, pcl::Normal, pcl::SHOT352> SHOTEstimator;
           typename pcl::search::KdTree<PointInT>::Ptr tree (new pcl::search::KdTree<PointInT>);
           tree->setInputCloud (processed);
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
@@ -183,8 +183,7 @@ namespace pcl
 
           if (out->isOrganized ())
           {
-            typedef typename pcl::IntegralImageNormalEstimation<PointInT, pcl::Normal> NormalEstimator_;
-            NormalEstimator_ n3d;
+            pcl::IntegralImageNormalEstimation<PointInT, pcl::Normal> n3d;
             n3d.setNormalEstimationMethod (n3d.COVARIANCE_MATRIX);
             //n3d.setNormalEstimationMethod (n3d.AVERAGE_3D_GRADIENT);
             n3d.setInputCloud (out);
@@ -223,8 +222,7 @@ namespace pcl
               out->height = 1;
             }
 
-            typedef typename pcl::NormalEstimation<PointInT, pcl::Normal> NormalEstimator_;
-            NormalEstimator_ n3d;
+            pcl::NormalEstimation<PointInT, pcl::Normal> n3d;
             typename pcl::search::KdTree<PointInT>::Ptr normals_tree (new pcl::search::KdTree<PointInT>);
             normals_tree->setInputCloud (out);
             n3d.setRadiusSearch (radius);

--- a/apps/src/openni_tracking.cpp
+++ b/apps/src/openni_tracking.cpp
@@ -116,16 +116,16 @@ public:
   
   typedef pcl::PointCloud<PointType> Cloud;
   typedef pcl::PointCloud<RefPointType> RefCloud;
-  typedef typename RefCloud::Ptr RefCloudPtr;
-  typedef typename RefCloud::ConstPtr RefCloudConstPtr;
+  typedef RefCloud::Ptr RefCloudPtr;
+  typedef RefCloud::ConstPtr RefCloudConstPtr;
   typedef typename Cloud::Ptr CloudPtr;
   typedef typename Cloud::ConstPtr CloudConstPtr;
   //typedef KLDAdaptiveParticleFilterTracker<RefPointType, ParticleT> ParticleFilter;
   //typedef KLDAdaptiveParticleFilterOMPTracker<RefPointType, ParticleT> ParticleFilter;
   //typedef ParticleFilterOMPTracker<RefPointType, ParticleT> ParticleFilter;
   typedef ParticleFilterTracker<RefPointType, ParticleT> ParticleFilter;
-  typedef typename ParticleFilter::CoherencePtr CoherencePtr;
-  typedef typename pcl::search::KdTree<PointType> KdTree;
+  typedef ParticleFilter::CoherencePtr CoherencePtr;
+  typedef pcl::search::KdTree<PointType> KdTree;
   typedef typename KdTree::Ptr KdTreePtr;
   OpenNISegmentTracking (const std::string& device_id, int thread_nr, double downsampling_grid_size,
                          bool use_convex_hull,

--- a/cuda/common/include/pcl/cuda/point_cloud.h
+++ b/cuda/common/include/pcl/cuda/point_cloud.h
@@ -64,7 +64,7 @@ namespace pcl
     struct Host
     {
       // vector type
-      typedef typename thrust::host_vector<T> type;
+      typedef thrust::host_vector<T> type;
 
 //      // iterator type
 //      typedef thrust::detail::normal_iterator<T*> type;
@@ -93,7 +93,7 @@ namespace pcl
     struct Device
     {
       // vector type
-      typedef typename thrust::device_vector<T> type;
+      typedef thrust::device_vector<T> type;
       
 //      // iterator type
 //      typedef thrust::detail::normal_iterator<thrust::device_ptr<T> > iterator_type;

--- a/doc/tutorials/content/hdl_grabber.rst
+++ b/doc/tutorials/content/hdl_grabber.rst
@@ -101,7 +101,7 @@ So let's look at the code. The following represents a simplified version of *vis
    {
      public:
        typedef pcl::PointCloud<pcl::PointXYZI> Cloud;
-       typedef typename Cloud::ConstPtr CloudConstPtr;
+       typedef Cloud::ConstPtr CloudConstPtr;
 
        SimpleHDLViewer (Grabber& grabber,
            pcl::visualization::PointCloudColorHandler<pcl::PointXYZI> &handler) :

--- a/doc/tutorials/content/sources/stick_segmentation/stick_segmentation.cpp
+++ b/doc/tutorials/content/sources/stick_segmentation/stick_segmentation.cpp
@@ -18,7 +18,7 @@ template <typename PointT>
 class ConditionThresholdHSV : public pcl::ConditionBase<PointT>
 {
   public:
-    typedef typename boost::shared_ptr<ConditionThresholdHSV<PointT> > Ptr;
+    typedef boost::shared_ptr<ConditionThresholdHSV<PointT> > Ptr;
     
     ConditionThresholdHSV (float min_h, float max_h, float min_s, float max_s, float min_v, float max_v) :
       min_h_(min_h), max_h_(max_h), min_s_(min_s), max_s_(max_s), min_v_(min_v), max_v_(max_v)

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -111,7 +111,7 @@ namespace pcl
       using PointCloudColorHandler<PointT>::cloud_;
 
       typedef typename PointCloudColorHandler<PointT>::PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::PointCloud<RGB>::ConstPtr RgbCloudConstPtr;
+      typedef pcl::PointCloud<RGB>::ConstPtr RgbCloudConstPtr;
 
       public:
         typedef boost::shared_ptr<PointCloudColorHandlerRGBCloud<PointT> > Ptr;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/standalone_marching_cubes.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/standalone_marching_cubes.h
@@ -77,8 +77,8 @@ namespace pcl
       class StandaloneMarchingCubes
       {
       public:
-          typedef typename pcl::PointCloud<PointT> PointCloud;
-          typedef typename pcl::PointCloud<PointT>::Ptr PointCloudPtr;
+          typedef pcl::PointCloud<PointT> PointCloud;
+          typedef typename PointCloud::Ptr PointCloudPtr;
           typedef boost::shared_ptr<pcl::PolygonMesh> MeshPtr;
 
       /** \brief Constructor        

--- a/gpu/kinfu_large_scale/tools/color_handler.h
+++ b/gpu/kinfu_large_scale/tools/color_handler.h
@@ -50,8 +50,8 @@ namespace pcl
       using PointCloudColorHandler<PointT>::capable_;
       using PointCloudColorHandler<PointT>::cloud_;
 
-      typedef typename PointCloudColorHandler<PointT>::PointCloud::ConstPtr PointCloudConstPtr;                            
-      typedef typename pcl::PointCloud<RGB>::ConstPtr RgbCloudConstPtr;
+      typedef typename PointCloudColorHandler<PointT>::PointCloud::ConstPtr PointCloudConstPtr;
+      typedef pcl::PointCloud<RGB>::ConstPtr RgbCloudConstPtr;
 
     public:
       typedef boost::shared_ptr<PointCloudColorHandlerRGBHack<PointT> > Ptr;

--- a/outofcore/include/pcl/outofcore/outofcore_breadth_first_iterator.h
+++ b/outofcore/include/pcl/outofcore/outofcore_breadth_first_iterator.h
@@ -54,11 +54,11 @@ namespace pcl
     class OutofcoreBreadthFirstIterator : public OutofcoreIteratorBase<PointT, ContainerT>
     {
       public:
-        typedef typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
-        typedef typename pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
+        typedef pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
+        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
 
-        typedef typename pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> LeafNode;
-        typedef typename pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> BranchNode;
+        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> LeafNode;
+        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> BranchNode;
 
 
         explicit

--- a/outofcore/include/pcl/outofcore/outofcore_depth_first_iterator.h
+++ b/outofcore/include/pcl/outofcore/outofcore_depth_first_iterator.h
@@ -53,11 +53,11 @@ namespace pcl
     class OutofcoreDepthFirstIterator : public OutofcoreIteratorBase<PointT, ContainerT>
     {
       public:
-        typedef typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
-        typedef typename pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
+        typedef pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
+        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
 
-        typedef typename pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> LeafNode;
-        typedef typename pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> BranchNode;
+        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> LeafNode;
+        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> BranchNode;
 
         explicit
         OutofcoreDepthFirstIterator (OctreeDisk& octree_arg);

--- a/outofcore/include/pcl/outofcore/outofcore_iterator_base.h
+++ b/outofcore/include/pcl/outofcore/outofcore_iterator_base.h
@@ -63,8 +63,8 @@ namespace pcl
                                                        const OutofcoreOctreeBaseNode<ContainerT, PointT>&>/*Reference type*/
     {
       public:
-        typedef typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
-        typedef typename pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
+        typedef pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
+        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
         
         typedef typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>::BranchNode BranchNode;
         typedef typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>::LeafNode LeafNode;

--- a/visualization/include/pcl/visualization/point_cloud_geometry_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_geometry_handlers.h
@@ -65,8 +65,8 @@ namespace pcl
         typedef typename PointCloud::Ptr PointCloudPtr;
         typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-        typedef typename boost::shared_ptr<PointCloudGeometryHandler<PointT> > Ptr;
-        typedef typename boost::shared_ptr<const PointCloudGeometryHandler<PointT> > ConstPtr;
+        typedef boost::shared_ptr<PointCloudGeometryHandler<PointT> > Ptr;
+        typedef boost::shared_ptr<const PointCloudGeometryHandler<PointT> > ConstPtr;
 
         /** \brief Constructor. */
         PointCloudGeometryHandler (const PointCloudConstPtr &cloud) :
@@ -143,8 +143,8 @@ namespace pcl
         typedef typename PointCloud::Ptr PointCloudPtr;
         typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-        typedef typename boost::shared_ptr<PointCloudGeometryHandlerXYZ<PointT> > Ptr;
-        typedef typename boost::shared_ptr<const PointCloudGeometryHandlerXYZ<PointT> > ConstPtr;
+        typedef boost::shared_ptr<PointCloudGeometryHandlerXYZ<PointT> > Ptr;
+        typedef boost::shared_ptr<const PointCloudGeometryHandlerXYZ<PointT> > ConstPtr;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerXYZ (const PointCloudConstPtr &cloud);
@@ -191,8 +191,8 @@ namespace pcl
         typedef typename PointCloud::Ptr PointCloudPtr;
         typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-        typedef typename boost::shared_ptr<PointCloudGeometryHandlerSurfaceNormal<PointT> > Ptr;
-        typedef typename boost::shared_ptr<const PointCloudGeometryHandlerSurfaceNormal<PointT> > ConstPtr;
+        typedef boost::shared_ptr<PointCloudGeometryHandlerSurfaceNormal<PointT> > Ptr;
+        typedef boost::shared_ptr<const PointCloudGeometryHandlerSurfaceNormal<PointT> > ConstPtr;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerSurfaceNormal (const PointCloudConstPtr &cloud);
@@ -236,8 +236,8 @@ namespace pcl
         typedef typename PointCloud::Ptr PointCloudPtr;
         typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-        typedef typename boost::shared_ptr<PointCloudGeometryHandlerCustom<PointT> > Ptr;
-        typedef typename boost::shared_ptr<const PointCloudGeometryHandlerCustom<PointT> > ConstPtr;
+        typedef boost::shared_ptr<PointCloudGeometryHandlerCustom<PointT> > Ptr;
+        typedef boost::shared_ptr<const PointCloudGeometryHandlerCustom<PointT> > ConstPtr;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerCustom (const PointCloudConstPtr &cloud,


### PR DESCRIPTION
While dealing with `boost::shared_ptr` transition I noticed that we have a lot of redundant `typename` keywords. I've grepped for `typedef typename` through the entire code base and removed `typename`  when it's not needed. It's a lot of changes, so I will submit a series of PRs to make review more manageable.