### PR TITLE
Add Mojave build to CI.

### DIFF
--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -1,12 +1,13 @@
 jobs:
   - job: osx
     strategy:
-      highSierra:
-        DISPLAYNAME: 'macOS High Sierra'
-        VMIMAGE: 'macOS-10.13'
-      mojave:
-        DISPLAYNAME: 'macOS Mojave'
-        VMIMAGE: 'macOS-10.14'
+      matrix:
+        highSierra:
+          DISPLAYNAME: 'macOS High Sierra'
+          VMIMAGE: 'macOS-10.13'
+        mojave:
+          DISPLAYNAME: 'macOS Mojave'
+          VMIMAGE: 'macOS-10.14'
     displayName: '$(DISPLAYNAME)'
     timeoutInMinutes: 0
     pool:

--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -1,9 +1,16 @@
 jobs:
   - job: osx
-    displayName: macOS High Sierra
+    strategy:
+      highSierra:
+        DISPLAYNAME: 'macOS High Sierra'
+        VMIMAGE: 'macOS-10.13'
+      mojave:
+        DISPLAYNAME: 'macOS Mojave'
+        VMIMAGE: 'macOS-10.14'
+    displayName: '$(DISPLAYNAME)'
     timeoutInMinutes: 0
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: '$(VMIMAGE)'
     variables:
       BUILD_DIR: '$(Agent.WorkFolder)/build'
       GOOGLE_TEST_DIR: '$(Agent.WorkFolder)/googletest'

--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -2,13 +2,10 @@ jobs:
   - job: osx
     strategy:
       matrix:
-        highSierra:
-          DISPLAYNAME: 'macOS High Sierra'
+        macOS High Sierra:
           VMIMAGE: 'macOS-10.13'
-        mojave:
-          DISPLAYNAME: 'macOS Mojave'
+        macOS Mojave:
           VMIMAGE: 'macOS-10.14'
-    displayName: '$(DISPLAYNAME)'
     timeoutInMinutes: 0
     pool:
       vmImage: '$(VMIMAGE)'

--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -2,8 +2,8 @@ jobs:
   - job: osx
     strategy:
       matrix:
-        macOS High Sierra:
-          VMIMAGE: 'macOS-10.13'
+        # macOS Catalina:
+        #   VMIMAGE: 'macOS-10.15'
         macOS Mojave:
           VMIMAGE: 'macOS-10.14'
     timeoutInMinutes: 0


### PR DESCRIPTION
Azure Pipelines added Mojave as a platform last [month](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops). Let's "test the waters".