### PR TITLE
Remove else after return statement [people, recognition, registration]

### DIFF
--- a/people/include/pcl/people/impl/person_classifier.hpp
+++ b/people/include/pcl/people/impl/person_classifier.hpp
@@ -85,10 +85,7 @@ pcl::people::PersonClassifier<PointT>::loadSVMFromFile (std::string svm_filename
     PCL_ERROR ("[pcl::people::PersonClassifier::loadSVMFromFile] Invalid SVM file!\n");
     return (false);
   }
-  else
-  {
-    return (true);
-  }
+  return (true);
 }
 
 template <typename PointT> void
@@ -305,9 +302,6 @@ pcl::people::PersonClassifier<PointT>::evaluate (PointCloudPtr& image,
   {
     return (evaluate(pixel_height, pixel_xc, pixel_yc, image));
   }
-  else
-  {
-    return (evaluate(pixel_width, pixel_yc, image->height-pixel_xc+1, image));
-  }
+  return (evaluate(pixel_width, pixel_yc, image->height-pixel_xc+1, image));
 }
 #endif /* PCL_PEOPLE_PERSON_CLASSIFIER_HPP_ */

--- a/recognition/include/pcl/recognition/ransac_based/auxiliary.h
+++ b/recognition/include/pcl/recognition/ransac_based/auxiliary.h
@@ -72,7 +72,7 @@ namespace pcl
       {
         if ( value < min )
           return min;
-        else if ( value > max )
+        if ( value > max )
           return max;
 
         return value;

--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -325,8 +325,7 @@ namespace pcl
           std::vector<float> distances (1);
           if (tree_->nearestKSearch (input_->points[index], 1, indices, distances))
             return (distances[0]);
-          else
-            return (std::numeric_limits<double>::max ());
+          return (std::numeric_limits<double>::max ());
         }
 
         /** \brief Get the correspondence score for a given pair of correspondent points

--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -227,9 +227,8 @@ namespace pcl
             {
               if (!source_features_ || !target_features_)
                 return (false);
-              else
-                return (source_features_->points.size () > 0 && 
-                        target_features_->points.size () > 0);
+              return (source_features_->points.size () > 0 && 
+                      target_features_->points.size () > 0);
             }
 
             /** \brief Provide a boost shared pointer to a PointRepresentation to be used when comparing features
@@ -281,10 +280,7 @@ namespace pcl
             inline bool
             isCorrespondenceValid (int index) override
             {
-              if (getCorrespondenceScore (index) < thresh_ * thresh_)
-                return (true);
-              else
-                return (false);
+              return (getCorrespondenceScore (index) < thresh_ * thresh_);
             }
              
           private:

--- a/registration/include/pcl/registration/correspondence_rejection_poly.h
+++ b/registration/include/pcl/registration/correspondence_rejection_poly.h
@@ -224,16 +224,17 @@ namespace pcl
                                          corr[ idx[0] ].index_match, corr[ idx[1] ].index_match,
                                          cardinality_));
           }
-          else
-          { // Otherwise check all edges
-            for (int i = 0; i < cardinality_; ++i)
-              if (!thresholdEdgeLength (corr[ idx[i] ].index_query, corr[ idx[(i+1)%cardinality_] ].index_query,
-                                        corr[ idx[i] ].index_match, corr[ idx[(i+1)%cardinality_] ].index_match,
-                                        similarity_threshold_squared_))
-                return (false);
-            
-            return (true);
+          // Otherwise check all edges
+          for (int i = 0; i < cardinality_; ++i)
+          {
+            if (!thresholdEdgeLength (corr[ idx[i] ].index_query, corr[ idx[(i+1)%cardinality_] ].index_query,
+                                      corr[ idx[i] ].index_match, corr[ idx[(i+1)%cardinality_] ].index_match,
+                                      similarity_threshold_squared_))
+            {
+              return (false);
+            }
           }
+          return (true);
         }
         
         /** \brief Polygonal rejection of a single polygon, indexed by two point index vectors

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -102,8 +102,7 @@ namespace pcl
           { 
             if (e <= threshold_)
               return (0.5 * e*e); 
-            else
-              return (0.5 * threshold_ * (2.0 * std::fabs (e) - threshold_));
+            return (0.5 * threshold_ * (2.0 * std::fabs (e) - threshold_));
           }
         protected:
           float threshold_;
@@ -121,8 +120,7 @@ namespace pcl
           { 
             if (e <= threshold_)
               return (e / threshold_);
-            else
-              return (1.0);
+            return (1.0);
           }
         protected:
           float threshold_;

--- a/registration/include/pcl/registration/impl/correspondence_rejection_features.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_features.hpp
@@ -56,8 +56,7 @@ pcl::registration::CorrespondenceRejectorFeatures::getSourceFeature (const std::
 {
   if (features_map_.count (key) == 0)
     return (nullptr);
-  else
-    return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getSourceFeature ());
+  return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getSourceFeature ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -76,8 +75,7 @@ pcl::registration::CorrespondenceRejectorFeatures::getTargetFeature (const std::
 {
   if (features_map_.count (key) == 0)
     return (nullptr);
-  else
-    return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getTargetFeature ());
+  return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getTargetFeature ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -96,46 +96,43 @@ pcl::registration::CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCo
        best_transformation_.setIdentity ();
        return;
      }
-     else
+     if (refine_ && !sac.refineModel ())
      {
-       if (refine_ && !sac.refineModel ())
-       {
-         PCL_ERROR ("[pcl::registration::CorrespondenceRejectorSampleConsensus::getRemainingCorrespondences] Could not refine the model! Returning an empty solution.\n");
-         return;
-       }
-       
-       std::vector<int> inliers;
-       sac.getInliers (inliers);
-
-       if (inliers.size () < 3)
-       {
-         remaining_correspondences = original_correspondences;
-         best_transformation_.setIdentity ();
-         return;
-       }
-       std::unordered_map<int, int> index_to_correspondence;
-       for (int i = 0; i < nr_correspondences; ++i)
-         index_to_correspondence[original_correspondences[i].index_query] = i;
-
-       remaining_correspondences.resize (inliers.size ());
-       for (size_t i = 0; i < inliers.size (); ++i)
-         remaining_correspondences[i] = original_correspondences[index_to_correspondence[inliers[i]]];
-
-       if (save_inliers_)
-       {
-         inlier_indices_.reserve (inliers.size ());
-         for (const int &inlier : inliers)
-           inlier_indices_.push_back (index_to_correspondence[inlier]);
-       }
-
-       // get best transformation
-       Eigen::VectorXf model_coefficients;
-       sac.getModelCoefficients (model_coefficients);
-       best_transformation_.row (0) = model_coefficients.segment<4>(0);
-       best_transformation_.row (1) = model_coefficients.segment<4>(4);
-       best_transformation_.row (2) = model_coefficients.segment<4>(8);
-       best_transformation_.row (3) = model_coefficients.segment<4>(12);
+       PCL_ERROR ("[pcl::registration::CorrespondenceRejectorSampleConsensus::getRemainingCorrespondences] Could not refine the model! Returning an empty solution.\n");
+       return;
      }
+
+     std::vector<int> inliers;
+     sac.getInliers (inliers);
+
+     if (inliers.size () < 3)
+     {
+       remaining_correspondences = original_correspondences;
+       best_transformation_.setIdentity ();
+       return;
+     }
+     std::unordered_map<int, int> index_to_correspondence;
+     for (int i = 0; i < nr_correspondences; ++i)
+       index_to_correspondence[original_correspondences[i].index_query] = i;
+
+     remaining_correspondences.resize (inliers.size ());
+     for (size_t i = 0; i < inliers.size (); ++i)
+       remaining_correspondences[i] = original_correspondences[index_to_correspondence[inliers[i]]];
+
+     if (save_inliers_)
+     {
+       inlier_indices_.reserve (inliers.size ());
+       for (const int &inlier : inliers)
+         inlier_indices_.push_back (index_to_correspondence[inlier]);
+     }
+
+     // get best transformation
+     Eigen::VectorXf model_coefficients;
+     sac.getModelCoefficients (model_coefficients);
+     best_transformation_.row (0) = model_coefficients.segment<4>(0);
+     best_transformation_.row (1) = model_coefficients.segment<4>(4);
+     best_transformation_.row (2) = model_coefficients.segment<4>(8);
+     best_transformation_.row (3) = model_coefficients.segment<4>(12);
    }
 }
 

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -491,7 +491,6 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (d
     return (false);
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
-  else
   if (g_t * (a_l - a_t) > 0)
   {
     a_l = a_t;
@@ -500,7 +499,6 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (d
     return (false);
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
-  else
   if (g_t * (a_l - a_t) < 0)
   {
     a_u = a_l;
@@ -513,8 +511,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (d
     return (false);
   }
   // Interval Converged
-  else
-    return (true);
+  return (true);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -539,11 +536,9 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelection
 
     if (std::fabs (a_c - a_l) < std::fabs (a_q - a_l))
       return (a_c);
-    else
-      return (0.5 * (a_q + a_c));
+    return (0.5 * (a_q + a_c));
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
-  else
   if (g_t * g_l < 0)
   {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
@@ -559,11 +554,9 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelection
 
     if (std::fabs (a_c - a_t) >= std::fabs (a_s - a_t))
       return (a_c);
-    else
-      return (a_s);
+    return (a_s);
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
-  else
   if (std::fabs (g_t) <= std::fabs (g_l))
   {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
@@ -585,19 +578,15 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelection
 
     if (a_t > a_l)
       return (std::min (a_t + 0.66 * (a_u - a_t), a_t_next));
-    else
-      return (std::max (a_t + 0.66 * (a_u - a_t), a_t_next));
+    return (std::max (a_t + 0.66 * (a_u - a_t), a_t_next));
   }
   // Case 4 in Trial Value Selection [More, Thuente 1994]
-  else
-  {
-    // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
-    // Equation 2.4.52 [Sun, Yuan 2006]
-    double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
-    double w = std::sqrt (z * z - g_t * g_u);
-    // Equation 2.4.56 [Sun, Yuan 2006]
-    return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
-  }
+  // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
+  // Equation 2.4.52 [Sun, Yuan 2006]
+  double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
+  double w = std::sqrt (z * z - g_t * g_u);
+  // Equation 2.4.56 [Sun, Yuan 2006]
+  return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -618,13 +607,10 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT
     // Not a decent direction
     if (d_phi_0 == 0)
       return 0;
-    else
-    {
-      // Reverse step direction and calculate optimal step.
-      d_phi_0 *= -1;
-      step_dir *= -1;
+    // Reverse step direction and calculate optimal step.
+    d_phi_0 *= -1;
+    step_dir *= -1;
 
-    }
   }
 
   // The Search Algorithm for T(mu) [More, Thuente 1994]

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -264,8 +264,7 @@ namespace pcl
           // the correct part of the grid:
           if (n)
             return n->test (transformed_pt, cos_theta, sin_theta);
-          else
-            return ValueAndDerivatives<3,double>::Zero ();
+          return ValueAndDerivatives<3,double>::Zero ();
         }
 
       protected:

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -263,9 +263,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::posesWithinErrorBounds (Eigen::A
 
   float rotation_diff_angle = fabsf (rotation_diff_mat.angle ());
 
-  if (position_diff < clustering_position_diff_threshold_ && rotation_diff_angle < clustering_rotation_diff_threshold_)
-    return true;
-  else return false;
+  return (position_diff < clustering_position_diff_threshold_ && rotation_diff_angle < clustering_rotation_diff_threshold_);
 }
 
 

--- a/registration/include/pcl/registration/impl/registration.hpp
+++ b/registration/include/pcl/registration/impl/registration.hpp
@@ -144,8 +144,7 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max
 
   if (nr > 0)
     return (fitness_score / nr);
-  else
-    return (std::numeric_limits<double>::max ());
+  return (std::numeric_limits<double>::max ());
 
 }
 

--- a/registration/include/pcl/registration/impl/transformation_validation_euclidean.hpp
+++ b/registration/include/pcl/registration/impl/transformation_validation_euclidean.hpp
@@ -90,8 +90,7 @@ pcl::registration::TransformationValidationEuclidean<PointSource, PointTarget, S
 
   if (nr > 0)
     return (fitness_score / nr);
-  else
-    return (std::numeric_limits<double>::max ());
+  return (std::numeric_limits<double>::max ());
 }
 
 #endif    // PCL_REGISTRATION_TRANSFORMATION_VALIDATION_EUCLIDEAN_IMPL_H_

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -387,8 +387,7 @@ namespace pcl
           update_visualizer_ = visualizerCallback;
           return (true);
         }
-        else
-          return (false);
+        return (false);
       }
 
       /** \brief Obtain the Euclidean fitness score (e.g., mean of squared distances from the source to the target)

--- a/registration/src/correspondence_rejection_one_to_one.cpp
+++ b/registration/src/correspondence_rejection_one_to_one.cpp
@@ -57,7 +57,7 @@ pcl::registration::CorrespondenceRejectorOneToOne::getRemainingCorrespondences (
   {
     if (i.index_match < 0)
       continue;
-    else if (i.index_match != index_last)
+    if (i.index_match != index_last)
     {
       remaining_correspondences[number_valid_correspondences] = i;
       index_last = i.index_match;


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-else-after-return' -fix`