### PR TITLE
Use nullptr in module simulation

### DIFF
--- a/simulation/src/glsl_shader.cpp
+++ b/simulation/src/glsl_shader.cpp
@@ -15,7 +15,7 @@ char*
 readTextFile (const char* filename)
 {
   using namespace std;
-  char* buf = NULL;
+  char* buf = nullptr;
   ifstream file;
   file.open (filename, ios::in|ios::binary|ios::ate);
   if (file.is_open ())
@@ -110,7 +110,7 @@ pcl::simulation::gllib::Program::addShaderText (const std::string& text, ShaderT
   id = glCreateShader (shader_type);
   const char* source_list = text.c_str ();
 
-  glShaderSource (id, 1, &source_list, NULL);
+  glShaderSource (id, 1, &source_list, nullptr);
 
   glCompileShader (id);
   printShaderInfoLog (id);
@@ -127,7 +127,7 @@ bool
 pcl::simulation::gllib::Program::addShaderFile (const std::string& filename, ShaderType shader_type)
 {
   char* text = readTextFile (filename.c_str ());
-  if(text == NULL)  return (false);
+  if(text == nullptr)  return (false);
 
   bool rval = addShaderText (text, shader_type);
   delete [] text;

--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -81,17 +81,17 @@ pcl::simulation::TriangleMeshModel::draw ()
   glBindBuffer (GL_ARRAY_BUFFER, vbo_);
   glBindBuffer (GL_ELEMENT_ARRAY_BUFFER, ibo_);
 
-  glVertexPointer (3, GL_FLOAT, sizeof (Vertex), 0);
+  glVertexPointer (3, GL_FLOAT, sizeof (Vertex), nullptr);
   glColorPointer (3, GL_FLOAT, sizeof (Vertex), reinterpret_cast<GLvoid*> (12));
 
   // glNormalPointer(GL_FLOAT, sizeof(Vertex), (GLvoid*)((char*)&(vertices_[0].norm)-(char*)&(vertices_[0].pos)));
   //  glDrawElements(GL_TRIANGLES, indices_.size(), GL_UNSIGNED_INT, 0);
-  glDrawElements (GL_TRIANGLES, size_, GL_UNSIGNED_INT, 0);
+  glDrawElements (GL_TRIANGLES, size_, GL_UNSIGNED_INT, nullptr);
   glDisableClientState (GL_VERTEX_ARRAY);
   glDisableClientState (GL_COLOR_ARRAY);
   //glDisableClientState(GL_NORMAL_ARRAY);
-  glVertexPointer (3, GL_FLOAT, 0, 0);
-  glColorPointer (3, GL_FLOAT, 0, 0);
+  glVertexPointer (3, GL_FLOAT, 0, nullptr);
+  glColorPointer (3, GL_FLOAT, 0, nullptr);
   //glNormalPointer(GL_FLOAT, 0, 0);
 
   glBindBuffer (GL_ARRAY_BUFFER, 0);
@@ -282,7 +282,7 @@ pcl::simulation::Quad::render ()
   glBindBuffer (GL_ARRAY_BUFFER, quad_vbo_);
   glEnableVertexAttribArray (0);
   glEnableVertexAttribArray (1);
-  glVertexAttribPointer (0, 3, GL_FLOAT, GL_FALSE, sizeof (float)*5, 0);
+  glVertexAttribPointer (0, 3, GL_FLOAT, GL_FALSE, sizeof (float)*5, nullptr);
   glVertexAttribPointer (1, 2, GL_FLOAT, GL_FALSE, sizeof (float)*5, (const GLvoid*)12);
 
   glDrawArrays (GL_QUADS, 0, 4);
@@ -309,7 +309,7 @@ pcl::simulation::TexturedQuad::TexturedQuad (int width, int height) : width_ (wi
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
-  glTexImage2D (GL_TEXTURE_2D, 0, GL_RGB, width_, height_, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D (GL_TEXTURE_2D, 0, GL_RGB, width_, height_, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
   glBindTexture (GL_TEXTURE_2D, 0);
 }
 

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -215,7 +215,7 @@ pcl::simulation::RangeLikelihood::RangeLikelihood (int rows, int cols, int row_h
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
-  glTexImage2D (GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+  glTexImage2D (GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
   glBindTexture (GL_TEXTURE_2D, 0);
 
   glGenTextures (1, &color_texture_);
@@ -226,7 +226,7 @@ pcl::simulation::RangeLikelihood::RangeLikelihood (int rows, int cols, int row_h
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
-  glTexImage2D (GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D (GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
   glBindTexture (GL_TEXTURE_2D, 0);
 
   // Setup texture for incoming image
@@ -238,7 +238,7 @@ pcl::simulation::RangeLikelihood::RangeLikelihood (int rows, int cols, int row_h
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
-  glTexImage2D (GL_TEXTURE_2D, 0, GL_R32F, col_width, row_height, 0, GL_RED, GL_FLOAT, NULL);
+  glTexImage2D (GL_TEXTURE_2D, 0, GL_R32F, col_width, row_height, 0, GL_RED, GL_FLOAT, nullptr);
   glBindTexture (GL_TEXTURE_2D, 0);
 
   // Texture for to score on each pixel
@@ -250,7 +250,7 @@ pcl::simulation::RangeLikelihood::RangeLikelihood (int rows, int cols, int row_h
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
   glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
-  glTexImage2D (GL_TEXTURE_2D, 0, GL_R32F, width_, height_, 0, GL_RED, GL_FLOAT, NULL);
+  glTexImage2D (GL_TEXTURE_2D, 0, GL_R32F, width_, height_, 0, GL_RED, GL_FLOAT, nullptr);
   glBindTexture (GL_TEXTURE_2D, 0);
 
   // Setup texture for likelihood function

--- a/simulation/src/sum_reduce.cpp
+++ b/simulation/src/sum_reduce.cpp
@@ -47,7 +47,7 @@ pcl::simulation::SumReduce::SumReduce (int width, int height, int levels) : leve
     glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
     glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
-    glTexImage2D (GL_TEXTURE_2D, 0, GL_R32F, level_width, level_height, 0, GL_RED, GL_FLOAT, NULL);
+    glTexImage2D (GL_TEXTURE_2D, 0, GL_R32F, level_width, level_height, 0, GL_RED, GL_FLOAT, nullptr);
     glBindTexture (GL_TEXTURE_2D, 0);
   }
 }

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -434,7 +434,7 @@ initialize (int, char** argv)
 int
 main (int argc, char** argv)
 {
-  srand (time (0));
+  srand (time (nullptr));
 
   print_info ("The viewer window provides interactive commands; for help, press 'h' or 'H' from within the window.\n");
 


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix