### PR TITLE
Use nullptr in module test

### DIFF
--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -363,7 +363,7 @@ TEST (PCL, IO)
   cloud.points.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   size_t nr_p = cloud.points.size ();
   // Randomly create a new point cloud
   for (size_t i = 0; i < nr_p; ++i)
@@ -674,7 +674,7 @@ TEST (PCL, PCDReaderWriter)
   cloud.points.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   size_t nr_p = cloud.points.size ();
   // Randomly create a new point cloud
   for (size_t i = 0; i < nr_p; ++i)
@@ -794,7 +794,7 @@ TEST (PCL, ASCIIRead)
 
   afile<< std::setprecision(10);
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   size_t nr_p = cloud.points.size ();
   // Randomly create a new point cloud
   for (size_t i = 0; i < nr_p; ++i)
@@ -1067,7 +1067,7 @@ TEST (PCL, LZF)
   cloud.points.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   size_t nr_p = cloud.points.size ();
   // Randomly create a new point cloud
   for (size_t i = 0; i < nr_p; ++i)
@@ -1125,7 +1125,7 @@ TEST (PCL, LZFExtended)
   cloud.points.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   size_t nr_p = cloud.points.size ();
   // Randomly create a new point cloud
   for (size_t i = 0; i < nr_p; ++i)
@@ -1178,7 +1178,7 @@ TEST (PCL, LZFInMem)
   cloud.points.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   size_t nr_p = cloud.points.size ();
   // Randomly create a new point cloud
   for (size_t i = 0; i < nr_p; ++i)
@@ -1249,7 +1249,7 @@ TEST (PCL, Locale)
     cloud.points.resize (cloud.width * cloud.height);
     cloud.is_dense = true;
 
-    srand (static_cast<unsigned int> (time (NULL)));
+    srand (static_cast<unsigned int> (time (nullptr)));
     size_t nr_p = cloud.points.size ();
     // Randomly create a new point cloud
     cloud.points[0].x = std::numeric_limits<float>::quiet_NaN ();

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -56,7 +56,7 @@ TEST (PCL, PLYReaderWriter)
   cloud.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   size_t nr_p = cloud.size ();
   // Randomly create a new point cloud
   for (size_t i = 0; i < nr_p; ++i)

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -77,7 +77,7 @@ init ()
 
   cloud_big.width  = 640;
   cloud_big.height = 480;
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   // Randomly create a new point cloud
   for (size_t i = 0; i < cloud_big.width * cloud_big.height; ++i)
     cloud_big.points.emplace_back(static_cast<float> (1024 * rand () / (RAND_MAX + 1.0)),

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -76,7 +76,7 @@ TEST (PCL, Octree_Test)
   };
   MyVoxel voxels[256];
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   // generate some voxel indices
   for (unsigned int i = 0; i < 256; i++)
@@ -390,7 +390,7 @@ TEST (PCL, Octree2Buf_Test)
   int data[256];
   MyVoxel voxels[256];
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   // generate some voxel indices
   for (unsigned int i = 0; i < 256; i++)
@@ -557,7 +557,7 @@ TEST (PCL, Octree2Buf_Base_Double_Buffering_Test)
   int data[TESTPOINTS];
   MyVoxel voxels[TESTPOINTS];
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   const unsigned int test_runs = 20;
 
@@ -638,7 +638,7 @@ TEST (PCL, Octree2Buf_Base_Double_Buffering_XOR_Test)
   int data[TESTPOINTS];
   MyVoxel voxels[TESTPOINTS];
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   const unsigned int test_runs = 15;
 
