### PR TITLE
Use nullptr in module cuda

### DIFF
--- a/cuda/common/include/pcl/cuda/time_cpu.h
+++ b/cuda/common/include/pcl/cuda/time_cpu.h
@@ -119,7 +119,7 @@ inline double
   return (double)(timer_tick.QuadPart)/(double)frequency.QuadPart;
 #else
   timeval current_time;
-  gettimeofday (&current_time, NULL);
+  gettimeofday (&current_time, nullptr);
   return (current_time.tv_sec + 1e-6 * current_time.tv_usec);
 #endif
 }


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix