### PR TITLE
Use using instead of typedef [out_of_core, people, recognition, sample_consensus]

### DIFF
--- a/outofcore/include/pcl/outofcore/impl/lru_cache.hpp
+++ b/outofcore/include/pcl/outofcore/impl/lru_cache.hpp
@@ -28,11 +28,11 @@ class LRUCache
 {
 public:
 
-  typedef std::list<KeyT> KeyIndex;
-  typedef typename KeyIndex::iterator KeyIndexIterator;
+  using KeyIndex = std::list<KeyT>;
+  using KeyIndexIterator = typename KeyIndex::iterator;
 
-  typedef std::map<KeyT, std::pair<CacheItemT, typename KeyIndex::iterator> > Cache;
-  typedef typename Cache::iterator CacheIterator;
+  using Cache = std::map<KeyT, std::pair<CacheItemT, typename KeyIndex::iterator> >;
+  using CacheIterator = typename Cache::iterator;
 
   LRUCache (size_t c) :
       capacity_ (c), size_ (0)

--- a/outofcore/include/pcl/outofcore/octree_abstract_node_container.h
+++ b/outofcore/include/pcl/outofcore/octree_abstract_node_container.h
@@ -53,7 +53,7 @@ namespace pcl
     {
 
       public:
-        typedef std::vector<PointT, Eigen::aligned_allocator<PointT> > AlignedPointTVector;
+        using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
 
         OutofcoreAbstractNodeContainer () 
           : container_ ()

--- a/outofcore/include/pcl/outofcore/octree_base.h
+++ b/outofcore/include/pcl/outofcore/octree_base.h
@@ -155,38 +155,38 @@ namespace pcl
       public:
 
         // public typedefs
-        typedef OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<PointT>, PointT > octree_disk;
-        typedef OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<PointT>, PointT > octree_disk_node;
+        using octree_disk = OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<PointT>, PointT >;
+        using octree_disk_node = OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<PointT>, PointT >;
 
-        typedef OutofcoreOctreeBase<OutofcoreOctreeRamContainer<PointT>, PointT> octree_ram;
-        typedef OutofcoreOctreeBaseNode<OutofcoreOctreeRamContainer<PointT>, PointT> octree_ram_node;
+        using octree_ram = OutofcoreOctreeBase<OutofcoreOctreeRamContainer<PointT>, PointT>;
+        using octree_ram_node = OutofcoreOctreeBaseNode<OutofcoreOctreeRamContainer<PointT>, PointT>;
 
-        typedef OutofcoreOctreeBaseNode<ContainerT, PointT> OutofcoreNodeType;
+        using OutofcoreNodeType = OutofcoreOctreeBaseNode<ContainerT, PointT>;
 
-        typedef OutofcoreOctreeBaseNode<ContainerT, PointT> BranchNode;
-        typedef OutofcoreOctreeBaseNode<ContainerT, PointT> LeafNode;
+        using BranchNode = OutofcoreOctreeBaseNode<ContainerT, PointT>;
+        using LeafNode = OutofcoreOctreeBaseNode<ContainerT, PointT>;
 
-        typedef OutofcoreDepthFirstIterator<PointT, ContainerT> Iterator;
-        typedef const OutofcoreDepthFirstIterator<PointT, ContainerT> ConstIterator;
+        using Iterator = OutofcoreDepthFirstIterator<PointT, ContainerT>;
+        using ConstIterator = const OutofcoreDepthFirstIterator<PointT, ContainerT>;
 
-        typedef OutofcoreBreadthFirstIterator<PointT, ContainerT> BreadthFirstIterator;
-        typedef const OutofcoreBreadthFirstIterator<PointT, ContainerT> BreadthFirstConstIterator;
+        using BreadthFirstIterator = OutofcoreBreadthFirstIterator<PointT, ContainerT>;
+        using BreadthFirstConstIterator = const OutofcoreBreadthFirstIterator<PointT, ContainerT>;
 
-        typedef OutofcoreDepthFirstIterator<PointT, ContainerT> DepthFirstIterator;
-        typedef const OutofcoreDepthFirstIterator<PointT, ContainerT> DepthFirstConstIterator;
+        using DepthFirstIterator = OutofcoreDepthFirstIterator<PointT, ContainerT>;
+        using DepthFirstConstIterator = const OutofcoreDepthFirstIterator<PointT, ContainerT>;
 
-        typedef boost::shared_ptr<OutofcoreOctreeBase<ContainerT, PointT> > Ptr;
-        typedef boost::shared_ptr<const OutofcoreOctreeBase<ContainerT, PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<OutofcoreOctreeBase<ContainerT, PointT> >;
+        using ConstPtr = boost::shared_ptr<const OutofcoreOctreeBase<ContainerT, PointT> >;
 
-        typedef pcl::PointCloud<PointT> PointCloud;
+        using PointCloud = pcl::PointCloud<PointT>;
 
-        typedef boost::shared_ptr<std::vector<int> > IndicesPtr;
-        typedef boost::shared_ptr<const std::vector<int> > IndicesConstPtr;
+        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
 
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
-        typedef std::vector<PointT, Eigen::aligned_allocator<PointT> > AlignedPointTVector;
+        using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
 
         // Constructors
         // -----------------------------------------------------------------------

--- a/outofcore/include/pcl/outofcore/octree_base_node.h
+++ b/outofcore/include/pcl/outofcore/octree_base_node.h
@@ -106,12 +106,12 @@ namespace pcl
       queryBBIntersects_noload<ContainerT, PointT> (OutofcoreOctreeBaseNode<ContainerT, PointT>* current, const Eigen::Vector3d &min, const Eigen::Vector3d &max, const boost::uint32_t query_depth, std::list<std::string> &bin_name);
   
       public:
-        typedef OutofcoreOctreeBase<OutofcoreOctreeDiskContainer < PointT > , PointT > octree_disk;
-        typedef OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer < PointT > , PointT > octree_disk_node;
+        using octree_disk = OutofcoreOctreeBase<OutofcoreOctreeDiskContainer < PointT > , PointT >;
+        using octree_disk_node = OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer < PointT > , PointT >;
 
-        typedef std::vector<PointT, Eigen::aligned_allocator<PointT> > AlignedPointTVector;
+        using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
 
-        typedef pcl::octree::node_type_t node_type_t;
+        using node_type_t = pcl::octree::node_type_t;
 
         const static std::string node_index_basename;
         const static std::string node_container_basename;

--- a/outofcore/include/pcl/outofcore/octree_disk_container.h
+++ b/outofcore/include/pcl/outofcore/octree_disk_container.h
@@ -77,7 +77,7 @@ namespace pcl
     {
   
       public:
-        typedef typename OutofcoreAbstractNodeContainer<PointT>::AlignedPointTVector AlignedPointTVector;
+        using AlignedPointTVector = typename OutofcoreAbstractNodeContainer<PointT>::AlignedPointTVector;
         
         /** \brief Empty constructor creates disk container and sets filename from random uuid string*/
         OutofcoreOctreeDiskContainer ();

--- a/outofcore/include/pcl/outofcore/octree_ram_container.h
+++ b/outofcore/include/pcl/outofcore/octree_ram_container.h
@@ -64,7 +64,7 @@ namespace pcl
     class OutofcoreOctreeRamContainer : public OutofcoreAbstractNodeContainer<PointT>
     {
       public:
-        typedef typename OutofcoreAbstractNodeContainer<PointT>::AlignedPointTVector AlignedPointTVector;
+        using AlignedPointTVector = typename OutofcoreAbstractNodeContainer<PointT>::AlignedPointTVector;
 
         /** \brief empty constructor (with a path parameter?)
           */

--- a/outofcore/include/pcl/outofcore/outofcore_base_data.h
+++ b/outofcore/include/pcl/outofcore/outofcore_base_data.h
@@ -96,7 +96,7 @@ namespace pcl
     class PCL_EXPORTS OutofcoreOctreeBaseMetadata : public OutofcoreAbstractMetadata
     {
       public:
-        typedef boost::shared_ptr<OutofcoreOctreeBaseMetadata> Ptr;
+        using Ptr = boost::shared_ptr<OutofcoreOctreeBaseMetadata>;
 
         /** \brief Empty constructor */
         OutofcoreOctreeBaseMetadata ();

--- a/outofcore/include/pcl/outofcore/outofcore_breadth_first_iterator.h
+++ b/outofcore/include/pcl/outofcore/outofcore_breadth_first_iterator.h
@@ -54,11 +54,11 @@ namespace pcl
     class OutofcoreBreadthFirstIterator : public OutofcoreIteratorBase<PointT, ContainerT>
     {
       public:
-        typedef pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
-        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
+        using OctreeDisk = pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>;
+        using OctreeDiskNode = pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT>;
 
-        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> LeafNode;
-        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> BranchNode;
+        using LeafNode = pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT>;
+        using BranchNode = pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT>;
 
 
         explicit

--- a/outofcore/include/pcl/outofcore/outofcore_depth_first_iterator.h
+++ b/outofcore/include/pcl/outofcore/outofcore_depth_first_iterator.h
@@ -53,11 +53,11 @@ namespace pcl
     class OutofcoreDepthFirstIterator : public OutofcoreIteratorBase<PointT, ContainerT>
     {
       public:
-        typedef pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
-        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
+        using OctreeDisk = pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>;
+        using OctreeDiskNode = pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT>;
 
-        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> LeafNode;
-        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> BranchNode;
+        using LeafNode = pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT>;
+        using BranchNode = pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT>;
 
         explicit
         OutofcoreDepthFirstIterator (OctreeDisk& octree_arg);

--- a/outofcore/include/pcl/outofcore/outofcore_iterator_base.h
+++ b/outofcore/include/pcl/outofcore/outofcore_iterator_base.h
@@ -63,13 +63,13 @@ namespace pcl
                                                        const OutofcoreOctreeBaseNode<ContainerT, PointT>&>/*Reference type*/
     {
       public:
-        typedef pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT> OctreeDisk;
-        typedef pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT> OctreeDiskNode;
+        using OctreeDisk = pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>;
+        using OctreeDiskNode = pcl::outofcore::OutofcoreOctreeBaseNode<ContainerT, PointT>;
         
-        typedef typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>::BranchNode BranchNode;
-        typedef typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>::LeafNode LeafNode;
+        using BranchNode = typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>::BranchNode;
+        using LeafNode = typename pcl::outofcore::OutofcoreOctreeBase<ContainerT, PointT>::LeafNode;
 
-        typedef typename OctreeDisk::OutofcoreNodeType OutofcoreNodeType;
+        using OutofcoreNodeType = typename OctreeDisk::OutofcoreNodeType;
 
         explicit
         OutofcoreIteratorBase (OctreeDisk& octree_arg) 

--- a/outofcore/include/pcl/outofcore/outofcore_node_data.h
+++ b/outofcore/include/pcl/outofcore/outofcore_node_data.h
@@ -84,8 +84,8 @@ namespace pcl
 
       public:
         //public typedefs
-        typedef boost::shared_ptr<OutofcoreOctreeNodeMetadata> Ptr;
-        typedef boost::shared_ptr<const OutofcoreOctreeNodeMetadata> ConstPtr;
+        using Ptr = boost::shared_ptr<OutofcoreOctreeNodeMetadata>;
+        using ConstPtr = boost::shared_ptr<const OutofcoreOctreeNodeMetadata>;
   
         /** \brief Empty constructor */
         OutofcoreOctreeNodeMetadata ();

--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -30,25 +30,25 @@ class OutofcoreCloud : public Object
 {
     // Typedefs
     // -----------------------------------------------------------------------------
-    typedef pcl::PointXYZ PointT;
-//    typedef pcl::outofcore::OutofcoreOctreeBase<pcl::outofcore::OutofcoreOctreeDiskContainer<PointT>, PointT> octree_disk;
-//    typedef pcl::outofcore::OutofcoreOctreeBaseNode<pcl::outofcore::OutofcoreOctreeDiskContainer<PointT>, PointT> octree_disk_node;
+    using PointT = pcl::PointXYZ;
+//    using octree_disk = pcl::outofcore::OutofcoreOctreeBase<pcl::outofcore::OutofcoreOctreeDiskContainer<PointT>, PointT>;
+//    using octree_disk_node = pcl::outofcore::OutofcoreOctreeBaseNode<pcl::outofcore::OutofcoreOctreeDiskContainer<PointT>, PointT>;
 
-    typedef pcl::outofcore::OutofcoreOctreeBase<> OctreeDisk;
-    typedef pcl::outofcore::OutofcoreOctreeBaseNode<> OctreeDiskNode;
-//    typedef pcl::outofcore::OutofcoreBreadthFirstIterator<> OctreeBreadthFirstIterator;
+    using OctreeDisk = pcl::outofcore::OutofcoreOctreeBase<>;
+    using OctreeDiskNode = pcl::outofcore::OutofcoreOctreeBaseNode<>;
+//    using OctreeBreadthFirstIterator = pcl::outofcore::OutofcoreBreadthFirstIterator<>;
 
-    typedef boost::shared_ptr<OctreeDisk> OctreeDiskPtr;
-    typedef Eigen::aligned_allocator<PointT> AlignedPointT;
+    using OctreeDiskPtr = boost::shared_ptr<OctreeDisk>;
+    using AlignedPointT = Eigen::aligned_allocator<PointT>;
 
 
 
-    typedef std::map<std::string, vtkSmartPointer<vtkActor> > CloudActorMap;
+    using CloudActorMap = std::map<std::string, vtkSmartPointer<vtkActor> >;
 
   public:
 
-//    typedef std::map<std::string, vtkSmartPointer<vtkPolyData> > CloudDataCache;
-//    typedef std::map<std::string, vtkSmartPointer<vtkPolyData> >::iterator CloudDataCacheIterator;
+//    using CloudDataCache = std::map<std::string, vtkSmartPointer<vtkPolyData> >;
+//    using CloudDataCacheIterator = std::map<std::string, vtkSmartPointer<vtkPolyData> >::iterator;
 
 
     static boost::shared_ptr<std::thread> pcd_reader_thread;
@@ -71,7 +71,7 @@ class OutofcoreCloud : public Object
       float coverage;
     };
 
-    typedef std::priority_queue<PcdQueueItem> PcdQueue;
+    using PcdQueue = std::priority_queue<PcdQueueItem>;
     static PcdQueue pcd_queue;
     static std::mutex pcd_queue_mutex;
     static std::condition_variable pcd_queue_ready;
@@ -101,7 +101,7 @@ class OutofcoreCloud : public Object
 
 //    static CloudDataCache cloud_data_map;
 //    static std::mutex cloud_data_map_mutex;
-    typedef LRUCache<std::string, CloudDataCacheItem> CloudDataCache;
+    using CloudDataCache = LRUCache<std::string, CloudDataCacheItem>;
     static CloudDataCache cloud_data_cache;
     static std::mutex cloud_data_cache_mutex;
 

--- a/outofcore/tools/outofcore_print.cpp
+++ b/outofcore/tools/outofcore_print.cpp
@@ -62,7 +62,7 @@ namespace ba = boost::accumulators;
 
 // todo: Read clouds as PCLPointCloud2 so we don't need to define PointT explicitly.
 //       This also requires our octree to take PCLPointCloud2 as an input.
-typedef pcl::PointXYZ PointT;
+using PointT = pcl::PointXYZ;
 
 using namespace pcl;
 using namespace pcl::outofcore;
@@ -77,12 +77,12 @@ using pcl::console::print;
 
 #include <boost/foreach.hpp>
 
-typedef OutofcoreOctreeBase<> OctreeDisk;
-typedef OutofcoreOctreeBaseNode<> OctreeDiskNode;
-typedef OutofcoreBreadthFirstIterator<> OctreeBreadthFirstIterator;
-typedef OutofcoreDepthFirstIterator<> OctreeDepthFirstIterator;
+using OctreeDisk = OutofcoreOctreeBase<>;
+using OctreeDiskNode = OutofcoreOctreeBaseNode<>;
+using OctreeBreadthFirstIterator = OutofcoreBreadthFirstIterator<>;
+using OctreeDepthFirstIterator = OutofcoreDepthFirstIterator<>;
 
-typedef Eigen::aligned_allocator<PointT> AlignedPointT;
+using AlignedPointT = Eigen::aligned_allocator<PointT>;
 
 void
 printDepth(size_t depth)

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -54,7 +54,7 @@
 
 // todo: Read clouds as PCLPointCloud2 so we don't need to define PointT explicitly.
 //       This also requires our octree to take PCLPointCloud2 as an input.
-typedef pcl::PointXYZ PointT;
+using PointT = pcl::PointXYZ;
 
 using namespace pcl;
 using namespace pcl::outofcore;
@@ -68,7 +68,7 @@ using pcl::console::print_info;
 
 #include <boost/foreach.hpp>
 
-typedef OutofcoreOctreeBase<> octree_disk;
+using octree_disk = OutofcoreOctreeBase<>;
 
 const int OCTREE_DEPTH (0);
 const int OCTREE_RESOLUTION (1);

--- a/outofcore/tools/outofcore_viewer.cpp
+++ b/outofcore/tools/outofcore_viewer.cpp
@@ -81,16 +81,16 @@ using pcl::console::print_error;
 using pcl::console::print_warn;
 using pcl::console::print_info;
 
-//typedef PCLPointCloud2 PointT;
-typedef PointXYZ PointT;
+//using PointT = PCLPointCloud2;
+using PointT = PointXYZ;
 
-typedef OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<PointT>, PointT> octree_disk;
-typedef OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<PointT>, PointT> octree_disk_node;
+using octree_disk = OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<PointT>, PointT>;
+using octree_disk_node = OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<PointT>, PointT>;
 
-//typedef octree_base<OutofcoreOctreeDiskContainer<PointT> , PointT> octree_disk;
-typedef boost::shared_ptr<octree_disk> OctreeDiskPtr;
-//typedef octree_base_node<octree_disk_container<PointT> , PointT> octree_disk_node;
-typedef Eigen::aligned_allocator<PointT> AlignedPointT;
+//using octree_disk = octree_base<OutofcoreOctreeDiskContainer<PointT> , PointT>;
+using OctreeDiskPtr = boost::shared_ptr<octree_disk>;
+//using octree_disk_node = octree_base_node<octree_disk_container<PointT> , PointT>;
+using AlignedPointT = Eigen::aligned_allocator<PointT>;
 
 // VTK
 #include <vtkActor.h>

--- a/people/apps/main_ground_based_people_detection.cpp
+++ b/people/apps/main_ground_based_people_detection.cpp
@@ -58,8 +58,8 @@
 
 using namespace std::chrono_literals;
 
-typedef pcl::PointXYZRGBA PointT;
-typedef pcl::PointCloud<PointT> PointCloudT;
+using PointT = pcl::PointXYZRGBA;
+using PointCloudT = pcl::PointCloud<PointT>;
 
 // PCL viewer //
 pcl::visualization::PCLVisualizer viewer("PCL Viewer");

--- a/people/include/pcl/people/ground_based_people_detection_app.h
+++ b/people/include/pcl/people/ground_based_people_detection_app.h
@@ -72,9 +72,9 @@ namespace pcl
     {
     public:
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-      typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = boost::shared_ptr<PointCloud>;
+      using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
       /** \brief Constructor. */
       GroundBasedPeopleDetectionApp ();

--- a/people/include/pcl/people/head_based_subcluster.h
+++ b/people/include/pcl/people/head_based_subcluster.h
@@ -59,9 +59,9 @@ namespace pcl
     {
     public:
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-      typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = boost::shared_ptr<PointCloud>;
+      using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
       /** \brief Constructor. */
       HeadBasedSubclustering ();

--- a/people/include/pcl/people/height_map_2d.h
+++ b/people/include/pcl/people/height_map_2d.h
@@ -58,9 +58,9 @@ namespace pcl
     {
     public:
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-      typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = boost::shared_ptr<PointCloud>;
+      using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
       /** \brief Constructor. */
       HeightMap2D();

--- a/people/include/pcl/people/person_classifier.h
+++ b/people/include/pcl/people/person_classifier.h
@@ -68,8 +68,8 @@ namespace pcl
 
     public:
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = boost::shared_ptr<PointCloud>;
 
       /** \brief Constructor. */
       PersonClassifier ();

--- a/people/include/pcl/people/person_cluster.h
+++ b/people/include/pcl/people/person_cluster.h
@@ -134,9 +134,9 @@ namespace pcl
 
     public:
 
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-      typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudPtr = boost::shared_ptr<PointCloud>;
+      using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
       /** \brief Constructor. */
       PersonCluster (

--- a/recognition/include/pcl/recognition/3rdparty/metslib/abstract-search.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/abstract-search.hh
@@ -240,7 +240,7 @@ namespace mets {
   class search_listener : public observer<abstract_search<move_manager_type> >
   {
   public:
-    typedef abstract_search<move_manager_type> search_type;
+    using search_type = abstract_search<move_manager_type>;
     /// @brief A new observer (listener) of a search process, remember
     /// to attach the created object to the search process to be
     /// observed (mets::search_type::attach())

--- a/recognition/include/pcl/recognition/3rdparty/metslib/local-search.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/local-search.hh
@@ -100,7 +100,7 @@ mets::local_search<move_manager_t>::local_search(evaluable_solution& working,
   : abstract_search<move_manager_t>(working, recorder, moveman),
     short_circuit_m(short_circuit), epsilon_m(epsilon)
 { 
-  typedef abstract_search<move_manager_t> base_t;
+  using base_t = abstract_search<move_manager_t>;
   base_t::step_m = 0; 
 }
 
@@ -109,7 +109,7 @@ void
 mets::local_search<move_manager_t>::search()
   throw(no_moves_error)
 {
-  typedef abstract_search<move_manager_t> base_t;
+  using base_t = abstract_search<move_manager_t>;
   typename move_manager_t::iterator best_movit;
 
   base_t::solution_recorder_m.accept(base_t::working_solution_m);

--- a/recognition/include/pcl/recognition/3rdparty/metslib/model.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/model.hh
@@ -42,7 +42,7 @@ namespace mets {
   /// You should be able to change this to "int" for your uses
   /// to improve performance if it suffice, no guarantee.
   ///
-  typedef double gol_type;
+  using gol_type = double;
 
   /// @brief Exception risen when some algorithm has no more moves to
   /// make.
@@ -522,10 +522,10 @@ namespace mets {
     refresh(mets::feasible_solution& s) = 0;
     
     /// @brief Iterator type to iterate over moves of the neighborhood
-    typedef std::deque<move*>::iterator iterator;
+    using iterator = std::deque<move *>::iterator;
     
     /// @brief Size type
-    typedef std::deque<move*>::size_type size_type;
+    using size_type = std::deque<move *>::size_type;
 
     /// @brief Begin iterator of available moves queue.
     iterator begin() 

--- a/recognition/include/pcl/recognition/3rdparty/metslib/simulated-annealing.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/simulated-annealing.hh
@@ -72,7 +72,7 @@ namespace mets {
   class simulated_annealing : public mets::abstract_search<move_manager_type>
   {
   public:
-    typedef simulated_annealing<move_manager_type> search_type;
+    using search_type = simulated_annealing<move_manager_type>;
     /// @brief Creates a search by simulated annealing instance.
     ///
     /// @param working The working solution (this will be modified
@@ -223,7 +223,7 @@ void
 mets::simulated_annealing<move_manager_t>::search()
   throw(no_moves_error)
 {
-  typedef abstract_search<move_manager_t> base_t;
+  using base_t = abstract_search<move_manager_t>;
 
   current_temp_m = starting_temp_m;
   while(!termination_criteria_m(base_t::working_solution_m) 

--- a/recognition/include/pcl/recognition/3rdparty/metslib/tabu-search.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/tabu-search.hh
@@ -198,7 +198,7 @@ namespace mets {
   class tabu_search : public abstract_search<move_manager_type>
   {
   public:
-    typedef tabu_search<move_manager_type> search_type;
+    using search_type = tabu_search<move_manager_type>;
     /// @brief Creates a tabu Search instance.
     ///
     /// @param starting_solution  The working solution (this
@@ -325,7 +325,7 @@ namespace mets {
     is_tabu(feasible_solution& sol, move& mov) const;
 
   protected:
-    typedef std::deque<move*> move_list_type;
+    using move_list_type = std::deque<move *>;
 #if defined (METSLIB_TR1_BOOST)
     typedef boost::unordered_map<
           mana_move*, // Key type
@@ -403,7 +403,7 @@ template<typename move_manager_t>
 void mets::tabu_search<move_manager_t>::search()
   throw(no_moves_error)
 {
-  typedef abstract_search<move_manager_t> base_t;
+  using base_t = abstract_search<move_manager_t>;
   while(!termination_criteria_m(base_t::working_solution_m))
     {
       // call listeners

--- a/recognition/include/pcl/recognition/cg/correspondence_grouping.h
+++ b/recognition/include/pcl/recognition/cg/correspondence_grouping.h
@@ -54,9 +54,9 @@ namespace pcl
   class CorrespondenceGrouping : public PCLBase<PointModelT>
   {
     public:
-      typedef pcl::PointCloud<PointSceneT> SceneCloud;
-      typedef typename SceneCloud::Ptr SceneCloudPtr;
-      typedef typename SceneCloud::ConstPtr SceneCloudConstPtr;
+      using SceneCloud = pcl::PointCloud<PointSceneT>;
+      using SceneCloudPtr = typename SceneCloud::Ptr;
+      using SceneCloudConstPtr = typename SceneCloud::ConstPtr;
 
       /** \brief Empty constructor. */
       CorrespondenceGrouping () : scene_ () {}

--- a/recognition/include/pcl/recognition/cg/geometric_consistency.h
+++ b/recognition/include/pcl/recognition/cg/geometric_consistency.h
@@ -54,11 +54,11 @@ namespace pcl
   class GeometricConsistencyGrouping : public CorrespondenceGrouping<PointModelT, PointSceneT>
   {
     public:
-      typedef pcl::PointCloud<PointModelT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointModelT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef typename pcl::CorrespondenceGrouping<PointModelT, PointSceneT>::SceneCloudConstPtr SceneCloudConstPtr;
+      using SceneCloudConstPtr = typename pcl::CorrespondenceGrouping<PointModelT, PointSceneT>::SceneCloudConstPtr;
 
       /** \brief Constructor */
       GeometricConsistencyGrouping () 

--- a/recognition/include/pcl/recognition/cg/hough_3d.h
+++ b/recognition/include/pcl/recognition/cg/hough_3d.h
@@ -60,7 +60,7 @@ namespace pcl
       
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-        typedef boost::shared_ptr<HoughSpace3D> Ptr;
+        using Ptr = boost::shared_ptr<HoughSpace3D>;
       
         /** \brief Constructor
           *
@@ -147,19 +147,19 @@ namespace pcl
   class Hough3DGrouping : public CorrespondenceGrouping<PointModelT, PointSceneT>
   {
     public:
-      typedef pcl::PointCloud<PointModelRfT> ModelRfCloud;
-      typedef typename ModelRfCloud::Ptr ModelRfCloudPtr;
-      typedef typename ModelRfCloud::ConstPtr ModelRfCloudConstPtr;
+      using ModelRfCloud = pcl::PointCloud<PointModelRfT>;
+      using ModelRfCloudPtr = typename ModelRfCloud::Ptr;
+      using ModelRfCloudConstPtr = typename ModelRfCloud::ConstPtr;
 
-      typedef pcl::PointCloud<PointSceneRfT> SceneRfCloud;
-      typedef typename SceneRfCloud::Ptr SceneRfCloudPtr;
-      typedef typename SceneRfCloud::ConstPtr SceneRfCloudConstPtr;
+      using SceneRfCloud = pcl::PointCloud<PointSceneRfT>;
+      using SceneRfCloudPtr = typename SceneRfCloud::Ptr;
+      using SceneRfCloudConstPtr = typename SceneRfCloud::ConstPtr;
 
-      typedef pcl::PointCloud<PointModelT> PointCloud;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+      using PointCloud = pcl::PointCloud<PointModelT>;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      typedef typename pcl::CorrespondenceGrouping<PointModelT, PointSceneT>::SceneCloudConstPtr SceneCloudConstPtr;
+      using SceneCloudConstPtr = typename pcl::CorrespondenceGrouping<PointModelT, PointSceneT>::SceneCloudConstPtr;
 
       /** \brief Constructor */
       Hough3DGrouping () 

--- a/recognition/include/pcl/recognition/color_gradient_dot_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_dot_modality.h
@@ -69,7 +69,7 @@ namespace pcl
     };
 
     public:
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
 
       ColorGradientDOTModality (size_t bin_size);
   

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -81,7 +81,7 @@ namespace pcl
       };
 
     public:
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
 
       /** \brief Different methods for feature selection/extraction. */
       enum FeatureSelectionMethod

--- a/recognition/include/pcl/recognition/color_modality.h
+++ b/recognition/include/pcl/recognition/color_modality.h
@@ -75,7 +75,7 @@ namespace pcl
       };
 
     public:
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
 
       ColorModality ();
   

--- a/recognition/include/pcl/recognition/crh_alignment.h
+++ b/recognition/include/pcl/recognition/crh_alignment.h
@@ -32,16 +32,16 @@ namespace pcl
     private:
 
       /** \brief Sorts peaks */
-      typedef struct
+      struct peaks_ordering
       {
         bool
         operator() (std::pair<float, int> const& a, std::pair<float, int> const& b)
         {
           return a.first > b.first;
         }
-      } peaks_ordering;
+      };
 
-      typedef typename pcl::PointCloud<PointT>::Ptr PointTPtr;
+      using PointTPtr = typename pcl::PointCloud<PointT>::Ptr;
 
       /** \brief View of the model to be aligned to input_view_ */
       PointTPtr target_view_;

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -112,7 +112,7 @@ namespace pcl
 
       public:
 
-        typedef boost::shared_ptr<FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>> Ptr;
+        using Ptr = boost::shared_ptr<FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>>;
 
         FaceDetectorDataProvider()
         {

--- a/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h
+++ b/recognition/include/pcl/recognition/face_detection/rf_face_detector_trainer.h
@@ -43,7 +43,7 @@ namespace pcl
       pcl::PointCloud<pcl::PointXYZ>::Ptr input_;
       pcl::PointCloud<pcl::PointXYZI>::Ptr face_heat_map_;
 
-      typedef face_detection::RFTreeNode<face_detection::FeatureType> NodeType;
+      using NodeType = face_detection::RFTreeNode<face_detection::FeatureType>;
       pcl::DecisionForest<NodeType> forest_;
 
       std::string model_path_;

--- a/recognition/include/pcl/recognition/hv/greedy_verification.h
+++ b/recognition/include/pcl/recognition/hv/greedy_verification.h
@@ -72,7 +72,7 @@ namespace pcl
         float regularizer_;
       };
 
-      typedef boost::shared_ptr<RecognitionModel> RecognitionModelPtr;
+      using RecognitionModelPtr = boost::shared_ptr<RecognitionModel>;
 
       /*
        * \brief Sorts recognition models based on the number of explained scene points and visible outliers

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -51,9 +51,9 @@ namespace pcl
           int id_;
       };
 
-      typedef boost::shared_ptr<RecognitionModel> RecognitionModelPtr;
+      using RecognitionModelPtr = boost::shared_ptr<RecognitionModel>;
 
-      typedef GlobalHypothesesVerification<ModelT, SceneT> SAOptimizerT;
+      using SAOptimizerT = GlobalHypothesesVerification<ModelT, SceneT>;
       class SAModel: public mets::evaluable_solution
       {
         public:
@@ -153,7 +153,7 @@ namespace pcl
       {
         public:
           std::vector<move*> moves_m;
-          typedef typename std::vector<move*>::iterator iterator;
+          using iterator = typename std::vector<move *>::iterator;
           iterator begin()
           {
             return moves_m.begin ();
@@ -193,7 +193,7 @@ namespace pcl
       using HypothesisVerification<ModelT, SceneT>::inliers_threshold_;
 
       //class attributes
-      typedef pcl::NormalEstimation<SceneT, pcl::Normal> NormalEstimator_;
+      using NormalEstimator_ = pcl::NormalEstimation<SceneT, pcl::Normal>;
       pcl::PointCloud<pcl::Normal>::Ptr scene_normals_;
       pcl::PointCloud<pcl::PointXYZI>::Ptr clusters_cloud_;
 

--- a/recognition/include/pcl/recognition/hv/hv_papazov.h
+++ b/recognition/include/pcl/recognition/hv/hv_papazov.h
@@ -75,14 +75,14 @@ namespace pcl
         int id_;
     };
 
-    typedef boost::shared_ptr<RecognitionModel> RecognitionModelPtr;
+    using RecognitionModelPtr = boost::shared_ptr<RecognitionModel>;
 
     std::vector<int> explained_by_RM_; //represents the points of scene_cloud_ that are explained by the recognition models
     std::vector<RecognitionModelPtr> recognition_models_;
     std::vector<std::vector<RecognitionModelPtr>> points_explained_by_rm_; //if inner size > 1, conflict
     std::map<int, RecognitionModelPtr> graph_id_model_map_;
 
-    typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RecognitionModelPtr> Graph;
+    using Graph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RecognitionModelPtr>;
     Graph conflict_graph_;
 
     //builds the conflict_graph

--- a/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_papazov.hpp
@@ -131,7 +131,7 @@ template<typename ModelT, typename SceneT>
   pcl::PapazovHV<ModelT, SceneT>::nonMaximaSuppresion ()
   {
     // iterate over all vertices of the graph and check if they have a better neighbour, then remove that vertex
-    typedef typename boost::graph_traits<Graph>::vertex_iterator VertexIterator;
+    using VertexIterator = typename boost::graph_traits<Graph>::vertex_iterator;
     VertexIterator vi, vi_end;
     boost::tie (vi, vi_end) = boost::vertices (conflict_graph_);
 

--- a/recognition/include/pcl/recognition/implicit_shape_model.h
+++ b/recognition/include/pcl/recognition/implicit_shape_model.h
@@ -75,7 +75,7 @@ namespace pcl
     {
       public:
 
-        typedef boost::shared_ptr<ISMVoteList<PointT>> Ptr;
+        using Ptr = boost::shared_ptr<ISMVoteList<PointT> >;
 
         /** \brief Empty constructor with member variables initialization. */
         ISMVoteList ();
@@ -241,9 +241,9 @@ namespace pcl
     {
       public:
 
-        typedef boost::shared_ptr<pcl::features::ISMModel> ISMModelPtr;
-        typedef pcl::Feature<PointT, pcl::Histogram<FeatureSize>> Feature;
-        typedef typename Feature::Ptr FeaturePtr;
+        using ISMModelPtr = boost::shared_ptr<pcl::features::ISMModel>;
+        using Feature = pcl::Feature<PointT, pcl::Histogram<FeatureSize>>;
+        using FeaturePtr = typename Feature::Ptr;
 
       protected:
 
@@ -277,7 +277,7 @@ namespace pcl
 
         /** \brief This structure is used for determining the end of the
           * k-means clustering process. */
-        typedef struct PCL_EXPORTS TC
+        struct PCL_EXPORTS TermCriteria
         {
           enum
           {
@@ -290,7 +290,7 @@ namespace pcl
             * \param[in] max_count defines the max number of iterations
             * \param[in] epsilon defines the desired accuracy
             */
-          TC(int type, int max_count, float epsilon) :
+          TermCriteria(int type, int max_count, float epsilon) :
             type_ (type),
             max_count_ (max_count),
             epsilon_ (epsilon) {};
@@ -308,7 +308,7 @@ namespace pcl
 
           /** \brief Defines the accuracy for k-means clustering. */
           float epsilon_;
-        } TermCriteria;
+        };
 
         /** \brief Structure for storing the visual word. */
         struct PCL_EXPORTS VisualWordStat

--- a/recognition/include/pcl/recognition/ransac_based/model_library.h
+++ b/recognition/include/pcl/recognition/ransac_based/model_library.h
@@ -58,8 +58,8 @@ namespace pcl
     class PCL_EXPORTS ModelLibrary
     {
       public:
-        typedef pcl::PointCloud<pcl::PointXYZ> PointCloudIn;
-        typedef pcl::PointCloud<pcl::Normal> PointCloudN;
+        using PointCloudIn = pcl::PointCloud<pcl::PointXYZ>;
+        using PointCloudN = pcl::PointCloud<pcl::Normal>;
 
         /** \brief Stores some information about the model. */
         class Model
@@ -170,9 +170,9 @@ namespace pcl
             void* user_data_;
         };
 
-        typedef std::list<std::pair<const ORROctree::Node::Data*, const ORROctree::Node::Data*> > node_data_pair_list;
-        typedef std::map<const Model*, node_data_pair_list> HashTableCell;
-        typedef VoxelStructure<HashTableCell, float> HashTable;
+        using node_data_pair_list = std::list<std::pair<const ORROctree::Node::Data*, const ORROctree::Node::Data*> >;
+        using HashTableCell = std::map<const Model*, node_data_pair_list>;
+        using HashTable = VoxelStructure<HashTableCell, float>;
 
       public:
         /** \brief This class is used by 'ObjRecRANSAC' to maintain the object models to be recognized. Normally, you do not need to use

--- a/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
+++ b/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
@@ -85,10 +85,10 @@ namespace pcl
     class PCL_EXPORTS ObjRecRANSAC
     {
       public:
-        typedef ModelLibrary::PointCloudIn PointCloudIn;
-        typedef ModelLibrary::PointCloudN PointCloudN;
+        using PointCloudIn = ModelLibrary::PointCloudIn;
+        using PointCloudN = ModelLibrary::PointCloudN;
 
-        typedef BVH<Hypothesis*> BVHH;
+        using BVHH = BVH<Hypothesis *>;
 
         /** \brief This is an output item of the ObjRecRANSAC::recognize() method. It contains the recognized model, its name (the ones passed to
           * ObjRecRANSAC::addModel()), the rigid transform which aligns the model with the input scene and the match confidence which is a number
@@ -138,7 +138,7 @@ namespace pcl
             Hypothesis* create (const SimpleOctree<Hypothesis, HypothesisCreator, float>::Node* ) const { return new Hypothesis ();}
         };
 
-        typedef SimpleOctree<Hypothesis, HypothesisCreator, float> HypothesisOctree;
+        using HypothesisOctree = SimpleOctree<Hypothesis, HypothesisCreator, float>;
 
       public:
         /** \brief Constructor with some important parameters which can not be changed once an instance of that class is created.

--- a/recognition/include/pcl/recognition/ransac_based/orr_octree.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_octree.h
@@ -70,9 +70,9 @@ namespace pcl
     class PCL_EXPORTS ORROctree
     {
       public:
-        typedef pcl::PointCloud<pcl::PointXYZ> PointCloudIn;
-        typedef pcl::PointCloud<pcl::PointXYZ> PointCloudOut;
-        typedef pcl::PointCloud<pcl::Normal> PointCloudN;
+        using PointCloudIn = pcl::PointCloud<pcl::PointXYZ>;
+        using PointCloudOut = pcl::PointCloud<pcl::PointXYZ>;
+        using PointCloudN = pcl::PointCloud<pcl::Normal>;
 
         class Node
         {

--- a/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
+++ b/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
@@ -183,7 +183,7 @@ namespace pcl
         }
     };
 
-    typedef SimpleOctree<RotationSpaceCell, RotationSpaceCellCreator, float> CellOctree;
+    using CellOctree = SimpleOctree<RotationSpaceCell, RotationSpaceCellCreator, float>;
 
     /** \brief This is a class for a discrete representation of the rotation space based on the axis-angle representation.
       * This class is not supposed to be very general. That's why it is dependent on the class ModelLibrary.
@@ -335,7 +335,7 @@ namespace pcl
         std::list<RotationSpace*> rotation_spaces_;
     };
 
-    typedef SimpleOctree<RotationSpace, RotationSpaceCreator, float> RotationSpaceOctree;
+    using RotationSpaceOctree = SimpleOctree<RotationSpace, RotationSpaceCreator, float>;
 
     class PCL_EXPORTS RigidTransformSpace
     {

--- a/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
+++ b/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
@@ -61,10 +61,10 @@ namespace pcl
     class PCL_EXPORTS TrimmedICP: public pcl::registration::TransformationEstimationSVD<PointT, PointT, Scalar>
     {
       public:
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef typename PointCloud::ConstPtr PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        typedef typename Eigen::Matrix<Scalar, 4, 4> Matrix4;
+        using Matrix4 = typename Eigen::Matrix<Scalar, 4, 4>;
 
       public:
         TrimmedICP ()

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -323,7 +323,7 @@ namespace pcl
       };
 
     public:
-      typedef pcl::PointCloud<PointInT> PointCloudIn;
+      using PointCloudIn = pcl::PointCloud<PointInT>;
 
       /** \brief Constructor. */
       SurfaceNormalModality ();

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -369,7 +369,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
       int neg_extracted = 0;
       int w_size_2 = static_cast<int> (w_size_ / 2);
 
-      typedef std::pair<int, int> pixelpair;
+      using pixelpair = std::pair<int, int>;
       std::vector < pixelpair > negative_p, positive_p;
       //get negative and positive indices to sample from
       for (int col = 0; col < (static_cast<int> (cloud_labels->width) - w_size_); col++)

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -282,7 +282,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
   if (use_normals_)
   {
-    typedef pcl::IntegralImageNormalEstimation<pcl::PointXYZ, pcl::Normal> NormalEstimator_;
+    using NormalEstimator_ = pcl::IntegralImageNormalEstimation<pcl::PointXYZ, pcl::Normal>;
     NormalEstimator_ n3d;
     n3d.setNormalEstimationMethod (n3d.COVARIANCE_MATRIX);
     n3d.setInputCloud (cloud);
@@ -436,7 +436,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
     pcl::PointCloud<pcl::Normal>::Ptr scene_normals (new pcl::PointCloud<pcl::Normal> ());
 
     {
-      typedef pcl::IntegralImageNormalEstimation<pcl::PointXYZ, pcl::Normal> NormalEstimator_;
+      using NormalEstimator_ = pcl::IntegralImageNormalEstimation<pcl::PointXYZ, pcl::Normal>;
       NormalEstimator_ n3d;
       n3d.setNormalEstimationMethod (n3d.COVARIANCE_MATRIX);
       n3d.setInputCloud (input_);

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -500,7 +500,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
     graph.getNodes ()[lin_id]->setData ((*obj)->getData ());
   }
 
-  typedef pair<int,int> ordered_int_pair;
+  using ordered_int_pair = pair<int,int>;
   // This is one is to make sure that we do not compute the same set intersection twice
   set<ordered_int_pair, bool(*)(const ordered_int_pair&, const ordered_int_pair&)> ordered_hypotheses_ids (aux::compareOrderedPairs<int>);
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -248,7 +248,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
     projected_points.width    = input_->width;
     projected_points.height   = input_->height;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < projected_points.points.size (); ++i)
       // Iterate over each dimension
@@ -272,7 +272,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
     projected_points.width    = static_cast<uint32_t> (inliers.size ());
     projected_points.height   = 1;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < inliers.size (); ++i)
       // Iterate over each dimension

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -310,7 +310,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::projectPoints (
     projected_points.width    = input_->width;
     projected_points.height   = input_->height;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < projected_points.points.size (); ++i)
       // Iterate over each dimension
@@ -352,7 +352,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::projectPoints (
     projected_points.width    = uint32_t (inliers.size ());
     projected_points.height   = 1;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < inliers.size (); ++i)
       // Iterate over each dimension

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -371,7 +371,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::projectPoints (
     projected_points.width    = input_->width;
     projected_points.height   = input_->height;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < projected_points.points.size (); ++i)
       // Iterate over each dimension
@@ -408,7 +408,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::projectPoints (
     projected_points.width    = static_cast<uint32_t> (inliers.size ());
     projected_points.height   = 1;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < inliers.size (); ++i)
       // Iterate over each dimension

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -326,7 +326,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
     projected_points.width    = input_->width;
     projected_points.height   = input_->height;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < projected_points.points.size (); ++i)
       // Iterate over each dimension
@@ -359,7 +359,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
     projected_points.width    = static_cast<uint32_t> (inliers.size ());
     projected_points.height   = 1;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < inliers.size (); ++i)
       // Iterate over each dimension

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -256,7 +256,7 @@ pcl::SampleConsensusModelLine<PointT>::projectPoints (
     projected_points.width    = input_->width;
     projected_points.height   = input_->height;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < projected_points.points.size (); ++i)
       // Iterate over each dimension
@@ -283,7 +283,7 @@ pcl::SampleConsensusModelLine<PointT>::projectPoints (
     projected_points.width    = static_cast<uint32_t> (inliers.size ());
     projected_points.height   = 1;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < inliers.size (); ++i)
       // Iterate over each dimension

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
@@ -289,7 +289,7 @@ pcl::SampleConsensusModelPlane<PointT>::projectPoints (
     projected_points.width    = input_->width;
     projected_points.height   = input_->height;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < input_->points.size (); ++i)
       // Iterate over each dimension
@@ -317,7 +317,7 @@ pcl::SampleConsensusModelPlane<PointT>::projectPoints (
     projected_points.width    = static_cast<uint32_t> (inliers.size ());
     projected_points.height   = 1;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < inliers.size (); ++i)
       // Iterate over each dimension

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
@@ -283,7 +283,7 @@ pcl::SampleConsensusModelStick<PointT>::projectPoints (
     projected_points.width    = input_->width;
     projected_points.height   = input_->height;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < projected_points.points.size (); ++i)
       // Iterate over each dimension
@@ -310,7 +310,7 @@ pcl::SampleConsensusModelStick<PointT>::projectPoints (
     projected_points.width    = static_cast<uint32_t> (inliers.size ());
     projected_points.height   = 1;
 
-    typedef typename pcl::traits::fieldList<PointT>::type FieldList;
+    using FieldList = typename pcl::traits::fieldList<PointT>::type;
     // Iterate over each point
     for (size_t i = 0; i < inliers.size (); ++i)
       // Iterate over each dimension

--- a/sample_consensus/include/pcl/sample_consensus/lmeds.h
+++ b/sample_consensus/include/pcl/sample_consensus/lmeds.h
@@ -55,11 +55,11 @@ namespace pcl
   template <typename PointT>
   class LeastMedianSquares : public SampleConsensus<PointT>
   {
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      typedef boost::shared_ptr<LeastMedianSquares> Ptr;
-      typedef boost::shared_ptr<const LeastMedianSquares> ConstPtr;
+      using Ptr = boost::shared_ptr<LeastMedianSquares<PointT> >;
+      using ConstPtr = boost::shared_ptr<const LeastMedianSquares<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/mlesac.h
+++ b/sample_consensus/include/pcl/sample_consensus/mlesac.h
@@ -55,12 +55,12 @@ namespace pcl
   template <typename PointT>
   class MaximumLikelihoodSampleConsensus : public SampleConsensus<PointT>
   {
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
-    typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr; 
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
+    using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr; 
 
     public:
-      typedef boost::shared_ptr<MaximumLikelihoodSampleConsensus> Ptr;
-      typedef boost::shared_ptr<const MaximumLikelihoodSampleConsensus> ConstPtr;
+      using Ptr = boost::shared_ptr<MaximumLikelihoodSampleConsensus<PointT> >;
+      using ConstPtr = boost::shared_ptr<const MaximumLikelihoodSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/msac.h
+++ b/sample_consensus/include/pcl/sample_consensus/msac.h
@@ -55,11 +55,11 @@ namespace pcl
   template <typename PointT>
   class MEstimatorSampleConsensus : public SampleConsensus<PointT>
   {
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      typedef boost::shared_ptr<MEstimatorSampleConsensus> Ptr;
-      typedef boost::shared_ptr<const MEstimatorSampleConsensus> ConstPtr;
+      using Ptr = boost::shared_ptr<MEstimatorSampleConsensus<PointT> >;
+      using ConstPtr = boost::shared_ptr<const MEstimatorSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/prosac.h
+++ b/sample_consensus/include/pcl/sample_consensus/prosac.h
@@ -54,11 +54,11 @@ namespace pcl
   template<typename PointT>
   class ProgressiveSampleConsensus : public SampleConsensus<PointT>
   {
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      typedef boost::shared_ptr<ProgressiveSampleConsensus> Ptr;
-      typedef boost::shared_ptr<const ProgressiveSampleConsensus> ConstPtr;
+      using Ptr = boost::shared_ptr<ProgressiveSampleConsensus>;
+      using ConstPtr = boost::shared_ptr<const ProgressiveSampleConsensus>;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/ransac.h
+++ b/sample_consensus/include/pcl/sample_consensus/ransac.h
@@ -54,11 +54,11 @@ namespace pcl
   template <typename PointT>
   class RandomSampleConsensus : public SampleConsensus<PointT>
   {
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      typedef boost::shared_ptr<RandomSampleConsensus> Ptr;
-      typedef boost::shared_ptr<const RandomSampleConsensus> ConstPtr;
+      using Ptr = boost::shared_ptr<RandomSampleConsensus<PointT> >;
+      using ConstPtr = boost::shared_ptr<const RandomSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/rmsac.h
+++ b/sample_consensus/include/pcl/sample_consensus/rmsac.h
@@ -56,11 +56,11 @@ namespace pcl
   template <typename PointT>
   class RandomizedMEstimatorSampleConsensus : public SampleConsensus<PointT>
   {
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      typedef boost::shared_ptr<RandomizedMEstimatorSampleConsensus> Ptr;
-      typedef boost::shared_ptr<const RandomizedMEstimatorSampleConsensus> ConstPtr;
+      using Ptr = boost::shared_ptr<RandomizedMEstimatorSampleConsensus<PointT> >;
+      using ConstPtr = boost::shared_ptr<const RandomizedMEstimatorSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/rransac.h
+++ b/sample_consensus/include/pcl/sample_consensus/rransac.h
@@ -55,11 +55,11 @@ namespace pcl
   template <typename PointT>
   class RandomizedRandomSampleConsensus : public SampleConsensus<PointT>
   {
-    typedef typename SampleConsensusModel<PointT>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      typedef boost::shared_ptr<RandomizedRandomSampleConsensus> Ptr;
-      typedef boost::shared_ptr<const RandomizedRandomSampleConsensus> ConstPtr;
+      using Ptr = boost::shared_ptr<RandomizedRandomSampleConsensus<PointT> >;
+      using ConstPtr = boost::shared_ptr<const RandomizedRandomSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/sac.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac.h
@@ -54,15 +54,15 @@ namespace pcl
   template <typename T>
   class SampleConsensus
   {
-    typedef typename SampleConsensusModel<T>::Ptr SampleConsensusModelPtr;
+    using SampleConsensusModelPtr = typename SampleConsensusModel<T>::Ptr;
 
     private:
       /** \brief Constructor for base SAC. */
       SampleConsensus () {};
 
     public:
-      typedef boost::shared_ptr<SampleConsensus> Ptr;
-      typedef boost::shared_ptr<const SampleConsensus> ConstPtr;
+      using Ptr = boost::shared_ptr<SampleConsensus<T> >;
+      using ConstPtr = boost::shared_ptr<const SampleConsensus<T> >;
 
       /** \brief Constructor for base SAC.
         * \param[in] model a Sample Consensus model

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -65,13 +65,13 @@ namespace pcl
   class SampleConsensusModel
   {
     public:
-      typedef pcl::PointCloud<PointT> PointCloud;
-      typedef typename PointCloud::ConstPtr PointCloudConstPtr;
-      typedef typename PointCloud::Ptr PointCloudPtr;
-      typedef typename pcl::search::Search<PointT>::Ptr SearchPtr;
+      using PointCloud = pcl::PointCloud<PointT>;
+      using PointCloudConstPtr = typename PointCloud::ConstPtr;
+      using PointCloudPtr = typename PointCloud::Ptr;
+      using SearchPtr = typename pcl::search::Search<PointT>::Ptr;
 
-      typedef boost::shared_ptr<SampleConsensusModel> Ptr;
-      typedef boost::shared_ptr<const SampleConsensusModel> ConstPtr;
+      using Ptr = boost::shared_ptr<SampleConsensusModel<PointT> >;
+      using ConstPtr = boost::shared_ptr<const SampleConsensusModel<PointT> >;
 
     protected:
       /** \brief Empty constructor for base SampleConsensusModel.
@@ -576,11 +576,11 @@ namespace pcl
   class SampleConsensusModelFromNormals //: public SampleConsensusModel<PointT>
   {
     public:
-      typedef typename pcl::PointCloud<PointNT>::ConstPtr PointCloudNConstPtr;
-      typedef typename pcl::PointCloud<PointNT>::Ptr PointCloudNPtr;
+      using PointCloudNConstPtr = typename pcl::PointCloud<PointNT>::ConstPtr;
+      using PointCloudNPtr = typename pcl::PointCloud<PointNT>::Ptr;
 
-      typedef boost::shared_ptr<SampleConsensusModelFromNormals> Ptr;
-      typedef boost::shared_ptr<const SampleConsensusModelFromNormals> ConstPtr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelFromNormals<PointT, PointNT> >;
+      using ConstPtr = boost::shared_ptr<const SampleConsensusModelFromNormals<PointT, PointNT> >;
 
       /** \brief Empty constructor for base SampleConsensusModelFromNormals. */
       SampleConsensusModelFromNormals () : normal_distance_weight_ (0.0), normals_ () {};
@@ -637,16 +637,16 @@ namespace pcl
   template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
   struct Functor
   {
-    typedef _Scalar Scalar;
+    using Scalar = _Scalar;
     enum 
     {
       InputsAtCompileTime = NX,
       ValuesAtCompileTime = NY
     };
 
-    typedef Eigen::Matrix<Scalar,ValuesAtCompileTime,1> ValueType;
-    typedef Eigen::Matrix<Scalar,InputsAtCompileTime,1> InputType;
-    typedef Eigen::Matrix<Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
+    using ValueType = Eigen::Matrix<Scalar,ValuesAtCompileTime,1>;
+    using InputType = Eigen::Matrix<Scalar,InputsAtCompileTime,1>;
+    using JacobianType = Eigen::Matrix<Scalar,ValuesAtCompileTime,InputsAtCompileTime>;
 
     /** \brief Empty Constructor. */
     Functor () : m_data_points_ (ValuesAtCompileTime) {}

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -66,11 +66,11 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelCircle2D> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelCircle2D<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelCircle2D.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -66,12 +66,12 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_min_;
       using SampleConsensusModel<PointT>::radius_max_;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelCircle3D<PointT> > Ptr;
-      typedef boost::shared_ptr<const SampleConsensusModelCircle3D<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelCircle3D<PointT> >;
+      using ConstPtr = boost::shared_ptr<const SampleConsensusModelCircle3D<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelCircle3D.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -73,11 +73,11 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelCone> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelCone<PointT, PointNT> >;
 
       /** \brief Constructor for base SampleConsensusModelCone.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -73,11 +73,11 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelCylinder> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelCylinder<PointT, PointNT> >;
 
       /** \brief Constructor for base SampleConsensusModelCylinder.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -68,11 +68,11 @@ namespace pcl
       using SampleConsensusModel<PointT>::error_sqr_dists_;
       using SampleConsensusModel<PointT>::isModelValid;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelLine> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelLine<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelLine.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -90,14 +90,14 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr PointCloudNPtr;
-      typedef typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr PointCloudNConstPtr;
+      using PointCloudNPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr;
+      using PointCloudNConstPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelNormalParallelPlane> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelNormalParallelPlane<PointT, PointNT> >;
 
       /** \brief Constructor for base SampleConsensusModelNormalParallelPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -83,14 +83,14 @@ namespace pcl
       using SampleConsensusModel<PointT>::error_sqr_dists_;
       using SampleConsensusModel<PointT>::isModelValid;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr PointCloudNPtr;
-      typedef typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr PointCloudNConstPtr;
+      using PointCloudNPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr;
+      using PointCloudNConstPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelNormalPlane> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelNormalPlane<PointT, PointNT> >;
 
       /** \brief Constructor for base SampleConsensusModelNormalPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -77,14 +77,14 @@ namespace pcl
       using SampleConsensusModelFromNormals<PointT, PointNT>::normal_distance_weight_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr PointCloudNPtr;
-      typedef typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr PointCloudNConstPtr;
+      using PointCloudNPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr;
+      using PointCloudNConstPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelNormalSphere> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelNormalSphere<PointT, PointNT> >;
 
       /** \brief Constructor for base SampleConsensusModelNormalSphere.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -67,11 +67,11 @@ namespace pcl
     public:
       using SampleConsensusModel<PointT>::model_name_;
 
-      typedef typename SampleConsensusModelLine<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModelLine<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModelLine<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModelLine<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModelLine<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModelLine<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelParallelLine> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelParallelLine<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelParallelLine.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -67,11 +67,11 @@ namespace pcl
     public:
       using SampleConsensusModel<PointT>::model_name_;
 
-      typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModelPlane<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModelPlane<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelParallelPlane> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelParallelPlane<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelParallelPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -72,11 +72,11 @@ namespace pcl
     public:
       using SampleConsensusModel<PointT>::model_name_;
 
-      typedef typename SampleConsensusModelPlane<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModelPlane<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModelPlane<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModelPlane<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelPerpendicularPlane> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelPerpendicularPlane<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelPerpendicularPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -141,11 +141,11 @@ namespace pcl
       using SampleConsensusModel<PointT>::error_sqr_dists_;
       using SampleConsensusModel<PointT>::isModelValid;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelPlane> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelPlane<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -63,11 +63,11 @@ namespace pcl
       using SampleConsensusModel<PointT>::error_sqr_dists_;
       using SampleConsensusModel<PointT>::isModelValid;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelRegistration> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelRegistration<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelRegistration.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -61,12 +61,12 @@ namespace pcl
       using pcl::SampleConsensusModelRegistration<PointT>::computeOriginalIndexMapping;
       using pcl::SampleConsensusModel<PointT>::isModelValid;
 
-      typedef typename pcl::SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename pcl::SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename pcl::SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename pcl::SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename pcl::SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename pcl::SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelRegistration2D> Ptr;
-      typedef boost::shared_ptr<const SampleConsensusModelRegistration2D> ConstPtr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelRegistration2D<PointT> >;
+      using ConstPtr = boost::shared_ptr<const SampleConsensusModelRegistration2D<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelRegistration2D.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -66,11 +66,11 @@ namespace pcl
       using SampleConsensusModel<PointT>::radius_max_;
       using SampleConsensusModel<PointT>::error_sqr_dists_;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelSphere> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelSphere<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelSphere.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -71,11 +71,11 @@ namespace pcl
       using SampleConsensusModel<PointT>::error_sqr_dists_;
       using SampleConsensusModel<PointT>::isModelValid;
 
-      typedef typename SampleConsensusModel<PointT>::PointCloud PointCloud;
-      typedef typename SampleConsensusModel<PointT>::PointCloudPtr PointCloudPtr;
-      typedef typename SampleConsensusModel<PointT>::PointCloudConstPtr PointCloudConstPtr;
+      using PointCloud = typename SampleConsensusModel<PointT>::PointCloud;
+      using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
+      using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      typedef boost::shared_ptr<SampleConsensusModelStick> Ptr;
+      using Ptr = boost::shared_ptr<SampleConsensusModelStick<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelStick.
         * \param[in] cloud the input point cloud dataset


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`