### PR TITLE
Remove redundant typename

### DIFF
--- a/recognition/include/pcl/recognition/color_gradient_dot_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_dot_modality.h
@@ -69,7 +69,7 @@ namespace pcl
     };
 
     public:
-      typedef typename pcl::PointCloud<PointInT> PointCloudIn;
+      typedef pcl::PointCloud<PointInT> PointCloudIn;
 
       ColorGradientDOTModality (size_t bin_size);
   

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -81,7 +81,7 @@ namespace pcl
       };
 
     public:
-      typedef typename pcl::PointCloud<PointInT> PointCloudIn;
+      typedef pcl::PointCloud<PointInT> PointCloudIn;
 
       /** \brief Different methods for feature selection/extraction. */
       enum FeatureSelectionMethod

--- a/recognition/include/pcl/recognition/color_modality.h
+++ b/recognition/include/pcl/recognition/color_modality.h
@@ -75,7 +75,7 @@ namespace pcl
       };
 
     public:
-      typedef typename pcl::PointCloud<PointInT> PointCloudIn;
+      typedef pcl::PointCloud<PointInT> PointCloudIn;
 
       ColorModality ();
   

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -185,7 +185,7 @@ namespace pcl
       using HypothesisVerification<ModelT, SceneT>::inliers_threshold_;
 
       //class attributes
-      typedef typename pcl::NormalEstimation<SceneT, pcl::Normal> NormalEstimator_;
+      typedef pcl::NormalEstimation<SceneT, pcl::Normal> NormalEstimator_;
       pcl::PointCloud<pcl::Normal>::Ptr scene_normals_;
       pcl::PointCloud<pcl::PointXYZI>::Ptr clusters_cloud_;
 

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -530,8 +530,7 @@ bool pcl::GlobalHypothesesVerification<ModelT, SceneT>::addModel(typename pcl::P
 
   //compute normals unless given (now do it always...)
   typename pcl::search::KdTree<ModelT>::Ptr normals_tree (new pcl::search::KdTree<ModelT>);
-  typedef typename pcl::NormalEstimation<ModelT, pcl::Normal> NormalEstimator_;
-  NormalEstimator_ n3d;
+  pcl::NormalEstimation<ModelT, pcl::Normal> n3d;
   recog_model->normals_.reset (new pcl::PointCloud<pcl::Normal> ());
   normals_tree->setInputCloud (recog_model->cloud_);
   n3d.setRadiusSearch (radius_normals_);

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -325,7 +325,7 @@ namespace pcl
       };
 
     public:
-      typedef typename pcl::PointCloud<PointInT> PointCloudIn;
+      typedef pcl::PointCloud<PointInT> PointCloudIn;
 
       /** \brief Constructor. */
       SurfaceNormalModality ();

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -258,8 +258,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
 
     if (USE_NORMALS_)
     {
-      typedef typename pcl::IntegralImageNormalEstimation<pcl::PointXYZ, pcl::Normal> NormalEstimator_;
-      NormalEstimator_ n3d;
+      pcl::IntegralImageNormalEstimation<pcl::PointXYZ, pcl::Normal> n3d;
       n3d.setNormalEstimationMethod (n3d.COVARIANCE_MATRIX);
       n3d.setInputCloud (cloud);
       n3d.setRadiusSearch (0.02);

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -382,7 +382,7 @@ namespace pcl
         using PCLBase<PointSource>::deinitCompute;
 
         typedef pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+        typedef typename KdTree::Ptr KdTreePtr;
 
         typedef pcl::PointCloud<PointSource> PointCloudSource;
         typedef typename PointCloudSource::Ptr PointCloudSourcePtr;

--- a/registration/include/pcl/registration/correspondence_estimation_backprojection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_backprojection.h
@@ -68,8 +68,8 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_indices_;
 
-        typedef typename pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+        typedef pcl::search::KdTree<PointTarget> KdTree;
+        typedef typename KdTree::Ptr KdTreePtr;
 
         typedef pcl::PointCloud<PointSource> PointCloudSource;
         typedef typename PointCloudSource::Ptr PointCloudSourcePtr;

--- a/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
+++ b/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
@@ -90,8 +90,8 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_indices_;
 
-        typedef typename pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+        typedef pcl::search::KdTree<PointTarget> KdTree;
+        typedef typename KdTree::Ptr KdTreePtr;
 
         typedef pcl::PointCloud<PointSource> PointCloudSource;
         typedef typename PointCloudSource::Ptr PointCloudSourcePtr;

--- a/registration/include/pcl/registration/elch.h
+++ b/registration/include/pcl/registration/elch.h
@@ -84,7 +84,7 @@ namespace pcl
 
         typedef boost::shared_ptr< LoopGraph > LoopGraphPtr;
 
-        typedef typename pcl::Registration<PointT, PointT> Registration;
+        typedef pcl::Registration<PointT, PointT> Registration;
         typedef typename Registration::Ptr RegistrationPtr;
         typedef typename Registration::ConstPtr RegistrationConstPtr;
 

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -128,7 +128,7 @@ namespace pcl
           float threshold_;
       };
 
-      typedef typename boost::shared_ptr<ErrorFunctor> ErrorFunctorPtr;
+      typedef boost::shared_ptr<ErrorFunctor> ErrorFunctorPtr;
 
       typedef typename KdTreeFLANN<FeatureT>::Ptr FeatureKdTreePtr; 
       /** \brief Constructor. */

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -216,9 +216,9 @@ namespace pcl
     template <typename PointT> 
     class NDTSingleGrid: public boost::noncopyable
     {
-      typedef typename pcl::PointCloud<PointT> PointCloud;
-      typedef typename pcl::PointCloud<PointT>::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::ndt2d::NormalDist<PointT> NormalDist;
+      typedef pcl::PointCloud<PointT> PointCloud;
+      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      typedef pcl::ndt2d::NormalDist<PointT> NormalDist;
 
       public:
         NDTSingleGrid (PointCloudConstPtr cloud,
@@ -303,8 +303,8 @@ namespace pcl
     template <typename PointT> 
     class NDT2D: public boost::noncopyable
     {
-      typedef typename pcl::PointCloud<PointT> PointCloud;
-      typedef typename pcl::PointCloud<PointT>::ConstPtr PointCloudConstPtr;
+      typedef pcl::PointCloud<PointT> PointCloud;
+      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
       typedef NDTSingleGrid<PointT> SingleGrid;
 
       public:

--- a/registration/include/pcl/registration/joint_icp.h
+++ b/registration/include/pcl/registration/joint_icp.h
@@ -63,7 +63,7 @@ namespace pcl
       typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
 
       typedef pcl::search::KdTree<PointTarget> KdTree;
-      typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
       typedef typename KdTree::Ptr KdTreeReciprocalPtr;
@@ -75,7 +75,7 @@ namespace pcl
       typedef boost::shared_ptr<JointIterativeClosestPoint<PointSource, PointTarget, Scalar> > Ptr;
       typedef boost::shared_ptr<const JointIterativeClosestPoint<PointSource, PointTarget, Scalar> > ConstPtr;
 
-      typedef typename pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> CorrespondenceEstimation;
+      typedef pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> CorrespondenceEstimation;
       typedef typename CorrespondenceEstimation::Ptr CorrespondenceEstimationPtr;
       typedef typename CorrespondenceEstimation::ConstPtr CorrespondenceEstimationConstPtr;
 

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -71,9 +71,9 @@ namespace pcl
       typedef boost::shared_ptr< Registration<PointSource, PointTarget, Scalar> > Ptr;
       typedef boost::shared_ptr< const Registration<PointSource, PointTarget, Scalar> > ConstPtr;
 
-      typedef typename pcl::registration::CorrespondenceRejector::Ptr CorrespondenceRejectorPtr;
+      typedef pcl::registration::CorrespondenceRejector::Ptr CorrespondenceRejectorPtr;
       typedef pcl::search::KdTree<PointTarget> KdTree;
-      typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
       typedef typename KdTreeReciprocal::Ptr KdTreeReciprocalPtr;
@@ -92,7 +92,7 @@ namespace pcl
       typedef typename TransformationEstimation::Ptr TransformationEstimationPtr;
       typedef typename TransformationEstimation::ConstPtr TransformationEstimationConstPtr;
 
-      typedef typename pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> CorrespondenceEstimation;
+      typedef pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> CorrespondenceEstimation;
       typedef typename CorrespondenceEstimation::Ptr CorrespondenceEstimationPtr;
       typedef typename CorrespondenceEstimation::ConstPtr CorrespondenceEstimationConstPtr;
 

--- a/registration/include/pcl/registration/transformation_validation_euclidean.h
+++ b/registration/include/pcl/registration/transformation_validation_euclidean.h
@@ -79,8 +79,8 @@ namespace pcl
         typedef boost::shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> > Ptr;
         typedef boost::shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> > ConstPtr;
 
-        typedef typename pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename pcl::search::KdTree<PointTarget>::Ptr KdTreePtr;
+        typedef pcl::search::KdTree<PointTarget> KdTree;
+        typedef typename KdTree::Ptr KdTreePtr;
 
         typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -65,9 +65,9 @@ namespace pcl
   class SampleConsensusModel
   {
     public:
-      typedef typename pcl::PointCloud<PointT> PointCloud;
-      typedef typename pcl::PointCloud<PointT>::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::PointCloud<PointT>::Ptr PointCloudPtr;
+      typedef pcl::PointCloud<PointT> PointCloud;
+      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename pcl::search::Search<PointT>::Ptr SearchPtr;
 
       typedef boost::shared_ptr<SampleConsensusModel> Ptr;

--- a/segmentation/include/pcl/segmentation/cpc_segmentation.h
+++ b/segmentation/include/pcl/segmentation/cpc_segmentation.h
@@ -174,7 +174,7 @@ namespace pcl
       
       class WeightedRandomSampleConsensus : public SampleConsensus<WeightSACPointType>
       {
-          typedef typename SampleConsensusModel<WeightSACPointType>::Ptr SampleConsensusModelPtr;
+          typedef SampleConsensusModel<WeightSACPointType>::Ptr SampleConsensusModelPtr;
 
         public:
           typedef boost::shared_ptr<WeightedRandomSampleConsensus> Ptr;

--- a/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
@@ -57,7 +57,7 @@ namespace pcl
       typedef typename Comparator<PointT>::PointCloud PointCloud;
       typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
       
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
       

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -58,7 +58,7 @@ namespace pcl
         using typename Comparator<PointT>::PointCloud;
         using typename Comparator<PointT>::PointCloudConstPtr;
 
-        typedef typename pcl::PointCloud<PointLT> PointCloudL;
+        typedef pcl::PointCloud<PointLT> PointCloudL;
         typedef typename PointCloudL::Ptr PointCloudLPtr;
         typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
 
@@ -201,7 +201,7 @@ namespace pcl
 
     public:
 
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
 

--- a/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
@@ -56,7 +56,7 @@ namespace pcl
     public:
       typedef typename Comparator<PointT>::PointCloud PointCloud;
       typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
       

--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -300,8 +300,8 @@ namespace pcl
       typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-      typedef typename pcl::search::Search<PointT> KdTree;
-      typedef typename pcl::search::Search<PointT>::Ptr KdTreePtr;
+      typedef pcl::search::Search<PointT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       typedef PointIndices::Ptr PointIndicesPtr;
       typedef PointIndices::ConstPtr PointIndicesConstPtr;

--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -76,8 +76,8 @@ namespace pcl
       typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-      typedef typename pcl::search::Search<PointT> KdTree;
-      typedef typename pcl::search::Search<PointT>::Ptr KdTreePtr;
+      typedef pcl::search::Search<PointT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       typedef PointIndices::Ptr PointIndicesPtr;
       typedef PointIndices::ConstPtr PointIndicesConstPtr;

--- a/segmentation/include/pcl/segmentation/grabcut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/grabcut_segmentation.h
@@ -317,8 +317,8 @@ namespace pcl
   class GrabCut : public pcl::PCLBase<PointT>
   {
     public:
-      typedef typename pcl::search::Search<PointT> KdTree;
-      typedef typename pcl::search::Search<PointT>::Ptr KdTreePtr;
+      typedef pcl::search::Search<PointT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
       typedef typename PCLBase<PointT>::PointCloudConstPtr PointCloudConstPtr;
       typedef typename PCLBase<PointT>::PointCloudPtr PointCloudPtr;
       using PCLBase<PointT>::input_;

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -57,7 +57,7 @@ namespace pcl
       typedef typename Comparator<PointT>::PointCloud PointCloud;
       typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
       
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
       

--- a/segmentation/include/pcl/segmentation/lccp_segmentation.h
+++ b/segmentation/include/pcl/segmentation/lccp_segmentation.h
@@ -81,7 +81,7 @@ namespace pcl
     public:
 
       // Adjacency list with nodes holding labels (uint32_t) and edges holding EdgeProperties.
-      typedef typename boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, EdgeProperties> SupervoxelAdjacencyList;
+      typedef boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, EdgeProperties> SupervoxelAdjacencyList;
       typedef typename boost::graph_traits<SupervoxelAdjacencyList>::vertex_iterator VertexIterator;
       typedef typename boost::graph_traits<SupervoxelAdjacencyList>::adjacency_iterator AdjacencyIterator;
 

--- a/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
@@ -63,15 +63,15 @@ namespace pcl
     using PCLBase<PointT>::deinitCompute;
 
     public:
-      typedef typename pcl::PointCloud<PointT> PointCloud;
+      typedef pcl::PointCloud<PointT> PointCloud;
       typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename PointCloud::ConstPtr PointCloudConstPtr;
       
-      typedef typename pcl::PointCloud<PointLT> PointCloudL;
+      typedef pcl::PointCloud<PointLT> PointCloudL;
       typedef typename PointCloudL::Ptr PointCloudLPtr;
       typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
 
-      typedef typename pcl::Comparator<PointT> Comparator;
+      typedef pcl::Comparator<PointT> Comparator;
       typedef typename Comparator::Ptr ComparatorPtr;
       typedef typename Comparator::ConstPtr ComparatorConstPtr;
       

--- a/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
@@ -70,19 +70,19 @@ namespace pcl
       typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
 
-      typedef typename pcl::PointCloud<PointLT> PointCloudL;
+      typedef pcl::PointCloud<PointLT> PointCloudL;
       typedef typename PointCloudL::Ptr PointCloudLPtr;
       typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
 
-      typedef typename pcl::PlaneCoefficientComparator<PointT, PointNT> PlaneComparator;
+      typedef pcl::PlaneCoefficientComparator<PointT, PointNT> PlaneComparator;
       typedef typename PlaneComparator::Ptr PlaneComparatorPtr;
       typedef typename PlaneComparator::ConstPtr PlaneComparatorConstPtr;
 
-      typedef typename pcl::PlaneRefinementComparator<PointT, PointNT, PointLT> PlaneRefinementComparator;
+      typedef pcl::PlaneRefinementComparator<PointT, PointNT, PointLT> PlaneRefinementComparator;
       typedef typename PlaneRefinementComparator::Ptr PlaneRefinementComparatorPtr;
       typedef typename PlaneRefinementComparator::ConstPtr PlaneRefinementComparatorConstPtr;
 

--- a/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
@@ -57,7 +57,7 @@ namespace pcl
       typedef typename Comparator<PointT>::PointCloud PointCloud;
       typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
       
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
       

--- a/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
@@ -57,11 +57,11 @@ namespace pcl
       typedef typename Comparator<PointT>::PointCloud PointCloud;
       typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
       
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
 
-      typedef typename pcl::PointCloud<PointLT> PointCloudL;
+      typedef pcl::PointCloud<PointLT> PointCloudL;
       typedef typename PointCloudL::Ptr PointCloudLPtr;
       typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
 

--- a/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
@@ -57,7 +57,7 @@ namespace pcl
       typedef typename Comparator<PointT>::PointCloud PointCloud;
       typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
       
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
       

--- a/segmentation/include/pcl/segmentation/sac_segmentation.h
+++ b/segmentation/include/pcl/segmentation/sac_segmentation.h
@@ -325,7 +325,7 @@ namespace pcl
       typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-      typedef typename pcl::PointCloud<PointNT> PointCloudN;
+      typedef pcl::PointCloud<PointNT> PointCloudN;
       typedef typename PointCloudN::Ptr PointCloudNPtr;
       typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
 

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -89,8 +89,8 @@ namespace pcl
       typedef typename PointCloud::Ptr PointCloudPtr;
       typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
-      typedef typename pcl::search::Search<PointT> KdTree;
-      typedef typename pcl::search::Search<PointT>::Ptr KdTreePtr;
+      typedef pcl::search::Search<PointT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       typedef PointIndices::Ptr PointIndicesPtr;
       typedef PointIndices::ConstPtr PointIndicesConstPtr;

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -166,11 +166,11 @@ namespace pcl
       typedef pcl::octree::OctreePointCloudAdjacencyContainer<PointT, VoxelData> LeafContainerT;
       typedef std::vector <LeafContainerT*> LeafVectorT;
 
-      typedef typename pcl::PointCloud<PointT> PointCloudT;
-      typedef typename pcl::PointCloud<Normal> NormalCloudT;
-      typedef typename pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT> OctreeAdjacencyT;
-      typedef typename pcl::octree::OctreePointCloudSearch <PointT> OctreeSearchT;
-      typedef typename pcl::search::KdTree<PointT> KdTreeT;
+      typedef pcl::PointCloud<PointT> PointCloudT;
+      typedef pcl::PointCloud<Normal> NormalCloudT;
+      typedef pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT> OctreeAdjacencyT;
+      typedef pcl::octree::OctreePointCloudSearch <PointT> OctreeSearchT;
+      typedef pcl::search::KdTree<PointT> KdTreeT;
       typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
 
       using PCLBase <PointT>::initCompute;

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -144,8 +144,8 @@ namespace pcl
       using MeshConstruction<PointInT>::input_;
       using MeshConstruction<PointInT>::indices_;
 
-      typedef typename pcl::KdTree<PointInT> KdTree;
-      typedef typename pcl::KdTree<PointInT>::Ptr KdTreePtr;
+      typedef pcl::KdTree<PointInT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       typedef pcl::PointCloud<PointInT> PointCloudIn;
       typedef typename PointCloudIn::Ptr PointCloudInPtr;

--- a/surface/include/pcl/surface/grid_projection.h
+++ b/surface/include/pcl/surface/grid_projection.h
@@ -79,8 +79,8 @@ namespace pcl
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 
-      typedef typename pcl::KdTree<PointNT> KdTree;
-      typedef typename pcl::KdTree<PointNT>::Ptr KdTreePtr;
+      typedef pcl::KdTree<PointNT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       /** \brief Data leaf. */
       struct Leaf

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -370,8 +370,8 @@ namespace pcl
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 
-      typedef typename pcl::KdTree<PointNT> KdTree;
-      typedef typename pcl::KdTree<PointNT>::Ptr KdTreePtr;
+      typedef pcl::KdTree<PointNT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       /** \brief Constructor. */
       MarchingCubes (const float percentage_extend_grid = 0.0f,

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -66,8 +66,8 @@ namespace pcl
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 
-      typedef typename pcl::KdTree<PointNT> KdTree;
-      typedef typename pcl::KdTree<PointNT>::Ptr KdTreePtr;
+      typedef pcl::KdTree<PointNT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
 
       /** \brief Constructor. */

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -68,8 +68,8 @@ namespace pcl
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 
-      typedef typename pcl::KdTree<PointNT> KdTree;
-      typedef typename pcl::KdTree<PointNT>::Ptr KdTreePtr;
+      typedef pcl::KdTree<PointNT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
 
       /** \brief Constructor. */

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -258,10 +258,10 @@ namespace pcl
       using PCLBase<PointInT>::initCompute;
       using PCLBase<PointInT>::deinitCompute;
 
-      typedef typename pcl::search::Search<PointInT> KdTree;
-      typedef typename pcl::search::Search<PointInT>::Ptr KdTreePtr;
+      typedef pcl::search::Search<PointInT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
       typedef pcl::PointCloud<pcl::Normal> NormalCloud;
-      typedef pcl::PointCloud<pcl::Normal>::Ptr NormalCloudPtr;
+      typedef NormalCloud::Ptr NormalCloudPtr;
 
       typedef pcl::PointCloud<PointOutT> PointCloudOut;
       typedef typename PointCloudOut::Ptr PointCloudOutPtr;

--- a/surface/include/pcl/surface/poisson.h
+++ b/surface/include/pcl/surface/poisson.h
@@ -67,8 +67,8 @@ namespace pcl
 
       typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
 
-      typedef typename pcl::KdTree<PointNT> KdTree;
-      typedef typename pcl::KdTree<PointNT>::Ptr KdTreePtr;
+      typedef pcl::KdTree<PointNT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       /** \brief Constructor that sets all the parameters to working default values. */
       Poisson ();

--- a/surface/include/pcl/surface/reconstruction.h
+++ b/surface/include/pcl/surface/reconstruction.h
@@ -63,8 +63,8 @@ namespace pcl
       typedef boost::shared_ptr<PCLSurfaceBase<PointInT> > Ptr;
       typedef boost::shared_ptr<const PCLSurfaceBase<PointInT> > ConstPtr;
 
-      typedef typename pcl::search::Search<PointInT> KdTree;
-      typedef typename pcl::search::Search<PointInT>::Ptr KdTreePtr;
+      typedef pcl::search::Search<PointInT> KdTree;
+      typedef typename KdTree::Ptr KdTreePtr;
 
       /** \brief Empty constructor. */
       PCLSurfaceBase () : tree_ () {}

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -986,7 +986,7 @@ struct OctreeBaseIteratorsPrePostTest : public OctreeBaseBeginEndIteratorsTest
 TEST_F (OctreeBaseIteratorsPrePostTest, DefaultIterator)
 {
   // Useful types
-  typedef typename OctreeT::Iterator IteratorT;
+  typedef OctreeT::Iterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1008,7 +1008,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, DefaultIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeDepthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeDepthFirstIterator IteratorT;
+  typedef OctreeT::LeafNodeDepthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1030,7 +1030,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeDepthFirstIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, DepthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::DepthFirstIterator IteratorT;
+  typedef OctreeT::DepthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1052,7 +1052,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, DepthFirstIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, BreadthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::BreadthFirstIterator IteratorT;
+  typedef OctreeT::BreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1074,7 +1074,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, BreadthFirstIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, FixedDepthIterator)
 {
   // Useful types
-  typedef typename OctreeT::FixedDepthIterator IteratorT;
+  typedef OctreeT::FixedDepthIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1103,7 +1103,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, FixedDepthIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeBreadthFirstIterator)
 {
   // Useful types
-  typedef typename OctreeT::LeafNodeBreadthFirstIterator IteratorT;
+  typedef OctreeT::LeafNodeBreadthFirstIterator IteratorT;
 
   // Default initialization
   IteratorT it_a_pre;


### PR DESCRIPTION
Continuation of #2896 and #2897. This is the last one. Unless I missed something (there were ~1.5k hits when grepping for `typedef typename`), the codebase should be free from redundant `typename`s.