### PR TITLE
Use random generator from C++11 instead of from Boost in module features

### DIFF
--- a/features/include/pcl/features/3dsc.h
+++ b/features/include/pcl/features/3dsc.h
@@ -40,6 +40,8 @@
 
 #pragma once
 
+#include <random>
+
 #include <pcl/point_types.h>
 #include <pcl/features/boost.h>
 #include <pcl/features/feature.h>
@@ -102,17 +104,20 @@ namespace pcl
         min_radius_(0.1),
         point_density_radius_(0.2),
         descriptor_length_ (),
-        rng_alg_ (),
-        rng_ (new boost::uniform_01<boost::mt19937> (rng_alg_))
+        rng_ (),
+        rng_dist_ (0.0f, 1.0f)
       {
         feature_name_ = "ShapeContext3DEstimation";
         search_radius_ = 2.5;
 
         // Create a random number generator object
         if (random)
-          rng_->base ().seed (static_cast<unsigned> (std::time(nullptr)));
+        {
+          std::random_device rd;
+          rng_.seed (rd());
+        }
         else
-          rng_->base ().seed (12345u);
+          rng_.seed (12345u);
       }
 
       ~ShapeContext3DEstimation() {}
@@ -211,11 +216,11 @@ namespace pcl
       /** \brief Descriptor length */
       size_t descriptor_length_;
 
-      /** \brief Boost-based random number generator algorithm. */
-      boost::mt19937 rng_alg_;
+      /** \brief Random number generator algorithm. */
+      std::mt19937 rng_;
 
-      /** \brief Boost-based random number generator distribution. */
-      boost::shared_ptr<boost::uniform_01<boost::mt19937> > rng_;
+      /** \brief Random number generator distribution. */
+      std::uniform_real_distribution<> rng_dist_;
 
      /*  \brief Shift computed descriptor "L" times along the azimuthal direction
        * \param[in] block_size the size of each azimuthal block
@@ -229,7 +234,7 @@ namespace pcl
       inline double
       rnd ()
       {
-        return ((*rng_) ());
+        return (rng_dist_ (rng_));
       }
   };
 }

--- a/features/include/pcl/features/3dsc.h
+++ b/features/include/pcl/features/3dsc.h
@@ -220,7 +220,7 @@ namespace pcl
       std::mt19937 rng_;
 
       /** \brief Random number generator distribution. */
-      std::uniform_real_distribution<> rng_dist_;
+      std::uniform_real_distribution<float> rng_dist_;
 
      /*  \brief Shift computed descriptor "L" times along the azimuthal direction
        * \param[in] block_size the size of each azimuthal block
@@ -231,7 +231,7 @@ namespace pcl
       //shiftAlongAzimuth (size_t block_size, std::vector<float>& desc);
 
       /** \brief Boost-based random number generator. */
-      inline double
+      inline float
       rnd ()
       {
         return (rng_dist_ (rng_));

--- a/features/include/pcl/features/boost.h
+++ b/features/include/pcl/features/boost.h
@@ -46,7 +46,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
-#include <boost/random.hpp>
 #include <boost/property_map/property_map.hpp>
 //#include <boost/graph/adjacency_list.hpp>
 //#include <boost/graph/johnson_all_pairs_shortest.hpp>

--- a/features/include/pcl/features/impl/3dsc.hpp
+++ b/features/include/pcl/features/impl/3dsc.hpp
@@ -166,9 +166,9 @@ pcl::ShapeContext3DEstimation<PointInT, PointNT, PointOutT>::computePoint (
   normal = normals[minIndex].getNormalVector3fMap ();
 
   // Compute and store the RF direction
-  x_axis[0] = static_cast<float> (rnd ());
-  x_axis[1] = static_cast<float> (rnd ());
-  x_axis[2] = static_cast<float> (rnd ());
+  x_axis[0] = rnd ();
+  x_axis[1] = rnd ();
+  x_axis[2] = rnd ();
   if (!pcl::utils::equal (normal[2], 0.0f))
     x_axis[2] = - (normal[0]*x_axis[0] + normal[1]*x_axis[1]) / normal[2];
   else if (!pcl::utils::equal (normal[1], 0.0f))

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -746,17 +746,17 @@ TEST (PCL,3DSCEstimation)
 
   //EXPECT_EQ ((*sc3ds)[0].descriptor.size (), 64);
 
-  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[88], 82.906754f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[88], 55.271168f);
   EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[584], 71.108765f);
   EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[1106], 79.5896f);
   EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[1560], 0.f);
-  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[1929], 0.f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[1929], 36.063553f);
 
   EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[67], 0.f);
-  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[548], 0.f);
-  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1091], 0.f);
-  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1421], 0.f);
-  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1900], 0.f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[548], 126.14106f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1091], 30.470392f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1421], 38.08799f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1900], 43.799442f);
 
   // Test results when setIndices and/or setSearchSurface are used
   boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -734,29 +734,29 @@ TEST (PCL,3DSCEstimation)
   //EXPECT_NEAR ((*sc3ds)[0].rf[7], -0.6074f, 1e-4f);
   //EXPECT_NEAR ((*sc3ds)[0].rf[8], -0.7843f, 1e-4f);
 
-  EXPECT_NEAR ((*sc3ds)[0].rf[0], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[1], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[2], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[3], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[4], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[5], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[6], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[7], 0.0f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[0].rf[8], 0.0f, 1e-4f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[0], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[1], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[2], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[3], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[4], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[5], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[6], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[7], 0.0f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[0].rf[8], 0.0f);
 
   //EXPECT_EQ ((*sc3ds)[0].descriptor.size (), 64);
 
-  EXPECT_NEAR ((*sc3ds)[94].descriptor[88], 55.2712f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[94].descriptor[584], 71.1088f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[94].descriptor[1106], 79.5896f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[94].descriptor[1560], 0.f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[94].descriptor[1929], 36.0636f, 1e-4f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[88], 82.906754f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[584], 71.108765f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[1106], 79.5896f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[1560], 0.f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[94].descriptor[1929], 0.f);
 
-  EXPECT_NEAR ((*sc3ds)[108].descriptor[67], 0.f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[108].descriptor[548], 126.141f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[108].descriptor[1091], 30.4704f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[108].descriptor[1421], 38.088f, 1e-4f);
-  EXPECT_NEAR ((*sc3ds)[108].descriptor[1900], 43.7994f, 1e-4f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[67], 0.f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[548], 0.f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1091], 0.f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1421], 0.f);
+  EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1900], 0.f);
 
   // Test results when setIndices and/or setSearchSurface are used
   boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));


### PR DESCRIPTION
Separation from #2956 due to the need to adapt tests.