### PR TITLE
Migrate boost::function to std::function

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
@@ -12,8 +12,10 @@
 #include <pcl/io/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h>
-#include <boost/function.hpp>
+
 #include <vtkTransformPolyDataFilter.h>
+
+#include <functional>
 
 namespace pcl
 {
@@ -42,7 +44,7 @@ namespace pcl
         float radius_sphere_;
         float view_angle_;
         bool gen_organized_;
-        boost::function<bool
+        std::function<bool
         (const Eigen::Vector3f &)> campos_constraints_func_;
 
       public:
@@ -62,7 +64,7 @@ namespace pcl
         }
 
         void
-        setCamPosConstraints (boost::function<bool
+        setCamPosConstraints (std::function<bool
         (const Eigen::Vector3f &)> & bb)
         {
           campos_constraints_func_ = bb;

--- a/apps/3d_rec_framework/src/tools/global_classification.cpp
+++ b/apps/3d_rec_framework/src/tools/global_classification.cpp
@@ -28,7 +28,7 @@ segmentAndClassify (typename pcl::rec_3d_framework::GlobalNNPipeline<DistT, Poin
   pcl::visualization::PCLVisualizer vis ("kinect");
 
   //keyboard callback to stop getting frames and finalize application
-  boost::function<void
+  std::function<void
   (const pcl::visualization::KeyboardEvent&)> keyboard_cb = boost::bind (&OpenNIFrameSource::OpenNIFrameSource::onKeyboardEvent, &camera, _1);
   vis.registerKeyboardCallback (keyboard_cb);
   size_t previous_cluster_size = 0;

--- a/apps/3d_rec_framework/src/tools/openni_frame_source.cpp
+++ b/apps/3d_rec_framework/src/tools/openni_frame_source.cpp
@@ -8,7 +8,7 @@ namespace OpenNIFrameSource
   OpenNIFrameSource::OpenNIFrameSource (const std::string& device_id) :
     grabber_ (device_id), frame_counter_ (0), active_ (true)
   {
-    boost::function<void
+    std::function<void
     (const PointCloudConstPtr&)> frame_cb = boost::bind (&OpenNIFrameSource::onNewFrame, this, _1);
     grabber_.registerCallback (frame_cb);
     grabber_.start ();

--- a/apps/in_hand_scanner/src/in_hand_scanner.cpp
+++ b/apps/in_hand_scanner/src/in_hand_scanner.cpp
@@ -481,7 +481,7 @@ pcl::ihs::InHandScanner::startGrabberImpl ()
   lock.lock ();
   if (destructor_called_) return;
 
-  boost::function <void (const CloudXYZRGBAConstPtr&)> new_data_cb = boost::bind (&pcl::ihs::InHandScanner::newDataCallback, this, _1);
+  std::function <void (const CloudXYZRGBAConstPtr&)> new_data_cb = boost::bind (&pcl::ihs::InHandScanner::newDataCallback, this, _1);
   new_data_connection_ = grabber_->registerCallback (new_data_cb);
   grabber_->start ();
 

--- a/apps/include/pcl/apps/render_views_tesselated_sphere.h
+++ b/apps/include/pcl/apps/render_views_tesselated_sphere.h
@@ -7,10 +7,12 @@
 
 #pragma once
 
+#include <pcl/common/common.h>
+
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
-#include <pcl/common/common.h>
-#include <boost/function.hpp>
+
+#include <functional>
 
 namespace pcl
 {
@@ -37,7 +39,7 @@ namespace pcl
       bool compute_entropy_;
       vtkSmartPointer<vtkPolyData> polydata_;
       bool gen_organized_;
-      boost::function<bool
+      std::function<bool
       (const Eigen::Vector3f &)> campos_constraints_func_;
 
       struct camPosConstraintsAllTrue
@@ -64,7 +66,7 @@ namespace pcl
       }
 
       void
-      setCamPosConstraints (boost::function<bool (const Eigen::Vector3f &)> & bb)
+      setCamPosConstraints (std::function<bool (const Eigen::Vector3f &)> & bb)
       {
         campos_constraints_func_ = bb;
       }

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
@@ -40,14 +40,16 @@
 
 #pragma once
 
-#include <QGLWidget>
-#include <boost/function.hpp>
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 #include <pcl/apps/point_cloud_editor/common.h>
 #include <pcl/apps/point_cloud_editor/commandQueue.h>
 #include <pcl/apps/point_cloud_editor/denoiseParameterForm.h>
 #include <pcl/apps/point_cloud_editor/statisticsDialog.h>
 #include <pcl/apps/point_cloud_editor/toolInterface.h>
+
+#include <QGLWidget>
+
+#include <functional>
 
 /// @brief class declaration for the widget for editing and viewing
 /// point clouds.
@@ -251,7 +253,7 @@ class CloudEditorWidget : public QGLWidget
         return lhs.compare(rhs) < 0;
       }
     };
-    typedef boost::function<void (CloudEditorWidget*, const std::string&)>
+    typedef std::function<void (CloudEditorWidget*, const std::string&)>
       FileLoadFunc;
     typedef std::map<std::string, FileLoadFunc, ExtCompare> FileLoadMap;
     /// a map of file type extensions to loader functions.
@@ -301,7 +303,7 @@ class CloudEditorWidget : public QGLWidget
     /// A flag indicates whether the cloud is initially colored or not.
     bool is_colored_;
 
-    typedef boost::function<void (CloudEditorWidget*)> KeyMapFunc;
+    typedef std::function<void (CloudEditorWidget*)> KeyMapFunc;
     /// map between pressed key and the corresponding functor
     std::map<int, KeyMapFunc> key_map_;
 

--- a/apps/src/dinast_grabber_example.cpp
+++ b/apps/src/dinast_grabber_example.cpp
@@ -74,7 +74,7 @@ class DinastProcessor
     run ()
     {
             
-      boost::function<void (const CloudConstPtr&)> f =
+      std::function<void (const CloudConstPtr&)> f =
         boost::bind (&DinastProcessor::cloud_cb_, this, _1);
       
       boost::signals2::connection c = interface.registerCallback (f);

--- a/apps/src/face_detection/openni_face_detection.cpp
+++ b/apps/src/face_detection/openni_face_detection.cpp
@@ -21,7 +21,7 @@ void run(pcl::RFFaceDetectorTrainer & fdrf, bool heat_map = false, bool show_vot
   vis.addCoordinateSystem (0.1, "global");
 
   //keyboard callback to stop getting frames and finalize application
-  boost::function<void(const pcl::visualization::KeyboardEvent&)> keyboard_cb = boost::bind (&OpenNIFrameSource::OpenNIFrameSource::onKeyboardEvent, &camera,
+  std::function<void(const pcl::visualization::KeyboardEvent&)> keyboard_cb = boost::bind (&OpenNIFrameSource::OpenNIFrameSource::onKeyboardEvent, &camera,
       _1);
   vis.registerKeyboardCallback (keyboard_cb);
 

--- a/apps/src/face_detection/openni_frame_source.cpp
+++ b/apps/src/face_detection/openni_frame_source.cpp
@@ -8,7 +8,7 @@ namespace OpenNIFrameSource
   OpenNIFrameSource::OpenNIFrameSource(const std::string& device_id) :
       grabber_ (device_id), frame_counter_ (0), active_ (true)
   {
-    boost::function<void(const PointCloudConstPtr&)> frame_cb = boost::bind (&OpenNIFrameSource::onNewFrame, this, _1);
+    std::function<void(const PointCloudConstPtr&)> frame_cb = boost::bind (&OpenNIFrameSource::onNewFrame, this, _1);
     grabber_.registerCallback (frame_cb);
     grabber_.start ();
   }

--- a/apps/src/ni_agast.cpp
+++ b/apps/src/ni_agast.cpp
@@ -193,7 +193,7 @@ class AGASTDemo
     void
     init ()
     {
-      boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&AGASTDemo::cloud_callback, this, _1);
+      std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&AGASTDemo::cloud_callback, this, _1);
       cloud_connection = grabber_.registerCallback (cloud_cb);      
     }
 

--- a/apps/src/ni_brisk.cpp
+++ b/apps/src/ni_brisk.cpp
@@ -99,7 +99,7 @@ class BRISKDemo
     void
     init ()
     {
-      boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&BRISKDemo::cloud_callback, this, _1);
+      std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&BRISKDemo::cloud_callback, this, _1);
       cloud_connection = grabber_.registerCallback (cloud_cb);
     }
 

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -473,7 +473,7 @@ class NILinemod
       cloud_viewer_.registerMouseCallback (&NILinemod::mouse_callback, *this);
       cloud_viewer_.registerKeyboardCallback(&NILinemod::keyboard_callback, *this);
       cloud_viewer_.registerPointPickingCallback (&NILinemod::pp_callback, *this);
-      boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&NILinemod::cloud_callback, this, _1);
+      std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&NILinemod::cloud_callback, this, _1);
       cloud_connection = grabber_.registerCallback (cloud_cb);
       
       image_viewer_.registerMouseCallback (&NILinemod::mouse_callback, *this);

--- a/apps/src/ni_susan.cpp
+++ b/apps/src/ni_susan.cpp
@@ -97,7 +97,7 @@ class SUSANDemo
     void
     init ()
     {
-      boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&SUSANDemo::cloud_callback, this, _1);
+      std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&SUSANDemo::cloud_callback, this, _1);
       cloud_connection = grabber_.registerCallback (cloud_cb);
     }
 

--- a/apps/src/ni_trajkovic.cpp
+++ b/apps/src/ni_trajkovic.cpp
@@ -111,7 +111,7 @@ class TrajkovicDemo
     void
     init ()
     {
-      boost::function<void (const CloudConstPtr&) > cloud_cb;
+      std::function<void (const CloudConstPtr&) > cloud_cb;
       if (enable_3d_)
         cloud_cb = boost::bind (&TrajkovicDemo::cloud_callback_3d, this, _1);
       else

--- a/apps/src/openni_3d_concave_hull.cpp
+++ b/apps/src/openni_3d_concave_hull.cpp
@@ -140,7 +140,7 @@ class OpenNI3DConcaveHull
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNI3DConcaveHull::cloud_cb, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNI3DConcaveHull::cloud_cb, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
      
       viewer.runOnVisualizationThread (boost::bind(&OpenNI3DConcaveHull::viz_cb, this, _1), "viz_cb");

--- a/apps/src/openni_3d_convex_hull.cpp
+++ b/apps/src/openni_3d_convex_hull.cpp
@@ -138,7 +138,7 @@ class OpenNI3DConvexHull
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNI3DConvexHull::cloud_cb, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNI3DConvexHull::cloud_cb, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
      
       viewer.runOnVisualizationThread (boost::bind(&OpenNI3DConvexHull::viz_cb, this, _1), "viz_cb");

--- a/apps/src/openni_boundary_estimation.cpp
+++ b/apps/src/openni_boundary_estimation.cpp
@@ -159,7 +159,7 @@ class OpenNIIntegralImageNormalEstimation
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr &)> f = boost::bind (&OpenNIIntegralImageNormalEstimation::cloud_cb, this, _1);
+      std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr &)> f = boost::bind (&OpenNIIntegralImageNormalEstimation::cloud_cb, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
      
       viewer.runOnVisualizationThread (boost::bind(&OpenNIIntegralImageNormalEstimation::viz_cb, this, _1), "viz_cb");

--- a/apps/src/openni_change_viewer.cpp
+++ b/apps/src/openni_change_viewer.cpp
@@ -123,7 +123,7 @@ class OpenNIChangeViewer
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber();
 
-      boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f = 
+      std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f = 
         boost::bind (&OpenNIChangeViewer::cloud_cb_, this, _1);
 
       boost::signals2::connection c = interface->registerCallback (f);

--- a/apps/src/openni_color_filter.cpp
+++ b/apps/src/openni_color_filter.cpp
@@ -73,7 +73,7 @@ class OpenNIPassthrough
     : viewer ("PCL OpenNI ColorFilter Viewer")
     , grabber_(grabber)
     {
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPassthrough::cloud_cb_, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPassthrough::cloud_cb_, this, _1);
       boost::signals2::connection c = grabber_.registerCallback (f);
 
       std::vector<bool> lookup(1<<24, false);

--- a/apps/src/openni_fast_mesh.cpp
+++ b/apps/src/openni_fast_mesh.cpp
@@ -106,7 +106,7 @@ class OpenNIFastMesh
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIFastMesh::cloud_cb, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIFastMesh::cloud_cb, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
      
       view.reset (new pcl::visualization::PCLVisualizer (argc, argv, "PCL OpenNI Mesh Viewer"));

--- a/apps/src/openni_feature_persistence.cpp
+++ b/apps/src/openni_feature_persistence.cpp
@@ -190,7 +190,7 @@ class OpenNIFeaturePersistence
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIFeaturePersistence::cloud_cb, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIFeaturePersistence::cloud_cb, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
 
       viewer.runOnVisualizationThread (boost::bind(&OpenNIFeaturePersistence::viz_cb, this, _1), "viz_cb");

--- a/apps/src/openni_grab_frame.cpp
+++ b/apps/src/openni_grab_frame.cpp
@@ -186,7 +186,7 @@ class OpenNIGrabFrame
       
 
       // make callback function from member function
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIGrabFrame::cloud_cb_, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIGrabFrame::cloud_cb_, this, _1);
 
       // connect callback function for desired signal. In this case its a point cloud with color values
       boost::signals2::connection c = grabber_.registerCallback (f);

--- a/apps/src/openni_grab_images.cpp
+++ b/apps/src/openni_grab_images.cpp
@@ -187,7 +187,7 @@ class OpenNIGrabFrame
       depth_image_viewer_.registerMouseCallback (&OpenNIGrabFrame::mouse_callback, *this);
       depth_image_viewer_.registerKeyboardCallback(&OpenNIGrabFrame::keyboard_callback, *this);
       
-      boost::function<void (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float) > image_cb = boost::bind (&OpenNIGrabFrame::image_callback, this, _1, _2, _3);
+      std::function<void (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float) > image_cb = boost::bind (&OpenNIGrabFrame::image_callback, this, _1, _2, _3);
       boost::signals2::connection image_connection = grabber_.registerCallback (image_cb);
       
       // start receiving point clouds

--- a/apps/src/openni_ii_normal_estimation.cpp
+++ b/apps/src/openni_ii_normal_estimation.cpp
@@ -163,7 +163,7 @@ class OpenNIIntegralImageNormalEstimation
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIIntegralImageNormalEstimation::cloud_cb, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIIntegralImageNormalEstimation::cloud_cb, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
 
       viewer.runOnVisualizationThread (boost::bind(&OpenNIIntegralImageNormalEstimation::viz_cb, this, _1), "viz_cb");

--- a/apps/src/openni_klt.cpp
+++ b/apps/src/openni_klt.cpp
@@ -206,14 +206,14 @@ class OpenNIViewer
     void
     run ()
     {
-      boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&OpenNIViewer::cloud_callback, this, _1);
+      std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&OpenNIViewer::cloud_callback, this, _1);
       boost::signals2::connection cloud_connection = grabber_.registerCallback (cloud_cb);
 
       boost::signals2::connection image_connection;
       if (grabber_.providesCallback<void (const openni_wrapper::Image::Ptr&)>())
       {
         image_viewer_.reset (new pcl::visualization::ImageViewer ("Pyramidal KLT Tracker"));
-        boost::function<void (const openni_wrapper::Image::Ptr&) > image_cb = boost::bind (&OpenNIViewer::image_callback, this, _1);
+        std::function<void (const openni_wrapper::Image::Ptr&) > image_cb = boost::bind (&OpenNIViewer::image_callback, this, _1);
         image_connection = grabber_.registerCallback (image_cb);
       }
 

--- a/apps/src/openni_mls_smoothing.cpp
+++ b/apps/src/openni_mls_smoothing.cpp
@@ -134,7 +134,7 @@ class OpenNISmoothing
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNISmoothing::cloud_cb_, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNISmoothing::cloud_cb_, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
 
       viewer.registerKeyboardCallback (keyboardEventOccurred, reinterpret_cast<void*> (&stop_computing_));

