### PR TITLE
Remove else after return statement [io]

### DIFF
--- a/io/include/pcl/io/file_grabber.h
+++ b/io/include/pcl/io/file_grabber.h
@@ -79,10 +79,7 @@ namespace pcl
         // Throw error 
         throw pcl::IOException ("[pcl::FileGrabber] Attempted to access element which is out of bounds!");
       }
-      else
-      {
-        return (operator[] (idx));
-      }
+      return (operator[] (idx));
     }
   };
 }

--- a/io/include/pcl/io/impl/buffers.hpp
+++ b/io/include/pcl/io/impl/buffers.hpp
@@ -250,8 +250,7 @@ pcl::io::AverageBuffer<T>::operator[] (size_t idx) const
   assert (idx < size_);
   if (data_invalid_count_[idx] == window_size_)
     return (buffer_traits<T>::invalid ());
-  else
-    return (data_sum_[idx] / static_cast<T> (window_size_ - data_invalid_count_[idx]));
+  return (data_sum_[idx] / static_cast<T> (window_size_ - data_invalid_count_[idx]));
 }
 
 template <typename T> void

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -546,15 +546,12 @@ pcl::PCDWriter::writeASCII (const std::string &file_name, const pcl::PointCloud<
               stream << boost::numeric_cast<uint32_t>(value);
               break;
             }
+            float value;
+            memcpy (&value, reinterpret_cast<const char*> (&cloud.points[i]) + fields[d].offset + c * sizeof (float), sizeof (float));
+            if (std::isnan (value))
+              stream << "nan";
             else
-            {
-              float value;
-              memcpy (&value, reinterpret_cast<const char*> (&cloud.points[i]) + fields[d].offset + c * sizeof (float), sizeof (float));
-              if (std::isnan (value))
-                stream << "nan";
-              else
-                stream << boost::numeric_cast<float>(value);
-            }
+              stream << boost::numeric_cast<float>(value);
             break;
           }
           case pcl::PCLPointField::FLOAT64:

--- a/io/include/pcl/io/openni2_grabber.h
+++ b/io/include/pcl/io/openni2_grabber.h
@@ -465,16 +465,13 @@ namespace pcl
           {
             if (mode1.getResolutionX () < mode2.getResolutionX ())
               return true;
-            else if (mode1.getResolutionX () > mode2.getResolutionX ())
+            if (mode1.getResolutionX () > mode2.getResolutionX ())
               return false;
-            else if (mode1.getResolutionY () < mode2.getResolutionY ())
+            if (mode1.getResolutionY () < mode2.getResolutionY ())
               return true;
-            else if (mode1.getResolutionY () > mode2.getResolutionY ())
+            if (mode1.getResolutionY () > mode2.getResolutionY ())
               return false;
-            else if (mode1.getFps () < mode2.getFps () )
-              return true;
-            else
-              return false;
+            return (mode1.getFps () < mode2.getFps ());
           }
         };
 

--- a/io/include/pcl/io/openni_camera/openni_device.h
+++ b/io/include/pcl/io/openni_camera/openni_device.h
@@ -579,8 +579,7 @@ namespace openni_wrapper
     float scale = static_cast<float> (output_x_resolution) / static_cast<float> (XN_SXGA_X_RES);
     if (isDepthRegistered ())
       return (rgb_focal_length_SXGA_ * scale);
-    else
-      return (depth_focal_length_SXGA_ * scale);
+    return (depth_focal_length_SXGA_ * scale);
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/include/pcl/io/openni_grabber.h
+++ b/io/include/pcl/io/openni_grabber.h
@@ -449,16 +449,13 @@ namespace pcl
         {
           if (mode1.nXRes < mode2.nXRes)
             return true;
-          else if (mode1.nXRes > mode2.nXRes)
+          if (mode1.nXRes > mode2.nXRes)
             return false;
-          else if (mode1.nYRes < mode2.nYRes)
+          if (mode1.nYRes < mode2.nYRes)
             return true;
-          else if (mode1.nYRes > mode2.nYRes)
+          if (mode1.nYRes > mode2.nYRes)
             return false;
-          else if (mode1.nFPS < mode2.nFPS)
-            return true;
-          else
-            return false;
+          return (mode1.nFPS < mode2.nFPS);
         }
       } ;
       std::map<int, XnMapOutputMode> config2xn_map_;

