### PR TITLE
Use using instead of typedef [test]

### DIFF
--- a/test/common/test_common.cpp
+++ b/test/common/test_common.cpp
@@ -298,7 +298,7 @@ TEST (PCL, PointTypes)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename T> class XYZPointTypesTest : public ::testing::Test { };
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_XYZ_POINT_TYPES)> XYZPointTypes;
+using XYZPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_XYZ_POINT_TYPES)>;
 TYPED_TEST_CASE(XYZPointTypesTest, XYZPointTypes);
 TYPED_TEST(XYZPointTypesTest, GetVectorXfMap)
 {
@@ -319,7 +319,7 @@ TYPED_TEST(XYZPointTypesTest, GetArrayXfMap)
 }
 
 template <typename T> class NormalPointTypesTest : public ::testing::Test { };
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_NORMAL_POINT_TYPES)> NormalPointTypes;
+using NormalPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_NORMAL_POINT_TYPES)>;
 TYPED_TEST_CASE(NormalPointTypesTest, NormalPointTypes);
 TYPED_TEST(NormalPointTypesTest, GetNormalVectorXfMap)
 {
@@ -331,7 +331,7 @@ TYPED_TEST(NormalPointTypesTest, GetNormalVectorXfMap)
 }
 
 template <typename T> class RGBPointTypesTest : public ::testing::Test { };
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_RGB_POINT_TYPES)> RGBPointTypes;
+using RGBPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_RGB_POINT_TYPES)>;
 TYPED_TEST_CASE(RGBPointTypesTest, RGBPointTypes);
 TYPED_TEST(RGBPointTypesTest, GetRGBVectorXi)
 {
@@ -390,7 +390,7 @@ TEST (PCL, CopyIfFieldExists)
   p.r = 127; p.g = 64; p.b = 254;
   p.normal_x = 1.0; p.normal_y = 0.0; p.normal_z = 0.0;
 
-  typedef pcl::traits::fieldList<PointXYZRGBNormal>::type FieldList;
+  using FieldList = pcl::traits::fieldList<PointXYZRGBNormal>::type;
   bool is_x = false, is_y = false, is_z = false, is_rgb = false, 
        is_normal_x = false, is_normal_y = false, is_normal_z = false;
 
@@ -443,7 +443,7 @@ TEST (PCL, SetIfFieldExists)
   p.r = p.g = p.b = 0;
   p.normal_x = p.normal_y = p.normal_z = 0.0;
 
-  typedef pcl::traits::fieldList<PointXYZRGBNormal>::type FieldList;
+  using FieldList = pcl::traits::fieldList<PointXYZRGBNormal>::type;
   pcl::for_each_type<FieldList> (SetIfFieldExists<PointXYZRGBNormal, float> (p, "x", 1.0));
   EXPECT_EQ (p.x, 1.0);
   pcl::for_each_type<FieldList> (SetIfFieldExists<PointXYZRGBNormal, float> (p, "y", 2.0));

--- a/test/common/test_eigen.cpp
+++ b/test/common/test_eigen.cpp
@@ -57,9 +57,9 @@ namespace
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, InverseGeneral3x3f)
 {
-  typedef float Scalar;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor> CMatrix;
+  using Scalar = float;
+  using RMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor>;
   RMatrix r_matrix = RMatrix::Zero ();
   RMatrix r_inverse = RMatrix::Zero ();
   CMatrix c_matrix = CMatrix::Zero ();
@@ -116,9 +116,9 @@ TEST (PCL, InverseGeneral3x3f)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, InverseGeneral3x3d)
 {
-  typedef double Scalar;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor> CMatrix;
+  using Scalar = double;
+  using RMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor>;
   RMatrix r_matrix = RMatrix::Zero ();
   RMatrix r_inverse = RMatrix::Zero ();
   CMatrix c_matrix = CMatrix::Zero ();
@@ -175,9 +175,9 @@ TEST (PCL, InverseGeneral3x3d)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, InverseSymmetric3x3f)
 {
-  typedef float Scalar;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor> CMatrix;
+  using Scalar = float;
+  using RMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor>;
   RMatrix r_matrix = RMatrix::Zero ();
   RMatrix r_inverse = RMatrix::Zero ();
   CMatrix c_matrix = CMatrix::Zero ();
@@ -240,9 +240,9 @@ TEST (PCL, InverseSymmetric3x3f)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, InverseSymmetric3x3d)
 {
-  typedef double Scalar;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor> CMatrix;
+  using Scalar = double;
+  using RMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor>;
   RMatrix r_matrix = RMatrix::Zero ();
   RMatrix r_inverse = RMatrix::Zero ();
   CMatrix c_matrix = CMatrix::Zero ();
@@ -306,9 +306,9 @@ TEST (PCL, InverseSymmetric3x3d)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, Inverse2x2f)
 {
-  typedef float Scalar;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor> CMatrix;
+  using Scalar = float;
+  using RMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor>;
   RMatrix r_matrix = RMatrix::Zero ();
   RMatrix r_inverse = RMatrix::Zero ();
   CMatrix c_matrix = CMatrix::Zero ();
@@ -364,9 +364,9 @@ TEST (PCL, Inverse2x2f)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, Inverse2x2d)
 {
-  typedef double Scalar;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor> CMatrix;
+  using Scalar = double;
+  using RMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor>;
   RMatrix r_matrix = RMatrix::Zero ();
   RMatrix r_inverse = RMatrix::Zero ();
   CMatrix c_matrix = CMatrix::Zero ();
@@ -422,7 +422,7 @@ TEST (PCL, Inverse2x2d)
 template<class Matrix>
 inline void generateSymPosMatrix2x2 (Matrix& matrix)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
 
   unsigned test_case = rand_uint (rng) % 10;
 
@@ -464,9 +464,9 @@ inline void generateSymPosMatrix2x2 (Matrix& matrix)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, eigen22d)
 {
-  typedef double Scalar;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor> CMatrix;
+  using Scalar = double;
+  using RMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor>;
   RMatrix r_matrix;
   RMatrix r_vectors;
   Eigen::Matrix<Scalar, 2, 1> r_eigenvalues;
@@ -522,9 +522,9 @@ TEST (PCL, eigen22d)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, eigen22f)
 {
-  typedef float Scalar;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor> CMatrix;
+  using Scalar = float;
+  using RMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 2, 2, Eigen::ColMajor>;
   RMatrix r_matrix;
   RMatrix r_vectors;
   Eigen::Matrix<Scalar, 2, 1> r_eigenvalues;
@@ -582,7 +582,7 @@ TEST (PCL, eigen22f)
 template<class Matrix>
 inline void generateSymPosMatrix3x3 (Matrix& matrix)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
 
   // 3 equal elements != 0
   // 2 equal elements none 0
@@ -661,9 +661,9 @@ inline void generateSymPosMatrix3x3 (Matrix& matrix)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, eigen33d)
 {
-  typedef double Scalar;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor> CMatrix;
+  using Scalar = double;
+  using RMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor>;
   RMatrix r_matrix;
   RMatrix r_vectors;
   Eigen::Matrix<Scalar, 3, 1> r_eigenvalues;
@@ -721,9 +721,9 @@ TEST (PCL, eigen33d)
 // some errors > 0.2 but less than 1% is > 1e-3 -> we will just check whether the failure rate is below 1%
 TEST (PCL, eigen33f)
 {
-  typedef float Scalar;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor> RMatrix;
-  typedef Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor> CMatrix;
+  using Scalar = float;
+  using RMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::RowMajor>;
+  using CMatrix = Eigen::Matrix<Scalar, 3, 3, Eigen::ColMajor>;
   RMatrix r_matrix;
   RMatrix r_vectors;
   Eigen::Matrix<Scalar, 3, 1> r_eigenvalues;

--- a/test/common/test_geometry.cpp
+++ b/test/common/test_geometry.cpp
@@ -45,7 +45,7 @@ using namespace pcl;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T> class XYZPointTypesTest : public ::testing::Test { };
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_XYZ_POINT_TYPES)> XYZPointTypes;
+using XYZPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_XYZ_POINT_TYPES)>;
 TYPED_TEST_CASE(XYZPointTypesTest, XYZPointTypes);
 
 TYPED_TEST(XYZPointTypesTest, Distance)

--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -43,10 +43,10 @@
 using namespace pcl;
 using namespace std;
 
-typedef PointCloud <PointXYZRGBA>      CloudXYZRGBA;
-typedef PointCloud <PointXYZRGB>       CloudXYZRGB;
-typedef PointCloud <PointXYZRGBNormal> CloudXYZRGBNormal;
-typedef PointCloud <PointXYZ>          CloudXYZ;
+using CloudXYZRGBA = PointCloud<PointXYZRGBA>;
+using CloudXYZRGB = PointCloud<PointXYZRGB>;
+using CloudXYZRGBNormal = PointCloud<PointXYZRGBNormal>;
+using CloudXYZ = PointCloud<PointXYZ>;
 
 PointXYZRGBA pt_xyz_rgba, pt_xyz_rgba2;
 PointXYZRGB pt_xyz_rgb;

--- a/test/common/test_transforms.cpp
+++ b/test/common/test_transforms.cpp
@@ -48,16 +48,17 @@
 
 using namespace pcl;
 
-typedef ::testing::Types<Eigen::Transform<float, 3, Eigen::Affine>,
-                         Eigen::Transform<double, 3, Eigen::Affine>,
-                         Eigen::Matrix<float, 4, 4>,
-                         Eigen::Matrix<double, 4,4> > TransformTypes;
+using TransformTypes = ::testing::Types
+        <Eigen::Transform<float, 3, Eigen::Affine>,
+         Eigen::Transform<double, 3, Eigen::Affine>,
+         Eigen::Matrix<float, 4, 4>,
+         Eigen::Matrix<double, 4,4> >;
 
 template <typename Transform>
 class Transforms : public ::testing::Test
 {
  public:
-  typedef typename Transform::Scalar Scalar;
+  using Scalar = typename Transform::Scalar;
 
   Transforms ()
   : ABS_ERROR (std::numeric_limits<Scalar>::epsilon () * 10)

--- a/test/features/test_base_feature.cpp
+++ b/test/features/test_base_feature.cpp
@@ -47,7 +47,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_board_estimation.cpp
+++ b/test/features/test_board_estimation.cpp
@@ -49,7 +49,7 @@ using namespace pcl::test;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_boundary_estimation.cpp
+++ b/test/features/test_boundary_estimation.cpp
@@ -47,7 +47,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_brisk.cpp
+++ b/test/features/test_brisk.cpp
@@ -47,8 +47,8 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef PointXYZRGBA PointT;
-typedef PointWithScale KeyPointT;
+using PointT = PointXYZRGBA;
+using KeyPointT = PointWithScale;
 
 
 PointCloud<PointT>::Ptr cloud_image (new PointCloud<PointT>);

--- a/test/features/test_cppf_estimation.cpp
+++ b/test/features/test_cppf_estimation.cpp
@@ -42,7 +42,7 @@
 #include <pcl/features/cppf.h>
 #include <pcl/io/pcd_io.h>
 
-typedef pcl::PointXYZRGBNormal PointT;
+using PointT = pcl::PointXYZRGBNormal;
 static pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT> ());
 
 

--- a/test/features/test_curvatures_estimation.cpp
+++ b/test/features/test_curvatures_estimation.cpp
@@ -47,7 +47,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_cvfh_estimation.cpp
+++ b/test/features/test_cvfh_estimation.cpp
@@ -48,8 +48,8 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
-typedef PointCloud<PointXYZ>::Ptr CloudPtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
+using CloudPtr = PointCloud<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_flare_estimation.cpp
+++ b/test/features/test_flare_estimation.cpp
@@ -44,8 +44,8 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/flare.h>
 
-typedef pcl::search::KdTree<pcl::PointXYZ>::Ptr KdTreePtr;
-typedef pcl::PointCloud<pcl::PointXYZ>::Ptr PointCloudPtr;
+using KdTreePtr = pcl::search::KdTree<pcl::PointXYZ>::Ptr;
+using PointCloudPtr = pcl::PointCloud<pcl::PointXYZ>::Ptr;
 
 PointCloudPtr cloud;
 KdTreePtr tree;

--- a/test/features/test_ii_normals.cpp
+++ b/test/features/test_ii_normals.cpp
@@ -46,7 +46,7 @@
 using namespace pcl;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 PointCloud<PointXYZ> cloud;
 KdTreePtr tree;
 

--- a/test/features/test_invariants_estimation.cpp
+++ b/test/features/test_invariants_estimation.cpp
@@ -46,7 +46,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -47,7 +47,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_pfh_estimation.cpp
+++ b/test/features/test_pfh_estimation.cpp
@@ -51,8 +51,8 @@
 #include <pcl/features/gfpfh.h>
 #include <pcl/io/pcd_io.h>
 
-typedef pcl::PointNormal PointT;
-typedef pcl::search::KdTree<PointT>::Ptr KdTreePtr;
+using PointT = pcl::PointNormal;
+using KdTreePtr = pcl::search::KdTree<PointT>::Ptr;
 using pcl::PointCloud;
 
 static PointCloud<PointT>::Ptr cloud (new PointCloud<PointT> ());
@@ -66,8 +66,8 @@ testIndicesAndSearchSurface (const typename PointCloud<PointT>::Ptr & points,
                              const boost::shared_ptr<std::vector<int> > & indices, int ndims)
 
 {
-  typedef pcl::search::KdTree<PointT> KdTreeT;
-  typedef FeatureEstimation<PointT, NormalT, OutputT> FeatureEstimationT;
+  using KdTreeT = pcl::search::KdTree<PointT>;
+  using FeatureEstimationT = FeatureEstimation<PointT, NormalT, OutputT>;
 
   //
   // Test setIndices and setSearchSurface
@@ -291,8 +291,9 @@ struct FPFHTest<FPFHEstimationOMP<PointT, PointT, FPFHSignature33> >
 };
 
 // Types which will be instantiated
-typedef ::testing::Types<FPFHEstimation<PointT, PointT, FPFHSignature33>,
-                         FPFHEstimationOMP<PointT, PointT, FPFHSignature33> > FPFHEstimatorTypes;
+using FPFHEstimatorTypes = ::testing::Types
+        <FPFHEstimation<PointT, PointT, FPFHSignature33>,
+         FPFHEstimationOMP<PointT, PointT, FPFHSignature33> >;
 TYPED_TEST_CASE (FPFHTest, FPFHEstimatorTypes);
 
 // This is a copy of the old FPFHEstimation test which will now

--- a/test/features/test_ppf_estimation.cpp
+++ b/test/features/test_ppf_estimation.cpp
@@ -47,7 +47,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_rift_estimation.cpp
+++ b/test/features/test_rift_estimation.cpp
@@ -103,7 +103,7 @@ TEST (PCL, RIFTEstimation)
   }
 
   // Compute the RIFT features
-  typedef Histogram<32> RIFTDescriptor;
+  using RIFTDescriptor = Histogram<32>;
   RIFTEstimation<PointXYZI, IntensityGradient, RIFTDescriptor> rift_est;
   search::KdTree<PointXYZI>::Ptr treept4 (new search::KdTree<PointXYZI> (false));
   rift_est.setSearchMethod (treept4);

--- a/test/features/test_rsd_estimation.cpp
+++ b/test/features/test_rsd_estimation.cpp
@@ -82,7 +82,7 @@ TEST (PCL, RSDEstimation)
   rsd.setSaveHistograms (true);
   rsd.compute (*rsds);
 
-  typedef std::vector<Eigen::MatrixXf, Eigen::aligned_allocator<Eigen::MatrixXf> > vec_matrixXf;
+  using vec_matrixXf = std::vector<Eigen::MatrixXf, Eigen::aligned_allocator<Eigen::MatrixXf> >;
   boost::shared_ptr<vec_matrixXf> mat (new vec_matrixXf);
 
   mat = rsd.getHistograms();

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -51,7 +51,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;
@@ -368,8 +368,9 @@ struct SHOTShapeTest<SHOTEstimationOMP<PointXYZ, Normal, SHOT352> >
 };
 
 // Types which will be instantiated
-typedef ::testing::Types<SHOTEstimation<PointXYZ, Normal, SHOT352>,
-                         SHOTEstimationOMP<PointXYZ, Normal, SHOT352> > SHOTEstimatorTypes;
+using SHOTEstimatorTypes = ::testing::Types
+        <SHOTEstimation<PointXYZ, Normal, SHOT352>,
+         SHOTEstimationOMP<PointXYZ, Normal, SHOT352> >;
 TYPED_TEST_CASE (SHOTShapeTest, SHOTEstimatorTypes);
 
 // This is a copy of the old SHOTShapeEstimation test which will now
@@ -556,8 +557,9 @@ struct SHOTShapeAndColorTest<SHOTColorEstimationOMP<PointXYZRGBA, Normal, SHOT13
 };
 
 // Types which will be instantiated
-typedef ::testing::Types<SHOTColorEstimation<PointXYZRGBA, Normal, SHOT1344>,
-                         SHOTColorEstimationOMP<PointXYZRGBA, Normal, SHOT1344> > SHOTColorEstimatorTypes;
+using SHOTColorEstimatorTypes= ::testing::Types
+        <SHOTColorEstimation<PointXYZRGBA, Normal, SHOT1344>,
+         SHOTColorEstimationOMP<PointXYZRGBA, Normal, SHOT1344> >;
 TYPED_TEST_CASE (SHOTShapeAndColorTest, SHOTColorEstimatorTypes);
 
 // This is a copy of the old SHOTShapeAndColorEstimation test which will now

--- a/test/features/test_shot_lrf_estimation.cpp
+++ b/test/features/test_shot_lrf_estimation.cpp
@@ -48,7 +48,7 @@ using namespace pcl::test;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;

--- a/test/features/test_spin_estimation.cpp
+++ b/test/features/test_spin_estimation.cpp
@@ -48,7 +48,7 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace std;
 
-typedef search::KdTree<PointXYZ>::Ptr KdTreePtr;
+using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
 vector<int> indices;
@@ -80,7 +80,7 @@ TEST (PCL, SpinImageEstimation)
   EXPECT_NEAR (normals->points[140].normal_y, -0.19499126, 1e-4);
   EXPECT_NEAR (normals->points[140].normal_z, -0.87091631, 1e-4);
 
-  typedef Histogram<153> SpinImage;
+  using SpinImage = Histogram<153>;
   SpinImageEstimation<PointXYZ, Normal, SpinImage> spin_est(8, 0.5, 16);
   // set parameters
   //spin_est.setInputWithNormals (cloud.makeShared (), normals);
@@ -257,7 +257,7 @@ TEST (PCL, IntensitySpinEstimation)
   cloud_xyzi.width = static_cast<uint32_t> (cloud_xyzi.points.size ());
 
   // Compute the intensity-domain spin features
-  typedef Histogram<20> IntensitySpin;
+  using IntensitySpin = Histogram<20>;
   IntensitySpinEstimation<PointXYZI, IntensitySpin> ispin_est;
   search::KdTree<PointXYZI>::Ptr treept3 (new search::KdTree<PointXYZI> (false));
   ispin_est.setSearchMethod (treept3);

--- a/test/geometry/test_mesh.cpp
+++ b/test/geometry/test_mesh.cpp
@@ -51,27 +51,27 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef pcl::geometry::VertexIndex   VertexIndex;
-typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-typedef pcl::geometry::EdgeIndex     EdgeIndex;
-typedef pcl::geometry::FaceIndex     FaceIndex;
+using VertexIndex = pcl::geometry::VertexIndex;
+using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+using EdgeIndex = pcl::geometry::EdgeIndex;
+using FaceIndex = pcl::geometry::FaceIndex;
 
-typedef std::vector <VertexIndex>   VertexIndices;
-typedef std::vector <HalfEdgeIndex> HalfEdgeIndices;
-typedef std::vector <FaceIndex>     FaceIndices;
+using VertexIndices = std::vector<VertexIndex>;
+using HalfEdgeIndices = std::vector<HalfEdgeIndex>;
+using FaceIndices = std::vector<FaceIndex>;
 
 template <bool IsManifoldT>
 struct MeshTraits
 {
-    typedef int                                          VertexData;
-    typedef pcl::geometry::NoData                        HalfEdgeData;
-    typedef pcl::geometry::NoData                        EdgeData;
-    typedef pcl::geometry::NoData                        FaceData;
-    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
+    using VertexData = int;
+    using HalfEdgeData = pcl::geometry::NoData;
+    using EdgeData = pcl::geometry::NoData;
+    using FaceData = pcl::geometry::NoData;
+    using IsManifold = std::integral_constant <bool, IsManifoldT>;
 };
 
-typedef pcl::geometry::TriangleMesh <MeshTraits <true > > ManifoldTriangleMesh;
-typedef pcl::geometry::TriangleMesh <MeshTraits <false> > NonManifoldTriangleMesh;
+using ManifoldTriangleMesh = pcl::geometry::TriangleMesh<MeshTraits<true> >;
+using NonManifoldTriangleMesh = pcl::geometry::TriangleMesh<MeshTraits<false> >;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -86,7 +86,7 @@ TEST (TestAddDeleteFace, NonManifold1)
   NonManifoldTriangleMesh mesh;
   for (unsigned int i=0; i<6; ++i) mesh.addVertex (i);
 
