### PR TITLE
Remove unnecessary nullptr check before delete

### DIFF
--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -45,10 +45,10 @@
 template <typename PointInT, typename PointOutT>
 pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::~IntegralImageNormalEstimation ()
 {
-  if (diff_x_ != NULL) delete[] diff_x_;
-  if (diff_y_ != NULL) delete[] diff_y_;
-  if (depth_data_ != NULL) delete[] depth_data_;
-  if (distance_map_ != NULL) delete[] distance_map_;
+  delete[] diff_x_;
+  delete[] diff_y_;
+  delete[] depth_data_;
+  delete[] distance_map_;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -68,10 +68,10 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::initData ()
                          "[pcl::IntegralImageNormalEstimation::initData] unknown normal estimation method.");
 
   // compute derivatives
-  if (diff_x_ != NULL) delete[] diff_x_;
-  if (diff_y_ != NULL) delete[] diff_y_;
-  if (depth_data_ != NULL) delete[] depth_data_;
-  if (distance_map_ != NULL) delete[] distance_map_;
+  delete[] diff_x_;
+  delete[] diff_y_;
+  delete[] depth_data_;
+  delete[] distance_map_;
   diff_x_ = NULL;
   diff_y_ = NULL;
   depth_data_ = NULL;
@@ -761,7 +761,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
 
   // compute distance map
   //float *distanceMap = new float[input_->points.size ()];
-  if (distance_map_ != NULL) delete[] distance_map_;
+  delete[] distance_map_;
   distance_map_ = new float[input_->points.size ()];
   float *distanceMap = distance_map_;
   for (size_t index = 0; index < input_->points.size (); ++index)

--- a/filters/include/pcl/filters/impl/normal_space.hpp
+++ b/filters/include/pcl/filters/impl/normal_space.hpp
@@ -61,8 +61,7 @@ pcl::NormalSpaceSampling<PointT, NormalT>::initCompute ()
 
   boost::mt19937 rng (static_cast<unsigned int> (seed_));
   boost::uniform_int<unsigned int> uniform_distrib (0, unsigned (input_->size ()));
-  if (rng_uniform_distribution_ != NULL)
-    delete rng_uniform_distribution_;
+  delete rng_uniform_distribution_;
   rng_uniform_distribution_ = new boost::variate_generator<boost::mt19937, boost::uniform_int<unsigned int> > (rng, uniform_distrib);
 
   return (true);

--- a/filters/include/pcl/filters/normal_space.h
+++ b/filters/include/pcl/filters/normal_space.h
@@ -85,8 +85,7 @@ namespace pcl
       /** \brief Destructor. */
       ~NormalSpaceSampling ()
       {
-        if (rng_uniform_distribution_ != NULL)
-          delete rng_uniform_distribution_;
+        delete rng_uniform_distribution_;
       }
 
       /** \brief Set number of indices to be sampled.

--- a/ml/src/permutohedral.cpp
+++ b/ml/src/permutohedral.cpp
@@ -330,9 +330,9 @@ pcl::Permutohedral::initOLD (const std::vector<float> &feature, const int featur
   HashTableOLD hash_table(d_, N_*(d_+1));
 
   // Allocate the class memory
-  if (offsetOLD_) delete [] offsetOLD_;
+  delete [] offsetOLD_;
   offsetOLD_ = new int[ (d_+1)*N_ ];
-  if (barycentricOLD_) delete [] barycentricOLD_;
+  delete [] barycentricOLD_;
   barycentricOLD_ = new float[ (d_+1)*N_ ];
 		
   // Allocate the local memory
@@ -453,7 +453,7 @@ pcl::Permutohedral::initOLD (const std::vector<float> &feature, const int featur
   M_ = hash_table.size();
 		
   // Create the neighborhood structure
-  if(blur_neighborsOLD_) delete[] blur_neighborsOLD_;
+  delete[] blur_neighborsOLD_;
   blur_neighborsOLD_ = new Neighbors[ (d_+1)*M_ ];
 		
   short * n1 = new short[d_+1];

--- a/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
@@ -57,8 +57,7 @@ pcl::occlusion_reasoning::ZBuffering<ModelT, SceneT>::ZBuffering () :
 template<typename ModelT, typename SceneT>
 pcl::occlusion_reasoning::ZBuffering<ModelT, SceneT>::~ZBuffering ()
 {
-  if (depth_ != NULL)
-    delete[] depth_;
+  delete[] depth_;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/recognition/include/pcl/recognition/ransac_based/simple_octree.h
+++ b/recognition/include/pcl/recognition/ransac_based/simple_octree.h
@@ -118,7 +118,7 @@ namespace pcl
 
           protected:
             void
-            setData (NodeData* data){ if ( data_ ) delete data_; data_ = data;}
+            setData (NodeData* data){ delete data_; data_ = data;}
 
             inline bool
             createChildren ();

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -157,8 +157,7 @@ namespace pcl
     /** \brief Destructor. */
     ~QuantizedNormalLookUpTable () 
     { 
-      if (lut != NULL) 
-        delete[] lut; 
+      delete[] lut; 
     }
 
     /** \brief Initializes the LUT.
@@ -182,8 +181,7 @@ namespace pcl
       //if (lut != NULL) free16(lut);
       //lut = malloc16(size_x*size_y*size_z);
 
-      if (lut != NULL) 
-        delete[] lut;
+      delete[] lut;
       lut = new unsigned char[size_x*size_y*size_z];
 
       const int nr_normals = 8;

--- a/stereo/src/stereo_matching.cpp
+++ b/stereo/src/stereo_matching.cpp
@@ -75,29 +75,13 @@ pcl::StereoMatching::StereoMatching ()
 //////////////////////////////////////////////////////////////////////////////
 pcl::StereoMatching::~StereoMatching ()
 {
-  if ( disp_map_ != NULL)
-  {
-    delete [] disp_map_;
-    //disp_map_ = NULL;
-  }
+  delete [] disp_map_;
+  delete [] disp_map_trg_;
 
-  if ( disp_map_trg_ != NULL)
-  {
-    delete [] disp_map_trg_;
-    //disp_map_trg_ = NULL;
-  }
-
-  if ( ref_img_ != NULL)
-  {
-    delete [] ref_img_;
-    delete [] trg_img_;
-  }
-
-  if ( pp_ref_img_ != NULL)
-  {
-    delete [] pp_ref_img_;
-    delete [] pp_trg_img_;
-  }
+  delete [] ref_img_;
+  delete [] trg_img_;
+  delete [] pp_ref_img_;
+  delete [] pp_trg_img_;
 
 }
 
@@ -528,19 +512,13 @@ pcl::GrayStereoMatching::compute (unsigned char* ref_img, unsigned char* trg_img
     delete [] disp_map_;
     disp_map_ = NULL;
 
-    if ( disp_map_trg_ != NULL)
-    {
-      delete [] disp_map_trg_;
-      disp_map_trg_ = NULL;
-    }
+    delete [] disp_map_trg_;
+    disp_map_trg_ = NULL;
 
-    if ( pp_ref_img_ != NULL)
-    {
-      delete [] pp_ref_img_;
-      delete [] pp_trg_img_;
-      pp_ref_img_ = NULL;
-      pp_trg_img_ = NULL;
-    }
+    delete [] pp_ref_img_;
+    delete [] pp_trg_img_;
+    pp_ref_img_ = NULL;
+    pp_trg_img_ = NULL;
   }
 
   if ( disp_map_ == NULL)
@@ -630,7 +608,7 @@ pcl::GrayStereoMatching::compute (unsigned char* ref_img, unsigned char* trg_img
   for (int j = 0; j < height_; j++)
     for (int i = 0; i < width_; i++)
       if ( disp_map_[j * width_ + i] > 0)
-	    disp_map_[j * width_ + i] += static_cast<short int> (x_off_ * 16);
+        disp_map_[j * width_ + i] += static_cast<short int> (x_off_ * 16);
 
 }
 

--- a/tools/openni2_viewer.cpp
+++ b/tools/openni2_viewer.cpp
@@ -142,8 +142,7 @@ public:
     {
       if (rgb_data_size_ < image->getWidth () * image->getHeight ())
       {
-        if (rgb_data_)
-          delete [] rgb_data_;
+        delete [] rgb_data_;
         rgb_data_size_ = image->getWidth () * image->getHeight ();
         rgb_data_ = new unsigned char [rgb_data_size_ * 3];
       }
@@ -265,8 +264,7 @@ public:
 
     cloud_connection.disconnect ();
     image_connection.disconnect ();
-    if (rgb_data_)
-      delete[] rgb_data_;
+    delete[] rgb_data_;
   }
 
   pcl::visualization::PCLVisualizer::Ptr cloud_viewer_;

--- a/tools/openni_save_image.cpp
+++ b/tools/openni_save_image.cpp
@@ -175,11 +175,8 @@ class SimpleOpenNIViewer
       }
 
       grabber_.stop ();
-      
       image_connection.disconnect ();
-      
-      if (rgb_data)
-        delete[] rgb_data;
+      delete[] rgb_data;
     }
 
     pcl::OpenNIGrabber& grabber_;

--- a/tools/openni_viewer.cpp
+++ b/tools/openni_viewer.cpp
@@ -135,8 +135,7 @@ class OpenNIViewer
       {
         if (rgb_data_size_ < image->getWidth () * image->getHeight ())
         {
-          if (rgb_data_)
-            delete [] rgb_data_;
+          delete [] rgb_data_;
           rgb_data_size_ = image->getWidth () * image->getHeight ();
           rgb_data_ = new unsigned char [rgb_data_size_ * 3];
         }
@@ -252,8 +251,7 @@ class OpenNIViewer
       
       cloud_connection.disconnect ();
       image_connection.disconnect ();
-      if (rgb_data_)
-        delete[] rgb_data_;
+      delete[] rgb_data_;
     }
     
     pcl::visualization::PCLVisualizer::Ptr cloud_viewer_;


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,readability-delete-null-pointer' -fix` (and additionally adjustments in `pcl::StereoMatching::~StereoMatching`)