### PR TITLE
Add pcl::make shared

### DIFF
--- a/2d/include/pcl/2d/convolution.h
+++ b/2d/include/pcl/2d/convolution.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/filters/filter.h>
 #include <pcl/point_types.h>
 
@@ -53,16 +54,16 @@ namespace pcl
     float direction;
     float magnitude_x;
     float magnitude_y;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW     // make sure our new allocators are aligned
+    PCL_MAKE_ALIGNED_OPERATOR_NEW     // make sure our new allocators are aligned
   } EIGEN_ALIGN16;                    // enforce SSE padding for correct memory alignment
 
-  /** \brief A 2D convolution class. */ 
+  /** \brief A 2D convolution class. */
   template <typename PointT>
   class Convolution : public Filter<PointT>
   {
     public:
       using Filter<PointT>::input_;
-      
+
       /**
        * Extra pixels are added to the input image so that convolution can be performed over the entire image.
        *

--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/2d/convolution.h>
 #include <pcl/2d/kernel.h>
 
@@ -298,7 +299,7 @@ namespace pcl
         input_ = input;
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 #include <pcl/2d/impl/edge.hpp>

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
@@ -40,6 +40,7 @@
 #include <QDebug>
 
 #include <pcl/apps/cloud_composer/items/cloud_composer_item.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/search/kdtree.h>
 
@@ -69,7 +70,7 @@ namespace pcl
       public:
         
         //This is needed because we have members which are Vector4f and Quaternionf
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
         
         CloudItem (const QString name,
                    const pcl::PCLPointCloud2::Ptr cloud_ptr,

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/impl/common_types.hpp
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/impl/common_types.hpp
@@ -43,6 +43,8 @@
 
 #include <limits>
 
+#include <pcl/pcl_macros.h>
+
 namespace pcl
 {
   namespace ihs
@@ -56,7 +58,7 @@ namespace pcl
       unsigned int age;
       uint32_t     directions;
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     struct PointIHS : public pcl::ihs::_PointIHS

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/in_hand_scanner.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/in_hand_scanner.h
@@ -41,6 +41,7 @@
 #pragma once
 
 #include <pcl/pcl_exports.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/apps/in_hand_scanner/boost.h>
 #include <pcl/apps/in_hand_scanner/common_types.h>
 #include <pcl/apps/in_hand_scanner/opengl_viewer.h>
@@ -299,8 +300,7 @@ namespace pcl
         bool destructor_called_;
 
       public:
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // End namespace ihs
 } // End namespace pcl

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
@@ -41,6 +41,7 @@
 #pragma once
 
 #include <pcl/pcl_exports.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/common/time.h>
 #include <pcl/apps/in_hand_scanner/common_types.h>
 #include <pcl/apps/in_hand_scanner/boost.h>
@@ -218,8 +219,7 @@ namespace pcl
         bool destructor_called_;
 
       public:
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // End namespace ihs
 } // End namespace pcl

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/opengl_viewer.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/opengl_viewer.h
@@ -41,6 +41,7 @@
 #pragma once
 
 #include <pcl/pcl_exports.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/common/time.h>
 #include <pcl/apps/in_hand_scanner/boost.h>
 #include <pcl/apps/in_hand_scanner/common_types.h>
@@ -98,8 +99,7 @@ namespace pcl
           Eigen::Isometry3d      transformation;
 
         public:
-
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
     } // End namespace detail
 
@@ -167,8 +167,7 @@ namespace pcl
             Eigen::Isometry3d transformation;
 
           public:
-
-            EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+            PCL_MAKE_ALIGNED_OPERATOR_NEW
         };
 
         /** \brief Constructor. */
@@ -445,8 +444,7 @@ namespace pcl
         int y_prev_;
 
       public:
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // End namespace ihs
 } // End namespace pcl

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/visibility_confidence.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/visibility_confidence.h
@@ -43,6 +43,7 @@
 #include <cstdint>
 
 #include <pcl/pcl_exports.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/apps/in_hand_scanner/eigen.h>
 
 namespace pcl
@@ -71,8 +72,7 @@ namespace pcl
         Vertices vertices_;
 
       public:
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     PCL_EXPORTS void

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -75,6 +75,7 @@ set(incs
   include/pcl/PointIndices.h
   include/pcl/register_point_struct.h
   include/pcl/conversions.h
+  include/pcl/make_shared.h
 )
 
 set(common_incs

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_traits.h>
 #include <pcl/PointIndices.h>
@@ -1050,7 +1051,7 @@ namespace pcl
         return (num_points_);
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     private:
 

--- a/common/include/pcl/common/impl/accumulators.hpp
+++ b/common/include/pcl/common/impl/accumulators.hpp
@@ -46,6 +46,7 @@
 #include <boost/fusion/include/as_vector.hpp>
 #include <boost/fusion/include/filter_if.hpp>
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 
 namespace pcl
@@ -80,7 +81,7 @@ namespace pcl
       template <typename PointT> void
       get (PointT& t, size_t n) const { t.getVector3fMap () = xyz / n; }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     };
 
@@ -113,7 +114,7 @@ namespace pcl
 #endif
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     };
 

--- a/common/include/pcl/common/poses_from_matches.h
+++ b/common/include/pcl/common/poses_from_matches.h
@@ -82,7 +82,7 @@ namespace pcl
           bool operator()(const PoseEstimate& pe1, const PoseEstimate& pe2) const { return pe1.score>pe2.score;}
         };
         public:
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
       
       // =====TYPEDEFS=====

--- a/common/include/pcl/common/vector_average.h
+++ b/common/include/pcl/common/vector_average.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/common/eigen.h>
 
 namespace pcl 
@@ -96,7 +97,7 @@ namespace pcl
         inline void
         getEigenVector1 (Eigen::Matrix<real, dimension, 1>& eigen_vector1) const;
 
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
         
         //-----VARIABLES-----
 

--- a/common/include/pcl/correspondence.h
+++ b/common/include/pcl/correspondence.h
@@ -46,6 +46,7 @@
 #include <Eigen/StdVector>
 #include <Eigen/Geometry>
 #include <pcl/pcl_exports.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl
 {
@@ -82,10 +83,10 @@ namespace pcl
 
     /** \brief Empty destructor. */
     virtual ~Correspondence () {}
-    
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
-  
+
   /** \brief overloaded << operator */
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const Correspondence& c);
 
@@ -128,7 +129,7 @@ namespace pcl
     /** \brief Empty destructor. */
     virtual ~PointCorrespondence3D () {}
     
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
   using PointCorrespondences3DVector = std::vector<PointCorrespondence3D, Eigen::aligned_allocator<PointCorrespondence3D> >;
 
@@ -144,7 +145,7 @@ namespace pcl
     /** \brief Empty destructor. */
     virtual ~PointCorrespondence6D () {}
 
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
   using PointCorrespondences6DVector = std::vector<PointCorrespondence6D, Eigen::aligned_allocator<PointCorrespondence6D> >;
 

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -45,6 +45,7 @@
 
 #include <Eigen/Core>
 #include <ostream>
+#include <pcl/pcl_macros.h>
 
 // Define all PCL point types
 #define PCL_POINT_TYPES         \
@@ -277,7 +278,7 @@ namespace pcl
   {
     PCL_ADD_POINT4D; // This adds the members x,y,z which can also be accessed using the point (which is float[4])
 
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZ& p);
@@ -304,7 +305,7 @@ namespace pcl
     }
 
     friend std::ostream& operator << (std::ostream& os, const PointXYZ& p);
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
@@ -457,7 +458,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZI& p);
@@ -489,7 +490,7 @@ namespace pcl
   {
     PCL_ADD_POINT4D; // This adds the members x,y,z which can also be accessed using the point (which is float[4])
     uint32_t label;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZL& p);
@@ -525,7 +526,7 @@ namespace pcl
   {
     PCL_ADD_POINT4D; // This adds the members x,y,z which can also be accessed using the point (which is float[4])
     PCL_ADD_RGB;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZRGBA& p);
@@ -573,7 +574,7 @@ namespace pcl
   {
     PCL_ADD_POINT4D; // This adds the members x,y,z which can also be accessed using the point (which is float[4])
     PCL_ADD_RGB;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   struct EIGEN_ALIGN16 _PointXYZRGBL
@@ -581,7 +582,7 @@ namespace pcl
     PCL_ADD_POINT4D; // This adds the members x,y,z which can also be accessed using the point (which is float[4])
     PCL_ADD_RGB;
     uint32_t label;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZRGB& p);
@@ -642,7 +643,7 @@ namespace pcl
     }
 
     friend std::ostream& operator << (std::ostream& os, const PointXYZRGB& p);
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
@@ -676,7 +677,7 @@ namespace pcl
     }
   
     friend std::ostream& operator << (std::ostream& os, const PointXYZRGBL& p);
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
@@ -693,7 +694,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   } EIGEN_ALIGN16;
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZHSV& p);
@@ -720,7 +721,7 @@ namespace pcl
     }
   
     friend std::ostream& operator << (std::ostream& os, const PointXYZHSV& p);
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
@@ -765,7 +766,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   
     friend std::ostream& operator << (std::ostream& os, const InterestPoint& p);
   };
@@ -781,7 +782,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const Normal& p);
@@ -811,14 +812,14 @@ namespace pcl
     }
 
     friend std::ostream& operator << (std::ostream& os, const Normal& p);
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
   struct EIGEN_ALIGN16 _Axis
   {
     PCL_ADD_NORMAL4D;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW 
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const Axis& p);
@@ -845,7 +846,7 @@ namespace pcl
     }
 
     friend std::ostream& operator << (std::ostream& os, const Axis& p);
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
@@ -861,7 +862,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointNormal& p);
@@ -903,7 +904,7 @@ namespace pcl
       float data_c[4];
     };
     PCL_ADD_EIGEN_MAPS_RGB;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZRGBNormal& p);
@@ -972,7 +973,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
   
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZINormal& p);
@@ -1015,7 +1016,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZLNormal& p);
@@ -1058,7 +1059,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointWithRange& p);
@@ -1097,7 +1098,7 @@ namespace pcl
       };
       float data_c[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointWithViewpoint& p);
@@ -1337,7 +1338,7 @@ namespace pcl
     inline Eigen::Map<Eigen::Matrix3f> getMatrix3fMap () { return (Eigen::Matrix3f::Map (rf)); }
     inline const Eigen::Map<const Eigen::Matrix3f> getMatrix3fMap () const { return (Eigen::Matrix3f::Map (rf)); }
 
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const ReferenceFrame& p);
@@ -1356,7 +1357,7 @@ namespace pcl
     }
 
     friend std::ostream& operator << (std::ostream& os, const ReferenceFrame& p);
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
@@ -1545,7 +1546,7 @@ namespace pcl
     /** \brief octave (pyramid layer) from which the keypoint has been extracted. */
     int   octave;
 
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointWithScale& p);
@@ -1617,7 +1618,7 @@ namespace pcl
       float data_c[4];
     };
     PCL_ADD_EIGEN_MAPS_RGB;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointSurfel& p);
@@ -1654,7 +1655,7 @@ namespace pcl
     float intensity;
     float intensity_variance;
     float height_variance;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointDEM& p);

