### PR TITLE
Fix `find_package_handle_standard_args` incorrect argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,12 +421,6 @@ configure_file("${pcl_config_h_in}" "${pcl_config_h}")
 PCL_ADD_INCLUDES(common "" "${pcl_config_h}")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
-### ---[ Set up for tests
-enable_testing()
-
-### ---[ Set up for examples
-#include("${PCL_SOURCE_DIR}/cmake/pcl_examples.cmake")
-
 ### ---[ Add the libraries subdirectories
 include("${PCL_SOURCE_DIR}/cmake/pcl_targets.cmake")
 

--- a/cmake/Modules/FindGTestSource.cmake
+++ b/cmake/Modules/FindGTestSource.cmake
@@ -32,7 +32,8 @@ set(GTEST_INCLUDE_DIRS ${GTEST_INCLUDE_DIR})
 set(CMAKE_FIND_FRAMEWORK)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Gtest DEFAULT_MSG GTEST_INCLUDE_DIR GTEST_SRC_DIR)
+find_package_handle_standard_args(GTestSource DEFAULT_MSG GTEST_INCLUDE_DIR GTEST_SRC_DIR)
+set(GTEST_FOUND ${GTestSource_FOUND})
 
 mark_as_advanced(GTEST_INCLUDE_DIR GTEST_SRC_DIR)
 


### PR DESCRIPTION
* Fix regression introduced in 32d6cefe6581239f69c61e243e85a5a1b5a51680
* find_package_handle_standard_args is meant to be invoked with the
same package name as a preceding call to find_package. Without it,
it won't be able to tell, if the package is required or optional.

Fixes #2722