--- a/apps/src/openni_mobile_server.cpp
+++ b/apps/src/openni_mobile_server.cpp
@@ -156,7 +156,7 @@ class PCLMobileServer
     run ()
     {
       pcl::OpenNIGrabber grabber (device_id_);
-      boost::function<void (const CloudConstPtr&)> handler_function = boost::bind (&PCLMobileServer::handleIncomingCloud, this, _1);
+      std::function<void (const CloudConstPtr&)> handler_function = boost::bind (&PCLMobileServer::handleIncomingCloud, this, _1);
       grabber.registerCallback (handler_function);
       grabber.start ();
 

--- a/apps/src/openni_octree_compression.cpp
+++ b/apps/src/openni_octree_compression.cpp
@@ -155,7 +155,7 @@ class SimpleOpenNIViewer
       pcl::Grabber* interface = new pcl::OpenNIGrabber();
 
       // make callback function from member function
-      boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
+      std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
         boost::bind (&SimpleOpenNIViewer::cloud_cb_, this, _1);
 
       // connect callback function for desired signal. In this case its a point cloud with color values
@@ -210,7 +210,7 @@ struct EventHelper
     pcl::Grabber* interface = new pcl::OpenNIGrabber ();
 
     // make callback function from member function
-    boost::function<void
+    std::function<void
     (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f = boost::bind (&EventHelper::cloud_cb_, this, _1);
 
     // connect callback function for desired signal. In this case its a point cloud with color values

--- a/apps/src/openni_organized_compression.cpp
+++ b/apps/src/openni_organized_compression.cpp
@@ -155,7 +155,7 @@ class SimpleOpenNIViewer
         pcl::Grabber* interface = new pcl::OpenNIGrabber();
 
         // make callback function from member function
-        boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
+        std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
           boost::bind (&SimpleOpenNIViewer::cloud_cb_, this, _1);
 
         // connect callback function for desired signal. In this case its a point cloud with color values
@@ -246,7 +246,7 @@ struct EventHelper
       pcl::Grabber* interface = new pcl::OpenNIGrabber ();
 
       // make callback function from member function
-      boost::function<void
+      std::function<void
       (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f = boost::bind (&EventHelper::cloud_cb_, this, _1);
 
       // connect callback function for desired signal. In this case its a point cloud with color values
@@ -271,7 +271,7 @@ struct EventHelper
       // Set the depth output format
       grabber.getDevice ()->setDepthOutputFormat (static_cast<openni_wrapper::OpenNIDevice::DepthMode> (depthformat));
 
-      boost::function<void (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float) > image_cb
+      std::function<void (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float) > image_cb
         = boost::bind (&EventHelper::image_callback, this, _1, _2, _3);
       boost::signals2::connection image_connection = grabber.registerCallback (image_cb);
 

--- a/apps/src/openni_organized_edge_detection.cpp
+++ b/apps/src/openni_organized_edge_detection.cpp
@@ -145,7 +145,7 @@ class OpenNIOrganizedEdgeDetection
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber ();
 
-      boost::function<void(const pcl::PointCloud<PointT>::ConstPtr&)> f = boost::bind (&OpenNIOrganizedEdgeDetection::cloud_cb_, this, _1);
+      std::function<void(const pcl::PointCloud<PointT>::ConstPtr&)> f = boost::bind (&OpenNIOrganizedEdgeDetection::cloud_cb_, this, _1);
 
       // Make and initialize a cloud viewer
       pcl::PointCloud<PointT>::Ptr init_cloud_ptr (new pcl::PointCloud<PointT>);

--- a/apps/src/openni_organized_multi_plane_segmentation.cpp
+++ b/apps/src/openni_organized_multi_plane_segmentation.cpp
@@ -111,7 +111,7 @@ class OpenNIOrganizedMultiPlaneSegmentation
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber ();
 
-      boost::function<void(const pcl::PointCloud<PointT>::ConstPtr&)> f = boost::bind (&OpenNIOrganizedMultiPlaneSegmentation::cloud_cb_, this, _1);
+      std::function<void(const pcl::PointCloud<PointT>::ConstPtr&)> f = boost::bind (&OpenNIOrganizedMultiPlaneSegmentation::cloud_cb_, this, _1);
 
       //make a viewer
       pcl::PointCloud<PointT>::Ptr init_cloud_ptr (new pcl::PointCloud<PointT>);

--- a/apps/src/openni_passthrough.cpp
+++ b/apps/src/openni_passthrough.cpp
@@ -71,7 +71,7 @@ OpenNIPassthrough::OpenNIPassthrough (pcl::OpenNIGrabber& grabber)
   ui_->qvtk_widget->update (); 
 
   // Start the OpenNI data acquision
-  boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPassthrough::cloud_cb, this, _1);
+  std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPassthrough::cloud_cb, this, _1);
   boost::signals2::connection c = grabber_.registerCallback (f);
 
   grabber_.start ();

--- a/apps/src/openni_planar_convex_hull.cpp
+++ b/apps/src/openni_planar_convex_hull.cpp
@@ -121,7 +121,7 @@ class OpenNIPlanarSegmentation
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPlanarSegmentation::cloud_cb_, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPlanarSegmentation::cloud_cb_, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
       
       interface->start ();

--- a/apps/src/openni_planar_segmentation.cpp
+++ b/apps/src/openni_planar_segmentation.cpp
@@ -116,7 +116,7 @@ class OpenNIPlanarSegmentation
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPlanarSegmentation::cloud_cb_, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIPlanarSegmentation::cloud_cb_, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
       
       interface->start ();

--- a/apps/src/openni_shift_to_depth_conversion.cpp
+++ b/apps/src/openni_shift_to_depth_conversion.cpp
@@ -133,7 +133,7 @@ class SimpleOpenNIViewer
       grabber_->getDevice ()->setDepthOutputFormat (static_cast<openni_wrapper::OpenNIDevice::DepthMode> (depthformat));
 
       // define image callback
-      boost::function<void
+      std::function<void
       (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float)> image_cb =
           boost::bind (&SimpleOpenNIViewer::image_callback, this, _1, _2, _3);
       boost::signals2::connection image_connection = grabber_->registerCallback (image_cb);

--- a/apps/src/openni_tracking.cpp
+++ b/apps/src/openni_tracking.cpp
@@ -638,7 +638,7 @@ public:
   run ()
   {
     pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
-    boost::function<void (const CloudConstPtr&)> f =
+    std::function<void (const CloudConstPtr&)> f =
       boost::bind (&OpenNISegmentTracking::cloud_cb, this, _1);
     interface->registerCallback (f);
     

--- a/apps/src/openni_uniform_sampling.cpp
+++ b/apps/src/openni_uniform_sampling.cpp
@@ -123,7 +123,7 @@ class OpenNIUniformSampling
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIUniformSampling::cloud_cb_, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIUniformSampling::cloud_cb_, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
       viewer.runOnVisualizationThread (boost::bind(&OpenNIUniformSampling::viz_cb, this, _1), "viz_cb");
       

--- a/apps/src/openni_voxel_grid.cpp
+++ b/apps/src/openni_voxel_grid.cpp
@@ -113,7 +113,7 @@ class OpenNIVoxelGrid
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id_);
 
-      boost::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIVoxelGrid::cloud_cb_, this, _1);
+      std::function<void (const CloudConstPtr&)> f = boost::bind (&OpenNIVoxelGrid::cloud_cb_, this, _1);
       boost::signals2::connection c = interface->registerCallback (f);
       
       interface->start ();

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -211,7 +211,7 @@ OrganizedSegmentationDemo::OrganizedSegmentationDemo (pcl::Grabber& grabber) : g
   vis_->getInteractorStyle ()->setKeyboardModifier (pcl::visualization::INTERACTOR_KB_MOD_SHIFT);
   ui_->qvtk_widget->update ();
 
-  boost::function<void (const CloudConstPtr&)> f = boost::bind (&OrganizedSegmentationDemo::cloud_cb, this, _1);
+  std::function<void (const CloudConstPtr&)> f = boost::bind (&OrganizedSegmentationDemo::cloud_cb, this, _1);
   boost::signals2::connection c = grabber_.registerCallback(f);
 
   connect (ui_->captureButton, SIGNAL(clicked()), this, SLOT(toggleCapturePressed()));

--- a/common/include/pcl/common/boost.h
+++ b/common/include/pcl/common/boost.h
@@ -49,7 +49,6 @@
 #include <boost/make_shared.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/function.hpp>
 #include <boost/signals2.hpp>
 #include <boost/signals2/slot.hpp>
 #include <boost/algorithm/string.hpp>

--- a/common/include/pcl/common/gaussian.h
+++ b/common/include/pcl/common/gaussian.h
@@ -39,10 +39,11 @@
 
 #pragma once
 
-#include <sstream>
 #include <pcl/common/eigen.h>
 #include <pcl/point_cloud.h>
-#include <boost/function.hpp>
+
+#include <functional>
+#include <sstream>
 
 namespace pcl
 {
@@ -56,8 +57,6 @@ namespace pcl
   class PCL_EXPORTS GaussianKernel
   {
     public:
-
-      GaussianKernel () {}
 
       static const unsigned MAX_KERNEL_WIDTH = 71;
       /** Computes the gaussian kernel and dervative assiociated to sigma.
@@ -108,7 +107,7 @@ namespace pcl
         */
      template <typename PointT> void
      convolveRows (const pcl::PointCloud<PointT> &input,
-                   boost::function <float (const PointT& p)> field_accessor,
+                   std::function <float (const PointT& p)> field_accessor,
                    const Eigen::VectorXf &kernel,
                    pcl::PointCloud<float> &output) const;
 
@@ -134,7 +133,7 @@ namespace pcl
         */
       template <typename PointT> void
       convolveCols (const pcl::PointCloud<PointT> &input,
-                    boost::function <float (const PointT& p)> field_accessor,
+                    std::function <float (const PointT& p)> field_accessor,
                     const Eigen::VectorXf &kernel,
                     pcl::PointCloud<float> &output) const;
 
@@ -170,7 +169,7 @@ namespace pcl
         */
       template <typename PointT> inline void
       convolve (const pcl::PointCloud<PointT> &input,
-                boost::function <float (const PointT& p)> field_accessor,
+                std::function <float (const PointT& p)> field_accessor,
                 const Eigen::VectorXf &horiz_kernel,
                 const Eigen::VectorXf &vert_kernel,
                 pcl::PointCloud<float> &output) const
@@ -216,7 +215,7 @@ namespace pcl
         */
       template <typename PointT> inline void
       computeGradients (const pcl::PointCloud<PointT> &input,
-                        boost::function <float (const PointT& p)> field_accessor,
+                        std::function <float (const PointT& p)> field_accessor,
                         const Eigen::VectorXf &gaussian_kernel,
                         const Eigen::VectorXf &gaussian_kernel_derivative,
                         pcl::PointCloud<float> &grad_x,
@@ -251,7 +250,7 @@ namespace pcl
         */
       template <typename PointT> inline void
       smooth (const pcl::PointCloud<PointT> &input,
-              boost::function <float (const PointT& p)> field_accessor,
+              std::function <float (const PointT& p)> field_accessor,
               const Eigen::VectorXf &gaussian_kernel,
               pcl::PointCloud<float> &output) const
       {

--- a/common/include/pcl/common/impl/gaussian.hpp
+++ b/common/include/pcl/common/impl/gaussian.hpp
@@ -42,9 +42,9 @@
 
 #include <pcl/exceptions.h>
 
-template <typename PointT> void 
+template <typename PointT> void
 pcl::GaussianKernel::convolveRows(const pcl::PointCloud<PointT> &input,
-                                  boost::function <float (const PointT& p)> field_accessor,
+                                  std::function <float (const PointT& p)> field_accessor,
                                   const Eigen::VectorXf& kernel,
                                   pcl::PointCloud<float> &output) const
 {
@@ -75,9 +75,9 @@ pcl::GaussianKernel::convolveRows(const pcl::PointCloud<PointT> &input,
   }
 }
 
-template <typename PointT> void 
+template <typename PointT> void
 pcl::GaussianKernel::convolveCols(const pcl::PointCloud<PointT> &input,
-                                  boost::function <float (const PointT& p)> field_accessor,
+                                  std::function <float (const PointT& p)> field_accessor,
                                   const Eigen::VectorXf& kernel,
                                   pcl::PointCloud<float> &output) const
 {

--- a/common/include/pcl/common/synchronizer.h
+++ b/common/include/pcl/common/synchronizer.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <functional>
 #include <mutex>
 
 namespace pcl
@@ -58,7 +59,7 @@ namespace pcl
     std::deque<T1Stamped> queueT1;
     std::deque<T2Stamped> queueT2;
 
-    using CallbackFunction = boost::function<void (T1, T2, unsigned long, unsigned long)>;
+    using CallbackFunction = std::function<void(T1, T2, unsigned long, unsigned long)>;
 
     std::map<int, CallbackFunction> cb_;
     int callback_counter;
@@ -109,7 +110,7 @@ namespace pcl
 
       for (typename std::map<int, CallbackFunction>::iterator cb = cb_.begin (); cb != cb_.end (); ++cb)
       {
-        if (!cb->second.empty ())
+        if (cb->second)
         {
           cb->second.operator()(queueT1.front ().second, queueT2.front ().second, queueT1.front ().first, queueT2.front ().first);
         }

--- a/common/include/pcl/common/time_trigger.h
+++ b/common/include/pcl/common/time_trigger.h
@@ -40,11 +40,11 @@
 
 #include <pcl/pcl_macros.h>
 #ifndef Q_MOC_RUN
-#include <boost/function.hpp>
 #include <boost/signals2.hpp>
 #endif
 
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 #include <thread>
 
@@ -56,7 +56,7 @@ namespace pcl
   class PCL_EXPORTS TimeTrigger
   {
     public:
-      using callback_type = boost::function<void ()>;
+      using callback_type = std::function<void ()>;
 
       /** \brief Timer class that calls a callback method periodically. Due to possible blocking calls, only one callback method can be registered per instance.
         * \param[in] interval_seconds interval in seconds
@@ -73,7 +73,7 @@ namespace pcl
       ~TimeTrigger ();
 
       /** \brief registers a callback
-        * \param[in] callback callback function to the list of callbacks. signature has to be boost::function<void()>
+        * \param[in] callback callback function to the list of callbacks. signature has to be std::function<void()>
         * \return connection the connection, which can be used to disable/enable and remove callback from list
         */
       boost::signals2::connection registerCallback (const callback_type& callback);

--- a/cuda/apps/src/kinect_debayering.cpp
+++ b/cuda/apps/src/kinect_debayering.cpp
@@ -44,6 +44,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -72,7 +73,7 @@ class SimpleKinectTool
 	    cv::namedWindow("test", CV_WINDOW_AUTOSIZE);
       pcl::Grabber* interface = new pcl::OpenNIGrabber(device_id);
 
-      boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image)> f = boost::bind (&SimpleKinectTool::cloud_cb_, this, _1);
+      std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image)> f = boost::bind (&SimpleKinectTool::cloud_cb_, this, _1);
 
       boost::signals2::connection c = interface->registerCallback (f);
 

--- a/cuda/apps/src/kinect_dediscretize.cpp
+++ b/cuda/apps/src/kinect_dediscretize.cpp
@@ -48,6 +48,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -76,7 +77,7 @@ class SimpleKinectTool
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber(device_id);
 
-      boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb_, this, _1, _2, _3);
+      std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb_, this, _1, _2, _3);
 
       boost::signals2::connection c = interface->registerCallback (f);
 

--- a/cuda/apps/src/kinect_mapping.cpp
+++ b/cuda/apps/src/kinect_mapping.cpp
@@ -35,24 +35,23 @@
  *
  */
 
-#include <pcl_cuda/time_cpu.h>
-#include <pcl_cuda/time_gpu.h>
 #include <pcl_cuda/io/cloud_to_pcl.h>
 #include <pcl_cuda/io/extract_indices.h>
 #include <pcl_cuda/io/disparity_to_cloud.h>
 #include <pcl_cuda/sample_consensus/sac_model_1point_plane.h>
 #include <pcl_cuda/sample_consensus/multi_ransac.h>
 #include <pcl_cuda/segmentation/connected_components.h>
+#include <pcl_cuda/time_cpu.h>
+#include <pcl_cuda/time_gpu.h>
 
+#include <pcl/common/transform.h>
 #include <pcl/io/openni_grabber.h>
 #include <pcl/io/pcd_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
 #include <pcl/visualization/point_cloud_handlers.h>
 #include <pcl/visualization/pcl_visualizer.h>
-#include <pcl/common/transform.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-
 
 #include <opencv2/opencv.hpp>
 #include <opencv2/gpu/gpu.hpp>
@@ -63,6 +62,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -243,13 +243,13 @@ class MultiRansac
       if (use_device)
       {
         std::cerr << "[RANSAC] Using GPU..." << std::endl;
-        boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<pcl_cuda::Device>, this, _1, _2, _3);
+        std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<pcl_cuda::Device>, this, _1, _2, _3);
         c = interface->registerCallback (f);
       }
       else
       {
         std::cerr << "[RANSAC] Using CPU..." << std::endl;
-        boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<pcl_cuda::Host>, this, _1, _2, _3);
+        std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<pcl_cuda::Host>, this, _1, _2, _3);
         c = interface->registerCallback (f);
       }
 

--- a/cuda/apps/src/kinect_normals_cuda.cpp
+++ b/cuda/apps/src/kinect_normals_cuda.cpp
@@ -54,6 +54,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -193,13 +194,13 @@ class NormalEstimation
         if (use_device)
         {
           std::cerr << "[NormalEstimation] Using GPU..." << std::endl;
-          boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&NormalEstimation::file_cloud_cb<Device>, this, _1);
+          std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&NormalEstimation::file_cloud_cb<Device>, this, _1);
           filegrabber->registerCallback (f);
         }
         else
         {
           std::cerr << "[NormalEstimation] Using CPU..." << std::endl;
-          boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&NormalEstimation::file_cloud_cb<Host>, this, _1);
+          std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&NormalEstimation::file_cloud_cb<Host>, this, _1);
           filegrabber->registerCallback (f);
         }
 
@@ -218,13 +219,13 @@ class NormalEstimation
         if (use_device)
         {
           std::cerr << "[NormalEstimation] Using GPU..." << std::endl;
-          boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&NormalEstimation::cloud_cb<Device>, this, _1, _2, _3);
+          std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&NormalEstimation::cloud_cb<Device>, this, _1, _2, _3);
           c = grabber->registerCallback (f);
         }
         else
         {
           std::cerr << "[NormalEstimation] Using CPU..." << std::endl;
-          boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&NormalEstimation::cloud_cb<Host>, this, _1, _2, _3);
+          std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&NormalEstimation::cloud_cb<Host>, this, _1, _2, _3);
           c = grabber->registerCallback (f);
         }
 

--- a/cuda/apps/src/kinect_planes_cuda.cpp
+++ b/cuda/apps/src/kinect_planes_cuda.cpp
@@ -63,6 +63,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -253,13 +254,13 @@ class MultiRansac
       if (use_device)
       {
         std::cerr << "[RANSAC] Using GPU..." << std::endl;
-        boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<Device>, this, _1, _2, _3);
+        std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<Device>, this, _1, _2, _3);
         c = interface->registerCallback (f);
       }
       else
       {
         std::cerr << "[RANSAC] Using CPU..." << std::endl;
-        boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<Host>, this, _1, _2, _3);
+        std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&MultiRansac::cloud_cb<Host>, this, _1, _2, _3);
         c = interface->registerCallback (f);
       }
 
@@ -282,7 +283,7 @@ class MultiRansac
       //else
       //  std::cerr << "did not find file" << std::endl;
       //
-      //boost::function<void(const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&) > f = boost::bind (&MultiRansac::logo_cb, this, _1);
+      //std::function<void(const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&) > f = boost::bind (&MultiRansac::logo_cb, this, _1);
       //boost::signals2::connection c1 = filegrabber->registerCallback (f);
 
       //filegrabber->start ();

--- a/cuda/apps/src/kinect_ransac.cpp
+++ b/cuda/apps/src/kinect_ransac.cpp
@@ -52,6 +52,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -168,13 +169,13 @@ class SimpleKinectTool
       if (use_device)
       {
         std::cerr << "[RANSAC] Using GPU..." << std::endl;
-        boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&SimpleKinectTool::file_cloud_cb<pcl_cuda::Device>, this, _1);
+        std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&SimpleKinectTool::file_cloud_cb<pcl_cuda::Device>, this, _1);
         filegrabber->registerCallback (f);
       }
       else
       {
         std::cerr << "[RANSAC] Using CPU..." << std::endl;
-        boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&SimpleKinectTool::file_cloud_cb<pcl_cuda::Host>, this, _1);
+        std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&SimpleKinectTool::file_cloud_cb<pcl_cuda::Host>, this, _1);
         filegrabber->registerCallback (f);
       }
 
@@ -196,13 +197,13 @@ class SimpleKinectTool
       if (use_device)
       {
         std::cerr << "[RANSAC] Using GPU..." << std::endl;
-        boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb<pcl_cuda::Device>, this, _1, _2, _3);
+        std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb<pcl_cuda::Device>, this, _1, _2, _3);
         c = interface->registerCallback (f);
       }
       else
       {
         std::cerr << "[RANSAC] Using CPU..." << std::endl;
-        boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb<pcl_cuda::Host>, this, _1, _2, _3);
+        std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb<pcl_cuda::Host>, this, _1, _2, _3);
         c = interface->registerCallback (f);
       }
 

--- a/cuda/apps/src/kinect_segmentation_cuda.cpp
+++ b/cuda/apps/src/kinect_segmentation_cuda.cpp
@@ -58,6 +58,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -367,13 +368,13 @@ class Segmentation
         if (use_device)
         {
           std::cerr << "[Segmentation] Using GPU..." << std::endl;
-          boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Device>, this, _1);
+          std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Device>, this, _1);
           filegrabber->registerCallback (f);
         }
         else
         {
 //          std::cerr << "[Segmentation] Using CPU..." << std::endl;
-//          boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Host>, this, _1);
+//          std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Host>, this, _1);
 //          filegrabber->registerCallback (f);
         }
 
@@ -392,13 +393,13 @@ class Segmentation
         if (use_device)
         {
           std::cerr << "[Segmentation] Using GPU..." << std::endl;
-          boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Device>, this, _1, _2, _3);
+          std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Device>, this, _1, _2, _3);
           c = grabber->registerCallback (f);
         }
         else
         {
 //          std::cerr << "[Segmentation] Using CPU..." << std::endl;
-//          boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Host>, this, _1, _2, _3);
+//          std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Host>, this, _1, _2, _3);
 //          c = grabber->registerCallback (f);
         }
 

--- a/cuda/apps/src/kinect_segmentation_planes_cuda.cpp
+++ b/cuda/apps/src/kinect_segmentation_planes_cuda.cpp
@@ -57,6 +57,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <functional>
 #include <mutex>
 
 using namespace pcl::cuda;
@@ -242,13 +243,13 @@ class Segmentation
         if (use_device)
         {
           std::cerr << "[Segmentation] Using GPU..." << std::endl;
-          boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Device>, this, _1);
+          std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Device>, this, _1);
           filegrabber->registerCallback (f);
         }
         else
         {
 //          std::cerr << "[Segmentation] Using CPU..." << std::endl;
-//          boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Host>, this, _1);
+//          std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f = boost::bind (&Segmentation::file_cloud_cb<Host>, this, _1);
 //          filegrabber->registerCallback (f);
         }
 
@@ -267,13 +268,13 @@ class Segmentation
         if (use_device)
         {
           std::cerr << "[Segmentation] Using GPU..." << std::endl;
-          boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Device>, this, _1, _2, _3);
+          std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Device>, this, _1, _2, _3);
           c = grabber->registerCallback (f);
         }
         else
         {
 //          std::cerr << "[Segmentation] Using CPU..." << std::endl;
-//          boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Host>, this, _1, _2, _3);
+//          std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&Segmentation::cloud_cb<Host>, this, _1, _2, _3);
 //          c = grabber->registerCallback (f);
         }
 

--- a/cuda/apps/src/kinect_tool_standalone.cpp
+++ b/cuda/apps/src/kinect_tool_standalone.cpp
@@ -45,6 +45,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -77,7 +78,7 @@ class SimpleKinectTool
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber(device_id);
 
-      boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb_, this, _1, _2, _3);
+      std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)> f = boost::bind (&SimpleKinectTool::cloud_cb_, this, _1, _2, _3);
 
       boost::signals2::connection c = interface->registerCallback (f);
 

--- a/cuda/apps/src/kinect_viewer_cuda.cpp
+++ b/cuda/apps/src/kinect_viewer_cuda.cpp
@@ -45,6 +45,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <functional>
 #include <iostream>
 #include <mutex>
 
@@ -75,7 +76,7 @@ class KinectViewerCuda
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber(device_id);
 
-      boost::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)>
+      std::function<void (const boost::shared_ptr<openni_wrapper::Image>& image, const boost::shared_ptr<openni_wrapper::DepthImage>& depth_image, float)>
         f = boost::bind (&KinectViewerCuda::cloud_cb_, this, _1, _2, _3);
 
       boost::signals2::connection c = interface->registerCallback (f);

--- a/doc/tutorials/content/dinast_grabber.rst
+++ b/doc/tutorials/content/dinast_grabber.rst
@@ -75,7 +75,7 @@ The code from *apps/src/dinast_grabber_example.cpp* will be used for this tutori
       run ()
       {
               
-        boost::function<void (const CloudConstPtr&)> f =
+        std::function<void (const CloudConstPtr&)> f =
           boost::bind (&DinastProcessor::cloud_cb_, this, _1);
         
         boost::signals2::connection c = interface.registerCallback (f);
@@ -119,13 +119,13 @@ At the run function what we first have is actually the callback and its registra
 
 .. code-block:: cpp    
 
-  boost::function<void (const CloudConstPtr&)> f =
+  std::function<void (const CloudConstPtr&)> f =
     boost::bind (&DinastProcessor::cloud_cb_, this, _1);
         
   boost::signals2::connection c = interface.registerCallback (f);
 
 We create a *boost::bind* object with the address of the callback *cloud_cb_*, we pass a reference to our DinastProcessor and the argument place holder *_1*.
-The bind then gets casted to a boost::function object which is templated on the callback function type, in this case *void (const CloudConstPtr&)*. The resulting function object is then registered with the DinastGrabber interface. 
+The bind then gets casted to a std::function object which is templated on the callback function type, in this case *void (const CloudConstPtr&)*. The resulting function object is then registered with the DinastGrabber interface. 
 
 The *registerCallback* call returns a *boost::signals2::connection* object, which we do not use in the this example. However, if you want to interrupt or cancel one or more of the registered data streams, you can call disconnect the callback without stopping the whole grabber:
 

--- a/doc/tutorials/content/hdl_grabber.rst
+++ b/doc/tutorials/content/hdl_grabber.rst
@@ -125,7 +125,7 @@ So let's look at the code. The following represents a simplified version of *vis
          cloud_viewer_->setCameraPosition (0.0, 0.0, 30.0, 0.0, 1.0, 0.0, 0);
          cloud_viewer_->setCameraClipDistances (0.0, 50.0);
 
-         boost::function<void (const CloudConstPtr&)> cloud_cb = boost::bind (
+         std::function<void (const CloudConstPtr&)> cloud_cb = boost::bind (
              &SimpleHDLViewer::cloud_callback, this, _1);
          boost::signals2::connection cloud_connection = grabber_.registerCallback (
              cloud_cb);

--- a/doc/tutorials/content/mobile_streaming.rst
+++ b/doc/tutorials/content/mobile_streaming.rst
@@ -100,7 +100,7 @@ few lines of the *run()* method:
 .. code-block:: cpp
 
     pcl::OpenNIGrabber grabber (device_id_);
-    boost::function<void (const CloudConstPtr&)> handler_function = boost::bind (&PCLMobileServer::handleIncomingCloud, this, _1);
+    std::function<void (const CloudConstPtr&)> handler_function = boost::bind (&PCLMobileServer::handleIncomingCloud, this, _1);
     grabber.registerCallback (handler_function);
     grabber.start ();
 

--- a/doc/tutorials/content/openni_grabber.rst
+++ b/doc/tutorials/content/openni_grabber.rst
@@ -59,7 +59,7 @@ So let's look at the code. From *visualization/tools/openni_viewer_simple.cpp*
         {   
           pcl::Grabber* interface = new pcl::OpenNIGrabber();
 
-          boost::function<void (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&)> f = 
+          std::function<void (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&)> f = 
             boost::bind (&SimpleOpenNIViewer::cloud_cb_, this, _1);
 
           interface->registerCallback (f);
@@ -91,7 +91,7 @@ first, but it's not that bad. We create a *boost::bind* object with the address
 of the callback *cloud_cb_*, we pass a reference to our *SimpleOpenNIViewer*
 and the argument place holder *_1*.
 
-The *bind* then gets casted to a *boost::function* object which is templated on
+The *bind* then gets casted to a *std::function* object which is templated on
 the callback function type, in this case *void (const
 pcl::PointCloud<pcl::PointXYZ>::ConstPtr&)*. The resulting function object can
 the be registered with the *OpenNIGrabber* and subsequently started.  Note that

--- a/doc/tutorials/content/sources/davidsdk/davidsdk_images_viewer.cpp
+++ b/doc/tutorials/content/sources/davidsdk/davidsdk_images_viewer.cpp
@@ -106,7 +106,7 @@ main (int argc,
     return (-1);
   PCL_WARN ("davidSDK connected\n");
 
-  boost::function<void (const pcl::PCLImage::Ptr &)> f = boost::bind (&grabberCallback, _1);
+  std::function<void (const pcl::PCLImage::Ptr &)> f = boost::bind (&grabberCallback, _1);
   davidsdk_ptr->registerCallback (f);
   davidsdk_ptr->start ();
   waitForUser ("Press enter to quit");

--- a/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
+++ b/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
@@ -129,7 +129,7 @@ main (void)
   //ensenso_ptr->initExtrinsicCalibration (5); // Disable projector if you want good looking images.
   // You won't be able to detect a calibration pattern with the projector enabled!
 
-  boost::function<void (const PointCloudT::Ptr&, const PairOfImagesPtr&)> f = boost::bind (&grabberCallback, _1, _2);
+  std::function<void (const PointCloudT::Ptr&, const PairOfImagesPtr&)> f = boost::bind (&grabberCallback, _1, _2);
   ensenso_ptr->registerCallback (f);
 
   cv::namedWindow ("Ensenso images", cv::WINDOW_AUTOSIZE);

--- a/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
+++ b/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
@@ -247,8 +247,8 @@ class PeoplePCDApp
       typedef openni_wrapper::DepthImage::Ptr DepthImagePtr;
       typedef openni_wrapper::Image::Ptr ImagePtr;
 
-      boost::function<void (const PointCloud<PointXYZRGBA>::ConstPtr&)> func1 = boost::bind (&PeoplePCDApp::source_cb1, this, _1);
-      boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func2 = boost::bind (&PeoplePCDApp::source_cb2, this, _1, _2, _3);
+      std::function<void (const PointCloud<PointXYZRGBA>::ConstPtr&)> func1 = boost::bind (&PeoplePCDApp::source_cb1, this, _1);
+      std::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func2 = boost::bind (&PeoplePCDApp::source_cb2, this, _1, _2, _3);
       boost::signals2::connection c = cloud_cb_ ? capture_.registerCallback (func1) : capture_.registerCallback (func2);
 
       {

--- a/doc/tutorials/content/sources/ground_based_rgbd_people_detection/src/main_ground_based_people_detection.cpp
+++ b/doc/tutorials/content/sources/ground_based_rgbd_people_detection/src/main_ground_based_people_detection.cpp
@@ -139,7 +139,7 @@ int main (int argc, char** argv)
   PointCloudT::Ptr cloud (new PointCloudT);
   bool new_cloud_available_flag = false;
   pcl::Grabber* interface = new pcl::OpenNIGrabber();
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
       boost::bind (&cloud_cb_, _1, cloud, &new_cloud_available_flag);
   interface->registerCallback (f);
   interface->start ();

--- a/doc/tutorials/content/sources/iccv2011/src/openni_capture.cpp
+++ b/doc/tutorials/content/sources/iccv2011/src/openni_capture.cpp
@@ -11,7 +11,7 @@ OpenNICapture::OpenNICapture (const std::string& device_id)
   , trigger_ (false)
 {
   // Register a callback function to our OpenNI grabber...
-  boost::function<void (const PointCloudConstPtr&)> frame_cb = boost::bind (&OpenNICapture::onNewFrame, this, _1);
+  std::function<void (const PointCloudConstPtr&)> frame_cb = boost::bind (&OpenNICapture::onNewFrame, this, _1);
   // ... and start grabbing frames
   grabber_.registerCallback (frame_cb);
   grabber_.start ();
@@ -39,7 +39,7 @@ OpenNICapture::snap ()
       // Initialize the visualizer ONLY if use_trigger is set to true
       preview_ = pcl::visualization::PCLVisualizer::Ptr (new pcl::visualization::PCLVisualizer ());
 
-      boost::function<void (const pcl::visualization::KeyboardEvent&)> keyboard_cb =
+      std::function<void (const pcl::visualization::KeyboardEvent&)> keyboard_cb =
         boost::bind (&OpenNICapture::onKeyboardEvent, this, _1);
 
       preview_->registerKeyboardCallback (keyboard_cb);

--- a/doc/tutorials/content/sources/iros2011/src/openni_capture.cpp
+++ b/doc/tutorials/content/sources/iros2011/src/openni_capture.cpp
@@ -12,7 +12,7 @@ OpenNICapture::OpenNICapture (const std::string& device_id)
   , preview_ ()
 {
   // Register a callback function to our OpenNI grabber...
-  boost::function<void (const PointCloudConstPtr&)> frame_cb = boost::bind (&OpenNICapture::onNewFrame, this, _1);
+  std::function<void (const PointCloudConstPtr&)> frame_cb = boost::bind (&OpenNICapture::onNewFrame, this, _1);
   // ... and start grabbing frames
   grabber_.registerCallback (frame_cb);
   grabber_.start ();
@@ -42,7 +42,7 @@ OpenNICapture::snap ()
       // Initialize the visualizer ONLY if use_trigger is set to true
       preview_ = new pcl::visualization::PCLVisualizer ();
 
-      boost::function<void (const pcl::visualization::KeyboardEvent&)> keyboard_cb =
+      std::function<void (const pcl::visualization::KeyboardEvent&)> keyboard_cb =
         boost::bind (&OpenNICapture::onKeyboardEvent, this, _1);
 
       preview_->registerKeyboardCallback (keyboard_cb);

--- a/doc/tutorials/content/sources/openni_grabber/openni_grabber.cpp
+++ b/doc/tutorials/content/sources/openni_grabber/openni_grabber.cpp
@@ -29,7 +29,7 @@ public:
     pcl::Grabber* interface = new pcl::OpenNIGrabber();
 
     // make callback function from member function
-    boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
+    std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
       boost::bind (&SimpleOpenNIProcessor::cloud_cb_, this, _1);
 
     // connect callback function for desired signal. In this case its a point cloud with color values

--- a/doc/tutorials/content/sources/openni_narf_keypoint_extraction/openni_narf_keypoint_extraction.cpp
+++ b/doc/tutorials/content/sources/openni_narf_keypoint_extraction/openni_narf_keypoint_extraction.cpp
@@ -117,7 +117,7 @@ int main (int argc, char** argv)
   pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id);
   EventHelper event_helper;
   
-  boost::function<void (const openni_wrapper::DepthImage::Ptr&) > f_depth_image =
+  std::function<void (const openni_wrapper::DepthImage::Ptr&) > f_depth_image =
     boost::bind (&EventHelper::depth_image_cb, &event_helper, _1);
   boost::signals2::connection c_depth_image = interface->registerCallback (f_depth_image);
   

--- a/doc/tutorials/content/sources/openni_range_image_visualization/openni_range_image_visualization.cpp
+++ b/doc/tutorials/content/sources/openni_range_image_visualization/openni_range_image_visualization.cpp
@@ -94,7 +94,7 @@ int main (int argc, char** argv)
   pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id);
   EventHelper event_helper;
   
-  boost::function<void (const openni_wrapper::DepthImage::Ptr&) > f_depth_image =
+  std::function<void (const openni_wrapper::DepthImage::Ptr&) > f_depth_image =
     boost::bind (&EventHelper::depth_image_cb, &event_helper, _1);
   boost::signals2::connection c_depth_image = interface->registerCallback (f_depth_image);
   

--- a/doc/tutorials/content/sources/point_cloud_compression/point_cloud_compression.cpp
+++ b/doc/tutorials/content/sources/point_cloud_compression/point_cloud_compression.cpp
@@ -60,7 +60,7 @@ public:
     pcl::Grabber* interface = new pcl::OpenNIGrabber ();
 
     // make callback function from member function
-    boost::function<void
+    std::function<void
     (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f = boost::bind (&SimpleOpenNIViewer::cloud_cb_, this, _1);
 
     // connect callback function for desired signal. In this case its a point cloud with color values

--- a/doc/tutorials/content/sources/tracking/tracking_sample.cpp
+++ b/doc/tutorials/content/sources/tracking/tracking_sample.cpp
@@ -275,7 +275,7 @@ main (int argc, char** argv)
   //Setup OpenNIGrabber and viewer
   pcl::visualization::CloudViewer* viewer_ = new pcl::visualization::CloudViewer("PCL OpenNI Tracking Viewer");
   pcl::Grabber* interface = new pcl::OpenNIGrabber (device_id);
-  boost::function<void (const CloudConstPtr&)> f =
+  std::function<void (const CloudConstPtr&)> f =
     boost::bind (&cloud_cb, _1);
   interface->registerCallback (f);
     

--- a/features/include/pcl/features/boost.h
+++ b/features/include/pcl/features/boost.h
@@ -43,6 +43,5 @@
 #  pragma GCC system_header 
 #endif
 
-#include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/property_map/property_map.hpp>

--- a/features/include/pcl/features/feature.h
+++ b/features/include/pcl/features/feature.h
@@ -44,11 +44,12 @@
 #  pragma GCC system_header 
 #endif
 
-#include <boost/function.hpp>
 #include <boost/bind.hpp>
 // PCL includes
 #include <pcl/pcl_base.h>
 #include <pcl/search/search.h>
+
+#include <functional>
 
 namespace pcl
 {
@@ -121,8 +122,8 @@ namespace pcl
 
       typedef pcl::PointCloud<PointOutT> PointCloudOut;
 
-      typedef boost::function<int (size_t, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
-      typedef boost::function<int (const PointCloudIn &cloud, size_t index, double, std::vector<int> &, std::vector<float> &)> SearchMethodSurface;
+      typedef std::function<int (size_t, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
+      typedef std::function<int (const PointCloudIn &cloud, size_t index, double, std::vector<int> &, std::vector<float> &)> SearchMethodSurface;
 
     public:
       /** \brief Empty constructor. */

--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -391,7 +391,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
 template <typename T>
 void
 sumArea (int start_x, int start_y, int end_x, int end_y, const int width, const int height,
-  const boost::function<T(unsigned, unsigned, unsigned, unsigned)> &f, 
+  const std::function<T(unsigned, unsigned, unsigned, unsigned)> &f, 
   T & result)
 {
   if (start_x < 0)

--- a/filters/include/pcl/filters/boost.h
+++ b/filters/include/pcl/filters/boost.h
@@ -53,5 +53,4 @@
 #include <boost/mpl/size.hpp>
 #include <boost/fusion/sequence/intrinsic/at_key.hpp>
 #include <boost/bind.hpp>
-#include <boost/function.hpp>
 #include <boost/optional.hpp>

--- a/filters/include/pcl/filters/model_outlier_removal.h
+++ b/filters/include/pcl/filters/model_outlier_removal.h
@@ -173,7 +173,7 @@ namespace pcl
        * \param[in] thresh pointer to a threshold function
        */
       void
-      setThresholdFunction (boost::function<bool (double)> thresh)
+      setThresholdFunction (std::function<bool (double)> thresh)
       {
         threshold_function_ = thresh;
       }
@@ -235,7 +235,7 @@ namespace pcl
 
       /** \brief The type of model to use (user given parameter). */
       pcl::SacModel model_type_;
-      boost::function<bool (double)> threshold_function_;
+      std::function<bool (double)> threshold_function_;
 
       inline bool
       checkSingleThreshold (double value)

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -37,6 +37,7 @@
 
 #define _CRT_SECURE_NO_DEPRECATE
 
+#include <functional>
 #include <iostream>
 #include <vector>
 
@@ -961,17 +962,17 @@ struct KinFuApp
     typedef boost::shared_ptr<DepthImage> DepthImagePtr;
     typedef boost::shared_ptr<Image> ImagePtr;
         
-    boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1_dev = boost::bind (&KinFuApp::source_cb2_device, this, _1, _2, _3);
-    boost::function<void (const DepthImagePtr&)> func2_dev = boost::bind (&KinFuApp::source_cb1_device, this, _1);
+    std::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1_dev = boost::bind (&KinFuApp::source_cb2_device, this, _1, _2, _3);
+    std::function<void (const DepthImagePtr&)> func2_dev = boost::bind (&KinFuApp::source_cb1_device, this, _1);
 
-    boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1_oni = boost::bind (&KinFuApp::source_cb2_oni, this, _1, _2, _3);
-    boost::function<void (const DepthImagePtr&)> func2_oni = boost::bind (&KinFuApp::source_cb1_oni, this, _1);
+    std::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1_oni = boost::bind (&KinFuApp::source_cb2_oni, this, _1, _2, _3);
+    std::function<void (const DepthImagePtr&)> func2_oni = boost::bind (&KinFuApp::source_cb1_oni, this, _1);
     
     bool is_oni = dynamic_cast<pcl::ONIGrabber*>(&capture_) != nullptr;
-    boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1 = is_oni ? func1_oni : func1_dev;
-    boost::function<void (const DepthImagePtr&)> func2 = is_oni ? func2_oni : func2_dev;
+    std::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1 = is_oni ? func1_oni : func1_dev;
+    std::function<void (const DepthImagePtr&)> func2 = is_oni ? func2_oni : func2_dev;
 
-    boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > func3 = boost::bind (&KinFuApp::source_cb3, this, _1);
+    std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > func3 = boost::bind (&KinFuApp::source_cb3, this, _1);
 
     bool need_colors = integrate_colors_ || registration_;
     if ( pcd_source_ && !capture_.providesCallback<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)>() )

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -47,6 +47,7 @@ Work in progress: patch by Marco (AUG,19th 2012)
 
 #define _CRT_SECURE_NO_DEPRECATE
 
+#include <functional>
 #include <iostream>
 #include <thread>
 
@@ -981,9 +982,9 @@ struct KinFuLSApp
     typedef boost::shared_ptr<DepthImage> DepthImagePtr;
     typedef boost::shared_ptr<Image>      ImagePtr;
 
-    boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1 = boost::bind (&KinFuLSApp::source_cb2, this, _1, _2, _3);
-    boost::function<void (const DepthImagePtr&)> func2 = boost::bind (&KinFuLSApp::source_cb1, this, _1);
-    boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > func3 = boost::bind (&KinFuLSApp::source_cb3, this, _1);
+    std::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func1 = boost::bind (&KinFuLSApp::source_cb2, this, _1, _2, _3);
+    std::function<void (const DepthImagePtr&)> func2 = boost::bind (&KinFuLSApp::source_cb1, this, _1);
+    std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > func3 = boost::bind (&KinFuLSApp::source_cb3, this, _1);
 
     bool need_colors = integrate_colors_ || registration_ || enable_texture_extraction_;
 

--- a/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
+++ b/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
@@ -46,6 +46,7 @@
 #include <condition_variable>
 #include <csignal>
 #include <ctime>
+#include <functional>
 #include <mutex>
 #include <thread>
 
@@ -257,9 +258,9 @@ void
 grabAndSend ()
 {
   pcl::Grabber* interface = new pcl::OpenNIGrabber ();
-  //boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& )> f = boost::bind(&grabberCallBack, _1);
+  //std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& )> f = boost::bind(&grabberCallBack, _1);
 
-  boost::function<void (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant)> f = boost::bind (&grabberMapsCallBack, _1, _2, _3);
+  std::function<void (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant)> f = boost::bind (&grabberMapsCallBack, _1, _2, _3);
 
 
   interface->registerCallback (f);

--- a/gpu/people/tools/people_app.cpp
+++ b/gpu/people/tools/people_app.cpp
@@ -56,6 +56,7 @@
 #include <pcl/io/png_io.h>
 #include <boost/filesystem.hpp>
 
+#include <functional>
 #include <iostream>
 
 namespace pc = pcl::console;
@@ -281,8 +282,8 @@ class PeoplePCDApp
       typedef boost::shared_ptr<openni_wrapper::DepthImage> DepthImagePtr;
       typedef boost::shared_ptr<openni_wrapper::Image> ImagePtr;
       
-      boost::function<void (const boost::shared_ptr<const PointCloud<PointXYZRGBA> >&)> func1 = boost::bind (&PeoplePCDApp::source_cb1, this, _1);
-      boost::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func2 = boost::bind (&PeoplePCDApp::source_cb2, this, _1, _2, _3);                  
+      std::function<void (const boost::shared_ptr<const PointCloud<PointXYZRGBA> >&)> func1 = boost::bind (&PeoplePCDApp::source_cb1, this, _1);
+      std::function<void (const ImagePtr&, const DepthImagePtr&, float constant)> func2 = boost::bind (&PeoplePCDApp::source_cb2, this, _1, _2, _3);                  
       boost::signals2::connection c = cloud_cb_ ? capture_.registerCallback (func1) : capture_.registerCallback (func2);
 
       {

--- a/gpu/people/tools/people_tracking.cpp
+++ b/gpu/people/tools/people_tracking.cpp
@@ -5,7 +5,6 @@
  **/
 
 ////// ALL INCLUDES /////////////
-#include <thread>
 #include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -15,14 +14,16 @@
 #include <pcl/segmentation/extract_labeled_clusters.h>
 #include <pcl/segmentation/seeded_hue_segmentation.h>
 #include <pcl/people/conversion/conversions.h>
-#include <opencv2/opencv.hpp>
 #include <pcl/people/label_skeleton/conversion.h>
 #include <pcl/people/trees/tree_live.h>
-//#include <pcl/filters/passthrough.h>
-//#include <pcl/common/time.h>
 #include <pcl/io/openni_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
 #include <pcl/console/parse.h>
+
+#include <opencv2/opencv.hpp>
+
+#include <functional>
+#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -58,7 +59,7 @@ class PeopleTrackingApp
     {
       pcl::Grabber* interface = new pcl::OpenNIGrabber();
 
-      boost::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f =
+      std::function<void (const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr&)> f =
         boost::bind (&PeopleTrackingApp::cloud_cb_, this, _1);
 
       interface->registerCallback (f);

--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -48,7 +48,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/bind.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/function.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>

--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -69,7 +69,7 @@ namespace pcl
         * \return Connection object, that can be used to disconnect the callback method from the signal again.
         */
       template<typename T> boost::signals2::connection 
-      registerCallback (const boost::function<T>& callback);
+      registerCallback (const std::function<T>& callback);
 
       /** \brief indicates whether a signal with given parameter-type exists or not
         * \return true if signal exists, false otherwise
@@ -231,7 +231,7 @@ namespace pcl
   }
 
   template<typename T> boost::signals2::connection
-  Grabber::registerCallback (const boost::function<T> & callback)
+  Grabber::registerCallback (const std::function<T> & callback)
   {
     typedef boost::signals2::signal<T> Signal;
     if (signals_.find (typeid (T).name ()) == signals_.end ())

--- a/io/include/pcl/io/openni2/openni2_device.h
+++ b/io/include/pcl/io/openni2/openni2_device.h
@@ -38,7 +38,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/bind.hpp>
-#include <boost/function.hpp>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -73,12 +73,12 @@ namespace pcl
       {
         public:
 
-          typedef boost::function<void(boost::shared_ptr<Image>, void* cookie) > ImageCallbackFunction;
-          typedef boost::function<void(boost::shared_ptr<DepthImage>, void* cookie) > DepthImageCallbackFunction;
-          typedef boost::function<void(boost::shared_ptr<IRImage>, void* cookie) > IRImageCallbackFunction;
+          typedef std::function<void(boost::shared_ptr<Image>, void* cookie) > ImageCallbackFunction;
+          typedef std::function<void(boost::shared_ptr<DepthImage>, void* cookie) > DepthImageCallbackFunction;
+          typedef std::function<void(boost::shared_ptr<IRImage>, void* cookie) > IRImageCallbackFunction;
           typedef unsigned CallbackHandle;
 
-          typedef boost::function<void(openni::VideoStream& stream)> StreamCallbackFunction;
+          typedef std::function<void(openni::VideoStream& stream)> StreamCallbackFunction;
 
           OpenNI2Device (const std::string& device_URI);
           virtual ~OpenNI2Device ();

--- a/io/include/pcl/io/openni2/openni2_frame_listener.h
+++ b/io/include/pcl/io/openni2/openni2_frame_listener.h
@@ -37,7 +37,7 @@
 
 #pragma once
 
-#include <boost/function.hpp>
+#include <functional>
 
 #include "OpenNI.h"
 
@@ -48,7 +48,7 @@ namespace pcl
     namespace openni2
     {
 
-      typedef boost::function<void(openni::VideoStream& stream)> StreamCallbackFunction;
+      typedef std::function<void(openni::VideoStream& stream)> StreamCallbackFunction;
 
       /* Each NewFrameListener may only listen to one VideoStream at a time.
       **/

--- a/io/include/pcl/io/openni_camera/openni_device.h
+++ b/io/include/pcl/io/openni_camera/openni_device.h
@@ -40,18 +40,19 @@
 #include <pcl/pcl_config.h>
 #ifdef HAVE_OPENNI
 
-#include <condition_variable>
-#include <map>
-#include <mutex>
-#include <thread>
-#include <utility>
-#include <vector>
 #include "openni_exception.h"
 #include "openni.h"
 
 #include <pcl/io/boost.h>
 #include <pcl/pcl_macros.h>
 
+#include <condition_variable>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <thread>
+#include <utility>
+#include <vector>
 
 /// @todo Get rid of all exception-specifications, these are useless and soon to be deprecated
 
@@ -79,9 +80,9 @@ namespace openni_wrapper
       } DepthMode;
 
       typedef boost::shared_ptr<OpenNIDevice> Ptr;
-      typedef boost::function<void(boost::shared_ptr<Image>, void* cookie) > ImageCallbackFunction;
-      typedef boost::function<void(boost::shared_ptr<DepthImage>, void* cookie) > DepthImageCallbackFunction;
-      typedef boost::function<void(boost::shared_ptr<IRImage>, void* cookie) > IRImageCallbackFunction;
+      typedef std::function<void(boost::shared_ptr<Image>, void* cookie) > ImageCallbackFunction;
+      typedef std::function<void(boost::shared_ptr<DepthImage>, void* cookie) > DepthImageCallbackFunction;
+      typedef std::function<void(boost::shared_ptr<IRImage>, void* cookie) > IRImageCallbackFunction;
       typedef unsigned CallbackHandle;
 
     public:
@@ -280,7 +281,7 @@ namespace openni_wrapper
       virtual bool 
       isIRStreamRunning () const throw ();
 
-      /** \brief registers a callback function of boost::function type for the image stream with an optional user defined parameter.
+      /** \brief registers a callback function of std::function type for the image stream with an optional user defined parameter.
         *        The callback will always be called with a new image and the user data "cookie".
         * \param[in] callback the user callback to be called if a new image is available
         * \param[in] cookie the cookie that needs to be passed to the callback together with the new image.
@@ -308,7 +309,7 @@ namespace openni_wrapper
       unregisterImageCallback (const CallbackHandle& callbackHandle) throw ();
 
 
-      /** \brief registers a callback function of boost::function type for the depth stream with an optional user defined parameter.
+      /** \brief registers a callback function of std::function type for the depth stream with an optional user defined parameter.
         *        The callback will always be called with a new depth image and the user data "cookie".
         * \param[in] callback the user callback to be called if a new depth image is available
         * \param[in] cookie the cookie that needs to be passed to the callback together with the new depth image.
@@ -335,7 +336,7 @@ namespace openni_wrapper
       bool 
       unregisterDepthCallback (const CallbackHandle& callbackHandle) throw ();
 
-      /** \brief registers a callback function of boost::function type for the IR stream with an optional user defined parameter.
+      /** \brief registers a callback function of std::function type for the IR stream with an optional user defined parameter.
         *        The callback will always be called with a new IR image and the user data "cookie".
         * \param[in] callback the user callback to be called if a new IR image is available
         * \param[in] cookie the cookie that needs to be passed to the callback together with the new IR image.
@@ -445,9 +446,9 @@ namespace openni_wrapper
       OpenNIDevice (OpenNIDevice const &);
       OpenNIDevice& operator=(OpenNIDevice const &);
     protected:
-      typedef boost::function<void(boost::shared_ptr<Image>) > ActualImageCallbackFunction;
-      typedef boost::function<void(boost::shared_ptr<DepthImage>) > ActualDepthImageCallbackFunction;
-      typedef boost::function<void(boost::shared_ptr<IRImage>) > ActualIRImageCallbackFunction;
+      typedef std::function<void(boost::shared_ptr<Image>) > ActualImageCallbackFunction;
+      typedef std::function<void(boost::shared_ptr<DepthImage>) > ActualDepthImageCallbackFunction;
+      typedef std::function<void(boost::shared_ptr<IRImage>) > ActualIRImageCallbackFunction;
 
       OpenNIDevice (xn::Context& context, const xn::NodeInfo& device_node, const xn::NodeInfo& image_node, const xn::NodeInfo& depth_node, const xn::NodeInfo& ir_node);
       OpenNIDevice (xn::Context& context, const xn::NodeInfo& device_node, const xn::NodeInfo& depth_node, const xn::NodeInfo& ir_node);

--- a/io/include/pcl/io/ply/ply_parser.h
+++ b/io/include/pcl/io/ply/ply_parser.h
@@ -77,32 +77,32 @@ namespace pcl
       {
         public:
 
-          typedef boost::function<void (std::size_t, const std::string&)> info_callback_type;
-          typedef boost::function<void (std::size_t, const std::string&)> warning_callback_type;
-          typedef boost::function<void (std::size_t, const std::string&)> error_callback_type;
+          typedef std::function<void (std::size_t, const std::string&)> info_callback_type;
+          typedef std::function<void (std::size_t, const std::string&)> warning_callback_type;
+          typedef std::function<void (std::size_t, const std::string&)> error_callback_type;
          
-          typedef boost::function<void ()> magic_callback_type;
-          typedef boost::function<void (format_type, const std::string&)> format_callback_type;
-          typedef boost::function<void (const std::string&)> comment_callback_type;
-          typedef boost::function<void (const std::string&)> obj_info_callback_type;
-          typedef boost::function<bool ()> end_header_callback_type;
+          typedef std::function<void ()> magic_callback_type;
+          typedef std::function<void (format_type, const std::string&)> format_callback_type;
+          typedef std::function<void (const std::string&)> comment_callback_type;
+          typedef std::function<void (const std::string&)> obj_info_callback_type;
+          typedef std::function<bool ()> end_header_callback_type;
          
-          typedef boost::function<void ()> begin_element_callback_type;
-          typedef boost::function<void ()> end_element_callback_type;
+          typedef std::function<void ()> begin_element_callback_type;
+          typedef std::function<void ()> end_element_callback_type;
           typedef boost::tuple<begin_element_callback_type, end_element_callback_type> element_callbacks_type;
-          typedef boost::function<element_callbacks_type (const std::string&, std::size_t)> element_definition_callback_type;
+          typedef std::function<element_callbacks_type (const std::string&, std::size_t)> element_definition_callback_type;
          
           template <typename ScalarType>
           struct scalar_property_callback_type
           {
-            typedef boost::function<void (ScalarType)> type;
+            typedef std::function<void (ScalarType)> type;
           };
 
           template <typename ScalarType>
           struct scalar_property_definition_callback_type
           {
             typedef typename scalar_property_callback_type<ScalarType>::type scalar_property_callback_type;
-            typedef boost::function<scalar_property_callback_type (const std::string&, const std::string&)> type;
+            typedef std::function<scalar_property_callback_type (const std::string&, const std::string&)> type;
           };
        
           typedef boost::mpl::vector<int8, int16, int32, uint8, uint16, uint32, float32, float64> scalar_types;
@@ -169,19 +169,19 @@ namespace pcl
           template <typename SizeType, typename ScalarType>
           struct list_property_begin_callback_type
           {
-            typedef boost::function<void (SizeType)> type;
+            typedef std::function<void (SizeType)> type;
           };
          
           template <typename SizeType, typename ScalarType>
           struct list_property_element_callback_type
           {
-            typedef boost::function<void (ScalarType)> type;
+            typedef std::function<void (ScalarType)> type;
           };
        
           template <typename SizeType, typename ScalarType>
           struct list_property_end_callback_type
           {
-            typedef boost::function<void ()> type;
+            typedef std::function<void ()> type;
           };
 
           template <typename SizeType, typename ScalarType>
@@ -190,7 +190,7 @@ namespace pcl
             typedef typename list_property_begin_callback_type<SizeType, ScalarType>::type list_property_begin_callback_type;
             typedef typename list_property_element_callback_type<SizeType, ScalarType>::type list_property_element_callback_type;
             typedef typename list_property_end_callback_type<SizeType, ScalarType>::type list_property_end_callback_type;
-            typedef boost::function<
+            typedef std::function<
             boost::tuple<
             list_property_begin_callback_type,
               list_property_element_callback_type,

--- a/io/include/pcl/io/ply_io.h
+++ b/io/include/pcl/io/ply_io.h
@@ -283,7 +283,7 @@ namespace pcl
         * \param[in] element_name element name
         * \param[in] count number of instances
         */
-      boost::tuple<boost::function<void ()>, boost::function<void ()> > 
+      boost::tuple<std::function<void ()>, std::function<void ()> > 
       elementDefinitionCallback (const std::string& element_name, std::size_t count);
       
       bool
@@ -293,7 +293,7 @@ namespace pcl
         * \param[in] element_name element name to which the property belongs
         * \param[in] property_name property name
         */
-      template <typename ScalarType> boost::function<void (ScalarType)> 
+      template <typename ScalarType> std::function<void (ScalarType)> 
       scalarPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name);
 
       /** \brief function called when a list property is parsed
@@ -301,7 +301,7 @@ namespace pcl
         * \param[in] property_name list property name
         */
       template <typename SizeType, typename ScalarType>
-      boost::tuple<boost::function<void (SizeType)>, boost::function<void (ScalarType)>, boost::function<void ()> >
+      boost::tuple<std::function<void (SizeType)>, std::function<void (ScalarType)>, std::function<void ()> >
       listPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name);
       
       /** \brief function called at the beginning of a list property parsing.

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -46,7 +46,7 @@
 #include <pcl/io/boost.h>
 #include <sstream>
 
-boost::tuple<boost::function<void ()>, boost::function<void ()> >
+boost::tuple<std::function<void ()>, std::function<void ()> >
 pcl::PLYReader::elementDefinitionCallback (const std::string& element_name, std::size_t count)
 {
   if (element_name == "vertex")
@@ -63,14 +63,14 @@ pcl::PLYReader::elementDefinitionCallback (const std::string& element_name, std:
     cloud_->point_step = 0;
     cloud_->row_step = 0;
     vertex_count_ = 0;
-    return (boost::tuple<boost::function<void ()>, boost::function<void ()> > (
+    return (boost::tuple<std::function<void ()>, std::function<void ()> > (
               boost::bind (&pcl::PLYReader::vertexBeginCallback, this),
               boost::bind (&pcl::PLYReader::vertexEndCallback, this)));
   }
   else if ((element_name == "face") && polygons_)
   {
     polygons_->reserve (count);
-    return (boost::tuple<boost::function<void ()>, boost::function<void ()> > (
+    return (boost::tuple<std::function<void ()>, std::function<void ()> > (
             boost::bind (&pcl::PLYReader::faceBeginCallback, this),
             boost::bind (&pcl::PLYReader::faceEndCallback, this)));
   }
@@ -82,7 +82,7 @@ pcl::PLYReader::elementDefinitionCallback (const std::string& element_name, std:
   else if (element_name == "range_grid")
   {
     range_grid_->reserve (count);
-    return (boost::tuple<boost::function<void ()>, boost::function<void ()> > (
+    return (boost::tuple<std::function<void ()>, std::function<void ()> > (
               boost::bind (&pcl::PLYReader::rangeGridBeginCallback, this),
               boost::bind (&pcl::PLYReader::rangeGridEndCallback, this)));
   }
@@ -127,7 +127,7 @@ pcl::PLYReader::amendProperty (const std::string& old_name, const std::string& n
 namespace pcl
 {
   template <>
-  boost::function<void (pcl::io::ply::float32)>
+  std::function<void (pcl::io::ply::float32)>
   PLYReader::scalarPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
     if (element_name == "vertex")
@@ -196,7 +196,7 @@ namespace pcl
     }
   }
 
-  template <> boost::function<void (pcl::io::ply::uint8)>
+  template <> std::function<void (pcl::io::ply::uint8)>
   PLYReader::scalarPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
     if (element_name == "vertex")
@@ -228,7 +228,7 @@ namespace pcl
       return {};
   }
 
-  template <> boost::function<void (pcl::io::ply::int32)>
+  template <> std::function<void (pcl::io::ply::int32)>
   PLYReader::scalarPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
     if (element_name == "vertex")
@@ -253,7 +253,7 @@ namespace pcl
       return {};
   }
 
-  template <typename Scalar> boost::function<void (Scalar)>
+  template <typename Scalar> std::function<void (Scalar)>
   PLYReader::scalarPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
     if (element_name == "vertex")
@@ -317,12 +317,12 @@ namespace pcl
   }
 
   template <>
-  boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> >
+  boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> >
   pcl::PLYReader::listPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
     if ((element_name == "range_grid") && (property_name == "vertex_indices" || property_name == "vertex_index"))
     {
-      return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
+      return boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
         boost::bind (&pcl::PLYReader::rangeGridVertexIndicesBeginCallback, this, _1),
         boost::bind (&pcl::PLYReader::rangeGridVertexIndicesElementCallback, this, _1),
         boost::bind (&pcl::PLYReader::rangeGridVertexIndicesEndCallback, this)
@@ -330,7 +330,7 @@ namespace pcl
     }
     else if ((element_name == "face") && (property_name == "vertex_indices" || property_name == "vertex_index") && polygons_)
     {
-      return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
+      return boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
         boost::bind (&pcl::PLYReader::faceVertexIndicesBeginCallback, this, _1),
         boost::bind (&pcl::PLYReader::faceVertexIndicesElementCallback, this, _1),
         boost::bind (&pcl::PLYReader::faceVertexIndicesEndCallback, this)
@@ -349,7 +349,7 @@ namespace pcl
       else
         cloud_->point_step = static_cast<uint32_t> (std::numeric_limits<uint32_t>::max ());
       do_resize_ = true;
-      return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
+      return boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
                                                                                                       boost::bind (&pcl::PLYReader::vertexListPropertyBeginCallback<pcl::io::ply::uint8>, this, property_name, _1),
         boost::bind (&pcl::PLYReader::vertexListPropertyContentCallback<pcl::io::ply::int32>, this, _1),
         boost::bind (&pcl::PLYReader::vertexListPropertyEndCallback, this)
@@ -362,7 +362,7 @@ namespace pcl
   }
 
   template <typename SizeType, typename ContentType>
-  boost::tuple<boost::function<void (SizeType)>, boost::function<void (ContentType)>, boost::function<void ()> >
+  boost::tuple<std::function<void (SizeType)>, std::function<void (ContentType)>, std::function<void ()> >
   pcl::PLYReader::listPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
     if (element_name == "vertex")
@@ -378,7 +378,7 @@ namespace pcl
       else
         cloud_->point_step = static_cast<uint32_t> (std::numeric_limits<uint32_t>::max ());
       do_resize_ = true;
-      return boost::tuple<boost::function<void (SizeType)>, boost::function<void (ContentType)>, boost::function<void ()> > (
+      return boost::tuple<std::function<void (SizeType)>, std::function<void (ContentType)>, std::function<void ()> > (
         boost::bind (&pcl::PLYReader::vertexListPropertyBeginCallback<SizeType>, this, property_name, _1),
         boost::bind (&pcl::PLYReader::vertexListPropertyContentCallback<ContentType>, this, _1),
         boost::bind (&pcl::PLYReader::vertexListPropertyEndCallback, this)

--- a/io/tools/hdl_grabber_example.cpp
+++ b/io/tools/hdl_grabber_example.cpp
@@ -70,14 +70,14 @@ class SimpleHDLGrabber
     {
       pcl::HDLGrabber interface (calibrationFile, pcapFile);
       // make callback function from member function
-      boost::function<void(const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&, float, float)> f =
+      std::function<void(const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&, float, float)> f =
           boost::bind(&SimpleHDLGrabber::sectorScan, this, _1, _2, _3);
 
       // connect callback function for desired signal. In this case its a sector with XYZ and intensity information
       //boost::signals2::connection c = interface.registerCallback(f);
 
       // Register a callback function that gets complete 360 degree sweeps.
-      boost::function<void(const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&)> f2 = boost::bind(
+      std::function<void(const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&)> f2 = boost::bind(
           &SimpleHDLGrabber::sweepScan, this, _1);
       boost::signals2::connection c2 = interface.registerCallback(f2);
 

--- a/io/tools/openni_grabber_depth_example.cpp
+++ b/io/tools/openni_grabber_depth_example.cpp
@@ -77,7 +77,7 @@ class SimpleOpenNIProcessor
       interface.getDevice ()->setDepthOutputFormat (mode);
 
       // make callback function from member function
-      boost::function<void (const boost::shared_ptr<openni_wrapper::DepthImage>&)> f2 = boost::bind (&SimpleOpenNIProcessor::imageDepthImageCallback, this, _1);
+      std::function<void (const boost::shared_ptr<openni_wrapper::DepthImage>&)> f2 = boost::bind (&SimpleOpenNIProcessor::imageDepthImageCallback, this, _1);
 
       // connect callback function for desired signal. In this case its a point cloud with color values
       boost::signals2::connection c2 = interface.registerCallback (f2);

--- a/io/tools/openni_grabber_example.cpp
+++ b/io/tools/openni_grabber_example.cpp
@@ -99,14 +99,14 @@ class SimpleOpenNIProcessor
       interface.getDevice ()->setDepthOutputFormat (mode);
 
       // make callback function from member function
-      boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
+      std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
         boost::bind (&SimpleOpenNIProcessor::cloud_cb_, this, _1);
 
       // connect callback function for desired signal. In this case its a point cloud with color values
       boost::signals2::connection c = interface.registerCallback (f);
 
       // make callback function from member function
-      boost::function<void (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant)> f2 =
+      std::function<void (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant)> f2 =
         boost::bind (&SimpleOpenNIProcessor::imageDepthImageCallback, this, _1, _2, _3);
 
       // connect callback function for desired signal. In this case its a point cloud with color values

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -232,7 +232,7 @@ class Producer
       grabber->getDevice ()->setDepthOutputFormat (depth_mode_);
 
       Grabber* interface = grabber;
-      boost::function<void (const typename PointCloud<PointT>::ConstPtr&)> f = boost::bind (&Producer::grabberCallBack, this, _1);
+      std::function<void (const typename PointCloud<PointT>::ConstPtr&)> f = boost::bind (&Producer::grabberCallBack, this, _1);
       interface->registerCallback (f);
       interface->start ();
 

--- a/io/tools/ply/ply2obj.cpp
+++ b/io/tools/ply/ply2obj.cpp
@@ -81,15 +81,15 @@ class ply_to_obj_converter
     void
     error_callback (const std::string& filename, std::size_t line_number, const std::string& message);
 
-    boost::tuple<boost::function<void ()>, boost::function<void ()> > 
+    boost::tuple<std::function<void ()>, std::function<void ()> > 
     element_definition_callback (const std::string& element_name, std::size_t count);
 
-    template <typename ScalarType> boost::function<void (ScalarType)> 
+    template <typename ScalarType> std::function<void (ScalarType)> 
     scalar_property_definition_callback (const std::string& element_name, const std::string& property_name);
 
-    template <typename SizeType, typename ScalarType> boost::tuple<boost::function<void (SizeType)>, 
-                                                                      boost::function<void (ScalarType)>, 
-                                                                      boost::function<void ()> > 
+    template <typename SizeType, typename ScalarType> boost::tuple<std::function<void (SizeType)>, 
+                                                                      std::function<void (ScalarType)>, 
+                                                                      std::function<void ()> > 
     list_property_definition_callback (const std::string& element_name, const std::string& property_name);
 
     void
@@ -155,19 +155,19 @@ ply_to_obj_converter::error_callback (const std::string& filename, std::size_t l
   std::cerr << filename << ":" << line_number << ": " << "error: " << message << std::endl;
 }
 
-boost::tuple<boost::function<void ()>, boost::function<void ()> > 
+boost::tuple<std::function<void ()>, std::function<void ()> > 
 ply_to_obj_converter::element_definition_callback (const std::string& element_name, std::size_t)
 {
   if (element_name == "vertex") 
   {
-    return boost::tuple<boost::function<void ()>, boost::function<void ()> > (
+    return boost::tuple<std::function<void ()>, std::function<void ()> > (
       boost::bind (&ply_to_obj_converter::vertex_begin, this),
       boost::bind (&ply_to_obj_converter::vertex_end, this)
     );
   }
   else if (element_name == "face") 
   {
-    return boost::tuple<boost::function<void ()>, boost::function<void ()> > (
+    return boost::tuple<std::function<void ()>, std::function<void ()> > (
       boost::bind (&ply_to_obj_converter::face_begin, this),
       boost::bind (&ply_to_obj_converter::face_end, this)
     );
@@ -177,7 +177,7 @@ ply_to_obj_converter::element_definition_callback (const std::string& element_na
   }
 }
 
-template <> boost::function<void (pcl::io::ply::float32)> 
+template <> std::function<void (pcl::io::ply::float32)> 
 ply_to_obj_converter::scalar_property_definition_callback (const std::string& element_name, const std::string& property_name)
 {
   if (element_name == "vertex") {
@@ -199,11 +199,11 @@ ply_to_obj_converter::scalar_property_definition_callback (const std::string& el
   }
 }
 
-template <> boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > 
+template <> boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > 
 ply_to_obj_converter::list_property_definition_callback (const std::string& element_name, const std::string& property_name)
 {
   if ((element_name == "face") && (property_name == "vertex_indices")) {
-    return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, boost::function<void (pcl::io::ply::int32)>, boost::function<void ()> > (
+    return boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
       boost::bind (&ply_to_obj_converter::face_vertex_indices_begin, this, _1),
       boost::bind (&ply_to_obj_converter::face_vertex_indices_element, this, _1),
       boost::bind (&ply_to_obj_converter::face_vertex_indices_end, this)

--- a/io/tools/ply/ply2ply.cpp
+++ b/io/tools/ply/ply2ply.cpp
@@ -95,13 +95,13 @@ class ply_to_ply_converter
     void
     element_end_callback();
 
-    boost::tuple<boost::function<void()>, boost::function<void()> > 
+    boost::tuple<std::function<void()>, std::function<void()> > 
     element_definition_callback(const std::string& element_name, std::size_t count);
 
     template <typename ScalarType> void
     scalar_property_callback(ScalarType scalar);
 
-    template <typename ScalarType> boost::function<void (ScalarType)> 
+    template <typename ScalarType> std::function<void (ScalarType)> 
     scalar_property_definition_callback(const std::string& element_name, const std::string& property_name);
 
     template <typename SizeType, typename ScalarType> void
@@ -113,9 +113,9 @@ class ply_to_ply_converter
     template <typename SizeType, typename ScalarType> void
     list_property_end_callback();
 
-    template <typename SizeType, typename ScalarType> boost::tuple<boost::function<void (SizeType)>, 
-                                                                      boost::function<void (ScalarType)>, 
-                                                                      boost::function<void ()> > 
+    template <typename SizeType, typename ScalarType> boost::tuple<std::function<void (SizeType)>, 
+                                                                      std::function<void (ScalarType)>, 
+                                                                      std::function<void ()> > 
     list_property_definition_callback(const std::string& element_name, const std::string& property_name);
     
     void
@@ -211,10 +211,10 @@ ply_to_ply_converter::element_end_callback()
   }
 }
 
-boost::tuple<boost::function<void()>, boost::function<void()> > ply_to_ply_converter::element_definition_callback(const std::string& element_name, std::size_t count)
+boost::tuple<std::function<void()>, std::function<void()> > ply_to_ply_converter::element_definition_callback(const std::string& element_name, std::size_t count)
 {
   (*ostream_) << "element " << element_name << " " << count << "\n";
-  return boost::tuple<boost::function<void()>, boost::function<void()> >(
+  return boost::tuple<std::function<void()>, std::function<void()> >(
     boost::bind(&ply_to_ply_converter::element_begin_callback, this),
     boost::bind(&ply_to_ply_converter::element_end_callback, this)
   );
@@ -244,7 +244,7 @@ ply_to_ply_converter::scalar_property_callback(ScalarType scalar)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename ScalarType> boost::function<void (ScalarType)> 
+template <typename ScalarType> std::function<void (ScalarType)> 
 ply_to_ply_converter::scalar_property_definition_callback (const std::string&, const std::string& property_name)
 {
   (*ostream_) << "property " << pcl::io::ply::type_traits<ScalarType>::old_name() << " " << property_name << "\n";
@@ -300,13 +300,13 @@ template <typename SizeType, typename ScalarType> void
 ply_to_ply_converter::list_property_end_callback() {}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename SizeType, typename ScalarType> boost::tuple<boost::function<void (SizeType)>, 
-                                                                  boost::function<void (ScalarType)>, 
-                                                                  boost::function<void ()> > 
+template <typename SizeType, typename ScalarType> boost::tuple<std::function<void (SizeType)>, 
+                                                                  std::function<void (ScalarType)>, 
+                                                                  std::function<void ()> > 
 ply_to_ply_converter::list_property_definition_callback (const std::string&, const std::string& property_name)
 {
   (*ostream_) << "property list " << pcl::io::ply::type_traits<SizeType>::old_name() << " " << pcl::io::ply::type_traits<ScalarType>::old_name() << " " << property_name << "\n";
-  return boost::tuple<boost::function<void (SizeType)>, boost::function<void (ScalarType)>, boost::function<void ()> >(
+  return boost::tuple<std::function<void (SizeType)>, std::function<void (ScalarType)>, std::function<void ()> >(
     boost::bind(&ply_to_ply_converter::list_property_begin_callback<SizeType, ScalarType>, this, _1),
     boost::bind(&ply_to_ply_converter::list_property_element_callback<SizeType, ScalarType>, this, _1),
     boost::bind(&ply_to_ply_converter::list_property_end_callback<SizeType, ScalarType>, this)

--- a/io/tools/ply/ply2raw.cpp
+++ b/io/tools/ply/ply2raw.cpp
@@ -103,15 +103,15 @@ class ply_to_raw_converter
     void
     error_callback (const std::string& filename, std::size_t line_number, const std::string& message);
 
-    boost::tuple<boost::function<void ()>, boost::function<void ()> > 
+    boost::tuple<std::function<void ()>, std::function<void ()> > 
     element_definition_callback (const std::string& element_name, std::size_t count);
 
-    template <typename ScalarType> boost::function<void (ScalarType)> 
+    template <typename ScalarType> std::function<void (ScalarType)> 
     scalar_property_definition_callback (const std::string& element_name, const std::string& property_name);
 
-    template <typename SizeType, typename ScalarType>  boost::tuple<boost::function<void (SizeType)>, 
-                                                                       boost::function<void (ScalarType)>, 
-                                                                       boost::function<void ()> > 
+    template <typename SizeType, typename ScalarType>  boost::tuple<std::function<void (SizeType)>, 
+                                                                       std::function<void (ScalarType)>, 
+                                                                       std::function<void ()> > 
     list_property_definition_callback (const std::string& element_name, const std::string& property_name);
 
     void
@@ -168,17 +168,17 @@ ply_to_raw_converter::error_callback (const std::string& filename, std::size_t l
   std::cerr << filename << ":" << line_number << ": " << "error: " << message << std::endl;
 }
 
-boost::tuple<boost::function<void ()>, boost::function<void ()> > 
+boost::tuple<std::function<void ()>, std::function<void ()> > 
 ply_to_raw_converter::element_definition_callback (const std::string& element_name, std::size_t)
 {
   if (element_name == "vertex") {
-    return boost::tuple<boost::function<void ()>, boost::function<void ()> > (
+    return boost::tuple<std::function<void ()>, std::function<void ()> > (
       boost::bind (&ply_to_raw_converter::vertex_begin, this),
       boost::bind (&ply_to_raw_converter::vertex_end, this)
     );
   }
   else if (element_name == "face") {
-    return boost::tuple<boost::function<void ()>, boost::function<void ()> > (
+    return boost::tuple<std::function<void ()>, std::function<void ()> > (
       boost::bind (&ply_to_raw_converter::face_begin, this),
       boost::bind (&ply_to_raw_converter::face_end, this)
     );
@@ -188,7 +188,7 @@ ply_to_raw_converter::element_definition_callback (const std::string& element_na
   }
 }
 
-template <> boost::function<void (pcl::io::ply::float32)> 
+template <> std::function<void (pcl::io::ply::float32)> 
 ply_to_raw_converter::scalar_property_definition_callback (const std::string& element_name, const std::string& property_name)
 {
   if (element_name == "vertex") {
@@ -210,16 +210,16 @@ ply_to_raw_converter::scalar_property_definition_callback (const std::string& el
   }
 }
 
-template <> boost::tuple<boost::function<void (pcl::io::ply::uint8)>, 
-                            boost::function<void (pcl::io::ply::int32)>, 
-                            boost::function<void ()> > 
+template <> boost::tuple<std::function<void (pcl::io::ply::uint8)>, 
+                            std::function<void (pcl::io::ply::int32)>, 
+                            std::function<void ()> > 
 ply_to_raw_converter::list_property_definition_callback (const std::string& element_name, const std::string& property_name)
 {
   if ((element_name == "face") && (property_name == "vertex_indices")) 
   {
-    return boost::tuple<boost::function<void (pcl::io::ply::uint8)>, 
-      boost::function<void (pcl::io::ply::int32)>, 
-      boost::function<void ()> > (
+    return boost::tuple<std::function<void (pcl::io::ply::uint8)>, 
+      std::function<void (pcl::io::ply::int32)>, 
+      std::function<void ()> > (
         boost::bind (&ply_to_raw_converter::face_vertex_indices_begin, this, _1),
       boost::bind (&ply_to_raw_converter::face_vertex_indices_element, this, _1),
       boost::bind (&ply_to_raw_converter::face_vertex_indices_end, this)

--- a/keypoints/include/pcl/keypoints/keypoint.h
+++ b/keypoints/include/pcl/keypoints/keypoint.h
@@ -39,10 +39,10 @@
 
 // PCL includes
 #include <pcl/pcl_base.h>
-#include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <pcl/search/pcl_search.h>
 #include <pcl/pcl_config.h>
+#include <functional>
 
 namespace pcl
 {
@@ -67,8 +67,8 @@ namespace pcl
       typedef typename PointCloudIn::Ptr PointCloudInPtr;
       typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
       typedef pcl::PointCloud<PointOutT> PointCloudOut;
-      typedef boost::function<int (int, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
-      typedef boost::function<int (const PointCloudIn &cloud, int index, double, std::vector<int> &, std::vector<float> &)> SearchMethodSurface;
+      typedef std::function<int (int, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
+      typedef std::function<int (const PointCloudIn &cloud, int index, double, std::vector<int> &, std::vector<float> &)> SearchMethodSurface;
 
     public:
       /** \brief Empty constructor. */

--- a/octree/include/pcl/octree/boost.h
+++ b/octree/include/pcl/octree/boost.h
@@ -45,4 +45,3 @@
 
 // Marking all Boost headers as system headers to remove warnings
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/function.hpp>

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency.h
@@ -154,7 +154,7 @@ namespace pcl
           * \param[in] transform_func A boost:function pointer to the transform to be used. The transform must have one
           * parameter (a point) which it modifies in place. */
         void
-        setTransformFunction (boost::function<void (PointT &p)> transform_func)
+        setTransformFunction (std::function<void (PointT &p)> transform_func)
         {
           transform_func_ = transform_func;
         }
@@ -216,7 +216,7 @@ namespace pcl
         /// Local leaf pointer vector used to make iterating through leaves fast.
         LeafVectorT leaf_vector_;
 
-        boost::function<void (PointT &p)> transform_func_;
+        std::function<void (PointT &p)> transform_func_;
 
     };
 

--- a/people/apps/main_ground_based_people_detection.cpp
+++ b/people/apps/main_ground_based_people_detection.cpp
@@ -143,7 +143,7 @@ int main (int argc, char** argv)
   PointCloudT::Ptr cloud (new PointCloudT);
   bool new_cloud_available_flag = false;
   pcl::Grabber* interface = new pcl::OpenNIGrabber();
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> f =
       boost::bind (&cloud_cb_, _1, cloud, &new_cloud_available_flag);
   interface->registerCallback (f);
   interface->start ();

--- a/registration/include/pcl/registration/boost.h
+++ b/registration/include/pcl/registration/boost.h
@@ -50,5 +50,4 @@
 
 #include <boost/noncopyable.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/function.hpp>
 #include <boost/bind.hpp>

--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -181,7 +181,7 @@ namespace pcl
         {
           public:
             typedef typename pcl::PointCloud<FeatureT>::ConstPtr FeatureCloudConstPtr;
-            typedef boost::function<int (const pcl::PointCloud<FeatureT> &, int, std::vector<int> &, 
+            typedef std::function<int (const pcl::PointCloud<FeatureT> &, int, std::vector<int> &, 
                                           std::vector<float> &)> SearchMethod;
             
             typedef typename pcl::PointRepresentation<FeatureT>::ConstPtr PointRepresentationConstPtr;

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -354,7 +354,7 @@ namespace pcl
         const GeneralizedIterativeClosestPoint *gicp_;
       };
       
-      boost::function<void(const pcl::PointCloud<PointSource> &cloud_src,
+      std::function<void(const pcl::PointCloud<PointSource> &cloud_src,
                            const std::vector<int> &src_indices,
                            const pcl::PointCloud<PointTarget> &cloud_tgt,
                            const std::vector<int> &tgt_indices,

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -148,7 +148,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformati
     p += delta_p;
 
     // Update Visualizer (untested)
-    if (!update_visualizer_.empty())
+    if (update_visualizer_)
       update_visualizer_ (output, std::vector<int>(), *target_, std::vector<int>() );
 
     double cos_angle = 0.5 * (transformation_.coeff (0, 0) + transformation_.coeff (1, 1) + transformation_.coeff (2, 2) - 1);

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -469,7 +469,7 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
 
     nr_iterations_++;
     
-    if (!update_visualizer_.empty())
+    if (update_visualizer_)
       update_visualizer_ (output, *indices_, *target_, *indices_);
 
     //std::cout << "eps=" << fabs ((transformation - previous_transformation_).sum ()) << std::endl;

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -95,6 +95,18 @@ namespace pcl
       typedef typename CorrespondenceEstimation::Ptr CorrespondenceEstimationPtr;
       typedef typename CorrespondenceEstimation::ConstPtr CorrespondenceEstimationConstPtr;
 
+      /** \brief The callback signature to the function updating intermediate source point cloud position
+        * during it's registration to the target point cloud.
+        * \param[in] cloud_src - the point cloud which will be updated to match target
+        * \param[in] indices_src - a selector of points in cloud_src
+        * \param[in] cloud_tgt - the point cloud we want to register against
+        * \param[in] indices_tgt - a selector of points in cloud_tgt
+        */
+      using UpdateVisualizerCallbackSignature = void (const pcl::PointCloud<PointSource>&,
+                                                      const std::vector<int>&,
+                                                      const pcl::PointCloud<PointTarget>&,
+                                                      const std::vector<int>&);
+
       /** \brief Empty constructor. */
       Registration () 
         : tree_ (new KdTree)
@@ -367,10 +379,10 @@ namespace pcl
        * in order to update point cloud obtained after each iteration
        * \param[in] visualizerCallback reference of the user callback function
        */
-      template<typename FunctionSignature> inline bool
-      registerVisualizationCallback (boost::function<FunctionSignature> &visualizerCallback)
+      inline bool
+      registerVisualizationCallback (std::function<UpdateVisualizerCallbackSignature> &visualizerCallback)
       {
-        if (!visualizerCallback.empty())
+        if (visualizerCallback)
         {
           update_visualizer_ = visualizerCallback;
           return (true);
@@ -572,10 +584,7 @@ namespace pcl
       /** \brief Callback function to update intermediate source point cloud position during it's registration
         * to the target point cloud.
         */
-      boost::function<void(const pcl::PointCloud<PointSource> &cloud_src,
-                           const std::vector<int> &indices_src,
-                           const pcl::PointCloud<PointTarget> &cloud_tgt,
-                           const std::vector<int> &indices_tgt)> update_visualizer_;
+      std::function<UpdateVisualizerCallbackSignature> update_visualizer_;
 
       /** \brief Search for the closest nearest neighbor of a given point.
         * \param cloud the point cloud dataset to use for nearest neighbor search

--- a/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
+++ b/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
@@ -37,10 +37,10 @@
 
 #pragma once
 
-#include <boost/function.hpp>
-
 #include <pcl/pcl_base.h>
 #include <pcl/search/pcl_search.h>
+
+#include <functional>
 
 namespace pcl
 {
@@ -148,7 +148,7 @@ namespace pcl
       /** \brief Set the condition that needs to hold for neighboring points to be considered part of the same cluster.
         * This is an overloaded function provided for convenience. See the documentation for setConditionFunction(). */
       inline void
-      setConditionFunction (boost::function<bool (const PointT&, const PointT&, float)> condition_function)
+      setConditionFunction (std::function<bool (const PointT&, const PointT&, float)> condition_function)
       {
         condition_function_ = condition_function;
       }
@@ -237,7 +237,7 @@ namespace pcl
       SearcherPtr searcher_;
 
       /** \brief The condition function that needs to hold for clustering */
-      boost::function<bool (const PointT&, const PointT&, float)> condition_function_;
+      std::function<bool (const PointT&, const PointT&, float)> condition_function_;
 
       /** \brief The distance to scan for cluster candidates (default = 0.0) */
       float cluster_tolerance_;

--- a/surface/include/pcl/surface/boost.h
+++ b/surface/include/pcl/surface/boost.h
@@ -44,6 +44,5 @@
 #endif
 
 #include <boost/bind.hpp>
-#include <boost/function.hpp>
 #include <boost/dynamic_bitset/dynamic_bitset.hpp>
 #include <boost/shared_ptr.hpp>

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -719,7 +719,7 @@ pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
                                    const std::vector<int> &nn_indices,
                                    double search_radius,
                                    int polynomial_order,
-                                   boost::function<double(const double)> weight_func)
+                                   std::function<double(const double)> weight_func)
 {
   // Compute the plane coefficients
   EIGEN_ALIGN16 Eigen::Matrix3d covariance_matrix;
@@ -777,7 +777,7 @@ pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
     {
       // Note: The max_sq_radius parameter is only used if weight_func was not defined
       double max_sq_radius = 1;
-      if (weight_func.empty())
+      if (!weight_func)
       {
         max_sq_radius = search_radius * search_radius;
         weight_func = boost::bind (&pcl::MLSResult::computeMLSWeight, this, _1, max_sq_radius);

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -39,10 +39,9 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <random>
-
-#include <boost/function.hpp>
 
 // PCL includes
 #include <pcl/pcl_base.h>
@@ -210,7 +209,7 @@ namespace pcl
                        const std::vector<int> &nn_indices,
                        double search_radius,
                        int polynomial_order = 2,
-                       boost::function<double(const double)> weight_func = {});
+                       std::function<double(const double)> weight_func = {});
 
     Eigen::Vector3d query_point;  /**< \brief The query point about which the mls surface was generated */
     Eigen::Vector3d mean;         /**< \brief The mean point of all the neighbors. */
@@ -274,7 +273,7 @@ namespace pcl
       typedef typename PointCloudIn::Ptr PointCloudInPtr;
       typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
 
-      typedef boost::function<int (int, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
+      typedef std::function<int (int, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
 
       enum UpsamplingMethod
       {

--- a/test/io/test_grabbers.cpp
+++ b/test/io/test_grabbers.cpp
@@ -45,7 +45,7 @@ TEST (PCL, PCDGrabber)
   pcl::PCDGrabber<PointT> grabber (pcd_files_, 10, false); // TODO add directory functionality
   EXPECT_EQ (grabber.size (), pcds_.size ());
   vector<CloudT::ConstPtr> grabbed_clouds;
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
     fxn = boost::bind (cloud_callback_vector, &grabbed_clouds, _1);
   grabber.registerCallback (fxn);
   grabber.start ();
@@ -116,7 +116,7 @@ TEST (PCL, ImageGrabberTIFF)
   vector<CloudT::ConstPtr> tiff_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
     fxn = boost::bind (cloud_callback, &signal_received, &cloud_buffer, _1);
   grabber.registerCallback (fxn);
   grabber.setCameraIntrinsics (525., 525., 320., 240.); // Setting old intrinsics which were used to generate these tests
@@ -199,7 +199,7 @@ TEST (PCL, ImageGrabberPCLZF)
   vector <CloudT::ConstPtr> pclzf_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
     fxn = boost::bind (cloud_callback, &signal_received, &cloud_buffer, _1);
   grabber.registerCallback (fxn);
   grabber.start ();
@@ -278,7 +278,7 @@ TEST (PCL, ImageGrabberOMP)
   vector <CloudT::ConstPtr> pclzf_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
     fxn = boost::bind (cloud_callback, &signal_received, &cloud_buffer, _1);
   grabber.registerCallback (fxn);
   grabber.setNumberOfThreads (0); // Let OMP select
@@ -371,7 +371,7 @@ TEST (PCL, ImageGrabberSetIntrinsicsTIFF)
   vector <CloudT::ConstPtr> tiff_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
     fxn = boost::bind (cloud_callback, &signal_received, &cloud_buffer, _1);
   grabber.registerCallback (fxn);
   grabber.start ();
@@ -449,7 +449,7 @@ TEST (PCL, ImageGrabberSetIntrinsicsPCLZF)
   vector <CloudT::ConstPtr> pclzf_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
-  boost::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
+  std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)> 
     fxn = boost::bind (cloud_callback, &signal_received, &cloud_buffer, _1);
   grabber.registerCallback (fxn);
   grabber.start ();

--- a/tools/davidsdk_viewer.cpp
+++ b/tools/davidsdk_viewer.cpp
@@ -93,7 +93,7 @@ main (int argc,
   //davidsdk_ptr->setFileFormatToPLY();
   std::cout << "Using " << davidsdk_ptr->getFileFormat () << " file format" << std::endl;
 
-  boost::function<void
+  std::function<void
   (const PointCloudXYZ::Ptr&)> f = boost::bind (&grabberCallback, _1);
   davidsdk_ptr->registerCallback (f);
   davidsdk_ptr->start ();

--- a/tools/depth_sense_viewer.cpp
+++ b/tools/depth_sense_viewer.cpp
@@ -140,7 +140,7 @@ class DepthSenseViewer
     void
     run ()
     {
-      boost::function<void (const typename PointCloudT::ConstPtr&)> f = boost::bind (&DepthSenseViewer::cloudCallback, this, _1);
+      std::function<void (const typename PointCloudT::ConstPtr&)> f = boost::bind (&DepthSenseViewer::cloudCallback, this, _1);
       connection_ = grabber_.registerCallback (f);
       grabber_.start ();
       while (!viewer_.wasStopped ())

--- a/tools/ensenso_viewer.cpp
+++ b/tools/ensenso_viewer.cpp
@@ -76,7 +76,7 @@ main (void)
   ensenso_ptr->openTcpPort ();
   ensenso_ptr->openDevice ();
 
-  boost::function<void
+  std::function<void
   (const PointCloudXYZ::Ptr&)> f = boost::bind (&grabberCallback, _1);
   ensenso_ptr->registerCallback (f);
   ensenso_ptr->start ();

--- a/tools/hdl_viewer_simple.cpp
+++ b/tools/hdl_viewer_simple.cpp
@@ -147,11 +147,8 @@ class SimpleHDLViewer
       cloud_viewer_->initCameraParameters ();
       cloud_viewer_->setCameraPosition (0.0, 0.0, 30.0, 0.0, 1.0, 0.0, 0);
       cloud_viewer_->setCameraClipDistances (0.0, 50.0);
-      //cloud_viewer_->registerMouseCallback(&SimpleHDLViewer::mouse_callback, *this);
-      //cloud_viewer_->registerKeyboardCallback (&SimpleHDLViewer::keyboard_callback, *this);
 
-      //boost::function<void(const CloudConstPtr&, float, float)> cloud_cb = boost::bind(&SimpleHDLViewer::cloud_callback, this, _1, _2, _3);
-      boost::function<void (const CloudConstPtr&)> cloud_cb = boost::bind (
+      std::function<void (const CloudConstPtr&)> cloud_cb = boost::bind (
           &SimpleHDLViewer::cloud_callback, this, _1);
       boost::signals2::connection cloud_connection = grabber_.registerCallback (
           cloud_cb);

--- a/tools/image_grabber_saver.cpp
+++ b/tools/image_grabber_saver.cpp
@@ -133,7 +133,7 @@ main (int argc, char** argv)
   //grabber->setFocalLength(focal_length); // FIXME
 
   EventHelper h;
-  boost::function<void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > f = boost::bind (&EventHelper::cloud_cb, &h, _1);
+  std::function<void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > f = boost::bind (&EventHelper::cloud_cb, &h, _1);
   boost::signals2::connection c1 = grabber->registerCallback (f);
 
   do

--- a/tools/image_grabber_viewer.cpp
+++ b/tools/image_grabber_viewer.cpp
@@ -222,7 +222,7 @@ main (int argc, char** argv)
   
 
   EventHelper h;
-  boost::function<void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > f = boost::bind (&EventHelper::cloud_cb, &h, _1);
+  std::function<void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > f = boost::bind (&EventHelper::cloud_cb, &h, _1);
   boost::signals2::connection c1 = grabber->registerCallback (f);
 
   std::string mouse_msg_3D ("Mouse coordinates in PCL Visualizer");

--- a/tools/oni2pcd.cpp
+++ b/tools/oni2pcd.cpp
@@ -83,7 +83,7 @@ main (int argc, char **argv)
   }
 
   pcl::ONIGrabber* grabber = new pcl::ONIGrabber (argv[1], false, false);
-  boost::function<void (const CloudConstPtr&) > f = boost::bind (&cloud_cb, _1);
+  std::function<void (const CloudConstPtr&) > f = boost::bind (&cloud_cb, _1);
   boost::signals2::connection c = grabber->registerCallback (f);
 
   while (grabber->hasDataLeft ())

--- a/tools/oni_viewer_simple.cpp
+++ b/tools/oni_viewer_simple.cpp
@@ -122,7 +122,7 @@ public:
   {
     //pcl::Grabber* interface = new pcl::OpenNIGrabber(device_id_, pcl::OpenNIGrabber::OpenNI_QQVGA_30Hz, pcl::OpenNIGrabber::OpenNI_VGA_30Hz);
 
-    boost::function<void (const CloudConstPtr&) > f = boost::bind (&SimpleONIViewer::cloud_cb_, this, _1);
+    std::function<void (const CloudConstPtr&) > f = boost::bind (&SimpleONIViewer::cloud_cb_, this, _1);
 
     boost::signals2::connection c = grabber_.registerCallback (f);
 

--- a/tools/openni2_viewer.cpp
+++ b/tools/openni2_viewer.cpp
@@ -177,7 +177,7 @@ public:
     cloud_viewer_->registerMouseCallback (&OpenNI2Viewer::mouse_callback, *this);
     cloud_viewer_->registerKeyboardCallback (&OpenNI2Viewer::keyboard_callback, *this);
     cloud_viewer_->setCameraFieldOfView (1.02259994f);
-    boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&OpenNI2Viewer::cloud_callback, this, _1);
+    std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&OpenNI2Viewer::cloud_callback, this, _1);
     boost::signals2::connection cloud_connection = grabber_.registerCallback (cloud_cb);
 
     boost::signals2::connection image_connection;
@@ -186,7 +186,7 @@ public:
       image_viewer_.reset (new pcl::visualization::ImageViewer ("PCL OpenNI image"));
       image_viewer_->registerMouseCallback (&OpenNI2Viewer::mouse_callback, *this);
       image_viewer_->registerKeyboardCallback (&OpenNI2Viewer::keyboard_callback, *this);
-      boost::function<void (const boost::shared_ptr<pcl::io::openni2::Image>&) > image_cb = boost::bind (&OpenNI2Viewer::image_callback, this, _1);
+      std::function<void (const boost::shared_ptr<pcl::io::openni2::Image>&) > image_cb = boost::bind (&OpenNI2Viewer::image_callback, this, _1);
       image_connection = grabber_.registerCallback (image_cb);
     }
 

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -414,7 +414,7 @@ class Driver
     void 
     grabAndSend ()
     {
-      boost::function<void (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float) > image_cb = boost::bind (&Driver::image_callback, this, _1, _2, _3);
+      std::function<void (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float) > image_cb = boost::bind (&Driver::image_callback, this, _1, _2, _3);
       boost::signals2::connection image_connection = grabber_.registerCallback (image_cb);
 
       grabber_.start ();

--- a/tools/openni_save_image.cpp
+++ b/tools/openni_save_image.cpp
@@ -104,7 +104,7 @@ class SimpleOpenNIViewer
     void
     run ()
     {
-      boost::function<void (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float) > image_cb = boost::bind (&SimpleOpenNIViewer::image_callback, this, _1, _2, _3);
+      std::function<void (const openni_wrapper::Image::Ptr&, const openni_wrapper::DepthImage::Ptr&, float) > image_cb = boost::bind (&SimpleOpenNIViewer::image_callback, this, _1, _2, _3);
       boost::signals2::connection image_connection = grabber_.registerCallback (image_cb);
       
       grabber_.start ();

--- a/tools/openni_viewer.cpp
+++ b/tools/openni_viewer.cpp
@@ -174,7 +174,7 @@ class OpenNIViewer
     {
       cloud_viewer_->registerMouseCallback (&OpenNIViewer::mouse_callback, *this);
       cloud_viewer_->registerKeyboardCallback(&OpenNIViewer::keyboard_callback, *this);
-      boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&OpenNIViewer::cloud_callback, this, _1);
+      std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&OpenNIViewer::cloud_callback, this, _1);
       boost::signals2::connection cloud_connection = grabber_.registerCallback (cloud_cb);
       
       boost::signals2::connection image_connection;
@@ -183,7 +183,7 @@ class OpenNIViewer
         image_viewer_.reset (new pcl::visualization::ImageViewer ("PCL OpenNI image"));
         image_viewer_->registerMouseCallback (&OpenNIViewer::mouse_callback, *this);
         image_viewer_->registerKeyboardCallback(&OpenNIViewer::keyboard_callback, *this);
-        boost::function<void (const boost::shared_ptr<openni_wrapper::Image>&) > image_cb = boost::bind (&OpenNIViewer::image_callback, this, _1);
+        std::function<void (const boost::shared_ptr<openni_wrapper::Image>&) > image_cb = boost::bind (&OpenNIViewer::image_callback, this, _1);
         image_connection = grabber_.registerCallback (image_cb);
       }
       

--- a/tools/openni_viewer_simple.cpp
+++ b/tools/openni_viewer_simple.cpp
@@ -172,7 +172,7 @@ class SimpleOpenNIViewer
       string keyMsg3D("Key event for PCL Visualizer");
       cloud_viewer_.registerMouseCallback (&SimpleOpenNIViewer::mouse_callback, *this, (void*)(&mouseMsg3D));    
       cloud_viewer_.registerKeyboardCallback(&SimpleOpenNIViewer::keyboard_callback, *this, (void*)(&keyMsg3D));
-      boost::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&SimpleOpenNIViewer::cloud_callback, this, _1);
+      std::function<void (const CloudConstPtr&) > cloud_cb = boost::bind (&SimpleOpenNIViewer::cloud_callback, this, _1);
       boost::signals2::connection cloud_connection = grabber_.registerCallback (cloud_cb);
       
       boost::signals2::connection image_connection;
@@ -182,7 +182,7 @@ class SimpleOpenNIViewer
           string keyMsg2D("Key event for image viewer");
           image_viewer_.registerMouseCallback (&SimpleOpenNIViewer::mouse_callback, *this, (void*)(&mouseMsg2D));
           image_viewer_.registerKeyboardCallback(&SimpleOpenNIViewer::keyboard_callback, *this, (void*)(&keyMsg2D));
-          boost::function<void (const boost::shared_ptr<openni_wrapper::Image>&) > image_cb = boost::bind (&SimpleOpenNIViewer::image_callback, this, _1);
+          std::function<void (const boost::shared_ptr<openni_wrapper::Image>&) > image_cb = boost::bind (&SimpleOpenNIViewer::image_callback, this, _1);
           image_connection = grabber_.registerCallback (image_cb);
       }
       unsigned char* rgb_data = 0;

--- a/tools/pcd_grabber_viewer.cpp
+++ b/tools/pcd_grabber_viewer.cpp
@@ -211,7 +211,7 @@ main (int argc, char** argv)
   }
 
   EventHelper h;
-  boost::function<void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > f = boost::bind (&EventHelper::cloud_cb, &h, _1);
+  std::function<void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&) > f = boost::bind (&EventHelper::cloud_cb, &h, _1);
   boost::signals2::connection c1 = grabber->registerCallback (f);
 
   std::string mouse_msg_3D ("Mouse coordinates in PCL Visualizer");

--- a/tools/pcl_video.cpp
+++ b/tools/pcl_video.cpp
@@ -191,7 +191,7 @@ class Recorder
             // Set up a callback to get clouds from a grabber and write them to the
             // file.
             pcl::Grabber* interface(new pcl::OpenNIGrabber());
-            boost::function<void (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&)> f(
+            std::function<void (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&)> f(
                     boost::bind(&Recorder::Callback, this, _1));
             interface->registerCallback(f);
             // Start the first cluster

--- a/tools/real_sense_viewer.cpp
+++ b/tools/real_sense_viewer.cpp
@@ -170,7 +170,7 @@ class RealSenseViewer
     void
     run ()
     {
-      boost::function<void (const typename PointCloudT::ConstPtr&)> f = boost::bind (&RealSenseViewer::cloudCallback, this, _1);
+      std::function<void (const typename PointCloudT::ConstPtr&)> f = boost::bind (&RealSenseViewer::cloudCallback, this, _1);
       connection_ = grabber_.registerCallback (f);
       grabber_.start ();
       printMode (grabber_.getMode ());

--- a/tools/vlp_viewer.cpp
+++ b/tools/vlp_viewer.cpp
@@ -160,7 +160,7 @@ class SimpleVLPViewer
       cloud_viewer_->setCameraClipDistances (0.0, 50.0);
       cloud_viewer_->registerKeyboardCallback (&SimpleVLPViewer::keyboard_callback, *this);
 
-      boost::function<void
+      std::function<void
       (const CloudConstPtr&)> cloud_cb = boost::bind (&SimpleVLPViewer::cloud_callback, this, _1);
       boost::signals2::connection cloud_connection = grabber_.registerCallback (cloud_cb);
 

--- a/visualization/include/pcl/visualization/boost.h
+++ b/visualization/include/pcl/visualization/boost.h
@@ -45,7 +45,6 @@
 
 //https://bugreports.qt-project.org/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-#include <boost/function.hpp>
 #include <boost/shared_array.hpp>
 #define BOOST_PARAMETER_MAX_ARITY 7
 #include <boost/signals2.hpp>

--- a/visualization/include/pcl/visualization/cloud_viewer.h
+++ b/visualization/include/pcl/visualization/cloud_viewer.h
@@ -109,7 +109,7 @@ namespace pcl
 
         /** Visualization callable function, may be used for running things on the UI thread.
          */
-        typedef boost::function1<void, pcl::visualization::PCLVisualizer&> VizCallable;
+        typedef std::function<void (pcl::visualization::PCLVisualizer&)> VizCallable;
 
         /** \brief Run a callbable object on the UI thread. Will persist until removed
          * @param x Use boost::ref(x) for a function object that you would like to not copy
@@ -206,13 +206,13 @@ namespace pcl
         boost::scoped_ptr<CloudViewer_impl> impl_;
         
         boost::signals2::connection 
-        registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)>);
+        registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)>);
 
         boost::signals2::connection 
-        registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)>);
+        registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)>);
 
         boost::signals2::connection 
-        registerPointPickingCallback (boost::function<void (const pcl::visualization::PointPickingEvent&)>);
+        registerPointPickingCallback (std::function<void (const pcl::visualization::PointPickingEvent&)>);
     };
   }
 }

--- a/visualization/include/pcl/visualization/image_viewer.h
+++ b/visualization/include/pcl/visualization/image_viewer.h
@@ -495,14 +495,14 @@ namespace pcl
           return (registerKeyboardCallback (boost::bind (callback,  boost::ref (instance), _1, cookie)));
         }
         
-        /** \brief Register a callback boost::function for keyboard events
+        /** \brief Register a callback std::function for keyboard events
           * \param[in] cb the boost function that will be registered as a callback for a keyboard event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection 
-        registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> cb);
+        registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> cb);
 
-        /** \brief Register a callback boost::function for mouse events
+        /** \brief Register a callback std::function for mouse events
           * \param[in] callback  the function that will be registered as a callback for a mouse event
           * \param[in] cookie    user data that is passed to the callback
           * \return a connection object that allows to disconnect the callback function.
@@ -532,7 +532,7 @@ namespace pcl
           * \return a connection object that allows to disconnect the callback function.
           */        
         boost::signals2::connection 
-        registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> cb);
+        registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> cb);
         
         /** \brief Set the position in screen coordinates.
           * \param[in] x where to move the window to (X)

--- a/visualization/include/pcl/visualization/interactor_style.h
+++ b/visualization/include/pcl/visualization/interactor_style.h
@@ -165,32 +165,32 @@ namespace pcl
         setUseVbos (const bool use_vbos) { use_vbos_ = use_vbos; }
 
         /** \brief Register a callback function for mouse events
-          * \param[in] cb a boost function that will be registered as a callback for a mouse event
+          * \param[in] cb a std function that will be registered as a callback for a mouse event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection 
-        registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> cb);
+        registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> cb);
 
-        /** \brief Register a callback boost::function for keyboard events
-          * \param[in] cb a boost function that will be registered as a callback for a keyboard event
+        /** \brief Register a callback std::function for keyboard events
+          * \param[in] cb a std function that will be registered as a callback for a keyboard event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection 
-        registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> cb);
+        registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> cb);
 
         /** \brief Register a callback function for point picking events
-          * \param[in] cb a boost function that will be registered as a callback for a point picking event
+          * \param[in] cb a std function that will be registered as a callback for a point picking event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection 
-        registerPointPickingCallback (boost::function<void (const pcl::visualization::PointPickingEvent&)> cb);
+        registerPointPickingCallback (std::function<void (const pcl::visualization::PointPickingEvent&)> cb);
 
         /** \brief Register a callback function for area picking events
-          * \param[in] cb a boost function that will be registered as a callback for a area picking event
+          * \param[in] cb a std function that will be registered as a callback for a area picking event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection
-        registerAreaPickingCallback (boost::function<void (const pcl::visualization::AreaPickingEvent&)> cb);
+        registerAreaPickingCallback (std::function<void (const pcl::visualization::AreaPickingEvent&)> cb);
 
         /** \brief Save the current rendered image to disk, as a PNG screenshot.
           * \param[in] file the name of the PNG file

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -159,12 +159,12 @@ namespace pcl
         void
         setWindowBorders (bool mode);
 
-        /** \brief Register a callback boost::function for keyboard events
-          * \param[in] cb a boost function that will be registered as a callback for a keyboard event
+        /** \brief Register a callback std::function for keyboard events
+          * \param[in] cb a std function that will be registered as a callback for a keyboard event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection
-        registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> cb);
+        registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> cb);
 
         /** \brief Register a callback function for keyboard events
           * \param[in] callback  the function that will be registered as a callback for a keyboard event
@@ -190,11 +190,11 @@ namespace pcl
         }
 
         /** \brief Register a callback function for mouse events
-          * \param[in] cb a boost function that will be registered as a callback for a mouse event
+          * \param[in] cb a std function that will be registered as a callback for a mouse event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection
-        registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> cb);
+        registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> cb);
 
         /** \brief Register a callback function for mouse events
           * \param[in] callback  the function that will be registered as a callback for a mouse event
@@ -220,11 +220,11 @@ namespace pcl
         }
 
         /** \brief Register a callback function for point picking events
-          * \param[in] cb a boost function that will be registered as a callback for a point picking event
+          * \param[in] cb a std function that will be registered as a callback for a point picking event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection
-        registerPointPickingCallback (boost::function<void (const pcl::visualization::PointPickingEvent&)> cb);
+        registerPointPickingCallback (std::function<void (const pcl::visualization::PointPickingEvent&)> cb);
 
         /** \brief Register a callback function for point picking events
           * \param[in] callback  the function that will be registered as a callback for a point picking event
@@ -247,11 +247,11 @@ namespace pcl
         }
 
         /** \brief Register a callback function for area picking events
-          * \param[in] cb a boost function that will be registered as a callback for an area picking event
+          * \param[in] cb a std function that will be registered as a callback for an area picking event
           * \return a connection object that allows to disconnect the callback function.
           */
         boost::signals2::connection
-        registerAreaPickingCallback (boost::function<void (const pcl::visualization::AreaPickingEvent&)> cb);
+        registerAreaPickingCallback (std::function<void (const pcl::visualization::AreaPickingEvent&)> cb);
 
         /** \brief Register a callback function for area picking events
           * \param[in] callback  the function that will be registered as a callback for an area picking event

--- a/visualization/include/pcl/visualization/registration_visualizer.h
+++ b/visualization/include/pcl/visualization/registration_visualizer.h
@@ -170,7 +170,7 @@ namespace pcl
       std::string registration_method_name_;
 
       /** \brief Callback function linked to pcl::Registration::update_visualizer_ */
-      boost::function<void
+      std::function<void
       (const pcl::PointCloud<PointSource> &cloud_src, const std::vector<int> &indices_src, const pcl::PointCloud<
           PointTarget> &cloud_tgt, const std::vector<int> &indices_tgt)> update_visualizer_;
 

--- a/visualization/include/pcl/visualization/window.h
+++ b/visualization/include/pcl/visualization/window.h
@@ -147,17 +147,17 @@ namespace pcl
           * @brief   registering a callback function for mouse events
           * @return  connection object that allows to disconnect the callback function.
           */
-         // param   the boost function that will be registered as a callback for a mouse event
+         // param   the std function that will be registered as a callback for a mouse event
         boost::signals2::connection
-        registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> );
+        registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> );
 
         /**
-         * @brief   registering a callback boost::function for keyboard events
+         * @brief   registering a callback std::function for keyboard events
          * @return  connection object that allows to disconnect the callback function.
          */
-         // param   the boost function that will be registered as a callback for a keyboard event
+         // param   the std function that will be registered as a callback for a keyboard event
         boost::signals2::connection
-        registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> );
+        registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> );
 
         void
         emitMouseEvent (unsigned long event_id);

--- a/visualization/src/cloud_viewer.cpp
+++ b/visualization/src/cloud_viewer.cpp
@@ -341,21 +341,21 @@ pcl::visualization::CloudViewer::wasStopped (int)
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::CloudViewer::registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> callback)
+pcl::visualization::CloudViewer::registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> callback)
 {
   return impl_->viewer_->registerKeyboardCallback (callback);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::CloudViewer::registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> callback)
+pcl::visualization::CloudViewer::registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> callback)
 {
   return impl_->viewer_->registerMouseCallback (callback);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::CloudViewer::registerPointPickingCallback (boost::function<void (const pcl::visualization::PointPickingEvent&)> callback)
+pcl::visualization::CloudViewer::registerPointPickingCallback (std::function<void (const pcl::visualization::PointPickingEvent&)> callback)
 {
   return (impl_->viewer_->registerPointPickingCallback (callback));
 }

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -388,7 +388,7 @@ pcl::visualization::ImageViewer::spinOnce (int time, bool force_redraw)
 //////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
 pcl::visualization::ImageViewer::registerMouseCallback (
-    boost::function<void (const pcl::visualization::MouseEvent&)> callback)
+    std::function<void (const pcl::visualization::MouseEvent&)> callback)
 {
   // just add observer at first time when a callback is registered
   if (mouse_signal_.empty ())
@@ -409,7 +409,7 @@ pcl::visualization::ImageViewer::registerMouseCallback (
 //////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
 pcl::visualization::ImageViewer::registerKeyboardCallback (
-    boost::function<void (const pcl::visualization::KeyboardEvent&)> callback)
+    std::function<void (const pcl::visualization::KeyboardEvent&)> callback)
 {
   // just add observer at first time when a callback is registered
   if (keyboard_signal_.empty ())

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -483,28 +483,28 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnChar ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizerInteractorStyle::registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> callback)
+pcl::visualization::PCLVisualizerInteractorStyle::registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> callback)
 {
   return (mouse_signal_.connect (callback));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizerInteractorStyle::registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> callback)
+pcl::visualization::PCLVisualizerInteractorStyle::registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> callback)
 {
   return (keyboard_signal_.connect (callback));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizerInteractorStyle::registerPointPickingCallback (boost::function<void (const pcl::visualization::PointPickingEvent&)> callback)
+pcl::visualization::PCLVisualizerInteractorStyle::registerPointPickingCallback (std::function<void (const pcl::visualization::PointPickingEvent&)> callback)
 {
   return (point_picking_signal_.connect (callback));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizerInteractorStyle::registerAreaPickingCallback (boost::function<void (const pcl::visualization::AreaPickingEvent&)> callback)
+pcl::visualization::PCLVisualizerInteractorStyle::registerAreaPickingCallback (std::function<void (const pcl::visualization::AreaPickingEvent&)> callback)
 {
   return (area_picking_signal_.connect (callback));
 }

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -464,21 +464,21 @@ pcl::visualization::PCLVisualizer::getCameraParameters (pcl::visualization::Came
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizer::registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> callback)
+pcl::visualization::PCLVisualizer::registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> callback)
 {
   return (style_->registerKeyboardCallback (callback));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizer::registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> callback)
+pcl::visualization::PCLVisualizer::registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> callback)
 {
   return (style_->registerMouseCallback (callback));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizer::registerPointPickingCallback (boost::function<void (const pcl::visualization::PointPickingEvent&)> callback)
+pcl::visualization::PCLVisualizer::registerPointPickingCallback (std::function<void (const pcl::visualization::PointPickingEvent&)> callback)
 {
   return (style_->registerPointPickingCallback (callback));
 }
@@ -492,7 +492,7 @@ pcl::visualization::PCLVisualizer::registerPointPickingCallback (void (*callback
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection
-pcl::visualization::PCLVisualizer::registerAreaPickingCallback (boost::function<void (const pcl::visualization::AreaPickingEvent&)> callback)
+pcl::visualization::PCLVisualizer::registerAreaPickingCallback (std::function<void (const pcl::visualization::AreaPickingEvent&)> callback)
 {
   return (style_->registerAreaPickingCallback (callback));
 }

--- a/visualization/src/window.cpp
+++ b/visualization/src/window.cpp
@@ -190,7 +190,7 @@ pcl::visualization::Window::spinOnce (int time, bool force_redraw)
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection 
-pcl::visualization::Window::registerMouseCallback (boost::function<void (const pcl::visualization::MouseEvent&)> callback)
+pcl::visualization::Window::registerMouseCallback (std::function<void (const pcl::visualization::MouseEvent&)> callback)
 {
   // just add observer at first time when a callback is registered
   if (mouse_signal_.empty ())
@@ -210,7 +210,7 @@ pcl::visualization::Window::registerMouseCallback (boost::function<void (const p
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 boost::signals2::connection 
-pcl::visualization::Window::registerKeyboardCallback (boost::function<void (const pcl::visualization::KeyboardEvent&)> callback)
+pcl::visualization::Window::registerKeyboardCallback (std::function<void (const pcl::visualization::KeyboardEvent&)> callback)
 {
   // just add observer at first time when a callback is registered
   if (keyboard_signal_.empty ())


### PR DESCRIPTION
This one requires some discussion. There's blatant API breakage, but I'm not really keen in keeping functions with signatures including boost types, around. I need more opinions on how to address this.