### PR TITLE
Force C++ over C math function

### DIFF
--- a/common/include/pcl/common/utils.h
+++ b/common/include/pcl/common/utils.h
@@ -53,7 +53,7 @@ namespace pcl
     template<typename T> bool 
     equal (T val1, T val2, T eps = std::numeric_limits<T>::min ())
     {
-      return (fabs (val1 - val2) < eps);
+      return (std::fabs (val1 - val2) < eps);
     }
   }
 }

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -110,11 +110,11 @@ RangeImage::createFromPointCloud (const PointCloudType& point_cloud,
 {
   setAngularResolution (angular_resolution_x, angular_resolution_y);
   
-  width  = static_cast<uint32_t> (pcl_lrint (floor (max_angle_width*angular_resolution_x_reciprocal_)));
-  height = static_cast<uint32_t> (pcl_lrint (floor (max_angle_height*angular_resolution_y_reciprocal_)));
+  width  = static_cast<uint32_t> (pcl_lrint (std::floor (max_angle_width*angular_resolution_x_reciprocal_)));
+  height = static_cast<uint32_t> (pcl_lrint (std::floor (max_angle_height*angular_resolution_y_reciprocal_)));
   
-  int full_width  = static_cast<int> (pcl_lrint (floor (pcl::deg2rad (360.0f)*angular_resolution_x_reciprocal_))),
-      full_height = static_cast<int> (pcl_lrint (floor (pcl::deg2rad (180.0f)*angular_resolution_y_reciprocal_)));
+  int full_width  = static_cast<int> (pcl_lrint (std::floor (pcl::deg2rad (360.0f)*angular_resolution_x_reciprocal_))),
+      full_height = static_cast<int> (pcl_lrint (std::floor (pcl::deg2rad (180.0f)*angular_resolution_y_reciprocal_)));
   image_offset_x_ = (full_width -static_cast<int> (width) )/2;
   image_offset_y_ = (full_height-static_cast<int> (height))/2;
   is_dense = false;
@@ -175,8 +175,8 @@ RangeImage::createFromPointCloudWithKnownSize (const PointCloudType& point_cloud
   to_range_image_system_ = to_world_system_.inverse (Eigen::Isometry);
   
   float max_angle_size = getMaxAngleSize (sensor_pose, point_cloud_center, point_cloud_radius);
-  int pixel_radius_x = pcl_lrint (ceil (0.5f*max_angle_size*angular_resolution_x_reciprocal_)),
-      pixel_radius_y = pcl_lrint (ceil (0.5f*max_angle_size*angular_resolution_y_reciprocal_));
+  int pixel_radius_x = pcl_lrint (std::ceil (0.5f*max_angle_size*angular_resolution_x_reciprocal_)),
+      pixel_radius_y = pcl_lrint (std::ceil (0.5f*max_angle_size*angular_resolution_y_reciprocal_));
   width  = 2*pixel_radius_x;
   height = 2*pixel_radius_y;
   is_dense = false;
@@ -254,8 +254,8 @@ RangeImage::doZBuffer (const PointCloudType& point_cloud, float noise_level, flo
     //std::cout << " ("<<current_point[0]<<", "<<current_point[1]<<", "<<current_point[2]<<") falls into pixel "<<x<<","<<y<<".\n";
     
     // Do some minor interpolation by checking the three closest neighbors to the point, that are not filled yet.
-    int floor_x = pcl_lrint (floor (x_real)), floor_y = pcl_lrint (floor (y_real)),
-        ceil_x  = pcl_lrint (ceil (x_real)),  ceil_y  = pcl_lrint (ceil (y_real));
+    int floor_x = pcl_lrint (std::floor (x_real)), floor_y = pcl_lrint (std::floor (y_real)),
+        ceil_x  = pcl_lrint (std::ceil (x_real)),  ceil_y  = pcl_lrint (std::ceil (y_real));
     
     int neighbor_x[4], neighbor_y[4];
     neighbor_x[0]=floor_x; neighbor_y[0]=floor_y;
@@ -299,7 +299,7 @@ RangeImage::doZBuffer (const PointCloudType& point_cloud, float noise_level, flo
       {
         replace_with_current_point = true;
       }
-      else if (fabs (range_of_current_point-range_at_image_point)<=noise_level)
+      else if (std::fabs (range_of_current_point-range_at_image_point)<=noise_level)
       {
         addCurrentPoint = true;
       }
@@ -652,7 +652,7 @@ RangeImage::getAcutenessValue (const PointWithRange& point1, const PointWithRang
   float impact_angle = getImpactAngle (point1, point2);
   if (std::isinf (impact_angle))
     return -std::numeric_limits<float>::infinity ();
-  float ret = 1.0f - float (fabs (impact_angle)/ (0.5f*M_PI));
+  float ret = 1.0f - float (std::fabs (impact_angle)/ (0.5f*M_PI));
   if (impact_angle < 0.0f)
     ret = -ret;
   //if (fabs (ret)>1)
@@ -1228,10 +1228,10 @@ RangeImage::integrateFarRanges (const PointCloudType& far_ranges)
     
     this->getImagePoint (current_point, x_real, y_real, range_of_current_point);
     
-    int floor_x = static_cast<int> (pcl_lrint (floor (x_real))), 
-        floor_y = static_cast<int> (pcl_lrint (floor (y_real))),
-        ceil_x  = static_cast<int> (pcl_lrint (ceil (x_real))),
-        ceil_y  = static_cast<int> (pcl_lrint (ceil (y_real)));
+    int floor_x = static_cast<int> (pcl_lrint (std::floor (x_real))), 
+        floor_y = static_cast<int> (pcl_lrint (std::floor (y_real))),
+        ceil_x  = static_cast<int> (pcl_lrint (std::ceil (x_real))),
+        ceil_y  = static_cast<int> (pcl_lrint (std::ceil (y_real)));
     
     int neighbor_x[4], neighbor_y[4];
     neighbor_x[0]=floor_x; neighbor_y[0]=floor_y;

--- a/common/src/gaussian.cpp
+++ b/common/src/gaussian.cpp
@@ -53,7 +53,7 @@ pcl::GaussianKernel::compute (float sigma,
     kernel[k] = kernel[j] = expf (-static_cast<float>(i) * static_cast<float>(i) * sigma_sqr);
   kernel[hw] = 1;
   unsigned g_width = kernel_width;
-  for (unsigned i = 0; fabs (kernel[i]/max_gauss) < factor; i++, g_width-= 2) ;
+  for (unsigned i = 0; std::fabs (kernel[i]/max_gauss) < factor; i++, g_width-= 2) ;
   if (g_width == kernel_width)
   { 
     PCL_THROW_EXCEPTION (pcl::KernelWidthTooSmallException,
@@ -98,8 +98,8 @@ pcl::GaussianKernel::compute (float sigma,
   // Compute kernel and derivative true width
   unsigned g_width = kernel_width;
   unsigned d_width = kernel_width;
-  for (unsigned i = 0; fabs (derivative[i]/max_deriv) < factor; i++, d_width-= 2) ;
-  for (unsigned i = 0; fabs (kernel[i]/max_gauss) < factor; i++, g_width-= 2) ;
+  for (unsigned i = 0; std::fabs (derivative[i]/max_deriv) < factor; i++, d_width-= 2) ;
+  for (unsigned i = 0; std::fabs (kernel[i]/max_gauss) < factor; i++, g_width-= 2) ;
   if (g_width == kernel_width || d_width == kernel_width)
   { 
     PCL_THROW_EXCEPTION (KernelWidthTooSmallException,

--- a/common/src/projection_matrix.cpp
+++ b/common/src/projection_matrix.cpp
@@ -56,17 +56,17 @@ pcl::getCameraMatrixFromProjectionMatrix (
   {
     camera_matrix.coeffRef (2) = cam.coeff (2);
     camera_matrix.coeffRef (5) = cam.coeff (5);
-    camera_matrix.coeffRef (4) = static_cast<float> (sqrt (cam.coeff (4) - cam.coeff (5) * cam.coeff (5)));
+    camera_matrix.coeffRef (4) = static_cast<float> (std::sqrt (cam.coeff (4) - cam.coeff (5) * cam.coeff (5)));
     camera_matrix.coeffRef (1) = (cam.coeff (1) - cam.coeff (2) * cam.coeff (5)) / camera_matrix.coeff (4);
-    camera_matrix.coeffRef (0) = static_cast<float> (sqrt (cam.coeff (0) - camera_matrix.coeff (1) * camera_matrix.coeff (1) - cam.coeff (2) * cam.coeff (2)));
+    camera_matrix.coeffRef (0) = static_cast<float> (std::sqrt (cam.coeff (0) - camera_matrix.coeff (1) * camera_matrix.coeff (1) - cam.coeff (2) * cam.coeff (2)));
   }
   else
   {
     camera_matrix.coeffRef (6) = cam.coeff (2);
     camera_matrix.coeffRef (7) = cam.coeff (5);
-    camera_matrix.coeffRef (4) = static_cast<float> (sqrt (cam.coeff (4) - cam.coeff (5) * cam.coeff (5)));
+    camera_matrix.coeffRef (4) = static_cast<float> (std::sqrt (cam.coeff (4) - cam.coeff (5) * cam.coeff (5)));
     camera_matrix.coeffRef (3) = (cam.coeff (1) - cam.coeff (2) * cam.coeff (5)) / camera_matrix.coeff (4);
-    camera_matrix.coeffRef (0) = static_cast<float> (sqrt (cam.coeff (0) - camera_matrix.coeff (3) * camera_matrix.coeff (3) - cam.coeff (2) * cam.coeff (2)));
+    camera_matrix.coeffRef (0) = static_cast<float> (std::sqrt (cam.coeff (0) - camera_matrix.coeff (3) * camera_matrix.coeff (3) - cam.coeff (2) * cam.coeff (2)));
   }
 }
 

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -149,11 +149,11 @@ RangeImage::createEmpty (float angular_resolution_x, float angular_resolution_y,
                          RangeImage::CoordinateFrame coordinate_frame, float angle_width, float angle_height)
 {
   setAngularResolution(angular_resolution_x, angular_resolution_y);
-  width  = static_cast<uint32_t> (pcl_lrint (floor (angle_width * angular_resolution_x_reciprocal_)));
-  height = static_cast<uint32_t> (pcl_lrint (floor (angle_height * angular_resolution_y_reciprocal_)));
+  width  = static_cast<uint32_t> (pcl_lrint (std::floor (angle_width * angular_resolution_x_reciprocal_)));
+  height = static_cast<uint32_t> (pcl_lrint (std::floor (angle_height * angular_resolution_y_reciprocal_)));
 
-  int full_width  = static_cast<int> (pcl_lrint (floor (pcl::deg2rad (360.0f)*angular_resolution_x_reciprocal_))),
-      full_height = static_cast<int> (pcl_lrint (floor (pcl::deg2rad (180.0f)*angular_resolution_y_reciprocal_)));
+  int full_width  = static_cast<int> (pcl_lrint (std::floor (pcl::deg2rad (360.0f)*angular_resolution_x_reciprocal_))),
+      full_height = static_cast<int> (pcl_lrint (std::floor (pcl::deg2rad (180.0f)*angular_resolution_y_reciprocal_)));
   image_offset_x_ = (full_width-width)/2;
   image_offset_y_ = (full_height-height)/2;
   is_dense = false;

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -65,7 +65,7 @@ namespace pcl
     float original_angular_resolution = atanf (0.5f * static_cast<float> (di_width) / static_cast<float> (focal_length)) / (0.5f * static_cast<float> (di_width));
     int skip = 1;
     if (desired_angular_resolution >= 2.0f*original_angular_resolution)
-      skip = static_cast<int> (pcl_lrint (floor (desired_angular_resolution / original_angular_resolution)));
+      skip = static_cast<int> (pcl_lrint (std::floor (desired_angular_resolution / original_angular_resolution)));
 
     setAngularResolution (original_angular_resolution * static_cast<float> (skip));
     width  = di_width / skip;
@@ -124,7 +124,7 @@ namespace pcl
     float original_angular_resolution = asinf (0.5f*static_cast<float> (di_width)/static_cast<float> (di_focal_length_x)) / (0.5f*static_cast<float> (di_width));
     int skip = 1;
     if (desired_angular_resolution >= 2.0f*original_angular_resolution)
-      skip = static_cast<int> (pcl_lrint (floor (desired_angular_resolution / original_angular_resolution)));
+      skip = static_cast<int> (pcl_lrint (std::floor (desired_angular_resolution / original_angular_resolution)));
 
     setAngularResolution (original_angular_resolution * static_cast<float> (skip));
     width  = di_width / skip;
@@ -170,7 +170,7 @@ namespace pcl
     float original_angular_resolution = asinf (0.5f*static_cast<float> (di_width)/static_cast<float> (di_focal_length_x)) / (0.5f*static_cast<float> (di_width));
     int skip = 1;
     if (desired_angular_resolution >= 2.0f*original_angular_resolution)
-      skip = static_cast<int> (pcl_lrint (floor (desired_angular_resolution/original_angular_resolution)));
+      skip = static_cast<int> (pcl_lrint (std::floor (desired_angular_resolution/original_angular_resolution)));
 
     setAngularResolution (original_angular_resolution * static_cast<float> (skip));
     width  = di_width / skip;

--- a/features/include/pcl/features/impl/board.hpp
+++ b/features/include/pcl/features/impl/board.hpp
@@ -307,7 +307,7 @@ pcl::BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT>::computePo
                               surface_->at (curr_neigh_idx).getVector3fMap (), indicating_normal_vect);
       float angle = getAngleBetweenUnitVectors (x_axis, indicating_normal_vect, fitted_normal);
 
-      int check_margin_array_idx = std::min (static_cast<int> (floor (angle / max_boundary_angle)), check_margin_array_size_ - 1);
+      int check_margin_array_idx = std::min (static_cast<int> (std::floor (angle / max_boundary_angle)), check_margin_array_size_ - 1);
       check_margin_array_[check_margin_array_idx] = true;
 
       if (angle < margin_array_min_angle_[check_margin_array_idx])

--- a/features/include/pcl/features/impl/cppf.hpp
+++ b/features/include/pcl/features/impl/cppf.hpp
@@ -94,7 +94,7 @@ pcl::CPPFEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
 
           Eigen::Vector3f model_point_transformed = transform_mg * model_point;
           float angle = atan2f ( -model_point_transformed(2), model_point_transformed(1));
-          if (sin (angle) * model_point_transformed(2) < 0.0f)
+          if (std::sin (angle) * model_point_transformed(2) < 0.0f)
             angle *= (-1);
           p.alpha_m = -angle;
         }

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -427,9 +427,9 @@ pcl::ESFEstimation<PointInT, PointOutT>::voxelize9 (PointCloudIn &cluster)
   int xi,yi,zi,xx,yy,zz;
   for (size_t i = 0; i < cluster.points.size (); ++i)
   {
-    xx = cluster.points[i].x<0.0? static_cast<int>(floor(cluster.points[i].x)+GRIDSIZE_H) : static_cast<int>(ceil(cluster.points[i].x)+GRIDSIZE_H-1);
-    yy = cluster.points[i].y<0.0? static_cast<int>(floor(cluster.points[i].y)+GRIDSIZE_H) : static_cast<int>(ceil(cluster.points[i].y)+GRIDSIZE_H-1);
-    zz = cluster.points[i].z<0.0? static_cast<int>(floor(cluster.points[i].z)+GRIDSIZE_H) : static_cast<int>(ceil(cluster.points[i].z)+GRIDSIZE_H-1);
+    xx = cluster.points[i].x<0.0? static_cast<int>(std::floor(cluster.points[i].x)+GRIDSIZE_H) : static_cast<int>(std::ceil(cluster.points[i].x)+GRIDSIZE_H-1);
+    yy = cluster.points[i].y<0.0? static_cast<int>(std::floor(cluster.points[i].y)+GRIDSIZE_H) : static_cast<int>(std::ceil(cluster.points[i].y)+GRIDSIZE_H-1);
+    zz = cluster.points[i].z<0.0? static_cast<int>(std::floor(cluster.points[i].z)+GRIDSIZE_H) : static_cast<int>(std::ceil(cluster.points[i].z)+GRIDSIZE_H-1);
 
     for (int x = -1; x < 2; x++)
       for (int y = -1; y < 2; y++)
@@ -456,9 +456,9 @@ pcl::ESFEstimation<PointInT, PointOutT>::cleanup9 (PointCloudIn &cluster)
   int xi,yi,zi,xx,yy,zz;
   for (size_t i = 0; i < cluster.points.size (); ++i)
   {
-    xx = cluster.points[i].x<0.0? static_cast<int>(floor(cluster.points[i].x)+GRIDSIZE_H) : static_cast<int>(ceil(cluster.points[i].x)+GRIDSIZE_H-1);
-    yy = cluster.points[i].y<0.0? static_cast<int>(floor(cluster.points[i].y)+GRIDSIZE_H) : static_cast<int>(ceil(cluster.points[i].y)+GRIDSIZE_H-1);
-    zz = cluster.points[i].z<0.0? static_cast<int>(floor(cluster.points[i].z)+GRIDSIZE_H) : static_cast<int>(ceil(cluster.points[i].z)+GRIDSIZE_H-1);
+    xx = cluster.points[i].x<0.0? static_cast<int>(std::floor(cluster.points[i].x)+GRIDSIZE_H) : static_cast<int>(std::ceil(cluster.points[i].x)+GRIDSIZE_H-1);
+    yy = cluster.points[i].y<0.0? static_cast<int>(std::floor(cluster.points[i].y)+GRIDSIZE_H) : static_cast<int>(std::ceil(cluster.points[i].y)+GRIDSIZE_H-1);
+    zz = cluster.points[i].z<0.0? static_cast<int>(std::floor(cluster.points[i].z)+GRIDSIZE_H) : static_cast<int>(std::ceil(cluster.points[i].z)+GRIDSIZE_H-1);
 
     for (int x = -1; x < 2; x++)
       for (int y = -1; y < 2; y++)

--- a/features/include/pcl/features/impl/gfpfh.hpp
+++ b/features/include/pcl/features/impl/gfpfh.hpp
@@ -211,7 +211,7 @@ pcl::GFPFHEstimation<PointInT, PointNT, PointOutT>::computeDistanceHistogram (co
   for (const float &distance : distances)
   {
     const float raw_bin = static_cast<float> (descriptorSize ()) * (distance - min_value) / range;
-    int bin = std::min (max_bin, static_cast<int> (floor (raw_bin)));
+    int bin = std::min (max_bin, static_cast<int> (std::floor (raw_bin)));
     histogram[bin] += 1;
   }
 }

--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -744,13 +744,13 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
       //const float depthDependendDepthChange = (max_depth_change_factor_ * (fabs(depth)+1.0f))/(500.0f*0.001f);
       const float depthDependendDepthChange = (max_depth_change_factor_ * (fabsf (depth) + 1.0f) * 2.0f);
 
-      if (fabs (depth - depthR) > depthDependendDepthChange
+      if (std::fabs (depth - depthR) > depthDependendDepthChange
         || !std::isfinite (depth) || !std::isfinite (depthR))
       {
         depthChangeMap[index] = 0;
         depthChangeMap[index+1] = 0;
       }
-      if (fabs (depth - depthD) > depthDependendDepthChange
+      if (std::fabs (depth - depthD) > depthDependendDepthChange
         || !std::isfinite (depth) || !std::isfinite (depthD))
       {
         depthChangeMap[index] = 0;

--- a/features/include/pcl/features/impl/intensity_spin.hpp
+++ b/features/include/pcl/features/impl/intensity_spin.hpp
@@ -86,10 +86,10 @@ pcl::IntensitySpinEstimation<PointInT, PointOutT>::computeIntensitySpinImage (
     else
     {
       // Compute the bin indices that need to be updated (+/- 3 standard deviations)
-      int d_idx_min = (std::max)(static_cast<int> (floor (d - 3*sigma)), 0);
-      int d_idx_max = (std::min)(static_cast<int> (ceil  (d + 3*sigma)), nr_distance_bins - 1);
-      int i_idx_min = (std::max)(static_cast<int> (floor (i - 3*sigma)), 0);
-      int i_idx_max = (std::min)(static_cast<int> (ceil  (i + 3*sigma)), nr_intensity_bins - 1);
+      int d_idx_min = (std::max)(static_cast<int> (std::floor (d - 3*sigma)), 0);
+      int d_idx_max = (std::min)(static_cast<int> (std::ceil  (d + 3*sigma)), nr_distance_bins - 1);
+      int i_idx_min = (std::max)(static_cast<int> (std::floor (i - 3*sigma)), 0);
+      int i_idx_max = (std::min)(static_cast<int> (std::ceil  (i + 3*sigma)), nr_intensity_bins - 1);
    
       // Update the appropriate bins of the histogram 
       for (int i_idx = i_idx_min; i_idx <= i_idx_max; ++i_idx)  

--- a/features/include/pcl/features/impl/linear_least_squares_normal.hpp
+++ b/features/include/pcl/features/impl/linear_least_squares_normal.hpp
@@ -110,7 +110,7 @@ pcl::LinearLeastSquaresNormalEstimation<PointInT, PointOutT>::computePointNormal
       float depthChangeThreshold = pz*pz * 0.05f * max_depth_change_factor_;
       if (use_depth_dependent_smoothing_) depthChangeThreshold *= pz;
 
-      const float f = fabs (delta) > depthChangeThreshold ? 0 : 1;
+      const float f = std::fabs (delta) > depthChangeThreshold ? 0 : 1;
 
       matA0 += f * i * i;
       matA1 += f * i * j;
@@ -219,7 +219,7 @@ pcl::LinearLeastSquaresNormalEstimation<PointInT, PointOutT>::computeFeature (Po
           const float j = qy - py;
 
           const float depthDependendDepthChange = (max_depth_change_factor_ * (fabsf (pz) + 1.0f) * 2.0f);
-          const float f = fabs(delta) > depthDependendDepthChange ? 0 : 1;
+          const float f = std::fabs(delta) > depthDependendDepthChange ? 0 : 1;
 
           //float f = fabs(delta) > (pz * 0.05f - 0.3f) ? 0 : 1;
           //const float f = fabs(delta) > (pz*pz * 0.05f * max_depth_change_factor_) ? 0 : 1;

--- a/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
+++ b/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
@@ -465,8 +465,8 @@ pcl::MomentOfInertiaEstimation<PointT>::rotateVector (const Eigen::Vector3f& vec
   const float y = axis (1);
   const float z = axis (2);
   const float rad = M_PI / 180.0f;
-  const float cosine = cos (angle * rad);
-  const float sine = sin (angle * rad);
+  const float cosine = std::cos (angle * rad);
+  const float sine = std::sin (angle * rad);
   rotation_matrix << cosine + (1 - cosine) * x * x,      (1 - cosine) * x * y - sine * z,    (1 - cosine) * x * z + sine * y,
                      (1 - cosine) * y * x + sine * z,    cosine + (1 - cosine) * y * y,      (1 - cosine) * y * z - sine * x,
                      (1 - cosine) * z * x - sine * y,    (1 - cosine) * z * y + sine * x,    cosine + (1 - cosine) * z * z;
@@ -540,13 +540,13 @@ pcl::MomentOfInertiaEstimation<PointT>::computeEccentricity (const Eigen::Matrix
   float eccentricity = 0.0f;
 
   if (major >= middle && major >= minor && middle_value != 0.0f)
-    eccentricity = pow (1.0f - (minor_value * minor_value) / (middle_value * middle_value), 0.5f);
+    eccentricity = std::pow (1.0f - (minor_value * minor_value) / (middle_value * middle_value), 0.5f);
 
   if (middle >= major && middle >= minor && major_value != 0.0f)
-    eccentricity = pow (1.0f - (minor_value * minor_value) / (major_value * major_value), 0.5f);
+    eccentricity = std::pow (1.0f - (minor_value * minor_value) / (major_value * major_value), 0.5f);
 
   if (minor >= major && minor >= middle && major_value != 0.0f)
-    eccentricity = pow (1.0f - (middle_value * middle_value) / (major_value * major_value), 0.5f);
+    eccentricity = std::pow (1.0f - (middle_value * middle_value) / (major_value * major_value), 0.5f);
 
   return (eccentricity);
 }

--- a/features/include/pcl/features/impl/ppf.hpp
+++ b/features/include/pcl/features/impl/ppf.hpp
@@ -93,7 +93,7 @@ pcl::PPFEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
 
           Eigen::Vector3f model_point_transformed = transform_mg * model_point;
           float angle = atan2f ( -model_point_transformed(2), model_point_transformed(1));
-          if (sin (angle) * model_point_transformed(2) < 0.0f)
+          if (std::sin (angle) * model_point_transformed(2) < 0.0f)
             angle *= (-1);
           p.alpha_m = -angle;
         }

--- a/features/include/pcl/features/impl/ppfrgb.hpp
+++ b/features/include/pcl/features/impl/ppfrgb.hpp
@@ -86,7 +86,7 @@ pcl::PPFRGBEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudO
 
           Eigen::Vector3f model_point_transformed = transform_mg * model_point;
           float angle = atan2f ( -model_point_transformed(2), model_point_transformed(1));
-          if (sin (angle) * model_point_transformed(2) < 0.0f)
+          if (std::sin (angle) * model_point_transformed(2) < 0.0f)
             angle *= (-1);
           p.alpha_m = -angle;
         }

--- a/features/include/pcl/features/impl/rift.hpp
+++ b/features/include/pcl/features/impl/rift.hpp
@@ -82,10 +82,10 @@ pcl::RIFTEstimation<PointInT, GradientT, PointOutT>::computeRIFT (
     float g = static_cast<float> (nr_gradient_bins) * gradient_angle_from_center / (static_cast<float> (M_PI) + eps);
 
     // Compute the bin indices that need to be updated
-    int d_idx_min = (std::max)(static_cast<int> (ceil (d - 1)), 0);
-    int d_idx_max = (std::min)(static_cast<int> (floor (d + 1)), nr_distance_bins - 1);
-    int g_idx_min = static_cast<int> (ceil (g - 1));
-    int g_idx_max = static_cast<int> (floor (g + 1));
+    int d_idx_min = (std::max)(static_cast<int> (std::ceil (d - 1)), 0);
+    int d_idx_max = (std::min)(static_cast<int> (std::floor (d + 1)), nr_distance_bins - 1);
+    int g_idx_min = static_cast<int> (std::ceil (g - 1));
+    int g_idx_max = static_cast<int> (std::floor (g + 1));
 
     // Update the appropriate bins of the histogram 
     for (int g_idx = g_idx_min; g_idx <= g_idx_max; ++g_idx)  

--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -265,7 +265,7 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeLRF (const PointInT& point, co
     triangle_area[i_triangle] = curr_area;
     total_area += curr_area;
 
-    distance_weight[i_triangle] = pow (support_radius_ - (feature_point - (pt[0] + pt[1] + pt[2]) * coeff_1_div_3).norm (), 2.0f);
+    distance_weight[i_triangle] = std::pow (support_radius_ - (feature_point - (pt[0] + pt[1] + pt[2]) * coeff_1_div_3).norm (), 2.0f);
 
     Eigen::Matrix3f curr_scatter_matrix;
     curr_scatter_matrix.setZero ();
@@ -411,8 +411,8 @@ pcl::ROPSEstimation <PointInT, PointOutT>::rotateCloud (const PointInT& axis, co
   const float y = axis.y;
   const float z = axis.z;
   const float rad = M_PI / 180.0f;
-  const float cosine = cos (angle * rad);
-  const float sine = sin (angle * rad);
+  const float cosine = std::cos (angle * rad);
+  const float sine = std::sin (angle * rad);
   rotation_matrix << cosine + (1 - cosine) * x * x,      (1 - cosine) * x * y - sine * z,    (1 - cosine) * x * z + sine * y,
                      (1 - cosine) * y * x + sine * z,    cosine + (1 - cosine) * y * y,      (1 - cosine) * y * z - sine * x,
                      (1 - cosine) * z * x - sine * y,    (1 - cosine) * z * y + sine * x,    cosine + (1 - cosine) * z * z;
@@ -527,9 +527,9 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeCentralMoments (const Eigen::M
       const float j_factor = static_cast <float> (j + 1) - mean_j;
       const float m = matrix (i, j);
       if (m > 0.0f)
-        entropy -= m * log (m);
+        entropy -= m * std::log (m);
       for (unsigned int i_moment = 0; i_moment < number_of_moments_to_compute; i_moment++)
-        moments[i_moment] += pow (i_factor, power[i_moment][0]) * pow (j_factor, power[i_moment][1]) * m;
+        moments[i_moment] += std::pow (i_factor, power[i_moment][0]) * std::pow (j_factor, power[i_moment][1]) * m;
     }
   }
 

--- a/features/include/pcl/features/impl/shot.hpp
+++ b/features/include/pcl/features/impl/shot.hpp
@@ -81,7 +81,7 @@ areEquals (double val1, double val2, double zeroDoubleEps = zeroDoubleEps15)
 inline bool
 areEquals (float val1, float val2, float zeroFloatEps = zeroFloatEps8)
 {
-  return (fabs (val1 - val2)<zeroFloatEps);
+  return (std::fabs (val1 - val2)<zeroFloatEps);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -703,7 +703,7 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::computePointSH
       a /= 120.0f;
       b /= 120.0f;   //normalized LAB components (0<L<1, -1<a<1, -1<b<1)
 
-      double colorDistance = (fabs (LRef - L) + ((fabs (aRef - a) + fabs (bRef - b)) / 2)) /3;
+      double colorDistance = (std::fabs (LRef - L) + ((std::fabs (aRef - a) + std::fabs (bRef - b)) / 2)) /3;
 
       if (colorDistance > 1.0)
         colorDistance = 1.0;

--- a/features/include/pcl/features/narf.h
+++ b/features/include/pcl/features/narf.h
@@ -145,7 +145,7 @@ namespace pcl
       
       //! How many points on each beam of the gradient star are used to calculate the descriptor?
       inline int 
-      getNoOfBeamPoints () const { return (static_cast<int> (pcl_lrint (ceil (0.5f * float (surface_patch_pixel_size_))))); }
+      getNoOfBeamPoints () const { return (static_cast<int> (pcl_lrint (std::ceil (0.5f * float (surface_patch_pixel_size_))))); }
       
       //! Copy the descriptor and pose to the point struct Narf36
       inline void 

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -289,8 +289,8 @@ Narf::getBlurredSurfacePatch (int new_pixel_size, int blur_radius) const
     for (int x=0; x<new_pixel_size; ++x)
     {
       float& integral_pixel = *(integral_image_ptr++);
-      int old_x = static_cast<int> (pcl_lrint (floor (new_to_old_factor * float (x)))),
-          old_y = static_cast<int> (pcl_lrint (floor (new_to_old_factor * float (y))));
+      int old_x = static_cast<int> (pcl_lrint (std::floor (new_to_old_factor * float (x)))),
+          old_y = static_cast<int> (pcl_lrint (std::floor (new_to_old_factor * float (y))));
       integral_pixel = surface_patch_[old_y*surface_patch_pixel_size_ + old_x];
       if (std::isinf(integral_pixel))
         integral_pixel = 0.5f*surface_patch_world_size_;

--- a/features/src/pfh.cpp
+++ b/features/src/pfh.cpp
@@ -64,7 +64,7 @@ pcl::computePairFeatures (const Eigen::Vector4f &p1, const Eigen::Vector4f &n1,
 
   // Make sure the same point is selected as 1 and 2 for each pair
   float angle2 = n2_copy.dot (dp2p1) / f4;
-  if (acos (fabs (angle1)) > acos (fabs (angle2)))
+  if (acos (std::fabs (angle1)) > acos (std::fabs (angle2)))
   {
     // switch p1 and p2
     n1_copy = n2;

--- a/gpu/features/src/features.cpp
+++ b/gpu/features/src/features.cpp
@@ -539,7 +539,7 @@ void pcl::gpu::SpinImageEstimation::compute(DeviceArray2D<SpinImage>& features, 
 	// suppose that points are uniformly distributed, so we lose ~40% // according to the volumes ratio
 	float bin_size = radius_ / image_width_;
 	if (!is_radial_)
-		bin_size /= sqrt(2.f);
+		bin_size /= std::sqrt(2.f);
 
 
 	const device::PointCloud& s = (const device::PointCloud&)surface_;

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -183,7 +183,7 @@ namespace pcl
         float root = sqrt(pow(parent.mean(0) - child.mean(0), 2) +
                           pow(parent.mean(1) - child.mean(1), 2) +
                           pow(parent.mean(2) - child.mean(2), 2));
-        float offset = fabs(LUT_ideal_length[(int)parent.label][child_nr] - root);
+        float offset = std::fabs(LUT_ideal_length[(int)parent.label][child_nr] - root);
         if(offset > LUT_max_length_offset[(int)parent.label][child_nr])
           return -1.0;
         else
@@ -208,7 +208,7 @@ namespace pcl
         float root = sqrt(pow(parent.mean(0) - child.mean(0), 2) +
                           pow(parent.mean(1) - child.mean(1), 2) +
                           pow(parent.mean(2) - child.mean(2), 2));
-        float offset = fabs(person_attribs->part_ideal_length_[(int)parent.label][child_nr] - root);
+        float offset = std::fabs(person_attribs->part_ideal_length_[(int)parent.label][child_nr] - root);
         if(offset > person_attribs->max_length_offset_[(int)parent.label][child_nr])
           return -1.0;
         else

--- a/gpu/people/src/probability_processor.cpp
+++ b/gpu/people/src/probability_processor.cpp
@@ -96,9 +96,9 @@ pcl::gpu::people::ProbabilityProcessor::CreateGaussianKernel ( float sigma,
 {
   float* f;
   f = static_cast<float*> (malloc(kernelSize * sizeof(float)));
-  float sigma_sq = static_cast<float> (pow (sigma,2.f));
+  float sigma_sq = static_cast<float> (std::pow (sigma,2.f));
   float mult = static_cast<float> (1/sqrt (2*M_PI*sigma_sq));
-  int mid = static_cast<int> (floor (static_cast<float> (kernelSize)/2.f));
+  int mid = static_cast<int> (std::floor (static_cast<float> (kernelSize)/2.f));
 
   // Create a symmetric kernel, could also be solved in CUDA kernel but let's do it here :D
   float sum = 0;

--- a/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
@@ -129,8 +129,8 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
         float d = std::min (r1, r2);
         if (d < first_threshold_) continue;
 
-        sn1 = sqrt (sn1);
-        sn2 = sqrt (sn2);
+        sn1 = std::sqrt (sn1);
+        sn2 = std::sqrt (sn2);
         float b1 = normalsDiff (right, up) * sn1;
         b1+= normalsDiff (left, down) * sn2;
         float b2 = normalsDiff (right, down) * sn2;

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -1455,8 +1455,8 @@ pcl::keypoints::brisk::Layer::getValue (
   (void)height;
   assert (!mat.empty ());
   // get the position
-  const int x = int (floor (xf));
-  const int y = int (floor (yf));
+  const int x = int (std::floor (xf));
+  const int y = int (std::floor (yf));
   const std::vector<unsigned char>& image = mat;
   const int& imagecols = width;
 

--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -287,7 +287,7 @@ pcl::people::HOG::normalization (float *H, int h, int w, int bin_size, int n_ori
   N = (float*) calloc(nb,sizeof(float));
   for( o=0; o<n_orients; o++ ) for( x=0; x<nb; x++ ) N[x]+=H[x+o*nb]*H[x+o*nb];
   for( x=0; x<wb-1; x++ ) for( y=0; y<hb-1; y++ ) {
-    N1=N+x*hb+y; *N1=1/float(sqrt( N1[0] + N1[1] + N1[hb] + N1[hb+1] +eps )); }
+    N1=N+x*hb+y; *N1=1/float(std::sqrt( N1[0] + N1[1] + N1[hb] + N1[hb+1] +eps )); }
   // perform 4 normalizations per spatial block (handling boundary regions)
   #define U(a,b) Gs[a][y]=H1[y]*N1[y-(b)]; if(Gs[a][y]>clip) Gs[a][y]=clip;
   for( o=0; o<n_orients; o++ ) for( x=0; x<wb; x++ ) {
@@ -453,7 +453,7 @@ pcl::people::HOG::acosTable () const
   {
     float t = i*ni - 1.01f;
     t = t<-1 ? -1 : (t>1 ? 1 : t);
-    t = (float) acos( t );
+    t = (float) std::acos( t );
     a[i] = (t <= M_PI-1e-5f) ? t : 0;
   }
   init = true;

--- a/recognition/include/pcl/recognition/face_detection/rf_face_utils.h
+++ b/recognition/include/pcl/recognition/face_detection/rf_face_utils.h
@@ -355,7 +355,7 @@ namespace pcl
             float pf = sums[branch_index] / static_cast<float> (branch_element_count[branch_index]);
             float pnf = (static_cast<LabelDataType>(branch_element_count[branch_index]) - sums[branch_index] + 1.f)
                         / static_cast<LabelDataType> (branch_element_count[branch_index]);
-            hp[branch_index] -= static_cast<float>(pf * log (pf) + pnf * log (pnf));
+            hp[branch_index] -= static_cast<float>(pf * std::log (pf) + pnf * std::log (pnf));
           }
 
           //use mean of the examples as purity

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -103,7 +103,7 @@ namespace pcl
             if (e <= threshold_)
               return (0.5 * e*e); 
             else
-              return (0.5 * threshold_ * (2.0 * fabs (e) - threshold_));
+              return (0.5 * threshold_ * (2.0 * std::fabs (e) - threshold_));
           }
         protected:
           float threshold_;

--- a/registration/include/pcl/registration/impl/lum.hpp
+++ b/registration/include/pcl/registration/impl/lum.hpp
@@ -379,9 +379,9 @@ pcl::registration::LUM<PointT>::computeEdge (const Edge &e)
   // Compute s^2
   float ss = 0.0f;
   for (int ci = 0; ci != oci; ++ci)  // ci = correspondence iterator
-    ss += static_cast<float> (pow (corrs_diff[ci] (0) - (D (0) + corrs_aver[ci] (2) * D (5) - corrs_aver[ci] (1) * D (4)), 2.0f)
-                            + pow (corrs_diff[ci] (1) - (D (1) + corrs_aver[ci] (0) * D (4) - corrs_aver[ci] (2) * D (3)), 2.0f)
-                            + pow (corrs_diff[ci] (2) - (D (2) + corrs_aver[ci] (1) * D (3) - corrs_aver[ci] (0) * D (5)), 2.0f));
+    ss += static_cast<float> (std::pow (corrs_diff[ci] (0) - (D (0) + corrs_aver[ci] (2) * D (5) - corrs_aver[ci] (1) * D (4)), 2.0f)
+                            + std::pow (corrs_diff[ci] (1) - (D (1) + corrs_aver[ci] (0) * D (4) - corrs_aver[ci] (2) * D (3)), 2.0f)
+                            + std::pow (corrs_diff[ci] (2) - (D (2) + corrs_aver[ci] (1) * D (3) - corrs_aver[ci] (0) * D (5)), 2.0f));
 
   // When reaching the limitations of computation due to linearization
   if (ss < 0.0000000000001 || !std::isfinite (ss))

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -125,7 +125,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
 
           Eigen::Vector3f scene_point_transformed = transform_sg * scene_point;
           float alpha_s = atan2f ( -scene_point_transformed(2), scene_point_transformed(1));
-          if (sin (alpha_s) * scene_point_transformed(2) < 0.0f)
+          if (std::sin (alpha_s) * scene_point_transformed(2) < 0.0f)
             alpha_s *= (-1);
           alpha_s *= (-1);
 
@@ -136,7 +136,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
             size_t model_point_index = nearest_index.second;
             // Calculate angle alpha = alpha_m - alpha_s
             float alpha = search_method_->alpha_m_[model_reference_index][model_point_index] - alpha_s;
-            unsigned int alpha_discretized = static_cast<unsigned int> (floor (alpha) + floor (M_PI / search_method_->getAngleDiscretizationStep ()));
+            unsigned int alpha_discretized = static_cast<unsigned int> (std::floor (alpha) + floor (M_PI / search_method_->getAngleDiscretizationStep ()));
             accumulator_array[model_reference_index][alpha_discretized] ++;
           }
         }

--- a/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
+++ b/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
@@ -249,7 +249,7 @@ pcl::PyramidFeatureHistogram<PointFeature>::at (std::vector<float> &feature,
 
   std::vector<size_t> access;
   for (size_t dim_i = 0; dim_i < nr_dimensions; ++dim_i)
-    access.push_back (static_cast<size_t> (floor ((feature[dim_i] - dimension_range_target_[dim_i].first) / hist_levels[level].bin_step[dim_i])));
+    access.push_back (static_cast<size_t> (std::floor ((feature[dim_i] - dimension_range_target_[dim_i].first) / hist_levels[level].bin_step[dim_i])));
 
   return at (access, level);
 }

--- a/registration/include/pcl/registration/impl/transformation_estimation_2D.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_2D.hpp
@@ -152,9 +152,9 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
   float angle = atan2 ((H (0, 1) - H (1, 0)), (H(0, 0) + H (1, 1)));
   
   Eigen::Matrix<Scalar, 3, 3> R (Eigen::Matrix<Scalar, 3, 3>::Identity ());
-  R (0, 0) = R (1, 1) = cos (angle);
-  R (0, 1) = -sin (angle);
-  R (1, 0) = sin (angle);
+  R (0, 0) = R (1, 1) = std::cos (angle);
+  R (0, 1) = -std::sin (angle);
+  R (1, 0) = std::sin (angle);
 
   // Return the correct transformation
   transformation_matrix.topLeftCorner (3, 3).matrix () = R;

--- a/registration/include/pcl/registration/warp_point_rigid_6d.h
+++ b/registration/include/pcl/registration/warp_point_rigid_6d.h
@@ -88,7 +88,7 @@ namespace pcl
           
           // Compute w from the unit quaternion
           Eigen::Quaternion<Scalar> q (0, p[3], p[4], p[5]);
-          q.w () = static_cast<Scalar> (sqrt (1 - q.dot (q)));
+          q.w () = static_cast<Scalar> (std::sqrt (1 - q.dot (q)));
           q.normalize ();
           transform_matrix_.topLeftCorner (3, 3) = q.toRotationMatrix ();
         }

--- a/registration/src/correspondence_rejection_organized_boundary.cpp
+++ b/registration/src/correspondence_rejection_organized_boundary.cpp
@@ -66,7 +66,7 @@ pcl::registration::CorrespondenceRejectionOrganizedBoundary::getRemainingCorresp
             y + y_d >= 0 && y + y_d < static_cast<int> (cloud->height))
         {
           if (!std::isfinite ((*cloud)(x + x_d, y + y_d).z) ||
-              fabs ((*cloud)(x, y).z - (*cloud)(x + x_d, y + y_d).z) > depth_step_threshold_)
+              std::fabs ((*cloud)(x, y).z - (*cloud)(x + x_d, y + y_d).z) > depth_step_threshold_)
             nan_count_tgt ++;
         }
 

--- a/registration/src/ppf_registration.cpp
+++ b/registration/src/ppf_registration.cpp
@@ -51,7 +51,7 @@ pcl::PPFHashMapSearch::setInputFeatureCloud (PointCloud<PPFSignature>::ConstPtr 
 {
   // Discretize the feature cloud and insert it in the hash map
   feature_hash_map_->clear ();
-  unsigned int n = static_cast<unsigned int> (sqrt (static_cast<float> (feature_cloud->points.size ())));
+  unsigned int n = static_cast<unsigned int> (std::sqrt (static_cast<float> (feature_cloud->points.size ())));
   int d1, d2, d3, d4;
   max_dist_ = -1.0;
   alpha_m_.resize (n);
@@ -60,10 +60,10 @@ pcl::PPFHashMapSearch::setInputFeatureCloud (PointCloud<PPFSignature>::ConstPtr 
     std::vector <float> alpha_m_row (n);
     for (size_t j = 0; j < n; ++j)
     {
-      d1 = static_cast<int> (floor (feature_cloud->points[i*n+j].f1 / angle_discretization_step_));
-      d2 = static_cast<int> (floor (feature_cloud->points[i*n+j].f2 / angle_discretization_step_));
-      d3 = static_cast<int> (floor (feature_cloud->points[i*n+j].f3 / angle_discretization_step_));
-      d4 = static_cast<int> (floor (feature_cloud->points[i*n+j].f4 / distance_discretization_step_));
+      d1 = static_cast<int> (std::floor (feature_cloud->points[i*n+j].f1 / angle_discretization_step_));
+      d2 = static_cast<int> (std::floor (feature_cloud->points[i*n+j].f2 / angle_discretization_step_));
+      d3 = static_cast<int> (std::floor (feature_cloud->points[i*n+j].f3 / angle_discretization_step_));
+      d4 = static_cast<int> (std::floor (feature_cloud->points[i*n+j].f4 / distance_discretization_step_));
       feature_hash_map_->insert (std::pair<HashKeyStruct, std::pair<size_t, size_t> > (HashKeyStruct (d1, d2, d3, d4), std::pair<size_t, size_t> (i, j)));
       alpha_m_row [j] = feature_cloud->points[i*n + j].alpha_m;
 
@@ -88,10 +88,10 @@ pcl::PPFHashMapSearch::nearestNeighborSearch (float &f1, float &f2, float &f3, f
     return;
   }
 
-  int d1 = static_cast<int> (floor (f1 / angle_discretization_step_)),
-      d2 = static_cast<int> (floor (f2 / angle_discretization_step_)),
-      d3 = static_cast<int> (floor (f3 / angle_discretization_step_)),
-      d4 = static_cast<int> (floor (f4 / distance_discretization_step_));
+  int d1 = static_cast<int> (std::floor (f1 / angle_discretization_step_)),
+      d2 = static_cast<int> (std::floor (f2 / angle_discretization_step_)),
+      d3 = static_cast<int> (std::floor (f3 / angle_discretization_step_)),
+      d4 = static_cast<int> (std::floor (f4 / distance_discretization_step_));
 
   indices.clear ();
   HashKeyStruct key = HashKeyStruct (d1, d2, d3, d4);

--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -294,11 +294,11 @@ pcl::search::OrganizedNeighbor<PointT>::getProjectedRadiusSearchBox (const Point
   }
   else
   {
-    float y1 = static_cast<float> ((b - sqrt (det)) / a);
-    float y2 = static_cast<float> ((b + sqrt (det)) / a);
+    float y1 = static_cast<float> ((b - std::sqrt (det)) / a);
+    float y2 = static_cast<float> ((b + std::sqrt (det)) / a);
 
-    min = std::min (static_cast<int> (floor (y1)), static_cast<int> (floor (y2)));
-    max = std::max (static_cast<int> (ceil (y1)), static_cast<int> (ceil (y2)));
+    min = std::min (static_cast<int> (std::floor (y1)), static_cast<int> (std::floor (y2)));
+    max = std::max (static_cast<int> (std::ceil (y1)), static_cast<int> (std::ceil (y2)));
     minY = static_cast<unsigned> (std::min (static_cast<int> (input_->height) - 1, std::max (0, min)));
     maxY = static_cast<unsigned> (std::max (std::min (static_cast<int> (input_->height) - 1, max), 0));
   }
@@ -314,11 +314,11 @@ pcl::search::OrganizedNeighbor<PointT>::getProjectedRadiusSearchBox (const Point
   }
   else
   {
-    float x1 = static_cast<float> ((b - sqrt (det)) / a);
-    float x2 = static_cast<float> ((b + sqrt (det)) / a);
+    float x1 = static_cast<float> ((b - std::sqrt (det)) / a);
+    float x2 = static_cast<float> ((b + std::sqrt (det)) / a);
 
-    min = std::min (static_cast<int> (floor (x1)), static_cast<int> (floor (x2)));
-    max = std::max (static_cast<int> (ceil (x1)), static_cast<int> (ceil (x2)));
+    min = std::min (static_cast<int> (std::floor (x1)), static_cast<int> (std::floor (x2)));
+    max = std::max (static_cast<int> (std::ceil (x1)), static_cast<int> (std::ceil (x2)));
     minX = static_cast<unsigned> (std::min (static_cast<int> (input_->width)- 1, std::max (0, min)));
     maxX = static_cast<unsigned> (std::max (std::min (static_cast<int> (input_->width) - 1, max), 0));
   }

--- a/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
@@ -284,8 +284,8 @@ pcl::GrabCut<PointT>::initGraph ()
     {
       case TrimapUnknown :
       {
-        fore = static_cast<float> (-log (background_GMM_.probabilityDensity (image_->points[point_index])));
-        back = static_cast<float> (-log (foreground_GMM_.probabilityDensity (image_->points[point_index])));
+        fore = static_cast<float> (-std::log (background_GMM_.probabilityDensity (image_->points[point_index])));
+        back = static_cast<float> (-std::log (foreground_GMM_.probabilityDensity (image_->points[point_index])));
         break;
       }
       case TrimapBackground :
@@ -342,7 +342,7 @@ pcl::GrabCut<PointT>::computeNLinksNonOrganized ()
           // We saved the color distance previously at the computeBeta stage for optimization purpose
           float color_distance = *weights_it;
           // Set the real weight
-          *weights_it = static_cast<float> (lambda_ * exp (-beta_ * color_distance) / sqrt (*dists_it));
+          *weights_it = static_cast<float> (lambda_ * std::exp (-beta_ * color_distance) / sqrt (*dists_it));
         }
       }
     }
@@ -362,16 +362,16 @@ pcl::GrabCut<PointT>::computeNLinksOrganized ()
       NLinks &links = n_links_[point_index];
 
       if( x > 0 && y < image_->height-1 )
-        links.weights[0] = lambda_ * exp (-beta_ * links.weights[0]) / links.dists[0];
+        links.weights[0] = lambda_ * std::exp (-beta_ * links.weights[0]) / links.dists[0];
 
       if( y < image_->height-1 )
-        links.weights[1] = lambda_ * exp (-beta_ * links.weights[1]) / links.dists[1];
+        links.weights[1] = lambda_ * std::exp (-beta_ * links.weights[1]) / links.dists[1];
 
       if( x < image_->width-1 && y < image_->height-1 )
-        links.weights[2] = lambda_ * exp (-beta_ * links.weights[2]) / links.dists[2];
+        links.weights[2] = lambda_ * std::exp (-beta_ * links.weights[2]) / links.dists[2];
 
       if( x < image_->width-1 )
-        links.weights[3] = lambda_ * exp (-beta_ * links.weights[3]) / links.dists[3];
+        links.weights[3] = lambda_ * std::exp (-beta_ * links.weights[3]) / links.dists[3];
     }
 	}
 }
@@ -436,7 +436,7 @@ pcl::GrabCut<PointT>::computeBetaOrganized ()
       {
         std::size_t upleft = (y+1)  * input_->width + x - 1;
         links.indices[0] = upleft;
-        links.dists[0] = sqrt (2.f);
+        links.dists[0] = std::sqrt (2.f);
         float color_dist =  squaredEuclideanDistance (image_->points[point_index],
                                                       image_->points[upleft]);
         links.weights[0] = color_dist;
@@ -460,7 +460,7 @@ pcl::GrabCut<PointT>::computeBetaOrganized ()
       {
         std::size_t upright = (y+1) * input_->width + x + 1;
         links.indices[2] = upright;
-        links.dists[2] = sqrt (2.f);
+        links.dists[2] = std::sqrt (2.f);
         float color_dist =  squaredEuclideanDistance (image_->points[point_index],
                                                       image_->points [upright]);
         links.weights[2] = color_dist;

--- a/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
@@ -100,7 +100,7 @@ pcl::seededHueSegmentation (const PointCloud<PointXYZRGB>          &cloud,
         PointXYZHSV h_l;
         PointXYZRGBtoXYZHSV(p_l, h_l);
 
-        if (fabs(h_l.h - h.h) < delta_hue)
+        if (std::fabs(h_l.h - h.h) < delta_hue)
         {
           seed_queue.push_back (nn_indices[j]);
           processed[nn_indices[j]] = true;
@@ -174,7 +174,7 @@ pcl::seededHueSegmentation (const PointCloud<PointXYZRGB>            &cloud,
         PointXYZHSV h_l;
         PointXYZRGBtoXYZHSV(p_l, h_l);
 
-        if (fabs(h_l.h - h.h) < delta_hue)
+        if (std::fabs(h_l.h - h.h) < delta_hue)
         {
           seed_queue.push_back (nn_indices[j]);
           processed[nn_indices[j]] = true;

--- a/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
@@ -193,7 +193,7 @@ namespace pcl
           float z = vec.dot (z_axis_);
           threshold *= z * z;
         }
-        return ( (fabs ((*plane_coeff_d_)[idx1] - (*plane_coeff_d_)[idx2]) < threshold)
+        return ( (std::fabs ((*plane_coeff_d_)[idx1] - (*plane_coeff_d_)[idx2]) < threshold)
                  && (normals_->points[idx1].getNormalVector3fMap ().dot (normals_->points[idx2].getNormalVector3fMap () ) > angular_threshold_ ) );
       }
       

--- a/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
@@ -186,7 +186,7 @@ namespace pcl
         const pcl::ModelCoefficients& model_coeff = (*models_)[(*label_to_model_)[current_label]];
         
         PointT pt = input_->points[idx2];
-        double ptp_dist = fabs (model_coeff.values[0] * pt.x + 
+        double ptp_dist = std::fabs (model_coeff.values[0] * pt.x + 
                                 model_coeff.values[1] * pt.y + 
                                 model_coeff.values[2] * pt.z +
                                 model_coeff.values[3]);

--- a/segmentation/src/grabcut_segmentation.cpp
+++ b/segmentation/src/grabcut_segmentation.cpp
@@ -655,7 +655,7 @@ pcl::segmentation::grabcut::GMM::probabilityDensity (std::size_t i, const Color 
                 g * (r*G.inverse (0,1) + g*G.inverse (1,1) + b*G.inverse (2,1)) +
                 b * (r*G.inverse (0,2) + g*G.inverse (1,2) + b*G.inverse (2,2));
 
-      result = static_cast<float> (1.0/(sqrt (G.determinant)) * exp (-0.5*d));
+      result = static_cast<float> (1.0/(std::sqrt (G.determinant)) * exp (-0.5*d));
     }
   }
 

--- a/stereo/src/stereo_matching.cpp
+++ b/stereo/src/stereo_matching.cpp
@@ -165,7 +165,7 @@ pcl::StereoMatching::getVisualMap (pcl::PointCloud<pcl::RGB>::Ptr vMap)
       }
       else
       {
-        unsigned char val = static_cast<unsigned char> (floor (scale*disp_map_[y * width_+ x]));
+        unsigned char val = static_cast<unsigned char> (std::floor (scale*disp_map_[y * width_+ x]));
         vMap->at (x, y).r = val;
         vMap->at (x, y).g = val;
         vMap->at (x, y).b = val;

--- a/surface/include/pcl/surface/convex_hull.h
+++ b/surface/include/pcl/surface/convex_hull.h
@@ -57,8 +57,8 @@ namespace pcl
   inline bool
   comparePoints2D (const std::pair<int, Eigen::Vector4f> & p1, const std::pair<int, Eigen::Vector4f> & p2)
   {
-    double angle1 = atan2 (p1.second[1], p1.second[0]) + M_PI;
-    double angle2 = atan2 (p2.second[1], p2.second[0]) + M_PI;
+    double angle1 = std::atan2 (p1.second[1], p1.second[0]) + M_PI;
+    double angle2 = std::atan2 (p2.second[1], p2.second[0]) + M_PI;
     return (angle1 > angle2);
   }
 

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -405,8 +405,8 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
           // Pruning by visibility criterion 
           if ((state_[nnIdx[i]] == FRINGE) && (ffn_[R_] != nnIdx[i]) && (sfn_[R_] != nnIdx[i]))
           {
-            double angle1 = atan2(e.first[1] - uvn_nn[i][1], e.first[0] - uvn_nn[i][0]);
-            double angle2 = atan2(e.second[1] - uvn_nn[i][1], e.second[0] - uvn_nn[i][0]);
+            double angle1 = std::atan2(e.first[1] - uvn_nn[i][1], e.first[0] - uvn_nn[i][0]);
+            double angle2 = std::atan2(e.second[1] - uvn_nn[i][1], e.second[0] - uvn_nn[i][0]);
             double angleMin, angleMax;
             if (angle1 < angle2)
             {
@@ -439,7 +439,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
               tmp_ = coords_[source_[nnIdx[i]]] - proj_qp_;
               uvn_s[0] = tmp_.dot(u_);
               uvn_s[1] = tmp_.dot(v_);
-              double angleS = atan2(uvn_s[1] - uvn_nn[i][1], uvn_s[0] - uvn_nn[i][0]);
+              double angleS = std::atan2(uvn_s[1] - uvn_nn[i][1], uvn_s[0] - uvn_nn[i][0]);
               if ((angleMin < angleS) && (angleS < angleMax))
               {
                 if ((angleMin < angleR) && (angleR < angleMax))

--- a/surface/include/pcl/surface/impl/grid_projection.hpp
+++ b/surface/include/pcl/surface/impl/grid_projection.hpp
@@ -405,7 +405,7 @@ pcl::GridProjection<PointNT>::getVectorAtPointKNN (const Eigen::Vector4f &p,
   for (int i = 0; i < k_; i++)
   {
     //k_weight[i] = pow (M_E, -pow (k_squared_distances[i], 2.0) / gaussian_scale_);
-    k_weight[i] = std::pow (static_cast<float>(M_E), static_cast<float>(-pow (static_cast<float>(k_squared_distances[i]), 2.0f) / gaussian_scale_));
+    k_weight[i] = std::pow (static_cast<float>(M_E), static_cast<float>(-std::pow (static_cast<float>(k_squared_distances[i]), 2.0f) / gaussian_scale_));
     sum += k_weight[i];
   }
   pcl::VectorAverage3f vector_average;

--- a/surface/include/pcl/surface/impl/surfel_smoothing.hpp
+++ b/surface/include/pcl/surface/impl/surfel_smoothing.hpp
@@ -174,7 +174,7 @@ pcl::SurfelSmoothing<PointT, PointNT>::smoothPoint (size_t &point_index,
   int big_iterations = 0;
   int max_big_iterations = 500;
 
-  while (fabs (error_residual) < fabs (last_error_residual) -error_residual_threshold_ &&
+  while (std::fabs (error_residual) < std::fabs (last_error_residual) -error_residual_threshold_ &&
          big_iterations < max_big_iterations)
   {
     average_normal = Eigen::Vector4f::Zero ();
@@ -201,7 +201,7 @@ pcl::SurfelSmoothing<PointT, PointNT>::smoothPoint (size_t &point_index,
     float e_residual_along_normal = 2, last_e_residual_along_normal = 3;
     int small_iterations = 0;
     int max_small_iterations = 10;
-    while ( fabs (e_residual_along_normal) < fabs (last_e_residual_along_normal) &&
+    while ( std::fabs (e_residual_along_normal) < std::fabs (last_e_residual_along_normal) &&
         small_iterations < max_small_iterations)
     {
       small_iterations ++;

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -394,7 +394,7 @@ pcl::TextureMapping<PointInT>::isPointOccluded (const PointInT &pt, OctreePtr oc
      continue;
    }
 
-   if (fabs (cloud->points[index].z - pt.z) <= distance_threshold)
+   if (std::fabs (cloud->points[index].z - pt.z) <= distance_threshold)
    {
      // points are very close to each-other, we do not consider the occlusion
      nbocc--;
@@ -450,7 +450,7 @@ pcl::TextureMapping<PointInT>::removeOccludedPoints (const PointCloudPtr &input_
         continue;
       }
 
-      if (fabs (input_cloud->points[index].z - input_cloud->points[i].z) <= maxDeltaZ)
+      if (std::fabs (input_cloud->points[index].z - input_cloud->points[i].z) <= maxDeltaZ)
       {
         // points are very close to each-other, we do not consider the occlusion
         nbocc--;
@@ -692,14 +692,14 @@ pcl::TextureMapping<PointInT>::showOcclusions (const PointCloudPtr &input_cloud,
       {
         nbocc--;
       }
-      else if (fabs (input_cloud->points[index].z - pt.z) <= maxDeltaZ)
+      else if (std::fabs (input_cloud->points[index].z - pt.z) <= maxDeltaZ)
       {
         // points are very close to each-other, we do not consider the occlusion
         nbocc--;
       }
       else
       {
-        zDist.push_back (fabs (input_cloud->points[index].z - pt.z));
+        zDist.push_back (std::fabs (input_cloud->points[index].z - pt.z));
         ptDist.push_back (pcl::euclideanDistance (input_cloud->points[index], pt));
       }
     }
@@ -1002,7 +1002,7 @@ pcl::TextureMapping<PointInT>::getTriangleCircumcenterAndSize(const pcl::PointXY
     circomcenter.y = static_cast<float> (p1.y + (ptB.x*(cx2 + cy2) - ptC.x*(bx2 + by2)) / D);
   }
 
-  radius = sqrt( (circomcenter.x - p1.x)*(circomcenter.x - p1.x)  + (circomcenter.y - p1.y)*(circomcenter.y - p1.y));//2.0* (p1.x*(p2.y - p3.y)  + p2.x*(p3.y - p1.y) + p3.x*(p1.y - p2.y));
+  radius = std::sqrt( (circomcenter.x - p1.x)*(circomcenter.x - p1.x)  + (circomcenter.y - p1.y)*(circomcenter.y - p1.y));//2.0* (p1.x*(p2.y - p3.y)  + p2.x*(p3.y - p1.y) + p3.x*(p1.y - p2.y));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/surface/include/pcl/surface/organized_fast_mesh.h
+++ b/surface/include/pcl/surface/organized_fast_mesh.h
@@ -364,7 +364,7 @@ namespace pcl
           float cos_angle = dir_a.dot (dir_b) / (distance_to_points*distance_between_points);
           if (std::isnan(cos_angle))
             cos_angle = 1.0f;
-          bool check_angle = fabs (cos_angle) >= cos_angle_tolerance_;
+          bool check_angle = std::fabs (cos_angle) >= cos_angle_tolerance_;
 
           bool check_distance = true;
           if (check_angle && (distance_tolerance_ > 0))
@@ -388,9 +388,9 @@ namespace pcl
         {
           float dist = (use_depth_as_distance_ ? std::max(point_a.z, point_b.z) : distance_to_points);
           float dist_thresh = max_edge_length_a_;
-          if (fabs(max_edge_length_b_) > std::numeric_limits<float>::min())
+          if (std::fabs(max_edge_length_b_) > std::numeric_limits<float>::min())
             dist_thresh += max_edge_length_b_ * dist;
-          if (fabs(max_edge_length_c_) > std::numeric_limits<float>::min())
+          if (std::fabs(max_edge_length_c_) > std::numeric_limits<float>::min())
             dist_thresh += max_edge_length_c_ * dist * dist;
           valid = (distance_between_points <= dist_thresh);
         }

--- a/test/geometry/test_iterator.cpp
+++ b/test/geometry/test_iterator.cpp
@@ -184,9 +184,9 @@ void checkGeneralLine (unsigned x_start, unsigned y_start, unsigned x_end, unsig
         // point need to be close to line
         float distance = dir_x * float(yIdx - int(y_start)) - dir_y * float(xIdx - int(x_start));
         if (neighorhood)        
-          EXPECT_LE (fabs(distance), 0.5f);
+          EXPECT_LE (std::fabs(distance), 0.5f);
         else
-          EXPECT_LE (fabs(distance), 0.70711f);
+          EXPECT_LE (std::fabs(distance), 0.70711f);
         
         // and within the endpoints
         float lambda = dir_y * float(yIdx - int(y_start)) + dir_x * float(xIdx - int(x_start));
@@ -250,8 +250,8 @@ TEST (PCL, LineIterator8NeighborsGeneral)
   float d_alpha = float(M_PI / angular_resolution);
   for (unsigned idx = 0; idx < angular_resolution; ++idx)
   {
-    unsigned x_end = unsigned (length * cos (float(idx) * d_alpha) + center_x + 0.5);
-    unsigned y_end = unsigned (length * sin (float(idx) * d_alpha) + center_y + 0.5);
+    unsigned x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);
+    unsigned y_end = unsigned (length * std::sin (float(idx) * d_alpha) + center_y + 0.5);
     
     // right
     checkGeneralLine (center_x, center_y, x_end, y_end, cloud, true);
@@ -274,8 +274,8 @@ TEST (PCL, LineIterator4NeighborsGeneral)
   float d_alpha = float(2.0 * M_PI / angular_resolution);
   for (unsigned idx = 0; idx < angular_resolution; ++idx)
   {
-    unsigned x_end = unsigned (length * cos (float(idx) * d_alpha) + center_x + 0.5);
-    unsigned y_end = unsigned (length * sin (float(idx) * d_alpha) + center_y + 0.5);
+    unsigned x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);
+    unsigned y_end = unsigned (length * std::sin (float(idx) * d_alpha) + center_y + 0.5);
     
     // right
     checkGeneralLine (center_x, center_y, x_end, y_end, cloud, false);


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,performance-type-promotion-in-math-fn' -fix`