### PR TITLE
Use preinstalled vcpkg on Azure

### DIFF
--- a/.ci/azure-pipelines/build-windows.yml
+++ b/.ci/azure-pipelines/build-windows.yml
@@ -16,28 +16,21 @@ jobs:
           GENERATOR: 'Visual Studio 15 2017 Win64'
     variables:
       BUILD_DIR: '$(Agent.WorkFolder)\build'
-      VCPKG_DIR: '$(Agent.WorkFolder)\vcpkg'
       VCVARSALL: '%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
       CONFIGURATION: 'Release'
     steps:
       - script: |
-          git clone https://github.com/microsoft/vcpkg --depth 1 %VCPKG_DIR%
-          echo.set(VCPKG_BUILD_TYPE release)>> %VCPKG_DIR%\triplets\%PLATFORM%-windows.cmake
-          %VCPKG_DIR%\bootstrap-vcpkg.bat
-          %VCPKG_DIR%\vcpkg.exe version
-        displayName: 'Bootstrap vcpkg'
-      - script: |
-          %VCPKG_DIR%\vcpkg.exe install boost-system boost-filesystem boost-thread boost-date-time boost-iostreams boost-chrono boost-asio boost-dynamic-bitset boost-foreach boost-graph boost-interprocess boost-multi-array boost-ptr-container boost-random boost-signals2 eigen3 flann gtest qhull --triplet %PLATFORM%-windows && %VCPKG_DIR%\vcpkg.exe list
+          vcpkg.exe install boost-system boost-filesystem boost-thread boost-date-time boost-iostreams boost-chrono boost-asio boost-dynamic-bitset boost-foreach boost-graph boost-interprocess boost-multi-array boost-ptr-container boost-random boost-signals2 eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
         displayName: 'Install Dependencies'
       - script: |
-          rmdir %VCPKG_DIR%\downloads /S /Q
-          rmdir %VCPKG_DIR%\packages /S /Q
+          rmdir %VCPKG_ROOT%\downloads /S /Q
+          rmdir %VCPKG_ROOT%\packages /S /Q
         displayName: 'Free Up Space'
       - script: |
           call "%VCVARSALL%" %ARCHITECTURE%
-          set PATH=%VCPKG_DIR%\installed\%PLATFORM%-windows\bin;%PATH%
+          set PATH=%VCPKG_ROOT%\installed\%PLATFORM%-windows\bin;%PATH%
           mkdir %BUILD_DIR% && cd %BUILD_DIR%
-          cmake $(Build.SourcesDirectory) -G"%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DVCPKG_APPLOCAL_DEPS=ON -DPCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32=ON -DPCL_BUILD_WITH_FLANN_DYNAMIC_LINKING_WIN32=ON -DPCL_BUILD_WITH_QHULL_DYNAMIC_LINKING_WIN32=ON -DBUILD_global_tests=ON -DBUILD_tools=OFF -DBUILD_surface_on_nurbs=ON
+          cmake $(Build.SourcesDirectory) -G"%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_APPLOCAL_DEPS=ON -DPCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32=ON -DPCL_BUILD_WITH_FLANN_DYNAMIC_LINKING_WIN32=ON -DPCL_BUILD_WITH_QHULL_DYNAMIC_LINKING_WIN32=ON -DBUILD_global_tests=ON -DBUILD_tools=OFF -DBUILD_surface_on_nurbs=ON
         displayName: 'CMake Configuration'
       - script: cd %BUILD_DIR% && cmake --build . --config %CONFIGURATION%
         displayName: 'Build Library'


### PR DESCRIPTION
Our Windows CI jobs have been failing for a day or so on the "Free Up Space" step. I did not investigate what exactly was the problem, but this commit fixes it.

Closes #2832.

While working on this I dropped installation of Boost through vcpkg to accelerate debugging of the job. To my surprise, at some point the overall job has passed. Apparently, there is Boost 1.69 already installed in the images! Thus I propose to switch to using this preinstalled Boost and not install it through vcpkg. This will save us ~20 minutes of CI time. Does anyone of our vcpkg gurus (@UnaNancyOwen, @jasjuang, @claudiofantacci) have an opinion on this? Can there be any downsides?