### PR TITLE
[io] Removed trailing semicolons after macro calls

### DIFF
--- a/io/include/pcl/io/ply/ply.h
+++ b/io/include/pcl/io/ply/ply.h
@@ -82,14 +82,14 @@ namespace pcl
         static const char* old_name () { return OLD_NAME; } \
       };
 
-      PLY_TYPE_TRAITS(int8, int16, "int8", "char");
-      PLY_TYPE_TRAITS(int16, int16, "int16", "short");
-      PLY_TYPE_TRAITS(int32, int32, "int32", "int");
-      PLY_TYPE_TRAITS(uint8, uint16, "uint8", "uchar");
-      PLY_TYPE_TRAITS(uint16, uint16, "uint16", "ushort");
-      PLY_TYPE_TRAITS(uint32, uint32, "uint32", "uint");
-      PLY_TYPE_TRAITS(float32, float32, "float32", "float");
-      PLY_TYPE_TRAITS(float64, float64, "float64", "double");
+      PLY_TYPE_TRAITS(int8, int16, "int8", "char")
+      PLY_TYPE_TRAITS(int16, int16, "int16", "short")
+      PLY_TYPE_TRAITS(int32, int32, "int32", "int")
+      PLY_TYPE_TRAITS(uint8, uint16, "uint8", "uchar")
+      PLY_TYPE_TRAITS(uint16, uint16, "uint16", "ushort")
+      PLY_TYPE_TRAITS(uint32, uint32, "uint32", "uint")
+      PLY_TYPE_TRAITS(float32, float32, "float32", "float")
+      PLY_TYPE_TRAITS(float64, float64, "float64", "double")
 
       
 #undef PLY_TYPE_TRAITS


### PR DESCRIPTION
This PR removes trailing semicolons, which were constantly flagged when building a pcl-dependent application with the flag `-Wpedantic`.