### PR TITLE
Use nullptr in module registration

### DIFF
--- a/registration/include/pcl/registration/exceptions.h
+++ b/registration/include/pcl/registration/exceptions.h
@@ -52,8 +52,8 @@ namespace pcl
     public:
     
     SolverDidntConvergeException (const std::string& error_description,
-                                  const char* file_name = NULL,
-                                  const char* function_name = NULL,
+                                  const char* file_name = nullptr,
+                                  const char* function_name = nullptr,
                                   unsigned line_number = 0)
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
@@ -67,8 +67,8 @@ namespace pcl
     public:
     
     NotEnoughPointsException (const std::string& error_description,
-                              const char* file_name = NULL,
-                              const char* function_name = NULL,
+                              const char* file_name = nullptr,
+                              const char* function_name = nullptr,
                               unsigned line_number = 0)
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -231,7 +231,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> bool
 pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::initCompute ()
 {
-  std::srand (static_cast <unsigned int> (std::time (NULL)));
+  std::srand (static_cast <unsigned int> (std::time (nullptr)));
 
   // basic pcl initialization
   if (!pcl::PCLBase <PointSource>::initCompute ())

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -47,7 +47,7 @@
 template <typename PointSource, typename PointTarget, typename FeatureT> void 
 pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setSourceFeatures (const FeatureCloudConstPtr &features)
 {
-  if (features == NULL || features->empty ())
+  if (features == nullptr || features->empty ())
   {
     PCL_ERROR ("[pcl::%s::setSourceFeatures] Invalid or empty point cloud dataset given!\n", getClassName ().c_str ());
     return;
@@ -59,7 +59,7 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setSou
 template <typename PointSource, typename PointTarget, typename FeatureT> void 
 pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setTargetFeatures (const FeatureCloudConstPtr &features)
 {
-  if (features == NULL || features->empty ())
+  if (features == nullptr || features->empty ())
   {
     PCL_ERROR ("[pcl::%s::setTargetFeatures] Invalid or empty point cloud dataset given!\n", getClassName ().c_str ());
     return;

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -153,7 +153,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformati
     p = p + delta_p;
 
     // Update Visualizer (untested)
-    if (update_visualizer_ != 0)
+    if (update_visualizer_ != nullptr)
       update_visualizer_ (output, std::vector<int>(), *target_, std::vector<int>() );
 
     double cos_angle = 0.5 * (transformation_.coeff (0, 0) + transformation_.coeff (1, 1) + transformation_.coeff (2, 2) - 1);

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -153,7 +153,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformati
     p = p + delta_p;
 
     // Update Visualizer (untested)
-    if (update_visualizer_ != nullptr)
+    if (!update_visualizer_.empty())
       update_visualizer_ (output, std::vector<int>(), *target_, std::vector<int>() );
 
     double cos_angle = 0.5 * (transformation_.coeff (0, 0) + transformation_.coeff (1, 1) + transformation_.coeff (2, 2) - 1);

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -280,7 +280,7 @@ namespace pcl
           Eigen::Vector2i idxi = idxf.cast<int> ();
           for (size_t i = 0; i < 2; i++)
             if (idxi[i] >= cells_[i] || idxi[i] < 0)
-              return NULL;
+              return nullptr;
           // const cast to avoid duplicating this function in const and
           // non-const variants...
           return const_cast<NormalDist*> (&normal_distributions_.coeffRef (idxi[0], idxi[1]));
@@ -469,7 +469,7 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
 
     nr_iterations_++;
     
-    if (update_visualizer_ != 0)
+    if (update_visualizer_ != nullptr)
       update_visualizer_ (output, *indices_, *target_, *indices_);
 
     //std::cout << "eps=" << fabs ((transformation - previous_transformation_).sum ()) << std::endl;

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -469,7 +469,7 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
 
     nr_iterations_++;
     
-    if (update_visualizer_ != nullptr)
+    if (!update_visualizer_.empty())
       update_visualizer_ (output, *indices_, *target_, *indices_);
 
     //std::cout << "eps=" << fabs ((transformation - previous_transformation_).sum ()) << std::endl;

--- a/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
+++ b/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
@@ -45,7 +45,7 @@
 template <typename PointSource, typename PointTarget, typename FeatureT> void 
 pcl::SampleConsensusPrerejective<PointSource, PointTarget, FeatureT>::setSourceFeatures (const FeatureCloudConstPtr &features)
 {
-  if (features == NULL || features->empty ())
+  if (features == nullptr || features->empty ())
   {
     PCL_ERROR ("[pcl::%s::setSourceFeatures] Invalid or empty point cloud dataset given!\n", getClassName ().c_str ());
     return;
@@ -57,7 +57,7 @@ pcl::SampleConsensusPrerejective<PointSource, PointTarget, FeatureT>::setSourceF
 template <typename PointSource, typename PointTarget, typename FeatureT> void 
 pcl::SampleConsensusPrerejective<PointSource, PointTarget, FeatureT>::setTargetFeatures (const FeatureCloudConstPtr &features)
 {
-  if (features == NULL || features->empty ())
+  if (features == nullptr || features->empty ())
   {
     PCL_ERROR ("[pcl::%s::setTargetFeatures] Invalid or empty point cloud dataset given!\n", getClassName ().c_str ());
     return;

--- a/registration/include/pcl/registration/impl/transformation_estimation_lm.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_lm.hpp
@@ -107,8 +107,8 @@ pcl::registration::TransformationEstimationLM<PointSource, PointTarget, MatScala
   warp_point_->setParam (x);
   transformation_matrix = warp_point_->getTransform ();
 
-  tmp_src_ = NULL;
-  tmp_tgt_ = NULL;
+  tmp_src_ = nullptr;
+  tmp_tgt_ = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -187,9 +187,9 @@ pcl::registration::TransformationEstimationLM<PointSource, PointTarget, MatScala
   warp_point_->setParam (x);
   transformation_matrix = warp_point_->getTransform ();
 
-  tmp_src_ = NULL;
-  tmp_tgt_ = NULL;
-  tmp_idx_src_ = tmp_idx_tgt_ = NULL;
+  tmp_src_ = nullptr;
+  tmp_tgt_ = nullptr;
+  tmp_idx_src_ = tmp_idx_tgt_ = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -372,7 +372,7 @@ namespace pcl
       template<typename FunctionSignature> inline bool
       registerVisualizationCallback (boost::function<FunctionSignature> &visualizerCallback)
       {
-        if (visualizerCallback != NULL)
+        if (visualizerCallback != nullptr)
         {
           update_visualizer_ = visualizerCallback;
           return (true);

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -372,7 +372,7 @@ namespace pcl
       template<typename FunctionSignature> inline bool
       registerVisualizationCallback (boost::function<FunctionSignature> &visualizerCallback)
       {
-        if (visualizerCallback != nullptr)
+        if (!visualizerCallback.empty())
         {
           update_visualizer_ = visualizerCallback;
           return (true);


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix