### PR TITLE
Use using instead of typedef [examples]

### DIFF
--- a/examples/common/example_copy_point_cloud.cpp
+++ b/examples/common/example_copy_point_cloud.cpp
@@ -73,7 +73,7 @@ main ()
 void
 sameType ()
 {
-  typedef pcl::PointCloud<pcl::PointXYZ> CloudType;
+  using CloudType = pcl::PointCloud<pcl::PointXYZ>;
   CloudType::Ptr cloud (new CloudType);
 
   CloudType::PointType p;
@@ -91,7 +91,7 @@ sameType ()
 void
 differenceType ()
 {
-  typedef pcl::PointCloud<pcl::PointXYZ> CloudType;
+  using CloudType = pcl::PointCloud<pcl::PointXYZ>;
   CloudType::Ptr cloud (new CloudType);
 
   CloudType::PointType p;
@@ -99,7 +99,7 @@ differenceType ()
   cloud->push_back(p);
   std::cout << p.x << " " << p.y << " " << p.z << std::endl;
 
-  typedef pcl::PointCloud<pcl::PointNormal> CloudType2;
+  using CloudType2 = pcl::PointCloud<pcl::PointNormal>;
   CloudType2::Ptr cloud2(new CloudType2);
   copyPointCloud(*cloud, *cloud2);
 
@@ -114,7 +114,7 @@ error: ‘pcl::PointCloud<pcl::Normal>::PointType’ has no member named ‘x’
 void
 badConversion ()
 {
-  typedef pcl::PointCloud<pcl::PointXYZ> CloudType;
+  using CloudType = pcl::PointCloud<pcl::PointXYZ>;
   CloudType::Ptr cloud (new CloudType);
   
   CloudType::PointType p;
@@ -122,7 +122,7 @@ badConversion ()
   cloud->push_back(p);
   std::cout << p.x << " " << p.y << " " << p.z << std::endl;
 
-  typedef pcl::PointCloud<pcl::Normal> CloudType2;
+  using CloudType2 = pcl::PointCloud<pcl::Normal>;
   CloudType2::Ptr cloud2(new CloudType2);
   copyPointCloud(*cloud, *cloud2);
   

--- a/examples/common/example_organized_point_cloud.cpp
+++ b/examples/common/example_organized_point_cloud.cpp
@@ -48,8 +48,8 @@ int
 main ()
 {
   // Setup the cloud
-  typedef pcl::PointXYZ PointType;
-  typedef pcl::PointCloud<PointType> CloudType;
+  using PointType = pcl::PointXYZ;
+  using CloudType = pcl::PointCloud<PointType>;
   CloudType::Ptr cloud (new CloudType);
   
   // Make the cloud a 10x10 grid

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -31,10 +31,10 @@
 using namespace pcl;
 using namespace std;
 
-typedef pcl::PointXYZRGB PointT;
-typedef pcl::PointNormal PointNT;
-typedef pcl::PointNormal PointOutT;
-typedef pcl::search::Search<PointT>::Ptr SearchPtr;
+using PointT = pcl::PointXYZRGB;
+using PointNT = pcl::PointNormal;
+using PointOutT = pcl::PointNormal;
+using SearchPtr = pcl::search::Search<PointT>::Ptr;
 
 int main (int argc, char *argv[])
 {

--- a/examples/filters/example_extract_indices.cpp
+++ b/examples/filters/example_extract_indices.cpp
@@ -47,8 +47,8 @@
 int
 main (int, char**)
 {
-  typedef pcl::PointXYZ PointType;
-  typedef pcl::PointCloud<PointType> CloudType;
+  using PointType = pcl::PointXYZ;
+  using CloudType = pcl::PointCloud<PointType>;
   CloudType::Ptr cloud (new CloudType);
   cloud->is_dense = false;
   PointType p;

--- a/examples/filters/example_remove_nan_from_point_cloud.cpp
+++ b/examples/filters/example_remove_nan_from_point_cloud.cpp
@@ -49,7 +49,7 @@
 int
 main (int, char**)
 {
-  typedef pcl::PointCloud<pcl::PointXYZ> CloudType;
+  using CloudType = pcl::PointCloud<pcl::PointXYZ>;
   CloudType::Ptr cloud (new CloudType);
   cloud->is_dense = false;
   CloudType::Ptr output_cloud (new CloudType);

--- a/examples/geometry/example_half_edge_mesh.cpp
+++ b/examples/geometry/example_half_edge_mesh.cpp
@@ -72,23 +72,23 @@ operator << (std::ostream& os, const MyVertexData& vd)
 ////////////////////////////////////////////////////////////////////////////////
 
 // Declare the mesh.
-typedef pcl::geometry::PolygonMesh <pcl::geometry::DefaultMeshTraits <MyVertexData> > Mesh;
+using Mesh = pcl::geometry::PolygonMesh<pcl::geometry::DefaultMeshTraits<MyVertexData> >;
 
-typedef Mesh::VertexIndex   VertexIndex;
-typedef Mesh::HalfEdgeIndex HalfEdgeIndex;
-typedef Mesh::FaceIndex     FaceIndex;
+using VertexIndex = Mesh::VertexIndex;
+using HalfEdgeIndex = Mesh::HalfEdgeIndex;
+using FaceIndex = Mesh::FaceIndex;
 
-typedef Mesh::VertexIndices   VertexIndices;
-typedef Mesh::HalfEdgeIndices HalfEdgeIndices;
-typedef Mesh::FaceIndices     FaceIndices;
+using VertexIndices = Mesh::VertexIndices;
+using HalfEdgeIndices = Mesh::HalfEdgeIndices;
+using FaceIndices = Mesh::FaceIndices;
 
-typedef Mesh::VertexAroundVertexCirculator           VAVC;
-typedef Mesh::OutgoingHalfEdgeAroundVertexCirculator OHEAVC;
-typedef Mesh::IncomingHalfEdgeAroundVertexCirculator IHEAVC;
-typedef Mesh::FaceAroundVertexCirculator             FAVC;
-typedef Mesh::VertexAroundFaceCirculator             VAFC;
-typedef Mesh::InnerHalfEdgeAroundFaceCirculator      IHEAFC;
-typedef Mesh::OuterHalfEdgeAroundFaceCirculator      OHEAFC;
+using VAVC = Mesh::VertexAroundVertexCirculator;
+using OHEAVC = Mesh::OutgoingHalfEdgeAroundVertexCirculator;
+using IHEAVC = Mesh::IncomingHalfEdgeAroundVertexCirculator;
+using FAVC = Mesh::FaceAroundVertexCirculator;
+using VAFC = Mesh::VertexAroundFaceCirculator;
+using IHEAFC = Mesh::InnerHalfEdgeAroundFaceCirculator;
+using OHEAFC = Mesh::OuterHalfEdgeAroundFaceCirculator;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/examples/outofcore/example_outofcore.cpp
+++ b/examples/outofcore/example_outofcore.cpp
@@ -48,8 +48,8 @@
 
 using namespace pcl::outofcore;
 
-typedef OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<pcl::PointXYZ>, pcl::PointXYZ> OctreeDisk;
-typedef OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<pcl::PointXY>, pcl::PointXYZ> OctreeDiskNode;
+using OctreeDisk = OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<pcl::PointXYZ>, pcl::PointXYZ>;
+using OctreeDiskNode = OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<pcl::PointXY>, pcl::PointXYZ>;
 
 int main (int, char** argv)
 {

--- a/examples/outofcore/example_outofcore_with_lod.cpp
+++ b/examples/outofcore/example_outofcore_with_lod.cpp
@@ -49,8 +49,8 @@
 
 using namespace pcl::outofcore;
 
-typedef OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<pcl::PointXYZ>, pcl::PointXYZ> OctreeDisk;
-typedef OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<pcl::PointXY>, pcl::PointXYZ> OctreeDiskNode;
+using OctreeDisk = OutofcoreOctreeBase<OutofcoreOctreeDiskContainer<pcl::PointXYZ>, pcl::PointXYZ>;
+using OctreeDiskNode = OutofcoreOctreeBaseNode<OutofcoreOctreeDiskContainer<pcl::PointXY>, pcl::PointXYZ>;
 
 int main (int, char** argv)
 {

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -68,8 +68,8 @@ using namespace std::chrono_literals;
 
 /// *****  Type Definitions ***** ///
 
-typedef pcl::PointXYZRGBA PointT;  // The point type used for input
-typedef pcl::LCCPSegmentation<PointT>::SupervoxelAdjacencyList SuperVoxelAdjacencyList;
+using PointT = pcl::PointXYZRGBA;  // The point type used for input
+using SuperVoxelAdjacencyList = pcl::LCCPSegmentation<PointT>::SupervoxelAdjacencyList;
 
 /// Callback and variables
 
@@ -448,9 +448,9 @@ CPCSegmentation Parameters: \n\
     // Currently this is a work-around creating a polygon mesh consisting of two triangles for each edge
     using namespace pcl;
 
-    typedef LCCPSegmentation<PointT>::VertexIterator VertexIterator;
-    typedef LCCPSegmentation<PointT>::AdjacencyIterator AdjacencyIterator;
-    typedef LCCPSegmentation<PointT>::EdgeID EdgeID;
+    using VertexIterator = LCCPSegmentation<PointT>::VertexIterator;
+    using AdjacencyIterator = LCCPSegmentation<PointT>::AdjacencyIterator;
+    using EdgeID = LCCPSegmentation<PointT>::EdgeID;
 
     std::set<EdgeID> edge_drawn;
 

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -68,8 +68,8 @@ using namespace std::chrono_literals;
 
 /// *****  Type Definitions ***** ///
 
-typedef pcl::PointXYZRGBA PointT;  // The point type used for input
-typedef pcl::LCCPSegmentation<PointT>::SupervoxelAdjacencyList SuperVoxelAdjacencyList;
+using PointT = pcl::PointXYZRGBA;  // The point type used for input
+using SuperVoxelAdjacencyList = pcl::LCCPSegmentation<PointT>::SupervoxelAdjacencyList;
 
 /// Callback and variables
 
@@ -373,9 +373,9 @@ LCCPSegmentation Parameters: \n\
     // Currently this is a work-around creating a polygon mesh consisting of two triangles for each edge
     using namespace pcl;
 
-    typedef LCCPSegmentation<PointT>::VertexIterator VertexIterator;
-    typedef LCCPSegmentation<PointT>::AdjacencyIterator AdjacencyIterator;
-    typedef LCCPSegmentation<PointT>::EdgeID EdgeID;
+    using VertexIterator = LCCPSegmentation<PointT>::VertexIterator;
+    using AdjacencyIterator = LCCPSegmentation<PointT>::AdjacencyIterator;
+    using EdgeID = LCCPSegmentation<PointT>::EdgeID;
 
     std::set<EdgeID> edge_drawn;
 

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -18,14 +18,14 @@
 using namespace std::chrono_literals;
 
 // Types
-typedef pcl::PointXYZRGBA PointT;
-typedef pcl::PointCloud<PointT> PointCloudT;
-typedef pcl::PointNormal PointNT;
-typedef pcl::PointCloud<PointNT> PointNCloudT;
-typedef pcl::PointXYZL PointLT;
-typedef pcl::PointCloud<PointLT> PointLCloudT;
-typedef pcl::Normal NormalT;
-typedef pcl::PointCloud<NormalT> NormalCloudT;
+using PointT = pcl::PointXYZRGBA;
+using PointCloudT = pcl::PointCloud<PointT>;
+using PointNT = pcl::PointNormal;
+using PointNCloudT = pcl::PointCloud<PointNT>;
+using PointLT = pcl::PointXYZL;
+using PointLCloudT = pcl::PointCloud<PointLT>;
+using NormalT = pcl::Normal;
+using NormalCloudT = pcl::PointCloud<NormalT>;
 
 bool show_voxel_centroids = true;
 bool show_supervoxels = true;
@@ -335,7 +335,7 @@ main (int argc, char ** argv)
   }
   
   std::cout << "Constructing Boost Graph Library Adjacency List...\n";
-  typedef boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, float> VoxelAdjacencyList;
+  using VoxelAdjacencyList = boost::adjacency_list<boost::setS, boost::setS, boost::undirectedS, uint32_t, float>;
   VoxelAdjacencyList supervoxel_adjacency_list;
   super.getSupervoxelAdjacencyList (supervoxel_adjacency_list);
 

--- a/examples/surface/example_nurbs_fitting_surface.cpp
+++ b/examples/surface/example_nurbs_fitting_surface.cpp
@@ -7,7 +7,7 @@
 #include <pcl/surface/on_nurbs/fitting_curve_2d_asdm.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 
-typedef pcl::PointXYZ Point;
+using Point = pcl::PointXYZ;
 
 void
 PointCloud2Vector3d (pcl::PointCloud<Point>::Ptr cloud, pcl::on_nurbs::vector_vec3d &data);

--- a/examples/surface/example_nurbs_viewer_surface.cpp
+++ b/examples/surface/example_nurbs_viewer_surface.cpp
@@ -7,7 +7,7 @@
 #include <pcl/surface/on_nurbs/fitting_curve_2d_asdm.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 
-typedef pcl::PointXYZ Point;
+using Point = pcl::PointXYZ;
 
 int
 main (int argc, char *argv[])

--- a/examples/surface/test_nurbs_fitting_surface.cpp
+++ b/examples/surface/test_nurbs_fitting_surface.cpp
@@ -6,7 +6,7 @@
 #include <pcl/surface/on_nurbs/fitting_surface_tdm.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 
-typedef pcl::PointXYZ Point;
+using Point = pcl::PointXYZ;
 
 void
 CreateCylinderPoints (pcl::PointCloud<Point>::Ptr cloud, pcl::on_nurbs::vector_vec3d &data, unsigned npoints,


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,modernize-use-using' -fix`