### PR TITLE
Use nullptr in module octree

### DIFF
--- a/octree/include/pcl/octree/impl/octree2buf_base.hpp
+++ b/octree/include/pcl/octree/impl/octree2buf_base.hpp
@@ -182,7 +182,7 @@ namespace pcl
       // we can safely remove children references of root node
       for (unsigned char child_idx = 0; child_idx < 8; child_idx++)
       {
-        root_node_->setChildPtr(buffer_selector_, child_idx, 0);
+        root_node_->setChildPtr(buffer_selector_, child_idx, nullptr);
       }
     }
 
@@ -197,7 +197,7 @@ namespace pcl
       binary_tree_out_arg.clear ();
       binary_tree_out_arg.reserve (this->branch_count_);
 
-      serializeTreeRecursive (root_node_, new_key, &binary_tree_out_arg, 0, do_XOR_encoding_arg, false);
+      serializeTreeRecursive (root_node_, new_key, &binary_tree_out_arg, nullptr, do_XOR_encoding_arg, false);
 
       // serializeTreeRecursive cleans-up unused octree nodes in previous octree
       tree_dirty_flag_ = false;
@@ -235,7 +235,7 @@ namespace pcl
 
       leaf_container_vector_arg.reserve (leaf_count_);
 
-      serializeTreeRecursive (root_node_, new_key, 0, &leaf_container_vector_arg, false, false);
+      serializeTreeRecursive (root_node_, new_key, nullptr, &leaf_container_vector_arg, false, false);
 
       // serializeLeafsRecursive cleans-up unused octree nodes in previous octree
       tree_dirty_flag_ = false;
@@ -256,7 +256,7 @@ namespace pcl
       std::vector<char>::const_iterator binary_tree_in_it_end = binary_tree_in_arg.end ();
 
       deserializeTreeRecursive (root_node_, depth_mask_, new_key,
-          binary_tree_in_it, binary_tree_in_it_end, 0, 0, false,
+          binary_tree_in_it, binary_tree_in_it_end, nullptr, nullptr, false,
           do_XOR_decoding_arg);
 
       // we modified the octree structure -> clean-up/tree-reset might be required
@@ -310,7 +310,7 @@ namespace pcl
       leaf_container_vector_arg.clear ();
       leaf_container_vector_arg.reserve (leaf_count_);
 
-      serializeTreeRecursive (root_node_, new_key, 0, &leaf_container_vector_arg, false, true);
+      serializeTreeRecursive (root_node_, new_key, nullptr, &leaf_container_vector_arg, false, true);
 
       // serializeLeafsRecursive cleans-up unused octree nodes in previous octree buffer
       tree_dirty_flag_ = false;
@@ -332,7 +332,7 @@ namespace pcl
         // we can safely remove children references
         for (unsigned char child_idx = 0; child_idx < 8; child_idx++)
         {
-          branch_arg->setChildPtr(buffer_selector_, child_idx, 0);
+          branch_arg->setChildPtr(buffer_selector_, child_idx, nullptr);
         }
       }
 
@@ -637,7 +637,7 @@ namespace pcl
         // we can safely remove children references
         for (unsigned char child_idx = 0; child_idx < 8; child_idx++)
         {
-          branch_arg->setChildPtr(buffer_selector_, child_idx, 0);
+          branch_arg->setChildPtr(buffer_selector_, child_idx, nullptr);
         }  
       }
 
@@ -765,7 +765,7 @@ namespace pcl
           else if (branch_arg->hasChild (!buffer_selector_, child_idx))
           {
             // remove old branch pointer information in current branch
-            branch_arg->setChildPtr(buffer_selector_, child_idx, 0);
+            branch_arg->setChildPtr(buffer_selector_, child_idx, nullptr);
             
             // remove unused branches in previous buffer
             deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);

--- a/octree/include/pcl/octree/impl/octree_base.hpp
+++ b/octree/include/pcl/octree/impl/octree_base.hpp
@@ -186,7 +186,7 @@ namespace pcl
         binary_tree_out_arg.clear ();
         binary_tree_out_arg.reserve (this->branch_count_);
 
-        serializeTreeRecursive (root_node_, new_key, &binary_tree_out_arg, 0);
+        serializeTreeRecursive (root_node_, new_key, &binary_tree_out_arg, nullptr);
       }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -220,7 +220,7 @@ namespace pcl
 
         leaf_container_vector_arg.reserve (this->leaf_count_);
 
-        serializeTreeRecursive (root_node_, new_key, 0, &leaf_container_vector_arg);
+        serializeTreeRecursive (root_node_, new_key, nullptr, &leaf_container_vector_arg);
       }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -242,8 +242,8 @@ namespace pcl
                                   new_key,
                                   binary_tree_out_it,
                                   binary_tree_out_it_end,
