### PR TITLE
Improve c/C command in `PCLVisualizer`

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -867,8 +867,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
     // display current camera settings/parameters
     case 'c': case 'C':
     {
-      Camera cam;
-      getCameraParameters (cam);
+      Camera cam (*CurrentRenderer->GetActiveCamera (), *Interactor->GetRenderWindow ());
       std::cerr <<  "Clipping plane [near,far] "  << cam.clip[0] << ", " << cam.clip[1] << endl <<
                     "Focal point [x,y,z] " << cam.focal[0] << ", " << cam.focal[1] << ", " << cam.focal[2] << endl <<
                     "Position [x,y,z] " << cam.pos[0] << ", " << cam.pos[1] << ", " << cam.pos[2] << endl <<


### PR DESCRIPTION
Old behavior was to print the camera parameters of the default viewport. After this commit the parameters of the camera of the currently focused (hovered with mouse) viewport are printed.