### PR TITLE
Update issue template.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,4 @@
-<!--- WARNING: This is an issue tracker, please use our mailing list for questions: www.pcl-users.org. -->
+<!--- WARNING: This is an issue tracker. Before opening a new issue make sure you read https://github.com/PointCloudLibrary/pcl/blob/master/CONTRIBUTING.md#using-the-issue-tracker. -->
 
 <!--- Provide a general summary of the issue in the Title above -->
 


### PR DESCRIPTION
A residual update to the issue template. It was still reporting the mailing list as the default contact point for questions.
