### PR TITLE
Use preinstalled Boost on Azure

### DIFF
--- a/.ci/azure-pipelines/build-windows.yml
+++ b/.ci/azure-pipelines/build-windows.yml
@@ -22,6 +22,9 @@ jobs:
       - script: set
         displayName: 'Print Environment Variables'
       - script: |
+          echo ##vso[task.prependpath]%BOOST_ROOT%\lib
+        displayName: 'Update System PATH'
+      - script: |
           vcpkg.exe install eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
         displayName: 'Install Dependencies'
       - script: |

--- a/.ci/azure-pipelines/build-windows.yml
+++ b/.ci/azure-pipelines/build-windows.yml
@@ -16,7 +16,6 @@ jobs:
           GENERATOR: 'Visual Studio 15 2017 Win64'
     variables:
       BUILD_DIR: '$(Agent.WorkFolder)\build'
-      VCVARSALL: '%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
       CONFIGURATION: 'Release'
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
@@ -30,8 +29,6 @@ jobs:
           rmdir %VCPKG_ROOT%\packages /S /Q
         displayName: 'Free Up Space'
       - script: |
-          call "%VCVARSALL%" %ARCHITECTURE%
-          set PATH=%VCPKG_ROOT%\installed\%PLATFORM%-windows\bin;%PATH%
           mkdir %BUILD_DIR% && cd %BUILD_DIR%
           cmake $(Build.SourcesDirectory) -G"%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_APPLOCAL_DEPS=ON -DPCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32=ON -DPCL_BUILD_WITH_FLANN_DYNAMIC_LINKING_WIN32=ON -DPCL_BUILD_WITH_QHULL_DYNAMIC_LINKING_WIN32=ON -DBUILD_global_tests=ON -DBUILD_tools=OFF -DBUILD_surface_on_nurbs=ON
         displayName: 'CMake Configuration'

--- a/.ci/azure-pipelines/build-windows.yml
+++ b/.ci/azure-pipelines/build-windows.yml
@@ -23,7 +23,7 @@ jobs:
       - script: set
         displayName: 'Print Environment Variables'
       - script: |
-          vcpkg.exe install boost-system boost-filesystem boost-thread boost-date-time boost-iostreams boost-chrono boost-asio boost-dynamic-bitset boost-foreach boost-graph boost-interprocess boost-multi-array boost-ptr-container boost-random boost-signals2 eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
+          vcpkg.exe install eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
         displayName: 'Install Dependencies'
       - script: |
           rmdir %VCPKG_ROOT%\downloads /S /Q


### PR DESCRIPTION
As discussed in #2928, use preinstalled Boost instead of installing through vcpkg.

This PR includes a temporary commit that fixes a problem with environment variables on Azure agents.

**Maintainer Edit:** 
> As I mentioned before, not all Azure runners have up-to-date images with Boost installed. Until this changes we should not merge this PR.