### PR TITLE
Fix: No member named 'timed_wait' in 'std::condition_variable'

### DIFF
--- a/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
+++ b/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
@@ -259,7 +259,7 @@ class PeoplePCDApp
           capture_.start ();
           while (!exit_ && !final_view_.wasStopped())
           {
-            bool has_data = data_ready_cond_.timed_wait(lock, boost::posix_time::millisec(100));
+            bool has_data = (data_ready_cond_.wait_for(lock, 100ms) == std::cv_status::no_timeout);
             if(has_data)
             {
               SampledScopeTime fps(time_ms_);

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -993,7 +993,7 @@ struct KinFuApp
       { 
         if (triggered_capture)
             capture_.start(); // Triggers new frame
-        bool has_data = data_ready_cond_.timed_wait (lock, boost::posix_time::millisec(100));        
+        bool has_data = (data_ready_cond_.wait_for(lock, 100ms) == std::cv_status::no_timeout);
                        
         try { this->execute (depth_, rgb24_, has_data); }
         catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; break; }

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -1004,7 +1004,7 @@ struct KinFuLSApp
         if (triggered_capture)
           capture_.start(); // Triggers new frame
 
-        bool has_data = data_ready_cond_.timed_wait (lock, boost::posix_time::millisec(100));
+        bool has_data = (data_ready_cond_.wait_for(lock, 100ms) == std::cv_status::no_timeout);
 
         try { this->execute (depth_, rgb24_, has_data); }
         catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; break; }

--- a/gpu/people/tools/people_app.cpp
+++ b/gpu/people/tools/people_app.cpp
@@ -293,7 +293,7 @@ class PeoplePCDApp
           capture_.start ();
           while (!exit_ && !final_view_.wasStopped())
           {                                    
-            bool has_data = data_ready_cond_.timed_wait(lock, boost::posix_time::millisec(100));
+            bool has_data = (data_ready_cond_.wait_for(lock, 100ms) == std::cv_status::no_timeout);
             if(has_data)
             {                   
               SampledScopeTime fps(time_ms_);


### PR DESCRIPTION
Currently I can't compile the master, because of issues like:
```
error: no member named 'timed_wait' in 'std::condition_variable'
        bool has_data = data_ready_cond_.timed_wait (lock, boost::posix_time::millisec(100));
```
Not sure why build servers didn't failed on #3093 and #3094.

I believe `using namespace std::chrono_literals;` is currently missing here, but because my build stops at 55% because of another failure, I'm not sure. I hope Azure build server will fail because of it, to see, if it is really necessary.