### PR TITLE
Replace random_shuffle by shuffle

### DIFF
--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -44,6 +44,7 @@
 // C++
 #include <iostream>
 #include <fstream>
+#include <random>
 #include <sstream>
 #include <string>
 #include <exception>
@@ -1682,7 +1683,7 @@ namespace pcl
           }//force the payload cache to deconstruct here
 
           //use STL random_shuffle and push back a random selection of the points onto our list
-          std::random_shuffle (payload_cache_within_region.begin (), payload_cache_within_region.end ());
+          std::shuffle (payload_cache_within_region.begin (), payload_cache_within_region.end (), std::mt19937(std::random_device()()));
           size_t numpick = static_cast<size_t> (percent * static_cast<double> (payload_cache_within_region.size ()));;
 
           for (size_t i = 0; i < numpick; i++)

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <random>
+
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
 
@@ -178,7 +180,7 @@ namespace pcl
 
           void refresh(mets::feasible_solution& /*s*/)
           {
-            std::random_shuffle (moves_m.begin (), moves_m.end ());
+            std::shuffle (moves_m.begin (), moves_m.end (), std::mt19937(std::random_device()()));
           }
 
       };

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -4,6 +4,8 @@
 #include <pcl/features/integral_image_normal.h>
 #include <pcl/io/pcd_io.h>
 
+#include <random>
+
 //Uncomment the following lines and set PCL_FACE_DETECTION_VIS_TRAINING_FDDP to 1
 //to visualize the training process and change the CMakeLists.txt accordingly.
 //#include <pcl/visualization/pcl_visualizer.h>
@@ -136,13 +138,14 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
   if (min_images_per_bin_ != -1)
   {
     std::cout << "Reducing unbalance of the dataset." << std::endl;
+    std::mt19937 rng((std::random_device()()));
     for (int i = 0; i < num_yaw; i++)
     {
       for (int j = 0; j < num_pitch; j++)
       {
         if (yaw_pitch_bins[i][j] >= min_images_per_bin_)
         {
-          std::random_shuffle (image_files_per_bin[i][j].begin (), image_files_per_bin[i][j].end ());
+          std::shuffle (image_files_per_bin[i][j].begin (), image_files_per_bin[i][j].end (), rng);
           image_files_per_bin[i][j].resize (min_images_per_bin_);
           yaw_pitch_bins[i][j] = min_images_per_bin_;
         }
@@ -167,8 +170,8 @@ template<class FeatureType, class DataSet, class LabelType, class ExampleIndex, 
 void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::getDatasetAndLabels(DataSet & data_set,
     std::vector<LabelType> & label_data, std::vector<ExampleIndex> & examples)
 {
-  srand (static_cast<unsigned int>(time (nullptr)));
-  std::random_shuffle (image_files_.begin (), image_files_.end ());
+  std::mt19937 rng((std::random_device()()));
+  std::shuffle (image_files_.begin (), image_files_.end (), rng);
   std::vector < std::string > files;
   files = image_files_;
   files.resize (std::min (num_images_, static_cast<int> (files.size ())));
@@ -393,8 +396,8 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
       }
 
       //shuffle and resize
-      std::random_shuffle (positive_p.begin (), positive_p.end ());
-      std::random_shuffle (negative_p.begin (), negative_p.end ());
+      std::shuffle (positive_p.begin (), positive_p.end (), rng);
+      std::shuffle (negative_p.begin (), negative_p.end (), rng);
       positive_p.resize (N_patches);
       negative_p.resize (N_patches);
 


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,modernize-replace-random-shuffle' -fix`