### PR TITLE
Add registerCallback overload to pcl grabber to support assignment of  boost functions with templated signatures

### DIFF
--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -68,8 +68,20 @@ namespace pcl
         * \param[in] callback: the callback function/method
         * \return Connection object, that can be used to disconnect the callback method from the signal again.
         */
-      template<typename T> boost::signals2::connection 
+      template<typename T> boost::signals2::connection
       registerCallback (const std::function<T>& callback);
+
+      /** \brief registers a callback function/method to a signal with the corresponding signature
+        * \param[in] callback: the callback function/method
+        * \return Connection object, that can be used to disconnect the callback method from the signal again.
+        */
+      template<typename T, template<typename> class FunctionT>
+      [[deprecated ("please assign the callback to a std::function.")]]
+      boost::signals2::connection
+      registerCallback (const FunctionT<T>& callback)
+      {
+        return registerCallback (std::function<T> (callback));
+      }
 
       /** \brief indicates whether a signal with given parameter-type exists or not
         * \return true if signal exists, false otherwise


### PR DESCRIPTION
Design to support callback registration from  `boost::function` objects.

```cpp
#include <boost/function.hpp>
#include <boost/bind.hpp>

#include <functional>
#include <iostream>
#include <typeinfo>

struct Grabber
{
  std::set<std::string> registered_types_;

  template<typename T, template<typename> class FunctionT>
  [[deprecated ("Bind the callback to a std::function.")]] void
  registerCallback (const FunctionT<T>& cb)
  {
    registerCallback<T> (std::function<T> (cb));
  }

  template<typename T> void
  registerCallback (const std::function<T>& cb)
  {
    registered_types_.insert (typeid (T).name ());
  }
};


using Sig = void (int);

void
number (int n1, int n2)
{
  std::cout << "I am number " << n1 << " and " << n2 << std::endl;
}

int
main()
{
  boost::function<Sig> bf = boost::bind (number, _1, 2);
  std::function<Sig> sf = bf;

  auto lambda = [] (int n1) { return number (n1, 2); };

 
  Grabber gb;

 

  // FunctionT<T>
  gb.registerCallback (bf); // triggers deprecation warning
  gb.registerCallback (sf);
  // gb.registerCallback (boost::bind (number, _1, 2)); // doesn't compile
  gb.registerCallback<Sig> (boost::bind (number, _1, 2));
  // gb.registerCallback (std::bind (number, std::placeholders::_1, 2)); // doesn't compile
  gb.registerCallback<Sig> (std::bind (number, std::placeholders::_1, 2));
  // gb.registerCallback (lambda); // Doesn't compile
  gb.registerCallback<Sig> (lambda);
  return 0;
}
```