### PR TITLE
Fix a bug in `ConvexHull` when indices are used

### DIFF
--- a/surface/include/pcl/surface/impl/convex_hull.hpp
+++ b/surface/include/pcl/surface/impl/convex_hull.hpp
@@ -373,7 +373,7 @@ pcl::ConvexHull<PointInT>::performReconstruction3D (
   {
     // Add vertices to hull point_cloud and store index
     hull_indices_.indices.push_back ((*indices_)[qh_pointid (vertex->point)]);
-    hull.points[i] = input_->points[(*indices_)[hull_indices_.indices.back ()]];
+    hull.points[i] = input_->points[hull_indices_.indices.back ()];
 
     qhid_to_pcidx[vertex->id] = i; // map the vertex id of qhull to the point cloud index
     ++i;


### PR DESCRIPTION
`qh_pointid` contains indices into the `indices_` vector, which in turn indices into `input_` point cloud. Line 375 already "dereferenced" `qh_pointid` indices, such that `hull_indices_` contains indices into the point cloud. Therefore, line 376 should not use `indices_` anymore.