### PR TITLE
Use nullptr in module visualization

### DIFF
--- a/visualization/include/pcl/visualization/cloud_viewer.h
+++ b/visualization/include/pcl/visualization/cloud_viewer.h
@@ -136,7 +136,7 @@ namespace pcl
           * \return              connection object that allows to disconnect the callback function.
           */
         inline boost::signals2::connection 
-        registerKeyboardCallback (void (*callback) (const pcl::visualization::KeyboardEvent&, void*), void* cookie = NULL)
+        registerKeyboardCallback (void (*callback) (const pcl::visualization::KeyboardEvent&, void*), void* cookie = nullptr)
         {
           return (registerKeyboardCallback (boost::bind (callback, _1, cookie)));
         }
@@ -148,7 +148,7 @@ namespace pcl
           * \return              connection object that allows to disconnect the callback function.
           */
         template<typename T> inline boost::signals2::connection 
-        registerKeyboardCallback (void (T::*callback) (const pcl::visualization::KeyboardEvent&, void*), T& instance, void* cookie = NULL)
+        registerKeyboardCallback (void (T::*callback) (const pcl::visualization::KeyboardEvent&, void*), T& instance, void* cookie = nullptr)
         {
           return (registerKeyboardCallback (boost::bind (callback,  boost::ref (instance), _1, cookie)));
         }
@@ -159,7 +159,7 @@ namespace pcl
           * \return              connection object that allows to disconnect the callback function.
           */
         inline boost::signals2::connection 
-        registerMouseCallback (void (*callback) (const pcl::visualization::MouseEvent&, void*), void* cookie = NULL)
+        registerMouseCallback (void (*callback) (const pcl::visualization::MouseEvent&, void*), void* cookie = nullptr)
         {
           return (registerMouseCallback (boost::bind (callback, _1, cookie)));
         }
@@ -171,7 +171,7 @@ namespace pcl
           * \return              connection object that allows to disconnect the callback function.
           */
         template<typename T> inline boost::signals2::connection 
-        registerMouseCallback (void (T::*callback) (const pcl::visualization::MouseEvent&, void*), T& instance, void* cookie = NULL)
+        registerMouseCallback (void (T::*callback) (const pcl::visualization::MouseEvent&, void*), T& instance, void* cookie = nullptr)
         {
           return (registerMouseCallback (boost::bind (callback, boost::ref (instance), _1, cookie)));
         }
@@ -183,7 +183,7 @@ namespace pcl
           * \return              connection object that allows to disconnect the callback function.
           */
         inline boost::signals2::connection 
-        registerPointPickingCallback (void (*callback) (const pcl::visualization::PointPickingEvent&, void*), void* cookie = NULL)
+        registerPointPickingCallback (void (*callback) (const pcl::visualization::PointPickingEvent&, void*), void* cookie = nullptr)
         {
           return (registerPointPickingCallback (boost::bind (callback, _1, cookie)));
         }
@@ -195,7 +195,7 @@ namespace pcl
           * \return              connection object that allows to disconnect the callback function.
           */
         template<typename T> inline boost::signals2::connection 
-        registerPointPickingCallback (void (T::*callback) (const pcl::visualization::PointPickingEvent&, void*), T& instance, void* cookie = NULL)
+        registerPointPickingCallback (void (T::*callback) (const pcl::visualization::PointPickingEvent&, void*), T& instance, void* cookie = nullptr)
         {
           return (registerPointPickingCallback (boost::bind (callback, boost::ref (instance), _1, cookie)));
         }

--- a/visualization/include/pcl/visualization/image_viewer.h
+++ b/visualization/include/pcl/visualization/image_viewer.h
@@ -477,7 +477,7 @@ namespace pcl
           */
         boost::signals2::connection 
         registerKeyboardCallback (void (*callback) (const pcl::visualization::KeyboardEvent&, void*), 
-                                  void* cookie = NULL)
+                                  void* cookie = nullptr)
         {
           return (registerKeyboardCallback (boost::bind (callback, _1, cookie)));
         }
@@ -490,7 +490,7 @@ namespace pcl
           */
         template<typename T> boost::signals2::connection 
         registerKeyboardCallback (void (T::*callback) (const pcl::visualization::KeyboardEvent&, void*), 
-                                  T& instance, void* cookie = NULL)
+                                  T& instance, void* cookie = nullptr)
         {
           return (registerKeyboardCallback (boost::bind (callback,  boost::ref (instance), _1, cookie)));
         }
@@ -509,7 +509,7 @@ namespace pcl
           */
         boost::signals2::connection 
         registerMouseCallback (void (*callback) (const pcl::visualization::MouseEvent&, void*), 
-                               void* cookie = NULL)
+                               void* cookie = nullptr)
         {
           return (registerMouseCallback (boost::bind (callback, _1, cookie)));
         }
