### PR TITLE
Check for empty container via .empty() instead of with .size()

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/fpfh_local_estimator.h
@@ -38,7 +38,7 @@ namespace pcl
             return false;
           }
 
-          if (keypoint_extractor_.size() == 0)
+          if (keypoint_extractor_.empty ())
           {
             PCL_ERROR("FPFHLocalEstimation :: This feature needs a keypoint extractor... please provide one\n");
             return false;
@@ -51,7 +51,7 @@ namespace pcl
           this->computeKeypoints(processed, keypoints, normals);
           std::cout << " " << normals->points.size() << " " << processed->points.size() << std::endl;
 
-          if (keypoints->points.size () == 0)
+          if (keypoints->points.empty ())
           {
             PCL_WARN("FPFHLocalEstimation :: No keypoints were found\n");
             return false;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator.h
@@ -39,7 +39,7 @@ namespace pcl
             return false;
           }
 
-          if (keypoint_extractor_.size() == 0)
+          if (keypoint_extractor_.empty ())
           {
             PCL_ERROR("SHOTLocalEstimation :: This feature needs a keypoint extractor... please provide one\n");
             return false;
@@ -99,7 +99,7 @@ namespace pcl
           keypoint_extractor_->setSupportRadius(support_radius_);
           keypoint_extractor_->compute (keypoints);*/
 
-          if (keypoints->points.size () == 0)
+          if (keypoints->points.empty ())
           {
             PCL_WARN("SHOTLocalEstimation :: No keypoints were found\n");
             return false;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator_omp.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/shot_local_estimator_omp.h
@@ -41,7 +41,7 @@ namespace pcl
             return false;
           }
 
-          if (keypoint_extractor_.size() == 0)
+          if (keypoint_extractor_.empty ())
           {
             PCL_ERROR("SHOTLocalEstimationOMP :: This feature needs a keypoint extractor... please provide one\n");
             return false;
@@ -88,7 +88,7 @@ namespace pcl
           this->computeKeypoints(processed, keypoints, normals);
           std::cout << " " << normals->points.size() << " " << processed->points.size() << std::endl;
 
-          if (keypoints->points.size () == 0)
+          if (keypoints->points.empty ())
           {
             PCL_WARN("SHOTLocalEstimationOMP :: No keypoints were found\n");
             return false;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
@@ -137,7 +137,7 @@ namespace pcl
             out = in;
           }
 
-          if (out->points.size () == 0)
+          if (out->points.empty ())
           {
             PCL_WARN("NORMAL estimator: Cloud has no points after voxel grid, won't be able to compute normals!\n");
             return;
@@ -167,7 +167,7 @@ namespace pcl
 
           }
 
-          if (out->points.size () == 0)
+          if (out->points.empty ())
           {
             PCL_WARN("NORMAL estimator: Cloud has no points after removing outliers...!\n");
             return;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_classifier.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_classifier.hpp
@@ -81,7 +81,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     typename pcl::PointCloud<FeatureT>::CloudVectorType signatures;
     std::vector < Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > centroids;
 
-    if (indices_.size ())
+    if (!indices_.empty ())
     {
       pcl::copyPointCloud (*input_, indices_, *in);
     }
@@ -93,7 +93,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     estimator_->estimate (in, processed, signatures, centroids);
     std::vector<index_score> indices_scores;
 
-    if (signatures.size () > 0)
+    if (!signatures.empty ())
     {
       for (size_t idx = 0; idx < signatures.size (); idx++)
       {

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
@@ -170,7 +170,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     std::vector<pcl::PointCloud<FeatureT>, Eigen::aligned_allocator<pcl::PointCloud<FeatureT> > > signatures;
     std::vector < Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > centroids;
 
-    if (indices_.size ())
+    if (!indices_.empty ())
       pcl::copyPointCloud (*input_, indices_, *in);
     else
       in = input_;
@@ -184,7 +184,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     crh_estimator_->getCRHHistograms (crh_histograms);
 
     std::vector<index_score> indices_scores;
-    if (signatures.size () > 0)
+    if (!signatures.empty ())
     {
 
       {

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
@@ -232,7 +232,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     std::vector<pcl::PointCloud<FeatureT>, Eigen::aligned_allocator<pcl::PointCloud<FeatureT> > > signatures;
     std::vector < Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > centroids;
 
-    if (indices_.size ())
+    if (!indices_.empty ())
       pcl::copyPointCloud (*input_, indices_, *in);
     else
       in = input_;
@@ -245,13 +245,13 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     std::vector<index_score> indices_scores;
     descriptor_distances_.clear ();
 
-    if (signatures.size () > 0)
+    if (!signatures.empty ())
     {
 
       {
         pcl::ScopeTime t_matching ("Matching and roll...");
 
-        if (use_single_categories_ && (categories_to_be_searched_.size () > 0))
+        if (use_single_categories_ && (!categories_to_be_searched_.empty ()))
         {
 
           //perform search of the different signatures in the categories_to_be_searched_
@@ -643,7 +643,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
           PointInTPtr processed (new pcl::PointCloud<PointInT>);
           PointInTPtr view = models->at (i).views_->at (v);
 
-          if (view->points.size () == 0)
+          if (view->points.empty ())
             PCL_WARN("View has no points!!!\n");
 
           if (noisify_)

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -216,7 +216,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     else
     {
       processed.reset( (new pcl::PointCloud<PointInT>));
-      if (indices_.size () > 0)
+      if (!indices_.empty ())
       {
         PointInTPtr sub_input (new pcl::PointCloud<PointInT>);
         pcl::copyPointCloud (*input_, indices_, *sub_input);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -153,7 +153,7 @@
        }    
      }
      typename PointCloud<PointT>::Ptr leftovers = boost::shared_ptr<PointCloud<PointT> > (new PointCloud<PointT>);
-     if (extracted_indices->size () == 0)
+     if (extracted_indices->empty ())
        pcl::copyPointCloud (*input_cloud,*leftovers);
      else
      {

--- a/apps/cloud_composer/src/commands.cpp
+++ b/apps/cloud_composer/src/commands.cpp
@@ -51,7 +51,7 @@ bool
 pcl::cloud_composer::CloudCommand::canUseTemplates (ConstItemList &input_data)
 {
   //Make sure the input list isn't empty
-  if (input_data.size () == 0)
+  if (input_data.empty ())
   {
     qCritical () << "Cannot call a templated tool on an empty input in CloudCommand::executeToolOnTemplateCloud!";
     template_type_ = -2;
@@ -118,7 +118,7 @@ bool
 pcl::cloud_composer::CloudCommand::replaceOriginalWithNew (QList <const CloudComposerItem*> originals, QList <CloudComposerItem*> new_items)
 { 
   //Find the input item's parent
-  if (originals.size () < 1)
+  if (originals.empty ())
   {
     qCritical () << "No items to replace specified!";
     return false;
@@ -225,7 +225,7 @@ pcl::cloud_composer::ModifyItemCommand::runCommand (AbstractTool* tool)
       output = tool->performAction (input_list, static_cast<PointTypeFlags::PointType> (template_type_));
     else
       output = tool->performAction (input_list);
-    if (output.size () == 0)
+    if (output.empty ())
       qWarning () << "Warning: Tool " << tool->getToolName () << "returned no item in a ModifyItemCommand";
     else 
     {
@@ -304,7 +304,7 @@ pcl::cloud_composer::NewItemCloudCommand::runCommand (AbstractTool* tool)
       output = tool->performAction (input_list, static_cast<PointTypeFlags::PointType> (template_type_));
     else
       output = tool->performAction (input_list);
-    if (output.size () == 0)
+    if (output.empty ())
       qWarning () << "Warning: Tool " << tool->getToolName () << "returned no item in a NewItemCloudCommand";
     else 
     {
@@ -412,7 +412,7 @@ pcl::cloud_composer::SplitCloudCommand::runCommand (AbstractTool* tool)
       output = tool->performAction (input_list, static_cast<PointTypeFlags::PointType> (template_type_));
     else
       output = tool->performAction (input_list);
-    if (output.size () == 0)
+    if (output.empty ())
       qWarning () << "Warning: Tool " << tool->getToolName () << "returned no item in a SplitCloudCommand";
     else 
     {
@@ -489,7 +489,7 @@ pcl::cloud_composer::DeleteItemCommand::runCommand (AbstractTool*)
     output_data_.append (output_pair);
     this->setText ("Delete "+item->text ());
   }
-  if (original_data_.size () > 0)
+  if (!original_data_.empty ())
     this->setText ("Delete multiple items");
   return true;
 }
@@ -553,7 +553,7 @@ pcl::cloud_composer::MergeCloudCommand::runCommand (AbstractTool* tool)
   OutputPair output_pair = {original_data_, output_items};
   output_data_.append (output_pair);
   
-  if (output_items.size () == 0)
+  if (output_items.empty ())
   {
     qWarning () << "Warning: Tool " << tool->getToolName () << "returned no item in a MergeCloudCommand";
     return false;

--- a/apps/cloud_composer/src/merge_selection.cpp
+++ b/apps/cloud_composer/src/merge_selection.cpp
@@ -37,7 +37,7 @@ pcl::cloud_composer::MergeSelection::performAction (ConstItemList input_data, Po
   QList <CloudComposerItem*> output;
 
   // Check input data length
-  if ( input_data.size () == 0 && selected_item_index_map_.isEmpty() )
+  if ( input_data.empty () && selected_item_index_map_.isEmpty() )
   {
     qCritical () << "Empty input in MergeSelection!";
     return output;

--- a/apps/cloud_composer/src/project_model.cpp
+++ b/apps/cloud_composer/src/project_model.cpp
@@ -112,7 +112,7 @@ pcl::cloud_composer::ProjectModel::setPointSelection (boost::shared_ptr<Selectio
   {
     pcl::PointIndices::Ptr found_indices = boost::make_shared<pcl::PointIndices>();
     selected_event->findIndicesInItem (cloud_item, found_indices);
-    if (found_indices->indices.size () > 0)
+    if (!found_indices->indices.empty ())
     {
       qDebug () << "Found "<<found_indices->indices.size ()<<" points in "<<cloud_item->text ();
       selected_item_index_map_. insert (cloud_item, found_indices);
@@ -195,11 +195,11 @@ pcl::cloud_composer::ProjectModel::insertNewCloudFromFile ()
   QString short_filename = file_info.baseName ();
   //Check if this name already exists in the project - if so, append digit
   QList <QStandardItem*> items = findItems (short_filename);
-  if (items.size () > 0)
+  if (!items.empty ())
   {
     int k = 2;
     items = findItems (short_filename+ tr ("-%1").arg (k));
-    while (items.size () > 0)
+    while (!items.empty ())
     {  
       ++k;
       items = findItems (short_filename+ tr ("-%1").arg (k));
@@ -232,7 +232,7 @@ pcl::cloud_composer::ProjectModel::insertNewCloudFromRGBandDepth ()
     depth_filter << base_name.split("_").at(0) + "_depth.*";
     last_directory_.setNameFilters (depth_filter);
     QFileInfoList depth_info_list = last_directory_.entryInfoList ();
-    if (depth_info_list.size () == 0)
+    if (depth_info_list.empty ())
     {
       qCritical () << "Could not find depth file in format (rgb file base name)_depth.*";
       return;
@@ -328,11 +328,11 @@ pcl::cloud_composer::ProjectModel::insertNewCloudFromRGBandDepth ()
   QString short_filename = file_info.baseName ();
   //Check if this name already exists in the project - if so, append digit
   QList <QStandardItem*> items = findItems (short_filename);
-  if (items.size () > 0)
+  if (!items.empty ())
   {
     int k = 2;
     items = findItems (short_filename+ tr ("-%1").arg (k));
-    while (items.size () > 0)
+    while (!items.empty ())
     {  
       ++k;
       items = findItems (short_filename+ tr ("-%1").arg (k));
@@ -350,7 +350,7 @@ pcl::cloud_composer::ProjectModel::saveSelectedCloudToFile ()
 {
   qDebug () << "Saving cloud to file...";
   QModelIndexList selected_indexes = selection_model_->selectedIndexes ();
-  if (selected_indexes.size () == 0)
+  if (selected_indexes.empty ())
   {
     QMessageBox::warning (qobject_cast<QWidget *>(this->parent ()), "No Cloud Selected", "Cannot save, no cloud is selected in the browser or cloud view");
     return;
@@ -395,7 +395,7 @@ pcl::cloud_composer::ProjectModel::enqueueToolAction (AbstractTool* tool)
   //Get the currently selected item(s), put them in a list, and create the command
   ConstItemList input_data;
   QModelIndexList selected_indexes = selection_model_->selectedIndexes ();
-  if (selected_indexes.size () == 0)
+  if (selected_indexes.empty ())
   {
     QMessageBox::warning (qobject_cast<QWidget *>(this->parent ()), "No Items Selected", "Cannot use tool, no item is selected in the browser or cloud view");
     return;
@@ -458,7 +458,7 @@ pcl::cloud_composer::ProjectModel::deleteSelectedItems ()
 {
   
   QModelIndexList selected_indexes = selection_model_->selectedIndexes ();
-  if (selected_indexes.size () == 0)
+  if (selected_indexes.empty ())
   {
     QMessageBox::warning (qobject_cast<QWidget *>(this->parent ()), "No Items Selected", "Cannot execute delete command, no item is selected in the browser or cloud view");
     return;

--- a/apps/cloud_composer/src/properties_model.cpp
+++ b/apps/cloud_composer/src/properties_model.cpp
@@ -49,7 +49,7 @@ pcl::cloud_composer::PropertiesModel::addProperty (const QString prop_name, QVar
   if (category.size () > 0)
   {
     QList<QStandardItem*> items = findItems (category);
-    if (items.size () == 0)
+    if (items.empty ())
       qWarning () << "No category named "<<prop_name<<" found in "<<parent_item_->text ()<<" adding to root";
     else if (items.size () > 1)
       qCritical () << "Multiple categories with same name found!! This is not good...";
@@ -82,7 +82,7 @@ pcl::cloud_composer::PropertiesModel::getProperty (const QString prop_name) cons
 {
   //qDebug () << "Searching for property " << prop_name;
   QList<QStandardItem*> items = findItems (prop_name, Qt::MatchExactly | Qt::MatchRecursive, 0);
-  if (items.size () == 0)
+  if (items.empty ())
   {
     qWarning () << "No property named "<<prop_name<<" found in "<<parent_item_->text ();
     return QVariant ();

--- a/apps/cloud_composer/src/toolbox_model.cpp
+++ b/apps/cloud_composer/src/toolbox_model.cpp
@@ -55,7 +55,7 @@ QStandardItem*
 pcl::cloud_composer::ToolBoxModel::addToolGroup (QString tool_group_name)
 {
   QList <QStandardItem*> matches_name = findItems (tool_group_name);
-  if (matches_name.size () == 0)
+  if (matches_name.empty ())
   {
     QStandardItem* new_group_item = new QStandardItem (tool_group_name);
     appendRow (new_group_item);
@@ -190,7 +190,7 @@ pcl::cloud_composer::ToolBoxModel::updateEnabledTools (const QItemSelection& cur
       disabled_tools.insert (tool_item, tr("Tool Requires item type %1 selected").arg (ITEM_TYPES_STRINGS.value (input_type - QStandardItem::UserType)));
     }
     //Check if any of selected items have required children
-    else if ( required_children_types.size () > 0)
+    else if ( !required_children_types.empty ())
     {  
       QList <QStandardItem*> matching_selected_items = type_items_map.values (input_type);
       bool found_valid_items = false;

--- a/apps/cloud_composer/tools/euclidean_clustering.cpp
+++ b/apps/cloud_composer/tools/euclidean_clustering.cpp
@@ -25,7 +25,7 @@ pcl::cloud_composer::EuclideanClusteringTool::performAction (ConstItemList input
   QList <CloudComposerItem*> output;
   const CloudComposerItem* input_item;
   // Check input data length
-  if ( input_data.size () == 0)
+  if ( input_data.empty ())
   {
     qCritical () << "Empty input in Euclidean Clustering Tool!";
     return output;
@@ -95,7 +95,7 @@ pcl::cloud_composer::EuclideanClusteringTool::performAction (ConstItemList input
       } 
       //We copy input cloud over for special case that no clusters found, since ExtractIndices doesn't work for 0 length vectors
       pcl::PCLPointCloud2::Ptr remainder_cloud (new pcl::PCLPointCloud2(*input_cloud));
-      if (cluster_indices.size () > 0)
+      if (!cluster_indices.empty ())
       {
         //make a cloud containing all the remaining points
         filter.setIndices (extracted_indices);

--- a/apps/cloud_composer/tools/fpfh_estimation.cpp
+++ b/apps/cloud_composer/tools/fpfh_estimation.cpp
@@ -27,7 +27,7 @@ pcl::cloud_composer::FPFHEstimationTool::performAction (ConstItemList input_data
   QList <CloudComposerItem*> output;
   const CloudComposerItem* input_item;
   // Check input data length
-  if ( input_data.size () == 0)
+  if ( input_data.empty ())
   {
     qCritical () << "Empty input in FPFH Estimation Tool!";
     return output;
@@ -43,7 +43,7 @@ pcl::cloud_composer::FPFHEstimationTool::performAction (ConstItemList input_data
   {
     //Check if this cloud has normals computed!
     QList <CloudComposerItem*> normals_list = input_item->getChildren (CloudComposerItem::NORMALS_ITEM);
-    if ( normals_list.size () == 0 )
+    if ( normals_list.empty () )
     {
       qCritical () << "No normals item child found in this cloud item";
       return output;

--- a/apps/cloud_composer/tools/normal_estimation.cpp
+++ b/apps/cloud_composer/tools/normal_estimation.cpp
@@ -24,7 +24,7 @@ pcl::cloud_composer::NormalEstimationTool::performAction (ConstItemList input_da
   QList <CloudComposerItem*> output;
   const CloudComposerItem* input_item;
   // Check input data length
-  if ( input_data.size () == 0)
+  if ( input_data.empty ())
   {
     qCritical () << "Empty input in Normal Estimation Tool!";
     return output;

--- a/apps/cloud_composer/tools/sanitize_cloud.cpp
+++ b/apps/cloud_composer/tools/sanitize_cloud.cpp
@@ -22,7 +22,7 @@ pcl::cloud_composer::SanitizeCloudTool::performAction (ConstItemList input_data,
   QList <CloudComposerItem*> output;
   const CloudComposerItem* input_item;
   // Check input data length
-  if ( input_data.size () == 0)
+  if ( input_data.empty ())
   {
     qCritical () << "Empty input in SanitizeCloudTool!";
     return output;

--- a/apps/cloud_composer/tools/statistical_outlier_removal.cpp
+++ b/apps/cloud_composer/tools/statistical_outlier_removal.cpp
@@ -24,7 +24,7 @@ pcl::cloud_composer::StatisticalOutlierRemovalTool::performAction (ConstItemList
   QList <CloudComposerItem*> output;
   const CloudComposerItem* input_item;
   // Check input data length
-  if ( input_data.size () == 0)
+  if ( input_data.empty ())
   {
     qCritical () << "Empty input in StatisticalOutlierRemovalTool!";
     return output;

--- a/apps/cloud_composer/tools/voxel_grid_downsample.cpp
+++ b/apps/cloud_composer/tools/voxel_grid_downsample.cpp
@@ -25,7 +25,7 @@ pcl::cloud_composer::VoxelGridDownsampleTool::performAction (ConstItemList input
   QList <CloudComposerItem*> output;
   const CloudComposerItem* input_item;
   // Check input data length
-  if ( input_data.size () == 0)
+  if ( input_data.empty ())
   {
     qCritical () << "Empty input in VoxelGridDownsampleTool!";
     return output;

--- a/apps/in_hand_scanner/src/offline_integration.cpp
+++ b/apps/in_hand_scanner/src/offline_integration.cpp
@@ -141,7 +141,7 @@ pcl::ihs::OfflineIntegration::computationThread ()
   Base::setPivot ("model");
   Base::addMesh (mesh_model_, "model");
 
-  if (filenames.size () < 1)
+  if (filenames.empty ())
   {
     return;
   }

--- a/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp
+++ b/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp
@@ -103,7 +103,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_table_plane ()
   seg_.setInputNormals (cloud_normals_);
   seg_.segment (*table_inliers_, *table_coefficients_);
 
-  if (table_inliers_->indices.size () == 0)
+  if (table_inliers_->indices.empty ())
   {
     PCL_WARN ("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.");
     return;
@@ -233,7 +233,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_fast (std::vector<Cloud
   seg_.setInputNormals (cloud_normals_);
   seg_.segment (*table_inliers_, *table_coefficients_);
 
-  if (table_inliers_->indices.size () == 0)
+  if (table_inliers_->indices.empty ())
   {
     PCL_WARN ("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.");
     return;
@@ -606,7 +606,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute (std::vector<CloudPtr> 
   seg_.setInputNormals (cloud_normals_);
   seg_.segment (*table_inliers_, *table_coefficients_);
 
-  if (table_inliers_->indices.size () == 0)
+  if (table_inliers_->indices.empty ())
   {
     PCL_WARN ("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.");
     return;
@@ -663,7 +663,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute (std::vector<CloudPtr> 
   extract_object_indices.setIndices (boost::make_shared<const pcl::PointIndices> (cloud_object_indices));
   extract_object_indices.filter (*cloud_objects_);
 
-  if (cloud_objects_->points.size () == 0)
+  if (cloud_objects_->points.empty ())
     return;
 
   //down_.reset(new Cloud(*cloud_downsampled_));
@@ -769,7 +769,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_full (std::vector<Cloud
   seg_.setInputNormals (cloud_normals_);
   seg_.segment (*table_inliers_, *table_coefficients_);
 
-  if (table_inliers_->indices.size () == 0)
+  if (table_inliers_->indices.empty ())
   {
     PCL_WARN ("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.");
     return;
@@ -826,7 +826,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_full (std::vector<Cloud
   extract_object_indices.setIndices (boost::make_shared<const pcl::PointIndices> (cloud_object_indices));
   extract_object_indices.filter (*cloud_objects_);
 
-  if (cloud_objects_->points.size () == 0)
+  if (cloud_objects_->points.empty ())
     return;
 
   // ---[ Split the objects into Euclidean clusters

--- a/apps/include/pcl/apps/nn_classification.h
+++ b/apps/include/pcl/apps/nn_classification.h
@@ -142,7 +142,7 @@ namespace pcl
         std::ifstream f (labels_file_name.c_str ());
         std::string label;
         while (getline (f, label))
-          if (label.size () > 0)
+          if (!label.empty ())
             labels.push_back(label);
         if (labels.size () != cloud->points.size ())
           return (false);

--- a/apps/include/pcl/apps/vfh_nn_classifier.h
+++ b/apps/include/pcl/apps/vfh_nn_classifier.h
@@ -198,7 +198,7 @@ namespace pcl
         std::ifstream f (labels_file_name.c_str ());
         std::string label;
         while (getline (f, label))
-          if (label.size () > 0)
+          if (!label.empty ())
             labels.push_back(label);
         return addTrainingFeatures (cloud, labels);
       }

--- a/apps/point_cloud_editor/src/selection.cpp
+++ b/apps/point_cloud_editor/src/selection.cpp
@@ -117,7 +117,7 @@ Selection::invertSelect ()
 std::string
 Selection::getStat () const
 {
-  if (selected_indices_.size() == 0)
+  if (selected_indices_.empty ())
     return ("");
   std::string title = "Total number of selected points: ";
   std::string num_str;

--- a/apps/src/feature_matching.cpp
+++ b/apps/src/feature_matching.cpp
@@ -212,7 +212,7 @@ void ICCVTutorial<FeatureType>::segmentation (typename pcl::PointCloud<pcl::Poin
   clustering.setInputCloud(segmented);
   clustering.extract (cluster_indices);
 
-  if (cluster_indices.size() > 0)//use largest cluster
+  if (!cluster_indices.empty ())//use largest cluster
   {
     cout << cluster_indices.size() << " clusters found";
     if (cluster_indices.size() > 1)

--- a/apps/src/openni_tracking.cpp
+++ b/apps/src/openni_tracking.cpp
@@ -573,7 +573,7 @@ public:
         PCL_INFO ("segmentation, please wait...\n");
         std::vector<pcl::PointIndices> cluster_indices;
         euclideanSegment (target_cloud, cluster_indices);
-        if (cluster_indices.size () > 0)
+        if (!cluster_indices.empty ())
         {
           // select the cluster to track
           CloudPtr temp_cloud (new Cloud);

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -307,7 +307,7 @@ OrganizedSegmentationDemo::cloud_cb (const CloudConstPtr& cloud)
   //Segment Objects
   pcl::PointCloud<PointT>::CloudVectorType clusters;
 
-  if (use_clustering_ && regions.size () > 0)
+  if (use_clustering_ && !regions.empty ())
   {
     boost::shared_ptr<std::set<uint32_t> > plane_labels = boost::make_shared<std::set<uint32_t> > ();
     for (size_t i = 0; i < label_indices.size (); ++i)

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -382,7 +382,7 @@ class HRCSSegmentation
       Eigen::Vector4f ground_plane_params (1.0, 0.0, 0.0, 1.0);
       Eigen::Vector4f ground_centroid (0.0, 0.0, 0.0, 0.0);
       
-      if (ground_cloud->points.size () > 0)
+      if (!ground_cloud->points.empty ())
       {
         ground_centroid = centroids[0];
         ground_plane_params = Eigen::Vector4f (model_coefficients[0].values[0], model_coefficients[0].values[1], model_coefficients[0].values[2], model_coefficients[0].values[3]);
@@ -391,7 +391,7 @@ class HRCSSegmentation
       if (detect_obstacles)
       {
         pcl::PointCloud<PointT>::CloudVectorType clusters;
-        if (ground_cloud->points.size () > 0)
+        if (!ground_cloud->points.empty ())
         {
           boost::shared_ptr<std::set<uint32_t> > plane_labels = boost::make_shared<std::set<uint32_t> > ();
           for (size_t i = 0; i < region_indices.size (); ++i)

--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -120,7 +120,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
   cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
   cloud_out.points.resize (cloud_in.points.size ());
 
-  if (cloud_in.points.size () == 0)
+  if (cloud_in.points.empty ())
     return;
 
   if (isSamePointType<PointInT, PointOutT> ())

--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -427,7 +427,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.push_back (val);
     }
   }
-  if (values.size () == 0)
+  if (values.empty ())
     return (false);
   else
     return (true);
@@ -446,7 +446,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.push_back (val);
     }
   }
-  if (values.size () == 0)
+  if (values.empty ())
     return (false);
   else
     return (true);
@@ -465,7 +465,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.push_back (val);
     }
   }
-  if (values.size () == 0)
+  if (values.empty ())
     return (false);
   else
     return (true);
@@ -483,7 +483,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.emplace_back(argv[i]);
     }
   }
-  if (values.size () == 0)
+  if (values.empty ())
     return (false);
   else
     return (true);
@@ -513,7 +513,7 @@ pcl::console::parse_multiple_2x_arguments (int argc, const char * const * argv, 
       values_s.push_back (s);
     }
   }
-  if (values_f.size () == 0)
+  if (values_f.empty ())
     return (false);
   else
     return (true);
@@ -548,7 +548,7 @@ pcl::console::parse_multiple_3x_arguments (int argc, const char * const * argv, 
       values_t.push_back (t);
     }
   }
-  if (values_f.size () == 0)
+  if (values_f.empty ())
     return (false);
   else
     return (true);

--- a/features/include/pcl/features/impl/cvfh.hpp
+++ b/features/include/pcl/features/impl/cvfh.hpp
@@ -270,7 +270,7 @@ pcl::CVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
   output.height = 1;
 
   // ---[ Step 1b : check if any dominant cluster was found
-  if (clusters.size () > 0)
+  if (!clusters.empty ())
   { // ---[ Step 1b.1 : If yes, compute CVFH using the cluster information
 
     for (const auto &cluster : clusters) //for each cluster

--- a/features/include/pcl/features/impl/gfpfh.hpp
+++ b/features/include/pcl/features/impl/gfpfh.hpp
@@ -106,7 +106,7 @@ pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOu
         std::vector<int> indices;
         octree.voxelSearch (intersected_cells[k], indices);
         int label = emptyLabel ();
-        if (indices.size () != 0)
+        if (!indices.empty ())
         {
           label = getDominantLabel (indices);
         }

--- a/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
+++ b/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
@@ -144,7 +144,7 @@ pcl::MomentOfInertiaEstimation<PointT>::compute ()
 
   if (normalize_)
   {
-    if (indices_->size () > 0)
+    if (!indices_->empty ())
       point_mass_ = 1.0f / static_cast <float> (indices_->size () * indices_->size ());
     else
       point_mass_ = 1.0f;

--- a/features/include/pcl/features/impl/normal_based_signature.hpp
+++ b/features/include/pcl/features/impl/normal_based_signature.hpp
@@ -113,7 +113,7 @@ pcl::NormalBasedSignatureEstimation<PointT, PointNT, PointFeature>::computeFeatu
         tree_->radiusSearch (zeta_point_pcl, search_radius_, k_indices, k_sqr_distances);
 
         // Do k nearest search if there are no neighbors nearby
-        if (k_indices.size () == 0)
+        if (k_indices.empty ())
         {
           k_indices.resize (5);
           k_sqr_distances.resize (5);

--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -531,7 +531,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeRFAndShapeDistribut
     }
   }
 
-  if (ourcvfh_output.points.size ())
+  if (!ourcvfh_output.points.empty ())
   {
     ourcvfh_output.height = 1;
   }
@@ -649,7 +649,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
       }
 
       //remove last cluster if no points found...
-      if (clusters_[cluster_filtered_idx].indices.size () == 0)
+      if (clusters_[cluster_filtered_idx].indices.empty ())
       {
         clusters_.pop_back ();
         clusters_filtered.pop_back ();
@@ -673,7 +673,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
   output.height = 1;
 
   // ---[ Step 1b : check if any dominant cluster was found
-  if (clusters.size () > 0)
+  if (!clusters.empty ())
   { // ---[ Step 1b.1 : If yes, compute CVFH using the cluster information
     for (const auto &cluster : clusters) //for each cluster
     {

--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -134,7 +134,7 @@ pcl::ROPSEstimation <PointInT, PointOutT>::getTriangles (std::vector <pcl::Verti
 template <typename PointInT, typename PointOutT> void
 pcl::ROPSEstimation <PointInT, PointOutT>::computeFeature (PointCloudOut &output)
 {
-  if (triangles_.size () == 0)
+  if (triangles_.empty ())
   {
     output.points.clear ();
     return;

--- a/filters/include/pcl/filters/impl/median_filter.hpp
+++ b/filters/include/pcl/filters/impl/median_filter.hpp
@@ -73,7 +73,7 @@ pcl::MedianFilter<PointT>::applyFilter (PointCloud &output)
               vals.push_back ((*input_)(x+x_dev, y+y_dev).z);
           }
 
-        if (vals.size () == 0)
+        if (vals.empty ())
           continue;
 
         // The output depth will be the median of all the depths in the window

--- a/filters/include/pcl/filters/impl/morphological_filter.hpp
+++ b/filters/include/pcl/filters/impl/morphological_filter.hpp
@@ -89,7 +89,7 @@ pcl::applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPt
         bbox_max = Eigen::Vector3f (maxx, maxy, maxz);
         tree.boxSearch (bbox_min, bbox_max, pt_indices);
 
-        if (pt_indices.size () > 0)
+        if (!pt_indices.empty ())
         {
           Eigen::Vector4f min_pt, max_pt;
           pcl::getMinMax3D<PointT> (*cloud_in, pt_indices, min_pt, max_pt);
@@ -132,7 +132,7 @@ pcl::applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPt
         bbox_max = Eigen::Vector3f (maxx, maxy, maxz);
         tree.boxSearch (bbox_min, bbox_max, pt_indices);
 
-        if (pt_indices.size () > 0)
+        if (!pt_indices.empty ())
         {
           Eigen::Vector4f min_pt, max_pt;
           pcl::getMinMax3D<PointT> (cloud_temp, pt_indices, min_pt, max_pt);
@@ -169,7 +169,7 @@ pcl::applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPt
         bbox_max = Eigen::Vector3f (maxx, maxy, maxz);
         tree.boxSearch (bbox_min, bbox_max, pt_indices);
 
-        if (pt_indices.size () > 0)
+        if (!pt_indices.empty ())
         {
           Eigen::Vector4f min_pt, max_pt;
           pcl::getMinMax3D<PointT> (cloud_temp, pt_indices, min_pt, max_pt);

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -270,7 +270,7 @@ namespace pcl
 
         voxel_centroids_ = PointCloudPtr (new PointCloud (output));
 
-        if (searchable_ && voxel_centroids_->size() > 0)
+        if (searchable_ && !voxel_centroids_->empty ())
         {
           // Initiates kdtree of the centroids of voxels containing a sufficient number of points
           kdtree_.setInputCloud (voxel_centroids_);
@@ -287,7 +287,7 @@ namespace pcl
         voxel_centroids_ = PointCloudPtr (new PointCloud);
         applyFilter (*voxel_centroids_);
 
-        if (searchable_ && voxel_centroids_->size() > 0)
+        if (searchable_ && !voxel_centroids_->empty ())
         {
           // Initiates kdtree of the centroids of voxels containing a sufficient number of points
           kdtree_.setInputCloud (voxel_centroids_);

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -1294,7 +1294,7 @@ main (int argc, char* argv[])
         
   std::string camera_pose_file;
   boost::shared_ptr<CameraPoseProcessor> pose_processor;
-  if (pc::parse_argument (argc, argv, "-save_pose", camera_pose_file) && camera_pose_file.size () > 0)
+  if (pc::parse_argument (argc, argv, "-save_pose", camera_pose_file) && !camera_pose_file.empty ())
   {
     pose_processor.reset (new CameraPoseWriter (camera_pose_file));
   }

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
@@ -112,7 +112,7 @@ pcl::kinfuLS::WorldModel<PointT>::getExistingData(const double previous_origin_x
   // apply filter
   condrem.filter (existing_slice);  
  
-  if(existing_slice.points.size () != 0)
+  if(!existing_slice.points.empty ())
   {
 	//transform the slice in new cube coordinates
 	Eigen::Affine3f transformation; 
@@ -133,7 +133,7 @@ void
 pcl::kinfuLS::WorldModel<PointT>::getWorldAsCubes (const double size, std::vector<typename WorldModel<PointT>::PointCloudPtr> &cubes, std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &transforms, double overlap)
 {
   
-  if(world_->points.size () == 0)
+  if(world_->points.empty ())
   {
 	PCL_INFO("The world is empty, returning nothing\n");
 	return;
@@ -219,7 +219,7 @@ pcl::kinfuLS::WorldModel<PointT>::getWorldAsCubes (const double size, std::vecto
 		condrem.filter (*box);
 
 		// also push transform along with points.
-		if(box->points.size() > 0)
+		if(!box->points.empty ())
 		{
 		  Eigen::Vector3f transform;
 		  transform[0] = origin.x, transform[1] = origin.y, transform[2] = origin.z;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
@@ -89,7 +89,7 @@ namespace pcl
           */
         void reset()
         {
-          if(world_->points.size () != 0)
+          if(!world_->points.empty ())
           {
             PCL_WARN("Clearing world model\n");
             world_->points.clear ();

--- a/gpu/kinfu_large_scale/src/cyclical_buffer.cpp
+++ b/gpu/kinfu_large_scale/src/cyclical_buffer.cpp
@@ -151,7 +151,7 @@ pcl::gpu::kinfuLS::CyclicalBuffer::performShift (const TsdfVolume::Ptr volume, c
   pcl::device::kinfuLS::clearTSDFSlice (volume->data (), &buffer_, offset_x, offset_y, offset_z);
 
   // insert current slice in the world if it contains any points
-  if (current_slice->points.size () != 0) {
+  if (!current_slice->points.empty ()) {
     world_model_.addSlice(current_slice);
   }
 
@@ -159,7 +159,7 @@ pcl::gpu::kinfuLS::CyclicalBuffer::performShift (const TsdfVolume::Ptr volume, c
   shiftOrigin (volume, offset_x, offset_y, offset_z);
 
   // push existing data in the TSDF buffer
-  if (previously_existing_slice->points.size () != 0 ) {
+  if (!previously_existing_slice->points.empty () ) {
     volume->pushSlice(previously_existing_slice, getBuffer () );
   }
 }

--- a/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
+++ b/gpu/kinfu_large_scale/tools/standalone_texture_mapping.cpp
@@ -177,7 +177,7 @@ saveOBJFile (const std::string &file_name,
 
   for (int m = 0; m < nr_meshes; ++m)
   {
-    if(tex_mesh.tex_coordinates.size() == 0)
+    if(tex_mesh.tex_coordinates.empty ())
       continue;
 
     PCL_INFO ("%d vertex textures in submesh %d\n", tex_mesh.tex_coordinates[m].size (), m);
@@ -198,7 +198,7 @@ saveOBJFile (const std::string &file_name,
     if (m > 0) 
       f_idx += tex_mesh.tex_polygons[m-1].size ();
 
-    if(tex_mesh.tex_materials.size() !=0)
+    if(!tex_mesh.tex_materials.empty ())
     {
       fs << "# The material will be used for mesh " << m << std::endl;
       //TODO pbl here with multi texture and unseen faces
@@ -233,7 +233,7 @@ saveOBJFile (const std::string &file_name,
   // Open file
   PCL_INFO ("Writing material files\n");
   //don't do it if no material to write
-  if(tex_mesh.tex_materials.size() ==0)
+  if(tex_mesh.tex_materials.empty ())
     return (0);
 
   std::ofstream m_fs;

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -122,7 +122,7 @@ namespace pcl
       leafBlobVector(   std::vector<std::vector<Blob2, Eigen::aligned_allocator<Blob2> > >& sorted,
                             int                               label )
       {
-        if(sorted[label].size() == 0)
+        if(sorted[label].empty ())
           return 0;
         for(auto &blob : sorted[label])
         {
@@ -144,7 +144,7 @@ namespace pcl
                               int                               label,
                               int                               child_number)
       {
-        if(sorted[label].size() == 0)
+        if(sorted[label].empty ())
           return 0;
         for(auto &blob : sorted[label]){
           blob.child_id[child_number] = NO_CHILD;
@@ -161,7 +161,7 @@ namespace pcl
                                   part_t                            label,
                                   int                               child_number)
       {
-        if(sorted[label].size() == 0)
+        if(sorted[label].empty ())
           return false;
         for(const auto &blob : sorted[label])
           if((blob.child_id[child_number] != NO_CHILD) && (blob.child_id[child_number] != LEAF))
@@ -236,10 +236,10 @@ namespace pcl
         assert(child_number >= 0);
         assert(child_number < MAX_CHILD);
 
-        if(sorted[parent_label].size() == 0){
+        if(sorted[parent_label].empty ()){
           return 0;   //if my size is 0, this is solved by my parent in his iteration	
         }
-        if(sorted[child_label].size() == 0){
+        if(sorted[child_label].empty ()){
           noChildBlobVector(sorted, parent_label, child_number);
           return 0;
         }
@@ -296,10 +296,10 @@ namespace pcl
         assert(child_number >= 0);
         assert(child_number < MAX_CHILD);
 
-        if(sorted[parent_label].size() == 0){
+        if(sorted[parent_label].empty ()){
           return 0;   //if my size is 0, this is solved by my parent in his iteration
         }
-        if(sorted[child_label].size() == 0){
+        if(sorted[child_label].empty ()){
           noChildBlobVector(sorted, parent_label, child_number);
           return 0;
         }
@@ -344,7 +344,7 @@ namespace pcl
       buildRelations( std::vector<std::vector<Blob2, Eigen::aligned_allocator<pcl::gpu::people::Blob2> > >& sorted)
       {
         PCL_VERBOSE("[pcl::gpu::people::buildRelations] : (I) : buildRelations : regular version\n");
-        if(sorted.size() == 0){
+        if(sorted.empty ()){
           std::cout << "(E) : Damn you, you gave me an empty matrix!" << std::endl;
           return (-1);
         }
@@ -448,7 +448,7 @@ namespace pcl
                       PersonAttribs::Ptr person_attribs)
       {
         PCL_DEBUG("[pcl::gpu::people::buildRelations] : (D) : person specific version\n");
-        if(sorted.size() == 0){
+        if(sorted.empty ()){
           PCL_ERROR("[pcl::gpu::people::buildRelations] : (E) : Damn you, you gave me an empty matrix!\n");
           return (-1);
         }
@@ -610,7 +610,7 @@ namespace pcl
                              int                                    part_lid,
                              Tree2&                                 tree)
       {
-        if(sorted.size() <= 0)
+        if(sorted.empty ())
         {
           std::cout << "(E) : buildTree(): hey man, don't fool me, you gave me an empty blob matrix" << std::endl;
           return -1;
@@ -640,7 +640,7 @@ namespace pcl
                              Tree2&                                 tree,
                              PersonAttribs::Ptr                     person_attribs)
       {
-        if(sorted.size() <= 0)
+        if(sorted.empty ())
         {
           std::cout << "(E) : buildTree(): hey man, don't fool me, you gave me an empty blob matrix" << std::endl;
           return -1;

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -188,7 +188,7 @@ pcl::gpu::people::PeopleDetector::process ()
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // if we found a neck display the tree, and continue with processing
-  if(sorted[Neck].size() != 0)
+  if(!sorted[Neck].empty ())
   {
     int c = 0;
     Tree2 t;
@@ -215,7 +215,7 @@ pcl::gpu::people::PeopleDetector::process ()
     const RDFBodyPartsDetector::BlobMatrix& sorted2 = rdf_detector_->getBlobMatrix();
 
     //brief Test if the second tree is build up correctly
-    if(sorted2[Neck].size() != 0)
+    if(!sorted2[Neck].empty ())
     {      
       Tree2 t2;
       buildTree(sorted2, cloud_host_, Neck, c, t2);
@@ -327,7 +327,7 @@ pcl::gpu::people::PeopleDetector::processProb ()
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // if we found a neck display the tree, and continue with processing
-  if(sorted[Neck].size() != 0)
+  if(!sorted[Neck].empty ())
   {
     int c = 0;
     Tree2 t;
@@ -366,7 +366,7 @@ pcl::gpu::people::PeopleDetector::processProb ()
     const RDFBodyPartsDetector::BlobMatrix& sorted2 = rdf_detector_->getBlobMatrix();
 
     //brief Test if the second tree is build up correctly
-    if(sorted2[Neck].size() != 0)
+    if(!sorted2[Neck].empty ())
     {
       Tree2 t2;
       buildTree(sorted2, cloud_host_, Neck, c, t2, person_attribs_);

--- a/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
@@ -173,7 +173,7 @@ namespace pcl
 
        size_t cloud_size = width_arg*height_arg;
        assert (disparityMap_arg.size()==cloud_size);
-       if (colorImage_arg.size())
+       if (!colorImage_arg.empty ())
        {
          assert (colorImage_arg.size()==cloud_size*3);
        }
@@ -220,7 +220,7 @@ namespace pcl
        compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedDisparity[0]), compressedDisparity.size () * sizeof(uint8_t));
 
        // Compress color information
-       if (colorImage_arg.size() && doColorEncoding)
+       if (!colorImage_arg.empty () && doColorEncoding)
        {
          if (convertToMono)
          {

--- a/io/include/pcl/compression/organized_pointcloud_conversion.h
+++ b/io/include/pcl/compression/organized_pointcloud_conversion.h
@@ -379,7 +379,7 @@ namespace pcl
                           pcl::PointCloud<PointT>& cloud_arg)
       {
         size_t cloud_size = width_arg*height_arg;
-        bool hasColor = (rgbData_arg.size () > 0);
+        bool hasColor = (!rgbData_arg.empty ());
 
         // Check size of input data
         assert (disparityData_arg.size()==cloud_size);
@@ -481,7 +481,7 @@ namespace pcl
                           pcl::PointCloud<PointT>& cloud_arg)
       {
         size_t cloud_size = width_arg*height_arg;
-        bool hasColor = (rgbData_arg.size () > 0);
+        bool hasColor = (!rgbData_arg.empty ());
 
         // Check size of input data
         assert (depthData_arg.size()==cloud_size);

--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -345,7 +345,7 @@ pcl::HDLGrabber::toPointClouds (HDLDataPacket *dataPacket)
     {
       if (firing_data.rotationalPosition < last_azimuth_)
       {
-        if (current_sweep_xyzrgba_->size () > 0)
+        if (!current_sweep_xyzrgba_->empty ())
         {
           current_sweep_xyz_->is_dense = current_sweep_xyzrgba_->is_dense = current_sweep_xyzi_->is_dense = false;
           current_sweep_xyz_->header.stamp = velodyne_time;

--- a/io/src/image_grabber.cpp
+++ b/io/src/image_grabber.cpp
@@ -329,7 +329,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
     }
   }
   sort (depth_image_files_.begin (), depth_image_files_.end ());
-  if (rgb_image_files_.size () > 0)
+  if (!rgb_image_files_.empty ())
     sort (rgb_image_files_.begin (), rgb_image_files_.end ());
 }
 
@@ -384,11 +384,11 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
   }
   if (depth_image_files_.size () != rgb_image_files_.size () )
     PCL_WARN ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : Watch out not same amount of depth and rgb images");
-  if (depth_image_files_.size () > 0)
+  if (!depth_image_files_.empty ())
     sort (depth_image_files_.begin (), depth_image_files_.end ());
   else
     PCL_ERROR ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : no depth images added");
-  if (rgb_image_files_.size () > 0)
+  if (!rgb_image_files_.empty ())
     sort (rgb_image_files_.begin (), rgb_image_files_.end ());
   else
     PCL_ERROR ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : no rgb images added");
@@ -427,7 +427,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadPCLZFFiles (const std::string &dir)
     }
   }
   sort (depth_pclzf_files_.begin (), depth_pclzf_files_.end ());
-  if (rgb_pclzf_files_.size () > 0)
+  if (!rgb_pclzf_files_.empty ())
     sort (rgb_pclzf_files_.begin (), rgb_pclzf_files_.end ());
   sort (xml_files_.begin(), xml_files_.end());
   if (depth_pclzf_files_.size() != xml_files_.size())
@@ -435,7 +435,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadPCLZFFiles (const std::string &dir)
     PCL_ERROR("[pcl::ImageGrabber::loadPCLZFFiles] # depth clouds != # xml files\n");
     return;
   }
-  if (depth_pclzf_files_.size() != rgb_pclzf_files_.size() && rgb_pclzf_files_.size() > 0)
+  if (depth_pclzf_files_.size() != rgb_pclzf_files_.size() && !rgb_pclzf_files_.empty ())
   {
     PCL_ERROR("[pcl::ImageGrabber::loadPCLZFFiles] # depth clouds != # rgb clouds\n");
     return;
@@ -500,7 +500,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudAt (size_t idx,
                                                      double &cx, 
                                                      double &cy) const
 {
-  if (depth_image_files_.size () > 0)
+  if (!depth_image_files_.empty ())
   {
     fx = focal_length_x_;
     fy = focal_length_y_;
@@ -508,7 +508,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudAt (size_t idx,
     cy = principal_point_y_;
     return (getCloudVTK (idx, blob, origin, orientation) );
   }
-  else if (depth_pclzf_files_.size () > 0)
+  else if (!depth_pclzf_files_.empty ())
     return (getCloudPCLZF (idx, blob, origin, orientation, fx, fy, cx, cy) );
   else
   {
@@ -534,7 +534,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudVTK (size_t idx,
   vtkSmartPointer<vtkImageData> rgb_image;
   const std::string &depth_image_file = depth_image_files_[idx];
   // If there are RGB files, load an rgb image
-  if (rgb_image_files_.size () != 0)
+  if (!rgb_image_files_.empty ())
   {
     const std::string &rgb_image_file = rgb_image_files_[idx];
     // If we were unable to pull a Vtk image, throw an error
@@ -570,7 +570,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudVTK (size_t idx,
     centerY = ((float)dims[1] - 1.f)/2.f;
   }
 
-  if(rgb_image_files_.size() > 0)
+  if(!rgb_image_files_.empty ())
   {
     pcl::PointCloud<pcl::PointXYZRGBA> cloud_color;
     cloud_color.width = dims[0];
@@ -669,7 +669,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudPCLZF (size_t idx,
   // Get the proper files
   const std::string &depth_pclzf_file = depth_pclzf_files_[idx];
   const std::string &xml_file = xml_files_[idx];
-  if (rgb_pclzf_files_.size () > 0)
+  if (!rgb_pclzf_files_.empty ())
   {
     pcl::PointCloud<pcl::PointXYZRGBA> cloud_color;
     const std::string &rgb_pclzf_file = rgb_pclzf_files_[idx];

--- a/io/src/libpng_wrapper.cpp
+++ b/io/src/libpng_wrapper.cpp
@@ -92,7 +92,7 @@ namespace pcl
       png_infop info_ptr;
       volatile int channels;
 
-      if (image_arg.size () ==0)
+      if (image_arg.empty ())
         return;
 
       // Get amount of channels
@@ -187,7 +187,7 @@ namespace pcl
 
       png_bytep * row_pointers;
 
-      if (pngData_arg.size () == 0)
+      if (pngData_arg.empty ())
         return;
 
       png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -465,7 +465,7 @@ pcl::OBJReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
     }
   }
 
-  if (material_files.size () > 0)
+  if (!material_files.empty ())
   {
     for (const auto &material_file : material_files)
     {

--- a/io/src/openni2/openni2_timer_filter.cpp
+++ b/io/src/openni2/openni2_timer_filter.cpp
@@ -56,7 +56,7 @@ namespace pcl
 
       double OpenNI2TimerFilter::getMedian ()
       {
-        if (buffer_.size ()>0)
+        if (!buffer_.empty ())
         {
           std::deque<double> sort_buffer = buffer_;
 
@@ -70,7 +70,7 @@ namespace pcl
       double
       OpenNI2TimerFilter::getMovingAvg ()
       {
-        if (buffer_.size () > 0)
+        if (!buffer_.empty ())
         {
           double sum = 0;
 

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -618,7 +618,7 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
     const static double d_nan = std::numeric_limits <double>::quiet_NaN ();
     for (size_t r = 0; r < r_size; ++r)
     {
-      if ((*range_grid_)[r].size () == 0)
+      if ((*range_grid_)[r].empty ())
       {
         for (const auto &field : cloud_->fields)
           if (field.datatype == ::pcl::PCLPointField::FLOAT32)
@@ -678,7 +678,7 @@ pcl::PLYReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
     const static double d_nan = std::numeric_limits <double>::quiet_NaN ();
     for (size_t r = 0; r < r_size; ++r)
     {
-      if ((*range_grid_)[r].size () == 0)
+      if ((*range_grid_)[r].empty ())
       {
         for (const auto &field : cloud_->fields)
           if (field.datatype == ::pcl::PCLPointField::FLOAT32)

--- a/io/src/vlp_grabber.cpp
+++ b/io/src/vlp_grabber.cpp
@@ -142,7 +142,7 @@ pcl::VLPGrabber::toPointClouds (HDLDataPacket *dataPacket)
       }
       if (current_azimuth < HDLGrabber::last_azimuth_)
       {
-        if (current_sweep_xyz_->size () > 0)
+        if (!current_sweep_xyz_->empty ())
         {
           current_sweep_xyz_->is_dense = current_sweep_xyzrgba_->is_dense = current_sweep_xyzi_->is_dense = false;
           current_sweep_xyz_->header.stamp = velodyne_time;

--- a/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/smoothed_surfaces_keypoint.hpp
@@ -193,7 +193,7 @@ pcl::SmoothedSurfacesKeypoint<PointT, PointNT>::initCompute ()
     PCL_ERROR ("[pcl::SmoothedSurfacesKeypoints::initCompute] Input normals were not set\n");
     return false;
   }
-  if (clouds_.size () == 0)
+  if (clouds_.empty ())
   {
     PCL_ERROR ("[pcl::SmoothedSurfacesKeypoints::initCompute] No other clouds were set apart from the input\n");
     return false;

--- a/ml/include/pcl/ml/impl/dt/decision_tree_evaluator.hpp
+++ b/ml/include/pcl/ml/impl/dt/decision_tree_evaluator.hpp
@@ -136,7 +136,7 @@ pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeTy
 
     NodeType * node = &(tree.getRoot ());
 
-    while (node->sub_nodes.size () != 0)
+    while (!node->sub_nodes.empty ())
     {
       float feature_result = 0.0f;
       unsigned char flag = 0;

--- a/ml/include/pcl/ml/impl/dt/decision_tree_trainer.hpp
+++ b/ml/include/pcl/ml/impl/dt/decision_tree_trainer.hpp
@@ -150,7 +150,7 @@ pcl::DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType
                                        flags );
 
     // get list of thresholds
-    if (thresholds_.size () > 0)
+    if (!thresholds_.empty ())
     {
       // compute information gain for each threshold and store threshold with highest information gain
       for (size_t threshold_index = 0; threshold_index < thresholds_.size (); ++threshold_index)

--- a/ml/src/permutohedral.cpp
+++ b/ml/src/permutohedral.cpp
@@ -56,11 +56,11 @@ pcl::Permutohedral::init (const std::vector<float> &feature, const int feature_d
   std::multimap<size_t, int> hash_table;
 
   // reserve class memory
-  if (offset_.size () > 0) 
+  if (!offset_.empty ()) 
     offset_.clear ();
   offset_.resize ((d_ + 1) * N_);
 
-  if (barycentric_.size () > 0) 
+  if (!barycentric_.empty ()) 
     barycentric_.clear ();
   barycentric_.resize ((d_ + 1) * N_);
 
@@ -219,7 +219,7 @@ pcl::Permutohedral::init (const std::vector<float> &feature, const int feature_d
   M_ = static_cast<int> (hash_table.size());
 		
   // Create the neighborhood structure
-  if (blur_neighbors_.size () > 0) 
+  if (!blur_neighbors_.empty ()) 
     blur_neighbors_.clear ();
   blur_neighbors_.resize ((d_+1)*M_);
 

--- a/ml/src/svm_wrapper.cpp
+++ b/ml/src/svm_wrapper.cpp
@@ -241,7 +241,7 @@ pcl::SVM::adaptInputToLibSVM (std::vector<SVMData> training_set, svm_problem &pr
 bool
 pcl::SVMTrain::trainClassifier ()
 {
-  if (training_set_.size() == 0)
+  if (training_set_.empty ())
   {
     // to be sure to have loaded the training set
     PCL_ERROR ("[pcl::%s::trainClassifier] Training data not set!\n", getClassName ().c_str ());

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -1477,7 +1477,7 @@ namespace pcl
             PCL_DEBUG ( "[pcl::outofcore::OutofcoreOctreeBaseNode::%s] Points in box: %d\n", __FUNCTION__, indices.size () );
             PCL_DEBUG ( "[pcl::outofcore::OutofcoreOctreeBaseNode::%s] Points remaining: %d\n", __FUNCTION__, tmp_cloud->width*tmp_cloud->height - indices.size () );
 
-            if ( indices.size () > 0 )
+            if ( !indices.empty () )
             {
               if( dst_blob->width*dst_blob->height > 0 )
               {

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -169,7 +169,7 @@ namespace pcl
     template<typename PointT> void
     OutofcoreOctreeDiskContainer<PointT>::flushWritebuff (const bool force_cache_dealloc)
     {
-      if (writebuff_.size () > 0)
+      if (!writebuff_.empty ())
       {
         //construct the point cloud for this node
         typename pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);

--- a/outofcore/include/pcl/outofcore/impl/outofcore_breadth_first_iterator.hpp
+++ b/outofcore/include/pcl/outofcore/impl/outofcore_breadth_first_iterator.hpp
@@ -64,7 +64,7 @@ namespace pcl
     OutofcoreBreadthFirstIterator<PointT, ContainerT>&
     OutofcoreBreadthFirstIterator<PointT, ContainerT>::operator++ ()
     {
-      if (FIFO_.size ())
+      if (!FIFO_.empty ())
       {
         // Get the first entry from the FIFO queue
         OctreeDiskNode *node = FIFO_.front ();
@@ -94,7 +94,7 @@ namespace pcl
       skip_child_voxels_ = false;
 
       // If there's a queue, set the current node to the first entry
-      if (FIFO_.size ())
+      if (!FIFO_.empty ())
       {
         this->currentNode_ = FIFO_.front ();
       }

--- a/outofcore/include/pcl/outofcore/impl/outofcore_depth_first_iterator.hpp
+++ b/outofcore/include/pcl/outofcore/impl/outofcore_depth_first_iterator.hpp
@@ -106,7 +106,7 @@ namespace pcl
         
         if (bTreeUp)
         {
-          if (stack_.size () > 0)
+          if (!stack_.empty ())
           {
             std::pair<OutofcoreOctreeBaseNode<ContainerT, PointT>*, unsigned char>& stackEntry = stack_.back ();
             stack_.pop_back ();

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -316,7 +316,7 @@ main (int argc, char* argv[])
   }
 
   // Check if we should process any files
-  if (pcd_paths.size () < 1)
+  if (pcd_paths.empty ())
   {
     PCL_ERROR ("No .pcd files specified\n");
     return -1;

--- a/people/include/pcl/people/impl/head_based_subcluster.hpp
+++ b/people/include/pcl/people/impl/head_based_subcluster.hpp
@@ -260,7 +260,7 @@ pcl::people::HeadBasedSubclustering<PointT>::subcluster (std::vector<pcl::people
     PCL_ERROR ("[pcl::people::pcl::people::HeadBasedSubclustering::subcluster] Floor parameters have not been set or they are not valid!\n");
     return;
   }
-  if (cluster_indices_.size() == 0)
+  if (cluster_indices_.empty ())
   {
     PCL_ERROR ("[pcl::people::pcl::people::HeadBasedSubclustering::subcluster] Cluster indices have not been set!\n");
     return;

--- a/people/include/pcl/people/impl/person_classifier.hpp
+++ b/people/include/pcl/people/impl/person_classifier.hpp
@@ -80,7 +80,7 @@ pcl::people::PersonClassifier<PointT>::loadSVMFromFile (std::string svm_filename
   }
   SVM_file.close();
   
-  if (SVM_weights_.size() == 0)
+  if (SVM_weights_.empty ())
   {
     PCL_ERROR ("[pcl::people::PersonClassifier::loadSVMFromFile] Invalid SVM file!\n");
     return (false);
@@ -218,7 +218,7 @@ pcl::people::PersonClassifier<PointT>::evaluate (float height_person,
               float yc,
               PointCloudPtr& image)
 {
-  if (SVM_weights_.size() == 0)
+  if (SVM_weights_.empty ())
   {
   PCL_ERROR ("[pcl::people::PersonClassifier::evaluate] SVM has not been set!\n");
   return (-1000);

--- a/recognition/include/pcl/recognition/face_detection/face_common.h
+++ b/recognition/include/pcl/recognition/face_detection/face_common.h
@@ -92,7 +92,7 @@ namespace pcl
           const int num_of_sub_nodes = static_cast<int> (sub_nodes.size ());
           stream.write (reinterpret_cast<const char*> (&num_of_sub_nodes), sizeof(num_of_sub_nodes));
 
-          if (sub_nodes.size () > 0)
+          if (!sub_nodes.empty ())
           {
             feature.serialize (stream);
             stream.write (reinterpret_cast<const char*> (&threshold), sizeof(threshold));

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -522,7 +522,7 @@ bool pcl::GlobalHypothesesVerification<ModelT, SceneT>::addModel(typename pcl::P
     recog_model->cloud_->height = 1;
   }
 
-  if (recog_model->cloud_->points.size () <= 0)
+  if (recog_model->cloud_->points.empty ())
   {
     PCL_WARN("The model cloud has no points..\n");
     return false;
@@ -604,7 +604,7 @@ bool pcl::GlobalHypothesesVerification<ModelT, SceneT>::addModel(typename pcl::P
   recog_model->outlier_indices_.resize (o);
 
   recog_model->outliers_weight_ = (std::accumulate (outliers_weight.begin (), outliers_weight.end (), 0.f) / static_cast<float> (outliers_weight.size ()));
-  if (outliers_weight.size () == 0)
+  if (outliers_weight.empty ())
     recog_model->outliers_weight_ = 1.f;
 
   pcl::IndicesPtr indices_scene (new std::vector<int>);

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -758,13 +758,13 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::findObject
 {
   typename pcl::features::ISMVoteList<PointT>::Ptr out_votes (new pcl::features::ISMVoteList<PointT> ());
 
-  if (in_cloud->points.size () == 0)
+  if (in_cloud->points.empty ())
     return (out_votes);
 
   typename pcl::PointCloud<PointT>::Ptr sampled_point_cloud (new pcl::PointCloud<PointT> ());
   typename pcl::PointCloud<NormalT>::Ptr sampled_normal_cloud (new pcl::PointCloud<NormalT> ());
   simplifyCloud (in_cloud, in_normals, sampled_point_cloud, sampled_normal_cloud);
-  if (sampled_point_cloud->points.size () == 0)
+  if (sampled_point_cloud->points.empty ())
     return (out_votes);
 
   typename pcl::PointCloud<pcl::Histogram<FeatureSize> >::Ptr feature_cloud (new pcl::PointCloud<pcl::Histogram<FeatureSize> > ());
@@ -854,7 +854,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::extractDes
 
   int n_key_points = 0;
 
-  if (training_clouds_.size () == 0 || training_classes_.size () == 0 || feature_estimator_ == nullptr)
+  if (training_clouds_.empty () || training_classes_.empty () || feature_estimator_ == nullptr)
     return (false);
 
   for (size_t i_cloud = 0; i_cloud < training_clouds_.size (); i_cloud++)
@@ -870,7 +870,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::extractDes
     typename pcl::PointCloud<PointT>::Ptr sampled_point_cloud (new pcl::PointCloud<PointT> ());
     typename pcl::PointCloud<NormalT>::Ptr sampled_normal_cloud (new pcl::PointCloud<NormalT> ());
     simplifyCloud (training_clouds_[i_cloud], training_normals_[i_cloud], sampled_point_cloud, sampled_normal_cloud);
-    if (sampled_point_cloud->points.size () == 0)
+    if (sampled_point_cloud->points.empty ())
       continue;
 
     shiftCloud (training_clouds_[i_cloud], models_center);
@@ -938,7 +938,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::clusterDes
 template <int FeatureSize, typename PointT, typename NormalT> void
 pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::calculateSigmas (std::vector<float>& sigmas)
 {
-  if (training_sigmas_.size () != 0)
+  if (!training_sigmas_.empty ())
   {
     sigmas.resize (training_sigmas_.size (), 0.0f);
     for (size_t i_sigma = 0; i_sigma < training_sigmas_.size (); i_sigma++)

--- a/recognition/include/pcl/recognition/ransac_based/bvh.h
+++ b/recognition/include/pcl/recognition/ransac_based/bvh.h
@@ -234,7 +234,7 @@ namespace pcl
         {
           this->clear();
 
-          if ( objects.size () == 0 )
+          if ( objects.empty () )
             return;
 
           sorted_objects_ = &objects;

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -426,7 +426,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
   faceVotesClustering ();
 
-  if (pose_refinement_ && (head_clusters_centers_.size () > 0))
+  if (pose_refinement_ && (!head_clusters_centers_.empty ()))
   {
     Eigen::Matrix4f icp_trans;
     float max_distance = 0.015f;

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -198,14 +198,14 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
             {
               // check and evaluate candidate matches and store them
               handleMatches (base_indices, matches, candidates);
-              if (candidates.size () != 0)
+              if (!candidates.empty ())
                 all_candidates[i] = candidates;
             }
           }
         }
 
         // check terminate early (time or fitness_score threshold reached)
-        abort = (candidates.size () > 0 ? candidates[0].fitness_score < score_threshold_ : abort);
+        abort = (!candidates.empty () ? candidates[0].fitness_score < score_threshold_ : abort);
         abort = (abort ? abort : timer.getTimeSeconds () > max_runtime_);
 
 
@@ -244,7 +244,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
     return (false);
   }
 
-  if (!target_indices_ || target_indices_->size () == 0)
+  if (!target_indices_ || target_indices_->empty ())
   {
     target_indices_.reset (new std::vector <int> (static_cast <int> (target_->size ())));
     int index = 0;
@@ -618,7 +618,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   }
 
   // return success if at least one correspondence was found
-  return (pairs.size () == 0 ? -1 : 0);
+  return (pairs.empty () ? -1 : 0);
 }
 
 
@@ -698,7 +698,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   }
 
   // return unsuccessful if no match was found
-  return (matches.size () > 0 ? 0 : -1);
+  return (!matches.empty () ? 0 : -1);
 }
 
 

--- a/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
+++ b/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
@@ -147,13 +147,13 @@ pcl::PyramidFeatureHistogram<PointFeature>::initializeHistogram ()
     return false;
   }
 
-  if (dimension_range_input_.size () == 0)
+  if (dimension_range_input_.empty ())
   {
     PCL_ERROR ("[pcl::PyramidFeatureHistogram::initializeHistogram] Input dimension range was not set\n");
     return false;
   }
 
-  if (dimension_range_target_.size () == 0)
+  if (dimension_range_target_.empty ())
   {
     PCL_ERROR ("[pcl::PyramidFeatureHistogram::initializeHistogram] Target dimension range was not set\n");
     return false;

--- a/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
+++ b/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
@@ -326,7 +326,7 @@ pcl::SampleConsensusPrerejective<PointSource, PointTarget, FeatureT>::getFitness
   }
 
   // Calculate MSE
-  if (inliers.size () > 0)
+  if (!inliers.empty ())
     fitness_score /= static_cast<float> (inliers.size ());
   else
     fitness_score = std::numeric_limits<float>::max ();

--- a/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
@@ -220,7 +220,7 @@ pcl::CPCSegmentation<PointT>::applyCuttingPlane (uint32_t depth_levels_left)
           cut_support_indices.insert (cut_support_indices.end (), cluster_index.indices.begin (), cluster_index.indices.end ());
         }
       }
-      if (cut_support_indices.size () == 0)
+      if (cut_support_indices.empty ())
       {
 //         std::cout << "Could not find planes which exceed required minimum score (threshold " << min_cut_score_ << "), not cutting" << std::endl;
         continue;

--- a/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
@@ -165,7 +165,7 @@ pcl::CrfSegmentation<PointT>::createVoxelGrid ()
   voxel_grid_.filter (*filtered_cloud_);
 
   // Filter the annotated cloud
-  if (anno_cloud_->points.size () > 0)
+  if (!anno_cloud_->points.empty ())
   {
     pcl::VoxelGridLabel vg;
 
@@ -181,7 +181,7 @@ pcl::CrfSegmentation<PointT>::createVoxelGrid ()
   }
 
   // Filter the annotated cloud
-  if (normal_cloud_->points.size () > 0)
+  if (!normal_cloud_->points.empty ())
   {
     pcl::VoxelGrid<pcl::PointNormal> vg;
     vg.setInputCloud (normal_cloud_);
@@ -342,7 +342,7 @@ pcl::CrfSegmentation<PointT>::createUnaryPotentials (std::vector<float> &unary,
   {
     int label = filtered_anno_->points[k].label;
 
-    if (labels.size () == 0 && label > 0)
+    if (labels.empty () && label > 0)
       labels.push_back (label);
 
     // add color to the color vector if not added yet
@@ -408,7 +408,7 @@ pcl::CrfSegmentation<PointT>::segmentPoints (pcl::PointCloud<pcl::PointXYZRGBL> 
   // create unary potentials
   std::vector<int> labels;
   std::vector<float> unary;
-  if (anno_cloud_->points.size () > 0)
+  if (!anno_cloud_->points.empty ())
   {
     unary.resize (N * n_labels);
     createUnaryPotentials (unary, labels, n_labels);

--- a/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
@@ -324,7 +324,7 @@ pcl::MinCutSegmentation<PointT>::buildGraph ()
   int number_of_points = static_cast<int> (input_->points.size ());
   int number_of_indices = static_cast<int> (indices_->size ());
 
-  if (input_->points.size () == 0 || number_of_points == 0 || foreground_points_.empty () == true )
+  if (input_->points.empty () || number_of_points == 0 || foreground_points_.empty () == true )
     return (false);
 
   if (search_ == 0)

--- a/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
@@ -297,7 +297,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segmentAndRefine
                                              model_coefficients[i].values[3]);
 
     Eigen::Vector3f vp (0.0, 0.0, 0.0);
-    if (project_points_ && boundary_cloud.points.size () > 0)
+    if (project_points_ && !boundary_cloud.points.empty ())
       boundary_cloud = projectToPlaneFromViewpoint (boundary_cloud, model, centroid, vp);
 
     regions[i] = PlanarRegion<PointT> (centroid,

--- a/segmentation/include/pcl/segmentation/impl/random_walker.hpp
+++ b/segmentation/include/pcl/segmentation/impl/random_walker.hpp
@@ -176,9 +176,9 @@ namespace pcl
             size_t num_colors = B_color_bimap.size ();
             L.resize (num_equations, num_equations);
             B.resize (num_equations, num_colors);
-            if (L_triplets.size ())
+            if (!L_triplets.empty ())
               L.setFromTriplets(L_triplets.begin(), L_triplets.end());
-            if (B_triplets.size ())
+            if (!B_triplets.empty ())
               B.setFromTriplets(B_triplets.begin(), B_triplets.end());
           }
 

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -308,7 +308,7 @@ template <typename PointT, typename NormalT> bool
 pcl::RegionGrowing<PointT, NormalT>::prepareForSegmentation ()
 {
   // if user forgot to pass point cloud or if it is empty
-  if ( input_->points.size () == 0 )
+  if ( input_->points.empty () )
     return (false);
 
   // if user forgot to pass normals or the sizes of point and normal cloud are different

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -217,7 +217,7 @@ template <typename PointT, typename NormalT> bool
 pcl::RegionGrowingRGB<PointT, NormalT>::prepareForSegmentation ()
 {
   // if user forgot to pass point cloud or if it is empty
-  if ( input_->points.size () == 0 )
+  if ( input_->points.empty () )
     return (false);
 
   // if normal/smoothness test is on then we need to check if all needed variables and parameters

--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -68,7 +68,7 @@ pcl::SupervoxelClustering<PointT>::~SupervoxelClustering ()
 template <typename PointT> void
 pcl::SupervoxelClustering<PointT>::setInputCloud (const typename pcl::PointCloud<PointT>::ConstPtr& cloud)
 {
-  if ( cloud->size () == 0 )
+  if ( cloud->empty () )
   {
     PCL_ERROR ("[pcl::SupervoxelClustering::setInputCloud] Empty cloud set, doing nothing \n");
     return;
@@ -82,7 +82,7 @@ pcl::SupervoxelClustering<PointT>::setInputCloud (const typename pcl::PointCloud
 template <typename PointT> void
 pcl::SupervoxelClustering<PointT>::setNormalCloud (typename NormalCloudT::ConstPtr normal_cloud)
 {
-  if ( normal_cloud->size () == 0 )
+  if ( normal_cloud->empty () )
   {
     PCL_ERROR ("[pcl::SupervoxelClustering::setNormalCloud] Empty cloud set, doing nothing \n");
     return;
@@ -147,7 +147,7 @@ pcl::SupervoxelClustering<PointT>::extract (std::map<uint32_t,typename Supervoxe
 template <typename PointT> void
 pcl::SupervoxelClustering<PointT>::refineSupervoxels (int num_itr, std::map<uint32_t,typename Supervoxel<PointT>::Ptr > &supervoxel_clusters)
 {
-  if (supervoxel_helpers_.size () == 0)
+  if (supervoxel_helpers_.empty ())
   {
     PCL_ERROR ("[pcl::SupervoxelClustering::refineVoxelNormals] Supervoxels not extracted, doing nothing - (Call extract first!) \n");
     return;
@@ -181,7 +181,7 @@ pcl::SupervoxelClustering<PointT>::prepareForSegmentation ()
 {
   
   // if user forgot to pass point cloud or if it is empty
-  if ( input_->points.size () == 0 )
+  if ( input_->points.empty () )
     return (false);
   
   //Add the new cloud of data to the octree

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -406,7 +406,7 @@ pcl::UnaryClassifier<PointT>::trainWithLabel (
 template <typename PointT> void
 pcl::UnaryClassifier<PointT>::segment (pcl::PointCloud<pcl::PointXYZRGBL>::Ptr &out)
 {
-  if (trained_features_.size () > 0)
+  if (!trained_features_.empty ())
   {
     // convert cloud into cloud with XYZ
     pcl::PointCloud<pcl::PointXYZ>::Ptr tmp_cloud (new pcl::PointCloud<pcl::PointXYZ>);

--- a/simulation/tools/sim_terminal_demo.cpp
+++ b/simulation/tools/sim_terminal_demo.cpp
@@ -57,7 +57,7 @@ void write_sim_output(const string &fname_root){
   simexample->rl_->getPointCloud (pc_out,false,simexample->camera_->getPose ());
   // TODO: what to do when there are more than one simulated view?
 
-  if (pc_out->points.size()>0){
+  if (!pc_out->points.empty ()){
     std::cout << pc_out->points.size() << " points written to file\n";
 
     pcl::PCDWriter writer;

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -474,7 +474,7 @@ main (int argc, char** argv)
   std::vector<int> p_file_indices   = pcl::console::parse_file_extension_argument (argc, argv, ".pcd");
   std::vector<int> vtk_file_indices = pcl::console::parse_file_extension_argument (argc, argv, ".vtk");
 
-  if (p_file_indices.size () == 0 && vtk_file_indices.size () == 0)
+  if (p_file_indices.empty () && vtk_file_indices.empty ())
   {
     print_error ("No .PCD or .VTK file given. Nothing to visualize.\n");
     return (-1);
@@ -488,13 +488,13 @@ main (int argc, char** argv)
     print_highlight ("Multi-viewport rendering enabled.\n");
 
     int y_s = 0;
-    if (p_file_indices.size () != 0)
+    if (!p_file_indices.empty ())
     {
       y_s = static_cast<int>(floor (sqrt (static_cast<float>(p_file_indices.size ()))));
       x_s = y_s + static_cast<int>(ceil ((p_file_indices.size () / static_cast<double>(y_s)) - y_s));
       print_highlight ("Preparing to load "); print_value ("%d", p_file_indices.size ());
     }
-    else if (vtk_file_indices.size () != 0)
+    else if (!vtk_file_indices.empty ())
     {
       y_s = static_cast<int>(floor (sqrt (static_cast<float>(vtk_file_indices.size ()))));
       x_s = y_s + static_cast<int>(ceil ((vtk_file_indices.size () / static_cast<double>(y_s)) - y_s));
@@ -509,10 +509,10 @@ main (int argc, char** argv)
   }
 
   // Fix invalid multiple arguments
-  if (psize.size () != p_file_indices.size () && psize.size () > 0)
+  if (psize.size () != p_file_indices.size () && !psize.empty ())
     for (size_t i = psize.size (); i < p_file_indices.size (); ++i)
       psize.push_back (1);
-  if (opaque.size () != p_file_indices.size () && opaque.size () > 0)
+  if (opaque.size () != p_file_indices.size () && !opaque.empty ())
     for (size_t i = opaque.size (); i < p_file_indices.size (); ++i)
       opaque.push_back (1.0);
 
@@ -569,11 +569,11 @@ main (int argc, char** argv)
       p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_COLOR, fcolor_r[i], fcolor_g[i], fcolor_b[i], cloud_name.str ());
 
     // Change the shape rendered point size
-    if (psize.size () > 0)
+    if (!psize.empty ())
       p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name.str ());
 
     // Change the shape rendered opacity
-    if (opaque.size () > 0)
+    if (!opaque.empty ())
       p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name.str ());
   }
 
@@ -752,11 +752,11 @@ main (int argc, char** argv)
     p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_IMMEDIATE_RENDERING, 1.0, cloud_name.str ());
 
     // Change the cloud rendered point size
-    if (psize.size () > 0)
+    if (!psize.empty ())
       p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name.str ());
 
     // Change the cloud rendered opacity
-    if (opaque.size () > 0)
+    if (!opaque.empty ())
       p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name.str ());
 
     // Reset camera viewpoint to center of cloud if camera parameters were not passed manually and this is the first loaded cloud

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -554,7 +554,7 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
     return (-1);
   }
 
-  if (cameras.size () == 0)
+  if (cameras.empty ())
   {
     PCL_ERROR ("Must provide at least one camera info!\n");
     return (-1);

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -196,7 +196,7 @@ SequentialFitter::is_back_facing (const Eigen::Vector3d &v0, const Eigen::Vector
 void
 SequentialFitter::setInputCloud (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_cloud)
 {
-  if (pcl_cloud.get () == nullptr || pcl_cloud->points.size () == 0)
+  if (pcl_cloud.get () == nullptr || pcl_cloud->points.empty ())
     throw std::runtime_error ("[SequentialFitter::setInputCloud] Error: Empty or invalid pcl-point-cloud.\n");
 
   m_cloud = pcl_cloud;
@@ -206,7 +206,7 @@ SequentialFitter::setInputCloud (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_clo
 void
 SequentialFitter::setBoundary (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 {
-  if (m_cloud.get () == nullptr || m_cloud->points.size () == 0)
+  if (m_cloud.get () == nullptr || m_cloud->points.empty ())
     throw std::runtime_error ("[SequentialFitter::setBoundary] Error: Empty or invalid pcl-point-cloud.\n");
 
   this->m_boundary_indices = pcl_cloud_indexes;
@@ -217,7 +217,7 @@ SequentialFitter::setBoundary (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 void
 SequentialFitter::setInterior (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 {
-  if (m_cloud.get () == nullptr || m_cloud->points.size () == 0)
+  if (m_cloud.get () == nullptr || m_cloud->points.empty ())
     throw std::runtime_error ("[SequentialFitter::setIndices] Error: Empty or invalid pcl-point-cloud.\n");
 
   this->m_interior_indices = pcl_cloud_indexes;
@@ -228,7 +228,7 @@ SequentialFitter::setInterior (pcl::PointIndices::Ptr &pcl_cloud_indexes)
 void
 SequentialFitter::setCorners (pcl::PointIndices::Ptr &corners, bool flip_on_demand)
 {
-  if (m_cloud.get () == nullptr || m_cloud->points.size () == 0)
+  if (m_cloud.get () == nullptr || m_cloud->points.empty ())
     throw std::runtime_error ("[SequentialFitter::setCorners] Error: Empty or invalid pcl-point-cloud.\n");
 
   if (corners->indices.size () < 4)
@@ -291,7 +291,7 @@ SequentialFitter::compute (bool assemble)
   //  TomGine::tgRenderModel nurbs;
   //  TomGine::tgRenderModel box;
 
-  if (m_data.boundary.size () > 0)
+  if (!m_data.boundary.empty ())
   {
     //    throw std::runtime_error("[SequentialFitter::compute] Error: empty boundary point-cloud.\n");
 
@@ -361,7 +361,7 @@ SequentialFitter::compute (bool assemble)
     }
   }
 
-  if (m_data.interior.size () > 0)
+  if (!m_data.interior.empty ())
     compute_interior (fitting);
 
   // update error
@@ -377,7 +377,7 @@ SequentialFitter::compute (bool assemble)
 ON_NurbsSurface
 SequentialFitter::compute_boundary (const ON_NurbsSurface &nurbs)
 {
-  if (m_data.boundary.size () <= 0)
+  if (m_data.boundary.empty ())
   {
     printf ("[SequentialFitter::compute_boundary] Warning, no boundary points given: setBoundary()\n");
     return nurbs;
@@ -400,7 +400,7 @@ SequentialFitter::compute_boundary (const ON_NurbsSurface &nurbs)
 ON_NurbsSurface
 SequentialFitter::compute_interior (const ON_NurbsSurface &nurbs)
 {
-  if (m_data.boundary.size () <= 0)
+  if (m_data.boundary.empty ())
   {
     printf ("[SequentialFitter::compute_interior] Warning, no interior points given: setInterior()\n");
     return nurbs;

--- a/surface/src/simplification_remove_unused_vertices.cpp
+++ b/surface/src/simplification_remove_unused_vertices.cpp
@@ -45,7 +45,7 @@
 void
 pcl::surface::SimplificationRemoveUnusedVertices::simplify(const pcl::PolygonMesh& input, pcl::PolygonMesh& output, std::vector<int>& indices)
 {
-  if (input.polygons.size () == 0)
+  if (input.polygons.empty ())
     return;
 
   unsigned int nr_points = input.cloud.width * input.cloud.height;

--- a/test/geometry/test_mesh.cpp
+++ b/test/geometry/test_mesh.cpp
@@ -318,7 +318,7 @@ TEST (TestAddDeleteFace, NonManifold2)
   }
 
   // Delete all faces
-  while (expected.size ())
+  while (!expected.empty ())
   {
     mesh.deleteFace (FaceIndex (0));
     mesh.cleanUp ();

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -115,7 +115,7 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
   //for (set<int>::const_iterator it=brute_force_result.begin(); it!=brute_force_result.end(); ++it)
   //cerr << "FLANN missed "<<*it<<"\n";
   
-  bool error = brute_force_result.size () > 0;
+  bool error = !brute_force_result.empty ();
   //if (error)  cerr << "Missed too many neighbors!\n";
   EXPECT_EQ (error, false);
 

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -1193,7 +1193,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
     unsigned idx = static_cast<unsigned> (pointCandidates.size ());
     k_indices_bruteforce.resize (idx);
     k_sqr_distances_bruteforce.resize (idx);
-    while (pointCandidates.size ())
+    while (!pointCandidates.empty ())
     {
       --idx;
       k_indices_bruteforce [idx] = pointCandidates.top ().pointIdx_;
@@ -1210,7 +1210,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
     ASSERT_EQ (k_indices_bruteforce.size (), k_indices.size());
 
     // compare nearest neighbor results of octree with bruteforce search
-    while (k_indices_bruteforce.size ())
+    while (!k_indices_bruteforce.empty ())
     {
       ASSERT_EQ (k_indices_bruteforce.back(), k_indices.back ());
       EXPECT_NEAR (k_sqr_distances_bruteforce.back (), k_sqr_distances.back (), 1e-4);

--- a/test/search/test_octree.cpp
+++ b/test/search/test_octree.cpp
@@ -137,7 +137,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
     unsigned idx = static_cast<unsigned> (pointCandidates.size ());
     k_indices_bruteforce.resize (idx);
     k_sqr_distances_bruteforce.resize (idx);
-    while (pointCandidates.size ())
+    while (!pointCandidates.empty ())
     {
       --idx;
       k_indices_bruteforce [idx] = pointCandidates.top ().pointIdx_;
@@ -152,7 +152,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
     ASSERT_EQ ( k_indices.size() , k_indices_bruteforce.size() );
 
     // compare nearest neighbor results of octree with bruteforce search
-    while (k_indices_bruteforce.size ())
+    while (!k_indices_bruteforce.empty ())
     {
       ASSERT_EQ ( k_indices.back() , k_indices_bruteforce.back() );
       EXPECT_NEAR (k_sqr_distances.back(), k_sqr_distances_bruteforce.back(), 1e-4);

--- a/test/search/test_organized.cpp
+++ b/test/search/test_organized.cpp
@@ -156,7 +156,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Nearest_K_Neighbour_Search)
       pointCandidates.pop ();
 
     // copy results into vectors
-    while (pointCandidates.size ())
+    while (!pointCandidates.empty ())
     {
       k_indices_bruteforce.push_back (pointCandidates.top ().pointIdx_);
       k_sqr_distances_bruteforce.push_back (float (pointCandidates.top ().pointDistance_));

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -291,7 +291,7 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
   vector<bool> indices_mask (point_cloud->size (), true);
   vector<bool> nan_mask (point_cloud->size (), true);
   
-  if (input_indices.size () != 0)
+  if (!input_indices.empty ())
   {
     indices_mask.assign (point_cloud->size (), false);
     for (const int &input_index : input_indices)
@@ -307,7 +307,7 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
   }
   
   boost::shared_ptr<vector<int> > input_indices_;
-  if (input_indices.size ())
+  if (!input_indices.empty ())
     input_indices_.reset (new vector<int> (input_indices));
   
   #pragma omp parallel for
@@ -361,7 +361,7 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
   vector<bool> indices_mask (point_cloud->size (), true);
   vector<bool> nan_mask (point_cloud->size (), true);
   
-  if (input_indices.size () != 0)
+  if (!input_indices.empty ())
   {
     indices_mask.assign (point_cloud->size (), false);
     for (const int &input_index : input_indices)
@@ -377,7 +377,7 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
   }
   
   boost::shared_ptr<vector<int> > input_indices_;
-  if (input_indices.size ())
+  if (!input_indices.empty ())
     input_indices_.reset (new vector<int> (input_indices));
   
   #pragma omp parallel for

--- a/tools/crop_to_hull.cpp
+++ b/tools/crop_to_hull.cpp
@@ -183,7 +183,7 @@ main (int argc, char** argv)
   cropToHull (output_cloud, input_cloud, hull_points, hull_polygons, dim);
   
 
-  if (output_cloud->size ())
+  if (!output_cloud->empty ())
     saveCloud (argv[p_file_indices[2]], *output_cloud);
   else
     print_error ("No points passed crop.\n");

--- a/tools/obj_rec_ransac_hash_table.cpp
+++ b/tools/obj_rec_ransac_hash_table.cpp
@@ -177,7 +177,7 @@ visualize (const ModelLibrary::HashTable& hash_table)
   // Just get the maximal number of entries in the cells
   for ( int i = 0 ; i < num_cells ; ++i, ++cells )
   {
-    if (cells->size ()) // That's the number of models in the cell (it's maximum one, since we loaded only one model)
+    if (!cells->empty ()) // That's the number of models in the cell (it's maximum one, since we loaded only one model)
     {
       size_t num_entries = (*cells->begin ()).second.size(); // That's the number of entries in the current cell for the model we loaded
       // Get the max number of entries
@@ -197,7 +197,7 @@ visualize (const ModelLibrary::HashTable& hash_table)
   for ( int i = 0; i < num_cells ; ++i, ++cells )
   {
     // Does the cell have any entries?
-    if (cells->size ())
+    if (!cells->empty ())
     {
       hash_table.compute3dId (i, id3);
       hash_table.computeVoxelCenter (id3, cell_center);

--- a/tools/obj_rec_ransac_orr_octree.cpp
+++ b/tools/obj_rec_ransac_orr_octree.cpp
@@ -200,7 +200,7 @@ void run (const char* file_name, float voxel_size)
 
   // Build the octree with the desired resolution
   ORROctree octree;
-  if ( normals_in->size () )
+  if ( !normals_in->empty () )
     octree.build (*points_in, voxel_size, &*normals_in);
   else
     octree.build (*points_in, voxel_size);
@@ -211,7 +211,7 @@ void run (const char* file_name, float voxel_size)
   // Get the average points in every full octree leaf
   octree.getFullLeavesPoints (*points_out);
   // Get the average normal at the points in each leaf
-  if ( normals_in->size () )
+  if ( !normals_in->empty () )
     octree.getNormalsOfFullLeaves (*normals_out);
 
   // The visualizer
@@ -224,7 +224,7 @@ void run (const char* file_name, float voxel_size)
   // Add the point clouds
   viz.addPointCloud (points_in, "cloud in");
   viz.addPointCloud (points_out, "cloud out");
-  if ( normals_in->size () )
+  if ( !normals_in->empty () )
     viz.addPointCloudNormals<PointXYZ,Normal> (points_out, normals_out, 1, 6.0f, "normals out");
 
   // Change the appearance

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -337,7 +337,7 @@ loadScene (const char* file_name, PointCloud<PointXYZ>& non_plane_points, PointC
   seg.setInputCloud (all_points);
   seg.segment (*inliers, *coefficients);
 
-  if (inliers->indices.size () == 0)
+  if (inliers->indices.empty ())
   {
     PCL_ERROR ("Could not estimate a planar model for the given dataset.");
     return false;

--- a/tools/pcd_viewer.cpp
+++ b/tools/pcd_viewer.cpp
@@ -235,7 +235,7 @@ main (int argc, char** argv)
   std::vector<int> p_file_indices   = pcl::console::parse_file_extension_argument (argc, argv, ".pcd");
   std::vector<int> vtk_file_indices = pcl::console::parse_file_extension_argument (argc, argv, ".vtk");
 
-  if (p_file_indices.size () == 0 && vtk_file_indices.size () == 0)
+  if (p_file_indices.empty () && vtk_file_indices.empty ())
   {
     print_error ("No .PCD or .VTK file given. Nothing to visualize.\n");
     return (-1);
@@ -306,12 +306,12 @@ main (int argc, char** argv)
     int y_s = static_cast<int>(floor (sqrt (static_cast<float>(p_file_indices.size () + vtk_file_indices.size ()))));
     x_s = y_s + static_cast<int>(ceil (double (p_file_indices.size () + vtk_file_indices.size ()) / double (y_s) - y_s));
 
-    if (p_file_indices.size () != 0)
+    if (!p_file_indices.empty ())
     {
       print_highlight ("Preparing to load "); print_value ("%d", p_file_indices.size ()); print_info (" pcd files.\n");
     }
 
-    if (vtk_file_indices.size () != 0)
+    if (!vtk_file_indices.empty ())
     {
       print_highlight ("Preparing to load "); print_value ("%d", vtk_file_indices.size ()); print_info (" vtk files.\n");
     }
@@ -324,14 +324,14 @@ main (int argc, char** argv)
   }
 
   // Fix invalid multiple arguments
-  if (psize.size () != p_file_indices.size () && psize.size () > 0)
+  if (psize.size () != p_file_indices.size () && !psize.empty ())
     for (size_t i = psize.size (); i < p_file_indices.size (); ++i)
       psize.push_back (1);
-  if (opaque.size () != p_file_indices.size () && opaque.size () > 0)
+  if (opaque.size () != p_file_indices.size () && !opaque.empty ())
     for (size_t i = opaque.size (); i < p_file_indices.size (); ++i)
       opaque.push_back (1.0);
 
-  if (shadings.size () != p_file_indices.size () && shadings.size () > 0)
+  if (shadings.size () != p_file_indices.size () && !shadings.empty ())
     for (size_t i = shadings.size (); i < p_file_indices.size (); ++i)
       shadings.emplace_back("flat");
 
@@ -387,15 +387,15 @@ main (int argc, char** argv)
       p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_COLOR, fcolor_r[i], fcolor_g[i], fcolor_b[i], cloud_name.str ());
 
     // Change the shape rendered point size
-    if (psize.size () > 0)
+    if (!psize.empty ())
       p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name.str ());
 
     // Change the shape rendered opacity
-    if (opaque.size () > 0)
+    if (!opaque.empty ())
       p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name.str ());
 
     // Change the shape rendered shading
-    if (shadings.size () > 0)
+    if (!shadings.empty ())
     {
       if (shadings[i] == "flat")
       {
@@ -650,11 +650,11 @@ main (int argc, char** argv)
       p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_IMMEDIATE_RENDERING, 1.0, cloud_name.str ());
 
     // Change the cloud rendered point size
-    if (psize.size () > 0)
+    if (!psize.empty ())
       p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name.str ());
 
     // Change the cloud rendered opacity
-    if (opaque.size () > 0)
+    if (!opaque.empty ())
       p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name.str ());
 
     // Reset camera viewpoint to center of cloud if camera parameters were not passed manually and this is the first loaded cloud

--- a/tools/pclzf2pcd.cpp
+++ b/tools/pclzf2pcd.cpp
@@ -137,7 +137,7 @@ main (int argc, char** argv)
   std::vector<int> pcd_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
   std::vector<int> pclzf_file_indices = parse_file_extension_argument (argc, argv, ".pclzf");
   std::vector<int> xml_file_indices = parse_file_extension_argument (argc, argv, ".xml");
-  if (pcd_file_indices.size () != 1 || pclzf_file_indices.size () < 1 || xml_file_indices.size () != 1)
+  if (pcd_file_indices.size () != 1 || pclzf_file_indices.empty () || xml_file_indices.size () != 1)
   {
     print_error ("Need at least 1 input PCLZF file, one input XML file, and one output PCD file.\n");
     return (-1);

--- a/tracking/include/pcl/tracking/impl/particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/particle_filter.hpp
@@ -224,7 +224,7 @@ pcl::tracking::ParticleFilterTracker<PointInT, StateT>::testChangeDetection
   std::vector<int> newPointIdxVector;
   change_detector_->getPointIndicesFromNewVoxels (newPointIdxVector, change_detector_filter_);
   change_detector_->switchBuffers ();
-  return newPointIdxVector.size () > 0;
+  return !newPointIdxVector.empty ();
 }
 
 template <typename PointInT, typename StateT> void

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1701,7 +1701,7 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (
     vtkSmartPointer<vtkCellArray> cell_array = vtkSmartPointer<vtkCellArray>::New ();
     vtkIdType *cell = cell_array->WritePointer (vertices.size (), vertices.size () * (max_size_of_polygon + 1));
     int idx = 0;
-    if (lookup.size () > 0)
+    if (!lookup.empty ())
     {
       for (size_t i = 0; i < vertices.size (); ++i, ++idx)
       {
@@ -1743,7 +1743,7 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (
     size_t n_points = vertices[0].vertices.size ();
     polygon->GetPointIds ()->SetNumberOfIds (n_points - 1);
 
-    if (lookup.size () > 0)
+    if (!lookup.empty ())
     {
       for (size_t j = 0; j < (n_points - 1); ++j)
         polygon->GetPointIds ()->SetId (j, lookup[vertices[0].vertices[j]]);
@@ -1878,7 +1878,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   cells = vtkSmartPointer<vtkCellArray>::New ();
   vtkIdType *cell = cells->WritePointer (verts.size (), verts.size () * (max_size_of_polygon + 1));
   int idx = 0;
-  if (lookup.size () > 0)
+  if (!lookup.empty ())
   {
     for (size_t i = 0; i < verts.size (); ++i, ++idx)
     {

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -831,7 +831,7 @@ pcl::visualization::ImageViewer::markPoints (
     const std::vector<int>& uv, Vector3ub fg_color, Vector3ub bg_color, double size,
     const std::string &layer_id, double opacity)
 {
-  if (uv.size () == 0)
+  if (uv.empty ())
     return;
 
   std::vector<float> float_uv (uv.size ());
@@ -846,7 +846,7 @@ pcl::visualization::ImageViewer::markPoints (
     const std::vector<float>& uv, Vector3ub fg_color, Vector3ub bg_color, double size,
     const std::string &layer_id, double opacity)
 {
-  if (uv.size () == 0)
+  if (uv.empty ())
     return;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -144,7 +144,7 @@ pcl::visualization::PCLPlotter::addPlotData (
     int type /* = vtkChart::LINE */, 
     std::vector<char> const &color)
 {
-  this->addPlotData (&array_X[0], &array_Y[0], static_cast<unsigned long> (array_X.size ()), name, type, (color.size () == 0) ? NULL : &color[0]);
+  this->addPlotData (&array_X[0], &array_Y[0], static_cast<unsigned long> (array_X.size ()), name, type, (color.empty ()) ? NULL : &color[0]);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -163,7 +163,7 @@ pcl::visualization::PCLPlotter::addPlotData (
     array_x[i] = plot_data[i].first;
     array_y[i] = plot_data[i].second;
   }
-  this->addPlotData (array_x, array_y, static_cast<unsigned long> (plot_data.size ()), name, type, (color.size () == 0) ? NULL : &color[0]);
+  this->addPlotData (array_x, array_y, static_cast<unsigned long> (plot_data.size ()), name, type, (color.empty ()) ? NULL : &color[0]);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3179,7 +3179,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   cells = vtkSmartPointer<vtkCellArray>::New ();
   vtkIdType *cell = cells->WritePointer (verts.size (), verts.size () * (max_size_of_polygon + 1));
   int idx = 0;
-  if (lookup.size () > 0)
+  if (!lookup.empty ())
   {
     for (size_t i = 0; i < verts.size (); ++i, ++idx)
     {
@@ -3285,7 +3285,7 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
     return (false);
   }
   // no texture materials --> exit
-  if (mesh.tex_materials.size () == 0)
+  if (mesh.tex_materials.empty ())
   {
     PCL_ERROR("[PCLVisualizer::addTextureMesh] No textures found!\n");
     return (false);
@@ -3335,7 +3335,7 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
   {
     pcl::PointCloud<pcl::PointXYZRGB> cloud;
     pcl::fromPCLPointCloud2 (mesh.cloud, cloud);
-    if (cloud.points.size () == 0)
+    if (cloud.points.empty ())
     {
       PCL_ERROR ("[PCLVisualizer::addTextureMesh] Cloud is empty!\n");
       return (false);
@@ -3358,7 +3358,7 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ> ());
     pcl::fromPCLPointCloud2 (mesh.cloud, *cloud);
     // no points --> exit
-    if (cloud->points.size () == 0)
+    if (cloud->points.empty ())
     {
       PCL_ERROR ("[PCLVisualizer::addTextureMesh] Cloud is empty!\n");
       return (false);
@@ -4584,7 +4584,7 @@ pcl::visualization::PCLVisualizer::getUniqueCameraFile (int argc, char **argv)
   std::ostringstream sstream;
 
   p_file_indices = pcl::console::parse_file_extension_argument (argc, argv, ".pcd");
-  if (p_file_indices.size () != 0)
+  if (!p_file_indices.empty ())
   {
     boost::uuids::detail::sha1 sha1;    
     bool valid = false;


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,readability-container-size-empty' -fix`