### PR TITLE
Use using instead of typedef [features]

### DIFF
--- a/features/include/pcl/features/3dsc.h
+++ b/features/include/pcl/features/3dsc.h
@@ -73,8 +73,8 @@ namespace pcl
   class ShapeContext3DEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<ShapeContext3DEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const ShapeContext3DEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ShapeContext3DEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const ShapeContext3DEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
@@ -86,8 +86,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::searchForNeighbors;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
       /** \brief Constructor.
         * \param[in] random If true the random seed is set to current time, else it is

--- a/features/include/pcl/features/board.h
+++ b/features/include/pcl/features/board.h
@@ -58,8 +58,8 @@ namespace pcl
   class BOARDLocalReferenceFrameEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
 
       /** \brief Constructor. */
       BOARDLocalReferenceFrameEstimation () :
@@ -230,8 +230,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::search_parameter_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       void
       resetData ()

--- a/features/include/pcl/features/boundary.h
+++ b/features/include/pcl/features/boundary.h
@@ -80,8 +80,8 @@ namespace pcl
   class BoundaryEstimation: public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<BoundaryEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const BoundaryEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<BoundaryEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const BoundaryEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
@@ -94,7 +94,7 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
     public:
       /** \brief Empty constructor. 

--- a/features/include/pcl/features/brisk_2d.h
+++ b/features/include/pcl/features/brisk_2d.h
@@ -67,17 +67,17 @@ namespace pcl
   class BRISK2DEstimation// : public Feature<PointT, KeyPointT>
   {
     public:
-      typedef boost::shared_ptr<BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> > Ptr;
-      typedef boost::shared_ptr<const BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> > ConstPtr;
+      using Ptr = boost::shared_ptr<BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> >;
+      using ConstPtr = boost::shared_ptr<const BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> >;
 
-      typedef pcl::PointCloud<PointInT> PointCloudInT;
-      typedef typename PointCloudInT::ConstPtr PointCloudInTConstPtr;
+      using PointCloudInT = pcl::PointCloud<PointInT>;
+      using PointCloudInTConstPtr = typename PointCloudInT::ConstPtr;
 
-      typedef pcl::PointCloud<KeypointT> KeypointPointCloudT;
-      typedef typename KeypointPointCloudT::Ptr KeypointPointCloudTPtr;
-      typedef typename KeypointPointCloudT::ConstPtr KeypointPointCloudTConstPtr;
+      using KeypointPointCloudT = pcl::PointCloud<KeypointT>;
+      using KeypointPointCloudTPtr = typename KeypointPointCloudT::Ptr;
+      using KeypointPointCloudTConstPtr = typename KeypointPointCloudT::ConstPtr;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOutT;
+      using PointCloudOutT = pcl::PointCloud<PointOutT>;
 
       /** \brief Constructor. */
       BRISK2DEstimation ();

--- a/features/include/pcl/features/cppf.h
+++ b/features/include/pcl/features/cppf.h
@@ -87,15 +87,15 @@ namespace pcl
   class CPPFEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<CPPFEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const CPPFEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<CPPFEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const CPPFEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
 
       /** \brief Empty Constructor. */
       CPPFEstimation ();

--- a/features/include/pcl/features/crh.h
+++ b/features/include/pcl/features/crh.h
@@ -60,8 +60,8 @@ namespace pcl
   class CRHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<CRHEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const CRHEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<CRHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const CRHEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
@@ -71,7 +71,7 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Constructor. */
       CRHEstimation () :

--- a/features/include/pcl/features/cvfh.h
+++ b/features/include/pcl/features/cvfh.h
@@ -63,8 +63,8 @@ namespace pcl
   class CVFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<CVFHEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const CVFHEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<CVFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const CVFHEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
@@ -74,9 +74,9 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename pcl::search::Search<PointNormal>::Ptr KdTreePtr;
-      typedef pcl::VFHEstimation<PointInT, PointNT, pcl::VFHSignature308> VFHEstimator;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using KdTreePtr = typename pcl::search::Search<PointNormal>::Ptr;
+      using VFHEstimator = pcl::VFHEstimation<PointInT, PointNT, pcl::VFHSignature308>;
 
       /** \brief Empty constructor. */
       CVFHEstimation () :

--- a/features/include/pcl/features/don.h
+++ b/features/include/pcl/features/don.h
@@ -70,13 +70,13 @@ namespace pcl
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::feature_name_;
       using PCLBase<PointInT>::input_;
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
     public:
-      typedef boost::shared_ptr<DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> >;
 
       /**
         * Creates a new Difference of Normals filter.

--- a/features/include/pcl/features/esf.h
+++ b/features/include/pcl/features/esf.h
@@ -59,8 +59,8 @@ namespace pcl
   class ESFEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<ESFEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const ESFEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ESFEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const ESFEstimation<PointInT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
@@ -70,8 +70,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::surface_;
 
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Empty constructor. */
       ESFEstimation () : local_cloud_ ()

--- a/features/include/pcl/features/feature.h
+++ b/features/include/pcl/features/feature.h
@@ -107,22 +107,22 @@ namespace pcl
       using PCLBase<PointInT>::indices_;
       using PCLBase<PointInT>::input_;
 
-      typedef PCLBase<PointInT> BaseClass;
+      using BaseClass = PCLBase<PointInT>;
 
-      typedef boost::shared_ptr< Feature<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr< const Feature<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr< Feature<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr< const Feature<PointInT, PointOutT> >;
 
-      typedef pcl::search::Search<PointInT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::search::Search<PointInT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename PointCloudIn::Ptr PointCloudInPtr;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudInPtr = typename PointCloudIn::Ptr;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
 
-      typedef boost::function<int (size_t, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
-      typedef boost::function<int (const PointCloudIn &cloud, size_t index, double, std::vector<int> &, std::vector<float> &)> SearchMethodSurface;
+      using SearchMethod = boost::function<int (size_t, double, std::vector<int> &, std::vector<float> &)>;
+      using SearchMethodSurface = boost::function<int (const PointCloudIn &cloud, size_t index, double, std::vector<int> &, std::vector<float> &)>;
 
     public:
       /** \brief Empty constructor. */
@@ -308,18 +308,18 @@ namespace pcl
   template <typename PointInT, typename PointNT, typename PointOutT>
   class FeatureFromNormals : public Feature<PointInT, PointOutT>
   {
-    typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-    typedef typename PointCloudIn::Ptr PointCloudInPtr;
-    typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
-    typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+    using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+    using PointCloudInPtr = typename PointCloudIn::Ptr;
+    using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
+    using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
     public:
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      typedef boost::shared_ptr< FeatureFromNormals<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr< const FeatureFromNormals<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr< FeatureFromNormals<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr< const FeatureFromNormals<PointInT, PointNT, PointOutT> >;
 
       // Members derived from the base class
       using Feature<PointInT, PointOutT>::input_;
@@ -366,19 +366,19 @@ namespace pcl
   template <typename PointInT, typename PointLT, typename PointOutT>
   class FeatureFromLabels : public Feature<PointInT, PointOutT>
   {
-    typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-    typedef typename PointCloudIn::Ptr PointCloudInPtr;
-    typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+    using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+    using PointCloudInPtr = typename PointCloudIn::Ptr;
+    using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
-    typedef pcl::PointCloud<PointLT> PointCloudL;
-    typedef typename PointCloudL::Ptr PointCloudNPtr;
-    typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+    using PointCloudL = pcl::PointCloud<PointLT>;
+    using PointCloudNPtr = typename PointCloudL::Ptr;
+    using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
-    typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+    using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
     public:
-      typedef boost::shared_ptr< FeatureFromLabels<PointInT, PointLT, PointOutT> > Ptr;
-      typedef boost::shared_ptr< const FeatureFromLabels<PointInT, PointLT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr< FeatureFromLabels<PointInT, PointLT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr< const FeatureFromLabels<PointInT, PointLT, PointOutT> >;
 
       // Members derived from the base class
       using Feature<PointInT, PointOutT>::input_;
@@ -446,9 +446,9 @@ namespace pcl
   class FeatureWithLocalReferenceFrames
   {
     public:
-      typedef pcl::PointCloud<PointRFT> PointCloudLRF;
-      typedef typename PointCloudLRF::Ptr PointCloudLRFPtr;
-      typedef typename PointCloudLRF::ConstPtr PointCloudLRFConstPtr;
+      using PointCloudLRF = pcl::PointCloud<PointRFT>;
+      using PointCloudLRFPtr = typename PointCloudLRF::Ptr;
+      using PointCloudLRFConstPtr = typename PointCloudLRF::ConstPtr;
 
       /** \brief Empty constructor. */
       FeatureWithLocalReferenceFrames () : frames_ (), frames_never_defined_ (true) {}
@@ -487,7 +487,7 @@ namespace pcl
         * \param lrf_estimation a pointer to a local reference frame estimation class to be used as default.
         * \return true if frames_ has been correctly initialized.
         */
-      typedef typename Feature<PointInT, PointRFT>::Ptr LRFEstimationPtr;
+      using LRFEstimationPtr = typename Feature<PointInT, PointRFT>::Ptr;
       virtual bool
       initLocalReferenceFrames (const size_t& indices_size,
                                 const LRFEstimationPtr& lrf_estimation = LRFEstimationPtr());

--- a/features/include/pcl/features/flare.h
+++ b/features/include/pcl/features/flare.h
@@ -81,11 +81,11 @@ namespace pcl
 
       using typename Feature<PointInT, PointOutT>::KdTreePtr;
 
-      typedef pcl::PointCloud<SignedDistanceT> PointCloudSignedDistance;
-      typedef typename PointCloudSignedDistance::Ptr PointCloudSignedDistancePtr;
+      using PointCloudSignedDistance = pcl::PointCloud<SignedDistanceT>;
+      using PointCloudSignedDistancePtr = typename PointCloudSignedDistance::Ptr;
 
-      typedef boost::shared_ptr<FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
 
     public:
       /** \brief Constructor. */

--- a/features/include/pcl/features/fpfh.h
+++ b/features/include/pcl/features/fpfh.h
@@ -79,8 +79,8 @@ namespace pcl
   class FPFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<FPFHEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const FPFHEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FPFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const FPFHEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -90,7 +90,7 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Empty constructor. */
       FPFHEstimation () : 

--- a/features/include/pcl/features/fpfh_omp.h
+++ b/features/include/pcl/features/fpfh_omp.h
@@ -74,8 +74,8 @@ namespace pcl
   class FPFHEstimationOMP : public FPFHEstimation<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<FPFHEstimationOMP<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const FPFHEstimationOMP<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FPFHEstimationOMP<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const FPFHEstimationOMP<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -89,7 +89,7 @@ namespace pcl
       using FPFHEstimation<PointInT, PointNT, PointOutT>::hist_f3_;
       using FPFHEstimation<PointInT, PointNT, PointOutT>::weightPointSPFHSignature;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Initialize the scheduler and set the number of threads to use.
         * \param[in] nr_threads the number of hardware threads to use (0 sets the value back to automatic)

--- a/features/include/pcl/features/gasd.h
+++ b/features/include/pcl/features/gasd.h
@@ -78,8 +78,8 @@ namespace pcl
     public:
       using typename Feature<PointInT, PointOutT>::PointCloudIn;
       using typename Feature<PointInT, PointOutT>::PointCloudOut;
-      typedef boost::shared_ptr<GASDEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const GASDEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<GASDEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const GASDEstimation<PointInT, PointOutT> >;
 
       /** \brief Constructor.
        * \param[in] view_direction view direction
@@ -259,8 +259,8 @@ namespace pcl
   {
     public:
       using typename Feature<PointInT, PointOutT>::PointCloudOut;
-      typedef boost::shared_ptr<GASDColorEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const GASDColorEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<GASDColorEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const GASDColorEstimation<PointInT, PointOutT> >;
 
       /** \brief Constructor.
        * \param[in] view_direction view direction

--- a/features/include/pcl/features/gfpfh.h
+++ b/features/include/pcl/features/gfpfh.h
@@ -64,8 +64,8 @@ namespace pcl
   class GFPFHEstimation : public FeatureFromLabels<PointInT, PointLT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<GFPFHEstimation<PointInT, PointLT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const GFPFHEstimation<PointInT, PointLT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<GFPFHEstimation<PointInT, PointLT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const GFPFHEstimation<PointInT, PointLT, PointOutT> >;
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::feature_name_;
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::getClassName;
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::indices_;
@@ -76,8 +76,8 @@ namespace pcl
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::input_;
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::labels_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn  PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
       /** \brief Empty constructor. */
       GFPFHEstimation () : 

--- a/features/include/pcl/features/grsd.h
+++ b/features/include/pcl/features/grsd.h
@@ -82,9 +82,9 @@ namespace pcl
       using Feature<PointInT, PointOutT>::setSearchSurface;
       //using Feature<PointInT, PointOutT>::computeFeature;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn  PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudInPtr  PointCloudInPtr;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudInPtr = typename Feature<PointInT, PointOutT>::PointCloudInPtr;
 
       /** \brief Constructor. */
       GRSDEstimation () : additive_ (true)

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -628,7 +628,7 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
       *(pvalues++) = smoothedIntensity (image_data, width, height, integral, x, y, scale, theta, i);
 
 #ifdef __GNUC__
-      typedef uint32_t __attribute__ ((__may_alias__)) UINT32_ALIAS;
+      using UINT32_ALIAS = uint32_t;
 #endif
 #ifdef _MSC_VER
       // Todo: find the equivalent to may_alias

--- a/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
+++ b/features/include/pcl/features/impl/statistical_multiscale_interest_region_extraction.hpp
@@ -57,8 +57,8 @@ pcl::StatisticalMultiscaleInterestRegionExtraction<PointT>::generateCloudGraph (
   kdtree.setInputCloud (input_);
 
   using namespace boost;
-  typedef property<edge_weight_t, float> Weight;
-  typedef adjacency_list<vecS, vecS, undirectedS, no_property, Weight> Graph;
+  using Weight = property<edge_weight_t, float>;
+  using Graph = adjacency_list<vecS, vecS, undirectedS, no_property, Weight>;
   Graph cloud_graph;
 
   for (size_t point_i = 0; point_i < input_->points.size (); ++point_i)

--- a/features/include/pcl/features/integral_image2D.h
+++ b/features/include/pcl/features/integral_image2D.h
@@ -48,57 +48,57 @@ namespace pcl
   template <typename DataType>
   struct IntegralImageTypeTraits
   {
-    typedef DataType Type;
-    typedef DataType IntegralType;
+    using Type = DataType;
+    using IntegralType = DataType;
   };
 
   template <>
   struct IntegralImageTypeTraits<float>
   {
-    typedef float Type;
-    typedef double IntegralType;
+    using Type = float;
+    using IntegralType = double;
   };
 
   template <>
   struct IntegralImageTypeTraits<char>
   {
-    typedef char Type;
-    typedef int IntegralType;
+    using Type = char;
+    using IntegralType = int;
   };
 
   template <>
   struct IntegralImageTypeTraits<short>
   {
-    typedef short Type;
-    typedef long IntegralType;
+    using Type = short;
+    using IntegralType = long;
   };
 
   template <>
   struct IntegralImageTypeTraits<unsigned short>
   {
-    typedef unsigned short Type;
-    typedef unsigned long IntegralType;
+    using Type = unsigned short;
+    using IntegralType = unsigned long;
   };
 
   template <>
   struct IntegralImageTypeTraits<unsigned char>
   {
-    typedef unsigned char Type;
-    typedef unsigned int IntegralType;
+    using Type = unsigned char;
+    using IntegralType = unsigned int;
   };
 
   template <>
   struct IntegralImageTypeTraits<int>
   {
-    typedef int Type;
-    typedef long IntegralType;
+    using Type = int;
+    using IntegralType = long;
   };
 
   template <>
   struct IntegralImageTypeTraits<unsigned int>
   {
-    typedef unsigned int Type;
-    typedef unsigned long IntegralType;
+    using Type = unsigned int;
+    using IntegralType = unsigned long;
   };
 
   /** \brief Determines an integral image representation for a given organized data array
@@ -108,10 +108,10 @@ namespace pcl
   class IntegralImage2D
   {
     public:
-      typedef boost::shared_ptr<IntegralImage2D<DataType, Dimension>> Ptr;
+      using Ptr = boost::shared_ptr<IntegralImage2D<DataType, Dimension>>;
       static const unsigned second_order_size = (Dimension * (Dimension + 1)) >> 1;
-      typedef Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::IntegralType, Dimension, 1> ElementType;
-      typedef Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::IntegralType, second_order_size, 1> SecondOrderType;
+      using ElementType = Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::IntegralType, Dimension, 1>;
+      using SecondOrderType = Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::IntegralType, second_order_size, 1>;
 
       /** \brief Constructor for an Integral Image
         * \param[in] compute_second_order_integral_images set to true if we want to compute a second order image
@@ -201,7 +201,7 @@ namespace pcl
       getFiniteElementsCountSE (unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const;
 
     private:
-      typedef Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::Type, Dimension, 1> InputType;
+      using InputType = Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::Type, Dimension, 1>;
 
       /** \brief Compute the actual integral image data
         * \param[in] data the input data
@@ -231,11 +231,11 @@ namespace pcl
   class IntegralImage2D <DataType, 1>
   {
     public:
-      typedef boost::shared_ptr<IntegralImage2D<DataType, 1>> Ptr;
+      using Ptr = boost::shared_ptr<IntegralImage2D<DataType, 1>>;
 
       static const unsigned second_order_size = 1;
-      typedef typename IntegralImageTypeTraits<DataType>::IntegralType ElementType;
-      typedef typename IntegralImageTypeTraits<DataType>::IntegralType SecondOrderType;
+      using ElementType = typename IntegralImageTypeTraits<DataType>::IntegralType;
+      using SecondOrderType = typename IntegralImageTypeTraits<DataType>::IntegralType;
 
       /** \brief Constructor for an Integral Image
         * \param[in] compute_second_order_integral_images set to true if we want to compute a second order image
@@ -319,7 +319,7 @@ namespace pcl
       getFiniteElementsCountSE (unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const;
 
   private:
-    //  typedef typename IntegralImageTypeTraits<DataType>::Type InputType;
+    //  using InputType = typename IntegralImageTypeTraits<DataType>::Type;
 
       /** \brief Compute the actual integral image data
         * \param[in] data the input data

--- a/features/include/pcl/features/integral_image_normal.h
+++ b/features/include/pcl/features/integral_image_normal.h
@@ -70,8 +70,8 @@ namespace pcl
     using Feature<PointInT, PointOutT>::indices_;
 
     public:
-      typedef boost::shared_ptr<IntegralImageNormalEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const IntegralImageNormalEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<IntegralImageNormalEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const IntegralImageNormalEstimation<PointInT, PointOutT> >;
 
       /** \brief Different types of border handling. */
         enum BorderPolicy
@@ -99,8 +99,8 @@ namespace pcl
         SIMPLE_3D_GRADIENT
       };
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn  PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Constructor */
       IntegralImageNormalEstimation ()

--- a/features/include/pcl/features/intensity_gradient.h
+++ b/features/include/pcl/features/intensity_gradient.h
@@ -56,8 +56,8 @@ namespace pcl
   class IntensityGradientEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> > Ptr;
-      typedef boost::shared_ptr<const IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> > ConstPtr;
+      using Ptr = boost::shared_ptr<IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> >;
+      using ConstPtr = boost::shared_ptr<const IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -66,7 +66,7 @@ namespace pcl
       using Feature<PointInT, PointOutT>::search_parameter_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Empty constructor. */
       IntensityGradientEstimation () : intensity_ (), threads_ (0)

--- a/features/include/pcl/features/intensity_spin.h
+++ b/features/include/pcl/features/intensity_spin.h
@@ -58,8 +58,8 @@ namespace pcl
   class IntensitySpinEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<IntensitySpinEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const IntensitySpinEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<IntensitySpinEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const IntensitySpinEstimation<PointInT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
 
@@ -70,8 +70,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::tree_;
       using Feature<PointInT, PointOutT>::search_radius_;
       
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Empty constructor. */
       IntensitySpinEstimation () : nr_distance_bins_ (4), nr_intensity_bins_ (5), sigma_ (1.0)

--- a/features/include/pcl/features/linear_least_squares_normal.h
+++ b/features/include/pcl/features/linear_least_squares_normal.h
@@ -51,10 +51,10 @@ namespace pcl
   class LinearLeastSquaresNormalEstimation : public Feature<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<LinearLeastSquaresNormalEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const LinearLeastSquaresNormalEstimation<PointInT, PointOutT> > ConstPtr;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn  PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using Ptr = boost::shared_ptr<LinearLeastSquaresNormalEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const LinearLeastSquaresNormalEstimation<PointInT, PointOutT> >;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::tree_;

--- a/features/include/pcl/features/moment_invariants.h
+++ b/features/include/pcl/features/moment_invariants.h
@@ -55,8 +55,8 @@ namespace pcl
   class MomentInvariantsEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<MomentInvariantsEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const MomentInvariantsEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<MomentInvariantsEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const MomentInvariantsEstimation<PointInT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -65,7 +65,7 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using Feature<PointInT, PointOutT>::input_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Empty constructor. */
       MomentInvariantsEstimation ()

--- a/features/include/pcl/features/moment_of_inertia_estimation.h
+++ b/features/include/pcl/features/moment_of_inertia_estimation.h
@@ -62,8 +62,8 @@ namespace pcl
       using PCLBase <PointT>::initCompute;
       using PCLBase <PointT>::deinitCompute;
 
-      typedef typename pcl::PCLBase <PointT>::PointCloudConstPtr PointCloudConstPtr;
-      typedef typename pcl::PCLBase <PointT>::PointIndicesConstPtr PointIndicesConstPtr;
+      using PointCloudConstPtr = typename pcl::PCLBase<PointT>::PointCloudConstPtr;
+      using PointIndicesConstPtr = typename pcl::PCLBase<PointT>::PointIndicesConstPtr;
 
     public:
 

--- a/features/include/pcl/features/multiscale_feature_persistence.h
+++ b/features/include/pcl/features/multiscale_feature_persistence.h
@@ -63,12 +63,12 @@ namespace pcl
   class MultiscaleFeaturePersistence : public PCLBase<PointSource>
   {
     public:
-      typedef boost::shared_ptr<MultiscaleFeaturePersistence<PointSource, PointFeature> > Ptr;
-      typedef boost::shared_ptr<const MultiscaleFeaturePersistence<PointSource, PointFeature> > ConstPtr;
-      typedef pcl::PointCloud<PointFeature> FeatureCloud;
-      typedef typename pcl::PointCloud<PointFeature>::Ptr FeatureCloudPtr;
-      typedef typename pcl::Feature<PointSource, PointFeature>::Ptr FeatureEstimatorPtr;
-      typedef boost::shared_ptr<const pcl::PointRepresentation <PointFeature> > FeatureRepresentationConstPtr;
+      using Ptr = boost::shared_ptr<MultiscaleFeaturePersistence<PointSource, PointFeature> >;
+      using ConstPtr = boost::shared_ptr<const MultiscaleFeaturePersistence<PointSource, PointFeature> >;
+      using FeatureCloud = pcl::PointCloud<PointFeature>;
+      using FeatureCloudPtr = typename pcl::PointCloud<PointFeature>::Ptr;
+      using FeatureEstimatorPtr = typename pcl::Feature<PointSource, PointFeature>::Ptr;
+      using FeatureRepresentationConstPtr = boost::shared_ptr<const pcl::PointRepresentation<PointFeature> >;
 
       using pcl::PCLBase<PointSource>::input_;
 

--- a/features/include/pcl/features/narf.h
+++ b/features/include/pcl/features/narf.h
@@ -235,7 +235,7 @@ namespace pcl
       // =====PUBLIC STRUCTS=====
       struct FeaturePointRepresentation : public PointRepresentation<Narf*>
       {
-        typedef Narf* PointT;
+        using PointT = Narf *;
         FeaturePointRepresentation(int nr_dimensions) { this->nr_dimensions_ = nr_dimensions; }
         /** \brief Empty destructor */
         ~FeaturePointRepresentation () {}

--- a/features/include/pcl/features/narf_descriptor.h
+++ b/features/include/pcl/features/narf_descriptor.h
@@ -55,10 +55,10 @@ namespace pcl
   class PCL_EXPORTS NarfDescriptor : public Feature<PointWithRange,Narf36>
   {
     public:
-      typedef boost::shared_ptr<NarfDescriptor> Ptr;
-      typedef boost::shared_ptr<const NarfDescriptor> ConstPtr;
+      using Ptr = boost::shared_ptr<NarfDescriptor>;
+      using ConstPtr = boost::shared_ptr<const NarfDescriptor>;
       // =====TYPEDEFS=====
-      typedef Feature<PointWithRange,Narf36> BaseClass;
+      using BaseClass = Feature<PointWithRange,Narf36>;
       
       // =====STRUCTS/CLASSES=====
       struct Parameters

--- a/features/include/pcl/features/normal_3d.h
+++ b/features/include/pcl/features/normal_3d.h
@@ -241,8 +241,8 @@ namespace pcl
   class NormalEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<NormalEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const NormalEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<NormalEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const NormalEstimation<PointInT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -252,8 +252,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::search_radius_;
       using Feature<PointInT, PointOutT>::search_parameter_;
       
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudConstPtr = typename Feature<PointInT, PointOutT>::PointCloudConstPtr;
       
       /** \brief Empty constructor. */
       NormalEstimation () 

--- a/features/include/pcl/features/normal_3d_omp.h
+++ b/features/include/pcl/features/normal_3d_omp.h
@@ -53,8 +53,8 @@ namespace pcl
   class NormalEstimationOMP: public NormalEstimation<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<NormalEstimationOMP<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const NormalEstimationOMP<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<NormalEstimationOMP<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const NormalEstimationOMP<PointInT, PointOutT> >;
       using NormalEstimation<PointInT, PointOutT>::feature_name_;
       using NormalEstimation<PointInT, PointOutT>::getClassName;
       using NormalEstimation<PointInT, PointOutT>::indices_;
@@ -67,7 +67,7 @@ namespace pcl
       using NormalEstimation<PointInT, PointOutT>::surface_;
       using NormalEstimation<PointInT, PointOutT>::getViewPoint;
 
-      typedef typename NormalEstimation<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename NormalEstimation<PointInT, PointOutT>::PointCloudOut;
 
     public:
       /** \brief Initialize the scheduler and set the number of threads to use.

--- a/features/include/pcl/features/normal_based_signature.h
+++ b/features/include/pcl/features/normal_based_signature.h
@@ -66,9 +66,9 @@ namespace pcl
       using PCLBase<PointT>::indices_;
       using FeatureFromNormals<PointT, PointNT, PointFeature>::normals_;
 
-      typedef pcl::PointCloud<PointFeature> FeatureCloud;
-      typedef boost::shared_ptr<NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> > Ptr;
-      typedef boost::shared_ptr<const NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> > ConstPtr;
+      using FeatureCloud = pcl::PointCloud<PointFeature>;
+      using Ptr = boost::shared_ptr<NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> >;
+      using ConstPtr = boost::shared_ptr<const NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> >;
 
 
 

--- a/features/include/pcl/features/organized_edge_detection.h
+++ b/features/include/pcl/features/organized_edge_detection.h
@@ -56,17 +56,17 @@ namespace pcl
   template <typename PointT, typename PointLT>
   class OrganizedEdgeBase : public PCLBase<PointT>
   {
-    typedef pcl::PointCloud<PointT> PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = pcl::PointCloud<PointT>;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
       
-    typedef pcl::PointCloud<PointLT> PointCloudL;
-    typedef typename PointCloudL::Ptr PointCloudLPtr;
-    typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+    using PointCloudL = pcl::PointCloud<PointLT>;
+    using PointCloudLPtr = typename PointCloudL::Ptr;
+    using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
     public:
-      typedef boost::shared_ptr<OrganizedEdgeBase<PointT, PointLT> > Ptr;
-      typedef boost::shared_ptr<const OrganizedEdgeBase<PointT, PointLT> > ConstPtr;
+      using Ptr = boost::shared_ptr<OrganizedEdgeBase<PointT, PointLT> >;
+      using ConstPtr = boost::shared_ptr<const OrganizedEdgeBase<PointT, PointLT> >;
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;
       using PCLBase<PointT>::initCompute;
@@ -181,13 +181,13 @@ namespace pcl
   template <typename PointT, typename PointLT>
   class OrganizedEdgeFromRGB : virtual public OrganizedEdgeBase<PointT, PointLT>
   {
-    typedef pcl::PointCloud<PointT> PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = pcl::PointCloud<PointT>;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
       
-    typedef pcl::PointCloud<PointLT> PointCloudL;
-    typedef typename PointCloudL::Ptr PointCloudLPtr;
-    typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+    using PointCloudL = pcl::PointCloud<PointLT>;
+    using PointCloudLPtr = typename PointCloudL::Ptr;
+    using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
     public:
       using OrganizedEdgeBase<PointT, PointLT>::input_;
@@ -267,17 +267,17 @@ namespace pcl
   template <typename PointT, typename PointNT, typename PointLT>
   class OrganizedEdgeFromNormals : virtual public OrganizedEdgeBase<PointT, PointLT>
   {
-    typedef pcl::PointCloud<PointT> PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = pcl::PointCloud<PointT>;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
       
-    typedef pcl::PointCloud<PointNT> PointCloudN;
-    typedef typename PointCloudN::Ptr PointCloudNPtr;
-    typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+    using PointCloudN = pcl::PointCloud<PointNT>;
+    using PointCloudNPtr = typename PointCloudN::Ptr;
+    using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-    typedef pcl::PointCloud<PointLT> PointCloudL;
-    typedef typename PointCloudL::Ptr PointCloudLPtr;
-    typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+    using PointCloudL = pcl::PointCloud<PointLT>;
+    using PointCloudLPtr = typename PointCloudL::Ptr;
+    using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
     public:
       using OrganizedEdgeBase<PointT, PointLT>::input_;
@@ -377,17 +377,17 @@ namespace pcl
   template <typename PointT, typename PointNT, typename PointLT>
   class OrganizedEdgeFromRGBNormals : public OrganizedEdgeFromRGB<PointT, PointLT>, public OrganizedEdgeFromNormals<PointT, PointNT, PointLT>
   {
-    typedef pcl::PointCloud<PointT> PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = pcl::PointCloud<PointT>;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
       
-    typedef pcl::PointCloud<PointNT> PointCloudN;
-    typedef typename PointCloudN::Ptr PointCloudNPtr;
-    typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+    using PointCloudN = pcl::PointCloud<PointNT>;
+    using PointCloudNPtr = typename PointCloudN::Ptr;
+    using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-    typedef pcl::PointCloud<PointLT> PointCloudL;
-    typedef typename PointCloudL::Ptr PointCloudLPtr;
-    typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+    using PointCloudL = pcl::PointCloud<PointLT>;
+    using PointCloudLPtr = typename PointCloudL::Ptr;
+    using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
     public:
       using OrganizedEdgeFromNormals<PointT, PointNT, PointLT>::input_;

--- a/features/include/pcl/features/our_cvfh.h
+++ b/features/include/pcl/features/our_cvfh.h
@@ -61,8 +61,8 @@ namespace pcl
   class OURCVFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<OURCVFHEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const OURCVFHEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<OURCVFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const OURCVFHEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -71,9 +71,9 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename pcl::search::Search<PointNormal>::Ptr KdTreePtr;
-      typedef typename pcl::PointCloud<PointInT>::Ptr PointInTPtr;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using KdTreePtr = typename pcl::search::Search<PointNormal>::Ptr;
+      using PointInTPtr = typename pcl::PointCloud<PointInT>::Ptr;
       /** \brief Empty constructor. */
       OURCVFHEstimation () :
         vpx_ (0), vpy_ (0), vpz_ (0), leaf_size_ (0.005f), normalize_bins_ (false), curv_threshold_ (0.03f), cluster_tolerance_ (leaf_size_ * 3),

--- a/features/include/pcl/features/pfh.h
+++ b/features/include/pcl/features/pfh.h
@@ -81,8 +81,8 @@ namespace pcl
   class PFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<PFHEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const PFHEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const PFHEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -92,8 +92,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::input_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn  PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
       /** \brief Empty constructor. 
         * Sets \a use_cache_ to false, \a nr_subdiv_ to 5, and the internal maximum cache size to 1GB.

--- a/features/include/pcl/features/pfhrgb.h
+++ b/features/include/pcl/features/pfhrgb.h
@@ -48,15 +48,15 @@ namespace pcl
   class PFHRGBEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<PFHRGBEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const PFHRGBEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PFHRGBEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const PFHRGBEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::surface_;
       using Feature<PointInT, PointOutT>::k_;
       using Feature<PointInT, PointOutT>::search_parameter_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
 
       PFHRGBEstimation ()

--- a/features/include/pcl/features/ppf.h
+++ b/features/include/pcl/features/ppf.h
@@ -76,15 +76,15 @@ namespace pcl
   class PPFEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<PPFEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const PPFEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PPFEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const PPFEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
 
       /** \brief Empty Constructor. */
       PPFEstimation ();

--- a/features/include/pcl/features/ppfrgb.h
+++ b/features/include/pcl/features/ppfrgb.h
@@ -52,7 +52,7 @@ namespace pcl
       using Feature<PointInT, PointOutT>::getClassName;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
 
       /**
         * \brief Empty Constructor
@@ -72,8 +72,8 @@ namespace pcl
   class PPFRGBRegionEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::feature_name_;
@@ -82,7 +82,7 @@ namespace pcl
       using Feature<PointInT, PointOutT>::getClassName;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
 
       PPFRGBRegionEstimation ();
 

--- a/features/include/pcl/features/principal_curvatures.h
+++ b/features/include/pcl/features/principal_curvatures.h
@@ -60,8 +60,8 @@ namespace pcl
   class PrincipalCurvaturesEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -71,8 +71,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::input_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
 
       /** \brief Empty constructor. */
       PrincipalCurvaturesEstimation () : 

--- a/features/include/pcl/features/range_image_border_extractor.h
+++ b/features/include/pcl/features/range_image_border_extractor.h
@@ -55,10 +55,10 @@ namespace pcl
   class PCL_EXPORTS RangeImageBorderExtractor : public Feature<PointWithRange,BorderDescription>
   {
     public:
-      typedef boost::shared_ptr<RangeImageBorderExtractor> Ptr;
-      typedef boost::shared_ptr<const RangeImageBorderExtractor> ConstPtr;
+      using Ptr = boost::shared_ptr<RangeImageBorderExtractor>;
+      using ConstPtr = boost::shared_ptr<const RangeImageBorderExtractor>;
       // =====TYPEDEFS=====
-      typedef Feature<PointWithRange,BorderDescription> BaseClass;
+      using BaseClass = Feature<PointWithRange,BorderDescription>;
       
       // =====PUBLIC STRUCTS=====
       //! Stores some information extracted from the neighborhood of a point

--- a/features/include/pcl/features/rift.h
+++ b/features/include/pcl/features/rift.h
@@ -68,15 +68,15 @@ namespace pcl
       using Feature<PointInT, PointOutT>::tree_;
       using Feature<PointInT, PointOutT>::search_radius_;
       
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
-      typedef pcl::PointCloud<GradientT> PointCloudGradient;
-      typedef typename PointCloudGradient::Ptr PointCloudGradientPtr;
-      typedef typename PointCloudGradient::ConstPtr PointCloudGradientConstPtr;
+      using PointCloudGradient = pcl::PointCloud<GradientT>;
+      using PointCloudGradientPtr = typename PointCloudGradient::Ptr;
+      using PointCloudGradientConstPtr = typename PointCloudGradient::ConstPtr;
 
-      typedef boost::shared_ptr<RIFTEstimation<PointInT, GradientT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const RIFTEstimation<PointInT, GradientT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<RIFTEstimation<PointInT, GradientT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const RIFTEstimation<PointInT, GradientT, PointOutT> >;
 
 
       /** \brief Empty constructor. */

--- a/features/include/pcl/features/rops_estimation.h
+++ b/features/include/pcl/features/rops_estimation.h
@@ -60,8 +60,8 @@ namespace pcl
       using Feature <PointInT, PointOutT>::surface_;
       using Feature <PointInT, PointOutT>::tree_;
 
-      typedef typename pcl::Feature <PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename pcl::Feature <PointInT, PointOutT>::PointCloudIn PointCloudIn;
+      using PointCloudOut = typename pcl::Feature <PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename pcl::Feature <PointInT, PointOutT>::PointCloudIn;
 
     public:
 

--- a/features/include/pcl/features/rsd.h
+++ b/features/include/pcl/features/rsd.h
@@ -157,11 +157,11 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn  PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
-      typedef boost::shared_ptr<RSDEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const RSDEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<RSDEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const RSDEstimation<PointInT, PointNT, PointOutT> >;
 
 
       /** \brief Empty constructor. */

--- a/features/include/pcl/features/shot.h
+++ b/features/include/pcl/features/shot.h
@@ -68,8 +68,8 @@ namespace pcl
                              public FeatureWithLocalReferenceFrames<PointInT, PointRFT>
   {
     public:
-      typedef boost::shared_ptr<SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> > Ptr;
-      typedef boost::shared_ptr<const SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = boost::shared_ptr<const SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::input_;
@@ -82,7 +82,7 @@ namespace pcl
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
       using FeatureWithLocalReferenceFrames<PointInT, PointRFT>::frames_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
     protected:
       /** \brief Empty constructor.
@@ -219,8 +219,8 @@ namespace pcl
   class SHOTEstimation : public SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      typedef boost::shared_ptr<SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> > Ptr;
-      typedef boost::shared_ptr<const SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = boost::shared_ptr<const SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::feature_name_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::getClassName;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::indices_;
@@ -242,7 +242,7 @@ namespace pcl
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::shot_;
       using FeatureWithLocalReferenceFrames<PointInT, PointRFT>::frames_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
       /** \brief Empty constructor. */
       SHOTEstimation () : SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> (10)
@@ -297,8 +297,8 @@ namespace pcl
   class SHOTColorEstimation : public SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      typedef boost::shared_ptr<SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> > Ptr;
-      typedef boost::shared_ptr<const SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = boost::shared_ptr<const SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::feature_name_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::getClassName;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::indices_;
@@ -320,7 +320,7 @@ namespace pcl
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::shot_;
       using FeatureWithLocalReferenceFrames<PointInT, PointRFT>::frames_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
       /** \brief Empty constructor.
         * \param[in] describe_shape

--- a/features/include/pcl/features/shot_lrf.h
+++ b/features/include/pcl/features/shot_lrf.h
@@ -65,8 +65,8 @@ namespace pcl
   class SHOTLocalReferenceFrameEstimation : public Feature<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> >;
       /** \brief Constructor */
       SHOTLocalReferenceFrameEstimation ()
       {
@@ -86,8 +86,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::tree_;
       using Feature<PointInT, PointOutT>::search_parameter_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Computes disambiguated local RF for a point index
         * \param[in] index the index

--- a/features/include/pcl/features/shot_lrf_omp.h
+++ b/features/include/pcl/features/shot_lrf_omp.h
@@ -66,8 +66,8 @@ namespace pcl
   class SHOTLocalReferenceFrameEstimationOMP : public SHOTLocalReferenceFrameEstimation<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> >;
       /** \brief Constructor */
     SHOTLocalReferenceFrameEstimationOMP ()
       {
@@ -95,8 +95,8 @@ namespace pcl
       using Feature<PointInT, PointOutT>::tree_;
       using Feature<PointInT, PointOutT>::search_parameter_;
       using SHOTLocalReferenceFrameEstimation<PointInT, PointOutT>::getLocalRF;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
       /** \brief Feature estimation method.
         * \param[out] output the resultant features

--- a/features/include/pcl/features/shot_omp.h
+++ b/features/include/pcl/features/shot_omp.h
@@ -69,8 +69,8 @@ namespace pcl
   class SHOTEstimationOMP : public SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      typedef boost::shared_ptr<SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> > Ptr;
-      typedef boost::shared_ptr<const SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = boost::shared_ptr<const SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::input_;
@@ -91,8 +91,8 @@ namespace pcl
       using SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT>::radius1_4_;
       using SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT>::radius1_2_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
       /** \brief Empty constructor. */
       SHOTEstimationOMP (unsigned int nr_threads = 0) : SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> ()
@@ -148,8 +148,8 @@ namespace pcl
   class SHOTColorEstimationOMP : public SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      typedef boost::shared_ptr<SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> > Ptr;
-      typedef boost::shared_ptr<const SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = boost::shared_ptr<const SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::input_;
@@ -173,8 +173,8 @@ namespace pcl
       using SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::b_describe_color_;
       using SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::nr_color_bins_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
       /** \brief Empty constructor. */
       SHOTColorEstimationOMP (bool describe_shape = true,

--- a/features/include/pcl/features/spin_image.h
+++ b/features/include/pcl/features/spin_image.h
@@ -87,8 +87,8 @@ namespace pcl
   class SpinImageEstimation : public Feature<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<SpinImageEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const SpinImageEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SpinImageEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const SpinImageEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;
@@ -98,15 +98,15 @@ namespace pcl
       using Feature<PointInT, PointOutT>::fake_surface_;
       using PCLBase<PointInT>::input_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename PointCloudIn::Ptr PointCloudInPtr;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudInPtr = typename PointCloudIn::Ptr;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
       
       /** \brief Constructs empty spin image estimator.
         * 

--- a/features/include/pcl/features/statistical_multiscale_interest_region_extraction.h
+++ b/features/include/pcl/features/statistical_multiscale_interest_region_extraction.h
@@ -64,9 +64,9 @@ namespace pcl
   class StatisticalMultiscaleInterestRegionExtraction : public PCLBase<PointT>
   {
     public:
-      typedef boost::shared_ptr <std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr<StatisticalMultiscaleInterestRegionExtraction<PointT> > Ptr;
-      typedef boost::shared_ptr<const StatisticalMultiscaleInterestRegionExtraction<PointT> > ConstPtr;
+      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+      using Ptr = boost::shared_ptr<StatisticalMultiscaleInterestRegionExtraction<PointT> >;
+      using ConstPtr = boost::shared_ptr<const StatisticalMultiscaleInterestRegionExtraction<PointT> >;
 
 
       /** \brief Empty constructor */

--- a/features/include/pcl/features/usc.h
+++ b/features/include/pcl/features/usc.h
@@ -75,10 +75,10 @@ namespace pcl
       using Feature<PointInT, PointOutT>::searchForNeighbors;
       using FeatureWithLocalReferenceFrames<PointInT, PointRFT>::frames_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef typename Feature<PointInT, PointOutT>::PointCloudIn PointCloudIn;
-      typedef boost::shared_ptr<UniqueShapeContext<PointInT, PointOutT, PointRFT> > Ptr;
-      typedef boost::shared_ptr<const UniqueShapeContext<PointInT, PointOutT, PointRFT> > ConstPtr;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
+      using Ptr = boost::shared_ptr<UniqueShapeContext<PointInT, PointOutT, PointRFT> >;
+      using ConstPtr = boost::shared_ptr<const UniqueShapeContext<PointInT, PointOutT, PointRFT> >;
 
 
       /** \brief Constructor. */

--- a/features/include/pcl/features/vfh.h
+++ b/features/include/pcl/features/vfh.h
@@ -79,9 +79,9 @@ namespace pcl
       using Feature<PointInT, PointOutT>::surface_;
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
-      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
-      typedef boost::shared_ptr<VFHEstimation<PointInT, PointNT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const VFHEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+      using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
+      using Ptr = boost::shared_ptr<VFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = boost::shared_ptr<const VFHEstimation<PointInT, PointNT, PointOutT> >;
 
 
       /** \brief Empty constructor. */


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`