### PR TITLE
Remove else after return statement [2d, apps, common, cuda, examples, features, filters, geometry, gpu]

### DIFF
--- a/2d/include/pcl/2d/impl/convolution.hpp
+++ b/2d/include/pcl/2d/impl/convolution.hpp
@@ -138,8 +138,7 @@ pcl::Convolution<PointT>::filter (pcl::PointCloud<PointT> &output)
               int ikkh = i + k - kh / 2, jlkw = j + l - kw / 2;
               if (ikkh < 0 || ikkh >= ih || jlkw < 0 || jlkw >= iw)
                 continue;
-              else
-                intensity += kernel_ (l, k).intensity * ((*input_)(jlkw, ikkh).intensity);
+              intensity += kernel_ (l, k).intensity * ((*input_)(jlkw, ikkh).intensity);
             }
           }
           output (j, i).intensity = intensity;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_recognizer_cvfh.h
@@ -92,25 +92,19 @@ namespace pcl
             {
               return true;
             }
-            else
-            {
 
-              if (this->model.id_ == other.model.id_)
+            if (this->model.id_ == other.model.id_)
+            {
+              //check view id
+              if ((this->view_id < other.view_id))
               {
-                //check view id
-                if ((this->view_id < other.view_id))
+                return true;
+              }
+              if (this->view_id == other.view_id)
+              {
+                if (this->descriptor_id < other.descriptor_id)
                 {
                   return true;
-                }
-                else
-                {
-                  if (this->view_id == other.view_id)
-                  {
-                    if (this->descriptor_id < other.descriptor_id)
-                    {
-                      return true;
-                    }
-                  }
                 }
               }
             }

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
@@ -57,10 +57,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
       PersistenceUtils::readMatrixFromFile (dir.str (), pose_matrix);
       return true;
     }
-    else
-    {
-      return false;
-    }
+    return false;
   }
 
 template<template<class > class Distance, typename PointInT, typename FeatureT>

--- a/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
+++ b/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
@@ -339,15 +339,12 @@ main (int argc, char ** argv)
     PCL_ERROR("Models dir path %s does not exist, use -models_dir [dir] option\n", path.c_str());
     return -1;
   }
-  else
-  {
-    std::vector < std::string > files;
-    std::string start;
-    std::string ext = std::string ("ply");
-    bf::path dir = models_dir_path;
-    getModelsInDirectory (dir, start, files, ext);
-    assert (files.size () == 4);
-  }
+  std::vector < std::string > files;
+  std::string start;
+  std::string ext = std::string ("ply");
+  bf::path dir = models_dir_path;
+  getModelsInDirectory (dir, start, files, ext);
+  assert (files.size () == 4);
 
   //configure mesh source
   boost::shared_ptr<pcl::rec_3d_framework::MeshSource<pcl::PointXYZ> > mesh_source (new pcl::rec_3d_framework::MeshSource<pcl::PointXYZ>);

--- a/apps/cloud_composer/src/cloud_viewer.cpp
+++ b/apps/cloud_composer/src/cloud_viewer.cpp
@@ -41,8 +41,7 @@ pcl::cloud_composer::CloudViewer::getModel () const
 {
   if (this->count() == 0)
     return nullptr;
-  else
-    return dynamic_cast<CloudView*> (currentWidget ())->getModel (); 
+  return dynamic_cast<CloudView*> (currentWidget ())->getModel ();
 }
 
 void

--- a/apps/cloud_composer/src/commands.cpp
+++ b/apps/cloud_composer/src/commands.cpp
@@ -244,10 +244,7 @@ pcl::cloud_composer::ModifyItemCommand::runCommand (AbstractTool* tool)
     qDebug () << "Modify Item command generated "<<num_items_returned<<" which does not match input of "<<original_data_.size () <<" items";
     return true;
   }
-  else
-  {
-    return true;
-  }
+  return true;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -319,12 +316,8 @@ pcl::cloud_composer::NewItemCloudCommand::runCommand (AbstractTool* tool)
     qDebug () << "New Item command generated "<<num_new_items<<" new items";
     return true;
   }
-  else
-  {
-    qWarning () << "New Item command generated no new items!";
-    return false;
-  }
-   
+  qWarning () << "New Item command generated no new items!";
+  return false;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -427,12 +420,8 @@ pcl::cloud_composer::SplitCloudCommand::runCommand (AbstractTool* tool)
     qDebug () << "Split Item command generated "<<num_new_items<<" new items";
     return true;
   }
-  else
-  {
-    qWarning () << "Split Item command generated no new items!";
-    return false;
-  }
-
+  qWarning () << "Split Item command generated no new items!";
+  return false;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/apps/cloud_composer/src/project_model.cpp
+++ b/apps/cloud_composer/src/project_model.cpp
@@ -168,12 +168,9 @@ pcl::cloud_composer::ProjectModel::insertNewCloudFromFile ()
     qWarning () << "No file selected, no cloud loaded";
     return;
   }
-  else
-  {
-    QFileInfo file_info (filename);
-    last_directory_ = file_info.absoluteDir ();
-  }
-    
+  QFileInfo file_info (filename);
+  last_directory_ = file_info.absoluteDir ();
+
   pcl::PCLPointCloud2::Ptr cloud_blob (new pcl::PCLPointCloud2);
   Eigen::Vector4f origin;
   Eigen::Quaternionf orientation;
@@ -191,7 +188,6 @@ pcl::cloud_composer::ProjectModel::insertNewCloudFromFile ()
     return;
   }
   
-  QFileInfo file_info (filename);
   QString short_filename = file_info.baseName ();
   //Check if this name already exists in the project - if so, append digit
   QList <QStandardItem*> items = findItems (short_filename);
@@ -223,27 +219,24 @@ pcl::cloud_composer::ProjectModel::insertNewCloudFromRGBandDepth ()
     qWarning () << "No file selected, no cloud loaded";
     return;
   }
-  else
+  QFileInfo file_info (rgb_filename);
+  last_directory_ = file_info.absoluteDir ();
+  QString base_name = file_info.baseName ();
+  QStringList depth_filter;
+  depth_filter << base_name.split("_").at(0) + "_depth.*";
+  last_directory_.setNameFilters (depth_filter);
+  QFileInfoList depth_info_list = last_directory_.entryInfoList ();
+  if (depth_info_list.empty ())
   {
-    QFileInfo file_info (rgb_filename);
-    last_directory_ = file_info.absoluteDir ();
-    QString base_name = file_info.baseName ();
-    QStringList depth_filter;
-    depth_filter << base_name.split("_").at(0) + "_depth.*";
-    last_directory_.setNameFilters (depth_filter);
-    QFileInfoList depth_info_list = last_directory_.entryInfoList ();
-    if (depth_info_list.empty ())
-    {
-      qCritical () << "Could not find depth file in format (rgb file base name)_depth.*";
-      return;
-    }
-    else if (depth_info_list.size () > 1)
-    {
-      qWarning () << "Found more than one file which matches depth naming format, using first one!";
-    }
-    depth_filename = depth_info_list.at (0).absoluteFilePath ();
+    qCritical () << "Could not find depth file in format (rgb file base name)_depth.*";
+    return;
   }
-  
+  if (depth_info_list.size () > 1)
+  {
+    qWarning () << "Found more than one file which matches depth naming format, using first one!";
+  }
+  depth_filename = depth_info_list.at (0).absoluteFilePath ();
+
   //Read the images
   vtkSmartPointer<vtkImageReader2Factory> reader_factory = vtkSmartPointer<vtkImageReader2Factory>::New ();
   vtkImageReader2* rgb_reader = reader_factory->CreateImageReader2 (rgb_filename.toStdString ().c_str ());
@@ -325,7 +318,7 @@ pcl::cloud_composer::ProjectModel::insertNewCloudFromRGBandDepth ()
     }
   }
   qDebug () << "Done making cloud!";
-  QFileInfo file_info (rgb_filename);
+
   QString short_filename = file_info.baseName ();
   //Check if this name already exists in the project - if so, append digit
   QList <QStandardItem*> items = findItems (short_filename);
@@ -356,7 +349,7 @@ pcl::cloud_composer::ProjectModel::saveSelectedCloudToFile ()
     QMessageBox::warning (qobject_cast<QWidget *>(this->parent ()), "No Cloud Selected", "Cannot save, no cloud is selected in the browser or cloud view");
     return;
   }
-  else if (selected_indexes.size () > 1)
+  if (selected_indexes.size () > 1)
   {
     QMessageBox::warning (qobject_cast<QWidget *>(this->parent ()), "Too many clouds Selected", "Cannot save, currently only support saving one cloud at a time");
     return;
@@ -376,12 +369,9 @@ pcl::cloud_composer::ProjectModel::saveSelectedCloudToFile ()
     qWarning () << "No file selected, not saving";
     return;
   }
-  else
-  {
-    QFileInfo file_info (filename);
-    last_directory_ = file_info.absoluteDir ();
-  }
-  
+  QFileInfo file_info (filename);
+  last_directory_ = file_info.absoluteDir ();
+
   pcl::PCLPointCloud2::ConstPtr cloud = cloud_to_save->data (ItemDataRole::CLOUD_BLOB).value <pcl::PCLPointCloud2::ConstPtr> ();
   Eigen::Vector4f origin = cloud_to_save->data (ItemDataRole::ORIGIN).value <Eigen::Vector4f> ();
   Eigen::Quaternionf orientation = cloud_to_save->data (ItemDataRole::ORIENTATION).value <Eigen::Quaternionf> ();

--- a/apps/cloud_composer/src/properties_model.cpp
+++ b/apps/cloud_composer/src/properties_model.cpp
@@ -87,7 +87,7 @@ pcl::cloud_composer::PropertiesModel::getProperty (const QString prop_name) cons
     qWarning () << "No property named "<<prop_name<<" found in "<<parent_item_->text ();
     return QVariant ();
   }
-  else if (items.size () > 1)
+  if (items.size () > 1)
   {
     qWarning () << "Multiple properties found with name "<<prop_name<<" in "<<parent_item_->text ();
   }

--- a/apps/cloud_composer/src/toolbox_model.cpp
+++ b/apps/cloud_composer/src/toolbox_model.cpp
@@ -60,7 +60,7 @@ pcl::cloud_composer::ToolBoxModel::addToolGroup (QString tool_group_name)
 
     return new_group_item;
   }
-  else if (matches_name.size () > 1)
+  if (matches_name.size () > 1)
   {
     qWarning () << "Multiple tool groups with same name in ToolBoxModel!!";
   }

--- a/apps/cloud_composer/tools/euclidean_clustering.cpp
+++ b/apps/cloud_composer/tools/euclidean_clustering.cpp
@@ -30,7 +30,7 @@ pcl::cloud_composer::EuclideanClusteringTool::performAction (ConstItemList input
     qCritical () << "Empty input in Euclidean Clustering Tool!";
     return output;
   }
-  else if ( input_data.size () > 1)
+  if ( input_data.size () > 1)
   {
     qWarning () << "Input vector has more than one item in Euclidean Clustering!";
   }

--- a/apps/cloud_composer/tools/fpfh_estimation.cpp
+++ b/apps/cloud_composer/tools/fpfh_estimation.cpp
@@ -32,7 +32,7 @@ pcl::cloud_composer::FPFHEstimationTool::performAction (ConstItemList input_data
     qCritical () << "Empty input in FPFH Estimation Tool!";
     return output;
   }
-  else if ( input_data.size () > 1)
+  if ( input_data.size () > 1)
   {
     qWarning () << "Input vector has more than one item in FPFH Estimation!";
   }

--- a/apps/cloud_composer/tools/normal_estimation.cpp
+++ b/apps/cloud_composer/tools/normal_estimation.cpp
@@ -29,7 +29,7 @@ pcl::cloud_composer::NormalEstimationTool::performAction (ConstItemList input_da
     qCritical () << "Empty input in Normal Estimation Tool!";
     return output;
   }
-  else if ( input_data.size () > 1)
+  if ( input_data.size () > 1)
   {
     qWarning () << "Input vector has more than one item in Normal Estimation!";
   }

--- a/apps/cloud_composer/tools/statistical_outlier_removal.cpp
+++ b/apps/cloud_composer/tools/statistical_outlier_removal.cpp
@@ -29,7 +29,7 @@ pcl::cloud_composer::StatisticalOutlierRemovalTool::performAction (ConstItemList
     qCritical () << "Empty input in StatisticalOutlierRemovalTool!";
     return output;
   }
-  else if ( input_data.size () > 1)
+  if ( input_data.size () > 1)
   {
     qWarning () << "Input vector has more than one item in StatisticalOutlierRemovalTool";
   }

--- a/apps/cloud_composer/tools/voxel_grid_downsample.cpp
+++ b/apps/cloud_composer/tools/voxel_grid_downsample.cpp
@@ -30,7 +30,7 @@ pcl::cloud_composer::VoxelGridDownsampleTool::performAction (ConstItemList input
     qCritical () << "Empty input in VoxelGridDownsampleTool!";
     return output;
   }
-  else if ( input_data.size () > 1)
+  if ( input_data.size () > 1)
   {
     qWarning () << "Input vector has more than one item in VoxelGridDownsampleTool";
   }

--- a/apps/in_hand_scanner/src/icp.cpp
+++ b/apps/in_hand_scanner/src/icp.cpp
@@ -356,16 +356,13 @@ pcl::ihs::ICP::findTransformation (const MeshConstPtr&              mesh_model,
   {
     return (false);
   }
-  else if (delta_fitness <= epsilon_)
+  if (delta_fitness <= epsilon_)
   {
     T_final = T_cur;
     return (true);
   }
-  else
-  {
-    std::cerr << "ERROR in icp.cpp: Congratulations! you found a bug.\n";
-    exit (EXIT_FAILURE);
-  }
+  std::cerr << "ERROR in icp.cpp: Congratulations! you found a bug.\n";
+  exit (EXIT_FAILURE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/apps/include/pcl/apps/dominant_plane_segmentation.h
+++ b/apps/include/pcl/apps/dominant_plane_segmentation.h
@@ -227,17 +227,14 @@ namespace pcl
         {
           if (p1.intensity == 0) //new label
             return 1;
-          else
+          //compute distance and check against max_dist
+          if ((p1.getVector3fMap () - p2.getVector3fMap ()).norm () <= max_dist)
           {
-            //compute distance and check against max_dist
-            if ((p1.getVector3fMap () - p2.getVector3fMap ()).norm () <= max_dist)
-            {
-              p2.intensity = p1.intensity;
-              return 0;
-            }
-            else //new label
-              return 1;
+            p2.intensity = p1.intensity;
+            return 0;
           }
+          //new label
+          return 1;
         }
 
         //components needed for cluster segmentation and plane extraction

--- a/apps/point_cloud_editor/src/selectionTransformTool.cpp
+++ b/apps/point_cloud_editor/src/selectionTransformTool.cpp
@@ -97,7 +97,7 @@ SelectionTransformTool::update (int x, int y, BitMask, BitMask buttons)
                                          0.0f);
     return;
   }
-  else if (modifiers_ & ALT)
+  if (modifiers_ & ALT)
   {
     // selection motion is not applied directly (waits for end)
     // as such we can not update x and y immediately

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -154,16 +154,13 @@ class NILinemod
           first_frame_ = true;
           return;
         }
-        else
-        {
-          plane_.reset (new Cloud);
+        plane_.reset (new Cloud);
 
-          // Compute the convex hull of the plane
-          ConvexHull<PointT> chull;
-          chull.setDimension (2);
-          chull.setInputCloud (plane_inliers);
-          chull.reconstruct (*plane_);
-        }
+        // Compute the convex hull of the plane
+        ConvexHull<PointT> chull;
+        chull.setDimension (2);
+        chull.setInputCloud (plane_inliers);
+        chull.reconstruct (*plane_);
       }
     }
 
@@ -421,20 +418,17 @@ class NILinemod
         return;
       }
       // Else, draw it on screen
-      else
-      {
-        //cloud_viewer_.addPolygon (region, 1.0, 0.0, 0.0, "region");
-        //cloud_viewer_.setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "region");
+      //cloud_viewer_.addPolygon (region, 1.0, 0.0, 0.0, "region");
+      //cloud_viewer_.setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "region");
 
-        PlanarRegion<PointT> refined_region;
-        pcl::approximatePolygon (region, refined_region, 0.01, false, true);
-        PCL_INFO ("Planar region: %lu points initial, %lu points after refinement.\n", region.getContour ().size (), refined_region.getContour ().size ());
-        cloud_viewer_.addPolygon (refined_region, 0.0, 0.0, 1.0, "refined_region");
-        cloud_viewer_.setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "refined_region");
+      PlanarRegion<PointT> refined_region;
+      pcl::approximatePolygon (region, refined_region, 0.01, false, true);
+      PCL_INFO ("Planar region: %lu points initial, %lu points after refinement.\n", region.getContour ().size (), refined_region.getContour ().size ());
+      cloud_viewer_.addPolygon (refined_region, 0.0, 0.0, 1.0, "refined_region");
+      cloud_viewer_.setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "refined_region");
 
-        // Draw in image space
-        image_viewer_.addPlanarPolygon (search_.getInputCloud (), refined_region, 0.0, 0.0, 1.0, "refined_region", 1.0);
-      }
+      // Draw in image space
+      image_viewer_.addPlanarPolygon (search_.getInputCloud (), refined_region, 0.0, 0.0, 1.0, "refined_region", 1.0);
 
       // If no object could be determined, exit
       if (!object)
@@ -442,28 +436,25 @@ class NILinemod
         PCL_ERROR ("No object detected. Please select another point or relax the thresholds and continue.\n");
         return;
       }
-      else
-      {
-        // Visualize the object in 3D...
-        visualization::PointCloudColorHandlerCustom<PointT> red (object, 255, 0, 0);
-        if (!cloud_viewer_.updatePointCloud (object, red, "object"))
-          cloud_viewer_.addPointCloud (object, red, "object");
-        // ...and 2D
-        image_viewer_.removeLayer ("object");
-        image_viewer_.addMask (search_.getInputCloud (), *object, "object");
+      // Visualize the object in 3D...
+      visualization::PointCloudColorHandlerCustom<PointT> red (object, 255, 0, 0);
+      if (!cloud_viewer_.updatePointCloud (object, red, "object"))
+        cloud_viewer_.addPointCloud (object, red, "object");
+      // ...and 2D
+      image_viewer_.removeLayer ("object");
+      image_viewer_.addMask (search_.getInputCloud (), *object, "object");
 
-        // Compute the min/max of the object
-        PointT min_pt, max_pt;
-        getMinMax3D (*object, min_pt, max_pt);
-        stringstream ss;
-        ss << "cube_" << idx;
-        // Visualize the bounding box in 3D...
-        cloud_viewer_.addCube (min_pt.x, max_pt.x, min_pt.y, max_pt.y, min_pt.z, max_pt.z, 0.0, 1.0, 0.0, ss.str ());
-        cloud_viewer_.setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, ss.str ());
+      // Compute the min/max of the object
+      PointT min_pt, max_pt;
+      getMinMax3D (*object, min_pt, max_pt);
+      stringstream ss2;
+      ss2 << "cube_" << idx;
+      // Visualize the bounding box in 3D...
+      cloud_viewer_.addCube (min_pt.x, max_pt.x, min_pt.y, max_pt.y, min_pt.z, max_pt.z, 0.0, 1.0, 0.0, ss2.str ());
+      cloud_viewer_.setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, ss2.str ());
 
-        // ...and 2D
-        image_viewer_.addRectangle (search_.getInputCloud (), *object);
-      }
+      // ...and 2D
+      image_viewer_.addRectangle (search_.getInputCloud (), *object);
     }
     
     /////////////////////////////////////////////////////////////////////////

--- a/apps/src/openni_klt.cpp
+++ b/apps/src/openni_klt.cpp
@@ -330,7 +330,7 @@ main (int argc, char** argv)
       printHelp(argc, argv);
       return 0;
     }
-    else if (device_id == "-l")
+    if (device_id == "-l")
     {
       if (argc >= 3)
       {

--- a/apps/src/openni_tracking.cpp
+++ b/apps/src/openni_tracking.cpp
@@ -220,11 +220,8 @@ public:
       }
       return true;
     }
-    else
-    {
-      PCL_WARN ("no particles\n");
-      return false;
-    }
+    PCL_WARN ("no particles\n");
+    return false;
   }
   
   void

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -184,11 +184,8 @@ comparePointToRegion (PointT& pt, pcl::ModelCoefficients& model, pcl::PointCloud
     PCL_INFO ("inside!\n");
     return true;
   }
-  else
-  {
-    PCL_INFO ("not inside!\n");
-    return false;
-  }
+  PCL_INFO ("not inside!\n");
+  return false;
 
 }
 

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -461,16 +461,13 @@ class ObjectSelection
         return;
       }
       // Else, draw it on screen
-      else
-      {
-        cloud_viewer_->addPolygon (region, 0.0, 0.0, 1.0, "region");
-        cloud_viewer_->setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "region");
+      cloud_viewer_->addPolygon (region, 0.0, 0.0, 1.0, "region");
+      cloud_viewer_->setShapeRenderingProperties (visualization::PCL_VISUALIZER_LINE_WIDTH, 10, "region");
 
-        // Draw in image space
-        if (image_viewer_)
-        {
-          image_viewer_->addPlanarPolygon (search_->getInputCloud (), region, 0.0, 0.0, 1.0, "refined_region", 1.0);
-        }
+      // Draw in image space
+      if (image_viewer_)
+      {
+        image_viewer_->addPlanarPolygon (search_->getInputCloud (), region, 0.0, 0.0, 1.0, "refined_region", 1.0);
       }
 
       // If no object could be determined, exit
@@ -479,23 +476,20 @@ class ObjectSelection
         PCL_ERROR ("No object detected. Please select another point or relax the thresholds and continue.\n");
         return;
       }
-      else
+      // Visualize the object in 3D...
+      visualization::PointCloudColorHandlerCustom<PointT> red (object_, 255, 0, 0);
+      if (!cloud_viewer_->updatePointCloud (object_, red, "object"))
+        cloud_viewer_->addPointCloud (object_, red, "object");
+      // ...and 2D
+      if (image_viewer_)
       {
-        // Visualize the object in 3D...
-        visualization::PointCloudColorHandlerCustom<PointT> red (object_, 255, 0, 0);
-        if (!cloud_viewer_->updatePointCloud (object_, red, "object"))
-          cloud_viewer_->addPointCloud (object_, red, "object");
-        // ...and 2D
-        if (image_viewer_)
-        {
-          image_viewer_->removeLayer ("object");
-          image_viewer_->addMask (search_->getInputCloud (), *object_, "object");
-        }
-
-        // ...and 2D
-        if (image_viewer_)
-          image_viewer_->addRectangle (search_->getInputCloud (), *object_);
+        image_viewer_->removeLayer ("object");
+        image_viewer_->addMask (search_->getInputCloud (), *object_, "object");
       }
+
+      // ...and 2D
+      if (image_viewer_)
+        image_viewer_->addRectangle (search_->getInputCloud (), *object_);
     }
     
     /////////////////////////////////////////////////////////////////////////

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -186,17 +186,14 @@ PCDVideoPlayer::selectFolderButtonPressed ()
     cloud_present_ = false;
     return;
   }
-  else
-  {
-    // Reset the Slider
-    ui_->indexSlider->setValue (0);                // set cursor back in the beginning
-    ui_->indexSlider->setRange (0, nr_of_frames_ - 1);  // rescale the slider
+  // Reset the Slider
+  ui_->indexSlider->setValue (0);                // set cursor back in the beginning
+  ui_->indexSlider->setRange (0, nr_of_frames_ - 1);  // rescale the slider
 
-    current_frame_ = 0;
+  current_frame_ = 0;
 
-    cloud_present_ = true;
-    cloud_modified_ = true;
-  }
+  cloud_present_ = true;
+  cloud_modified_ = true;
 }
 
 void 
@@ -218,22 +215,20 @@ PCDVideoPlayer::selectFilesButtonPressed ()
     cloud_present_ = false;
     return;
   }
-  else
+
+  for(int i = 0; i < qt_pcd_files.size (); i++)
   {
-    for(int i = 0; i < qt_pcd_files.size (); i++)
-    {
-      pcd_files_.push_back (qt_pcd_files.at (i).toStdString ());
-    }
-
-    current_frame_ = 0;
-
-    // Reset the Slider
-    ui_->indexSlider->setValue (0);                // set cursor back in the beginning
-    ui_->indexSlider->setRange (0, nr_of_frames_ - 1);  // rescale the slider
-
-    cloud_present_ = true;
-    cloud_modified_ = true;
+    pcd_files_.push_back (qt_pcd_files.at (i).toStdString ());
   }
+
+  current_frame_ = 0;
+
+  // Reset the Slider
+  ui_->indexSlider->setValue (0);                // set cursor back in the beginning
+  ui_->indexSlider->setRange (0, nr_of_frames_ - 1);  // rescale the slider
+
+  cloud_present_ = true;
+  cloud_modified_ = true;
 }
 
 void 

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -100,25 +100,22 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
     return (static_cast<unsigned int> (cloud.size ()));
   }
   // NaN or Inf values could exist => check for them
-  else
+  unsigned cp = 0;
+  for (size_t i = 0; i < cloud.size (); ++i)
   {
-    unsigned cp = 0;
-    for (size_t i = 0; i < cloud.size (); ++i)
-    {
-      // Check if the point is invalid
-      if (!isFinite (cloud [i]))
-        continue;
+    // Check if the point is invalid
+    if (!isFinite (cloud [i]))
+      continue;
 
-      centroid[0] += cloud[i].x;
-      centroid[1] += cloud[i].y;
-      centroid[2] += cloud[i].z;
-      ++cp;
-    }
-    centroid /= static_cast<Scalar> (cp);
-    centroid[3] = 1;
-
-    return (cp);
+    centroid[0] += cloud[i].x;
+    centroid[1] += cloud[i].y;
+    centroid[2] += cloud[i].z;
+    ++cp;
   }
+  centroid /= static_cast<Scalar> (cp);
+  centroid[3] = 1;
+
+  return (cp);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -146,24 +143,21 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
     return (static_cast<unsigned int> (indices.size ()));
   }
   // NaN or Inf values could exist => check for them
-  else
-  {
     unsigned cp = 0;
-    for (const int &index : indices)
-    {
-      // Check if the point is invalid
-      if (!isFinite (cloud [index]))
-        continue;
+  for (const int &index : indices)
+  {
+    // Check if the point is invalid
+    if (!isFinite (cloud [index]))
+      continue;
 
-      centroid[0] += cloud[index].x;
-      centroid[1] += cloud[index].y;
-      centroid[2] += cloud[index].z;
-      ++cp;
-    }
-    centroid /= static_cast<Scalar> (cp);
-    centroid[3] = 1;
-    return (cp);
+    centroid[0] += cloud[index].x;
+    centroid[1] += cloud[index].y;
+    centroid[2] += cloud[index].z;
+    ++cp;
   }
+  centroid /= static_cast<Scalar> (cp);
+  centroid[3] = 1;
+  return (cp);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -414,8 +414,7 @@ RangeImage::getRangeDifference (const Eigen::Vector3f& point) const
   {
     if (image_point_range > 0.0f)
       return std::numeric_limits<float>::infinity ();
-    else
-      return -std::numeric_limits<float>::infinity ();
+    return -std::numeric_limits<float>::infinity ();
   }
   return image_point_range - range;
 }
@@ -866,8 +865,7 @@ RangeImage::getAverageEuclideanDistance (int x, int y, int offset_x, int offset_
       //std::cout << x<<","<<y<<"->"<<x2<<","<<y2<<": "<<pixel_distance<<"\n";
       if (i==0)
         return pixel_distance;
-      else
-        break;
+      break;
     }
     //std::cout << x<<","<<y<<"->"<<x2<<","<<y2<<": "<<std::sqrt (pixel_distance)<<"m\n";
     weight += 1.0f;

--- a/common/src/correspondence.cpp
+++ b/common/src/correspondence.cpp
@@ -54,7 +54,7 @@ pcl::getRejectedQueryIndices (const pcl::Correspondences &correspondences_before
 
   if (nr_correspondences_before == 0)
     return;
-  else if (nr_correspondences_after == 0)
+  if (nr_correspondences_after == 0)
   {
     indices.resize(nr_correspondences_before);
     for (int i = 0; i < nr_correspondences_before; ++i)

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -226,7 +226,7 @@ pcl::concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
     cloud_out = cloud2;
     return (true);
   }
-  else if (cloud1.width*cloud1.height > 0 && cloud2.width*cloud2.height == 0)
+  if (cloud1.width*cloud1.height > 0 && cloud2.width*cloud2.height == 0)
   {
     cloud_out = cloud1;
     return (true);

--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -427,10 +427,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.push_back (val);
     }
   }
-  if (values.empty ())
-    return (false);
-  else
-    return (true);
+  return (!values.empty ());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -446,10 +443,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.push_back (val);
     }
   }
-  if (values.empty ())
-    return (false);
-  else
-    return (true);
+  return (!values.empty ());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -465,10 +459,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.push_back (val);
     }
   }
-  if (values.empty ())
-    return (false);
-  else
-    return (true);
+  return (!values.empty ());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -483,10 +474,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
       values.emplace_back(argv[i]);
     }
   }
-  if (values.empty ())
-    return (false);
-  else
-    return (true);
+  return (!values.empty ());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -513,10 +501,7 @@ pcl::console::parse_multiple_2x_arguments (int argc, const char * const * argv, 
       values_s.push_back (s);
     }
   }
-  if (values_f.empty ())
-    return (false);
-  else
-    return (true);
+  return (!values_f.empty ());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -548,9 +533,6 @@ pcl::console::parse_multiple_3x_arguments (int argc, const char * const * argv, 
       values_t.push_back (t);
     }
   }
-  if (values_f.empty ())
-    return (false);
-  else
-    return (true);
+  return (!values_f.empty ());
 }
 

--- a/cuda/common/include/pcl/cuda/point_cloud.h
+++ b/cuda/common/include/pcl/cuda/point_cloud.h
@@ -165,12 +165,11 @@ namespace pcl
         {
           if (this->height > 1)
             return (points[v * this->width + u]);
-          else
-            return (PointXYZRGB (std::numeric_limits<float>::quiet_NaN (),
-                                 std::numeric_limits<float>::quiet_NaN (),
-                                 std::numeric_limits<float>::quiet_NaN (),
-                                 0));
-            // throw IsNotDenseException ("Can't use 2D indexing with a sparse point cloud");
+          return (PointXYZRGB (std::numeric_limits<float>::quiet_NaN (),
+                               std::numeric_limits<float>::quiet_NaN (),
+                               std::numeric_limits<float>::quiet_NaN (),
+                               0));
+          // throw IsNotDenseException ("Can't use 2D indexing with a sparse point cloud");
         }
   
         //////////////////////////////////////////////////////////////////////////////////////

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -116,10 +116,8 @@ main (int argc, char ** argv)
     {
       std::cout << "No cloud specified!\n";
       return (1);
-    }else
-    {
-      pcl::console::parse (argc,argv,"-p",pcd_path);
     }
+    pcl::console::parse (argc,argv,"-p",pcd_path);
   }
   
   bool disable_transform = pcl::console::find_switch (argc, argv, "--NT");

--- a/features/include/pcl/features/impl/board.hpp
+++ b/features/include/pcl/features/impl/board.hpp
@@ -545,10 +545,7 @@ pcl::BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT>::computePo
       {
         break;
       }
-      else
-      {
-        ch = hole_end - 1;
-      }
+      ch = hole_end - 1;
     }
   }
 

--- a/features/include/pcl/features/impl/boundary.hpp
+++ b/features/include/pcl/features/impl/boundary.hpp
@@ -106,10 +106,7 @@ pcl::BoundaryEstimation<PointInT, PointNT, PointOutT>::isBoundaryPoint (
     max_dif = dif;
 
   // Check results
-  if (max_dif > angle_threshold)
-    return (true);
-  else
-    return (false);
+  return (max_dif > angle_threshold);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/features/include/pcl/features/impl/grsd.hpp
+++ b/features/include/pcl/features/impl/grsd.hpp
@@ -50,14 +50,13 @@ pcl::GRSDEstimation<PointInT, PointNT, PointOutT>::getSimpleType (float min_radi
 {
   if (min_radius > min_radius_plane)
     return (1); // plane
-  else if (max_radius > min_radius_cylinder)
+  if (max_radius > min_radius_cylinder)
     return (2); // cylinder (rim)
-  else if (min_radius < max_radius_noise)
+  if (min_radius < max_radius_noise)
     return (0); // noise/corner
-  else if (max_radius - min_radius < max_min_radius_diff)
+  if (max_radius - min_radius < max_min_radius_diff)
     return (3); // sphere/corner
-  else
-    return (4); // edge
+  return (4);   // edge
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -250,7 +250,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
 
     return;
   }
-  else if (normal_estimation_method_ == AVERAGE_3D_GRADIENT)
+  if (normal_estimation_method_ == AVERAGE_3D_GRADIENT)
   {
     if (!init_average_3d_gradient_)
       initAverage3DGradientMethod ();
@@ -288,7 +288,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
     normal.curvature = bad_point;
     return;
   }
-  else if (normal_estimation_method_ == AVERAGE_DEPTH_CHANGE)
+  if (normal_estimation_method_ == AVERAGE_DEPTH_CHANGE)
   {
     if (!init_depth_change_)
       initAverageDepthChangeMethod ();
@@ -347,7 +347,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
 
     return;
   }
-  else if (normal_estimation_method_ == SIMPLE_3D_GRADIENT)
+  if (normal_estimation_method_ == SIMPLE_3D_GRADIENT)
   {
     if (!init_simple_3d_gradient_)
       initSimple3DGradientMethod ();
@@ -539,7 +539,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormalMirro
     return;
   }
   // =======================================================
-  else if (normal_estimation_method_ == AVERAGE_3D_GRADIENT) 
+  if (normal_estimation_method_ == AVERAGE_3D_GRADIENT) 
   {
     if (!init_average_3d_gradient_)
       initAverage3DGradientMethod ();
@@ -596,7 +596,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormalMirro
     return;
   }
   // ======================================================
-  else if (normal_estimation_method_ == AVERAGE_DEPTH_CHANGE) 
+  if (normal_estimation_method_ == AVERAGE_DEPTH_CHANGE) 
   {
     if (!init_depth_change_)
       initAverageDepthChangeMethod ();
@@ -716,7 +716,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormalMirro
     return;
   }
   // ========================================================
-  else if (normal_estimation_method_ == SIMPLE_3D_GRADIENT) 
+  if (normal_estimation_method_ == SIMPLE_3D_GRADIENT) 
   {
     PCL_THROW_EXCEPTION (PCLException, "BORDER_POLICY_MIRROR not supported for normal estimation method SIMPLE_3D_GRADIENT");
   }

--- a/features/include/pcl/features/impl/range_image_border_extractor.hpp
+++ b/features/include/pcl/features/impl/range_image_border_extractor.hpp
@@ -78,11 +78,8 @@ float RangeImageBorderExtractor::getNeighborDistanceChangeScore(
   {
     if (neighbor.range < 0.0f)
       return 0.0f;
-    else
-    {
-      //cout << "INF edge -> Setting to 1.0\n";
-      return 1.0f;  // TODO: Something more intelligent
-    }
+    //cout << "INF edge -> Setting to 1.0\n";
+    return 1.0f;  // TODO: Something more intelligent
   }
   
   float neighbor_distance_squared = squaredEuclideanDistance(neighbor, point);

--- a/filters/include/pcl/filters/impl/fast_bilateral.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral.hpp
@@ -175,14 +175,11 @@ pcl::FastBilateralFilter<PointT>::Array3D::clamp (const size_t min_value,
   {
     return x;
   }
-  else if (x < min_value)
+  if (x < min_value)
   {
     return (min_value);
   }
-  else
-  {
-    return (max_value);
-  }
+  return (max_value);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
+++ b/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
@@ -299,9 +299,9 @@ pcl::SamplingSurfaceNormal<PointT>::findCutVal (
 {
   if (cut_dim == 0)
     return (cloud.points[cut_index].x);
-  else if (cut_dim == 1)
+  if (cut_dim == 1)
     return (cloud.points[cut_index].y);
-  else if (cut_dim == 2)
+  if (cut_dim == 2)
     return (cloud.points[cut_index].z);
 
   return (0.0f);

--- a/filters/include/pcl/filters/sampling_surface_normal.h
+++ b/filters/include/pcl/filters/sampling_surface_normal.h
@@ -163,9 +163,9 @@ namespace pcl
         {
           if (dim == 0)
             return (cloud.points[p0].x < cloud.points[p1].x);
-          else if (dim == 1)
+          if (dim == 1)
             return (cloud.points[p0].y < cloud.points[p1].y);
-          else if (dim == 2)
+          if (dim == 2)
             return (cloud.points[p0].z < cloud.points[p1].z);
           return (false);
         }

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -305,8 +305,7 @@ namespace pcl
           LeafConstPtr ret (&(leaf_iter->second));
           return ret;
         }
-        else
-          return nullptr;
+        return nullptr;
       }
 
       /** \brief Get the voxel containing point p.
@@ -332,8 +331,7 @@ namespace pcl
           LeafConstPtr ret (&(leaf_iter->second));
           return ret;
         }
-        else
-          return nullptr;
+        return nullptr;
       }
 
       /** \brief Get the voxel containing point p.
@@ -359,8 +357,7 @@ namespace pcl
           LeafConstPtr ret (&(leaf_iter->second));
           return ret;
         }
-        else
-          return nullptr;
+        return nullptr;
 
       }
 

--- a/filters/src/passthrough.cpp
+++ b/filters/src/passthrough.cpp
@@ -151,11 +151,8 @@ pcl::PassThrough<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
             memcpy (&output.data[xyz_offset[2]], &badpt, sizeof (float));
             continue;
           }
-          else
-          {
-            if (extract_removed_indices_)
-              (*removed_indices_)[nr_removed_p++] = cp;
-          }
+          if (extract_removed_indices_)
+            (*removed_indices_)[nr_removed_p++] = cp;
         }
         else
         {
@@ -168,11 +165,8 @@ pcl::PassThrough<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
             memcpy (&output.data[xyz_offset[2]], &badpt, sizeof (float));
             continue;
           }
-          else
-          {
-            if (extract_removed_indices_)
-              (*removed_indices_)[nr_removed_p++] = cp;
-          }
+          if (extract_removed_indices_)
+            (*removed_indices_)[nr_removed_p++] = cp;
         }
       }
     }

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -918,10 +918,7 @@ namespace pcl
             vertex_data_cloud_ = vertex_data_cloud;
             return (true);
           }
-          else
-          {
-            return (false);
-          }
+          return (false);
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -956,10 +953,7 @@ namespace pcl
             half_edge_data_cloud_ = half_edge_data_cloud;
             return (true);
           }
-          else
-          {
-            return (false);
-          }
+          return (false);
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -994,10 +988,7 @@ namespace pcl
             edge_data_cloud_ = edge_data_cloud;
             return (true);
           }
-          else
-          {
-            return (false);
-          }
+          return (false);
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -1032,10 +1023,7 @@ namespace pcl
             face_data_cloud_ = face_data_cloud;
             return (true);
           }
-          else
-          {
-            return (false);
-          }
+          return (false);
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -1053,10 +1041,7 @@ namespace pcl
             assert (&vertex_data >= &vertex_data_cloud_.front () && &vertex_data <= &vertex_data_cloud_.back ());
             return (VertexIndex (std::distance (&vertex_data_cloud_.front (), &vertex_data)));
           }
-          else
-          {
-            return (VertexIndex ());
-          }
+          return (VertexIndex ());
         }
 
         /** \brief Get the index associated to the given half-edge data. */
@@ -1068,10 +1053,7 @@ namespace pcl
             assert (&half_edge_data >= &half_edge_data_cloud_.front () && &half_edge_data <= &half_edge_data_cloud_.back ());
             return (HalfEdgeIndex (std::distance (&half_edge_data_cloud_.front (), &half_edge_data)));
           }
-          else
-          {
-            return (HalfEdgeIndex ());
-          }
+          return (HalfEdgeIndex ());
         }
 
         /** \brief Get the index associated to the given edge data. */
@@ -1083,10 +1065,7 @@ namespace pcl
             assert (&edge_data >= &edge_data_cloud_.front () && &edge_data <= &edge_data_cloud_.back ());
             return (EdgeIndex (std::distance (&edge_data_cloud_.front (), &edge_data)));
           }
-          else
-          {
-            return (EdgeIndex ());
-          }
+          return (EdgeIndex ());
         }
 
         /** \brief Get the index associated to the given face data. */
@@ -1098,10 +1077,7 @@ namespace pcl
             assert (&face_data >= &face_data_cloud_.front () && &face_data <= &face_data_cloud_.back ());
             return (FaceIndex (std::distance (&face_data_cloud_.front (), &face_data)));
           }
-          else
-          {
-            return (FaceIndex ());
-          }
+          return (FaceIndex ());
         }
 
       protected:
@@ -1287,8 +1263,7 @@ namespace pcl
                         HalfEdgeIndex&                /*idx_free_half_edge*/,
                         std::true_type              /*is_manifold*/) const
         {
-          if (is_new_ab && is_new_bc && !is_isolated_b) return (false);
-          else                                          return (true);
+          return !(is_new_ab && is_new_bc && !is_isolated_b);
         }
 
         /** \brief Check if the half-edge bc is the next half-edge of ab.
@@ -1331,8 +1306,7 @@ namespace pcl
           idx_free_half_edge = circ.getTargetIndex ();
 
           // This would detach the faces around the vertex from each other.
-          if (circ.getTargetIndex () == idx_he_ab) return (false);
-          else                                     return (true);
+          return (circ.getTargetIndex () != idx_he_ab);
         }
 
         /** \brief Make the half-edges bc the next half-edge of ab.

--- a/geometry/include/pcl/geometry/quad_mesh.h
+++ b/geometry/include/pcl/geometry/quad_mesh.h
@@ -156,8 +156,7 @@ namespace pcl
         {
           if (vertices.size () == 4)
             return (this->addFaceImplBase (vertices, face_data, edge_data, half_edge_data));
-          else
-            return (FaceIndex ());
+          return (FaceIndex ());
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/geometry/include/pcl/geometry/triangle_mesh.h
+++ b/geometry/include/pcl/geometry/triangle_mesh.h
@@ -162,10 +162,7 @@ namespace pcl
           {
             return (std::make_pair (FaceIndex (), FaceIndex ()));
           }
-          else
-          {
-            return (this->addTrianglePair (vertices [0], vertices [1], vertices [2], vertices [3], face_data, edge_data, half_edge_data));
-          }
+          return (this->addTrianglePair (vertices [0], vertices [1], vertices [2], vertices [3], face_data, edge_data, half_edge_data));
         }
 
         /** \brief Add two triangles for the four given input vertices. When using a manifold triangle mesh it is not possible to connect two bounded regions without going through a non-manifold intermediate step. This method first tries to add the triangles individually and if this fails connects the whole configuration at once (if possible).
@@ -199,7 +196,7 @@ namespace pcl
           {
             return (std::make_pair (idx_face_0, idx_face_1));
           }
-          else if (idx_face_1.isValid ())
+          if (idx_face_1.isValid ())
           {
             idx_face_0 = this->addFace (idx_v_0, idx_v_1, idx_v_2, face_data); // might be possible to add now
             return (std::make_pair (idx_face_1, idx_face_0));
@@ -216,7 +213,7 @@ namespace pcl
           {
             return (std::make_pair (idx_face_0, idx_face_1));
           }
-          else if (idx_face_1.isValid ())
+          if (idx_face_1.isValid ())
           {
             idx_face_0 = this->addFace (idx_v_1, idx_v_2, idx_v_3, face_data); // might be possible to add now
             return (std::make_pair (idx_face_1, idx_face_0));
@@ -241,14 +238,11 @@ namespace pcl
           {
             return (this->connectTrianglePair (inner_he_atp_ [0], inner_he_atp_ [2], idx_v_0, idx_v_1, idx_v_2, idx_v_3, face_data, edge_data, half_edge_data));
           }
-          else if (is_new_atp_ [0] && !is_new_atp_ [1] && is_new_atp_ [2] && !is_new_atp_ [3])
+          if (is_new_atp_ [0] && !is_new_atp_ [1] && is_new_atp_ [2] && !is_new_atp_ [3])
           {
             return (this->connectTrianglePair (inner_he_atp_ [1], inner_he_atp_ [3], idx_v_1, idx_v_2, idx_v_3, idx_v_0, face_data, edge_data, half_edge_data));
           }
-          else
-          {
-            return (std::make_pair (FaceIndex (), FaceIndex ()));
-          }
+          return (std::make_pair (FaceIndex (), FaceIndex ()));
         }
 
       private:
@@ -265,8 +259,7 @@ namespace pcl
         {
           if (vertices.size () == 3)
             return (this->addFaceImplBase (vertices, face_data, edge_data, half_edge_data));
-          else
-            return (FaceIndex ());
+          return (FaceIndex ());
         }
 
         /** \brief Connect the triangles a-b-c and a-c-d. The edges a-b and c-d must be old and the edges b-c and d-a must be new. */

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -197,13 +197,8 @@ pcl::gpu::kinfuLS::KinfuTracker::extractAndSaveWorld ()
     PCL_WARN ("World model currently has no points. Skipping save procedure.\n");
     return;
   }
-  else
-  {
-    PCL_INFO ("Saving current world to world.pcd with %d points.\n", cloud_size);
-    pcl::io::savePCDFile<pcl::PointXYZI> ("world.pcd", *(cyclical_.getWorldModel ()->getWorld ()), true);
-    return;
-  }
-  
+  PCL_INFO ("Saving current world to world.pcd with %d points.\n", cloud_size);
+  pcl::io::savePCDFile<pcl::PointXYZI> ("world.pcd", *(cyclical_.getWorldModel ()->getWorld ()), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -641,16 +636,14 @@ pcl::gpu::kinfuLS::KinfuTracker::operator() (const DepthMap& depth_raw)
     saveCurrentMaps ();
     return (true);
   }
-  else
-  {
-    // ICP based on synthetic maps succeeded
-    // Save newly-computed pose
-    rmats_.push_back (current_global_rotation); 
-    tvecs_.push_back (current_global_translation);
-    // Update last estimated pose to current pairwise ICP result
-    last_estimated_translation_ = current_global_translation;
-    last_estimated_rotation_ = current_global_rotation;
-  }  
+
+  // ICP based on synthetic maps succeeded
+  // Save newly-computed pose
+  rmats_.push_back (current_global_rotation); 
+  tvecs_.push_back (current_global_translation);
+  // Update last estimated pose to current pairwise ICP result
+  last_estimated_translation_ = current_global_translation;
+  last_estimated_rotation_ = current_global_rotation;
 
   ///////////////////////////////////////////////////////////////////////////////////////////  
   // check if we need to shift

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -186,8 +186,7 @@ namespace pcl
         float offset = std::fabs(LUT_ideal_length[(int)parent.label][child_nr] - root);
         if(offset > LUT_max_length_offset[(int)parent.label][child_nr])
           return -1.0;
-        else
-          return offset;
+        return offset;
       }
 
       /**
@@ -211,8 +210,7 @@ namespace pcl
         float offset = std::fabs(person_attribs->part_ideal_length_[(int)parent.label][child_nr] - root);
         if(offset > person_attribs->max_length_offset_[(int)parent.label][child_nr])
           return -1.0;
-        else
-          return offset;
+        return offset;
       }
 
       /**

--- a/gpu/people/src/cuda/nvidia/NCVHaarObjectDetection.hpp
+++ b/gpu/people/src/cuda/nvidia/NCVHaarObjectDetection.hpp
@@ -187,10 +187,7 @@ struct HaarClassifierNodeDescriptor32
 
     __host__ bool isLeaf()                                  // TODO: check this hack don't know if is correct
     {
-      if( _ui1.x == 0)
-        return (false);
-      else
-        return (true);
+      return ( _ui1.x != 0);
     }
 
 #ifdef __CUDACC__

--- a/gpu/people/src/face_detector.cpp
+++ b/gpu/people/src/face_detector.cpp
@@ -158,8 +158,7 @@ pcl::gpu::people::FaceDetector::loadFromXML2(const std::string                  
               PCL_WARN("[pcl::gpu::people::FaceDetector::loadFromXML2] : (D) : level 2 : size node format error\n");   //  format error: line doesn't start with an int.
               return (NCV_HAAR_XML_LOADING_EXCEPTION);
             }
-            else
-              PCL_DEBUG("[pcl::gpu::people::FaceDetector::loadFromXML2] : (D) : level2 : size int1 %d, int2 %d\n", haar.ClassifierSize.width, haar.ClassifierSize.height);
+            PCL_DEBUG("[pcl::gpu::people::FaceDetector::loadFromXML2] : (D) : level2 : size int1 %d, int2 %d\n", haar.ClassifierSize.width, haar.ClassifierSize.height);
 
             int level3 = 0;
             /// LEVEL3 (Stages)


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-else-after-return' -fix`