### PR TITLE
Transition to standard smart pointers, part 7

### DIFF
--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -57,8 +57,9 @@
 namespace pcl
 {
   // definitions used everywhere
-  using IndicesPtr = boost::shared_ptr <std::vector<int> >;
-  using IndicesConstPtr = boost::shared_ptr <const std::vector<int> >;
+  using Indices = std::vector<int>;
+  using IndicesPtr = boost::shared_ptr<Indices>;
+  using IndicesConstPtr = boost::shared_ptr<const Indices>;
 
   /////////////////////////////////////////////////////////////////////////////////////////
   /** \brief PCL base class. Implements methods that are used by most PCL algorithms.

--- a/test/features/test_board_estimation.cpp
+++ b/test/features/test_board_estimation.cpp
@@ -61,7 +61,7 @@ TEST (PCL, BOARDLocalReferenceFrameEstimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   PointCloud<ReferenceFrame> bunny_LRF;
 
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
 
   // Compute normals
   NormalEstimation<PointXYZ, Normal> ne;

--- a/test/features/test_boundary_estimation.cpp
+++ b/test/features/test_boundary_estimation.cpp
@@ -64,7 +64,7 @@ TEST (PCL, BoundaryEstimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   // set parameters
   n.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   n.setSearchMethod (tree);
   n.setKSearch (static_cast<int> (indices.size ()));

--- a/test/features/test_curvatures_estimation.cpp
+++ b/test/features/test_curvatures_estimation.cpp
@@ -63,7 +63,7 @@ TEST (PCL, PrincipalCurvaturesEstimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   // set parameters
   n.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   n.setSearchMethod (tree);
   n.setKSearch (10); // Use 10 nearest neighbors to estimate the normals

--- a/test/features/test_cvfh_estimation.cpp
+++ b/test/features/test_cvfh_estimation.cpp
@@ -67,7 +67,7 @@ TEST (PCL, CVFHEstimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   // set parameters
   n.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   n.setSearchMethod (tree);
   n.setKSearch (10); // Use 10 nearest neighbors to estimate the normals

--- a/test/features/test_invariants_estimation.cpp
+++ b/test/features/test_invariants_estimation.cpp
@@ -76,7 +76,7 @@ TEST (PCL, MomentInvariantsEstimation)
 
   // set parameters
   mi.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   mi.setIndices (indicesptr);
   mi.setSearchMethod (tree);
   mi.setKSearch (static_cast<int> (indices.size ()));

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -142,7 +142,7 @@ TEST (PCL, NormalEstimation)
   PointCloud<PointXYZ>::Ptr cloudptr = cloud.makeShared ();
   n.setInputCloud (cloudptr);
   EXPECT_EQ (n.getInputCloud (), cloudptr);
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   EXPECT_EQ (n.getIndices (), indicesptr);
   n.setSearchMethod (tree);
@@ -193,7 +193,7 @@ TEST (PCL, NormalEstimationOpenMP)
   PointCloud<PointXYZ>::Ptr cloudptr = cloud.makeShared ();
   n.setInputCloud (cloudptr);
   EXPECT_EQ (n.getInputCloud (), cloudptr);
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   EXPECT_EQ (n.getIndices (), indicesptr);
   n.setSearchMethod (tree);

--- a/test/features/test_pfh_estimation.cpp
+++ b/test/features/test_pfh_estimation.cpp
@@ -63,7 +63,7 @@ static KdTreePtr tree;
 template<template<class, class, class> class FeatureEstimation, typename PointT, typename NormalT, typename OutputT> void
 testIndicesAndSearchSurface (const typename PointCloud<PointT>::Ptr & points,
                              const typename PointCloud<NormalT>::Ptr & normals,
-                             const boost::shared_ptr<std::vector<int> > & indices, int ndims)
+                             const pcl::IndicesPtr & indices, int ndims)
 
 {
   using KdTreeT = pcl::search::KdTree<PointT>;
@@ -120,7 +120,7 @@ testIndicesAndSearchSurface (const typename PointCloud<PointT>::Ptr & points,
   //
   PointCloud<OutputT> output3, output4;
 
-  boost::shared_ptr<std::vector<int> > indices2 (new std::vector<int> (0));
+  pcl::IndicesPtr indices2 (new pcl::Indices (0));
   for (size_t i = 0; i < (indices->size ()/2); ++i)
     indices2->push_back (static_cast<int> (i));
 
@@ -204,7 +204,7 @@ TEST (PCL, PFHEstimation)
 
   // Object
   PointCloud<PFHSignature125>::Ptr pfhs (new PointCloud<PFHSignature125> ());
-  boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
 
   // set parameters
   pfh.setInputCloud (cloud);
@@ -251,7 +251,7 @@ TEST (PCL, PFHEstimation)
 
   // Test results when setIndices and/or setSearchSurface are used
 
-  boost::shared_ptr<std::vector<int> > test_indices (new std::vector<int> (0));
+  pcl::IndicesPtr test_indices (new pcl::Indices (0));
   for (size_t i = 0; i < cloud->size (); i+=3)
     test_indices->push_back (static_cast<int> (i));
 
@@ -391,7 +391,7 @@ TYPED_TEST (FPFHTest, Estimation)
 
   // Object
   PointCloud<FPFHSignature33>::Ptr fpfhs (new PointCloud<FPFHSignature33> ());
-  boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
 
   // set parameters
   fpfh.setInputCloud (cloud);
@@ -440,7 +440,7 @@ TYPED_TEST (FPFHTest, Estimation)
 
   // Test results when setIndices and/or setSearchSurface are used
 
-  boost::shared_ptr<std::vector<int> > test_indices (new std::vector<int> (0));
+  pcl::IndicesPtr test_indices (new pcl::Indices (0));
   for (size_t i = 0; i < cloud->size (); i+=3)
     test_indices->push_back (static_cast<int> (i));
 
@@ -457,7 +457,7 @@ TEST (PCL, VFHEstimation)
   // Object
   pcl::VFHEstimation<PointT, PointT, VFHSignature308> vfh;
   PointCloud<VFHSignature308>::Ptr vfhs (new PointCloud<VFHSignature308> ());
-  boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
 
   // set parameters
   vfh.setInputCloud (cloud);

--- a/test/features/test_ppf_estimation.cpp
+++ b/test/features/test_ppf_estimation.cpp
@@ -50,7 +50,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+pcl::Indices indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@ TEST (PCL, PPFEstimation)
   NormalEstimation<PointXYZ, Normal> normal_estimation;
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   normal_estimation.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   normal_estimation.setIndices (indicesptr);
   normal_estimation.setSearchMethod (tree);
   normal_estimation.setKSearch (10); // Use 10 nearest neighbors to estimate the normals

--- a/test/features/test_rops_estimation.cpp
+++ b/test/features/test_rops_estimation.cpp
@@ -135,7 +135,7 @@ main (int argc, char** argv)
     return (-1);
   }
 
-  indices = boost::shared_ptr <pcl::PointIndices> (new pcl::PointIndices ());
+  indices.reset (new pcl::PointIndices);
   std::ifstream indices_file;
   indices_file.open (argv[2], std::ifstream::in);
   for (std::string line; std::getline (indices_file, line);)

--- a/test/features/test_rsd_estimation.cpp
+++ b/test/features/test_rsd_estimation.cpp
@@ -82,10 +82,7 @@ TEST (PCL, RSDEstimation)
   rsd.setSaveHistograms (true);
   rsd.compute (*rsds);
 
-  using vec_matrixXf = std::vector<Eigen::MatrixXf, Eigen::aligned_allocator<Eigen::MatrixXf> >;
-  boost::shared_ptr<vec_matrixXf> mat (new vec_matrixXf);
-
-  mat = rsd.getHistograms();
+  auto mat = rsd.getHistograms();
 
   EXPECT_EQ (1, (*mat)[140](0, 0));
   EXPECT_EQ (3, (*mat)[140](0, 1));

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -208,7 +208,7 @@ struct createSHOTDesc<UniqueShapeContext<PointT, OutputT>, PointT, NormalT, Outp
 template <typename FeatureEstimation, typename PointT, typename NormalT, typename OutputT> void
 testSHOTIndicesAndSearchSurface (const typename PointCloud<PointT>::Ptr & points,
                                  const typename PointCloud<NormalT>::Ptr & normals,
-                                 const boost::shared_ptr<vector<int> > & indices,
+                                 const pcl::IndicesPtr & indices,
                                  const int nr_shape_bins = 10,
                                  const int nr_color_bins = 30,
                                  const bool describe_shape = true,
@@ -256,7 +256,7 @@ testSHOTIndicesAndSearchSurface (const typename PointCloud<PointT>::Ptr & points
   //
   PointCloud<OutputT> output3, output4;
 
-  boost::shared_ptr<vector<int> > indices2 (new vector<int> (0));
+  pcl::IndicesPtr indices2 (new pcl::Indices (0));
   for (size_t i = 0; i < (indices->size ()/2); ++i)
     indices2->push_back (static_cast<int> (i));
 
@@ -280,7 +280,7 @@ testSHOTIndicesAndSearchSurface (const typename PointCloud<PointT>::Ptr & points
 template <typename FeatureEstimation, typename PointT, typename NormalT, typename OutputT> void
 testSHOTLocalReferenceFrame (const typename PointCloud<PointT>::Ptr & points,
                              const typename PointCloud<NormalT>::Ptr & normals,
-                             const boost::shared_ptr<vector<int> > & indices,
+                             const pcl::IndicesPtr & indices,
                              const int nr_shape_bins = 10,
                              const int nr_color_bins = 30,
                              const bool describe_shape = true,
@@ -291,7 +291,7 @@ testSHOTLocalReferenceFrame (const typename PointCloud<PointT>::Ptr & points,
   typename PointCloud<PointT>::Ptr subpoints (new PointCloud<PointT> ());
   copyPointCloud (*points, *indices, *subpoints);
 
-  boost::shared_ptr<vector<int> > indices2 (new vector<int> (0));
+  pcl::IndicesPtr indices2 (new pcl::Indices (0));
   for (size_t i = 0; i < (indices->size ()/2); ++i)
     indices2->push_back (static_cast<int> (i));
   //
@@ -383,7 +383,7 @@ TYPED_TEST (SHOTShapeTest, Estimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   // set parameters
   n.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   n.setSearchMethod (tree);
   n.setRadiusSearch (20 * mr);
@@ -462,7 +462,7 @@ TYPED_TEST (SHOTShapeTest, Estimation)
 
   // Test results when setIndices and/or setSearchSurface are used
 
-  boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));
+  pcl::IndicesPtr test_indices (new pcl::Indices (0));
   for (size_t i = 0; i < cloud.size (); i+=3)
     test_indices->push_back (static_cast<int> (i));
 
@@ -487,7 +487,7 @@ TEST (PCL, GenericSHOTShapeEstimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   // set parameters
   n.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   n.setSearchMethod (tree);
   n.setRadiusSearch (20 * mr);
@@ -522,7 +522,7 @@ TEST (PCL, GenericSHOTShapeEstimation)
   EXPECT_NEAR (shots->points[103].descriptor[123], 0.019105887, 1e-5);
 
   // Test results when setIndices and/or setSearchSurface are used
-  boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));
+  pcl::IndicesPtr test_indices (new pcl::Indices (0));
   for (size_t i = 0; i < cloud.size (); i+=3)
     test_indices->push_back (static_cast<int> (i));
 
@@ -572,7 +572,7 @@ TYPED_TEST (SHOTShapeAndColorTest, Estimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   // set parameters
   n.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   n.setSearchMethod (tree);
   n.setRadiusSearch (20 * mr);
@@ -676,7 +676,7 @@ TYPED_TEST (SHOTShapeAndColorTest, Estimation)
   EXPECT_NEAR (shots1344->points[103].descriptor[512], 0.048375979, 1e-5);
 
   // Test results when setIndices and/or setSearchSurface are used
-  boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));
+  pcl::IndicesPtr test_indices (new pcl::Indices (0));
   for (size_t i = 0; i < cloud.size (); i+=3)
     test_indices->push_back (static_cast<int> (i));
 
@@ -761,7 +761,7 @@ TEST (PCL,3DSCEstimation)
   EXPECT_FLOAT_EQ ((*sc3ds)[108].descriptor[1900], 43.799442f);
 
   // Test results when setIndices and/or setSearchSurface are used
-  boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));
+  pcl::IndicesPtr test_indices (new pcl::Indices (0));
   for (size_t i = 0; i < cloud.size (); i++)
     test_indices->push_back (static_cast<int> (i));
 
@@ -814,7 +814,7 @@ TEST (PCL, USCEstimation)
   EXPECT_NEAR ((*uscds)[168].descriptor[1756], 65.1737f, 1e-4f);
 
   // Test results when setIndices and/or setSearchSurface are used
-  boost::shared_ptr<vector<int> > test_indices (new vector<int> (0));
+  pcl::IndicesPtr test_indices (new pcl::Indices (0));
   for (size_t i = 0; i < cloud.size (); i+=3)
     test_indices->push_back (static_cast<int> (i));
 

--- a/test/features/test_shot_lrf_estimation.cpp
+++ b/test/features/test_shot_lrf_estimation.cpp
@@ -59,7 +59,7 @@ TEST (PCL, SHOTLocalReferenceFrameEstimation)
 {
   PointCloud<ReferenceFrame> bunny_LRF;
 
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
 
   // Compute SHOT LRF
   SHOTLocalReferenceFrameEstimation<PointXYZ, ReferenceFrame> lrf_estimator;

--- a/test/features/test_spin_estimation.cpp
+++ b/test/features/test_spin_estimation.cpp
@@ -63,7 +63,7 @@ TEST (PCL, SpinImageEstimation)
   PointCloud<Normal>::Ptr normals (new PointCloud<Normal> ());
   // set parameters
   n.setInputCloud (cloud.makeShared ());
-  boost::shared_ptr<vector<int> > indicesptr (new vector<int> (indices));
+  pcl::IndicesPtr indicesptr (new pcl::Indices (indices));
   n.setIndices (indicesptr);
   n.setSearchMethod (tree);
   n.setRadiusSearch (20 * mr);

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -82,7 +82,7 @@ TEST (ExtractIndicesSelf, Filters)
 {
   // Test the PointCloud<PointT> method
   ExtractIndices<PointXYZ> ei;
-  boost::shared_ptr<vector<int> > indices (new vector<int> (2));
+  pcl::IndicesPtr indices (new pcl::Indices (2));
   (*indices)[0] = 0;
   (*indices)[1] = static_cast<int> (cloud->points.size ()) - 1;
 
@@ -109,7 +109,7 @@ TEST (ExtractIndices, Filters)
 {
   // Test the PointCloud<PointT> method
   ExtractIndices<PointXYZ> ei;
-  boost::shared_ptr<vector<int> > indices (new vector<int> (2));
+  pcl::IndicesPtr indices (new pcl::Indices (2));
   (*indices)[0] = 0;
   (*indices)[1] = static_cast<int> (cloud->points.size ()) - 1;
 
@@ -230,7 +230,7 @@ TEST (ExtractIndices, Filters)
   eie.filter (result);
   EXPECT_EQ (int (result.points.size ()), 0);
 
-  boost::shared_ptr<vector<int> > idx (new vector<int> (10));
+  pcl::IndicesPtr idx (new pcl::Indices (10));
   eie.setIndices (idx);
   eie.setNegative (false);
   eie.filter (result);
@@ -1651,7 +1651,7 @@ TEST (ConditionalRemovalSetIndices, Filters)
   PointCloud<PointXYZ> output;
 
   // build some indices
-  boost::shared_ptr<vector<int> > indices (new vector<int> (2));
+  pcl::IndicesPtr indices (new pcl::Indices (2));
   (*indices)[0] = 0;
   (*indices)[1] = static_cast<int> (cloud->points.size ()) - 1;
 

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -254,7 +254,7 @@ TEST (PCL, KdTreeFLANN_setPointRepresentation)
   }
   
   // Find k nearest neighbors with a different point representation
-  boost::shared_ptr<MyPointRepresentationXY> ptrep (new MyPointRepresentationXY);
+  KdTreeFLANN<MyPoint>::PointRepresentationConstPtr ptrep (new MyPointRepresentationXY);
   kdtree.setPointRepresentation (ptrep);
   kdtree.nearestKSearch (p, k, k_indices, k_distances);
   for (int i = 0; i < k; ++i)

--- a/test/keypoints/test_keypoints.cpp
+++ b/test/keypoints/test_keypoints.cpp
@@ -128,7 +128,7 @@ TEST (PCL, SIFTKeypoint_radiusSearch)
   const float scale = 0.02f;
 
   KdTreeFLANN<PointXYZI>::Ptr tree_ (new KdTreeFLANN<PointXYZI>);
-  boost::shared_ptr<pcl::PointCloud<PointXYZI> > cloud = cloud_xyzi->makeShared ();
+  auto cloud = cloud_xyzi->makeShared ();
 
   ApproximateVoxelGrid<PointXYZI> voxel_grid;
   const float s = 1.0 * scale;

--- a/test/outofcore/test_outofcore.cpp
+++ b/test/outofcore/test_outofcore.cpp
@@ -724,7 +724,7 @@ TEST_F (OutofcoreTest, PointCloud2_Constructors)
     test_cloud->points.push_back (tmp);
   }
 
-  boost::shared_ptr<pcl::PCLPointCloud2> point_cloud (new pcl::PCLPointCloud2 ());
+  pcl::PCLPointCloud2::Ptr point_cloud (new pcl::PCLPointCloud2);
   
   pcl::toPCLPointCloud2 (*test_cloud, *point_cloud);
 

--- a/test/recognition/test_recognition_ism.cpp
+++ b/test/recognition/test_recognition_ism.cpp
@@ -70,7 +70,7 @@ TEST (ISM, TrainRecognize)
   fpfh->setRadiusSearch (30.0);
   pcl::Feature< pcl::PointXYZ, pcl::Histogram<153> >::Ptr feature_estimator(fpfh);
 
-  pcl::ism::ImplicitShapeModelEstimation<153, pcl::PointXYZ, pcl::Normal>::ISMModelPtr model = boost::shared_ptr<pcl::features::ISMModel> (new pcl::features::ISMModel);
+  pcl::ism::ImplicitShapeModelEstimation<153, pcl::PointXYZ, pcl::Normal>::ISMModelPtr model (new pcl::features::ISMModel);
 
   pcl::ism::ImplicitShapeModelEstimation<153, pcl::PointXYZ, pcl::Normal> ism;
   ism.setFeatureEstimator(feature_estimator);
@@ -84,7 +84,7 @@ TEST (ISM, TrainRecognize)
   double radius = model->sigmas_[_class] * 10.0;
   double sigma = model->sigmas_[_class];
 
-  boost::shared_ptr<pcl::features::ISMVoteList<pcl::PointXYZ> > vote_list = ism.findObjects (model, testing_cloud, testing_normals, _class);
+  auto vote_list = ism.findObjects (model, testing_cloud, testing_normals, _class);
   EXPECT_NE (vote_list->getNumberOfVotes (), 0);
   std::vector<pcl::ISMPeak, Eigen::aligned_allocator<pcl::ISMPeak> > strongest_peaks;
   vote_list->findStrongestPeaks (strongest_peaks, _class, radius, sigma);

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -401,7 +401,7 @@ TEST (PCL, IterativeClosestPoint_PointToPlane)
 
   IterativeClosestPoint<PointT, PointT> reg;
   using PointToPlane = registration::TransformationEstimationPointToPlane<PointT, PointT>;
-  boost::shared_ptr<PointToPlane> point_to_plane (new PointToPlane);
+  PointToPlane::Ptr point_to_plane (new PointToPlane);
   reg.setTransformationEstimation (point_to_plane);
   reg.setInputSource (src);
   reg.setInputTarget (tgt);

--- a/test/registration/test_registration_api.cpp
+++ b/test/registration/test_registration_api.cpp
@@ -80,7 +80,7 @@ TEST (PCL, CorrespondenceEstimation)
   CloudXYZConstPtr source (new CloudXYZ (cloud_source));
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
@@ -104,7 +104,7 @@ TEST (PCL, CorrespondenceEstimationReciprocal)
   CloudXYZConstPtr source (new CloudXYZ (cloud_source));
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
@@ -129,13 +129,13 @@ TEST (PCL, CorrespondenceRejectorDistance)
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
   // re-do correspondence estimation
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
   corr_est.determineCorrespondences (*correspondences);
 
-  boost::shared_ptr<pcl::Correspondences>  correspondences_result_rej_dist (new pcl::Correspondences);
+  pcl::CorrespondencesPtr  correspondences_result_rej_dist (new pcl::Correspondences);
   pcl::registration::CorrespondenceRejectorDistance corr_rej_dist;
   corr_rej_dist.setInputCorrespondences (correspondences);
   corr_rej_dist.setMaximumDistance (rej_dist_max_dist);
@@ -160,13 +160,13 @@ TEST (PCL, CorrespondenceRejectorMedianDistance)
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
   // re-do correspondence estimation
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
   corr_est.determineCorrespondences (*correspondences);
 
-  boost::shared_ptr<pcl::Correspondences>  correspondences_result_rej_median_dist (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences_result_rej_median_dist (new pcl::Correspondences);
   pcl::registration::CorrespondenceRejectorMedianDistance corr_rej_median_dist;
   corr_rej_median_dist.setInputCorrespondences(correspondences);
   corr_rej_median_dist.setMedianFactor (rej_median_factor);
@@ -193,13 +193,13 @@ TEST (PCL, CorrespondenceRejectorOneToOne)
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
   // re-do correspondence estimation
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
   corr_est.determineCorrespondences (*correspondences);
 
-  boost::shared_ptr<pcl::Correspondences> correspondences_result_rej_one_to_one (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences_result_rej_one_to_one (new pcl::Correspondences);
   pcl::registration::CorrespondenceRejectorOneToOne corr_rej_one_to_one;
   corr_rej_one_to_one.setInputCorrespondences(correspondences);
   corr_rej_one_to_one.getCorrespondences(*correspondences_result_rej_one_to_one);
@@ -223,14 +223,14 @@ TEST (PCL, CorrespondenceRejectorSampleConsensus)
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
   // re-do correspondence estimation
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
   corr_est.determineCorrespondences (*correspondences);
   EXPECT_EQ (int (correspondences->size ()), nr_original_correspondences);
 
-  boost::shared_ptr<pcl::Correspondences> correspondences_result_rej_sac (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences_result_rej_sac (new pcl::Correspondences);
   pcl::registration::CorrespondenceRejectorSampleConsensus<PointXYZ> corr_rej_sac;
   corr_rej_sac.setInputSource (source);
   corr_rej_sac.setInputTarget (target);
@@ -264,7 +264,7 @@ TEST (PCL, CorrespondenceRejectorSurfaceNormal)
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
   // re-do correspondence estimation
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
@@ -295,7 +295,7 @@ TEST (PCL, CorrespondenceRejectorSurfaceNormal)
   corr_rej_surf_norm.setInputNormals <PointXYZ, PointNormal> (source_normals);
   corr_rej_surf_norm.setTargetNormals <PointXYZ, PointNormal> (target_normals);
 
-  boost::shared_ptr<pcl::Correspondences>  correspondences_result_rej_surf_norm (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences_result_rej_surf_norm (new pcl::Correspondences);
   corr_rej_surf_norm.setInputCorrespondences (correspondences);
   corr_rej_surf_norm.setThreshold (0.5);
 
@@ -318,13 +318,13 @@ TEST (PCL, CorrespondenceRejectorTrimmed)
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
   // re-do correspondence estimation
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
   corr_est.determineCorrespondences (*correspondences);
 
-  boost::shared_ptr<pcl::Correspondences> correspondences_result_rej_trimmed (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences_result_rej_trimmed (new pcl::Correspondences);
   pcl::registration::CorrespondenceRejectorTrimmed corr_rej_trimmed;
   corr_rej_trimmed.setOverlapRatio(rej_trimmed_overlap);
   corr_rej_trimmed.setInputCorrespondences(correspondences);
@@ -349,13 +349,13 @@ TEST (PCL, CorrespondenceRejectorVarTrimmed)
   CloudXYZConstPtr target (new CloudXYZ (cloud_target));
 
   // re-do correspondence estimation
-  boost::shared_ptr<pcl::Correspondences> correspondences (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences (new pcl::Correspondences);
   pcl::registration::CorrespondenceEstimation<PointXYZ, PointXYZ> corr_est;
   corr_est.setInputSource (source);
   corr_est.setInputTarget (target);
   corr_est.determineCorrespondences (*correspondences);
 
-  boost::shared_ptr<pcl::Correspondences>  correspondences_result_rej_var_trimmed_dist (new pcl::Correspondences);
+  pcl::CorrespondencesPtr correspondences_result_rej_var_trimmed_dist (new pcl::Correspondences);
   pcl::registration::CorrespondenceRejectorVarTrimmed corr_rej_var_trimmed_dist;
   corr_rej_var_trimmed_dist.setInputSource<PointXYZ> (source);
   corr_rej_var_trimmed_dist.setInputTarget<PointXYZ> (target);

--- a/test/sample_consensus/test_sample_consensus_plane_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_plane_models.cpp
@@ -123,7 +123,7 @@ TEST (SampleConsensusModelPlane, Base)
   cloud = model->getInputCloud ();
   ASSERT_EQ (cloud_->points.size (), cloud->points.size ());
 
-  boost::shared_ptr<std::vector<int> > indices = model->getIndices ();
+  auto indices = model->getIndices ();
   ASSERT_EQ (indices_.size (), indices->size ());
   model->setIndices (indices_);
   indices = model->getIndices ();

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -306,9 +306,9 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
       nan_mask [pIdx] = false;
   }
   
-  boost::shared_ptr<vector<int> > input_indices_;
+  pcl::IndicesPtr input_indices_;
   if (!input_indices.empty ())
-    input_indices_.reset (new vector<int> (input_indices));
+    input_indices_.reset (new pcl::Indices (input_indices));
   
   #pragma omp parallel for
   for (int sIdx = 0; sIdx < int (search_methods.size ()); ++sIdx)
@@ -376,9 +376,9 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<sear
       nan_mask [pIdx] = false;
   }
   
-  boost::shared_ptr<vector<int> > input_indices_;
+  pcl::IndicesPtr input_indices_;
   if (!input_indices.empty ())
-    input_indices_.reset (new vector<int> (input_indices));
+    input_indices_.reset (new pcl::Indices (input_indices));
   
   #pragma omp parallel for
   for (int sIdx = 0; sIdx < int (search_methods.size ()); ++sIdx)


### PR DESCRIPTION
Partially addresses #2792.

This eliminates all usages of `boost::shared_ptr` in "test/".