### PR TITLE
Enforce right-hand-rule on PCA Eigenvectors.

### DIFF
--- a/common/include/pcl/common/impl/pca.hpp
+++ b/common/include/pcl/common/impl/pca.hpp
@@ -77,6 +77,8 @@ pcl::PCA<PointT>::initCompute ()
     eigenvalues_[i] = evd.eigenvalues () [2-i];
     eigenvectors_.col (i) = evd.eigenvectors ().col (2-i);
   }
+  // Enforce right hand rule 
+  eigenvectors_.col(2) = eigenvectors_.col(0).cross(eigenvectors_.col(1));
   // If not basis only then compute the coefficients
   if (!basis_only_)
     coefficients_ = eigenvectors_.transpose() * cloud_demean.topRows<3> ();

--- a/common/include/pcl/common/pca.h
+++ b/common/include/pcl/common/pca.h
@@ -46,8 +46,10 @@ namespace pcl
   /** Principal Component analysis (PCA) class.\n
     *  Principal components are extracted by singular values decomposition on the 
     * covariance matrix of the centered input cloud. Available data after pca computation 
-    * are the mean of the input data, the eigenvalues (in descending order) and 
-    * corresponding eigenvectors.\n
+    * are:\n
+    * - The Mean of the input data\n
+    * - The Eigenvectors: Ordered set of vectors representing the resultant principal components and the eigenspace cartesian basis (right-handed coordinate system).\n
+    * - The Eigenvalues: Eigenvectors correspondent loadings ordered in descending order.\n\n
     * Other methods allow projection in the eigenspace, reconstruction from eigenspace and 
     *  update of the eigenspace with a new datum (according Matej Artec, Matjaz Jogan and 
     * Ales Leonardis: "Incremental PCA for On-line Visual Learning and Recognition").
@@ -189,6 +191,7 @@ namespace pcl
       }
 
       /** Eigen Vectors accessor
+        * \return Column ordered eigenvectors, representing the eigenspace cartesian basis (right-handed coordinate system).        
         * \throw InitFailedException
         */
       inline Eigen::Matrix3f& 


### PR DESCRIPTION
Since eigenvectors can be interpreted as a vector space basis (i.e. a Rotation matrix) this commits enforce the behavior where the eigenvectors follow the right-hand rule and thus can be used directly as a rotation matrix/space vector basis.

This PR addresses the issue pointed out in #2879