### PR TITLE
Use newly build libs when testing

### DIFF
--- a/cmake/pcl_targets.cmake
+++ b/cmake/pcl_targets.cmake
@@ -383,6 +383,8 @@ macro(PCL_ADD_TEST _name _exename)
   endif()
 
   add_test(NAME ${_name} COMMAND ${_exename} ${PCL_ADD_TEST_ARGUMENTS})
+  set_tests_properties(${_name} PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/${LIB_INSTALL_DIR}")
+
 
   add_dependencies(tests ${_exename})
 endmacro()


### PR DESCRIPTION
This exports the LD_LIBRARY_PATH so the newly build libs will be used.