### PR TITLE
Use using instead of typedef [io]

### DIFF
--- a/io/include/pcl/compression/color_coding.h
+++ b/io/include/pcl/compression/color_coding.h
@@ -62,9 +62,9 @@ namespace pcl
       {
 
       // public typedefs
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
       public:
 

--- a/io/include/pcl/compression/entropy_range_coder.h
+++ b/io/include/pcl/compression/entropy_range_coder.h
@@ -97,7 +97,7 @@ namespace pcl
     decodeStreamToCharVector (std::istream& inputByteStream_arg, std::vector<char>& outputByteVector_arg);
 
   protected:
-    typedef boost::uint32_t DWord; // 4 bytes
+    using DWord = boost::uint32_t; // 4 bytes
 
   private:
     /** vector containing compressed data
@@ -162,7 +162,7 @@ namespace pcl
       decodeStreamToCharVector (std::istream& inputByteStream_arg, std::vector<char>& outputByteVector_arg);
 
     protected:
-      typedef boost::uint32_t DWord; // 4 bytes
+      using DWord = boost::uint32_t; // 4 bytes
 
       /** \brief Helper function to calculate the binary logarithm
        * \param n_arg: some value

--- a/io/include/pcl/compression/octree_pointcloud_compression.h
+++ b/io/include/pcl/compression/octree_pointcloud_compression.h
@@ -73,19 +73,19 @@ namespace pcl
     {
       public:
         // public typedefs
-        typedef typename OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::PointCloud PointCloud;
-        typedef typename OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::PointCloudPtr PointCloudPtr;
-        typedef typename OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::PointCloudConstPtr PointCloudConstPtr;
+        using PointCloud = typename OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::PointCloud;
+        using PointCloudPtr = typename OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::PointCloudPtr;
+        using PointCloudConstPtr = typename OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::PointCloudConstPtr;
 
         // Boost shared pointers
-        typedef boost::shared_ptr<OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> > Ptr;
-        typedef boost::shared_ptr<const OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> > ConstPtr;
+        using Ptr = boost::shared_ptr<OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> >;
+        using ConstPtr = boost::shared_ptr<const OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> >;
 
-        typedef typename OctreeT::LeafNode LeafNode;
-        typedef typename OctreeT::BranchNode BranchNode;
+        using LeafNode = typename OctreeT::LeafNode;
+        using BranchNode = typename OctreeT::BranchNode;
 
-        typedef OctreePointCloudCompression<PointT, LeafT, BranchT, Octree2BufBase<LeafT, BranchT> > RealTimeStreamCompression;
-        typedef OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeBase<LeafT, BranchT> > SinglePointCloudCompressionLowMemory;
+        using RealTimeStreamCompression = OctreePointCloudCompression<PointT, LeafT, BranchT, Octree2BufBase<LeafT, BranchT> >;
+        using SinglePointCloudCompressionLowMemory = OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeBase<LeafT, BranchT> >;
 
 
         /** \brief Constructor

--- a/io/include/pcl/compression/organized_pointcloud_compression.h
+++ b/io/include/pcl/compression/organized_pointcloud_compression.h
@@ -60,9 +60,9 @@ namespace pcl
     class OrganizedPointCloudCompression
     {
       public:
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
         /** \brief Empty Constructor. */
         OrganizedPointCloudCompression ()

--- a/io/include/pcl/compression/point_coding.h
+++ b/io/include/pcl/compression/point_coding.h
@@ -56,9 +56,9 @@ namespace pcl
     class PointCoding
     {
         // public typedefs
-        typedef pcl::PointCloud<PointT> PointCloud;
-        typedef boost::shared_ptr<PointCloud> PointCloudPtr;
-        typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
+        using PointCloud = pcl::PointCloud<PointT>;
+        using PointCloudPtr = boost::shared_ptr<PointCloud>;
+        using PointCloudConstPtr = boost::shared_ptr<const PointCloud>;
 
       public:
         /** \brief Constructor. */

--- a/io/include/pcl/io/buffers.h
+++ b/io/include/pcl/io/buffers.h
@@ -68,7 +68,7 @@ namespace pcl
 
       public:
 
-        typedef T value_type;
+        using value_type = T;
 
         virtual
         ~Buffer ();

--- a/io/include/pcl/io/davidsdk_grabber.h
+++ b/io/include/pcl/io/davidsdk_grabber.h
@@ -67,26 +67,21 @@ namespace pcl
   {
     public:
       /** @cond */
-      typedef boost::shared_ptr<DavidSDKGrabber> Ptr;
-      typedef boost::shared_ptr<const DavidSDKGrabber> ConstPtr;
+      using Ptr = boost::shared_ptr<DavidSDKGrabber>;
+      using ConstPtr = boost::shared_ptr<const DavidSDKGrabber>;
 
       // Define callback signature typedefs
-      typedef void
-      (sig_cb_davidsdk_point_cloud) (const pcl::PointCloud<pcl::PointXYZ>::Ptr &);
+      using sig_cb_davidsdk_point_cloud = void() (const pcl::PointCloud<pcl::PointXYZ>::Ptr &);
 
-      typedef void
-      (sig_cb_davidsdk_mesh) (const pcl::PolygonMesh::Ptr &);
+      using sig_cb_davidsdk_mesh = void() (const pcl::PolygonMesh::Ptr &);
 
-      typedef void
-      (sig_cb_davidsdk_image) (const boost::shared_ptr<pcl::PCLImage> &);
+      using sig_cb_davidsdk_image = void() (const boost::shared_ptr<pcl::PCLImage> &);
 
-      typedef void
-      (sig_cb_davidsdk_point_cloud_image) (const pcl::PointCloud<pcl::PointXYZ>::Ptr &,
-                                           const boost::shared_ptr<pcl::PCLImage> &);
+      using sig_cb_davidsdk_point_cloud_image = void()
+	    (const pcl::PointCloud<pcl::PointXYZ>::Ptr &, const boost::shared_ptr<pcl::PCLImage> &);
 
-      typedef void
-      (sig_cb_davidsdk_mesh_image) (const pcl::PolygonMesh::Ptr &,
-                                    const boost::shared_ptr<pcl::PCLImage> &);
+      using sig_cb_davidsdk_mesh_image = void()
+	    (const pcl::PolygonMesh::Ptr &, const boost::shared_ptr<pcl::PCLImage> &);
       /** @endcond */
 
       /** @brief Constructor */

--- a/io/include/pcl/io/depth_sense/depth_sense_device_manager.h
+++ b/io/include/pcl/io/depth_sense/depth_sense_device_manager.h
@@ -64,7 +64,7 @@ namespace pcl
 
         public:
 
-          typedef boost::shared_ptr<DepthSenseDeviceManager> Ptr;
+          using Ptr = boost::shared_ptr<DepthSenseDeviceManager>;
 
           static Ptr&
           getInstance ()

--- a/io/include/pcl/io/depth_sense/depth_sense_grabber_impl.h
+++ b/io/include/pcl/io/depth_sense/depth_sense_grabber_impl.h
@@ -71,8 +71,8 @@ namespace pcl
 
         boost::shared_ptr<DepthSense::ProjectionHelper> projection_;
 
-        typedef DepthSenseGrabber::sig_cb_depth_sense_point_cloud sig_cb_depth_sense_point_cloud;
-        typedef DepthSenseGrabber::sig_cb_depth_sense_point_cloud_rgba sig_cb_depth_sense_point_cloud_rgba;
+        using sig_cb_depth_sense_point_cloud = DepthSenseGrabber::sig_cb_depth_sense_point_cloud;
+        using sig_cb_depth_sense_point_cloud_rgba = DepthSenseGrabber::sig_cb_depth_sense_point_cloud_rgba;
 
         /// Signal to indicate whether new XYZ cloud is available
         boost::signals2::signal<sig_cb_depth_sense_point_cloud>* point_cloud_signal_;

--- a/io/include/pcl/io/depth_sense_grabber.h
+++ b/io/include/pcl/io/depth_sense_grabber.h
@@ -58,13 +58,9 @@ namespace pcl
 
     public:
 
-      typedef
-        void (sig_cb_depth_sense_point_cloud)
-          (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&);
+      using sig_cb_depth_sense_point_cloud = void () (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&);
 
-      typedef
-        void (sig_cb_depth_sense_point_cloud_rgba)
-          (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&);
+      using sig_cb_depth_sense_point_cloud_rgba = void () (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&);
 
       enum Mode
       {

--- a/io/include/pcl/io/dinast_grabber.h
+++ b/io/include/pcl/io/dinast_grabber.h
@@ -59,7 +59,7 @@ namespace pcl
   class PCL_EXPORTS DinastGrabber: public Grabber
   {
     // Define callback signature typedefs
-    typedef void (sig_cb_dinast_point_cloud) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&);
+    using sig_cb_dinast_point_cloud = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> > &);
     
     public:
       /** \brief Constructor that sets up the grabber constants.

--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -67,23 +67,20 @@ namespace pcl
    */
   class PCL_EXPORTS EnsensoGrabber : public Grabber
   {
-      typedef std::pair<pcl::PCLImage, pcl::PCLImage> PairOfImages;
+      using PairOfImages = std::pair<pcl::PCLImage, pcl::PCLImage>;
 
     public:
       /** @cond */
-      typedef boost::shared_ptr<EnsensoGrabber> Ptr;
-      typedef boost::shared_ptr<const EnsensoGrabber> ConstPtr;
+      using Ptr = boost::shared_ptr<EnsensoGrabber>;
+      using ConstPtr = boost::shared_ptr<const EnsensoGrabber>;
 
       // Define callback signature typedefs
-      typedef void
-      (sig_cb_ensenso_point_cloud) (const pcl::PointCloud<pcl::PointXYZ>::Ptr &);
+      using sig_cb_ensenso_point_cloud = void() (const pcl::PointCloud<pcl::PointXYZ>::Ptr &);
 
-      typedef void
-      (sig_cb_ensenso_images) (const boost::shared_ptr<PairOfImages> &);
+      using sig_cb_ensenso_images void() (const boost::shared_ptr<PairOfImages> &);
 
-      typedef void
-      (sig_cb_ensenso_point_cloud_images) (const pcl::PointCloud<pcl::PointXYZ>::Ptr &,
-                                           const boost::shared_ptr<PairOfImages> &);
+      using sig_cb_ensenso_point_cloud_images = void()
+	    (const pcl::PointCloud<pcl::PointXYZ>::Ptr &, const boost::shared_ptr<PairOfImages> &);
      /** @endcond */
 
       /** @brief Constructor */

--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -160,7 +160,7 @@ namespace pcl
   template<typename T> boost::signals2::signal<T>*
   Grabber::find_signal () const
   {
-    typedef boost::signals2::signal<T> Signal;
+    using Signal = boost::signals2::signal<T>;
 
     std::map<std::string, boost::signals2::signal_base*>::const_iterator signal_it = signals_.find (typeid (T).name ());
     if (signal_it != signals_.end ())
@@ -172,7 +172,7 @@ namespace pcl
   template<typename T> void
   Grabber::disconnect_all_slots ()
   {
-    typedef boost::signals2::signal<T> Signal;
+    using Signal = boost::signals2::signal<T>;
 
     if (signals_.find (typeid (T).name ()) != signals_.end ())
     {
@@ -216,7 +216,7 @@ namespace pcl
   template<typename T> int
   Grabber::num_slots () const
   {
-    typedef boost::signals2::signal<T> Signal;
+    using Signal = boost::signals2::signal<T>;
 
     // see if we have a signal for this type
     std::map<std::string, boost::signals2::signal_base*>::const_iterator signal_it = signals_.find (typeid (T).name ());
@@ -231,7 +231,7 @@ namespace pcl
   template<typename T> boost::signals2::signal<T>*
   Grabber::createSignal ()
   {
-    typedef boost::signals2::signal<T> Signal;
+    using Signal = boost::signals2::signal<T>;
 
     if (signals_.find (typeid (T).name ()) == signals_.end ())
     {
@@ -245,7 +245,7 @@ namespace pcl
   template<typename T> boost::signals2::connection
   Grabber::registerCallback (const std::function<T> & callback)
   {
-    typedef boost::signals2::signal<T> Signal;
+    using Signal = boost::signals2::signal<T>;
     if (signals_.find (typeid (T).name ()) == signals_.end ())
     {
       std::stringstream sstream;

--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -63,53 +63,41 @@ namespace pcl
       /** \brief Signal used for a single sector
        *         Represents 1 corrected packet from the HDL Velodyne
        */
-      typedef void
-      (sig_cb_velodyne_hdl_scan_point_cloud_xyz) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&,
-                                                  float,
-                                                  float);
+      using sig_cb_velodyne_hdl_scan_point_cloud_xyz = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> > &, float, float);
 
       /** \brief Signal used for a single sector
        *         Represents 1 corrected packet from the HDL Velodyne.  Each laser has a different RGB
        */
-      typedef void
-      (sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> >&,
-                                                      float,
-                                                      float);
+      using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> > &, float, float);
 
-      [[deprecated("use sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba instead")]]
-      typedef sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb;
+      using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb [[deprecated("use sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba instead")]]
+              = sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba;
 
       /** \brief Signal used for a single sector
        *         Represents 1 corrected packet from the HDL Velodyne with the returned intensity.
        */
-      typedef void
-      (sig_cb_velodyne_hdl_scan_point_cloud_xyzi) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&,
-                                                   float startAngle,
-                                                   float);
+      using sig_cb_velodyne_hdl_scan_point_cloud_xyzi = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> > &, float, float);
 
       /** \brief Signal used for a 360 degree sweep
        *         Represents multiple corrected packets from the HDL Velodyne
        *         This signal is sent when the Velodyne passes angle "0"
        */
-      typedef void
-      (sig_cb_velodyne_hdl_sweep_point_cloud_xyz) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&);
+      using sig_cb_velodyne_hdl_sweep_point_cloud_xyz = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> > &);
 
       /** \brief Signal used for a 360 degree sweep
        *         Represents multiple corrected packets from the HDL Velodyne with the returned intensity
        *         This signal is sent when the Velodyne passes angle "0"
        */
-      typedef void
-      (sig_cb_velodyne_hdl_sweep_point_cloud_xyzi) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&);
+      using sig_cb_velodyne_hdl_sweep_point_cloud_xyzi = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> > &);
 
       /** \brief Signal used for a 360 degree sweep
        *         Represents multiple corrected packets from the HDL Velodyne
        *         This signal is sent when the Velodyne passes angle "0".  Each laser has a different RGB
        */
-      typedef void
-      (sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> >&);
+      using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> > &);
 
-      [[deprecated("use sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba instead")]]
-      typedef sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb;
+      using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb [[deprecated("use sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba instead")]]
+              = sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba;
 
       /** \brief Constructor taking an optional path to an HDL corrections file.  The Grabber will listen on the default IP/port for data packets [192.168.3.255/2368]
        * \param[in] correctionsFile Path to a file which contains the correction parameters for the HDL.  This parameter is mandatory for the HDL-64, optional for the HDL-32
@@ -224,11 +212,11 @@ namespace pcl
       };
 
 #pragma pack(push, 1)
-      typedef struct HDLLaserReturn
+      struct HDLLaserReturn
       {
           uint16_t distance;
           uint8_t intensity;
-      } HDLLaserReturn;
+      };
 #pragma pack(pop)
 
       struct HDLFiringData

--- a/io/include/pcl/io/image.h
+++ b/io/include/pcl/io/image.h
@@ -57,18 +57,18 @@ namespace pcl
     class PCL_EXPORTS Image
     {
       public:
-        typedef boost::shared_ptr<Image> Ptr;
-        typedef boost::shared_ptr<const Image> ConstPtr;
+        using Ptr = boost::shared_ptr<Image>;
+        using ConstPtr = boost::shared_ptr<const Image>;
 
-        typedef boost::chrono::high_resolution_clock Clock;
-        typedef boost::chrono::high_resolution_clock::time_point Timestamp;
+        using Clock = boost::chrono::high_resolution_clock;
+        using Timestamp = boost::chrono::high_resolution_clock::time_point;
 
-        typedef enum
+        enum Encoding
         {
           BAYER_GRBG,
           YUV422,
           RGB
-        } Encoding;
+        };
 
         Image (FrameWrapper::Ptr image_metadata)
           : wrapper_ (image_metadata)

--- a/io/include/pcl/io/image_depth.h
+++ b/io/include/pcl/io/image_depth.h
@@ -55,11 +55,11 @@ namespace pcl
     class PCL_EXPORTS DepthImage
     {
       public:
-        typedef boost::shared_ptr<DepthImage> Ptr;
-        typedef boost::shared_ptr<const DepthImage> ConstPtr;
+        using Ptr = boost::shared_ptr<DepthImage>;
+        using ConstPtr = boost::shared_ptr<const DepthImage>;
 
-        typedef boost::chrono::high_resolution_clock Clock;
-        typedef boost::chrono::high_resolution_clock::time_point Timestamp;
+        using Clock = boost::chrono::high_resolution_clock;
+        using Timestamp = boost::chrono::high_resolution_clock::time_point;
 
         /** \brief Constructor
           * \param[in] depth_metadata the actual data from the OpenNI library

--- a/io/include/pcl/io/image_ir.h
+++ b/io/include/pcl/io/image_ir.h
@@ -52,11 +52,11 @@ namespace pcl
     class PCL_EXPORTS IRImage
     {
       public:
-        typedef boost::shared_ptr<IRImage> Ptr;
-        typedef boost::shared_ptr<const IRImage> ConstPtr;
+        using Ptr = boost::shared_ptr<IRImage>;
+        using ConstPtr = boost::shared_ptr<const IRImage>;
 
-        typedef boost::chrono::high_resolution_clock Clock;
-        typedef boost::chrono::high_resolution_clock::time_point Timestamp;
+        using Clock = boost::chrono::high_resolution_clock;
+        using Timestamp = boost::chrono::high_resolution_clock::time_point;
 
         IRImage (FrameWrapper::Ptr ir_metadata);
         IRImage (FrameWrapper::Ptr ir_metadata, Timestamp time);

--- a/io/include/pcl/io/image_metadata_wrapper.h
+++ b/io/include/pcl/io/image_metadata_wrapper.h
@@ -53,7 +53,7 @@ namespace pcl
     class FrameWrapper
     {
       public:
-        typedef boost::shared_ptr<FrameWrapper> Ptr;
+        using Ptr = boost::shared_ptr<FrameWrapper>;
 
         virtual
         ~FrameWrapper() = default;

--- a/io/include/pcl/io/image_rgb24.h
+++ b/io/include/pcl/io/image_rgb24.h
@@ -77,12 +77,12 @@ namespace pcl
       private:
 
         // Struct used for type conversion
-        typedef struct
+        struct RGB888Pixel
         {
           uint8_t r;
           uint8_t g;
           uint8_t b;
-        } RGB888Pixel;
+        };
     };
 
   } // namespace

--- a/io/include/pcl/io/low_level_io.h
+++ b/io/include/pcl/io/low_level_io.h
@@ -52,7 +52,7 @@
 # include <io.h>
 # include <windows.h>
 # include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
+using ssize_t = SSIZE_T;
 #else
 # include <unistd.h>
 # include <sys/mman.h>

--- a/io/include/pcl/io/oni_grabber.h
+++ b/io/include/pcl/io/oni_grabber.h
@@ -73,15 +73,15 @@ namespace pcl
   {
     public:
       //define callback signature typedefs
-      typedef void (sig_cb_openni_image) (const boost::shared_ptr<openni_wrapper::Image>&);
-      typedef void (sig_cb_openni_depth_image) (const boost::shared_ptr<openni_wrapper::DepthImage>&);
-      typedef void (sig_cb_openni_ir_image) (const boost::shared_ptr<openni_wrapper::IRImage>&);
-      typedef void (sig_cb_openni_image_depth_image) (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant) ;
-      typedef void (sig_cb_openni_ir_depth_image) (const boost::shared_ptr<openni_wrapper::IRImage>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant) ;
-      typedef void (sig_cb_openni_point_cloud) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&);
-      typedef void (sig_cb_openni_point_cloud_rgb) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> >&);
-      typedef void (sig_cb_openni_point_cloud_rgba) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> >&);
-      typedef void (sig_cb_openni_point_cloud_i) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&);
+      using sig_cb_openni_image = void (const boost::shared_ptr<openni_wrapper::Image> &);
+      using sig_cb_openni_depth_image = void (const boost::shared_ptr<openni_wrapper::DepthImage> &);
+      using sig_cb_openni_ir_image = void (const boost::shared_ptr<openni_wrapper::IRImage> &);
+      using sig_cb_openni_image_depth_image = void (const boost::shared_ptr<openni_wrapper::Image> &, const boost::shared_ptr<openni_wrapper::DepthImage> &, float) ;
+      using sig_cb_openni_ir_depth_image = void (const boost::shared_ptr<openni_wrapper::IRImage> &, const boost::shared_ptr<openni_wrapper::DepthImage> &, float) ;
+      using sig_cb_openni_point_cloud = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> > &);
+      using sig_cb_openni_point_cloud_rgb = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> > &);
+      using sig_cb_openni_point_cloud_rgba = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> > &);
+      using sig_cb_openni_point_cloud_i = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> > &);
 
       /** \brief constructor
         * \param[in] file_name the path to the ONI file

--- a/io/include/pcl/io/openni2/openni2_device.h
+++ b/io/include/pcl/io/openni2/openni2_device.h
@@ -63,9 +63,9 @@ namespace pcl
   {
     namespace openni2
     {
-      typedef pcl::io::DepthImage DepthImage;
-      typedef pcl::io::IRImage IRImage;
-      typedef pcl::io::Image Image;
+      using DepthImage = pcl::io::DepthImage;
+      using IRImage = pcl::io::IRImage;
+      using Image = pcl::io::Image;
 
       class OpenNI2FrameListener;
 
@@ -73,12 +73,12 @@ namespace pcl
       {
         public:
 
-          typedef std::function<void(boost::shared_ptr<Image>, void* cookie) > ImageCallbackFunction;
-          typedef std::function<void(boost::shared_ptr<DepthImage>, void* cookie) > DepthImageCallbackFunction;
-          typedef std::function<void(boost::shared_ptr<IRImage>, void* cookie) > IRImageCallbackFunction;
-          typedef unsigned CallbackHandle;
+          using ImageCallbackFunction = std::function<void(boost::shared_ptr<Image>, void* cookie) >;
+          using DepthImageCallbackFunction = std::function<void(boost::shared_ptr<DepthImage>, void* cookie) >;
+          using IRImageCallbackFunction = std::function<void(boost::shared_ptr<IRImage>, void* cookie) >;
+          using CallbackHandle = unsigned;
 
-          typedef std::function<void(openni::VideoStream& stream)> StreamCallbackFunction;
+          using StreamCallbackFunction = std::function<void(openni::VideoStream& stream)>;
 
           OpenNI2Device (const std::string& device_URI);
           virtual ~OpenNI2Device ();

--- a/io/include/pcl/io/openni2/openni2_frame_listener.h
+++ b/io/include/pcl/io/openni2/openni2_frame_listener.h
@@ -48,7 +48,7 @@ namespace pcl
     namespace openni2
     {
 
-      typedef std::function<void(openni::VideoStream& stream)> StreamCallbackFunction;
+      using StreamCallbackFunction = std::function<void(openni::VideoStream& stream)>;
 
       /* Each NewFrameListener may only listen to one VideoStream at a time.
       **/

--- a/io/include/pcl/io/openni2/openni2_video_mode.h
+++ b/io/include/pcl/io/openni2/openni2_video_mode.h
@@ -43,7 +43,7 @@ namespace pcl
     namespace openni2
     {
       // copied from OniEnums.h
-      typedef enum
+      enum PixelFormat
       {
 	      // Depth
         PIXEL_FORMAT_DEPTH_1_MM = 100,
@@ -58,7 +58,7 @@ namespace pcl
         PIXEL_FORMAT_GRAY16 = 203,
         PIXEL_FORMAT_JPEG = 204,
         PIXEL_FORMAT_YUYV = 205,
-      } PixelFormat;
+      };
 
       struct OpenNI2VideoMode
       {

--- a/io/include/pcl/io/openni2_grabber.h
+++ b/io/include/pcl/io/openni2_grabber.h
@@ -74,13 +74,13 @@ namespace pcl
     class PCL_EXPORTS OpenNI2Grabber : public Grabber
     {
       public:
-        typedef boost::shared_ptr<OpenNI2Grabber> Ptr;
-        typedef boost::shared_ptr<const OpenNI2Grabber> ConstPtr;
+        using Ptr = boost::shared_ptr<OpenNI2Grabber>;
+        using ConstPtr = boost::shared_ptr<const OpenNI2Grabber>;
 
         // Templated images
-        typedef pcl::io::DepthImage DepthImage;
-        typedef pcl::io::IRImage IRImage;
-        typedef pcl::io::Image Image;
+        using DepthImage = pcl::io::DepthImage;
+        using IRImage = pcl::io::IRImage;
+        using Image = pcl::io::Image;
 
         /** \brief Basic camera parameters placeholder. */
         struct CameraParameters
@@ -104,7 +104,7 @@ namespace pcl
           { }
         };
 
-        typedef enum
+        enum Mode
         {
           OpenNI_Default_Mode = 0, // This can depend on the device. For now all devices (PSDK, Xtion, Kinect) its VGA@30Hz
           OpenNI_SXGA_15Hz = 1,    // Only supported by the Kinect
@@ -116,18 +116,18 @@ namespace pcl
           OpenNI_QQVGA_25Hz = 7,   // Not supported -> using software downsampling (only for integer scale factor and only NN)
           OpenNI_QQVGA_30Hz = 8,   // Not supported -> using software downsampling (only for integer scale factor and only NN)
           OpenNI_QQVGA_60Hz = 9    // Not supported -> using software downsampling (only for integer scale factor and only NN)
-        } Mode;
+        };
 
         //define callback signature typedefs
-        typedef void (sig_cb_openni_image) (const boost::shared_ptr<Image>&);
-        typedef void (sig_cb_openni_depth_image) (const boost::shared_ptr<DepthImage>&);
-        typedef void (sig_cb_openni_ir_image) (const boost::shared_ptr<IRImage>&);
-        typedef void (sig_cb_openni_image_depth_image) (const boost::shared_ptr<Image>&, const boost::shared_ptr<DepthImage>&, float reciprocalFocalLength) ;
-        typedef void (sig_cb_openni_ir_depth_image) (const boost::shared_ptr<IRImage>&, const boost::shared_ptr<DepthImage>&, float reciprocalFocalLength) ;
-        typedef void (sig_cb_openni_point_cloud) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&);
-        typedef void (sig_cb_openni_point_cloud_rgb) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> >&);
-        typedef void (sig_cb_openni_point_cloud_rgba) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> >&);
-        typedef void (sig_cb_openni_point_cloud_i) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&);
+        using sig_cb_openni_image = void (const boost::shared_ptr<Image> &);
+        using sig_cb_openni_depth_image = void (const boost::shared_ptr<DepthImage> &);
+        using sig_cb_openni_ir_image = void (const boost::shared_ptr<IRImage> &);
+        using sig_cb_openni_image_depth_image = void (const boost::shared_ptr<Image> &, const boost::shared_ptr<DepthImage> &, float) ;
+        using sig_cb_openni_ir_depth_image = void (const boost::shared_ptr<IRImage> &, const boost::shared_ptr<DepthImage> &, float) ;
+        using sig_cb_openni_point_cloud = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> > &);
+        using sig_cb_openni_point_cloud_rgb = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> > &);
+        using sig_cb_openni_point_cloud_rgba = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> > &);
+        using sig_cb_openni_point_cloud_i = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> > &);
 
       public:
         /** \brief Constructor

--- a/io/include/pcl/io/openni_camera/openni_depth_image.h
+++ b/io/include/pcl/io/openni_camera/openni_depth_image.h
@@ -56,8 +56,8 @@ namespace openni_wrapper
   class PCL_EXPORTS DepthImage
   {
     public:
-      typedef boost::shared_ptr<DepthImage> Ptr;
-      typedef boost::shared_ptr<const DepthImage> ConstPtr;
+      using Ptr = boost::shared_ptr<DepthImage>;
+      using ConstPtr = boost::shared_ptr<const DepthImage>;
 
       /** \brief Constructor
         * \param[in] depth_meta_data the actual data from the OpenNI library

--- a/io/include/pcl/io/openni_camera/openni_device.h
+++ b/io/include/pcl/io/openni_camera/openni_device.h
@@ -73,17 +73,17 @@ namespace openni_wrapper
   class PCL_EXPORTS OpenNIDevice
   {
     public:
-      typedef enum
+      enum DepthMode
       {
         OpenNI_shift_values = 0, // Shift values (disparity)
         OpenNI_12_bit_depth = 1, // Default mode: regular 12-bit depth
-      } DepthMode;
+      };
 
-      typedef boost::shared_ptr<OpenNIDevice> Ptr;
-      typedef std::function<void(boost::shared_ptr<Image>, void* cookie) > ImageCallbackFunction;
-      typedef std::function<void(boost::shared_ptr<DepthImage>, void* cookie) > DepthImageCallbackFunction;
-      typedef std::function<void(boost::shared_ptr<IRImage>, void* cookie) > IRImageCallbackFunction;
-      typedef unsigned CallbackHandle;
+      using Ptr = boost::shared_ptr<OpenNIDevice>;
+      using ImageCallbackFunction = std::function<void(boost::shared_ptr<Image>, void* cookie) >;
+      using DepthImageCallbackFunction = std::function<void(boost::shared_ptr<DepthImage>, void* cookie) >;
+      using IRImageCallbackFunction = std::function<void(boost::shared_ptr<IRImage>, void* cookie) >;
+      using CallbackHandle = unsigned;
 
     public:
 
@@ -446,9 +446,9 @@ namespace openni_wrapper
       OpenNIDevice (OpenNIDevice const &);
       OpenNIDevice& operator=(OpenNIDevice const &);
     protected:
-      typedef std::function<void(boost::shared_ptr<Image>) > ActualImageCallbackFunction;
-      typedef std::function<void(boost::shared_ptr<DepthImage>) > ActualDepthImageCallbackFunction;
-      typedef std::function<void(boost::shared_ptr<IRImage>) > ActualIRImageCallbackFunction;
+      using ActualImageCallbackFunction = std::function<void(boost::shared_ptr<Image>) >;
+      using ActualDepthImageCallbackFunction = std::function<void(boost::shared_ptr<DepthImage>) >;
+      using ActualIRImageCallbackFunction = std::function<void(boost::shared_ptr<IRImage>) >;
 
       OpenNIDevice (xn::Context& context, const xn::NodeInfo& device_node, const xn::NodeInfo& image_node, const xn::NodeInfo& depth_node, const xn::NodeInfo& ir_node);
       OpenNIDevice (xn::Context& context, const xn::NodeInfo& device_node, const xn::NodeInfo& depth_node, const xn::NodeInfo& ir_node);

--- a/io/include/pcl/io/openni_camera/openni_image.h
+++ b/io/include/pcl/io/openni_camera/openni_image.h
@@ -58,15 +58,15 @@ namespace openni_wrapper
   class PCL_EXPORTS Image
   {
   public:
-    typedef boost::shared_ptr<Image> Ptr;
-    typedef boost::shared_ptr<const Image> ConstPtr;
+    using Ptr = boost::shared_ptr<Image>;
+    using ConstPtr = boost::shared_ptr<const Image>;
 
-    typedef enum
+    enum Encoding
     {
       BAYER_GRBG,
       YUV422,
       RGB
-    } Encoding;
+    };
 
     /**
      * @author Suat Gedikli

--- a/io/include/pcl/io/openni_camera/openni_image_bayer_grbg.h
+++ b/io/include/pcl/io/openni_camera/openni_image_bayer_grbg.h
@@ -53,12 +53,12 @@ namespace openni_wrapper
   class PCL_EXPORTS ImageBayerGRBG : public Image
   {
     public:
-      typedef enum
+      enum DebayeringMethod
       {
         Bilinear = 0,
         EdgeAware,
         EdgeAwareWeighted
-      } DebayeringMethod;
+      };
 
       ImageBayerGRBG (boost::shared_ptr<xn::ImageMetaData> image_meta_data, DebayeringMethod method) throw ();
       ~ImageBayerGRBG () throw ();

--- a/io/include/pcl/io/openni_camera/openni_ir_image.h
+++ b/io/include/pcl/io/openni_camera/openni_ir_image.h
@@ -51,8 +51,8 @@ namespace openni_wrapper
 class PCL_EXPORTS IRImage
 {
 public:
-  typedef boost::shared_ptr<IRImage> Ptr;
-  typedef boost::shared_ptr<const IRImage> ConstPtr;
+  using Ptr = boost::shared_ptr<IRImage>;
+  using ConstPtr = boost::shared_ptr<const IRImage>;
 
   inline IRImage (boost::shared_ptr<xn::IRMetaData> ir_meta_data) throw ();
   inline virtual ~IRImage () throw ();

--- a/io/include/pcl/io/openni_grabber.h
+++ b/io/include/pcl/io/openni_grabber.h
@@ -68,10 +68,10 @@ namespace pcl
   class PCL_EXPORTS OpenNIGrabber : public Grabber
   {
     public:
-      typedef boost::shared_ptr<OpenNIGrabber> Ptr;
-      typedef boost::shared_ptr<const OpenNIGrabber> ConstPtr;
+      using Ptr = boost::shared_ptr<OpenNIGrabber>;
+      using ConstPtr = boost::shared_ptr<const OpenNIGrabber>;
 
-      typedef enum
+      enum Mode
       {
         OpenNI_Default_Mode = 0, // This can depend on the device. For now all devices (PSDK, Xtion, Kinect) its VGA@30Hz
         OpenNI_SXGA_15Hz = 1,    // Only supported by the Kinect
@@ -83,18 +83,18 @@ namespace pcl
         OpenNI_QQVGA_25Hz = 7,   // Not supported -> using software downsampling (only for integer scale factor and only NN)
         OpenNI_QQVGA_30Hz = 8,   // Not supported -> using software downsampling (only for integer scale factor and only NN)
         OpenNI_QQVGA_60Hz = 9    // Not supported -> using software downsampling (only for integer scale factor and only NN)
-      } Mode;
+      };
 
       //define callback signature typedefs
-      typedef void (sig_cb_openni_image) (const boost::shared_ptr<openni_wrapper::Image>&);
-      typedef void (sig_cb_openni_depth_image) (const boost::shared_ptr<openni_wrapper::DepthImage>&);
-      typedef void (sig_cb_openni_ir_image) (const boost::shared_ptr<openni_wrapper::IRImage>&);
-      typedef void (sig_cb_openni_image_depth_image) (const boost::shared_ptr<openni_wrapper::Image>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant) ;
-      typedef void (sig_cb_openni_ir_depth_image) (const boost::shared_ptr<openni_wrapper::IRImage>&, const boost::shared_ptr<openni_wrapper::DepthImage>&, float constant) ;
-      typedef void (sig_cb_openni_point_cloud) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> >&);
-      typedef void (sig_cb_openni_point_cloud_rgb) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> >&);
-      typedef void (sig_cb_openni_point_cloud_rgba) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> >&);
-      typedef void (sig_cb_openni_point_cloud_i) (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&);
+      using sig_cb_openni_image = void (const boost::shared_ptr<openni_wrapper::Image> &);
+      using sig_cb_openni_depth_image = void (const boost::shared_ptr<openni_wrapper::DepthImage> &);
+      using sig_cb_openni_ir_image = void (const boost::shared_ptr<openni_wrapper::IRImage> &);
+      using sig_cb_openni_image_depth_image = void (const boost::shared_ptr<openni_wrapper::Image> &, const boost::shared_ptr<openni_wrapper::DepthImage> &, float) ;
+      using sig_cb_openni_ir_depth_image = void (const boost::shared_ptr<openni_wrapper::IRImage> &, const boost::shared_ptr<openni_wrapper::DepthImage> &, float) ;
+      using sig_cb_openni_point_cloud = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZ> > &);
+      using sig_cb_openni_point_cloud_rgb = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGB> > &);
+      using sig_cb_openni_point_cloud_rgba = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZRGBA> > &);
+      using sig_cb_openni_point_cloud_i = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> > &);
 
     public:
       /** \brief Constructor

--- a/io/include/pcl/io/ply/ply.h
+++ b/io/include/pcl/io/ply/ply.h
@@ -55,15 +55,15 @@ namespace pcl
   {
     namespace ply 
     {
-      typedef boost::int8_t int8;
-      typedef boost::int16_t int16;
-      typedef boost::int32_t int32;
-      typedef boost::uint8_t uint8;
-      typedef boost::uint16_t uint16;
-      typedef boost::uint32_t uint32;         
+      using int8 = boost::int8_t;
+      using int16 = boost::int16_t;
+      using int32 = boost::int32_t;
+      using uint8 = boost::uint8_t;
+      using uint16 = boost::uint16_t;
+      using uint32 = boost::uint32_t;         
       
-      typedef float float32;
-      typedef double float64;
+      using float32 = float;
+      using float64 = double;
       
       template <typename ScalarType>
         struct type_traits;
@@ -76,8 +76,8 @@ namespace pcl
       template <>                                           \
       struct type_traits<TYPE>                              \
       {                                                     \
-        typedef TYPE type;                                  \
-        typedef PARSE_TYPE parse_type;                      \
+        using type = TYPE;                                  \
+        using parse_type = PARSE_TYPE;                      \
         static const char* name () { return NAME; }         \
         static const char* old_name () { return OLD_NAME; } \
       };
@@ -94,7 +94,7 @@ namespace pcl
       
 #undef PLY_TYPE_TRAITS
       
-      typedef int format_type;
+      using format_type = int;
       enum format { ascii_format, binary_little_endian_format, binary_big_endian_format, unknown };  
     } // namespace ply
   } // namespace io

--- a/io/include/pcl/io/ply/ply_parser.h
+++ b/io/include/pcl/io/ply/ply_parser.h
@@ -77,35 +77,35 @@ namespace pcl
       {
         public:
 
-          typedef std::function<void (std::size_t, const std::string&)> info_callback_type;
-          typedef std::function<void (std::size_t, const std::string&)> warning_callback_type;
-          typedef std::function<void (std::size_t, const std::string&)> error_callback_type;
+          using info_callback_type = std::function<void (std::size_t, const std::string&)>;
+          using warning_callback_type = std::function<void (std::size_t, const std::string&)>;
+          using error_callback_type = std::function<void (std::size_t, const std::string&)>;
          
-          typedef std::function<void ()> magic_callback_type;
-          typedef std::function<void (format_type, const std::string&)> format_callback_type;
-          typedef std::function<void (const std::string&)> comment_callback_type;
-          typedef std::function<void (const std::string&)> obj_info_callback_type;
-          typedef std::function<bool ()> end_header_callback_type;
+          using magic_callback_type = std::function<void ()>;
+          using format_callback_type = std::function<void (format_type, const std::string&)>;
+          using comment_callback_type = std::function<void (const std::string&)>;
+          using obj_info_callback_type = std::function<void (const std::string&)>;
+          using end_header_callback_type = std::function<bool ()>;
          
-          typedef std::function<void ()> begin_element_callback_type;
-          typedef std::function<void ()> end_element_callback_type;
-          typedef boost::tuple<begin_element_callback_type, end_element_callback_type> element_callbacks_type;
-          typedef std::function<element_callbacks_type (const std::string&, std::size_t)> element_definition_callback_type;
+          using begin_element_callback_type = std::function<void ()>;
+          using end_element_callback_type = std::function<void ()>;
+          using element_callbacks_type = boost::tuple<begin_element_callback_type, end_element_callback_type>;
+          using element_definition_callback_type = std::function<element_callbacks_type (const std::string&, std::size_t)>;
          
           template <typename ScalarType>
           struct scalar_property_callback_type
           {
-            typedef std::function<void (ScalarType)> type;
+            using type = std::function<void (ScalarType)>;
           };
 
           template <typename ScalarType>
           struct scalar_property_definition_callback_type
           {
-            typedef typename scalar_property_callback_type<ScalarType>::type scalar_property_callback_type;
-            typedef std::function<scalar_property_callback_type (const std::string&, const std::string&)> type;
+            using scalar_property_callback_type = typename scalar_property_callback_type<ScalarType>::type;
+            using type = std::function<scalar_property_callback_type (const std::string&, const std::string&)>;
           };
        
-          typedef boost::mpl::vector<int8, int16, int32, uint8, uint16, uint32, float32, float64> scalar_types;
+          using scalar_types = boost::mpl::vector<int8, int16, int32, uint8, uint16, uint32, float32, float64>;
 
           class scalar_property_definition_callbacks_type
           {
@@ -114,17 +114,17 @@ namespace pcl
               struct callbacks_element
               {
 //                callbacks_element () : callback ();
-                typedef T scalar_type;
+                using scalar_type = T;
                 typename scalar_property_definition_callback_type<scalar_type>::type callback;
               };
              
-              typedef boost::mpl::inherit_linearly<
+              using callbacks = boost::mpl::inherit_linearly<
                 scalar_types,
                 boost::mpl::inherit<
                 boost::mpl::_1,
                 callbacks_element<boost::mpl::_2>
                 >
-                >::type callbacks;
+                >::type;
               callbacks callbacks_;
              
             public:
@@ -169,36 +169,35 @@ namespace pcl
           template <typename SizeType, typename ScalarType>
           struct list_property_begin_callback_type
           {
-            typedef std::function<void (SizeType)> type;
+            using type = std::function<void (SizeType)>;
           };
          
           template <typename SizeType, typename ScalarType>
           struct list_property_element_callback_type
           {
-            typedef std::function<void (ScalarType)> type;
+            using type = std::function<void (ScalarType)>;
           };
        
           template <typename SizeType, typename ScalarType>
           struct list_property_end_callback_type
           {
-            typedef std::function<void ()> type;
+            using type = std::function<void ()>;
           };
 
           template <typename SizeType, typename ScalarType>
           struct list_property_definition_callback_type
           {
-            typedef typename list_property_begin_callback_type<SizeType, ScalarType>::type list_property_begin_callback_type;
-            typedef typename list_property_element_callback_type<SizeType, ScalarType>::type list_property_element_callback_type;
-            typedef typename list_property_end_callback_type<SizeType, ScalarType>::type list_property_end_callback_type;
-            typedef std::function<
-            boost::tuple<
-            list_property_begin_callback_type,
+            using list_property_begin_callback_type = typename list_property_begin_callback_type<SizeType, ScalarType>::type;
+            using list_property_element_callback_type = typename list_property_element_callback_type<SizeType, ScalarType>::type;
+            using list_property_end_callback_type = typename list_property_end_callback_type<SizeType, ScalarType>::type;
+            using type = std::function<boost::tuple<
+              list_property_begin_callback_type,
               list_property_element_callback_type,
               list_property_end_callback_type
-              > (const std::string&, const std::string&)> type;
+              > (const std::string&, const std::string&)>;
           };
 
-          typedef boost::mpl::vector<uint8, uint16, uint32> size_types;
+          using size_types = boost::mpl::vector<uint8, uint16, uint32>;
      
           class list_property_definition_callbacks_type
           {
@@ -215,12 +214,12 @@ namespace pcl
               template <typename T>
               struct callbacks_element
               {
-                typedef typename T::first size_type;
-                typedef typename T::second scalar_type;
+                using size_type = typename T::first;
+                using scalar_type = typename T::second;
                 typename list_property_definition_callback_type<size_type, scalar_type>::type callback;
               };
            
-              typedef boost::mpl::inherit_linearly<sequence_product<size_types, scalar_types>::type, boost::mpl::inherit<boost::mpl::_1, callbacks_element<boost::mpl::_2> > >::type callbacks;
+              using callbacks = boost::mpl::inherit_linearly<sequence_product<size_types, scalar_types>::type, boost::mpl::inherit<boost::mpl::_1, callbacks_element<boost::mpl::_2> > >::type;
               callbacks callbacks_;
      
             public:
@@ -295,7 +294,7 @@ namespace pcl
           inline void
           end_header_callback (const end_header_callback_type& end_header_callback);
 
-          typedef int flags_type;
+          using flags_type = int;
           enum flags { };
 
           ply_parser () :
@@ -318,8 +317,8 @@ namespace pcl
           template <typename ScalarType>
           struct scalar_property : public property
           {
-            typedef ScalarType scalar_type;
-            typedef typename scalar_property_callback_type<scalar_type>::type callback_type;
+            using scalar_type = ScalarType;
+            using callback_type = typename scalar_property_callback_type<scalar_type>::type;
             scalar_property (const std::string& name, callback_type callback)
               : property (name)
               , callback (callback)
@@ -336,11 +335,11 @@ namespace pcl
           template <typename SizeType, typename ScalarType>
           struct list_property : public property
           {
-            typedef SizeType size_type;
-            typedef ScalarType scalar_type;
-            typedef typename list_property_begin_callback_type<size_type, scalar_type>::type begin_callback_type;
-            typedef typename list_property_element_callback_type<size_type, scalar_type>::type element_callback_type;
-            typedef typename list_property_end_callback_type<size_type, scalar_type>::type end_callback_type;
+            using size_type = SizeType;
+            using scalar_type = ScalarType;
+            using begin_callback_type = typename list_property_begin_callback_type<size_type, scalar_type>::type;
+            using element_callback_type = typename list_property_element_callback_type<size_type, scalar_type>::type;
+            using end_callback_type = typename list_property_end_callback_type<size_type, scalar_type>::type;
             list_property (const std::string& name, 
                            begin_callback_type begin_callback, 
                            element_callback_type element_callback, 
@@ -485,7 +484,7 @@ inline void pcl::io::ply::ply_parser::end_header_callback (const end_header_call
 template <typename ScalarType>
 inline void pcl::io::ply::ply_parser::parse_scalar_property_definition (const std::string& property_name)
 {
-  typedef ScalarType scalar_type;
+  using scalar_type = ScalarType;
   typename scalar_property_definition_callback_type<scalar_type>::type& scalar_property_definition_callback = 
     scalar_property_definition_callbacks_.get<scalar_type> ();
   typename scalar_property_callback_type<scalar_type>::type scalar_property_callback;
@@ -508,13 +507,13 @@ inline void pcl::io::ply::ply_parser::parse_scalar_property_definition (const st
 template <typename SizeType, typename ScalarType>
 inline void pcl::io::ply::ply_parser::parse_list_property_definition (const std::string& property_name)
 {
-  typedef SizeType size_type;
-  typedef ScalarType scalar_type;
-  typedef typename  list_property_definition_callback_type<size_type, scalar_type>::type list_property_definition_callback_type;
+  using size_type = SizeType;
+  using scalar_type = ScalarType;
+  using list_property_definition_callback_type = typename  list_property_definition_callback_type<size_type, scalar_type>::type;
   list_property_definition_callback_type& list_property_definition_callback = list_property_definition_callbacks_.get<size_type, scalar_type> ();
-  typedef typename list_property_begin_callback_type<size_type, scalar_type>::type list_property_begin_callback_type;
-  typedef typename list_property_element_callback_type<size_type, scalar_type>::type list_property_element_callback_type;
-  typedef typename list_property_end_callback_type<size_type, scalar_type>::type list_property_end_callback_type;
+  using list_property_begin_callback_type = typename list_property_begin_callback_type<size_type, scalar_type>::type;
+  using list_property_element_callback_type = typename list_property_element_callback_type<size_type, scalar_type>::type;
+  using list_property_end_callback_type = typename list_property_end_callback_type<size_type, scalar_type>::type;
   boost::tuple<list_property_begin_callback_type, list_property_element_callback_type, list_property_end_callback_type> list_property_callbacks;
   if (list_property_definition_callback)
   {
@@ -545,7 +544,7 @@ inline bool pcl::io::ply::ply_parser::parse_scalar_property (format_type format,
                                                              const typename scalar_property_callback_type<ScalarType>::type& scalar_property_callback)
 {
   using namespace io_operators;
-  typedef ScalarType scalar_type;
+  using scalar_type = ScalarType;
   if (format == ascii_format)
   {
     std::string value_s;
@@ -599,8 +598,8 @@ inline bool pcl::io::ply::ply_parser::parse_list_property (format_type format, s
                                                            const typename list_property_end_callback_type<SizeType, ScalarType>::type& list_property_end_callback)
 {
   using namespace io_operators;
-  typedef SizeType size_type;
-  typedef ScalarType scalar_type;
+  using size_type = SizeType;
+  using scalar_type = ScalarType;
   if (format == ascii_format)
   {
     size_type size = std::numeric_limits<size_type>::infinity ();

--- a/io/include/pcl/io/png_io.h
+++ b/io/include/pcl/io/png_io.h
@@ -117,7 +117,7 @@ namespace pcl
     template <typename PointT> void
     savePNGFile (const std::string& file_name, const pcl::PointCloud<PointT>& cloud, const std::string& field_name)
     {
-      typedef typename PointCloudImageExtractor<PointT>::Ptr PointCloudImageExtractorPtr;
+      using PointCloudImageExtractorPtr = typename PointCloudImageExtractor<PointT>::Ptr;
       PointCloudImageExtractorPtr pcie;
       if (field_name == "normal")
       {

--- a/io/include/pcl/io/point_cloud_image_extractors.h
+++ b/io/include/pcl/io/point_cloud_image_extractors.h
@@ -78,10 +78,10 @@ namespace pcl
     class PointCloudImageExtractor
     {
       public:
-        typedef pcl::PointCloud<PointT> PointCloud;
+        using PointCloud = pcl::PointCloud<PointT>;
 
-        typedef boost::shared_ptr<PointCloudImageExtractor<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractor<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractor<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractor<PointT> >;
 
         /** \brief Constructor. */
         PointCloudImageExtractor ()
@@ -130,11 +130,11 @@ namespace pcl
     template <typename PointT>
     class PointCloudImageExtractorWithScaling : public PointCloudImageExtractor<PointT>
     {
-      typedef typename PointCloudImageExtractor<PointT>::PointCloud PointCloud;
+      using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        typedef boost::shared_ptr<PointCloudImageExtractorWithScaling<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractorWithScaling<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractorWithScaling<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorWithScaling<PointT> >;
 
         /** \brief Different scaling methods.
           * <ul>
@@ -202,11 +202,11 @@ namespace pcl
     template <typename PointT>
     class PointCloudImageExtractorFromNormalField : public PointCloudImageExtractor<PointT>
     {
-      typedef typename PointCloudImageExtractor<PointT>::PointCloud PointCloud;
+      using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        typedef boost::shared_ptr<PointCloudImageExtractorFromNormalField<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractorFromNormalField<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromNormalField<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromNormalField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudImageExtractorFromNormalField () {}
@@ -229,11 +229,11 @@ namespace pcl
     template <typename PointT>
     class PointCloudImageExtractorFromRGBField : public PointCloudImageExtractor<PointT>
     {
-      typedef typename PointCloudImageExtractor<PointT>::PointCloud PointCloud;
+      using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        typedef boost::shared_ptr<PointCloudImageExtractorFromRGBField<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractorFromRGBField<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromRGBField<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromRGBField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudImageExtractorFromRGBField () {}
@@ -258,11 +258,11 @@ namespace pcl
     template <typename PointT>
     class PointCloudImageExtractorFromLabelField : public PointCloudImageExtractor<PointT>
     {
-      typedef typename PointCloudImageExtractor<PointT>::PointCloud PointCloud;
+      using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        typedef boost::shared_ptr<PointCloudImageExtractorFromLabelField<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractorFromLabelField<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromLabelField<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromLabelField<PointT> >;
 
         /** \brief Different modes for color mapping. */
         enum ColorMode
@@ -315,12 +315,12 @@ namespace pcl
     template <typename PointT>
     class PointCloudImageExtractorFromZField : public PointCloudImageExtractorWithScaling<PointT>
     {
-      typedef typename PointCloudImageExtractor<PointT>::PointCloud PointCloud;
-      typedef typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod ScalingMethod;
+      using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
+      using ScalingMethod = typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod;
 
       public:
-        typedef boost::shared_ptr<PointCloudImageExtractorFromZField<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractorFromZField<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromZField<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromZField<PointT> >;
 
         /** \brief Constructor.
           * \param[in] scaling_factor a scaling factor to apply to each depth value (default 10000)
@@ -357,12 +357,12 @@ namespace pcl
     template <typename PointT>
     class PointCloudImageExtractorFromCurvatureField : public PointCloudImageExtractorWithScaling<PointT>
     {
-      typedef typename PointCloudImageExtractor<PointT>::PointCloud PointCloud;
-      typedef typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod ScalingMethod;
+      using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
+      using ScalingMethod = typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod;
 
       public:
-        typedef boost::shared_ptr<PointCloudImageExtractorFromCurvatureField<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractorFromCurvatureField<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromCurvatureField<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromCurvatureField<PointT> >;
 
         /** \brief Constructor.
           * \param[in] scaling_method a scaling method to use (default SCALING_FULL_RANGE)
@@ -399,12 +399,12 @@ namespace pcl
     template <typename PointT>
     class PointCloudImageExtractorFromIntensityField : public PointCloudImageExtractorWithScaling<PointT>
     {
-      typedef typename PointCloudImageExtractor<PointT>::PointCloud PointCloud;
-      typedef typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod ScalingMethod;
+      using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
+      using ScalingMethod = typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod;
 
       public:
-        typedef boost::shared_ptr<PointCloudImageExtractorFromIntensityField<PointT> > Ptr;
-        typedef boost::shared_ptr<const PointCloudImageExtractorFromIntensityField<PointT> > ConstPtr;
+        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromIntensityField<PointT> >;
+        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromIntensityField<PointT> >;
 
         /** \brief Constructor.
           * \param[in] scaling_method a scaling method to use (default SCALING_NO)

--- a/io/include/pcl/io/real_sense/real_sense_device_manager.h
+++ b/io/include/pcl/io/real_sense/real_sense_device_manager.h
@@ -65,7 +65,7 @@ namespace pcl
 
         public:
 
-          typedef boost::shared_ptr<RealSenseDeviceManager> Ptr;
+          using Ptr = boost::shared_ptr<RealSenseDeviceManager>;
 
           static Ptr&
           getInstance ()
@@ -133,7 +133,7 @@ namespace pcl
 
         public:
 
-          typedef boost::shared_ptr<RealSenseDevice> Ptr;
+          using Ptr = boost::shared_ptr<RealSenseDevice>;
 
           inline const std::string&
           getSerialNumber () { return (device_id_); }

--- a/io/include/pcl/io/real_sense_grabber.h
+++ b/io/include/pcl/io/real_sense_grabber.h
@@ -64,13 +64,9 @@ namespace pcl
 
     public:
 
-      typedef
-        void (sig_cb_real_sense_point_cloud)
-          (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&);
+      using sig_cb_real_sense_point_cloud = void () (const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&);
 
-      typedef
-        void (sig_cb_real_sense_point_cloud_rgba)
-          (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&);
+      using sig_cb_real_sense_point_cloud_rgba = void () (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&);
 
       /** A descriptor for capturing mode.
         *

--- a/io/include/pcl/io/robot_eye_grabber.h
+++ b/io/include/pcl/io/robot_eye_grabber.h
@@ -61,8 +61,7 @@ namespace pcl
        * This signal is sent when the accumulated number of points reaches
        * the limit specified by setSignalPointCloudSize().
        */
-      typedef void (sig_cb_robot_eye_point_cloud_xyzi) (
-          const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> >&);
+      using sig_cb_robot_eye_point_cloud_xyzi = void (const boost::shared_ptr<const pcl::PointCloud<pcl::PointXYZI> > &);
 
       /** \brief RobotEyeGrabber default constructor. */
       RobotEyeGrabber ();

--- a/io/src/lzf.cpp
+++ b/io/src/lzf.cpp
@@ -51,8 +51,8 @@
  */
 #define HLOG 13
 
-typedef unsigned int LZF_HSLOT;
-typedef unsigned int LZF_STATE[1 << (HLOG)];
+using LZF_HSLOT = unsigned int;
+using LZF_STATE = unsigned int[1 << (HLOG)];
 
 #if !(defined(__i386) || defined (__amd64))
 # define STRICT_ALIGN 1
@@ -62,9 +62,9 @@ typedef unsigned int LZF_STATE[1 << (HLOG)];
 #if !STRICT_ALIGN
 /* for unaligned accesses we need a 16 bit datatype. */
 # if USHRT_MAX == 65535
-    typedef unsigned short u16;
+    using u16 = unsigned short;
 # elif UINT_MAX == 65535
-    typedef unsigned int u16;
+    using u16 = unsigned int;
 # else
 #  undef STRICT_ALIGN
 #  define STRICT_ALIGN 1

--- a/io/src/lzf_image_io.cpp
+++ b/io/src/lzf_image_io.cpp
@@ -51,9 +51,9 @@
 // See https://github.com/PointCloudLibrary/pcl/issues/864
 #include <boost/version.hpp>
 #if (BOOST_VERSION >= 105600)
-  typedef boost::property_tree::xml_writer_settings<std::string> xml_writer_settings;
+  using xml_writer_settings = boost::property_tree::xml_writer_settings<std::string>;
 #else
-  typedef boost::property_tree::xml_writer_settings<char> xml_writer_settings;
+  using xml_writer_settings = boost::property_tree::xml_writer_settings<char>;
 #endif
 
 

--- a/io/src/oni_grabber.cpp
+++ b/io/src/oni_grabber.cpp
@@ -48,7 +48,7 @@
 
 namespace
 {
-  typedef union
+  union RGBValue
   {
     struct /*anonymous*/
     {
@@ -59,7 +59,7 @@ namespace
     };
     float float_value;
     long long_value;
-  } RGBValue;
+  };
 }
 
 namespace pcl

--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -51,7 +51,7 @@ using namespace pcl::io::openni2;
 using openni::VideoMode;
 using std::vector;
 
-typedef boost::chrono::high_resolution_clock hr_clock;
+using hr_clock = boost::chrono::high_resolution_clock;
 
 pcl::io::openni2::OpenNI2Device::OpenNI2Device (const std::string& device_URI) :
   ir_video_started_(false),

--- a/io/src/openni2/openni2_device_manager.cpp
+++ b/io/src/openni2/openni2_device_manager.cpp
@@ -58,7 +58,7 @@ namespace pcl
         }
       };
 
-      typedef std::set<OpenNI2DeviceInfo, OpenNI2DeviceInfoComparator> DeviceSet;
+      using DeviceSet = std::set<OpenNI2DeviceInfo, OpenNI2DeviceInfoComparator>;
 
 
 

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -56,7 +56,7 @@ using namespace pcl::io::openni2;
 namespace
 {
   // Treat color as chars, float32, or uint32
-  typedef union
+  union RGBValue
   {
     struct
     {
@@ -67,7 +67,7 @@ namespace
     };
     float float_value;
     uint32_t long_value;
-  } RGBValue;
+  };
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -343,7 +343,7 @@ pcl::io::OpenNI2Grabber::setupDevice (const std::string& device_id, const Mode& 
     PCL_THROW_EXCEPTION (pcl::IOException, "unknown error occurred");
   }
 
-  typedef pcl::io::openni2::OpenNI2VideoMode VideoMode;
+  using VideoMode = pcl::io::openni2::OpenNI2VideoMode;
 
   VideoMode depth_md;
   // Set the selected output mode
@@ -802,7 +802,7 @@ pcl::io::OpenNI2Grabber::convertToXYZIPointCloud (const IRImage::Ptr &ir_image, 
 void
 pcl::io::OpenNI2Grabber::updateModeMaps ()
 {
-  typedef pcl::io::openni2::OpenNI2VideoMode VideoMode;
+  using VideoMode = pcl::io::openni2::OpenNI2VideoMode;
 
 pcl::io::openni2::OpenNI2VideoMode output_mode;
 

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -430,7 +430,7 @@ openni_wrapper::OpenNIDriver::getDeviceType (const std::string& connectionString
 {
 #if _WIN32
     // expected format: "\\?\usb#vid_[ID]&pid_[ID]#[SERIAL]#{GUID}"
-    typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
+    using tokenizer = boost::tokenizer<boost::char_separator<char> >;
     boost::char_separator<char> separators("#&_");
     tokenizer tokens (connectionString, separators);
 

--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -343,7 +343,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
           }
           if ((size_type_string == type_traits<uint8>::name ()) || (size_type_string == type_traits<uint8>::old_name ()))
           {
-            typedef uint8 size_type;
+            using size_type = uint8;
             if ((scalar_type_string == type_traits<int8>::name ()) || (scalar_type_string == type_traits<int8>::old_name ()))
             {
               parse_list_property_definition<size_type, int8>(name);
@@ -387,7 +387,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
           }
           else if ((size_type_string == type_traits<uint16>::name ()) || (size_type_string == type_traits<uint16>::old_name ()))
           {
-            typedef uint16 size_type;
+            using size_type = uint16;
             if ((scalar_type_string == type_traits<int8>::name ()) || (scalar_type_string == type_traits<int8>::old_name ()))
             {
               parse_list_property_definition<size_type, int8>(name);
@@ -429,7 +429,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
           }
           else if ((size_type_string == type_traits<uint32>::name ()) || (size_type_string == type_traits<uint32>::old_name ()))
           {
-            typedef uint32 size_type;
+            using size_type = uint32;
             if ((scalar_type_string == type_traits<int8>::name ()) || (scalar_type_string == type_traits<int8>::old_name ()))
             {
               parse_list_property_definition<size_type, int8>(name);

--- a/io/tools/pcd_introduce_nan.cpp
+++ b/io/tools/pcd_introduce_nan.cpp
@@ -39,10 +39,10 @@
 #include <pcl/io/pcd_io.h>
 
 /** @brief PCL point object */
-typedef pcl::PointXYZRGBA PointT;
+using PointT = pcl::PointXYZRGBA;
 
 /** @brief PCL Point cloud object */
-typedef pcl::PointCloud<PointT> PointCloudT;
+using PointCloudT = pcl::PointCloud<PointT>;
 
 int
 main (int argc,

--- a/io/tools/ply/ply2obj.cpp
+++ b/io/tools/ply/ply2obj.cpp
@@ -62,7 +62,7 @@
 class ply_to_obj_converter
 {
   public:
-    typedef int flags_type;
+    using flags_type = int;
     enum { triangulate = 1 << 0 };
 
     ply_to_obj_converter (flags_type flags = 0);

--- a/io/tools/ply/ply2ply.cpp
+++ b/io/tools/ply/ply2ply.cpp
@@ -56,7 +56,7 @@
 class ply_to_ply_converter
 {
   public:
-    typedef int format_type;
+    using format_type = int;
     enum format
     {
       same_format,


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`