### PR TITLE
Transition to std type_traits

### DIFF
--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/boost.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/boost.h
@@ -49,4 +49,3 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/signals2/connection.hpp>
-#include <boost/type_traits/is_same.hpp>

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/common_types.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/common_types.h
@@ -83,7 +83,7 @@ namespace pcl
       typedef pcl::geometry::NoData HalfEdgeData;
       typedef pcl::geometry::NoData EdgeData;
       typedef pcl::geometry::NoData FaceData;
-      typedef boost::true_type      IsManifold;
+      typedef std::true_type      IsManifold;
     };
 
     // NOTE: The drawMesh method in pcl::ihs::InHandScanner only supports triangles!

--- a/common/include/pcl/common/concatenate.h
+++ b/common/include/pcl/common/concatenate.h
@@ -40,15 +40,7 @@
 
 #include <pcl/conversions.h>
 
-// We're doing a lot of black magic with Boost here, so disable warnings in Maintainer mode, as we will never
-// be able to fix them anyway
-#ifdef BUILD_Maintainer
-#  if defined __GNUC__
-#    pragma GCC system_header 
-#  elif defined _MSC_VER
-#    pragma warning(push, 1)
-#  endif
-#endif
+#include <type_traits>
 
 namespace pcl
 {
@@ -73,7 +65,7 @@ namespace pcl
       typedef typename pcl::traits::datatype<PointInT, Key>::type InT;
       typedef typename pcl::traits::datatype<PointOutT, Key>::type OutT;
       // Note: don't currently support different types for the same field (e.g. converting double to float)
-      BOOST_MPL_ASSERT_MSG ((boost::is_same<InT, OutT>::value),
+      BOOST_MPL_ASSERT_MSG ((std::is_same<InT, OutT>::value),
                             POINT_IN_AND_POINT_OUT_HAVE_DIFFERENT_TYPES_FOR_FIELD,
                             (Key, PointInT&, InT, PointOutT&, OutT));
       memcpy (reinterpret_cast<uint8_t*>(&p2_) + pcl::traits::offset<PointOutT, Key>::value,
@@ -86,14 +78,3 @@ namespace pcl
       PodOut &p2_;
   };
 }
-
-#ifdef BUILD_Maintainer
-#  if defined __GNUC__
-#    if __GNUC__ == 4 && __GNUC_MINOR__ > 3
-#      pragma GCC diagnostic warning "-Weffc++"
-#      pragma GCC diagnostic warning "-pedantic"
-#    endif
-#  elif defined _MSC_VER
-#    pragma warning(pop)
-#  endif
-#endif

--- a/common/include/pcl/common/impl/copy_point.hpp
+++ b/common/include/pcl/common/impl/copy_point.hpp
@@ -77,7 +77,7 @@ namespace pcl
     struct CopyPointHelper { };
 
     template <typename PointInT, typename PointOutT>
-    struct CopyPointHelper<PointInT, PointOutT, typename boost::enable_if<boost::is_same<PointInT, PointOutT> >::type>
+    struct CopyPointHelper<PointInT, PointOutT, std::enable_if_t<std::is_same<PointInT, PointOutT>::value>>
     {
       void operator () (const PointInT& point_in, PointOutT& point_out) const
       {
@@ -87,13 +87,13 @@ namespace pcl
 
     template <typename PointInT, typename PointOutT>
     struct CopyPointHelper<PointInT, PointOutT,
-                           typename boost::enable_if<boost::mpl::and_<boost::mpl::not_<boost::is_same<PointInT, PointOutT> >,
-                                                                      boost::mpl::or_<boost::mpl::not_<pcl::traits::has_color<PointInT> >,
-                                                                                      boost::mpl::not_<pcl::traits::has_color<PointOutT> >,
-                                                                                      boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
-                                                                                                       pcl::traits::has_field<PointOutT, pcl::fields::rgb> >,
-                                                                                      boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
-                                                                                                       pcl::traits::has_field<PointOutT, pcl::fields::rgba> > > > >::type>
+                           std::enable_if_t<boost::mpl::and_<boost::mpl::not_<std::is_same<PointInT, PointOutT>>,
+                                                             boost::mpl::or_<boost::mpl::not_<pcl::traits::has_color<PointInT>>,
+                                                                             boost::mpl::not_<pcl::traits::has_color<PointOutT>>,
+                                                                             boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
+                                                                                              pcl::traits::has_field<PointOutT, pcl::fields::rgb>>,
+                                                                             boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
+                                                                                              pcl::traits::has_field<PointOutT, pcl::fields::rgba>>>>::value>>
     {
       void operator () (const PointInT& point_in, PointOutT& point_out) const
       {
@@ -106,11 +106,11 @@ namespace pcl
 
     template <typename PointInT, typename PointOutT>
     struct CopyPointHelper<PointInT, PointOutT,
-                           typename boost::enable_if<boost::mpl::and_<boost::mpl::not_<boost::is_same<PointInT, PointOutT> >,
-                                                                      boost::mpl::or_<boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
-                                                                                                       pcl::traits::has_field<PointOutT, pcl::fields::rgba> >,
-                                                                                      boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
-                                                                                                       pcl::traits::has_field<PointOutT, pcl::fields::rgb> > > > >::type>
+                           std::enable_if_t<boost::mpl::and_<boost::mpl::not_<std::is_same<PointInT, PointOutT>>,
+                                            boost::mpl::or_<boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
+                                                                             pcl::traits::has_field<PointOutT, pcl::fields::rgba>>,
+                                                            boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
+                                                                             pcl::traits::has_field<PointOutT, pcl::fields::rgb>>>>::value>>
     {
       void operator () (const PointInT& point_in, PointOutT& point_out) const
       {

--- a/common/include/pcl/for_each_type.h
+++ b/common/include/pcl/for_each_type.h
@@ -53,8 +53,9 @@
 #include <boost/mpl/contains.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/mpl/aux_/unwrap.hpp>
-#include <boost/type_traits/is_same.hpp>
 #endif
+
+#include <type_traits>
 
 namespace pcl 
 {
@@ -82,7 +83,7 @@ namespace pcl
 #endif
 
       typedef typename boost::mpl::next<Iterator>::type iter;
-      for_each_type_impl<boost::is_same<iter, LastIterator>::value>
+      for_each_type_impl<std::is_same<iter, LastIterator>::value>
         ::template execute<iter, LastIterator, F> (f);
     }
   };
@@ -94,7 +95,7 @@ namespace pcl
     BOOST_MPL_ASSERT (( boost::mpl::is_sequence<Sequence> ));
     typedef typename boost::mpl::begin<Sequence>::type first;
     typedef typename boost::mpl::end<Sequence>::type last;
-    for_each_type_impl<boost::is_same<first, last>::value>::template execute<first, last, F> (f);
+    for_each_type_impl<std::is_same<first, last>::value>::template execute<first, last, F> (f);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -45,8 +45,6 @@
 #include "pcl/pcl_macros.h"
 
 #include <pcl/PCLPointField.h>
-#include <boost/type_traits/remove_all_extents.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/assert.hpp>
 
 // This is required for the workaround at line 109
@@ -54,6 +52,8 @@
 #include <Eigen/Core>
 #include <Eigen/src/StlSupport/details.h>
 #endif
+
+#include <type_traits>
 
 namespace pcl
 {
@@ -98,7 +98,7 @@ namespace pcl
     // its scalar type and total number of elements.
     template<typename T> struct decomposeArray
     {
-      typedef typename boost::remove_all_extents<T>::type type;
+      typedef std::remove_all_extents_t<T> type;
       static const uint32_t value = sizeof (T) / sizeof (type);
     };
 
@@ -144,7 +144,7 @@ namespace pcl
       // static const char value[];
 
       // Avoid infinite compile-time recursion
-      BOOST_MPL_ASSERT_MSG((!boost::is_same<PointT, typename POD<PointT>::type>::value),
+      BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
                            POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
     };
 
@@ -156,7 +156,7 @@ namespace pcl
       // static const size_t value;
 
       // Avoid infinite compile-time recursion
-      BOOST_MPL_ASSERT_MSG((!boost::is_same<PointT, typename POD<PointT>::type>::value),
+      BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
                            POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
     };
 
@@ -170,7 +170,7 @@ namespace pcl
       // static const uint32_t size;
 
       // Avoid infinite compile-time recursion
-      BOOST_MPL_ASSERT_MSG((!boost::is_same<PointT, typename POD<PointT>::type>::value),
+      BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
                            POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
     };
 
@@ -182,20 +182,9 @@ namespace pcl
       // typedef boost::mpl::vector<...> type;
 
       // Avoid infinite compile-time recursion
-      BOOST_MPL_ASSERT_MSG((!boost::is_same<PointT, typename POD<PointT>::type>::value),
+      BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
                            POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
     };
-#if PCL_LINEAR_VERSION(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__) == PCL_LINEAR_VERSION(4,4,3)
-    /*
-      At least on GCC 4.4.3, but not later versions, some valid usages of the above traits for
-      non-POD (but registered) point types fail with:
-      error: ‘!(bool)mpl_::bool_<false>::value’ is not a valid template argument for type ‘bool’ because it is a non-constant expression
-
-      "Priming the pump" with the trivial assertion below somehow fixes the problem...
-     */
-    //BOOST_MPL_ASSERT_MSG((!bool (mpl_::bool_<false>::value)), WTF_GCC443, (bool));
-    BOOST_MPL_ASSERT_MSG((!bool (boost::mpl::bool_<false>::value)), WTF_GCC443, (bool));
-#endif
   } //namespace traits
 
   // Return true if the PCLPointField matches the expected name and data type.

--- a/common/include/pcl/register_point_struct.h
+++ b/common/include/pcl/register_point_struct.h
@@ -60,10 +60,10 @@
 #include <boost/preprocessor/seq/transform.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/comparison.hpp>
-#include <boost/utility.hpp>
-#include <boost/type_traits.hpp>
 #endif
-#include <stddef.h> //offsetof
+
+#include <cstddef> //offsetof
+#include <type_traits>
 
 // Must be used in global namespace with name fully qualified
 #define POINT_CLOUD_REGISTER_POINT_STRUCT(name, fseq)               \
@@ -94,102 +94,102 @@ namespace pcl
   namespace traits
   {
     template<typename T> inline
-    typename boost::disable_if_c<boost::is_array<T>::value>::type
+    std::enable_if_t<!std::is_array<T>::value>
     plus (T &l, const T &r)
     {
       l += r;
     }
 
     template<typename T> inline
-    typename boost::enable_if_c<boost::is_array<T>::value>::type
-    plus (typename boost::remove_const<T>::type &l, const T &r)
+    std::enable_if_t<std::is_array<T>::value>
+    plus (std::remove_const_t<T> &l, const T &r)
     {
-      typedef typename boost::remove_all_extents<T>::type type;
+      typedef std::remove_all_extents_t<T> type;
       static const uint32_t count = sizeof (T) / sizeof (type);
       for (int i = 0; i < count; ++i)
         l[i] += r[i];
     }
 
     template<typename T1, typename T2> inline
-    typename boost::disable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<!std::is_array<T1>::value>
     plusscalar (T1 &p, const T2 &scalar)
     {
       p += scalar;
     }
 
     template<typename T1, typename T2> inline
-    typename boost::enable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<std::is_array<T1>::value>
     plusscalar (T1 &p, const T2 &scalar)
     {
-      typedef typename boost::remove_all_extents<T1>::type type;
+      typedef std::remove_all_extents_t<T1> type;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] += scalar;
     }
 
     template<typename T> inline
-    typename boost::disable_if_c<boost::is_array<T>::value>::type
+    std::enable_if_t<!std::is_array<T>::value>
     minus (T &l, const T &r)
     {
       l -= r;
     }
 
     template<typename T> inline
-    typename boost::enable_if_c<boost::is_array<T>::value>::type
-    minus (typename boost::remove_const<T>::type &l, const T &r)
+    std::enable_if_t<std::is_array<T>::value>
+    minus (std::remove_const_t<T> &l, const T &r)
     {
-      typedef typename boost::remove_all_extents<T>::type type;
+      typedef std::remove_all_extents_t<T> type;
       static const uint32_t count = sizeof (T) / sizeof (type);
       for (int i = 0; i < count; ++i)
         l[i] -= r[i];
     }
 
     template<typename T1, typename T2> inline
-    typename boost::disable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<!std::is_array<T1>::value>
     minusscalar (T1 &p, const T2 &scalar)
     {
       p -= scalar;
     }
 
     template<typename T1, typename T2> inline
-    typename boost::enable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<std::is_array<T1>::value>
     minusscalar (T1 &p, const T2 &scalar)
     {
-      typedef typename boost::remove_all_extents<T1>::type type;
+      typedef std::remove_all_extents_t<T1> type;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] -= scalar;
     }
 
     template<typename T1, typename T2> inline
-    typename boost::disable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<!std::is_array<T1>::value>
     mulscalar (T1 &p, const T2 &scalar)
     {
       p *= scalar;
     }
 
     template<typename T1, typename T2> inline
-    typename boost::enable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<std::is_array<T1>::value>
     mulscalar (T1 &p, const T2 &scalar)
     {
-      typedef typename boost::remove_all_extents<T1>::type type;
+      typedef std::remove_all_extents_t<T1> type;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] *= scalar;
     }
 
     template<typename T1, typename T2> inline
-    typename boost::disable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<!std::is_array<T1>::value>
     divscalar (T1 &p, const T2 &scalar)
     {
       p /= scalar;
     }
 
     template<typename T1, typename T2> inline
-    typename boost::enable_if_c<boost::is_array<T1>::value>::type
+    std::enable_if_t<std::is_array<T1>::value>
     divscalar (T1 &p, const T2 &scalar)
     {
-      typedef typename boost::remove_all_extents<T1>::type type;
+      typedef std::remove_all_extents_t<T1> type;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] /= scalar;
@@ -231,7 +231,7 @@ namespace pcl
   /***/
 
 // Construct type traits given full sequence of (type, name, tag) triples
-//  BOOST_MPL_ASSERT_MSG(boost::is_pod<name>::value,
+//  BOOST_MPL_ASSERT_MSG(std::is_pod<name>::value,
 //                       REGISTERED_POINT_TYPE_MUST_BE_PLAIN_OLD_DATA, (name));
 #define POINT_CLOUD_REGISTER_POINT_STRUCT_I(name, seq)                           \
   namespace pcl                                                                  \

--- a/geometry/include/pcl/geometry/boost.h
+++ b/geometry/include/pcl/geometry/boost.h
@@ -44,9 +44,6 @@
 #  pragma GCC system_header
 #endif
 
-#include <boost/concept_check.hpp>
 #include <boost/operators.hpp>
-#include <boost/type_traits/integral_constant.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/version.hpp>

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -40,8 +40,6 @@
 
 #pragma once
 
-#include <vector>
-
 #include <pcl/geometry/boost.h>
 #include <pcl/geometry/eigen.h>
 #include <pcl/geometry/mesh_circulators.h>
@@ -49,6 +47,9 @@
 #include <pcl/geometry/mesh_elements.h>
 #include <pcl/geometry/mesh_traits.h>
 #include <pcl/point_cloud.h>
+
+#include <vector>
+#include <type_traits>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Global variables used during testing
@@ -112,15 +113,15 @@ namespace pcl
         typedef typename MeshTraitsT::IsManifold   IsManifold;
 
         // Check if the mesh traits are defined correctly.
-        BOOST_CONCEPT_ASSERT ((boost::Convertible <IsManifold, bool>));
+        static_assert (std::is_convertible<IsManifold, bool>::value, "MeshTraitsT::IsManifold is not convertible to bool");
 
         typedef MeshTagT MeshTag;
 
         // Data
-        typedef boost::integral_constant <bool, !boost::is_same <VertexData  , pcl::geometry::NoData>::value> HasVertexData;
-        typedef boost::integral_constant <bool, !boost::is_same <HalfEdgeData, pcl::geometry::NoData>::value> HasHalfEdgeData;
-        typedef boost::integral_constant <bool, !boost::is_same <EdgeData    , pcl::geometry::NoData>::value> HasEdgeData;
-        typedef boost::integral_constant <bool, !boost::is_same <FaceData    , pcl::geometry::NoData>::value> HasFaceData;
+        typedef std::integral_constant <bool, !std::is_same <VertexData  , pcl::geometry::NoData>::value> HasVertexData;
+        typedef std::integral_constant <bool, !std::is_same <HalfEdgeData, pcl::geometry::NoData>::value> HasHalfEdgeData;
+        typedef std::integral_constant <bool, !std::is_same <EdgeData    , pcl::geometry::NoData>::value> HasEdgeData;
+        typedef std::integral_constant <bool, !std::is_same <FaceData    , pcl::geometry::NoData>::value> HasFaceData;
 
         typedef pcl::PointCloud <VertexData>   VertexDataCloud;
         typedef pcl::PointCloud <HalfEdgeData> HalfEdgeDataCloud;
@@ -709,7 +710,7 @@ namespace pcl
         isBoundary (const FaceIndex& idx_face) const
         {
           assert (this->isValid (idx_face));
-          return (this->isBoundary (idx_face, boost::integral_constant <bool, CheckVerticesT> ()));
+          return (this->isBoundary (idx_face, std::integral_constant <bool, CheckVerticesT> ()));
         }
 
         /** \brief Check if the given face lies on the boundary. This method uses isBoundary \c true which checks if any vertex lies on the boundary. */
@@ -717,7 +718,7 @@ namespace pcl
         isBoundary (const FaceIndex& idx_face) const
         {
           assert (this->isValid (idx_face));
-          return (this->isBoundary (idx_face, boost::true_type ()));
+          return (this->isBoundary (idx_face, std::true_type ()));
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -1232,7 +1233,7 @@ namespace pcl
                         const VertexIndex&            idx_v_b,
                         HalfEdgeIndex&                idx_he_ab,
                         std::vector <bool>::reference is_new_ab,
-                        boost::true_type              /*is_manifold*/) const
+                        std::true_type              /*is_manifold*/) const
         {
           is_new_ab = true;
           if (this->isIsolated (idx_v_a)) return (true);
@@ -1250,7 +1251,7 @@ namespace pcl
                         const VertexIndex&            idx_v_b,
                         HalfEdgeIndex&                idx_he_ab,
                         std::vector <bool>::reference is_new_ab,
-                        boost::false_type              /*is_manifold*/) const
+                        std::false_type              /*is_manifold*/) const
         {
           is_new_ab = true;
           if (this->isIsolated (idx_v_a))                                   return (true);
@@ -1283,7 +1284,7 @@ namespace pcl
                         const bool                    is_isolated_b,
                         std::vector <bool>::reference /*make_adjacent_ab_bc*/,
                         HalfEdgeIndex&                /*idx_free_half_edge*/,
-                        boost::true_type              /*is_manifold*/) const
+                        std::true_type              /*is_manifold*/) const
         {
           if (is_new_ab && is_new_bc && !is_isolated_b) return (false);
           else                                          return (true);
@@ -1306,7 +1307,7 @@ namespace pcl
                         const bool                    /*is_isolated_b*/,
                         std::vector <bool>::reference make_adjacent_ab_bc,
                         HalfEdgeIndex&                idx_free_half_edge,
-                        boost::false_type             /*is_manifold*/) const
+                        std::false_type             /*is_manifold*/) const
         {
           if (is_new_ab || is_new_bc)
           {
@@ -1393,7 +1394,7 @@ namespace pcl
         connectNewNew (const HalfEdgeIndex& idx_he_ab,
                        const HalfEdgeIndex& idx_he_bc,
                        const VertexIndex&   idx_v_b,
-                       boost::true_type     /*is_manifold*/)
+                       std::true_type     /*is_manifold*/)
         {
           const HalfEdgeIndex idx_he_ba = this->getOppositeHalfEdgeIndex (idx_he_ab);
           const HalfEdgeIndex idx_he_cb = this->getOppositeHalfEdgeIndex (idx_he_bc);
@@ -1409,11 +1410,11 @@ namespace pcl
         connectNewNew (const HalfEdgeIndex& idx_he_ab,
                        const HalfEdgeIndex& idx_he_bc,
                        const VertexIndex&   idx_v_b,
-                       boost::false_type    /*is_manifold*/)
+                       std::false_type    /*is_manifold*/)
         {
           if (this->isIsolated (idx_v_b))
           {
-            this->connectNewNew (idx_he_ab, idx_he_bc, idx_v_b, boost::true_type ());
+            this->connectNewNew (idx_he_ab, idx_he_bc, idx_v_b, std::true_type ());
           }
           else
           {
@@ -1465,7 +1466,7 @@ namespace pcl
         connectOldOld (const HalfEdgeIndex& /*idx_he_ab*/,
                        const HalfEdgeIndex& /*idx_he_bc*/,
                        const VertexIndex&   /*idx_v_b*/,
-                       boost::true_type     /*is_manifold*/)
+                       std::true_type     /*is_manifold*/)
         {
         }
 
@@ -1474,7 +1475,7 @@ namespace pcl
         connectOldOld (const HalfEdgeIndex& /*idx_he_ab*/,
                        const HalfEdgeIndex& idx_he_bc,
                        const VertexIndex&   idx_v_b,
-                       boost::false_type    /*is_manifold*/)
+                       std::false_type    /*is_manifold*/)
         {
           const HalfEdgeIndex& idx_he_b_out = this->getOutgoingHalfEdgeIndex (idx_v_b);
 
@@ -1502,7 +1503,7 @@ namespace pcl
         /** \brief Add mesh data. */
         template <class DataT>
         inline void
-        addData (pcl::PointCloud <DataT>& cloud, const DataT& data, boost::true_type /*has_data*/)
+        addData (pcl::PointCloud <DataT>& cloud, const DataT& data, std::true_type /*has_data*/)
         {
           cloud.push_back (data);
         }
@@ -1510,7 +1511,7 @@ namespace pcl
         /** \brief Does nothing. */
         template <class DataT>
         inline void
-        addData (pcl::PointCloud <DataT>& /*cloud*/, const DataT& /*data*/, boost::false_type /*has_data*/)
+        addData (pcl::PointCloud <DataT>& /*cloud*/, const DataT& /*data*/, std::false_type /*has_data*/)
         {
         }
 
@@ -1521,7 +1522,7 @@ namespace pcl
         /** \brief Manifold version of deleteFace. If the mesh becomes non-manifold due to the delete operation the faces around the non-manifold vertex are deleted until the mesh becomes manifold again. */
         void
         deleteFace (const FaceIndex& idx_face,
-                    boost::true_type /*is_manifold*/)
+                    std::true_type /*is_manifold*/)
         {
           assert (this->isValid (idx_face));
           delete_faces_face_.clear ();
@@ -1533,14 +1534,14 @@ namespace pcl
             delete_faces_face_.pop_back ();
 
             // This calls the non-manifold version of deleteFace, which will call the manifold version of reconnect.
-            this->deleteFace (idx_face_cur, boost::false_type ());
+            this->deleteFace (idx_face_cur, std::false_type ());
           }
         }
 
         /** \brief Non-manifold version of deleteFace. */
         void
         deleteFace (const FaceIndex&  idx_face,
-                    boost::false_type /*is_manifold*/)
+                    std::false_type /*is_manifold*/)
         {
           assert (this->isValid (idx_face));
           if (this->isDeleted (idx_face)) return;
@@ -1642,7 +1643,7 @@ namespace pcl
         reconnectNBNB (const HalfEdgeIndex& idx_he_bc,
                        const HalfEdgeIndex& idx_he_cb,
                        const VertexIndex&   idx_v_b,
-                       boost::true_type     /*is_manifold*/)
+                       std::true_type     /*is_manifold*/)
         {
           if (this->isBoundary (idx_v_b))
           {
@@ -1660,7 +1661,7 @@ namespace pcl
                 // In a manifold mesh we can't invalidate the face while reconnecting!
                 // See the implementation of
                 // deleteFace (const FaceIndex&  idx_face,
-                //             boost::false_type /*is_manifold*/)
+                //             std::false_type /*is_manifold*/)
                 pcl::geometry::g_pcl_geometry_mesh_base_test_delete_face_manifold_2_success = false;
                 return;
               }
@@ -1678,7 +1679,7 @@ namespace pcl
         reconnectNBNB (const HalfEdgeIndex& idx_he_bc,
                        const HalfEdgeIndex& /*idx_he_cb*/,
                        const VertexIndex&   idx_v_b,
-                       boost::false_type    /*is_manifold*/)
+                       std::false_type    /*is_manifold*/)
         {
           if (!this->isBoundary (idx_v_b))
           {
@@ -1792,27 +1793,27 @@ namespace pcl
 
         /** \brief Increment the iterator. */
         template <class IteratorT> inline void
-        incrementIf (IteratorT& it, boost::true_type /*has_data*/) const
+        incrementIf (IteratorT& it, std::true_type /*has_data*/) const
         {
           ++it;
         }
 
         /** \brief Does nothing. */
         template <class IteratorT> inline void
-        incrementIf (IteratorT& /*it*/, boost::false_type /*has_data*/) const
+        incrementIf (IteratorT& /*it*/, std::false_type /*has_data*/) const
         {
         }
 
         /** \brief Assign the source iterator to the target iterator. */
         template <class ConstIteratorT, class IteratorT> inline void
-        assignIf (const ConstIteratorT source, IteratorT target, boost::true_type /*has_data*/) const
+        assignIf (const ConstIteratorT source, IteratorT target, std::true_type /*has_data*/) const
         {
           *target = *source;
         }
 
         /** \brief Does nothing. */
         template <class ConstIteratorT, class IteratorT> inline void
-        assignIf (const ConstIteratorT /*source*/, IteratorT /*target*/, boost::false_type /*has_data*/) const
+        assignIf (const ConstIteratorT /*source*/, IteratorT /*target*/, std::false_type /*has_data*/) const
         {
         }
 
@@ -1875,7 +1876,7 @@ namespace pcl
 
         /** \brief Check if any vertex of the face lies on the boundary. */
         bool
-        isBoundary (const FaceIndex& idx_face, boost::true_type /*check_vertices*/) const
+        isBoundary (const FaceIndex& idx_face, std::true_type /*check_vertices*/) const
         {
           VertexAroundFaceCirculator       circ     = this->getVertexAroundFaceCirculator (idx_face);
           const VertexAroundFaceCirculator circ_end = circ;
@@ -1893,7 +1894,7 @@ namespace pcl
 
         /** \brief Check if any edge of the face lies on the boundary. */
         bool
-        isBoundary (const FaceIndex& idx_face, boost::false_type /*check_vertices*/) const
+        isBoundary (const FaceIndex& idx_face, std::false_type /*check_vertices*/) const
         {
           OuterHalfEdgeAroundFaceCirculator       circ     = this->getOuterHalfEdgeAroundFaceCirculator (idx_face);
           const OuterHalfEdgeAroundFaceCirculator circ_end = circ;
@@ -1911,14 +1912,14 @@ namespace pcl
 
         /** \brief Always manifold. */
         inline bool
-        isManifold (const VertexIndex&, boost::true_type /*is_manifold*/) const
+        isManifold (const VertexIndex&, std::true_type /*is_manifold*/) const
         {
           return (true);
         }
 
         /** \brief Check if the given vertex is manifold. */
         bool
-        isManifold (const VertexIndex& idx_vertex, boost::false_type /*is_manifold*/) const
+        isManifold (const VertexIndex& idx_vertex, std::false_type /*is_manifold*/) const
         {
           OutgoingHalfEdgeAroundVertexCirculator       circ     = this->getOutgoingHalfEdgeAroundVertexCirculator (idx_vertex);
           const OutgoingHalfEdgeAroundVertexCirculator circ_end = circ;
@@ -1934,14 +1935,14 @@ namespace pcl
 
         /** \brief Always manifold. */
         inline bool
-        isManifold (boost::true_type /*is_manifold*/) const
+        isManifold (std::true_type /*is_manifold*/) const
         {
           return (true);
         }
 
         /** \brief Check if all vertices in the mesh are manifold. */
         bool
-        isManifold (boost::false_type /*is_manifold*/) const
+        isManifold (std::false_type /*is_manifold*/) const
         {
           for (size_t i=0; i<this->sizeVertices (); ++i)
           {
@@ -1956,40 +1957,40 @@ namespace pcl
 
         /** \brief Reserve storage space for the mesh data. */
         template <class DataCloudT> inline void
-        reserveData (DataCloudT& cloud, const size_t n, boost::true_type /*has_data*/) const
+        reserveData (DataCloudT& cloud, const size_t n, std::true_type /*has_data*/) const
         {
           cloud.reserve (n);
         }
 
         /** \brief Does nothing */
         template <class DataCloudT> inline void
-        reserveData (DataCloudT& /*cloud*/, const size_t /*n*/, boost::false_type /*has_data*/) const
+        reserveData (DataCloudT& /*cloud*/, const size_t /*n*/, std::false_type /*has_data*/) const
         {
         }
 
         /** \brief Resize the mesh data. */
         template <class DataCloudT> inline void
-        resizeData (DataCloudT& /*data_cloud*/, const size_t n, const typename DataCloudT::value_type& data, boost::true_type /*has_data*/) const
+        resizeData (DataCloudT& /*data_cloud*/, const size_t n, const typename DataCloudT::value_type& data, std::true_type /*has_data*/) const
         {
           data.resize (n, data);
         }
 
         /** \brief Does nothing. */
         template <class DataCloudT> inline void
-        resizeData (DataCloudT& /*data_cloud*/, const size_t /*n*/, const typename DataCloudT::value_type& /*data*/, boost::false_type /*has_data*/) const
+        resizeData (DataCloudT& /*data_cloud*/, const size_t /*n*/, const typename DataCloudT::value_type& /*data*/, std::false_type /*has_data*/) const
         {
         }
 
         /** \brief Clear the mesh data. */
         template <class DataCloudT> inline void
-        clearData (DataCloudT& cloud, boost::true_type /*has_data*/) const
+        clearData (DataCloudT& cloud, std::true_type /*has_data*/) const
         {
           cloud.clear ();
         }
 
         /** \brief Does nothing. */
         template <class DataCloudT> inline void
-        clearData (DataCloudT& /*cloud*/, boost::false_type /*has_data*/) const
+        clearData (DataCloudT& /*cloud*/, std::false_type /*has_data*/) const
         {
         }
 

--- a/geometry/include/pcl/geometry/mesh_traits.h
+++ b/geometry/include/pcl/geometry/mesh_traits.h
@@ -40,22 +40,14 @@
 
 #pragma once
 
-#include <pcl/geometry/boost.h>
+#include <type_traits>
 
 namespace pcl
-{ 
+{
   namespace geometry
   {
     /** \brief No data is associated with the vertices / half-edges / edges / faces. */
-    struct NoData
-    {
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION <= 1101
-      operator unsigned char() const
-      {
-        return 0;
-      }
-#endif
-    };
+    struct NoData {};
 
     /** \brief The mesh traits are used to set up compile time settings for the mesh.
       * \tparam VertexDataT   Data stored for each vertex. Defaults to pcl::NoData.
@@ -77,7 +69,7 @@ namespace pcl
       typedef FaceDataT     FaceData;
 
       /** \brief Specifies whether the mesh is manifold or not (only non-manifold vertices can be represented). */
-      typedef boost::false_type IsManifold;
+      typedef std::false_type IsManifold;
     };
   } // End namespace geometry
 } // End namespace pcl

--- a/test/geometry/test_mesh.cpp
+++ b/test/geometry/test_mesh.cpp
@@ -67,7 +67,7 @@ struct MeshTraits
     typedef pcl::geometry::NoData                        HalfEdgeData;
     typedef pcl::geometry::NoData                        EdgeData;
     typedef pcl::geometry::NoData                        FaceData;
-    typedef boost::integral_constant <bool, IsManifoldT> IsManifold;
+    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
 };
 
 typedef pcl::geometry::TriangleMesh <MeshTraits <true > > ManifoldTriangleMesh;

--- a/test/geometry/test_mesh_circulators.cpp
+++ b/test/geometry/test_mesh_circulators.cpp
@@ -64,7 +64,7 @@ class TestMeshCirculators : public ::testing::Test
       typedef pcl::geometry::NoData HalfEdgeData;
       typedef pcl::geometry::NoData EdgeData;
       typedef pcl::geometry::NoData FaceData;
-      typedef boost::true_type      IsManifold;
+      typedef std::true_type      IsManifold;
     };
 
     typedef pcl::geometry::TriangleMesh <MeshTraits>     Mesh;

--- a/test/geometry/test_mesh_conversion.cpp
+++ b/test/geometry/test_mesh_conversion.cpp
@@ -49,6 +49,8 @@
 
 #include "test_mesh_common_functions.h"
 
+#include <type_traits>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template <class MeshTraitsT>
@@ -141,7 +143,7 @@ struct MeshTraits
     typedef pcl::geometry::NoData                        HalfEdgeData;
     typedef pcl::geometry::NoData                        EdgeData;
     typedef pcl::geometry::NoData                        FaceData;
-    typedef boost::integral_constant <bool, IsManifoldT> IsManifold;
+    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
 };
 
 typedef MeshTraits <true > ManifoldMeshTraits;

--- a/test/geometry/test_mesh_get_boundary.cpp
+++ b/test/geometry/test_mesh_get_boundary.cpp
@@ -53,7 +53,7 @@ struct MeshTraits
     typedef pcl::geometry::NoData                        HalfEdgeData;
     typedef pcl::geometry::NoData                        EdgeData;
     typedef pcl::geometry::NoData                        FaceData;
-    typedef boost::integral_constant <bool, IsManifoldT> IsManifold;
+    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
 };
 
 typedef pcl::geometry::PolygonMesh <MeshTraits <true > > ManifoldMesh;

--- a/test/geometry/test_polygon_mesh.cpp
+++ b/test/geometry/test_polygon_mesh.cpp
@@ -47,6 +47,8 @@
 
 #include "test_mesh_common_functions.h"
 
+#include <type_traits>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef pcl::geometry::VertexIndex   VertexIndex;
@@ -65,7 +67,7 @@ struct MeshTraits
     typedef pcl::geometry::NoData                        HalfEdgeData;
     typedef pcl::geometry::NoData                        EdgeData;
     typedef pcl::geometry::NoData                        FaceData;
-    typedef boost::integral_constant <bool, IsManifoldT> IsManifold;
+    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
 };
 
 typedef pcl::geometry::PolygonMesh <MeshTraits <true > > ManifoldPolygonMesh;

--- a/test/geometry/test_quad_mesh.cpp
+++ b/test/geometry/test_quad_mesh.cpp
@@ -65,7 +65,7 @@ struct MeshTraits
     typedef pcl::geometry::NoData                        HalfEdgeData;
     typedef pcl::geometry::NoData                        EdgeData;
     typedef pcl::geometry::NoData                        FaceData;
-    typedef boost::integral_constant <bool, IsManifoldT> IsManifold;
+    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
 };
 
 typedef pcl::geometry::QuadMesh <MeshTraits <true > > ManifoldQuadMesh;

--- a/test/geometry/test_triangle_mesh.cpp
+++ b/test/geometry/test_triangle_mesh.cpp
@@ -65,7 +65,7 @@ struct MeshTraits
     typedef pcl::geometry::NoData                        HalfEdgeData;
     typedef pcl::geometry::NoData                        EdgeData;
     typedef pcl::geometry::NoData                        FaceData;
-    typedef boost::integral_constant <bool, IsManifoldT> IsManifold;
+    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
 };
 
 typedef pcl::geometry::TriangleMesh <MeshTraits <true > > ManifoldTriangleMesh;


### PR DESCRIPTION
I performed all trivial replacement from type traits. There's still a lot being used from Boost.MPL, Boost.Preprocessor and Boost.Concept. Stripping those out is not feasible at this point.