--- a/common/include/pcl/make_shared.h
+++ b/common/include/pcl/make_shared.h
@@ -1,0 +1,86 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2019-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#pragma once
+
+
+#include <type_traits>
+#include <utility>
+
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <pcl/point_traits.h>
+
+
+namespace pcl
+{
+
+#ifdef DOXYGEN_ONLY
+
+/**
+ * \brief Returns a boost::shared_ptr compliant with type T's allocation policy.
+ *
+ * boost::allocate_shared or boost::make_shared will be invoked in case T has or
+ * doesn't have a custom allocator, respectively.
+ *
+ * \see pcl::has_custom_allocator, PCL_MAKE_ALIGNED_OPERATOR_NEW
+ * \tparam T Type of the object to create a boost::shared_ptr of
+ * \tparam Args Types for the arguments to pcl::make_shared
+ * \param args List of arguments with which an instance of T will be constructed
+ * \return boost::shared_ptr of an instance of type T
+ */
+template<typename T, typename ... Args>
+boost::shared_ptr<T> make_shared(Args&&... args);
+
+#else
+
+template<typename T, typename ... Args>
+std::enable_if_t<has_custom_allocator<T>::value, boost::shared_ptr<T>> make_shared(Args&&... args)
+{
+  return boost::allocate_shared<T>(Eigen::aligned_allocator<T>(), std::forward<Args> (args)...);
+}
+
+template<typename T, typename ... Args>
+std::enable_if_t<!has_custom_allocator<T>::value, boost::shared_ptr<T>> make_shared(Args&&... args)
+{
+  return boost::make_shared<T>(std::forward<Args> (args)...);
+}
+
+#endif
+
+} // namespace pcl

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -42,7 +42,7 @@
 #  pragma GCC system_header
 #endif
 
-// Include PCL macros such as PCL_ERROR, etc
+// Include PCL macros such as PCL_ERROR, PCL_MAKE_ALIGNED_OPERATOR_NEW, etc
 #include <pcl/pcl_macros.h>
 
 #include <boost/shared_ptr.hpp>
@@ -177,7 +177,7 @@ namespace pcl
       deinitCompute ();
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /////////////////////////////////////////////////////////////////////////////////////////
@@ -253,7 +253,7 @@ namespace pcl
       bool initCompute ();
       bool deinitCompute ();
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -36,7 +36,12 @@
 
 #pragma once
 
-
+/**
+ * \file pcl/pcl_macros.h
+ *
+ * \brief Defines all the PCL and non-PCL macros used
+ * \ingroup common
+ */
 
 #if defined __INTEL_COMPILER
   #pragma warning disable 2196 2536 279
@@ -60,6 +65,12 @@
 #include <iostream>
 
 #include <boost/cstdint.hpp>
+
+//Eigen has an enum that clashes with X11 Success define, which is ultimately included by pcl
+#ifdef Success
+  #undef Success
+#endif
+#include <Eigen/Core>
 
 #include <pcl/pcl_config.h>
 
@@ -320,3 +331,16 @@ aligned_free (void* ptr)
   #error aligned_free not supported on your platform
 #endif
 }
+
+/**
+ * \brief Macro to signal a class requires a custom allocator
+ *
+ *  It's an implementation detail to have pcl::has_custom_allocator work, a
+ *  thin wrapper over Eigen's own macro
+ *
+ * \see pcl::has_custom_allocator, pcl::make_shared
+ * \ingroup common
+ */
+#define PCL_MAKE_ALIGNED_OPERATOR_NEW \
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW \
+  using _custom_allocator_type_trait = void;

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -46,6 +46,7 @@
 #include <Eigen/Geometry>
 #include <pcl/PCLHeader.h>
 #include <pcl/exceptions.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_traits.h>
 
 namespace pcl
@@ -94,7 +95,7 @@ namespace pcl
       Pod &p2_;
       int f_idx_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
    };
 
   /** \brief Helper functor structure for copying data between an Eigen type and a PointT. */
@@ -125,7 +126,7 @@ namespace pcl
       Eigen::VectorXf &p2_;
       int f_idx_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   namespace detail
@@ -594,7 +595,7 @@ namespace pcl
       friend boost::shared_ptr<MsgFieldMap>& detail::getMapping<PointT>(pcl::PointCloud<PointT> &p);
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   namespace detail

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -337,4 +337,23 @@ namespace pcl
     const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(&pt) + field_offset;
     value = *reinterpret_cast<const ValT*>(data_ptr);
   }
+
+  template <typename ...> using void_t = void; // part of std in c++17
+
+#ifdef DOXYGEN_ONLY
+
+  /**
+   * \brief Tests at compile time if type T has a custom allocator
+   *
+   * \see pcl::make_shared, PCL_MAKE_ALIGNED_OPERATOR_NEW
+   * \tparam T Type of the object to test
+   */
+  template <typename T> struct has_custom_allocator;
+
+#else
+
+  template <typename, typename = void_t<>> struct has_custom_allocator : std::false_type {};
+  template <typename T> struct has_custom_allocator<T, void_t<typename T::_custom_allocator_type_trait>> : std::true_type {};
+
+#endif
 }

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -805,7 +805,7 @@ namespace pcl
 
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /**

--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -279,7 +279,8 @@ PREDEFINED =           = "HAVE_QHULL=1" \
                          "HAVE_ENSENSO=1" \
                          "HAVE_DAVIDSDK=1" \
                          "HAVE_DSSDK=1" \
-                         "HAVE_RSSDK=1"
+                         "HAVE_RSSDK=1" \
+                         "DOXYGEN_ONLY=1"
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 

--- a/doc/tutorials/content/adding_custom_ptype.rst
+++ b/doc/tutorials/content/adding_custom_ptype.rst
@@ -820,6 +820,7 @@ data (SSE padded), together with a test float.
    :linenos:
 
    #define PCL_NO_PRECOMPILE
+   #include <pcl/pcl_macros.h>
    #include <pcl/point_types.h>
    #include <pcl/point_cloud.h>
    #include <pcl/io/pcd_io.h>
@@ -828,7 +829,7 @@ data (SSE padded), together with a test float.
    {
      PCL_ADD_POINT4D;                  // preferred way of adding a XYZ+padding
      float test;
-     EIGEN_MAKE_ALIGNED_OPERATOR_NEW   // make sure our new allocators are aligned
+     PCL_MAKE_ALIGNED_OPERATOR_NEW     // make sure our new allocators are aligned
    } EIGEN_ALIGN16;                    // enforce SSE padding for correct memory alignment
 
    POINT_CLOUD_REGISTER_POINT_STRUCT (MyPointType,           // here we assume a XYZ + "test" (as fields)

--- a/doc/tutorials/content/sources/template_alignment/template_alignment.cpp
+++ b/doc/tutorials/content/sources/template_alignment/template_alignment.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <vector>
 #include <Eigen/Core>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 #include <pcl/io/pcd_io.h>
@@ -124,7 +125,7 @@ class TemplateAlignment
     {
       float fitness_score;
       Eigen::Matrix4f final_transformation;
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     TemplateAlignment () :

--- a/doc/tutorials/content/template_alignment.rst
+++ b/doc/tutorials/content/template_alignment.rst
@@ -75,7 +75,7 @@ We start by defining a structure to store the alignment results.  It contains a 
 
 .. note::
 
-   Because we are including an Eigen::Matrix4f in this struct, we need to include the EIGEN_MAKE_ALIGNED_OPERATOR_NEW macro, which will overload the struct's "operator new" so that it will generate 16-bytes-aligned pointers.  If you're curious, you can find more information about this issue `here <http://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html>`_.
+   Because we are including an Eigen::Matrix4f in this struct, we need to include the EIGEN_MAKE_ALIGNED_OPERATOR_NEW macro, which will overload the struct's "operator new" so that it will generate 16-bytes-aligned pointers.  If you're curious, you can find more information about this issue `here <http://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html>`_. For convenience, there is a redefinition of the macro in pcl_macros.h, aptly named PCL_MAKE_ALIGNED_OPERATOR_NEW which will let us for example call `pcl::make_shared` to create a `shared_ptr` of over-aligned classes.
 
 .. literalinclude:: sources/template_alignment/template_alignment.cpp
    :language: cpp

--- a/features/include/pcl/features/feature.h
+++ b/features/include/pcl/features/feature.h
@@ -46,6 +46,7 @@
 
 // PCL includes
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/search/search.h>
 
 #include <functional>
@@ -298,7 +299,7 @@ namespace pcl
       computeFeature (PointCloudOut &output) = 0;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 
@@ -357,7 +358,7 @@ namespace pcl
       initCompute ();
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   ////////////////////////////////////////////////////////////////////////////////////////////
@@ -425,7 +426,7 @@ namespace pcl
       initCompute ();
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   ////////////////////////////////////////////////////////////////////////////////////////////

--- a/features/include/pcl/features/integral_image_normal.h
+++ b/features/include/pcl/features/integral_image_normal.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/features/feature.h>
@@ -464,7 +465,7 @@ namespace pcl
       initSimple3DGradientMethod ();
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/features/include/pcl/features/moment_of_inertia_estimation.h
+++ b/features/include/pcl/features/moment_of_inertia_estimation.h
@@ -42,6 +42,7 @@
 #include <vector>
 #include <cmath>
 #include <pcl/features/feature.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/PointIndices.h>
 
 namespace pcl
@@ -348,7 +349,7 @@ namespace pcl
       Eigen::Matrix3f obb_rotational_matrix_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/features/include/pcl/features/narf.h
+++ b/features/include/pcl/features/narf.h
@@ -38,11 +38,12 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/features/eigen.h>
 #include <pcl/common/common_headers.h>
 #include <pcl/point_representation.h>
 
-namespace pcl 
+namespace pcl
 {
   // Forward declarations
   class RangeImage;
@@ -281,7 +282,7 @@ namespace pcl
       // =====STATIC PROTECTED=====
       
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 #undef NARF_DEFAULT_SURFACE_PATCH_PIXEL_SIZE
 

--- a/features/include/pcl/features/normal_3d.h
+++ b/features/include/pcl/features/normal_3d.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/features/feature.h>
 #include <pcl/common/centroid.h>
 
@@ -413,7 +414,7 @@ namespace pcl
       bool use_sensor_origin_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/features/include/pcl/features/rops_estimation.h
+++ b/features/include/pcl/features/rops_estimation.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/PolygonMesh.h>
 #include <pcl/features/feature.h>
 #include <set>
@@ -221,8 +222,7 @@ namespace pcl
       std::vector <std::vector <unsigned int> > triangles_of_the_point_;
 
     public:
-
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/features/include/pcl/features/rsd.h
+++ b/features/include/pcl/features/rsd.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/features/feature.h>
 
 namespace pcl
@@ -246,7 +247,7 @@ namespace pcl
       bool save_histograms_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/filters/include/pcl/filters/box_clipper3D.h
+++ b/filters/include/pcl/filters/box_clipper3D.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include "clipper3D.h"
 
 namespace pcl
@@ -118,7 +119,7 @@ namespace pcl
       Eigen::Affine3f transformation_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/filters/include/pcl/filters/clipper3D.h
+++ b/filters/include/pcl/filters/clipper3D.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <vector>
 #include <Eigen/StdVector>
@@ -109,6 +110,6 @@ namespace pcl
         */
       virtual Clipper3D<PointT>*
       clone () const = 0;
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/filters/include/pcl/filters/conditional_removal.h
+++ b/filters/include/pcl/filters/conditional_removal.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/common/eigen.h>
 #include <pcl/filters/filter.h>
 
@@ -309,7 +310,7 @@ namespace pcl
   class TfQuadraticXYZComparison : public pcl::ComparisonBase<PointT>
   {
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW     //needed whenever there is a fixed size Eigen:: vector or matrix in a class
+      PCL_MAKE_ALIGNED_OPERATOR_NEW  // needed whenever there is a fixed size Eigen:: vector or matrix in a class
 
       using Ptr = boost::shared_ptr<TfQuadraticXYZComparison<PointT> >;
       using ConstPtr = boost::shared_ptr<const TfQuadraticXYZComparison<PointT> >;

--- a/filters/include/pcl/filters/covariance_sampling.h
+++ b/filters/include/pcl/filters/covariance_sampling.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/filters/filter_indices.h>
 
 namespace pcl
@@ -158,7 +159,7 @@ namespace pcl
       { return (a.second > b.second); }
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/filters/filter_indices.h>
 #include <pcl/common/transforms.h>
@@ -229,7 +230,7 @@ namespace pcl
       float fp_dist_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/filters/include/pcl/filters/pyramid.h
+++ b/filters/include/pcl/filters/pyramid.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/common/point_operators.h>
 #include <pcl/point_cloud.h>
 #include <pcl/pcl_config.h>
@@ -160,7 +161,7 @@ namespace pcl
         unsigned int threads_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -46,6 +46,7 @@
 #include <pcl/geometry/mesh_indices.h>
 #include <pcl/geometry/mesh_elements.h>
 #include <pcl/geometry/mesh_traits.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 
 #include <vector>
@@ -2133,7 +2134,7 @@ namespace pcl
         template <class MeshT>
         friend class pcl::geometry::MeshIO;
 
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // End namespace geometry
 } // End namespace pcl

--- a/geometry/include/pcl/geometry/planar_polygon.h
+++ b/geometry/include/pcl/geometry/planar_polygon.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <pcl/common/eigen.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/ModelCoefficients.h>
 
@@ -135,6 +136,6 @@ namespace pcl
       Eigen::Vector4f coefficients_;
     
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/geometry/include/pcl/geometry/polygon_mesh.h
+++ b/geometry/include/pcl/geometry/polygon_mesh.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/geometry/mesh_base.h>
 
 namespace pcl
@@ -193,8 +194,7 @@ namespace pcl
         VertexIndices add_quad_;
 
       public:
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // End namespace geom
 } // End namespace pcl

--- a/geometry/include/pcl/geometry/quad_mesh.h
+++ b/geometry/include/pcl/geometry/quad_mesh.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/geometry/mesh_base.h>
 
 namespace pcl
@@ -167,8 +168,7 @@ namespace pcl
         VertexIndices add_quad_;
 
       public:
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // End namespace geom
 } // End namespace pcl

--- a/geometry/include/pcl/geometry/triangle_mesh.h
+++ b/geometry/include/pcl/geometry/triangle_mesh.h
@@ -42,6 +42,7 @@
 
 #include <utility>
 
+#include <pcl/pcl_macros.h>
 #include <pcl/geometry/mesh_base.h>
 
 namespace pcl
@@ -351,8 +352,7 @@ namespace pcl
         std::vector <bool> is_new_atp_;
 
       public:
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // End namespace geom
 } // End namespace pcl

--- a/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
@@ -100,7 +100,7 @@ namespace pcl
       DeviceArray2D<int> color_volume_;
 
 public:
-	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     };
   }

--- a/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
@@ -296,7 +296,7 @@ namespace pcl
         reset ();
 
 public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     };
   }

--- a/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
@@ -139,9 +139,9 @@ namespace pcl
       Eigen::Vector3f volume_size_;
 
 public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
-    
+
     /** \brief Converts from map representation to organized not-dence point cloud. */
     template<typename PointType>
     void convertMapToOranizedCloud(const RayCaster::MapArr& map, DeviceArray2D<PointType>& cloud);

--- a/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
@@ -159,7 +159,7 @@ namespace pcl
       float tranc_dist_;
 
 public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     };
   }

--- a/gpu/kinfu/tools/tsdf_volume.h
+++ b/gpu/kinfu/tools/tsdf_volume.h
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/console/print.h>
@@ -95,7 +96,7 @@ namespace pcl
       }
 
 public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     };
 
@@ -289,7 +290,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     VolumePtr volume_;
     WeightsPtr weights_;
 public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
   };
 

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
@@ -52,19 +52,21 @@ namespace pcl
     {
       class TsdfVolume;
 
-      /** \brief ColorVolume class
-        * \author Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
-        */
+      /**
+       * \brief ColorVolume class
+       * \author Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
+       */
       class PCL_EXPORTS ColorVolume
       {
       public:
         using PointType = PointXYZ;
         using Ptr = boost::shared_ptr<ColorVolume>;
 
-        /** \brief Constructor
-          * \param[in] tsdf tsdf volume to get parameters from
-          * \param[in] max_weight max weight for running average. Can be less than 255. Negative means default.
-          */
+        /**
+         * \brief Constructor
+         * \param[in] tsdf tsdf volume to get parameters from
+         * \param[in] max_weight max weight for running average. Can be less than 255. Negative means default.
+         */
         ColorVolume(const TsdfVolume& tsdf, int max_weight = -1);
 
         /** \brief Destructor */
@@ -82,10 +84,11 @@ namespace pcl
         DeviceArray2D<int>
         data() const;
 
-        /** \brief Computes colors from color volume
-          * \param[in] cloud Points for which colors are to be computed.
-          * \param[out] colors output array for colors
-          */
+        /**
+         * \brief Computes colors from color volume
+         * \param[in] cloud Points for which colors are to be computed.
+         * \param[out] colors output array for colors
+         */
         void
         fetchColors (const DeviceArray<PointType>& cloud, DeviceArray<RGB>& colors) const; 
 
@@ -97,13 +100,13 @@ namespace pcl
         Eigen::Vector3f volume_size_;
 
         /** \brief Length of running average */
-        int max_weight_;     
+        int max_weight_;
 
         /** \brief color volume data */
         DeviceArray2D<int> color_volume_;
 
-		public:
-			EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      public:
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
     }
   }

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/kinfu.h
@@ -451,7 +451,7 @@ namespace pcl
           bool has_shifted_;
           
         public:
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
 
       };
     }

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/point_intensity.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/point_intensity.h
@@ -34,17 +34,19 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 #pragma once
 
 #include <iostream>
+
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 
 struct EIGEN_ALIGN16 PointIntensity
 {
 
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+  PCL_MAKE_ALIGNED_OPERATOR_NEW;
   union
   {
     struct

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
@@ -146,7 +146,7 @@ namespace pcl
         Eigen::Vector3f volume_size_;
 
 public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
       };
       

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
@@ -58,7 +58,7 @@ namespace pcl
       /** \brief TsdfVolume class
         * \author Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
         */
-      class PCL_EXPORTS TsdfVolume 
+      class PCL_EXPORTS TsdfVolume
       {
       public:
         using Ptr = boost::shared_ptr<TsdfVolume>;
@@ -66,7 +66,7 @@ namespace pcl
         /** \brief Supported Point Types */
         using PointType = PointXYZ;
         using NormalType = Normal;
-        
+
         /** \brief Structure storing voxel grid resolution, volume size (in mm) and element_size of data stored on host*/
         struct Header
         {
@@ -99,38 +99,38 @@ namespace pcl
             return (os);
           }
 
-		  public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-        };        
-        
+          public:
+            PCL_MAKE_ALIGNED_OPERATOR_NEW
+        };
+
         /** \brief Default buffer size for fetching cloud. It limits max number of points that can be extracted */
         enum { DEFAULT_CLOUD_BUFFER_SIZE = 10 * 1000 * 1000 };
-              
+
         /** \brief Constructor
           * \param[in] resolution volume resolution
           */
-        TsdfVolume (const Eigen::Vector3i& resolution);           
-              
+        TsdfVolume (const Eigen::Vector3i& resolution);
+
         /** \brief Sets Tsdf volume size for each dimension
           * \param[in] size size of tsdf volume in meters
           */
         void
         setSize (const Eigen::Vector3f& size);
-        
+
         /** \brief Sets Tsdf truncation distance. Must be greater than 2 * volume_voxel_size
-          * \param[in] distance TSDF truncation distance 
+          * \param[in] distance TSDF truncation distance
           */
         void
         setTsdfTruncDist (float distance);
 
         /** \brief Returns tsdf volume container that point to data in GPU memory */
-        DeviceArray2D<int> 
+        DeviceArray2D<int>
         data () const;
 
         /** \brief Returns volume size in meters */
         const Eigen::Vector3f&
         getSize () const;
-              
+
         /** \brief Returns volume resolution */
         const Eigen::Vector3i&
         getResolution() const;
@@ -138,13 +138,13 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         /** \brief Returns volume voxel size in meters */
         const Eigen::Vector3f
         getVoxelSize () const;
-        
+
         /** \brief Returns tsdf truncation distance in meters */
         float
         getTsdfTruncDist () const;
-      
+
         /** \brief Resets tsdf volume data to uninitialized state */
-        void 
+        void
         reset ();
 
         /** \brief Generates cloud using CPU (downloads volumetric representation to CPU memory)
@@ -153,7 +153,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
           */
         void
         fetchCloudHost (PointCloud<PointType>& cloud, bool connected26 = false) const;
-        
+
         /** \brief Generates cloud using CPU (downloads volumetric representation to CPU memory)
           * \param[out] cloud output array for cloud
           * \param[in] connected26 If false point cloud is extracted using 6 neighbor, otherwise 26.
@@ -172,7 +172,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
             * \param[in] existing_data_cloud point cloud pointer to the existing data. This data will be pushed to the TSDf volume. The points with indices outside the range [0 ... VOLUME_X - 1][0 ... VOLUME_Y - 1][0 ... VOLUME_Z - 1] will not be added.
             * \param buffer
             */
-        void 
+        void
         pushSlice (const PointCloud<PointXYZI>::Ptr existing_data_cloud, const tsdf_buffer* buffer) const;
 
         /** \brief Generates cloud using GPU in connected6 mode only
@@ -202,7 +202,7 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         void
         fetchNormals(const DeviceArray<PointType>& cloud, DeviceArray<NormalType>& normals) const;
 
-        /** \brief Downloads tsdf volume from GPU memory.           
+        /** \brief Downloads tsdf volume from GPU memory.
           * \param[out] tsdf Array with tsdf values. if volume resolution is 512x512x512, so for voxel (x,y,z) tsdf value can be retrieved as volume[512*512*z + 512*y + x];
           */
         void
@@ -211,23 +211,23 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         /** \brief Downloads tsdf volume from GPU memory to local CPU buffer*/
         void
         downloadTsdfLocal () const;
-        
+
         /** \brief Downloads TSDF volume and according voxel weights from GPU memory
           * \param[out] tsdf Array with tsdf values. if volume resolution is 512x512x512, so for voxel (x,y,z) tsdf value can be retrieved as volume[512*512*z + 512*y + x];
           * \param[out] weights Array with tsdf voxel weights. Same size and access index as for tsdf. A weight of 0 indicates the voxel was never used.
           */
         void
         downloadTsdfAndWeights (std::vector<float>& tsdf, std::vector<short>& weights) const;
-        
+
         /** \brief Downloads TSDF volume and according voxel weights from GPU memory to local CPU buffers*/
         void
         downloadTsdfAndWeightsLocal () const;
-        
+
         /** \brief Releases tsdf buffer on GPU */
         void releaseVolume () {volume_.release();}
-        
+
         void print_warn(const char* arg1, size_t size);
-        
+
         /** \brief Set the header for data stored on host directly. Useful if directly writing into volume and weights */
         inline void
         setHeader (const Eigen::Vector3i& resolution, const Eigen::Vector3f& volume_size) {
@@ -235,13 +235,13 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
           if (volume_host_->size() != this->size())
             pcl::console::print_warn ("[TSDFVolume::setHeader] Header volume size (%d) doesn't fit underlying data size (%d)", volume_host_->size(), size());
         }
-        
+
         /** \brief Returns overall number of voxels in grid stored on host */
         inline size_t
         size () const {
-          return header_.getVolumeSize ();          
+          return header_.getVolumeSize ();
         }
-        
+
         /** \brief Converts volume stored on host to cloud of TSDF values
           * \param[ou] cloud - the output point cloud
           * \param[in] step - the decimation step to use
@@ -249,42 +249,42 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         void
         convertToTsdfCloud (pcl::PointCloud<pcl::PointXYZI>::Ptr &cloud,
                             const unsigned step = 2) const;
-        
+
         /** \brief Returns the voxel grid resolution */
         inline const Eigen::Vector3i &
         gridResolution () const { return header_.resolution; };
-        
+
         /** \brief Saves local volume buffer to file */
         bool
         save (const std::string &filename = "tsdf_volume.dat", bool binary = true) const;
-        
+
         /** \brief Loads local volume from file */
         bool
         load (const std::string &filename, bool binary = true);
-        
+
       private:
         /** \brief tsdf volume size in meters */
         Eigen::Vector3f size_;
-        
+
         /** \brief tsdf volume resolution */
-        Eigen::Vector3i resolution_;      
+        Eigen::Vector3i resolution_;
 
         /** \brief tsdf volume data container */
         DeviceArray2D<int> volume_;
 
         /** \brief tsdf truncation distance */
         float tranc_dist_;
-        
+
         // The following member are resulting from the merge of TSDFVolume with TsdfVolume class.
-        
         using VolumePtr = boost::shared_ptr<std::vector<float> >;
         using WeightsPtr = boost::shared_ptr<std::vector<short> >;
-        
+
         Header header_;
         VolumePtr volume_host_;
         WeightsPtr weights_host_;
-public:
-EIGEN_MAKE_ALIGNED_OPERATOR_NEW        
+
+      public:
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
     }
   }

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -51,6 +51,7 @@ Work in progress: patch by Marco (AUG,19th 2012)
 #include <iostream>
 #include <thread>
 
+#include <pcl/pcl_macros.h>
 #include <pcl/console/parse.h>
 
 #include <boost/filesystem.hpp>
@@ -681,7 +682,7 @@ struct SceneCloudView
   boost::shared_ptr<pcl::PolygonMesh> mesh_ptr_;
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
 };
 

--- a/io/include/pcl/io/obj_io.h
+++ b/io/include/pcl/io/obj_io.h
@@ -86,7 +86,7 @@ namespace pcl
       /// matrix to convert CIE to RGB
       Eigen::Matrix3f xyz_to_rgb_matrix_;
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   class PCL_EXPORTS OBJReader : public FileReader

--- a/io/include/pcl/io/oni_grabber.h
+++ b/io/include/pcl/io/oni_grabber.h
@@ -38,6 +38,8 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
+
 #ifdef HAVE_OPENNI
 
 #include <pcl/io/eigen.h>
@@ -199,7 +201,7 @@ namespace pcl
       boost::signals2::signal<sig_cb_openni_point_cloud_rgba >*  point_cloud_rgba_signal_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 } // namespace

--- a/io/include/pcl/io/openni2_grabber.h
+++ b/io/include/pcl/io/openni2_grabber.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
 
 #ifdef HAVE_OPENNI2
 
@@ -489,7 +490,7 @@ namespace pcl
         CameraParameters depth_parameters_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     boost::shared_ptr<pcl::io::openni2::OpenNI2Device>

--- a/io/include/pcl/io/openni_grabber.h
+++ b/io/include/pcl/io/openni_grabber.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
 
 #ifdef HAVE_OPENNI
 
@@ -490,7 +491,7 @@ namespace pcl
       double depth_principal_point_y_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   boost::shared_ptr<openni_wrapper::OpenNIDevice>

--- a/io/include/pcl/io/pcd_io.h
+++ b/io/include/pcl/io/pcd_io.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/io/file_io.h>
 
@@ -284,7 +285,7 @@ namespace pcl
         return (res);
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /** \brief Point Cloud Data (PCD) file format writer.

--- a/io/include/pcl/io/ply_io.h
+++ b/io/include/pcl/io/ply_io.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/io/boost.h>
 #include <pcl/io/file_io.h>
 #include <pcl/io/ply/ply_parser.h>
@@ -527,7 +528,7 @@ namespace pcl
       //face element artifact
       std::vector<pcl::Vertices> *polygons_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
       
     private:
       // RGB values stored by vertexColorCallback()

--- a/io/src/image_grabber.cpp
+++ b/io/src/image_grabber.cpp
@@ -35,13 +35,14 @@
  *
  */
 // Looking for PCL_BUILT_WITH_VTK
-#include <pcl/pcl_config.h>
+#include <pcl/for_each_type.h>
 #include <pcl/io/image_grabber.h>
+#include <pcl/io/lzf_image_io.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/for_each_type.h>
-#include <pcl/io/lzf_image_io.h>
 
 #ifdef PCL_BUILT_WITH_VTK
   #include <vtkImageReader2.h>
@@ -152,7 +153,7 @@ struct pcl::ImageGrabberBase::ImageGrabberImpl
   pcl::PointCloud<pcl::PointXYZRGBA> next_cloud_color_;
   Eigen::Vector4f origin_;
   Eigen::Quaternionf orientation_;
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   bool valid_;
   //! Flag to say if a user set the focal length by hand
   //  (so we don't attempt to adjust for QVGA, QQVGA, etc).

--- a/io/src/pcd_grabber.cpp
+++ b/io/src/pcd_grabber.cpp
@@ -35,13 +35,14 @@
  *
  */
 
-#include <pcl/pcl_config.h>
 #include <pcl/io/low_level_io.h>
 #include <pcl/io/pcd_grabber.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/io/tar.h>
+#include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////// GrabberImplementation //////////////////////
@@ -101,7 +102,7 @@ struct pcl::PCDGrabberBase::PCDGrabberImpl
   // simultaneous asynchronous read-aheads
   std::mutex read_ahead_mutex_;
 
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW 
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/ml/include/pcl/ml/densecrf.h
+++ b/ml/include/pcl/ml/densecrf.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -158,6 +159,6 @@ namespace pcl
       bool xyz_, rgb_, normal_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/ml/include/pcl/ml/kmeans.h
+++ b/ml/include/pcl/ml/kmeans.h
@@ -48,6 +48,7 @@
 #include <pcl/common/io.h>
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl
 {
@@ -195,10 +196,7 @@ namespace pcl
       PointsToClusters points_to_clusters_;
       Centroids centroids_;
 
-      
-      
-
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
  };
 }

--- a/ml/include/pcl/ml/permutohedral.h
+++ b/ml/include/pcl/ml/permutohedral.h
@@ -53,6 +53,8 @@
 #include <cstdio>
 #include <cmath>
 
+#include <pcl/pcl_macros.h>
+
 namespace pcl
 {
   /** \brief Implementation of a high-dimensional gaussian filtering using the permutohedral lattice
@@ -139,9 +141,9 @@ namespace pcl
       int * offsetOLD_;
       float * barycentricOLD_;
       std::vector<float> baryOLD_;
-      
+
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW      
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
 
   };
 

--- a/octree/include/pcl/octree/octree_nodes.h
+++ b/octree/include/pcl/octree/octree_nodes.h
@@ -191,7 +191,7 @@ namespace pcl
         
       public:
         //Type ContainerT may have fixed-size Eigen objects inside
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -7,6 +7,7 @@
 #include <thread>
 
 // PCL
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 
 // PCL - outofcore
@@ -279,5 +280,5 @@ class OutofcoreCloud : public Object
     vtkSmartPointer<vtkActorCollection> cloud_actors_;
 
   public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/recognition/include/pcl/recognition/cg/hough_3d.h
+++ b/recognition/include/pcl/recognition/cg/hough_3d.h
@@ -3,7 +3,7 @@
  *
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2010-2012, Willow Garage, Inc.
- *  
+ *
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,7 @@
 
 #include <pcl/recognition/cg/correspondence_grouping.h>
 #include <pcl/recognition/boost.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 
 #include <unordered_map>
@@ -57,14 +58,13 @@ namespace pcl
     {
 
       public:
-      
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
 
         using Ptr = boost::shared_ptr<HoughSpace3D>;
-      
+
         /** \brief Constructor
           *
-          * \param[in] min_coord minimum (x,y,z) coordinates of the Hough space 
+          * \param[in] min_coord minimum (x,y,z) coordinates of the Hough space
           * \param[in] bin_size  size of each bing of the Hough space.
           * \param[in] max_coord maximum (x,y,z) coordinates of the Hough space.
           */
@@ -75,7 +75,7 @@ namespace pcl
         reset ();
 
         /** \brief Casting a vote for a given position in the Hough space.
-          * 
+          *
           * \param[in] single_vote_coord coordinates of the vote being cast (in absolute coordinates)
           * \param[in] weight weight associated with the vote.
           * \param[in] voter_id the numeric id of the voter. Useful to trace back the voting correspondence, if the vote is returned by findMaxima as part of a maximum of the Hough Space.
@@ -85,7 +85,7 @@ namespace pcl
         vote (const Eigen::Vector3d &single_vote_coord, double weight, int voter_id);
 
         /** \brief Vote for a given position in the 3D space. The weight is interpolated between the bin pointed by single_vote_coord and its neighbors.
-          * 
+          *
           * \param[in] single_vote_coord coordinates of the vote being cast.
           * \param[in] weight weight associated with the vote.
           * \param[in] voter_id the numeric id of the voter. Useful to trace back the voting correspondence, if the vote is returned by findMaxima as a part of a maximum of the Hough Space.
@@ -95,11 +95,11 @@ namespace pcl
         voteInt (const Eigen::Vector3d &single_vote_coord, double weight, int voter_id);
 
         /** \brief Find the bins with most votes.
-          * 
-          * \param[in] min_threshold the minimum number of votes to be included in a bin in order to have its value returned. 
+          *
+          * \param[in] min_threshold the minimum number of votes to be included in a bin in order to have its value returned.
           * If set to a value between -1 and 0 the Hough space maximum_vote is found and the returned values are all the votes greater than -min_threshold * maximum_vote.
           * \param[out] maxima_values the list of Hough Space bin values greater than min_threshold.
-          * \param[out] maxima_voter_ids for each value returned, a list of the voter ids who cast a vote in that position. 
+          * \param[out] maxima_voter_ids for each value returned, a list of the voter ids who cast a vote in that position.
           * \return The min_threshold used, either set by the user or found by this method.
           */
         double
@@ -132,9 +132,9 @@ namespace pcl
 
   /** \brief Class implementing a 3D correspondence grouping algorithm that can deal with multiple instances of a model template
     * found into a given scene. Each correspondence casts a vote for a reference point in a 3D Hough Space.
-	* The remaining 3 DOF are taken into account by associating each correspondence with a local Reference Frame. 
+	* The remaining 3 DOF are taken into account by associating each correspondence with a local Reference Frame.
     * The suggested PointModelRfT is pcl::ReferenceFrame
-    * 
+    *
     * \note If you use this code in any academic work, please cite the original paper:
     *   - F. Tombari, L. Di Stefano:
     *     Object recognition in 3D scenes with occlusions and clutter by Hough voting.
@@ -162,7 +162,7 @@ namespace pcl
       using SceneCloudConstPtr = typename pcl::CorrespondenceGrouping<PointModelT, PointSceneT>::SceneCloudConstPtr;
 
       /** \brief Constructor */
-      Hough3DGrouping () 
+      Hough3DGrouping ()
         : input_rf_ ()
         , scene_rf_ ()
         , needs_training_ (true)
@@ -187,10 +187,10 @@ namespace pcl
         input_rf_.reset();
       }
 
-      /** \brief Provide a pointer to the input dataset's reference frames. 
+      /** \brief Provide a pointer to the input dataset's reference frames.
         * Each point in the reference frame cloud should be the reference frame of
         * the correspondent point in the input dataset.
-        * 
+        *
         * \param[in] input_rf the pointer to the input cloud's reference frames.
         */
       inline void
@@ -201,10 +201,10 @@ namespace pcl
         hough_space_initialized_ = false;
       }
 
-      /** \brief Getter for the input dataset's reference frames. 
+      /** \brief Getter for the input dataset's reference frames.
         * Each point in the reference frame cloud should be the reference frame of
         * the correspondent point in the input dataset.
-        * 
+        *
         * \return the pointer to the input cloud's reference frames.
         */
       inline ModelRfCloudConstPtr
@@ -212,9 +212,9 @@ namespace pcl
       {
         return (input_rf_);
       }
-      
+
       /** \brief Provide a pointer to the scene dataset (i.e. the cloud in which the algorithm has to search for instances of the input model)
-        * 
+        *
         * \param[in] scene the const boost shared pointer to a PointCloud message.
         */
       inline void
@@ -225,10 +225,10 @@ namespace pcl
         scene_rf_.reset();
       }
 
-      /** \brief Provide a pointer to the scene dataset's reference frames. 
+      /** \brief Provide a pointer to the scene dataset's reference frames.
         * Each point in the reference frame cloud should be the reference frame of
         * the correspondent point in the scene dataset.
-        * 
+        *
         * \param[in] scene_rf the pointer to the scene cloud's reference frames.
         */
       inline void
@@ -238,10 +238,10 @@ namespace pcl
         hough_space_initialized_ = false;
       }
 
-      /** \brief Getter for the scene dataset's reference frames. 
+      /** \brief Getter for the scene dataset's reference frames.
         * Each point in the reference frame cloud should be the reference frame of
         * the correspondent point in the scene dataset.
-        * 
+        *
         * \return the pointer to the scene cloud's reference frames.
         */
       inline SceneRfCloudConstPtr
@@ -250,10 +250,10 @@ namespace pcl
         return (scene_rf_);
       }
 
-      /** \brief Provide a pointer to the precomputed correspondences between points in the input dataset and 
+      /** \brief Provide a pointer to the precomputed correspondences between points in the input dataset and
         * points in the scene dataset. The correspondences are going to be clustered into different model instances
         * by the algorithm.
-        * 
+        *
         * \param[in] corrs the correspondences between the model and the scene.
         */
       inline void
@@ -264,7 +264,7 @@ namespace pcl
       }
 
       /** \brief Sets the minimum number of votes in the Hough space needed to infer the presence of a model instance into the scene cloud.
-        * 
+        *
         * \param[in] threshold the threshold for the Hough space voting, if set between -1 and 0 the maximum vote in the
         * entire space is automatically calculated and -threshold the maximum value is used as a threshold. This means
         * that a value between -1 and 0 should be used only if at least one instance of the model is always present in
@@ -277,7 +277,7 @@ namespace pcl
       }
 
       /** \brief Gets the minimum number of votes in the Hough space needed to infer the presence of a model instance into the scene cloud.
-        * 
+        *
         * \return the threshold for the Hough space voting.
         */
       inline double
@@ -287,7 +287,7 @@ namespace pcl
       }
 
       /** \brief Sets the size of each bin into the Hough space.
-        * 
+        *
         * \param[in] bin_size the size of each Hough space's bin.
         */
       inline void
@@ -298,7 +298,7 @@ namespace pcl
       }
 
       /** \brief Gets the size of each bin into the Hough space.
-        * 
+        *
         * \return the size of each Hough space's bin.
         */
       inline double
@@ -309,7 +309,7 @@ namespace pcl
 
       /** \brief Sets whether the vote casting procedure interpolates
         * the score between neighboring bins of the Hough space or not.
-        * 
+        *
         * \param[in] use_interpolation the algorithm should interpolate the vote score between neighboring bins.
         */
       inline void
@@ -321,7 +321,7 @@ namespace pcl
 
       /** \brief Gets whether the vote casting procedure interpolates
         * the score between neighboring bins of the Hough space or not.
-        * 
+        *
         * \return if the algorithm should interpolate the vote score between neighboring bins.
         */
       inline bool
@@ -331,7 +331,7 @@ namespace pcl
       }
 
       /** \brief Sets whether the vote casting procedure uses the correspondence's distance as a score.
-        * 
+        *
         * \param[in] use_distance_weight the algorithm should use the weighted distance when calculating the Hough voting score.
         */
       inline void
@@ -342,14 +342,14 @@ namespace pcl
       }
 
       /** \brief Gets whether the vote casting procedure uses the correspondence's distance as a score.
-        * 
+        *
         * \return if the algorithm should use the weighted distance when calculating the Hough voting score.
         */
       inline bool
       getUseDistanceWeight () const
       {
         return (use_distance_weight_);
-      }	
+      }
 
       /** \brief If the Local reference frame has not been set for either the model cloud or the scene cloud,
         * this algorithm makes the computation itself but needs a suitable search radius to compute the normals
@@ -379,7 +379,7 @@ namespace pcl
 
       /** \brief If the Local reference frame has not been set for either the model cloud or the scene cloud,
         * this algorithm makes the computation itself but needs a suitable search radius to do so.
-        * \attention This parameter NEEDS to be set if the reference frames are not precomputed externally, 
+        * \attention This parameter NEEDS to be set if the reference frames are not precomputed externally,
         * otherwise the recognition results won't be correct.
         *
         * \param[in] local_rf_search_radius the search radius for the local reference frame calculation.
@@ -394,7 +394,7 @@ namespace pcl
 
       /** \brief If the Local reference frame has not been set for either the model cloud or the scene cloud,
         * this algorithm makes the computation itself but needs a suitable search radius to do so.
-        * \attention This parameter NEEDS to be set if the reference frames are not precomputed externally, 
+        * \attention This parameter NEEDS to be set if the reference frames are not precomputed externally,
         * otherwise the recognition results won't be correct.
         *
         * \return the search radius for the local reference frame calculation.
@@ -407,14 +407,14 @@ namespace pcl
 
       /** \brief Call this function after setting the input, the input_rf and the hough_bin_size parameters to perform an off line training of the algorithm. This might be useful if one wants to perform once and for all a pre-computation of votes that only concern the models, increasing the on-line efficiency of the grouping algorithm. 
         * The algorithm is automatically trained on the first invocation of the recognize method or the cluster method if this training function has not been manually invoked.
-        * 
+        *
         * \return true if the training had been successful or false if errors have occurred.
         */
       bool
       train ();
 
       /** \brief The main function, recognizes instances of the model into the scene set by the user.
-        * 
+        *
         * \param[out] transformations a vector containing one transformation matrix for each instance of the model recognized into the scene.
         *
         * \return true if the recognition had been successful or false if errors have occurred.
@@ -423,7 +423,7 @@ namespace pcl
       recognize (std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > &transformations);
 
       /** \brief The main function, recognizes instances of the model into the scene set by the user.
-        * 
+        *
         * \param[out] transformations a vector containing one transformation matrix for each instance of the model recognized into the scene.
         * \param[out] clustered_corrs a vector containing the correspondences for each instance of the model found within the input data (the same output of clusterCorrespondences).
         *
@@ -479,10 +479,10 @@ namespace pcl
       bool hough_space_initialized_;
 
       /** \brief Cluster the input correspondences in order to distinguish between different instances of the model into the scene.
-        * 
+        *
         * \param[out] model_instances a vector containing the clustered correspondences for each model found on the scene.
         * \return true if the clustering had been successful or false if errors have occurred.
-        */ 
+        */
       void
       clusterCorrespondences (std::vector<Correspondences> &model_instances) override;
 

--- a/recognition/include/pcl/recognition/face_detection/face_common.h
+++ b/recognition/include/pcl/recognition/face_detection/face_common.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <pcl/features/integral_image2D.h>
+#include <pcl/pcl_macros.h>
+
 #include <Eigen/Core>
 
 namespace pcl
@@ -18,7 +20,7 @@ namespace pcl
         //save pose head information
         Eigen::Vector3f trans_;
         Eigen::Vector3f rot_;
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     class FeatureType
@@ -84,7 +86,7 @@ namespace pcl
         Eigen::Matrix3d covariance_trans_;
         Eigen::Matrix3d covariance_rot_;
 
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
 
         void serialize(::std::ostream & stream) const
         {

--- a/recognition/include/pcl/recognition/implicit_shape_model.h
+++ b/recognition/include/pcl/recognition/implicit_shape_model.h
@@ -40,6 +40,7 @@
 #include <limits>
 #include <Eigen/src/Core/Matrix.h>
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/point_representation.h>
 #include <pcl/features/feature.h>
@@ -63,7 +64,7 @@ namespace pcl
     /** \brief Determines which class this peak belongs. */
     int class_id;
 
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   } EIGEN_ALIGN16;
 
   namespace features
@@ -219,7 +220,7 @@ namespace pcl
       /** \brief Stores descriptors dimension. */
       unsigned int descriptors_dimension_;
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 

--- a/recognition/include/pcl/recognition/point_types.h
+++ b/recognition/include/pcl/recognition/point_types.h
@@ -4,7 +4,7 @@
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2010-2011, Willow Garage, Inc.
  *
- *  All rights reserved. 
+ *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -60,7 +61,7 @@ namespace pcl
       };
       float data[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     inline bool operator< (const GradientXY & rhs)
     {

--- a/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/correspondence_estimation.h>
 
 namespace pcl
@@ -198,7 +199,7 @@ namespace pcl
         Eigen::Matrix3f projection_matrix_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
@@ -40,6 +40,8 @@
 
 #pragma once
 
+
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/correspondence_rejection.h>
 
 #include <pcl/sample_consensus/ransac.h>
@@ -238,7 +240,7 @@ namespace pcl
         bool save_inliers_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus_2d.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus_2d.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/correspondence_rejection_sample_consensus.h>
 
 namespace pcl
@@ -153,7 +154,7 @@ namespace pcl
         Eigen::Matrix3f projection_matrix_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/registration/include/pcl/registration/default_convergence_criteria.h
+++ b/registration/include/pcl/registration/default_convergence_criteria.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/eigen.h>
 #include <pcl/correspondence.h>
 #include <pcl/registration/convergence_criteria.h>
@@ -270,7 +271,7 @@ namespace pcl
         ConvergenceState convergence_state_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
      };
   }
 }

--- a/registration/include/pcl/registration/edge_measurements.h
+++ b/registration/include/pcl/registration/edge_measurements.h
@@ -40,6 +40,8 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
+
 namespace pcl
 {
   namespace registration
@@ -61,7 +63,7 @@ namespace pcl
       VertexT v_start, v_end;
       Eigen::Matrix4f relative_transformation;
       InformationT information_matrix;
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
 
       PoseMeasurement (const VertexT& v_s, const VertexT& v_e, const Eigen::Matrix4f& tr, const InformationT& mtx)
         : v_start (v_s), v_end (v_e), relative_transformation (tr), information_matrix (mtx) {}

--- a/registration/include/pcl/registration/elch.h
+++ b/registration/include/pcl/registration/elch.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -245,7 +246,7 @@ namespace pcl
         typename boost::graph_traits<LoopGraph>::vertex_descriptor vd_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/registration/include/pcl/registration/gicp6d.h
+++ b/registration/include/pcl/registration/gicp6d.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_representation.h>
@@ -59,7 +60,7 @@ namespace pcl
       };
       float data_lab[4];
     };
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /** \brief A custom point type for position and CIELAB color value */

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/registration.h>
 #include <pcl/registration/transformation_estimation_svd.h>
 
@@ -271,7 +272,7 @@ namespace pcl
 
       ErrorFunctorPtr error_functor_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/registration/include/pcl/registration/lum.h
+++ b/registration/include/pcl/registration/lum.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/pcl_base.h>
 #include <pcl/registration/eigen.h>
 #include <pcl/registration/boost.h>
@@ -120,14 +121,14 @@ namespace pcl
         {
           PointCloudPtr cloud_;
           Eigen::Vector6f pose_;
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
         };
         struct EdgeProperties
         {
           pcl::CorrespondencesPtr corrs_;
           Eigen::Matrix6f cinv_;
           Eigen::Vector6f cinvd_;
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
         };
 
         using SLAMGraph = boost::adjacency_list<boost::eigen_vecS, boost::eigen_vecS, boost::bidirectionalS, VertexProperties, EdgeProperties, boost::no_property, boost::eigen_listS>;

--- a/registration/include/pcl/registration/matching_candidate.h
+++ b/registration/include/pcl/registration/matching_candidate.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/registration.h>
 #include <pcl/common/common.h>
 
@@ -80,7 +81,7 @@ namespace pcl
       /** \brief Corresponding transformation matrix retrieved using \a corrs. */
       Eigen::Matrix4f transformation;
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     using MatchingCandidates = std::vector<MatchingCandidate, Eigen::aligned_allocator<MatchingCandidate> >;

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/registration.h>
 #include <pcl/filters/voxel_grid_covariance.h>
 
@@ -458,10 +459,8 @@ namespace pcl
       Eigen::Matrix<double, 18, 6> point_hessian_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
-
 }
 
 #include <pcl/registration/impl/ndt.hpp>

--- a/registration/include/pcl/registration/ndt_2d.h
+++ b/registration/include/pcl/registration/ndt_2d.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/registration.h>
 
 namespace pcl
@@ -146,7 +147,7 @@ namespace pcl
       Eigen::Vector2f grid_extent_;
       Eigen::Vector3d newton_lambda_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 } // namespace pcl

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -609,7 +609,7 @@ namespace pcl
       /** \brief The point representation used (internal). */
       PointRepresentationConstPtr point_representation_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
    };
 }
 

--- a/registration/include/pcl/registration/transformation_estimation_lm.h
+++ b/registration/include/pcl/registration/transformation_estimation_lm.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/transformation_estimation.h>
 #include <pcl/registration/warp_point_rigid.h>
 #include <pcl/registration/distances.h>
@@ -345,7 +346,7 @@ namespace pcl
           const TransformationEstimationLM<PointSource, PointTarget, MatScalar> *estimator_;
         };
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/transformation_estimation_point_to_plane.h>
 #include <pcl/registration/warp_point_rigid.h>
 #include <pcl/registration/distances.h>
@@ -328,7 +329,7 @@ namespace pcl
           const TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> *estimator_;
         };
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/registration/include/pcl/registration/transformation_validation_euclidean.h
+++ b/registration/include/pcl/registration/transformation_validation_euclidean.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_representation.h>
 #include <pcl/search/kdtree.h>
 #include <pcl/kdtree/kdtree.h>
@@ -258,7 +259,7 @@ namespace pcl
         };
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/registration/include/pcl/registration/warp_point_rigid.h
+++ b/registration/include/pcl/registration/warp_point_rigid.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/registration/eigen.h>
 
 namespace pcl
@@ -120,7 +121,7 @@ namespace pcl
         getTransform () const { return (transform_matrix_); }
         
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
 
       protected:
         int nr_dim_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -46,6 +46,7 @@
 #include <memory>
 #include <set>
 
+#include <pcl/pcl_macros.h>
 #include <pcl/console/print.h>
 #include <pcl/point_cloud.h>
 #include <pcl/sample_consensus/boost.h>
@@ -567,7 +568,7 @@ namespace pcl
         return ((*rng_gen_) ());
       }
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
  };
 
   /** \brief @b SampleConsensusModelFromNormals represents the base model class

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -42,6 +42,7 @@
 
 #include <pcl/sample_consensus/sac_model_normal_plane.h>
 #include <pcl/sample_consensus/model_types.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl
 {
@@ -185,7 +186,7 @@ namespace pcl
       inline pcl::SacModel
       getModelType () const override { return (SACMODEL_NORMAL_PARALLEL_PLANE); }
 
-    	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    	PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     protected:
       using SampleConsensusModel<PointT>::sample_size_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/sac_model_plane.h>
 #include <pcl/sample_consensus/sac_model_perpendicular_plane.h>
@@ -157,7 +158,7 @@ namespace pcl
       inline pcl::SacModel 
       getModelType () const override { return (SACMODEL_NORMAL_PLANE); }
 
-    	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    	PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     protected:
       using SampleConsensusModel<PointT>::sample_size_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -44,6 +44,7 @@
 #include <pcl/sample_consensus/sac_model_sphere.h>
 #include <pcl/sample_consensus/model_types.h>
 #include <pcl/common/common.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl
 {
@@ -150,7 +151,7 @@ namespace pcl
       inline pcl::SacModel 
       getModelType () const override { return (SACMODEL_NORMAL_SPHERE); }
 
-    	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    	PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     protected:
       using SampleConsensusModel<PointT>::sample_size_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/sample_consensus/eigen.h>
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/model_types.h>
@@ -321,7 +322,7 @@ namespace pcl
       /** \brief Internal distance threshold used for the sample selection step. */
       double sample_dist_thresh_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <pcl/sample_consensus/sac_model_registration.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl
 {
@@ -215,7 +216,7 @@ namespace pcl
       Eigen::Matrix3f projection_matrix_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/search/search.h>
@@ -274,7 +275,7 @@ namespace pcl
         /** \brief mask, indicating whether the point was in the indices list or not.*/
         std::vector<unsigned char> mask_;
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/segmentation/include/pcl/segmentation/comparator.h
+++ b/segmentation/include/pcl/segmentation/comparator.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 
 namespace pcl
@@ -97,6 +98,6 @@ namespace pcl
     protected:
       PointCloudConstPtr input_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
+++ b/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/search/pcl_search.h>
 
 #include <functional>
@@ -258,7 +259,7 @@ namespace pcl
       pcl::IndicesClustersPtr large_clusters_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/segmentation/include/pcl/segmentation/crf_normal_segmentation.h
+++ b/segmentation/include/pcl/segmentation/crf_normal_segmentation.h
@@ -36,28 +36,29 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 
 namespace pcl
 {
-  /** \brief
-    * \author Christian Potthast
-    * 
-    */
+  /**
+   * \brief
+   * \author Christian Potthast
+   */
   template <typename PointT>
   class PCL_EXPORTS CrfNormalSegmentation
   {
     public:
-
       /** \brief Constructor that sets default values for member variables. */
       CrfNormalSegmentation ();
 
       /** \brief Destructor that frees memory. */
       ~CrfNormalSegmentation ();
 
-      /** \brief This method sets the input cloud.
-        * \param[in] input_cloud input point cloud
-        */
+      /**
+       * \brief This method sets the input cloud.
+       * \param[in] input_cloud input point cloud
+       */
       void
       setCloud (typename pcl::PointCloud<PointT>::Ptr input_cloud);
 
@@ -65,13 +66,7 @@ namespace pcl
       void
       segmentPoints ();
 
-    protected:
-
-    protected:
-
-
-    public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/segmentation/include/pcl/segmentation/crf_segmentation.h
+++ b/segmentation/include/pcl/segmentation/crf_segmentation.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -206,7 +207,7 @@ namespace pcl
       //typename pcl::PointCloud<PointT>::Ptr cloud_for_segmentation_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
  };
 }
 

--- a/segmentation/include/pcl/segmentation/grabcut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/grabcut_segmentation.h
@@ -41,6 +41,7 @@
 
 #include <pcl/point_cloud.h>
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/segmentation/boost.h>
 #include <pcl/search/search.h>
@@ -285,7 +286,7 @@ namespace pcl
         uint32_t count_;
         /// small value to add to covariance matrix diagonal to avoid singular values
         float epsilon_;
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
 
       /** Build the initial GMMs using the Orchard and Bouman color clustering algorithm */

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <pcl/common/angles.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/segmentation/comparator.h>
 #include <boost/make_shared.hpp>
 
@@ -241,6 +242,6 @@ namespace pcl
       Eigen::Vector3f desired_road_axis_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/segmentation/include/pcl/segmentation/min_cut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/min_cut_segmentation.h
@@ -40,6 +40,7 @@
 
 #include <pcl/segmentation/boost.h>
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/search/search.h>
@@ -318,7 +319,7 @@ namespace pcl
       double max_flow_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/segmentation/include/pcl/segmentation/planar_region.h
+++ b/segmentation/include/pcl/segmentation/planar_region.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/segmentation/region_3d.h>
 #include <pcl/geometry/planar_polygon.h>
 
@@ -101,6 +102,6 @@ namespace pcl
       std::vector<bool> contour_labels_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <pcl/common/angles.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/segmentation/boost.h>
 #include <pcl/segmentation/comparator.h>
 
@@ -206,6 +207,6 @@ namespace pcl
       Eigen::Vector3f z_axis_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/segmentation/include/pcl/segmentation/region_3d.h
+++ b/segmentation/include/pcl/segmentation/region_3d.h
@@ -40,6 +40,8 @@
 #include <Eigen/Core>
 #include <vector>
 
+#include <pcl/pcl_macros.h>
+
 namespace pcl
 {
   /** \brief Region3D represents summary statistics of a 3D collection of points.
@@ -53,34 +55,34 @@ namespace pcl
       Region3D () : centroid_ (Eigen::Vector3f::Zero ()), covariance_ (Eigen::Matrix3f::Identity ()), count_ (0)
       {
       }
-      
-      /** \brief Constructor for Region3D. 
+
+      /** \brief Constructor for Region3D.
         * \param[in] centroid The centroid of the region.
         * \param[in] covariance The covariance of the region.
         * \param[in] count The number of points in the region.
         */
-      Region3D (Eigen::Vector3f& centroid, Eigen::Matrix3f& covariance, unsigned count) 
+      Region3D (Eigen::Vector3f& centroid, Eigen::Matrix3f& covariance, unsigned count)
         : centroid_ (centroid), covariance_ (covariance), count_ (count)
       {
       }
-     
+
       /** \brief Destructor. */
       virtual ~Region3D () {}
 
       /** \brief Get the centroid of the region. */
-      inline Eigen::Vector3f 
+      inline Eigen::Vector3f
       getCentroid () const
       {
         return (centroid_);
       }
-      
+
       /** \brief Get the covariance of the region. */
       inline Eigen::Matrix3f
       getCovariance () const
       {
         return (covariance_);
       }
-      
+
       /** \brief Get the number of points in the region. */
       unsigned
       getCount () const
@@ -105,17 +107,17 @@ namespace pcl
     protected:
       /** \brief The centroid of the region. */
       Eigen::Vector3f centroid_;
-      
+
       /** \brief The covariance of the region. */
       Eigen::Matrix3f covariance_;
-      
+
       /** \brief The number of points in the region. */
       unsigned count_;
 
       /** \brief The mean curvature of the region. */
       float curvature_;
-      
+
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/segmentation/include/pcl/segmentation/region_growing.h
+++ b/segmentation/include/pcl/segmentation/region_growing.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/search/search.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -332,7 +333,7 @@ namespace pcl
       int number_of_segments_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /** \brief This function is used as a comparator for sorting. */

--- a/segmentation/include/pcl/segmentation/region_growing_rgb.h
+++ b/segmentation/include/pcl/segmentation/region_growing_rgb.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/segmentation/region_growing.h>
 
 namespace pcl
@@ -273,7 +274,7 @@ namespace pcl
       std::vector<int> segment_labels_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -1,4 +1,4 @@
- 
+
 /*
  * Software License Agreement (BSD License)
  *
@@ -44,6 +44,7 @@
 
 #include <pcl/features/normal_3d.h>
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/octree/octree_search.h>
@@ -59,7 +60,7 @@
 
 namespace pcl
 {
-  /** \brief Supervoxel container class - stores a cluster extracted using supervoxel clustering 
+  /** \brief Supervoxel container class - stores a cluster extracted using supervoxel clustering
    */
   template <typename PointT>
   class Supervoxel
@@ -75,17 +76,17 @@ namespace pcl
 
       /** \brief Gets the centroid of the supervoxel
        *  \param[out] centroid_arg centroid of the supervoxel
-       */ 
+       */
       void
       getCentroidPoint (PointXYZRGBA &centroid_arg)
       {
         centroid_arg = centroid_;
       }
 
-      /** \brief Gets the point normal for the supervoxel 
+      /** \brief Gets the point normal for the supervoxel
        * \param[out] normal_arg Point normal of the supervoxel
        * \note This isn't an average, it is a normal computed using all of the voxels in the supervoxel as support
-       */ 
+       */
       void
       getCentroidPointNormal (PointNormal &normal_arg)
       {
@@ -108,16 +109,16 @@ namespace pcl
       typename pcl::PointCloud<Normal>::Ptr normals_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW  
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
-  
+
   /** \brief Implements a supervoxel algorithm based on voxel structure, normals, and rgb values
-   *   \note Supervoxels are oversegmented volumetric patches (usually surfaces) 
+   *   \note Supervoxels are oversegmented volumetric patches (usually surfaces)
    *   \note Usually, color isn't needed (and can be detrimental)- spatial structure is mainly used
     * - J. Papon, A. Abramov, M. Schoeler, F. Woergoetter
     *   Voxel Cloud Connectivity Segmentation - Supervoxels from PointClouds
     *   In Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR) 2013
-    *  \ingroup segmentation 
+    *  \ingroup segmentation
     *  \author Jeremie Papon (jpapon@gmail.com)
     */
   template <typename PointT>
@@ -143,13 +144,13 @@ namespace pcl
 
           /** \brief Gets the data of in the form of a point
            *  \param[out] point_arg Will contain the point value of the voxeldata
-           */  
+           */
           void
           getPoint (PointT &point_arg) const;
 
           /** \brief Gets the data of in the form of a normal
            *  \param[out] normal_arg Will contain the normal value of the voxeldata
-           */            
+           */
           void
           getNormal (Normal &normal_arg) const;
 
@@ -162,7 +163,7 @@ namespace pcl
           SupervoxelHelper* owner_;
 
         public:
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
 
       using LeafContainerT = pcl::octree::OctreePointCloudAdjacencyContainer<PointT, VoxelData>;
@@ -185,7 +186,7 @@ namespace pcl
 
     public:
 
-      /** \brief Constructor that sets default values for member variables. 
+      /** \brief Constructor that sets default values for member variables.
        *  \param[in] voxel_resolution The resolution (in meters) of voxels used
        *  \param[in] seed_resolution The average size (in meters) of resulting supervoxels
        */
@@ -197,7 +198,7 @@ namespace pcl
       /** \brief This destructor destroys the cloud, normals and search method used for
         * finding neighbors. In other words it frees memory.
         */
-      
+
       ~SupervoxelClustering ();
 
       /** \brief Set the resolution of the octree voxels */
@@ -205,7 +206,7 @@ namespace pcl
       setVoxelResolution (float resolution);
 
       /** \brief Get the resolution of the octree voxels */
-      float 
+      float
       getVoxelResolution () const;
 
       /** \brief Set the resolution of the octree seed voxels */
@@ -213,7 +214,7 @@ namespace pcl
       setSeedResolution (float seed_resolution);
 
       /** \brief Get the resolution of the octree seed voxels */
-      float 
+      float
       getSeedResolution () const;
 
       /** \brief Set the importance of color for supervoxels */
@@ -228,7 +229,7 @@ namespace pcl
       void
       setNormalImportance (float val);
 
-      /** \brief Set whether or not to use the single camera transform 
+      /** \brief Set whether or not to use the single camera transform
        *  \note By default it will be used for organized clouds, but not for unorganized - this parameter will override that behavior
        *  The single camera transform scales bin size so that it increases exponentially with depth (z dimension).
        *  This is done to account for the decreasing point density found with depth when using an RGB-D camera.
@@ -240,7 +241,7 @@ namespace pcl
        */
       void
       setUseSingleCameraTransform (bool val);
-      
+
       /** \brief This method launches the segmentation algorithm and returns the supervoxels that were
        * obtained during the segmentation.
        * \param[out] supervoxel_clusters A map of labels to pointers to supervoxel structures
@@ -255,7 +256,7 @@ namespace pcl
       setInputCloud (const typename pcl::PointCloud<PointT>::ConstPtr& cloud) override;
 
       /** \brief This method sets the normals to be used for supervoxels (should be same size as input cloud)
-      * \param[in] normal_cloud The input normals                         
+      * \param[in] normal_cloud The input normals
       */
       virtual void
       setNormalCloud (typename NormalCloudT::ConstPtr normal_cloud);
@@ -310,7 +311,7 @@ namespace pcl
       /** \brief Returns labeled voxelized cloud
        * Points that belong to the same supervoxel have the same label.
        * Labels for segments start from 1, unlabled points have label 0
-       */      
+       */
       pcl::PointCloud<pcl::PointXYZL>::Ptr
       getLabeledVoxelCloud () const;
 
@@ -323,13 +324,13 @@ namespace pcl
       /** \brief Get a multimap which gives supervoxel adjacency
        *  \param[out] label_adjacency Multi-Map which maps a supervoxel label to all adjacent supervoxel labels
        */
-      void 
+      void
       getSupervoxelAdjacency (std::multimap<uint32_t, uint32_t> &label_adjacency) const;
 
-      /** \brief Static helper function which returns a pointcloud of normals for the input supervoxels 
+      /** \brief Static helper function which returns a pointcloud of normals for the input supervoxels
        *  \param[in] supervoxel_clusters Supervoxel cluster map coming from this class
        *  \returns Cloud of PointNormals of the supervoxels
-       * 
+       *
        */
       static pcl::PointCloud<pcl::PointNormal>::Ptr
       makeSupervoxelNormalCloud (std::map<uint32_t,typename Supervoxel<PointT>::Ptr > &supervoxel_clusters);
@@ -362,7 +363,7 @@ namespace pcl
       expandSupervoxels (int depth);
 
       /** \brief This sets the data of the voxels in the tree */
-      void 
+      void
       computeVoxelData ();
 
       /** \brief Reseeds the supervoxels by finding the voxel closest to current centroid */
@@ -405,18 +406,18 @@ namespace pcl
       float spatial_importance_;
       /** \brief Importance of similarity in normals for clustering */
       float normal_importance_;
-      
-      /** \brief Whether or not to use the transform compressing depth in Z 
+
+      /** \brief Whether or not to use the transform compressing depth in Z
        *  This is only checked if it has been manually set by the user.
        *  The default behavior is to use the transform for organized, and not for unorganized.
        */
       bool use_single_camera_transform_;
       /** \brief Whether to use default transform behavior or not */
       bool use_default_transform_behaviour_;
-      
-      /** \brief Internal storage class for supervoxels 
-       * \note Stores pointers to leaves of clustering internal octree, 
-       * \note so should not be used outside of clustering class 
+
+      /** \brief Internal storage class for supervoxels
+       * \note Stores pointers to leaves of clustering internal octree,
+       * \note so should not be used outside of clustering class
        */
       class SupervoxelHelper
       {
@@ -451,37 +452,37 @@ namespace pcl
           void
           removeAllLeaves ();
 
-          void 
+          void
           expand ();
 
-          void 
+          void
           refineNormals ();
 
-          void 
+          void
           updateCentroid ();
 
-          void 
+          void
           getVoxels (typename pcl::PointCloud<PointT>::Ptr &voxels) const;
 
-          void 
+          void
           getNormals (typename pcl::PointCloud<Normal>::Ptr &normals) const;
 
           using DistFuncPtr = float (SupervoxelClustering<PointT>::*)(const VoxelData &, const VoxelData &);
 
           uint32_t
-          getLabel () const 
+          getLabel () const
           { return label_; }
 
-          Eigen::Vector4f 
-          getNormal () const 
+          Eigen::Vector4f
+          getNormal () const
           { return centroid_.normal_; }
 
-          Eigen::Vector3f 
-          getRGB () const 
+          Eigen::Vector3f
+          getRGB () const
           { return centroid_.rgb_; }
 
           Eigen::Vector3f
-          getXYZ () const 
+          getXYZ () const
           { return centroid_.xyz_;}
 
           void
@@ -490,15 +491,15 @@ namespace pcl
 
           void
           getRGB (uint32_t &rgba) const
-          { 
-            rgba = static_cast<uint32_t>(centroid_.rgb_[0]) << 16 | 
-                   static_cast<uint32_t>(centroid_.rgb_[1]) << 8 | 
-                   static_cast<uint32_t>(centroid_.rgb_[2]); 
+          {
+            rgba = static_cast<uint32_t>(centroid_.rgb_[0]) << 16 |
+                   static_cast<uint32_t>(centroid_.rgb_[1]) << 8 |
+                   static_cast<uint32_t>(centroid_.rgb_[2]);
           }
 
-          void 
-          getNormal (pcl::Normal &normal_arg) const 
-          { 
+          void
+          getNormal (pcl::Normal &normal_arg) const
+          {
             normal_arg.normal_x = centroid_.normal_[0];
             normal_arg.normal_y = centroid_.normal_[1];
             normal_arg.normal_z = centroid_.normal_[2];
@@ -522,7 +523,7 @@ namespace pcl
           SupervoxelClustering* parent_;
         public:
           //Type VoxelData may have fixed-size Eigen objects inside
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
 
       //Make boost::ptr_list can access the private class SupervoxelHelper
@@ -538,8 +539,7 @@ namespace pcl
       //TODO DEBUG REMOVE
       StopWatch timer_;
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
 }

--- a/segmentation/include/pcl/segmentation/unary_classifier.h
+++ b/segmentation/include/pcl/segmentation/unary_classifier.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -167,7 +168,7 @@ namespace pcl
       //typename pcl::PointCloud<PointT>::Ptr cloud_for_segmentation_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
  };
 }
 

--- a/simulation/include/pcl/simulation/camera.h
+++ b/simulation/include/pcl/simulation/camera.h
@@ -85,7 +85,6 @@ namespace pcl
         return Eigen::Vector3d (yaw_, pitch_, roll_);
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     private:
       void
       updatePose ();
@@ -95,10 +94,10 @@ namespace pcl
 
       void
       updateProjectionMatrix ();
-    
+
       double x_,y_,z_;
       double roll_,pitch_,yaw_;
-    
+
       Eigen::Isometry3d pose_;
 
       // Camera Intrinsic Parameters
@@ -114,6 +113,9 @@ namespace pcl
       float z_far_;
 
       Eigen::Matrix4f projection_matrix_;
+
+    public:
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   } // namespace - simulation
 } // namespace - pcl

--- a/surface/include/pcl/surface/bilateral_upsampling.h
+++ b/surface/include/pcl/surface/bilateral_upsampling.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/processing.h>
 
 namespace pcl
@@ -151,6 +152,6 @@ namespace pcl
       Eigen::Matrix3f projection_matrix_, unprojection_matrix_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/surface/include/pcl/surface/convex_hull.h
+++ b/surface/include/pcl/surface/convex_hull.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/pcl_config.h>
 #ifdef HAVE_QHULL 
 
@@ -266,7 +267,7 @@ namespace pcl
       pcl::PointIndices hull_indices_;
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/surface/include/pcl/surface/grid_projection.h
+++ b/surface/include/pcl/surface/grid_projection.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/boost.h>
 #include <pcl/surface/reconstruction.h>
 
@@ -499,6 +500,6 @@ namespace pcl
       std::string getClassName () const override { return ("GridProjection"); }
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/boost.h>
 #include <pcl/surface/reconstruction.h>
 
@@ -517,7 +518,7 @@ namespace pcl
                               std::vector<pcl::Vertices> &polygons) override;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/boost.h>
 #include <pcl/surface/marching_cubes.h>
 
@@ -110,7 +111,7 @@ namespace pcl
       float dist_ignore_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/boost.h>
 #include <pcl/surface/marching_cubes.h>
 
@@ -112,7 +113,7 @@ namespace pcl
       float off_surface_epsilon_;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -45,6 +45,7 @@
 
 // PCL includes
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/search/pcl_search.h>
 #include <pcl/common/common.h>
 
@@ -85,7 +86,7 @@ namespace pcl
       double v;               /**< \brief The u-coordinate of the projected point in local MLS frame. */
       Eigen::Vector3d point;  /**< \brief The projected point. */
       Eigen::Vector3d normal; /**< \brief The projected point's normal. */
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     inline
@@ -221,7 +222,7 @@ namespace pcl
     float curvature;              /**< \brief The curvature at the query point. */
     int order;                    /**< \brief The order of the polynomial. If order > 1 then use polynomial fit */
     bool valid;                   /**< \brief If True, the mls results data is valid, otherwise False. */
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
     private:
       /**
         * \brief The default weight function used when fitting a polynomial surface
@@ -648,7 +649,7 @@ namespace pcl
           Eigen::Vector4f bounding_min_, bounding_max_;
           uint64_t data_size_;
           float voxel_size_;
-          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+          PCL_MAKE_ALIGNED_OPERATOR_NEW
       };
 
 

--- a/surface/include/pcl/surface/on_nurbs/fitting_surface_im.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_surface_im.h
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *
- * 
+ *
  *
  */
 
@@ -41,6 +41,7 @@
 #include <pcl/surface/on_nurbs/nurbs_data.h>
 #include <pcl/surface/on_nurbs/nurbs_solve.h>
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -79,8 +80,7 @@ namespace pcl
       computeMean () const;
 
     public:
-
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
 
       inline ON_NurbsSurface&
       getSurface ()

--- a/surface/include/pcl/surface/on_nurbs/nurbs_data.h
+++ b/surface/include/pcl/surface/on_nurbs/nurbs_data.h
@@ -44,6 +44,8 @@
 #undef Success
 #include <Eigen/StdVector>
 
+#include <pcl/pcl_macros.h>
+
 namespace pcl
 {
   namespace on_nurbs
@@ -128,7 +130,7 @@ namespace pcl
         common_boundary_param.clear ();
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     /** \brief Data structure for 3D NURBS curve fitting
@@ -157,7 +159,7 @@ namespace pcl
         interior_normals.clear ();
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     /** \brief Data structure for 2D NURBS curve fitting
@@ -203,7 +205,7 @@ namespace pcl
         interior_normals.clear ();
       }
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
   }

--- a/surface/include/pcl/surface/on_nurbs/nurbs_solve.h
+++ b/surface/include/pcl/surface/on_nurbs/nurbs_solve.h
@@ -40,6 +40,7 @@
 #undef Success
 #include <Eigen/Dense>
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/on_nurbs/sparse_mat.h>
 
 namespace pcl
@@ -129,7 +130,7 @@ namespace pcl
       Eigen::MatrixXd m_feig;
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
   }

--- a/surface/include/pcl/surface/on_nurbs/sequential_fitter.h
+++ b/surface/include/pcl/surface/on_nurbs/sequential_fitter.h
@@ -51,6 +51,7 @@
 #include <pcl/surface/on_nurbs/nurbs_data.h>
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 
 //#include "v4r/NurbsConvertion/DataLoading.h"
@@ -218,7 +219,7 @@ namespace pcl
         PCL2ON (pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pcl_cloud, const std::vector<int> &indices, vector_vec3d &cloud);
 
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
   }

--- a/surface/include/pcl/surface/poisson.h
+++ b/surface/include/pcl/surface/poisson.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/reconstruction.h>
 
 namespace pcl
@@ -248,7 +249,7 @@ namespace pcl
                float &scale);
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }
 

--- a/surface/include/pcl/surface/texture_mapping.h
+++ b/surface/include/pcl/surface/texture_mapping.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/surface/reconstruction.h>
 #include <pcl/common/transforms.h>
 #include <pcl/TextureMesh.h>
@@ -73,7 +74,7 @@ namespace pcl
       double width;
       std::string texture_file;
 
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     /** \brief Structure that links a uv coordinate to its 3D point and face.
@@ -418,6 +419,6 @@ namespace pcl
       }
 
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 }

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -35,6 +35,7 @@ PCL_ADD_TEST(common_bearing_angle_image test_bearing_angle_image FILES test_bear
 
 PCL_ADD_TEST(common_point_type_conversion test_common_point_type_conversion FILES test_point_type_conversion.cpp LINK_WITH pcl_gtest pcl_common)
 PCL_ADD_TEST(common_colors test_colors FILES test_colors.cpp LINK_WITH pcl_gtest pcl_common)
+PCL_ADD_TEST(common_type_traits test_type_traits FILES test_type_traits.cpp LINK_WITH pcl_gtest pcl_common)
 
 if(BUILD_io)
   PCL_ADD_TEST(common_centroid test_centroid FILES test_centroid.cpp LINK_WITH pcl_gtest pcl_io ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")

--- a/test/common/test_transforms.cpp
+++ b/test/common/test_transforms.cpp
@@ -39,6 +39,7 @@
 
 #include <gtest/gtest.h>
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 #include <pcl/common/transforms.h>
@@ -103,7 +104,7 @@ class Transforms : public ::testing::Test
   // Indices, every second point
   std::vector<int> indices;
 
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+  PCL_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 TYPED_TEST_CASE (Transforms, TransformTypes);

--- a/test/common/test_type_traits.cpp
+++ b/test/common/test_type_traits.cpp
@@ -1,0 +1,67 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2019-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+
+#include <pcl/pcl_macros.h>
+#include <pcl/point_traits.h>
+
+#include <gtest/gtest.h>
+
+
+struct Foo
+{
+public:
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct Bar
+{
+};
+
+TEST (TypeTraits, HasCustomAllocatorTrait)
+{
+  EXPECT_TRUE(pcl::has_custom_allocator<Foo>::value);
+  EXPECT_FALSE(pcl::has_custom_allocator<Bar>::value);
+}
+
+
+int
+main (int argc, char** argv)
+{
+  testing::InitGoogleTest (&argc, argv);
+  return (RUN_ALL_TESTS ());
+}

--- a/test/geometry/test_mesh_circulators.cpp
+++ b/test/geometry/test_mesh_circulators.cpp
@@ -41,6 +41,8 @@
 #include <gtest/gtest.h>
 
 #include <pcl/geometry/triangle_mesh.h>
+#include <pcl/pcl_macros.h>
+
 #include "test_mesh_common_functions.h"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -113,7 +115,7 @@ class TestMeshCirculators : public ::testing::Test
     VertexIndices expected_123456_;
     VertexIndices expected_654321_;
   public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/geometry/test_mesh_conversion.cpp
+++ b/test/geometry/test_mesh_conversion.cpp
@@ -44,6 +44,7 @@
 #include <pcl/geometry/quad_mesh.h>
 #include <pcl/geometry/polygon_mesh.h>
 #include <pcl/geometry/mesh_conversion.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 
@@ -133,7 +134,7 @@ class TestMeshConversion : public ::testing::Test
     std::vector <std::vector <uint32_t> >    manifold_faces_;
 
   public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 template <bool IsManifoldT>

--- a/tracking/include/pcl/tracking/impl/tracking.hpp
+++ b/tracking/include/pcl/tracking/impl/tracking.hpp
@@ -1,6 +1,7 @@
 #ifndef PCL_TRACKING_IMPL_TRACKING_H_
 #define PCL_TRACKING_IMPL_TRACKING_H_
 
+#include <pcl/pcl_macros.h>
 #include <pcl/common/eigen.h>
 #include <ctime>
 #include <pcl/tracking/tracking.h>
@@ -137,7 +138,7 @@ namespace pcl
         }
       }
       
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
     
     inline std::ostream& operator << (std::ostream& os, const ParticleXYZRPY& p)
@@ -292,7 +293,7 @@ namespace pcl
         }
       }
       
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
     
     inline std::ostream& operator << (std::ostream& os, const ParticleXYZR& p)
@@ -447,7 +448,7 @@ namespace pcl
         }
       }
       
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
     
     inline std::ostream& operator << (std::ostream& os, const ParticleXYRPY& p)
@@ -600,7 +601,7 @@ namespace pcl
         }
       }
       
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
     
     inline std::ostream& operator << (std::ostream& os, const ParticleXYRP& p)
@@ -753,7 +754,7 @@ namespace pcl
         }
       }
       
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
     
     inline std::ostream& operator << (std::ostream& os, const ParticleXYR& p)

--- a/tracking/include/pcl/tracking/pyramidal_klt.h
+++ b/tracking/include/pcl/tracking/pyramidal_klt.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/tracking/tracker.h>
 #include <pcl/common/intensity.h>
@@ -369,7 +370,7 @@ namespace pcl
         /// \brief index of last element in kernel
         int kernel_last_;
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/tracking/include/pcl/tracking/tracker.h
+++ b/tracking/include/pcl/tracking/tracker.h
@@ -41,6 +41,7 @@
 
 #include <pcl/tracking/tracking.h>
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/search/search.h>
 
 namespace pcl
@@ -125,7 +126,7 @@ namespace pcl
       computeTracking () = 0;
       
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }

--- a/visualization/include/pcl/visualization/image_viewer.h
+++ b/visualization/include/pcl/visualization/image_viewer.h
@@ -1037,10 +1037,10 @@ namespace pcl
           {
             return (layer.layer_name == str_);
           }
-        };        
-        
+        };
+
       public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
     };
   }
 }


### PR DESCRIPTION
Cherry-picked the relevant commits from #3146 to only add the function.

I would argue that this PR (plus the automated clang-tidy changes from the previous PR) eases the job of transitioning into C++14 and from boost::shared_ptr to std::shared_ptr in particular.

There is also left to discuss [this comment from Sergio](https://github.com/PointCloudLibrary/pcl/pull/3146/#discussion_r292864961) here (apart from the whole "do you want this").