-                                  0,
-                                  0);
+                                  nullptr,
+                                  nullptr);
 
       }
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -201,7 +201,7 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
   const PointT& point_arg) const
 {
   OctreeKey key;
-  LeafContainerT* leaf = 0;
+  LeafContainerT* leaf = nullptr;
   // generate key
   this->genOctreeKeyforPoint (point_arg, key);
   

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -127,7 +127,7 @@ namespace pcl
         inline bool hasChild (unsigned char buffer_arg, unsigned char index_arg) const
         {
           assert( (buffer_arg<2) && (index_arg<8));
-          return (child_node_array_[buffer_arg][index_arg] != 0);
+          return (child_node_array_[buffer_arg][index_arg] != nullptr);
         }
 
         /** \brief Get the type of octree node. Returns LEAVE_NODE type */
@@ -299,7 +299,7 @@ namespace pcl
 
         const LeafNodeBreadthIterator leaf_breadth_end ()
         {
-          return LeafNodeBreadthIterator (this, 0, NULL);
+          return LeafNodeBreadthIterator (this, 0, nullptr);
         };
 
         /** \brief Empty constructor. */
@@ -503,7 +503,7 @@ namespace pcl
         inline LeafContainerT*
         findLeaf (const OctreeKey& key_arg) const
         {
-          LeafContainerT* result = 0;
+          LeafContainerT* result = nullptr;
           findLeafRecursive (key_arg, depth_mask_, root_node_, result);
           return result;
         }
@@ -532,7 +532,7 @@ namespace pcl
          * */
         inline bool existLeaf (const OctreeKey& key_arg) const
         {
-          return (findLeaf(key_arg) != 0);
+          return (findLeaf(key_arg) != nullptr);
         }
 
         /** \brief Remove leaf node from octree
@@ -562,7 +562,7 @@ namespace pcl
         branchHasChild (const BranchNode& branch_arg, unsigned char child_idx_arg) const
         {
           // test occupancyByte for child existence
-          return (branch_arg.getChildPtr(buffer_selector_, child_idx_arg) != 0);
+          return (branch_arg.getChildPtr(buffer_selector_, child_idx_arg) != nullptr);
         }
 
         /** \brief Retrieve a child node pointer for child node at child_idx.
@@ -697,7 +697,7 @@ namespace pcl
             }
 
             // set branch child pointer to 0
-            branch_arg.setChildPtr(buffer_selector_arg, child_idx_arg, 0);
+            branch_arg.setChildPtr(buffer_selector_arg, child_idx_arg, nullptr);
           }
         }
 
@@ -725,8 +725,8 @@ namespace pcl
               deleteBranchChild (branch_arg, 0, i);
 
               // remove pointers from both buffers
-              branch_arg.setChildPtr(0, i, 0);
-              branch_arg.setChildPtr(1, i, 0);
+              branch_arg.setChildPtr(0, i, nullptr);
+              branch_arg.setChildPtr(1, i, nullptr);
             }
             else
             {

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -118,7 +118,7 @@ namespace pcl
 
         const Iterator end ()
         {
-          return Iterator (this, 0, NULL);
+          return Iterator (this, 0, nullptr);
         };
 
         // Octree leaf node iterators
@@ -137,7 +137,7 @@ namespace pcl
         [[deprecated("use leaf_depth_end() instead")]]
         const LeafNodeIterator leaf_end ()
         {
-          return LeafNodeIterator (this, 0, NULL);
+          return LeafNodeIterator (this, 0, nullptr);
         };
 
         // The currently valide names
@@ -151,7 +151,7 @@ namespace pcl
 
         const LeafNodeDepthFirstIterator leaf_depth_end ()
         {
-          return LeafNodeDepthFirstIterator (this, 0, NULL);
+          return LeafNodeDepthFirstIterator (this, 0, nullptr);
         };
 
         // Octree depth-first iterators
@@ -165,7 +165,7 @@ namespace pcl
 
         const DepthFirstIterator depth_end ()
         {
-          return DepthFirstIterator (this, 0, NULL);
+          return DepthFirstIterator (this, 0, nullptr);
         };
 
         // Octree breadth-first iterators
@@ -179,7 +179,7 @@ namespace pcl
 
         const BreadthFirstIterator breadth_end ()
         {
-          return BreadthFirstIterator (this, 0, NULL);
+          return BreadthFirstIterator (this, 0, nullptr);
         };
 
         // Octree breadth iterators at a given depth
@@ -193,7 +193,7 @@ namespace pcl
 
         const FixedDepthIterator fixed_depth_end ()
         {
-          return FixedDepthIterator (this, 0, NULL);
+          return FixedDepthIterator (this, 0, nullptr);
         };
 
         // Octree leaf node iterators
@@ -207,7 +207,7 @@ namespace pcl
 
         const LeafNodeBreadthFirstIterator leaf_breadth_end ()
         {
-          return LeafNodeBreadthFirstIterator (this, 0, NULL);
+          return LeafNodeBreadthFirstIterator (this, 0, nullptr);
         };
 
         /** \brief Empty constructor. */
@@ -386,7 +386,7 @@ namespace pcl
         LeafContainerT*
         findLeaf (const OctreeKey& key_arg) const
         {
-          LeafContainerT* result = 0;
+          LeafContainerT* result = nullptr;
           findLeafRecursive (key_arg, depth_mask_, root_node_, result);
           return result;
         }
@@ -398,7 +398,7 @@ namespace pcl
         bool
         existLeaf (const OctreeKey& key_arg) const
         {
-          return (findLeaf(key_arg) != 0);
+          return (findLeaf(key_arg) != nullptr);
         }
 
         /** \brief Remove leaf node from octree
@@ -432,7 +432,7 @@ namespace pcl
                         unsigned char child_idx_arg) const
         {
           // test occupancyByte for child existence
-          return (branch_arg.getChildPtr(child_idx_arg) != 0);
+          return (branch_arg.getChildPtr(child_idx_arg) != nullptr);
         }
 
         /** \brief Retrieve a child node pointer for child node at child_idx.
@@ -511,7 +511,7 @@ namespace pcl
             }
 
             // set branch child pointer to 0
-            branch_arg[child_idx_arg] = 0;
+            branch_arg[child_idx_arg] = nullptr;
           }
         }
 

--- a/octree/include/pcl/octree/octree_nodes.h
+++ b/octree/include/pcl/octree/octree_nodes.h
@@ -286,7 +286,7 @@ namespace pcl
          * */
         inline bool hasChild (unsigned char child_idx_arg) const
         {
-          return (child_node_array_[child_idx_arg] != 0);
+          return (child_node_array_[child_idx_arg] != nullptr);
         }
 
 


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix