### PR TITLE
Identify AppleClang as a valid Clang compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
 # Compiler identification
 # Define a variable CMAKE_COMPILER_IS_X where X is the compiler short name.
 # Note: CMake automatically defines one for GNUCXX, nothing to do in this case.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANG 1)
 elseif(__COMPILER_PATHSCALE)
   set(CMAKE_COMPILER_IS_PATHSCALE 1)

--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -46,5 +46,5 @@ if(CUDA_FOUND)
   APPEND_TARGET_ARCH_FLAGS()
 
   # Prevent compilation issues between recent gcc versions and old CUDA versions
-  list(APPEND CUDA_NVCC_FLAGS "-D_FORCE_INLINES")
+  list(APPEND CUDA_NVCC_FLAGS "-D_FORCE_INLINES" $<$<OR:$<BOOL:CMAKE_COMPILER_IS_GNUXX>,$<BOOL:CMAKE_COMPILER_IS_CLANG>>:-std=c++11>)
 endif()

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -3,7 +3,7 @@
 // Ensure the compiler is meeting the minimum C++ standard
 // MSVC is not checked via __cplusplus due to
 // https://developercommunity.visualstudio.com/content/problem/120156/-cplusplus-macro-still-defined-as-pre-c11-value.html
-#if (!defined(_MSC_VER) && __cplusplus < 201402L) || (defined(_MSC_VER) && _MSC_VER < 1900)
+#if (!defined(_MSC_VER) && !defined(__CUDACC__) && __cplusplus < 201402L) || (defined(_MSC_VER) && _MSC_VER < 1900)
   #error PCL requires C++14 or above
 #endif
 


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.5/variable/CMAKE_LANG_COMPILER_ID.html

I just printed some make verbose and noticed there were no SSE flags.