### PR TITLE
Drop unnecessary __CUDA_ARCH__ checks

### DIFF
--- a/gpu/kinfu/src/cuda/extract.cu
+++ b/gpu/kinfu/src/cuda/extract.cu
@@ -86,21 +86,13 @@ namespace pcl
         int x = threadIdx.x + blockIdx.x * CTA_SIZE_X;
         int y = threadIdx.y + blockIdx.y * CTA_SIZE_Y;
        
-#if __CUDA_ARCH__ < 200
-        __shared__ int cta_buffer[CTA_SIZE];
-#endif
-
 #if CUDART_VERSION >= 9000
         if (__all_sync (__activemask (), x >= VOLUME_X)
             || __all_sync (__activemask (), y >= VOLUME_Y))
           return;
-#elif __CUDA_ARCH__ >= 120
+#else 
         if (__all (x >= VOLUME_X) || __all (y >= VOLUME_Y))
           return;
-#else         
-        if (Emulation::All(x >= VOLUME_X, cta_buffer) || 
-            Emulation::All(y >= VOLUME_Y, cta_buffer))
-            return;
 #endif
 
         float3 V;
@@ -195,13 +187,9 @@ namespace pcl
           int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                          + __popc (__ballot_sync (__activemask (), local_count > 1))
                          + __popc (__ballot_sync (__activemask (), local_count > 2));
-#elif __CUDA_ARCH__ >= 200
+#else
           ///not we fulfilled points array at current iteration
           int total_warp = __popc (__ballot (local_count > 0)) + __popc (__ballot (local_count > 1)) + __popc (__ballot (local_count > 2));
-#else
-          int tid = Block::flattenedThreadId();				
-		  cta_buffer[tid] = local_count;
-          int total_warp = Emulation::warp_reduce(cta_buffer, tid);
 #endif
 
           if (total_warp > 0)

--- a/gpu/kinfu/src/cuda/marching_cubes.cu
+++ b/gpu/kinfu/src/cuda/marching_cubes.cu
@@ -138,22 +138,13 @@ namespace pcl
         int x = threadIdx.x + blockIdx.x * CTA_SIZE_X;
         int y = threadIdx.y + blockIdx.y * CTA_SIZE_Y;
 
-#if __CUDA_ARCH__ < 200
-        __shared__ int cta_buffer[CTA_SIZE];
-#endif
-
-
 #if CUDART_VERSION >= 9000
         if (__all_sync (__activemask (), x >= VOLUME_X)
             || __all_sync (__activemask (), y >= VOLUME_Y))
           return;
-#elif __CUDA_ARCH__ >= 200
+#else
         if (__all (x >= VOLUME_X) || __all (y >= VOLUME_Y))
           return;
-#else        
-        if (Emulation::All(x >= VOLUME_X, cta_buffer) || 
-            Emulation::All(y >= VOLUME_Y, cta_buffer))
-            return;
 #endif
 
         int ftid = Block::flattenedThreadId ();
@@ -175,10 +166,8 @@ namespace pcl
           }
 #if CUDART_VERSION >= 9000
           int total = __popc (__ballot_sync (__activemask (), numVerts > 0));
-#elif __CUDA_ARCH__ >= 200
-          int total = __popc (__ballot (numVerts > 0));
 #else
-          int total = __popc (Emulation::Ballot(numVerts > 0, cta_buffer));
+          int total = __popc (__ballot (numVerts > 0));
 #endif
 		  if (total == 0)
 			continue;
@@ -192,10 +181,8 @@ namespace pcl
 
 #if CUDART_VERSION >= 9000
           int offs = Warp::binaryExclScan (__ballot_sync (__activemask (), numVerts > 0));
-#elif __CUDA_ARCH__ >= 200
+#else
           int offs = Warp::binaryExclScan (__ballot (numVerts > 0));
-#else          
-          int offs = Warp::binaryExclScan(Emulation::Ballot(numVerts > 0, cta_buffer));
 #endif
 
           if (old_global_voxels_count + offs < max_size && numVerts > 0)
@@ -285,11 +272,7 @@ namespace pcl
   {
     struct TrianglesGenerator : public CubeIndexEstimator
     {
-#if __CUDA_ARCH__ >= 200
       enum { CTA_SIZE = 256, MAX_GRID_SIZE_X = 65536 };
-#else
-      enum { CTA_SIZE = 96, MAX_GRID_SIZE_X = 65536 };
-#endif
 
       const int* occupied_voxels;
       const int* vertex_ofssets;

--- a/gpu/kinfu/src/cuda/utils.hpp
+++ b/gpu/kinfu/src/cuda/utils.hpp
@@ -564,13 +564,9 @@ namespace pcl
       static __device__ __forceinline__ 
       int laneMaskLt()
       {
-#if (__CUDA_ARCH__ >= 200)
         unsigned int ret;
 	    asm("mov.u32 %0, %lanemask_lt;" : "=r"(ret) );
 	    return ret;
-#else
-        return 0xFFFFFFFF >> (32 - laneId());
-#endif
       }
 
       static __device__ __forceinline__ int binaryExclScan(int ballot_mask)
@@ -606,13 +602,9 @@ namespace pcl
 #if CUDA_VERSION >= 9000
       (void)cta_buffer;
       return __ballot_sync (__activemask (), predicate);
-#elif __CUDA_ARCH__ >= 200
+#else
 	    (void)cta_buffer;
 		  return __ballot(predicate);
-#else
-        int tid = Block::flattenedThreadId();				
-		cta_buffer[tid] = predicate ? (1 << (tid & 31)) : 0;
-		return warp_reduce(cta_buffer, tid);
 #endif
       }
 
@@ -622,13 +614,9 @@ namespace pcl
 #if CUDA_VERSION >= 9000
       (void)cta_buffer;
       return __all_sync (__activemask (), predicate);
-#elif __CUDA_ARCH__ >= 200
+#else
 	    (void)cta_buffer;
 		return __all(predicate);
-#else
-        int tid = Block::flattenedThreadId();				
-		cta_buffer[tid] = predicate ? 1 : 0;
-        return warp_reduce(cta_buffer, tid) == 32;
 #endif
       }
     };

--- a/gpu/kinfu_large_scale/src/cuda/extract.cu
+++ b/gpu/kinfu_large_scale/src/cuda/extract.cu
@@ -104,21 +104,13 @@ namespace pcl
           int x = threadIdx.x + blockIdx.x * CTA_SIZE_X;
           int y = threadIdx.y + blockIdx.y * CTA_SIZE_Y;
 
-  #if __CUDA_ARCH__ < 200
-          __shared__ int cta_buffer[CTA_SIZE];
-  #endif
-
   #if CUDART_VERSION >= 9000
           if (__all_sync (__activemask (), x >= VOLUME_X)
               || __all_sync (__activemask (), y >= VOLUME_Y))
             return;
-  #elif __CUDA_ARCH__ >= 120
+  #else
           if (__all (x >= VOLUME_X) || __all (y >= VOLUME_Y))
             return;
-  #else         
-          if (Emulation::All(x >= VOLUME_X, cta_buffer) || 
-              Emulation::All(y >= VOLUME_Y, cta_buffer))
-              return;
   #endif
 
           float3 V;
@@ -214,13 +206,9 @@ namespace pcl
             int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                            + __popc (__ballot_sync (__activemask (), local_count > 1))
                            + __popc (__ballot_sync (__activemask (), local_count > 2));
-  #elif __CUDA_ARCH__ >= 200
+  #else
             //not we fulfilled points array at current iteration
             int total_warp = __popc (__ballot (local_count > 0)) + __popc (__ballot (local_count > 1)) + __popc (__ballot (local_count > 2));
-  #else
-            int tid = Block::flattenedThreadId ();				
-                        cta_buffer[tid] = local_count;
-            int total_warp = Emulation::warp_reduce (cta_buffer, tid);
   #endif
 
             if (total_warp > 0)

--- a/gpu/kinfu_large_scale/src/cuda/utils.hpp
+++ b/gpu/kinfu_large_scale/src/cuda/utils.hpp
@@ -566,13 +566,9 @@ namespace pcl
         static __device__ __forceinline__ 
         int laneMaskLt()
         {
-  #if (__CUDA_ARCH__ >= 200)
           unsigned int ret;
               asm("mov.u32 %0, %lanemask_lt;" : "=r"(ret) );
               return ret;
-  #else
-          return 0xFFFFFFFF >> (32 - laneId());
-  #endif
         }
 
         static __device__ __forceinline__ int binaryExclScan(int ballot_mask)
@@ -608,13 +604,9 @@ namespace pcl
   #if CUDA_VERSION >= 9000
               (void)cta_buffer;
                   return __ballot_sync (__activemask (), predicate);
-  #elif __CUDA_ARCH__ >= 200
+  #else
               (void)cta_buffer;
                   return __ballot (predicate);
-  #else
-          int tid = Block::flattenedThreadId();				
-                  cta_buffer[tid] = predicate ? (1 << (tid & 31)) : 0;
-                  return warp_reduce(cta_buffer, tid);
   #endif
         }
 
@@ -624,13 +616,9 @@ namespace pcl
   #if CUDA_VERSION >= 9000
               (void)cta_buffer;
                   return __all_sync (__activemask (), predicate);
-  #elif __CUDA_ARCH__ >= 200
+  #else
               (void)cta_buffer;
                   return __all (predicate);
-  #else
-          int tid = Block::flattenedThreadId();				
-                  cta_buffer[tid] = predicate ? 1 : 0;
-          return warp_reduce(cta_buffer, tid) == 32;
   #endif
         }
       };

--- a/gpu/octree/src/utils/emulation.hpp
+++ b/gpu/octree/src/utils/emulation.hpp
@@ -47,14 +47,8 @@ namespace pcl
 		{
 			static __forceinline__ __device__ int Ballot(int predicate, volatile int* cta_buffer)
 			{
-#if __CUDA_ARCH__ >= 200
 				(void)cta_buffer;
 				return __ballot(predicate);
-#else
-				int tid = threadIdx.x;				
-				cta_buffer[tid] = predicate ? (1 << (tid & 31)) : 0;
-				return warp_reduce(cta_buffer);
-#endif
 			}
 		};
 	}

--- a/gpu/people/src/cuda/elec.cu
+++ b/gpu/people/src/cuda/elec.cu
@@ -360,28 +360,6 @@ namespace pcl
 {
   namespace device
   {   
-
-//// Register modifier for pointer-types (for inlining PTX assembly)
-//#if defined(_WIN64) || defined(__LP64__)	
-//	// 64-bit register modifier for inlined asm
-//	#define _ASM_PTR_ "l"
-//#else	
-//	// 32-bit register modifier for inlined asm
-//	#define _ASM_PTR_ "r"
-//#endif
-//    struct GlobalLoad
-//    {        
-//        static __device__ __forceinline__ void CG(int &val, int* ptr)
-//        {
-//          #if (__CUDA_ARCH__ >= 200)
-//            asm("ld.global.cg.s32 %0, [%1];" : "=r"(reinterpret_cast<int&>(val)) : _ASM_PTR_(ptr));
-//          #else
-//            val = *ptr;
-//          #endif
-//        }
-//    };
-//#undef _ASM_PTR_
-
     __device__ __forceinline__ int findRoot(const PtrStepSz<int>& comps, int label)
     {                       
         for(;;)

--- a/gpu/people/src/cuda/nvidia/NCVHaarObjectDetection.cu
+++ b/gpu/people/src/cuda/nvidia/NCVHaarObjectDetection.cu
@@ -230,8 +230,6 @@ __device__ Ncv32u d_outMaskPosition;
 
 __device__ void compactBlockWriteOutAnchorParallel(Ncv32u threadPassFlag, Ncv32u threadElem, Ncv32u *vectorOut)
 {
-#if __CUDA_ARCH__ >= 110
-    
     __shared__ Ncv32u shmem[NUM_THREADS_ANCHORSPARALLEL * 2];
     __shared__ Ncv32u numPassed;
     __shared__ Ncv32u outMaskOffset;
@@ -257,7 +255,6 @@ __device__ void compactBlockWriteOutAnchorParallel(Ncv32u threadPassFlag, Ncv32u
     {
         vectorOut[outMaskOffset + threadIdx.x] = shmem[threadIdx.x];
     }
-#endif
 }
 
 
@@ -586,13 +583,11 @@ __global__ void applyHaarClassifierClassifierParallel(Ncv32u *d_IImg, Ncv32u IIm
     }
     else
     {
-#if __CUDA_ARCH__ >= 110
         if (bPass && !threadIdx.x)
         {
             Ncv32u outMaskOffset = atomicAdd(&d_outMaskPosition, 1);
             d_outMask[outMaskOffset] = outMaskVal;
         }
-#endif
     }
 }
 

--- a/gpu/utils/include/pcl/gpu/utils/device/cache.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/cache.hpp
@@ -12,13 +12,8 @@ namespace pcl
         {
             __device__ static T Invoke(const T* ptr)
             {
-
-#if (__CUDA_ARCH__ < 200)
-                return *ptr;
-#else
                 //asm code insertion 
                 asm(...);
-#endif
             }
         };
 

--- a/gpu/utils/include/pcl/gpu/utils/device/emulation.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/emulation.hpp
@@ -47,14 +47,8 @@ namespace pcl
 		{
 			static __forceinline__ __device__ int ballot(int predicate, volatile int* cta_buffer)
 			{
-#if __CUDA_ARCH__ >= 200
 				(void)cta_buffer;
 				return __ballot(predicate);
-#else
-				int tid = threadIdx.x;				
-				cta_buffer[tid] = predicate ? (1 << (tid & 31)) : 0;
-				return warp_reduce(cta_buffer);
-#endif
 			}          
 		};
 	}

--- a/gpu/utils/include/pcl/gpu/utils/device/warp.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/warp.hpp
@@ -60,24 +60,16 @@ namespace pcl
 
             static __device__ __forceinline__ int laneMaskLe()
             {
-#if (__CUDA_ARCH__ >= 200)
                 unsigned int ret;
 	            asm("mov.u32 %0, %lanemask_le;" : "=r"(ret) );
 	            return ret;
-#else
-                return 0xFFFFFFFF >> (31 - laneId());
-#endif
             }
 
             static __device__ __forceinline__ int laneMaskLt()
             {
-#if (__CUDA_ARCH__ >= 200)
                 unsigned int ret;
 	            asm("mov.u32 %0, %lanemask_lt;" : "=r"(ret) );
 	            return ret;
-#else
-                return 0xFFFFFFFF >> (32 - laneId());
-#endif
             }
             static __device__ __forceinline__ unsigned int id()
             {


### PR DESCRIPTION
Drop unnecessary `__CUDA_ARCH__` checks, because we require at minimum CUDA 7.5 => minimum supported CUDA architecture is 2.0 (as already mentioned [here](https://github.com/PointCloudLibrary/pcl/pull/3152#issuecomment-501696946)).