### PR TITLE
Fix missing #include <array> in render_views_tesselated_sphere.cpp

### DIFF
--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -4,6 +4,8 @@
  *  Created on: Dec 23, 2011
  *      Author: aitor
  */
+#include <array>
+
 #include <pcl/point_types.h>
 #include <pcl/apps/render_views_tesselated_sphere.h>
 #include <vtkCellData.h>


### PR DESCRIPTION
Currently I got on MSVC 2017
```
1>D:\pcl\apps\src\render_views_tesselated_sphere.cpp(159): error C2079: 'cam_pos' uses undefined class 'std::array<double,3>'
1>D:\pcl\apps\src\render_views_tesselated_sphere.cpp(160): error C2079: 'first_cam_pos' uses undefined class 'std::array<double,3>'
```
This app is not build on Azure MSVC machines, thats why we didn't saw the issue before.