### PR TITLE
Use nullptr in module tools

### DIFF
--- a/tools/generate.cpp
+++ b/tools/generate.cpp
@@ -175,7 +175,7 @@ main (int argc, char** argv)
   if (distribution == "uniform")
   {
     CloudGenerator<pcl::PointXYZ, UniformGenerator<float> > generator;
-    uint32_t seed = static_cast<uint32_t> (time (NULL));
+    uint32_t seed = static_cast<uint32_t> (time (nullptr));
     UniformGenerator<float>::Parameters x_params (xmin, xmax, seed++);
     generator.setParametersForX (x_params);
     UniformGenerator<float>::Parameters y_params (ymin, ymax, seed++);
@@ -188,7 +188,7 @@ main (int argc, char** argv)
   else if (distribution == "normal")
   {
     CloudGenerator<pcl::PointXYZ, NormalGenerator<float> > generator;
-    uint32_t seed = static_cast<uint32_t> (time (NULL));
+    uint32_t seed = static_cast<uint32_t> (time (nullptr));
     NormalGenerator<float>::Parameters x_params (xmean, xstddev, seed++);
     generator.setParametersForX (x_params);
     NormalGenerator<float>::Parameters y_params (ymean, ystddev, seed++);

--- a/tools/image_grabber_viewer.cpp
+++ b/tools/image_grabber_viewer.cpp
@@ -129,7 +129,7 @@ mouse_callback (const pcl::visualization::MouseEvent& mouse_event, void* cookie)
 int
 main (int argc, char** argv)
 {
-  srand (unsigned (time (0)));
+  srand (unsigned (time (nullptr)));
 
   if (argc > 1)
   {

--- a/tools/mesh_sampling.cpp
+++ b/tools/mesh_sampling.cpp
@@ -87,7 +87,7 @@ randPSurface (vtkPolyData * polydata, std::vector<double> * cumulativeAreas, dou
 
   double A[3], B[3], C[3];
   vtkIdType npts = 0;
-  vtkIdType *ptIds = NULL;
+  vtkIdType *ptIds = nullptr;
   polydata->GetCellPoints (el, npts, ptIds);
   polydata->GetPoint (ptIds[0], A);
   polydata->GetPoint (ptIds[1], B);
@@ -138,7 +138,7 @@ uniform_sampling (vtkSmartPointer<vtkPolyData> polydata, size_t n_samples, bool 
 
   double p1[3], p2[3], p3[3], totalArea = 0;
   std::vector<double> cumulativeAreas (cells->GetNumberOfCells (), 0);
-  vtkIdType npts = 0, *ptIds = NULL;
+  vtkIdType npts = 0, *ptIds = nullptr;
   size_t cellId = 0;
   for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds); cellId++)
   {

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -73,7 +73,7 @@ using namespace recognition;
 using namespace visualization;
 
 bool
-vtk_to_pointcloud (const char* file_name, PointCloud<PointXYZ>& pcl_points, PointCloud<Normal>& pcl_normals, vtkPolyData* vtk_dst = NULL);
+vtk_to_pointcloud (const char* file_name, PointCloud<PointXYZ>& pcl_points, PointCloud<Normal>& pcl_normals, vtkPolyData* vtk_dst = nullptr);
 
 //#define _SHOW_SCENE_POINTS_
 #define _SHOW_OCTREE_POINTS_

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -319,7 +319,7 @@ loadScene (const char* file_name, PointCloud<PointXYZ>& non_plane_points, PointC
   PointCloud<Normal>::Ptr all_normals (new PointCloud<Normal> ());
 
   // Get the points and normals from the input scene
-  if ( !vtk2PointCloud (file_name, *all_points, *all_normals, NULL) )
+  if ( !vtk2PointCloud (file_name, *all_points, *all_normals, nullptr) )
     return false;
 
   // Detect the largest plane and remove it from the sets

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -77,7 +77,7 @@ public:
       return;
 
     //register keyboard callbacks
-    viz.registerKeyboardCallback(&OctreeViewer::keyboardEventOccurred, *this, 0);
+    viz.registerKeyboardCallback(&OctreeViewer::keyboardEventOccurred, *this, nullptr);
 
     //key legends
     viz.addText ("Keys:", 0, 170, 0.0, 1.0, 0.0, "keys_t");

--- a/tools/oni_viewer_simple.cpp
+++ b/tools/oni_viewer_simple.cpp
@@ -184,7 +184,7 @@ main(int argc, char ** argv)
 
   pcl::TimeTrigger trigger;
   
-  pcl::ONIGrabber* grabber = 0;
+  pcl::ONIGrabber* grabber = nullptr;
   if (frame_rate == 0)
     grabber = new  pcl::ONIGrabber(arg, true, true);
   else

--- a/tools/openni2_viewer.cpp
+++ b/tools/openni2_viewer.cpp
@@ -119,7 +119,7 @@ public:
     : cloud_viewer_ (new pcl::visualization::PCLVisualizer ("PCL OpenNI2 cloud"))
     , image_viewer_ ()
     , grabber_ (grabber)
-    , rgb_data_ (0), rgb_data_size_ (0)
+    , rgb_data_ (nullptr), rgb_data_size_ (0)
   {
   }
 

--- a/tools/openni_save_image.cpp
+++ b/tools/openni_save_image.cpp
@@ -109,7 +109,7 @@ class SimpleOpenNIViewer
       
       grabber_.start ();
       
-      unsigned char* rgb_data = 0;
+      unsigned char* rgb_data = nullptr;
       unsigned rgb_data_size = 0;
       const void* data;
        

--- a/tools/openni_viewer.cpp
+++ b/tools/openni_viewer.cpp
@@ -112,7 +112,7 @@ class OpenNIViewer
       : cloud_viewer_ (new pcl::visualization::PCLVisualizer ("PCL OpenNI cloud"))
       , image_viewer_ ()
       , grabber_ (grabber)
-      , rgb_data_ (0), rgb_data_size_ (0)
+      , rgb_data_ (nullptr), rgb_data_size_ (0)
     {
     }
 

--- a/tools/pcd_grabber_viewer.cpp
+++ b/tools/pcd_grabber_viewer.cpp
@@ -114,7 +114,7 @@ mouse_callback (const pcl::visualization::MouseEvent& mouse_event, void* cookie)
 int
 main (int argc, char** argv)
 {
-  srand (unsigned (time (0)));
+  srand (unsigned (time (nullptr)));
 
   if (argc > 1)
   {

--- a/tools/pcd_viewer.cpp
+++ b/tools/pcd_viewer.cpp
@@ -216,7 +216,7 @@ pp_callback (const pcl::visualization::PointPickingEvent& event, void* cookie)
 int
 main (int argc, char** argv)
 {
-  srand (static_cast<unsigned int> (time (0)));
+  srand (static_cast<unsigned int> (time (nullptr)));
 
   print_info ("The viewer window provides interactive commands; for help, press 'h' or 'H' from within the window.\n");
 

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -94,7 +94,7 @@ loadDataSet (const char* file_name)
   else
   {
     PCL_ERROR ("Needs a VTK/PLY file to continue.\n");
-    return (NULL);
+    return (nullptr);
   }
 }
 

--- a/tools/voxel_grid_occlusion_estimation.cpp
+++ b/tools/voxel_grid_occlusion_estimation.cpp
@@ -265,7 +265,7 @@ int main (int argc, char** argv)
   vtkActor* a;
   coll->InitTraversal ();
   a = coll->GetNextActor ();
-  while(a!=0)
+  while(a!=nullptr)
     {
       renderer->AddActor (a);
       a = coll->GetNextActor ();


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix