### PR TITLE
Remove unnecessary flann includes

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_classifier.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_classifier.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <flann/flann.h>
+#include <flann/flann.hpp>
+
 #include <pcl/common/common.h>
 #include <pcl/apps/3d_rec_framework/pc_source/source.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h>

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <flann/flann.h>
+#include <flann/util/matrix.h>
+
 #include <pcl/common/common.h>
 #include <pcl/apps/3d_rec_framework/pc_source/source.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/global/global_estimator.h>

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
@@ -5,6 +5,7 @@
  *      Author: aitor
  */
 
+#include <flann/flann.hpp>
 #include <pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h>
 #include <pcl/registration/icp.h>
 #include <pcl/common/time.h>

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -1,3 +1,5 @@
+#include <flann/flann.hpp>
+
 #include <pcl/apps/3d_rec_framework/pipeline/local_recognizer.h>
 #include <pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h>
 #include <pcl/registration/correspondence_rejection_sample_consensus.h>

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/local_recognizer.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/local_recognizer.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-//#include <opencv2/opencv.hpp>
-#include <flann/flann.h>
+#include <flann/util/matrix.h>
 #include <pcl/common/common.h>
 #include <pcl/apps/3d_rec_framework/pc_source/source.h>
 #include <pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h>

--- a/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
+++ b/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
@@ -4,6 +4,9 @@
  *  Created on: Mar 24, 2012
  *      Author: aitor
  */
+
+#include <flann/algorithms/dist.h>
+
 #include <pcl/recognition/hv/hv_papazov.h>
 #include <pcl/console/parse.h>
 #include <pcl/apps/3d_rec_framework/pipeline/local_recognizer.h>

--- a/apps/include/pcl/apps/nn_classification.h
+++ b/apps/include/pcl/apps/nn_classification.h
@@ -44,7 +44,6 @@
 #include <algorithm>
 #include <boost/foreach.hpp>
 #include <boost/shared_ptr.hpp>
