### PR TITLE
Remove else after return statement [kdtree, keypoints, ml, octree]

### DIFF
--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -205,11 +205,8 @@ namespace pcl
           assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in nearestKSearch!");
           return (nearestKSearch (input_->points[index], k, k_indices, k_sqr_distances));
         }
-        else
-        {
-          assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in nearestKSearch!");
-          return (nearestKSearch (input_->points[(*indices_)[index]], k, k_indices, k_sqr_distances));
-        }
+        assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in nearestKSearch!");
+        return (nearestKSearch (input_->points[(*indices_)[index]], k, k_indices, k_sqr_distances));
       }
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.
@@ -299,11 +296,8 @@ namespace pcl
           assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in radiusSearch!");
           return (radiusSearch (input_->points[index], radius, k_indices, k_sqr_distances, max_nn));
         }
-        else
-        {
-          assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in radiusSearch!");
-          return (radiusSearch (input_->points[(*indices_)[index]], radius, k_indices, k_sqr_distances, max_nn));
-        }
+        assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in radiusSearch!");
+        return (radiusSearch (input_->points[(*indices_)[index]], radius, k_indices, k_sqr_distances, max_nn));
       }
 
       /** \brief Set the search epsilon precision (error bound) for nearest neighbors searches.

--- a/keypoints/include/pcl/keypoints/impl/keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/keypoint.hpp
@@ -69,25 +69,24 @@ pcl::Keypoint<PointInT, PointOutT>::initCompute ()
       PCL_ERROR ("[pcl::%s::initCompute] Both radius (%f) and K (%d) defined! Set one of them to zero first and then re-run compute ().\n", getClassName ().c_str (), search_radius_, k_);
       return (false);
     }
-    else                  // Use the radiusSearch () function
+
+    // Use the radiusSearch () function
+    search_parameter_ = search_radius_;
+    if (surface_ == input_)       // if the two surfaces are the same
     {
-      search_parameter_ = search_radius_;
-      if (surface_ == input_)       // if the two surfaces are the same
+      // Declare the search locator definition
+      search_method_ = [this] (int index, double radius, std::vector<int> &k_indices, std::vector<float> &k_distances)
       {
-        // Declare the search locator definition
-        search_method_ = [this] (int index, double radius, std::vector<int> &k_indices, std::vector<float> &k_distances)
-        {
-          return tree_->radiusSearch (index, radius, k_indices, k_distances, 0);
-        };
-      }
-      else
+        return tree_->radiusSearch (index, radius, k_indices, k_distances, 0);
+      };
+    }
+    else
+    {
+      // Declare the search locator definition
+      search_method_surface_ = [this] (const PointCloudIn &cloud, int index, double radius, std::vector<int> &k_indices, std::vector<float> &k_distances)
       {
-        // Declare the search locator definition
-        search_method_surface_ = [this] (const PointCloudIn &cloud, int index, double radius, std::vector<int> &k_indices, std::vector<float> &k_distances)
-        {
-          return tree_->radiusSearch (cloud, index, radius, k_indices, k_distances, 0);
-        };
-      }
+        return tree_->radiusSearch (cloud, index, radius, k_indices, k_distances, 0);
+      };
     }
   }
   else

--- a/keypoints/include/pcl/keypoints/keypoint.h
+++ b/keypoints/include/pcl/keypoints/keypoint.h
@@ -156,8 +156,7 @@ namespace pcl
       {
         if (surface_ == input_)       // if the two surfaces are the same
           return (search_method_ (index, parameter, indices, distances));
-        else
-          return (search_method_surface_ (*input_, index, parameter, indices, distances));
+        return (search_method_surface_ (*input_, index, parameter, indices, distances));
       }
 
     protected:

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -254,23 +254,22 @@ pcl::keypoints::brisk::ScaleSpace::getScoreAbove (
  
     return (score);
   }
-  else
-  { // intra
-    const int eighths_x = 6 * x_layer - 1;
-    const int x_above = eighths_x / 8;
-    const int eighths_y = 6 * y_layer - 1;
-    const int y_above = eighths_y / 8;
-    const int r_x = (eighths_x % 8);
-    const int r_x_1 = 8 - r_x;
-    const int r_y = (eighths_y % 8);
-    const int r_y_1 = 8 - r_y;
-    uint8_t score = static_cast<uint8_t> (
-                    0xFF & ((r_x_1 * r_y_1 * l.getAgastScore (x_above,     y_above,     1) +
-                             r_x   * r_y_1  * l.getAgastScore (x_above + 1, y_above,     1) +
-                             r_x_1 * r_y    * l.getAgastScore (x_above ,    y_above + 1, 1) +
-                             r_x   * r_y    * l.getAgastScore (x_above + 1, y_above + 1, 1) + 32) / 64));
-    return (score);
-  }
+
+  // intra
+  const int eighths_x = 6 * x_layer - 1;
+  const int x_above = eighths_x / 8;
+  const int eighths_y = 6 * y_layer - 1;
+  const int y_above = eighths_y / 8;
+  const int r_x = (eighths_x % 8);
+  const int r_x_1 = 8 - r_x;
+  const int r_y = (eighths_y % 8);
+  const int r_y_1 = 8 - r_y;
+  uint8_t score = static_cast<uint8_t> (
+                  0xFF & ((r_x_1 * r_y_1 * l.getAgastScore (x_above,     y_above,     1) +
+                           r_x   * r_y_1  * l.getAgastScore (x_above + 1, y_above,     1) +
+                           r_x_1 * r_y    * l.getAgastScore (x_above ,    y_above + 1, 1) +
+                           r_x   * r_y    * l.getAgastScore (x_above + 1, y_above + 1, 1) + 32) / 64));
+  return (score);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -1277,12 +1276,9 @@ pcl::keypoints::brisk::ScaleSpace::subpixel2D (
       delta_y = delta_x1;
       return (max1);
     }
-    else
-    {
-      delta_x = delta_x2;
-      delta_y = delta_x2;
-      return (max2);
-    }
+    delta_x = delta_x2;
+    delta_y = delta_x2;
+    return (max2);
   }
 
   // this is the case of the maximum inside the boundaries:
@@ -1431,17 +1427,15 @@ pcl::keypoints::brisk::Layer::getAgastScore (float xf, float yf, uint8_t thresho
 
     return (static_cast<uint8_t> (value));
   }
-  else
-  {
-    // this means we overlap area smoothing
-    const float halfscale = scale / 2.0f;
-    // get the scores first:
-    for (int x = int (xf - halfscale); x <= int (xf + halfscale + 1.0f); x++)
-      for (int y = int (yf - halfscale); y <= int (yf + halfscale + 1.0f); y++)
-        getAgastScore (x, y, threshold);
-    // get the smoothed value
-    return (getValue (scores_, img_width_, img_height_, xf, yf, scale));
-  }
+
+  // this means we overlap area smoothing
+  const float halfscale = scale / 2.0f;
+  // get the scores first:
+  for (int x = int (xf - halfscale); x <= int (xf + halfscale + 1.0f); x++)
+    for (int y = int (yf - halfscale); y <= int (yf + halfscale + 1.0f); y++)
+      getAgastScore (x, y, threshold);
+  // get the smoothed value
+  return (getValue (scores_, img_width_, img_height_, xf, yf, scale));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -732,8 +732,7 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 
       if (select_working_set (i, j) != 0)
         break;
-      else
-        counter = 1; // do shrinking next iteration
+      counter = 1; // do shrinking next iteration
     }
 
     ++iter;
@@ -1071,19 +1070,15 @@ bool Solver::be_shrunk (int i, double Gmax1, double Gmax2)
   {
     if (y[i] == + 1)
       return (-G[i] > Gmax1);
-    else
-      return (-G[i] > Gmax2);
+    return (-G[i] > Gmax2);
   }
-  else
-    if (is_lower_bound (i))
-    {
-      if (y[i] == + 1)
-        return (G[i] > Gmax2);
-      else
-        return (G[i] > Gmax1);
-    }
-    else
-      return (false);
+  if (is_lower_bound (i))
+  {
+    if (y[i] == + 1)
+      return (G[i] > Gmax2);
+    return (G[i] > Gmax1);
+  }
+  return (false);
 }
 
 void Solver::do_shrinking()
@@ -1348,19 +1343,16 @@ bool Solver_NU::be_shrunk (int i, double Gmax1, double Gmax2, double Gmax3, doub
   {
     if (y[i] == + 1)
       return (-G[i] > Gmax1);
-    else
-      return (-G[i] > Gmax4);
+    return (-G[i] > Gmax4);
   }
-  else
-    if (is_lower_bound (i))
-    {
-      if (y[i] == + 1)
-        return (G[i] > Gmax2);
-      else
-        return (G[i] > Gmax3);
-    }
-    else
-      return (false);
+  if (is_lower_bound (i))
+  {
+    if (y[i] == + 1)
+      return (G[i] > Gmax2);
+
+      return (G[i] > Gmax3);
+  }
+  return (false);
 }
 
 void Solver_NU::do_shrinking()
@@ -2094,8 +2086,7 @@ static void sigmoid_train (
         fval = newf;
         break;
       }
-      else
-        stepsize /= 2.0;
+      stepsize /= 2.0;
     }
 
     if (stepsize < min_step)
@@ -2118,8 +2109,7 @@ static double sigmoid_predict (double decision_value, double A, double B)
 
   if (fApB >= 0)
     return exp (-fApB) / (1.0 + exp (-fApB));
-  else
-    return 1.0 / (1 + exp (fApB)) ;
+  return 1.0 / (1 + exp (fApB)) ;
 }
 
 // Method 2 from the multiclass_prob paper by Wu, Lin, and Weng
@@ -2876,11 +2866,8 @@ double svm_get_svr_probability (const svm_model *model)
   if ( (model->param.svm_type == EPSILON_SVR || model->param.svm_type == NU_SVR) &&
        model->probA != nullptr)
     return model->probA[0];
-  else
-  {
-    fprintf (stderr, "Model doesn't contain information for SVR probability inference\n");
-    return 0;
-  }
+  fprintf (stderr, "Model doesn't contain information for SVR probability inference\n");
+  return 0;
 }
 
 double svm_predict_values (const svm_model *model, const svm_node *x, double* dec_values)
@@ -2901,77 +2888,72 @@ double svm_predict_values (const svm_model *model, const svm_node *x, double* de
 
     if (model->param.svm_type == ONE_CLASS)
       return (sum > 0) ? 1 : -1;
-    else
-      return sum;
+    return sum;
   }
-  else
-  {
-    int nr_class = model->nr_class;
-    int l = model->l;
 
-    double *kvalue = Malloc (double, l);
+  int nr_class = model->nr_class;
+  int l = model->l;
 
-    for (int i = 0; i < l; i++)
-      kvalue[i] = Kernel::k_function (x, model->SV[i], model->param);
+  double *kvalue = Malloc (double, l);
 
-    int *start = Malloc (int, nr_class);
+  for (int i = 0; i < l; i++)
+    kvalue[i] = Kernel::k_function (x, model->SV[i], model->param);
 
-    start[0] = 0;
+  int *start = Malloc (int, nr_class);
 
-    for (int i = 1; i < nr_class; i++)
-      start[i] = start[i-1] + model->nSV[i-1];
+  start[0] = 0;
 
-    int *vote = Malloc (int, nr_class);
+  for (int i = 1; i < nr_class; i++)
+    start[i] = start[i-1] + model->nSV[i-1];
 
-    for (int i = 0; i < nr_class; i++)
-      vote[i] = 0;
+  int *vote = Malloc (int, nr_class);
 
-    int p = 0;
+  for (int i = 0; i < nr_class; i++)
+    vote[i] = 0;
 
-    for (int i = 0; i < nr_class; i++)
-      for (int j = i + 1;j < nr_class;j++)
-      {
-        double sum = 0;
-        int si = start[i];
-        int sj = start[j];
-        int ci = model->nSV[i];
-        int cj = model->nSV[j];
+  int p = 0;
 
-        double *coef1 = model->sv_coef[j-1];
-        double *coef2 = model->sv_coef[i];
+  for (int i = 0; i < nr_class; i++)
+    for (int j = i + 1;j < nr_class;j++)
+    {
+      double sum = 0;
+      int si = start[i];
+      int sj = start[j];
+      int ci = model->nSV[i];
+      int cj = model->nSV[j];
 
-        for (int k = 0; k < ci; k++)
-          sum += coef1[si+k] * kvalue[si+k];
+      double *coef1 = model->sv_coef[j-1];
+      double *coef2 = model->sv_coef[i];
 
-        for (int k = 0 ;k < cj; k++)
-          sum += coef2[sj+k] * kvalue[sj+k];
+      for (int k = 0; k < ci; k++)
+        sum += coef1[si+k] * kvalue[si+k];
 
-        sum -= model->rho[p];
+      for (int k = 0 ;k < cj; k++)
+        sum += coef2[sj+k] * kvalue[sj+k];
 
-        dec_values[p] = sum;
+      sum -= model->rho[p];
 
-        if (dec_values[p] > 0)
-          ++vote[i];
-        else
-          ++vote[j];
+      dec_values[p] = sum;
 
-        p++;
-      }
+      if (dec_values[p] > 0)
+        ++vote[i];
+      else
+        ++vote[j];
 
-    int vote_max_idx = 0;
+      p++;
+    }
 
-    for (int i = 1; i < nr_class; i++)
-      if (vote[i] > vote[vote_max_idx])
-        vote_max_idx = i;
+  int vote_max_idx = 0;
 
-    free (kvalue);
+  for (int i = 1; i < nr_class; i++)
+    if (vote[i] > vote[vote_max_idx])
+      vote_max_idx = i;
 
-    free (start);
+  free (kvalue);
+  free (start);
+  free (vote);
 
-    free (vote);
-
-    return model->label[vote_max_idx];
-  }
+  return model->label[vote_max_idx];
 }
 
 double svm_predict (const svm_model *model, const svm_node *x)
@@ -3036,8 +3018,7 @@ double svm_predict_probability (
 
     return model->label[prob_max_idx];
   }
-  else
-    return svm_predict (model, x);
+  return svm_predict (model, x);
 }
 
 static const char *svm_type_table[] =
@@ -3169,8 +3150,7 @@ int svm_save_model (const char *model_file_name, const svm_model *model)
 
   if (ferror (fp) != 0 || fclose (fp) != 0)
     return -1;
-  else
-    return 0;
+  return 0;
 }
 
 static char *line = nullptr;

--- a/ml/src/svm_wrapper.cpp
+++ b/ml/src/svm_wrapper.cpp
@@ -44,16 +44,6 @@
 #include <cassert>
 #include <fstream>
 
-
-template <typename T>
-inline T module (T a)
-{
-  if (a > 0)
-    return a;
-  else
-    return -a;
-}
-
 char*
 pcl::SVM::readline (FILE *input)
 {
@@ -154,10 +144,10 @@ pcl::SVMTrain::scaleFactors (std::vector<SVMData> training_set, svm_scaling &sca
   for (const auto &svm_data : training_set)
     for (const auto &sample : svm_data.SV)
       // save scaling factor finding the maximum value
-      if (module (sample.value) > scaling.obj[sample.idx].value)
+      if (std::abs (sample.value) > scaling.obj[sample.idx].value)
       {
         scaling.obj[sample.idx].index = 1;
-        scaling.obj[sample.idx].value = module (sample.value);
+        scaling.obj[sample.idx].value = std::abs (sample.value);
       }
 };
 

--- a/octree/include/pcl/octree/impl/octree2buf_base.hpp
+++ b/octree/include/pcl/octree/impl/octree2buf_base.hpp
@@ -383,47 +383,45 @@ namespace pcl
         // recursively proceed with indexed child branch
         return createLeafRecursive (key_arg, depth_mask_arg / 2, child_branch, return_leaf_arg, parent_of_leaf_arg, doNodeReset);
       }
-      else
-      {
-        // branch childs are leaf nodes
-        LeafNode* child_leaf;
-        if (!branch_arg->hasChild(buffer_selector_, child_idx))
-        {
-          // leaf node at child_idx does not exist
-          
-          // check if we can take copy a reference from previous buffer
-          if (branch_arg->hasChild(!buffer_selector_, child_idx))
-          {
 
-            OctreeNode * child_node = branch_arg->getChildPtr(!buffer_selector_,child_idx);
-            if (child_node->getNodeType () == LEAF_NODE)
-            {
-              child_leaf = static_cast<LeafNode*> (child_node);
-              branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
-            } else {
-              // depth has changed.. child in preceding buffer is a leaf node.
-              deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
-              child_leaf = createLeafChild (*branch_arg, child_idx);
-            }
-            leaf_count_++;  
-          }
-          else
+      // branch childs are leaf nodes
+      LeafNode* child_leaf;
+      if (!branch_arg->hasChild(buffer_selector_, child_idx))
+      {
+        // leaf node at child_idx does not exist
+
+        // check if we can take copy a reference from previous buffer
+        if (branch_arg->hasChild(!buffer_selector_, child_idx))
+        {
+
+          OctreeNode * child_node = branch_arg->getChildPtr(!buffer_selector_,child_idx);
+          if (child_node->getNodeType () == LEAF_NODE)
           {
-            // if required leaf does not exist -> create it
+            child_leaf = static_cast<LeafNode*> (child_node);
+            branch_arg->setChildPtr(buffer_selector_, child_idx, child_node);
+          } else {
+            // depth has changed.. child in preceding buffer is a leaf node.
+            deleteBranchChild (*branch_arg, !buffer_selector_, child_idx);
             child_leaf = createLeafChild (*branch_arg, child_idx);
-            leaf_count_++;
           }
-          
-          // return leaf node
-          return_leaf_arg = child_leaf;
-          parent_of_leaf_arg = branch_arg;
+          leaf_count_++;  
         }
         else
         {
-          // leaf node already exist
-          return_leaf_arg = static_cast<LeafNode*> (branch_arg->getChildPtr(buffer_selector_,child_idx));;
-          parent_of_leaf_arg = branch_arg;
+          // if required leaf does not exist -> create it
+          child_leaf = createLeafChild (*branch_arg, child_idx);
+          leaf_count_++;
         }
+        
+        // return leaf node
+        return_leaf_arg = child_leaf;
+        parent_of_leaf_arg = branch_arg;
+      }
+      else
+      {
+        // leaf node already exist
+        return_leaf_arg = static_cast<LeafNode*> (branch_arg->getChildPtr(buffer_selector_,child_idx));;
+        parent_of_leaf_arg = branch_arg;
       }
 
       return depth_mask_arg;

--- a/octree/include/pcl/octree/impl/octree_base.hpp
+++ b/octree/include/pcl/octree/impl/octree_base.hpp
@@ -307,14 +307,11 @@ namespace pcl
             return createLeafRecursive (key_arg, depth_mask_arg / 2, childBranch, return_leaf_arg, parent_of_leaf_arg);
 
           }
-          else
-          {
-            // if leaf node at child_idx does not exist
-            LeafNode* leaf_node = createLeafChild (*branch_arg, child_idx);
-            return_leaf_arg = leaf_node;
-            parent_of_leaf_arg = branch_arg;
-            this->leaf_count_++;
-          }
+          // if leaf node at child_idx does not exist
+          LeafNode* leaf_node = createLeafChild (*branch_arg, child_idx);
+          return_leaf_arg = leaf_node;
+          parent_of_leaf_arg = branch_arg;
+          this->leaf_count_++;
         }
         else
         {

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -581,18 +581,11 @@ namespace pcl
           {
             if (x < z)
               return a;
-            else
-              return c;
+            return c;
           }
-          else
-          {
-            if (y < z)
-              return b;
-            else
-              return c;
-          }
-
-          return 0;
+          if (y < z)
+            return b;
+          return c;
         }
 
       };


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-else-after-return' -fix`

Skipped agast_2d.cpp, because of #3092 (and because I don't want to change indentation of thousands lines of code)