### PR TITLE
Use using instead of typedef [simulation, stereo, surface ]

### DIFF
--- a/simulation/include/pcl/simulation/camera.h
+++ b/simulation/include/pcl/simulation/camera.h
@@ -13,8 +13,8 @@ namespace pcl
     class PCL_EXPORTS Camera
     {
     public:
-      typedef boost::shared_ptr<Camera> Ptr;
-      typedef boost::shared_ptr<const Camera> ConstPtr;
+      using Ptr = boost::shared_ptr<Camera>;
+      using ConstPtr = boost::shared_ptr<const Camera>;
 
       Camera () : x_ (0), y_ (0), z_ (0), roll_ (0), pitch_ (0), yaw_ (0)
       {

--- a/simulation/include/pcl/simulation/glsl_shader.h
+++ b/simulation/include/pcl/simulation/glsl_shader.h
@@ -31,8 +31,8 @@ namespace pcl
       class PCL_EXPORTS Program
       {
         public:
-          typedef boost::shared_ptr<Program> Ptr;
-          typedef boost::shared_ptr<const Program> ConstPtr;
+          using Ptr = boost::shared_ptr<Program>;
+          using ConstPtr = boost::shared_ptr<const Program>;
 
           /**
            * Construct an empty shader program.

--- a/simulation/include/pcl/simulation/model.h
+++ b/simulation/include/pcl/simulation/model.h
@@ -27,13 +27,13 @@ namespace pcl
 {
   namespace simulation
   {
-    typedef struct _SinglePoly
+    struct SinglePoly
     {
       float* vertices_;
       float* colors_;
       GLenum mode_;
       GLuint nvertices_;
-    } SinglePoly;
+    };
 
     struct Vertex
     {
@@ -56,23 +56,23 @@ namespace pcl
       Eigen::Vector3f norm;
     };
 
-    typedef std::vector<Vertex> Vertices;
-    typedef std::vector<GLuint> Indices;
+    using Vertices = std::vector<Vertex>;
+    using Indices = std::vector<GLuint>;
 
     class Model
     {
       public:
         virtual void draw () = 0;
 
-        typedef boost::shared_ptr<Model> Ptr;
-        typedef boost::shared_ptr<const Model> ConstPtr;
+        using Ptr = boost::shared_ptr<Model>;
+        using ConstPtr = boost::shared_ptr<const Model>;
     };
 
     class PCL_EXPORTS TriangleMeshModel : public Model
     {
       public:
-        typedef boost::shared_ptr<TriangleMeshModel> Ptr;
-        typedef boost::shared_ptr<const TriangleMeshModel> ConstPtr;
+        using Ptr = boost::shared_ptr<TriangleMeshModel>;
+        using ConstPtr = boost::shared_ptr<const TriangleMeshModel>;
 
         TriangleMeshModel (pcl::PolygonMesh::Ptr plg);
 
@@ -97,8 +97,8 @@ namespace pcl
         virtual ~PolygonMeshModel();
         void draw() override;
 
-        typedef boost::shared_ptr<PolygonMeshModel> Ptr;
-        typedef boost::shared_ptr<const PolygonMeshModel> ConstPtr;
+        using Ptr = boost::shared_ptr<PolygonMeshModel>;
+        using ConstPtr = boost::shared_ptr<const PolygonMeshModel>;
       private:
         std::vector<SinglePoly> polygons;
 
@@ -120,8 +120,8 @@ namespace pcl
     class PCL_EXPORTS PointCloudModel : public Model
     {
       public:
-        typedef boost::shared_ptr<PointCloudModel> Ptr;
-        typedef boost::shared_ptr<const PointCloudModel> ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudModel>;
+        using ConstPtr = boost::shared_ptr<const PointCloudModel>;
 
         PointCloudModel (GLenum mode, pcl::PointCloud<pcl::PointXYZRGB>::Ptr pc);
 
@@ -185,8 +185,8 @@ namespace pcl
     class PCL_EXPORTS TexturedQuad
     {
       public:
-        typedef boost::shared_ptr<TexturedQuad> Ptr;
-        typedef boost::shared_ptr<const TexturedQuad> ConstPtr;
+        using Ptr = boost::shared_ptr<TexturedQuad>;
+        using ConstPtr = boost::shared_ptr<const TexturedQuad>;
 
         TexturedQuad (int width, int height);
         ~TexturedQuad ();

--- a/simulation/include/pcl/simulation/range_likelihood.h
+++ b/simulation/include/pcl/simulation/range_likelihood.h
@@ -30,8 +30,8 @@ namespace pcl
     class PCL_EXPORTS RangeLikelihood
     {
       public:
-        typedef boost::shared_ptr<RangeLikelihood> Ptr;
-        typedef boost::shared_ptr<const RangeLikelihood> ConstPtr;
+        using Ptr = boost::shared_ptr<RangeLikelihood>;
+        using ConstPtr = boost::shared_ptr<const RangeLikelihood>;
 
       public:
         /**

--- a/simulation/include/pcl/simulation/scene.h
+++ b/simulation/include/pcl/simulation/scene.h
@@ -22,8 +22,8 @@ namespace pcl
     class PCL_EXPORTS Scene
     {
     public:
-      typedef boost::shared_ptr<Scene> Ptr;
-      typedef boost::shared_ptr<Scene> ConstPtr;
+      using Ptr = boost::shared_ptr<Scene>;
+      using ConstPtr = boost::shared_ptr<Scene>;
 
       void
       draw ();

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -106,13 +106,13 @@ using namespace pcl::simulation;
 
 using namespace std;
 
-typedef pcl::visualization::PointCloudColorHandler<pcl::PCLPointCloud2> ColorHandler;
-typedef ColorHandler::Ptr ColorHandlerPtr;
-typedef ColorHandler::ConstPtr ColorHandlerConstPtr;
+using ColorHandler = pcl::visualization::PointCloudColorHandler<pcl::PCLPointCloud2>;
+using ColorHandlerPtr = ColorHandler::Ptr;
+using ColorHandlerConstPtr = ColorHandler::ConstPtr;
 
-typedef pcl::visualization::PointCloudGeometryHandler<pcl::PCLPointCloud2> GeometryHandler;
-typedef GeometryHandler::Ptr GeometryHandlerPtr;
-typedef GeometryHandler::ConstPtr GeometryHandlerConstPtr;
+using GeometryHandler = pcl::visualization::PointCloudGeometryHandler<pcl::PCLPointCloud2>;
+using GeometryHandlerPtr = GeometryHandler::Ptr;
+using GeometryHandlerConstPtr = GeometryHandler::ConstPtr;
 
 #define NORMALS_SCALE 0.01
 #define PC_SCALE 0.001

--- a/simulation/tools/simulation_io.hpp
+++ b/simulation/tools/simulation_io.hpp
@@ -37,8 +37,8 @@ namespace pcl
     class PCL_EXPORTS SimExample
     {
       public:
-        typedef boost::shared_ptr<SimExample> Ptr;
-        typedef boost::shared_ptr<const SimExample> ConstPtr;
+        using Ptr = boost::shared_ptr<SimExample>;
+        using ConstPtr = boost::shared_ptr<const SimExample>;
     	
         SimExample (int argc, char** argv,
     		int height,int width);

--- a/stereo/include/pcl/stereo/disparity_map_converter.h
+++ b/stereo/include/pcl/stereo/disparity_map_converter.h
@@ -77,7 +77,7 @@ namespace pcl
   class DisparityMapConverter
   {
     protected:
-      typedef pcl::PointCloud<PointT> PointCloud;
+      using PointCloud = pcl::PointCloud<PointT>;
 
     public:
       /** \brief DisparityMapConverter constructor. */

--- a/surface/include/pcl/surface/bilateral_upsampling.h
+++ b/surface/include/pcl/surface/bilateral_upsampling.h
@@ -70,7 +70,7 @@ namespace pcl
       using PCLBase<PointInT>::deinitCompute;
       using CloudSurfaceProcessing<PointInT, PointOutT>::process;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
 
       Eigen::Matrix3f KinectVGAProjectionMatrix, KinectSXGAProjectionMatrix;
 

--- a/surface/include/pcl/surface/concave_hull.h
+++ b/surface/include/pcl/surface/concave_hull.h
@@ -55,8 +55,8 @@ namespace pcl
   class ConcaveHull : public MeshConstruction<PointInT>
   {
     protected:
-      typedef boost::shared_ptr<ConcaveHull<PointInT> > Ptr;
-      typedef boost::shared_ptr<const ConcaveHull<PointInT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ConcaveHull<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const ConcaveHull<PointInT> >;
 
       using PCLBase<PointInT>::input_;
       using PCLBase<PointInT>::indices_;
@@ -66,9 +66,9 @@ namespace pcl
     public:
       using MeshConstruction<PointInT>::reconstruct;
 
-      typedef pcl::PointCloud<PointInT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointInT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       /** \brief Empty constructor. */
       ConcaveHull () : alpha_ (0), keep_information_ (false), voronoi_centers_ (), dim_(0)

--- a/surface/include/pcl/surface/convex_hull.h
+++ b/surface/include/pcl/surface/convex_hull.h
@@ -77,14 +77,14 @@ namespace pcl
       using PCLBase<PointInT>::deinitCompute;
 
     public:
-      typedef boost::shared_ptr<ConvexHull<PointInT> > Ptr;
-      typedef boost::shared_ptr<const ConvexHull<PointInT> > ConstPtr;
+      using Ptr = boost::shared_ptr<ConvexHull<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const ConvexHull<PointInT> >;
 
       using MeshConstruction<PointInT>::reconstruct;
 
-      typedef pcl::PointCloud<PointInT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointInT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       /** \brief Empty constructor. */
       ConvexHull () : compute_area_ (false), total_area_ (0), total_volume_ (0), dimension_ (0), 

--- a/surface/include/pcl/surface/ear_clipping.h
+++ b/surface/include/pcl/surface/ear_clipping.h
@@ -52,8 +52,8 @@ namespace pcl
   class PCL_EXPORTS EarClipping : public MeshProcessing
   {
     public:
-      typedef boost::shared_ptr<EarClipping> Ptr;
-      typedef boost::shared_ptr<const EarClipping> ConstPtr;
+      using Ptr = boost::shared_ptr<EarClipping>;
+      using ConstPtr = boost::shared_ptr<const EarClipping>;
 
       using MeshProcessing::input_mesh_;
       using MeshProcessing::initCompute;

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -136,19 +136,19 @@ namespace pcl
   class GreedyProjectionTriangulation : public MeshConstruction<PointInT>
   {
     public:
-      typedef boost::shared_ptr<GreedyProjectionTriangulation<PointInT> > Ptr;
-      typedef boost::shared_ptr<const GreedyProjectionTriangulation<PointInT> > ConstPtr;
+      using Ptr = boost::shared_ptr<GreedyProjectionTriangulation<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const GreedyProjectionTriangulation<PointInT> >;
 
       using MeshConstruction<PointInT>::tree_;
       using MeshConstruction<PointInT>::input_;
       using MeshConstruction<PointInT>::indices_;
 
-      typedef pcl::KdTree<PointInT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::KdTree<PointInT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename PointCloudIn::Ptr PointCloudInPtr;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudInPtr = typename PointCloudIn::Ptr;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
       enum GP3Type
       { 

--- a/surface/include/pcl/surface/grid_projection.h
+++ b/surface/include/pcl/surface/grid_projection.h
@@ -73,16 +73,16 @@ namespace pcl
   class GridProjection : public SurfaceReconstruction<PointNT>
   {
     public:
-      typedef boost::shared_ptr<GridProjection<PointNT> > Ptr;
-      typedef boost::shared_ptr<const GridProjection<PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<GridProjection<PointNT> >;
+      using ConstPtr = boost::shared_ptr<const GridProjection<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;
 
-      typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
+      using PointCloudPtr = typename pcl::PointCloud<PointNT>::Ptr;
 
-      typedef pcl::KdTree<PointNT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::KdTree<PointNT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
       /** \brief Data leaf. */
       struct Leaf

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -150,7 +150,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::process (PointCloudOut &output)
 
     for (size_t i = 0; i < output.size (); ++i)
     {
-      typedef typename pcl::traits::fieldList<PointOutT>::type FieldList;
+      using FieldList = typename pcl::traits::fieldList<PointOutT>::type;
       pcl::for_each_type<FieldList> (SetIfFieldExists<PointOutT, float> (output.points[i], "normal_x", normals_->points[i].normal_x));
       pcl::for_each_type<FieldList> (SetIfFieldExists<PointOutT, float> (output.points[i], "normal_y", normals_->points[i].normal_y));
       pcl::for_each_type<FieldList> (SetIfFieldExists<PointOutT, float> (output.points[i], "normal_z", normals_->points[i].normal_z));

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -362,16 +362,16 @@ namespace pcl
   class MarchingCubes : public SurfaceReconstruction<PointNT>
   {
     public:
-      typedef boost::shared_ptr<MarchingCubes<PointNT> > Ptr;
-      typedef boost::shared_ptr<const MarchingCubes<PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<MarchingCubes<PointNT> >;
+      using ConstPtr = boost::shared_ptr<const MarchingCubes<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;
 
-      typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
+      using PointCloudPtr = typename pcl::PointCloud<PointNT>::Ptr;
 
-      typedef pcl::KdTree<PointNT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::KdTree<PointNT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
       /** \brief Constructor. */
       MarchingCubes (const float percentage_extend_grid = 0.0f,

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -51,8 +51,8 @@ namespace pcl
   class MarchingCubesHoppe : public MarchingCubes<PointNT>
   {
     public:
-      typedef boost::shared_ptr<MarchingCubesHoppe<PointNT> > Ptr;
-      typedef boost::shared_ptr<const MarchingCubesHoppe<PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<MarchingCubesHoppe<PointNT> >;
+      using ConstPtr = boost::shared_ptr<const MarchingCubesHoppe<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;
@@ -64,10 +64,10 @@ namespace pcl
       using MarchingCubes<PointNT>::upper_boundary_;
       using MarchingCubes<PointNT>::lower_boundary_;
 
-      typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
+      using PointCloudPtr = typename pcl::PointCloud<PointNT>::Ptr;
 
-      typedef pcl::KdTree<PointNT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::KdTree<PointNT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
 
       /** \brief Constructor. */

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -53,8 +53,8 @@ namespace pcl
   class MarchingCubesRBF : public MarchingCubes<PointNT>
   {
     public:
-      typedef boost::shared_ptr<MarchingCubesRBF<PointNT> > Ptr;
-      typedef boost::shared_ptr<const MarchingCubesRBF<PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<MarchingCubesRBF<PointNT> >;
+      using ConstPtr = boost::shared_ptr<const MarchingCubesRBF<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;
@@ -66,10 +66,10 @@ namespace pcl
       using MarchingCubes<PointNT>::upper_boundary_;
       using MarchingCubes<PointNT>::lower_boundary_;
 
-      typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
+      using PointCloudPtr = typename pcl::PointCloud<PointNT>::Ptr;
 
-      typedef pcl::KdTree<PointNT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::KdTree<PointNT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
 
       /** \brief Constructor. */

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -260,20 +260,20 @@ namespace pcl
       using PCLBase<PointInT>::initCompute;
       using PCLBase<PointInT>::deinitCompute;
 
-      typedef pcl::search::Search<PointInT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
-      typedef pcl::PointCloud<pcl::Normal> NormalCloud;
-      typedef NormalCloud::Ptr NormalCloudPtr;
+      using KdTree = pcl::search::Search<PointInT>;
+      using KdTreePtr = typename KdTree::Ptr;
+      using NormalCloud = pcl::PointCloud<pcl::Normal>;
+      using NormalCloudPtr = NormalCloud::Ptr;
 
-      typedef pcl::PointCloud<PointOutT> PointCloudOut;
-      typedef typename PointCloudOut::Ptr PointCloudOutPtr;
-      typedef typename PointCloudOut::ConstPtr PointCloudOutConstPtr;
+      using PointCloudOut = pcl::PointCloud<PointOutT>;
+      using PointCloudOutPtr = typename PointCloudOut::Ptr;
+      using PointCloudOutConstPtr = typename PointCloudOut::ConstPtr;
 
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
-      typedef typename PointCloudIn::Ptr PointCloudInPtr;
-      typedef typename PointCloudIn::ConstPtr PointCloudInConstPtr;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
+      using PointCloudInPtr = typename PointCloudIn::Ptr;
+      using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
 
-      typedef std::function<int (int, double, std::vector<int> &, std::vector<float> &)> SearchMethod;
+      using SearchMethod = std::function<int (int, double, std::vector<int> &, std::vector<float> &)>;
 
       enum UpsamplingMethod
       {

--- a/surface/include/pcl/surface/organized_fast_mesh.h
+++ b/surface/include/pcl/surface/organized_fast_mesh.h
@@ -64,15 +64,15 @@ namespace pcl
   class OrganizedFastMesh : public MeshConstruction<PointInT>
   {
     public:
-      typedef boost::shared_ptr<OrganizedFastMesh<PointInT> > Ptr;
-      typedef boost::shared_ptr<const OrganizedFastMesh<PointInT> > ConstPtr;
+      using Ptr = boost::shared_ptr<OrganizedFastMesh<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const OrganizedFastMesh<PointInT> >;
 
       using MeshConstruction<PointInT>::input_;
       using MeshConstruction<PointInT>::check_tree_;
 
-      typedef typename pcl::PointCloud<PointInT>::Ptr PointCloudPtr;
+      using PointCloudPtr = typename pcl::PointCloud<PointInT>::Ptr;
 
-      typedef std::vector<pcl::Vertices> Polygons;
+      using Polygons = std::vector<pcl::Vertices>;
 
       enum TriangulationType
       {

--- a/surface/include/pcl/surface/poisson.h
+++ b/surface/include/pcl/surface/poisson.h
@@ -59,16 +59,16 @@ namespace pcl
   class Poisson : public SurfaceReconstruction<PointNT>
   {
     public:
-      typedef boost::shared_ptr<Poisson<PointNT> > Ptr;
-      typedef boost::shared_ptr<const Poisson<PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<Poisson<PointNT> >;
+      using ConstPtr = boost::shared_ptr<const Poisson<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;
 
-      typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudPtr;
+      using PointCloudPtr = typename pcl::PointCloud<PointNT>::Ptr;
 
-      typedef pcl::KdTree<PointNT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::KdTree<PointNT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
       /** \brief Constructor that sets all the parameters to working default values. */
       Poisson ();

--- a/surface/include/pcl/surface/processing.h
+++ b/surface/include/pcl/surface/processing.h
@@ -93,10 +93,10 @@ namespace pcl
   class PCL_EXPORTS MeshProcessing
   {
     public:
-      typedef boost::shared_ptr<MeshProcessing> Ptr;
-      typedef boost::shared_ptr<const MeshProcessing> ConstPtr;
+      using Ptr = boost::shared_ptr<MeshProcessing>;
+      using ConstPtr = boost::shared_ptr<const MeshProcessing>;
 
-      typedef PolygonMesh::ConstPtr PolygonMeshConstPtr;
+      using PolygonMeshConstPtr = PolygonMesh::ConstPtr;
 
       /** \brief Constructor. */
       MeshProcessing () {}

--- a/surface/include/pcl/surface/reconstruction.h
+++ b/surface/include/pcl/surface/reconstruction.h
@@ -60,11 +60,11 @@ namespace pcl
   class PCLSurfaceBase: public PCLBase<PointInT>
   {
     public:
-      typedef boost::shared_ptr<PCLSurfaceBase<PointInT> > Ptr;
-      typedef boost::shared_ptr<const PCLSurfaceBase<PointInT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PCLSurfaceBase<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const PCLSurfaceBase<PointInT> >;
 
-      typedef pcl::search::Search<PointInT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::search::Search<PointInT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
       /** \brief Empty constructor. */
       PCLSurfaceBase () : tree_ () {}
@@ -118,8 +118,8 @@ namespace pcl
   class SurfaceReconstruction: public PCLSurfaceBase<PointInT>
   {
     public:
-      typedef boost::shared_ptr<SurfaceReconstruction<PointInT> > Ptr;
-      typedef boost::shared_ptr<const SurfaceReconstruction<PointInT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SurfaceReconstruction<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const SurfaceReconstruction<PointInT> >;
 
       using PCLSurfaceBase<PointInT>::input_;
       using PCLSurfaceBase<PointInT>::indices_;
@@ -187,8 +187,8 @@ namespace pcl
   class MeshConstruction: public PCLSurfaceBase<PointInT>
   {
     public:
-      typedef boost::shared_ptr<MeshConstruction<PointInT> > Ptr;
-      typedef boost::shared_ptr<const MeshConstruction<PointInT> > ConstPtr;
+      using Ptr = boost::shared_ptr<MeshConstruction<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const MeshConstruction<PointInT> >;
 
       using PCLSurfaceBase<PointInT>::input_;
       using PCLSurfaceBase<PointInT>::indices_;

--- a/surface/include/pcl/surface/simplification_remove_unused_vertices.h
+++ b/surface/include/pcl/surface/simplification_remove_unused_vertices.h
@@ -48,8 +48,8 @@ namespace pcl
     class PCL_EXPORTS SimplificationRemoveUnusedVertices
     {
       public:
-        typedef boost::shared_ptr<SimplificationRemoveUnusedVertices> Ptr;
-        typedef boost::shared_ptr<const SimplificationRemoveUnusedVertices> ConstPtr;
+        using Ptr = boost::shared_ptr<SimplificationRemoveUnusedVertices>;
+        using ConstPtr = boost::shared_ptr<const SimplificationRemoveUnusedVertices>;
 
         /** \brief Constructor. */
         SimplificationRemoveUnusedVertices () {};

--- a/surface/include/pcl/surface/surfel_smoothing.h
+++ b/surface/include/pcl/surface/surfel_smoothing.h
@@ -52,12 +52,12 @@ namespace pcl
       typedef boost::shared_ptr<SurfelSmoothing<PointT, PointNT> > Ptr;
       typedef boost::shared_ptr<const SurfelSmoothing<PointT, PointNT> > ConstPtr;
 
-      typedef pcl::PointCloud<PointT> PointCloudIn;
-      typedef typename pcl::PointCloud<PointT>::Ptr PointCloudInPtr;
-      typedef pcl::PointCloud<PointNT> NormalCloud;
-      typedef typename pcl::PointCloud<PointNT>::Ptr NormalCloudPtr;
-      typedef pcl::search::Search<PointT> CloudKdTree;
-      typedef typename pcl::search::Search<PointT>::Ptr CloudKdTreePtr;
+      using PointCloudIn = pcl::PointCloud<PointT>;
+      using PointCloudInPtr = typename pcl::PointCloud<PointT>::Ptr;
+      using NormalCloud = pcl::PointCloud<PointNT>;
+      using NormalCloudPtr = typename pcl::PointCloud<PointNT>::Ptr;
+      using CloudKdTree = pcl::search::Search<PointT>;
+      using CloudKdTreePtr = typename pcl::search::Search<PointT>::Ptr;
 
       SurfelSmoothing (float a_scale = 0.01)
         : PCLBase<PointT> ()

--- a/surface/include/pcl/surface/texture_mapping.h
+++ b/surface/include/pcl/surface/texture_mapping.h
@@ -85,7 +85,7 @@ namespace pcl
       int idx_face; // Face corresponding to that projection
     };
     
-    typedef std::vector<Camera, Eigen::aligned_allocator<Camera> > CameraVector;
+    using CameraVector = std::vector<Camera, Eigen::aligned_allocator<Camera> >;
     
   }
   
@@ -98,19 +98,19 @@ namespace pcl
   {
     public:
      
-      typedef boost::shared_ptr< TextureMapping < PointInT > > Ptr;
-      typedef boost::shared_ptr< const TextureMapping < PointInT > > ConstPtr;
+      using Ptr = boost::shared_ptr<TextureMapping<PointInT> >;
+      using ConstPtr = boost::shared_ptr<const TextureMapping<PointInT> >;
 
-      typedef pcl::PointCloud<PointInT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointInT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef pcl::octree::OctreePointCloudSearch<PointInT> Octree;
-      typedef typename Octree::Ptr OctreePtr;
-      typedef typename Octree::ConstPtr OctreeConstPtr;
+      using Octree = pcl::octree::OctreePointCloudSearch<PointInT>;
+      using OctreePtr = typename Octree::Ptr;
+      using OctreeConstPtr = typename Octree::ConstPtr;
       
-      typedef pcl::texture_mapping::Camera Camera;
-      typedef pcl::texture_mapping::UvIndex UvIndex;
+      using Camera = pcl::texture_mapping::Camera;
+      using UvIndex = pcl::texture_mapping::UvIndex;
 
       /** \brief Constructor. */
       TextureMapping () :

--- a/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
@@ -5898,7 +5898,7 @@ static int compare3dPoint( const ON_3dPoint* a, const ON_3dPoint* b )
   return 0;
 }
 
-typedef int (*ON_COMPAR_LPVOID_LPVOID)(const void*,const void*);
+using ON_COMPAR_LPVOID_LPVOID = int (*)(const void *, const void *);
 
 static 
 int GetPointMap( int pt_count, const ON_3fPoint* fV, const ON_3dPoint* dV, ON_SimpleArray<int>& pt_map )

--- a/surface/src/3rdparty/opennurbs/opennurbs_mesh_tools.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_mesh_tools.cpp
@@ -186,7 +186,7 @@ public:
   int newvi;
 };
 
-typedef int (*QSORTCMPFUNC)(const void*,const void*);
+using QSORTCMPFUNC = int (*)(const void *, const void *);
 
 static int CompareMESHEDGE( const ON__MESHEDGE* a, const ON__MESHEDGE* b )
 {

--- a/surface/src/3rdparty/opennurbs/opennurbs_rtree.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_rtree.cpp
@@ -43,7 +43,7 @@ struct ON_RTreePartitionVars
   double m_coverSplitArea;
 }; 
 
-typedef bool (*ON_RTreeSearchCallback)(void* a_context, ON__INT_PTR a_id );
+using ON_RTreeSearchCallback = bool (*)(void *, ON__INT_PTR);
 
 struct ON_RTreeSearchResultCallback
 {
@@ -1158,7 +1158,7 @@ bool ON_RTree::Search(
   return true;
 }
 
-typedef void (*ON_RTreePairSearchCallback)(void*, ON__INT_PTR, ON__INT_PTR);
+using ON_RTreePairSearchCallback = void (*)(void *, ON__INT_PTR, ON__INT_PTR);
 
 struct ON_RTreePairSearchCallbackResult
 {
@@ -1167,7 +1167,7 @@ struct ON_RTreePairSearchCallbackResult
   ON_RTreePairSearchCallback m_resultCallback;
 };
 
-typedef bool (*ON_RTreePairSearchCallbackBool)(void*, ON__INT_PTR, ON__INT_PTR);
+using ON_RTreePairSearchCallbackBool = bool (*)(void *, ON__INT_PTR, ON__INT_PTR);
 
 struct ON_RTreePairSearchCallbackResultBool
 {


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`