### PR TITLE
Use using instead of typedef [2d, ml, search]

### DIFF
--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -47,8 +47,8 @@ namespace pcl
   class Edge
   {
     private:
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename PointCloudIn::Ptr PointCloudInPtr;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudInPtr = typename PointCloudIn::Ptr;
 
       PointCloudInPtr input_;
       pcl::Convolution<PointInT> convolution_;
@@ -83,8 +83,8 @@ namespace pcl
                          pcl::PointCloud<pcl::PointXYZI> &maxima, float tLow);
 
     public:
-      typedef boost::shared_ptr<Edge> Ptr;
-      typedef boost::shared_ptr<const Edge> ConstPtr;
+      using Ptr = boost::shared_ptr<Edge<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const Edge<PointInT, PointOutT> >;
 
       enum OUTPUT_TYPE
       {

--- a/2d/include/pcl/2d/morphology.h
+++ b/2d/include/pcl/2d/morphology.h
@@ -45,8 +45,8 @@ namespace pcl
   class Morphology : public PCLBase<PointT>
   {
     private:
-      typedef pcl::PointCloud<PointT> PointCloudIn;
-      typedef typename PointCloudIn::Ptr PointCloudInPtr;
+      using PointCloudIn = pcl::PointCloud<PointT>;
+      using PointCloudInPtr = typename PointCloudIn::Ptr;
 
       PointCloudInPtr structuring_element_;
 

--- a/ml/include/pcl/ml/dt/decision_tree_data_provider.h
+++ b/ml/include/pcl/ml/dt/decision_tree_data_provider.h
@@ -54,7 +54,7 @@ namespace pcl
 
     public:
 
-      typedef boost::shared_ptr<DecisionTreeTrainerDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>> Ptr;
+      using Ptr = boost::shared_ptr<DecisionTreeTrainerDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>>;
 
       /** \brief Constructor. */
       DecisionTreeTrainerDataProvider()

--- a/ml/include/pcl/ml/kmeans.h
+++ b/ml/include/pcl/ml/kmeans.h
@@ -60,35 +60,35 @@ namespace pcl
   class PCL_EXPORTS Kmeans
   {
 /*
-    typedef PCLBase<PointT> BasePCLBase;
+    using BasePCLBase = PCLBase<PointT>;
 
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 */
 
     public:
 
-      typedef unsigned int PointId;    // the id of this point
-      typedef unsigned int ClusterId;  // the id of this cluster
+      using PointId = unsigned int;    // the id of this point
+      using ClusterId = unsigned int;  // the id of this cluster
 
 
-      //typedef std::vector<Coord> Point;    // a point (a centroid)
+      //using Point = std::vector<Coord>;    // a point (a centroid)
 
-      typedef std::set<PointId> SetPoints; // set of points
+      using SetPoints = std::set<PointId>; // set of points
 
-      typedef std::vector<float> Point;
+      using Point = std::vector<float>;
 
       // ClusterId -> (PointId, PointId, PointId, .... )
-      typedef std::vector<SetPoints> ClustersToPoints;
+      using ClustersToPoints = std::vector<SetPoints>;
       // PointId -> ClusterId
-      typedef std::vector<ClusterId> PointsToClusters; 
+      using PointsToClusters = std::vector<ClusterId>; 
       // coll of centroids
-      typedef std::vector<Point> Centroids;
+      using Centroids = std::vector<Point>;
 
 
       /** \brief Empty constructor. */

--- a/ml/include/pcl/ml/multi_channel_2d_comparison_feature_handler.h
+++ b/ml/include/pcl/ml/multi_channel_2d_comparison_feature_handler.h
@@ -381,15 +381,15 @@ namespace pcl
   }
 
 
-  typedef MultiChannel2DComparisonFeatureHandler<float, 1> Depth2DComparisonFeatureHandler;
-  typedef MultiChannel2DComparisonFeatureHandler<float, 2> IntensityDepth2DComparisonFeatureHandler;
-  typedef MultiChannel2DComparisonFeatureHandler<float, 3> RGB2DComparisonFeatureHandler;
-  typedef MultiChannel2DComparisonFeatureHandler<float, 4> RGBD2DComparisonFeatureHandler;
+  using Depth2DComparisonFeatureHandler = MultiChannel2DComparisonFeatureHandler<float, 1>;
+  using IntensityDepth2DComparisonFeatureHandler = MultiChannel2DComparisonFeatureHandler<float, 2>;
+  using RGB2DComparisonFeatureHandler = MultiChannel2DComparisonFeatureHandler<float, 3>;
+  using RGBD2DComparisonFeatureHandler = MultiChannel2DComparisonFeatureHandler<float, 4>;
 
-  typedef ScaledMultiChannel2DComparisonFeatureHandler<float, 1, 0, true> ScaledDepth2DComparisonFeatureHandler;
-  typedef ScaledMultiChannel2DComparisonFeatureHandler<float, 2, 1, true> ScaledIntensityDepth2DComparisonFeatureHandler;
-  typedef ScaledMultiChannel2DComparisonFeatureHandler<float, 4, 3, true> ScaledRGBD2DComparisonFeatureHandler;
+  using ScaledDepth2DComparisonFeatureHandler = ScaledMultiChannel2DComparisonFeatureHandler<float, 1, 0, true>;
+  using ScaledIntensityDepth2DComparisonFeatureHandler = ScaledMultiChannel2DComparisonFeatureHandler<float, 2, 1, true>;
+  using ScaledRGBD2DComparisonFeatureHandler = ScaledMultiChannel2DComparisonFeatureHandler<float, 4, 3, true>;
 
-  typedef ScaledMultiChannel2DComparisonFeatureHandlerCCodeGenerator<float, 1, 0, true> ScaledDepth2DComparisonFeatureHandlerCCodeGenerator;
+  using ScaledDepth2DComparisonFeatureHandlerCCodeGenerator = ScaledMultiChannel2DComparisonFeatureHandlerCCodeGenerator<float, 1, 0, true>;
 
 }

--- a/ml/include/pcl/ml/multi_channel_2d_data_set.h
+++ b/ml/include/pcl/ml/multi_channel_2d_data_set.h
@@ -225,9 +225,9 @@ namespace pcl
       std::vector<MultiChannel2DData<DATA_TYPE, NUM_OF_CHANNELS>*> data_set_;
   };
 
-  typedef MultiChannel2DDataSet<float, 1> Depth2DDataSet;
-  typedef MultiChannel2DDataSet<float, 2> IntensityDepth2DDataSet;
-  typedef MultiChannel2DDataSet<float, 3> RGB2DDataSet;
-  typedef MultiChannel2DDataSet<float, 4> RGBD2DDataSet;
+  using Depth2DDataSet = MultiChannel2DDataSet<float, 1>;
+  using IntensityDepth2DDataSet = MultiChannel2DDataSet<float, 2>;
+  using RGB2DDataSet = MultiChannel2DDataSet<float, 3>;
+  using RGBD2DDataSet = MultiChannel2DDataSet<float, 4>;
 
 }

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -50,8 +50,8 @@
 #include <pcl/ml/svm.h>
 #include <iostream>
 int libsvm_version = LIBSVM_VERSION;
-typedef float Qfloat;
-typedef signed char schar;
+using Qfloat = float;
+using schar = signed char;
 #ifndef min
 template <class T> static inline T min (T x, T y)
 {

--- a/search/include/pcl/search/brute_force.h
+++ b/search/include/pcl/search/brute_force.h
@@ -50,11 +50,11 @@ namespace pcl
     template<typename PointT>
     class BruteForce: public Search<PointT>
     {
-      typedef typename Search<PointT>::PointCloud PointCloud;
-      typedef typename Search<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename Search<PointT>::PointCloud;
+      using PointCloudConstPtr = typename Search<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+      using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
       using pcl::search::Search<PointT>::input_;
       using pcl::search::Search<PointT>::indices_;

--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -66,14 +66,14 @@ namespace pcl
       * 
       * \code
       * // Feature and distance type
-      * typedef SHOT352 FeatureT;
-      * typedef flann::L2<float> DistanceT;
+      * using FeatureT = SHOT352;
+      * using DistanceT = flann::L2<float>;
       * 
       * // Search and index types
-      * typedef search::FlannSearch<FeatureT, DistanceT> SearchT;
-      * typedef typename SearchT::FlannIndexCreatorPtr CreatorPtrT;
-      * typedef typename SearchT::KdTreeMultiIndexCreator IndexT;
-      * typedef typename SearchT::PointRepresentationPtr RepresentationPtrT;
+      * using SearchT = search::FlannSearch<FeatureT, DistanceT>;
+      * using CreatorPtrT = typename SearchT::FlannIndexCreatorPtr;
+      * using IndexT = typename SearchT::KdTreeMultiIndexCreator;
+      * using RepresentationPtrT = typename SearchT::PointRepresentationPtr;
       * 
       * // Features
       * PointCloud<FeatureT>::Ptr query, target;
@@ -104,24 +104,24 @@ namespace pcl
       using Search<PointT>::sorted_results_;
 
       public:
-        typedef boost::shared_ptr<FlannSearch<PointT, FlannDistance> > Ptr;
-        typedef boost::shared_ptr<const FlannSearch<PointT, FlannDistance> > ConstPtr;
+        using Ptr = boost::shared_ptr<FlannSearch<PointT, FlannDistance> >;
+        using ConstPtr = boost::shared_ptr<const FlannSearch<PointT, FlannDistance> >;
         
-        typedef typename Search<PointT>::PointCloud PointCloud;
-        typedef typename Search<PointT>::PointCloudConstPtr PointCloudConstPtr;
+        using PointCloud = typename Search<PointT>::PointCloud;
+        using PointCloudConstPtr = typename Search<PointT>::PointCloudConstPtr;
 
-        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-        typedef boost::shared_ptr<flann::Matrix <float> > MatrixPtr;
-        typedef boost::shared_ptr<const flann::Matrix <float> > MatrixConstPtr;
+        using MatrixPtr = boost::shared_ptr<flann::Matrix<float> >;
+        using MatrixConstPtr = boost::shared_ptr<const flann::Matrix<float> >;
 
-        typedef flann::NNIndex< FlannDistance > Index;
-        typedef boost::shared_ptr<flann::NNIndex <FlannDistance > > IndexPtr;
+        using Index = flann::NNIndex<FlannDistance>;
+        using IndexPtr = boost::shared_ptr<flann::NNIndex<FlannDistance> >;
 
-        typedef pcl::PointRepresentation<PointT> PointRepresentation;
-        typedef boost::shared_ptr<PointRepresentation> PointRepresentationPtr;
-        typedef boost::shared_ptr<const PointRepresentation> PointRepresentationConstPtr;
+        using PointRepresentation = pcl::PointRepresentation<PointT>;
+        using PointRepresentationPtr = boost::shared_ptr<PointRepresentation>;
+        using PointRepresentationConstPtr = boost::shared_ptr<const PointRepresentation>;
 
         /** \brief Helper class that creates a FLANN index from a given FLANN matrix. To
           * use a FLANN index type with FlannSearch, implement this interface and
@@ -141,7 +141,7 @@ namespace pcl
             */
             virtual ~FlannIndexCreator () {}
         };
-        typedef boost::shared_ptr<FlannIndexCreator> FlannIndexCreatorPtr;
+        using FlannIndexCreatorPtr = boost::shared_ptr<FlannIndexCreator>;
 
         /** \brief Creates a FLANN KdTreeSingleIndex from the given input data.
           */

--- a/search/include/pcl/search/kdtree.h
+++ b/search/include/pcl/search/kdtree.h
@@ -61,11 +61,11 @@ namespace pcl
     class KdTree: public Search<PointT>
     {
       public:
-        typedef typename Search<PointT>::PointCloud PointCloud;
-        typedef typename Search<PointT>::PointCloudConstPtr PointCloudConstPtr;
+        using PointCloud = typename Search<PointT>::PointCloud;
+        using PointCloudConstPtr = typename Search<PointT>::PointCloudConstPtr;
 
-        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
         using pcl::search::Search<PointT>::indices_;
         using pcl::search::Search<PointT>::input_;
@@ -75,12 +75,12 @@ namespace pcl
         using pcl::search::Search<PointT>::radiusSearch;
         using pcl::search::Search<PointT>::sorted_results_;
 
-        typedef boost::shared_ptr<KdTree<PointT, Tree> > Ptr;
-        typedef boost::shared_ptr<const KdTree<PointT, Tree> > ConstPtr;
+        using Ptr = boost::shared_ptr<KdTree<PointT, Tree> >;
+        using ConstPtr = boost::shared_ptr<const KdTree<PointT, Tree> >;
 
-        typedef boost::shared_ptr<Tree> KdTreePtr;
-        typedef boost::shared_ptr<const Tree> KdTreeConstPtr;
-        typedef boost::shared_ptr<const PointRepresentation<PointT> > PointRepresentationConstPtr;
+        using KdTreePtr = boost::shared_ptr<Tree>;
+        using KdTreeConstPtr = boost::shared_ptr<const Tree>;
+        using PointRepresentationConstPtr = boost::shared_ptr<const PointRepresentation<PointT> >;
 
         /** \brief Constructor for KdTree. 
           *

--- a/search/include/pcl/search/octree.h
+++ b/search/include/pcl/search/octree.h
@@ -69,19 +69,19 @@ namespace pcl
     {
       public:
         // public typedefs
-        typedef boost::shared_ptr<pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> > Ptr;
-        typedef boost::shared_ptr<const pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> > ConstPtr;
+        using Ptr = boost::shared_ptr<pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> >;
+        using ConstPtr = boost::shared_ptr<const pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> >;
 
-        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
         // Boost shared pointers
-        typedef boost::shared_ptr<pcl::octree::OctreePointCloudSearch<PointT, LeafTWrap, BranchTWrap> > OctreePointCloudSearchPtr;
-        typedef boost::shared_ptr<const pcl::octree::OctreePointCloudSearch<PointT, LeafTWrap, BranchTWrap> > OctreePointCloudSearchConstPtr;
+        using OctreePointCloudSearchPtr = boost::shared_ptr<pcl::octree::OctreePointCloudSearch<PointT, LeafTWrap, BranchTWrap> >;
+        using OctreePointCloudSearchConstPtr = boost::shared_ptr<const pcl::octree::OctreePointCloudSearch<PointT, LeafTWrap, BranchTWrap> >;
         OctreePointCloudSearchPtr tree_;
 
         using pcl::search::Search<PointT>::input_;

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -63,14 +63,14 @@ namespace pcl
 
       public:
         // public typedefs
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
 
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-        typedef boost::shared_ptr<pcl::search::OrganizedNeighbor<PointT> > Ptr;
-        typedef boost::shared_ptr<const pcl::search::OrganizedNeighbor<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<pcl::search::OrganizedNeighbor<PointT> >;
+        using ConstPtr = boost::shared_ptr<const pcl::search::OrganizedNeighbor<PointT> >;
 
         using pcl::search::Search<PointT>::indices_;
         using pcl::search::Search<PointT>::sorted_results_;

--- a/search/include/pcl/search/search.h
+++ b/search/include/pcl/search/search.h
@@ -73,15 +73,15 @@ namespace pcl
     class Search
     {
       public:
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef typename PointCloud::Ptr PointCloudPtr;
-        typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = typename PointCloud::Ptr;
+        using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        typedef boost::shared_ptr<pcl::search::Search<PointT> > Ptr;
-        typedef boost::shared_ptr<const pcl::search::Search<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<pcl::search::Search<PointT> >;
+        using ConstPtr = boost::shared_ptr<const pcl::search::Search<PointT> >;
 
-        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
         /** Constructor. */
         Search (const std::string& name = "", bool sorted = false);
@@ -231,9 +231,9 @@ namespace pcl
                          std::vector< std::vector<float> > &k_sqr_distances) const
         {
           // Copy all the data fields from the input cloud to the output one
-          typedef typename pcl::traits::fieldList<PointT>::type FieldListInT;
-          typedef typename pcl::traits::fieldList<PointTDiff>::type FieldListOutT;
-          typedef typename pcl::intersect<FieldListInT, FieldListOutT>::type FieldList;
+          using FieldListInT = typename pcl::traits::fieldList<PointT>::type;
+          using FieldListOutT = typename pcl::traits::fieldList<PointTDiff>::type;
+          using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
 
           pcl::PointCloud<PointT> pc;
           if (indices.empty ())
@@ -374,9 +374,9 @@ namespace pcl
                        unsigned int max_nn = 0) const
         {
           // Copy all the data fields from the input cloud to the output one
-          typedef typename pcl::traits::fieldList<PointT>::type FieldListInT;
-          typedef typename pcl::traits::fieldList<PointTDiff>::type FieldListOutT;
-          typedef typename pcl::intersect<FieldListInT, FieldListOutT>::type FieldList;
+          using FieldListInT = typename pcl::traits::fieldList<PointT>::type;
+          using FieldListOutT = typename pcl::traits::fieldList<PointTDiff>::type;
+          using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
 
           pcl::PointCloud<PointT> pc;
           if (indices.empty ())


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`