### PR TITLE
Use COMPONENTS when finding VTK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,7 +356,28 @@ endif()
 # Find VTK
 option(WITH_VTK "Build VTK-Visualizations" TRUE)
 if(WITH_VTK AND NOT ANDROID)
-  find_package(VTK)
+  set(PCL_IO_VTK_COMPONENTS
+    vtkFiltersCore
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkImagingCore
+  )
+  set(PCL_VISUALIZATION_VTK_COMPONENTS
+    vtkChartsCore
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingLOD
+    vtkViewsContext2D
+  )
+
+  find_package(VTK COMPONENTS
+    ${PCL_IO_VTK_COMPONENTS}
+    ${PCL_VISUALIZATION_VTK_COMPONENTS}
+  )
   if(VTK_FOUND AND ("${VTK_VERSION}" VERSION_LESS 6.2))
     message(WARNING "The minimum required version of VTK is 6.2, but found ${VTK_VERSION}")
     set(VTK_FOUND FALSE)
@@ -368,6 +389,8 @@ if(WITH_VTK AND NOT ANDROID)
       # safe to assume OpenGL backend
       set(VTK_RENDERING_BACKEND "OpenGL")
     endif()
+    find_package(VTK COMPONENTS vtkRenderingContext${VTK_RENDERING_BACKEND} REQUIRED)
+    list(APPEND PCL_VISUALIZATION_VTK_COMPONENTS vtkRenderingContext${VTK_RENDERING_BACKEND})
     message(STATUS "VTK_MAJOR_VERSION ${VTK_MAJOR_VERSION}, rendering backend: ${VTK_RENDERING_BACKEND}")
     if(PCL_SHARED_LIBS OR (NOT (PCL_SHARED_LIBS) AND NOT (VTK_BUILD_SHARED_LIBS)))
       set(VTK_FOUND TRUE)

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -325,7 +325,11 @@ add_definitions(${VTK_DEFINES})
 PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${incs} ${compression_incs} ${impl_incs} ${OPENNI_INCLUDES} ${OPENNI2_INCLUDES})
 target_include_directories(${LIB_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 link_directories(${VTK_LINK_DIRECTORIES})
-target_link_libraries("${LIB_NAME}" pcl_common pcl_io_ply ${VTK_LIBRARIES})
+target_link_libraries("${LIB_NAME}"
+    pcl_common
+    pcl_io_ply
+    ${PCL_IO_VTK_COMPONENTS}
+  )
 if(PNG_FOUND)
   target_link_libraries("${LIB_NAME}" ${PNG_LIBRARIES})
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -192,7 +192,7 @@ else()
   target_link_libraries (pcl_organized_pcd_to_png pcl_common pcl_io)
 
   PCL_ADD_EXECUTABLE(pcl_tiff2pcd "${SUBSYS_NAME}" tiff2pcd.cpp)
-  target_link_libraries(pcl_tiff2pcd pcl_common pcl_io)
+  target_link_libraries(pcl_tiff2pcd pcl_common pcl_io vtkRenderingFreeType vtkRenderingContext${VTK_RENDERING_BACKEND})
 
   PCL_ADD_EXECUTABLE(pcl_ply2vtk "${SUBSYS_NAME}" ply2vtk.cpp)
   target_link_libraries(pcl_ply2vtk pcl_common pcl_io)

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -143,7 +143,13 @@ if(APPLE)
   target_link_libraries("${LIB_NAME}" "-framework Cocoa")
 endif()
 
-target_link_libraries("${LIB_NAME}" pcl_common pcl_io pcl_kdtree ${VTK_LIBRARIES} ${OPENGL_LIBRARIES})
+target_link_libraries("${LIB_NAME}"
+  pcl_common
+  pcl_io
+  pcl_kdtree
+  ${OPENGL_LIBRARIES}
+  ${PCL_VISUALIZATION_VTK_COMPONENTS}
+)
 
 set(EXT_DEPS "")
 if(WITH_OPENNI)


### PR DESCRIPTION
This is the first part of #2967, it will only look for the components of VTK that are actually used by PCL.