### PR TITLE
Fix Garbled docstrings

### DIFF
--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -568,7 +568,7 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
     if (true) // kp.angle==-1
     {
       if (!rotation_invariance_enabled_)
-        // don't compute the gradient direction, just assign a rotation of 0°
+        // don't compute the gradient direction, just assign a rotation of 0 degree
         theta = 0;
       else
       {

--- a/filters/include/pcl/filters/fast_bilateral.h
+++ b/filters/include/pcl/filters/fast_bilateral.h
@@ -46,7 +46,7 @@ namespace pcl
 {
   /** \brief Implementation of a fast bilateral filter for smoothing depth information in organized point clouds
    *  Based on the following paper:
-   *    * Sylvain Paris and Frédo Durand
+   *    * Sylvain Paris and Fredo Durand
    *      "A Fast Approximation of the Bilateral Filter using a Signal Processing Approach"
    *       European Conference on Computer Vision (ECCV'06)
    *

--- a/filters/include/pcl/filters/fast_bilateral_omp.h
+++ b/filters/include/pcl/filters/fast_bilateral_omp.h
@@ -47,7 +47,7 @@ namespace pcl
 {
   /** \brief Implementation of a fast bilateral filter for smoothing depth information in organized point clouds
    *  Based on the following paper:
-   *    * Sylvain Paris and Frdo Durand
+   *    * Sylvain Paris and Fredo Durand
    *      "A Fast Approximation of the Bilateral Filter using a Signal Processing Approach"
    *       European Conference on Computer Vision (ECCV'06)
    *


### PR DESCRIPTION
Reason for fix :

If the comment is garbled, an error will occur when generating xml with "doxygen".