-#include <pcl/kdtree/kdtree_flann.h>
 
 namespace pcl
 {

--- a/apps/src/feature_matching.cpp
+++ b/apps/src/feature_matching.cpp
@@ -17,8 +17,6 @@
 #include <pcl/features/pfhrgb.h>
 #include <pcl/features/3dsc.h>
 #include <pcl/features/shot_omp.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/kdtree/impl/kdtree_flann.hpp>
 #include <pcl/registration/transformation_estimation_svd.h>
 #include <pcl/registration/icp.h>
 #include <pcl/registration/correspondence_rejection_sample_consensus.h>

--- a/apps/src/openni_mls_smoothing.cpp
+++ b/apps/src/openni_mls_smoothing.cpp
@@ -41,7 +41,6 @@
 #include <pcl/console/parse.h>
 #include <pcl/common/time.h>
 #include <pcl/surface/mls.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 #define FPS_CALC(_WHAT_) \
 do \

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -75,12 +75,13 @@ namespace pcl
 
 #if defined _WIN32 && defined _MSC_VER
 
-// If M_PI is not defined, then probably all of them are undefined
+// If M_PI & M_E is not defined, then probably all of them are undefined
 #ifndef M_PI
 // Copied from math.h
-# define M_PI   3.14159265358979323846     // pi
-# define M_PI_2    1.57079632679489661923  // pi/2
-# define M_PI_4    0.78539816339744830962  // pi/4
+# define M_E     2.7182818284590452353   // e
+# define M_PI    3.14159265358979323846  // pi
+# define M_PI_2  1.57079632679489661923  // pi/2
+# define M_PI_4  0.78539816339744830962  // pi/4
 # define M_PIl   3.1415926535897932384626433832795029L  // pi
 # define M_PI_2l 1.5707963267948966192313216916397514L  // pi/2
 # define M_PI_4l 0.7853981633974483096156608458198757L  // pi/4

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -9,7 +9,6 @@
 
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/common/point_operators.h>
 #include <pcl/common/io.h>
 #include <pcl/search/organized.h>

--- a/examples/features/example_normal_estimation.cpp
+++ b/examples/features/example_normal_estimation.cpp
@@ -42,7 +42,6 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl/features/normal_3d.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 int
 main (int, char** argv)

--- a/examples/features/example_rift_estimation.cpp
+++ b/examples/features/example_rift_estimation.cpp
@@ -45,7 +45,6 @@
 #include <pcl/point_types.h>
 #include <pcl/common/io.h>
 #include <pcl/features/normal_3d.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/features/rift.h>
 #include <pcl/features/intensity_gradient.h>
 

--- a/examples/segmentation/example_extract_clusters_normals.cpp
+++ b/examples/segmentation/example_extract_clusters_normals.cpp
@@ -47,7 +47,6 @@
 #include <pcl/filters/extract_indices.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/kdtree/kdtree.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/segmentation/extract_clusters.h>
 
 

--- a/features/include/pcl/features/grsd.h
+++ b/features/include/pcl/features/grsd.h
@@ -41,7 +41,6 @@
 #include <pcl/features/feature.h>
 #include <pcl/features/rsd.h>
 #include <pcl/filters/voxel_grid.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 namespace pcl
 {

--- a/features/include/pcl/features/impl/spin_image.hpp
+++ b/features/include/pcl/features/impl/spin_image.hpp
@@ -45,7 +45,6 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/exceptions.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/features/spin_image.h>
 #include <cmath>
 

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -44,15 +44,9 @@
 #include <sstream>
 
 #include <pcl/common/transforms.h>
-
-#include <pcl/kdtree/kdtree_flann.h>
-
 #include <pcl/features/normal_3d.h>
-
 #include <pcl/visualization/pcl_visualizer.h>
-
 #include <pcl/surface/texture_mapping.h>
-
 #include <pcl/io/vtk_lib_io.h>
 
 using namespace pcl;

--- a/kdtree/include/pcl/kdtree/flann.h
+++ b/kdtree/include/pcl/kdtree/flann.h
@@ -38,9 +38,9 @@
 
 #pragma once
 
-#if defined __GNUC__
-#  pragma GCC system_header 
-#endif
+#include <pcl/pcl_macros.h>
+
+PCL_PRAGMA_WARNING("This header is deprecated and will be removed in an upcoming release.")
 
 #if defined _MSC_VER
 #  pragma warning(disable: 4267 4244)

--- a/kdtree/include/pcl/kdtree/impl/io.hpp
+++ b/kdtree/include/pcl/kdtree/impl/io.hpp
@@ -41,7 +41,6 @@
 #define PCL_KDTREE_IO_IMPL_HPP_
 
 #include <pcl/kdtree/io.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename Point1T, typename Point2T> void

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -40,8 +40,10 @@
 #define PCL_KDTREE_KDTREE_IMPL_FLANN_H_
 
 #include <cstdio>
+
+#include <flann/flann.hpp>
+
 #include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/kdtree/flann.h>
 #include <pcl/console/print.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -41,14 +41,13 @@
 #pragma once
 
 #include <pcl/kdtree/kdtree.h>
-#include <pcl/kdtree/flann.h>
+#include <flann/util/params.h>
 
 #include <boost/shared_array.hpp>
 
 // Forward declarations
 namespace flann
 {
-  struct SearchParams;
   template <typename T> struct L2_Simple;
   template <typename T> class Index;
 }

--- a/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
@@ -39,7 +39,6 @@
 #define PCL_KEYPOINTS_IMPL_SMOOTHEDSURFACESKEYPOINT_H_
 
 #include <pcl/keypoints/smoothed_surfaces_keypoint.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 //#include <pcl/io/pcd_io.h>
 

--- a/recognition/include/pcl/recognition/implicit_shape_model.h
+++ b/recognition/include/pcl/recognition/implicit_shape_model.h
@@ -48,8 +48,6 @@
 #include <pcl/filters/extract_indices.h>
 #include <pcl/search/search.h>
 #include <pcl/kdtree/kdtree.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/kdtree/impl/kdtree_flann.hpp>
 
 namespace pcl
 {

--- a/recognition/src/ransac_based/model_library.cpp
+++ b/recognition/src/ransac_based/model_library.cpp
@@ -39,8 +39,6 @@
 
 #include <pcl/recognition/ransac_based/model_library.h>
 #include <pcl/recognition/ransac_based/obj_rec_ransac.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/kdtree/impl/kdtree_flann.hpp>
 #include <pcl/console/print.h>
 #include <cmath>
 

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -45,7 +45,6 @@
 #include <pcl/common/transforms.h>
 #include <pcl/pcl_macros.h>
 #include <pcl/search/kdtree.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/registration/boost.h>
 #include <pcl/registration/transformation_estimation.h>
 #include <pcl/registration/correspondence_estimation.h>

--- a/registration/include/pcl/registration/transformation_validation_euclidean.h
+++ b/registration/include/pcl/registration/transformation_validation_euclidean.h
@@ -43,7 +43,6 @@
 #include <pcl/point_representation.h>
 #include <pcl/search/kdtree.h>
 #include <pcl/kdtree/kdtree.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/registration/transformation_validation.h>
 
 namespace pcl

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -40,8 +40,11 @@
 #ifndef PCL_SEARCH_IMPL_FLANN_SEARCH_H_
 #define PCL_SEARCH_IMPL_FLANN_SEARCH_H_
 
+#include <flann/algorithms/kdtree_index.h>
+#include <flann/algorithms/kdtree_single_index.h>
+#include <flann/algorithms/kmeans_index.h>
+
 #include <pcl/search/flann_search.h>
-#include <pcl/kdtree/flann.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename FlannDistance>

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -41,9 +41,11 @@
 #define PCL_UNARY_CLASSIFIER_HPP_
 
 #include <Eigen/Core>
+#include <flann/algorithms/center_chooser.h>
+#include <flann/util/matrix.h>
+
 #include <pcl/segmentation/unary_classifier.h>
 #include <pcl/common/io.h>
-#include <pcl/kdtree/flann.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>

--- a/segmentation/src/unary_classifier.cpp
+++ b/segmentation/src/unary_classifier.cpp
@@ -37,6 +37,8 @@
  *
  */
 
+#include <flann/flann.hpp>
+
 #include <pcl/point_types.h>
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/segmentation/unary_classifier.h>

--- a/simulation/tools/sim_test_performance.cpp
+++ b/simulation/tools/sim_test_performance.cpp
@@ -37,7 +37,6 @@
 
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/surface/gp3.h>
 

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -49,7 +49,6 @@
 
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/surface/gp3.h>
 

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -63,7 +63,6 @@
 
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/surface/gp3.h>
 

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -45,7 +45,6 @@
 
 #include <pcl/conversions.h>
 #include <pcl/kdtree/kdtree.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/PolygonMesh.h>
 
 #include <fstream>

--- a/surface/include/pcl/surface/impl/concave_hull.hpp
+++ b/surface/include/pcl/surface/impl/concave_hull.hpp
@@ -49,7 +49,6 @@
 #include <pcl/common/eigen.h>
 #include <pcl/common/centroid.h>
 #include <pcl/common/transforms.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/common/io.h>
 #include <cstdio>
 #include <cstdlib>

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -39,7 +39,6 @@
 #define PCL_SURFACE_IMPL_GP3_H_
 
 #include <pcl/surface/gp3.h>
-#include <pcl/kdtree/impl/kdtree_flann.hpp>
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT> void

--- a/surface/include/pcl/surface/impl/marching_cubes.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes.hpp
@@ -40,7 +40,6 @@
 #include <pcl/common/common.h>
 #include <pcl/common/vector_average.h>
 #include <pcl/Vertices.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT>

--- a/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_hoppe.hpp
@@ -40,7 +40,6 @@
 #include <pcl/common/common.h>
 #include <pcl/common/vector_average.h>
 #include <pcl/Vertices.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT>

--- a/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
@@ -43,7 +43,6 @@
 #include <pcl/common/common.h>
 #include <pcl/common/vector_average.h>
 #include <pcl/Vertices.h>
-#include <pcl/kdtree/kdtree_flann.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT>

--- a/test/features/test_grsd_estimation.cpp
+++ b/test/features/test_grsd_estimation.cpp
@@ -42,9 +42,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/features/grsd.h>
 #include <pcl/features/normal_3d.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/io/pcd_io.h>
-
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_rsd_estimation.cpp
+++ b/test/features/test_rsd_estimation.cpp
@@ -42,9 +42,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/features/rsd.h>
 #include <pcl/features/normal_3d.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/io/pcd_io.h>
-
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -40,11 +40,11 @@
 #include <iostream>  // For debug
 #include <map>
 #include <pcl/common/time.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/common/distances.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/kdtree/impl/kdtree_flann.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
@@ -63,9 +63,6 @@ struct MyPoint : public PointXYZ
 };
 
 PointCloud<MyPoint> cloud, cloud_big;
-
-// Include the implementation so that KdTree<MyPoint> works
-#include <pcl/kdtree/impl/kdtree_flann.hpp>
 
 void 
 init ()

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -47,8 +47,6 @@
 #include <pcl/filters/uniform_sampling.h>
 #include <pcl/recognition/cg/hough_3d.h>
 #include <pcl/recognition/cg/geometric_consistency.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/kdtree/impl/kdtree_flann.hpp>
 #include <pcl/common/eigen.h>
 
 using namespace std;

--- a/test/recognition/test_recognition_ism.cpp
+++ b/test/recognition/test_recognition_ism.cpp
@@ -38,7 +38,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 #include <pcl/io/pcd_io.h>

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -41,7 +41,6 @@
 #include <pcl/common/distances.h>
 #include <pcl/common/time.h>
 #include <pcl/search/pcl_search.h>
-#include <pcl/search/flann_search.h>
 #include <pcl/search/impl/flann_search.hpp>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>

--- a/test/segmentation/test_segmentation.cpp
+++ b/test/segmentation/test_segmentation.cpp
@@ -38,7 +38,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 #include <pcl/io/pcd_io.h>

--- a/visualization/include/pcl/visualization/common/io.h
+++ b/visualization/include/pcl/visualization/common/io.h
@@ -39,7 +39,6 @@
 #pragma once
 
 #include <pcl/visualization/common/actor_map.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/console/print.h>
 
 class vtkPolyData;

--- a/visualization/src/common/io.cpp
+++ b/visualization/src/common/io.cpp
@@ -42,6 +42,7 @@
 #include <vtkSmartPointer.h>
 
 #include <pcl/visualization/common/io.h>
+#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/visualization/eigen.h>
 

--- a/visualization/test/test_geometry.cpp
+++ b/visualization/test/test_geometry.cpp
@@ -1,5 +1,4 @@
 #include <pcl/io/pcd_io.h>
-#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/filters/passthrough.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/visualization/pcl_visualizer.h>


### PR DESCRIPTION
Current stable of flann (1.9.1) is only compatible to C++14, but not to C++17 (their master is already C++17 compatible since this [patch](https://github.com/mariusmuja/flann/commit/be80cefa69b314a3d9e1ab971715e84145863ebb)). With this PR I hope it is possible to compile a C++17 project against PCL, when PCL is build with C++14.

Interesting fact: Clang/Gcc can compile a C++17 project against PCL, during MSVC cannot. Seems Clang/Gcc are not checking standard of a C++ feature, if this function is not used (only explanation for me, why Clang/Gcc can compile it, but MSVC not).

Skipped doc directory from cleanup, because they are not build by default on my machine ;).