### PR TITLE
Use nullptr in module search

### DIFF
--- a/search/include/pcl/search/impl/brute_force.hpp
+++ b/search/include/pcl/search/impl/brute_force.hpp
@@ -76,7 +76,7 @@ pcl::search::BruteForce<PointT>::denseKSearch (
   std::vector<Entry> result;
   result.reserve (k);
   std::priority_queue<Entry> queue;
-  if (indices_ != nullptr)
+  if (indices_)
   {
     std::vector<int>::const_iterator iIt =indices_->begin ();
     std::vector<int>::const_iterator iEnd = indices_->begin () + std::min (static_cast<unsigned> (k), static_cast<unsigned> (indices_->size ()));
@@ -145,7 +145,7 @@ pcl::search::BruteForce<PointT>::sparseKSearch (
   result.reserve (k);
   
   std::priority_queue<Entry> queue;
-  if (indices_ != nullptr)
+  if (indices_)
   {
     std::vector<int>::const_iterator iIt =indices_->begin ();
     for (; iIt != indices_->end () && result.size () < static_cast<unsigned> (k); ++iIt)
@@ -226,7 +226,7 @@ pcl::search::BruteForce<PointT>::denseRadiusSearch (
   size_t reserve = max_nn;
   if (reserve == 0)
   {
-    if (indices_ != nullptr)
+    if (indices_)
       reserve = std::min (indices_->size (), input_->size ());
     else
       reserve = input_->size ();
@@ -234,7 +234,7 @@ pcl::search::BruteForce<PointT>::denseRadiusSearch (
   k_indices.reserve (reserve);
   k_sqr_distances.reserve (reserve);
   float distance;
-  if (indices_ != nullptr)
+  if (indices_)
   {
     for (std::vector<int>::const_iterator iIt =indices_->begin (); iIt != indices_->end (); ++iIt)
     {
@@ -281,7 +281,7 @@ pcl::search::BruteForce<PointT>::sparseRadiusSearch (
   size_t reserve = max_nn;
   if (reserve == 0)
   {
-    if (indices_ != nullptr)
+    if (indices_)
       reserve = std::min (indices_->size (), input_->size ());
     else
       reserve = input_->size ();
@@ -290,7 +290,7 @@ pcl::search::BruteForce<PointT>::sparseRadiusSearch (
   k_sqr_distances.reserve (reserve);
 
   float distance;
-  if (indices_ != nullptr)
+  if (indices_)
   {
     for (std::vector<int>::const_iterator iIt =indices_->begin (); iIt != indices_->end (); ++iIt)
     {

--- a/search/include/pcl/search/impl/brute_force.hpp
+++ b/search/include/pcl/search/impl/brute_force.hpp
@@ -76,7 +76,7 @@ pcl::search::BruteForce<PointT>::denseKSearch (
   std::vector<Entry> result;
   result.reserve (k);
   std::priority_queue<Entry> queue;
-  if (indices_ != NULL)
+  if (indices_ != nullptr)
   {
     std::vector<int>::const_iterator iIt =indices_->begin ();
     std::vector<int>::const_iterator iEnd = indices_->begin () + std::min (static_cast<unsigned> (k), static_cast<unsigned> (indices_->size ()));
@@ -145,7 +145,7 @@ pcl::search::BruteForce<PointT>::sparseKSearch (
   result.reserve (k);
   
   std::priority_queue<Entry> queue;
-  if (indices_ != NULL)
+  if (indices_ != nullptr)
   {
     std::vector<int>::const_iterator iIt =indices_->begin ();
     for (; iIt != indices_->end () && result.size () < static_cast<unsigned> (k); ++iIt)
@@ -226,7 +226,7 @@ pcl::search::BruteForce<PointT>::denseRadiusSearch (
   size_t reserve = max_nn;
   if (reserve == 0)
   {
-    if (indices_ != NULL)
+    if (indices_ != nullptr)
       reserve = std::min (indices_->size (), input_->size ());
     else
       reserve = input_->size ();
@@ -234,7 +234,7 @@ pcl::search::BruteForce<PointT>::denseRadiusSearch (
   k_indices.reserve (reserve);
   k_sqr_distances.reserve (reserve);
   float distance;
-  if (indices_ != NULL)
+  if (indices_ != nullptr)
   {
     for (std::vector<int>::const_iterator iIt =indices_->begin (); iIt != indices_->end (); ++iIt)
     {
@@ -281,7 +281,7 @@ pcl::search::BruteForce<PointT>::sparseRadiusSearch (
   size_t reserve = max_nn;
   if (reserve == 0)
   {
-    if (indices_ != NULL)
+    if (indices_ != nullptr)
       reserve = std::min (indices_->size (), input_->size ());
     else
       reserve = input_->size ();
@@ -290,7 +290,7 @@ pcl::search::BruteForce<PointT>::sparseRadiusSearch (
   k_sqr_distances.reserve (reserve);
 
   float distance;
-  if (indices_ != NULL)
+  if (indices_ != nullptr)
   {
     for (std::vector<int>::const_iterator iIt =indices_->begin (); iIt != indices_->end (); ++iIt)
     {

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -105,7 +105,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (const PointT &p
   assert (point_representation_->isValid (point) && "Invalid (NaN, Inf) point coordinates given to nearestKSearch!"); // remove this check as soon as FLANN does NaN checks internally
   bool can_cast = point_representation_->isTrivial ();
 
-  float* data = 0;
+  float* data = nullptr;
   if (!can_cast)
   {
     data = new float [point_representation_->getNumberOfDimensions ()];
@@ -162,7 +162,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
     bool can_cast = point_representation_->isTrivial ();
 
     // full point cloud + trivial copy operation = no need to do any conversion/copying to the flann matrix!
-    float* data=0;
+    float* data=nullptr;
     if (!can_cast)
     {
       data = new float[dim_*cloud.size ()];
@@ -236,7 +236,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (const PointT& poi
   assert (point_representation_->isValid (point) && "Invalid (NaN, Inf) point coordinates given to radiusSearch!"); // remove this check as soon as FLANN does NaN checks internally
   bool can_cast = point_representation_->isTrivial ();
 
-  float* data = 0;
+  float* data = nullptr;
   if (!can_cast)
   {
     data = new float [point_representation_->getNumberOfDimensions ()];
@@ -290,7 +290,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (
 
     bool can_cast = point_representation_->isTrivial ();
 
-    float* data = 0;
+    float* data = nullptr;
     if (!can_cast)
     {
       data = new float[dim_*cloud.size ()];

--- a/search/include/pcl/search/impl/search.hpp
+++ b/search/include/pcl/search/impl/search.hpp
@@ -98,7 +98,7 @@ pcl::search::Search<PointT>::nearestKSearch (
     std::vector<int> &k_indices, 
     std::vector<float> &k_sqr_distances) const
 {
-  if (indices_ == NULL)
+  if (indices_ == nullptr)
   {
     assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in nearestKSearch!");
     return (nearestKSearch (input_->points[index], k, k_indices, k_sqr_distances));
@@ -152,7 +152,7 @@ pcl::search::Search<PointT>::radiusSearch (
     int index, double radius, std::vector<int> &k_indices,
     std::vector<float> &k_sqr_distances, unsigned int max_nn ) const
 {
-  if (indices_ == NULL)
+  if (indices_ == nullptr)
   {
     assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in radiusSearch!");
     return (radiusSearch (input_->points[index], radius, k_indices, k_sqr_distances, max_nn));

--- a/search/include/pcl/search/impl/search.hpp
+++ b/search/include/pcl/search/impl/search.hpp
@@ -98,7 +98,7 @@ pcl::search::Search<PointT>::nearestKSearch (
     std::vector<int> &k_indices, 
     std::vector<float> &k_sqr_distances) const
 {
-  if (indices_ == nullptr)
+  if (!indices_)
   {
     assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in nearestKSearch!");
     return (nearestKSearch (input_->points[index], k, k_indices, k_sqr_distances));
@@ -152,7 +152,7 @@ pcl::search::Search<PointT>::radiusSearch (
     int index, double radius, std::vector<int> &k_indices,
     std::vector<float> &k_sqr_distances, unsigned int max_nn ) const
 {
-  if (indices_ == nullptr)
+  if (!indices_)
   {
     assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in radiusSearch!");
     return (radiusSearch (input_->points[index], radius, k_indices, k_sqr_distances, max_nn));

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -133,7 +133,7 @@ namespace pcl
           input_ = cloud;
           indices_ = indices;
 
-          if (indices_.get () != NULL && indices_->size () != 0)
+          if (indices_.get () != nullptr && indices_->size () != 0)
           {
             mask_.assign (input_->size (), 0);
             for (std::vector<int>::const_iterator iIt = indices_->begin (); iIt != indices_->end (); ++iIt)

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -133,7 +133,7 @@ namespace pcl
           input_ = cloud;
           indices_ = indices;
 
-          if (indices_.get () != nullptr && indices_->size () != 0)
+          if (indices_ && !indices_->empty())
           {
             mask_.assign (input_->size (), 0);
             for (std::vector<int>::const_iterator iIt = indices_->begin (); iIt != indices_->end (); ++iIt)


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix