### PR TITLE
Remove else after return statement [outofcore]

### DIFF
--- a/outofcore/include/pcl/outofcore/octree_base_node.h
+++ b/outofcore/include/pcl/outofcore/octree_base_node.h
@@ -256,10 +256,7 @@ namespace pcl
           {
             return (pcl::octree::BRANCH_NODE);
           }
-          else
-          {
-            return (pcl::octree::LEAF_NODE);
-          }
+          return (pcl::octree::LEAF_NODE);
         }
         
         

--- a/outofcore/src/outofcore_node_data.cpp
+++ b/outofcore/src/outofcore_node_data.cpp
@@ -260,7 +260,7 @@ namespace pcl
         PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeNodeMetadata] Can not find index metadata at %s.\n", metadata_filename_.c_str ());
         return (0);
       }
-      else if(boost::filesystem::is_directory (metadata_filename_))
+      if(boost::filesystem::is_directory (metadata_filename_))
       {
         PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeNodeMetadata] Got a directory, but no oct_idx metadata?\n");
         return (0);


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-else-after-return' -fix`

Only a small PR (just big because of changed indentation)