--- a/io/include/pcl/io/pcd_io.h
+++ b/io/include/pcl/io/pcd_io.h
@@ -455,8 +455,7 @@ namespace pcl
       {
         if (binary)
           return (writeBinary (file_name, cloud, origin, orientation));
-        else
-          return (writeASCII (file_name, cloud, origin, orientation, 8));
+        return (writeASCII (file_name, cloud, origin, orientation, 8));
       }
 
       /** \brief Save point cloud data to a PCD file containing n-D points
@@ -555,8 +554,7 @@ namespace pcl
       {
         if (binary)
           return (writeBinary<PointT> (file_name, cloud));
-        else
-          return (writeASCII<PointT> (file_name, cloud));
+        return (writeASCII<PointT> (file_name, cloud));
       }
 
       /** \brief Save point cloud data to a PCD file containing n-D points
@@ -581,8 +579,7 @@ namespace pcl
       {
         if (binary)
           return (writeBinary<PointT> (file_name, cloud, indices));
-        else
-          return (writeASCII<PointT> (file_name, cloud, indices));
+        return (writeASCII<PointT> (file_name, cloud, indices));
       }
 
     protected:

--- a/io/include/pcl/io/ply_io.h
+++ b/io/include/pcl/io/ply_io.h
@@ -633,8 +633,7 @@ namespace pcl
       {
         if (binary)
           return (this->writeBinary (file_name, cloud, origin, orientation, true));
-        else
-          return (this->writeASCII (file_name, cloud, origin, orientation, 8, true));
+        return (this->writeASCII (file_name, cloud, origin, orientation, 8, true));
       }
 
       /** \brief Save point cloud data to a PLY file containing n-D points
@@ -656,8 +655,7 @@ namespace pcl
       {
         if (binary)
           return (this->writeBinary (file_name, cloud, origin, orientation, use_camera));
-        else
-          return (this->writeASCII (file_name, cloud, origin, orientation, 8, use_camera));
+        return (this->writeASCII (file_name, cloud, origin, orientation, 8, use_camera));
       }
 
       /** \brief Save point cloud data to a PLY file containing n-D points

--- a/io/src/image_grabber.cpp
+++ b/io/src/image_grabber.cpp
@@ -493,14 +493,11 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getCloudAt (size_t idx,
     cy = principal_point_y_;
     return (getCloudVTK (idx, blob, origin, orientation) );
   }
-  else if (!depth_pclzf_files_.empty ())
+  if (!depth_pclzf_files_.empty ())
     return (getCloudPCLZF (idx, blob, origin, orientation, fx, fy, cx, cy) );
-  else
-  {
-    PCL_ERROR ("[pcl::ImageGrabber::getCloudAt] Could not find VTK or PCLZF files.\n");
-    return (false);
-  }
-}  
+  PCL_ERROR ("[pcl::ImageGrabber::getCloudAt] Could not find VTK or PCLZF files.\n");
+  return (false);
+}
 
 bool
 pcl::ImageGrabberBase::ImageGrabberImpl::getCloudVTK (size_t idx, 
@@ -810,7 +807,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::getVtkImage (
     PCL_ERROR ("[pcl::ImageGrabber::getVtkImage] Image file can't be read: %s\n", filename.c_str ());
     return (false);
   }
-  else if (retval == 1)
+  if (retval == 1)
   {
     PCL_ERROR ("[pcl::ImageGrabber::getVtkImage] Can't prove that I can read: %s\n", filename.c_str ());
     return (false);
@@ -828,8 +825,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::numFrames () const
 {
   if (pclzf_mode_)
     return (depth_pclzf_files_.size ());
-  else
-    return (depth_image_files_.size ());
+  return (depth_image_files_.size ());
 }
 
 //////////////////////// GrabberBase //////////////////////
@@ -996,10 +992,7 @@ pcl::ImageGrabberBase::getCloudAt (size_t idx,
 bool
 pcl::ImageGrabberBase::atLastFrame () const
 {
-  if (impl_->cur_frame_ == numFrames () - 1)
-    return (true);
-  else
-    return (false);
+  return (impl_->cur_frame_ == numFrames () - 1);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -221,35 +221,32 @@ pcl::MTLReader::read (const std::string& mtl_file_path)
           materials_.clear ();
           return (-1);
         }
+        pcl::TexMaterial::RGB *rgb = &materials_.back ().tex_Ka;
+        if (st[0] == "Kd")
+          rgb = &materials_.back ().tex_Kd;
+        else if (st[0] == "Ks")
+          rgb = &materials_.back ().tex_Ks;
+
+        if (st[1] == "xyz")
+        {
+          if (fillRGBfromXYZ (st, *rgb))
+          {
+            PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values",
+                       line.c_str ());
+            mtl_file.close ();
+            materials_.clear ();
+            return (-1);
+          }
+        }
         else
         {
-          pcl::TexMaterial::RGB *rgb = &materials_.back ().tex_Ka;
-          if (st[0] == "Kd")
-            rgb = &materials_.back ().tex_Kd;
-          else if (st[0] == "Ks")
-            rgb = &materials_.back ().tex_Ks;
-
-          if (st[1] == "xyz")
+          if (fillRGBfromRGB (st, *rgb))
           {
-            if (fillRGBfromXYZ (st, *rgb))
-            {
-              PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values",
-                         line.c_str ());
-              mtl_file.close ();
-              materials_.clear ();
-              return (-1);
-            }
-          }
-          else
-          {
-            if (fillRGBfromRGB (st, *rgb))
-            {
-              PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values",
-                         line.c_str ());
-              mtl_file.close ();
-              materials_.clear ();
-              return (-1);
-            }
+            PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values",
+                       line.c_str ());
+            mtl_file.close ();
+            materials_.clear ();
+            return (-1);
           }
         }
         continue;
@@ -400,14 +397,14 @@ pcl::OBJReader::readHeader (const std::string &file_name, pcl::PCLPointCloud2 &c
         }
 
         // Vertex texture (vt)
-        else if ((line[1] == 't') && !vertex_texture_found)
+        if ((line[1] == 't') && !vertex_texture_found)
         {
           vertex_texture_found = true;
           continue;
         }
 
         // Vertex normal (vn)
-        else if ((line[1] == 'n') && !vertex_normal_found)
+        if ((line[1] == 'n') && !vertex_normal_found)
         {
           vertex_normal_found = true;
           continue;

--- a/io/src/oni_grabber.cpp
+++ b/io/src/oni_grabber.cpp
@@ -244,8 +244,7 @@ ONIGrabber::getFramesPerSecond () const
 {
   if (device_->isStreaming())
     return (static_cast<float> (device_->getDepthOutputMode ().nFPS));
-  else
-    return (0);
+  return (0);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -583,13 +583,10 @@ pcl::io::openni2::OpenNI2Device::findCompatibleIRMode (const OpenNI2VideoMode& r
     actual_mode = requested_mode;
     return (true);
   }
-  else
-  {
-    // Find a resize-compatable mode
-    std::vector<OpenNI2VideoMode> supportedModes = getSupportedIRVideoModes ();
-    bool found = findCompatibleVideoMode (supportedModes, requested_mode, actual_mode);
-    return (found);
-  }
+  // Find a resize-compatable mode
+  std::vector<OpenNI2VideoMode> supportedModes = getSupportedIRVideoModes ();
+  bool found = findCompatibleVideoMode (supportedModes, requested_mode, actual_mode);
+  return (found);
 }
 
 bool
@@ -600,13 +597,10 @@ pcl::io::openni2::OpenNI2Device::findCompatibleColorMode (const OpenNI2VideoMode
     actual_mode = requested_mode;
     return (true);
   }
-  else
-  {
-    // Find a resize-compatable mode
-    std::vector<OpenNI2VideoMode> supportedModes = getSupportedColorVideoModes ();
-    bool found = findCompatibleVideoMode (supportedModes, requested_mode, actual_mode);
-    return (found);
-  }
+  // Find a resize-compatable mode
+  std::vector<OpenNI2VideoMode> supportedModes = getSupportedColorVideoModes ();
+  bool found = findCompatibleVideoMode (supportedModes, requested_mode, actual_mode);
+  return (found);
 }
 
 bool
@@ -617,13 +611,10 @@ pcl::io::openni2::OpenNI2Device::findCompatibleDepthMode (const OpenNI2VideoMode
     actual_mode = requested_mode;
     return (true);
   }
-  else
-  {
-    // Find a resize-compatable mode
-    std::vector<OpenNI2VideoMode> supportedModes = getSupportedDepthVideoModes ();
-    bool found = findCompatibleVideoMode (supportedModes, requested_mode, actual_mode);
-    return (found);
-  }
+  // Find a resize-compatable mode
+  std::vector<OpenNI2VideoMode> supportedModes = getSupportedDepthVideoModes ();
+  bool found = findCompatibleVideoMode (supportedModes, requested_mode, actual_mode);
+  return (found);
 }
 
 // Generic support method for the above findCompatable...Mode calls above

--- a/io/src/openni2/openni2_timer_filter.cpp
+++ b/io/src/openni2/openni2_timer_filter.cpp
@@ -63,8 +63,8 @@ namespace pcl
           std::sort (sort_buffer.begin (), sort_buffer.end ());
 
           return sort_buffer[sort_buffer.size ()/2];
-        } else
-          return (0.0);
+        }
+        return (0.0);
       }
 
       double
@@ -83,8 +83,8 @@ namespace pcl
           }
 
           return sum / static_cast<double>(buffer_.size ());
-        } else
-          return (0.0);
+        }
+        return (0.0);
       }
 
 

--- a/io/src/openni2_grabber.cpp
+++ b/io/src/openni2_grabber.cpp
@@ -830,10 +830,7 @@ pcl::io::OpenNI2Grabber::mapMode2XnMode (int mode, OpenNI2VideoMode &xnmode) con
     xnmode = it->second;
     return (true);
   }
-  else
-  {
-    return (false);
-  }
+  return (false);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/openni_camera/openni_device.cpp
+++ b/io/src/openni_camera/openni_device.cpp
@@ -766,8 +766,7 @@ openni_wrapper::OpenNIDevice::isSynchronized () const throw ()
     xn::ImageGenerator& image_generator = const_cast<xn::ImageGenerator&>(image_generator_);
     return (depth_generator.GetFrameSyncCap ().CanFrameSyncWith (image_generator) && depth_generator.GetFrameSyncCap ().IsFrameSyncedWith (image_generator));
   }
-  else
-    return (false);
+  return (false);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1079,27 +1078,24 @@ openni_wrapper::OpenNIDevice::findCompatibleImageMode (const XnMapOutputMode& ou
     mode = output_mode;
     return (true);
   }
-  else
+  bool found = false;
+  for (const auto &available_image_mode : available_image_modes_)
   {
-    bool found = false;
-    for (const auto &available_image_mode : available_image_modes_)
+    if (available_image_mode.nFPS == output_mode.nFPS && isImageResizeSupported (available_image_mode.nXRes, available_image_mode.nYRes, output_mode.nXRes, output_mode.nYRes))
     {
-      if (available_image_mode.nFPS == output_mode.nFPS && isImageResizeSupported (available_image_mode.nXRes, available_image_mode.nYRes, output_mode.nXRes, output_mode.nYRes))
-      {
-        if (found)
-        { // check whether the new mode is better -> smaller than the current one.
-          if (mode.nXRes * mode.nYRes > available_image_mode.nXRes * available_image_mode.nYRes )
-            mode = available_image_mode;
-        }
-        else
-        {
+      if (found)
+      { // check whether the new mode is better -> smaller than the current one.
+        if (mode.nXRes * mode.nYRes > available_image_mode.nXRes * available_image_mode.nYRes )
           mode = available_image_mode;
-          found = true;
-        }
+      }
+      else
+      {
+        mode = available_image_mode;
+        found = true;
       }
     }
-    return (found);
   }
+  return (found);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1111,27 +1107,24 @@ openni_wrapper::OpenNIDevice::findCompatibleDepthMode (const XnMapOutputMode& ou
     mode = output_mode;
     return (true);
   }
-  else
+  bool found = false;
+  for (const auto &available_depth_mode : available_depth_modes_)
   {
-    bool found = false;
-    for (const auto &available_depth_mode : available_depth_modes_)
+    if (available_depth_mode.nFPS == output_mode.nFPS && isImageResizeSupported (available_depth_mode.nXRes, available_depth_mode.nYRes, output_mode.nXRes, output_mode.nYRes))
     {
-      if (available_depth_mode.nFPS == output_mode.nFPS && isImageResizeSupported (available_depth_mode.nXRes, available_depth_mode.nYRes, output_mode.nXRes, output_mode.nYRes))
-      {
-        if (found)
-        { // check whether the new mode is better -> smaller than the current one.
-          if (mode.nXRes * mode.nYRes > available_depth_mode.nXRes * available_depth_mode.nYRes )
-            mode = available_depth_mode;
-        }
-        else
-        {
+      if (found)
+      { // check whether the new mode is better -> smaller than the current one.
+        if (mode.nXRes * mode.nYRes > available_depth_mode.nXRes * available_depth_mode.nYRes )
           mode = available_depth_mode;
-          found = true;
-        }
+      }
+      else
+      {
+        mode = available_depth_mode;
+        found = true;
       }
     }
-    return (found);
   }
+  return (found);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/openni_grabber.cpp
+++ b/io/src/openni_grabber.cpp
@@ -843,10 +843,7 @@ pcl::OpenNIGrabber::mapConfigMode2XnMode (int mode, XnMapOutputMode &xnmode) con
     xnmode = it->second;
     return (true);
   }
-  else
-  {
-    return (false);
-  }
+  return (false);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -73,29 +73,26 @@ pcl::PLYReader::elementDefinitionCallback (const std::string& element_name, std:
               boost::bind (&pcl::PLYReader::vertexBeginCallback, this),
               boost::bind (&pcl::PLYReader::vertexEndCallback, this)));
   }
-  else if ((element_name == "face") && polygons_)
+  if ((element_name == "face") && polygons_)
   {
     polygons_->reserve (count);
     return (boost::tuple<std::function<void ()>, std::function<void ()> > (
             boost::bind (&pcl::PLYReader::faceBeginCallback, this),
             boost::bind (&pcl::PLYReader::faceEndCallback, this)));
   }
-  else if (element_name == "camera")
+  if (element_name == "camera")
   {
     cloud_->is_dense = true;
     return {};
   }
-  else if (element_name == "range_grid")
+  if (element_name == "range_grid")
   {
     range_grid_->reserve (count);
     return (boost::tuple<std::function<void ()>, std::function<void ()> > (
               boost::bind (&pcl::PLYReader::rangeGridBeginCallback, this),
               boost::bind (&pcl::PLYReader::rangeGridEndCallback, this)));
   }
-  else
-  {
-    return {};
-  }
+  return {};
 }
 
 bool
@@ -141,65 +138,58 @@ namespace pcl
       appendScalarProperty<pcl::io::ply::float32> (property_name, 1);
       return (boost::bind (&pcl::PLYReader::vertexScalarPropertyCallback<pcl::io::ply::float32>, this, _1));
     }
-    else if (element_name == "camera")
+    if (element_name == "camera")
     {
       if (property_name == "view_px")
       {
         return boost::bind (&pcl::PLYReader::originXCallback, this, _1);
       }
-      else if (property_name == "view_py")
+      if (property_name == "view_py")
       {
         return boost::bind (&pcl::PLYReader::originYCallback, this, _1);
       }
-      else if (property_name == "view_pz")
+      if (property_name == "view_pz")
       {
         return boost::bind (&pcl::PLYReader::originZCallback, this, _1);
       }
-      else if (property_name == "x_axisx")
+      if (property_name == "x_axisx")
       {
         return boost::bind (&pcl::PLYReader::orientationXaxisXCallback, this, _1);
       }
-      else if (property_name == "x_axisy")
+      if (property_name == "x_axisy")
       {
         return boost::bind (&pcl::PLYReader::orientationXaxisYCallback, this, _1);
       }
-      else if (property_name == "x_axisz")
+      if (property_name == "x_axisz")
       {
         return boost::bind (&pcl::PLYReader::orientationXaxisZCallback, this, _1);
       }
-      else if (property_name == "y_axisx")
+      if (property_name == "y_axisx")
       {
         return boost::bind (&pcl::PLYReader::orientationYaxisXCallback, this, _1);
       }
-      else if (property_name == "y_axisy")
+      if (property_name == "y_axisy")
       {
         return boost::bind (&pcl::PLYReader::orientationYaxisYCallback, this, _1);
       }
-      else if (property_name == "y_axisz")
+      if (property_name == "y_axisz")
       {
         return boost::bind (&pcl::PLYReader::orientationYaxisZCallback, this, _1);
       }
-      else if (property_name == "z_axisx")
+      if (property_name == "z_axisx")
       {
         return boost::bind (&pcl::PLYReader::orientationZaxisXCallback, this, _1);
       }
-      else if (property_name == "z_axisy")
+      if (property_name == "z_axisy")
       {
         return boost::bind (&pcl::PLYReader::orientationZaxisYCallback, this, _1);
       }
-      else if (property_name == "z_axisz")
+      if (property_name == "z_axisz")
       {
         return boost::bind (&pcl::PLYReader::orientationZaxisZCallback, this, _1);
       }
-      else
-      {
-        return {};
-      }
     }
-    else
-    {
-      return {};
-    }
+    return {};
   }
 
   template <> std::function<void (pcl::io::ply::uint8)>
@@ -214,24 +204,20 @@ namespace pcl
           appendScalarProperty<pcl::io::ply::float32> ("rgb");
         return boost::bind (&pcl::PLYReader::vertexColorCallback, this, property_name, _1);
       }
-      else if (property_name == "alpha")
+      if (property_name == "alpha")
       {
         amendProperty ("rgb", "rgba", pcl::PCLPointField::UINT32);
         return boost::bind (&pcl::PLYReader::vertexAlphaCallback, this, _1);
       }
-      else if (property_name == "intensity")
+      if (property_name == "intensity")
       {
         appendScalarProperty<pcl::io::ply::float32> (property_name);
         return boost::bind (&pcl::PLYReader::vertexIntensityCallback, this, _1);
       }
-      else
-      {
-        appendScalarProperty<pcl::io::ply::uint8> (property_name);
-        return boost::bind (&pcl::PLYReader::vertexScalarPropertyCallback<pcl::io::ply::uint8>, this, _1);
-      }
+      appendScalarProperty<pcl::io::ply::uint8> (property_name);
+      return boost::bind (&pcl::PLYReader::vertexScalarPropertyCallback<pcl::io::ply::uint8>, this, _1);
     }
-    else
-      return {};
+    return {};
   }
 
   template <> std::function<void (pcl::io::ply::int32)>
@@ -248,15 +234,13 @@ namespace pcl
       {
         return boost::bind (&pcl::PLYReader::cloudWidthCallback, this, _1);
       }
-      else if (property_name == "viewporty")
+      if (property_name == "viewporty")
       {
         return boost::bind (&pcl::PLYReader::cloudHeightCallback, this, _1);
       }
-      else
-        return {};
-    }
-    else
       return {};
+    }
+    return {};
   }
 
   template <typename Scalar> std::function<void (Scalar)>
@@ -334,7 +318,7 @@ namespace pcl
         boost::bind (&pcl::PLYReader::rangeGridVertexIndicesEndCallback, this)
       );
     }
-    else if ((element_name == "face") && (property_name == "vertex_indices" || property_name == "vertex_index") && polygons_)
+    if ((element_name == "face") && (property_name == "vertex_indices" || property_name == "vertex_index") && polygons_)
     {
       return boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
         boost::bind (&pcl::PLYReader::faceVertexIndicesBeginCallback, this, _1),
@@ -342,7 +326,7 @@ namespace pcl
         boost::bind (&pcl::PLYReader::faceVertexIndicesEndCallback, this)
       );
     }
-    else if (element_name == "vertex")
+    if (element_name == "vertex")
     {
       cloud_->fields.emplace_back();
       pcl::PCLPointField &current_field = cloud_->fields.back ();
@@ -361,10 +345,7 @@ namespace pcl
         boost::bind (&pcl::PLYReader::vertexListPropertyEndCallback, this)
       );
     }
-    else
-    {
-      return {};
-    }
+    return {};
   }
 
   template <typename SizeType, typename ContentType>
@@ -390,10 +371,7 @@ namespace pcl
         boost::bind (&pcl::PLYReader::vertexListPropertyEndCallback, this)
       );
     }
-    else
-    {
-      return {};
-    }
+    return {};
   }
 }
 

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -65,19 +65,16 @@ pcl::io::loadPolygonFile (const std::string &file_name, pcl::PolygonMesh& mesh)
     mesh.polygons.resize (0);
     return (static_cast<int> (mesh.cloud.width * mesh.cloud.height));
   }
-  else if (extension == "vtk")
+  if (extension == "vtk")
    return (pcl::io::loadPolygonFileVTK (file_name, mesh));
-  else if (extension == "ply")
+  if (extension == "ply")
    return (pcl::io::loadPolygonFilePLY (file_name, mesh));
-  else if (extension == "obj")
+  if (extension == "obj")
     return (pcl::io::loadPolygonFileOBJ (file_name, mesh));
-  else if (extension == "stl" )
+  if (extension == "stl" )
     return (pcl::io::loadPolygonFileSTL (file_name, mesh));
-  else
-  {
-    PCL_ERROR ("[pcl::io::loadPolygonFile]: Unsupported file type (%s)\n", extension.c_str ());
-    return (0);
-  }
+  PCL_ERROR ("[pcl::io::loadPolygonFile]: Unsupported file type (%s)\n", extension.c_str ());
+  return (0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -90,17 +87,14 @@ pcl::io::savePolygonFile (const std::string &file_name,
   std::string extension = file_name.substr (file_name.find_last_of ('.') + 1);
   if (extension == "pcd")  // no Polygon, but only a point cloud
     return (pcl::io::savePCDFile (file_name, mesh.cloud, Eigen::Vector4f::Zero (), Eigen::Quaternionf::Identity (), binary_format) == 0);
-  else if (extension == "vtk")
+  if (extension == "vtk")
     return (pcl::io::savePolygonFileVTK (file_name, mesh, binary_format));
-  else if (extension == "ply")
+  if (extension == "ply")
     return (pcl::io::savePolygonFilePLY (file_name, mesh, binary_format));
-  else if (extension == "stl")
+  if (extension == "stl")
     return (pcl::io::savePolygonFileSTL (file_name, mesh, binary_format));
-  else
-  {
-    PCL_ERROR ("[pcl::io::savePolygonFile]: Unsupported file type (%s)\n", extension.c_str ());
-    return (false);
-  }
+  PCL_ERROR ("[pcl::io::savePolygonFile]: Unsupported file type (%s)\n", extension.c_str ());
+  return (false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -392,7 +392,7 @@ main (int argc, char** argv)
       printHelp (buff_size, argc, argv);
       return 0;
     }
-    else if (device_id == "-l")
+    if (device_id == "-l")
     {
       if (argc >= 3)
       {

--- a/io/tools/ply/ply2obj.cpp
+++ b/io/tools/ply/ply2obj.cpp
@@ -165,16 +165,14 @@ ply_to_obj_converter::element_definition_callback (const std::string& element_na
       boost::bind (&ply_to_obj_converter::vertex_end, this)
     );
   }
-  else if (element_name == "face") 
+  if (element_name == "face") 
   {
     return boost::tuple<std::function<void ()>, std::function<void ()> > (
       boost::bind (&ply_to_obj_converter::face_begin, this),
       boost::bind (&ply_to_obj_converter::face_end, this)
     );
   }
-  else {
-    return {};
-  }
+  return {};
 }
 
 template <> std::function<void (pcl::io::ply::float32)> 
@@ -184,19 +182,14 @@ ply_to_obj_converter::scalar_property_definition_callback (const std::string& el
     if (property_name == "x") {
       return boost::bind (&ply_to_obj_converter::vertex_x, this, _1);
     }
-    else if (property_name == "y") {
+    if (property_name == "y") {
       return boost::bind (&ply_to_obj_converter::vertex_y, this, _1);
     }
-    else if (property_name == "z") {
+    if (property_name == "z") {
       return boost::bind (&ply_to_obj_converter::vertex_z, this, _1);
     }
-    else {
-      return {};
-    }
   }
-  else {
-    return {};
-  }
+  return {};
 }
 
 template <> boost::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > 
@@ -209,9 +202,7 @@ ply_to_obj_converter::list_property_definition_callback (const std::string& elem
       boost::bind (&ply_to_obj_converter::face_vertex_indices_end, this)
     );
   }
-  else {
-    return {};
-  }
+  return {};
 }
 
 void 
@@ -374,7 +365,7 @@ int main (int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else if ((short_opt == 'v') || (std::strcmp (long_opt, "version") == 0)) {
+    if ((short_opt == 'v') || (std::strcmp (long_opt, "version") == 0)) {
       std::cout << "ply2obj \n";
       std::cout << " Point Cloud Library (PCL) - www.pointclouds.org\n";
       std::cout << " Copyright (c) 2007-2012, Ares Lagae\n";
@@ -407,7 +398,7 @@ int main (int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else if ((short_opt == 'f') || (std::strcmp (long_opt, "flag") == 0)) {
+    if ((short_opt == 'f') || (std::strcmp (long_opt, "flag") == 0)) {
       if (strcmp (opt_arg, "triangulate") == 0) {
         ply_to_obj_converter_flags |= ply_to_obj_converter::triangulate;
       }

--- a/io/tools/ply/ply2ply.cpp
+++ b/io/tools/ply/ply2ply.cpp
@@ -456,7 +456,7 @@ main(int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else if ((short_opt == 'v') || (std::strcmp(long_opt, "version") == 0)) {
+    if ((short_opt == 'v') || (std::strcmp(long_opt, "version") == 0)) {
       std::cout << "ply2ply\n";
       std::cout << " Point Cloud Library (PCL) - www.pointclouds.org\n";
       std::cout << " Copyright (c) 2007-2012, Ares Lagae\n";
@@ -489,7 +489,7 @@ main(int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else if ((short_opt == 'f') || (std::strcmp(long_opt, "format") == 0)) {
+    if ((short_opt == 'f') || (std::strcmp(long_opt, "format") == 0)) {
       if (strcmp(opt_arg, "ascii") == 0) {
         ply_to_ply_converter_format = ply_to_ply_converter::ascii_format;
       }

--- a/io/tools/ply/ply2raw.cpp
+++ b/io/tools/ply/ply2raw.cpp
@@ -177,15 +177,13 @@ ply_to_raw_converter::element_definition_callback (const std::string& element_na
       boost::bind (&ply_to_raw_converter::vertex_end, this)
     );
   }
-  else if (element_name == "face") {
+  if (element_name == "face") {
     return boost::tuple<std::function<void ()>, std::function<void ()> > (
       boost::bind (&ply_to_raw_converter::face_begin, this),
       boost::bind (&ply_to_raw_converter::face_end, this)
     );
   }
-  else {
-    return {};
-  }
+  return {};
 }
 
 template <> std::function<void (pcl::io::ply::float32)> 
@@ -195,19 +193,14 @@ ply_to_raw_converter::scalar_property_definition_callback (const std::string& el
     if (property_name == "x") {
       return boost::bind (&ply_to_raw_converter::vertex_x, this, _1);
     }
-    else if (property_name == "y") {
+    if (property_name == "y") {
       return boost::bind (&ply_to_raw_converter::vertex_y, this, _1);
     }
-    else if (property_name == "z") {
+    if (property_name == "z") {
       return boost::bind (&ply_to_raw_converter::vertex_z, this, _1);
     }
-    else {
-      return {};
-    }
   }
-  else {
-    return {};
-  }
+  return {};
 }
 
 template <> boost::tuple<std::function<void (pcl::io::ply::uint8)>, 
@@ -225,9 +218,7 @@ ply_to_raw_converter::list_property_definition_callback (const std::string& elem
       boost::bind (&ply_to_raw_converter::face_vertex_indices_end, this)
     );
   }
-  else {
-    return {};
-  }
+  return {};
 }
 
 void
@@ -374,7 +365,7 @@ int main (int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else if ((short_opt == 'v') || (std::strcmp (long_opt, "version") == 0)) {
+    if ((short_opt == 'v') || (std::strcmp (long_opt, "version") == 0)) {
       std::cout << "ply2raw \n";
       std::cout << " Point Cloud Library (PCL) - www.pointclouds.org\n";
       std::cout << " Copyright (c) 2007-2012, Ares Lagae\n";
@@ -407,11 +398,9 @@ int main (int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else {
-      std::cerr << "ply2raw: " << "invalid option `" << argv[argi] << "'" << "\n";
-      std::cerr << "Try `" << argv[0] << " --help' for more information.\n";
-      return EXIT_FAILURE;
-    }
+    std::cerr << "ply2raw: " << "invalid option `" << argv[argi] << "'" << "\n";
+    std::cerr << "Try `" << argv[0] << " --help' for more information.\n";
+    return EXIT_FAILURE;
   }
 
   int parc = argc - argi;

--- a/io/tools/ply/plyheader.cpp
+++ b/io/tools/ply/plyheader.cpp
@@ -94,7 +94,7 @@ int main (int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else if ((short_opt == 'v') || (strcmp (long_opt, "version") == 0)) {
+    if ((short_opt == 'v') || (strcmp (long_opt, "version") == 0)) {
       std::cout << "plyheader \n";
       std::cout << " Point Cloud Library (PCL) - www.pointclouds.org\n";
       std::cout << " Copyright (c) 2007-2012, Ares Lagae\n";
@@ -127,11 +127,9 @@ int main (int argc, char* argv[])
       return EXIT_SUCCESS;
     }
 
-    else {
-      std::cerr << "plyheader: " << "invalid option `" << argv[argi] << "'" << "\n";
-      std::cerr << "Try `" << argv[0] << " --help' for more information.\n";
-      return EXIT_FAILURE;
-    }
+    std::cerr << "plyheader: " << "invalid option `" << argv[argi] << "'" << "\n";
+    std::cerr << "Try `" << argv[0] << " --help' for more information.\n";
+    return EXIT_FAILURE;
   }
 
   int parc = argc - argi;


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-else-after-return' -fix`