### PR TITLE
Include pcl_config.h before testing `HAVE_QHULL`

### DIFF
--- a/surface/include/pcl/surface/concave_hull.h
+++ b/surface/include/pcl/surface/concave_hull.h
@@ -39,9 +39,9 @@
  
 #pragma once
 
+#include <pcl/pcl_config.h>
 #ifdef HAVE_QHULL
 
-#include <pcl/pcl_config.h>
 #include <pcl/surface/convex_hull.h>
 
 namespace pcl

--- a/surface/include/pcl/surface/convex_hull.h
+++ b/surface/include/pcl/surface/convex_hull.h
@@ -39,10 +39,10 @@
 
 #pragma once
 
+#include <pcl/pcl_config.h>
 #ifdef HAVE_QHULL 
 
 // PCL includes
-#include <pcl/pcl_config.h>
 #include <pcl/surface/reconstruction.h>
 #include <pcl/ModelCoefficients.h>
 #include <pcl/PolygonMesh.h>

--- a/surface/include/pcl/surface/qhull.h
+++ b/surface/include/pcl/surface/qhull.h
@@ -39,9 +39,8 @@
 
 #pragma once
 
-#ifdef HAVE_QHULL
-
 #include <pcl/pcl_config.h>
+#ifdef HAVE_QHULL
 
 #if defined __GNUC__
 #  pragma GCC system_header 

--- a/surface/src/concave_hull.cpp
+++ b/surface/src/concave_hull.cpp
@@ -36,8 +36,6 @@
  */
 
 #include <pcl/pcl_config.h>
-
-
 #ifdef HAVE_QHULL
 
 #include <pcl/impl/instantiate.hpp>


### PR DESCRIPTION
`HAVE_QHULL` is defined (or not) in pcl_config.h, therefore it always has to be included before `#ifdef HAVE_QHULL` tests.