### PR TITLE
Use nullptr in module geometry

### DIFF
--- a/geometry/include/pcl/geometry/mesh_circulators.h
+++ b/geometry/include/pcl/geometry/mesh_circulators.h
@@ -77,7 +77,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         VertexAroundVertexCirculator ()
-          : mesh_                   (NULL),
+          : mesh_                   (nullptr),
             idx_outgoing_half_edge_ ()
         {
         }
@@ -185,7 +185,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         OutgoingHalfEdgeAroundVertexCirculator ()
-          : mesh_                   (NULL),
+          : mesh_                   (nullptr),
             idx_outgoing_half_edge_ ()
         {
         }
@@ -293,7 +293,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         IncomingHalfEdgeAroundVertexCirculator ()
-          : mesh_                   (NULL),
+          : mesh_                   (nullptr),
             idx_incoming_half_edge_ ()
         {
         }
@@ -402,7 +402,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         FaceAroundVertexCirculator ()
-          : mesh_                   (NULL),
+          : mesh_                   (nullptr),
             idx_outgoing_half_edge_ ()
         {
         }
@@ -511,7 +511,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         VertexAroundFaceCirculator ()
-          : mesh_                (NULL),
+          : mesh_                (nullptr),
             idx_inner_half_edge_ ()
         {
         }
@@ -619,7 +619,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         InnerHalfEdgeAroundFaceCirculator ()
-          : mesh_                (NULL),
+          : mesh_                (nullptr),
             idx_inner_half_edge_ ()
         {
         }
@@ -727,7 +727,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         OuterHalfEdgeAroundFaceCirculator ()
-          : mesh_                (NULL),
+          : mesh_                (nullptr),
             idx_inner_half_edge_ ()
         {
         }
@@ -835,7 +835,7 @@ namespace pcl
 
         /** \brief Constructor resulting in an invalid circulator. */
         FaceAroundFaceCirculator ()
-          : mesh_                (NULL),
+          : mesh_                (nullptr),
             idx_inner_half_edge_ ()
         {
         }


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix