### PR TITLE
Use using instead of typedef [kdtree, keypoints, octree]

### DIFF
--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -55,20 +55,20 @@ namespace pcl
   class KdTree
   {
     public:
-      typedef boost::shared_ptr <std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr <const std::vector<int> > IndicesConstPtr;
+      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+      using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-      typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = boost::shared_ptr<PointCloud>;
+      using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
-      typedef pcl::PointRepresentation<PointT> PointRepresentation;
-      //typedef boost::shared_ptr<PointRepresentation> PointRepresentationPtr;
-      typedef boost::shared_ptr<const PointRepresentation> PointRepresentationConstPtr;
+      using PointRepresentation = pcl::PointRepresentation<PointT>;
+      //using PointRepresentationPtr = boost::shared_ptr<PointRepresentation>;
+      using PointRepresentationConstPtr = boost::shared_ptr<const PointRepresentation>;
 
       // Boost shared pointers
-      typedef boost::shared_ptr<KdTree<PointT> > Ptr;
-      typedef boost::shared_ptr<const KdTree<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<KdTree<PointT> >;
+      using ConstPtr = boost::shared_ptr<const KdTree<PointT> >;
 
       /** \brief Empty constructor for KdTree. Sets some internal values to their defaults. 
         * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise. 

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -75,17 +75,17 @@ namespace pcl
       using KdTree<PointT>::nearestKSearch;
       using KdTree<PointT>::radiusSearch;
 
-      typedef typename KdTree<PointT>::PointCloud PointCloud;
-      typedef typename KdTree<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename KdTree<PointT>::PointCloud;
+      using PointCloudConstPtr = typename KdTree<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+      using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-      typedef ::flann::Index<Dist> FLANNIndex;
+      using FLANNIndex = ::flann::Index<Dist>;
 
       // Boost shared pointers
-      typedef boost::shared_ptr<KdTreeFLANN<PointT, Dist> > Ptr;
-      typedef boost::shared_ptr<const KdTreeFLANN<PointT, Dist> > ConstPtr;
+      using Ptr = boost::shared_ptr<KdTreeFLANN<PointT, Dist> >;
+      using ConstPtr = boost::shared_ptr<const KdTreeFLANN<PointT, Dist> >;
 
       /** \brief Default Constructor for KdTreeFLANN.
         * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise. 

--- a/keypoints/include/pcl/keypoints/agast_2d.h
+++ b/keypoints/include/pcl/keypoints/agast_2d.h
@@ -63,8 +63,8 @@ namespace pcl
       class PCL_EXPORTS AbstractAgastDetector
       {
         public:
-          typedef boost::shared_ptr<AbstractAgastDetector> Ptr;
-          typedef boost::shared_ptr<const AbstractAgastDetector> ConstPtr;
+          using Ptr = boost::shared_ptr<AbstractAgastDetector>;
+          using ConstPtr = boost::shared_ptr<const AbstractAgastDetector>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process
@@ -265,8 +265,8 @@ namespace pcl
       class PCL_EXPORTS AgastDetector7_12s : public AbstractAgastDetector
       {
         public:
-          typedef boost::shared_ptr<AgastDetector7_12s> Ptr;
-          typedef boost::shared_ptr<const AgastDetector7_12s> ConstPtr;
+          using Ptr = boost::shared_ptr<AgastDetector7_12s>;
+          using ConstPtr = boost::shared_ptr<const AgastDetector7_12s>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process
@@ -336,8 +336,8 @@ namespace pcl
       class PCL_EXPORTS AgastDetector5_8 : public AbstractAgastDetector
       {
         public:
-          typedef boost::shared_ptr<AgastDetector5_8> Ptr;
-          typedef boost::shared_ptr<const AgastDetector5_8> ConstPtr;
+          using Ptr = boost::shared_ptr<AgastDetector5_8>;
+          using ConstPtr = boost::shared_ptr<const AgastDetector5_8>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process
@@ -407,8 +407,8 @@ namespace pcl
       class PCL_EXPORTS OastDetector9_16 : public AbstractAgastDetector
       {
         public:
-          typedef boost::shared_ptr<OastDetector9_16> Ptr;
-          typedef boost::shared_ptr<const OastDetector9_16> ConstPtr;
+          using Ptr = boost::shared_ptr<OastDetector9_16>;
+          using ConstPtr = boost::shared_ptr<const OastDetector9_16>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process
@@ -555,12 +555,12 @@ namespace pcl
   class AgastKeypoint2DBase : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Keypoint<PointInT, PointOutT>::KdTree KdTree;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using KdTree = typename Keypoint<PointInT, PointOutT>::KdTree;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
-      typedef pcl::keypoints::agast::AbstractAgastDetector::Ptr AgastDetectorPtr;
+      using AgastDetectorPtr = pcl::keypoints::agast::AbstractAgastDetector::Ptr;
      
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;
@@ -718,7 +718,7 @@ namespace pcl
   class AgastKeypoint2D : public AgastKeypoint2DBase<PointInT, PointOutT, pcl::common::IntensityFieldAccessor<PointInT> >
   {
     public:
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;

--- a/keypoints/include/pcl/keypoints/brisk_2d.h
+++ b/keypoints/include/pcl/keypoints/brisk_2d.h
@@ -71,13 +71,13 @@ namespace pcl
   class BriskKeypoint2D: public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<BriskKeypoint2D<PointInT, PointOutT, IntensityT> > Ptr;
-      typedef boost::shared_ptr<const BriskKeypoint2D<PointInT, PointOutT, IntensityT> > ConstPtr;
+      using Ptr = boost::shared_ptr<BriskKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using ConstPtr = boost::shared_ptr<const BriskKeypoint2D<PointInT, PointOutT, IntensityT> >;
 
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Keypoint<PointInT, PointOutT>::KdTree KdTree;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using KdTree = typename Keypoint<PointInT, PointOutT>::KdTree;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;

--- a/keypoints/include/pcl/keypoints/harris_2d.h
+++ b/keypoints/include/pcl/keypoints/harris_2d.h
@@ -53,20 +53,20 @@ namespace pcl
   class HarrisKeypoint2D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<HarrisKeypoint2D<PointInT, PointOutT, IntensityT> > Ptr;
-      typedef boost::shared_ptr<const HarrisKeypoint2D<PointInT, PointOutT, IntensityT> > ConstPtr;
+      using Ptr = boost::shared_ptr<HarrisKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using ConstPtr = boost::shared_ptr<const HarrisKeypoint2D<PointInT, PointOutT, IntensityT> >;
 
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Keypoint<PointInT, PointOutT>::KdTree KdTree;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using KdTree = typename Keypoint<PointInT, PointOutT>::KdTree;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;
       using Keypoint<PointInT, PointOutT>::indices_;
       using Keypoint<PointInT, PointOutT>::keypoints_indices_;
 
-      typedef enum {HARRIS = 1, NOBLE, LOWE, TOMASI} ResponseMethod;
+      enum ResponseMethod {HARRIS = 1, NOBLE, LOWE, TOMASI};
 
       /** \brief Constructor
         * \param[in] method the method to be used to determine the corner responses

--- a/keypoints/include/pcl/keypoints/harris_3d.h
+++ b/keypoints/include/pcl/keypoints/harris_3d.h
@@ -51,17 +51,17 @@ namespace pcl
   class HarrisKeypoint3D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<HarrisKeypoint3D<PointInT, PointOutT, NormalT> > Ptr;
-      typedef boost::shared_ptr<const HarrisKeypoint3D<PointInT, PointOutT, NormalT> > ConstPtr;
+      using Ptr = boost::shared_ptr<HarrisKeypoint3D<PointInT, PointOutT, NormalT> >;
+      using ConstPtr = boost::shared_ptr<const HarrisKeypoint3D<PointInT, PointOutT, NormalT> >;
 
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Keypoint<PointInT, PointOutT>::KdTree KdTree;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using KdTree = typename Keypoint<PointInT, PointOutT>::KdTree;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
-      typedef pcl::PointCloud<NormalT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<NormalT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;
@@ -75,7 +75,7 @@ namespace pcl
       using Keypoint<PointInT, PointOutT>::initCompute;
       using PCLBase<PointInT>::setInputCloud;
 
-      typedef enum {HARRIS = 1, NOBLE, LOWE, TOMASI, CURVATURE} ResponseMethod;
+      enum ResponseMethod {HARRIS = 1, NOBLE, LOWE, TOMASI, CURVATURE};
 
       /** \brief Constructor
         * \param[in] method the method to be used to determine the corner responses

--- a/keypoints/include/pcl/keypoints/harris_6d.h
+++ b/keypoints/include/pcl/keypoints/harris_6d.h
@@ -49,13 +49,13 @@ namespace pcl
   class HarrisKeypoint6D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<HarrisKeypoint6D<PointInT, PointOutT, NormalT> > Ptr;
-      typedef boost::shared_ptr<const HarrisKeypoint6D<PointInT, PointOutT, NormalT> > ConstPtr;
+      using Ptr = boost::shared_ptr<HarrisKeypoint6D<PointInT, PointOutT, NormalT> >;
+      using ConstPtr = boost::shared_ptr<const HarrisKeypoint6D<PointInT, PointOutT, NormalT> >;
 
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Keypoint<PointInT, PointOutT>::KdTree KdTree;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using KdTree = typename Keypoint<PointInT, PointOutT>::KdTree;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;

--- a/keypoints/include/pcl/keypoints/iss_3d.h
+++ b/keypoints/include/pcl/keypoints/iss_3d.h
@@ -84,18 +84,18 @@ namespace pcl
   class ISSKeypoint3D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<ISSKeypoint3D<PointInT, PointOutT, NormalT> > Ptr;
-      typedef boost::shared_ptr<const ISSKeypoint3D<PointInT, PointOutT, NormalT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ISSKeypoint3D<PointInT, PointOutT, NormalT> >;
+      using ConstPtr = boost::shared_ptr<const ISSKeypoint3D<PointInT, PointOutT, NormalT> >;
 
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
 
-      typedef pcl::PointCloud<NormalT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<NormalT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      typedef pcl::octree::OctreePointCloudSearch<PointInT> OctreeSearchIn;
-      typedef typename OctreeSearchIn::Ptr OctreeSearchInPtr;
+      using OctreeSearchIn = pcl::octree::OctreePointCloudSearch<PointInT>;
+      using OctreeSearchInPtr = typename OctreeSearchIn::Ptr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;

--- a/keypoints/include/pcl/keypoints/keypoint.h
+++ b/keypoints/include/pcl/keypoints/keypoint.h
@@ -54,21 +54,21 @@ namespace pcl
   class Keypoint : public PCLBase<PointInT>
   {
     public:
-      typedef boost::shared_ptr<Keypoint<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const Keypoint<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<Keypoint<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const Keypoint<PointInT, PointOutT> >;
 
       using PCLBase<PointInT>::indices_;
       using PCLBase<PointInT>::input_;
 
-      typedef PCLBase<PointInT> BaseClass;
-      typedef pcl::search::Search<PointInT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename PointCloudIn::Ptr PointCloudInPtr;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
-      typedef std::function<int (int, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
-      typedef std::function<int (const PointCloudIn &cloud, int index, double, std::vector<int> &, std::vector<float> &)> SearchMethodSurface;
+      using BaseClass = PCLBase<PointInT>;
+      using KdTree = pcl::search::Search<PointInT>;
+      using KdTreePtr = typename KdTree::Ptr;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudInPtr = typename PointCloudIn::Ptr;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
+      using SearchMethod = std::function<int (int, double, std::vector<int> &, std::vector<float> &)>;
+      using SearchMethodSurface = std::function<int (const PointCloudIn &cloud, int index, double, std::vector<int> &, std::vector<float> &)>;
 
     public:
       /** \brief Empty constructor. */

--- a/keypoints/include/pcl/keypoints/narf_keypoint.h
+++ b/keypoints/include/pcl/keypoints/narf_keypoint.h
@@ -59,13 +59,13 @@ class RangeImageBorderExtractor;
 class PCL_EXPORTS NarfKeypoint : public Keypoint<PointWithRange, int>
 {
   public:
-    typedef boost::shared_ptr<NarfKeypoint> Ptr;
-    typedef boost::shared_ptr<const NarfKeypoint> ConstPtr;
+    using Ptr = boost::shared_ptr<NarfKeypoint>;
+    using ConstPtr = boost::shared_ptr<const NarfKeypoint>;
 
     // =====TYPEDEFS=====
-    typedef Keypoint<PointWithRange, int> BaseClass;
+    using BaseClass = Keypoint<PointWithRange, int>;
     
-    typedef Keypoint<PointWithRange, int>::PointCloudOut PointCloudOut;
+    using PointCloudOut = Keypoint<PointWithRange, int>::PointCloudOut;
 
     // =====PUBLIC STRUCTS=====
     //! Parameters used in this class

--- a/keypoints/include/pcl/keypoints/sift_keypoint.h
+++ b/keypoints/include/pcl/keypoints/sift_keypoint.h
@@ -93,12 +93,12 @@ namespace pcl
   class SIFTKeypoint : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<SIFTKeypoint<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const SIFTKeypoint<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SIFTKeypoint<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const SIFTKeypoint<PointInT, PointOutT> >;
 
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Keypoint<PointInT, PointOutT>::KdTree KdTree;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using KdTree = typename Keypoint<PointInT, PointOutT>::KdTree;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;

--- a/keypoints/include/pcl/keypoints/smoothed_surfaces_keypoint.h
+++ b/keypoints/include/pcl/keypoints/smoothed_surfaces_keypoint.h
@@ -54,8 +54,8 @@ namespace pcl
   class SmoothedSurfacesKeypoint : public Keypoint <PointT, PointT>
   {
     public:
-      typedef boost::shared_ptr<SmoothedSurfacesKeypoint<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr<const SmoothedSurfacesKeypoint<PointT, PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SmoothedSurfacesKeypoint<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr<const SmoothedSurfacesKeypoint<PointT, PointNT> >;
 
       using PCLBase<PointT>::input_;
       using Keypoint<PointT, PointT>::name_;
@@ -63,12 +63,12 @@ namespace pcl
       using Keypoint<PointT, PointT>::keypoints_indices_;
       using Keypoint<PointT, PointT>::initCompute;
 
-      typedef pcl::PointCloud<PointT> PointCloudT;
-      typedef typename PointCloudT::ConstPtr PointCloudTConstPtr;
-      typedef pcl::PointCloud<PointNT> PointCloudNT;
-      typedef typename PointCloudNT::ConstPtr PointCloudNTConstPtr;
-      typedef typename PointCloudT::Ptr PointCloudTPtr;
-      typedef typename Keypoint<PointT, PointT>::KdTreePtr KdTreePtr;
+      using PointCloudT = pcl::PointCloud<PointT>;
+      using PointCloudTConstPtr = typename PointCloudT::ConstPtr;
+      using PointCloudNT = pcl::PointCloud<PointNT>;
+      using PointCloudNTConstPtr = typename PointCloudNT::ConstPtr;
+      using PointCloudTPtr = typename PointCloudT::Ptr;
+      using KdTreePtr = typename Keypoint<PointT, PointT>::KdTreePtr;
 
       SmoothedSurfacesKeypoint ()
         : Keypoint<PointT, PointT> (),

--- a/keypoints/include/pcl/keypoints/susan.h
+++ b/keypoints/include/pcl/keypoints/susan.h
@@ -56,17 +56,17 @@ namespace pcl
   class SUSANKeypoint : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT> > Ptr;
-      typedef boost::shared_ptr<const SUSANKeypoint<PointInT, PointOutT, NormalT, Intensity> > ConstPtr;
+      using Ptr = boost::shared_ptr<SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT> >;
+      using ConstPtr = boost::shared_ptr<const SUSANKeypoint<PointInT, PointOutT, NormalT, Intensity> >;
 
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Keypoint<PointInT, PointOutT>::KdTree KdTree;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using KdTree = typename Keypoint<PointInT, PointOutT>::KdTree;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
-      typedef pcl::PointCloud<NormalT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<NormalT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;

--- a/keypoints/include/pcl/keypoints/trajkovic_2d.h
+++ b/keypoints/include/pcl/keypoints/trajkovic_2d.h
@@ -54,18 +54,18 @@ namespace pcl
   class TrajkovicKeypoint2D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> > Ptr;
-      typedef boost::shared_ptr<const TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> > ConstPtr;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using Ptr = boost::shared_ptr<TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using ConstPtr = boost::shared_ptr<const TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;
       using Keypoint<PointInT, PointOutT>::indices_;
       using Keypoint<PointInT, PointOutT>::keypoints_indices_;
 
-      typedef enum { FOUR_CORNERS, EIGHT_CORNERS } ComputationMethod;
+      enum ComputationMethod { FOUR_CORNERS, EIGHT_CORNERS };
 
       /** \brief Constructor
         * \param[in] method the method to be used to determine the corner responses

--- a/keypoints/include/pcl/keypoints/trajkovic_3d.h
+++ b/keypoints/include/pcl/keypoints/trajkovic_3d.h
@@ -54,14 +54,14 @@ namespace pcl
   class TrajkovicKeypoint3D : public Keypoint<PointInT, PointOutT>
   {
     public:
-    typedef boost::shared_ptr<TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> > Ptr;
-    typedef boost::shared_ptr<const TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> > ConstPtr;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Keypoint<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
-      typedef pcl::PointCloud<NormalT> Normals;
-      typedef typename Normals::Ptr NormalsPtr;
-      typedef typename Normals::ConstPtr NormalsConstPtr;
+    using Ptr = boost::shared_ptr<TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> >;
+    using ConstPtr = boost::shared_ptr<const TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> >;
+      using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
+      using Normals = pcl::PointCloud<NormalT>;
+      using NormalsPtr = typename Normals::Ptr;
+      using NormalsConstPtr = typename Normals::ConstPtr;
 
       using Keypoint<PointInT, PointOutT>::name_;
       using Keypoint<PointInT, PointOutT>::input_;
@@ -69,7 +69,7 @@ namespace pcl
       using Keypoint<PointInT, PointOutT>::keypoints_indices_;
       using Keypoint<PointInT, PointOutT>::initCompute;
 
-      typedef enum { FOUR_CORNERS, EIGHT_CORNERS } ComputationMethod;
+      enum ComputationMethod { FOUR_CORNERS, EIGHT_CORNERS };
 
       /** \brief Constructor
         * \param[in] method the method to be used to determine the corner responses

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -1669,7 +1669,7 @@ pcl::keypoints::brisk::Layer::halfsample (
       // compute horizontal pairwise average and store
       p_dest_char = reinterpret_cast<unsigned char*> (p_dest);
 #ifdef __GNUC__
-      typedef unsigned char __attribute__ ((__may_alias__)) UCHAR_ALIAS;
+      using UCHAR_ALIAS __attribute__ ((__may_alias__)) = unsigned char;
 #endif
 #ifdef _MSC_VER
       // Todo: find the equivalent to may_alias

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -716,7 +716,7 @@ NarfKeypoint::calculateInterestPoints ()
   is_interest_point_image_.clear ();
   is_interest_point_image_.resize (size, false);
   
-  typedef double RealForPolynomial;
+  using RealForPolynomial = double;
   PolynomialCalculationsT<RealForPolynomial> polynomial_calculations;
   BivariatePolynomialT<RealForPolynomial> polynomial (2);
   std::vector<Eigen::Matrix<RealForPolynomial, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<RealForPolynomial, 3, 1> > > sample_points;

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -223,7 +223,7 @@ namespace pcl
 
       public:
 
-        typedef Octree2BufBase<LeafContainerT, BranchContainerT> OctreeT;
+        using OctreeT = Octree2BufBase<LeafContainerT, BranchContainerT>;
 
         // iterators are friends
         friend class OctreeIteratorBase<OctreeT> ;
@@ -232,15 +232,15 @@ namespace pcl
         friend class OctreeLeafNodeDepthFirstIterator<OctreeT> ;
         friend class OctreeLeafNodeBreadthFirstIterator<OctreeT> ;
 
-        typedef BufferedBranchNode<BranchContainerT> BranchNode;
-        typedef OctreeLeafNode<LeafContainerT> LeafNode;
+        using BranchNode = BufferedBranchNode<BranchContainerT>;
+        using LeafNode = OctreeLeafNode<LeafContainerT>;
 
-        typedef BranchContainerT BranchContainer;
-        typedef LeafContainerT LeafContainer;
+        using BranchContainer = BranchContainerT;
+        using LeafContainer = LeafContainerT;
 
         // Octree default iterators
-        typedef OctreeDepthFirstIterator<OctreeT> Iterator;
-        typedef const OctreeDepthFirstIterator<OctreeT> ConstIterator;
+        using Iterator = OctreeDepthFirstIterator<OctreeT>;
+        using ConstIterator = const OctreeDepthFirstIterator<OctreeT>;
         Iterator begin(unsigned int max_depth_arg = 0) {return Iterator(this, max_depth_arg);};
         const Iterator end() {return Iterator();};
 
@@ -248,8 +248,8 @@ namespace pcl
         // The previous deprecated names
         // LeafNodeIterator and ConstLeafNodeIterator are deprecated.
         // Please use LeafNodeDepthFirstIterator and ConstLeafNodeDepthFirstIterator instead.
-        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeIterator;
-        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeIterator;
+        using LeafNodeIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
+        using ConstLeafNodeIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
         [[deprecated("use leaf_depth_begin() instead")]]
         LeafNodeIterator leaf_begin (unsigned int max_depth_arg = 0)
@@ -264,8 +264,8 @@ namespace pcl
         };
 
         // The currently valide names
-        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeDepthFirstIterator;
-        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeDepthFirstIterator;
+        using LeafNodeDepthFirstIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
+        using ConstLeafNodeDepthFirstIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
         LeafNodeDepthFirstIterator leaf_depth_begin (unsigned int max_depth_arg = 0)
         {
           return LeafNodeDepthFirstIterator (this, max_depth_arg);
@@ -277,20 +277,20 @@ namespace pcl
         };
 
         // Octree depth-first iterators
-        typedef OctreeDepthFirstIterator<OctreeT> DepthFirstIterator;
-        typedef const OctreeDepthFirstIterator<OctreeT> ConstDepthFirstIterator;
+        using DepthFirstIterator = OctreeDepthFirstIterator<OctreeT>;
+        using ConstDepthFirstIterator = const OctreeDepthFirstIterator<OctreeT>;
         DepthFirstIterator depth_begin(unsigned int maxDepth_arg = 0) {return DepthFirstIterator(this, maxDepth_arg);};
         const DepthFirstIterator depth_end() {return DepthFirstIterator();};
 
         // Octree breadth-first iterators
-        typedef OctreeBreadthFirstIterator<OctreeT> BreadthFirstIterator;
-        typedef const OctreeBreadthFirstIterator<OctreeT> ConstBreadthFirstIterator;
+        using BreadthFirstIterator = OctreeBreadthFirstIterator<OctreeT>;
+        using ConstBreadthFirstIterator = const OctreeBreadthFirstIterator<OctreeT>;
         BreadthFirstIterator breadth_begin(unsigned int max_depth_arg = 0) {return BreadthFirstIterator(this, max_depth_arg);};
         const BreadthFirstIterator breadth_end() {return BreadthFirstIterator();};
 
         // Octree leaf node iterators
-        typedef OctreeLeafNodeBreadthFirstIterator<OctreeT> LeafNodeBreadthIterator;
-        typedef const OctreeLeafNodeBreadthFirstIterator<OctreeT> ConstLeafNodeBreadthIterator;
+        using LeafNodeBreadthIterator = OctreeLeafNodeBreadthFirstIterator<OctreeT>;
+        using ConstLeafNodeBreadthIterator = const OctreeLeafNodeBreadthFirstIterator<OctreeT>;
 
         LeafNodeBreadthIterator leaf_breadth_begin (unsigned int max_depth_arg = 0u)
         {

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -62,13 +62,13 @@ namespace pcl
     {
       public:
 
-        typedef OctreeBase<LeafContainerT, BranchContainerT> OctreeT;
+        using OctreeT = OctreeBase<LeafContainerT, BranchContainerT>;
 
-        typedef OctreeBranchNode<BranchContainerT> BranchNode;
-        typedef OctreeLeafNode<LeafContainerT> LeafNode;
+        using BranchNode = OctreeBranchNode<BranchContainerT>;
+        using LeafNode = OctreeLeafNode<LeafContainerT>;
 
-        typedef BranchContainerT BranchContainer;
-        typedef LeafContainerT LeafContainer;
+        using BranchContainer = BranchContainerT;
+        using LeafContainer = LeafContainerT;
 
       protected:
 
@@ -108,8 +108,8 @@ namespace pcl
         friend class OctreeLeafNodeBreadthFirstIterator<OctreeT> ;
 
         // Octree default iterators
-        typedef OctreeDepthFirstIterator<OctreeT> Iterator;
-        typedef const OctreeDepthFirstIterator<OctreeT> ConstIterator;
+        using Iterator = OctreeDepthFirstIterator<OctreeT>;
+        using ConstIterator = const OctreeDepthFirstIterator<OctreeT>;
 
         Iterator begin (unsigned int max_depth_arg = 0u)
         {
@@ -125,8 +125,8 @@ namespace pcl
         // The previous deprecated names
         // LeafNodeIterator and ConstLeafNodeIterator are deprecated.
         // Please use LeafNodeDepthFirstIterator and ConstLeafNodeDepthFirstIterator instead.
-        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeIterator;
-        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeIterator;
+        using LeafNodeIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
+        using ConstLeafNodeIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
         [[deprecated("use leaf_depth_begin() instead")]]
         LeafNodeIterator leaf_begin (unsigned int max_depth_arg = 0u)
@@ -141,8 +141,8 @@ namespace pcl
         };
 
         // The currently valide names
-        typedef OctreeLeafNodeDepthFirstIterator<OctreeT> LeafNodeDepthFirstIterator;
-        typedef const OctreeLeafNodeDepthFirstIterator<OctreeT> ConstLeafNodeDepthFirstIterator;
+        using LeafNodeDepthFirstIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
+        using ConstLeafNodeDepthFirstIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
         LeafNodeDepthFirstIterator leaf_depth_begin (unsigned int max_depth_arg = 0u)
         {
@@ -155,8 +155,8 @@ namespace pcl
         };
 
         // Octree depth-first iterators
-        typedef OctreeDepthFirstIterator<OctreeT> DepthFirstIterator;
-        typedef const OctreeDepthFirstIterator<OctreeT> ConstDepthFirstIterator;
+        using DepthFirstIterator = OctreeDepthFirstIterator<OctreeT>;
+        using ConstDepthFirstIterator = const OctreeDepthFirstIterator<OctreeT>;
 
         DepthFirstIterator depth_begin (unsigned int max_depth_arg = 0u)
         {
@@ -169,8 +169,8 @@ namespace pcl
         };
 
         // Octree breadth-first iterators
-        typedef OctreeBreadthFirstIterator<OctreeT> BreadthFirstIterator;
-        typedef const OctreeBreadthFirstIterator<OctreeT> ConstBreadthFirstIterator;
+        using BreadthFirstIterator = OctreeBreadthFirstIterator<OctreeT>;
+        using ConstBreadthFirstIterator = const OctreeBreadthFirstIterator<OctreeT>;
 
         BreadthFirstIterator breadth_begin (unsigned int max_depth_arg = 0u)
         {
@@ -183,8 +183,8 @@ namespace pcl
         };
 
         // Octree breadth iterators at a given depth
-        typedef OctreeFixedDepthIterator<OctreeT> FixedDepthIterator;
-        typedef const OctreeFixedDepthIterator<OctreeT> ConstFixedDepthIterator;
+        using FixedDepthIterator = OctreeFixedDepthIterator<OctreeT>;
+        using ConstFixedDepthIterator = const OctreeFixedDepthIterator<OctreeT>;
 
         FixedDepthIterator fixed_depth_begin (unsigned int fixed_depth_arg = 0u)
         {
@@ -197,8 +197,8 @@ namespace pcl
         };
 
         // Octree leaf node iterators
-        typedef OctreeLeafNodeBreadthFirstIterator<OctreeT> LeafNodeBreadthFirstIterator;
-        typedef const OctreeLeafNodeBreadthFirstIterator<OctreeT> ConstLeafNodeBreadthFirstIterator;
+        using LeafNodeBreadthFirstIterator = OctreeLeafNodeBreadthFirstIterator<OctreeT>;
+        using ConstLeafNodeBreadthFirstIterator = const OctreeLeafNodeBreadthFirstIterator<OctreeT>;
 
         LeafNodeBreadthFirstIterator leaf_breadth_begin (unsigned int max_depth_arg = 0u)
         {

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -77,11 +77,11 @@ namespace pcl
       {
       public:
 
-        typedef typename OctreeT::LeafNode LeafNode;
-        typedef typename OctreeT::BranchNode BranchNode;
+        using LeafNode = typename OctreeT::LeafNode;
+        using BranchNode = typename OctreeT::BranchNode;
 
-        typedef typename OctreeT::LeafContainer LeafContainer;
-        typedef typename OctreeT::BranchContainer BranchContainer;
+        using LeafContainer = typename OctreeT::LeafContainer;
+        using BranchContainer = typename OctreeT::BranchContainer;
 
         /** \brief Empty constructor.
          */
@@ -369,8 +369,8 @@ namespace pcl
 
       public:
 
-        typedef typename OctreeIteratorBase<OctreeT>::LeafNode LeafNode;
-        typedef typename OctreeIteratorBase<OctreeT>::BranchNode BranchNode;
+        using LeafNode = typename OctreeIteratorBase<OctreeT>::LeafNode;
+        using BranchNode = typename OctreeIteratorBase<OctreeT>::BranchNode;
 
         /** \brief Empty constructor.
          * \param[in] max_depth_arg Depth limitation during traversal
@@ -476,8 +476,8 @@ namespace pcl
       {
       public:
         // public typedefs
-        typedef typename OctreeIteratorBase<OctreeT>::BranchNode BranchNode;
-        typedef typename OctreeIteratorBase<OctreeT>::LeafNode LeafNode;
+        using BranchNode = typename OctreeIteratorBase<OctreeT>::BranchNode;
+        using LeafNode = typename OctreeIteratorBase<OctreeT>::LeafNode;
 
         /** \brief Empty constructor.
          * \param[in] max_depth_arg Depth limitation during traversal
@@ -663,8 +663,8 @@ namespace pcl
     template<typename OctreeT>
       class OctreeLeafNodeDepthFirstIterator : public OctreeDepthFirstIterator<OctreeT>
       {
-        typedef typename OctreeDepthFirstIterator<OctreeT>::BranchNode BranchNode;
-        typedef typename OctreeDepthFirstIterator<OctreeT>::LeafNode LeafNode;
+        using BranchNode = typename OctreeDepthFirstIterator<OctreeT>::BranchNode;
+        using LeafNode = typename OctreeDepthFirstIterator<OctreeT>::LeafNode;
 
       public:
         /** \brief Empty constructor.
@@ -766,8 +766,8 @@ namespace pcl
     template<typename OctreeT>
       class OctreeLeafNodeBreadthFirstIterator : public OctreeBreadthFirstIterator<OctreeT>
       {
-        typedef typename OctreeBreadthFirstIterator<OctreeT>::BranchNode BranchNode;
-        typedef typename OctreeBreadthFirstIterator<OctreeT>::LeafNode LeafNode;
+        using BranchNode = typename OctreeBreadthFirstIterator<OctreeT>::BranchNode;
+        using LeafNode = typename OctreeBreadthFirstIterator<OctreeT>::LeafNode;
 
       public:
         /** \brief Empty constructor.

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -72,10 +72,10 @@ namespace pcl
     class OctreePointCloud : public OctreeT
     {
       public:
-        typedef OctreeT Base;
+        using Base = OctreeT;
 
-        typedef typename OctreeT::LeafNode LeafNode;
-        typedef typename OctreeT::BranchNode BranchNode;
+        using LeafNode = typename OctreeT::LeafNode;
+        using BranchNode = typename OctreeT::BranchNode;
 
         /** \brief Octree pointcloud constructor.
          * \param[in] resolution_arg octree resolution at lowest octree level
@@ -87,24 +87,24 @@ namespace pcl
         ~OctreePointCloud ();
 
         // public typedefs
-        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
         // public typedefs for single/double buffering
-        typedef OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeBase<LeafContainerT> > SingleBuffer;
-       // typedef OctreePointCloud<PointT, LeafContainerT, BranchContainerT, Octree2BufBase<LeafContainerT> > DoubleBuffer;
+        using SingleBuffer = OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeBase<LeafContainerT> >;
+       // using DoubleBuffer = OctreePointCloud<PointT, LeafContainerT, BranchContainerT, Octree2BufBase<LeafContainerT> >;
 
         // Boost shared pointers
-        typedef boost::shared_ptr<OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> > Ptr;
-        typedef boost::shared_ptr<const OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> > ConstPtr;
+        using Ptr = boost::shared_ptr<OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> >;
+        using ConstPtr = boost::shared_ptr<const OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> >;
 
         // Eigen aligned allocator
-        typedef std::vector<PointT, Eigen::aligned_allocator<PointT> > AlignedPointTVector;
-        typedef std::vector<PointXYZ, Eigen::aligned_allocator<PointXYZ> > AlignedPointXYZVector;
+        using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
+        using AlignedPointXYZVector = std::vector<PointXYZ, Eigen::aligned_allocator<PointXYZ> >;
 
         /** \brief Provide a pointer to the input data set.
          * \param[in] cloud_arg the const boost shared pointer to a PointCloud message

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency.h
@@ -80,31 +80,31 @@ namespace pcl
 
       public:
 
-        typedef OctreeBase<LeafContainerT, BranchContainerT> OctreeBaseT;
+        using OctreeBaseT = OctreeBase<LeafContainerT, BranchContainerT>;
 
-        typedef OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT> OctreeAdjacencyT;
-        typedef boost::shared_ptr<OctreeAdjacencyT> Ptr;
-        typedef boost::shared_ptr<const OctreeAdjacencyT> ConstPtr;
+        using OctreeAdjacencyT = OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>;
+        using Ptr = boost::shared_ptr<OctreeAdjacencyT>;
+        using ConstPtr = boost::shared_ptr<const OctreeAdjacencyT>;
 
-        typedef OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeBaseT> OctreePointCloudT;
-        typedef typename OctreePointCloudT::LeafNode LeafNode;
-        typedef typename OctreePointCloudT::BranchNode BranchNode;
+        using OctreePointCloudT = OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeBaseT>;
+        using LeafNode = typename OctreePointCloudT::LeafNode;
+        using BranchNode = typename OctreePointCloudT::BranchNode;
 
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
         // BGL graph
-        typedef boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, PointT, float> VoxelAdjacencyList;
-        typedef typename VoxelAdjacencyList::vertex_descriptor VoxelID;
-        typedef typename VoxelAdjacencyList::edge_descriptor EdgeID;
+        using VoxelAdjacencyList = boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, PointT, float>;
+        using VoxelID = typename VoxelAdjacencyList::vertex_descriptor;
+        using EdgeID = typename VoxelAdjacencyList::edge_descriptor;
 
         // Leaf vector - pointers to all leaves
-        typedef std::vector<LeafContainerT*> LeafVectorT;
+        using LeafVectorT = std::vector<LeafContainerT *>;
 
         // Fast leaf iterators that don't require traversing tree
-        typedef typename LeafVectorT::iterator iterator;
-        typedef typename LeafVectorT::const_iterator const_iterator;
+        using iterator = typename LeafVectorT::iterator;
+        using const_iterator = typename LeafVectorT::const_iterator;
 
         inline iterator begin () { return (leaf_vector_.begin ()); }
         inline iterator end ()   { return (leaf_vector_.end ()); }

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
@@ -55,8 +55,8 @@ namespace pcl
       template<typename T, typename U, typename V>
       friend class OctreePointCloudAdjacency;
     public:
-      typedef std::list<OctreePointCloudAdjacencyContainer*> NeighborListT;
-      typedef typename NeighborListT::const_iterator const_iterator;
+      using NeighborListT = std::list<OctreePointCloudAdjacencyContainer<PointInT, DataT> *>;
+      using const_iterator = typename NeighborListT::const_iterator;
       //const iterators to neighbors
       inline const_iterator cbegin () const { return (neighbors_.begin ()); }
       inline const_iterator cend () const  { return (neighbors_.end ()); }
@@ -108,7 +108,7 @@ namespace pcl
       }
     protected:
       //iterators to neighbors
-      typedef typename NeighborListT::iterator iterator;
+      using iterator = typename NeighborListT::iterator;
       inline iterator begin () { return (neighbors_.begin ()); }
       inline iterator end ()   { return (neighbors_.end ()); }
 

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -69,7 +69,7 @@ namespace pcl
 
       public:
 
-        typedef boost::shared_ptr<OctreePointCloudChangeDetector<PointT, LeafContainerT, BranchContainerT>> Ptr;
+        using Ptr = boost::shared_ptr<OctreePointCloudChangeDetector<PointT, LeafContainerT, BranchContainerT>>;
 
         /** \brief Constructor.
          *  \param resolution_arg:  octree resolution at lowest octree level

--- a/octree/include/pcl/octree/octree_pointcloud_occupancy.h
+++ b/octree/include/pcl/octree/octree_pointcloud_occupancy.h
@@ -65,13 +65,13 @@ namespace pcl
 
       public:
         // public typedefs for single/double buffering
-        typedef OctreePointCloudOccupancy<PointT, LeafContainerT, BranchContainerT> SingleBuffer;
-        typedef OctreePointCloudOccupancy<PointT, LeafContainerT, BranchContainerT> DoubleBuffer;
+        using SingleBuffer = OctreePointCloudOccupancy<PointT, LeafContainerT, BranchContainerT>;
+        using DoubleBuffer = OctreePointCloudOccupancy<PointT, LeafContainerT, BranchContainerT>;
 
         // public point cloud typedefs
-        typedef typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::PointCloud PointCloud;
-        typedef typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::PointCloudPtr PointCloudPtr;
-        typedef typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::PointCloudConstPtr PointCloudConstPtr;
+        using PointCloud = typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::PointCloud;
+        using PointCloudPtr = typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::PointCloudPtr;
+        using PointCloudConstPtr = typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::PointCloudConstPtr;
 
         /** \brief Constructor.
          *  \param resolution_arg:  octree resolution at lowest octree level

--- a/octree/include/pcl/octree/octree_pointcloud_pointvector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_pointvector.h
@@ -64,8 +64,8 @@ namespace pcl
 
       public:
         // public typedefs for single/double buffering
-        typedef OctreePointCloudPointVector<PointT, LeafContainerT, BranchContainerT,
-            OctreeBase<LeafContainerT, BranchContainerT> > SingleBuffer;
+        using SingleBuffer = OctreePointCloudPointVector<PointT, LeafContainerT, BranchContainerT,
+            OctreeBase<LeafContainerT, BranchContainerT> >;
       //  typedef OctreePointCloudPointVector<PointT, LeafContainerT, BranchContainerT,
      //       Octree2BufBase<int, LeafContainerT, BranchContainerT> > DoubleBuffer;
 

--- a/octree/include/pcl/octree/octree_pointcloud_singlepoint.h
+++ b/octree/include/pcl/octree/octree_pointcloud_singlepoint.h
@@ -64,8 +64,8 @@ namespace pcl
 
       public:
         // public typedefs for single/double buffering
-        typedef OctreePointCloudSinglePoint<PointT, LeafContainerT, BranchContainerT,
-            OctreeBase<LeafContainerT, BranchContainerT> > SingleBuffer;
+        using SingleBuffer = OctreePointCloudSinglePoint<PointT, LeafContainerT, BranchContainerT,
+            OctreeBase<LeafContainerT, BranchContainerT> >;
   //      typedef OctreePointCloudSinglePoint<PointT, LeafContainerT, BranchContainerT,
    //         Octree2BufBase<int, LeafContainerT, BranchContainerT> > DoubleBuffer;
 

--- a/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
+++ b/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
@@ -141,12 +141,12 @@ namespace pcl
     class OctreePointCloudVoxelCentroid : public OctreePointCloud<PointT, LeafContainerT, BranchContainerT>
     {
       public:
-        typedef boost::shared_ptr<OctreePointCloudVoxelCentroid<PointT, LeafContainerT> > Ptr;
-        typedef boost::shared_ptr<const OctreePointCloudVoxelCentroid<PointT, LeafContainerT> > ConstPtr;
+        using Ptr = boost::shared_ptr<OctreePointCloudVoxelCentroid<PointT, LeafContainerT> >;
+        using ConstPtr = boost::shared_ptr<const OctreePointCloudVoxelCentroid<PointT, LeafContainerT> >;
 
-        typedef OctreePointCloud<PointT, LeafContainerT, BranchContainerT> OctreeT;
-        typedef typename OctreeT::LeafNode LeafNode;
-        typedef typename OctreeT::BranchNode BranchNode;
+        using OctreeT = OctreePointCloud<PointT, LeafContainerT, BranchContainerT>;
+        using LeafNode = typename OctreeT::LeafNode;
+        using BranchNode = typename OctreeT::BranchNode;
 
         /** \brief OctreePointCloudVoxelCentroids class constructor.
           * \param[in] resolution_arg octree resolution at lowest octree level

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -57,23 +57,23 @@ namespace pcl
     {
       public:
         // public typedefs
-        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
         // Boost shared pointers
-        typedef boost::shared_ptr<OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> > Ptr;
-        typedef boost::shared_ptr<const OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> > ConstPtr;
+        using Ptr = boost::shared_ptr<OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> >;
+        using ConstPtr = boost::shared_ptr<const OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> >;
 
         // Eigen aligned allocator
-        typedef std::vector<PointT, Eigen::aligned_allocator<PointT> > AlignedPointTVector;
+        using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
 
-        typedef OctreePointCloud<PointT, LeafContainerT, BranchContainerT> OctreeT;
-        typedef typename OctreeT::LeafNode LeafNode;
-        typedef typename OctreeT::BranchNode BranchNode;
+        using OctreeT = OctreePointCloud<PointT, LeafContainerT, BranchContainerT>;
+        using LeafNode = typename OctreeT::LeafNode;
+        using BranchNode = typename OctreeT::BranchNode;
 
         /** \brief Constructor.
           * \param[in] resolution octree resolution at lowest octree level


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`