### PR TITLE
Use nullptr in module sample_consensus

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac.h
@@ -82,7 +82,7 @@ namespace pcl
       {
          // Create a random number generator object
          if (random)
-           rng_->base ().seed (static_cast<unsigned> (std::time (0)));
+           rng_->base ().seed (static_cast<unsigned> (std::time (nullptr)));
          else
            rng_->base ().seed (12345u);
       };
@@ -108,7 +108,7 @@ namespace pcl
       {
          // Create a random number generator object
          if (random)
-           rng_->base ().seed (static_cast<unsigned> (std::time (0)));
+           rng_->base ().seed (static_cast<unsigned> (std::time (nullptr)));
          else
            rng_->base ().seed (12345u);
       };

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -92,7 +92,7 @@ namespace pcl
       {
         // Create a random number generator object
         if (random)
-          rng_alg_.seed (static_cast<unsigned> (std::time(0)));
+          rng_alg_.seed (static_cast<unsigned> (std::time(nullptr)));
         else
           rng_alg_.seed (12345u);
 
@@ -118,7 +118,7 @@ namespace pcl
         , error_sqr_dists_ ()
       {
         if (random)
-          rng_alg_.seed (static_cast<unsigned> (std::time (0)));
+          rng_alg_.seed (static_cast<unsigned> (std::time (nullptr)));
         else
           rng_alg_.seed (12345u);
 
@@ -150,7 +150,7 @@ namespace pcl
         , error_sqr_dists_ ()
       {
         if (random)
-          rng_alg_.seed (static_cast<unsigned> (std::time(0)));
+          rng_alg_.seed (static_cast<unsigned> (std::time(nullptr)));
         else
           rng_alg_.seed (12345u);
 


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix