### PR TITLE
Fix/Update CUDA version check

### DIFF
--- a/cuda/common/include/pcl/cuda/cutil_inline_drvapi.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_drvapi.h
@@ -155,13 +155,8 @@ inline int cutilDrvGetMaxGflopsGraphicsDeviceId()
 	while ( current_device < device_count ) {
 		cutilDrvSafeCallNoSync( cuDeviceGetName(deviceName, 256, current_device) );
 		cutilDrvSafeCallNoSync( cuDeviceComputeCapability(&major, &minor, current_device ) );
+		cutilDrvSafeCallNoSync( cuDeviceGetAttribute(&bTCC, CU_DEVICE_ATTRIBUTE_TCC_DRIVER, current_device) );
 
-#if CUDA_VERSION >= 3020
-		cutilDrvSafeCallNoSync( cuDeviceGetAttribute( &bTCC,  CU_DEVICE_ATTRIBUTE_TCC_DRIVER, current_device ) );
-#else
-		// Assume a Tesla GPU is running in TCC if we are running CUDA 3.1
-		if (deviceName[0] == 'T') bTCC = 1;
-#endif
 		if (!bTCC) {
 			if (major > 0 && major < 9999) {
 				best_SM_arch = MAX(best_SM_arch, major);
@@ -181,12 +176,7 @@ inline int cutilDrvGetMaxGflopsGraphicsDeviceId()
                                                             current_device ) );
 		cutilDrvSafeCallNoSync( cuDeviceComputeCapability(&major, &minor, current_device ) );
 
-#if CUDA_VERSION >= 3020
 		cutilDrvSafeCallNoSync( cuDeviceGetAttribute( &bTCC,  CU_DEVICE_ATTRIBUTE_TCC_DRIVER, current_device ) );
-#else
-		// Assume a Tesla GPU is running in TCC if we are running CUDA 3.1
-		if (deviceName[0] == 'T') bTCC = 1;
-#endif
 
 		if (major == 9999 && minor == 9999) {
 		    sm_per_multiproc = 1;

--- a/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
@@ -163,12 +163,7 @@ inline int cutGetMaxGflopsGraphicsDeviceId()
 	while ( current_device < device_count ) {
 		cudaGetDeviceProperties( &deviceProp, current_device );
 
-#if CUDA_VERSION >= 3020
 		if (deviceProp.tccDriver) bTCC = 1;
-#else
-		// Assume a Tesla GPU is running in TCC if we are running CUDA 3.1
-		if (deviceProp.name[0] == 'T') bTCC = 1;
-#endif
 
 		if (!bTCC) {
 			if (deviceProp.major > 0 && deviceProp.major < 9999) {
@@ -188,12 +183,7 @@ inline int cutGetMaxGflopsGraphicsDeviceId()
 			sm_per_multiproc = _ConvertSMVer2Cores(deviceProp.major, deviceProp.minor);
 		}
 
-#if CUDA_VERSION >= 3020
 		if (deviceProp.tccDriver) bTCC = 1;
-#else
-		// Assume a Tesla GPU is running in TCC if we are running CUDA 3.1
-		if (deviceProp.name[0] == 'T') bTCC = 1;
-#endif
 
 		if (!bTCC) // Is this GPU running the TCC driver?  If so we pass on this
 		{

--- a/gpu/kinfu/src/cuda/extract.cu
+++ b/gpu/kinfu/src/cuda/extract.cu
@@ -90,7 +90,7 @@ namespace pcl
         __shared__ int cta_buffer[CTA_SIZE];
 #endif
 
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
         if (__all_sync (__activemask (), x >= VOLUME_X)
             || __all_sync (__activemask (), y >= VOLUME_Y))
           return;
@@ -191,7 +191,7 @@ namespace pcl
             }              /* if (W != 0 && F != 1.f) */
           }            /* if (x < VOLUME_X && y < VOLUME_Y) */
 
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
           int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                          + __popc (__ballot_sync (__activemask (), local_count > 1))
                          + __popc (__ballot_sync (__activemask (), local_count > 2));

--- a/gpu/kinfu/src/cuda/marching_cubes.cu
+++ b/gpu/kinfu/src/cuda/marching_cubes.cu
@@ -143,7 +143,7 @@ namespace pcl
 #endif
 
 
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
         if (__all_sync (__activemask (), x >= VOLUME_X)
             || __all_sync (__activemask (), y >= VOLUME_Y))
           return;
@@ -173,7 +173,7 @@ namespace pcl
             // read number of vertices from texture
             numVerts = (cubeindex == 0 || cubeindex == 255) ? 0 : tex1Dfetch (numVertsTex, cubeindex);
           }
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
           int total = __popc (__ballot_sync (__activemask (), numVerts > 0));
 #elif __CUDA_ARCH__ >= 200
           int total = __popc (__ballot (numVerts > 0));
@@ -190,7 +190,7 @@ namespace pcl
           }
           int old_global_voxels_count = warps_buffer[warp_id];
 
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
           int offs = Warp::binaryExclScan (__ballot_sync (__activemask (), numVerts > 0));
 #elif __CUDA_ARCH__ >= 200
           int offs = Warp::binaryExclScan (__ballot (numVerts > 0));

--- a/gpu/kinfu_large_scale/src/cuda/extract.cu
+++ b/gpu/kinfu_large_scale/src/cuda/extract.cu
@@ -108,7 +108,7 @@ namespace pcl
           __shared__ int cta_buffer[CTA_SIZE];
   #endif
 
-  #if CUDA_VERSION >= 9000
+  #if CUDART_VERSION >= 9000
           if (__all_sync (__activemask (), x >= VOLUME_X)
               || __all_sync (__activemask (), y >= VOLUME_Y))
             return;
@@ -210,7 +210,7 @@ namespace pcl
             }/* if (x < VOLUME_X && y < VOLUME_Y) */
 
 
-  #if CUDA_VERSION >= 9000
+  #if CUDART_VERSION >= 9000
             int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                            + __popc (__ballot_sync (__activemask (), local_count > 1))
                            + __popc (__ballot_sync (__activemask (), local_count > 2));
@@ -324,7 +324,7 @@ namespace pcl
 
             // local_count counts the number of zero crossing for the current thread. Now we need to merge this knowledge with the other threads
             // not we fulfilled points array at current iteration
-          #if CUDA_VERSION >= 9000
+          #if CUDART_VERSION >= 9000
             int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                            + __popc (__ballot_sync (__activemask (), local_count > 1))
                            + __popc (__ballot_sync (__activemask (), local_count > 2));

--- a/gpu/kinfu_large_scale/src/cuda/marching_cubes.cu
+++ b/gpu/kinfu_large_scale/src/cuda/marching_cubes.cu
@@ -146,7 +146,7 @@ namespace pcl
           int x = threadIdx.x + blockIdx.x * CTA_SIZE_X;
           int y = threadIdx.y + blockIdx.y * CTA_SIZE_Y;
 
-        #if CUDA_VERSION >= 9000
+        #if CUDART_VERSION >= 9000
           if (__all_sync (__activemask (), x >= VOLUME_X)
               || __all_sync (__activemask (), y >= VOLUME_Y))
             return;
@@ -173,7 +173,7 @@ namespace pcl
               numVerts = (cubeindex == 0 || cubeindex == 255) ? 0 : tex1Dfetch (numVertsTex, cubeindex);
             }
 
-          #if CUDA_VERSION >= 9000
+          #if CUDART_VERSION >= 9000
             int total = __popc (__ballot_sync (__activemask (), numVerts > 0));
           #else
             int total = __popc (__ballot (numVerts > 0));
@@ -188,7 +188,7 @@ namespace pcl
             }
             int old_global_voxels_count = warps_buffer[warp_id];
 
-          #if CUDA_VERSION >= 9000
+          #if CUDART_VERSION >= 9000
             int offs = Warp::binaryExclScan (__ballot_sync (__activemask (), numVerts > 0));
           #else
             int offs = Warp::binaryExclScan (__ballot (numVerts > 0));

--- a/gpu/octree/src/cuda/bfrs.cu
+++ b/gpu/octree/src/cuda/bfrs.cu
@@ -72,13 +72,6 @@ namespace pcl
     }
 }
 
-#if defined(CUDA_VERSION) && CUDA_VERSION == 4000
-    //workaround of bug in Thrust
-    typedef thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default> It;
-    template<> struct thrust::iterator_difference<It> { typedef int type; };
-#endif
-
-
 void pcl::device::bruteForceRadiusSearch(const OctreeImpl::PointCloud& cloud, const OctreeImpl::PointType& query, float radius, DeviceArray<int>& result, DeviceArray<int>& buffer)
 {   
     typedef OctreeImpl::PointType PointType;

--- a/gpu/surface/src/cuda/convex_hull.cu
+++ b/gpu/surface/src/cuda/convex_hull.cu
@@ -467,7 +467,7 @@ namespace pcl
 		{
 			int idx = threadIdx.x + blockIdx.x * blockDim.x;
 
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
       if (__all_sync (__activemask (), idx >= facet_count))
         return;
 #else
@@ -497,14 +497,14 @@ namespace pcl
 				  empty = 1;                
 			}
 
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
       int total = __popc (__ballot_sync (__activemask (), empty));
 #else
 			int total = __popc (__ballot (empty));
 #endif
 			if (total > 0)
 			{
-#if CUDA_VERSION >= 9000
+#if CUDART_VERSION >= 9000
         int offset = Warp::binaryExclScan (__ballot_sync (__activemask (), empty));
 #else
 				int offset = Warp::binaryExclScan (__ballot (empty));


### PR DESCRIPTION
* In *.cu files version number of CUDA is stored in `CUDART_VERSION` (cuda_runtime_api.h) instead of `CUDA_VERSION` (cuda.h)
* Remove code for CUDA below CUDA 7.5

Fixes following compile issue I had during building #3140
```
2>Building NVCC (Device) object gpu/surface/CMakeFiles/pcl_gpu_surface.dir/src/cuda/Release/pcl_gpu_surface_generated_convex_hull.cu.obj
2>convex_hull.cu
2>D:/pcl/gpu/surface/src/cuda/convex_hull.cu(474): warning : function "__all"
2>c:\program files\nvidia gpu computing toolkit\cuda\v10.1\include\device_atomic_functions.h(179): here was declared deprecated ("__all() is not valid on compute_70 and above, and should be replaced with __all_sync().To continue using __all(), specify virtual architecture compute_60 when targeting sm_70 and above, for example, using the pair of compiler options: -arch=compute_60 -code=sm_70.")
2>
2>D:/pcl/gpu/surface/src/cuda/convex_hull.cu(503): warning : function "__ballot"
2>c:\program files\nvidia gpu computing toolkit\cuda\v10.1\include\sm_20_intrinsics.h(405): here was declared deprecated ("__ballot() is not valid on compute_70 and above, and should be replaced with __ballot_sync().To continue using __ballot(), specify virtual architecture compute_60 when targeting sm_70 and above, for example, using the pair of compiler options: -arch=compute_60 -code=sm_70.")
2>
2>D:/pcl/gpu/surface/src/cuda/convex_hull.cu(510): warning : function "__ballot"
2>c:\program files\nvidia gpu computing toolkit\cuda\v10.1\include\sm_20_intrinsics.h(405): here was declared deprecated ("__ballot() is not valid on compute_70 and above, and should be replaced with __ballot_sync().To continue using __ballot(), specify virtual architecture compute_60 when targeting sm_70 and above, for example, using the pair of compiler options: -arch=compute_60 -code=sm_70.")
2>
2>D:/pcl/gpu/surface/src/cuda/convex_hull.cu(474): warning : function "__all"
2>c:\program files\nvidia gpu computing toolkit\cuda\v10.1\include\device_atomic_functions.h(179): here was declared deprecated ("__all() is deprecated in favor of __all_sync() and may be removed in a future release (Use -Wno-deprecated-declarations to suppress this warning).")
2>
2>D:/pcl/gpu/surface/src/cuda/convex_hull.cu(503): warning : function "__ballot"
2>c:\program files\nvidia gpu computing toolkit\cuda\v10.1\include\sm_20_intrinsics.h(405): here was declared deprecated ("__ballot() is deprecated in favor of __ballot_sync() and may be removed in a future release (Use -Wno-deprecated-declarations to suppress this warning).")
2>
2>D:/pcl/gpu/surface/src/cuda/convex_hull.cu(510): warning : function "__ballot"
2>c:\program files\nvidia gpu computing toolkit\cuda\v10.1\include\sm_20_intrinsics.h(405): here was declared deprecated ("__ballot() is deprecated in favor of __ballot_sync() and may be removed in a future release (Use -Wno-deprecated-declarations to suppress this warning).")
...
```