### PR TITLE
Use using instead of typedef [geometry]

### DIFF
--- a/geometry/include/pcl/geometry/get_boundary.h
+++ b/geometry/include/pcl/geometry/get_boundary.h
@@ -58,10 +58,10 @@ namespace pcl
                                std::vector <typename MeshT::HalfEdgeIndices>& boundary_he_collection,
                                const size_t                                   expected_size = 3)
     {
-      typedef MeshT                                            Mesh;
-      typedef typename Mesh::HalfEdgeIndex                     HalfEdgeIndex;
-      typedef typename Mesh::HalfEdgeIndices                   HalfEdgeIndices;
-      typedef typename Mesh::InnerHalfEdgeAroundFaceCirculator IHEAFC;
+      using Mesh = MeshT;
+      using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
+      using HalfEdgeIndices = typename Mesh::HalfEdgeIndices;
+      using IHEAFC = typename Mesh::InnerHalfEdgeAroundFaceCirculator;
 
       boundary_he_collection.clear ();
 

--- a/geometry/include/pcl/geometry/line_iterator.h
+++ b/geometry/include/pcl/geometry/line_iterator.h
@@ -49,7 +49,7 @@ class LineIterator : public OrganizedIndexIterator
 {
   public:
     /** \brief Neighborhood connectivity  */
-    typedef enum {Neighbor4 = 4, Neighbor8 = 8} Neighborhood;
+    enum Neighborhood {Neighbor4 = 4, Neighbor8 = 8};
   public:
     /** \brief Constructor
       * \param x_start column of the start pixel of the line

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -99,55 +99,55 @@ namespace pcl
     {
       public:
 
-        typedef MeshBase <DerivedT, MeshTraitsT, MeshTagT> Self;
-        typedef boost::shared_ptr <Self>                   Ptr;
-        typedef boost::shared_ptr <const Self>             ConstPtr;
+        using Self = MeshBase <DerivedT, MeshTraitsT, MeshTagT>;
+        using Ptr = boost::shared_ptr<Self>;
+        using ConstPtr = boost::shared_ptr<const Self>;
 
-        typedef DerivedT Derived;
+        using Derived = DerivedT;
 
         // These have to be defined in the traits class.
-        typedef typename MeshTraitsT::VertexData   VertexData;
-        typedef typename MeshTraitsT::HalfEdgeData HalfEdgeData;
-        typedef typename MeshTraitsT::EdgeData     EdgeData;
-        typedef typename MeshTraitsT::FaceData     FaceData;
-        typedef typename MeshTraitsT::IsManifold   IsManifold;
+        using VertexData = typename MeshTraitsT::VertexData;
+        using HalfEdgeData = typename MeshTraitsT::HalfEdgeData;
+        using EdgeData = typename MeshTraitsT::EdgeData;
+        using FaceData = typename MeshTraitsT::FaceData;
+        using IsManifold = typename MeshTraitsT::IsManifold;
 
         // Check if the mesh traits are defined correctly.
         static_assert (std::is_convertible<IsManifold, bool>::value, "MeshTraitsT::IsManifold is not convertible to bool");
 
-        typedef MeshTagT MeshTag;
+        using MeshTag = MeshTagT;
 
         // Data
-        typedef std::integral_constant <bool, !std::is_same <VertexData  , pcl::geometry::NoData>::value> HasVertexData;
-        typedef std::integral_constant <bool, !std::is_same <HalfEdgeData, pcl::geometry::NoData>::value> HasHalfEdgeData;
-        typedef std::integral_constant <bool, !std::is_same <EdgeData    , pcl::geometry::NoData>::value> HasEdgeData;
-        typedef std::integral_constant <bool, !std::is_same <FaceData    , pcl::geometry::NoData>::value> HasFaceData;
+        using HasVertexData = std::integral_constant <bool, !std::is_same <VertexData  , pcl::geometry::NoData>::value>;
+        using HasHalfEdgeData = std::integral_constant <bool, !std::is_same <HalfEdgeData, pcl::geometry::NoData>::value>;
+        using HasEdgeData = std::integral_constant <bool, !std::is_same <EdgeData    , pcl::geometry::NoData>::value>;
+        using HasFaceData = std::integral_constant <bool, !std::is_same <FaceData    , pcl::geometry::NoData>::value>;
 
-        typedef pcl::PointCloud <VertexData>   VertexDataCloud;
-        typedef pcl::PointCloud <HalfEdgeData> HalfEdgeDataCloud;
-        typedef pcl::PointCloud <EdgeData>     EdgeDataCloud;
-        typedef pcl::PointCloud <FaceData>     FaceDataCloud;
+        using VertexDataCloud = pcl::PointCloud<VertexData>;
+        using HalfEdgeDataCloud = pcl::PointCloud<HalfEdgeData>;
+        using EdgeDataCloud = pcl::PointCloud<EdgeData>;
+        using FaceDataCloud = pcl::PointCloud<FaceData>;
 
         // Indices
-        typedef pcl::geometry::VertexIndex   VertexIndex;
-        typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-        typedef pcl::geometry::EdgeIndex     EdgeIndex;
-        typedef pcl::geometry::FaceIndex     FaceIndex;
+        using VertexIndex = pcl::geometry::VertexIndex;
+        using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+        using EdgeIndex = pcl::geometry::EdgeIndex;
+        using FaceIndex = pcl::geometry::FaceIndex;
 
-        typedef std::vector <VertexIndex>   VertexIndices;
-        typedef std::vector <HalfEdgeIndex> HalfEdgeIndices;
-        typedef std::vector <EdgeIndex>     EdgeIndices;
-        typedef std::vector <FaceIndex>     FaceIndices;
+        using VertexIndices = std::vector<VertexIndex>;
+        using HalfEdgeIndices = std::vector<HalfEdgeIndex>;
+        using EdgeIndices = std::vector<EdgeIndex>;
+        using FaceIndices = std::vector<FaceIndex>;
 
         // Circulators
-        typedef pcl::geometry::VertexAroundVertexCirculator           <const Self> VertexAroundVertexCirculator;
-        typedef pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator <const Self> OutgoingHalfEdgeAroundVertexCirculator;
-        typedef pcl::geometry::IncomingHalfEdgeAroundVertexCirculator <const Self> IncomingHalfEdgeAroundVertexCirculator;
-        typedef pcl::geometry::FaceAroundVertexCirculator             <const Self> FaceAroundVertexCirculator;
-        typedef pcl::geometry::VertexAroundFaceCirculator             <const Self> VertexAroundFaceCirculator;
-        typedef pcl::geometry::InnerHalfEdgeAroundFaceCirculator      <const Self> InnerHalfEdgeAroundFaceCirculator;
-        typedef pcl::geometry::OuterHalfEdgeAroundFaceCirculator      <const Self> OuterHalfEdgeAroundFaceCirculator;
-        typedef pcl::geometry::FaceAroundFaceCirculator               <const Self> FaceAroundFaceCirculator;
+        using VertexAroundVertexCirculator = pcl::geometry::VertexAroundVertexCirculator<const Self>;
+        using OutgoingHalfEdgeAroundVertexCirculator = pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator<const Self>;
+        using IncomingHalfEdgeAroundVertexCirculator = pcl::geometry::IncomingHalfEdgeAroundVertexCirculator<const Self>;
+        using FaceAroundVertexCirculator = pcl::geometry::FaceAroundVertexCirculator<const Self>;
+        using VertexAroundFaceCirculator = pcl::geometry::VertexAroundFaceCirculator<const Self>;
+        using InnerHalfEdgeAroundFaceCirculator = pcl::geometry::InnerHalfEdgeAroundFaceCirculator<const Self>;
+        using OuterHalfEdgeAroundFaceCirculator = pcl::geometry::OuterHalfEdgeAroundFaceCirculator<const Self>;
+        using FaceAroundFaceCirculator = pcl::geometry::FaceAroundFaceCirculator<const Self>;
 
         /** \brief Constructor. */
         MeshBase ()
@@ -1110,21 +1110,21 @@ namespace pcl
         ////////////////////////////////////////////////////////////////////////
 
         // Elements
-        typedef pcl::geometry::Vertex   Vertex;
-        typedef pcl::geometry::HalfEdge HalfEdge;
-        typedef pcl::geometry::Face     Face;
+        using Vertex = pcl::geometry::Vertex;
+        using HalfEdge = pcl::geometry::HalfEdge;
+        using Face = pcl::geometry::Face;
 
-        typedef std::vector <Vertex>   Vertices;
-        typedef std::vector <HalfEdge> HalfEdges;
-        typedef std::vector <Face>     Faces;
+        using Vertices = std::vector<Vertex>;
+        using HalfEdges = std::vector<HalfEdge>;
+        using Faces = std::vector<Face>;
 
-        typedef typename Vertices::iterator  VertexIterator;
-        typedef typename HalfEdges::iterator HalfEdgeIterator;
-        typedef typename Faces::iterator     FaceIterator;
+        using VertexIterator = typename Vertices::iterator;
+        using HalfEdgeIterator = typename HalfEdges::iterator;
+        using FaceIterator = typename Faces::iterator;
 
-        typedef typename Vertices::const_iterator  VertexConstIterator;
-        typedef typename HalfEdges::const_iterator HalfEdgeConstIterator;
-        typedef typename Faces::const_iterator     FaceConstIterator;
+        using VertexConstIterator = typename Vertices::const_iterator;
+        using HalfEdgeConstIterator = typename HalfEdges::const_iterator;
+        using FaceConstIterator = typename Faces::const_iterator;
 
         /** \brief General implementation of addFace. */
         FaceIndex
@@ -1741,8 +1741,8 @@ namespace pcl
         template <class ElementContainerT, class DataContainerT, class IndexContainerT, class HasDataT> IndexContainerT
         remove (ElementContainerT& elements, DataContainerT& data_cloud)
         {
-          typedef typename IndexContainerT::value_type   Index;
-          typedef typename ElementContainerT::value_type Element;
+          using Index = typename IndexContainerT::value_type;
+          using Element = typename ElementContainerT::value_type;
 
           if (HasDataT::value) assert (elements.size () == data_cloud.size ());
           else                 assert (data_cloud.empty ()); // Bug in this class!

--- a/geometry/include/pcl/geometry/mesh_circulators.h
+++ b/geometry/include/pcl/geometry/mesh_circulators.h
@@ -67,13 +67,13 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::VertexAroundVertexCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::VertexAroundVertexCirculator <MeshT> > > Base;
-        typedef pcl::geometry::VertexAroundVertexCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::VertexAroundVertexCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::VertexAroundVertexCirculator <MeshT> > >;
+        using Self = pcl::geometry::VertexAroundVertexCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::VertexIndex VertexIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using VertexIndex = typename Mesh::VertexIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         VertexAroundVertexCirculator ()
@@ -175,13 +175,13 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator <MeshT> > > Base;
-        typedef pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator <MeshT> > >;
+        using Self = pcl::geometry::OutgoingHalfEdgeAroundVertexCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::VertexIndex VertexIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using VertexIndex = typename Mesh::VertexIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         OutgoingHalfEdgeAroundVertexCirculator ()
@@ -283,13 +283,13 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::IncomingHalfEdgeAroundVertexCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::IncomingHalfEdgeAroundVertexCirculator <MeshT> > > Base;
-        typedef pcl::geometry::IncomingHalfEdgeAroundVertexCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::IncomingHalfEdgeAroundVertexCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::IncomingHalfEdgeAroundVertexCirculator <MeshT> > >;
+        using Self = pcl::geometry::IncomingHalfEdgeAroundVertexCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::VertexIndex VertexIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using VertexIndex = typename Mesh::VertexIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         IncomingHalfEdgeAroundVertexCirculator ()
@@ -391,14 +391,14 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::FaceAroundVertexCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::FaceAroundVertexCirculator <MeshT> > > Base;
-        typedef pcl::geometry::FaceAroundVertexCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::FaceAroundVertexCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::FaceAroundVertexCirculator <MeshT> > >;
+        using Self = pcl::geometry::FaceAroundVertexCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::FaceIndex FaceIndex;
-        typedef typename Mesh::VertexIndex VertexIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using FaceIndex = typename Mesh::FaceIndex;
+        using VertexIndex = typename Mesh::VertexIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         FaceAroundVertexCirculator ()
@@ -500,14 +500,14 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::VertexAroundFaceCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::VertexAroundFaceCirculator <MeshT> > > Base;
-        typedef pcl::geometry::VertexAroundFaceCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::VertexAroundFaceCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::VertexAroundFaceCirculator <MeshT> > >;
+        using Self = pcl::geometry::VertexAroundFaceCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::VertexIndex VertexIndex;
-        typedef typename Mesh::FaceIndex FaceIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using VertexIndex = typename Mesh::VertexIndex;
+        using FaceIndex = typename Mesh::FaceIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         VertexAroundFaceCirculator ()
@@ -609,13 +609,13 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::InnerHalfEdgeAroundFaceCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::InnerHalfEdgeAroundFaceCirculator <MeshT> > > Base;
-        typedef pcl::geometry::InnerHalfEdgeAroundFaceCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::InnerHalfEdgeAroundFaceCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::InnerHalfEdgeAroundFaceCirculator <MeshT> > >;
+        using Self = pcl::geometry::InnerHalfEdgeAroundFaceCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::FaceIndex FaceIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using FaceIndex = typename Mesh::FaceIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         InnerHalfEdgeAroundFaceCirculator ()
@@ -717,13 +717,13 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::OuterHalfEdgeAroundFaceCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::OuterHalfEdgeAroundFaceCirculator <MeshT> > > Base;
-        typedef pcl::geometry::OuterHalfEdgeAroundFaceCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::OuterHalfEdgeAroundFaceCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::OuterHalfEdgeAroundFaceCirculator <MeshT> > >;
+        using Self = pcl::geometry::OuterHalfEdgeAroundFaceCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::FaceIndex FaceIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using FaceIndex = typename Mesh::FaceIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         OuterHalfEdgeAroundFaceCirculator ()
@@ -825,13 +825,13 @@ namespace pcl
     {
       public:
 
-        typedef boost::equality_comparable <pcl::geometry::FaceAroundFaceCirculator <MeshT>
-              , boost::unit_steppable      <pcl::geometry::FaceAroundFaceCirculator <MeshT> > > Base;
-        typedef pcl::geometry::FaceAroundFaceCirculator <MeshT> Self;
+        using Base = boost::equality_comparable <pcl::geometry::FaceAroundFaceCirculator <MeshT>,
+                     boost::unit_steppable      <pcl::geometry::FaceAroundFaceCirculator <MeshT> > >;
+        using Self = pcl::geometry::FaceAroundFaceCirculator<MeshT>;
 
-        typedef MeshT Mesh;
-        typedef typename Mesh::FaceIndex FaceIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+        using Mesh = MeshT;
+        using FaceIndex = typename Mesh::FaceIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
 
         /** \brief Constructor resulting in an invalid circulator. */
         FaceAroundFaceCirculator ()

--- a/geometry/include/pcl/geometry/mesh_conversion.h
+++ b/geometry/include/pcl/geometry/mesh_conversion.h
@@ -56,9 +56,9 @@ namespace pcl
     template <class HalfEdgeMeshT> void
     toFaceVertexMesh (const HalfEdgeMeshT& half_edge_mesh, pcl::PolygonMesh& face_vertex_mesh)
     {
-      typedef HalfEdgeMeshT HalfEdgeMesh;
-      typedef typename HalfEdgeMesh::VertexAroundFaceCirculator VAFC;
-      typedef typename HalfEdgeMesh::FaceIndex FaceIndex;
+      using HalfEdgeMesh = HalfEdgeMeshT;
+      using VAFC = typename HalfEdgeMesh::VertexAroundFaceCirculator;
+      using FaceIndex = typename HalfEdgeMesh::FaceIndex;
 
       pcl::Vertices polygon;
       pcl::toPCLPointCloud2 (half_edge_mesh.getVertexDataCloud (), face_vertex_mesh.cloud);
@@ -87,9 +87,9 @@ namespace pcl
     template <class HalfEdgeMeshT> int
     toHalfEdgeMesh (const pcl::PolygonMesh& face_vertex_mesh, HalfEdgeMeshT& half_edge_mesh)
     {
-      typedef HalfEdgeMeshT                          HalfEdgeMesh;
-      typedef typename HalfEdgeMesh::VertexDataCloud VertexDataCloud;
-      typedef typename HalfEdgeMesh::VertexIndices   VertexIndices;
+      using HalfEdgeMesh = HalfEdgeMeshT;
+      using VertexDataCloud = typename HalfEdgeMesh::VertexDataCloud;
+      using VertexIndices = typename HalfEdgeMesh::VertexIndices;
 
       static_assert (HalfEdgeMesh::HasVertexData::value, "Output mesh must have data associated with the vertices!");
 

--- a/geometry/include/pcl/geometry/mesh_elements.h
+++ b/geometry/include/pcl/geometry/mesh_elements.h
@@ -70,7 +70,7 @@ namespace pcl
     {
       private:
 
-        typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
+        using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
 
         /** \brief Constructor.
           * \param[in] idx_outgoing_half_edge Index to the outgoing half-edge. Defaults to an invalid index.
@@ -107,9 +107,9 @@ namespace pcl
     {
       private:
 
-        typedef pcl::geometry::VertexIndex   VertexIndex;
-        typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
-        typedef pcl::geometry::FaceIndex     FaceIndex;
+        using VertexIndex = pcl::geometry::VertexIndex;
+        using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
+        using FaceIndex = pcl::geometry::FaceIndex;
 
         /** \brief Constructor.
           * \param[in] idx_terminating_vertex Index to the terminating vertex. Defaults to an invalid index.
@@ -165,7 +165,7 @@ namespace pcl
     {
       private:
 
-        typedef pcl::geometry::HalfEdgeIndex HalfEdgeIndex;
+        using HalfEdgeIndex = pcl::geometry::HalfEdgeIndex;
 
         /** \brief Constructor.
           * \param[in] inner_half_edge_idx Index to the outgoing half-edge. Defaults to an invalid index

--- a/geometry/include/pcl/geometry/mesh_indices.h
+++ b/geometry/include/pcl/geometry/mesh_indices.h
@@ -66,10 +66,10 @@ namespace pcl
     {
       public:
 
-        typedef boost::totally_ordered <pcl::geometry::VertexIndex,
-                boost::unit_steppable  <pcl::geometry::VertexIndex,
-                boost::additive        <pcl::geometry::VertexIndex> > > Base;
-        typedef pcl::geometry::VertexIndex                              Self;
+        using Base = boost::totally_ordered <pcl::geometry::VertexIndex,
+                     boost::unit_steppable  <pcl::geometry::VertexIndex,
+                     boost::additive        <pcl::geometry::VertexIndex> > >;
+        using Self = pcl::geometry::VertexIndex;
 
         /** \brief Constructor. Initializes with an invalid index. */
         VertexIndex ()
@@ -205,10 +205,10 @@ namespace pcl
     {
       public:
 
-        typedef boost::totally_ordered <pcl::geometry::HalfEdgeIndex,
-                boost::unit_steppable  <pcl::geometry::HalfEdgeIndex,
-                boost::additive        <pcl::geometry::HalfEdgeIndex> > > Base;
-        typedef pcl::geometry::HalfEdgeIndex                              Self;
+        using Base = boost::totally_ordered <pcl::geometry::HalfEdgeIndex,
+                     boost::unit_steppable  <pcl::geometry::HalfEdgeIndex,
+                     boost::additive        <pcl::geometry::HalfEdgeIndex> > >;
+        using Self = pcl::geometry::HalfEdgeIndex;
 
         /** \brief Constructor. Initializes with an invalid index. */
         HalfEdgeIndex ()
@@ -344,10 +344,10 @@ namespace pcl
     {
       public:
 
-        typedef boost::totally_ordered <pcl::geometry::EdgeIndex,
-                boost::unit_steppable  <pcl::geometry::EdgeIndex,
-                boost::additive        <pcl::geometry::EdgeIndex> > > Base;
-        typedef pcl::geometry::EdgeIndex                              Self;
+        using Base = boost::totally_ordered <pcl::geometry::EdgeIndex,
+                     boost::unit_steppable  <pcl::geometry::EdgeIndex,
+                     boost::additive        <pcl::geometry::EdgeIndex> > >;
+        using Self = pcl::geometry::EdgeIndex;
 
         /** \brief Constructor. Initializes with an invalid index. */
         EdgeIndex ()
@@ -483,10 +483,10 @@ namespace pcl
     {
       public:
 
-        typedef boost::totally_ordered <pcl::geometry::FaceIndex,
-                boost::unit_steppable  <pcl::geometry::FaceIndex,
-                boost::additive        <pcl::geometry::FaceIndex> > > Base;
-        typedef pcl::geometry::FaceIndex                              Self;
+        using Base = boost::totally_ordered <pcl::geometry::FaceIndex,
+                     boost::unit_steppable  <pcl::geometry::FaceIndex,
+                     boost::additive        <pcl::geometry::FaceIndex> > >;
+        using Self = pcl::geometry::FaceIndex;
 
         /** \brief Constructor. Initializes with an invalid index. */
         FaceIndex ()

--- a/geometry/include/pcl/geometry/mesh_io.h
+++ b/geometry/include/pcl/geometry/mesh_io.h
@@ -63,19 +63,19 @@ namespace pcl
     {
       public:
 
-        typedef MeshT Mesh;
+        using Mesh = MeshT;
 
-        typedef typename Mesh::Vertex   Vertex;
-        typedef typename Mesh::HalfEdge HalfEdge;
-        typedef typename Mesh::Face     Face;
+        using Vertex = typename Mesh::Vertex;
+        using HalfEdge = typename Mesh::HalfEdge;
+        using Face = typename Mesh::Face;
 
-        typedef typename Mesh::Vertices  Vertices;
-        typedef typename Mesh::HalfEdges HalfEdges;
-        typedef typename Mesh::Faces     Faces;
+        using Vertices = typename Mesh::Vertices;
+        using HalfEdges = typename Mesh::HalfEdges;
+        using Faces = typename Mesh::Faces;
 
-        typedef typename Mesh::VertexIndex   VertexIndex;
-        typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
-        typedef typename Mesh::FaceIndex     FaceIndex;
+        using VertexIndex = typename Mesh::VertexIndex;
+        using HalfEdgeIndex = typename Mesh::HalfEdgeIndex;
+        using FaceIndex = typename Mesh::FaceIndex;
 
         /** \brief Constructor. */
         MeshIO ()

--- a/geometry/include/pcl/geometry/mesh_traits.h
+++ b/geometry/include/pcl/geometry/mesh_traits.h
@@ -63,13 +63,13 @@ namespace pcl
               class FaceDataT     = pcl::geometry::NoData>
     struct DefaultMeshTraits
     {
-      typedef VertexDataT   VertexData;
-      typedef HalfEdgeDataT HalfEdgeData;
-      typedef EdgeDataT     EdgeData;
-      typedef FaceDataT     FaceData;
+      using VertexData = VertexDataT;
+      using HalfEdgeData = HalfEdgeDataT;
+      using EdgeData = EdgeDataT;
+      using FaceData = FaceDataT;
 
       /** \brief Specifies whether the mesh is manifold or not (only non-manifold vertices can be represented). */
-      typedef std::false_type IsManifold;
+      using IsManifold = std::false_type;
     };
   } // End namespace geometry
 } // End namespace pcl

--- a/geometry/include/pcl/geometry/planar_polygon.h
+++ b/geometry/include/pcl/geometry/planar_polygon.h
@@ -52,8 +52,8 @@ namespace pcl
   class PlanarPolygon
   {
     public:
-      typedef boost::shared_ptr<PlanarPolygon<PointT> > Ptr;
-      typedef boost::shared_ptr<const PlanarPolygon<PointT> > ConstPtr;
+      using Ptr = boost::shared_ptr<PlanarPolygon<PointT> >;
+      using ConstPtr = boost::shared_ptr<const PlanarPolygon<PointT> >;
 
        /** \brief Empty constructor for PlanarPolygon */
       PlanarPolygon () : contour_ ()

--- a/geometry/include/pcl/geometry/polygon_mesh.h
+++ b/geometry/include/pcl/geometry/polygon_mesh.h
@@ -59,49 +59,49 @@ namespace pcl
     {
       public:
 
-        typedef pcl::geometry::MeshBase <PolygonMesh <MeshTraitsT>, MeshTraitsT, PolygonMeshTag> Base;
+        using Base = pcl::geometry::MeshBase <PolygonMesh <MeshTraitsT>, MeshTraitsT, PolygonMeshTag>;
 
-        typedef PolygonMesh <MeshTraitsT>      Self;
-        typedef boost::shared_ptr <Self>       Ptr;
-        typedef boost::shared_ptr <const Self> ConstPtr;
+        using Self = PolygonMesh<MeshTraitsT>;
+        using Ptr = boost::shared_ptr<Self>;
+        using ConstPtr = boost::shared_ptr<const Self>;
 
-        typedef typename Base::VertexData   VertexData;
-        typedef typename Base::HalfEdgeData HalfEdgeData;
-        typedef typename Base::EdgeData     EdgeData;
-        typedef typename Base::FaceData     FaceData;
-        typedef typename Base::IsManifold   IsManifold;
-        typedef typename Base::MeshTag      MeshTag;
+        using VertexData = typename Base::VertexData;
+        using HalfEdgeData = typename Base::HalfEdgeData;
+        using EdgeData = typename Base::EdgeData;
+        using FaceData = typename Base::FaceData;
+        using IsManifold = typename Base::IsManifold;
+        using MeshTag = typename Base::MeshTag;
 
-        typedef typename Base::HasVertexData   HasVertexData;
-        typedef typename Base::HasHalfEdgeData HasHalfEdgeData;
-        typedef typename Base::HasEdgeData     HasEdgeData;
-        typedef typename Base::HasFaceData     HasFaceData;
+        using HasVertexData = typename Base::HasVertexData;
+        using HasHalfEdgeData = typename Base::HasHalfEdgeData;
+        using HasEdgeData = typename Base::HasEdgeData;
+        using HasFaceData = typename Base::HasFaceData;
 
-        typedef typename Base::VertexDataCloud   VertexDataCloud;
-        typedef typename Base::HalfEdgeDataCloud HalfEdgeDataCloud;
-        typedef typename Base::EdgeDataCloud     EdgeDataCloud;
-        typedef typename Base::FaceDataCloud     FaceDataCloud;
+        using VertexDataCloud = typename Base::VertexDataCloud;
+        using HalfEdgeDataCloud = typename Base::HalfEdgeDataCloud;
+        using EdgeDataCloud = typename Base::EdgeDataCloud;
+        using FaceDataCloud = typename Base::FaceDataCloud;
 
         // Indices
-        typedef typename Base::VertexIndex   VertexIndex;
-        typedef typename Base::HalfEdgeIndex HalfEdgeIndex;
-        typedef typename Base::EdgeIndex     EdgeIndex;
-        typedef typename Base::FaceIndex     FaceIndex;
+        using VertexIndex = typename Base::VertexIndex;
+        using HalfEdgeIndex = typename Base::HalfEdgeIndex;
+        using EdgeIndex = typename Base::EdgeIndex;
+        using FaceIndex = typename Base::FaceIndex;
 
-        typedef typename Base::VertexIndices   VertexIndices;
-        typedef typename Base::HalfEdgeIndices HalfEdgeIndices;
-        typedef typename Base::EdgeIndices     EdgeIndices;
-        typedef typename Base::FaceIndices     FaceIndices;
+        using VertexIndices = typename Base::VertexIndices;
+        using HalfEdgeIndices = typename Base::HalfEdgeIndices;
+        using EdgeIndices = typename Base::EdgeIndices;
+        using FaceIndices = typename Base::FaceIndices;
 
         // Circulators
-        typedef typename Base::VertexAroundVertexCirculator           VertexAroundVertexCirculator;
-        typedef typename Base::OutgoingHalfEdgeAroundVertexCirculator OutgoingHalfEdgeAroundVertexCirculator;
-        typedef typename Base::IncomingHalfEdgeAroundVertexCirculator IncomingHalfEdgeAroundVertexCirculator;
-        typedef typename Base::FaceAroundVertexCirculator             FaceAroundVertexCirculator;
-        typedef typename Base::VertexAroundFaceCirculator             VertexAroundFaceCirculator;
-        typedef typename Base::InnerHalfEdgeAroundFaceCirculator      InnerHalfEdgeAroundFaceCirculator;
-        typedef typename Base::OuterHalfEdgeAroundFaceCirculator      OuterHalfEdgeAroundFaceCirculator;
-        typedef typename Base::FaceAroundFaceCirculator               FaceAroundFaceCirculator;
+        using VertexAroundVertexCirculator = typename Base::VertexAroundVertexCirculator;
+        using OutgoingHalfEdgeAroundVertexCirculator = typename Base::OutgoingHalfEdgeAroundVertexCirculator;
+        using IncomingHalfEdgeAroundVertexCirculator = typename Base::IncomingHalfEdgeAroundVertexCirculator;
+        using FaceAroundVertexCirculator = typename Base::FaceAroundVertexCirculator;
+        using VertexAroundFaceCirculator = typename Base::VertexAroundFaceCirculator;
+        using InnerHalfEdgeAroundFaceCirculator = typename Base::InnerHalfEdgeAroundFaceCirculator;
+        using OuterHalfEdgeAroundFaceCirculator = typename Base::OuterHalfEdgeAroundFaceCirculator;
+        using FaceAroundFaceCirculator = typename Base::FaceAroundFaceCirculator;
 
         /** \brief Constructor. */
         PolygonMesh ()

--- a/geometry/include/pcl/geometry/quad_mesh.h
+++ b/geometry/include/pcl/geometry/quad_mesh.h
@@ -59,49 +59,49 @@ namespace pcl
     {
       public:
 
-        typedef pcl::geometry::MeshBase <QuadMesh <MeshTraitsT>, MeshTraitsT, QuadMeshTag> Base;
+        using Base = pcl::geometry::MeshBase <QuadMesh <MeshTraitsT>, MeshTraitsT, QuadMeshTag>;
 
-        typedef QuadMesh <MeshTraitsT>         Self;
-        typedef boost::shared_ptr <Self>       Ptr;
-        typedef boost::shared_ptr <const Self> ConstPtr;
+        using Self = QuadMesh<MeshTraitsT>;
+        using Ptr = boost::shared_ptr<Self>;
+        using ConstPtr = boost::shared_ptr<const Self>;
 
-        typedef typename Base::VertexData   VertexData;
-        typedef typename Base::HalfEdgeData HalfEdgeData;
-        typedef typename Base::EdgeData     EdgeData;
-        typedef typename Base::FaceData     FaceData;
-        typedef typename Base::IsManifold   IsManifold;
-        typedef typename Base::MeshTag      MeshTag;
+        using VertexData = typename Base::VertexData;
+        using HalfEdgeData = typename Base::HalfEdgeData;
+        using EdgeData = typename Base::EdgeData;
+        using FaceData = typename Base::FaceData;
+        using IsManifold = typename Base::IsManifold;
+        using MeshTag = typename Base::MeshTag;
 
-        typedef typename Base::HasVertexData   HasVertexData;
-        typedef typename Base::HasHalfEdgeData HasHalfEdgeData;
-        typedef typename Base::HasEdgeData     HasEdgeData;
-        typedef typename Base::HasFaceData     HasFaceData;
+        using HasVertexData = typename Base::HasVertexData;
+        using HasHalfEdgeData = typename Base::HasHalfEdgeData;
+        using HasEdgeData = typename Base::HasEdgeData;
+        using HasFaceData = typename Base::HasFaceData;
 
-        typedef typename Base::VertexDataCloud   VertexDataCloud;
-        typedef typename Base::HalfEdgeDataCloud HalfEdgeDataCloud;
-        typedef typename Base::EdgeDataCloud     EdgeDataCloud;
-        typedef typename Base::FaceDataCloud     FaceDataCloud;
+        using VertexDataCloud = typename Base::VertexDataCloud;
+        using HalfEdgeDataCloud = typename Base::HalfEdgeDataCloud;
+        using EdgeDataCloud = typename Base::EdgeDataCloud;
+        using FaceDataCloud = typename Base::FaceDataCloud;
 
         // Indices
-        typedef typename Base::VertexIndex   VertexIndex;
-        typedef typename Base::HalfEdgeIndex HalfEdgeIndex;
-        typedef typename Base::EdgeIndex     EdgeIndex;
-        typedef typename Base::FaceIndex     FaceIndex;
+        using VertexIndex = typename Base::VertexIndex;
+        using HalfEdgeIndex = typename Base::HalfEdgeIndex;
+        using EdgeIndex = typename Base::EdgeIndex;
+        using FaceIndex = typename Base::FaceIndex;
 
-        typedef typename Base::VertexIndices   VertexIndices;
-        typedef typename Base::HalfEdgeIndices HalfEdgeIndices;
-        typedef typename Base::EdgeIndices     EdgeIndices;
-        typedef typename Base::FaceIndices     FaceIndices;
+        using VertexIndices = typename Base::VertexIndices;
+        using HalfEdgeIndices = typename Base::HalfEdgeIndices;
+        using EdgeIndices = typename Base::EdgeIndices;
+        using FaceIndices = typename Base::FaceIndices;
 
         // Circulators
-        typedef typename Base::VertexAroundVertexCirculator           VertexAroundVertexCirculator;
-        typedef typename Base::OutgoingHalfEdgeAroundVertexCirculator OutgoingHalfEdgeAroundVertexCirculator;
-        typedef typename Base::IncomingHalfEdgeAroundVertexCirculator IncomingHalfEdgeAroundVertexCirculator;
-        typedef typename Base::FaceAroundVertexCirculator             FaceAroundVertexCirculator;
-        typedef typename Base::VertexAroundFaceCirculator             VertexAroundFaceCirculator;
-        typedef typename Base::InnerHalfEdgeAroundFaceCirculator      InnerHalfEdgeAroundFaceCirculator;
-        typedef typename Base::OuterHalfEdgeAroundFaceCirculator      OuterHalfEdgeAroundFaceCirculator;
-        typedef typename Base::FaceAroundFaceCirculator               FaceAroundFaceCirculator;
+        using VertexAroundVertexCirculator = typename Base::VertexAroundVertexCirculator;
+        using OutgoingHalfEdgeAroundVertexCirculator = typename Base::OutgoingHalfEdgeAroundVertexCirculator;
+        using IncomingHalfEdgeAroundVertexCirculator = typename Base::IncomingHalfEdgeAroundVertexCirculator;
+        using FaceAroundVertexCirculator = typename Base::FaceAroundVertexCirculator;
+        using VertexAroundFaceCirculator = typename Base::VertexAroundFaceCirculator;
+        using InnerHalfEdgeAroundFaceCirculator = typename Base::InnerHalfEdgeAroundFaceCirculator;
+        using OuterHalfEdgeAroundFaceCirculator = typename Base::OuterHalfEdgeAroundFaceCirculator;
+        using FaceAroundFaceCirculator = typename Base::FaceAroundFaceCirculator;
 
         /** \brief Constructor. */
         QuadMesh ()

--- a/geometry/include/pcl/geometry/triangle_mesh.h
+++ b/geometry/include/pcl/geometry/triangle_mesh.h
@@ -61,50 +61,50 @@ namespace pcl
     {
       public:
 
-        typedef pcl::geometry::MeshBase <TriangleMesh <MeshTraitsT>, MeshTraitsT, TriangleMeshTag> Base;
+        using Base = pcl::geometry::MeshBase <TriangleMesh <MeshTraitsT>, MeshTraitsT, TriangleMeshTag>;
 
-        typedef TriangleMesh <MeshTraitsT>     Self;
-        typedef boost::shared_ptr <Self>       Ptr;
-        typedef boost::shared_ptr <const Self> ConstPtr;
+        using Self = TriangleMesh<MeshTraitsT>;
+        using Ptr = boost::shared_ptr<Self>;
+        using ConstPtr = boost::shared_ptr<const Self>;
 
-        typedef typename Base::VertexData   VertexData;
-        typedef typename Base::HalfEdgeData HalfEdgeData;
-        typedef typename Base::EdgeData     EdgeData;
-        typedef typename Base::FaceData     FaceData;
-        typedef typename Base::IsManifold   IsManifold;
-        typedef typename Base::MeshTag      MeshTag;
+        using VertexData = typename Base::VertexData;
+        using HalfEdgeData = typename Base::HalfEdgeData;
+        using EdgeData = typename Base::EdgeData;
+        using FaceData = typename Base::FaceData;
+        using IsManifold = typename Base::IsManifold;
+        using MeshTag = typename Base::MeshTag;
 
-        typedef typename Base::HasVertexData   HasVertexData;
-        typedef typename Base::HasHalfEdgeData HasHalfEdgeData;
-        typedef typename Base::HasEdgeData     HasEdgeData;
-        typedef typename Base::HasFaceData     HasFaceData;
+        using HasVertexData = typename Base::HasVertexData;
+        using HasHalfEdgeData = typename Base::HasHalfEdgeData;
+        using HasEdgeData = typename Base::HasEdgeData;
+        using HasFaceData = typename Base::HasFaceData;
 
-        typedef typename Base::VertexDataCloud   VertexDataCloud;
-        typedef typename Base::HalfEdgeDataCloud HalfEdgeDataCloud;
-        typedef typename Base::EdgeDataCloud     EdgeDataCloud;
-        typedef typename Base::FaceDataCloud     FaceDataCloud;
+        using VertexDataCloud = typename Base::VertexDataCloud;
+        using HalfEdgeDataCloud = typename Base::HalfEdgeDataCloud;
+        using EdgeDataCloud = typename Base::EdgeDataCloud;
+        using FaceDataCloud = typename Base::FaceDataCloud;
 
         // Indices
-        typedef typename Base::VertexIndex       VertexIndex;
-        typedef typename Base::HalfEdgeIndex     HalfEdgeIndex;
-        typedef typename Base::EdgeIndex         EdgeIndex;
-        typedef typename Base::FaceIndex         FaceIndex;
-        typedef std::pair <FaceIndex, FaceIndex> FaceIndexPair;
+        using VertexIndex = typename Base::VertexIndex;
+        using HalfEdgeIndex = typename Base::HalfEdgeIndex;
+        using EdgeIndex = typename Base::EdgeIndex;
+        using FaceIndex = typename Base::FaceIndex;
+        using FaceIndexPair = std::pair <FaceIndex, FaceIndex>;
 
-        typedef typename Base::VertexIndices   VertexIndices;
-        typedef typename Base::HalfEdgeIndices HalfEdgeIndices;
-        typedef typename Base::EdgeIndices     EdgeIndices;
-        typedef typename Base::FaceIndices     FaceIndices;
+        using VertexIndices = typename Base::VertexIndices;
+        using HalfEdgeIndices = typename Base::HalfEdgeIndices;
+        using EdgeIndices = typename Base::EdgeIndices;
+        using FaceIndices = typename Base::FaceIndices;
 
         // Circulators
-        typedef typename Base::VertexAroundVertexCirculator           VertexAroundVertexCirculator;
-        typedef typename Base::OutgoingHalfEdgeAroundVertexCirculator OutgoingHalfEdgeAroundVertexCirculator;
-        typedef typename Base::IncomingHalfEdgeAroundVertexCirculator IncomingHalfEdgeAroundVertexCirculator;
-        typedef typename Base::FaceAroundVertexCirculator             FaceAroundVertexCirculator;
-        typedef typename Base::VertexAroundFaceCirculator             VertexAroundFaceCirculator;
-        typedef typename Base::InnerHalfEdgeAroundFaceCirculator      InnerHalfEdgeAroundFaceCirculator;
-        typedef typename Base::OuterHalfEdgeAroundFaceCirculator      OuterHalfEdgeAroundFaceCirculator;
-        typedef typename Base::FaceAroundFaceCirculator               FaceAroundFaceCirculator;
+        using VertexAroundVertexCirculator = typename Base::VertexAroundVertexCirculator;
+        using OutgoingHalfEdgeAroundVertexCirculator = typename Base::OutgoingHalfEdgeAroundVertexCirculator;
+        using IncomingHalfEdgeAroundVertexCirculator = typename Base::IncomingHalfEdgeAroundVertexCirculator;
+        using FaceAroundVertexCirculator = typename Base::FaceAroundVertexCirculator;
+        using VertexAroundFaceCirculator = typename Base::VertexAroundFaceCirculator;
+        using InnerHalfEdgeAroundFaceCirculator = typename Base::InnerHalfEdgeAroundFaceCirculator;
+        using OuterHalfEdgeAroundFaceCirculator = typename Base::OuterHalfEdgeAroundFaceCirculator;
+        using FaceAroundFaceCirculator = typename Base::FaceAroundFaceCirculator;
 
         /** \brief Constructor. */
         TriangleMesh ()


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`