### PR TITLE
Use nullptr in module apps

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -112,7 +112,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     } else {
       models = source_->getModels (search_model_);
       //reset cache and flann structures
-      if(flann_index_ != 0)
+      if(flann_index_ != nullptr)
         delete flann_index_;
 
       flann_models_.clear();
@@ -206,7 +206,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     //pcl::PointCloud<int> keypoints_input;
     PointInTPtr keypoints_pointcloud;
 
-    if (signatures_ != 0 && processed_ != 0 && (signatures_->size () == keypoints_pointcloud->points.size ()))
+    if (signatures_ != nullptr && processed_ != nullptr && (signatures_->size () == keypoints_pointcloud->points.size ()))
     {
       keypoints_pointcloud = keypoints_input_;
       signatures = signatures_;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
@@ -62,10 +62,10 @@ namespace pcl
 
       double A[3], B[3], C[3];
       vtkIdType npts = 0;
-      vtkIdType *ptIds = NULL;
+      vtkIdType *ptIds = nullptr;
       polydata->GetCellPoints (el, npts, ptIds);
 
-      if (ptIds == NULL)
+      if (ptIds == nullptr)
         return;
 
       polydata->GetPoint (ptIds[0], A);
@@ -84,7 +84,7 @@ namespace pcl
         double p1[3], p2[3], p3[3], totalArea = 0;
         std::vector<double> cumulativeAreas (cells->GetNumberOfCells (), 0);
         size_t i = 0;
-        vtkIdType npts = 0, *ptIds = NULL;
+        vtkIdType npts = 0, *ptIds = nullptr;
         for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds); i++)
         {
           polydata->GetPoint (ptIds[0], p1);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_browser.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_browser.h
@@ -55,7 +55,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        CloudBrowser (QWidget* parent = 0);
+        CloudBrowser (QWidget* parent = nullptr);
         
         void 
         setModel (QAbstractItemModel* new_model) override;
@@ -69,7 +69,7 @@ namespace pcl
     {
       public:
         explicit 
-        BackgroundDelegate (QObject *parent = 0)
+        BackgroundDelegate (QObject *parent = nullptr)
           : QStyledItemDelegate(parent) {}
           
         void

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_composer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_composer.h
@@ -70,7 +70,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        explicit ComposerMainWindow (QWidget *parent = 0);
+        explicit ComposerMainWindow (QWidget *parent = nullptr);
         ~ComposerMainWindow ();
   
       Q_SIGNALS:

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
@@ -61,9 +61,9 @@ namespace pcl
       Q_OBJECT
       
     public:
-      CloudView (QWidget* parent = 0);
+      CloudView (QWidget* parent = nullptr);
       CloudView (const CloudView& to_copy);
-      CloudView (ProjectModel* model, QWidget* parent = 0);
+      CloudView (ProjectModel* model, QWidget* parent = nullptr);
       ~CloudView ();
       
       void 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_viewer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_viewer.h
@@ -58,7 +58,7 @@ namespace pcl
 
       public:
         
-        CloudViewer (QWidget* parent = 0);
+        CloudViewer (QWidget* parent = nullptr);
         ~CloudViewer();
         ProjectModel* getModel () const;
 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
@@ -58,7 +58,7 @@ namespace pcl
     class CloudCommand : public QUndoCommand
     {
       public: 
-        CloudCommand (ConstItemList input_data, QUndoCommand* parent = 0);
+        CloudCommand (ConstItemList input_data, QUndoCommand* parent = nullptr);
         
         
         ~CloudCommand ();
@@ -121,7 +121,7 @@ namespace pcl
     class ModifyItemCommand : public CloudCommand
     {
       public: 
-        ModifyItemCommand (ConstItemList input_data, QUndoCommand* parent = 0);
+        ModifyItemCommand (ConstItemList input_data, QUndoCommand* parent = nullptr);
     
         bool
         runCommand (AbstractTool* tool) override;
@@ -140,7 +140,7 @@ namespace pcl
     class NewItemCloudCommand : public CloudCommand
     {
       public: 
-        NewItemCloudCommand (ConstItemList input_data, QUndoCommand* parent = 0);
+        NewItemCloudCommand (ConstItemList input_data, QUndoCommand* parent = nullptr);
       
         bool
         runCommand (AbstractTool* tool) override;
@@ -157,7 +157,7 @@ namespace pcl
     class SplitCloudCommand : public CloudCommand
     {
       public: 
-        SplitCloudCommand (ConstItemList input_data, QUndoCommand* parent = 0);
+        SplitCloudCommand (ConstItemList input_data, QUndoCommand* parent = nullptr);
       
         bool
         runCommand (AbstractTool* tool) override;
@@ -174,7 +174,7 @@ namespace pcl
     class DeleteItemCommand : public CloudCommand
     {
       public: 
-        DeleteItemCommand (ConstItemList input_data, QUndoCommand* parent = 0);
+        DeleteItemCommand (ConstItemList input_data, QUndoCommand* parent = nullptr);
       
         bool
         runCommand (AbstractTool* tool) override;
@@ -194,7 +194,7 @@ namespace pcl
          *  \param[in] input_data Input list of CloudItem s from the project model which will be merged
          *  \param[in] temporary_clouds Input list of CloudItems which 
          */
-        MergeCloudCommand (ConstItemList input_data, QUndoCommand* parent = 0);
+        MergeCloudCommand (ConstItemList input_data, QUndoCommand* parent = nullptr);
       
         bool
         runCommand (AbstractTool* tool) override;

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/item_inspector.h
@@ -57,7 +57,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        ItemInspector (QWidget* parent = 0);
+        ItemInspector (QWidget* parent = nullptr);
         ~ItemInspector();
       
       public Q_SLOTS:

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/merge_selection.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/merge_selection.h
@@ -47,7 +47,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        MergeSelection (QMap <const CloudItem*, pcl::PointIndices::ConstPtr > selected_item_index_map, QObject* parent = 0);
+        MergeSelection (QMap <const CloudItem*, pcl::PointIndices::ConstPtr > selected_item_index_map, QObject* parent = nullptr);
         ~MergeSelection ();
         
         QList <CloudComposerItem*>

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
@@ -68,11 +68,11 @@ namespace pcl
         Q_OBJECT
 
       public:
-        ProjectModel (QObject *parent = 0);
+        ProjectModel (QObject *parent = nullptr);
         ProjectModel (const ProjectModel& to_copy);
         ~ProjectModel ();
         
-        ProjectModel (QString project_name, QObject *parent = 0);
+        ProjectModel (QString project_name, QObject *parent = nullptr);
         
         inline const QString
         getName () { return horizontalHeaderItem (0)->text (); }
@@ -156,7 +156,7 @@ namespace pcl
         
         /** \brief Selects all items in the model */
         void 
-        selectAllItems (QStandardItem* item = 0 );
+        selectAllItems (QStandardItem* item = nullptr );
       Q_SIGNALS:
         void
         enqueueNewAction (AbstractTool* tool, ConstItemList data);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
@@ -52,9 +52,9 @@ namespace pcl
       public:
         
         /** \brief Constructor used for tool parameters */
-        PropertiesModel (QObject *parent = 0);
+        PropertiesModel (QObject *parent = nullptr);
         /** \brief Constructor used for item parameters */
-        PropertiesModel (CloudComposerItem* parent_item, QObject *parent = 0);
+        PropertiesModel (CloudComposerItem* parent_item, QObject *parent = nullptr);
         PropertiesModel (const PropertiesModel& to_copy);
         ~PropertiesModel ();
         

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/signal_multiplexer.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/signal_multiplexer.h
@@ -53,7 +53,7 @@ namespace pcl
       Q_OBJECT
 
       public:
-        SignalMultiplexer(QObject *parent = 0);
+        SignalMultiplexer(QObject *parent = nullptr);
 
         /**
                 Use this connect function instead of QObject::connect() to connect

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/tool_factory.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/tool_factory.h
@@ -55,7 +55,7 @@ namespace pcl
     {
       public:
         virtual AbstractTool*
-        createTool (PropertiesModel* parameter_model = 0, QObject* parent = 0) = 0;
+        createTool (PropertiesModel* parameter_model = nullptr, QObject* parent = nullptr) = 0;
             
         virtual PropertiesModel*
         createToolParameterModel (QObject* parent) = 0;

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
@@ -68,7 +68,7 @@ namespace pcl
       Q_OBJECT
       
     public:
-      ToolBoxModel (QTreeView* tool_view = 0, QTreeView* parameter_view = 0, QObject *parent = 0);
+      ToolBoxModel (QTreeView* tool_view = nullptr, QTreeView* parameter_view = nullptr, QObject *parent = nullptr);
       ToolBoxModel (const ToolBoxModel& to_copy);
       ~ToolBoxModel ();
       

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/euclidean_clustering.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/euclidean_clustering.h
@@ -66,7 +66,7 @@ namespace pcl
       Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
       public:
         SplitItemTool*
-        createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+        createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
         {
             return new EuclideanClusteringTool(parameter_model, parent);
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/fpfh_estimation.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/fpfh_estimation.h
@@ -67,7 +67,7 @@ namespace pcl
       Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
       public:
         NewItemTool*
-        createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+        createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
         {
             return new FPFHEstimationTool(parameter_model, parent);
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/normal_estimation.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/normal_estimation.h
@@ -66,7 +66,7 @@ namespace pcl
       Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
       public:
         NewItemTool*
-        createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+        createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
         {
             return new NormalEstimationTool(parameter_model, parent);
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/organized_segmentation.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/organized_segmentation.h
@@ -70,7 +70,7 @@
        Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
      public:
        SplitItemTool*
-       createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+       createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
        {
          return new OrganizedSegmentationTool(parameter_model, parent);
        }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/sanitize_cloud.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/sanitize_cloud.h
@@ -66,7 +66,7 @@ namespace pcl
         Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
       public:
         ModifyItemTool*
-        createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+        createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
         {
           return new SanitizeCloudTool(parameter_model, parent);
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/statistical_outlier_removal.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/statistical_outlier_removal.h
@@ -67,7 +67,7 @@ namespace pcl
       Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
       public:
         ModifyItemTool*
-        createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+        createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
         {
             return new StatisticalOutlierRemovalTool(parameter_model, parent);
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/supervoxels.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/supervoxels.h
@@ -72,7 +72,7 @@
        Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
      public:
        SplitItemTool*
-       createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+       createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
        {
          return new SupervoxelsTool(parameter_model, parent);
        }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/voxel_grid_downsample.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/voxel_grid_downsample.h
@@ -66,7 +66,7 @@ namespace pcl
       Q_PLUGIN_METADATA(IID "cloud_composer.ToolFactory/1.0")
       public:
         ModifyItemTool*
-        createTool (PropertiesModel* parameter_model, QObject* parent = 0) override 
+        createTool (PropertiesModel* parameter_model, QObject* parent = nullptr) override 
         {
             return new VoxelGridDownsampleTool(parameter_model, parent);
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/transform_clouds.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/transform_clouds.h
@@ -47,7 +47,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        TransformClouds (QMap <QString, vtkSmartPointer<vtkMatrix4x4> > transform_map, QObject* parent = 0);
+        TransformClouds (QMap <QString, vtkSmartPointer<vtkMatrix4x4> > transform_map, QObject* parent = nullptr);
         ~TransformClouds ();
         
         QList <CloudComposerItem*>

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/work_queue.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/work_queue.h
@@ -58,7 +58,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        WorkQueue (QObject* parent = 0);  
+        WorkQueue (QObject* parent = nullptr);  
         ~WorkQueue();  
       public Q_SLOTS:
         void

--- a/apps/cloud_composer/src/cloud_composer.cpp
+++ b/apps/cloud_composer/src/cloud_composer.cpp
@@ -33,7 +33,7 @@ pcl::cloud_composer::ComposerMainWindow::ComposerMainWindow (QWidget *parent)
   qRegisterMetaType<CloudView> ("CloudView");
   qRegisterMetaType<ConstItemList> ("ConstComposerItemList");
   
-  current_model_ = 0;
+  current_model_ = nullptr;
   
   multiplexer_ = new SignalMultiplexer (this);
   

--- a/apps/cloud_composer/src/cloud_viewer.cpp
+++ b/apps/cloud_composer/src/cloud_viewer.cpp
@@ -40,7 +40,7 @@ pcl::cloud_composer::ProjectModel*
 pcl::cloud_composer::CloudViewer::getModel () const
 {
   if (this->count() == 0)
-    return 0;
+    return nullptr;
   else
     return dynamic_cast<CloudView*> (currentWidget ())->getModel (); 
 }

--- a/apps/cloud_composer/src/commands.cpp
+++ b/apps/cloud_composer/src/commands.cpp
@@ -135,7 +135,7 @@ pcl::cloud_composer::CloudCommand::replaceOriginalWithNew (QList <const CloudCom
     }
   }
   // If parent is 0, it's parent is invisiblerootitem (That's how Qt defines it... boo!)
-  if (parent_item == 0)
+  if (parent_item == nullptr)
     parent_item = project_model_->invisibleRootItem ();
   
   //Now remove all the originals
@@ -169,7 +169,7 @@ pcl::cloud_composer::CloudCommand::restoreOriginalRemoveNew (QList <const CloudC
   {
     QStandardItem* parent_item = item->parent ();
     // If parent is 0, it's parent is invisiblerootitem (That's how Qt defines it... boo!)
-    if (parent_item == 0)
+    if (parent_item == nullptr)
       parent_item = project_model_->invisibleRootItem ();
     QPersistentModelIndex to_remove_index = QPersistentModelIndex(project_model_->indexFromItem (item));
     if (!to_remove_index.isValid ())

--- a/apps/cloud_composer/src/item_inspector.cpp
+++ b/apps/cloud_composer/src/item_inspector.cpp
@@ -6,9 +6,9 @@
 pcl::cloud_composer::ItemInspector::ItemInspector (QWidget* parent)
   : QTabWidget(parent)
 {
-  current_item_properties_model_ = 0;
-  current_project_model_ = 0;
-  current_selection_model_ = 0;
+  current_item_properties_model_ = nullptr;
+  current_project_model_ = nullptr;
+  current_selection_model_ = nullptr;
   
   parameter_view_ = new QTreeView ();
   addTab (parameter_view_, "Parameters");
@@ -109,10 +109,10 @@ void
 pcl::cloud_composer::ItemInspector::updateView ()
 {
 
-  current_item_properties_model_ = 0;
+  current_item_properties_model_ = nullptr;
   QModelIndex current_item = current_selection_model_->currentIndex ();
-  const QStandardItemModel* model = 0;
-  CloudComposerItem* cloud_item = 0;
+  const QStandardItemModel* model = nullptr;
+  CloudComposerItem* cloud_item = nullptr;
   if (current_item.isValid ())
     model = dynamic_cast<const QStandardItemModel*> (current_item.model ());
         

--- a/apps/cloud_composer/src/items/cloud_item.cpp
+++ b/apps/cloud_composer/src/items/cloud_item.cpp
@@ -172,7 +172,7 @@ pcl::cloud_composer::CloudItem::setTemplateCloudFromBlob ()
       }
         
       case (PointTypeFlags::NONE):
-        QMessageBox::warning (0,"Unknown blob type!", "Could not find appropriate template type for this cloud blob! Only blob functionality enabled!");
+        QMessageBox::warning (nullptr,"Unknown blob type!", "Could not find appropriate template type for this cloud blob! Only blob functionality enabled!");
     }
     
     this->setData (cloud_pointer_variant, ItemDataRole::CLOUD_TEMPLATED);

--- a/apps/cloud_composer/src/merge_selection.cpp
+++ b/apps/cloud_composer/src/merge_selection.cpp
@@ -7,7 +7,7 @@
 #include <pcl/apps/cloud_composer/impl/merge_selection.hpp>
 
 pcl::cloud_composer::MergeSelection::MergeSelection (QMap <const CloudItem*, pcl::PointIndices::ConstPtr > selected_item_index_map, QObject* parent)
-  : MergeCloudTool (0, parent)
+  : MergeCloudTool (nullptr, parent)
   , selected_item_index_map_ (selected_item_index_map)
 {
   

--- a/apps/cloud_composer/src/point_selectors/interactor_style_switch.cpp
+++ b/apps/cloud_composer/src/point_selectors/interactor_style_switch.cpp
@@ -31,7 +31,7 @@ pcl::cloud_composer::InteractorStyleSwitch::InteractorStyleSwitch ()
   area_picker_ = vtkSmartPointer<vtkAreaPicker>::New();
   point_picker_ = vtkSmartPointer<vtkPointPicker>::New ();
   
-  current_style_ = 0;
+  current_style_ = nullptr;
   
 }
 
@@ -67,7 +67,7 @@ pcl::cloud_composer::InteractorStyleSwitch::setCurrentInteractorStyle (interacto
   qDebug () << "Setting interactor style";
   vtkSmartPointer <vtkInteractorStyle> style_ptr = name_to_style_map_.value (interactor_style);
   if (current_style_)
-    current_style_->SetInteractor (0);
+    current_style_->SetInteractor (nullptr);
   current_style_= style_ptr;
   
   if (current_style_)

--- a/apps/cloud_composer/src/point_selectors/rectangular_frustum_selector.cpp
+++ b/apps/cloud_composer/src/point_selectors/rectangular_frustum_selector.cpp
@@ -78,7 +78,7 @@ pcl::cloud_composer::RectangularFrustumSelector::OnLeftButtonUp ()
 
   this->CurrentRenderer->AddActor (selected_actor);
   this->GetInteractor ()->GetRenderWindow ()->Render ();
-  this->HighlightProp (NULL);
+  this->HighlightProp (nullptr);
  
   if (all_points->GetNumberOfPoints () > 0)
   {

--- a/apps/cloud_composer/src/point_selectors/selected_trackball_interactor_style.cpp
+++ b/apps/cloud_composer/src/point_selectors/selected_trackball_interactor_style.cpp
@@ -102,7 +102,7 @@ pcl::cloud_composer::SelectedTrackballStyleInteractor::OnRightButtonUp ()
 void
 pcl::cloud_composer::SelectedTrackballStyleInteractor::Rotate ()
 {
-  if (this->CurrentRenderer == NULL || this->InteractionProp == NULL)
+  if (this->CurrentRenderer == nullptr || this->InteractionProp == nullptr)
   {
     return;
   }
@@ -204,7 +204,7 @@ pcl::cloud_composer::SelectedTrackballStyleInteractor::Rotate ()
 void
 pcl::cloud_composer::SelectedTrackballStyleInteractor::Spin ()
 {
-  if ( this->CurrentRenderer == NULL || this->InteractionProp == NULL )
+  if ( this->CurrentRenderer == nullptr || this->InteractionProp == nullptr )
   {
     return;
   }
@@ -283,7 +283,7 @@ pcl::cloud_composer::SelectedTrackballStyleInteractor::Spin ()
 void
 pcl::cloud_composer::SelectedTrackballStyleInteractor::Pan ()
 {
-  if (this->CurrentRenderer == NULL || this->InteractionProp == NULL)
+  if (this->CurrentRenderer == nullptr || this->InteractionProp == nullptr)
   {
     return;
   }
@@ -317,7 +317,7 @@ pcl::cloud_composer::SelectedTrackballStyleInteractor::Pan ()
   foreach (QString id, selected_actors_map_.keys ())
   {
     vtkLODActor* actor = selected_actors_map_.value (id);
-    if (actor->GetUserMatrix() != NULL)
+    if (actor->GetUserMatrix() != nullptr)
     {
       vtkTransform *t = vtkTransform::New();
       t->PostMultiply();
@@ -346,7 +346,7 @@ pcl::cloud_composer::SelectedTrackballStyleInteractor::Pan ()
 void
 pcl::cloud_composer::SelectedTrackballStyleInteractor::UniformScale ()
 {
-  if (this->CurrentRenderer == NULL || this->InteractionProp == NULL)
+  if (this->CurrentRenderer == nullptr || this->InteractionProp == nullptr)
   {
     return;
   }
@@ -361,7 +361,7 @@ pcl::cloud_composer::SelectedTrackballStyleInteractor::UniformScale ()
   double yf = dy / center[1] * this->MotionFactor;
   double scaleFactor = pow(1.1, yf);
   
-  double **rotate = NULL;
+  double **rotate = nullptr;
   
   double scale[3];
   scale[0] = scale[1] = scale[2] = scaleFactor;

--- a/apps/cloud_composer/src/project_model.cpp
+++ b/apps/cloud_composer/src/project_model.cpp
@@ -162,7 +162,7 @@ void
 pcl::cloud_composer::ProjectModel::insertNewCloudFromFile ()
 {
   qDebug () << "Inserting cloud from file...";
-  QString filename = QFileDialog::getOpenFileName (0,tr ("Select cloud to open"), last_directory_.absolutePath (), tr ("PointCloud(*.pcd)"));
+  QString filename = QFileDialog::getOpenFileName (nullptr,tr ("Select cloud to open"), last_directory_.absolutePath (), tr ("PointCloud(*.pcd)"));
   if ( filename.isNull ())
   {
     qWarning () << "No file selected, no cloud loaded";
@@ -216,7 +216,7 @@ void
 pcl::cloud_composer::ProjectModel::insertNewCloudFromRGBandDepth ()
 {
   qDebug () << "Inserting cloud from RGB and Depth files...";
-  QString rgb_filename = QFileDialog::getOpenFileName (0,tr ("Select rgb image file to open"), last_directory_.absolutePath (), tr ("Images(*.png *.bmp *.tif *.ppm)"));
+  QString rgb_filename = QFileDialog::getOpenFileName (nullptr,tr ("Select rgb image file to open"), last_directory_.absolutePath (), tr ("Images(*.png *.bmp *.tif *.ppm)"));
   QString depth_filename;
   if ( rgb_filename.isNull ())
   {
@@ -369,7 +369,7 @@ pcl::cloud_composer::ProjectModel::saveSelectedCloudToFile ()
     return;
   }
   
-  QString filename = QFileDialog::getSaveFileName (0,tr ("Save Cloud"), last_directory_.absolutePath (), tr ("PointCloud(*.pcd)"));
+  QString filename = QFileDialog::getSaveFileName (nullptr,tr ("Save Cloud"), last_directory_.absolutePath (), tr ("PointCloud(*.pcd)"));
   if ( filename.isNull ())
   {
     qWarning () << "No file selected, not saving";
@@ -475,7 +475,7 @@ pcl::cloud_composer::ProjectModel::deleteSelectedItems ()
  // qDebug () << "Input for command is "<<input_data.size () << " element(s)";
   DeleteItemCommand* delete_command = new DeleteItemCommand (ConstItemList ());
   delete_command->setInputData (input_data);
-  if (delete_command->runCommand (0))
+  if (delete_command->runCommand (nullptr))
     commandCompleted(delete_command);
   else
     qCritical () << "Execution of delete command failed!";

--- a/apps/cloud_composer/src/properties_model.cpp
+++ b/apps/cloud_composer/src/properties_model.cpp
@@ -97,7 +97,7 @@ pcl::cloud_composer::PropertiesModel::getProperty (const QString prop_name) cons
  // qDebug () << "Prop name="<<prop_name<<" row="<<property->row ()<<" col="<<property->column();
   int row = property->row ();
   QStandardItem* parent_item = property->parent ();
-  if (parent_item == 0)
+  if (parent_item == nullptr)
     parent_item = invisibleRootItem ();
   return parent_item->child (row,1)->data (Qt::EditRole);
 }

--- a/apps/cloud_composer/src/toolbox_model.cpp
+++ b/apps/cloud_composer/src/toolbox_model.cpp
@@ -11,7 +11,7 @@ pcl::cloud_composer::ToolBoxModel::ToolBoxModel (QTreeView* tool_view, QTreeView
 : QStandardItemModel (parent)
 , tool_view_ (tool_view)
 , parameter_view_ (parameter_view_)
-, project_model_ (0)
+, project_model_ (nullptr)
 {
   
 }

--- a/apps/cloud_composer/src/transform_clouds.cpp
+++ b/apps/cloud_composer/src/transform_clouds.cpp
@@ -7,7 +7,7 @@
 #include <pcl/apps/cloud_composer/impl/transform_clouds.hpp>
 
 pcl::cloud_composer::TransformClouds::TransformClouds (QMap <QString, vtkSmartPointer<vtkMatrix4x4> > transform_map, QObject* parent)
-  : ModifyItemTool (0, parent)
+  : ModifyItemTool (nullptr, parent)
   , transform_map_ (transform_map)
 {
   

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/help_window.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/help_window.h
@@ -56,7 +56,7 @@ namespace pcl
       Q_OBJECT
 
       public:
-        explicit HelpWindow (QWidget* parent = 0);
+        explicit HelpWindow (QWidget* parent = nullptr);
         ~HelpWindow ();
 
       private:

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/in_hand_scanner.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/in_hand_scanner.h
@@ -120,7 +120,7 @@ namespace pcl
         } FileType;
 
         /** \brief Constructor. */
-        explicit InHandScanner (Base* parent=0);
+        explicit InHandScanner (Base* parent=nullptr);
 
         /** \brief Destructor. */
         ~InHandScanner ();

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/main_window.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/main_window.h
@@ -79,7 +79,7 @@ namespace pcl
         typedef pcl::ihs::HelpWindow       HelpWindow;
         typedef InHandScanner::RunningMode RunningMode;
 
-        explicit MainWindow (QWidget* parent = 0);
+        explicit MainWindow (QWidget* parent = nullptr);
         ~MainWindow ();
 
       public Q_SLOTS:

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
@@ -86,7 +86,7 @@ namespace pcl
         typedef pcl::ihs::OfflineIntegration Self;
 
         /** \brief Constructor. */
-        explicit OfflineIntegration (Base* parent=0);
+        explicit OfflineIntegration (Base* parent=nullptr);
 
         /** \brief Destructor. */
         ~OfflineIntegration ();

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/opengl_viewer.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/opengl_viewer.h
@@ -170,7 +170,7 @@ namespace pcl
         };
 
         /** \brief Constructor. */
-        explicit OpenGLViewer (QWidget* parent=0);
+        explicit OpenGLViewer (QWidget* parent=nullptr);
 
         /** \brief Destructor. */
         ~OpenGLViewer ();

--- a/apps/in_hand_scanner/src/offline_integration.cpp
+++ b/apps/in_hand_scanner/src/offline_integration.cpp
@@ -96,7 +96,7 @@ pcl::ihs::OfflineIntegration::~OfflineIntegration ()
 void
 pcl::ihs::OfflineIntegration::start ()
 {
-  QString dir = QFileDialog::getExistingDirectory (0, "Please select a directory containing .pcd and .transform files.");
+  QString dir = QFileDialog::getExistingDirectory (nullptr, "Please select a directory containing .pcd and .transform files.");
 
   if (dir.isEmpty ())
   {

--- a/apps/modeler/include/pcl/apps/modeler/abstract_worker.h
+++ b/apps/modeler/include/pcl/apps/modeler/abstract_worker.h
@@ -50,7 +50,7 @@ namespace pcl
       Q_OBJECT
 
       public:
-        AbstractWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=0);
+        AbstractWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=nullptr);
         ~AbstractWorker();
 
         int

--- a/apps/modeler/include/pcl/apps/modeler/dock_widget.h
+++ b/apps/modeler/include/pcl/apps/modeler/dock_widget.h
@@ -45,8 +45,8 @@ namespace pcl
     class DockWidget : public QDockWidget
     {
       public:
-        explicit DockWidget(const QString &title, QWidget *parent = 0, Qt::WindowFlags flags = 0); 
-        explicit DockWidget(QWidget *parent = 0, Qt::WindowFlags flags = 0); 
+        explicit DockWidget(const QString &title, QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr); 
+        explicit DockWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr); 
         ~DockWidget();
 
         void

--- a/apps/modeler/include/pcl/apps/modeler/dock_widget.h
+++ b/apps/modeler/include/pcl/apps/modeler/dock_widget.h
@@ -45,8 +45,8 @@ namespace pcl
     class DockWidget : public QDockWidget
     {
       public:
-        explicit DockWidget(const QString &title, QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr); 
-        explicit DockWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr); 
+        explicit DockWidget(const QString &title, QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags()); 
+        explicit DockWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags()); 
         ~DockWidget();
 
         void

--- a/apps/modeler/include/pcl/apps/modeler/icp_registration_worker.h
+++ b/apps/modeler/include/pcl/apps/modeler/icp_registration_worker.h
@@ -49,7 +49,7 @@ namespace pcl
     class ICPRegistrationWorker : public AbstractWorker 
     {
       public:
-        ICPRegistrationWorker(CloudMesh::PointCloudPtr cloud, const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=0);
+        ICPRegistrationWorker(CloudMesh::PointCloudPtr cloud, const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=nullptr);
         ~ICPRegistrationWorker();
 
       protected:

--- a/apps/modeler/include/pcl/apps/modeler/impl/scene_tree.hpp
+++ b/apps/modeler/include/pcl/apps/modeler/impl/scene_tree.hpp
@@ -52,7 +52,7 @@ namespace pcl
        for (auto &selected_item : selected_items)
        {
          T* t_item = dynamic_cast<T*>(selected_item);
-         if(t_item != NULL)
+         if(t_item != nullptr)
            selected_t_items.push_back(t_item);
        }
 

--- a/apps/modeler/include/pcl/apps/modeler/normal_estimation_worker.h
+++ b/apps/modeler/include/pcl/apps/modeler/normal_estimation_worker.h
@@ -47,7 +47,7 @@ namespace pcl
     class NormalEstimationWorker : public AbstractWorker 
     {
       public:
-        NormalEstimationWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent = 0);
+        NormalEstimationWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent = nullptr);
         ~NormalEstimationWorker();
 
       protected:

--- a/apps/modeler/include/pcl/apps/modeler/parameter_dialog.h
+++ b/apps/modeler/include/pcl/apps/modeler/parameter_dialog.h
@@ -49,8 +49,8 @@ namespace pcl
     class ParameterModel: public QStandardItemModel
     {
       public: 
-        ParameterModel(QObject * parent = 0) : QStandardItemModel(parent){}
-        ParameterModel(int rows, int columns, QObject * parent = 0) : QStandardItemModel(rows, columns, parent){}
+        ParameterModel(QObject * parent = nullptr) : QStandardItemModel(parent){}
+        ParameterModel(int rows, int columns, QObject * parent = nullptr) : QStandardItemModel(rows, columns, parent){}
         ~ParameterModel() {}
 
         Qt::ItemFlags
@@ -64,7 +64,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        ParameterDialog(const std::string& title, QWidget* parent=0);
+        ParameterDialog(const std::string& title, QWidget* parent=nullptr);
         ~ParameterDialog(){}
 
         void
@@ -86,7 +86,7 @@ namespace pcl
     {
       Q_OBJECT
       public:
-        ParameterDelegate(std::map<std::string, Parameter*>& parameterMap, QObject *parent = 0);
+        ParameterDelegate(std::map<std::string, Parameter*>& parameterMap, QObject *parent = nullptr);
 
         QWidget *
         createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;

--- a/apps/modeler/include/pcl/apps/modeler/poisson_worker.h
+++ b/apps/modeler/include/pcl/apps/modeler/poisson_worker.h
@@ -48,7 +48,7 @@ namespace pcl
     class PoissonReconstructionWorker : public AbstractWorker 
     {
       public:
-        PoissonReconstructionWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=0);
+        PoissonReconstructionWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=nullptr);
         ~PoissonReconstructionWorker();
 
       protected:

--- a/apps/modeler/include/pcl/apps/modeler/render_window.h
+++ b/apps/modeler/include/pcl/apps/modeler/render_window.h
@@ -51,7 +51,7 @@ namespace pcl
     class RenderWindow : public QVTKWidget
     {
       public:
-        RenderWindow(RenderWindowItem* render_window_item, QWidget *parent = 0, Qt::WindowFlags flags = 0);
+        RenderWindow(RenderWindowItem* render_window_item, QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr);
         ~RenderWindow();
 
         QSize

--- a/apps/modeler/include/pcl/apps/modeler/scene_tree.h
+++ b/apps/modeler/include/pcl/apps/modeler/scene_tree.h
@@ -50,7 +50,7 @@ namespace pcl
       Q_OBJECT
 
       public:
-        SceneTree(QWidget * parent = 0);
+        SceneTree(QWidget * parent = nullptr);
         ~SceneTree();
 
         QSize

--- a/apps/modeler/include/pcl/apps/modeler/statistical_outlier_removal_worker.h
+++ b/apps/modeler/include/pcl/apps/modeler/statistical_outlier_removal_worker.h
@@ -48,7 +48,7 @@ namespace pcl
     class StatisticalOutlierRemovalWorker : public AbstractWorker 
     {
       public:
-        StatisticalOutlierRemovalWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=0);
+        StatisticalOutlierRemovalWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=nullptr);
         ~StatisticalOutlierRemovalWorker();
 
       protected:

--- a/apps/modeler/include/pcl/apps/modeler/voxel_grid_downsample_worker.h
+++ b/apps/modeler/include/pcl/apps/modeler/voxel_grid_downsample_worker.h
@@ -47,7 +47,7 @@ namespace pcl
     class VoxelGridDownampleWorker : public AbstractWorker 
     {
       public:
-        VoxelGridDownampleWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=0);
+        VoxelGridDownampleWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent=nullptr);
         ~VoxelGridDownampleWorker();
 
       protected:

--- a/apps/modeler/src/cloud_mesh.cpp
+++ b/apps/modeler/src/cloud_mesh.cpp
@@ -162,7 +162,7 @@ pcl::modeler::CloudMesh::getColorScalarsFromField(vtkSmartPointer<vtkDataArray> 
 void
 pcl::modeler::CloudMesh::updateVtkPoints()
 {
-  if (vtk_points_->GetData() == NULL)
+  if (vtk_points_->GetData() == nullptr)
     vtk_points_->SetData(vtkSmartPointer<vtkFloatArray>::New ());
 
   vtkFloatArray* data = dynamic_cast<vtkFloatArray*>(vtk_points_->GetData());

--- a/apps/modeler/src/icp_registration_worker.cpp
+++ b/apps/modeler/src/icp_registration_worker.cpp
@@ -49,10 +49,10 @@ pcl::modeler::ICPRegistrationWorker::ICPRegistrationWorker(CloudMesh::PointCloud
   x_min_(std::numeric_limits<double>::max()), x_max_(std::numeric_limits<double>::min()),
   y_min_(std::numeric_limits<double>::max()), y_max_(std::numeric_limits<double>::min()),
   z_min_(std::numeric_limits<double>::max()), z_max_(std::numeric_limits<double>::min()),
-  max_correspondence_distance_(NULL),
-  max_iterations_(NULL),
-  transformation_epsilon_(NULL),
-  euclidean_fitness_epsilon_(NULL)
+  max_correspondence_distance_(nullptr),
+  max_iterations_(nullptr),
+  transformation_epsilon_(nullptr),
+  euclidean_fitness_epsilon_(nullptr)
 {
 
 }

--- a/apps/modeler/src/normal_estimation_worker.cpp
+++ b/apps/modeler/src/normal_estimation_worker.cpp
@@ -50,7 +50,7 @@ pcl::modeler::NormalEstimationWorker::NormalEstimationWorker(const QList<CloudMe
   x_min_(std::numeric_limits<double>::max()), x_max_(std::numeric_limits<double>::min()),
   y_min_(std::numeric_limits<double>::max()), y_max_(std::numeric_limits<double>::min()),
   z_min_(std::numeric_limits<double>::max()), z_max_(std::numeric_limits<double>::min()),
-  search_radius_(NULL)
+  search_radius_(nullptr)
 {
 
 }

--- a/apps/modeler/src/normals_actor_item.cpp
+++ b/apps/modeler/src/normals_actor_item.cpp
@@ -72,7 +72,7 @@ pcl::modeler::NormalsActorItem::createNormalLines()
   if (cloud->empty())
     return;
 
-  if (points->GetData() == NULL)
+  if (points->GetData() == nullptr)
     points->SetData(vtkSmartPointer<vtkFloatArray>::New ());
 
   vtkFloatArray* data = dynamic_cast<vtkFloatArray*>(points->GetData());

--- a/apps/modeler/src/parameter_dialog.cpp
+++ b/apps/modeler/src/parameter_dialog.cpp
@@ -63,7 +63,7 @@ pcl::modeler::ParameterDialog::addParameter(pcl::modeler::Parameter* parameter)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-pcl::modeler::ParameterDialog::ParameterDialog(const std::string& title, QWidget* parent) : QDialog(parent), parameter_model_(NULL)
+pcl::modeler::ParameterDialog::ParameterDialog(const std::string& title, QWidget* parent) : QDialog(parent), parameter_model_(nullptr)
 {
   setModal(false);
   setWindowTitle(QString(title.c_str())+" Parameters");

--- a/apps/modeler/src/poisson_worker.cpp
+++ b/apps/modeler/src/poisson_worker.cpp
@@ -45,7 +45,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 pcl::modeler::PoissonReconstructionWorker::PoissonReconstructionWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent) :
   AbstractWorker(cloud_mesh_items, parent),
-  depth_(NULL), solver_divide_(NULL), iso_divide_(NULL), degree_(NULL), scale_(NULL), samples_per_node_(NULL)
+  depth_(nullptr), solver_divide_(nullptr), iso_divide_(nullptr), degree_(nullptr), scale_(nullptr), samples_per_node_(nullptr)
 {
 
 }

--- a/apps/modeler/src/render_window.cpp
+++ b/apps/modeler/src/render_window.cpp
@@ -64,7 +64,7 @@ pcl::modeler::RenderWindow::RenderWindow(RenderWindowItem* render_window_item, Q
 pcl::modeler::RenderWindow::~RenderWindow()
 {
   DockWidget* dock_widget = dynamic_cast<DockWidget*>(parent());
-  if (dock_widget != NULL)
+  if (dock_widget != nullptr)
   {
     MainWindow::getInstance().removeDockWidget(dock_widget);
     dock_widget->deleteLater();
@@ -115,7 +115,7 @@ void
 pcl::modeler::RenderWindow::setActive(bool flag)
 {
   DockWidget* dock_widget = dynamic_cast<DockWidget*>(parent());
-  if (dock_widget != NULL)
+  if (dock_widget != nullptr)
     dock_widget->setFocusBasedStyle(flag);
 
   return;
@@ -126,7 +126,7 @@ void
 pcl::modeler::RenderWindow::setTitle(const QString& title)
 {
   DockWidget* dock_widget = dynamic_cast<DockWidget*>(parent());
-  if (dock_widget != NULL)
+  if (dock_widget != nullptr)
     dock_widget->setWindowTitle(title);
 
   return;

--- a/apps/modeler/src/scene_tree.cpp
+++ b/apps/modeler/src/scene_tree.cpp
@@ -262,7 +262,7 @@ pcl::modeler::SceneTree::closePointCloud(const QList<CloudMeshItem*>& items)
   for (const auto &item : items)
   {
     RenderWindowItem* render_window_item = dynamic_cast<RenderWindowItem*>(item->parent());
-    if (render_window_item != NULL)
+    if (render_window_item != nullptr)
       render_window_items.push_back(render_window_item);
 
     item->parent()->removeChild(item);
@@ -394,7 +394,7 @@ pcl::modeler::SceneTree::slotUpdateOnSelectionChange(const QItemSelection & sele
   {
     QTreeWidgetItem* item = itemFromIndex(*selected_indices_it);
     RenderWindowItem* render_window_item = dynamic_cast<RenderWindowItem*>(item);
-    if (render_window_item != NULL)
+    if (render_window_item != nullptr)
     {
       render_window_item->getRenderWindow()->setActive(true);
     }
@@ -407,7 +407,7 @@ pcl::modeler::SceneTree::slotUpdateOnSelectionChange(const QItemSelection & sele
   {
     QTreeWidgetItem* item = itemFromIndex(*deselected_indices_it);
     RenderWindowItem* render_window_item = dynamic_cast<RenderWindowItem*>(item);
-    if (render_window_item != NULL)
+    if (render_window_item != nullptr)
     {
       render_window_item->getRenderWindow()->setActive(false);
     }
@@ -423,7 +423,7 @@ pcl::modeler::SceneTree::slotUpdateOnInsertOrRemove()
   for (int i = 0, i_end = topLevelItemCount(); i < i_end; ++ i)
   {
     RenderWindowItem* render_window_item = dynamic_cast<RenderWindowItem*>(topLevelItem(i));
-    if (render_window_item == NULL)
+    if (render_window_item == nullptr)
       continue;
 
     QString title = (i == 0)?("Central Render Window"):(QString("Render Window #%1").arg(i));
@@ -472,7 +472,7 @@ pcl::modeler::SceneTree::dropEvent(QDropEvent * event)
   for (const auto &cloud_mesh_item : selected_cloud_meshes)
   {
     RenderWindowItem* render_window_item = dynamic_cast<RenderWindowItem*>(cloud_mesh_item->parent());
-    if (render_window_item != NULL)
+    if (render_window_item != nullptr)
       previous_parents.insert(render_window_item);
   }
 
@@ -481,7 +481,7 @@ pcl::modeler::SceneTree::dropEvent(QDropEvent * event)
   std::vector<CloudMeshItem*> cloud_mesh_items;
   for (const auto &cloud_mesh_item : selected_cloud_meshes)
   {
-    if (dynamic_cast<RenderWindowItem*>(cloud_mesh_item->parent()) == NULL)
+    if (dynamic_cast<RenderWindowItem*>(cloud_mesh_item->parent()) == nullptr)
       cloud_mesh_items.push_back(cloud_mesh_item);
     else
       cloud_mesh_item->updateRenderWindow();
@@ -514,7 +514,7 @@ pcl::modeler::SceneTree::dropMimeData(QTreeWidgetItem * parent, int, const QMime
   QList<CloudMeshItem*> selected_cloud_meshes = selectedTypeItems<CloudMeshItem>();
 
   RenderWindowItem* render_window_item =
-    (parent == NULL)?(MainWindow::getInstance().createRenderWindow()):(dynamic_cast<RenderWindowItem*>(parent));
+    (parent == nullptr)?(MainWindow::getInstance().createRenderWindow()):(dynamic_cast<RenderWindowItem*>(parent));
 
   for (auto &selected_cloud_mesh : selected_cloud_meshes)
   {

--- a/apps/modeler/src/statistical_outlier_removal_worker.cpp
+++ b/apps/modeler/src/statistical_outlier_removal_worker.cpp
@@ -45,7 +45,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 pcl::modeler::StatisticalOutlierRemovalWorker::StatisticalOutlierRemovalWorker(const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent) :
   AbstractWorker(cloud_mesh_items, parent),
-  mean_k_(NULL), stddev_mul_thresh_(NULL)
+  mean_k_(nullptr), stddev_mul_thresh_(nullptr)
 {
 }
 

--- a/apps/modeler/src/voxel_grid_downsample_worker.cpp
+++ b/apps/modeler/src/voxel_grid_downsample_worker.cpp
@@ -49,7 +49,7 @@ pcl::modeler::VoxelGridDownampleWorker::VoxelGridDownampleWorker(const QList<Clo
   x_min_(std::numeric_limits<double>::max()), x_max_(std::numeric_limits<double>::min()),
   y_min_(std::numeric_limits<double>::max()), y_max_(std::numeric_limits<double>::min()),
   z_min_(std::numeric_limits<double>::max()), z_max_(std::numeric_limits<double>::min()),
-  leaf_size_x_(NULL), leaf_size_y_(NULL), leaf_size_z_(NULL)
+  leaf_size_x_(nullptr), leaf_size_y_(nullptr), leaf_size_z_(nullptr)
 {
 }
 

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
@@ -57,7 +57,7 @@ class CloudEditorWidget : public QGLWidget
   public:
     /// @brief Constructor
     /// @param parent a pointer which points to the parent widget
-    CloudEditorWidget (QWidget *parent = 0);
+    CloudEditorWidget (QWidget *parent = nullptr);
 
     /// @brief Destructor
     ~CloudEditorWidget ();

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
@@ -56,7 +56,7 @@ class StatisticsDialog : public QDialog
 
   public:
     /// @brief Default Constructor
-    StatisticsDialog(QWidget *parent = 0);
+    StatisticsDialog(QWidget *parent = nullptr);
     /// @brief Destructor
     ~StatisticsDialog ();
     

--- a/apps/src/feature_matching.cpp
+++ b/apps/src/feature_matching.cpp
@@ -147,7 +147,7 @@ ICCVTutorial<FeatureType>::ICCVTutorial(boost::shared_ptr<pcl::Keypoint<pcl::Poi
 , show_target2source_ (false)
 , show_correspondences (false)
 {
-  visualizer_.registerKeyboardCallback(&ICCVTutorial::keyboard_callback, *this, 0);
+  visualizer_.registerKeyboardCallback(&ICCVTutorial::keyboard_callback, *this, nullptr);
 
   segmentation (source_, source_segmented_);
   segmentation (target_, target_segmented_);

--- a/apps/src/grabcut_2d.cpp
+++ b/apps/src/grabcut_2d.cpp
@@ -317,7 +317,7 @@ idle_callback ()
   if (!changed)
   {
     refining_ = false;
-    glutIdleFunc (NULL);
+    glutIdleFunc (nullptr);
   }
 }
 
@@ -452,7 +452,7 @@ keyboard_callback (unsigned char key, int, int)
       break;
     case 27:
       refining_ = false;
-      glutIdleFunc(NULL);
+      glutIdleFunc(nullptr);
     default:
       break;
   }

--- a/apps/src/openni_klt.cpp
+++ b/apps/src/openni_klt.cpp
@@ -111,7 +111,7 @@ class OpenNIViewer
     OpenNIViewer (pcl::Grabber& grabber)
       : image_viewer_ ()
       , grabber_ (grabber)
-      , rgb_data_ (0), rgb_data_size_ (0)
+      , rgb_data_ (nullptr), rgb_data_size_ (0)
     { }
 
     void

--- a/apps/src/openni_shift_to_depth_conversion.cpp
+++ b/apps/src/openni_shift_to_depth_conversion.cpp
@@ -66,7 +66,7 @@ class SimpleOpenNIViewer
   public:
     SimpleOpenNIViewer () :
       viewer_ ("Input Point Cloud - Shift-to-depth conversion viewer"),
-      grabber_(0)
+      grabber_(nullptr)
     {
     }
 

--- a/apps/src/openni_tracking.cpp
+++ b/apps/src/openni_tracking.cpp
@@ -568,7 +568,7 @@ public:
         target_cloud = cloud_pass_downsampled_;
       }
       
-      if (target_cloud != NULL)
+      if (target_cloud != nullptr)
       {
         PCL_INFO ("segmentation, please wait...\n");
         std::vector<pcl::PointIndices> cluster_indices;

--- a/apps/src/pcd_organized_multi_plane_segmentation.cpp
+++ b/apps/src/pcd_organized_multi_plane_segmentation.cpp
@@ -70,7 +70,7 @@ class PCDOrganizedMultiPlaneSegmentation
       //viewer.setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, 0.15, "cloud");
       viewer.addCoordinateSystem (1.0, "global");
       viewer.initCameraParameters ();
-      viewer.registerKeyboardCallback(&PCDOrganizedMultiPlaneSegmentation::keyboard_callback, *this, 0);
+      viewer.registerKeyboardCallback(&PCDOrganizedMultiPlaneSegmentation::keyboard_callback, *this, nullptr);
     }
 
     void keyboard_callback (const pcl::visualization::KeyboardEvent& event, void*)

--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -31,7 +31,7 @@ void
 pcl::apps::RenderViewsTesselatedSphere::generateViews() {
   //center object
   double CoM[3];
-  vtkIdType npts_com = 0, *ptIds_com = NULL;
+  vtkIdType npts_com = 0, *ptIds_com = nullptr;
   vtkSmartPointer<vtkCellArray> cells_com = polydata_->GetPolys ();
 
   double center[3], p1_com[3], p2_com[3], p3_com[3], totalArea_com = 0;
@@ -90,7 +90,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
   // * Compute area of the mesh
   //////////////////////////////
   vtkSmartPointer<vtkCellArray> cells = mapper->GetInput ()->GetPolys ();
-  vtkIdType npts = 0, *ptIds = NULL;
+  vtkIdType npts = 0, *ptIds = nullptr;
 
   double p1[3], p2[3], p3[3], totalArea = 0;
   for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)
@@ -359,7 +359,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
       polydata->BuildCells ();
 
       vtkSmartPointer<vtkCellArray> cells = polydata->GetPolys ();
-      vtkIdType npts = 0, *ptIds = NULL;
+      vtkIdType npts = 0, *ptIds = nullptr;
 
       double p1[3], p2[3], p3[3], area, totalArea = 0;
       for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -125,7 +125,7 @@ class HRCSSegmentation
       viewer->setBackgroundColor (0, 0, 0);
       viewer->addCoordinateSystem (1.0, "global");
       viewer->initCameraParameters ();
-      viewer->registerKeyboardCallback (&HRCSSegmentation::keyboardCallback, *this, 0);
+      viewer->registerKeyboardCallback (&HRCSSegmentation::keyboardCallback, *this, nullptr);
       
       // Set up the stereo matching
       stereo.setMaxDisparity(60);


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix