### PR TITLE
Add version info on Windows for DLLs/Exe

### DIFF
--- a/cmake/version.rc.in
+++ b/cmake/version.rc.in
@@ -1,0 +1,44 @@
+#include <winres.h>
+
+#ifndef _DEBUG
+#define VER_DEBUG 0
+#else
+#define VER_DEBUG VS_FF_DEBUG
+#endif
+
+IDI_ICON1 ICON "@VERSION_INFO_ICON_PATH@"
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    @VERSION_INFO_VERSION_WITH_COMMA@
+  PRODUCTVERSION @VERSION_INFO_VERSION_WITH_COMMA@
+  FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+  FILEFLAGS      VER_DEBUG
+  FILEOS         VOS_NT_WINDOWS32
+  FILETYPE       VFT_APP
+  FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904E4"
+    BEGIN
+      VALUE "CompanyName",      "Open Perception Foundation"
+      VALUE "FileDescription",  "@VERSION_INFO_DISPLAY_NAME@"
+      VALUE "FileVersion",      "@PCL_VERSION_PRETTY@"
+      VALUE "LegalCopyright",   "©Open Perception Foundation. All rights reserved."
+      VALUE "ProductName",      "Point Cloud Library"
+      VALUE "ProductVersion",   "@PCL_VERSION_PRETTY@"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    /* The following line should only be modified for localized versions.     */
+    /* It consists of any number of WORD,WORD pairs, with each pair           */
+    /* describing a language,codepage combination supported by the file.      */
+    /*                                                                        */
+    /* For example, a file might have values "0x409,1252" indicating that it  */
+    /* supports English language (0x409) in the Windows ANSI codepage (1252). */
+
+    VALUE "Translation", 0x409, 1252
+  END
+END


### PR DESCRIPTION
Something I want to see in upcoming release:

![version_info](https://user-images.githubusercontent.com/483922/57074666-d85fa180-6ce4-11e9-81b2-13d1aac735e6.PNG)

File description is sometimes a bit incorrect, because `SUBSYS_DESC` or `SUBSUBSYS_DESC` are used for multiple files, but this we can fix later. More important for me was the version number.

PR bases on #3044 (to prevent need to rebase ;) ).

//Edit: Just as hint: We don't see properties of selected file in screenshot. Instead we see properties of a DLL. I just selected the Exe to show you that the ICO file needs an update too^^ (only one resolution included and no transparency)