@@ -522,7 +522,7 @@ namespace pcl
           */
         template<typename T> boost::signals2::connection 
         registerMouseCallback (void (T::*callback) (const pcl::visualization::MouseEvent&, void*), 
-                               T& instance, void* cookie = NULL)
+                               T& instance, void* cookie = nullptr)
         {
           return (registerMouseCallback (boost::bind (callback, boost::ref (instance), _1, cookie)));
         }

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -658,7 +658,7 @@ pcl::visualization::PCLVisualizer::addText3D (
 
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  for (size_t i = viewport; rens_->GetNextItem () != NULL; ++i)
+  for (size_t i = viewport; rens_->GetNextItem () != nullptr; ++i)
   {
     const std::string uid = tid + std::string (i, '*');
     if (contains (uid))
@@ -685,7 +685,7 @@ pcl::visualization::PCLVisualizer::addText3D (
   rens_->InitTraversal ();
   vtkRenderer* renderer;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Should we add the actor to all renderers or just to i-nth renderer?
     if (viewport == 0 || viewport == i)
@@ -745,7 +745,7 @@ pcl::visualization::PCLVisualizer::addText3D (
 
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  for (size_t i = viewport; rens_->GetNextItem () != NULL; ++i)
+  for (size_t i = viewport; rens_->GetNextItem () != nullptr; ++i)
   {
     const std::string uid = tid + std::string (i, '*');
     if (contains (uid))
@@ -779,7 +779,7 @@ pcl::visualization::PCLVisualizer::addText3D (
   rens_->InitTraversal ();
   int i = 0;
   for ( vtkRenderer* renderer = rens_->GetNextItem ();
-        renderer != NULL;
+        renderer != nullptr;
         renderer = rens_->GetNextItem (), ++i)
   {
     if (viewport == 0 || viewport == i)
@@ -837,7 +837,7 @@ pcl::visualization::PCLVisualizer::addPointCloudNormals (
 
 
   vtkIdType nr_normals = 0;
-  float* pts = 0;
+  float* pts = nullptr;
 
   // If the cloud is organized, then distribute the normal step in both directions
   if (cloud->isOrganized () && normals->isOrganized ())

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -658,7 +658,7 @@ pcl::visualization::PCLVisualizer::addText3D (
 
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  for (size_t i = viewport; rens_->GetNextItem () != nullptr; ++i)
+  for (size_t i = viewport; rens_->GetNextItem (); ++i)
   {
     const std::string uid = tid + std::string (i, '*');
     if (contains (uid))
@@ -685,7 +685,7 @@ pcl::visualization::PCLVisualizer::addText3D (
   rens_->InitTraversal ();
   vtkRenderer* renderer;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while ((renderer = rens_->GetNextItem ()))
   {
     // Should we add the actor to all renderers or just to i-nth renderer?
     if (viewport == 0 || viewport == i)
@@ -745,7 +745,7 @@ pcl::visualization::PCLVisualizer::addText3D (
 
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  for (size_t i = viewport; rens_->GetNextItem () != nullptr; ++i)
+  for (size_t i = viewport; rens_->GetNextItem (); ++i)
   {
     const std::string uid = tid + std::string (i, '*');
     if (contains (uid))
@@ -779,7 +779,7 @@ pcl::visualization::PCLVisualizer::addText3D (
   rens_->InitTraversal ();
   int i = 0;
   for ( vtkRenderer* renderer = rens_->GetNextItem ();
-        renderer != nullptr;
+        renderer;
         renderer = rens_->GetNextItem (), ++i)
   {
     if (viewport == 0 || viewport == i)

--- a/visualization/include/pcl/visualization/pcl_plotter.h
+++ b/visualization/include/pcl/visualization/pcl_plotter.h
@@ -109,7 +109,7 @@ namespace pcl
                      unsigned long size, 
                      char const * name = "Y Axis", 
                      int type  = vtkChart::LINE ,
-                     char const *color=NULL);
+                     char const *color=nullptr);
 	
         /** \brief Adds a plot with correspondences in vectors arrayX and arrayY. This is the vector version of the addPlotData function. 
           * \param[in] array_x X coordinates of point correspondence array

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -172,7 +172,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         inline boost::signals2::connection
-        registerKeyboardCallback (void (*callback) (const pcl::visualization::KeyboardEvent&, void*), void* cookie = NULL)
+        registerKeyboardCallback (void (*callback) (const pcl::visualization::KeyboardEvent&, void*), void* cookie = nullptr)
         {
           return (registerKeyboardCallback (boost::bind (callback, _1, cookie)));
         }
@@ -184,7 +184,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         template<typename T> inline boost::signals2::connection
-        registerKeyboardCallback (void (T::*callback) (const pcl::visualization::KeyboardEvent&, void*), T& instance, void* cookie = NULL)
+        registerKeyboardCallback (void (T::*callback) (const pcl::visualization::KeyboardEvent&, void*), T& instance, void* cookie = nullptr)
         {
           return (registerKeyboardCallback (boost::bind (callback,  boost::ref (instance), _1, cookie)));
         }
@@ -202,7 +202,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         inline boost::signals2::connection
-        registerMouseCallback (void (*callback) (const pcl::visualization::MouseEvent&, void*), void* cookie = NULL)
+        registerMouseCallback (void (*callback) (const pcl::visualization::MouseEvent&, void*), void* cookie = nullptr)
         {
           return (registerMouseCallback (boost::bind (callback, _1, cookie)));
         }
@@ -214,7 +214,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         template<typename T> inline boost::signals2::connection
-        registerMouseCallback (void (T::*callback) (const pcl::visualization::MouseEvent&, void*), T& instance, void* cookie = NULL)
+        registerMouseCallback (void (T::*callback) (const pcl::visualization::MouseEvent&, void*), T& instance, void* cookie = nullptr)
         {
           return (registerMouseCallback (boost::bind (callback, boost::ref (instance), _1, cookie)));
         }
@@ -232,7 +232,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection
-        registerPointPickingCallback (void (*callback) (const pcl::visualization::PointPickingEvent&, void*), void* cookie = NULL);
+        registerPointPickingCallback (void (*callback) (const pcl::visualization::PointPickingEvent&, void*), void* cookie = nullptr);
 
         /** \brief Register a callback function for point picking events
           * \param[in] callback  the member function that will be registered as a callback for a point picking event
@@ -241,7 +241,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         template<typename T> inline boost::signals2::connection
-        registerPointPickingCallback (void (T::*callback) (const pcl::visualization::PointPickingEvent&, void*), T& instance, void* cookie = NULL)
+        registerPointPickingCallback (void (T::*callback) (const pcl::visualization::PointPickingEvent&, void*), T& instance, void* cookie = nullptr)
         {
           return (registerPointPickingCallback (boost::bind (callback, boost::ref (instance), _1, cookie)));
         }
@@ -259,7 +259,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection
-        registerAreaPickingCallback (void (*callback) (const pcl::visualization::AreaPickingEvent&, void*), void* cookie = NULL);
+        registerAreaPickingCallback (void (*callback) (const pcl::visualization::AreaPickingEvent&, void*), void* cookie = nullptr);
 
         /** \brief Register a callback function for area picking events
           * \param[in] callback  the member function that will be registered as a callback for an area picking event
@@ -268,7 +268,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */
         template<typename T> inline boost::signals2::connection
-        registerAreaPickingCallback (void (T::*callback) (const pcl::visualization::AreaPickingEvent&, void*), T& instance, void* cookie = NULL)
+        registerAreaPickingCallback (void (T::*callback) (const pcl::visualization::AreaPickingEvent&, void*), T& instance, void* cookie = nullptr)
         {
           return (registerAreaPickingCallback (boost::bind (callback, boost::ref (instance), _1, cookie)));
         }

--- a/visualization/include/pcl/visualization/window.h
+++ b/visualization/include/pcl/visualization/window.h
@@ -91,7 +91,7 @@ namespace pcl
           */
         boost::signals2::connection
         registerKeyboardCallback (void (*callback) (const pcl::visualization::KeyboardEvent&, void*),
-                                  void* cookie = NULL)
+                                  void* cookie = nullptr)
         {
           return registerKeyboardCallback (boost::bind (callback, _1, cookie));
         }
@@ -105,7 +105,7 @@ namespace pcl
           */
         template<typename T> boost::signals2::connection
         registerKeyboardCallback (void (T::*callback) (const pcl::visualization::KeyboardEvent&, void*),
-                                  T& instance, void* cookie = NULL)
+                                  T& instance, void* cookie = nullptr)
         {
           return registerKeyboardCallback (boost::bind (callback,  boost::ref (instance), _1, cookie));
         }
@@ -118,7 +118,7 @@ namespace pcl
           */
         boost::signals2::connection
         registerMouseCallback (void (*callback) (const pcl::visualization::MouseEvent&, void*),
-                               void* cookie = NULL)
+                               void* cookie = nullptr)
         {
           return registerMouseCallback (boost::bind (callback, _1, cookie));
         }
@@ -132,7 +132,7 @@ namespace pcl
           */
         template<typename T> boost::signals2::connection
         registerMouseCallback (void (T::*callback) (const pcl::visualization::MouseEvent&, void*),
-                               T& instance, void* cookie = NULL)
+                               T& instance, void* cookie = nullptr)
         {
           return registerMouseCallback (boost::bind (callback, boost::ref (instance), _1, cookie));
         }

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -962,7 +962,7 @@ pcl::visualization::ImageViewerInteractorStyle::OnLeftButtonDown ()
   int y = Interactor->GetEventPosition ()[1];
 
   FindPokedRenderer (x, y);
-  if (CurrentRenderer == NULL)
+  if (CurrentRenderer == nullptr)
     return;
 
   // Redefine this button to handle window/level

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -962,7 +962,7 @@ pcl::visualization::ImageViewerInteractorStyle::OnLeftButtonDown ()
   int y = Interactor->GetEventPosition ()[1];
 
   FindPokedRenderer (x, y);
-  if (CurrentRenderer == nullptr)
+  if (!CurrentRenderer)
     return;
 
   // Redefine this button to handle window/level

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -167,7 +167,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::getCameraParameters (pcl::visu
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     if (viewport++ == i)
     {
@@ -243,7 +243,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::setCameraParameters (const Eig
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -269,7 +269,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::setCameraParameters (const pcl
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -527,7 +527,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
 
   FindPokedRenderer (Interactor->GetEventPosition ()[0], Interactor->GetEventPosition ()[1]);
 
-  if (wif_->GetInput () == nullptr)
+  if (!wif_->GetInput ())
   {
     wif_->SetInput (Interactor->GetRenderWindow ());
     wif_->Modified ();
@@ -974,7 +974,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         vtkAbstractPropPicker *picker;
         if ((picker = vtkAbstractPropPicker::SafeDownCast (Interactor->GetPicker ())))
           path = picker->GetPath ();
-        if (path != nullptr)
+        if (path)
           Interactor->FlyTo (CurrentRenderer, picker->GetPickPosition ());
         AnimState = VTKIS_ANIM_OFF;
       }
@@ -1061,7 +1061,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
       if (!keymod)
       {
         FindPokedRenderer(Interactor->GetEventPosition ()[0], Interactor->GetEventPosition ()[1]);
-        if(CurrentRenderer != nullptr)
+        if(CurrentRenderer)
           CurrentRenderer->ResetCamera ();
         else
           PCL_WARN ("no current renderer on the interactor style.");

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -165,9 +165,9 @@ void
 pcl::visualization::PCLVisualizerInteractorStyle::getCameraParameters (pcl::visualization::Camera &camera, int viewport) const
 {
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     if (viewport++ == i)
     {
@@ -241,9 +241,9 @@ pcl::visualization::PCLVisualizerInteractorStyle::setCameraParameters (const Eig
 
 
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -267,9 +267,9 @@ void
 pcl::visualization::PCLVisualizerInteractorStyle::setCameraParameters (const pcl::visualization::Camera &camera, int viewport)
 {
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -527,7 +527,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
 
   FindPokedRenderer (Interactor->GetEventPosition ()[0], Interactor->GetEventPosition ()[1]);
 
-  if (wif_->GetInput () == NULL)
+  if (wif_->GetInput () == nullptr)
   {
     wif_->SetInput (Interactor->GetRenderWindow ());
     wif_->Modified ();
@@ -854,7 +854,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
     case 'j': case 'J':
     {
       char cam_fn[80], snapshot_fn[80];
-      unsigned t = static_cast<unsigned> (time (0));
+      unsigned t = static_cast<unsigned> (time (nullptr));
       sprintf (snapshot_fn, "screenshot-%d.png" , t);
       saveScreenshot (snapshot_fn);
 
@@ -969,12 +969,12 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
       else
       {
         AnimState = VTKIS_ANIM_ON;
-        vtkAssemblyPath *path = NULL;
+        vtkAssemblyPath *path = nullptr;
         Interactor->GetPicker ()->Pick (Interactor->GetEventPosition ()[0], Interactor->GetEventPosition ()[1], 0.0, CurrentRenderer);
         vtkAbstractPropPicker *picker;
         if ((picker = vtkAbstractPropPicker::SafeDownCast (Interactor->GetPicker ())))
           path = picker->GetPath ();
-        if (path != NULL)
+        if (path != nullptr)
           Interactor->FlyTo (CurrentRenderer, picker->GetPickPosition ());
         AnimState = VTKIS_ANIM_OFF;
       }
@@ -1061,7 +1061,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
       if (!keymod)
       {
         FindPokedRenderer(Interactor->GetEventPosition ()[0], Interactor->GetEventPosition ()[1]);
-        if(CurrentRenderer != 0)
+        if(CurrentRenderer != nullptr)
           CurrentRenderer->ResetCamera ();
         else
           PCL_WARN ("no current renderer on the interactor style.");

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -126,7 +126,7 @@ pcl::visualization::PCLPlotter::addPlotData (
   line->SetInputData (table, 0, 1);
   line->SetWidth (1);
 
-  if (color == nullptr)    //color automatically based on the ColorScheme
+  if (!color)    //color automatically based on the ColorScheme
   {
     vtkColor3ub vcolor = color_series_->GetColorRepeating (current_plot_);
     line->SetColor (vcolor[0], vcolor[1], vcolor[2], 255);
@@ -653,7 +653,7 @@ pcl::visualization::PCLPlotter::setViewInteractor (
 bool
 pcl::visualization::PCLPlotter::wasStopped () const
 {
-  if (view_->GetInteractor() != nullptr) 
+  if (view_->GetInteractor()) 
     return (stopped_); 
   else 
     return (true);

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -126,7 +126,7 @@ pcl::visualization::PCLPlotter::addPlotData (
   line->SetInputData (table, 0, 1);
   line->SetWidth (1);
 
-  if (color == NULL)    //color automatically based on the ColorScheme
+  if (color == nullptr)    //color automatically based on the ColorScheme
   {
     vtkColor3ub vcolor = color_series_->GetColorRepeating (current_plot_);
     line->SetColor (vcolor[0], vcolor[1], vcolor[2], 255);
@@ -144,7 +144,7 @@ pcl::visualization::PCLPlotter::addPlotData (
     int type /* = vtkChart::LINE */, 
     std::vector<char> const &color)
 {
-  this->addPlotData (&array_X[0], &array_Y[0], static_cast<unsigned long> (array_X.size ()), name, type, (color.empty ()) ? NULL : &color[0]);
+  this->addPlotData (&array_X[0], &array_Y[0], static_cast<unsigned long> (array_X.size ()), name, type, (color.empty ()) ? nullptr : &color[0]);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -163,7 +163,7 @@ pcl::visualization::PCLPlotter::addPlotData (
     array_x[i] = plot_data[i].first;
     array_y[i] = plot_data[i].second;
   }
-  this->addPlotData (array_x, array_y, static_cast<unsigned long> (plot_data.size ()), name, type, (color.empty ()) ? NULL : &color[0]);
+  this->addPlotData (array_x, array_y, static_cast<unsigned long> (plot_data.size ()), name, type, (color.empty ()) ? nullptr : &color[0]);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -653,7 +653,7 @@ pcl::visualization::PCLPlotter::setViewInteractor (
 bool
 pcl::visualization::PCLPlotter::wasStopped () const
 {
-  if (view_->GetInteractor() != NULL) 
+  if (view_->GetInteractor() != nullptr) 
     return (stopped_); 
   else 
     return (true);

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -385,8 +385,8 @@ void pcl::visualization::PCLVisualizer::setupRenderWindow (const std::string& na
 
   // Add all renderers to the window
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  vtkRenderer* renderer = nullptr;
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
     win_->AddRenderer (renderer);
 }
 
@@ -447,7 +447,7 @@ void pcl::visualization::PCLVisualizer::setupCamera (int argc, char **argv)
 /////////////////////////////////////////////////////////////////////////////////////////////
 pcl::visualization::PCLVisualizer::~PCLVisualizer ()
 {
-  if (interactor_ != NULL)
+  if (interactor_ != nullptr)
     interactor_->DestroyTimer (timer_id_);
   // Clear the collections
   rens_->RemoveAllItems ();
@@ -874,7 +874,7 @@ pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int view
 
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  for (size_t i = viewport; rens_->GetNextItem () != NULL; ++i)
+  for (size_t i = viewport; rens_->GetNextItem () != nullptr; ++i)
   {
     const std::string uid = id + std::string (i, '*');
     ShapeActorMap::iterator am_it = shape_actor_map_->find (uid);
@@ -970,9 +970,9 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
 
   // Add it to all renderers
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Should we remove the actor from all renderers?
     if (viewport == 0)
@@ -984,8 +984,8 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
       // Iterate over all actors in this renderer
       vtkPropCollection* actors = renderer->GetViewProps ();
       actors->InitTraversal ();
-      vtkProp* current_actor = NULL;
-      while ((current_actor = actors->GetNextProp ()) != NULL)
+      vtkProp* current_actor = nullptr;
+      while ((current_actor = actors->GetNextProp ()) != nullptr)
       {
         if (current_actor != actor_to_remove)
           continue;
@@ -1008,9 +1008,9 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
 
   // Add it to all renderers
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Should we remove the actor from all renderers?
     if (viewport == 0)
@@ -1022,8 +1022,8 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
       // Iterate over all actors in this renderer
       vtkPropCollection* actors = renderer->GetViewProps ();
       actors->InitTraversal ();
-      vtkProp* current_actor = NULL;
-      while ((current_actor = actors->GetNextProp ()) != NULL)
+      vtkProp* current_actor = nullptr;
+      while ((current_actor = actors->GetNextProp ()) != nullptr)
       {
         if (current_actor != actor_to_remove)
           continue;
@@ -1044,9 +1044,9 @@ pcl::visualization::PCLVisualizer::addActorToRenderer (const vtkSmartPointer<vtk
 {
   // Add it to all renderers
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Should we add the actor to all renderers?
     if (viewport == 0)
@@ -1069,9 +1069,9 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
 
   // Initialize traversal
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Should we remove the actor from all renderers?
     if (viewport == 0)
@@ -1083,8 +1083,8 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
       // Iterate over all actors in this renderer
       vtkPropCollection* actors = renderer->GetViewProps ();
       actors->InitTraversal ();
-      vtkProp* current_actor = NULL;
-      while ((current_actor = actors->GetNextProp ()) != NULL)
+      vtkProp* current_actor = nullptr;
+      while ((current_actor = actors->GetNextProp ()) != nullptr)
       {
         if (current_actor != actor_to_remove)
           continue;
@@ -1314,9 +1314,9 @@ pcl::visualization::PCLVisualizer::setBackgroundColor (
     const double &r, const double &g, const double &b, int viewport)
 {
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Should we add the actor to all renderers?
     if (viewport == 0)
@@ -2024,8 +2024,8 @@ pcl::visualization::PCLVisualizer::getCameras (std::vector<pcl::visualization::C
 {
   cameras.clear ();
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  vtkRenderer* renderer = nullptr;
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
     cameras.emplace_back (*renderer->GetActiveCamera (), *renderer->GetRenderWindow ());
 }
 
@@ -2036,11 +2036,11 @@ pcl::visualization::PCLVisualizer::getViewerPose (int viewport)
   Eigen::Affine3f ret (Eigen::Affine3f::Identity ());
 
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   if (viewport == 0)
     viewport = 1;
   int viewport_i = 1;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     if (viewport_i == viewport)
     {
@@ -2072,8 +2072,8 @@ pcl::visualization::PCLVisualizer::resetCamera ()
 {
   // Update the camera parameters
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  vtkRenderer* renderer = nullptr;
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
     renderer->ResetCamera ();
 }
 
@@ -2087,9 +2087,9 @@ pcl::visualization::PCLVisualizer::setCameraPosition (
     int viewport)
 {
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2112,9 +2112,9 @@ pcl::visualization::PCLVisualizer::setCameraPosition (
     double up_x, double up_y, double up_z, int viewport)
 {
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2149,9 +2149,9 @@ void
 pcl::visualization::PCLVisualizer::setCameraClipDistances (double near, double far, int viewport)
 {
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2168,9 +2168,9 @@ void
 pcl::visualization::PCLVisualizer::setCameraFieldOfView (double fovy, int viewport)
 {
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2200,8 +2200,8 @@ pcl::visualization::PCLVisualizer::resetCameraViewpoint (const std::string &id)
 
   // set all renderer to this viewpoint
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  vtkRenderer* renderer = nullptr;
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     vtkSmartPointer<vtkCamera> cam = renderer->GetActiveCamera ();
     cam->SetPosition (camera_pose->GetElement (0, 3),
@@ -2715,9 +2715,9 @@ pcl::visualization::PCLVisualizer::createViewPortCamera (const int viewport)
 {
   vtkSmartPointer<vtkCamera> cam = vtkSmartPointer<vtkCamera>::New ();
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
+  vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     if (viewport == 0)
       continue;
@@ -3466,13 +3466,13 @@ pcl::visualization::PCLVisualizer::setRepresentationToSurfaceForAllActors ()
 {
   ShapeActorMap::iterator am_it;
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  vtkRenderer* renderer = nullptr;
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     vtkActorCollection * actors = renderer->GetActors ();
     actors->InitTraversal ();
     vtkActor * actor;
-    while ((actor = actors->GetNextActor ()) != NULL)
+    while ((actor = actors->GetNextActor ()) != nullptr)
     {
       actor->GetProperty ()->SetRepresentationToSurface ();
       actor->GetProperty ()->SetLighting (true);
@@ -3486,13 +3486,13 @@ pcl::visualization::PCLVisualizer::setRepresentationToPointsForAllActors ()
 {
   ShapeActorMap::iterator am_it;
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  vtkRenderer* renderer = nullptr;
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     vtkActorCollection * actors = renderer->GetActors ();
     actors->InitTraversal ();
     vtkActor * actor;
-    while ((actor = actors->GetNextActor ()) != NULL)
+    while ((actor = actors->GetNextActor ()) != nullptr)
     {
       actor->GetProperty ()->SetRepresentationToPoints ();
     }
@@ -3505,13 +3505,13 @@ pcl::visualization::PCLVisualizer::setRepresentationToWireframeForAllActors ()
 {
   ShapeActorMap::iterator am_it;
   rens_->InitTraversal ();
-  vtkRenderer* renderer = NULL;
-  while ((renderer = rens_->GetNextItem ()) != NULL)
+  vtkRenderer* renderer = nullptr;
+  while ((renderer = rens_->GetNextItem ()) != nullptr)
   {
     vtkActorCollection * actors = renderer->GetActors ();
     actors->InitTraversal ();
     vtkActor * actor;
-    while ((actor = actors->GetNextActor ()) != NULL)
+    while ((actor = actors->GetNextActor ()) != nullptr)
     {
       actor->GetProperty ()->SetRepresentationToWireframe ();
       actor->GetProperty ()->SetLighting (false);
@@ -3569,7 +3569,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
 
   //center object
   double CoM[3];
-  vtkIdType npts_com = 0, *ptIds_com = NULL;
+  vtkIdType npts_com = 0, *ptIds_com = nullptr;
   vtkSmartPointer<vtkCellArray> cells_com = polydata->GetPolys ();
 
   double center[3], p1_com[3], p2_com[3], p3_com[3], totalArea_com = 0;
@@ -3628,7 +3628,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
   // * Compute area of the mesh
   //////////////////////////////
   vtkSmartPointer<vtkCellArray> cells = mapper->GetInput ()->GetPolys ();
-  vtkIdType npts = 0, *ptIds = NULL;
+  vtkIdType npts = 0, *ptIds = nullptr;
 
   double p1[3], p2[3], p3[3], totalArea = 0;
   for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)
@@ -3847,7 +3847,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
     polydata->BuildCells ();
 
     vtkSmartPointer<vtkCellArray> cells = polydata->GetPolys ();
-    vtkIdType npts = 0, *ptIds = NULL;
+    vtkIdType npts = 0, *ptIds = nullptr;
 
     double p1[3], p2[3], p3[3], area, totalArea = 0;
     for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)
@@ -4379,7 +4379,7 @@ pcl::visualization::PCLVisualizer::getGeometryHandlerIndex (const std::string &i
 bool
 pcl::visualization::PCLVisualizer::wasStopped () const
 {
-  if (interactor_ != NULL)
+  if (interactor_ != nullptr)
     return (stopped_);
   return (true);
 }
@@ -4388,7 +4388,7 @@ pcl::visualization::PCLVisualizer::wasStopped () const
 void
 pcl::visualization::PCLVisualizer::resetStoppedFlag ()
 {
-  if (interactor_ != NULL)
+  if (interactor_ != nullptr)
     stopped_ = false;
 }
 

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -386,7 +386,7 @@ void pcl::visualization::PCLVisualizer::setupRenderWindow (const std::string& na
   // Add all renderers to the window
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
     win_->AddRenderer (renderer);
 }
 
@@ -447,7 +447,7 @@ void pcl::visualization::PCLVisualizer::setupCamera (int argc, char **argv)
 /////////////////////////////////////////////////////////////////////////////////////////////
 pcl::visualization::PCLVisualizer::~PCLVisualizer ()
 {
-  if (interactor_ != nullptr)
+  if (interactor_)
     interactor_->DestroyTimer (timer_id_);
   // Clear the collections
   rens_->RemoveAllItems ();
@@ -874,7 +874,7 @@ pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int view
 
   // check all or an individual viewport for a similar id
   rens_->InitTraversal ();
-  for (size_t i = viewport; rens_->GetNextItem () != nullptr; ++i)
+  for (size_t i = viewport; rens_->GetNextItem (); ++i)
   {
     const std::string uid = id + std::string (i, '*');
     ShapeActorMap::iterator am_it = shape_actor_map_->find (uid);
@@ -972,7 +972,7 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Should we remove the actor from all renderers?
     if (viewport == 0)
@@ -985,7 +985,7 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
       vtkPropCollection* actors = renderer->GetViewProps ();
       actors->InitTraversal ();
       vtkProp* current_actor = nullptr;
-      while ((current_actor = actors->GetNextProp ()) != nullptr)
+      while (current_actor = actors->GetNextProp ())
       {
         if (current_actor != actor_to_remove)
           continue;
@@ -1010,7 +1010,7 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Should we remove the actor from all renderers?
     if (viewport == 0)
@@ -1023,7 +1023,7 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
       vtkPropCollection* actors = renderer->GetViewProps ();
       actors->InitTraversal ();
       vtkProp* current_actor = nullptr;
-      while ((current_actor = actors->GetNextProp ()) != nullptr)
+      while (current_actor = actors->GetNextProp ())
       {
         if (current_actor != actor_to_remove)
           continue;
@@ -1046,7 +1046,7 @@ pcl::visualization::PCLVisualizer::addActorToRenderer (const vtkSmartPointer<vtk
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Should we add the actor to all renderers?
     if (viewport == 0)
@@ -1071,7 +1071,7 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Should we remove the actor from all renderers?
     if (viewport == 0)
@@ -1084,7 +1084,7 @@ pcl::visualization::PCLVisualizer::removeActorFromRenderer (const vtkSmartPointe
       vtkPropCollection* actors = renderer->GetViewProps ();
       actors->InitTraversal ();
       vtkProp* current_actor = nullptr;
-      while ((current_actor = actors->GetNextProp ()) != nullptr)
+      while (current_actor = actors->GetNextProp ())
       {
         if (current_actor != actor_to_remove)
           continue;
@@ -1316,7 +1316,7 @@ pcl::visualization::PCLVisualizer::setBackgroundColor (
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Should we add the actor to all renderers?
     if (viewport == 0)
@@ -2025,7 +2025,7 @@ pcl::visualization::PCLVisualizer::getCameras (std::vector<pcl::visualization::C
   cameras.clear ();
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
     cameras.emplace_back (*renderer->GetActiveCamera (), *renderer->GetRenderWindow ());
 }
 
@@ -2040,7 +2040,7 @@ pcl::visualization::PCLVisualizer::getViewerPose (int viewport)
   if (viewport == 0)
     viewport = 1;
   int viewport_i = 1;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     if (viewport_i == viewport)
     {
@@ -2073,7 +2073,7 @@ pcl::visualization::PCLVisualizer::resetCamera ()
   // Update the camera parameters
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
     renderer->ResetCamera ();
 }
 
@@ -2089,7 +2089,7 @@ pcl::visualization::PCLVisualizer::setCameraPosition (
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2114,7 +2114,7 @@ pcl::visualization::PCLVisualizer::setCameraPosition (
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2151,7 +2151,7 @@ pcl::visualization::PCLVisualizer::setCameraClipDistances (double near, double f
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2170,7 +2170,7 @@ pcl::visualization::PCLVisualizer::setCameraFieldOfView (double fovy, int viewpo
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     // Modify all renderer's cameras
     if (viewport == 0 || viewport == i)
@@ -2201,7 +2201,7 @@ pcl::visualization::PCLVisualizer::resetCameraViewpoint (const std::string &id)
   // set all renderer to this viewpoint
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     vtkSmartPointer<vtkCamera> cam = renderer->GetActiveCamera ();
     cam->SetPosition (camera_pose->GetElement (0, 3),
@@ -2717,7 +2717,7 @@ pcl::visualization::PCLVisualizer::createViewPortCamera (const int viewport)
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
   int i = 0;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     if (viewport == 0)
       continue;
@@ -3467,12 +3467,12 @@ pcl::visualization::PCLVisualizer::setRepresentationToSurfaceForAllActors ()
   ShapeActorMap::iterator am_it;
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     vtkActorCollection * actors = renderer->GetActors ();
     actors->InitTraversal ();
     vtkActor * actor;
-    while ((actor = actors->GetNextActor ()) != nullptr)
+    while (actor = actors->GetNextActor ())
     {
       actor->GetProperty ()->SetRepresentationToSurface ();
       actor->GetProperty ()->SetLighting (true);
@@ -3487,12 +3487,12 @@ pcl::visualization::PCLVisualizer::setRepresentationToPointsForAllActors ()
   ShapeActorMap::iterator am_it;
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     vtkActorCollection * actors = renderer->GetActors ();
     actors->InitTraversal ();
     vtkActor * actor;
-    while ((actor = actors->GetNextActor ()) != nullptr)
+    while (actor = actors->GetNextActor ())
     {
       actor->GetProperty ()->SetRepresentationToPoints ();
     }
@@ -3506,12 +3506,12 @@ pcl::visualization::PCLVisualizer::setRepresentationToWireframeForAllActors ()
   ShapeActorMap::iterator am_it;
   rens_->InitTraversal ();
   vtkRenderer* renderer = nullptr;
-  while ((renderer = rens_->GetNextItem ()) != nullptr)
+  while (renderer = rens_->GetNextItem ())
   {
     vtkActorCollection * actors = renderer->GetActors ();
     actors->InitTraversal ();
     vtkActor * actor;
-    while ((actor = actors->GetNextActor ()) != nullptr)
+    while (actor = actors->GetNextActor ())
     {
       actor->GetProperty ()->SetRepresentationToWireframe ();
       actor->GetProperty ()->SetLighting (false);
@@ -4379,7 +4379,7 @@ pcl::visualization::PCLVisualizer::getGeometryHandlerIndex (const std::string &i
 bool
 pcl::visualization::PCLVisualizer::wasStopped () const
 {
-  if (interactor_ != nullptr)
+  if (interactor_)
     return (stopped_);
   return (true);
 }
@@ -4388,7 +4388,7 @@ pcl::visualization::PCLVisualizer::wasStopped () const
 void
 pcl::visualization::PCLVisualizer::resetStoppedFlag ()
 {
-  if (interactor_ != nullptr)
+  if (interactor_)
     stopped_ = false;
 }
 

--- a/visualization/src/point_picking_event.cpp
+++ b/visualization/src/point_picking_event.cpp
@@ -154,7 +154,7 @@ pcl::visualization::PointPickingCallback::performSinglePick (
   point_picker->Pick (mouse_x, mouse_y, 0.0, ren);
 
   int idx = static_cast<int> (point_picker->GetPointId ());
-  if (point_picker->GetDataSet () != NULL)
+  if (point_picker->GetDataSet () != nullptr)
   {
     double p[3];
     point_picker->GetDataSet ()->GetPoint (idx, p);

--- a/visualization/src/point_picking_event.cpp
+++ b/visualization/src/point_picking_event.cpp
@@ -154,7 +154,7 @@ pcl::visualization::PointPickingCallback::performSinglePick (
   point_picker->Pick (mouse_x, mouse_y, 0.0, ren);
 
   int idx = static_cast<int> (point_picker->GetPointId ());
-  if (point_picker->GetDataSet () != nullptr)
+  if (point_picker->GetDataSet ())
   {
     double p[3];
     point_picker->GetDataSet ()->GetPoint (idx, p);

--- a/visualization/src/vtk/pcl_context_item.cpp
+++ b/visualization/src/vtk/pcl_context_item.cpp
@@ -259,10 +259,10 @@ pcl::visualization::context_items::Markers::Paint (vtkContext2D *painter)
 
   painter->GetPen ()->SetWidth (size);
   painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
-  painter->DrawPointSprites (0, &params[0], nb_points);
+  painter->DrawPointSprites (nullptr, &params[0], nb_points);
   painter->GetPen ()->SetWidth (1);
   painter->GetPen ()->SetColor (point_colors[0], point_colors[1], point_colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
-  painter->DrawPointSprites (0, &params[0], nb_points);
+  painter->DrawPointSprites (nullptr, &params[0], nb_points);
   return (true);
 }
 

--- a/visualization/src/vtk/vtkVertexBufferObject.cxx
+++ b/visualization/src/vtk/vtkVertexBufferObject.cxx
@@ -74,7 +74,7 @@ vtkStandardNewMacro(vtkVertexBufferObject);
 vtkVertexBufferObject::vtkVertexBufferObject()
 {
   this->Handle = 0;
-  this->Context = 0;
+  this->Context = nullptr;
   this->BufferTarget = 0;
   this->Size=0;
   this->Count=0;
@@ -90,7 +90,7 @@ vtkVertexBufferObject::vtkVertexBufferObject()
 //----------------------------------------------------------------------------
 vtkVertexBufferObject::~vtkVertexBufferObject()
 {
-  this->SetContext(0);
+  this->SetContext(nullptr);
 }
 
 //----------------------------------------------------------------------------
@@ -162,7 +162,7 @@ void vtkVertexBufferObject::SetContext(vtkRenderWindow* renWin)
     {
     if (!this->LoadRequiredExtensions(openGLRenWin->GetExtensionManager()))
       {
-      this->Context = 0;
+      this->Context = nullptr;
       vtkErrorMacro("Required OpenGL extensions not supported by the context.");
       }
     }
@@ -227,25 +227,25 @@ void vtkVertexBufferObject::Bind()
                                this->AttributeType,
                                static_cast<GLboolean> (this->AttributeNormalized),
                                this->AttributeStride,
-                               0);
+                               nullptr);
     vtkgl::EnableVertexAttribArray(this->AttributeIndex);
   } else {
     glEnableClientState(this->ArrayType);
     switch(this->ArrayType){
       case GL_VERTEX_ARRAY:
-        glVertexPointer(this->AttributeSize, this->AttributeType, this->AttributeStride, 0);
+        glVertexPointer(this->AttributeSize, this->AttributeType, this->AttributeStride, nullptr);
         break;
 
       case GL_INDEX_ARRAY:
-        glIndexPointer(this->AttributeType, this->AttributeStride, 0);
+        glIndexPointer(this->AttributeType, this->AttributeStride, nullptr);
         break;
 
       case GL_COLOR_ARRAY:
-        glColorPointer(this->AttributeSize, this->AttributeType, this->AttributeStride, 0);
+        glColorPointer(this->AttributeSize, this->AttributeType, this->AttributeStride, nullptr);
         break;
 
       case GL_NORMAL_ARRAY:
-        glNormalPointer(this->AttributeType, this->AttributeStride, 0);
+        glNormalPointer(this->AttributeType, this->AttributeStride, nullptr);
         break;
 
       default:
@@ -462,7 +462,7 @@ void vtkVertexBufferObject::ReleaseMemory()
   if (this->Context && this->Handle)
     {
     this->Bind();
-    vtkgl::BufferData(this->BufferTarget, 0, NULL, OpenGLVertexBufferObjectUsage[this->Usage]);
+    vtkgl::BufferData(this->BufferTarget, 0, nullptr, OpenGLVertexBufferObjectUsage[this->Usage]);
     this->Size = 0;
     this->Count = 0;
     }

--- a/visualization/src/vtk/vtkVertexBufferObjectMapper.cxx
+++ b/visualization/src/vtk/vtkVertexBufferObjectMapper.cxx
@@ -47,7 +47,7 @@ vtkVertexBufferObjectMapper::vtkVertexBufferObjectMapper()
   initialized = false;
 //  shadersInitialized = false;
 
-  program = NULL;
+  program = nullptr;
   vertexVbo = vtkVertexBufferObject::New();
   indiceVbo = vtkVertexBufferObject::New();
   colorVbo = vtkVertexBufferObject::New();
@@ -103,7 +103,7 @@ void vtkVertexBufferObjectMapper::Render(vtkRenderer *ren, vtkActor *act)
     normalVbo->Bind();
 
   // Draw
-  ren->GetRenderWindow()->GetPainterDeviceAdapter()->DrawElements(VTK_VERTEX, indiceVbo->GetCount(), VTK_UNSIGNED_INT, 0);
+  ren->GetRenderWindow()->GetPainterDeviceAdapter()->DrawElements(VTK_VERTEX, indiceVbo->GetCount(), VTK_UNSIGNED_INT, nullptr);
   //glDrawElements(GL_POINTS, indiceVbo->GetCount(), GL_UNSIGNED_INT, 0);
 
   // Unbind vertices and indices
@@ -152,7 +152,7 @@ void vtkVertexBufferObjectMapper::SetInput(vtkPolyData *input)
   else
   {
     // Setting a NULL input removes the connection.
-    this->SetInputConnection(0, 0);
+    this->SetInputConnection(0, nullptr);
   }
   initialized = false;
 
@@ -168,7 +168,7 @@ void vtkVertexBufferObjectMapper::SetInput(vtkDataSet *input)
   else
   {
     // Setting a NULL input removes the connection.
-    this->SetInputConnection(0, 0);
+    this->SetInputConnection(0, nullptr);
   }
 }
 


### PR DESCRIPTION
Changes are done by run-clang-tidy -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix