### PR TITLE
Use nullptr in module surface

### DIFF
--- a/surface/include/pcl/surface/impl/concave_hull.hpp
+++ b/surface/include/pcl/surface/impl/concave_hull.hpp
@@ -176,7 +176,7 @@ pcl::ConcaveHull<PointInT>::performReconstruction (PointCloud &alpha_shape, std:
   // option flags for qhull, see qh_opt.htm
   char flags[] = "qhull d QJ";
   // output from qh_produce_output(), use NULL to skip qh_produce_output()
-  FILE *outfile = NULL;
+  FILE *outfile = nullptr;
   // error messages from qhull code
   FILE *errfile = stderr;
   // 0 if no error from qhull

--- a/surface/include/pcl/surface/impl/convex_hull.hpp
+++ b/surface/include/pcl/surface/impl/convex_hull.hpp
@@ -134,7 +134,7 @@ pcl::ConvexHull<PointInT>::performReconstruction2D (PointCloud &hull, std::vecto
   // True if qhull should free points in qh_freeqhull() or reallocation
   boolT ismalloc = True;
   // output from qh_produce_output(), use NULL to skip qh_produce_output()
-  FILE *outfile = NULL;
+  FILE *outfile = nullptr;
 
 #ifndef HAVE_QHULL_2011
   if (compute_area_)
@@ -297,7 +297,7 @@ pcl::ConvexHull<PointInT>::performReconstruction3D (
   // True if qhull should free points in qh_freeqhull() or reallocation
   boolT ismalloc = True;
   // output from qh_produce_output(), use NULL to skip qh_produce_output()
-  FILE *outfile = NULL;
+  FILE *outfile = nullptr;
 
 #ifndef HAVE_QHULL_2011
   if (compute_area_)

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -777,7 +777,7 @@ pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
     {
       // Note: The max_sq_radius parameter is only used if weight_func was not defined
       double max_sq_radius = 1;
-      if (weight_func == nullptr)
+      if (weight_func.empty())
       {
         max_sq_radius = search_radius * search_radius;
         weight_func = boost::bind (&pcl::MLSResult::computeMLSWeight, this, _1, max_sq_radius);

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -777,7 +777,7 @@ pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
     {
       // Note: The max_sq_radius parameter is only used if weight_func was not defined
       double max_sq_radius = 1;
-      if (weight_func == 0)
+      if (weight_func == nullptr)
       {
         max_sq_radius = search_radius * search_radius;
         weight_func = boost::bind (&pcl::MLSResult::computeMLSWeight, this, _1, max_sq_radius);

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -210,7 +210,7 @@ namespace pcl
                        const std::vector<int> &nn_indices,
                        double search_radius,
                        int polynomial_order = 2,
-                       boost::function<double(const double)> weight_func = nullptr);
+                       boost::function<double(const double)> weight_func = {});
 
     Eigen::Vector3d query_point;  /**< \brief The query point about which the mls surface was generated */
     Eigen::Vector3d mean;         /**< \brief The mean point of all the neighbors. */

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -210,7 +210,7 @@ namespace pcl
                        const std::vector<int> &nn_indices,
                        double search_radius,
                        int polynomial_order = 2,
-                       boost::function<double(const double)> weight_func = 0);
+                       boost::function<double(const double)> weight_func = nullptr);
 
     Eigen::Vector3d query_point;  /**< \brief The query point about which the mls surface was generated */
     Eigen::Vector3d mean;         /**< \brief The mean point of all the neighbors. */

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -196,7 +196,7 @@ SequentialFitter::is_back_facing (const Eigen::Vector3d &v0, const Eigen::Vector
 void
 SequentialFitter::setInputCloud (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_cloud)
 {
-  if (pcl_cloud.get () == 0 || pcl_cloud->points.size () == 0)
+  if (pcl_cloud.get () == nullptr || pcl_cloud->points.size () == 0)
     throw std::runtime_error ("[SequentialFitter::setInputCloud] Error: Empty or invalid pcl-point-cloud.\n");
 
   m_cloud = pcl_cloud;
@@ -206,7 +206,7 @@ SequentialFitter::setInputCloud (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_clo
 void
 SequentialFitter::setBoundary (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 {
-  if (m_cloud.get () == 0 || m_cloud->points.size () == 0)
+  if (m_cloud.get () == nullptr || m_cloud->points.size () == 0)
     throw std::runtime_error ("[SequentialFitter::setBoundary] Error: Empty or invalid pcl-point-cloud.\n");
 
   this->m_boundary_indices = pcl_cloud_indexes;
@@ -217,7 +217,7 @@ SequentialFitter::setBoundary (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 void
 SequentialFitter::setInterior (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 {
-  if (m_cloud.get () == 0 || m_cloud->points.size () == 0)
+  if (m_cloud.get () == nullptr || m_cloud->points.size () == 0)
     throw std::runtime_error ("[SequentialFitter::setIndices] Error: Empty or invalid pcl-point-cloud.\n");
 
   this->m_interior_indices = pcl_cloud_indexes;
@@ -228,7 +228,7 @@ SequentialFitter::setInterior (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 void
 SequentialFitter::setCorners (pcl::PointIndices::Ptr &corners, bool flip_on_demand)
 {
-  if (m_cloud.get () == 0 || m_cloud->points.size () == 0)
+  if (m_cloud.get () == nullptr || m_cloud->points.size () == 0)
     throw std::runtime_error ("[SequentialFitter::setCorners] Error: Empty or invalid pcl-point-cloud.\n");
 
   if (corners->indices.size () < 4)

--- a/surface/src/vtk_smoothing/vtk_utils.cpp
+++ b/surface/src/vtk_smoothing/vtk_utils.cpp
@@ -101,8 +101,8 @@ pcl::VTKUtils::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::Pol
   if (nr_points == 0)
     return 0;
 
-  vtkUnsignedCharArray* poly_colors = NULL;
-  if (poly_data->GetPointData() != NULL)
+  vtkUnsignedCharArray* poly_colors = nullptr;
+  if (poly_data->GetPointData() != nullptr)
     poly_colors = vtkUnsignedCharArray::SafeDownCast (poly_data->GetPointData ()->GetScalars ("Colors"));
 
   // Some applications do not save the name of scalars (including PCL's native vtk_io)
@@ -261,7 +261,7 @@ pcl::VTKUtils::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyDa
     poly_data->GetPointData()->SetNormals (normals);
   }
 
-  if (poly_data->GetPoints() == NULL)
+  if (poly_data->GetPoints() == nullptr)
     return (0);
   return (static_cast<int> (poly_data->GetPoints()->GetNumberOfPoints ()));
 }


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix