### PR TITLE
Use nullptr in module examples

### DIFF
--- a/examples/outofcore/example_outofcore.cpp
+++ b/examples/outofcore/example_outofcore.cpp
@@ -80,7 +80,7 @@ int main (int, char** argv)
   OutofcoreDepthFirstIterator<pcl::PointXYZ, pcl::outofcore::OutofcoreOctreeDiskContainer<pcl::PointXYZ> > it (*octree);
   OctreeDisk::Iterator myit (*octree);
 
-  while ( *myit !=0 )
+  while ( *myit !=nullptr )
   {
     octree->printBoundingBox (**myit);
     myit++;

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -459,7 +459,7 @@ CPCSegmentation Parameters: \n\
     const unsigned char concave_color [3] = {255,  0,  0};
     const unsigned char cut_color     [3] = {  0,255,  0};
     const unsigned char* convex_color     = bg_white ? black_color : white_color;
-    const unsigned char* color = NULL;
+    const unsigned char* color = nullptr;
 
     //The vertices in the supervoxel adjacency list are the supervoxel centroids
     //This iterates through them, finding the edges
@@ -529,7 +529,7 @@ CPCSegmentation Parameters: \n\
     pcl::visualization::PCLVisualizer::Ptr viewer (new pcl::visualization::PCLVisualizer ("3D Viewer"));
     float bg_color = bg_white?1:0;
     viewer->setBackgroundColor (bg_color, bg_color, bg_color);
-    viewer->registerKeyboardCallback (keyboardEventOccurred, 0);
+    viewer->registerKeyboardCallback (keyboardEventOccurred, nullptr);
     viewer->addPointCloud (cpc_labeled_cloud, "cpc_cloud");
     /// Visualization Loop
     PCL_INFO ("Loading viewer\n");

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -450,7 +450,7 @@ LCCPSegmentation Parameters: \n\
     /// Configure Visualizer
     pcl::visualization::PCLVisualizer::Ptr viewer (new pcl::visualization::PCLVisualizer ("3D Viewer"));
     viewer->setBackgroundColor (0, 0, 0);
-    viewer->registerKeyboardCallback (keyboardEventOccurred, 0);
+    viewer->registerKeyboardCallback (keyboardEventOccurred, nullptr);
     viewer->addPointCloud (lccp_labeled_cloud, "maincloud");
 
     /// Visualization Loop

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -343,7 +343,7 @@ main (int argc, char ** argv)
   std::cout << "Loading visualization...\n";
   pcl::visualization::PCLVisualizer::Ptr viewer (new pcl::visualization::PCLVisualizer ("3D Viewer"));
   viewer->setBackgroundColor (0, 0, 0);
-  viewer->registerKeyboardCallback(keyboard_callback, 0);
+  viewer->registerKeyboardCallback(keyboard_callback, nullptr);
 
  
   bool refined_normal_shown = show_refined;

--- a/examples/surface/example_nurbs_viewer_surface.cpp
+++ b/examples/surface/example_nurbs_viewer_surface.cpp
@@ -48,7 +48,7 @@ main (int argc, char *argv[])
   }
 
   const ON_Object* on_object = on_model.m_object_table[0].m_object;
-  if(on_object==NULL)
+  if(on_object==nullptr)
   {
     std::cout << "object[0] not valid." << std::endl;
     return -1;
@@ -68,7 +68,7 @@ main (int argc, char *argv[])
   else
   {
     on_object = on_model.m_object_table[1].m_object;
-    if(on_object==NULL)
+    if(on_object==nullptr)
     {
       std::cout << "object[1] not valid." << std::endl;
       return -1;


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix