### PR TITLE
Use using instead of typedef [segmentation]

### DIFF
--- a/segmentation/include/pcl/segmentation/approximate_progressive_morphological_filter.h
+++ b/segmentation/include/pcl/segmentation/approximate_progressive_morphological_filter.h
@@ -57,7 +57,7 @@ namespace pcl
   {
     public:
 
-      typedef pcl::PointCloud <PointT> PointCloud;
+      using PointCloud = pcl::PointCloud<PointT>;
 
       using PCLBase <PointT>::input_;
       using PCLBase <PointT>::indices_;

--- a/segmentation/include/pcl/segmentation/comparator.h
+++ b/segmentation/include/pcl/segmentation/comparator.h
@@ -52,12 +52,12 @@ namespace pcl
   class Comparator
   {
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef boost::shared_ptr<Comparator<PointT> > Ptr;
-      typedef boost::shared_ptr<const Comparator<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<Comparator<PointT> >;
+      using ConstPtr = boost::shared_ptr<const Comparator<PointT> >;
 
       /** \brief Empty constructor for comparator. */
       Comparator () : input_ ()

--- a/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
+++ b/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
@@ -44,8 +44,8 @@
 
 namespace pcl
 {
-  typedef std::vector<pcl::PointIndices> IndicesClusters;
-  typedef boost::shared_ptr<std::vector<pcl::PointIndices> > IndicesClustersPtr;
+  using IndicesClusters = std::vector<pcl::PointIndices>;
+  using IndicesClustersPtr = boost::shared_ptr<std::vector<pcl::PointIndices> >;
 
   /** \brief @b ConditionalEuclideanClustering performs segmentation based on Euclidean distance and a user-defined clustering condition.
     * \details The condition that need to hold is currently passed using a function pointer.
@@ -82,7 +82,7 @@ namespace pcl
   class ConditionalEuclideanClustering : public PCLBase<PointT>
   {
     protected:
-      typedef typename pcl::search::Search<PointT>::Ptr SearcherPtr;
+      using SearcherPtr = typename pcl::search::Search<PointT>::Ptr;
 
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;

--- a/segmentation/include/pcl/segmentation/cpc_segmentation.h
+++ b/segmentation/include/pcl/segmentation/cpc_segmentation.h
@@ -66,11 +66,11 @@ namespace pcl
   template <typename PointT>
   class CPCSegmentation : public LCCPSegmentation<PointT>
   {
-      typedef PointXYZINormal WeightSACPointType;
-      typedef LCCPSegmentation<PointT> LCCP;
+      using WeightSACPointType = PointXYZINormal;
+      using LCCP = LCCPSegmentation<PointT>;
       // LCCP typedefs
-      typedef typename LCCP::EdgeID EdgeID;
-      typedef typename LCCP::EdgeIterator EdgeIterator;
+      using EdgeID = typename LCCP::EdgeID;
+      using EdgeIterator = typename LCCP::EdgeIterator;
       // LCCP methods
       using LCCP::calculateConvexConnections;
       using LCCP::applyKconvexity;
@@ -174,11 +174,11 @@ namespace pcl
       
       class WeightedRandomSampleConsensus : public SampleConsensus<WeightSACPointType>
       {
-          typedef SampleConsensusModel<WeightSACPointType>::Ptr SampleConsensusModelPtr;
+          using SampleConsensusModelPtr = SampleConsensusModel<WeightSACPointType>::Ptr;
 
         public:
-          typedef boost::shared_ptr<WeightedRandomSampleConsensus> Ptr;
-          typedef boost::shared_ptr<const WeightedRandomSampleConsensus> ConstPtr;
+          using Ptr = boost::shared_ptr<WeightedRandomSampleConsensus>;
+          using ConstPtr = boost::shared_ptr<const WeightedRandomSampleConsensus>;
 
           /** \brief WeightedRandomSampleConsensus (Weighted RAndom SAmple Consensus) main constructor
             * \param[in] model a Sample Consensus model

--- a/segmentation/include/pcl/segmentation/crf_segmentation.h
+++ b/segmentation/include/pcl/segmentation/crf_segmentation.h
@@ -58,7 +58,7 @@ namespace pcl
   {
     public:
 
-    //typedef boost::shared_ptr<std::vector<int> > pcl::IndicesPtr;
+    //using pcl::IndicesPtr = boost::shared_ptr<std::vector<int> >;
     
 
       /** \brief Constructor that sets default values for member variables. */

--- a/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
@@ -54,15 +54,15 @@ namespace pcl
   class EdgeAwarePlaneComparator: public PlaneCoefficientComparator<PointT, PointNT>
   {
     public:
-      typedef typename Comparator<PointT>::PointCloud PointCloud;
-      typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename Comparator<PointT>::PointCloud;
+      using PointCloudConstPtr = typename Comparator<PointT>::PointCloudConstPtr;
       
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      typedef boost::shared_ptr<EdgeAwarePlaneComparator<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr<const EdgeAwarePlaneComparator<PointT, PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<EdgeAwarePlaneComparator<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr<const EdgeAwarePlaneComparator<PointT, PointNT> >;
 
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -58,16 +58,16 @@ namespace pcl
         using typename Comparator<PointT>::PointCloud;
         using typename Comparator<PointT>::PointCloudConstPtr;
 
-        typedef pcl::PointCloud<PointLT> PointCloudL;
-        typedef typename PointCloudL::Ptr PointCloudLPtr;
-        typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+        using PointCloudL = pcl::PointCloud<PointLT>;
+        using PointCloudLPtr = typename PointCloudL::Ptr;
+        using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
-        typedef boost::shared_ptr<EuclideanClusterComparator<PointT, PointLT> > Ptr;
-        typedef boost::shared_ptr<const EuclideanClusterComparator<PointT, PointLT> > ConstPtr;
+        using Ptr = boost::shared_ptr<EuclideanClusterComparator<PointT, PointLT> >;
+        using ConstPtr = boost::shared_ptr<const EuclideanClusterComparator<PointT, PointLT> >;
 
-        typedef std::set<uint32_t> ExcludeLabelSet;
-        typedef boost::shared_ptr<ExcludeLabelSet> ExcludeLabelSetPtr;
-        typedef boost::shared_ptr<const ExcludeLabelSet> ExcludeLabelSetConstPtr;
+        using ExcludeLabelSet = std::set<uint32_t>;
+        using ExcludeLabelSetPtr = boost::shared_ptr<ExcludeLabelSet>;
+        using ExcludeLabelSetConstPtr = boost::shared_ptr<const ExcludeLabelSet>;
 
         /** \brief Default constructor for EuclideanClusterComparator. */
         EuclideanClusterComparator ()
@@ -200,12 +200,12 @@ namespace pcl
 
     public:
 
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      typedef boost::shared_ptr<EuclideanClusterComparator<PointT, PointNT, PointLT> > Ptr;
-      typedef boost::shared_ptr<const EuclideanClusterComparator<PointT, PointNT, PointLT> > ConstPtr;
+      using Ptr = boost::shared_ptr<EuclideanClusterComparator<PointT, PointNT, PointLT> >;
+      using ConstPtr = boost::shared_ptr<const EuclideanClusterComparator<PointT, PointNT, PointLT> >;
 
       using experimental::EuclideanClusterComparator<PointT, PointLT>::setExcludeLabels;
 

--- a/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
@@ -54,14 +54,14 @@ namespace pcl
   class EuclideanPlaneCoefficientComparator: public PlaneCoefficientComparator<PointT, PointNT>
   {
     public:
-      typedef typename Comparator<PointT>::PointCloud PointCloud;
-      typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloud = typename Comparator<PointT>::PointCloud;
+      using PointCloudConstPtr = typename Comparator<PointT>::PointCloudConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      typedef boost::shared_ptr<EuclideanPlaneCoefficientComparator<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr<const EuclideanPlaneCoefficientComparator<PointT, PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<EuclideanPlaneCoefficientComparator<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr<const EuclideanPlaneCoefficientComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;

--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -293,18 +293,18 @@ namespace pcl
   template <typename PointT>
   class EuclideanClusterExtraction: public PCLBase<PointT>
   {
-    typedef PCLBase<PointT> BasePCLBase;
+    using BasePCLBase = PCLBase<PointT>;
 
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef pcl::search::Search<PointT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::search::Search<PointT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       /** \brief Empty constructor. */

--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -69,18 +69,18 @@ namespace pcl
   template <typename PointT>
   class LabeledEuclideanClusterExtraction: public PCLBase<PointT>
   {
-    typedef PCLBase<PointT> BasePCLBase;
+    using BasePCLBase = PCLBase<PointT>;
 
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef pcl::search::Search<PointT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::search::Search<PointT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       /** \brief Empty constructor. */

--- a/segmentation/include/pcl/segmentation/extract_polygonal_prism_data.h
+++ b/segmentation/include/pcl/segmentation/extract_polygonal_prism_data.h
@@ -106,12 +106,12 @@ namespace pcl
     using PCLBase<PointT>::deinitCompute;
 
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       /** \brief Empty constructor. */
       ExtractPolygonalPrismData () : planar_hull_ (), min_pts_hull_ (3), 

--- a/segmentation/include/pcl/segmentation/grabcut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/grabcut_segmentation.h
@@ -60,8 +60,8 @@ namespace pcl
       class PCL_EXPORTS BoykovKolmogorov
       {
         public:
-          typedef int vertex_descriptor;
-          typedef double edge_capacity_type;
+          using vertex_descriptor = int;
+          using edge_capacity_type = double;
 
           /// construct a maxflow/mincut problem with estimated max_nodes
           BoykovKolmogorov (std::size_t max_nodes = 0);
@@ -113,11 +113,11 @@ namespace pcl
 
         protected:
           /// tree states
-          typedef enum { FREE = 0x00, SOURCE = 0x01, TARGET = 0x02 } nodestate;
+          enum nodestate { FREE = 0x00, SOURCE = 0x01, TARGET = 0x02 };
           /// capacitated edge
-          typedef std::map<int, double> capacitated_edge;
+          using capacitated_edge = std::map<int, double>;
           /// edge pair
-          typedef std::pair<capacitated_edge::iterator, capacitated_edge::iterator> edge_pair;
+          using edge_pair = std::pair<capacitated_edge::iterator, capacitated_edge::iterator>;
           /// pre-augment s-u-t and s-u-v-t paths
           void
           preAugmentPaths ();
@@ -184,7 +184,7 @@ namespace pcl
         float r, g, b;
       };
       /// An Image is a point cloud of Color
-      typedef pcl::PointCloud<Color> Image;
+      using Image = pcl::PointCloud<Color>;
       /** \brief Compute squared distance between two colors
        * \param[in] c1 first color
        * \param[in] c2 second color
@@ -317,10 +317,10 @@ namespace pcl
   class GrabCut : public pcl::PCLBase<PointT>
   {
     public:
-      typedef pcl::search::Search<PointT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
-      typedef typename PCLBase<PointT>::PointCloudConstPtr PointCloudConstPtr;
-      typedef typename PCLBase<PointT>::PointCloudPtr PointCloudPtr;
+      using KdTree = pcl::search::Search<PointT>;
+      using KdTreePtr = typename KdTree::Ptr;
+      using PointCloudConstPtr = typename PCLBase<PointT>::PointCloudConstPtr;
+      using PointCloudPtr = typename PCLBase<PointT>::PointCloudPtr;
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;
       using PCLBase<PointT>::fake_indices_;
@@ -405,7 +405,7 @@ namespace pcl
       };
       bool
       initCompute ();
-      typedef pcl::segmentation::grabcut::BoykovKolmogorov::vertex_descriptor vertex_descriptor;
+      using vertex_descriptor = pcl::segmentation::grabcut::BoykovKolmogorov::vertex_descriptor;
       /// Compute beta from image
       void
       computeBetaOrganized ();

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -54,15 +54,15 @@ namespace pcl
   class GroundPlaneComparator: public Comparator<PointT>
   {
     public:
-      typedef typename Comparator<PointT>::PointCloud PointCloud;
-      typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename Comparator<PointT>::PointCloud;
+      using PointCloudConstPtr = typename Comparator<PointT>::PointCloudConstPtr;
       
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      typedef boost::shared_ptr<GroundPlaneComparator<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr<const GroundPlaneComparator<PointT, PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<GroundPlaneComparator<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr<const GroundPlaneComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       

--- a/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
@@ -85,7 +85,7 @@ pcl::CPCSegmentation<PointT>::segment ()
 template <typename PointT> void
 pcl::CPCSegmentation<PointT>::applyCuttingPlane (uint32_t depth_levels_left)
 {
-  typedef std::map<uint32_t, pcl::PointCloud<WeightSACPointType>::Ptr> SegLabel2ClusterMap;
+  using SegLabel2ClusterMap = std::map<uint32_t, pcl::PointCloud<WeightSACPointType>::Ptr>;
   
   pcl::console::print_info ("Cutting at level %d (maximum %d)\n", max_cuts_ - depth_levels_left + 1, max_cuts_);
   // stop if we reached the 0 level

--- a/segmentation/include/pcl/segmentation/impl/random_walker.hpp
+++ b/segmentation/include/pcl/segmentation/impl/random_walker.hpp
@@ -67,19 +67,19 @@ namespace pcl
 
         public:
 
-          typedef typename boost::property_traits<VertexColorMap>::value_type Color;
-          typedef typename boost::property_traits<EdgeWeightMap>::value_type Weight;
-          typedef boost::graph_traits<Graph> GraphTraits;
-          typedef typename GraphTraits::edge_descriptor EdgeDescriptor;
-          typedef typename GraphTraits::vertex_descriptor VertexDescriptor;
-          typedef typename GraphTraits::edge_iterator EdgeIterator;
-          typedef typename GraphTraits::out_edge_iterator OutEdgeIterator;
-          typedef typename GraphTraits::vertex_iterator VertexIterator;
-          typedef typename boost::property_map<Graph, boost::vertex_index_t>::type VertexIndexMap;
-          typedef boost::iterator_property_map<typename std::vector<Weight>::iterator, VertexIndexMap> VertexDegreeMap;
-          typedef Eigen::SparseMatrix<Weight> SparseMatrix;
-          typedef Eigen::Matrix<Weight, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-          typedef Eigen::Matrix<Weight, Eigen::Dynamic, 1> Vector;
+          using Color = typename boost::property_traits<VertexColorMap>::value_type;
+          using Weight = typename boost::property_traits<EdgeWeightMap>::value_type;
+          using GraphTraits = boost::graph_traits<Graph>;
+          using EdgeDescriptor = typename GraphTraits::edge_descriptor;
+          using VertexDescriptor = typename GraphTraits::vertex_descriptor;
+          using EdgeIterator = typename GraphTraits::edge_iterator;
+          using OutEdgeIterator = typename GraphTraits::out_edge_iterator;
+          using VertexIterator = typename GraphTraits::vertex_iterator;
+          using VertexIndexMap = typename boost::property_map<Graph, boost::vertex_index_t>::type;
+          using VertexDegreeMap = boost::iterator_property_map<typename std::vector<Weight>::iterator, VertexIndexMap>;
+          using SparseMatrix = Eigen::SparseMatrix<Weight>;
+          using Matrix = Eigen::Matrix<Weight, Eigen::Dynamic, Eigen::Dynamic>;
+          using Vector = Eigen::Matrix<Weight, Eigen::Dynamic, 1>;
 
           RandomWalker (Graph& g, EdgeWeightMap weights, VertexColorMap colors)
           : g_ (g)
@@ -117,8 +117,8 @@ namespace pcl
           {
             using namespace boost;
 
-            typedef Eigen::Triplet<float> T;
-            typedef std::vector<T> Triplets;
+            using T = Eigen::Triplet<float>;
+            using Triplets = std::vector<T>;
             Triplets L_triplets;
             Triplets B_triplets;
 
@@ -294,8 +294,8 @@ namespace pcl
     {
       using namespace boost;
 
-      typedef typename graph_traits<Graph>::edge_descriptor EdgeDescriptor;
-      typedef typename graph_traits<Graph>::vertex_descriptor VertexDescriptor;
+      using EdgeDescriptor = typename graph_traits<Graph>::edge_descriptor;
+      using VertexDescriptor = typename graph_traits<Graph>::vertex_descriptor;
 
       BOOST_CONCEPT_ASSERT ((VertexListGraphConcept<Graph>));                                 // to have vertices(), num_vertices()
       BOOST_CONCEPT_ASSERT ((EdgeListGraphConcept<Graph>));                                   // to have edges()
@@ -322,8 +322,8 @@ namespace pcl
     {
       using namespace boost;
 
-      typedef typename graph_traits<Graph>::edge_descriptor EdgeDescriptor;
-      typedef typename graph_traits<Graph>::vertex_descriptor VertexDescriptor;
+      using EdgeDescriptor = typename graph_traits<Graph>::edge_descriptor;
+      using VertexDescriptor = typename graph_traits<Graph>::vertex_descriptor;
 
       BOOST_CONCEPT_ASSERT ((VertexListGraphConcept<Graph>));                                 // to have vertices(), num_vertices()
       BOOST_CONCEPT_ASSERT ((EdgeListGraphConcept<Graph>));                                   // to have edges()

--- a/segmentation/include/pcl/segmentation/lccp_segmentation.h
+++ b/segmentation/include/pcl/segmentation/lccp_segmentation.h
@@ -81,14 +81,14 @@ namespace pcl
     public:
 
       // Adjacency list with nodes holding labels (uint32_t) and edges holding EdgeProperties.
-      typedef boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, EdgeProperties> SupervoxelAdjacencyList;
-      typedef typename boost::graph_traits<SupervoxelAdjacencyList>::vertex_iterator VertexIterator;
-      typedef typename boost::graph_traits<SupervoxelAdjacencyList>::adjacency_iterator AdjacencyIterator;
+      using SupervoxelAdjacencyList = boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, EdgeProperties>;
+      using VertexIterator = typename boost::graph_traits<SupervoxelAdjacencyList>::vertex_iterator;
+      using AdjacencyIterator = typename boost::graph_traits<SupervoxelAdjacencyList>::adjacency_iterator;
 
-      typedef typename boost::graph_traits<SupervoxelAdjacencyList>::vertex_descriptor VertexID;
-      typedef typename boost::graph_traits<SupervoxelAdjacencyList>::edge_iterator EdgeIterator;
-      typedef typename boost::graph_traits<SupervoxelAdjacencyList>::out_edge_iterator OutEdgeIterator;
-      typedef typename boost::graph_traits<SupervoxelAdjacencyList>::edge_descriptor EdgeID;
+      using VertexID = typename boost::graph_traits<SupervoxelAdjacencyList>::vertex_descriptor;
+      using EdgeIterator = typename boost::graph_traits<SupervoxelAdjacencyList>::edge_iterator;
+      using OutEdgeIterator = typename boost::graph_traits<SupervoxelAdjacencyList>::out_edge_iterator;
+      using EdgeID = typename boost::graph_traits<SupervoxelAdjacencyList>::edge_descriptor;
 
       LCCPSegmentation ();
       virtual

--- a/segmentation/include/pcl/segmentation/min_cut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/min_cut_segmentation.h
@@ -58,10 +58,10 @@ namespace pcl
   {
     public:
 
-      typedef pcl::search::Search <PointT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
-      typedef pcl::PointCloud< PointT > PointCloud;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using KdTree = pcl::search::Search<PointT>;
+      using KdTreePtr = typename KdTree::Ptr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       using PCLBase <PointT>::input_;
       using PCLBase <PointT>::indices_;
@@ -70,37 +70,37 @@ namespace pcl
 
     public:
 
-      typedef boost::adjacency_list_traits< boost::vecS, boost::vecS, boost::directedS > Traits;
+      using Traits = boost::adjacency_list_traits< boost::vecS, boost::vecS, boost::directedS >;
 
-      typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::directedS,
-                                     boost::property< boost::vertex_name_t, std::string,
-                                       boost::property< boost::vertex_index_t, long,
-                                         boost::property< boost::vertex_color_t, boost::default_color_type,
-                                           boost::property< boost::vertex_distance_t, long,
-                                             boost::property< boost::vertex_predecessor_t, Traits::edge_descriptor > > > > >,
-                                     boost::property< boost::edge_capacity_t, double,
-                                       boost::property< boost::edge_residual_capacity_t, double,
-                                         boost::property< boost::edge_reverse_t, Traits::edge_descriptor > > > > mGraph;
+      using mGraph = boost::adjacency_list< boost::vecS, boost::vecS, boost::directedS,
+                                            boost::property< boost::vertex_name_t, std::string,
+                                              boost::property< boost::vertex_index_t, long,
+                                                boost::property< boost::vertex_color_t, boost::default_color_type,
+                                                  boost::property< boost::vertex_distance_t, long,
+                                                    boost::property< boost::vertex_predecessor_t, Traits::edge_descriptor > > > > >,
+                                            boost::property< boost::edge_capacity_t, double,
+                                              boost::property< boost::edge_residual_capacity_t, double,
+                                                boost::property< boost::edge_reverse_t, Traits::edge_descriptor > > > >;
 
-      typedef boost::property_map< mGraph, boost::edge_capacity_t >::type CapacityMap;
+      using CapacityMap = boost::property_map< mGraph, boost::edge_capacity_t >::type;
 
-      typedef boost::property_map< mGraph, boost::edge_reverse_t>::type ReverseEdgeMap;
+      using ReverseEdgeMap = boost::property_map< mGraph, boost::edge_reverse_t>::type;
 
-      typedef Traits::vertex_descriptor VertexDescriptor;
+      using VertexDescriptor = Traits::vertex_descriptor;
 
-      typedef boost::graph_traits< mGraph >::edge_descriptor EdgeDescriptor;
+      using EdgeDescriptor = boost::graph_traits<mGraph>::edge_descriptor;
 
-      typedef boost::graph_traits< mGraph >::out_edge_iterator OutEdgeIterator;
+      using OutEdgeIterator = boost::graph_traits<mGraph>::out_edge_iterator;
 
-      typedef boost::graph_traits< mGraph >::vertex_iterator VertexIterator;
+      using VertexIterator = boost::graph_traits<mGraph>::vertex_iterator;
 
-      typedef boost::property_map< mGraph, boost::edge_residual_capacity_t >::type ResidualCapacityMap;
+      using ResidualCapacityMap = boost::property_map< mGraph, boost::edge_residual_capacity_t >::type;
 
-      typedef boost::property_map< mGraph, boost::vertex_index_t >::type IndexMap;
+      using IndexMap = boost::property_map< mGraph, boost::vertex_index_t >::type;
 
-      typedef boost::graph_traits< mGraph >::in_edge_iterator InEdgeIterator;
+      using InEdgeIterator = boost::graph_traits<mGraph>::in_edge_iterator;
 
-      typedef boost::shared_ptr<mGraph> mGraphPtr;
+      using mGraphPtr = boost::shared_ptr<mGraph>;
 
     public:
 

--- a/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_connected_component_segmentation.h
@@ -63,17 +63,17 @@ namespace pcl
     using PCLBase<PointT>::deinitCompute;
 
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
       
-      typedef pcl::PointCloud<PointLT> PointCloudL;
-      typedef typename PointCloudL::Ptr PointCloudLPtr;
-      typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+      using PointCloudL = pcl::PointCloud<PointLT>;
+      using PointCloudLPtr = typename PointCloudL::Ptr;
+      using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
-      typedef pcl::Comparator<PointT> Comparator;
-      typedef typename Comparator::Ptr ComparatorPtr;
-      typedef typename Comparator::ConstPtr ComparatorConstPtr;
+      using Comparator = pcl::Comparator<PointT>;
+      using ComparatorPtr = typename Comparator::Ptr;
+      using ComparatorConstPtr = typename Comparator::ConstPtr;
       
       /** \brief Constructor for OrganizedConnectedComponentSegmentation
         * \param[in] compare A pointer to the comparator to be used for segmentation.  Must be an instance of pcl::Comparator.

--- a/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
@@ -66,25 +66,25 @@ namespace pcl
     using PCLBase<PointT>::deinitCompute;
 
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      typedef pcl::PointCloud<PointLT> PointCloudL;
-      typedef typename PointCloudL::Ptr PointCloudLPtr;
-      typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+      using PointCloudL = pcl::PointCloud<PointLT>;
+      using PointCloudLPtr = typename PointCloudL::Ptr;
+      using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
-      typedef pcl::PlaneCoefficientComparator<PointT, PointNT> PlaneComparator;
-      typedef typename PlaneComparator::Ptr PlaneComparatorPtr;
-      typedef typename PlaneComparator::ConstPtr PlaneComparatorConstPtr;
+      using PlaneComparator = pcl::PlaneCoefficientComparator<PointT, PointNT>;
+      using PlaneComparatorPtr = typename PlaneComparator::Ptr;
+      using PlaneComparatorConstPtr = typename PlaneComparator::ConstPtr;
 
-      typedef pcl::PlaneRefinementComparator<PointT, PointNT, PointLT> PlaneRefinementComparator;
-      typedef typename PlaneRefinementComparator::Ptr PlaneRefinementComparatorPtr;
-      typedef typename PlaneRefinementComparator::ConstPtr PlaneRefinementComparatorConstPtr;
+      using PlaneRefinementComparator = pcl::PlaneRefinementComparator<PointT, PointNT, PointLT>;
+      using PlaneRefinementComparatorPtr = typename PlaneRefinementComparator::Ptr;
+      using PlaneRefinementComparatorConstPtr = typename PlaneRefinementComparator::ConstPtr;
 
       /** \brief Constructor for OrganizedMultiPlaneSegmentation. */
       OrganizedMultiPlaneSegmentation () :

--- a/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
@@ -54,15 +54,15 @@ namespace pcl
   class PlaneCoefficientComparator: public Comparator<PointT>
   {
     public:
-      typedef typename Comparator<PointT>::PointCloud PointCloud;
-      typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename Comparator<PointT>::PointCloud;
+      using PointCloudConstPtr = typename Comparator<PointT>::PointCloudConstPtr;
       
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      typedef boost::shared_ptr<PlaneCoefficientComparator<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr<const PlaneCoefficientComparator<PointT, PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PlaneCoefficientComparator<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr<const PlaneCoefficientComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       

--- a/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
@@ -54,19 +54,19 @@ namespace pcl
   class PlaneRefinementComparator: public PlaneCoefficientComparator<PointT, PointNT>
   {
     public:
-      typedef typename Comparator<PointT>::PointCloud PointCloud;
-      typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename Comparator<PointT>::PointCloud;
+      using PointCloudConstPtr = typename Comparator<PointT>::PointCloudConstPtr;
       
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      typedef pcl::PointCloud<PointLT> PointCloudL;
-      typedef typename PointCloudL::Ptr PointCloudLPtr;
-      typedef typename PointCloudL::ConstPtr PointCloudLConstPtr;
+      using PointCloudL = pcl::PointCloud<PointLT>;
+      using PointCloudLPtr = typename PointCloudL::Ptr;
+      using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
-      typedef boost::shared_ptr<PlaneRefinementComparator<PointT, PointNT, PointLT> > Ptr;
-      typedef boost::shared_ptr<const PlaneRefinementComparator<PointT, PointNT, PointLT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PlaneRefinementComparator<PointT, PointNT, PointLT> >;
+      using ConstPtr = boost::shared_ptr<const PlaneRefinementComparator<PointT, PointNT, PointLT> >;
 
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;

--- a/segmentation/include/pcl/segmentation/progressive_morphological_filter.h
+++ b/segmentation/include/pcl/segmentation/progressive_morphological_filter.h
@@ -57,7 +57,7 @@ namespace pcl
   {
     public:
 
-      typedef pcl::PointCloud <PointT> PointCloud;
+      using PointCloud = pcl::PointCloud<PointT>;
 
       using PCLBase <PointT>::input_;
       using PCLBase <PointT>::indices_;

--- a/segmentation/include/pcl/segmentation/region_growing.h
+++ b/segmentation/include/pcl/segmentation/region_growing.h
@@ -61,11 +61,11 @@ namespace pcl
   {
     public:
 
-      typedef pcl::search::Search <PointT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
-      typedef pcl::PointCloud <NormalT> Normal;
-      typedef typename Normal::Ptr NormalPtr;
-      typedef pcl::PointCloud <PointT> PointCloud;
+      using KdTree = pcl::search::Search<PointT>;
+      using KdTreePtr = typename KdTree::Ptr;
+      using Normal = pcl::PointCloud<NormalT>;
+      using NormalPtr = typename Normal::Ptr;
+      using PointCloud = pcl::PointCloud<PointT>;
 
       using PCLBase <PointT>::input_;
       using PCLBase <PointT>::indices_;

--- a/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
@@ -54,15 +54,15 @@ namespace pcl
   class RGBPlaneCoefficientComparator: public PlaneCoefficientComparator<PointT, PointNT>
   {
     public:
-      typedef typename Comparator<PointT>::PointCloud PointCloud;
-      typedef typename Comparator<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename Comparator<PointT>::PointCloud;
+      using PointCloudConstPtr = typename Comparator<PointT>::PointCloudConstPtr;
       
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      typedef boost::shared_ptr<RGBPlaneCoefficientComparator<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr<const RGBPlaneCoefficientComparator<PointT, PointNT> > ConstPtr;
+      using Ptr = boost::shared_ptr<RGBPlaneCoefficientComparator<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr<const RGBPlaneCoefficientComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;

--- a/segmentation/include/pcl/segmentation/sac_segmentation.h
+++ b/segmentation/include/pcl/segmentation/sac_segmentation.h
@@ -70,13 +70,13 @@ namespace pcl
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename pcl::search::Search<PointT>::Ptr SearchPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using SearchPtr = typename pcl::search::Search<PointT>::Ptr;
 
-      typedef typename SampleConsensus<PointT>::Ptr SampleConsensusPtr;
-      typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+      using SampleConsensusPtr = typename SampleConsensus<PointT>::Ptr;
+      using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
       /** \brief Empty constructor. 
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
@@ -321,17 +321,17 @@ namespace pcl
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;
 
-      typedef typename SACSegmentation<PointT>::PointCloud PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = typename SACSegmentation<PointT>::PointCloud;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef pcl::PointCloud<PointNT> PointCloudN;
-      typedef typename PointCloudN::Ptr PointCloudNPtr;
-      typedef typename PointCloudN::ConstPtr PointCloudNConstPtr;
+      using PointCloudN = pcl::PointCloud<PointNT>;
+      using PointCloudNPtr = typename PointCloudN::Ptr;
+      using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      typedef typename SampleConsensus<PointT>::Ptr SampleConsensusPtr;
-      typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
-      typedef typename SampleConsensusModelFromNormals<PointT, PointNT>::Ptr SampleConsensusModelFromNormalsPtr;
+      using SampleConsensusPtr = typename SampleConsensus<PointT>::Ptr;
+      using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
+      using SampleConsensusModelFromNormalsPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::Ptr;
 
       /** \brief Empty constructor.
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)

--- a/segmentation/include/pcl/segmentation/seeded_hue_segmentation.h
+++ b/segmentation/include/pcl/segmentation/seeded_hue_segmentation.h
@@ -92,18 +92,18 @@ namespace pcl
     */
   class SeededHueSegmentation: public PCLBase<PointXYZRGB>
   {
-    typedef PCLBase<PointXYZRGB> BasePCLBase;
+    using BasePCLBase = PCLBase<PointXYZRGB>;
 
     public:
-      typedef pcl::PointCloud<PointXYZRGB> PointCloud;
-      typedef PointCloud::Ptr PointCloudPtr;
-      typedef PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointXYZRGB>;
+      using PointCloudPtr = PointCloud::Ptr;
+      using PointCloudConstPtr = PointCloud::ConstPtr;
 
-      typedef pcl::search::Search<PointXYZRGB> KdTree;
-      typedef pcl::search::Search<PointXYZRGB>::Ptr KdTreePtr;
+      using KdTree = pcl::search::Search<PointXYZRGB>;
+      using KdTreePtr = pcl::search::Search<PointXYZRGB>::Ptr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       /** \brief Empty constructor. */

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -82,18 +82,18 @@ namespace pcl
   template <typename PointT>
   class SegmentDifferences: public PCLBase<PointT>
   {
-    typedef PCLBase<PointT> BasePCLBase;
+    using BasePCLBase = PCLBase<PointT>;
 
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef pcl::search::Search<PointT> KdTree;
-      typedef typename KdTree::Ptr KdTreePtr;
+      using KdTree = pcl::search::Search<PointT>;
+      using KdTreePtr = typename KdTree::Ptr;
 
-      typedef PointIndices::Ptr PointIndicesPtr;
-      typedef PointIndices::ConstPtr PointIndicesConstPtr;
+      using PointIndicesPtr = PointIndices::Ptr;
+      using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       /** \brief Empty constructor. */
       SegmentDifferences () : 

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -70,8 +70,8 @@ namespace pcl
         normals_ (new pcl::PointCloud<Normal> ())
         {  } 
 
-      typedef boost::shared_ptr<Supervoxel<PointT> > Ptr;
-      typedef boost::shared_ptr<const Supervoxel<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<Supervoxel<PointT> >;
+      using ConstPtr = boost::shared_ptr<const Supervoxel<PointT> >;
 
       /** \brief Gets the centroid of the supervoxel
        *  \param[out] centroid_arg centroid of the supervoxel
@@ -165,23 +165,23 @@ namespace pcl
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW
       };
 
-      typedef pcl::octree::OctreePointCloudAdjacencyContainer<PointT, VoxelData> LeafContainerT;
-      typedef std::vector <LeafContainerT*> LeafVectorT;
+      using LeafContainerT = pcl::octree::OctreePointCloudAdjacencyContainer<PointT, VoxelData>;
+      using LeafVectorT = std::vector<LeafContainerT *>;
 
-      typedef pcl::PointCloud<PointT> PointCloudT;
-      typedef pcl::PointCloud<Normal> NormalCloudT;
-      typedef pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT> OctreeAdjacencyT;
-      typedef pcl::octree::OctreePointCloudSearch <PointT> OctreeSearchT;
-      typedef pcl::search::KdTree<PointT> KdTreeT;
-      typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
+      using PointCloudT = pcl::PointCloud<PointT>;
+      using NormalCloudT = pcl::PointCloud<Normal>;
+      using OctreeAdjacencyT = pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT>;
+      using OctreeSearchT = pcl::octree::OctreePointCloudSearch<PointT>;
+      using KdTreeT = pcl::search::KdTree<PointT>;
+      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
 
       using PCLBase <PointT>::initCompute;
       using PCLBase <PointT>::deinitCompute;
       using PCLBase <PointT>::input_;
 
-      typedef boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, float> VoxelAdjacencyList;
-      typedef VoxelAdjacencyList::vertex_descriptor VoxelID;
-      typedef VoxelAdjacencyList::edge_descriptor EdgeID;
+      using VoxelAdjacencyList = boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, float>;
+      using VoxelID = VoxelAdjacencyList::vertex_descriptor;
+      using EdgeID = VoxelAdjacencyList::edge_descriptor;
 
     public:
 
@@ -433,9 +433,9 @@ namespace pcl
               return leaf_data_left.idx_ < leaf_data_right.idx_;
             }
           };
-          typedef std::set<LeafContainerT*, typename SupervoxelHelper::compareLeaves> LeafSetT;
-          typedef typename LeafSetT::iterator iterator;
-          typedef typename LeafSetT::const_iterator const_iterator;
+          using LeafSetT = std::set<LeafContainerT*, typename SupervoxelHelper::compareLeaves>;
+          using iterator = typename LeafSetT::iterator;
+          using const_iterator = typename LeafSetT::const_iterator;
 
           SupervoxelHelper (uint32_t label, SupervoxelClustering* parent_arg):
             label_ (label),
@@ -466,7 +466,7 @@ namespace pcl
           void 
           getNormals (typename pcl::PointCloud<Normal>::Ptr &normals) const;
 
-          typedef float (SupervoxelClustering::*DistFuncPtr)(const VoxelData &v1, const VoxelData &v2);
+          using DistFuncPtr = float (SupervoxelClustering<PointT>::*)(const VoxelData &, const VoxelData &);
 
           uint32_t
           getLabel () const 
@@ -532,7 +532,7 @@ namespace pcl
       friend void boost::checked_delete<> (const typename pcl::SupervoxelClustering<PointT>::SupervoxelHelper *);
 #endif
 
-      typedef boost::ptr_list<SupervoxelHelper> HelperListT;
+      using HelperListT = boost::ptr_list<SupervoxelHelper>;
       HelperListT supervoxel_helpers_;
 
       //TODO DEBUG REMOVE

--- a/segmentation/src/supervoxel_clustering.cpp
+++ b/segmentation/src/supervoxel_clustering.cpp
@@ -160,13 +160,13 @@ namespace pcl
   }
 }
 
-typedef pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData VoxelDataT;
-typedef pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData VoxelDataRGBT;
-typedef pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData VoxelDataRGBAT;
+using VoxelDataT = pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData;
+using VoxelDataRGBT = pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData;
+using VoxelDataRGBAT = pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData;
 
-typedef pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ, VoxelDataT> AdjacencyContainerT;
-typedef pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB, VoxelDataRGBT> AdjacencyContainerRGBT;
-typedef pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA, VoxelDataRGBAT> AdjacencyContainerRGBAT;
+using AdjacencyContainerT = pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ, VoxelDataT>;
+using AdjacencyContainerRGBT = pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB, VoxelDataRGBT>;
+using AdjacencyContainerRGBAT = pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA, VoxelDataRGBAT>;
 
 template class pcl::SupervoxelClustering<pcl::PointXYZ>;
 template class pcl::SupervoxelClustering<pcl::PointXYZRGB>;


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`