### PR TITLE
Use nullptr in module segmentation

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
@@ -71,9 +71,6 @@ pcl::CrfSegmentation<PointT>::~CrfSegmentation ()
 template <typename PointT> void
 pcl::CrfSegmentation<PointT>::setInputCloud (typename pcl::PointCloud<PointT>::Ptr input_cloud)
 {
-  if (input_cloud_ != nullptr)
-    input_cloud_.reset ();
-
   input_cloud_ = input_cloud;
 }
 
@@ -81,9 +78,6 @@ pcl::CrfSegmentation<PointT>::setInputCloud (typename pcl::PointCloud<PointT>::P
 template <typename PointT> void
 pcl::CrfSegmentation<PointT>::setAnnotatedCloud (typename pcl::PointCloud<pcl::PointXYZRGBL>::Ptr anno_cloud)
 {
-  if (anno_cloud_ != nullptr)
-    anno_cloud_.reset ();
-
   anno_cloud_ = anno_cloud;
 }
 
@@ -91,9 +85,6 @@ pcl::CrfSegmentation<PointT>::setAnnotatedCloud (typename pcl::PointCloud<pcl::P
 template <typename PointT> void
 pcl::CrfSegmentation<PointT>::setNormalCloud (typename pcl::PointCloud<pcl::PointNormal>::Ptr normal_cloud)
 {
-  if (normal_cloud_ != nullptr)
-    normal_cloud_.reset ();
-
   normal_cloud_ = normal_cloud;
 }
 

--- a/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
@@ -71,7 +71,7 @@ pcl::CrfSegmentation<PointT>::~CrfSegmentation ()
 template <typename PointT> void
 pcl::CrfSegmentation<PointT>::setInputCloud (typename pcl::PointCloud<PointT>::Ptr input_cloud)
 {
-  if (input_cloud_ != NULL)
+  if (input_cloud_ != nullptr)
     input_cloud_.reset ();
 
   input_cloud_ = input_cloud;
@@ -81,7 +81,7 @@ pcl::CrfSegmentation<PointT>::setInputCloud (typename pcl::PointCloud<PointT>::P
 template <typename PointT> void
 pcl::CrfSegmentation<PointT>::setAnnotatedCloud (typename pcl::PointCloud<pcl::PointXYZRGBL>::Ptr anno_cloud)
 {
-  if (anno_cloud_ != NULL)
+  if (anno_cloud_ != nullptr)
     anno_cloud_.reset ();
 
   anno_cloud_ = anno_cloud;
@@ -91,7 +91,7 @@ pcl::CrfSegmentation<PointT>::setAnnotatedCloud (typename pcl::PointCloud<pcl::P
 template <typename PointT> void
 pcl::CrfSegmentation<PointT>::setNormalCloud (typename pcl::PointCloud<pcl::PointNormal>::Ptr normal_cloud)
 {
-  if (normal_cloud_ != NULL)
+  if (normal_cloud_ != nullptr)
     normal_cloud_.reset ();
 
   normal_cloud_ = normal_cloud;
@@ -329,7 +329,7 @@ pcl::CrfSegmentation<PointT>::createUnaryPotentials (std::vector<float> &unary,
                                                      unsigned int n_labels)
 {
   /* initialize random seed: */
-  srand ( static_cast<unsigned int> (time (NULL)) );
+  srand ( static_cast<unsigned int> (time (nullptr)) );
   //srand ( time (NULL) );
 
   // Certainty that the groundtruth is correct

--- a/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
@@ -210,8 +210,8 @@ template <typename PointT> void
 pcl::EuclideanClusterExtraction<PointT>::extract (std::vector<PointIndices> &clusters)
 {
   if (!initCompute () || 
-      (input_ != nullptr   && input_->points.empty ()) ||
-      (indices_ != nullptr && indices_->empty ()))
+      (input_   && input_->points.empty ()) ||
+      (indices_ && indices_->empty ()))
   {
     clusters.clear ();
     return;

--- a/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
@@ -210,8 +210,8 @@ template <typename PointT> void
 pcl::EuclideanClusterExtraction<PointT>::extract (std::vector<PointIndices> &clusters)
 {
   if (!initCompute () || 
-      (input_ != 0   && input_->points.empty ()) ||
-      (indices_ != 0 && indices_->empty ()))
+      (input_ != nullptr   && input_->points.empty ()) ||
+      (indices_ != nullptr && indices_->empty ()))
   {
     clusters.clear ();
     return;

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -123,8 +123,8 @@ template <typename PointT> void
 pcl::LabeledEuclideanClusterExtraction<PointT>::extract (std::vector<std::vector<PointIndices> > &labeled_clusters)
 {
   if (!initCompute () || 
-      (input_ != nullptr   && input_->points.empty ()) ||
-      (indices_ != nullptr && indices_->empty ()))
+      (input_   && input_->points.empty ()) ||
+      (indices_ && indices_->empty ()))
   {
     labeled_clusters.clear ();
     return;

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -123,8 +123,8 @@ template <typename PointT> void
 pcl::LabeledEuclideanClusterExtraction<PointT>::extract (std::vector<std::vector<PointIndices> > &labeled_clusters)
 {
   if (!initCompute () || 
-      (input_ != 0   && input_->points.empty ()) ||
-      (indices_ != 0 && indices_->empty ()))
+      (input_ != nullptr   && input_->points.empty ()) ||
+      (indices_ != nullptr && indices_->empty ()))
   {
     labeled_clusters.clear ();
     return;

--- a/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
@@ -76,13 +76,13 @@ pcl::MinCutSegmentation<PointT>::MinCutSegmentation () :
 template <typename PointT>
 pcl::MinCutSegmentation<PointT>::~MinCutSegmentation ()
 {
-  if (search_ != 0)
+  if (search_ != nullptr)
     search_.reset ();
-  if (graph_ != 0)
+  if (graph_ != nullptr)
     graph_.reset ();
-  if (capacity_ != 0)
+  if (capacity_ != nullptr)
     capacity_.reset ();
-  if (reverse_edges_ != 0)
+  if (reverse_edges_ != nullptr)
     reverse_edges_.reset ();
 
   foreground_points_.clear ();
@@ -167,7 +167,7 @@ pcl::MinCutSegmentation<PointT>::getSearchMethod () const
 template <typename PointT> void
 pcl::MinCutSegmentation<PointT>::setSearchMethod (const KdTreePtr& tree)
 {
-  if (search_ != 0)
+  if (search_ != nullptr)
     search_.reset ();
 
   search_ = tree;
@@ -327,7 +327,7 @@ pcl::MinCutSegmentation<PointT>::buildGraph ()
   if (input_->points.size () == 0 || number_of_points == 0 || foreground_points_.empty () == true )
     return (false);
 
-  if (search_ == 0)
+  if (search_ == nullptr)
     search_.reset (new pcl::search::KdTree<PointT>);
 
   graph_.reset (new mGraph);

--- a/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
@@ -76,15 +76,6 @@ pcl::MinCutSegmentation<PointT>::MinCutSegmentation () :
 template <typename PointT>
 pcl::MinCutSegmentation<PointT>::~MinCutSegmentation ()
 {
-  if (search_ != nullptr)
-    search_.reset ();
-  if (graph_ != nullptr)
-    graph_.reset ();
-  if (capacity_ != nullptr)
-    capacity_.reset ();
-  if (reverse_edges_ != nullptr)
-    reverse_edges_.reset ();
-
   foreground_points_.clear ();
   background_points_.clear ();
   clusters_.clear ();
@@ -167,9 +158,6 @@ pcl::MinCutSegmentation<PointT>::getSearchMethod () const
 template <typename PointT> void
 pcl::MinCutSegmentation<PointT>::setSearchMethod (const KdTreePtr& tree)
 {
-  if (search_ != nullptr)
-    search_.reset ();
-
   search_ = tree;
 }
 
@@ -327,7 +315,7 @@ pcl::MinCutSegmentation<PointT>::buildGraph ()
   if (input_->points.size () == 0 || number_of_points == 0 || foreground_points_.empty () == true )
     return (false);
 
-  if (search_ == nullptr)
+  if (!search_)
     search_.reset (new pcl::search::KdTree<PointT>);
 
   graph_.reset (new mGraph);

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -79,9 +79,9 @@ pcl::RegionGrowing<PointT, NormalT>::RegionGrowing () :
 template <typename PointT, typename NormalT>
 pcl::RegionGrowing<PointT, NormalT>::~RegionGrowing ()
 {
-  if (search_ != 0)
+  if (search_ != nullptr)
     search_.reset ();
-  if (normals_ != 0)
+  if (normals_ != nullptr)
     normals_.reset ();
 
   point_neighbours_.clear ();
@@ -233,7 +233,7 @@ pcl::RegionGrowing<PointT, NormalT>::getSearchMethod () const
 template <typename PointT, typename NormalT> void
 pcl::RegionGrowing<PointT, NormalT>::setSearchMethod (const KdTreePtr& tree)
 {
-  if (search_ != 0)
+  if (search_ != nullptr)
     search_.reset ();
 
   search_ = tree;
@@ -250,7 +250,7 @@ pcl::RegionGrowing<PointT, NormalT>::getInputNormals () const
 template <typename PointT, typename NormalT> void
 pcl::RegionGrowing<PointT, NormalT>::setInputNormals (const NormalPtr& norm)
 {
-  if (normals_ != 0)
+  if (normals_ != nullptr)
     normals_.reset ();
 
   normals_ = norm;
@@ -312,7 +312,7 @@ pcl::RegionGrowing<PointT, NormalT>::prepareForSegmentation ()
     return (false);
 
   // if user forgot to pass normals or the sizes of point and normal cloud are different
-  if ( normals_ == 0 || input_->points.size () != normals_->points.size () )
+  if ( normals_ == nullptr || input_->points.size () != normals_->points.size () )
     return (false);
 
   // if residual test is on then we need to check if all needed parameters were correctly initialized
@@ -656,7 +656,7 @@ pcl::RegionGrowing<PointT, NormalT>::getColoredCloud ()
   {
     colored_cloud = (new pcl::PointCloud<pcl::PointXYZRGB>)->makeShared ();
 
-    srand (static_cast<unsigned int> (time (0)));
+    srand (static_cast<unsigned int> (time (nullptr)));
     std::vector<unsigned char> colors;
     for (size_t i_segment = 0; i_segment < clusters_.size (); i_segment++)
     {
@@ -708,7 +708,7 @@ pcl::RegionGrowing<PointT, NormalT>::getColoredCloudRGBA ()
   {
     colored_cloud = (new pcl::PointCloud<pcl::PointXYZRGBA>)->makeShared ();
 
-    srand (static_cast<unsigned int> (time (0)));
+    srand (static_cast<unsigned int> (time (nullptr)));
     std::vector<unsigned char> colors;
     for (size_t i_segment = 0; i_segment < clusters_.size (); i_segment++)
     {

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -79,11 +79,6 @@ pcl::RegionGrowing<PointT, NormalT>::RegionGrowing () :
 template <typename PointT, typename NormalT>
 pcl::RegionGrowing<PointT, NormalT>::~RegionGrowing ()
 {
-  if (search_ != nullptr)
-    search_.reset ();
-  if (normals_ != nullptr)
-    normals_.reset ();
-
   point_neighbours_.clear ();
   point_labels_.clear ();
   num_pts_in_segment_.clear ();
@@ -233,9 +228,6 @@ pcl::RegionGrowing<PointT, NormalT>::getSearchMethod () const
 template <typename PointT, typename NormalT> void
 pcl::RegionGrowing<PointT, NormalT>::setSearchMethod (const KdTreePtr& tree)
 {
-  if (search_ != nullptr)
-    search_.reset ();
-
   search_ = tree;
 }
 
@@ -250,9 +242,6 @@ pcl::RegionGrowing<PointT, NormalT>::getInputNormals () const
 template <typename PointT, typename NormalT> void
 pcl::RegionGrowing<PointT, NormalT>::setInputNormals (const NormalPtr& norm)
 {
-  if (normals_ != nullptr)
-    normals_.reset ();
-
   normals_ = norm;
 }
 
@@ -312,7 +301,7 @@ pcl::RegionGrowing<PointT, NormalT>::prepareForSegmentation ()
     return (false);
 
   // if user forgot to pass normals or the sizes of point and normal cloud are different
-  if ( normals_ == nullptr || input_->points.size () != normals_->points.size () )
+  if ( !normals_ || input_->points.size () != normals_->points.size () )
     return (false);
 
   // if residual test is on then we need to check if all needed parameters were correctly initialized

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -225,7 +225,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::prepareForSegmentation ()
   if (normal_flag_)
   {
     // if user forgot to pass normals or the sizes of point and normal cloud are different
-    if ( normals_ == nullptr || input_->points.size () != normals_->points.size () )
+    if ( !normals_ || input_->points.size () != normals_->points.size () )
       return (false);
   }
 

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -225,7 +225,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::prepareForSegmentation ()
   if (normal_flag_)
   {
     // if user forgot to pass normals or the sizes of point and normal cloud are different
-    if ( normals_ == 0 || input_->points.size () != normals_->points.size () )
+    if ( normals_ == nullptr || input_->points.size () != normals_->points.size () )
       return (false);
   }
 

--- a/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
@@ -197,8 +197,8 @@ void
 pcl::SeededHueSegmentation::segment (PointIndices &indices_in, PointIndices &indices_out)
 {
   if (!initCompute () || 
-      (input_ != 0   && input_->points.empty ()) ||
-      (indices_ != 0 && indices_->empty ()))
+      (input_ != nullptr   && input_->points.empty ()) ||
+      (indices_ != nullptr && indices_->empty ()))
   {
     indices_out.indices.clear ();
     return;

--- a/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
@@ -197,8 +197,8 @@ void
 pcl::SeededHueSegmentation::segment (PointIndices &indices_in, PointIndices &indices_out)
 {
   if (!initCompute () || 
-      (input_ != nullptr   && input_->points.empty ()) ||
-      (indices_ != nullptr && indices_->empty ()))
+      (input_   && input_->points.empty ()) ||
+      (indices_ && indices_->empty ()))
   {
     indices_out.indices.clear ();
     return;

--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -246,7 +246,7 @@ pcl::SupervoxelClustering<PointT>::computeVoxelData ()
     {
       VoxelData& voxel_data = (*leaf_itr)->getData ();
       voxel_data.normal_.normalize ();
-      voxel_data.owner_ = 0;
+      voxel_data.owner_ = nullptr;
       voxel_data.distance_ = std::numeric_limits<float>::max ();
       //Get the number of points in this leaf
       int num_points = (*leaf_itr)->getPointCounter ();
@@ -280,7 +280,7 @@ pcl::SupervoxelClustering<PointT>::computeVoxelData ()
       pcl::flipNormalTowardsViewpoint (voxel_centroid_cloud_->points[new_voxel_data.idx_], 0.0f,0.0f,0.0f, new_voxel_data.normal_);
       new_voxel_data.normal_[3] = 0.0f;
       new_voxel_data.normal_.normalize ();
-      new_voxel_data.owner_ = 0;
+      new_voxel_data.owner_ = nullptr;
       new_voxel_data.distance_ = std::numeric_limits<float>::max ();
     }
   }
@@ -384,7 +384,7 @@ pcl::SupervoxelClustering<PointT>::selectInitialSupervoxelSeeds (std::vector<int
   std::vector<float> distance;
   closest_index.resize(1,0);
   distance.resize(1,0);
-  if (voxel_kdtree_ == 0)
+  if (voxel_kdtree_ == nullptr)
   {
     voxel_kdtree_.reset (new pcl::search::KdTree<PointT>);
     voxel_kdtree_ ->setInputCloud (voxel_centroid_cloud_);
@@ -781,7 +781,7 @@ pcl::SupervoxelClustering<PointT>::SupervoxelHelper::removeAllLeaves ()
   for (auto leaf_itr = leaves_.cbegin (); leaf_itr != leaves_.cend (); ++leaf_itr)
   {
     VoxelData& voxel = ((*leaf_itr)->getData ());
-    voxel.owner_ = 0;
+    voxel.owner_ = nullptr;
     voxel.distance_ = std::numeric_limits<float>::max ();
   }
   leaves_.clear ();

--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -384,7 +384,7 @@ pcl::SupervoxelClustering<PointT>::selectInitialSupervoxelSeeds (std::vector<int
   std::vector<float> distance;
   closest_index.resize(1,0);
   distance.resize(1,0);
-  if (voxel_kdtree_ == nullptr)
+  if (!voxel_kdtree_)
   {
     voxel_kdtree_.reset (new pcl::search::KdTree<PointT>);
     voxel_kdtree_ ->setInputCloud (voxel_centroid_cloud_);

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -68,9 +68,6 @@ pcl::UnaryClassifier<PointT>::~UnaryClassifier ()
 template <typename PointT> void
 pcl::UnaryClassifier<PointT>::setInputCloud (typename pcl::PointCloud<PointT>::Ptr input_cloud)
 {
-  if (input_cloud_ != nullptr)
-    input_cloud_.reset ();
-
   input_cloud_ = input_cloud;
 
   pcl::PointCloud <PointT> point;

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -68,7 +68,7 @@ pcl::UnaryClassifier<PointT>::~UnaryClassifier ()
 template <typename PointT> void
 pcl::UnaryClassifier<PointT>::setInputCloud (typename pcl::PointCloud<PointT>::Ptr input_cloud)
 {
-  if (input_cloud_ != NULL)
+  if (input_cloud_ != nullptr)
     input_cloud_.reset ();
 
   input_cloud_ = input_cloud;

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -138,7 +138,7 @@ namespace pcl
             rgb_ (0.0f, 0.0f, 0.0f),
             normal_ (0.0f, 0.0f, 0.0f, 0.0f),
             curvature_ (0.0f),
-            owner_ (0)
+            owner_ (nullptr)
             {}
 
           /** \brief Gets the data of in the form of a point


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix