### PR TITLE
Use using instead of typedef [registration]

### DIFF
--- a/registration/include/pcl/registration/bfgs.h
+++ b/registration/include/pcl/registration/bfgs.h
@@ -12,7 +12,7 @@ namespace Eigen
   class PolynomialSolver<_Scalar,2> : public PolynomialSolverBase<_Scalar,2>
   {
     public:
-      typedef PolynomialSolverBase<_Scalar,2>    PS_Base;
+      using PS_Base = PolynomialSolverBase<_Scalar,2>;
       EIGEN_POLYNOMIAL_SOLVER_BASE_INHERITED_TYPES( PS_Base )
         
     public:
@@ -72,9 +72,9 @@ namespace Eigen
 template<typename _Scalar, int NX=Eigen::Dynamic>
 struct BFGSDummyFunctor
 {
-  typedef _Scalar Scalar;
+  using Scalar = _Scalar;
   enum { InputsAtCompileTime = NX };
-  typedef Eigen::Matrix<Scalar,InputsAtCompileTime,1> VectorType;
+  using VectorType = Eigen::Matrix<Scalar,InputsAtCompileTime,1>;
 
   const int m_inputs;
 
@@ -113,13 +113,13 @@ template<typename FunctorType>
 class BFGS
 {
 public:
-  typedef typename FunctorType::Scalar Scalar;
-  typedef typename FunctorType::VectorType FVectorType;
+  using Scalar = typename FunctorType::Scalar;
+  using FVectorType = typename FunctorType::VectorType;
 
   BFGS(FunctorType &_functor) 
       : pnorm(0), g0norm(0), iter(-1), functor(_functor) {  }
 
-  typedef Eigen::DenseIndex Index;
+  using Index = Eigen::DenseIndex;
 
   struct Parameters {
     Parameters()

--- a/registration/include/pcl/registration/boost_graph.h
+++ b/registration/include/pcl/registration/boost_graph.h
@@ -53,13 +53,13 @@ namespace boost
   template <class ValueType>
     struct container_gen<eigen_vecS, ValueType>
     {
-      typedef std::vector<ValueType, Eigen::aligned_allocator<ValueType> > type;
+      using type = std::vector<ValueType, Eigen::aligned_allocator<ValueType> >;
     };
 
   template <>
     struct parallel_edge_traits<eigen_vecS>
     {
-      typedef allow_parallel_edge_tag type;
+      using type = allow_parallel_edge_tag;
     };
 
   namespace detail
@@ -68,7 +68,7 @@ namespace boost
       struct is_random_access<eigen_vecS>
       {
         enum { value = true };
-        typedef mpl::true_ type;
+        using type = mpl::true_;
       };
   }
 
@@ -79,13 +79,13 @@ namespace boost
   template <class ValueType>
     struct container_gen<eigen_listS, ValueType>
     {
-      typedef std::list<ValueType, Eigen::aligned_allocator<ValueType> > type;
+      using type = std::list<ValueType, Eigen::aligned_allocator<ValueType> >;
     };
 
   template <>
     struct parallel_edge_traits<eigen_listS>
     {
-      typedef allow_parallel_edge_tag type;
+      using type = allow_parallel_edge_tag;
     };
 
   namespace detail
@@ -94,7 +94,7 @@ namespace boost
       struct is_random_access<eigen_listS>
       {
         enum { value = false };
-        typedef mpl::false_ type;
+        using type = mpl::false_;
       };
   }
 }

--- a/registration/include/pcl/registration/convergence_criteria.h
+++ b/registration/include/pcl/registration/convergence_criteria.h
@@ -63,8 +63,8 @@ namespace pcl
     class PCL_EXPORTS ConvergenceCriteria
     {
       public:
-        typedef boost::shared_ptr<ConvergenceCriteria> Ptr;
-        typedef boost::shared_ptr<const ConvergenceCriteria> ConstPtr;
+        using Ptr = boost::shared_ptr<ConvergenceCriteria>;
+        using ConstPtr = boost::shared_ptr<const ConvergenceCriteria>;
 
         /** \brief Empty constructor. */
         ConvergenceCriteria () {}

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -62,8 +62,8 @@ namespace pcl
     class CorrespondenceEstimationBase: public PCLBase<PointSource>
     {
       public:
-        typedef boost::shared_ptr<CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> >;
 
         // using PCLBase<PointSource>::initCompute;
         using PCLBase<PointSource>::deinitCompute;
@@ -71,21 +71,21 @@ namespace pcl
         using PCLBase<PointSource>::indices_;
         using PCLBase<PointSource>::setIndices;
 
-        typedef pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename KdTree::Ptr KdTreePtr;
+        using KdTree = pcl::search::KdTree<PointTarget>;
+        using KdTreePtr = typename KdTree::Ptr;
 
-        typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
-        typedef typename KdTree::Ptr KdTreeReciprocalPtr;
+        using KdTreeReciprocal = pcl::search::KdTree<PointSource>;
+        using KdTreeReciprocalPtr = typename KdTree::Ptr;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using PointCloudSource = pcl::PointCloud<PointSource>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using PointCloudTarget = pcl::PointCloud<PointTarget>;
+        using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+        using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-        typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
+        using PointRepresentationConstPtr = typename KdTree::PointRepresentationConstPtr;
 
         /** \brief Empty constructor. */
         CorrespondenceEstimationBase () 
@@ -361,8 +361,8 @@ namespace pcl
     class CorrespondenceEstimation : public CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<CorrespondenceEstimation<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const CorrespondenceEstimation<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceEstimation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimation<PointSource, PointTarget, Scalar> >;
 
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_transformed_;
@@ -379,18 +379,18 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_fields_;
         using PCLBase<PointSource>::deinitCompute;
 
-        typedef pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename KdTree::Ptr KdTreePtr;
+        using KdTree = pcl::search::KdTree<PointTarget>;
+        using KdTreePtr = typename KdTree::Ptr;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using PointCloudSource = pcl::PointCloud<PointSource>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using PointCloudTarget = pcl::PointCloud<PointTarget>;
+        using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+        using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-        typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
+        using PointRepresentationConstPtr = typename KdTree::PointRepresentationConstPtr;
 
         /** \brief Empty constructor. */
         CorrespondenceEstimation () 

--- a/registration/include/pcl/registration/correspondence_estimation_backprojection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_backprojection.h
@@ -55,8 +55,8 @@ namespace pcl
     class CorrespondenceEstimationBackProjection : public CorrespondenceEstimationBase <PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> > Ptr;
-        typedef boost::shared_ptr<const CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> >;
 
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;
@@ -68,20 +68,20 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_indices_;
 
-        typedef pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename KdTree::Ptr KdTreePtr;
+        using KdTree = pcl::search::KdTree<PointTarget>;
+        using KdTreePtr = typename KdTree::Ptr;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using PointCloudSource = pcl::PointCloud<PointSource>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using PointCloudTarget = pcl::PointCloud<PointTarget>;
+        using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+        using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-        typedef pcl::PointCloud<NormalT> PointCloudNormals;
-        typedef typename PointCloudNormals::Ptr NormalsPtr;
-        typedef typename PointCloudNormals::ConstPtr NormalsConstPtr;
+        using PointCloudNormals = pcl::PointCloud<NormalT>;
+        using NormalsPtr = typename PointCloudNormals::Ptr;
+        using NormalsConstPtr = typename PointCloudNormals::ConstPtr;
 
         /** \brief Empty constructor. 
           *

--- a/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
+++ b/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
@@ -77,8 +77,8 @@ namespace pcl
     class CorrespondenceEstimationNormalShooting : public CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> > Ptr;
-        typedef boost::shared_ptr<const CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> >;
 
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;
@@ -90,20 +90,20 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_indices_;
 
-        typedef pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename KdTree::Ptr KdTreePtr;
+        using KdTree = pcl::search::KdTree<PointTarget>;
+        using KdTreePtr = typename KdTree::Ptr;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using PointCloudSource = pcl::PointCloud<PointSource>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using PointCloudTarget = pcl::PointCloud<PointTarget>;
+        using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+        using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-        typedef pcl::PointCloud<NormalT> PointCloudNormals;
-        typedef typename PointCloudNormals::Ptr NormalsPtr;
-        typedef typename PointCloudNormals::ConstPtr NormalsConstPtr;
+        using PointCloudNormals = pcl::PointCloud<NormalT>;
+        using NormalsPtr = typename PointCloudNormals::Ptr;
+        using NormalsConstPtr = typename PointCloudNormals::ConstPtr;
 
         /** \brief Empty constructor. 
           *

--- a/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
@@ -68,16 +68,16 @@ namespace pcl
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::target_cloud_updated_;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using PointCloudSource = pcl::PointCloud<PointSource>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using PointCloudTarget = pcl::PointCloud<PointTarget>;
+        using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+        using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-        typedef boost::shared_ptr< CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr< const CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr< CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr< const CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> >;
 
 
 

--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -58,8 +58,8 @@ namespace pcl
     class CorrespondenceRejector
     {
       public:
-        typedef boost::shared_ptr<CorrespondenceRejector> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejector> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejector>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejector>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejector () 
@@ -212,15 +212,15 @@ namespace pcl
     template <typename PointT, typename NormalT = pcl::PointNormal>
     class DataContainer : public DataContainerInterface
     {
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef typename pcl::search::KdTree<PointT>::Ptr KdTreePtr;
+      using KdTreePtr = typename pcl::search::KdTree<PointT>::Ptr;
       
-      typedef pcl::PointCloud<NormalT> Normals;
-      typedef typename Normals::Ptr NormalsPtr;
-      typedef typename Normals::ConstPtr NormalsConstPtr;
+      using Normals = pcl::PointCloud<NormalT>;
+      using NormalsPtr = typename Normals::Ptr;
+      using NormalsConstPtr = typename Normals::ConstPtr;
 
       public:
 

--- a/registration/include/pcl/registration/correspondence_rejection_distance.h
+++ b/registration/include/pcl/registration/correspondence_rejection_distance.h
@@ -65,8 +65,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorDistance> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorDistance> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorDistance>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorDistance>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorDistance () : max_distance_(std::numeric_limits<float>::max ())
@@ -195,7 +195,7 @@ namespace pcl
           */
         float max_distance_;
 
-        typedef boost::shared_ptr<DataContainerInterface> DataContainerPtr;
+        using DataContainerPtr = boost::shared_ptr<DataContainerInterface>;
 
         /** \brief A pointer to the DataContainer object containing the input and target point clouds */
         DataContainerPtr data_container_;

--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -66,8 +66,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorFeatures> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorFeatures> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorFeatures>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorFeatures>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorFeatures () : max_distance_ (std::numeric_limits<float>::max ())
@@ -162,10 +162,10 @@ namespace pcl
             virtual double getCorrespondenceScore (int index) = 0;
             virtual bool isCorrespondenceValid (int index) = 0;
 
-            typedef boost::shared_ptr<FeatureContainerInterface> Ptr;
+            using Ptr = boost::shared_ptr<FeatureContainerInterface>;
         };
 
-        typedef std::unordered_map<std::string, FeatureContainerInterface::Ptr> FeaturesMap;
+        using FeaturesMap = std::unordered_map<std::string, FeatureContainerInterface::Ptr>;
 
         /** \brief An STL map containing features to use when performing the correspondence search.*/
         FeaturesMap features_map_;
@@ -180,11 +180,10 @@ namespace pcl
         class FeatureContainer : public pcl::registration::CorrespondenceRejectorFeatures::FeatureContainerInterface
         {
           public:
-            typedef typename pcl::PointCloud<FeatureT>::ConstPtr FeatureCloudConstPtr;
-            typedef std::function<int (const pcl::PointCloud<FeatureT> &, int, std::vector<int> &, 
-                                          std::vector<float> &)> SearchMethod;
+            using FeatureCloudConstPtr = typename pcl::PointCloud<FeatureT>::ConstPtr;
+            using SearchMethod = std::function<int (const pcl::PointCloud<FeatureT> &, int, std::vector<int> &,  std::vector<float> &)>;
             
-            typedef typename pcl::PointRepresentation<FeatureT>::ConstPtr PointRepresentationConstPtr;
+            using PointRepresentationConstPtr = typename pcl::PointRepresentation<FeatureT>::ConstPtr;
 
             FeatureContainer () : thresh_(std::numeric_limits<double>::max ()), feature_representation_()
             {

--- a/registration/include/pcl/registration/correspondence_rejection_median_distance.h
+++ b/registration/include/pcl/registration/correspondence_rejection_median_distance.h
@@ -65,8 +65,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorMedianDistance> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorMedianDistance> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorMedianDistance>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorMedianDistance>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorMedianDistance () 
@@ -199,7 +199,7 @@ namespace pcl
          */
         double factor_;
 
-        typedef boost::shared_ptr<DataContainerInterface> DataContainerPtr;
+        using DataContainerPtr = boost::shared_ptr<DataContainerInterface>;
 
         /** \brief A pointer to the DataContainer object containing the input and target point clouds */
         DataContainerPtr data_container_;

--- a/registration/include/pcl/registration/correspondence_rejection_one_to_one.h
+++ b/registration/include/pcl/registration/correspondence_rejection_one_to_one.h
@@ -62,8 +62,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorOneToOne> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorOneToOne> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorOneToOne>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorOneToOne>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorOneToOne ()

--- a/registration/include/pcl/registration/correspondence_rejection_organized_boundary.h
+++ b/registration/include/pcl/registration/correspondence_rejection_organized_boundary.h
@@ -135,7 +135,7 @@ namespace pcl
       int window_size_;
       float depth_step_threshold_;
 
-      typedef boost::shared_ptr<pcl::registration::DataContainerInterface> DataContainerPtr;
+      using DataContainerPtr = boost::shared_ptr<pcl::registration::DataContainerInterface>;
       DataContainerPtr data_container_;
     };
   }

--- a/registration/include/pcl/registration/correspondence_rejection_poly.h
+++ b/registration/include/pcl/registration/correspondence_rejection_poly.h
@@ -68,16 +68,16 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorPoly> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorPoly> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorPoly<SourceT, TargetT> >;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorPoly<SourceT, TargetT> >;
         
-        typedef pcl::PointCloud<SourceT> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using PointCloudSource = pcl::PointCloud<SourceT>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
         
-        typedef pcl::PointCloud<TargetT> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using PointCloudTarget = pcl::PointCloud<TargetT>;
+        using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+        using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
         /** \brief Empty constructor */
         CorrespondenceRejectorPoly ()

--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
@@ -58,17 +58,17 @@ namespace pcl
     template <typename PointT>
     class CorrespondenceRejectorSampleConsensus: public CorrespondenceRejector
     {
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
         using CorrespondenceRejector::input_correspondences_;
         using CorrespondenceRejector::rejection_name_;
         using CorrespondenceRejector::getClassName;
 
-        typedef boost::shared_ptr<CorrespondenceRejectorSampleConsensus> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorSampleConsensus> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorSampleConsensus<PointT> >;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorSampleConsensus<PointT> >;
 
         /** \brief Empty constructor. Sets the inlier threshold to 5cm (0.05m), 
           * and the maximum number of iterations to 1000. 

--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus_2d.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus_2d.h
@@ -53,9 +53,9 @@ namespace pcl
     template <typename PointT>
     class CorrespondenceRejectorSampleConsensus2D: public CorrespondenceRejectorSampleConsensus<PointT>
     {
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
         using CorrespondenceRejectorSampleConsensus<PointT>::refine_;
@@ -68,8 +68,8 @@ namespace pcl
         using CorrespondenceRejectorSampleConsensus<PointT>::max_iterations_;
         using CorrespondenceRejectorSampleConsensus<PointT>::best_transformation_;
 
-        typedef boost::shared_ptr<CorrespondenceRejectorSampleConsensus2D> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorSampleConsensus2D> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorSampleConsensus2D<PointT> >;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorSampleConsensus2D<PointT> >;
 
         /** \brief Empty constructor. Sets the inlier threshold to 5cm (0.05m), 
           * and the maximum number of iterations to 1000. 

--- a/registration/include/pcl/registration/correspondence_rejection_surface_normal.h
+++ b/registration/include/pcl/registration/correspondence_rejection_surface_normal.h
@@ -64,8 +64,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorSurfaceNormal> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorSurfaceNormal> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorSurfaceNormal>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorSurfaceNormal>;
 
         /** \brief Empty constructor. Sets the threshold to 1.0. */
         CorrespondenceRejectorSurfaceNormal () 
@@ -312,7 +312,7 @@ namespace pcl
         /** \brief The median distance threshold between two correspondent points in source <-> target. */
         double threshold_;
 
-        typedef boost::shared_ptr<DataContainerInterface> DataContainerPtr;
+        using DataContainerPtr = boost::shared_ptr<DataContainerInterface>;
         /** \brief A pointer to the DataContainer object containing the input and target point clouds */
         DataContainerPtr data_container_;
     };

--- a/registration/include/pcl/registration/correspondence_rejection_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_trimmed.h
@@ -67,8 +67,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorTrimmed> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorTrimmed> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorTrimmed>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorTrimmed>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorTrimmed () : 

--- a/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
@@ -68,8 +68,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        typedef boost::shared_ptr<CorrespondenceRejectorVarTrimmed> Ptr;
-        typedef boost::shared_ptr<const CorrespondenceRejectorVarTrimmed> ConstPtr;
+        using Ptr = boost::shared_ptr<CorrespondenceRejectorVarTrimmed>;
+        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorVarTrimmed>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorVarTrimmed () : 
@@ -235,7 +235,7 @@ namespace pcl
          */
         double lambda_;
 
-        typedef boost::shared_ptr<DataContainerInterface> DataContainerPtr;
+        using DataContainerPtr = boost::shared_ptr<DataContainerInterface>;
 
         /** \brief A pointer to the DataContainer object containing the input and target point clouds */
         DataContainerPtr data_container_;

--- a/registration/include/pcl/registration/correspondence_sorting.h
+++ b/registration/include/pcl/registration/correspondence_sorting.h
@@ -56,9 +56,9 @@ namespace pcl
       */
     struct sortCorrespondencesByQueryIndex
     {
-      typedef pcl::Correspondence first_argument_type;
-      typedef pcl::Correspondence second_argument_type;
-      typedef bool result_type;
+      using first_argument_type = pcl::Correspondence;
+      using second_argument_type = pcl::Correspondence;
+      using result_type = bool;
       bool
       operator()( pcl::Correspondence a, pcl::Correspondence b)
       {
@@ -72,9 +72,9 @@ namespace pcl
       */
     struct sortCorrespondencesByMatchIndex
     {
-      typedef pcl::Correspondence first_argument_type;
-      typedef pcl::Correspondence second_argument_type;
-      typedef bool result_type;
+      using first_argument_type = pcl::Correspondence;
+      using second_argument_type = pcl::Correspondence;
+      using result_type = bool;
       bool 
       operator()( pcl::Correspondence a, pcl::Correspondence b)
       {
@@ -88,9 +88,9 @@ namespace pcl
       */
     struct sortCorrespondencesByDistance
     {
-      typedef pcl::Correspondence first_argument_type;
-      typedef pcl::Correspondence second_argument_type;
-      typedef bool result_type;
+      using first_argument_type = pcl::Correspondence;
+      using second_argument_type = pcl::Correspondence;
+      using result_type = bool;
       bool 
       operator()( pcl::Correspondence a, pcl::Correspondence b)
       {
@@ -104,9 +104,9 @@ namespace pcl
       */
     struct sortCorrespondencesByQueryIndexAndDistance
     {
-      typedef pcl::Correspondence first_argument_type;
-      typedef pcl::Correspondence second_argument_type;
-      typedef bool result_type;
+      using first_argument_type = pcl::Correspondence;
+      using second_argument_type = pcl::Correspondence;
+      using result_type = bool;
       inline bool 
       operator()( pcl::Correspondence a, pcl::Correspondence b)
       {
@@ -124,9 +124,9 @@ namespace pcl
       */
     struct sortCorrespondencesByMatchIndexAndDistance
     {
-      typedef pcl::Correspondence first_argument_type;
-      typedef pcl::Correspondence second_argument_type;
-      typedef bool result_type;
+      using first_argument_type = pcl::Correspondence;
+      using second_argument_type = pcl::Correspondence;
+      using result_type = bool;
       inline bool 
       operator()( pcl::Correspondence a, pcl::Correspondence b)
       {

--- a/registration/include/pcl/registration/default_convergence_criteria.h
+++ b/registration/include/pcl/registration/default_convergence_criteria.h
@@ -64,10 +64,10 @@ namespace pcl
     class DefaultConvergenceCriteria : public ConvergenceCriteria
     {
       public:
-        typedef boost::shared_ptr<DefaultConvergenceCriteria<Scalar> > Ptr;
-        typedef boost::shared_ptr<const DefaultConvergenceCriteria<Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<DefaultConvergenceCriteria<Scalar> >;
+        using ConstPtr = boost::shared_ptr<const DefaultConvergenceCriteria<Scalar> >;
 
-        typedef Eigen::Matrix<Scalar, 4, 4> Matrix4;
+        using Matrix4 = Eigen::Matrix<Scalar, 4, 4>;
 
         enum ConvergenceState
         {

--- a/registration/include/pcl/registration/elch.h
+++ b/registration/include/pcl/registration/elch.h
@@ -61,12 +61,12 @@ namespace pcl
     class ELCH : public PCLBase<PointT>
     {
       public:
-        typedef boost::shared_ptr< ELCH<PointT> > Ptr;
-        typedef boost::shared_ptr< const ELCH<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<ELCH<PointT> >;
+        using ConstPtr = boost::shared_ptr<const ELCH<PointT> >;
 
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef typename PointCloud::Ptr PointCloudPtr;
-        typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = typename PointCloud::Ptr;
+        using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
         struct Vertex
         {
@@ -76,17 +76,16 @@ namespace pcl
         };
 
         /** \brief graph structure to hold the SLAM graph */
-        typedef boost::adjacency_list<
+        using LoopGraph = boost::adjacency_list<
           boost::listS, boost::eigen_vecS, boost::undirectedS,
           Vertex,
-          boost::no_property>
-        LoopGraph;
+          boost::no_property>;
 
-        typedef boost::shared_ptr< LoopGraph > LoopGraphPtr;
+        using LoopGraphPtr = boost::shared_ptr<LoopGraph>;
 
-        typedef pcl::Registration<PointT, PointT> Registration;
-        typedef typename Registration::Ptr RegistrationPtr;
-        typedef typename Registration::ConstPtr RegistrationConstPtr;
+        using Registration = pcl::Registration<PointT, PointT>;
+        using RegistrationPtr = typename Registration::Ptr;
+        using RegistrationConstPtr = typename Registration::ConstPtr;
 
         /** \brief Empty constructor. */
         ELCH () : 
@@ -211,11 +210,10 @@ namespace pcl
 
       private:
         /** \brief graph structure for the internal optimization graph */
-        typedef boost::adjacency_list<
+        using LOAGraph = boost::adjacency_list<
           boost::listS, boost::vecS, boost::undirectedS,
           boost::no_property,
-          boost::property< boost::edge_weight_t, double > >
-        LOAGraph;
+          boost::property< boost::edge_weight_t, double > >;
 
         /**
          * graph balancer algorithm computes the weights

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -78,29 +78,29 @@ namespace pcl
       using IterativeClosestPoint<PointSource, PointTarget>::min_number_correspondences_;
       using IterativeClosestPoint<PointSource, PointTarget>::update_visualizer_;
 
-      typedef pcl::PointCloud<PointSource> PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = pcl::PointCloud<PointSource>;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-      typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-      typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+      using PointCloudTarget = pcl::PointCloud<PointTarget>;
+      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+      using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-      typedef std::vector< Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> > MatricesVector;
-      typedef boost::shared_ptr< MatricesVector > MatricesVectorPtr;
-      typedef boost::shared_ptr< const MatricesVector > MatricesVectorConstPtr;
+      using MatricesVector = std::vector< Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >;
+      using MatricesVectorPtr = boost::shared_ptr<MatricesVector>;
+      using MatricesVectorConstPtr = boost::shared_ptr<const MatricesVector>;
       
-      typedef typename Registration<PointSource, PointTarget>::KdTree InputKdTree;
-      typedef typename Registration<PointSource, PointTarget>::KdTreePtr InputKdTreePtr;
+      using InputKdTree = typename Registration<PointSource, PointTarget>::KdTree;
+      using InputKdTreePtr = typename Registration<PointSource, PointTarget>::KdTreePtr;
 
-      typedef boost::shared_ptr< GeneralizedIterativeClosestPoint<PointSource, PointTarget> > Ptr;
-      typedef boost::shared_ptr< const GeneralizedIterativeClosestPoint<PointSource, PointTarget> > ConstPtr;
+      using Ptr = boost::shared_ptr< GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+      using ConstPtr = boost::shared_ptr< const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
 
 
-      typedef Eigen::Matrix<double, 6, 1> Vector6d;
+      using Vector6d = Eigen::Matrix<double, 6, 1>;
 
       /** \brief Empty constructor. */
       GeneralizedIterativeClosestPoint () 

--- a/registration/include/pcl/registration/gicp6d.h
+++ b/registration/include/pcl/registration/gicp6d.h
@@ -103,8 +103,8 @@ namespace pcl
    */
   class PCL_EXPORTS GeneralizedIterativeClosestPoint6D : public GeneralizedIterativeClosestPoint<PointXYZRGBA, PointXYZRGBA>
   {
-    typedef PointXYZRGBA PointSource;
-    typedef PointXYZRGBA PointTarget;
+    using PointSource = PointXYZRGBA;
+    using PointTarget = PointXYZRGBA;
 
     public:
 
@@ -168,8 +168,8 @@ namespace pcl
           using PointRepresentation<PointXYZLAB>::trivial_;
 
         public:
-          typedef boost::shared_ptr<MyPointRepresentation> Ptr;
-          typedef boost::shared_ptr<const MyPointRepresentation> ConstPtr;
+          using Ptr = boost::shared_ptr<MyPointRepresentation>;
+          using ConstPtr = boost::shared_ptr<const MyPointRepresentation>;
 
           MyPointRepresentation ()
           {

--- a/registration/include/pcl/registration/graph_handler.h
+++ b/registration/include/pcl/registration/graph_handler.h
@@ -81,13 +81,13 @@ namespace pcl
     class GraphHandler
     {
       public:
-        typedef boost::shared_ptr<GraphHandler<GraphT> > Ptr;
-        typedef boost::shared_ptr<const GraphHandler<GraphT> > ConstPtr;
-        typedef boost::shared_ptr<GraphT> GraphPtr;
-        typedef boost::shared_ptr<const GraphT> GraphConstPtr;
+        using Ptr = boost::shared_ptr<GraphHandler<GraphT> >;
+        using ConstPtr = boost::shared_ptr<const GraphHandler<GraphT> >;
+        using GraphPtr = boost::shared_ptr<GraphT>;
+        using GraphConstPtr = boost::shared_ptr<const GraphT>;
 
-        typedef typename boost::graph_traits<GraphT>::vertex_descriptor Vertex;
-        typedef typename boost::graph_traits<GraphT>::edge_descriptor Edge;
+        using Vertex = typename boost::graph_traits<GraphT>::vertex_descriptor;
+        using Edge = typename boost::graph_traits<GraphT>::edge_descriptor;
 
         /** \brief Empty constructor. */
         GraphHandler () : graph_impl_ (new GraphT ())

--- a/registration/include/pcl/registration/graph_registration.h
+++ b/registration/include/pcl/registration/graph_registration.h
@@ -53,10 +53,10 @@ namespace pcl
   class GraphRegistration
   {
     public:
-      typedef pcl::registration::GraphHandler<GraphT> GraphHandler;
-      typedef typename pcl::registration::GraphHandler<GraphT>::Ptr GraphHandlerPtr;
-      typedef typename pcl::registration::GraphHandler<GraphT>::ConstPtr GraphHandlerConstPtr;
-      typedef typename pcl::registration::GraphHandler<GraphT>::Vertex GraphHandlerVertex;
+      using GraphHandler = pcl::registration::GraphHandler<GraphT>;
+      using GraphHandlerPtr = typename pcl::registration::GraphHandler<GraphT>::Ptr;
+      using GraphHandlerConstPtr = typename pcl::registration::GraphHandler<GraphT>::ConstPtr;
+      using GraphHandlerVertex = typename pcl::registration::GraphHandler<GraphT>::Vertex;
 
       /** \brief Empty constructor */
       GraphRegistration ()  : graph_handler_ (new GraphHandler),

--- a/registration/include/pcl/registration/ia_fpcs.h
+++ b/registration/include/pcl/registration/ia_fpcs.h
@@ -77,22 +77,22 @@ namespace pcl
     {
     public:
       /** \cond */
-      typedef boost::shared_ptr <FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> > Ptr;
-      typedef boost::shared_ptr <const FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> > ConstPtr;
+      using Ptr = boost::shared_ptr <FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
+      using ConstPtr = boost::shared_ptr <const FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
 
-      typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
-      typedef typename KdTreeReciprocal::Ptr KdTreeReciprocalPtr;
+      using KdTreeReciprocal = pcl::search::KdTree<PointSource>;
+      using KdTreeReciprocalPtr = typename KdTreeReciprocal::Ptr;
 
-      typedef pcl::PointCloud <PointTarget> PointCloudTarget;
-      typedef pcl::PointCloud <PointSource> PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::iterator PointCloudSourceIterator;      
+      using PointCloudTarget = pcl::PointCloud<PointTarget>;
+      using PointCloudSource = pcl::PointCloud<PointSource>;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceIterator = typename PointCloudSource::iterator;      
 
-      typedef pcl::PointCloud <NormalT> Normals;
-      typedef typename Normals::ConstPtr NormalsConstPtr;
+      using Normals = pcl::PointCloud<NormalT>;
+      using NormalsConstPtr = typename Normals::ConstPtr;
 
-      typedef pcl::registration::MatchingCandidate MatchingCandidate;
-      typedef pcl::registration::MatchingCandidates MatchingCandidates;
+      using MatchingCandidate = pcl::registration::MatchingCandidate;
+      using MatchingCandidates = pcl::registration::MatchingCandidates;
       /** \endcond */
 
 

--- a/registration/include/pcl/registration/ia_kfpcs.h
+++ b/registration/include/pcl/registration/ia_kfpcs.h
@@ -55,19 +55,19 @@ namespace pcl
     {
     public:
       /** \cond */
-      typedef boost::shared_ptr <KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> > Ptr;
-      typedef boost::shared_ptr <const KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> > ConstPtr;
+      using Ptr = boost::shared_ptr <KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
+      using ConstPtr = boost::shared_ptr <const KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
 
-      typedef pcl::PointCloud <PointSource> PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::iterator PointCloudSourceIterator;
+      using PointCloudSource = pcl::PointCloud<PointSource>;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceIterator = typename PointCloudSource::iterator;
 
-      typedef pcl::PointCloud <PointTarget> PointCloudTarget;
-      typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-      typedef typename PointCloudTarget::iterator PointCloudTargetIterator;
+      using PointCloudTarget = pcl::PointCloud<PointTarget>;
+      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+      using PointCloudTargetIterator = typename PointCloudTarget::iterator;
 
-      typedef pcl::registration::MatchingCandidate MatchingCandidate;
-      typedef pcl::registration::MatchingCandidates MatchingCandidates;
+      using MatchingCandidate = pcl::registration::MatchingCandidate;
+      using MatchingCandidates = pcl::registration::MatchingCandidates;
       /** \endcond */
 
 

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -68,21 +68,21 @@ namespace pcl
       using Registration<PointSource, PointTarget>::converged_;
       using Registration<PointSource, PointTarget>::getClassName;
 
-      typedef typename Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = typename Registration<PointSource, PointTarget>::PointCloudSource;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef typename Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
+      using PointCloudTarget = typename Registration<PointSource, PointTarget>::PointCloudTarget;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-      typedef pcl::PointCloud<FeatureT> FeatureCloud;
-      typedef typename FeatureCloud::Ptr FeatureCloudPtr;
-      typedef typename FeatureCloud::ConstPtr FeatureCloudConstPtr;
+      using FeatureCloud = pcl::PointCloud<FeatureT>;
+      using FeatureCloudPtr = typename FeatureCloud::Ptr;
+      using FeatureCloudConstPtr = typename FeatureCloud::ConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> > Ptr;
-      typedef boost::shared_ptr<const SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> >;
+      using ConstPtr = boost::shared_ptr<const SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> >;
 
 
       class ErrorFunctor
@@ -128,9 +128,9 @@ namespace pcl
           float threshold_;
       };
 
-      typedef boost::shared_ptr<ErrorFunctor> ErrorFunctorPtr;
+      using ErrorFunctorPtr = boost::shared_ptr<ErrorFunctor>;
 
-      typedef typename KdTreeFLANN<FeatureT>::Ptr FeatureKdTreePtr; 
+      using FeatureKdTreePtr = typename KdTreeFLANN<FeatureT>::Ptr; 
       /** \brief Constructor. */
       SampleConsensusInitialAlignment () : 
         input_features_ (), target_features_ (), 

--- a/registration/include/pcl/registration/icp.h
+++ b/registration/include/pcl/registration/icp.h
@@ -93,19 +93,19 @@ namespace pcl
   class IterativeClosestPoint : public Registration<PointSource, PointTarget, Scalar>
   {
     public:
-      typedef typename Registration<PointSource, PointTarget, Scalar>::PointCloudSource PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = typename Registration<PointSource, PointTarget, Scalar>::PointCloudSource;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef typename Registration<PointSource, PointTarget, Scalar>::PointCloudTarget PointCloudTarget;
-      typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-      typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+      using PointCloudTarget = typename Registration<PointSource, PointTarget, Scalar>::PointCloudTarget;
+      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+      using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-      typedef boost::shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> > Ptr;
-      typedef boost::shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> > ConstPtr;
+      using Ptr = boost::shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = boost::shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
 
       using Registration<PointSource, PointTarget, Scalar>::reg_name_;
       using Registration<PointSource, PointTarget, Scalar>::getClassName;
@@ -131,7 +131,7 @@ namespace pcl
       using Registration<PointSource, PointTarget, Scalar>::correspondence_rejectors_;
 
       typename pcl::registration::DefaultConvergenceCriteria<Scalar>::Ptr convergence_criteria_;
-      typedef typename Registration<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+      using Matrix4 = typename Registration<PointSource, PointTarget, Scalar>::Matrix4;
 
       /** \brief Empty constructor. */
       IterativeClosestPoint () 
@@ -296,16 +296,16 @@ namespace pcl
   class IterativeClosestPointWithNormals : public IterativeClosestPoint<PointSource, PointTarget, Scalar>
   {
     public:
-      typedef typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudSource PointCloudSource;
-      typedef typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudTarget PointCloudTarget;
-      typedef typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+      using PointCloudSource = typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudSource;
+      using PointCloudTarget = typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudTarget;
+      using Matrix4 = typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::Matrix4;
 
       using IterativeClosestPoint<PointSource, PointTarget, Scalar>::reg_name_;
       using IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformation_estimation_;
       using IterativeClosestPoint<PointSource, PointTarget, Scalar>::correspondence_rejectors_;
 
-      typedef boost::shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> > Ptr;
-      typedef boost::shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> > ConstPtr;
+      using Ptr = boost::shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = boost::shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
 
       /** \brief Empty constructor. */
       IterativeClosestPointWithNormals () 

--- a/registration/include/pcl/registration/icp_nl.h
+++ b/registration/include/pcl/registration/icp_nl.h
@@ -73,10 +73,10 @@ namespace pcl
 
     public:
 
-      typedef boost::shared_ptr< IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> > Ptr;
-      typedef boost::shared_ptr< const IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> > ConstPtr;
+      using Ptr = boost::shared_ptr< IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = boost::shared_ptr< const IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> >;
 
-      typedef typename Registration<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+      using Matrix4 = typename Registration<PointSource, PointTarget, Scalar>::Matrix4;
 
       /** \brief Empty constructor. */
       IterativeClosestPointNonLinear ()

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -80,7 +80,7 @@ pcl::registration::CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCo
    {
      // From the set of correspondences found, attempt to remove outliers
      // Create the registration model
-     typedef typename pcl::SampleConsensusModelRegistration<PointT>::Ptr SampleConsensusModelRegistrationPtr;
+     using SampleConsensusModelRegistrationPtr = typename pcl::SampleConsensusModelRegistration<PointT>::Ptr;
      SampleConsensusModelRegistrationPtr model;
      model.reset (new pcl::SampleConsensusModelRegistration<PointT> (input_, source_indices));
      // Pass the target_indices

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -95,7 +95,7 @@ namespace pcl
     template <typename PointT>
     class NormalDist
     {
-      typedef pcl::PointCloud<PointT> PointCloud;
+      using PointCloud = pcl::PointCloud<PointT>;
 
       public:
         NormalDist ()
@@ -216,9 +216,9 @@ namespace pcl
     template <typename PointT> 
     class NDTSingleGrid: public boost::noncopyable
     {
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef pcl::ndt2d::NormalDist<PointT> NormalDist;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using NormalDist = pcl::ndt2d::NormalDist<PointT>;
 
       public:
         NDTSingleGrid (PointCloudConstPtr cloud,
@@ -303,9 +303,9 @@ namespace pcl
     template <typename PointT> 
     class NDT2D: public boost::noncopyable
     {
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef NDTSingleGrid<PointT> SingleGrid;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using SingleGrid = NDTSingleGrid<PointT>;
 
       public:
         /** \brief
@@ -356,8 +356,8 @@ namespace Eigen
    */
   template<typename PointT> struct NumTraits<pcl::ndt2d::NormalDist<PointT> >
   {
-    typedef double Real;
-    typedef double Literal;
+    using Real = double;
+    using Literal = double;
     static Real dummy_precision () { return 1.0; }
     enum {
       IsComplex = 0,

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
@@ -145,8 +145,8 @@ template <typename PointSource, typename PointTarget, typename Scalar> inline vo
 pcl::registration::TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCloudIterator<PointTarget>& target_it, Matrix4 &transformation_matrix) const
 {
-  typedef Eigen::Matrix<double, 6, 1> Vector6d;
-  typedef Eigen::Matrix<double, 6, 6> Matrix6d;
+  using Vector6d = Eigen::Matrix<double, 6, 1>;
+  using Matrix6d = Eigen::Matrix<double, 6, 6>;
 
   Matrix6d ATA;
   Vector6d ATb;

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
@@ -173,8 +173,8 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it,
                              typename std::vector<Scalar>::const_iterator& weights_it,
                              Matrix4 &transformation_matrix) const
 {
-  typedef Eigen::Matrix<double, 6, 1> Vector6d;
-  typedef Eigen::Matrix<double, 6, 6> Matrix6d;
+  using Vector6d = Eigen::Matrix<double, 6, 1>;
+  using Matrix6d = Eigen::Matrix<double, 6, 6>;
 
   Matrix6d ATA;
   Vector6d ATb;

--- a/registration/include/pcl/registration/incremental_registration.h
+++ b/registration/include/pcl/registration/incremental_registration.h
@@ -72,11 +72,11 @@ namespace pcl {
     template <typename PointT, typename Scalar = float>
     class IncrementalRegistration {
       public:
-        typedef typename pcl::PointCloud<PointT>::Ptr PointCloudPtr;
-        typedef typename pcl::PointCloud<PointT>::ConstPtr PointCloudConstPtr;
+        using PointCloudPtr = typename pcl::PointCloud<PointT>::Ptr;
+        using PointCloudConstPtr = typename pcl::PointCloud<PointT>::ConstPtr;
 
-        typedef typename pcl::Registration<PointT,PointT,Scalar>::Ptr RegistrationPtr;
-        typedef typename pcl::Registration<PointT,PointT,Scalar>::Matrix4 Matrix4;
+        using RegistrationPtr = typename pcl::Registration<PointT,PointT,Scalar>::Ptr;
+        using Matrix4 = typename pcl::Registration<PointT,PointT,Scalar>::Matrix4;
 
         IncrementalRegistration ();
 

--- a/registration/include/pcl/registration/joint_icp.h
+++ b/registration/include/pcl/registration/joint_icp.h
@@ -54,30 +54,30 @@ namespace pcl
   class JointIterativeClosestPoint : public IterativeClosestPoint<PointSource, PointTarget, Scalar>
   {
     public:
-      typedef typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudSource PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudSource;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudTarget PointCloudTarget;
-      typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-      typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+      using PointCloudTarget = typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::PointCloudTarget;
+      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+      using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-      typedef pcl::search::KdTree<PointTarget> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::search::KdTree<PointTarget>;
+      using KdTreePtr = typename KdTree::Ptr;
 
-      typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
-      typedef typename KdTree::Ptr KdTreeReciprocalPtr;
+      using KdTreeReciprocal = pcl::search::KdTree<PointSource>;
+      using KdTreeReciprocalPtr = typename KdTree::Ptr;
 
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-      typedef boost::shared_ptr<JointIterativeClosestPoint<PointSource, PointTarget, Scalar> > Ptr;
-      typedef boost::shared_ptr<const JointIterativeClosestPoint<PointSource, PointTarget, Scalar> > ConstPtr;
+      using Ptr = boost::shared_ptr<JointIterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = boost::shared_ptr<const JointIterativeClosestPoint<PointSource, PointTarget, Scalar> >;
 
-      typedef pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> CorrespondenceEstimation;
-      typedef typename CorrespondenceEstimation::Ptr CorrespondenceEstimationPtr;
-      typedef typename CorrespondenceEstimation::ConstPtr CorrespondenceEstimationConstPtr;
+      using CorrespondenceEstimation = pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>;
+      using CorrespondenceEstimationPtr = typename CorrespondenceEstimation::Ptr;
+      using CorrespondenceEstimationConstPtr = typename CorrespondenceEstimation::ConstPtr;
 
 
       using IterativeClosestPoint<PointSource, PointTarget, Scalar>::reg_name_;
@@ -112,7 +112,7 @@ namespace pcl
       using IterativeClosestPoint<PointSource, PointTarget, Scalar>::need_target_blob_;
 
 
-      typedef typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+      using Matrix4 = typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::Matrix4;
 
       /** \brief Empty constructor. */
       JointIterativeClosestPoint ()

--- a/registration/include/pcl/registration/lum.h
+++ b/registration/include/pcl/registration/lum.h
@@ -49,8 +49,8 @@
 
 namespace Eigen
 {
-  typedef Eigen::Matrix<float, 6, 1> Vector6f;
-  typedef Eigen::Matrix<float, 6, 6> Matrix6f;
+  using Vector6f = Eigen::Matrix<float, 6, 1>;
+  using Matrix6f = Eigen::Matrix<float, 6, 6>;
 }
 
 namespace pcl
@@ -109,12 +109,12 @@ namespace pcl
     class LUM
     {
       public:
-        typedef boost::shared_ptr<LUM<PointT> > Ptr;
-        typedef boost::shared_ptr<const LUM<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<LUM<PointT> >;
+        using ConstPtr = boost::shared_ptr<const LUM<PointT> >;
 
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef typename PointCloud::Ptr PointCloudPtr;
-        typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = typename PointCloud::Ptr;
+        using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
         struct VertexProperties
         {
@@ -130,10 +130,10 @@ namespace pcl
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         };
 
-        typedef boost::adjacency_list<boost::eigen_vecS, boost::eigen_vecS, boost::bidirectionalS, VertexProperties, EdgeProperties, boost::no_property, boost::eigen_listS> SLAMGraph;
-        typedef boost::shared_ptr<SLAMGraph> SLAMGraphPtr;
-        typedef typename SLAMGraph::vertex_descriptor Vertex;
-        typedef typename SLAMGraph::edge_descriptor Edge;
+        using SLAMGraph = boost::adjacency_list<boost::eigen_vecS, boost::eigen_vecS, boost::bidirectionalS, VertexProperties, EdgeProperties, boost::no_property, boost::eigen_listS>;
+        using SLAMGraphPtr = boost::shared_ptr<SLAMGraph>;
+        using Vertex = typename SLAMGraph::vertex_descriptor;
+        using Edge = typename SLAMGraph::edge_descriptor;
 
         /** \brief Empty constructor.
           */

--- a/registration/include/pcl/registration/matching_candidate.h
+++ b/registration/include/pcl/registration/matching_candidate.h
@@ -83,7 +83,7 @@ namespace pcl
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };
 
-    typedef std::vector<MatchingCandidate, Eigen::aligned_allocator<MatchingCandidate> > MatchingCandidates;
+    using MatchingCandidates = std::vector<MatchingCandidate, Eigen::aligned_allocator<MatchingCandidate> >;
 
     /** \brief Sorting of candidates based on fitness score value. */
     struct by_score

--- a/registration/include/pcl/registration/meta_registration.h
+++ b/registration/include/pcl/registration/meta_registration.h
@@ -75,11 +75,11 @@ namespace pcl {
     template <typename PointT, typename Scalar = float>
     class MetaRegistration {
       public:
-        typedef typename pcl::PointCloud<PointT>::Ptr PointCloudPtr;
-        typedef typename pcl::PointCloud<PointT>::ConstPtr PointCloudConstPtr;
+        using PointCloudPtr = typename pcl::PointCloud<PointT>::Ptr;
+        using PointCloudConstPtr = typename pcl::PointCloud<PointT>::ConstPtr;
 
-        typedef typename pcl::Registration<PointT,PointT,Scalar>::Ptr RegistrationPtr;
-        typedef typename pcl::Registration<PointT,PointT,Scalar>::Matrix4 Matrix4;
+        using RegistrationPtr = typename pcl::Registration<PointT,PointT,Scalar>::Ptr;
+        using Matrix4 = typename pcl::Registration<PointT,PointT,Scalar>::Matrix4;
 
         MetaRegistration ();
 

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -63,31 +63,31 @@ namespace pcl
   {
     protected:
 
-      typedef typename Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = typename Registration<PointSource, PointTarget>::PointCloudSource;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef typename Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
-      typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-      typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+      using PointCloudTarget = typename Registration<PointSource, PointTarget>::PointCloudTarget;
+      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+      using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       /** \brief Typename of searchable voxel grid containing mean and covariance. */
-      typedef VoxelGridCovariance<PointTarget> TargetGrid;
+      using TargetGrid = VoxelGridCovariance<PointTarget>;
       /** \brief Typename of pointer to searchable voxel grid. */
-      typedef TargetGrid* TargetGridPtr;
+      using TargetGridPtr = TargetGrid *;
       /** \brief Typename of const pointer to searchable voxel grid. */
-      typedef const TargetGrid* TargetGridConstPtr;
+      using TargetGridConstPtr = const TargetGrid *;
       /** \brief Typename of const pointer to searchable voxel grid leaf. */
-      typedef typename TargetGrid::LeafConstPtr TargetGridLeafConstPtr;
+      using TargetGridLeafConstPtr = typename TargetGrid::LeafConstPtr;
 
 
     public:
 
-      typedef boost::shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> > Ptr;
-      typedef boost::shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> > ConstPtr;
+      using Ptr = boost::shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> >;
+      using ConstPtr = boost::shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> >;
 
 
       /** \brief Constructor.

--- a/registration/include/pcl/registration/ndt_2d.h
+++ b/registration/include/pcl/registration/ndt_2d.h
@@ -58,19 +58,19 @@ namespace pcl
   template <typename PointSource, typename PointTarget>
   class NormalDistributionsTransform2D : public Registration<PointSource, PointTarget>
   {
-    typedef typename Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
-    typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-    typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+    using PointCloudSource = typename Registration<PointSource, PointTarget>::PointCloudSource;
+    using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+    using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-    typedef typename Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
+    using PointCloudTarget = typename Registration<PointSource, PointTarget>::PointCloudTarget;
 
-    typedef PointIndices::Ptr PointIndicesPtr;
-    typedef PointIndices::ConstPtr PointIndicesConstPtr;
+    using PointIndicesPtr = PointIndices::Ptr;
+    using PointIndicesConstPtr = PointIndices::ConstPtr;
 
     public:
 
-        typedef boost::shared_ptr< NormalDistributionsTransform2D<PointSource, PointTarget> > Ptr;
-        typedef boost::shared_ptr< const NormalDistributionsTransform2D<PointSource, PointTarget> > ConstPtr;
+        using Ptr = boost::shared_ptr< NormalDistributionsTransform2D<PointSource, PointTarget> >;
+        using ConstPtr = boost::shared_ptr< const NormalDistributionsTransform2D<PointSource, PointTarget> >;
 
       /** \brief Empty constructor. */
       NormalDistributionsTransform2D ()

--- a/registration/include/pcl/registration/pairwise_graph_registration.h
+++ b/registration/include/pcl/registration/pairwise_graph_registration.h
@@ -57,8 +57,8 @@ namespace pcl
       using GraphRegistration<GraphT>::last_aligned_vertex_;
       using GraphRegistration<GraphT>::last_vertices_;
 
-      typedef typename Registration<PointT, PointT>::Ptr RegistrationPtr;
-      typedef typename pcl::registration::GraphHandler<GraphT>::Vertex GraphHandlerVertex;
+      using RegistrationPtr = typename Registration<PointT, PointT>::Ptr;
+      using GraphHandlerVertex = typename pcl::registration::GraphHandler<GraphT>::Vertex;
 
       /** \brief Empty destructor */
       virtual ~PairwiseGraphRegistration () {}

--- a/registration/include/pcl/registration/ppf_registration.h
+++ b/registration/include/pcl/registration/ppf_registration.h
@@ -77,9 +77,9 @@ namespace pcl
             return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3);
         }
       };
-      typedef std::unordered_multimap<HashKeyStruct, std::pair<size_t, size_t>, HashKeyStruct> FeatureHashMapType;
-      typedef boost::shared_ptr<FeatureHashMapType> FeatureHashMapTypePtr;
-      typedef boost::shared_ptr<PPFHashMapSearch> Ptr;
+      using FeatureHashMapType = std::unordered_multimap<HashKeyStruct, std::pair<size_t, size_t>, HashKeyStruct>;
+      using FeatureHashMapTypePtr = boost::shared_ptr<FeatureHashMapType>;
+      using Ptr = boost::shared_ptr<PPFHashMapSearch>;
 
 
       /** \brief Constructor for the PPFHashMapSearch class which sets the two step parameters for the enclosed data structure
@@ -168,7 +168,7 @@ namespace pcl
         Eigen::Affine3f pose;
         unsigned int votes;
       };
-      typedef std::vector<PoseWithVotes, Eigen::aligned_allocator<PoseWithVotes> > PoseWithVotesList;
+      using PoseWithVotesList = std::vector<PoseWithVotes, Eigen::aligned_allocator<PoseWithVotes> >;
 
       /// input_ is the model cloud
       using Registration<PointSource, PointTarget>::input_;
@@ -178,13 +178,13 @@ namespace pcl
       using Registration<PointSource, PointTarget>::final_transformation_;
       using Registration<PointSource, PointTarget>::transformation_;
 
-      typedef pcl::PointCloud<PointSource> PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = pcl::PointCloud<PointSource>;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-      typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-      typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+      using PointCloudTarget = pcl::PointCloud<PointTarget>;
+      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+      using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
 
       /** \brief Empty constructor that initializes all the parameters of the algorithm with default values */

--- a/registration/include/pcl/registration/pyramid_feature_matching.h
+++ b/registration/include/pcl/registration/pyramid_feature_matching.h
@@ -69,9 +69,9 @@ namespace pcl
     public:
       using PCLBase<PointFeature>::input_;
 
-      typedef boost::shared_ptr<PyramidFeatureHistogram<PointFeature> > Ptr;
-      typedef Ptr PyramidFeatureHistogramPtr;
-      typedef boost::shared_ptr<const pcl::PointRepresentation<PointFeature> > FeatureRepresentationConstPtr;
+      using Ptr = boost::shared_ptr<PyramidFeatureHistogram<PointFeature> >;
+      using PyramidFeatureHistogramPtr = Ptr;
+      using FeatureRepresentationConstPtr = boost::shared_ptr<const pcl::PointRepresentation<PointFeature> >;
 
 
       /** \brief Empty constructor that instantiates the feature representation variable */

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -60,40 +60,40 @@ namespace pcl
   class Registration : public PCLBase<PointSource>
   {
     public:
-      typedef Eigen::Matrix<Scalar, 4, 4> Matrix4;
+      using Matrix4 = Eigen::Matrix<Scalar, 4, 4>;
 
       // using PCLBase<PointSource>::initCompute;
       using PCLBase<PointSource>::deinitCompute;
       using PCLBase<PointSource>::input_;
       using PCLBase<PointSource>::indices_;
 
-      typedef boost::shared_ptr< Registration<PointSource, PointTarget, Scalar> > Ptr;
-      typedef boost::shared_ptr< const Registration<PointSource, PointTarget, Scalar> > ConstPtr;
+      using Ptr = boost::shared_ptr< Registration<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = boost::shared_ptr< const Registration<PointSource, PointTarget, Scalar> >;
 
-      typedef pcl::registration::CorrespondenceRejector::Ptr CorrespondenceRejectorPtr;
-      typedef pcl::search::KdTree<PointTarget> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using CorrespondenceRejectorPtr = pcl::registration::CorrespondenceRejector::Ptr;
+      using KdTree = pcl::search::KdTree<PointTarget>;
+      using KdTreePtr = typename KdTree::Ptr;
 
-      typedef pcl::search::KdTree<PointSource> KdTreeReciprocal;
-      typedef typename KdTreeReciprocal::Ptr KdTreeReciprocalPtr;
+      using KdTreeReciprocal = pcl::search::KdTree<PointSource>;
+      using KdTreeReciprocalPtr = typename KdTreeReciprocal::Ptr;
      
-      typedef pcl::PointCloud<PointSource> PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = pcl::PointCloud<PointSource>;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-      typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-      typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+      using PointCloudTarget = pcl::PointCloud<PointTarget>;
+      using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+      using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-      typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
+      using PointRepresentationConstPtr = typename KdTree::PointRepresentationConstPtr;
       
-      typedef typename pcl::registration::TransformationEstimation<PointSource, PointTarget, Scalar> TransformationEstimation;
-      typedef typename TransformationEstimation::Ptr TransformationEstimationPtr;
-      typedef typename TransformationEstimation::ConstPtr TransformationEstimationConstPtr;
+      using TransformationEstimation = typename pcl::registration::TransformationEstimation<PointSource, PointTarget, Scalar>;
+      using TransformationEstimationPtr = typename TransformationEstimation::Ptr;
+      using TransformationEstimationConstPtr = typename TransformationEstimation::ConstPtr;
 
-      typedef pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> CorrespondenceEstimation;
-      typedef typename CorrespondenceEstimation::Ptr CorrespondenceEstimationPtr;
-      typedef typename CorrespondenceEstimation::ConstPtr CorrespondenceEstimationConstPtr;
+      using CorrespondenceEstimation = pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>;
+      using CorrespondenceEstimationPtr = typename CorrespondenceEstimation::Ptr;
+      using CorrespondenceEstimationConstPtr = typename CorrespondenceEstimation::ConstPtr;
 
       /** \brief The callback signature to the function updating intermediate source point cloud position
         * during it's registration to the target point cloud.

--- a/registration/include/pcl/registration/sample_consensus_prerejective.h
+++ b/registration/include/pcl/registration/sample_consensus_prerejective.h
@@ -76,7 +76,7 @@ namespace pcl
   class SampleConsensusPrerejective : public Registration<PointSource, PointTarget>
   {
     public:
-      typedef typename Registration<PointSource, PointTarget>::Matrix4 Matrix4;
+      using Matrix4 = typename Registration<PointSource, PointTarget>::Matrix4;
       
       using Registration<PointSource, PointTarget>::reg_name_;
       using Registration<PointSource, PointTarget>::getClassName;
@@ -91,27 +91,27 @@ namespace pcl
       using Registration<PointSource, PointTarget>::getFitnessScore;
       using Registration<PointSource, PointTarget>::converged_;
 
-      typedef typename Registration<PointSource, PointTarget>::PointCloudSource PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = typename Registration<PointSource, PointTarget>::PointCloudSource;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef typename Registration<PointSource, PointTarget>::PointCloudTarget PointCloudTarget;
+      using PointCloudTarget = typename Registration<PointSource, PointTarget>::PointCloudTarget;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-      typedef pcl::PointCloud<FeatureT> FeatureCloud;
-      typedef typename FeatureCloud::Ptr FeatureCloudPtr;
-      typedef typename FeatureCloud::ConstPtr FeatureCloudConstPtr;
+      using FeatureCloud = pcl::PointCloud<FeatureT>;
+      using FeatureCloudPtr = typename FeatureCloud::Ptr;
+      using FeatureCloudConstPtr = typename FeatureCloud::ConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> > Ptr;
-      typedef boost::shared_ptr<const SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> >;
+      using ConstPtr = boost::shared_ptr<const SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> >;
 
-      typedef typename KdTreeFLANN<FeatureT>::Ptr FeatureKdTreePtr;
+      using FeatureKdTreePtr = typename KdTreeFLANN<FeatureT>::Ptr;
       
-      typedef pcl::registration::CorrespondenceRejectorPoly<PointSource, PointTarget> CorrespondenceRejectorPoly;
-      typedef typename CorrespondenceRejectorPoly::Ptr CorrespondenceRejectorPolyPtr;
-      typedef typename CorrespondenceRejectorPoly::ConstPtr CorrespondenceRejectorPolyConstPtr;
+      using CorrespondenceRejectorPoly = pcl::registration::CorrespondenceRejectorPoly<PointSource, PointTarget>;
+      using CorrespondenceRejectorPolyPtr = typename CorrespondenceRejectorPoly::Ptr;
+      using CorrespondenceRejectorPolyConstPtr = typename CorrespondenceRejectorPoly::ConstPtr;
       
       /** \brief Constructor */
       SampleConsensusPrerejective ()

--- a/registration/include/pcl/registration/transformation_estimation.h
+++ b/registration/include/pcl/registration/transformation_estimation.h
@@ -62,7 +62,7 @@ namespace pcl
     class TransformationEstimation
     {
       public:
-        typedef Eigen::Matrix<Scalar, 4, 4> Matrix4;
+        using Matrix4 = Eigen::Matrix<Scalar, 4, 4>;
 
         TransformationEstimation () {};
         virtual ~TransformationEstimation () {};
@@ -120,8 +120,8 @@ namespace pcl
             Matrix4 &transformation_matrix) const = 0;
 
 
-        typedef boost::shared_ptr<TransformationEstimation<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimation<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimation<PointSource, PointTarget, Scalar> >;
     };
   }
 }

--- a/registration/include/pcl/registration/transformation_estimation_2D.h
+++ b/registration/include/pcl/registration/transformation_estimation_2D.h
@@ -59,10 +59,10 @@ namespace pcl
     class TransformationEstimation2D : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimation2D<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimation2D<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimation2D<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimation2D<PointSource, PointTarget, Scalar> >;
 
-        typedef typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 
         TransformationEstimation2D () {};
         virtual ~TransformationEstimation2D () {};

--- a/registration/include/pcl/registration/transformation_estimation_3point.h
+++ b/registration/include/pcl/registration/transformation_estimation_3point.h
@@ -60,9 +60,9 @@ namespace pcl
     {
       public:
         /** \cond */
-        typedef boost::shared_ptr<TransformationEstimation3Point<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimation3Point<PointSource, PointTarget, Scalar> > ConstPtr;        
-        typedef typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Ptr = boost::shared_ptr<TransformationEstimation3Point<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimation3Point<PointSource, PointTarget, Scalar> >;        
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
         /** \endcond */
 
         /** \brief Constructor */

--- a/registration/include/pcl/registration/transformation_estimation_dq.h
+++ b/registration/include/pcl/registration/transformation_estimation_dq.h
@@ -57,10 +57,10 @@ namespace pcl
     class TransformationEstimationDQ : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
 
-        typedef typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 
         TransformationEstimationDQ () {};
         virtual ~TransformationEstimationDQ () {};

--- a/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
+++ b/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
@@ -57,10 +57,10 @@ namespace pcl
     class TransformationEstimationDualQuaternion : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> >;
 
-        typedef typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 
         TransformationEstimationDualQuaternion () {};
         ~TransformationEstimationDualQuaternion () {};

--- a/registration/include/pcl/registration/transformation_estimation_lm.h
+++ b/registration/include/pcl/registration/transformation_estimation_lm.h
@@ -58,22 +58,22 @@ namespace pcl
     template <typename PointSource, typename PointTarget, typename MatScalar = float>
     class TransformationEstimationLM : public TransformationEstimation<PointSource, PointTarget, MatScalar>
     {
-      typedef pcl::PointCloud<PointSource> PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = pcl::PointCloud<PointSource>;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef pcl::PointCloud<PointTarget> PointCloudTarget;
+      using PointCloudTarget = pcl::PointCloud<PointTarget>;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       public:
-        typedef boost::shared_ptr<TransformationEstimationLM<PointSource, PointTarget, MatScalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationLM<PointSource, PointTarget, MatScalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationLM<PointSource, PointTarget, MatScalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationLM<PointSource, PointTarget, MatScalar> >;
 
-        typedef Eigen::Matrix<MatScalar, Eigen::Dynamic, 1> VectorX;
-        typedef Eigen::Matrix<MatScalar, 4, 1> Vector4;
-        typedef typename TransformationEstimation<PointSource, PointTarget, MatScalar>::Matrix4 Matrix4;
+        using VectorX = Eigen::Matrix<MatScalar, Eigen::Dynamic, 1>;
+        using Vector4 = Eigen::Matrix<MatScalar, 4, 1>;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, MatScalar>::Matrix4;
         
         /** \brief Constructor. */
         TransformationEstimationLM ();
@@ -224,15 +224,15 @@ namespace pcl
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor
         {
-          typedef _Scalar Scalar;
+          using Scalar = _Scalar;
           enum 
           {
             InputsAtCompileTime = NX,
             ValuesAtCompileTime = NY
           };
-          typedef Eigen::Matrix<_Scalar,InputsAtCompileTime,1> InputType;
-          typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,1> ValueType;
-          typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
+          using InputType = Eigen::Matrix<_Scalar,InputsAtCompileTime,1>;
+          using ValueType = Eigen::Matrix<_Scalar,ValuesAtCompileTime,1>;
+          using JacobianType = Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime>;
 
           /** \brief Empty Constructor. */
           Functor () : m_data_points_ (ValuesAtCompileTime) {}

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane.h
@@ -58,17 +58,17 @@ namespace pcl
     class TransformationEstimationPointToPlane : public TransformationEstimationLM<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> >;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef PointIndices::Ptr PointIndicesPtr;
-        typedef PointIndices::ConstPtr PointIndicesConstPtr;
+        using PointCloudSource = pcl::PointCloud<PointSource>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
+        using PointCloudTarget = pcl::PointCloud<PointTarget>;
+        using PointIndicesPtr = PointIndices::Ptr;
+        using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-        typedef Eigen::Matrix<Scalar, 4, 1> Vector4;
+        using Vector4 = Eigen::Matrix<Scalar, 4, 1>;
 
         TransformationEstimationPointToPlane () {};
         ~TransformationEstimationPointToPlane () {};

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
@@ -63,10 +63,10 @@ namespace pcl
     class TransformationEstimationPointToPlaneLLS : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
 
-        typedef typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
         
         TransformationEstimationPointToPlaneLLS () {};
         ~TransformationEstimationPointToPlaneLLS () {};

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
@@ -63,10 +63,10 @@ namespace pcl
     class TransformationEstimationPointToPlaneLLSWeighted : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> >;
 
-        typedef typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
         
         TransformationEstimationPointToPlaneLLSWeighted () { };
         virtual ~TransformationEstimationPointToPlaneLLSWeighted () { };

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -56,22 +56,22 @@ namespace pcl
     template <typename PointSource, typename PointTarget, typename MatScalar = float>
     class TransformationEstimationPointToPlaneWeighted : public TransformationEstimationPointToPlane<PointSource, PointTarget, MatScalar>
     {
-      typedef pcl::PointCloud<PointSource> PointCloudSource;
-      typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-      typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+      using PointCloudSource = pcl::PointCloud<PointSource>;
+      using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+      using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-      typedef pcl::PointCloud<PointTarget> PointCloudTarget;
+      using PointCloudTarget = pcl::PointCloud<PointTarget>;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       public:
-        typedef boost::shared_ptr<TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> >;
 
-        typedef Eigen::Matrix<MatScalar, Eigen::Dynamic, 1> VectorX;
-        typedef Eigen::Matrix<MatScalar, 4, 1> Vector4;
-        typedef typename TransformationEstimation<PointSource, PointTarget, MatScalar>::Matrix4 Matrix4;
+        using VectorX = Eigen::Matrix<MatScalar, Eigen::Dynamic, 1>;
+        using Vector4 = Eigen::Matrix<MatScalar, 4, 1>;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, MatScalar>::Matrix4;
         
         /** \brief Constructor. */
         TransformationEstimationPointToPlaneWeighted ();
@@ -207,15 +207,15 @@ namespace pcl
         template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
         struct Functor
         {
-          typedef _Scalar Scalar;
+          using Scalar = _Scalar;
           enum 
           {
             InputsAtCompileTime = NX,
             ValuesAtCompileTime = NY
           };
-          typedef Eigen::Matrix<_Scalar,InputsAtCompileTime,1> InputType;
-          typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,1> ValueType;
-          typedef Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
+          using InputType = Eigen::Matrix<_Scalar,InputsAtCompileTime,1>;
+          using ValueType = Eigen::Matrix<_Scalar,ValuesAtCompileTime,1>;
+          using JacobianType = Eigen::Matrix<_Scalar,ValuesAtCompileTime,InputsAtCompileTime>;
 
           /** \brief Empty Constructor. */
           Functor () : m_data_points_ (ValuesAtCompileTime) {}

--- a/registration/include/pcl/registration/transformation_estimation_svd.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd.h
@@ -58,10 +58,10 @@ namespace pcl
     class TransformationEstimationSVD : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimationSVD<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationSVD<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationSVD<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationSVD<PointSource, PointTarget, Scalar> >;
 
-        typedef typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 
         /** \brief Constructor
           * \param[in] use_umeyama Toggles whether or not to use 3rd party software*/

--- a/registration/include/pcl/registration/transformation_estimation_svd_scale.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd_scale.h
@@ -58,10 +58,10 @@ namespace pcl
     class TransformationEstimationSVDScale : public TransformationEstimationSVD<PointSource, PointTarget, Scalar>
     {
       public:
-        typedef boost::shared_ptr<TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> >;
 
-        typedef typename TransformationEstimationSVD<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationEstimationSVD<PointSource, PointTarget, Scalar>::Matrix4;
 
         /** \brief Inherits from TransformationEstimationSVD, but forces it to not use the Umeyama method */
         TransformationEstimationSVDScale ():

--- a/registration/include/pcl/registration/transformation_validation.h
+++ b/registration/include/pcl/registration/transformation_validation.h
@@ -68,17 +68,17 @@ namespace pcl
     class TransformationValidation
     {
       public:
-        typedef Eigen::Matrix<Scalar, 4, 4> Matrix4;
-        typedef boost::shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Matrix4 = Eigen::Matrix<Scalar, 4, 4>;
+        using Ptr = boost::shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> >;
 
-        typedef pcl::PointCloud<PointSource> PointCloudSource;
-        typedef typename PointCloudSource::Ptr PointCloudSourcePtr;
-        typedef typename PointCloudSource::ConstPtr PointCloudSourceConstPtr;
+        using PointCloudSource = pcl::PointCloud<PointSource>;
+        using PointCloudSourcePtr = typename PointCloudSource::Ptr;
+        using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
-        typedef pcl::PointCloud<PointTarget> PointCloudTarget;
-        typedef typename PointCloudTarget::Ptr PointCloudTargetPtr;
-        typedef typename PointCloudTarget::ConstPtr PointCloudTargetConstPtr;
+        using PointCloudTarget = pcl::PointCloud<PointTarget>;
+        using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
+        using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
         TransformationValidation () {};
         virtual ~TransformationValidation () {};

--- a/registration/include/pcl/registration/transformation_validation_euclidean.h
+++ b/registration/include/pcl/registration/transformation_validation_euclidean.h
@@ -73,18 +73,18 @@ namespace pcl
     class TransformationValidationEuclidean
     {
       public:
-        typedef typename TransformationValidation<PointSource, PointTarget, Scalar>::Matrix4 Matrix4;
+        using Matrix4 = typename TransformationValidation<PointSource, PointTarget, Scalar>::Matrix4;
         
-        typedef boost::shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> > Ptr;
-        typedef boost::shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> >;
 
-        typedef pcl::search::KdTree<PointTarget> KdTree;
-        typedef typename KdTree::Ptr KdTreePtr;
+        using KdTree = pcl::search::KdTree<PointTarget>;
+        using KdTreePtr = typename KdTree::Ptr;
 
-        typedef typename KdTree::PointRepresentationConstPtr PointRepresentationConstPtr;
+        using PointRepresentationConstPtr = typename KdTree::PointRepresentationConstPtr;
 
-        typedef typename TransformationValidation<PointSource, PointTarget>::PointCloudSourceConstPtr PointCloudSourceConstPtr;
-        typedef typename TransformationValidation<PointSource, PointTarget>::PointCloudTargetConstPtr PointCloudTargetConstPtr;
+        using PointCloudSourceConstPtr = typename TransformationValidation<PointSource, PointTarget>::PointCloudSourceConstPtr;
+        using PointCloudTargetConstPtr = typename TransformationValidation<PointSource, PointTarget>::PointCloudTargetConstPtr;
 
         /** \brief Constructor.
           * Sets the \a max_range parameter to double::max, \a threshold_ to NaN
@@ -236,8 +236,8 @@ namespace pcl
           using pcl::PointRepresentation<PointTarget>::nr_dimensions_;
           using pcl::PointRepresentation<PointTarget>::trivial_;
           public:
-            typedef boost::shared_ptr<MyPointRepresentation> Ptr;
-            typedef boost::shared_ptr<const MyPointRepresentation> ConstPtr;
+            using Ptr = boost::shared_ptr<MyPointRepresentation>;
+            using ConstPtr = boost::shared_ptr<const MyPointRepresentation>;
             
             MyPointRepresentation ()
             {

--- a/registration/include/pcl/registration/warp_point_rigid.h
+++ b/registration/include/pcl/registration/warp_point_rigid.h
@@ -56,12 +56,12 @@ namespace pcl
     class WarpPointRigid
     {
       public:
-        typedef Eigen::Matrix<Scalar, 4, 4> Matrix4;
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> VectorX;
-        typedef Eigen::Matrix<Scalar, 4, 1> Vector4;
+        using Matrix4 = Eigen::Matrix<Scalar, 4, 4>;
+        using VectorX = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+        using Vector4 = Eigen::Matrix<Scalar, 4, 1>;
 
-        typedef boost::shared_ptr<WarpPointRigid<PointSourceT, PointTargetT, Scalar> > Ptr;
-        typedef boost::shared_ptr<const WarpPointRigid<PointSourceT, PointTargetT, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<WarpPointRigid<PointSourceT, PointTargetT, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const WarpPointRigid<PointSourceT, PointTargetT, Scalar> >;
 
         /** \brief Constructor
           * \param[in] nr_dim the number of dimensions

--- a/registration/include/pcl/registration/warp_point_rigid_3d.h
+++ b/registration/include/pcl/registration/warp_point_rigid_3d.h
@@ -58,11 +58,11 @@ namespace pcl
     class WarpPointRigid3D : public WarpPointRigid<PointSourceT, PointTargetT, Scalar>
     {
       public:
-        typedef typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::Matrix4 Matrix4;
-        typedef typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::VectorX VectorX;
+        using Matrix4 = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::Matrix4;
+        using VectorX = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::VectorX;
 
-        typedef boost::shared_ptr<WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> > Ptr;
-        typedef boost::shared_ptr<const WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> >;
 
         /** \brief Constructor. */
         WarpPointRigid3D () : WarpPointRigid<PointSourceT, PointTargetT, Scalar> (3) {}

--- a/registration/include/pcl/registration/warp_point_rigid_6d.h
+++ b/registration/include/pcl/registration/warp_point_rigid_6d.h
@@ -59,11 +59,11 @@ namespace pcl
       public:
         using WarpPointRigid<PointSourceT, PointTargetT, Scalar>::transform_matrix_;
 
-        typedef typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::Matrix4 Matrix4;
-        typedef typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::VectorX VectorX;
+        using Matrix4 = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::Matrix4;
+        using VectorX = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::VectorX;
 
-        typedef boost::shared_ptr<WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> > Ptr;
-        typedef boost::shared_ptr<const WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> > ConstPtr;
+        using Ptr = boost::shared_ptr<WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> >;
+        using ConstPtr = boost::shared_ptr<const WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> >;
 
         WarpPointRigid6D () : WarpPointRigid<PointSourceT, PointTargetT, Scalar> (6) {}
       

--- a/registration/src/correspondence_rejection_var_trimmed.cpp
+++ b/registration/src/correspondence_rejection_var_trimmed.cpp
@@ -87,7 +87,7 @@ pcl::registration::CorrespondenceRejectorVarTrimmed::optimizeInlierRatio (std::v
   const int min_el = int (floor (min_ratio_ * points_nbr));
   const int max_el = int (floor (max_ratio_ * points_nbr));
 
-  typedef Eigen::Array <double, Eigen::Dynamic, 1> LineArray;
+  using LineArray = Eigen::Array <double, Eigen::Dynamic, 1>;
   Eigen::Map<LineArray> sorted_dist (&dists[0], points_nbr);
 
   const LineArray trunk_sorted_dist = sorted_dist.segment (min_el, max_el-min_el);

--- a/registration/src/registration.cpp
+++ b/registration/src/registration.cpp
@@ -50,8 +50,8 @@
 #include <pcl/registration/correspondence_sorting.h>
 */
 
-typedef pcl::IterativeClosestPoint<pcl::PointXYZ,pcl::PointXYZ> IterativeClosestPoint;
-typedef pcl::IterativeClosestPointNonLinear<pcl::PointXYZ,pcl::PointXYZ> IterativeClosestPointNonLinear;
+using IterativeClosestPoint = pcl::IterativeClosestPoint<pcl::PointXYZ,pcl::PointXYZ>;
+using IterativeClosestPointNonLinear = pcl::IterativeClosestPointNonLinear<pcl::PointXYZ,pcl::PointXYZ>;
 //PLUGINLIB_DECLARE_CLASS (pcl, IterativeClosestPoint, IterativeClosestPoint, nodelet::Nodelet);
 //PLUGINLIB_DECLARE_CLASS (pcl, IterativeClosestPointNonLinear, IterativeClosestPointNonLinear, nodelet::Nodelet);
 


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`