### PR TITLE
Use nullptr in module filters

### DIFF
--- a/filters/include/pcl/filters/impl/conditional_removal.hpp
+++ b/filters/include/pcl/filters/impl/conditional_removal.hpp
@@ -49,7 +49,7 @@ template <typename PointT>
 pcl::FieldComparison<PointT>::FieldComparison (
     const std::string &field_name, ComparisonOps::CompareOp op, double compare_val) 
   : ComparisonBase<PointT> ()
-  , compare_val_ (compare_val), point_data_ (NULL)
+  , compare_val_ (compare_val), point_data_ (nullptr)
 {
   field_name_ = field_name;
   op_ = op;
@@ -93,10 +93,10 @@ pcl::FieldComparison<PointT>::FieldComparison (
 template <typename PointT>
 pcl::FieldComparison<PointT>::~FieldComparison () 
 {
-  if (point_data_ != NULL)
+  if (point_data_ != nullptr)
   {
     delete point_data_;
-    point_data_ = NULL;
+    point_data_ = nullptr;
   }
 }
 
@@ -682,7 +682,7 @@ pcl::ConditionalRemoval<PointT>::applyFilter (PointCloud &output)
     return;
   }
 
-  if (condition_.get () == NULL) 
+  if (condition_.get () == nullptr) 
   {
     PCL_WARN ("[pcl::%s::applyFilter] No filtering condition given!\n", getClassName ().c_str ());
     return;

--- a/filters/include/pcl/filters/normal_space.h
+++ b/filters/include/pcl/filters/normal_space.h
@@ -72,12 +72,12 @@ namespace pcl
       /** \brief Empty constructor. */
       NormalSpaceSampling ()
         : sample_ (std::numeric_limits<unsigned int>::max ())
-        , seed_ (static_cast<unsigned int> (time (NULL)))
+        , seed_ (static_cast<unsigned int> (time (nullptr)))
         , binsx_ ()
         , binsy_ ()
         , binsz_ ()
         , input_normals_ ()
-        , rng_uniform_distribution_ (NULL)
+        , rng_uniform_distribution_ (nullptr)
       {
         filter_name_ = "NormalSpaceSampling";
       }

--- a/filters/include/pcl/filters/random_sample.h
+++ b/filters/include/pcl/filters/random_sample.h
@@ -77,7 +77,7 @@ namespace pcl
       RandomSample (bool extract_removed_indices = false) : 
         FilterIndices<PointT> (extract_removed_indices),
         sample_ (UINT_MAX), 
-        seed_ (static_cast<unsigned int> (time (NULL)))
+        seed_ (static_cast<unsigned int> (time (nullptr)))
       {
         filter_name_ = "RandomSample";
       }
@@ -166,7 +166,7 @@ namespace pcl
       typedef boost::shared_ptr<const RandomSample<pcl::PCLPointCloud2> > ConstPtr;
   
       /** \brief Empty constructor. */
-      RandomSample () : sample_ (UINT_MAX), seed_ (static_cast<unsigned int> (time (NULL)))
+      RandomSample () : sample_ (UINT_MAX), seed_ (static_cast<unsigned int> (time (nullptr)))
       {
         filter_name_ = "RandomSample";
       }

--- a/filters/include/pcl/filters/sampling_surface_normal.h
+++ b/filters/include/pcl/filters/sampling_surface_normal.h
@@ -71,7 +71,7 @@ namespace pcl
 
       /** \brief Empty constructor. */
       SamplingSurfaceNormal () : 
-        sample_ (10), seed_ (static_cast<unsigned int> (time (NULL))), ratio_ ()
+        sample_ (10), seed_ (static_cast<unsigned int> (time (nullptr))), ratio_ ()
       {
         filter_name_ = "SamplingSurfaceNormal";
         srand (seed_);

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -308,7 +308,7 @@ namespace pcl
           return ret;
         }
         else
-          return NULL;
+          return nullptr;
       }
 
       /** \brief Get the voxel containing point p.
@@ -335,7 +335,7 @@ namespace pcl
           return ret;
         }
         else
-          return NULL;
+          return nullptr;
       }
 
       /** \brief Get the voxel containing point p.
@@ -362,7 +362,7 @@ namespace pcl
           return ret;
         }
         else
-          return NULL;
+          return nullptr;
 
       }
 


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix