### PR TITLE
Fix pcl::Registration::getFitnessScore documentation

### DIFF
--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -379,14 +379,14 @@ namespace pcl
           return (false);
       }
 
-      /** \brief Obtain the Euclidean fitness score (e.g., sum of squared distances from the source to the target)
+      /** \brief Obtain the Euclidean fitness score (e.g., mean of squared distances from the source to the target)
         * \param[in] max_range maximum allowable distance between a point and its correspondence in the target 
         * (default: double::max)
         */
       inline double 
       getFitnessScore (double max_range = std::numeric_limits<double>::max ());
 
-      /** \brief Obtain the Euclidean fitness score (e.g., sum of squared distances from the source to the target)
+      /** \brief Obtain the Euclidean fitness score (e.g., mean of squared distances from the source to the target)
         * from two sets of correspondence distances (distances between source and target points)
         * \param[in] distances_a the first set of distances between correspondences
         * \param[in] distances_b the second set of distances between correspondences


### PR DESCRIPTION
The documentation reported that the fitness score was the sum of the squared distances, 
but  the actual implementation returns the mean of the squared distances.