@@ -936,7 +936,7 @@ TEST(PCL, Octree_Pointcloud_Occupancy_Test)
 
   OctreePointCloudOccupancy<PointXYZ> octree (0.00001f);
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
   {
@@ -975,7 +975,7 @@ TEST (PCL, Octree_Pointcloud_Change_Detector_Test)
 
   OctreePointCloudChangeDetector<PointXYZ> octree (0.01f);
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   cloudIn->width = 1000;
   cloudIn->height = 1;
@@ -1036,7 +1036,7 @@ TEST (PCL, Octree_Pointcloud_Voxel_Centroid_Test)
   OctreePointCloudVoxelCentroid<PointXYZ> octree (1.0f);
   octree.defineBoundingBox (10.0, 10.0, 10.0);
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   cloudIn->width = 10 * 3;
   cloudIn->height = 1;
@@ -1132,7 +1132,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
   // instantiate point cloud
   PointCloud<PointXYZ>::Ptr cloudIn (new PointCloud<PointXYZ> ());
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   std::priority_queue<prioPointQueueEntry, pcl::PointCloud<prioPointQueueEntry>::VectorType> pointCandidates;
 
@@ -1231,7 +1231,7 @@ TEST (PCL, Octree_Pointcloud_Box_Search)
   // instantiate point cloud
   PointCloud<PointXYZ>::Ptr cloudIn (new PointCloud<PointXYZ> ());
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   // create octree
   OctreePointCloudSearch<PointXYZ> octree (1);
@@ -1300,7 +1300,7 @@ TEST(PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
   // instantiate point cloud
   PointCloud<PointXYZ>::Ptr cloudIn (new PointCloud<PointXYZ> ());
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   constexpr double voxelResolution = 0.1;
 
@@ -1373,7 +1373,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
   PointCloud<PointXYZ>::Ptr cloudIn (new PointCloud<PointXYZ> ());
   PointCloud<PointXYZ>::Ptr cloudOut (new PointCloud<PointXYZ> ());
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
   {
@@ -1465,7 +1465,7 @@ TEST (PCL, Octree_Pointcloud_Ray_Traversal)
   // Indices in ray
   std::vector<int> indicesInRay, indicesInRay2;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
   {
@@ -1537,7 +1537,7 @@ TEST (PCL, Octree_Pointcloud_Adjacency)
 {
   constexpr unsigned int test_runs = 100;
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
   {

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -63,7 +63,7 @@ init ()
 
   cloud_big.width = 640;
   cloud_big.height = 480;
-  srand (int (time (NULL)));
+  srand (int (time (nullptr)));
   // Randomly create a new point cloud
   for (size_t i = 0; i < cloud_big.width * cloud_big.height; ++i)
     cloud_big.points.emplace_back(

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -61,7 +61,7 @@ init ()
 
   cloud_big.width = 640;
   cloud_big.height = 480;
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
   // Randomly create a new point cloud
   for (size_t i = 0; i < cloud_big.width * cloud_big.height; ++i)
     cloud_big.points.emplace_back(static_cast<float> (1024 * rand () / (RAND_MAX + 1.0)), 

--- a/test/search/test_octree.cpp
+++ b/test/search/test_octree.cpp
@@ -78,7 +78,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
   // instantiate point cloud
   PointCloud<PointXYZ>::Ptr cloudIn (new PointCloud<PointXYZ> ());
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   std::priority_queue<prioPointQueueEntry, pcl::PointCloud<prioPointQueueEntry>::VectorType> pointCandidates;
 
@@ -277,7 +277,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
   PointCloud<PointXYZ>::Ptr cloudIn (new PointCloud<PointXYZ> ());
   PointCloud<PointXYZ>::Ptr cloudOut (new PointCloud<PointXYZ> ());
 
-  srand (static_cast<unsigned int> (time (NULL)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
   {

--- a/test/search/test_organized.cpp
+++ b/test/search/test_organized.cpp
@@ -84,7 +84,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Nearest_K_Neighbour_Search)
   // instantiate point cloud
   PointCloud<PointXYZ>::Ptr cloudIn (new PointCloud<PointXYZ> ());
 
-  srand (int (time (NULL)));
+  srand (int (time (nullptr)));
 
   // create organized search
   search::OrganizedNeighbor<PointXYZ> organizedNeighborSearch;
@@ -185,7 +185,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Neighbours_Within_Radius_Search)
 {
   constexpr unsigned int test_runs = 10;
 
-  srand (int (time (NULL)));
+  srand (int (time (nullptr)));
 
   search::OrganizedNeighbor<PointXYZ> organizedNeighborSearch;
 


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix