### PR TITLE
Fix a docs typo for isXYPointIn2DXYPolygon

### DIFF
--- a/segmentation/include/pcl/segmentation/extract_polygonal_prism_data.h
+++ b/segmentation/include/pcl/segmentation/extract_polygonal_prism_data.h
@@ -59,7 +59,7 @@ namespace pcl
     *
     * \note (This is highly optimized code taken from http://www.visibone.com/inpoly/)
     *       Copyright (c) 1995-1996 Galacticomm, Inc.  Freeware source code.
-    * \param point a 3D point projected onto the same plane as the polygon
+    * \param point a 2D point projected onto the same plane as the polygon
     * \param polygon a polygon
     * \ingroup segmentation
     */


### PR DESCRIPTION
Hey there! I noticed that there was a typo in the docs for this function (the docs refer to a 3D point, but this function operates only on 2D points) so figured I would submit a pull request.