### PR TITLE
Use using instead of typedef [common]

### DIFF
--- a/common/include/pcl/ModelCoefficients.h
+++ b/common/include/pcl/ModelCoefficients.h
@@ -20,12 +20,12 @@ namespace pcl
     std::vector<float> values;
 
   public:
-    typedef boost::shared_ptr< ::pcl::ModelCoefficients> Ptr;
-    typedef boost::shared_ptr< ::pcl::ModelCoefficients  const> ConstPtr;
+    using Ptr = boost::shared_ptr< ::pcl::ModelCoefficients>;
+    using ConstPtr = boost::shared_ptr<const ::pcl::ModelCoefficients>;
   }; // struct ModelCoefficients
 
-  typedef boost::shared_ptr< ::pcl::ModelCoefficients> ModelCoefficientsPtr;
-  typedef boost::shared_ptr< ::pcl::ModelCoefficients const> ModelCoefficientsConstPtr;
+  using ModelCoefficientsPtr = boost::shared_ptr< ::pcl::ModelCoefficients>;
+  using ModelCoefficientsConstPtr = boost::shared_ptr<const ::pcl::ModelCoefficients>;
 
   inline std::ostream& operator<<(std::ostream& s, const  ::pcl::ModelCoefficients & v)
   {

--- a/common/include/pcl/PCLHeader.h
+++ b/common/include/pcl/PCLHeader.h
@@ -27,12 +27,12 @@ namespace pcl
     /** \brief Coordinate frame ID */
     std::string frame_id;
 
-    typedef boost::shared_ptr<PCLHeader> Ptr;
-    typedef boost::shared_ptr<PCLHeader const> ConstPtr;
+    using Ptr = boost::shared_ptr<PCLHeader>;
+    using ConstPtr = boost::shared_ptr<const PCLHeader>;
   }; // struct PCLHeader
 
-  typedef boost::shared_ptr<PCLHeader> HeaderPtr;
-  typedef boost::shared_ptr<PCLHeader const> HeaderConstPtr;
+  using HeaderPtr = boost::shared_ptr<PCLHeader>;
+  using HeaderConstPtr = boost::shared_ptr<const PCLHeader>;
 
   inline std::ostream& operator << (std::ostream& out, const PCLHeader &h)
   {

--- a/common/include/pcl/PCLImage.h
+++ b/common/include/pcl/PCLImage.h
@@ -30,12 +30,12 @@ namespace pcl
 
     std::vector<pcl::uint8_t> data;
 
-    typedef boost::shared_ptr< ::pcl::PCLImage> Ptr;
-    typedef boost::shared_ptr< ::pcl::PCLImage  const> ConstPtr;
+    using Ptr = boost::shared_ptr< ::pcl::PCLImage>;
+    using ConstPtr = boost::shared_ptr<const ::pcl::PCLImage>;
   }; // struct PCLImage
 
-  typedef boost::shared_ptr< ::pcl::PCLImage> PCLImagePtr;
-  typedef boost::shared_ptr< ::pcl::PCLImage const> PCLImageConstPtr;
+  using PCLImagePtr = boost::shared_ptr< ::pcl::PCLImage>;
+  using PCLImageConstPtr = boost::shared_ptr<const ::pcl::PCLImage>;
 
   inline std::ostream& operator<<(std::ostream& s, const  ::pcl::PCLImage & v)
   {

--- a/common/include/pcl/PCLPointCloud2.h
+++ b/common/include/pcl/PCLPointCloud2.h
@@ -47,12 +47,12 @@ namespace pcl
     pcl::uint8_t is_dense;
 
   public:
-    typedef boost::shared_ptr< ::pcl::PCLPointCloud2> Ptr;
-    typedef boost::shared_ptr< ::pcl::PCLPointCloud2  const> ConstPtr;
+    using Ptr = boost::shared_ptr< ::pcl::PCLPointCloud2>;
+    using ConstPtr = boost::shared_ptr<const ::pcl::PCLPointCloud2>;
   }; // struct PCLPointCloud2
 
-  typedef boost::shared_ptr< ::pcl::PCLPointCloud2> PCLPointCloud2Ptr;
-  typedef boost::shared_ptr< ::pcl::PCLPointCloud2 const> PCLPointCloud2ConstPtr;
+  using PCLPointCloud2Ptr = boost::shared_ptr< ::pcl::PCLPointCloud2>;
+  using PCLPointCloud2ConstPtr = boost::shared_ptr<const ::pcl::PCLPointCloud2>;
 
   inline std::ostream& operator<<(std::ostream& s, const  ::pcl::PCLPointCloud2 &v)
   {

--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -33,12 +33,12 @@ namespace pcl
                            FLOAT64 = 8 };
 
   public:
-    typedef boost::shared_ptr< ::pcl::PCLPointField> Ptr;
-    typedef boost::shared_ptr< ::pcl::PCLPointField const> ConstPtr;
+    using Ptr = boost::shared_ptr< ::pcl::PCLPointField>;
+    using ConstPtr = boost::shared_ptr<const ::pcl::PCLPointField>;
   }; // struct PCLPointField
 
-  typedef boost::shared_ptr< ::pcl::PCLPointField> PCLPointFieldPtr;
-  typedef boost::shared_ptr< ::pcl::PCLPointField const> PCLPointFieldConstPtr;
+  using PCLPointFieldPtr = boost::shared_ptr< ::pcl::PCLPointField>;
+  using PCLPointFieldConstPtr = boost::shared_ptr<const ::pcl::PCLPointField>;
 
   inline std::ostream& operator<<(std::ostream& s, const  ::pcl::PCLPointField & v)
   {

--- a/common/include/pcl/PointIndices.h
+++ b/common/include/pcl/PointIndices.h
@@ -19,12 +19,12 @@ namespace pcl
     std::vector<int> indices;
 
     public:
-      typedef boost::shared_ptr< ::pcl::PointIndices> Ptr;
-      typedef boost::shared_ptr< ::pcl::PointIndices const> ConstPtr;
+      using Ptr = boost::shared_ptr< ::pcl::PointIndices>;
+      using ConstPtr = boost::shared_ptr<const ::pcl::PointIndices>;
   }; // struct PointIndices
 
-  typedef boost::shared_ptr< ::pcl::PointIndices> PointIndicesPtr;
-  typedef boost::shared_ptr< ::pcl::PointIndices const> PointIndicesConstPtr;
+  using PointIndicesPtr = boost::shared_ptr< ::pcl::PointIndices>;
+  using PointIndicesConstPtr = boost::shared_ptr<const ::pcl::PointIndices>;
 
   inline std::ostream& operator << (std::ostream& s, const ::pcl::PointIndices &v)
   {

--- a/common/include/pcl/PolygonMesh.h
+++ b/common/include/pcl/PolygonMesh.h
@@ -25,12 +25,12 @@ namespace pcl
 
 
   public:
-    typedef boost::shared_ptr< ::pcl::PolygonMesh> Ptr;
-    typedef boost::shared_ptr< ::pcl::PolygonMesh const> ConstPtr;
+    using Ptr = boost::shared_ptr< ::pcl::PolygonMesh>;
+    using ConstPtr = boost::shared_ptr<const ::pcl::PolygonMesh>;
   }; // struct PolygonMesh
 
-  typedef boost::shared_ptr< ::pcl::PolygonMesh> PolygonMeshPtr;
-  typedef boost::shared_ptr< ::pcl::PolygonMesh const> PolygonMeshConstPtr;
+  using PolygonMeshPtr = boost::shared_ptr< ::pcl::PolygonMesh>;
+  using PolygonMeshConstPtr = boost::shared_ptr<const ::pcl::PolygonMesh>;
 
   inline std::ostream& operator<<(std::ostream& s, const  ::pcl::PolygonMesh &v)
   {

--- a/common/include/pcl/TextureMesh.h
+++ b/common/include/pcl/TextureMesh.h
@@ -100,10 +100,10 @@ namespace pcl
     std::vector<pcl::TexMaterial>               tex_materials;    // define texture material
 
     public:
-      typedef boost::shared_ptr<pcl::TextureMesh> Ptr;
-      typedef boost::shared_ptr<pcl::TextureMesh const> ConstPtr;
+      using Ptr = boost::shared_ptr<pcl::TextureMesh>;
+      using ConstPtr = boost::shared_ptr<const pcl::TextureMesh>;
    }; // struct TextureMesh
 
-   typedef boost::shared_ptr<pcl::TextureMesh> TextureMeshPtr;
-   typedef boost::shared_ptr<pcl::TextureMesh const> TextureMeshConstPtr;
+   using TextureMeshPtr = boost::shared_ptr<pcl::TextureMesh>;
+   using TextureMeshConstPtr = boost::shared_ptr<const pcl::TextureMesh>;
 } // namespace pcl

--- a/common/include/pcl/Vertices.h
+++ b/common/include/pcl/Vertices.h
@@ -19,13 +19,13 @@ namespace pcl
     std::vector<uint32_t> vertices;
 
   public:
-    typedef boost::shared_ptr<Vertices> Ptr;
-    typedef boost::shared_ptr<Vertices const> ConstPtr;
+    using Ptr = boost::shared_ptr<Vertices>;
+    using ConstPtr = boost::shared_ptr<const Vertices>;
   }; // struct Vertices
 
 
-  typedef boost::shared_ptr<Vertices> VerticesPtr;
-  typedef boost::shared_ptr<Vertices const> VerticesConstPtr;
+  using VerticesPtr = boost::shared_ptr<Vertices>;
+  using VerticesConstPtr = boost::shared_ptr<const Vertices>;
 
   inline std::ostream& operator<<(std::ostream& s, const  ::pcl::Vertices & v)
   {

--- a/common/include/pcl/common/bivariate_polynomial.h
+++ b/common/include/pcl/common/bivariate_polynomial.h
@@ -133,8 +133,8 @@ namespace pcl
   std::ostream&
     operator<< (std::ostream& os, const BivariatePolynomialT<real>& p);
 
-  typedef BivariatePolynomialT<double> BivariatePolynomiald;
-  typedef BivariatePolynomialT<float>  BivariatePolynomial;
+  using BivariatePolynomiald = BivariatePolynomialT<double>;
+  using BivariatePolynomial = BivariatePolynomialT<float>;
 
 }  // end namespace
 

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -839,7 +839,7 @@ namespace pcl
   template<typename PointT, typename Scalar>
   struct NdCentroidFunctor
   {
-    typedef typename traits::POD<PointT>::type Pod;
+    using Pod = typename traits::POD<PointT>::type;
 
     NdCentroidFunctor (const PointT &p, Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
       : f_idx_ (0),
@@ -848,7 +848,7 @@ namespace pcl
 
     template<typename Key> inline void operator() ()
     {
-      typedef typename pcl::traits::datatype<PointT, Key>::type T;
+      using T = typename pcl::traits::datatype<PointT, Key>::type;
       const uint8_t* raw_ptr = reinterpret_cast<const uint8_t*>(&p_) + pcl::traits::offset<PointT, Key>::value;
       const T* data_ptr = reinterpret_cast<const T*>(raw_ptr);
 

--- a/common/include/pcl/common/colors.h
+++ b/common/include/pcl/common/colors.h
@@ -80,7 +80,7 @@ namespace pcl
 
   };
 
-  typedef ColorLUT<pcl::LUT_GLASBEY> GlasbeyLUT;
-  typedef ColorLUT<pcl::LUT_VIRIDIS> ViridisLUT;
+  using GlasbeyLUT = ColorLUT<pcl::LUT_GLASBEY>;
+  using ViridisLUT = ColorLUT<pcl::LUT_VIRIDIS>;
 
 }

--- a/common/include/pcl/common/concatenate.h
+++ b/common/include/pcl/common/concatenate.h
@@ -50,8 +50,8 @@ namespace pcl
   template<typename PointInT, typename PointOutT>
   struct NdConcatenateFunctor
   {
-    typedef typename traits::POD<PointInT>::type PodIn;
-    typedef typename traits::POD<PointOutT>::type PodOut;
+    using PodIn = typename traits::POD<PointInT>::type;
+    using PodOut = typename traits::POD<PointOutT>::type;
     
     NdConcatenateFunctor (const PointInT &p1, PointOutT &p2)
       : p1_ (reinterpret_cast<const PodIn&> (p1))
@@ -62,8 +62,8 @@ namespace pcl
     {
       // This sucks without Fusion :(
       //boost::fusion::at_key<Key> (p2_) = boost::fusion::at_key<Key> (p1_);
-      typedef typename pcl::traits::datatype<PointInT, Key>::type InT;
-      typedef typename pcl::traits::datatype<PointOutT, Key>::type OutT;
+      using InT = typename pcl::traits::datatype<PointInT, Key>::type;
+      using OutT = typename pcl::traits::datatype<PointOutT, Key>::type;
       // Note: don't currently support different types for the same field (e.g. converting double to float)
       BOOST_MPL_ASSERT_MSG ((std::is_same<InT, OutT>::value),
                             POINT_IN_AND_POINT_OUT_HAVE_DIFFERENT_TYPES_FOR_FIELD,

--- a/common/include/pcl/common/fft/_kiss_fft_guts.h
+++ b/common/include/pcl/common/fft/_kiss_fft_guts.h
@@ -15,7 +15,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /* kiss_fft.h
    defines kiss_fft_scalar as either short or a float type
    and defines
-   typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
+   using r = kiss_fft_cpx { kiss_fft_scalar; kiss_fft_scalar i; }; */
 #include "kiss_fft.h"
 #include <limits.h>
 

--- a/common/include/pcl/common/fft/_kiss_fft_guts.h
+++ b/common/include/pcl/common/fft/_kiss_fft_guts.h
@@ -15,7 +15,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /* kiss_fft.h
    defines kiss_fft_scalar as either short or a float type
    and defines
-   using r = kiss_fft_cpx { kiss_fft_scalar; kiss_fft_scalar i; }; */
+   struct kiss_fft_cpx { kiss_fft_scalar r; kiss_fft_scalar i; }; */
 #include "kiss_fft.h"
 #include <limits.h>
 

--- a/common/include/pcl/common/generate.h
+++ b/common/include/pcl/common/generate.h
@@ -58,7 +58,7 @@ namespace pcl
     class CloudGenerator
     {
       public:
-      typedef typename GeneratorT::Parameters GeneratorParameters;
+      using GeneratorParameters = typename GeneratorT::Parameters;
 
       /// Default constructor
       CloudGenerator ();
@@ -143,7 +143,7 @@ namespace pcl
     class CloudGenerator<pcl::PointXY, GeneratorT>
     {
       public:
-      typedef typename GeneratorT::Parameters GeneratorParameters;
+      using GeneratorParameters = typename GeneratorT::Parameters;
       
       CloudGenerator ();
       

--- a/common/include/pcl/common/impl/accumulators.hpp
+++ b/common/include/pcl/common/impl/accumulators.hpp
@@ -67,7 +67,7 @@ namespace pcl
     {
 
       // Requires that point type has x, y, and z fields
-      typedef pcl::traits::has_xyz<boost::mpl::_1> IsCompatible;
+      using IsCompatible = pcl::traits::has_xyz<boost::mpl::_1>;
 
       // Storage
       Eigen::Vector3f xyz;
@@ -88,7 +88,7 @@ namespace pcl
     {
 
       // Requires that point type has normal_x, normal_y, and normal_z fields
-      typedef pcl::traits::has_normal<boost::mpl::_1> IsCompatible;
+      using IsCompatible = pcl::traits::has_normal<boost::mpl::_1>;
 
       // Storage
       Eigen::Vector4f normal;
@@ -121,7 +121,7 @@ namespace pcl
     {
 
       // Requires that point type has curvature field
-      typedef pcl::traits::has_curvature<boost::mpl::_1> IsCompatible;
+      using IsCompatible = pcl::traits::has_curvature<boost::mpl::_1>;
 
       // Storage
       float curvature;
@@ -140,7 +140,7 @@ namespace pcl
     {
 
       // Requires that point type has rgb or rgba field
-      typedef pcl::traits::has_color<boost::mpl::_1> IsCompatible;
+      using IsCompatible = pcl::traits::has_color<boost::mpl::_1>;
 
       // Storage
       float r, g, b, a;
@@ -171,7 +171,7 @@ namespace pcl
     {
 
       // Requires that point type has intensity field
-      typedef pcl::traits::has_intensity<boost::mpl::_1> IsCompatible;
+      using IsCompatible = pcl::traits::has_intensity<boost::mpl::_1>;
 
       // Storage
       float intensity;
@@ -190,7 +190,7 @@ namespace pcl
     {
 
       // Requires that point type has label field
-      typedef pcl::traits::has_label<boost::mpl::_1> IsCompatible;
+      using IsCompatible = pcl::traits::has_label<boost::mpl::_1>;
 
       // Storage
       // A better performance may be achieved with a heap structure
@@ -239,7 +239,7 @@ namespace pcl
     template <typename PointT>
     struct Accumulators
     {
-      typedef
+      using type =
         typename boost::fusion::result_of::as_vector<
           typename boost::mpl::filter_view<
             boost::mpl::vector<
@@ -252,8 +252,7 @@ namespace pcl
             >
           , IsAccumulatorCompatible<PointT>
           >
-        >::type
-      type;
+        >::type;
     };
 
     /* Fusion function object to invoke point addition on every accumulator in

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -809,7 +809,7 @@ template <typename PointT, typename Scalar> inline void
 pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
                         Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
 {
-  typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+  using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
   // Get the size of the fields
   centroid.setZero (boost::mpl::size<FieldList>::value);
@@ -832,7 +832,7 @@ pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
                         const std::vector<int> &indices,
                         Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
 {
-  typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+  using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
   // Get the size of the fields
   centroid.setZero (boost::mpl::size<FieldList>::value);

--- a/common/include/pcl/common/impl/copy_point.hpp
+++ b/common/include/pcl/common/impl/copy_point.hpp
@@ -97,9 +97,9 @@ namespace pcl
     {
       void operator () (const PointInT& point_in, PointOutT& point_out) const
       {
-        typedef typename pcl::traits::fieldList<PointInT>::type FieldListInT;
-        typedef typename pcl::traits::fieldList<PointOutT>::type FieldListOutT;
-        typedef typename pcl::intersect<FieldListInT, FieldListOutT>::type FieldList;
+        using FieldListInT = typename pcl::traits::fieldList<PointInT>::type;
+        using FieldListOutT = typename pcl::traits::fieldList<PointOutT>::type;
+        using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
         pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointInT, PointOutT> (point_in, point_out));
       }
     };
@@ -114,9 +114,9 @@ namespace pcl
     {
       void operator () (const PointInT& point_in, PointOutT& point_out) const
       {
-        typedef typename pcl::traits::fieldList<PointInT>::type FieldListInT;
-        typedef typename pcl::traits::fieldList<PointOutT>::type FieldListOutT;
-        typedef typename pcl::intersect<FieldListInT, FieldListOutT>::type FieldList;
+        using FieldListInT = typename pcl::traits::fieldList<PointInT>::type;
+        using FieldListOutT = typename pcl::traits::fieldList<PointOutT>::type;
+        using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
         const uint32_t offset_in  = boost::mpl::if_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
                                                     pcl::traits::offset<PointInT, pcl::fields::rgb>,
                                                     pcl::traits::offset<PointInT, pcl::fields::rgba> >::type::value;

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -60,7 +60,7 @@ pcl::computeRoots2 (const Scalar& b, const Scalar& c, Roots& roots)
 template <typename Matrix, typename Roots> inline void
 pcl::computeRoots (const Matrix& m, Roots& roots)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
 
   // The characteristic equation is x^3 - c2*x^2 + c1*x - c0 = 0.  The
   // eigenvalues are the roots to this equation, all guaranteed to be
@@ -218,7 +218,7 @@ pcl::eigen22 (const Matrix& mat, Matrix& eigenvectors, Vector& eigenvalues)
 template <typename Matrix, typename Vector> inline void
 pcl::computeCorrespondingEigenVector (const Matrix& mat, const typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
   // Scale the matrix so its entries are in [-1,1].  The scaling is applied
   // only when at least one matrix entry has magnitude larger than 1.
 
@@ -250,7 +250,7 @@ pcl::computeCorrespondingEigenVector (const Matrix& mat, const typename Matrix::
 template <typename Matrix, typename Vector> inline void
 pcl::eigen33 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
   // Scale the matrix so its entries are in [-1,1].  The scaling is applied
   // only when at least one matrix entry has magnitude larger than 1.
 
@@ -287,7 +287,7 @@ pcl::eigen33 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& ei
 template <typename Matrix, typename Vector> inline void
 pcl::eigen33 (const Matrix& mat, Vector& evals)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
   Scalar scale = mat.cwiseAbs ().maxCoeff ();
   if (scale <= std::numeric_limits < Scalar > ::min ())
     scale = Scalar (1.0);
@@ -301,7 +301,7 @@ pcl::eigen33 (const Matrix& mat, Vector& evals)
 template <typename Matrix, typename Vector> inline void
 pcl::eigen33 (const Matrix& mat, Matrix& evecs, Vector& evals)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
   // Scale the matrix so its entries are in [-1,1].  The scaling is applied
   // only when at least one matrix entry has magnitude larger than 1.
 
@@ -484,7 +484,7 @@ pcl::eigen33 (const Matrix& mat, Matrix& evecs, Vector& evals)
 template <typename Matrix> inline typename Matrix::Scalar
 pcl::invert2x2 (const Matrix& matrix, Matrix& inverse)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
   Scalar det = matrix.coeff (0) * matrix.coeff (3) - matrix.coeff (1) * matrix.coeff (2);
 
   if (det != 0)
@@ -503,7 +503,7 @@ pcl::invert2x2 (const Matrix& matrix, Matrix& inverse)
 template <typename Matrix> inline typename Matrix::Scalar
 pcl::invert3x3SymMatrix (const Matrix& matrix, Matrix& inverse)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
   // elements
   // a b c
   // b d e
@@ -538,7 +538,7 @@ pcl::invert3x3SymMatrix (const Matrix& matrix, Matrix& inverse)
 template <typename Matrix> inline typename Matrix::Scalar
 pcl::invert3x3Matrix (const Matrix& matrix, Matrix& inverse)
 {
-  typedef typename Matrix::Scalar Scalar;
+  using Scalar = typename Matrix::Scalar;
 
   //| a b c |-1             |   ie-hf    hc-ib   fb-ec  |
   //| d e f |    =  1/det * |   gf-id    ia-gc   dc-fa  |
@@ -741,10 +741,10 @@ pcl::umeyama (const Eigen::MatrixBase<Derived>& src, const Eigen::MatrixBase<Oth
 #if EIGEN_VERSION_AT_LEAST (3, 3, 0)
   return Eigen::umeyama (src, dst, with_scaling);
 #else
-  typedef typename Eigen::internal::umeyama_transform_matrix_type<Derived, OtherDerived>::type TransformationMatrixType;
-  typedef typename Eigen::internal::traits<TransformationMatrixType>::Scalar Scalar;
-  typedef typename Eigen::NumTraits<Scalar>::Real RealScalar;
-  typedef typename Derived::Index Index;
+  using TransformationMatrixType = typename Eigen::internal::umeyama_transform_matrix_type<Derived, OtherDerived>::type;
+  using Scalar = typename Eigen::internal::traits<TransformationMatrixType>::Scalar;
+  using RealScalar = typename Eigen::NumTraits<Scalar>::Real;
+  using Index = typename Derived::Index;
 
   static_assert (!Eigen::NumTraits<Scalar>::IsComplex, "Numeric type must be real.");
   static_assert ((Eigen::internal::is_same<Scalar, typename Eigen::internal::traits<OtherDerived>::Scalar>::value),
@@ -752,9 +752,9 @@ pcl::umeyama (const Eigen::MatrixBase<Derived>& src, const Eigen::MatrixBase<Oth
 
   enum { Dimension = PCL_EIGEN_SIZE_MIN_PREFER_DYNAMIC (Derived::RowsAtCompileTime, OtherDerived::RowsAtCompileTime) };
 
-  typedef Eigen::Matrix<Scalar, Dimension, 1> VectorType;
-  typedef Eigen::Matrix<Scalar, Dimension, Dimension> MatrixType;
-  typedef typename Eigen::internal::plain_matrix_type_row_major<Derived>::type RowMajorMatrixType;
+  using VectorType = Eigen::Matrix<Scalar, Dimension, 1>;
+  using MatrixType = Eigen::Matrix<Scalar, Dimension, Dimension>;
+  using RowMajorMatrixType = typename Eigen::internal::plain_matrix_type_row_major<Derived>::type;
 
   const Index m = src.rows (); // dimension
   const Index n = src.cols (); // number of measurements

--- a/common/include/pcl/common/impl/intersections.hpp
+++ b/common/include/pcl/common/impl/intersections.hpp
@@ -78,10 +78,10 @@ pcl::planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
                                  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line,
                                  double angular_tolerance)
 {
-  typedef Eigen::Matrix<Scalar, 3, 1> Vector3;
-  typedef Eigen::Matrix<Scalar, 4, 1> Vector4;
-  typedef Eigen::Matrix<Scalar, 5, 1> Vector5;
-  typedef Eigen::Matrix<Scalar, 5, 5> Matrix5;
+  using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
+  using Vector4 = Eigen::Matrix<Scalar, 4, 1>;
+  using Vector5 = Eigen::Matrix<Scalar, 5, 1>;
+  using Matrix5 = Eigen::Matrix<Scalar, 5, 5>;
 
   // Normalize plane normals
   Vector3 plane_a_norm (plane_a.template head<3> ());
@@ -127,8 +127,8 @@ pcl::threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
                               Eigen::Matrix<Scalar, 3, 1> &intersection_point,
                               double determinant_tolerance)
 {
-  typedef Eigen::Matrix<Scalar, 3, 1> Vector3;
-  typedef Eigen::Matrix<Scalar, 3, 3> Matrix3;
+  using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
+  using Matrix3 = Eigen::Matrix<Scalar, 3, 3>;
 
   // TODO: Using Eigen::HyperPlanes is better to solve this problem
   // Check if some planes are parallel

--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -347,8 +347,8 @@ pcl::concatenateFields (const pcl::PointCloud<PointIn1T> &cloud1_in,
                         const pcl::PointCloud<PointIn2T> &cloud2_in,
                         pcl::PointCloud<PointOutT> &cloud_out)
 {
-  typedef typename pcl::traits::fieldList<PointIn1T>::type FieldList1;
-  typedef typename pcl::traits::fieldList<PointIn2T>::type FieldList2;
+  using FieldList1 = typename pcl::traits::fieldList<PointIn1T>::type;
+  using FieldList2 = typename pcl::traits::fieldList<PointIn2T>::type;
 
   if (cloud1_in.points.size () != cloud2_in.points.size ())
   {

--- a/common/include/pcl/common/impl/projection_matrix.hpp
+++ b/common/include/pcl/common/impl/projection_matrix.hpp
@@ -81,7 +81,7 @@ pcl::estimateProjectionMatrix (
     const std::vector<int>& indices)
 {
   // internally we calculate with double but store the result into float matrices.
-  typedef double Scalar;
+  using Scalar = double;
   projection_matrix.setZero ();
   if (cloud->height == 1 || cloud->width == 1)
   {

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -226,13 +226,13 @@ namespace pcl
     }
   }
 
-  typedef enum
+  enum InterpolationType
   {
     BORDER_CONSTANT = 0, BORDER_REPLICATE = 1,
     BORDER_REFLECT = 2, BORDER_WRAP = 3,
     BORDER_REFLECT_101 = 4, BORDER_TRANSPARENT = 5,
     BORDER_DEFAULT = BORDER_REFLECT_101
-  } InterpolationType;
+  };
 
   /** \brief \return the right index according to the interpolation type.
     * \note this is adapted from OpenCV

--- a/common/include/pcl/common/pca.h
+++ b/common/include/pcl/common/pca.h
@@ -61,12 +61,12 @@ namespace pcl
   class PCA : public pcl::PCLBase <PointT>
   {
     public:
-      typedef pcl::PCLBase <PointT> Base;
-      typedef typename Base::PointCloud PointCloud;
-      typedef typename Base::PointCloudPtr PointCloudPtr;
-      typedef typename Base::PointCloudConstPtr PointCloudConstPtr;
-      typedef typename Base::PointIndicesPtr PointIndicesPtr;
-      typedef typename Base::PointIndicesConstPtr PointIndicesConstPtr;
+      using Base = pcl::PCLBase<PointT>;
+      using PointCloud = typename Base::PointCloud;
+      using PointCloudPtr = typename Base::PointCloudPtr;
+      using PointCloudConstPtr = typename Base::PointCloudConstPtr;
+      using PointIndicesPtr = typename Base::PointIndicesPtr;
+      using PointIndicesConstPtr = typename Base::PointIndicesConstPtr;
 
       using Base::input_;
       using Base::indices_;

--- a/common/include/pcl/common/polynomial_calculations.h
+++ b/common/include/pcl/common/polynomial_calculations.h
@@ -124,8 +124,8 @@ namespace pcl
       Parameters parameters_;
   };
 
-  typedef PolynomialCalculationsT<double> PolynomialCalculationsd;
-  typedef PolynomialCalculationsT<float>  PolynomialCalculations;
+  using PolynomialCalculationsd = PolynomialCalculationsT<double>;
+  using PolynomialCalculations = PolynomialCalculationsT<float>;
 
 }  // end namespace
 

--- a/common/include/pcl/common/poses_from_matches.h
+++ b/common/include/pcl/common/poses_from_matches.h
@@ -86,7 +86,7 @@ namespace pcl
       };
       
       // =====TYPEDEFS=====
-      typedef std::vector<PoseEstimate, Eigen::aligned_allocator<PoseEstimate> > PoseEstimatesVector;
+      using PoseEstimatesVector = std::vector<PoseEstimate, Eigen::aligned_allocator<PoseEstimate> >;
 
       
       // =====STATIC METHODS=====

--- a/common/include/pcl/common/random.h
+++ b/common/include/pcl/common/random.h
@@ -53,19 +53,19 @@ namespace pcl
     template <typename T>
     struct uniform_distribution<T, std::enable_if_t<std::is_integral<T>::value>>
     {
-      typedef std::uniform_int_distribution<T> type;
+      using type = std::uniform_int_distribution<T>;
     };
     /// uniform distribution float specialized
     template <typename T>
     struct uniform_distribution<T, std::enable_if_t<std::is_floating_point<T>::value>>
     {
-      typedef std::uniform_real_distribution<T> type;
+      using type = std::uniform_real_distribution<T>;
     };
     ///  normal distribution
     template<typename T> 
     struct normal_distribution
     {
-      typedef std::normal_distribution<T> type;
+      using type = std::normal_distribution<T>;
     };
 
     /** \brief UniformGenerator class generates a random number from range [min, max] at each run picked
@@ -132,7 +132,7 @@ namespace pcl
         run () { return (distribution_ (rng_)); }
 
       private:
-        typedef typename uniform_distribution<T>::type DistributionType;
+        using DistributionType = typename uniform_distribution<T>::type;
         /// parameters
         Parameters parameters_;
         /// random number generator
@@ -203,7 +203,7 @@ namespace pcl
         inline T 
         run () { return (distribution_ (rng_)); }
 
-        typedef typename normal_distribution<T>::type DistributionType;
+        using DistributionType = typename normal_distribution<T>::type;
         /// parameters
         Parameters parameters_;
         /// random number generator

--- a/common/include/pcl/common/synchronizer.h
+++ b/common/include/pcl/common/synchronizer.h
@@ -50,15 +50,15 @@ namespace pcl
   template <typename T1, typename T2>
   class Synchronizer
   {
-    typedef std::pair<unsigned long, T1> T1Stamped;
-    typedef std::pair<unsigned long, T2> T2Stamped;
+    using T1Stamped = std::pair<unsigned long, T1>;
+    using T2Stamped = std::pair<unsigned long, T2>;
     std::mutex mutex1_;
     std::mutex mutex2_;
     std::mutex publish_mutex_;
     std::deque<T1Stamped> queueT1;
     std::deque<T2Stamped> queueT2;
 
-    typedef boost::function<void(T1, T2, unsigned long, unsigned long) > CallbackFunction;
+    using CallbackFunction = boost::function<void (T1, T2, unsigned long, unsigned long)>;
 
     std::map<int, CallbackFunction> cb_;
     int callback_counter;

--- a/common/include/pcl/common/time_trigger.h
+++ b/common/include/pcl/common/time_trigger.h
@@ -56,7 +56,7 @@ namespace pcl
   class PCL_EXPORTS TimeTrigger
   {
     public:
-      typedef boost::function<void() > callback_type;
+      using callback_type = boost::function<void ()>;
 
       /** \brief Timer class that calls a callback method periodically. Due to possible blocking calls, only one callback method can be registered per instance.
         * \param[in] interval_seconds interval in seconds

--- a/common/include/pcl/common/vector_average.h
+++ b/common/include/pcl/common/vector_average.h
@@ -110,9 +110,9 @@ namespace pcl
         Eigen::Matrix<real, dimension, dimension> covariance_;
   };
 
-  typedef VectorAverage<float, 2> VectorAverage2f;
-  typedef VectorAverage<float, 3> VectorAverage3f;
-  typedef VectorAverage<float, 4> VectorAverage4f;
+  using VectorAverage2f = VectorAverage<float, 2>;
+  using VectorAverage3f = VectorAverage<float, 3>;
+  using VectorAverage4f = VectorAverage<float, 4>;
 }  // END namespace
 
 #include <pcl/common/impl/vector_average.hpp>

--- a/common/include/pcl/correspondence.h
+++ b/common/include/pcl/correspondence.h
@@ -89,9 +89,9 @@ namespace pcl
   /** \brief overloaded << operator */
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const Correspondence& c);
 
-  typedef std::vector< pcl::Correspondence, Eigen::aligned_allocator<pcl::Correspondence> > Correspondences;
-  typedef boost::shared_ptr<Correspondences> CorrespondencesPtr;
-  typedef boost::shared_ptr<const Correspondences > CorrespondencesConstPtr;
+  using Correspondences = std::vector< pcl::Correspondence, Eigen::aligned_allocator<pcl::Correspondence> >;
+  using CorrespondencesPtr = boost::shared_ptr<Correspondences>;
+  using CorrespondencesConstPtr = boost::shared_ptr<const Correspondences >;
 
   /**
     * \brief Get the query points of correspondences that are present in
@@ -130,7 +130,7 @@ namespace pcl
     
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
-  typedef std::vector<PointCorrespondence3D, Eigen::aligned_allocator<PointCorrespondence3D> > PointCorrespondences3DVector;
+  using PointCorrespondences3DVector = std::vector<PointCorrespondence3D, Eigen::aligned_allocator<PointCorrespondence3D> >;
 
   /**
     * \brief Representation of a (possible) correspondence between two points (e.g. from feature matching),
@@ -146,7 +146,7 @@ namespace pcl
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
-  typedef std::vector<PointCorrespondence6D, Eigen::aligned_allocator<PointCorrespondence6D> > PointCorrespondences6DVector;
+  using PointCorrespondences6DVector = std::vector<PointCorrespondence6D, Eigen::aligned_allocator<PointCorrespondence6D> >;
 
   /**
     * \brief Comparator to enable us to sort a vector of PointCorrespondences according to their scores using

--- a/common/include/pcl/for_each_type.h
+++ b/common/include/pcl/for_each_type.h
@@ -74,7 +74,7 @@ namespace pcl
     template<typename Iterator, typename LastIterator, typename F>
     static void execute (F f)
     {
-      typedef typename boost::mpl::deref<Iterator>::type arg;
+      using arg = typename boost::mpl::deref<Iterator>::type;
 
 #if (defined _WIN32 && defined _MSC_VER)
       boost::mpl::aux::unwrap (f, 0).operator()<arg> ();
@@ -82,7 +82,7 @@ namespace pcl
       boost::mpl::aux::unwrap (f, 0).template operator()<arg> ();
 #endif
 
-      typedef typename boost::mpl::next<Iterator>::type iter;
+      using iter = typename boost::mpl::next<Iterator>::type;
       for_each_type_impl<std::is_same<iter, LastIterator>::value>
         ::template execute<iter, LastIterator, F> (f);
     }
@@ -93,8 +93,8 @@ namespace pcl
   for_each_type (F f)
   {
     BOOST_MPL_ASSERT (( boost::mpl::is_sequence<Sequence> ));
-    typedef typename boost::mpl::begin<Sequence>::type first;
-    typedef typename boost::mpl::end<Sequence>::type last;
+    using first = typename boost::mpl::begin<Sequence>::type;
+    using last = typename boost::mpl::end<Sequence>::type;
     for_each_type_impl<std::is_same<first, last>::value>::template execute<first, last, F> (f);
   }
 
@@ -102,6 +102,6 @@ namespace pcl
   template <typename Sequence1, typename Sequence2>
   struct intersect 
   { 
-    typedef typename boost::mpl::remove_if<Sequence1, boost::mpl::not_<boost::mpl::contains<Sequence2, boost::mpl::_1> > >::type type; 
+    using type = typename boost::mpl::remove_if<Sequence1, boost::mpl::not_<boost::mpl::contains<Sequence2, boost::mpl::_1> > >::type; 
   }; 
 }

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -160,21 +160,21 @@
 namespace pcl
 {
 
-  typedef Eigen::Map<Eigen::Array3f> Array3fMap;
-  typedef const Eigen::Map<const Eigen::Array3f> Array3fMapConst;
-  typedef Eigen::Map<Eigen::Array4f, Eigen::Aligned> Array4fMap;
-  typedef const Eigen::Map<const Eigen::Array4f, Eigen::Aligned> Array4fMapConst;
-  typedef Eigen::Map<Eigen::Vector3f> Vector3fMap;
-  typedef const Eigen::Map<const Eigen::Vector3f> Vector3fMapConst;
-  typedef Eigen::Map<Eigen::Vector4f, Eigen::Aligned> Vector4fMap;
-  typedef const Eigen::Map<const Eigen::Vector4f, Eigen::Aligned> Vector4fMapConst;
+  using Array3fMap = Eigen::Map<Eigen::Array3f>;
+  using Array3fMapConst = const Eigen::Map<const Eigen::Array3f>;
+  using Array4fMap = Eigen::Map<Eigen::Array4f, Eigen::Aligned>;
+  using Array4fMapConst = const Eigen::Map<const Eigen::Array4f, Eigen::Aligned>;
+  using Vector3fMap = Eigen::Map<Eigen::Vector3f>;
+  using Vector3fMapConst = const Eigen::Map<const Eigen::Vector3f>;
+  using Vector4fMap = Eigen::Map<Eigen::Vector4f, Eigen::Aligned>;
+  using Vector4fMapConst = const Eigen::Map<const Eigen::Vector4f, Eigen::Aligned>;
 
-  typedef Eigen::Matrix<uint8_t, 3, 1> Vector3c;
-  typedef Eigen::Map<Vector3c> Vector3cMap;
-  typedef const Eigen::Map<const Vector3c> Vector3cMapConst;
-  typedef Eigen::Matrix<uint8_t, 4, 1> Vector4c;
-  typedef Eigen::Map<Vector4c, Eigen::Aligned> Vector4cMap;
-  typedef const Eigen::Map<const Vector4c, Eigen::Aligned> Vector4cMapConst;
+  using Vector3c = Eigen::Matrix<uint8_t, 3, 1>;
+  using Vector3cMap = Eigen::Map<Vector3c>;
+  using Vector3cMapConst = const Eigen::Map<const Vector3c>;
+  using Vector4c = Eigen::Matrix<uint8_t, 4, 1>;
+  using Vector4cMap = Eigen::Map<Vector4c, Eigen::Aligned>;
+  using Vector4cMapConst = const Eigen::Map<const Vector4c, Eigen::Aligned>;
 
 #define PCL_ADD_UNION_POINT4D \
   union EIGEN_ALIGN16 { \

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -57,8 +57,8 @@
 namespace pcl
 {
   // definitions used everywhere
-  typedef boost::shared_ptr <std::vector<int> > IndicesPtr;
-  typedef boost::shared_ptr <const std::vector<int> > IndicesConstPtr;
+  using IndicesPtr = boost::shared_ptr <std::vector<int> >;
+  using IndicesConstPtr = boost::shared_ptr <const std::vector<int> >;
 
   /////////////////////////////////////////////////////////////////////////////////////////
   /** \brief PCL base class. Implements methods that are used by most PCL algorithms.
@@ -68,12 +68,12 @@ namespace pcl
   class PCLBase
   {
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef boost::shared_ptr<PointIndices> PointIndicesPtr;
-      typedef boost::shared_ptr<PointIndices const> PointIndicesConstPtr;
+      using PointIndicesPtr = boost::shared_ptr<PointIndices>;
+      using PointIndicesConstPtr = boost::shared_ptr<PointIndices const>;
 
       /** \brief Empty constructor. */
       PCLBase ();
@@ -184,12 +184,12 @@ namespace pcl
   class PCL_EXPORTS PCLBase<pcl::PCLPointCloud2>
   {
     public:
-      typedef pcl::PCLPointCloud2 PCLPointCloud2;
-      typedef boost::shared_ptr<PCLPointCloud2> PCLPointCloud2Ptr;
-      typedef boost::shared_ptr<PCLPointCloud2 const> PCLPointCloud2ConstPtr;
+      using PCLPointCloud2 = pcl::PCLPointCloud2;
+      using PCLPointCloud2Ptr = boost::shared_ptr<PCLPointCloud2>;
+      using PCLPointCloud2ConstPtr = boost::shared_ptr<PCLPointCloud2 const>;
 
-      typedef boost::shared_ptr<PointIndices> PointIndicesPtr;
-      typedef boost::shared_ptr<PointIndices const> PointIndicesConstPtr;
+      using PointIndicesPtr = boost::shared_ptr<PointIndices>;
+      using PointIndicesConstPtr = boost::shared_ptr<PointIndices const>;
 
       /** \brief Empty constructor. */
       PCLBase ();

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -62,13 +62,13 @@ namespace pcl
 
   // Forward declarations
   template <typename PointT> class PointCloud;
-  typedef std::vector<detail::FieldMapping> MsgFieldMap;
+  using MsgFieldMap = std::vector<detail::FieldMapping>;
 
   /** \brief Helper functor structure for copying data between an Eigen type and a PointT. */
   template <typename PointOutT>
   struct NdCopyEigenPointFunctor
   {
-    typedef typename traits::POD<PointOutT>::type Pod;
+    using Pod = typename traits::POD<PointOutT>::type;
 
     /** \brief Constructor
       * \param[in] p1 the input Eigen type
@@ -84,7 +84,7 @@ namespace pcl
     operator() ()
     {
       //boost::fusion::at_key<Key> (p2_) = p1_[f_idx_++];
-      typedef typename pcl::traits::datatype<PointOutT, Key>::type T;
+      using T = typename pcl::traits::datatype<PointOutT, Key>::type;
       uint8_t* data_ptr = reinterpret_cast<uint8_t*>(&p2_) + pcl::traits::offset<PointOutT, Key>::value;
       *reinterpret_cast<T*>(data_ptr) = static_cast<T> (p1_[f_idx_++]);
     }
@@ -101,7 +101,7 @@ namespace pcl
   template <typename PointInT>
   struct NdCopyPointEigenFunctor
   {
-    typedef typename traits::POD<PointInT>::type Pod;
+    using Pod = typename traits::POD<PointInT>::type;
 
     /** \brief Constructor
       * \param[in] p1 the input Point type
@@ -115,7 +115,7 @@ namespace pcl
     operator() ()
     {
       //p2_[f_idx_++] = boost::fusion::at_key<Key> (p1_);
-      typedef typename pcl::traits::datatype<PointInT, Key>::type T;
+      using T = typename pcl::traits::datatype<PointInT, Key>::type;
       const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(&p1_) + pcl::traits::offset<PointInT, Key>::value;
       p2_[f_idx_++] = static_cast<float> (*reinterpret_cast<const T*>(data_ptr));
     }
@@ -421,23 +421,23 @@ namespace pcl
       /** \brief Sensor acquisition pose (rotation). */
       Eigen::Quaternionf sensor_orientation_;
 
-      typedef PointT PointType;  // Make the template class available from the outside
-      typedef std::vector<PointT, Eigen::aligned_allocator<PointT> > VectorType;
-      typedef std::vector<PointCloud<PointT>, Eigen::aligned_allocator<PointCloud<PointT> > > CloudVectorType;
-      typedef boost::shared_ptr<PointCloud<PointT> > Ptr;
-      typedef boost::shared_ptr<const PointCloud<PointT> > ConstPtr;
+      using PointType = PointT;  // Make the template class available from the outside
+      using VectorType = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
+      using CloudVectorType = std::vector<PointCloud<PointT>, Eigen::aligned_allocator<PointCloud<PointT> > >;
+      using Ptr = boost::shared_ptr<PointCloud<PointT> >;
+      using ConstPtr = boost::shared_ptr<const PointCloud<PointT> >;
 
       // std container compatibility typedefs according to
       // http://en.cppreference.com/w/cpp/concept/Container
-      typedef PointT        value_type;
-      typedef PointT&       reference;
-      typedef const PointT& const_reference;
-      typedef typename VectorType::difference_type difference_type;
-      typedef typename VectorType::size_type size_type;
+      using value_type = PointT;
+      using reference = PointT&;
+      using const_reference = const PointT&;
+      using difference_type = typename VectorType::difference_type;
+      using size_type = typename VectorType::size_type;
 
       // iterators
-      typedef typename VectorType::iterator iterator;
-      typedef typename VectorType::const_iterator const_iterator;
+      using iterator = typename VectorType::iterator;
+      using const_iterator = typename VectorType::const_iterator;
       inline iterator begin () { return (points.begin ()); }
       inline iterator end ()   { return (points.end ()); }
       inline const_iterator begin () const { return (points.begin ()); }

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -71,8 +71,8 @@ namespace pcl
       bool trivial_;
 
     public:
-      typedef boost::shared_ptr<PointRepresentation<PointT> > Ptr;
-      typedef boost::shared_ptr<const PointRepresentation<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PointRepresentation<PointT> >;
+      using ConstPtr = boost::shared_ptr<const PointRepresentation<PointT> >;
 
       /** \brief Empty constructor */
       PointRepresentation () : nr_dimensions_ (0), alpha_ (0), trivial_ (false) {}
@@ -182,8 +182,8 @@ namespace pcl
 
     public:
       // Boost shared pointers
-      typedef boost::shared_ptr<DefaultPointRepresentation<PointDefault> > Ptr;
-      typedef boost::shared_ptr<const DefaultPointRepresentation<PointDefault> > ConstPtr;
+      using Ptr = boost::shared_ptr<DefaultPointRepresentation<PointDefault> >;
+      using ConstPtr = boost::shared_ptr<const DefaultPointRepresentation<PointDefault> >;
 
       DefaultPointRepresentation ()
       {
@@ -242,14 +242,14 @@ namespace pcl
 
     struct NdCopyPointFunctor
     {
-      typedef typename traits::POD<PointDefault>::type Pod;
+      using Pod = typename traits::POD<PointDefault>::type;
 
       NdCopyPointFunctor (const PointDefault &p1, float * p2)
         : p1_ (reinterpret_cast<const Pod&>(p1)), p2_ (p2), f_idx_ (0) { }
 
       template<typename Key> inline void operator() ()
       {
-        typedef typename pcl::traits::datatype<PointDefault, Key>::type FieldT;
+        using FieldT = typename pcl::traits::datatype<PointDefault, Key>::type;
         const int NrDims = pcl::traits::datatype<PointDefault, Key>::size;
         Helper<Key, FieldT, NrDims>::copyPoint (p1_, p2_, f_idx_);
       }
@@ -290,9 +290,9 @@ namespace pcl
 
     public:
       // Boost shared pointers
-      typedef typename boost::shared_ptr<DefaultFeatureRepresentation<PointDefault> > Ptr;
-      typedef typename boost::shared_ptr<const DefaultFeatureRepresentation<PointDefault> > ConstPtr;
-      typedef typename pcl::traits::fieldList<PointDefault>::type FieldList;
+      using Ptr = typename boost::shared_ptr<DefaultFeatureRepresentation<PointDefault> >;
+      using ConstPtr = typename boost::shared_ptr<const DefaultFeatureRepresentation<PointDefault> >;
+      using FieldList = typename pcl::traits::fieldList<PointDefault>::type;
 
       DefaultFeatureRepresentation ()
       {
@@ -536,8 +536,8 @@ namespace pcl
 
     public:
       // Boost shared pointers
-      typedef boost::shared_ptr<CustomPointRepresentation<PointDefault> > Ptr;
-      typedef boost::shared_ptr<const CustomPointRepresentation<PointDefault> > ConstPtr;
+      using Ptr = boost::shared_ptr<CustomPointRepresentation<PointDefault> >;
+      using ConstPtr = boost::shared_ptr<const CustomPointRepresentation<PointDefault> >;
 
       /** \brief Constructor
         * \param[in] max_dim the maximum number of dimensions to use

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -85,20 +85,20 @@ namespace pcl
 
     // Metafunction to return type of enum value
     template<int> struct asType {};
-    template<> struct asType<pcl::PCLPointField::INT8>    { typedef int8_t   type; };
-    template<> struct asType<pcl::PCLPointField::UINT8>   { typedef uint8_t  type; };
-    template<> struct asType<pcl::PCLPointField::INT16>   { typedef int16_t  type; };
-    template<> struct asType<pcl::PCLPointField::UINT16>  { typedef uint16_t type; };
-    template<> struct asType<pcl::PCLPointField::INT32>   { typedef int32_t  type; };
-    template<> struct asType<pcl::PCLPointField::UINT32>  { typedef uint32_t type; };
-    template<> struct asType<pcl::PCLPointField::FLOAT32> { typedef float    type; };
-    template<> struct asType<pcl::PCLPointField::FLOAT64> { typedef double   type; };
+    template<> struct asType<pcl::PCLPointField::INT8>    { using type = int8_t; };
+    template<> struct asType<pcl::PCLPointField::UINT8>   { using type = uint8_t; };
+    template<> struct asType<pcl::PCLPointField::INT16>   { using type = int16_t; };
+    template<> struct asType<pcl::PCLPointField::UINT16>  { using type = uint16_t; };
+    template<> struct asType<pcl::PCLPointField::INT32>   { using type = int32_t; };
+    template<> struct asType<pcl::PCLPointField::UINT32>  { using type = uint32_t; };
+    template<> struct asType<pcl::PCLPointField::FLOAT32> { using type = float; };
+    template<> struct asType<pcl::PCLPointField::FLOAT64> { using type = double; };
 
     // Metafunction to decompose a type (possibly of array of any number of dimensions) into
     // its scalar type and total number of elements.
     template<typename T> struct decomposeArray
     {
-      typedef std::remove_all_extents_t<T> type;
+      using type = std::remove_all_extents_t<T>;
       static const uint32_t value = sizeof (T) / sizeof (type);
     };
 
@@ -106,7 +106,7 @@ namespace pcl
     template<typename PointT>
     struct POD
     {
-      typedef PointT type;
+      using type = PointT;
     };
 
 #ifdef _MSC_VER
@@ -122,7 +122,7 @@ namespace pcl
     template<typename PointT>
     struct POD<Eigen::internal::workaround_msvc_stl_support<PointT> >
     {
-      typedef PointT type;
+      using type = PointT;
     };
 
 #endif
@@ -165,7 +165,7 @@ namespace pcl
     struct datatype : datatype<typename POD<PointT>::type, Tag>
     {
       // Contents of specialization:
-      // typedef ... type;
+      // using type = ...;
       // static const uint8_t value;
       // static const uint32_t size;
 
@@ -179,7 +179,7 @@ namespace pcl
     struct fieldList : fieldList<typename POD<PointT>::type>
     {
       // Contents of specialization:
-      // typedef boost::mpl::vector<...> type;
+      // using type = boost::mpl::vector<...>;
 
       // Avoid infinite compile-time recursion
       BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
@@ -210,14 +210,14 @@ namespace pcl
     * PointInT p;
     * bool exists;
     * float value;
-    * typedef typename pcl::traits::fieldList<PointInT>::type FieldList;
+    * using FieldList = typename pcl::traits::fieldList<PointInT>::type;
     * pcl::for_each_type<FieldList> (pcl::CopyIfFieldExists<PointT, float> (p, "intensity", exists, value));
     * \endcode
     */
   template <typename PointInT, typename OutT>
   struct CopyIfFieldExists
   {
-    typedef typename traits::POD<PointInT>::type Pod;
+    using Pod = typename traits::POD<PointInT>::type;
 
     /** \brief Constructor.
       * \param[in] pt the input point
@@ -253,7 +253,7 @@ namespace pcl
       if (name_ == pcl::traits::name<PointInT, Key>::value)
       {
         exists_ = true;
-        typedef typename pcl::traits::datatype<PointInT, Key>::type T;
+        using T = typename pcl::traits::datatype<PointInT, Key>::type;
         const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(&pt_) + pcl::traits::offset<PointInT, Key>::value;
         value_ = static_cast<OutT> (*reinterpret_cast<const T*>(data_ptr));
       }
@@ -275,14 +275,14 @@ namespace pcl
     *
     * \code
     * PointT p;
-    * typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    * using FieldList = typename pcl::traits::fieldList<PointT>::type;
     * pcl::for_each_type<FieldList> (pcl::SetIfFieldExists<PointT, float> (p, "intensity", 42.0f));
     * \endcode
     */
   template <typename PointOutT, typename InT>
   struct SetIfFieldExists
   {
-    typedef typename traits::POD<PointOutT>::type Pod;
+    using Pod = typename traits::POD<PointOutT>::type;
 
     /** \brief Constructor.
       * \param[in] pt the input point
@@ -302,7 +302,7 @@ namespace pcl
     {
       if (name_ == pcl::traits::name<PointOutT, Key>::value)
       {
-        typedef typename pcl::traits::datatype<PointOutT, Key>::type T;
+        using T = typename pcl::traits::datatype<PointOutT, Key>::type;
         uint8_t* data_ptr = reinterpret_cast<uint8_t*>(&pt_) + pcl::traits::offset<PointOutT, Key>::value;
         *reinterpret_cast<T*>(data_ptr) = static_cast<T> (value_);
       }

--- a/common/include/pcl/point_types.h
+++ b/common/include/pcl/point_types.h
@@ -308,7 +308,7 @@ namespace pcl
   /** \brief Data type to store extended information about a transition from foreground to backgroundSpecification of the fields for BorderDescription::traits.
     * \ingroup common
     */
-  typedef std::bitset<32> BorderTraits;
+  using BorderTraits = std::bitset<32>;
 
   /** \brief Specification of the fields for BorderDescription::traits.
     * \ingroup common

--- a/common/include/pcl/range_image/bearing_angle_image.h
+++ b/common/include/pcl/range_image/bearing_angle_image.h
@@ -54,7 +54,7 @@ namespace pcl
   {
     public:
       // ===== TYPEDEFS =====
-      typedef pcl::PointCloud<PointXYZRGBA> BaseClass;
+      using BaseClass = pcl::PointCloud<PointXYZRGBA>;
 
       // =====CONSTRUCTOR & DESTRUCTOR=====
       /** Constructor */

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -229,7 +229,7 @@ RangeImage::createFromPointCloudWithViewpoints (const PointCloudTypeWithViewpoin
 template <typename PointCloudType> void 
 RangeImage::doZBuffer (const PointCloudType& point_cloud, float noise_level, float min_range, int& top, int& right, int& bottom, int& left)
 {
-  typedef typename PointCloudType::PointType PointType2;
+  using PointType2 = typename PointCloudType::PointType;
   const typename pcl::PointCloud<PointType2>::VectorType &points2 = point_cloud.points;
   
   unsigned int size = width*height;

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -55,10 +55,10 @@ namespace pcl
   {
     public:
       // =====TYPEDEFS=====
-      typedef pcl::PointCloud<PointWithRange> BaseClass;
-      typedef std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > VectorOfEigenVector3f;
-      typedef boost::shared_ptr<RangeImage> Ptr;
-      typedef boost::shared_ptr<const RangeImage> ConstPtr;
+      using BaseClass = pcl::PointCloud<PointWithRange>;
+      using VectorOfEigenVector3f = std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> >;
+      using Ptr = boost::shared_ptr<RangeImage>;
+      using ConstPtr = boost::shared_ptr<const RangeImage>;
       
       enum CoordinateFrame
       {

--- a/common/include/pcl/range_image/range_image_planar.h
+++ b/common/include/pcl/range_image/range_image_planar.h
@@ -52,9 +52,9 @@ namespace pcl
   {
     public:
       // =====TYPEDEFS=====
-      typedef RangeImage BaseClass;
-      typedef boost::shared_ptr<RangeImagePlanar> Ptr;
-      typedef boost::shared_ptr<const RangeImagePlanar> ConstPtr;
+      using BaseClass = RangeImage;
+      using Ptr = boost::shared_ptr<RangeImagePlanar>;
+      using ConstPtr = boost::shared_ptr<const RangeImagePlanar>;
       
       // =====CONSTRUCTOR & DESTRUCTOR=====
       /** Constructor */

--- a/common/include/pcl/range_image/range_image_spherical.h
+++ b/common/include/pcl/range_image/range_image_spherical.h
@@ -51,9 +51,9 @@ namespace pcl
   {
     public:
       // =====TYPEDEFS=====
-      typedef RangeImage BaseClass;
-      typedef boost::shared_ptr<RangeImageSpherical> Ptr;
-      typedef boost::shared_ptr<const RangeImageSpherical> ConstPtr;
+      using BaseClass = RangeImage;
+      using Ptr = boost::shared_ptr<RangeImageSpherical>;
+      using ConstPtr = boost::shared_ptr<const RangeImageSpherical>;
 
       // =====CONSTRUCTOR & DESTRUCTOR=====
       /** Constructor */

--- a/common/include/pcl/register_point_struct.h
+++ b/common/include/pcl/register_point_struct.h
@@ -334,10 +334,6 @@ namespace pcl
   };                                                                    \
   /***/
 
-// \note: the mpl::identity weirdness is to support array types without requiring the
-// user to wrap them. The basic problem is:
-// using type = float[81]; // SYNTAX ERROR!
-// using type[81] = float; // OK, can now use "type" as a synonym for float[81]
 #define POINT_CLOUD_REGISTER_FIELD_DATATYPE(r, name, elem)              \
   template<> struct datatype<name, pcl::fields::BOOST_PP_TUPLE_ELEM(3, 2, elem)> \
   {                                                                     \

--- a/common/include/pcl/register_point_struct.h
+++ b/common/include/pcl/register_point_struct.h
@@ -75,7 +75,7 @@
   BOOST_MPL_ASSERT_MSG(sizeof(wrapper) == sizeof(pod), POINT_WRAPPER_AND_POD_TYPES_HAVE_DIFFERENT_SIZES, (wrapper&, pod&)); \
   namespace pcl {                                           \
     namespace traits {                                      \
-      template<> struct POD<wrapper> { typedef pod type; }; \
+      template<> struct POD<wrapper> { using type = pod; }; \
     }                                                       \
   }                                                         \
   /***/
@@ -104,7 +104,7 @@ namespace pcl
     std::enable_if_t<std::is_array<T>::value>
     plus (std::remove_const_t<T> &l, const T &r)
     {
-      typedef std::remove_all_extents_t<T> type;
+      using type = std::remove_all_extents_t<T>;
       static const uint32_t count = sizeof (T) / sizeof (type);
       for (int i = 0; i < count; ++i)
         l[i] += r[i];
@@ -121,7 +121,7 @@ namespace pcl
     std::enable_if_t<std::is_array<T1>::value>
     plusscalar (T1 &p, const T2 &scalar)
     {
-      typedef std::remove_all_extents_t<T1> type;
+      using type = std::remove_all_extents_t<T1>;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] += scalar;
@@ -138,7 +138,7 @@ namespace pcl
     std::enable_if_t<std::is_array<T>::value>
     minus (std::remove_const_t<T> &l, const T &r)
     {
-      typedef std::remove_all_extents_t<T> type;
+      using type = std::remove_all_extents_t<T>;
       static const uint32_t count = sizeof (T) / sizeof (type);
       for (int i = 0; i < count; ++i)
         l[i] -= r[i];
@@ -155,7 +155,7 @@ namespace pcl
     std::enable_if_t<std::is_array<T1>::value>
     minusscalar (T1 &p, const T2 &scalar)
     {
-      typedef std::remove_all_extents_t<T1> type;
+      using type = std::remove_all_extents_t<T1>;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] -= scalar;
@@ -172,7 +172,7 @@ namespace pcl
     std::enable_if_t<std::is_array<T1>::value>
     mulscalar (T1 &p, const T2 &scalar)
     {
-      typedef std::remove_all_extents_t<T1> type;
+      using type = std::remove_all_extents_t<T1>;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] *= scalar;
@@ -189,7 +189,7 @@ namespace pcl
     std::enable_if_t<std::is_array<T1>::value>
     divscalar (T1 &p, const T2 &scalar)
     {
-      typedef std::remove_all_extents_t<T1> type;
+      using type = std::remove_all_extents_t<T1>;
       static const uint32_t count = sizeof (T1) / sizeof (type);
       for (int i = 0; i < count; ++i)
         p[i] /= scalar;
@@ -336,13 +336,13 @@ namespace pcl
 
 // \note: the mpl::identity weirdness is to support array types without requiring the
 // user to wrap them. The basic problem is:
-// typedef float[81] type; // SYNTAX ERROR!
-// typedef float type[81]; // OK, can now use "type" as a synonym for float[81]
+// using type = float[81]; // SYNTAX ERROR!
+// using type[81] = float; // OK, can now use "type" as a synonym for float[81]
 #define POINT_CLOUD_REGISTER_FIELD_DATATYPE(r, name, elem)              \
   template<> struct datatype<name, pcl::fields::BOOST_PP_TUPLE_ELEM(3, 2, elem)> \
   {                                                                     \
-    typedef boost::mpl::identity<BOOST_PP_TUPLE_ELEM(3, 0, elem)>::type type; \
-    typedef decomposeArray<type> decomposed;                            \
+    using type = boost::mpl::identity<BOOST_PP_TUPLE_ELEM(3, 0, elem)>::type; \
+    using decomposed = decomposeArray<type>;                            \
     static const uint8_t value = asEnum<decomposed::type>::value;       \
     static const uint32_t size = decomposed::value;                     \
   };                                                                    \
@@ -355,7 +355,7 @@ namespace pcl
 #define POINT_CLOUD_REGISTER_POINT_FIELD_LIST(name, seq)        \
   template<> struct fieldList<name>                             \
   {                                                             \
-    typedef boost::mpl::vector<BOOST_PP_SEQ_ENUM(seq)> type;    \
+    using type = boost::mpl::vector<BOOST_PP_SEQ_ENUM(seq)>;    \
   };                                                            \
   /***/
 


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`