### PR TITLE
Use nullptr in module recognition

### DIFF
--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -311,7 +311,7 @@ computeGaussianKernel (const size_t kernel_size, const float sigma, std::vector 
   };
 
   const float* fixed_kernel = n % 2 == 1 && n <= SMALL_GAUSSIAN_SIZE && sigma <= 0 ?
-      small_gaussian_tab[n>>1] : 0;
+      small_gaussian_tab[n>>1] : nullptr;
 
   //CV_Assert( ktype == CV_32F || ktype == CV_64F );
   /*Mat kernel(n, 1, ktype);*/

--- a/recognition/include/pcl/recognition/crh_alignment.h
+++ b/recognition/include/pcl/recognition/crh_alignment.h
@@ -220,7 +220,7 @@ namespace pcl
 
         multAB[nbins_ - 1].r = input_ftt_negate.points[0].histogram[nbins_ - 1] * target_ftt.points[0].histogram[nbins_ - 1];
 
-        kiss_fft_cfg mycfg = kiss_fft_alloc (nr_bins_after_padding, 1, NULL, NULL);
+        kiss_fft_cfg mycfg = kiss_fft_alloc (nr_bins_after_padding, 1, nullptr, nullptr);
         kiss_fft_cpx * invAB = new kiss_fft_cpx[nr_bins_after_padding];
         kiss_fft (mycfg, multAB, invAB);
 

--- a/recognition/include/pcl/recognition/face_detection/rf_face_utils.h
+++ b/recognition/include/pcl/recognition/face_detection/rf_face_utils.h
@@ -93,7 +93,7 @@ namespace pcl
 
         void createRandomFeatures(const size_t num_of_features, std::vector<FT> & features) override
         {
-          srand (static_cast<unsigned int>(time (NULL)));
+          srand (static_cast<unsigned int>(time (nullptr)));
           int min_s = 20;
           float range_d = 0.05f;
           float incr_d = 0.01f;

--- a/recognition/include/pcl/recognition/hv/hypotheses_verification.h
+++ b/recognition/include/pcl/recognition/hv/hypotheses_verification.h
@@ -230,7 +230,7 @@ namespace pcl
       else
       {
         //we need to reason about occlusions before setting the model
-        if (scene_cloud_ == 0)
+        if (scene_cloud_ == nullptr)
         {
           PCL_ERROR("setSceneCloud should be called before adding the model if reasoning about occlusions...");
         }

--- a/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
@@ -42,14 +42,14 @@
 ///////////////////////////////////////////////////////////////////////////////////////////
 template<typename ModelT, typename SceneT>
 pcl::occlusion_reasoning::ZBuffering<ModelT, SceneT>::ZBuffering (int resx, int resy, float f) :
-  f_ (f), cx_ (resx), cy_ (resy), depth_ (NULL)
+  f_ (f), cx_ (resx), cy_ (resy), depth_ (nullptr)
 {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template<typename ModelT, typename SceneT>
 pcl::occlusion_reasoning::ZBuffering<ModelT, SceneT>::ZBuffering () :
-  f_ (), cx_ (), cy_ (), depth_ (NULL)
+  f_ (), cx_ (), cy_ (), depth_ (nullptr)
 {
 }
 

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -89,7 +89,7 @@ pcl::features::ISMVoteList<PointT>::getColoredCloud (typename pcl::PointCloud<Po
   colored_cloud->height = 0;
   colored_cloud->width = 1;
 
-  if (cloud != 0)
+  if (cloud != nullptr)
   {
     colored_cloud->height += static_cast<uint32_t> (cloud->points.size ());
     point.r = 255;
@@ -227,7 +227,7 @@ pcl::features::ISMVoteList<PointT>::validateTree ()
 {
   if (!tree_is_valid_)
   {
-    if (tree_ == 0)
+    if (tree_ == nullptr)
       tree_.reset (new pcl::KdTreeFLANN<pcl::InterestPoint>);
     tree_->setInputCloud (votes_);
     k_ind_.resize ( votes_->points.size (), -1 );
@@ -427,7 +427,7 @@ pcl::features::ISMModel::loadModelFromfile (std::string& file_name)
   char line[256];
 
   input_file.getline (line, 256, ' ');
-  number_of_classes_ = static_cast<unsigned int> (strtol (line, 0, 10));
+  number_of_classes_ = static_cast<unsigned int> (strtol (line, nullptr, 10));
   input_file.getline (line, 256, ' '); number_of_visual_words_ = atoi (line);
   input_file.getline (line, 256, ' '); number_of_clusters_ = atoi (line);
   input_file.getline (line, 256, ' '); descriptors_dimension_ = atoi (line);
@@ -700,7 +700,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::trainISM (
 {
   bool success = true;
 
-  if (trained_model == 0)
+  if (trained_model == nullptr)
     return (false);
   trained_model->reset ();
 
@@ -854,7 +854,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::extractDes
 
   int n_key_points = 0;
 
-  if (training_clouds_.size () == 0 || training_classes_.size () == 0 || feature_estimator_ == 0)
+  if (training_clouds_.size () == 0 || training_classes_.size () == 0 || feature_estimator_ == nullptr)
     return (false);
 
   for (size_t i_cloud = 0; i_cloud < training_clouds_.size (); i_cloud++)
@@ -1272,7 +1272,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeKMe
   int feature_dimension = points_to_cluster.rows () > 1 ? FeatureSize : 1;
 
   attempts = std::max (attempts, 1);
-  srand (static_cast<unsigned int> (time (0)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   Eigen::MatrixXi labels (number_of_points, 1);
 

--- a/recognition/include/pcl/recognition/impl/ransac_based/simple_octree.hpp
+++ b/recognition/include/pcl/recognition/impl/ransac_based/simple_octree.hpp
@@ -12,9 +12,9 @@
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
 pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::Node ()
-: data_ (0),
-  parent_ (0),
-  children_(0)
+: data_ (nullptr),
+  parent_ (nullptr),
+  children_(nullptr)
 {}
 
 //===============================================================================================================================
@@ -157,7 +157,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteC
   if ( children_ )
   {
     delete[] children_;
-    children_ = 0;
+    children_ = nullptr;
   }
 }
 
@@ -169,7 +169,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteD
   if ( data_ )
   {
     delete data_;
-    data_ = 0;
+    data_ = nullptr;
   }
 }
 
@@ -190,7 +190,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::makeNei
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
 pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::SimpleOctree ()
 : tree_levels_ (0),
-  root_ (0)
+  root_ (nullptr)
 {
 }
 
@@ -210,7 +210,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::clear ()
   if ( root_ )
   {
     delete root_;
-    root_ = 0;
+    root_ = nullptr;
   }
 
   full_leaves_.clear();
@@ -258,7 +258,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::build (const 
   root_ = new Node ();
   root_->setCenter (center);
   root_->setBounds (bounds_);
-  root_->setParent (NULL);
+  root_->setParent (nullptr);
   root_->computeRadius ();
 }
 
@@ -273,7 +273,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::createLeaf (S
        y < bounds_[2] || y > bounds_[3] ||
        z < bounds_[4] || z > bounds_[5] )
   {
-    return (NULL);
+    return (nullptr);
   }
 
   Node* node = root_;
@@ -329,7 +329,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (
        y < bounds_[2] || y > bounds_[3] ||
        z < bounds_[4] || z > bounds_[5] )
   {
-    return (NULL);
+    return (nullptr);
   }
 
   Node* node = root_;
@@ -340,7 +340,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (
   for ( int l = 0 ; l < tree_levels_ ; ++l )
   {
     if ( !node->hasChildren () )
-      return (NULL);
+      return (nullptr);
 
     c = node->getCenter ();
     id = 0;
@@ -353,7 +353,7 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (
   }
 
   if ( !node->hasData () )
-    return (NULL);
+    return (nullptr);
 
   return (node);
 }

--- a/recognition/include/pcl/recognition/impl/ransac_based/voxel_structure.hpp
+++ b/recognition/include/pcl/recognition/impl/ransac_based/voxel_structure.hpp
@@ -78,7 +78,7 @@ template<class T, typename REAL> inline T*
 pcl::recognition::VoxelStructure<T,REAL>::getVoxel (const REAL p[3])
 {
   if ( p[0] < bounds_[0] || p[0] >= bounds_[1] || p[1] < bounds_[2] || p[1] >= bounds_[3] || p[2] < bounds_[4] || p[2] >= bounds_[5] )
-    return NULL;
+    return nullptr;
 
   int x = static_cast<int> ((p[0] - bounds_[0])/spacing_[0]);
   int y = static_cast<int> ((p[1] - bounds_[2])/spacing_[1]);
@@ -92,9 +92,9 @@ pcl::recognition::VoxelStructure<T,REAL>::getVoxel (const REAL p[3])
 template<class T, typename REAL> inline T*
 pcl::recognition::VoxelStructure<T,REAL>::getVoxel (int x, int y, int z) const
 {
-  if ( x < 0 || x >= num_of_voxels_[0] ) return NULL;
-  if ( y < 0 || y >= num_of_voxels_[1] ) return NULL;
-  if ( z < 0 || z >= num_of_voxels_[2] ) return NULL;
+  if ( x < 0 || x >= num_of_voxels_[0] ) return nullptr;
+  if ( y < 0 || y >= num_of_voxels_[1] ) return nullptr;
+  if ( z < 0 || z >= num_of_voxels_[2] ) return nullptr;
 
   return &voxels_[z*num_of_voxels_xy_plane_ + y*num_of_voxels_[0] + x];
 }

--- a/recognition/include/pcl/recognition/linemod.h
+++ b/recognition/include/pcl/recognition/linemod.h
@@ -93,7 +93,7 @@ namespace pcl
       void 
       initialize (const size_t width, const size_t height, const size_t nr_bins)
       {
-        maps_.resize(nr_bins, NULL);
+        maps_.resize(nr_bins, nullptr);
         width_ = width;
         height_ = height;
         nr_bins_ = nr_bins;
@@ -114,7 +114,7 @@ namespace pcl
       {
         for (auto &map : maps_)
           //if (maps_[map_index] != NULL) delete[] maps_[map_index];
-          if (map != NULL) aligned_free (map);
+          if (map != nullptr) aligned_free (map);
 
         maps_.clear ();
         width_ = 0;
@@ -233,7 +233,7 @@ namespace pcl
       void 
       initialize (const size_t width, const size_t height, const size_t step_size)
       {
-        maps_.resize(step_size*step_size, NULL);
+        maps_.resize(step_size*step_size, nullptr);
         width_ = width;
         height_ = height;
         mem_width_ = width / step_size;
@@ -256,7 +256,7 @@ namespace pcl
       {
         for (auto &map : maps_)
           //if (maps_[map_index] != NULL) delete[] maps_[map_index];
-          if (map != NULL) aligned_free (map);
+          if (map != nullptr) aligned_free (map);
 
         maps_.clear ();
         width_ = 0;

--- a/recognition/include/pcl/recognition/ransac_based/bvh.h
+++ b/recognition/include/pcl/recognition/ransac_based/bvh.h
@@ -145,7 +145,7 @@ namespace pcl
               {
                 // We reached a leaf
                 object_ = sorted_objects[first_id];
-                children_[0] = children_[1] = 0;
+                children_[0] = children_[1] = nullptr;
               }
             }
 
@@ -213,8 +213,8 @@ namespace pcl
 
       public:
         BVH()
-        : root_ (0),
-          sorted_objects_ (0)
+        : root_ (nullptr),
+          sorted_objects_ (nullptr)
         {
         }
 
@@ -253,7 +253,7 @@ namespace pcl
           if ( root_ )
           {
             delete root_;
-            root_ = 0;
+            root_ = nullptr;
           }
         }
 

--- a/recognition/include/pcl/recognition/ransac_based/hypothesis.h
+++ b/recognition/include/pcl/recognition/ransac_based/hypothesis.h
@@ -81,7 +81,7 @@ namespace pcl
     class Hypothesis: public HypothesisBase
     {
       public:
-        Hypothesis (const ModelLibrary::Model* obj_model = NULL)
+        Hypothesis (const ModelLibrary::Model* obj_model = nullptr)
          : HypothesisBase (obj_model),
            match_confidence_ (-1.0f),
            linear_id_ (-1)

--- a/recognition/include/pcl/recognition/ransac_based/model_library.h
+++ b/recognition/include/pcl/recognition/ransac_based/model_library.h
@@ -66,7 +66,7 @@ namespace pcl
         {
           public:
             Model (const PointCloudIn& points, const PointCloudN& normals, float voxel_size, const std::string& object_name,
-                   float frac_of_points_for_registration, void* user_data = NULL)
+                   float frac_of_points_for_registration, void* user_data = nullptr)
             : obj_name_(object_name),
               user_data_ (user_data)
             {
@@ -104,7 +104,7 @@ namespace pcl
                 ids[i] = i;
 
               // The random generator
-              pcl::common::UniformGenerator<int> randgen (0, num_octree_points - 1, static_cast<uint32_t> (time (NULL)));
+              pcl::common::UniformGenerator<int> randgen (0, num_octree_points - 1, static_cast<uint32_t> (time (nullptr)));
 
               // Randomly sample some points from the octree
               for ( int i = 0 ; i < num_points_for_registration ; ++i )
@@ -223,7 +223,7 @@ namespace pcl
           * Returns true if model successfully added and false otherwise (e.g., if object_name is not unique). */
         bool
         addModel (const PointCloudIn& points, const PointCloudN& normals, const std::string& object_name,
-                  float frac_of_points_for_registration, void* user_data = NULL);
+                  float frac_of_points_for_registration, void* user_data = nullptr);
 
         /** \brief Returns the hash table built by this instance. */
         inline const HashTable&
@@ -239,7 +239,7 @@ namespace pcl
           if ( it != models_.end () )
             return (it->second);
 
-          return (NULL);
+          return (nullptr);
         }
 
         inline const std::map<std::string,Model*>&

--- a/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
+++ b/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
@@ -226,7 +226,7 @@ namespace pcl
           * The method returns true if the model was successfully added to the model library and false otherwise (e.g., if 'object_name' is already in use).
           */
         inline bool
-        addModel (const PointCloudIn& points, const PointCloudN& normals, const std::string& object_name, void* user_data = NULL)
+        addModel (const PointCloudIn& points, const PointCloudN& normals, const std::string& object_name, void* user_data = nullptr)
         {
           return (model_library_.addModel (points, normals, object_name, frac_of_points_for_icp_refinement_, user_data));
         }

--- a/recognition/include/pcl/recognition/ransac_based/orr_octree.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_octree.h
@@ -80,7 +80,7 @@ namespace pcl
             class Data
             {
               public:
-                Data (int id_x, int id_y, int id_z, int lin_id, void* user_data = NULL)
+                Data (int id_x, int id_y, int id_z, int lin_id, void* user_data = nullptr)
                 : id_x_ (id_x),
                   id_y_ (id_y),
                   id_z_ (id_z),
@@ -165,9 +165,9 @@ namespace pcl
             };
 
             Node ()
-            : data_ (NULL),
-              parent_ (NULL),
-              children_(NULL)
+            : data_ (nullptr),
+              parent_ (nullptr),
+              children_(nullptr)
             {}
 
             virtual~ Node ()
@@ -245,7 +245,7 @@ namespace pcl
               if ( children_ )
               {
                 delete[] children_;
-                children_ = NULL;
+                children_ = nullptr;
               }
             }
 
@@ -255,7 +255,7 @@ namespace pcl
               if ( data_ )
               {
                 delete data_;
-                data_ = NULL;
+                data_ = nullptr;
               }
             }
 
@@ -288,7 +288,7 @@ namespace pcl
           * by enlarging the bounds by that factor. For example, enlarge_bounds = 1 means that the
           * bounds will be enlarged by 100%. The default value is fine. */
         void
-        build (const PointCloudIn& points, float voxel_size, const PointCloudN* normals = NULL, float enlarge_bounds = 0.00001f);
+        build (const PointCloudIn& points, float voxel_size, const PointCloudN* normals = nullptr, float enlarge_bounds = 0.00001f);
 
         /** \brief Creates an empty octree with bounds at least as large as the ones provided as input and with leaf
           * size equal to 'voxel_size'. */
@@ -307,7 +307,7 @@ namespace pcl
                y < bounds_[2] || y > bounds_[3] ||
                z < bounds_[4] || z > bounds_[5] )
           {
-            return (NULL);
+            return (nullptr);
           }
 
           ORROctree::Node* node = root_;
@@ -380,7 +380,7 @@ namespace pcl
                y < bounds_[2] || y > bounds_[3] ||
                z < bounds_[4] || z > bounds_[5] )
           {
-            return (NULL);
+            return (nullptr);
           }
 
           ORROctree::Node* node = root_;
@@ -391,7 +391,7 @@ namespace pcl
           for ( int l = 0 ; l < tree_levels_ ; ++l )
           {
             if ( !node->hasChildren () )
-              return (NULL);
+              return (nullptr);
 
             c = node->getCenter ();
             id = 0;

--- a/recognition/include/pcl/recognition/ransac_based/orr_octree_zprojection.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_octree_zprojection.h
@@ -116,8 +116,8 @@ namespace pcl
 
       public:
         ORROctreeZProjection ()
-        : pixels_(NULL),
-          sets_(NULL)
+        : pixels_(nullptr),
+          sets_(nullptr)
         {}
         virtual ~ORROctreeZProjection (){ this->clear();}
 
@@ -139,8 +139,8 @@ namespace pcl
         {
           int x, y; this->getPixelCoordinates (p, x, y);
 
-          if ( x < 0 || x >= num_pixels_x_ ) return (NULL);
-          if ( y < 0 || y >= num_pixels_y_ ) return (NULL);
+          if ( x < 0 || x >= num_pixels_x_ ) return (nullptr);
+          if ( y < 0 || y >= num_pixels_y_ ) return (nullptr);
 
           return (pixels_[x][y]);
         }
@@ -150,8 +150,8 @@ namespace pcl
         {
           int x, y; this->getPixelCoordinates (p, x, y);
 
-          if ( x < 0 || x >= num_pixels_x_ ) return (NULL);
-          if ( y < 0 || y >= num_pixels_y_ ) return (NULL);
+          if ( x < 0 || x >= num_pixels_x_ ) return (nullptr);
+          if ( y < 0 || y >= num_pixels_y_ ) return (nullptr);
 
           return (pixels_[x][y]);
         }
@@ -161,11 +161,11 @@ namespace pcl
         {
           int x, y; this->getPixelCoordinates (p, x, y);
 
-          if ( x < 0 || x >= num_pixels_x_ ) return (NULL);
-          if ( y < 0 || y >= num_pixels_y_ ) return (NULL);
+          if ( x < 0 || x >= num_pixels_x_ ) return (nullptr);
+          if ( y < 0 || y >= num_pixels_y_ ) return (nullptr);
 
           if ( !sets_[x][y] )
-            return NULL;
+            return nullptr;
 
           return (&sets_[x][y]->get_nodes ());
         }

--- a/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
+++ b/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
@@ -95,7 +95,7 @@ namespace pcl
             }
 
             inline void
-            computeAverageRigidTransform (float *rigid_transform = NULL)
+            computeAverageRigidTransform (float *rigid_transform = nullptr)
             {
               if ( num_transforms_ >= 2 )
               {
@@ -158,7 +158,7 @@ namespace pcl
           if ( res != model_to_entry_.end () )
             return (&res->second);
 
-          return (NULL);
+          return (nullptr);
         }
 
         inline const RotationSpaceCell::Entry&

--- a/recognition/include/pcl/recognition/ransac_based/voxel_structure.h
+++ b/recognition/include/pcl/recognition/ransac_based/voxel_structure.h
@@ -49,7 +49,7 @@ namespace pcl
     class VoxelStructure
     {
     public:
-      inline VoxelStructure (): voxels_(NULL){}
+      inline VoxelStructure (): voxels_(nullptr){}
       inline virtual ~VoxelStructure (){ this->clear();}
 
       /** \brief Call this method before using an instance of this class. Parameter meaning is obvious. */
@@ -58,7 +58,7 @@ namespace pcl
 
       /** \brief Release the memory allocated for the voxels. */
       inline void
-      clear (){ if ( voxels_ ){ delete[] voxels_; voxels_ = NULL;}}
+      clear (){ if ( voxels_ ){ delete[] voxels_; voxels_ = nullptr;}}
 
       /** \brief Returns a pointer to the voxel which contains p or NULL if p is not inside the structure. */
       inline T*

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -151,7 +151,7 @@ namespace pcl
     QuantizedNormalLookUpTable () : 
       range_x (-1), range_y (-1), range_z (-1), 
       offset_x (-1), offset_y (-1), offset_z (-1), 
-      size_x (-1), size_y (-1), size_z (-1), lut (NULL) 
+      size_x (-1), size_y (-1), size_z (-1), lut (nullptr) 
     {}
 
     /** \brief Destructor. */

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -167,7 +167,7 @@ template<class FeatureType, class DataSet, class LabelType, class ExampleIndex, 
 void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::getDatasetAndLabels(DataSet & data_set,
     std::vector<LabelType> & label_data, std::vector<ExampleIndex> & examples)
 {
-  srand (static_cast<unsigned int>(time (NULL)));
+  srand (static_cast<unsigned int>(time (nullptr)));
   std::random_shuffle (image_files_.begin (), image_files_.end ());
   std::vector < std::string > files;
   files = image_files_;

--- a/recognition/src/ransac_based/model_library.cpp
+++ b/recognition/src/ransac_based/model_library.cpp
@@ -109,7 +109,7 @@ ModelLibrary::addModel (const PointCloudIn& points, const PointCloudN& normals, 
 #endif
 
   // Try to insert a new model entry
-  pair<map<string,Model*>::iterator, bool> result = models_.insert (pair<string,Model*> (object_name, static_cast<Model*> (NULL)));
+  pair<map<string,Model*>::iterator, bool> result = models_.insert (pair<string,Model*> (object_name, static_cast<Model*> (nullptr)));
 
   // Check if 'object_name' is unique
   if (!result.second)

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -181,7 +181,7 @@ pcl::recognition::ObjRecRANSAC::sampleOrientedPointPairs (int num_iterations, co
   }
 
   // The random generator
-  UniformGenerator<int> randgen (0, num_full_leaves - 1, static_cast<uint32_t> (time (NULL)));
+  UniformGenerator<int> randgen (0, num_full_leaves - 1, static_cast<uint32_t> (time (nullptr)));
 
   // Init the vector with the ids
   vector<int> ids (num_full_leaves);
@@ -632,7 +632,7 @@ pcl::recognition::ObjRecRANSAC::testHypothesis (Hypothesis* hypothesis, int& mat
     // Get the pixel 'transformed_point' lies in
     const ORROctreeZProjection::Pixel* pixel = scene_octree_proj_.getPixel (transformed_point);
     // Check if we have a valid pixel
-    if ( pixel == NULL )
+    if ( pixel == nullptr )
       continue;
 
     if ( transformed_point[2] < pixel->z1 () ) // The transformed model point overshadows a pixel -> penalize the hypothesis
@@ -669,7 +669,7 @@ pcl::recognition::ObjRecRANSAC::testHypothesisNormalBased (Hypothesis* hypothesi
     // Get the pixel 'transformed_point' lies in
     const ORROctreeZProjection::Pixel* pixel = scene_octree_proj_.getPixel (transformed_point);
     // Check if we have a valid pixel
-    if ( pixel == NULL )
+    if ( pixel == nullptr )
       continue;
 
     // Check if the point is OK

--- a/recognition/src/ransac_based/orr_octree.cpp
+++ b/recognition/src/ransac_based/orr_octree.cpp
@@ -51,7 +51,7 @@ using namespace pcl::recognition;
 pcl::recognition::ORROctree::ORROctree ()
 : voxel_size_ (-1.0),
   tree_levels_ (-1),
-  root_ (NULL)
+  root_ (nullptr)
 {
 }
 
@@ -63,7 +63,7 @@ pcl::recognition::ORROctree::clear ()
   if ( root_ )
   {
     delete root_;
-    root_ = NULL;
+    root_ = nullptr;
   }
 
   full_leaves_.clear();
@@ -106,7 +106,7 @@ pcl::recognition::ORROctree::build (const float* bounds, float voxel_size)
   root_ = new ORROctree::Node();
   root_->setCenter(center);
   root_->setBounds(bounds_);
-  root_->setParent(NULL);
+  root_->setParent(nullptr);
   root_->computeRadius();
 }
 
@@ -333,7 +333,7 @@ pcl::recognition::ORROctree::getRandomFullLeafOnSphere (const float* p, float ra
   vector<int> tmp_ids;
   tmp_ids.reserve (8);
 
-  pcl::common::UniformGenerator<int> randgen (0, 1, static_cast<uint32_t> (time (NULL)));
+  pcl::common::UniformGenerator<int> randgen (0, 1, static_cast<uint32_t> (time (nullptr)));
 
   list<ORROctree::Node*> nodes;
   nodes.push_back (root_);
@@ -370,7 +370,7 @@ pcl::recognition::ORROctree::getRandomFullLeafOnSphere (const float* p, float ra
     }
   }
 
-  return NULL;
+  return nullptr;
 }
 
 //================================================================================================================================================================

--- a/recognition/src/ransac_based/orr_octree_zprojection.cpp
+++ b/recognition/src/ransac_based/orr_octree_zprojection.cpp
@@ -68,7 +68,7 @@ pcl::recognition::ORROctreeZProjection::clear ()
     }
 
     delete[] pixels_;
-    pixels_ = NULL;
+    pixels_ = nullptr;
   }
 
   if ( sets_ )
@@ -83,7 +83,7 @@ pcl::recognition::ORROctreeZProjection::clear ()
     }
 
     delete[] sets_;
-    sets_ = NULL;
+    sets_ = nullptr;
   }
 
   full_sets_.clear ();
@@ -144,8 +144,8 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
 
     for ( int j = 0 ; j < num_pixels_y_ ; ++j )
     {
-      pixels_[i][j] = NULL;
-      sets_[i][j] = NULL;
+      pixels_[i][j] = nullptr;
+      sets_[i][j] = nullptr;
     }
   }
 
@@ -156,7 +156,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   {
     this->getPixelCoordinates (full_leaf->getCenter(), num_pixels_x_, num_pixels_y_);
     // If there is no set/pixel and at this position -> create one
-    if ( sets_[num_pixels_x_][num_pixels_y_] == NULL )
+    if ( sets_[num_pixels_x_][num_pixels_y_] == nullptr )
     {
       pixels_[num_pixels_x_][num_pixels_y_] = new Pixel (pixel_id++);
       sets_[num_pixels_x_][num_pixels_y_] = new Set (num_pixels_x_, num_pixels_y_);


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix