### PR TITLE
Simplify readability of string compare 

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
@@ -188,7 +188,7 @@ namespace pcl
             boost::split (strs, file, boost::is_any_of ("."));
             std::string extension = strs[strs.size () - 1];
 
-            if (extension.compare (ext) == 0)
+            if (extension == ext)
             {
               std::string path = rel_path_so_far + (itr->path ().filename ()).string();
 
@@ -229,7 +229,7 @@ namespace pcl
         typename std::vector<ModelT>::iterator it = models_->begin ();
         while (it != models_->end ())
         {
-          if (model_id.compare ((*it).id_) != 0)
+          if (model_id != (*it).id_)
           {
             it = models_->erase (it);
           }

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
@@ -94,7 +94,7 @@ namespace pcl
             else
             {
 
-              if (this->model.id_.compare (other.model.id_) == 0)
+              if (this->model.id_ == other.model.id_)
               {
                 //check view id
                 if ((this->view_id < other.view_id))

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -105,7 +105,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
   {
     boost::shared_ptr < std::vector<ModelT> > models;
 
-    if(search_model_.compare("") == 0) {
+    if(search_model_ == "") {
       models = source_->getModels ();
     } else {
       models = source_->getModels (search_model_);

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -105,7 +105,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
   {
     boost::shared_ptr < std::vector<ModelT> > models;
 
-    if(search_model_ == "") {
+    if(search_model_.empty()) {
       models = source_->getModels ();
     } else {
       models = source_->getModels (search_model_);

--- a/apps/3d_rec_framework/src/tools/global_classification.cpp
+++ b/apps/3d_rec_framework/src/tools/global_classification.cpp
@@ -168,7 +168,7 @@ main (int argc, char ** argv)
   normal_estimator->setRemoveOutliers (true);
   normal_estimator->setFactorsForCMR (3, 7);
 
-  if (desc_name.compare ("vfh") == 0)
+  if (desc_name == "vfh")
   {
     boost::shared_ptr<pcl::rec_3d_framework::VFHEstimation<pcl::PointXYZ, pcl::VFHSignature308> > vfh_estimator;
     vfh_estimator.reset (new pcl::rec_3d_framework::VFHEstimation<pcl::PointXYZ, pcl::VFHSignature308>);
@@ -188,7 +188,7 @@ main (int argc, char ** argv)
     segmentAndClassify<flann::L1, pcl::PointXYZ, pcl::VFHSignature308> (global);
   }
 
-  if (desc_name.compare ("cvfh") == 0)
+  if (desc_name == "cvfh")
   {
     boost::shared_ptr<pcl::rec_3d_framework::CVFHEstimation<pcl::PointXYZ, pcl::VFHSignature308> > vfh_estimator;
     vfh_estimator.reset (new pcl::rec_3d_framework::CVFHEstimation<pcl::PointXYZ, pcl::VFHSignature308>);
@@ -208,7 +208,7 @@ main (int argc, char ** argv)
     segmentAndClassify<Metrics::HistIntersectionUnionDistance, pcl::PointXYZ, pcl::VFHSignature308> (global);
   }
 
-  if (desc_name.compare ("esf") == 0)
+  if (desc_name == "esf")
   {
     boost::shared_ptr<pcl::rec_3d_framework::ESFEstimation<pcl::PointXYZ, pcl::ESFSignature640> > estimator;
     estimator.reset (new pcl::rec_3d_framework::ESFEstimation<pcl::PointXYZ, pcl::ESFSignature640>);

--- a/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
+++ b/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
@@ -318,13 +318,13 @@ main (int argc, char ** argv)
   pcl::console::parse_argument (argc, argv, "-use_hv", use_hv);
   pcl::console::parse_argument (argc, argv, "-thres_hyp", thres_hyp_);
 
-  if (mians_scenes == "")
+  if (mians_scenes.empty())
   {
     PCL_ERROR("Set the directory containing mians scenes using the -mians_scenes_dir [dir] option\n");
     return -1;
   }
 
-  if (path == "")
+  if (path.empty())
   {
     PCL_ERROR("Set the directory containing the models of mian dataset using the -models_dir [dir] option\n");
     return -1;

--- a/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
+++ b/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
@@ -142,19 +142,19 @@ template<template<class > class DistT, typename PointT, typename FeatureT>
           g = 0.0f;
           b = 0.0f;
 
-          if (models->at (j).id_.compare ("cheff") == 0)
+          if (models->at (j).id_ == "cheff")
           {
             r = 0.0f;
             g = 255.0f;
             b = 0.0f;
           }
-          else if (models->at (j).id_.compare ("chicken_high") == 0)
+          else if (models->at (j).id_ == "chicken_high")
           {
             r = 0.0f;
             g = 255.0f;
             b = 255.0f;
           }
-          else if (models->at (j).id_.compare ("parasaurolophus_high") == 0)
+          else if (models->at (j).id_ == "parasaurolophus_high")
           {
             r = 255.0f;
             g = 255.0f;
@@ -260,7 +260,7 @@ getModelsInDirectory (bf::path & dir, std::string & rel_path_so_far, std::vector
       boost::split (strs, file, boost::is_any_of ("."));
       std::string extension = strs[strs.size () - 1];
 
-      if (extension.compare (ext) == 0)
+      if (extension == ext)
       {
         std::string path = rel_path_so_far + (itr->path ().filename ()).string();
 
@@ -318,13 +318,13 @@ main (int argc, char ** argv)
   pcl::console::parse_argument (argc, argv, "-use_hv", use_hv);
   pcl::console::parse_argument (argc, argv, "-thres_hyp", thres_hyp_);
 
-  if (mians_scenes.compare ("") == 0)
+  if (mians_scenes == "")
   {
     PCL_ERROR("Set the directory containing mians scenes using the -mians_scenes_dir [dir] option\n");
     return -1;
   }
 
-  if (path.compare ("") == 0)
+  if (path == "")
   {
     PCL_ERROR("Set the directory containing the models of mian dataset using the -models_dir [dir] option\n");
     return -1;
@@ -428,7 +428,7 @@ main (int argc, char ** argv)
       cast_hv_alg = boost::static_pointer_cast<pcl::HypothesisVerification<pcl::PointXYZ, pcl::PointXYZ> > (go);
   }
 
-  if (desc_name.compare ("shot") == 0)
+  if (desc_name == "shot")
   {
     boost::shared_ptr<pcl::rec_3d_framework::SHOTLocalEstimation<pcl::PointXYZ, pcl::Histogram<352> > > estimator;
     estimator.reset (new pcl::rec_3d_framework::SHOTLocalEstimation<pcl::PointXYZ, pcl::Histogram<352> >);
@@ -458,7 +458,7 @@ main (int argc, char ** argv)
 
   }
 
-  if (desc_name.compare ("shot_omp") == 0)
+  if (desc_name == "shot_omp")
   {
     desc_name = std::string ("shot");
     boost::shared_ptr<pcl::rec_3d_framework::SHOTLocalEstimationOMP<pcl::PointXYZ, pcl::Histogram<352> > > estimator;
@@ -492,7 +492,7 @@ main (int argc, char ** argv)
 
   }
 
-  if (desc_name.compare ("fpfh") == 0)
+  if (desc_name == "fpfh")
   {
     boost::shared_ptr<pcl::rec_3d_framework::FPFHLocalEstimation<pcl::PointXYZ, pcl::FPFHSignature33> > estimator;
     estimator.reset (new pcl::rec_3d_framework::FPFHLocalEstimation<pcl::PointXYZ, pcl::FPFHSignature33>);

--- a/apps/in_hand_scanner/src/offline_integration.cpp
+++ b/apps/in_hand_scanner/src/offline_integration.cpp
@@ -190,7 +190,7 @@ pcl::ihs::OfflineIntegration::getFilesFromDirectory (const std::string          
                                                      const std::string          extension,
                                                      std::vector <std::string>& files) const
 {
-  if (path_dir == "" || !boost::filesystem::exists (path_dir))
+  if (path_dir.empty() || !boost::filesystem::exists (path_dir))
   {
     std::cerr << "ERROR in offline_integration.cpp: Invalid path\n  '" << path_dir << "'\n";
     return (false);

--- a/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
+++ b/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
@@ -89,7 +89,7 @@ namespace face_detection_apps_utils
         boost::split (strs, file, boost::is_any_of ("."));
         std::string extension = strs[strs.size () - 1];
 
-        if (extension.compare (ext) == 0)
+        if (extension == ext)
         {
           std::string path = rel_path_so_far + (itr->path().filename()).string();
           relative_paths.push_back (path);

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -577,7 +577,7 @@ CloudEditorWidget::isColored (const std::string &fileName) const
   {
     std::string name(field.name);
     stringToLower(name);
-    if ((name.compare("rgb") == 0) || (name.compare("rgba") == 0))
+    if ((name == "rgb") || (name == "rgba"))
       return true;
   }
   return false;

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -132,7 +132,7 @@ CloudEditorWidget::save ()
   QString file_path = QFileDialog::getSaveFileName(this,tr("Save point cloud"));
   
   std::string file_path_std = file_path.toStdString();
-  if ( (file_path_std == "") || (!cloud_ptr_) )
+  if ( (file_path_std.empty()) || (!cloud_ptr_) )
     return;
 
   if (is_colored_)

--- a/apps/point_cloud_editor/src/statistics.cpp
+++ b/apps/point_cloud_editor/src/statistics.cpp
@@ -48,13 +48,13 @@ Statistics::getStats()
   for(const auto &stat_vec : stat_vec_)
   {
     std::string stat_string = stat_vec -> getStat();
-    if (stat_string != "")
+    if (!stat_string.empty())
     {
       result += (stat_string + '\n');
     }
   }
     
-  if (result == "")
+  if (result.empty())
     return ("Please load your cloud.");
   return (result);
 }

--- a/apps/src/face_detection/filesystem_face_detection.cpp
+++ b/apps/src/face_detection/filesystem_face_detection.cpp
@@ -214,7 +214,7 @@ int main(int argc, char ** argv)
 
   pcl::visualization::PCLVisualizer vis ("PCL Face detection");
 
-  if (test_directory.compare ("") != 0)
+  if (test_directory != "")
   {
     //recognize all files in directory...
     std::string start;

--- a/apps/src/face_detection/filesystem_face_detection.cpp
+++ b/apps/src/face_detection/filesystem_face_detection.cpp
@@ -214,7 +214,7 @@ int main(int argc, char ** argv)
 
   pcl::visualization::PCLVisualizer vis ("PCL Face detection");
 
-  if (test_directory != "")
+  if (!test_directory.empty())
   {
     //recognize all files in directory...
     std::string start;

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -160,7 +160,7 @@ PCDVideoPlayer::selectFolderButtonPressed ()
     for (boost::filesystem::directory_iterator itr (dir_.toStdString ()); itr != end_itr; ++itr)
     {
       std::string ext = itr->path ().extension ().string ();
-      if (ext.compare (".pcd") == 0)
+      if (ext == ".pcd")
       {
         pcd_files_.push_back (itr->path ().string ());
         pcd_paths_.push_back (itr->path ());

--- a/cuda/apps/src/kinect_planes_cuda.cpp
+++ b/cuda/apps/src/kinect_planes_cuda.cpp
@@ -275,7 +275,7 @@ class MultiRansac
       //bool repeat = false;
 
       //std::string path = "./pcl_logo.pcd";
-      //if (path != "" && boost::filesystem::exists (path))
+      //if (!path.empty() && boost::filesystem::exists (path))
       //{
       //  filegrabber = new pcl::PCDGrabber<pcl::PointXYZRGB > (path, frames_per_second, repeat);
       //}

--- a/geometry/include/pcl/geometry/mesh_io.h
+++ b/geometry/include/pcl/geometry/mesh_io.h
@@ -103,7 +103,7 @@ namespace pcl
           unsigned int line_number = 1;
           int n_v = -1, n_he = -1, n_f = -1;
 
-          if (!std::getline (file, line) || line.compare ("PCL half-edge mesh") != 0)
+          if (!std::getline (file, line) || line != "PCL half-edge mesh")
           {
             std::cerr << "Error loading '" << filename << "' (line " << line_number << "): Wrong file format.\n";
             return (false);

--- a/io/src/depth_sense/depth_sense_grabber_impl.cpp
+++ b/io/src/depth_sense/depth_sense_grabber_impl.cpp
@@ -48,7 +48,7 @@ pcl::io::depth_sense::DepthSenseGrabberImpl::DepthSenseGrabberImpl (DepthSenseGr
 , color_data_ (COLOR_SIZE * 3)
 , depth_buffer_ (new pcl::io::SingleBuffer<float> (SIZE))
 {
-  if (device_id == "")
+  if (device_id.empty())
     device_id_ = DepthSenseDeviceManager::getInstance ()->captureDevice (this);
   else if (device_id[0] == '#')
     device_id_ = DepthSenseDeviceManager::getInstance ()->captureDevice (this, boost::lexical_cast<int> (device_id.substr (1)) - 1);

--- a/io/src/ifs_io.cpp
+++ b/io/src/ifs_io.cpp
@@ -62,7 +62,7 @@ pcl::IFSReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
   std::ifstream fs;
   std::string line;
 
-  if (file_name == "" || !boost::filesystem::exists (file_name))
+  if (file_name.empty() || !boost::filesystem::exists (file_name))
   {
     PCL_ERROR ("[pcl::IFSReader::readHeader] Could not find file '%s'.\n", file_name.c_str ());
     return (-1);

--- a/io/src/lzf_image_io.cpp
+++ b/io/src/lzf_image_io.cpp
@@ -360,7 +360,7 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
                                         std::vector<char> &data,
                                         uint32_t &uncompressed_size)
 {
-  if (filename == "" || !boost::filesystem::exists (filename))
+  if (filename.empty() || !boost::filesystem::exists (filename))
   {
     PCL_ERROR ("[pcl::io::LZFImageReader::loadImage] Could not find file '%s'.\n", filename.c_str ());
     return (false);

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -143,14 +143,14 @@ int
 pcl::MTLReader::read (const std::string& obj_file_name,
                       const std::string& mtl_file_name)
 {
-  if (obj_file_name == "" || !boost::filesystem::exists (obj_file_name))
+  if (obj_file_name.empty() || !boost::filesystem::exists (obj_file_name))
   {
     PCL_ERROR ("[pcl::MTLReader::read] Could not find file '%s'!\n",
                obj_file_name.c_str ());
     return (-1);
   }
 
-  if (mtl_file_name == "")
+  if (mtl_file_name.empty())
   {
     PCL_ERROR ("[pcl::MTLReader::read] MTL file name is empty!\n");
     return (-1);
@@ -165,7 +165,7 @@ pcl::MTLReader::read (const std::string& obj_file_name,
 int
 pcl::MTLReader::read (const std::string& mtl_file_path)
 {
-  if (mtl_file_path == "" || !boost::filesystem::exists (mtl_file_path))
+  if (mtl_file_path.empty() || !boost::filesystem::exists (mtl_file_path))
   {
     PCL_ERROR ("[pcl::MTLReader::read] Could not find file '%s'.\n", mtl_file_path.c_str ());
     return (-1);
@@ -192,7 +192,7 @@ pcl::MTLReader::read (const std::string& mtl_file_path)
     {
       getline (mtl_file, line);
       // Ignore empty lines
-      if (line == "")
+      if (line.empty())
         continue;
 
       // Tokenize the line
@@ -347,7 +347,7 @@ pcl::OBJReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
   std::ifstream fs;
   std::string line;
 
-  if (file_name == "" || !boost::filesystem::exists (file_name))
+  if (file_name.empty() || !boost::filesystem::exists (file_name))
   {
     PCL_ERROR ("[pcl::OBJReader::readHeader] Could not find file '%s'.\n", file_name.c_str ());
     return (-1);
@@ -380,7 +380,7 @@ pcl::OBJReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
     {
       getline (fs, line);
       // Ignore empty lines
-      if (line == "")
+      if (line.empty())
         continue;
 
       // Trim the line
@@ -548,7 +548,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
       std::string line;
       getline (fs, line);
       // Ignore empty lines
-      if (line == "")
+      if (line.empty())
         continue;
 
       // Tokenize the line
@@ -691,7 +691,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
     {
       getline (fs, line);
       // Ignore empty lines
-      if (line == "")
+      if (line.empty())
         continue;
 
       // Tokenize the line
@@ -782,7 +782,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
           }
         }
         // We didn't find the appropriate material so we create it here with name only.
-        if (mesh.tex_materials.back ().tex_name == "")
+        if (mesh.tex_materials.back ().tex_name.empty())
           mesh.tex_materials.back ().tex_name = st[1];
         mesh.tex_coordinates.push_back (coordinates);
         coordinates.clear ();
@@ -880,7 +880,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
       std::string line;
       getline (fs, line);
       // Ignore empty lines
-      if (line == "")
+      if (line.empty())
         continue;
 
       // Tokenize the line

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -142,7 +142,7 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
     {
       getline (fs, line);
       // Ignore empty lines
-      if (line == "")
+      if (line.empty())
         continue;
 
       // Tokenize the line
@@ -380,7 +380,7 @@ pcl::PCDReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
                             Eigen::Vector4f &origin, Eigen::Quaternionf &orientation, 
                             int &pcd_version, int &data_type, unsigned int &data_idx, const int offset)
 {
-  if (file_name == "" || !boost::filesystem::exists (file_name))
+  if (file_name.empty() || !boost::filesystem::exists (file_name))
   {
     PCL_ERROR ("[pcl::PCDReader::readHeader] Could not find file '%s'.\n", file_name.c_str ());
     return (-1);
@@ -442,7 +442,7 @@ pcl::PCDReader::readBodyASCII (std::istream &fs, pcl::PCLPointCloud2 &cloud, int
     {
       getline (fs, line);
       // Ignore empty lines
-      if (line == "")
+      if (line.empty())
         continue;
 
       // Tokenize the line
@@ -692,7 +692,7 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
   pcl::console::TicToc tt;
   tt.tic ();
 
-  if (file_name == "" || !boost::filesystem::exists (file_name))
+  if (file_name.empty() || !boost::filesystem::exists (file_name))
   {
     PCL_ERROR ("[pcl::PCDReader::read] Could not find file '%s'.\n", file_name.c_str ());
     return (-1);

--- a/io/src/real_sense_grabber.cpp
+++ b/io/src/real_sense_grabber.cpp
@@ -119,7 +119,7 @@ pcl::RealSenseGrabber::RealSenseGrabber (const std::string& device_id, const Mod
 , mode_requested_ (mode)
 , strict_ (strict)
 {
-  if (device_id == "")
+  if (device_id.empty())
     device_ = RealSenseDeviceManager::getInstance ()->captureDevice ();
   else if (device_id[0] == '#')
     device_ = RealSenseDeviceManager::getInstance ()->captureDevice (boost::lexical_cast<int> (device_id.substr (1)) - 1);

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -55,7 +55,7 @@ namespace pcl
               boost::split (strs, file, boost::is_any_of ("."));
               std::string extension = strs[strs.size () - 1];
 
-              if (extension.compare (ext) == 0)
+              if (extension == ext)
               {
                 std::string path = rel_path_so_far + (itr->path ().filename ()).string ();
                 relative_paths.push_back (path);

--- a/tools/fast_bilateral_filter.cpp
+++ b/tools/fast_bilateral_filter.cpp
@@ -205,7 +205,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/grid_min.cpp
+++ b/tools/grid_min.cpp
@@ -198,7 +198,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/image_grabber_saver.cpp
+++ b/tools/image_grabber_saver.cpp
@@ -112,7 +112,7 @@ main (int argc, char** argv)
 
   pcl::console::parse_argument (argc, argv, "-out_dir", out_folder);
 
-  if (out_folder == "" || !boost::filesystem::exists (out_folder))
+  if (out_folder.empty() || !boost::filesystem::exists (out_folder))
   {
     PCL_INFO("No correct directory was given with the -out_dir flag. Setting to current dir\n");
     out_folder = "./";
@@ -120,7 +120,7 @@ main (int argc, char** argv)
   else
     PCL_INFO("Using %s as output dir", out_folder.c_str());
 
-  if (rgb_path != "" && depth_path != "" && boost::filesystem::exists (rgb_path) && boost::filesystem::exists (depth_path))
+  if (!rgb_path.empty() && !depth_path.empty() && boost::filesystem::exists (rgb_path) && boost::filesystem::exists (depth_path))
   {
     grabber.reset (new pcl::ImageGrabber<pcl::PointXYZRGBA> (depth_path, rgb_path, frames_per_second, false));
   }

--- a/tools/image_grabber_viewer.cpp
+++ b/tools/image_grabber_viewer.cpp
@@ -197,7 +197,7 @@ main (int argc, char** argv)
   std::string path;
   pcl::console::parse_argument (argc, argv, "-dir", path);
   std::cout << "path: " << path << std::endl;
-  if (path != "" && boost::filesystem::exists (path))
+  if (!path.empty() && boost::filesystem::exists (path))
   {
     grabber.reset (new pcl::ImageGrabber<pcl::PointXYZRGBA> (path, frames_per_second, repeat, use_pclzf));
   }

--- a/tools/local_max.cpp
+++ b/tools/local_max.cpp
@@ -199,7 +199,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/morph.cpp
+++ b/tools/morph.cpp
@@ -222,7 +222,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/normal_estimation.cpp
+++ b/tools/normal_estimation.cpp
@@ -224,7 +224,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/passthrough_filter.cpp
+++ b/tools/passthrough_filter.cpp
@@ -216,7 +216,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/pcd_grabber_viewer.cpp
+++ b/tools/pcd_grabber_viewer.cpp
@@ -179,7 +179,7 @@ main (int argc, char** argv)
   std::string path;
   pcl::console::parse_argument (argc, argv, "-file", path);
   std::cout << "path: " << path << std::endl;
-  if (path != "" && boost::filesystem::exists (path))
+  if (!path.empty() && boost::filesystem::exists (path))
   {
     grabber.reset (new pcl::PCDGrabber<pcl::PointXYZRGBA> (path, frames_per_second, repeat));
   }
@@ -188,7 +188,7 @@ main (int argc, char** argv)
     std::vector<std::string> pcd_files;
     pcl::console::parse_argument (argc, argv, "-dir", path);
     std::cout << "path: " << path << std::endl;
-    if (path != "" && boost::filesystem::exists (path))
+    if (!path.empty() && boost::filesystem::exists (path))
     {
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (path); itr != end_itr; ++itr)

--- a/tools/png2pcd.cpp
+++ b/tools/png2pcd.cpp
@@ -150,7 +150,7 @@ main (int argc, char** argv)
   std::string mode = "DEFAULT";
   if (parse_argument (argc, argv, "-mode", mode) != -1)
   {
-    if (! (mode.compare ("DEFAULT") == 0 || mode.compare ("FORCE_COLOR") == 0 || mode.compare ("FORCE_GRAYSCALE") == 0) )
+    if (! (mode == "DEFAULT" || mode == "FORCE_COLOR" || mode == "FORCE_GRAYSCALE") )
     {
       std::cout << "Wrong mode name.\n";
       printHelp (argc, argv);
@@ -230,7 +230,7 @@ main (int argc, char** argv)
 
   std::string intensity_type;
 
-  if (mode.compare ("DEFAULT") == 0)
+  if (mode == "DEFAULT")
   {
     //
     // If the input image is a monochrome image the output cloud will be:
@@ -241,7 +241,7 @@ main (int argc, char** argv)
 
     if (pcl::console::parse_argument (argc, argv, "--intensity_type", intensity_type) != -1)
     {
-      if (intensity_type.compare ("FLOAT") != 0 && intensity_type.compare ("UINT_8") != 0)
+      if (intensity_type != "FLOAT" && intensity_type != "UINT_8")
       {
         print_error ("Wrong intensity option.\n");
         printHelp (argc, argv);
@@ -263,7 +263,7 @@ main (int argc, char** argv)
 
     switch (components)
     {
-      case 1: if (intensity_type.compare ("FLOAT") == 0)
+      case 1: if (intensity_type == "FLOAT")
       {
         if (enable_depth)
         {
@@ -485,7 +485,7 @@ main (int argc, char** argv)
       break;
     }
   }
-  else if (mode.compare ("FORCE_COLOR") == 0)
+  else if (mode == "FORCE_COLOR")
   {
     //
     // Force the output cloud to be colored even if the input image is a
@@ -625,7 +625,7 @@ main (int argc, char** argv)
       saveCloud<RGB> (argv[pcd_file_indices[0]], cloud, format);
     }
   }
-  else if (mode.compare ("FORCE_GRAYSCALE") == 0)
+  else if (mode == "FORCE_GRAYSCALE")
   {
     if (enable_depth)
     {
@@ -686,7 +686,7 @@ main (int argc, char** argv)
 
       if (pcl::console::parse_argument (argc, argv, "--intensity_type", intensity_type) != -1)
       {
-        if (intensity_type.compare ("FLOAT") == 0)
+        if (intensity_type == "FLOAT")
         {
           cloud.width = dimensions[0];
           cloud.height = dimensions[1]; // This indicates that the point cloud is organized
@@ -725,7 +725,7 @@ main (int argc, char** argv)
           // Save the point cloud into a PCD file
           saveCloud<Intensity> (argv[pcd_file_indices[0]], cloud, format);
         }
-        else if (intensity_type.compare ("UINT_8") != 0)
+        else if (intensity_type != "UINT_8")
         {
           cloud8u.width = dimensions[0];
           cloud8u.height = dimensions[1]; // This indicates that the point cloud is organized

--- a/tools/progressive_morphological_filter.cpp
+++ b/tools/progressive_morphological_filter.cpp
@@ -300,7 +300,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/radius_filter.cpp
+++ b/tools/radius_filter.cpp
@@ -203,7 +203,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       std::vector<std::string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -279,7 +279,7 @@ main (int argc, char** argv)
   }
   else
   {
-    if (input_dir != "" && boost::filesystem::exists (input_dir))
+    if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
       vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;

--- a/tools/tiff2pcd.cpp
+++ b/tools/tiff2pcd.cpp
@@ -256,7 +256,7 @@ int main(int argc, char ** argv)
     for (boost::filesystem::directory_iterator itr(rgb_path_); itr != end_itr; ++itr)
     {
       std::string ext = itr->path().extension().string();
-      if(ext.compare(".tiff") == 0)
+      if(ext == ".tiff")
       {
         tiff_rgb_files.push_back (itr->path ().string ());
         tiff_rgb_paths.push_back (itr->path ());
@@ -298,7 +298,7 @@ int main(int argc, char ** argv)
     for (boost::filesystem::directory_iterator itr(depth_path_); itr != end_itr; ++itr)
     {
       std::string ext = itr->path().extension().string();
-      if(ext.compare(".tiff") == 0)
+      if(ext == ".tiff")
       {
         tiff_depth_files.push_back (itr->path ().string ());
         tiff_depth_paths.push_back (itr->path ());
@@ -358,7 +358,7 @@ int main(int argc, char ** argv)
         std::string depth_filename = tiff_depth_paths[i].filename().string();
         std::string depth_time = depth_filename.substr(6,22);
 
-        if(depth_time.compare(rgb_time) == 0) // found the correct depth
+        if(depth_time == rgb_time) // found the correct depth
         {
           //std::cout << "Depth Time: " << depth_time << std::endl;
           found = 1;

--- a/tools/uniform_sampling.cpp
+++ b/tools/uniform_sampling.cpp
@@ -122,15 +122,15 @@ saveCloud (const string &filename, const pcl::PCLPointCloud2 &output)
   std::string output_ext = boost::filesystem::extension (filename);
   std::transform (output_ext.begin (), output_ext.end (), output_ext.begin (), ::tolower);
 
-  if (output_ext.compare (".pcd") == 0)
+  if (output_ext == ".pcd")
   {
     w_pcd.writeBinaryCompressed (filename, output);
   }
-  else if (output_ext.compare (".ply") == 0)
+  else if (output_ext == ".ply")
   {
     w_ply.writeBinary (filename, output);
   }
-  else if (output_ext.compare (".vtk") == 0)
+  else if (output_ext == ".vtk")
   {
     w_ply.writeBinary (filename, output);
   }

--- a/tools/xyz2pcd.cpp
+++ b/tools/xyz2pcd.cpp
@@ -69,7 +69,7 @@ loadCloud (const string &filename, PointCloud<PointXYZ> &cloud)
   {
     getline (fs, line);
     // Ignore empty lines
-    if (line == "")
+    if (line.empty())
       continue;
 
     // Tokenize the line

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -196,7 +196,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::loadCameraParameters (const st
   while (!fs.eof ())
   {
     getline (fs, line);
-    if (line == "")
+    if (line.empty())
       continue;
 
     boost::split (camera, line, boost::is_any_of ("/"), boost::token_compress_on);
@@ -1171,7 +1171,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::updateLookUpTableDisplay (bool
   if (!lut_enabled_ && !add_lut)
     return;
 
-  if (lut_actor_id_ != "")  // Search if provided actor id is in CloudActorMap or ShapeActorMap
+  if (!lut_actor_id_.empty())  // Search if provided actor id is in CloudActorMap or ShapeActorMap
   {
     auto am_it = cloud_actors_->find (lut_actor_id_);
     if (am_it == cloud_actors_->end ())
@@ -1227,7 +1227,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::updateLookUpTableDisplay (bool
       actor_found = true;
     }
   }
-  else  // lut_actor_id_ == "", the user did not specify which cloud/shape LUT should be displayed
+  else  // lut_actor_id_.empty(), the user did not specify which cloud/shape LUT should be displayed
   // Circling through all clouds/shapes and displaying first LUT found
   {
     for (const auto &actor : *cloud_actors_)

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -4459,7 +4459,7 @@ int
 pcl::visualization::PCLVisualizer::textureFromTexMaterial (const pcl::TexMaterial& tex_mat,
                                                            vtkTexture* vtk_tex) const
 {
-  if (tex_mat.tex_file == "")
+  if (tex_mat.tex_file.empty())
   {
     PCL_WARN ("[PCLVisualizer::textureFromTexMaterial] No texture file given for material %s!\n",
                tex_mat.tex_name.c_str ());
@@ -4510,7 +4510,7 @@ pcl::visualization::PCLVisualizer::textureFromTexMaterial (const pcl::TexMateria
         }
       }
       // Check texture file existence
-      if (real_name == "")
+      if (real_name.empty())
       {
         PCL_WARN ("[PCLVisualizer::textureFromTexMaterial] Can not find texture file %s!\n",
                    tex_mat.tex_file.c_str ());


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,readability-string-compare' -fix`