-  typedef VertexIndex VI;
+  using VI = VertexIndex;
   VertexIndices vi;
   std::vector <VertexIndices> faces;
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear (); // 0
@@ -143,7 +143,7 @@ TEST (TestAddDeleteFace, NonManifold2)
 {
   NonManifoldTriangleMesh mesh;
   for (unsigned int i=0; i<9; ++i) mesh.addVertex (i);
-  typedef VertexIndex VI;
+  using VI = VertexIndex;
   VertexIndices vi;
   std::vector <VertexIndices> faces;
 
@@ -333,8 +333,8 @@ TEST (TestAddDeleteFace, NonManifold2)
 
 TEST (TestAddDeleteFace, Manifold1)
 {
-  typedef ManifoldTriangleMesh Mesh;
-  typedef VertexIndex          VI;
+  using Mesh = ManifoldTriangleMesh;
+  using VI = VertexIndex;
   Mesh mesh;
   for (unsigned int i=0; i<7; ++i) mesh.addVertex (i);
 
@@ -432,8 +432,8 @@ TEST (TestAddDeleteFace, Manifold1)
 
 TEST (TestAddDeleteFace, Manifold2)
 {
-  typedef ManifoldTriangleMesh Mesh;
-  typedef VertexIndex          VI;
+  using Mesh = ManifoldTriangleMesh;
+  using VI = VertexIndex;
 
   //  1 ----- 3  //
   //  \ \   / /  //
@@ -498,8 +498,8 @@ TEST (TestAddDeleteFace, Manifold2)
 
 TEST (TestDelete, VertexAndEdge)
 {
-  typedef NonManifoldTriangleMesh Mesh;
-  typedef VertexIndex             VI;
+  using Mesh = NonManifoldTriangleMesh;
+  using VI = VertexIndex;
   Mesh mesh;
   for (unsigned int i=0; i<7; ++i) mesh.addVertex (i);
 
@@ -578,7 +578,7 @@ TEST (TestMesh, IsBoundaryIsManifold)
   NonManifoldTriangleMesh mesh;
   for (unsigned int i=0; i<6; ++i) mesh.addVertex (i);
 
-  typedef VertexIndex VI;
+  using VI = VertexIndex;
   VertexIndices vi;
   std::vector <VertexIndices> faces;
   vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (1)); faces.push_back (vi); vi.clear (); // 0

--- a/test/geometry/test_mesh_circulators.cpp
+++ b/test/geometry/test_mesh_circulators.cpp
@@ -49,33 +49,33 @@ class TestMeshCirculators : public ::testing::Test
 {
   protected:
 
-    typedef pcl::geometry::VertexIndex   VertexIndex;
-    typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-    typedef pcl::geometry::EdgeIndex     EdgeIndex;
-    typedef pcl::geometry::FaceIndex     FaceIndex;
+    using VertexIndex = pcl::geometry::VertexIndex;
+    using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+    using EdgeIndex = pcl::geometry::EdgeIndex;
+    using FaceIndex = pcl::geometry::FaceIndex;
 
-    typedef std::vector <VertexIndex>   VertexIndices;
-    typedef std::vector <HalfEdgeIndex> HalfEdgeIndices;
-    typedef std::vector <FaceIndex>     FaceIndices;
+    using VertexIndices = std::vector<VertexIndex>;
+    using HalfEdgeIndices = std::vector<HalfEdgeIndex>;
+    using FaceIndices = std::vector<FaceIndex>;
 
     struct MeshTraits
     {
-      typedef pcl::geometry::NoData VertexData;
-      typedef pcl::geometry::NoData HalfEdgeData;
-      typedef pcl::geometry::NoData EdgeData;
-      typedef pcl::geometry::NoData FaceData;
-      typedef std::true_type      IsManifold;
+      using VertexData = pcl::geometry::NoData;
+      using HalfEdgeData = pcl::geometry::NoData;
+      using EdgeData = pcl::geometry::NoData;
+      using FaceData = pcl::geometry::NoData;
+      using IsManifold = std::true_type;
     };
 
-    typedef pcl::geometry::TriangleMesh <MeshTraits>     Mesh;
-    typedef Mesh::VertexAroundVertexCirculator           VAVC;
-    typedef Mesh::OutgoingHalfEdgeAroundVertexCirculator OHEAVC;
-    typedef Mesh::IncomingHalfEdgeAroundVertexCirculator IHEAVC;
-    typedef Mesh::FaceAroundVertexCirculator             FAVC;
-    typedef Mesh::VertexAroundFaceCirculator             VAFC;
-    typedef Mesh::InnerHalfEdgeAroundFaceCirculator      IHEAFC;
-    typedef Mesh::OuterHalfEdgeAroundFaceCirculator      OHEAFC;
-    typedef Mesh::FaceAroundFaceCirculator               FAFC;
+    using Mesh = pcl::geometry::TriangleMesh<MeshTraits>;
+    using VAVC = Mesh::VertexAroundVertexCirculator;
+    using OHEAVC = Mesh::OutgoingHalfEdgeAroundVertexCirculator;
+    using IHEAVC = Mesh::IncomingHalfEdgeAroundVertexCirculator;
+    using FAVC = Mesh::FaceAroundVertexCirculator;
+    using VAFC = Mesh::VertexAroundFaceCirculator;
+    using IHEAFC = Mesh::InnerHalfEdgeAroundFaceCirculator;
+    using OHEAFC = Mesh::OuterHalfEdgeAroundFaceCirculator;
+    using FAFC = Mesh::FaceAroundFaceCirculator;
 
     //   1 - 6   //
     //  / \ / \  //
@@ -88,7 +88,7 @@ class TestMeshCirculators : public ::testing::Test
       for (int i=0; i<7; ++i) mesh_.addVertex ();
 
       VertexIndices vi;
-      typedef VertexIndex VI;
+      using VI = VertexIndex;
       vi.push_back (VI (0)); vi.push_back (VI (1)); vi.push_back (VI (2)); faces_.push_back (vi); vi.clear ();
       vi.push_back (VI (0)); vi.push_back (VI (2)); vi.push_back (VI (3)); faces_.push_back (vi); vi.clear ();
       vi.push_back (VI (0)); vi.push_back (VI (3)); vi.push_back (VI (4)); faces_.push_back (vi); vi.clear ();

--- a/test/geometry/test_mesh_common_functions.h
+++ b/test/geometry/test_mesh_common_functions.h
@@ -55,9 +55,9 @@ const unsigned int max_number_boundary_vertices = 100;
 template <class MeshT> bool
 hasFaces (const MeshT& mesh, const std::vector <typename MeshT::VertexIndices> &faces, const bool verbose = false)
 {
-  typedef typename MeshT::VertexAroundFaceCirculator VAFC;
-  typedef typename MeshT::VertexIndices              VertexIndices;
-  typedef typename MeshT::FaceIndex                  FaceIndex;
+  using VAFC = typename MeshT::VertexAroundFaceCirculator;
+  using VertexIndices = typename MeshT::VertexIndices;
+  using FaceIndex = typename MeshT::FaceIndex;
 
   if (mesh.sizeFaces () != faces.size ())
   {
@@ -116,9 +116,9 @@ hasFaces (const MeshT& mesh, const std::vector <typename MeshT::VertexIndices> &
 template <class MeshT> bool
 hasFaces (const MeshT& mesh, const std::vector <std::vector <int> > &faces, const bool verbose = false)
 {
-  typedef typename MeshT::VertexAroundFaceCirculator VAFC;
-  typedef typename MeshT::FaceIndex                  FaceIndex;
-  typedef typename MeshT::VertexDataCloud            VertexDataCloud;
+  using VAFC = typename MeshT::VertexAroundFaceCirculator;
+  using FaceIndex = typename MeshT::FaceIndex;
+  using VertexDataCloud = typename MeshT::VertexDataCloud;
 
   if (mesh.sizeFaces () != faces.size ())
   {
@@ -177,9 +177,9 @@ hasFaces (const MeshT& mesh, const std::vector <std::vector <int> > &faces, cons
 template <class MeshT> typename MeshT::VertexIndices
 getBoundaryVertices (const MeshT& mesh, const typename MeshT::VertexIndex& first, const bool verbose = false)
 {
-  typedef typename MeshT::VertexAroundFaceCirculator VAFC;
-  typedef typename MeshT::HalfEdgeIndex              HalfEdgeIndex;
-  typedef typename MeshT::VertexIndices              VertexIndices;
+  using VAFC = typename MeshT::VertexAroundFaceCirculator;
+  using HalfEdgeIndex = typename MeshT::HalfEdgeIndex;
+  using VertexIndices = typename MeshT::VertexIndices;
 
   const HalfEdgeIndex boundary_he = mesh.getOutgoingHalfEdgeIndex (first);
   if (!mesh.isBoundary (boundary_he))
@@ -217,9 +217,9 @@ getBoundaryVertices (const MeshT& mesh, const typename MeshT::VertexIndex& first
 template <class MeshT> std::vector <int>
 getBoundaryVertices (const MeshT& mesh, const int first, const bool verbose = false)
 {
-  typedef typename MeshT::VertexAroundFaceCirculator VAFC;
-  typedef typename MeshT::VertexIndex                VertexIndex;
-  typedef typename MeshT::HalfEdgeIndex              HalfEdgeIndex;
+  using VAFC = typename MeshT::VertexAroundFaceCirculator;
+  using VertexIndex = typename MeshT::VertexIndex;
+  using HalfEdgeIndex = typename MeshT::HalfEdgeIndex;
 
   const HalfEdgeIndex boundary_he = mesh.getOutgoingHalfEdgeIndex (VertexIndex (first));
   if (!mesh.isBoundary (boundary_he))
@@ -333,8 +333,8 @@ findHalfEdge (const MeshT&                       mesh,
               const typename MeshT::VertexIndex& idx_v_0,
               const typename MeshT::VertexIndex& idx_v_1)
 {
-  typedef typename MeshT::HalfEdgeIndex                HalfEdgeIndex;
-  typedef typename MeshT::VertexAroundVertexCirculator VAVC;
+  using HalfEdgeIndex = typename MeshT::HalfEdgeIndex;
+  using VAVC = typename MeshT::VertexAroundVertexCirculator;
 
   if (mesh.isIsolated (idx_v_0) || mesh.isIsolated (idx_v_1))
   {

--- a/test/geometry/test_mesh_conversion.cpp
+++ b/test/geometry/test_mesh_conversion.cpp
@@ -58,7 +58,7 @@ class TestMeshConversion : public ::testing::Test
 {
   protected:
 
-    typedef MeshTraitsT MeshTraits;
+    using MeshTraits = MeshTraitsT;
 
     // 2 - 1  7 - 6         17 - 16   //
     //  \ /   |   |        /       \  //
@@ -139,17 +139,17 @@ class TestMeshConversion : public ::testing::Test
 template <bool IsManifoldT>
 struct MeshTraits
 {
-    typedef pcl::PointXYZRGBNormal                       VertexData;
-    typedef pcl::geometry::NoData                        HalfEdgeData;
-    typedef pcl::geometry::NoData                        EdgeData;
-    typedef pcl::geometry::NoData                        FaceData;
-    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
+    using VertexData = pcl::PointXYZRGBNormal;
+    using HalfEdgeData = pcl::geometry::NoData;
+    using EdgeData = pcl::geometry::NoData;
+    using FaceData = pcl::geometry::NoData;
+    using IsManifold = std::integral_constant <bool, IsManifoldT>;
 };
 
-typedef MeshTraits <true > ManifoldMeshTraits;
-typedef MeshTraits <false> NonManifoldMeshTraits;
+using ManifoldMeshTraits = MeshTraits<true>;
+using NonManifoldMeshTraits = MeshTraits<false>;
 
-typedef testing::Types <ManifoldMeshTraits, NonManifoldMeshTraits> MeshTraitsTypes;
+using MeshTraitsTypes = testing::Types <ManifoldMeshTraits, NonManifoldMeshTraits>;
 
 TYPED_TEST_CASE (TestMeshConversion, MeshTraitsTypes);
 
@@ -157,10 +157,10 @@ TYPED_TEST_CASE (TestMeshConversion, MeshTraitsTypes);
 
 TYPED_TEST (TestMeshConversion, HalfEdgeMeshToFaceVertexMesh)
 {
-  typedef typename TestFixture::MeshTraits    Traits;
-  typedef pcl::geometry::PolygonMesh <Traits> Mesh;
-  typedef typename Mesh::VertexIndex          VertexIndex;
-  typedef typename Mesh::VertexIndices        VertexIndices;
+  using Traits = typename TestFixture::MeshTraits;
+  using Mesh = pcl::geometry::PolygonMesh<Traits>;
+  using VertexIndex = typename Mesh::VertexIndex;
+  using VertexIndices = typename Mesh::VertexIndices;
 
   const std::vector <std::vector <uint32_t> > faces =
       Mesh::IsManifold::value ? this->manifold_faces_ :
@@ -224,10 +224,10 @@ TYPED_TEST (TestMeshConversion, HalfEdgeMeshToFaceVertexMesh)
 
 TYPED_TEST (TestMeshConversion, FaceVertexMeshToHalfEdgeMesh)
 {
-  typedef typename TestFixture::MeshTraits          Traits;
-  typedef pcl::geometry::PolygonMesh <Traits>       Mesh;
-  typedef typename Mesh::FaceIndex                  FaceIndex;
-  typedef typename Mesh::VertexAroundFaceCirculator VAFC;
+  using Traits = typename TestFixture::MeshTraits;
+  using Mesh = pcl::geometry::PolygonMesh<Traits>;
+  using FaceIndex = typename Mesh::FaceIndex;
+  using VAFC = typename Mesh::VertexAroundFaceCirculator;
 
   // Generate the mesh
   pcl::PolygonMesh face_vertex_mesh;
@@ -294,8 +294,8 @@ TYPED_TEST (TestMeshConversion, FaceVertexMeshToHalfEdgeMesh)
 
 //TEST (TestFaceVertexMeshToHalfEdgeMesh, NoVertexData)
 //{
-//  typedef pcl::geometry::DefaultMeshTraits <>     MeshTraits;
-//  typedef pcl::geometry::PolygonMesh <MeshTraits> Mesh;
+//  using MeshTraits = pcl::geometry::DefaultMeshTraits <>;
+//  using Mesh = pcl::geometry::PolygonMesh <MeshTraits>;
 
 //  Mesh half_edge_mesh;
 //  pcl::PolygonMesh face_vertex_mesh;
@@ -307,10 +307,10 @@ TYPED_TEST (TestMeshConversion, FaceVertexMeshToHalfEdgeMesh)
 
 TYPED_TEST (TestMeshConversion, NonConvertibleCases)
 {
-  typedef typename TestFixture::MeshTraits     Traits;
-  typedef pcl::geometry::TriangleMesh <Traits> TriangleMesh;
-  typedef pcl::geometry::QuadMesh     <Traits> QuadMesh;
-  typedef pcl::geometry::PolygonMesh  <Traits> PolygonMesh;
+  using Traits = typename TestFixture::MeshTraits;
+  using TriangleMesh = pcl::geometry::TriangleMesh<Traits>;
+  using QuadMesh = pcl::geometry::QuadMesh<Traits>;
+  using PolygonMesh = pcl::geometry::PolygonMesh<Traits>;
 
   // Generate the mesh
   pcl::PolygonMesh face_vertex_mesh;

--- a/test/geometry/test_mesh_data.cpp
+++ b/test/geometry/test_mesh_data.cpp
@@ -45,27 +45,27 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef pcl::geometry::NoData NoData;
-typedef pcl::geometry::DefaultMeshTraits <int   , NoData , NoData, NoData> TraitsV;
-typedef pcl::geometry::DefaultMeshTraits <NoData, int    , NoData, NoData> TraitsHE;
-typedef pcl::geometry::DefaultMeshTraits <NoData, NoData , int   , NoData> TraitsE;
-typedef pcl::geometry::DefaultMeshTraits <NoData, NoData , NoData, int   > TraitsF;
-typedef pcl::geometry::DefaultMeshTraits <int   , int    , int   , int   > TraitsAD;
+using NoData = pcl::geometry::NoData;
+using TraitsV = pcl::geometry::DefaultMeshTraits <int   , NoData , NoData, NoData>;
+using TraitsHE = pcl::geometry::DefaultMeshTraits <NoData, int    , NoData, NoData>;
+using TraitsE = pcl::geometry::DefaultMeshTraits <NoData, NoData , int   , NoData>;
+using TraitsF = pcl::geometry::DefaultMeshTraits <NoData, NoData , NoData, int   >;
+using TraitsAD = pcl::geometry::DefaultMeshTraits <int   , int    , int   , int   >;
 
-typedef pcl::geometry::PolygonMesh <TraitsV>  MeshV;
-typedef pcl::geometry::PolygonMesh <TraitsHE> MeshHE;
-typedef pcl::geometry::PolygonMesh <TraitsE>  MeshE;
-typedef pcl::geometry::PolygonMesh <TraitsF>  MeshF;
-typedef pcl::geometry::PolygonMesh <TraitsAD> MeshAD;
+using MeshV = pcl::geometry::PolygonMesh<TraitsV>;
+using MeshHE = pcl::geometry::PolygonMesh<TraitsHE>;
+using MeshE = pcl::geometry::PolygonMesh<TraitsE>;
+using MeshF = pcl::geometry::PolygonMesh<TraitsF>;
+using MeshAD = pcl::geometry::PolygonMesh<TraitsAD>;
 
-typedef pcl::geometry::VertexIndex   VertexIndex;
-typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-typedef pcl::geometry::EdgeIndex     EdgeIndex;
-typedef pcl::geometry::FaceIndex     FaceIndex;
+using VertexIndex = pcl::geometry::VertexIndex;
+using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+using EdgeIndex = pcl::geometry::EdgeIndex;
+using FaceIndex = pcl::geometry::FaceIndex;
 
-typedef std::vector <VertexIndex>   VertexIndices;
-typedef std::vector <HalfEdgeIndex> HalfEdgeIndices;
-typedef std::vector <FaceIndex>     FaceIndices;
+using VertexIndices = std::vector<VertexIndex>;
+using HalfEdgeIndices = std::vector<HalfEdgeIndex>;
+using FaceIndices = std::vector<FaceIndex>;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_mesh_get_boundary.cpp
+++ b/test/geometry/test_mesh_get_boundary.cpp
@@ -49,23 +49,23 @@
 template <bool IsManifoldT>
 struct MeshTraits
 {
-    typedef pcl::geometry::NoData                        VertexData;
-    typedef pcl::geometry::NoData                        HalfEdgeData;
-    typedef pcl::geometry::NoData                        EdgeData;
-    typedef pcl::geometry::NoData                        FaceData;
-    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
+    using VertexData = pcl::geometry::NoData;
+    using HalfEdgeData = pcl::geometry::NoData;
+    using EdgeData = pcl::geometry::NoData;
+    using FaceData = pcl::geometry::NoData;
+    using IsManifold = std::integral_constant <bool, IsManifoldT>;
 };
 
-typedef pcl::geometry::PolygonMesh <MeshTraits <true > > ManifoldMesh;
-typedef pcl::geometry::PolygonMesh <MeshTraits <false> > NonManifoldMesh;
+using ManifoldMesh = pcl::geometry::PolygonMesh<MeshTraits<true> >;
+using NonManifoldMesh = pcl::geometry::PolygonMesh<MeshTraits<false> >;
 
-typedef testing::Types <ManifoldMesh, NonManifoldMesh> MeshTypes;
+using MeshTypes = testing::Types <ManifoldMesh, NonManifoldMesh>;
 
 template <class MeshT>
 class TestGetBoundary : public testing::Test
 {
   protected:
-    typedef MeshT Mesh;
+    using Mesh = MeshT;
 };
 
 TYPED_TEST_CASE (TestGetBoundary, MeshTypes);
@@ -74,11 +74,11 @@ TYPED_TEST_CASE (TestGetBoundary, MeshTypes);
 
 TYPED_TEST (TestGetBoundary, GetBoundaryHalfEdges)
 {
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
 
-  typedef typename Mesh::VertexIndices   VertexIndices;
-  typedef typename Mesh::HalfEdgeIndices HalfEdgeIndices;
+  using VertexIndices = typename Mesh::VertexIndices;
+  using HalfEdgeIndices = typename Mesh::HalfEdgeIndices;
 
   //  0 -  1 -  2 -  3
   //  |    |    |    |

--- a/test/geometry/test_mesh_indices.cpp
+++ b/test/geometry/test_mesh_indices.cpp
@@ -47,10 +47,10 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef pcl::geometry::VertexIndex   VertexIndex;
-typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-typedef pcl::geometry::EdgeIndex     EdgeIndex;
-typedef pcl::geometry::FaceIndex     FaceIndex;
+using VertexIndex = pcl::geometry::VertexIndex;
+using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+using EdgeIndex = pcl::geometry::EdgeIndex;
+using FaceIndex = pcl::geometry::FaceIndex;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -58,10 +58,10 @@ template <class MeshIndexT>
 class TestMeshIndicesTyped : public testing::Test
 {
   protected:
-    typedef MeshIndexT MeshIndex;
+    using MeshIndex = MeshIndexT;
 };
 
-typedef testing::Types <VertexIndex, HalfEdgeIndex, EdgeIndex, FaceIndex> MeshIndexTypes;
+using MeshIndexTypes = testing::Types <VertexIndex, HalfEdgeIndex, EdgeIndex, FaceIndex>;
 
 TYPED_TEST_CASE (TestMeshIndicesTyped, MeshIndexTypes);
 
@@ -69,7 +69,7 @@ TYPED_TEST_CASE (TestMeshIndicesTyped, MeshIndexTypes);
 
 TYPED_TEST (TestMeshIndicesTyped, General)
 {
-  typedef typename TestFixture::MeshIndex MeshIndex;
+  using MeshIndex = typename TestFixture::MeshIndex;
   MeshIndex vi0, vi1 (-5), vi2 (0), vi3 (5), vi4 (5), vi5 (6);
 
   EXPECT_FALSE (vi0.isValid ());

--- a/test/geometry/test_mesh_io.cpp
+++ b/test/geometry/test_mesh_io.cpp
@@ -49,13 +49,13 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef pcl::geometry::DefaultMeshTraits <>      MeshTraits;
-typedef pcl::geometry::TriangleMesh <MeshTraits> Mesh;
-typedef pcl::geometry::MeshIO <Mesh>             MeshIO;
+using MeshTraits = pcl::geometry::DefaultMeshTraits<>;
+using Mesh = pcl::geometry::TriangleMesh<MeshTraits>;
+using MeshIO = pcl::geometry::MeshIO<Mesh>;
 
-typedef Mesh::VertexIndex   VertexIndex;
-typedef Mesh::HalfEdgeIndex HalfEdgeIndex;
-typedef Mesh::FaceIndex     FaceIndex;
+using VertexIndex = Mesh::VertexIndex;
+using HalfEdgeIndex = Mesh::HalfEdgeIndex;
+using FaceIndex = Mesh::FaceIndex;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_polygon_mesh.cpp
+++ b/test/geometry/test_polygon_mesh.cpp
@@ -51,35 +51,35 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef pcl::geometry::VertexIndex   VertexIndex;
-typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-typedef pcl::geometry::EdgeIndex     EdgeIndex;
-typedef pcl::geometry::FaceIndex     FaceIndex;
+using VertexIndex = pcl::geometry::VertexIndex;
+using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+using EdgeIndex = pcl::geometry::EdgeIndex;
+using FaceIndex = pcl::geometry::FaceIndex;
 
-typedef std::vector <VertexIndex>   VertexIndices;
-typedef std::vector <HalfEdgeIndex> HalfEdgeIndices;
-typedef std::vector <FaceIndex>     FaceIndices;
+using VertexIndices = std::vector<VertexIndex>;
+using HalfEdgeIndices = std::vector<HalfEdgeIndex>;
+using FaceIndices = std::vector<FaceIndex>;
 
 template <bool IsManifoldT>
 struct MeshTraits
 {
-    typedef int                                          VertexData;
-    typedef pcl::geometry::NoData                        HalfEdgeData;
-    typedef pcl::geometry::NoData                        EdgeData;
-    typedef pcl::geometry::NoData                        FaceData;
-    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
+    using VertexData = int;
+    using HalfEdgeData = pcl::geometry::NoData;
+    using EdgeData = pcl::geometry::NoData;
+    using FaceData = pcl::geometry::NoData;
+    using IsManifold = std::integral_constant <bool, IsManifoldT>;
 };
 
-typedef pcl::geometry::PolygonMesh <MeshTraits <true > > ManifoldPolygonMesh;
-typedef pcl::geometry::PolygonMesh <MeshTraits <false> > NonManifoldPolygonMesh;
+using ManifoldPolygonMesh = pcl::geometry::PolygonMesh<MeshTraits<true> >;
+using NonManifoldPolygonMesh = pcl::geometry::PolygonMesh<MeshTraits<false> >;
 
-typedef testing::Types <ManifoldPolygonMesh, NonManifoldPolygonMesh> PolygonMeshTypes;
+using PolygonMeshTypes = testing::Types <ManifoldPolygonMesh, NonManifoldPolygonMesh>;
 
 template <class MeshT>
 class TestPolygonMesh : public testing::Test
 {
   protected:
-    typedef MeshT Mesh;
+    using Mesh = MeshT;
 };
 
 TYPED_TEST_CASE (TestPolygonMesh, PolygonMeshTypes);
@@ -88,8 +88,8 @@ TYPED_TEST_CASE (TestPolygonMesh, PolygonMeshTypes);
 
 TYPED_TEST (TestPolygonMesh, CorrectMeshTag)
 {
-  typedef typename TestFixture::Mesh Mesh;
-  typedef typename Mesh::MeshTag     MeshTag;
+  using Mesh = typename TestFixture::Mesh;
+  using MeshTag = typename Mesh::MeshTag;
 
   ASSERT_EQ (typeid (pcl::geometry::PolygonMeshTag), typeid (MeshTag));
 }
@@ -100,7 +100,7 @@ TYPED_TEST (TestPolygonMesh, CorrectMeshTag)
 
 //TYPED_TEST (TestPolygonMesh, OutOfRange)
 //{
-//  typedef typename TestFixture::Mesh Mesh;
+//  using Mesh = typename TestFixture::Mesh;
 
 //  Mesh mesh;
 //  VertexIndices vi;
@@ -125,7 +125,7 @@ TYPED_TEST (TestPolygonMesh, CorrectMeshTag)
 TYPED_TEST (TestPolygonMesh, CorrectNumberOfVertices)
 {
   // Make sure that only quads can be added
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   for (unsigned int n=1; n<=5; ++n)
   {
@@ -147,7 +147,7 @@ TYPED_TEST (TestPolygonMesh, CorrectNumberOfVertices)
 
 TYPED_TEST (TestPolygonMesh, ThreePolygons)
 {
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   //   1 - 6   //
   //  / \   \  //

--- a/test/geometry/test_quad_mesh.cpp
+++ b/test/geometry/test_quad_mesh.cpp
@@ -49,35 +49,35 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef pcl::geometry::VertexIndex   VertexIndex;
-typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-typedef pcl::geometry::EdgeIndex     EdgeIndex;
-typedef pcl::geometry::FaceIndex     FaceIndex;
+using VertexIndex = pcl::geometry::VertexIndex;
+using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+using EdgeIndex = pcl::geometry::EdgeIndex;
+using FaceIndex = pcl::geometry::FaceIndex;
 
-typedef std::vector <VertexIndex>   VertexIndices;
-typedef std::vector <HalfEdgeIndex> HalfEdgeIndices;
-typedef std::vector <FaceIndex>     FaceIndices;
+using VertexIndices = std::vector<VertexIndex>;
+using HalfEdgeIndices = std::vector<HalfEdgeIndex>;
+using FaceIndices = std::vector<FaceIndex>;
 
 template <bool IsManifoldT>
 struct MeshTraits
 {
-    typedef int                                          VertexData;
-    typedef pcl::geometry::NoData                        HalfEdgeData;
-    typedef pcl::geometry::NoData                        EdgeData;
-    typedef pcl::geometry::NoData                        FaceData;
-    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
+    using VertexData = int;
+    using HalfEdgeData = pcl::geometry::NoData;
+    using EdgeData = pcl::geometry::NoData;
+    using FaceData = pcl::geometry::NoData;
+    using IsManifold = std::integral_constant <bool, IsManifoldT>;
 };
 
-typedef pcl::geometry::QuadMesh <MeshTraits <true > > ManifoldQuadMesh;
-typedef pcl::geometry::QuadMesh <MeshTraits <false> > NonManifoldQuadMesh;
+using ManifoldQuadMesh = pcl::geometry::QuadMesh<MeshTraits<true> >;
+using NonManifoldQuadMesh = pcl::geometry::QuadMesh<MeshTraits<false> >;
 
-typedef testing::Types <ManifoldQuadMesh, NonManifoldQuadMesh> QuadMeshTypes;
+using QuadMeshTypes = testing::Types <ManifoldQuadMesh, NonManifoldQuadMesh>;
 
 template <class MeshT>
 class TestQuadMesh : public testing::Test
 {
   protected:
-    typedef MeshT Mesh;
+    using Mesh = MeshT;
 };
 
 TYPED_TEST_CASE (TestQuadMesh, QuadMeshTypes);
@@ -86,8 +86,8 @@ TYPED_TEST_CASE (TestQuadMesh, QuadMeshTypes);
 
 TYPED_TEST (TestQuadMesh, CorrectMeshTag)
 {
-  typedef typename TestFixture::Mesh Mesh;
-  typedef typename Mesh::MeshTag     MeshTag;
+  using Mesh = typename TestFixture::Mesh;
+  using MeshTag = typename Mesh::MeshTag;
 
   ASSERT_EQ (typeid (pcl::geometry::QuadMeshTag), typeid (MeshTag));
 }
@@ -97,7 +97,7 @@ TYPED_TEST (TestQuadMesh, CorrectMeshTag)
 TYPED_TEST (TestQuadMesh, CorrectNumberOfVertices)
 {
   // Make sure that only quads can be added
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   for (unsigned int n=1; n<=5; ++n)
   {
@@ -119,7 +119,7 @@ TYPED_TEST (TestQuadMesh, CorrectNumberOfVertices)
 
 TYPED_TEST (TestQuadMesh, OneQuad)
 {
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   // 3 - 2 //
   // |   | //
@@ -221,7 +221,7 @@ TYPED_TEST (TestQuadMesh, OneQuad)
 
 TYPED_TEST (TestQuadMesh, NineQuads)
 {
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
   const int int_max = std::numeric_limits <int>::max ();
 
   // Order
@@ -329,7 +329,7 @@ TYPED_TEST (TestQuadMesh, NineQuads)
   // 08 - 09 - 10 - 11 //
   //  |    |    |    | //
   // 12 - 13 - 14 - 15 //
-  typedef VertexIndex VI;
+  using VI = VertexIndex;
   std::vector <VertexIndices> faces;
   VertexIndices vi;
   vi.push_back (VI ( 0)); vi.push_back (VI ( 4)); vi.push_back (VI ( 5)); vi.push_back (VI ( 1)); faces.push_back (vi); vi.clear ();

--- a/test/geometry/test_triangle_mesh.cpp
+++ b/test/geometry/test_triangle_mesh.cpp
@@ -49,35 +49,35 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef pcl::geometry::VertexIndex   VertexIndex;
-typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-typedef pcl::geometry::EdgeIndex     EdgeIndex;
-typedef pcl::geometry::FaceIndex     FaceIndex;
+using VertexIndex = pcl::geometry::VertexIndex;
+using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+using EdgeIndex = pcl::geometry::EdgeIndex;
+using FaceIndex = pcl::geometry::FaceIndex;
 
-typedef std::vector <VertexIndex>   VertexIndices;
-typedef std::vector <HalfEdgeIndex> HalfEdgeIndices;
-typedef std::vector <FaceIndex>     FaceIndices;
+using VertexIndices = std::vector<VertexIndex>;
+using HalfEdgeIndices = std::vector<HalfEdgeIndex>;
+using FaceIndices = std::vector<FaceIndex>;
 
 template <bool IsManifoldT>
 struct MeshTraits
 {
-    typedef int                                          VertexData;
-    typedef pcl::geometry::NoData                        HalfEdgeData;
-    typedef pcl::geometry::NoData                        EdgeData;
-    typedef pcl::geometry::NoData                        FaceData;
-    typedef std::integral_constant <bool, IsManifoldT> IsManifold;
+    using VertexData = int;
+    using HalfEdgeData = pcl::geometry::NoData;
+    using EdgeData = pcl::geometry::NoData;
+    using FaceData = pcl::geometry::NoData;
+    using IsManifold = std::integral_constant <bool, IsManifoldT>;
 };
 
-typedef pcl::geometry::TriangleMesh <MeshTraits <true > > ManifoldTriangleMesh;
-typedef pcl::geometry::TriangleMesh <MeshTraits <false> > NonManifoldTriangleMesh;
+using ManifoldTriangleMesh = pcl::geometry::TriangleMesh<MeshTraits<true> >;
+using NonManifoldTriangleMesh = pcl::geometry::TriangleMesh<MeshTraits<false> >;
 
-typedef testing::Types <ManifoldTriangleMesh, NonManifoldTriangleMesh> TriangleMeshTypes;
+using TriangleMeshTypes = testing::Types <ManifoldTriangleMesh, NonManifoldTriangleMesh>;
 
 template <class MeshT>
 class TestTriangleMesh : public testing::Test
 {
   protected:
-    typedef MeshT Mesh;
+    using Mesh = MeshT;
 };
 
 TYPED_TEST_CASE (TestTriangleMesh, TriangleMeshTypes);
@@ -86,8 +86,8 @@ TYPED_TEST_CASE (TestTriangleMesh, TriangleMeshTypes);
 
 TYPED_TEST (TestTriangleMesh, CorrectMeshTag)
 {
-  typedef typename TestFixture::Mesh Mesh;
-  typedef typename Mesh::MeshTag     MeshTag;
+  using Mesh = typename TestFixture::Mesh;
+  using MeshTag = typename Mesh::MeshTag;
 
   ASSERT_EQ (typeid (pcl::geometry::TriangleMeshTag), typeid (MeshTag));
 }
@@ -97,7 +97,7 @@ TYPED_TEST (TestTriangleMesh, CorrectMeshTag)
 TYPED_TEST (TestTriangleMesh, CorrectNumberOfVertices)
 {
   // Make sure that only quads can be added
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   for (unsigned int n=1; n<=5; ++n)
   {
@@ -119,7 +119,7 @@ TYPED_TEST (TestTriangleMesh, CorrectNumberOfVertices)
 
 TYPED_TEST (TestTriangleMesh, OneTriangle)
 {
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   //   2   //
   //  / \  //
@@ -205,7 +205,7 @@ TYPED_TEST (TestTriangleMesh, OneTriangle)
 
 TYPED_TEST (TestTriangleMesh, TwoTriangles)
 {
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   // 3 - 2   //
   //  \ / \  //
@@ -341,7 +341,7 @@ TYPED_TEST (TestTriangleMesh, TwoTriangles)
 
 TYPED_TEST (TestTriangleMesh, ThreeTriangles)
 {
-  typedef typename TestFixture::Mesh Mesh;
+  using Mesh = typename TestFixture::Mesh;
 
   //  1 ----- 3  //
   //  \ \   / /  //

--- a/test/io/test_buffers.cpp
+++ b/test/io/test_buffers.cpp
@@ -83,7 +83,7 @@ class BuffersTest : public ::testing::Test
 
 };
 
-typedef ::testing::Types<int8_t, int32_t, float> DataTypes;
+using DataTypes = ::testing::Types<int8_t, int32_t, float>;
 TYPED_TEST_CASE (BuffersTest, DataTypes);
 
 TYPED_TEST (BuffersTest, SingleBuffer)

--- a/test/io/test_grabbers.cpp
+++ b/test/io/test_grabbers.cpp
@@ -12,8 +12,8 @@
 using namespace std;
 using namespace std::chrono_literals;
 
-typedef pcl::PointXYZRGBA PointT;
-typedef pcl::PointCloud<PointT> CloudT;
+using PointT = pcl::PointXYZRGBA;
+using CloudT = pcl::PointCloud<PointT>;
 
 string tiff_dir_;
 string pclzf_dir_;

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -1319,7 +1319,7 @@ TEST (PCL, Locale)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T> class AutoIOTest : public testing::Test { };
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES PCL_NORMAL_POINT_TYPES)> PCLXyzNormalPointTypes;
+using PCLXyzNormalPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES PCL_NORMAL_POINT_TYPES)>;
 TYPED_TEST_CASE (AutoIOTest, PCLXyzNormalPointTypes);
 TYPED_TEST (AutoIOTest, AutoLoadCloudFiles)
 {

--- a/test/io/test_iterators.cpp
+++ b/test/io/test_iterators.cpp
@@ -43,8 +43,8 @@
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 
-typedef pcl::PointXYZ Point;
-typedef pcl::PointCloud<Point> PointCloud;
+using Point = pcl::PointXYZ;
+using PointCloud = pcl::PointCloud<Point>;
 
 PointCloud cloud;
 

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -287,7 +287,7 @@ TEST_F (PLYColorTest, LoadPLYFileColoredASCIIIntoPolygonMesh)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T> class PLYPointCloudTest : public PLYColorTest { };
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_RGB_POINT_TYPES)> RGBPointTypes;
+using RGBPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_RGB_POINT_TYPES)>;
 TYPED_TEST_CASE (PLYPointCloudTest, RGBPointTypes);
 TYPED_TEST (PLYPointCloudTest, LoadPLYFileColoredASCIIIntoPointCloud)
 {
@@ -315,7 +315,7 @@ TYPED_TEST (PLYPointCloudTest, LoadPLYFileColoredASCIIIntoPointCloud)
 template<typename T>
 struct PLYCoordinatesIsDenseTest : public PLYTest {};
 
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES)> XYZPointTypes;
+using XYZPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES)>;
 TYPED_TEST_CASE (PLYCoordinatesIsDenseTest, XYZPointTypes);
 
 TYPED_TEST (PLYCoordinatesIsDenseTest, NaNInCoordinates)
@@ -409,7 +409,7 @@ TYPED_TEST (PLYCoordinatesIsDenseTest, InfInCoordinates)
 template<typename T>
 struct PLYNormalsIsDenseTest : public PLYTest {};
 
-typedef ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_NORMAL_POINT_TYPES)> NormalPointTypes;
+using NormalPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_NORMAL_POINT_TYPES)>;
 TYPED_TEST_CASE (PLYNormalsIsDenseTest, NormalPointTypes);
 
 TYPED_TEST (PLYNormalsIsDenseTest, NaNInNormals)

--- a/test/io/test_point_cloud_image_extractors.cpp
+++ b/test/io/test_point_cloud_image_extractors.cpp
@@ -49,7 +49,7 @@ using namespace pcl::io;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromNormalField)
 {
-  typedef PointNormal PointT;
+  using PointT = PointNormal;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -87,7 +87,7 @@ TEST (PCL, PointCloudImageExtractorFromNormalField)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromRGBField)
 {
-  typedef PointXYZRGB PointT;
+  using PointT = PointXYZRGB;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -125,7 +125,7 @@ TEST (PCL, PointCloudImageExtractorFromRGBField)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromRGBAField)
 {
-  typedef PointXYZRGBA PointT;
+  using PointT = PointXYZRGBA;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -164,7 +164,7 @@ TEST (PCL, PointCloudImageExtractorFromRGBAField)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromLabelFieldMono)
 {
-  typedef PointXYZL PointT;
+  using PointT = PointXYZL;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -191,7 +191,7 @@ TEST (PCL, PointCloudImageExtractorFromLabelFieldMono)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromLabelFieldRGB)
 {
-  typedef PointXYZL PointT;
+  using PointT = PointXYZL;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -229,7 +229,7 @@ TEST (PCL, PointCloudImageExtractorFromLabelFieldRGB)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromLabelFieldGlasbey)
 {
-  typedef PointXYZL PointT;
+  using PointT = PointXYZL;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -266,7 +266,7 @@ TEST (PCL, PointCloudImageExtractorFromLabelFieldGlasbey)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromZField)
 {
-  typedef PointXYZL PointT;
+  using PointT = PointXYZL;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -293,7 +293,7 @@ TEST (PCL, PointCloudImageExtractorFromZField)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromCurvatureField)
 {
-  typedef PointNormal PointT;
+  using PointT = PointNormal;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -325,7 +325,7 @@ TEST (PCL, PointCloudImageExtractorFromCurvatureField)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorFromIntensityField)
 {
-  typedef PointXYZI PointT;
+  using PointT = PointXYZI;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -355,7 +355,7 @@ TEST (PCL, PointCloudImageExtractorFromIntensityField)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorBadInput)
 {
-  typedef PointXY PointT; // none of point cloud image extractors support this
+  using PointT = PointXY; // none of point cloud image extractors support this
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;
@@ -392,7 +392,7 @@ TEST (PCL, PointCloudImageExtractorBadInput)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PointCloudImageExtractorBlackNaNs)
 {
-  typedef PointNormal PointT;
+  using PointT = PointNormal;
   PointCloud<PointT> cloud;
   cloud.width = 2;
   cloud.height = 2;

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -53,8 +53,8 @@ using pcl::octree::OctreeKey;
 struct OctreeIteratorBaseTest : public testing::Test
 {
   // types
-  typedef OctreeBase<int> OctreeBaseT;
-  typedef OctreeIteratorBase<OctreeBaseT> OctreeIteratorBaseT;
+  using OctreeBaseT = OctreeBase<int>;
+  using OctreeIteratorBaseT = OctreeIteratorBase<OctreeBaseT>;
 
 
   // methods
@@ -103,7 +103,7 @@ template<typename T>
 struct OctreeIteratorTest : public OctreeIteratorBaseTest
 {
   // types
-  typedef OctreeKey OctreeKeyT;
+  using OctreeKeyT = OctreeKey;
 
   // methods
   OctreeIteratorTest () : it_ (&octree_, tree_depth_) {}
@@ -148,11 +148,12 @@ using pcl::octree::OctreeLeafNodeDepthFirstIterator;
 using pcl::octree::OctreeFixedDepthIterator;
 using pcl::octree::OctreeLeafNodeBreadthFirstIterator;
 
-typedef testing::Types<OctreeDepthFirstIterator<OctreeBase<int> >,
-                       OctreeBreadthFirstIterator<OctreeBase<int> >,
-                       OctreeLeafNodeDepthFirstIterator<OctreeBase<int> >,
-                       OctreeFixedDepthIterator<OctreeBase<int> >,
-                       OctreeLeafNodeBreadthFirstIterator<OctreeBase<int> > > OctreeIteratorTypes;
+using OctreeIteratorTypes = testing::Types
+        <OctreeDepthFirstIterator<OctreeBase<int> >,
+         OctreeBreadthFirstIterator<OctreeBase<int> >,
+         OctreeLeafNodeDepthFirstIterator<OctreeBase<int> >,
+         OctreeFixedDepthIterator<OctreeBase<int> >,
+         OctreeLeafNodeBreadthFirstIterator<OctreeBase<int> > >;
 TYPED_TEST_CASE (OctreeIteratorTest, OctreeIteratorTypes);
 
 TYPED_TEST (OctreeIteratorTest, CopyConstructor)
@@ -207,7 +208,7 @@ TYPED_TEST (OctreeIteratorTest, CopyAssignment)
 struct OctreeBaseBeginEndIteratorsTest : public testing::Test
 {
   // Types
-  typedef OctreeBase<int> OctreeT;
+  using OctreeT = OctreeBase<int>;
 
   // Methods
   void SetUp () override
@@ -761,7 +762,7 @@ TEST_F (OctreeBaseIteratorsForLoopTest, LeafNodeBreadthFirstIterator)
 struct OctreeBaseWalkThroughIteratorsTest : public testing::Test
 {
   // Types
-  typedef OctreeBase<int> OctreeT;
+  using OctreeT = OctreeBase<int>;
 
   // Methods
   void SetUp () override
@@ -986,7 +987,7 @@ struct OctreeBaseIteratorsPrePostTest : public OctreeBaseBeginEndIteratorsTest
 TEST_F (OctreeBaseIteratorsPrePostTest, DefaultIterator)
 {
   // Useful types
-  typedef OctreeT::Iterator IteratorT;
+  using IteratorT = OctreeT::Iterator;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1008,7 +1009,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, DefaultIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeDepthFirstIterator)
 {
   // Useful types
-  typedef OctreeT::LeafNodeDepthFirstIterator IteratorT;
+  using IteratorT = OctreeT::LeafNodeDepthFirstIterator;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1030,7 +1031,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeDepthFirstIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, DepthFirstIterator)
 {
   // Useful types
-  typedef OctreeT::DepthFirstIterator IteratorT;
+  using IteratorT = OctreeT::DepthFirstIterator;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1052,7 +1053,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, DepthFirstIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, BreadthFirstIterator)
 {
   // Useful types
-  typedef OctreeT::BreadthFirstIterator IteratorT;
+  using IteratorT = OctreeT::BreadthFirstIterator;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1074,7 +1075,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, BreadthFirstIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, FixedDepthIterator)
 {
   // Useful types
-  typedef OctreeT::FixedDepthIterator IteratorT;
+  using IteratorT = OctreeT::FixedDepthIterator;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1103,7 +1104,7 @@ TEST_F (OctreeBaseIteratorsPrePostTest, FixedDepthIterator)
 TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeBreadthFirstIterator)
 {
   // Useful types
-  typedef OctreeT::LeafNodeBreadthFirstIterator IteratorT;
+  using IteratorT = OctreeT::LeafNodeBreadthFirstIterator;
 
   // Default initialization
   IteratorT it_a_pre;
@@ -1130,9 +1131,9 @@ struct OctreePointCloudAdjacencyBeginEndIteratorsTest
   : public testing::Test
 {
   // Types
-  typedef pcl::PointXYZ PointT;
-  typedef pcl::PointCloud<PointT> PointCloudT;
-  typedef pcl::octree::OctreePointCloudAdjacency<PointT> OctreeT;
+  using PointT = pcl::PointXYZ;
+  using PointCloudT = pcl::PointCloud<PointT>;
+  using OctreeT = pcl::octree::OctreePointCloudAdjacency<PointT>;
 
   // Methods
   OctreePointCloudAdjacencyBeginEndIteratorsTest ()
@@ -1348,9 +1349,9 @@ struct OctreePointCloudSierpinskiTest
   : public testing::Test
 {
   // Types
-  typedef pcl::PointXYZ PointT;
-  typedef pcl::PointCloud<PointT> PointCloudT;
-  typedef pcl::octree::OctreePointCloud<PointT> OctreeT;
+  using PointT = pcl::PointXYZ;
+  using PointCloudT = pcl::PointCloud<PointT>;
+  using OctreeT = pcl::octree::OctreePointCloud<PointT>;
 
   // Methods
   OctreePointCloudSierpinskiTest ()

--- a/test/outofcore/test_outofcore.cpp
+++ b/test/outofcore/test_outofcore.cpp
@@ -83,16 +83,16 @@ const static boost::filesystem::path filename_otreeB_LOD = "treeB_LOD/tree_test.
 const static  boost::filesystem::path outofcore_path ("point_cloud_octree/tree_test.oct_idx");
 
 
-typedef pcl::PointXYZ PointT;
+using PointT = pcl::PointXYZ;
 
 // UR Typedefs
-typedef OutofcoreOctreeBase<OutofcoreOctreeDiskContainer < PointT > , PointT > octree_disk;
-typedef OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer < PointT > , PointT > octree_disk_node;
+using octree_disk = OutofcoreOctreeBase<OutofcoreOctreeDiskContainer < PointT > , PointT >;
+using octree_disk_node = OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer < PointT > , PointT >;
 
-typedef OutofcoreOctreeBase<OutofcoreOctreeRamContainer< PointT> , PointT> octree_ram;
-typedef OutofcoreOctreeBaseNode<OutofcoreOctreeRamContainer<PointT> , PointT> octree_ram_node;
+using octree_ram = OutofcoreOctreeBase<OutofcoreOctreeRamContainer< PointT> , PointT>;
+using octree_ram_node = OutofcoreOctreeBaseNode<OutofcoreOctreeRamContainer<PointT> , PointT>;
 
-typedef std::vector<PointT, Eigen::aligned_allocator<PointT> > AlignedPointTVector;
+using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
 
 AlignedPointTVector points;
 

--- a/test/people/test_people_groundBasedPeopleDetectionApp.cpp
+++ b/test/people/test_people_groundBasedPeopleDetectionApp.cpp
@@ -52,8 +52,8 @@
 #include <pcl/sample_consensus/sac_model_plane.h>
 #include <pcl/people/ground_based_people_detection_app.h>
 
-typedef pcl::PointXYZRGB PointT;
-typedef pcl::PointCloud<PointT> PointCloudT;
+using PointT = pcl::PointXYZRGB;
+using PointCloudT = pcl::PointCloud<PointT>;
 
 enum { COLS = 640, ROWS = 480 };
 PointCloudT::Ptr cloud;

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -53,10 +53,10 @@ using namespace std;
 using namespace pcl;
 using namespace pcl::io;
 
-typedef PointXYZ PointType;
-typedef Normal NormalType;
-typedef ReferenceFrame RFType;
-typedef SHOT352 DescriptorType;
+using PointType = PointXYZ;
+using NormalType = Normal;
+using RFType = ReferenceFrame;
+using DescriptorType = SHOT352;
 
 PointCloud<PointType>::Ptr model_ (new PointCloud<PointType> ());
 PointCloud<PointType>::Ptr model_downsampled_ (new PointCloud<PointType> ());

--- a/test/registration/test_ndt.cpp
+++ b/test/registration/test_ndt.cpp
@@ -52,7 +52,7 @@ PointCloud<PointXYZ> cloud_source, cloud_target;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, NormalDistributionsTransform)
 {
-  typedef PointNormal PointT;
+  using PointT = PointNormal;
   PointCloud<PointT>::Ptr src (new PointCloud<PointT>);
   copyPointCloud (cloud_source, *src);
   PointCloud<PointT>::Ptr tgt (new PointCloud<PointT>);

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -88,8 +88,8 @@ public:
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, findFeatureCorrespondences)
 {
-  typedef Histogram<2> FeatureT;
-  typedef PointCloud<FeatureT> FeatureCloud;
+  using FeatureT = Histogram<2>;
+  using FeatureCloud = PointCloud<FeatureT>;
 
   RegistrationWrapper <PointXYZ, PointXYZ> reg;
 
@@ -315,7 +315,7 @@ TEST (PCL, JointIterativeClosestPoint)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, IterativeClosestPointNonLinear)
 {
-  typedef PointXYZRGB PointT;
+  using PointT = PointXYZRGB;
   PointCloud<PointT>::Ptr temp_src (new PointCloud<PointT>);
   copyPointCloud (cloud_source, *temp_src);
   PointCloud<PointT>::Ptr temp_tgt (new PointCloud<PointT>);
@@ -386,7 +386,7 @@ TEST (PCL, IterativeClosestPointNonLinear)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, IterativeClosestPoint_PointToPlane)
 {
-  typedef PointNormal PointT;
+  using PointT = PointNormal;
   PointCloud<PointT>::Ptr src (new PointCloud<PointT>);
   copyPointCloud (cloud_source, *src);
   PointCloud<PointT>::Ptr tgt (new PointCloud<PointT>);
@@ -400,7 +400,7 @@ TEST (PCL, IterativeClosestPoint_PointToPlane)
   norm_est.compute (*tgt);
 
   IterativeClosestPoint<PointT, PointT> reg;
-  typedef registration::TransformationEstimationPointToPlane<PointT, PointT> PointToPlane;
+  using PointToPlane = registration::TransformationEstimationPointToPlane<PointT, PointT>;
   boost::shared_ptr<PointToPlane> point_to_plane (new PointToPlane);
   reg.setTransformationEstimation (point_to_plane);
   reg.setInputSource (src);
@@ -475,7 +475,7 @@ TEST (PCL, IterativeClosestPoint_PointToPlane)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, GeneralizedIterativeClosestPoint)
 {
-  typedef PointXYZ PointT;
+  using PointT = PointXYZ;
   PointCloud<PointT>::Ptr src (new PointCloud<PointT>);
   copyPointCloud (cloud_source, *src);
   PointCloud<PointT>::Ptr tgt (new PointCloud<PointT>);
@@ -536,7 +536,7 @@ TEST (PCL, GeneralizedIterativeClosestPoint)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, GeneralizedIterativeClosestPoint6D)
 {
-  typedef PointXYZRGBA PointT;
+  using PointT = PointXYZRGBA;
   Eigen::Affine3f delta_transform;
   PointCloud<PointT>::Ptr src_full (new PointCloud<PointT>);
   copyPointCloud (cloud_with_color, *src_full);

--- a/test/registration/test_registration_api.cpp
+++ b/test/registration/test_registration_api.cpp
@@ -62,15 +62,15 @@
 
 #include "test_registration_api_data.h"
 
-typedef pcl::PointXYZ              PointXYZ;
-typedef pcl::PointCloud <PointXYZ> CloudXYZ;
-typedef CloudXYZ::Ptr              CloudXYZPtr;
-typedef CloudXYZ::ConstPtr         CloudXYZConstPtr;
+using PointXYZ = pcl::PointXYZ;
+using CloudXYZ = pcl::PointCloud<PointXYZ>;
+using CloudXYZPtr = CloudXYZ::Ptr;
+using CloudXYZConstPtr = CloudXYZ::ConstPtr;
 
-typedef pcl::PointNormal              PointNormal;
-typedef pcl::PointCloud <PointNormal> CloudNormal;
-typedef CloudNormal::Ptr              CloudNormalPtr;
-typedef CloudNormal::ConstPtr         CloudNormalConstPtr;
+using PointNormal = pcl::PointNormal;
+using CloudNormal = pcl::PointCloud<PointNormal>;
+using CloudNormalPtr = CloudNormal::Ptr;
+using CloudNormalConstPtr = CloudNormal::ConstPtr;
 
 CloudXYZ cloud_source, cloud_target, cloud_reg;
 

--- a/test/registration/test_sac_ia.cpp
+++ b/test/registration/test_sac_ia.cpp
@@ -112,7 +112,7 @@ TEST (PCL, SampleConsensusInitialAlignment)
   EXPECT_LT (reg.getFitnessScore (), 0.0005);
 
   // Check again, for all possible caching schemes
-  typedef pcl::PointXYZ PointT;
+  using PointT = pcl::PointXYZ;
   for (int iter = 0; iter < 4; iter++)
   {
     bool force_cache = (bool) iter/2;
@@ -209,7 +209,7 @@ TEST (PCL, SampleConsensusPrerejective)
   EXPECT_GT (inlier_fraction, 0.95f);
 
   // Check again, for all possible caching schemes
-  typedef pcl::PointXYZ PointT;
+  using PointT = pcl::PointXYZ;
   for (int iter = 0; iter < 4; iter++)
   {
     bool force_cache = (bool) iter/2;

--- a/test/sample_consensus/test_sample_consensus.cpp
+++ b/test/sample_consensus/test_sample_consensus.cpp
@@ -54,7 +54,7 @@
 
 using namespace pcl;
 
-typedef SampleConsensusModelSphere<PointXYZ>::Ptr SampleConsensusModelSpherePtr;
+using SampleConsensusModelSpherePtr = SampleConsensusModelSphere<PointXYZ>::Ptr;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (SampleConsensus, Base)

--- a/test/sample_consensus/test_sample_consensus_line_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_line_models.cpp
@@ -47,8 +47,8 @@
 
 using namespace pcl;
 
-typedef SampleConsensusModelLine<PointXYZ>::Ptr SampleConsensusModelLinePtr;
-typedef SampleConsensusModelParallelLine<PointXYZ>::Ptr SampleConsensusModelParallelLinePtr;
+using SampleConsensusModelLinePtr = SampleConsensusModelLine<PointXYZ>::Ptr;
+using SampleConsensusModelParallelLinePtr = SampleConsensusModelParallelLine<PointXYZ>::Ptr;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (SampleConsensusModelLine, RANSAC)

--- a/test/sample_consensus/test_sample_consensus_plane_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_plane_models.cpp
@@ -55,9 +55,9 @@
 using namespace pcl;
 using namespace pcl::io;
 
-typedef SampleConsensusModelPlane<PointXYZ>::Ptr SampleConsensusModelPlanePtr;
-typedef SampleConsensusModelNormalPlane<PointXYZ, Normal>::Ptr SampleConsensusModelNormalPlanePtr;
-typedef SampleConsensusModelNormalParallelPlane<PointXYZ, Normal>::Ptr SampleConsensusModelNormalParallelPlanePtr;
+using SampleConsensusModelPlanePtr = SampleConsensusModelPlane<PointXYZ>::Ptr;
+using SampleConsensusModelNormalPlanePtr = SampleConsensusModelNormalPlane<PointXYZ, Normal>::Ptr;
+using SampleConsensusModelNormalParallelPlanePtr = SampleConsensusModelNormalParallelPlane<PointXYZ, Normal>::Ptr;
 
 PointCloud<PointXYZ>::Ptr cloud_ (new PointCloud<PointXYZ> ());
 PointCloud<Normal>::Ptr normals_ (new PointCloud<Normal> ());

--- a/test/sample_consensus/test_sample_consensus_quadric_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_quadric_models.cpp
@@ -48,12 +48,12 @@
 
 using namespace pcl;
 
-typedef SampleConsensusModelSphere<PointXYZ>::Ptr SampleConsensusModelSpherePtr;
-typedef SampleConsensusModelCone<PointXYZ, Normal>::Ptr SampleConsensusModelConePtr;
-typedef SampleConsensusModelCircle2D<PointXYZ>::Ptr SampleConsensusModelCircle2DPtr;
-typedef SampleConsensusModelCircle3D<PointXYZ>::Ptr SampleConsensusModelCircle3DPtr;
-typedef SampleConsensusModelCylinder<PointXYZ, Normal>::Ptr SampleConsensusModelCylinderPtr;
-typedef SampleConsensusModelNormalSphere<PointXYZ, Normal>::Ptr SampleConsensusModelNormalSpherePtr;
+using SampleConsensusModelSpherePtr = SampleConsensusModelSphere<PointXYZ>::Ptr;
+using SampleConsensusModelConePtr = SampleConsensusModelCone<PointXYZ, Normal>::Ptr;
+using SampleConsensusModelCircle2DPtr = SampleConsensusModelCircle2D<PointXYZ>::Ptr;
+using SampleConsensusModelCircle3DPtr = SampleConsensusModelCircle3D<PointXYZ>::Ptr;
+using SampleConsensusModelCylinderPtr = SampleConsensusModelCylinder<PointXYZ, Normal>::Ptr;
+using SampleConsensusModelNormalSpherePtr = SampleConsensusModelNormalSphere<PointXYZ, Normal>::Ptr;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (SampleConsensusModelSphere, RANSAC)

--- a/test/segmentation/test_random_walker.cpp
+++ b/test/segmentation/test_random_walker.cpp
@@ -51,28 +51,28 @@
 
 std::string TEST_DATA_DIR;
 
-typedef float Weight;
-typedef uint32_t Color;
-typedef boost::adjacency_list
+using Weight = float;
+using Color = uint32_t;
+using Graph = boost::adjacency_list
         <boost::vecS,
          boost::vecS,
          boost::undirectedS,
          boost::property<boost::vertex_color_t, Color,
          boost::property<boost::vertex_degree_t, Weight> >,
-         boost::property<boost::edge_weight_t, Weight> > Graph;
-typedef boost::graph_traits<Graph> GraphTraits;
-typedef GraphTraits::edge_descriptor EdgeDescriptor;
-typedef GraphTraits::vertex_descriptor VertexDescriptor;
-typedef GraphTraits::edge_iterator EdgeIterator;
-typedef GraphTraits::vertex_iterator VertexIterator;
-typedef boost::property_map<Graph, boost::edge_weight_t>::type EdgeWeightMap;
-typedef boost::property_map<Graph, boost::vertex_color_t>::type VertexColorMap;
-typedef Eigen::SparseMatrix<Weight> SparseMatrix;
-typedef Eigen::Matrix<Weight, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-typedef Eigen::Matrix<Weight, Eigen::Dynamic, 1> Vector;
-typedef boost::bimap<size_t, VertexDescriptor> VertexDescriptorBimap;
-typedef boost::bimap<size_t, Color> ColorBimap;
-typedef pcl::segmentation::detail::RandomWalker<Graph, EdgeWeightMap, VertexColorMap> RandomWalker;
+         boost::property<boost::edge_weight_t, Weight> >;
+using GraphTraits = boost::graph_traits<Graph>;
+using EdgeDescriptor = GraphTraits::edge_descriptor;
+using VertexDescriptor = GraphTraits::vertex_descriptor;
+using EdgeIterator = GraphTraits::edge_iterator;
+using VertexIterator = GraphTraits::vertex_iterator;
+using EdgeWeightMap = boost::property_map<Graph, boost::edge_weight_t>::type;
+using VertexColorMap = boost::property_map<Graph, boost::vertex_color_t>::type;
+using SparseMatrix = Eigen::SparseMatrix<Weight>;
+using Matrix = Eigen::Matrix<Weight, Eigen::Dynamic, Eigen::Dynamic>;
+using Vector = Eigen::Matrix<Weight, Eigen::Dynamic, 1>;
+using VertexDescriptorBimap = boost::bimap<size_t, VertexDescriptor>;
+using ColorBimap = boost::bimap<size_t, Color>;
+using RandomWalker = pcl::segmentation::detail::RandomWalker<Graph, EdgeWeightMap, VertexColorMap>;
 
 
 struct GraphInfo

--- a/test/test_recognition_ransac_based_ORROctree.cpp
+++ b/test/test_recognition_ransac_based_ORROctree.cpp
@@ -50,11 +50,11 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace pcl::recognition;
 
-typedef pcl::PointXYZ PointT;
-typedef pcl::PointCloud<PointT> PointCloudT;
-typedef pcl::PointCloud<pcl::Normal> PointCloudTN;
-typedef pcl::PointCloud<PointT>::Ptr PointCloudTPtr;
-typedef pcl::PointCloud<pcl::Normal>::Ptr PointCloudTNPtr;
+using PointT = pcl::PointXYZ;
+using PointCloudT = pcl::PointCloud<PointT>;
+using PointCloudTN = pcl::PointCloud<pcl::Normal>;
+using PointCloudTPtr = pcl::PointCloud<PointT>::Ptr;
+using PointCloudTNPtr = pcl::PointCloud<pcl::Normal>::Ptr;
 
 PointCloud<PointXYZ>::Ptr cloud_;
 PointCloudTPtr model_cloud(new pcl::PointCloud<PointT>);


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`