### PR TITLE
Use return braced init list

### DIFF
--- a/apps/modeler/include/pcl/apps/modeler/render_window.h
+++ b/apps/modeler/include/pcl/apps/modeler/render_window.h
@@ -55,7 +55,7 @@ namespace pcl
         ~RenderWindow();
 
         QSize
-        sizeHint() const override {return QSize(512, 512);}
+        sizeHint() const override {return {512, 512};}
 
         void
         setActive(bool flag);

--- a/apps/modeler/src/scene_tree.cpp
+++ b/apps/modeler/src/scene_tree.cpp
@@ -84,7 +84,7 @@ pcl::modeler::SceneTree::~SceneTree()
 QSize
 pcl::modeler::SceneTree::sizeHint() const
 {
-  return QSize(256, 512);
+  return {256, 512};
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/gpu/octree/include/pcl/gpu/octree/device_format.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/device_format.hpp
@@ -78,7 +78,7 @@ namespace pcl
 
             operator PtrStep<int>() const
             {
-                return PtrStep<int>((int*)data.ptr(), max_elems * sizeof(int));
+                return {(int*)data.ptr(), max_elems * sizeof(int)};
             }            
 
             size_t neighboors_size() const { return data.size()/max_elems; }

--- a/tracking/include/pcl/tracking/impl/tracking.hpp
+++ b/tracking/include/pcl/tracking/impl/tracking.hpp
@@ -119,7 +119,7 @@ namespace pcl
         getTranslationAndEulerAngles (trans,
                                       trans_x, trans_y, trans_z,
                                       trans_roll, trans_pitch, trans_yaw);
-        return pcl::tracking::ParticleXYZRPY (trans_x, trans_y, trans_z, trans_roll, trans_pitch, trans_yaw);
+        return {trans_x, trans_y, trans_z, trans_roll, trans_pitch, trans_yaw};
       }
 
       // a[i]


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,modernize-return-braced-init-list' -fix`

I expected a really big PR, at the time I started this job, but I was fully wrong :D