### PR TITLE
Use nullptr in module common

### DIFF
--- a/common/include/pcl/common/impl/bivariate_polynomial.hpp
+++ b/common/include/pcl/common/impl/bivariate_polynomial.hpp
@@ -42,7 +42,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename real>
 pcl::BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree) :
-  degree(0), parameters(NULL), gradient_x(NULL), gradient_y(NULL)
+  degree(0), parameters(nullptr), gradient_x(nullptr), gradient_y(nullptr)
 {
   setDegree(new_degree);
 }
@@ -79,17 +79,17 @@ pcl::BivariatePolynomialT<real>::setDegree (int newDegree)
     delete[] parameters;
     parameters = new real[getNoOfParameters ()];
   }
-  delete gradient_x; gradient_x = NULL;
-  delete gradient_y; gradient_y = NULL;
+  delete gradient_x; gradient_x = nullptr;
+  delete gradient_y; gradient_y = nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename real> void
 pcl::BivariatePolynomialT<real>::memoryCleanUp ()
 {
-  delete[] parameters; parameters = NULL;
-  delete gradient_x; gradient_x = NULL;
-  delete gradient_y; gradient_y = NULL;
+  delete[] parameters; parameters = nullptr;
+  delete gradient_x; gradient_x = nullptr;
+  delete gradient_y; gradient_y = nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/common/include/pcl/common/impl/file_io.hpp
+++ b/common/include/pcl/common/impl/file_io.hpp
@@ -47,11 +47,11 @@ namespace pcl
   {
     DIR *dp;
     struct dirent *dirp;
-    if((dp  = opendir(directory.c_str())) == NULL) {
+    if((dp  = opendir(directory.c_str())) == nullptr) {
       std::cerr << "Could not open directory.\n";
       return;
     }
-    while ((dirp = readdir(dp)) != NULL) {
+    while ((dirp = readdir(dp)) != nullptr) {
       if (dirp->d_type == DT_REG)  // Only regular files
       {
         std::string file_name = dirp->d_name;

--- a/common/include/pcl/exceptions.h
+++ b/common/include/pcl/exceptions.h
@@ -66,8 +66,8 @@ namespace pcl
     public:
 
       PCLException (const std::string& error_description,
-                    const char* file_name = NULL,
-                    const char* function_name = NULL,
+                    const char* file_name = nullptr,
+                    const char* function_name = nullptr,
                     unsigned line_number = 0)
         : std::runtime_error (createDetailedMessage (error_description,
                                                      file_name,
@@ -111,10 +111,10 @@ namespace pcl
                              unsigned line_number)
       {
         std::ostringstream sstream;
-        if (function_name != NULL)
+        if (function_name != nullptr)
           sstream << function_name << " ";
         
-        if (file_name != NULL)
+        if (file_name != nullptr)
         {
           sstream << "in " << file_name << " ";
           if (line_number != 0)
@@ -138,8 +138,8 @@ namespace pcl
     public:
 
       InvalidConversionException (const std::string& error_description,
-                                  const char* file_name = NULL,
-                                  const char* function_name = NULL,
+                                  const char* file_name = nullptr,
+                                  const char* function_name = nullptr,
                                   unsigned line_number = 0)
         : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -152,8 +152,8 @@ namespace pcl
     public:
 
       IsNotDenseException (const std::string& error_description,
-                           const char* file_name = NULL,
-                           const char* function_name = NULL,
+                           const char* file_name = nullptr,
+                           const char* function_name = nullptr,
                            unsigned line_number = 0)
         : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -167,8 +167,8 @@ namespace pcl
     public:
 
       InvalidSACModelTypeException (const std::string& error_description,
-                                    const char* file_name = NULL,
-                                    const char* function_name = NULL,
+                                    const char* file_name = nullptr,
+                                    const char* function_name = nullptr,
                                     unsigned line_number = 0)
         : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -181,8 +181,8 @@ namespace pcl
     public:
 
       IOException (const std::string& error_description,
-                   const char* file_name = NULL,
-                   const char* function_name = NULL,
+                   const char* file_name = nullptr,
+                   const char* function_name = nullptr,
                    unsigned line_number = 0)
         : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -195,8 +195,8 @@ namespace pcl
   {
     public:
       InitFailedException (const std::string& error_description = "",
-                           const char* file_name = NULL,
-                           const char* function_name = NULL,
+                           const char* file_name = nullptr,
+                           const char* function_name = nullptr,
                            unsigned line_number = 0)
         : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -210,8 +210,8 @@ namespace pcl
     public:
     
       UnorganizedPointCloudException (const std::string& error_description,
-                                      const char* file_name = NULL,
-                                      const char* function_name = NULL,
+                                      const char* file_name = nullptr,
+                                      const char* function_name = nullptr,
                                       unsigned line_number = 0)
         : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -224,8 +224,8 @@ namespace pcl
     public:
     
     KernelWidthTooSmallException (const std::string& error_description,
-                                  const char* file_name = NULL,
-                                  const char* function_name = NULL,
+                                  const char* file_name = nullptr,
+                                  const char* function_name = nullptr,
                                   unsigned line_number = 0)
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -234,8 +234,8 @@ namespace pcl
   {
     public:
     UnhandledPointTypeException (const std::string& error_description,
-                                 const char* file_name = NULL,
-                                 const char* function_name = NULL,
+                                 const char* file_name = nullptr,
+                                 const char* function_name = nullptr,
                                  unsigned line_number = 0)
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   };
@@ -244,8 +244,8 @@ namespace pcl
   {
     public:
     ComputeFailedException (const std::string& error_description,
-                            const char* file_name = NULL,
-                            const char* function_name = NULL,
+                            const char* file_name = nullptr,
+                            const char* function_name = nullptr,
                             unsigned line_number = 0)
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   };
@@ -257,8 +257,8 @@ namespace pcl
   {
     public:
     BadArgumentException (const std::string& error_description,
-                          const char* file_name = NULL,
-                          const char* function_name = NULL,
+                          const char* file_name = nullptr,
+                          const char* function_name = nullptr,
                           unsigned line_number = 0)
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   };

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -936,7 +936,7 @@ bool
 RangeImage::getNormalForClosestNeighbors (int x, int y, int radius, const PointWithRange& point,
                                               int no_of_nearest_neighbors, Eigen::Vector3f& normal, int step_size) const
 {
-  return getNormalForClosestNeighbors (x, y, radius, Eigen::Vector3f (point.x, point.y, point.z), no_of_nearest_neighbors, normal, NULL, step_size);
+  return getNormalForClosestNeighbors (x, y, radius, Eigen::Vector3f (point.x, point.y, point.z), no_of_nearest_neighbors, normal, nullptr, step_size);
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -969,11 +969,11 @@ RangeImage::getSurfaceInformation (int x, int y, int radius, const Eigen::Vector
 {
   max_closest_neighbor_distance_squared=0.0f;
   normal.setZero (); mean.setZero (); eigen_values.setZero ();
-  if (normal_all_neighbors!=NULL)
+  if (normal_all_neighbors!=nullptr)
     normal_all_neighbors->setZero ();
-  if (mean_all_neighbors!=NULL)
+  if (mean_all_neighbors!=nullptr)
     mean_all_neighbors->setZero ();
-  if (eigen_values_all_neighbors!=NULL)
+  if (eigen_values_all_neighbors!=nullptr)
     eigen_values_all_neighbors->setZero ();
   
   int blocksize = static_cast<int> (pow (static_cast<double> ( (2.0 * radius + 1.0)), 2.0));
@@ -1027,7 +1027,7 @@ RangeImage::getSurfaceInformation (int x, int y, int radius, const Eigen::Vector
     normal *= -1.0f;
   mean = vector_average.getMean ();
   
-  if (normal_all_neighbors==NULL)
+  if (normal_all_neighbors==nullptr)
     return true;
   
   // Add remaining neighbors
@@ -1086,7 +1086,7 @@ RangeImage::getNormalForClosestNeighbors (int x, int y, int radius, const Eigen:
   
   if (ret)
   {
-    if (point_on_plane != NULL)
+    if (point_on_plane != nullptr)
       *point_on_plane = (normal.dot (mean) - normal.dot (point))*normal + point;
   }
   return ret;

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -535,7 +535,7 @@ namespace pcl
       inline bool
       getNormalForClosestNeighbors (int x, int y, int radius, const Eigen::Vector3f& point,
                                     int no_of_nearest_neighbors, Eigen::Vector3f& normal,
-                                    Eigen::Vector3f* point_on_plane=NULL, int step_size=1) const;
+                                    Eigen::Vector3f* point_on_plane=nullptr, int step_size=1) const;
       
       /** Same as above, using default values */
       inline bool
@@ -548,9 +548,9 @@ namespace pcl
                              int no_of_closest_neighbors, int step_size,
                              float& max_closest_neighbor_distance_squared,
                              Eigen::Vector3f& normal, Eigen::Vector3f& mean, Eigen::Vector3f& eigen_values,
-                             Eigen::Vector3f* normal_all_neighbors=NULL,
-                             Eigen::Vector3f* mean_all_neighbors=NULL,
-                             Eigen::Vector3f* eigen_values_all_neighbors=NULL) const;
+                             Eigen::Vector3f* normal_all_neighbors=nullptr,
+                             Eigen::Vector3f* mean_all_neighbors=nullptr,
+                             Eigen::Vector3f* eigen_values_all_neighbors=nullptr) const;
       
       // Return the squared distance to the n-th neighbors of the point at x,y
       inline float


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix