### PR TITLE
Use using instead of typedef [filters]

### DIFF
--- a/filters/include/pcl/filters/approximate_voxel_grid.h
+++ b/filters/include/pcl/filters/approximate_voxel_grid.h
@@ -46,7 +46,7 @@ namespace pcl
   template <typename PointT>
   struct xNdCopyEigenPointFunctor
   {
-    typedef typename traits::POD<PointT>::type Pod;
+    using Pod = typename traits::POD<PointT>::type;
     
     xNdCopyEigenPointFunctor (const Eigen::VectorXf &p1, PointT &p2)
       : p1_ (p1),
@@ -56,7 +56,7 @@ namespace pcl
     template<typename Key> inline void operator() ()
     {
       //boost::fusion::at_key<Key> (p2_) = p1_[f_idx_++];
-      typedef typename pcl::traits::datatype<PointT, Key>::type T;
+      using T = typename pcl::traits::datatype<PointT, Key>::type;
       uint8_t* data_ptr = reinterpret_cast<uint8_t*>(&p2_) + pcl::traits::offset<PointT, Key>::value;
       *reinterpret_cast<T*>(data_ptr) = static_cast<T> (p1_[f_idx_++]);
     }
@@ -71,7 +71,7 @@ namespace pcl
   template <typename PointT>
   struct xNdCopyPointEigenFunctor
   {
-    typedef typename traits::POD<PointT>::type Pod;
+    using Pod = typename traits::POD<PointT>::type;
     
     xNdCopyPointEigenFunctor (const PointT &p1, Eigen::VectorXf &p2)
       : p1_ (reinterpret_cast<const Pod&>(p1)), p2_ (p2), f_idx_ (0) { }
@@ -79,7 +79,7 @@ namespace pcl
     template<typename Key> inline void operator() ()
     {
       //p2_[f_idx_++] = boost::fusion::at_key<Key> (p1_);
-      typedef typename pcl::traits::datatype<PointT, Key>::type T;
+      using T = typename pcl::traits::datatype<PointT, Key>::type;
       const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(&p1_) + pcl::traits::offset<PointT, Key>::value;
       p2_[f_idx_++] = static_cast<float> (*reinterpret_cast<const T*>(data_ptr));
     }
@@ -103,9 +103,9 @@ namespace pcl
     using Filter<PointT>::input_;
     using Filter<PointT>::indices_;
 
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     private:
       struct he
@@ -118,8 +118,8 @@ namespace pcl
 
     public:
 
-      typedef boost::shared_ptr< ApproximateVoxelGrid<PointT> > Ptr;
-      typedef boost::shared_ptr< const ApproximateVoxelGrid<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ApproximateVoxelGrid<PointT> >;
+      using ConstPtr = boost::shared_ptr<const ApproximateVoxelGrid<PointT> >;
 
 
       /** \brief Empty constructor. */
@@ -227,7 +227,7 @@ namespace pcl
       /** \brief history buffer */
       struct he* history_;
 
-      typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+      using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
       /** \brief Downsample a Point Cloud using a voxelized grid approach
         * \param output the resultant point cloud message

--- a/filters/include/pcl/filters/bilateral.h
+++ b/filters/include/pcl/filters/bilateral.h
@@ -57,13 +57,13 @@ namespace pcl
   {
     using Filter<PointT>::input_;
     using Filter<PointT>::indices_;
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename pcl::search::Search<PointT>::Ptr KdTreePtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using KdTreePtr = typename pcl::search::Search<PointT>::Ptr;
 
     public:
 
-      typedef boost::shared_ptr< BilateralFilter<PointT> > Ptr;
-      typedef boost::shared_ptr< const BilateralFilter<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<BilateralFilter<PointT> >;
+      using ConstPtr = boost::shared_ptr<const BilateralFilter<PointT> >;
  
 
       /** \brief Constructor. 

--- a/filters/include/pcl/filters/box_clipper3D.h
+++ b/filters/include/pcl/filters/box_clipper3D.h
@@ -52,8 +52,8 @@ namespace pcl
   {
     public:
 
-      typedef boost::shared_ptr< BoxClipper3D<PointT> > Ptr;
-      typedef boost::shared_ptr< const BoxClipper3D<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<BoxClipper3D<PointT> >;
+      using ConstPtr = boost::shared_ptr<const BoxClipper3D<PointT> >;
 
 
       /**

--- a/filters/include/pcl/filters/clipper3D.h
+++ b/filters/include/pcl/filters/clipper3D.h
@@ -52,8 +52,8 @@ namespace pcl
   class Clipper3D
   {
     public:
-      typedef boost::shared_ptr< Clipper3D<PointT> > Ptr;
-      typedef boost::shared_ptr< const Clipper3D<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<Clipper3D<PointT> >;
+      using ConstPtr = boost::shared_ptr<const Clipper3D<PointT> >;
  
       /**
         * \brief virtual destructor. Never throws an exception.

--- a/filters/include/pcl/filters/conditional_removal.h
+++ b/filters/include/pcl/filters/conditional_removal.h
@@ -48,10 +48,10 @@ namespace pcl
     /** \brief The kind of comparison operations that are possible within a 
       * comparison object
       */
-    typedef enum
+    enum CompareOp
     {
       GT, GE, LT, LE, EQ
-    } CompareOp;
+    };
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////
@@ -88,8 +88,8 @@ namespace pcl
   class ComparisonBase
   {
     public:
-      typedef boost::shared_ptr< ComparisonBase<PointT> > Ptr;
-      typedef boost::shared_ptr< const ComparisonBase<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ComparisonBase<PointT> >;
+      using ConstPtr = boost::shared_ptr<const ComparisonBase<PointT> >;
 
       /** \brief Constructor. */
       ComparisonBase () : capable_ (false), offset_ (), op_ () {}
@@ -132,8 +132,8 @@ namespace pcl
     using ComparisonBase<PointT>::capable_;
 
     public:
-      typedef boost::shared_ptr< FieldComparison<PointT> > Ptr;
-      typedef boost::shared_ptr< const FieldComparison<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FieldComparison<PointT> >;
+      using ConstPtr = boost::shared_ptr<const FieldComparison<PointT> >;
 
 
       /** \brief Construct a FieldComparison
@@ -196,8 +196,8 @@ namespace pcl
     using ComparisonBase<PointT>::op_;
 
     public:
-      typedef boost::shared_ptr< PackedRGBComparison<PointT> > Ptr;
-      typedef boost::shared_ptr< const PackedRGBComparison<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PackedRGBComparison<PointT> >;
+      using ConstPtr = boost::shared_ptr<const PackedRGBComparison<PointT> >;
 
       /** \brief Construct a PackedRGBComparison
         * \param component_name either "r", "g" or "b"
@@ -243,8 +243,8 @@ namespace pcl
     using ComparisonBase<PointT>::op_;
 
     public:
-      typedef boost::shared_ptr< PackedHSIComparison<PointT> > Ptr;
-      typedef boost::shared_ptr< const PackedHSIComparison<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PackedHSIComparison<PointT> >;
+      using ConstPtr = boost::shared_ptr<const PackedHSIComparison<PointT> >;
  
       /** \brief Construct a PackedHSIComparison 
         * \param component_name either "h", "s" or "i"
@@ -263,12 +263,12 @@ namespace pcl
       bool
       evaluate (const PointT &point) const override;
 
-      typedef enum
+      enum ComponentId
       {
         H, // -128 to 127 corresponds to -pi to pi
         S, // 0 to 255
         I  // 0 to 255
-      } ComponentId;
+      };
 
     protected:
       /** \brief The name of the component. */
@@ -311,8 +311,8 @@ namespace pcl
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW     //needed whenever there is a fixed size Eigen:: vector or matrix in a class
 
-      typedef boost::shared_ptr<TfQuadraticXYZComparison<PointT> > Ptr;
-      typedef boost::shared_ptr<const TfQuadraticXYZComparison<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<TfQuadraticXYZComparison<PointT> >;
+      using ConstPtr = boost::shared_ptr<const TfQuadraticXYZComparison<PointT> >;
 
       /** \brief Constructor.
        */
@@ -445,12 +445,12 @@ namespace pcl
   class ConditionBase
   {
     public:
-      typedef pcl::ComparisonBase<PointT> ComparisonBase;
-      typedef typename ComparisonBase::Ptr ComparisonBasePtr;
-      typedef typename ComparisonBase::ConstPtr ComparisonBaseConstPtr;
+      using ComparisonBase = pcl::ComparisonBase<PointT>;
+      using ComparisonBasePtr = typename ComparisonBase::Ptr;
+      using ComparisonBaseConstPtr = typename ComparisonBase::ConstPtr;
 
-      typedef boost::shared_ptr<ConditionBase<PointT> > Ptr;
-      typedef boost::shared_ptr<const ConditionBase<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ConditionBase<PointT> >;
+      using ConstPtr = boost::shared_ptr<const ConditionBase<PointT> >;
 
       /** \brief Constructor. */
       ConditionBase () : capable_ (true), comparisons_ (), conditions_ ()
@@ -512,8 +512,8 @@ namespace pcl
     using ConditionBase<PointT>::comparisons_;
 
     public:
-      typedef boost::shared_ptr<ConditionAnd<PointT> > Ptr;
-      typedef boost::shared_ptr<const ConditionAnd<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ConditionAnd<PointT> >;
+      using ConstPtr = boost::shared_ptr<const ConditionAnd<PointT> >;
 
       /** \brief Constructor. */
       ConditionAnd () :
@@ -540,8 +540,8 @@ namespace pcl
     using ConditionBase<PointT>::comparisons_;
 
     public:
-      typedef boost::shared_ptr<ConditionOr<PointT> > Ptr;
-      typedef boost::shared_ptr<const ConditionOr<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ConditionOr<PointT> >;
+      using ConstPtr = boost::shared_ptr<const ConditionOr<PointT> >;
 
       /** \brief Constructor. */
       ConditionOr () :
@@ -600,14 +600,14 @@ namespace pcl
     using Filter<PointT>::removed_indices_;
     using Filter<PointT>::extract_removed_indices_;
 
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
-      typedef pcl::ConditionBase<PointT> ConditionBase;
-      typedef typename ConditionBase::Ptr ConditionBasePtr;
-      typedef typename ConditionBase::ConstPtr ConditionBaseConstPtr;
+      using ConditionBase = pcl::ConditionBase<PointT>;
+      using ConditionBasePtr = typename ConditionBase::Ptr;
+      using ConditionBaseConstPtr = typename ConditionBase::ConstPtr;
 
       /** \brief the default constructor.  
         *

--- a/filters/include/pcl/filters/convolution.h
+++ b/filters/include/pcl/filters/convolution.h
@@ -76,12 +76,12 @@ namespace pcl
     class Convolution
     {
       public:
-        typedef pcl::PointCloud<PointIn> PointCloudIn;
-        typedef typename PointCloudIn::Ptr PointCloudInPtr;
-        typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
-        typedef pcl::PointCloud<PointOut> PointCloudOut;
-        typedef boost::shared_ptr< Convolution<PointIn, PointOut> > Ptr;
-        typedef boost::shared_ptr< const Convolution<PointIn, PointOut> > ConstPtr;
+        using PointCloudIn = pcl::PointCloud<PointIn>;
+        using PointCloudInPtr = typename PointCloudIn::Ptr;
+        using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
+        using PointCloudOut = pcl::PointCloud<PointOut>;
+        using Ptr = boost::shared_ptr< Convolution<PointIn, PointOut> >;
+        using ConstPtr = boost::shared_ptr< const Convolution<PointIn, PointOut> >;
 
 
         /// The borders policy available

--- a/filters/include/pcl/filters/convolution_3d.h
+++ b/filters/include/pcl/filters/convolution_3d.h
@@ -54,10 +54,10 @@ namespace pcl
     class ConvolvingKernel
     {
       public:
-        typedef boost::shared_ptr<ConvolvingKernel<PointInT, PointOutT> > Ptr;
-        typedef boost::shared_ptr<const ConvolvingKernel<PointInT, PointOutT> > ConstPtr;
+        using Ptr = boost::shared_ptr<ConvolvingKernel<PointInT, PointOutT> >;
+        using ConstPtr = boost::shared_ptr<const ConvolvingKernel<PointInT, PointOutT> >;
  
-        typedef typename PointCloud<PointInT>::ConstPtr PointCloudInConstPtr;
+        using PointCloudInConstPtr = typename PointCloud<PointInT>::ConstPtr;
 
         /// \brief empty constructor
         ConvolvingKernel () {}
@@ -118,8 +118,8 @@ namespace pcl
         using ConvolvingKernel<PointInT, PointOutT>::input_;
         using ConvolvingKernel<PointInT, PointOutT>::operator ();
         using ConvolvingKernel<PointInT, PointOutT>::makeInfinite;
-        typedef boost::shared_ptr<GaussianKernel<PointInT, PointOutT> > Ptr;
-        typedef boost::shared_ptr<GaussianKernel<PointInT, PointOutT> > ConstPtr;
+        using Ptr = boost::shared_ptr<GaussianKernel<PointInT, PointOutT> >;
+        using ConstPtr = boost::shared_ptr<GaussianKernel<PointInT, PointOutT> >;
 
         /** Default constructor */
         GaussianKernel ()
@@ -176,8 +176,8 @@ namespace pcl
         using GaussianKernel<PointInT, PointOutT>::makeInfinite;
         using GaussianKernel<PointInT, PointOutT>::sigma_sqr_;
         using GaussianKernel<PointInT, PointOutT>::threshold_;
-        typedef boost::shared_ptr<GaussianKernelRGB<PointInT, PointOutT> > Ptr;
-        typedef boost::shared_ptr<GaussianKernelRGB<PointInT, PointOutT> > ConstPtr;
+        using Ptr = boost::shared_ptr<GaussianKernelRGB<PointInT, PointOutT> >;
+        using ConstPtr = boost::shared_ptr<GaussianKernelRGB<PointInT, PointOutT> >;
 
         /** Default constructor */
         GaussianKernelRGB ()
@@ -199,13 +199,13 @@ namespace pcl
     class Convolution3D : public pcl::PCLBase <PointIn>
     {
       public:
-        typedef pcl::PointCloud<PointIn> PointCloudIn;
-        typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
-        typedef pcl::search::Search<PointIn> KdTree;
-        typedef typename KdTree::Ptr KdTreePtr;
-        typedef pcl::PointCloud<PointOut> PointCloudOut;
-        typedef boost::shared_ptr<Convolution3D<PointIn, PointOut, KernelT> > Ptr;
-        typedef boost::shared_ptr<Convolution3D<PointIn, PointOut, KernelT> > ConstPtr;
+        using PointCloudIn = pcl::PointCloud<PointIn>;
+        using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
+        using KdTree = pcl::search::Search<PointIn>;
+        using KdTreePtr = typename KdTree::Ptr;
+        using PointCloudOut = pcl::PointCloud<PointOut>;
+        using Ptr = boost::shared_ptr<Convolution3D<PointIn, PointOut, KernelT> >;
+        using ConstPtr = boost::shared_ptr<Convolution3D<PointIn, PointOut, KernelT> >;
 
         using pcl::PCLBase<PointIn>::indices_;
         using pcl::PCLBase<PointIn>::input_;

--- a/filters/include/pcl/filters/covariance_sampling.h
+++ b/filters/include/pcl/filters/covariance_sampling.h
@@ -65,14 +65,14 @@ namespace pcl
       using FilterIndices<PointT>::input_;
       using FilterIndices<PointT>::initCompute;
 
-      typedef typename FilterIndices<PointT>::PointCloud Cloud;
-      typedef typename Cloud::Ptr CloudPtr;
-      typedef typename Cloud::ConstPtr CloudConstPtr;
-      typedef typename pcl::PointCloud<PointNT>::ConstPtr NormalsConstPtr;
+      using Cloud = typename FilterIndices<PointT>::PointCloud;
+      using CloudPtr = typename Cloud::Ptr;
+      using CloudConstPtr = typename Cloud::ConstPtr;
+      using NormalsConstPtr = typename pcl::PointCloud<PointNT>::ConstPtr;
 
     public:
-      typedef boost::shared_ptr< CovarianceSampling<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr< const CovarianceSampling<PointT, PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr< CovarianceSampling<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr< const CovarianceSampling<PointT, PointNT> >;
  
       /** \brief Empty constructor. */
       CovarianceSampling ()

--- a/filters/include/pcl/filters/crop_box.h
+++ b/filters/include/pcl/filters/crop_box.h
@@ -57,14 +57,14 @@ namespace pcl
   {
     using Filter<PointT>::getClassName;
 
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
 
-      typedef boost::shared_ptr< CropBox<PointT> > Ptr;
-      typedef boost::shared_ptr< const CropBox<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<CropBox<PointT> >;
+      using ConstPtr = boost::shared_ptr<const CropBox<PointT> >;
 
       /** \brief Constructor.
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).
@@ -211,9 +211,9 @@ namespace pcl
     using Filter<pcl::PCLPointCloud2>::filter_name_;
     using Filter<pcl::PCLPointCloud2>::getClassName;
 
-    typedef pcl::PCLPointCloud2 PCLPointCloud2;
-    typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-    typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+    using PCLPointCloud2 = pcl::PCLPointCloud2;
+    using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+    using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
     public:
       /** \brief Constructor.

--- a/filters/include/pcl/filters/crop_hull.h
+++ b/filters/include/pcl/filters/crop_hull.h
@@ -55,14 +55,14 @@ namespace pcl
     using Filter<PointT>::indices_;
     using Filter<PointT>::input_;
     
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
 
-      typedef boost::shared_ptr< CropHull<PointT> > Ptr;
-      typedef boost::shared_ptr< const CropHull<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<CropHull<PointT> >;
+      using ConstPtr = boost::shared_ptr<const CropHull<PointT> >;
 
       /** \brief Empty Constructor. */
       CropHull () :

--- a/filters/include/pcl/filters/extract_indices.h
+++ b/filters/include/pcl/filters/extract_indices.h
@@ -69,15 +69,15 @@ namespace pcl
   class ExtractIndices : public FilterIndices<PointT>
   {
     protected:
-      typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+      using PointCloud = typename FilterIndices<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
     public:
 
-      typedef boost::shared_ptr< ExtractIndices<PointT> > Ptr;
-      typedef boost::shared_ptr< const ExtractIndices<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ExtractIndices<PointT> >;
+      using ConstPtr = boost::shared_ptr<const ExtractIndices<PointT> >;
 
       /** \brief Constructor.
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).
@@ -160,9 +160,9 @@ namespace pcl
   class PCL_EXPORTS ExtractIndices<pcl::PCLPointCloud2> : public FilterIndices<pcl::PCLPointCloud2>
   {
     public:
-      typedef pcl::PCLPointCloud2 PCLPointCloud2;
-      typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-      typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+      using PCLPointCloud2 = pcl::PCLPointCloud2;
+      using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+      using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
       /** \brief Empty constructor. */
       ExtractIndices ()

--- a/filters/include/pcl/filters/fast_bilateral.h
+++ b/filters/include/pcl/filters/fast_bilateral.h
@@ -57,12 +57,12 @@ namespace pcl
   {
     protected:
       using Filter<PointT>::input_;
-      typedef typename Filter<PointT>::PointCloud PointCloud;
+      using PointCloud = typename Filter<PointT>::PointCloud;
 
     public:
     
-      typedef boost::shared_ptr< FastBilateralFilter<PointT> > Ptr;
-      typedef boost::shared_ptr< const FastBilateralFilter<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FastBilateralFilter<PointT> >;
+      using ConstPtr = boost::shared_ptr<const FastBilateralFilter<PointT> >;
 
       /** \brief Empty constructor. */
       FastBilateralFilter ()

--- a/filters/include/pcl/filters/fast_bilateral_omp.h
+++ b/filters/include/pcl/filters/fast_bilateral_omp.h
@@ -61,14 +61,14 @@ namespace pcl
     using FastBilateralFilter<PointT>::sigma_s_;
     using FastBilateralFilter<PointT>::sigma_r_;
     using FastBilateralFilter<PointT>::early_division_;
-    typedef typename FastBilateralFilter<PointT>::Array3D Array3D;
+    using Array3D = typename FastBilateralFilter<PointT>::Array3D;
 
-    typedef typename Filter<PointT>::PointCloud PointCloud;
+    using PointCloud = typename Filter<PointT>::PointCloud;
 
     public:
 
-      typedef boost::shared_ptr< FastBilateralFilterOMP<PointT> > Ptr;
-      typedef boost::shared_ptr< const FastBilateralFilterOMP<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FastBilateralFilterOMP<PointT> >;
+      using ConstPtr = boost::shared_ptr<const FastBilateralFilterOMP<PointT> >;
 
       /** \brief Empty constructor. */
       FastBilateralFilterOMP (unsigned int nr_threads = 0)

--- a/filters/include/pcl/filters/filter.h
+++ b/filters/include/pcl/filters/filter.h
@@ -86,13 +86,13 @@ namespace pcl
       using PCLBase<PointT>::indices_;
       using PCLBase<PointT>::input_;
 
-      typedef boost::shared_ptr< Filter<PointT> > Ptr;
-      typedef boost::shared_ptr< const Filter<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<Filter<PointT> >;
+      using ConstPtr = boost::shared_ptr<const Filter<PointT> >;
 
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       /** \brief Empty constructor.
         * \param[in] extract_removed_indices set to true if the filtered data indices should be saved in a
@@ -192,12 +192,12 @@ namespace pcl
   class PCL_EXPORTS Filter<pcl::PCLPointCloud2> : public PCLBase<pcl::PCLPointCloud2>
   {
     public:
-      typedef boost::shared_ptr< Filter<pcl::PCLPointCloud2> > Ptr;
-      typedef boost::shared_ptr< const Filter<pcl::PCLPointCloud2> > ConstPtr;
+      using Ptr = boost::shared_ptr<Filter<pcl::PCLPointCloud2> >;
+      using ConstPtr = boost::shared_ptr<const Filter<pcl::PCLPointCloud2> >;
 
-      typedef pcl::PCLPointCloud2 PCLPointCloud2;
-      typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-      typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+      using PCLPointCloud2 = pcl::PCLPointCloud2;
+      using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+      using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
       /** \brief Empty constructor.
         * \param[in] extract_removed_indices set to true if the filtered data indices should be saved in a

--- a/filters/include/pcl/filters/filter_indices.h
+++ b/filters/include/pcl/filters/filter_indices.h
@@ -75,10 +75,10 @@ namespace pcl
   {
     public:
       using Filter<PointT>::extract_removed_indices_;
-      typedef pcl::PointCloud<PointT> PointCloud;
+      using PointCloud = pcl::PointCloud<PointT>;
 
-      typedef boost::shared_ptr< FilterIndices<PointT> > Ptr;
-      typedef boost::shared_ptr< const FilterIndices<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FilterIndices<PointT> >;
+      using ConstPtr = boost::shared_ptr<const FilterIndices<PointT> >;
 
 
       /** \brief Constructor.
@@ -204,7 +204,7 @@ namespace pcl
   class PCL_EXPORTS FilterIndices<pcl::PCLPointCloud2> : public Filter<pcl::PCLPointCloud2>
   {
     public:
-      typedef pcl::PCLPointCloud2 PCLPointCloud2;
+      using PCLPointCloud2 = pcl::PCLPointCloud2;
 
       /** \brief Constructor.
         * \param[in] extract_removed_indices Set to true if you want to extract the indices of points being removed (default = false).

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -75,14 +75,14 @@ namespace pcl
   template <typename PointT>
   class FrustumCulling : public FilterIndices<PointT>
   {
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
 
-      typedef boost::shared_ptr< FrustumCulling<PointT> > Ptr;
-      typedef boost::shared_ptr< const FrustumCulling<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<FrustumCulling<PointT> >;
+      using ConstPtr = boost::shared_ptr<const FrustumCulling<PointT> >;
 
 
       using Filter<PointT>::getClassName;

--- a/filters/include/pcl/filters/grid_minimum.h
+++ b/filters/include/pcl/filters/grid_minimum.h
@@ -67,7 +67,7 @@ namespace pcl
       using Filter<PointT>::input_;
       using Filter<PointT>::indices_;
 
-      typedef typename FilterIndices<PointT>::PointCloud PointCloud;
+      using PointCloud = typename FilterIndices<PointT>::PointCloud;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/impl/covariance_sampling.hpp
+++ b/filters/include/pcl/filters/impl/covariance_sampling.hpp
@@ -145,7 +145,7 @@ pcl::CovarianceSampling<PointT, PointNT>::applyFilter (std::vector<int> &sampled
     candidate_indices[p_i] = p_i;
 
   // Compute the v 6-vectors
-  typedef Eigen::Matrix<double, 6, 1> Vector6d;
+  using Vector6d = Eigen::Matrix<double, 6, 1>;
   std::vector<Vector6d, Eigen::aligned_allocator<Vector6d> > v;
   v.resize (candidate_indices.size ());
   for (size_t p_i = 0; p_i < candidate_indices.size (); ++p_i)

--- a/filters/include/pcl/filters/impl/model_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/model_outlier_removal.hpp
@@ -179,7 +179,7 @@ pcl::ModelOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &indices)
 
   valid_setup &= initSACModel (model_type_);
 
-  typedef SampleConsensusModelFromNormals<PointT, pcl::Normal> SACModelFromNormals;
+  using SACModelFromNormals = SampleConsensusModelFromNormals<PointT, pcl::Normal>;
   // Returns NULL if cast isn't possible
   SACModelFromNormals *model_from_normals = dynamic_cast<SACModelFromNormals *> (& (*model_));
 

--- a/filters/include/pcl/filters/local_maximum.h
+++ b/filters/include/pcl/filters/local_maximum.h
@@ -60,8 +60,8 @@ namespace pcl
   class LocalMaximum: public FilterIndices<PointT>
   {
     protected:
-      typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-      typedef typename pcl::search::Search<PointT>::Ptr SearcherPtr;
+      using PointCloud = typename FilterIndices<PointT>::PointCloud;
+      using SearcherPtr = typename pcl::search::Search<PointT>::Ptr;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/median_filter.h
+++ b/filters/include/pcl/filters/median_filter.h
@@ -60,7 +60,7 @@ namespace pcl
   class MedianFilter : public pcl::Filter<PointT>
   {
       using pcl::Filter<PointT>::input_;
-      typedef typename pcl::Filter<PointT>::PointCloud PointCloud;
+      using PointCloud = typename pcl::Filter<PointT>::PointCloud;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/model_outlier_removal.h
+++ b/filters/include/pcl/filters/model_outlier_removal.h
@@ -68,14 +68,14 @@ namespace pcl
   class ModelOutlierRemoval : public FilterIndices<PointT>
   {
     protected:
-      typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+      using PointCloud = typename FilterIndices<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      typedef pcl::PointCloud<pcl::Normal>::Ptr PointCloudNPtr;
-      typedef pcl::PointCloud<pcl::Normal>::ConstPtr PointCloudNConstPtr;
+      using PointCloudNPtr = pcl::PointCloud<pcl::Normal>::Ptr;
+      using PointCloudNConstPtr = pcl::PointCloud<pcl::Normal>::ConstPtr;
 
       /** \brief Constructor.
        * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).

--- a/filters/include/pcl/filters/normal_refinement.h
+++ b/filters/include/pcl/filters/normal_refinement.h
@@ -190,9 +190,9 @@ namespace pcl
     using Filter<NormalT>::filter_name_;
     using Filter<NormalT>::getClassName;
 
-    typedef typename Filter<NormalT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<NormalT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
       /** \brief Empty constructor, sets default convergence parameters

--- a/filters/include/pcl/filters/normal_space.h
+++ b/filters/include/pcl/filters/normal_space.h
@@ -59,15 +59,15 @@ namespace pcl
     using FilterIndices<PointT>::removed_indices_;
     using FilterIndices<PointT>::user_filter_value_;
 
-    typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-    typedef typename pcl::PointCloud<NormalT>::ConstPtr NormalsConstPtr;
+    using PointCloud = typename FilterIndices<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
+    using NormalsConstPtr = typename pcl::PointCloud<NormalT>::ConstPtr;
 
     public:
       
-      typedef boost::shared_ptr<NormalSpaceSampling<PointT, NormalT> > Ptr;
-      typedef boost::shared_ptr<const NormalSpaceSampling<PointT, NormalT> > ConstPtr;
+      using Ptr = boost::shared_ptr<NormalSpaceSampling<PointT, NormalT> >;
+      using ConstPtr = boost::shared_ptr<const NormalSpaceSampling<PointT, NormalT> >;
 
       /** \brief Empty constructor. */
       NormalSpaceSampling ()

--- a/filters/include/pcl/filters/passthrough.h
+++ b/filters/include/pcl/filters/passthrough.h
@@ -79,15 +79,15 @@ namespace pcl
   class PassThrough : public FilterIndices<PointT>
   {
     protected:
-      typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+      using PointCloud = typename FilterIndices<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
     public:
 
-      typedef boost::shared_ptr< PassThrough<PointT> > Ptr;
-      typedef boost::shared_ptr< const PassThrough<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PassThrough<PointT> >;
+      using ConstPtr = boost::shared_ptr<const PassThrough<PointT> >;
 
 
       /** \brief Constructor.
@@ -227,9 +227,9 @@ namespace pcl
   template<>
   class PCL_EXPORTS PassThrough<pcl::PCLPointCloud2> : public Filter<pcl::PCLPointCloud2>
   {
-    typedef pcl::PCLPointCloud2 PCLPointCloud2;
-    typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-    typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+    using PCLPointCloud2 = pcl::PCLPointCloud2;
+    using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+    using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
     using Filter<pcl::PCLPointCloud2>::removed_indices_;
     using Filter<pcl::PCLPointCloud2>::extract_removed_indices_;

--- a/filters/include/pcl/filters/plane_clipper3D.h
+++ b/filters/include/pcl/filters/plane_clipper3D.h
@@ -51,8 +51,8 @@ namespace pcl
   {
     public:
 
-      typedef boost::shared_ptr< PlaneClipper3D<PointT> > Ptr;
-      typedef boost::shared_ptr< const PlaneClipper3D<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr< PlaneClipper3D<PointT> >;
+      using ConstPtr = boost::shared_ptr< const PlaneClipper3D<PointT> >;
 
       /**
        * @author Suat Gedikli <gedikli@willowgarage.com>

--- a/filters/include/pcl/filters/project_inliers.h
+++ b/filters/include/pcl/filters/project_inliers.h
@@ -72,15 +72,15 @@ namespace pcl
     using Filter<PointT>::filter_name_;
     using Filter<PointT>::getClassName;
 
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
     public:
 
-      typedef boost::shared_ptr< ProjectInliers<PointT> > Ptr;
-      typedef boost::shared_ptr< const ProjectInliers<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ProjectInliers<PointT> >;
+      using ConstPtr = boost::shared_ptr<const ProjectInliers<PointT> >;
 
 
       /** \brief Empty constructor. */
@@ -180,11 +180,11 @@ namespace pcl
     using Filter<pcl::PCLPointCloud2>::filter_name_;
     using Filter<pcl::PCLPointCloud2>::getClassName;
 
-    typedef pcl::PCLPointCloud2 PCLPointCloud2;
-    typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-    typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+    using PCLPointCloud2 = pcl::PCLPointCloud2;
+    using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+    using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
-    typedef SampleConsensusModel<PointXYZ>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = SampleConsensusModel<PointXYZ>::Ptr;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/pyramid.h
+++ b/filters/include/pcl/filters/pyramid.h
@@ -61,10 +61,10 @@ namespace pcl
     class Pyramid
     {
       public:
-        typedef typename PointCloud<PointT>::Ptr PointCloudPtr;
-        typedef typename PointCloud<PointT>::ConstPtr PointCloudConstPtr;
-        typedef boost::shared_ptr< Pyramid<PointT> > Ptr;
-        typedef boost::shared_ptr< const Pyramid<PointT> > ConstPtr;
+        using PointCloudPtr = typename PointCloud<PointT>::Ptr;
+        using PointCloudConstPtr = typename PointCloud<PointT>::ConstPtr;
+        using Ptr = boost::shared_ptr< Pyramid<PointT> >;
+        using ConstPtr = boost::shared_ptr< const Pyramid<PointT> >;
  
         Pyramid (int levels = 4)
           : levels_ (levels)

--- a/filters/include/pcl/filters/radius_outlier_removal.h
+++ b/filters/include/pcl/filters/radius_outlier_removal.h
@@ -71,15 +71,15 @@ namespace pcl
   class RadiusOutlierRemoval : public FilterIndices<PointT>
   {
     protected:
-      typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::search::Search<PointT>::Ptr SearcherPtr;
+      using PointCloud = typename FilterIndices<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using SearcherPtr = typename pcl::search::Search<PointT>::Ptr;
 
     public:
 
-      typedef boost::shared_ptr< RadiusOutlierRemoval<PointT> > Ptr;
-      typedef boost::shared_ptr< const RadiusOutlierRemoval<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<RadiusOutlierRemoval<PointT> >;
+      using ConstPtr = boost::shared_ptr<const RadiusOutlierRemoval<PointT> >;
   
 
       /** \brief Constructor.
@@ -197,12 +197,12 @@ namespace pcl
     using Filter<pcl::PCLPointCloud2>::removed_indices_;
     using Filter<pcl::PCLPointCloud2>::extract_removed_indices_;
 
-    typedef pcl::search::Search<pcl::PointXYZ> KdTree;
-    typedef pcl::search::Search<pcl::PointXYZ>::Ptr KdTreePtr;
+    using KdTree = pcl::search::Search<pcl::PointXYZ>;
+    using KdTreePtr = pcl::search::Search<pcl::PointXYZ>::Ptr;
 
-    typedef pcl::PCLPointCloud2 PCLPointCloud2;
-    typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-    typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+    using PCLPointCloud2 = pcl::PCLPointCloud2;
+    using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+    using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/random_sample.h
+++ b/filters/include/pcl/filters/random_sample.h
@@ -64,14 +64,14 @@ namespace pcl
     using FilterIndices<PointT>::extract_removed_indices_;
     using FilterIndices<PointT>::removed_indices_;
 
-    typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename FilterIndices<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
 
-      typedef boost::shared_ptr< RandomSample<PointT> > Ptr;
-      typedef boost::shared_ptr< const RandomSample<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<RandomSample<PointT> >;
+      using ConstPtr = boost::shared_ptr<const RandomSample<PointT> >;
 
       /** \brief Empty constructor. */
       RandomSample (bool extract_removed_indices = false) : 
@@ -156,14 +156,14 @@ namespace pcl
     using FilterIndices<pcl::PCLPointCloud2>::filter_name_;
     using FilterIndices<pcl::PCLPointCloud2>::getClassName;
 
-    typedef pcl::PCLPointCloud2 PCLPointCloud2;
-    typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-    typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+    using PCLPointCloud2 = pcl::PCLPointCloud2;
+    using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+    using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
     public:
   
-      typedef boost::shared_ptr<RandomSample<pcl::PCLPointCloud2> > Ptr;
-      typedef boost::shared_ptr<const RandomSample<pcl::PCLPointCloud2> > ConstPtr;
+      using Ptr = boost::shared_ptr<RandomSample<pcl::PCLPointCloud2> >;
+      using ConstPtr = boost::shared_ptr<const RandomSample<pcl::PCLPointCloud2> >;
   
       /** \brief Empty constructor. */
       RandomSample () : sample_ (UINT_MAX), seed_ (static_cast<unsigned int> (time (nullptr)))

--- a/filters/include/pcl/filters/sampling_surface_normal.h
+++ b/filters/include/pcl/filters/sampling_surface_normal.h
@@ -58,16 +58,16 @@ namespace pcl
     using Filter<PointT>::indices_;
     using Filter<PointT>::input_;
 
-    typedef typename Filter<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-    typedef Eigen::Matrix<float, Eigen::Dynamic, 1> Vector;
+    using Vector = Eigen::Matrix<float, Eigen::Dynamic, 1>;
 
     public:
 
-      typedef boost::shared_ptr< SamplingSurfaceNormal<PointT> > Ptr;
-      typedef boost::shared_ptr< const SamplingSurfaceNormal<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SamplingSurfaceNormal<PointT> >;
+      using ConstPtr = boost::shared_ptr<const SamplingSurfaceNormal<PointT> >;
 
       /** \brief Empty constructor. */
       SamplingSurfaceNormal () : 

--- a/filters/include/pcl/filters/shadowpoints.h
+++ b/filters/include/pcl/filters/shadowpoints.h
@@ -61,15 +61,15 @@ namespace pcl
     using FilterIndices<PointT>::user_filter_value_;
     using FilterIndices<PointT>::keep_organized_;
 
-    typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-    typedef typename PointCloud::Ptr PointCloudPtr;
-    typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-    typedef typename pcl::PointCloud<NormalT>::Ptr NormalsPtr;
+    using PointCloud = typename FilterIndices<PointT>::PointCloud;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
+    using NormalsPtr = typename pcl::PointCloud<NormalT>::Ptr;
 
     public:
 
-      typedef boost::shared_ptr< ShadowPoints<PointT, NormalT> > Ptr;
-      typedef boost::shared_ptr< const ShadowPoints<PointT, NormalT> > ConstPtr;
+      using Ptr = boost::shared_ptr< ShadowPoints<PointT, NormalT> >;
+      using ConstPtr = boost::shared_ptr< const ShadowPoints<PointT, NormalT> >;
 
       /** \brief Empty constructor. */
       ShadowPoints (bool extract_removed_indices = false) : 

--- a/filters/include/pcl/filters/statistical_outlier_removal.h
+++ b/filters/include/pcl/filters/statistical_outlier_removal.h
@@ -80,15 +80,15 @@ namespace pcl
   class StatisticalOutlierRemoval : public FilterIndices<PointT>
   {
     protected:
-      typedef typename FilterIndices<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::search::Search<PointT>::Ptr SearcherPtr;
+      using PointCloud = typename FilterIndices<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using SearcherPtr = typename pcl::search::Search<PointT>::Ptr;
 
     public:
 
-      typedef boost::shared_ptr< StatisticalOutlierRemoval<PointT> > Ptr;
-      typedef boost::shared_ptr< const StatisticalOutlierRemoval<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<StatisticalOutlierRemoval<PointT> >;
+      using ConstPtr = boost::shared_ptr<const StatisticalOutlierRemoval<PointT> >;
 
 
       /** \brief Constructor.
@@ -205,12 +205,12 @@ namespace pcl
     using FilterIndices<pcl::PCLPointCloud2>::removed_indices_;
     using FilterIndices<pcl::PCLPointCloud2>::extract_removed_indices_;
 
-    typedef pcl::search::Search<pcl::PointXYZ> KdTree;
-    typedef pcl::search::Search<pcl::PointXYZ>::Ptr KdTreePtr;
+    using KdTree = pcl::search::Search<pcl::PointXYZ>;
+    using KdTreePtr = pcl::search::Search<pcl::PointXYZ>::Ptr;
 
-    typedef pcl::PCLPointCloud2 PCLPointCloud2;
-    typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-    typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+    using PCLPointCloud2 = pcl::PCLPointCloud2;
+    using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+    using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -60,7 +60,7 @@ namespace pcl
   template <typename PointT>
   class UniformSampling: public Filter<PointT>
   {
-    typedef typename Filter<PointT>::PointCloud PointCloud;
+    using PointCloud = typename Filter<PointT>::PointCloud;
 
     using Filter<PointT>::filter_name_;
     using Filter<PointT>::input_;
@@ -68,8 +68,8 @@ namespace pcl
     using Filter<PointT>::getClassName;
 
     public:
-      typedef boost::shared_ptr<UniformSampling<PointT> > Ptr;
-      typedef boost::shared_ptr<const UniformSampling<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<UniformSampling<PointT> >;
+      using ConstPtr = boost::shared_ptr<const UniformSampling<PointT> >;
 
       /** \brief Empty constructor. */
       UniformSampling (bool extract_removed_indices = false) :

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -182,14 +182,14 @@ namespace pcl
       using Filter<PointT>::input_;
       using Filter<PointT>::indices_;
 
-      typedef typename Filter<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = typename Filter<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
 
-      typedef boost::shared_ptr< VoxelGrid<PointT> > Ptr;
-      typedef boost::shared_ptr< const VoxelGrid<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<VoxelGrid<PointT> >;
+      using ConstPtr = boost::shared_ptr<const VoxelGrid<PointT> >;
 
       /** \brief Empty constructor. */
       VoxelGrid () :
@@ -485,7 +485,7 @@ namespace pcl
       /** \brief Minimum number of points per voxel for the centroid to be computed */
       unsigned int min_points_per_voxel_;
 
-      typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+      using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
       /** \brief Downsample a Point Cloud using a voxelized grid approach
         * \param[out] output the resultant point cloud message
@@ -512,9 +512,9 @@ namespace pcl
     using Filter<pcl::PCLPointCloud2>::filter_name_;
     using Filter<pcl::PCLPointCloud2>::getClassName;
 
-    typedef pcl::PCLPointCloud2 PCLPointCloud2;
-    typedef PCLPointCloud2::Ptr PCLPointCloud2Ptr;
-    typedef PCLPointCloud2::ConstPtr PCLPointCloud2ConstPtr;
+    using PCLPointCloud2 = pcl::PCLPointCloud2;
+    using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;
+    using PCLPointCloud2ConstPtr = PCLPointCloud2::ConstPtr;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -76,15 +76,15 @@ namespace pcl
       using VoxelGrid<PointT>::divb_mul_;
 
 
-      typedef typename pcl::traits::fieldList<PointT>::type FieldList;
-      typedef typename Filter<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using FieldList = typename pcl::traits::fieldList<PointT>::type;
+      using PointCloud = typename Filter<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
 
-      typedef boost::shared_ptr< VoxelGrid<PointT> > Ptr;
-      typedef boost::shared_ptr< const VoxelGrid<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<VoxelGrid<PointT> >;
+      using ConstPtr = boost::shared_ptr<const VoxelGrid<PointT> >;
 
 
       /** \brief Simple structure to hold a centroid, covarince and the number of points in a leaf.
@@ -186,10 +186,10 @@ namespace pcl
       };
 
       /** \brief Pointer to VoxelGridCovariance leaf structure */
-      typedef Leaf* LeafPtr;
+      using LeafPtr = Leaf *;
 
       /** \brief Const pointer to VoxelGridCovariance leaf structure */
-      typedef const Leaf* LeafConstPtr;
+      using LeafConstPtr = const Leaf *;
 
     public:
 

--- a/filters/include/pcl/filters/voxel_grid_label.h
+++ b/filters/include/pcl/filters/voxel_grid_label.h
@@ -51,8 +51,8 @@ namespace pcl
   {
     public:
 
-      typedef boost::shared_ptr< VoxelGridLabel > Ptr;
-      typedef boost::shared_ptr< const VoxelGridLabel > ConstPtr;
+      using Ptr = boost::shared_ptr<VoxelGridLabel>;
+      using ConstPtr = boost::shared_ptr<const VoxelGridLabel>;
 
 
       /** \brief Constructor.

--- a/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
+++ b/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
@@ -61,9 +61,9 @@ namespace pcl
       using VoxelGrid<PointT>::leaf_size_;
       using VoxelGrid<PointT>::inverse_leaf_size_;
 
-      typedef typename Filter<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = typename Filter<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
       /** \brief Empty constructor. */

--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -42,7 +42,7 @@
 #include <pcl/common/io.h>
 #include <pcl/filters/impl/voxel_grid.hpp>
 
-typedef Eigen::Array<size_t, 4, 1> Array4size_t;
+using Array4size_t = Eigen::Array<size_t, 4, 1>;
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 void


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`