### PR TITLE
Remove else after return statement [sample_consensus, search, segmentation, stereo, surface]

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -57,10 +57,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::isSampleGood (
   p1 -= p0;
   p2 -= p0;
 
-  if (p1.dot (p2) < 0.000001)
-    return (true);
-  else
-    return (false);
+  return (p1.dot (p2) < 0.000001);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/search/include/pcl/search/impl/brute_force.hpp
+++ b/search/include/pcl/search/impl/brute_force.hpp
@@ -63,8 +63,7 @@ pcl::search::BruteForce<PointT>::nearestKSearch (
 
   if (input_->is_dense)
     return denseKSearch (point, k, k_indices, k_distances);
-  else
-    return sparseKSearch (point, k, k_indices, k_distances);
+  return sparseKSearch (point, k, k_indices, k_distances);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -345,8 +344,7 @@ pcl::search::BruteForce<PointT>::radiusSearch (
 
   if (input_->is_dense)
     return denseRadiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
-  else
-    return sparseRadiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
+  return sparseRadiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
 }
 
 #define PCL_INSTANTIATE_BruteForce(T) template class PCL_EXPORTS pcl::search::BruteForce<T>;

--- a/search/include/pcl/search/impl/search.hpp
+++ b/search/include/pcl/search/impl/search.hpp
@@ -102,15 +102,12 @@ pcl::search::Search<PointT>::nearestKSearch (
     assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in nearestKSearch!");
     return (nearestKSearch (input_->points[index], k, k_indices, k_sqr_distances));
   }
-  else
-  {
-    assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in nearestKSearch!");
-    if (index >= static_cast<int> (indices_->size ()) || index < 0)
-      return (0);
-    return (nearestKSearch (input_->points[(*indices_)[index]], k, k_indices, k_sqr_distances));
-  }
+  assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in nearestKSearch!");
+  if (index >= static_cast<int> (indices_->size ()) || index < 0)
+    return (0);
+  return (nearestKSearch (input_->points[(*indices_)[index]], k, k_indices, k_sqr_distances));
 }
- 
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::search::Search<PointT>::nearestKSearch (
@@ -156,11 +153,8 @@ pcl::search::Search<PointT>::radiusSearch (
     assert (index >= 0 && index < static_cast<int> (input_->points.size ()) && "Out-of-bounds error in radiusSearch!");
     return (radiusSearch (input_->points[index], radius, k_indices, k_sqr_distances, max_nn));
   }
-  else
-  {
-    assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in radiusSearch!");
-    return (radiusSearch (input_->points[(*indices_)[index]], radius, k_indices, k_sqr_distances, max_nn));
-  }
+  assert (index >= 0 && index < static_cast<int> (indices_->size ()) && "Out-of-bounds error in radiusSearch!");
+  return (radiusSearch (input_->points[(*indices_)[index]], radius, k_indices, k_sqr_distances, max_nn));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -226,7 +226,7 @@ namespace pcl
               queue.push (Entry (index, squared_distance));
               return queue.size () == k;
             }
-            else if (queue.top ().distance > squared_distance)
+            if (queue.top ().distance > squared_distance)
             {
               queue.pop ();
               queue.push (Entry (index, squared_distance));

--- a/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_connected_component_segmentation.hpp
@@ -139,7 +139,7 @@ pcl::OrganizedConnectedComponentSegmentation<PointT, PointLT>::segment (pcl::Poi
   {
     if (!std::isfinite (input_->points[colIdx].x))
       continue;
-    else if (compare_->compare (colIdx, colIdx - 1 ))
+    if (compare_->compare (colIdx, colIdx - 1 ))
     {
       labels[colIdx].label = labels[colIdx - 1].label;
     }

--- a/segmentation/include/pcl/segmentation/impl/random_walker.hpp
+++ b/segmentation/include/pcl/segmentation/impl/random_walker.hpp
@@ -248,12 +248,9 @@ namespace pcl
             {
               return bimap.right.at (value);
             }
-            else
-            {
-              size_t s = bimap.size ();
-              bimap.insert (typename boost::bimap<size_t, T>::value_type (s, value));
-              return s;
-            }
+            size_t s = bimap.size ();
+            bimap.insert (typename boost::bimap<size_t, T>::value_type (s, value));
+            return s;
           }
 
           Graph& g_;

--- a/stereo/include/pcl/stereo/stereo_matching.h
+++ b/stereo/include/pcl/stereo/stereo_matching.h
@@ -268,8 +268,7 @@ namespace pcl
         int den = (s1+s3-2*s2);
         if (den != 0)
           return (static_cast<short int> (16*dbest + (((s1 - s3)*8) / den)));
-        else
-          return (static_cast<short int> (dbest*16));
+        return (static_cast<short int> (dbest*16));
       }
 
       inline short int 
@@ -278,8 +277,7 @@ namespace pcl
         float den = (s1+s3-2*s2);
         if (den != 0)
           return (static_cast<short int> (16*dbest + floor(.5 + (((s1 - s3)*8) / den))));
-        else
-          return (static_cast<short int> (dbest*16));
+        return (static_cast<short int> (dbest*16));
       }
 
       inline short int 
@@ -297,8 +295,7 @@ namespace pcl
 
         if (sad_min * precision > (precision - ratio_filter) * sad_second_min)
           return (-2);
-        else	
-          return (dbest);
+        return (dbest);
       }
 
       inline short int 
@@ -316,8 +313,7 @@ namespace pcl
 
         if (sad_min * static_cast<float> (precision) > static_cast<float> (precision - ratio_filter) * sad_second_min)
           return (-2);
-        else
-          return (dbest);
+        return (dbest);
       }
 
       inline short int 
@@ -328,8 +324,7 @@ namespace pcl
 
         if (da + db < peak_filter)
           return (-4);
-        else
-          return (dbest);
+        return (dbest);
       }
 
       inline short int 
@@ -340,8 +335,7 @@ namespace pcl
 
         if (da + db < peak_filter)
           return (-4);
-        else
-          return (dbest);
+        return (dbest);
       }
 
   };

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -111,20 +111,16 @@ namespace pcl
     }
     if (intersection_outside_XR)
       return true;
-    else
-    {
-      if (S1[0] > S2[0])
-        return (x <= S2[0]) || (x >= S1[0]);
-      else if (S1[0] < S2[0])
-        return (x >= S2[0]) || (x <= S1[0]);
-      else if (S1[1] > S2[1])
-        return (y <= S2[1]) || (y >= S1[1]);
-      else if (S1[1] < S2[1])                                                                                                                     
-        return (y >= S2[1]) || (y <= S1[1]);
-      else
-        return false;
-    }
-  }  
+    if (S1[0] > S2[0])
+      return (x <= S2[0]) || (x >= S1[0]);
+    if (S1[0] < S2[0])
+      return (x >= S2[0]) || (x <= S1[0]);
+    if (S1[1] > S2[1])
+      return (y <= S2[1]) || (y >= S1[1]);
+    if (S1[1] < S2[1])                                                                                                                     
+      return (y >= S2[1]) || (y <= S1[1]);
+    return false;
+  }
 
   /** \brief GreedyProjectionTriangulation is an implementation of a greedy triangulation algorithm for 3D points
     * based on local 2D projections. It assumes locally smooth surfaces and relatively smooth transitions between
@@ -515,8 +511,7 @@ namespace pcl
       {
         if (a1.visible == a2.visible)
           return (a1.angle < a2.angle);
-        else
-          return a1.visible;
+        return a1.visible;
       }
   };
 

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -239,37 +239,34 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
         while ((left < nnn_) && ((!angles_[left].visible) || (state_[nnIdx[left]] > FREE))) left++;
         if (left >= nnn_)
           break;
-        else
+        int right = left+1;
+        do
         {
-          int right = left+1;
-          do
+          while ((right < nnn_) && ((!angles_[right].visible) || (state_[nnIdx[right]] > FREE))) right++;
+          if (right >= nnn_)
+            break;
+          if ((coords_[nnIdx[left]] - coords_[nnIdx[right]]).squaredNorm () > sqr_max_edge)
+            right++;
+          else
           {
-            while ((right < nnn_) && ((!angles_[right].visible) || (state_[nnIdx[right]] > FREE))) right++;
-            if (right >= nnn_)
-              break;
-            else if ((coords_[nnIdx[left]] - coords_[nnIdx[right]]).squaredNorm () > sqr_max_edge)
-              right++;
-            else
-            {
-              addFringePoint (nnIdx[right], R_);
-              addFringePoint (nnIdx[left], nnIdx[right]);
-              addFringePoint (R_, nnIdx[left]);
-              state_[R_] = state_[nnIdx[left]] = state_[nnIdx[right]] = FRINGE;
-              ffn_[R_] = nnIdx[left];
-              sfn_[R_] = nnIdx[right];
-              ffn_[nnIdx[left]] = nnIdx[right];
-              sfn_[nnIdx[left]] = R_;
-              ffn_[nnIdx[right]] = R_;
-              sfn_[nnIdx[right]] = nnIdx[left];
-              addTriangle (R_, nnIdx[left], nnIdx[right], polygons);
-              nr_parts++;
-              not_found = false;
-              break;
-            }
+            addFringePoint (nnIdx[right], R_);
+            addFringePoint (nnIdx[left], nnIdx[right]);
+            addFringePoint (R_, nnIdx[left]);
+            state_[R_] = state_[nnIdx[left]] = state_[nnIdx[right]] = FRINGE;
+            ffn_[R_] = nnIdx[left];
+            sfn_[R_] = nnIdx[right];
+            ffn_[nnIdx[left]] = nnIdx[right];
+            sfn_[nnIdx[left]] = R_;
+            ffn_[nnIdx[right]] = R_;
+            sfn_[nnIdx[right]] = nnIdx[left];
+            addTriangle (R_, nnIdx[left], nnIdx[right], polygons);
+            nr_parts++;
+            not_found = false;
+            break;
           }
-          while (true);
-          left++;
         }
+        while (true);
+        left++;
       }
       while (not_found);
     }

--- a/surface/include/pcl/surface/impl/grid_projection.hpp
+++ b/surface/include/pcl/surface/impl/grid_projection.hpp
@@ -203,8 +203,7 @@ pcl::GridProjection<PointNT>::createSurfaceForCell (const Eigen::Vector3i &index
     if (cell_hash_map_.find (index_1d) == cell_hash_map_.end () ||
         occupied_cell_list_[index_1d] == 0)
       return;
-    else
-      vector_at_pts[i] = cell_hash_map_.at (index_1d).vect_at_grid_pt;
+    vector_at_pts[i] = cell_hash_map_.at (index_1d).vect_at_grid_pt;
   }
 
   // Go through the 3 edges, test whether they are intersected by the surface
@@ -525,32 +524,29 @@ pcl::GridProjection<PointNT>::findIntersection (int level,
     intersection = start_pt;
     return;
   }
-  else
+  vec.normalize ();
+  if (vec.dot (vect_at_end_pts[0]) < 0)
   {
-    vec.normalize ();
-    if (vec.dot (vect_at_end_pts[0]) < 0)
-    {
-      Eigen::Vector4f new_start_pt = end_pts[0] + (start_pt - end_pts[0]) * 0.5;
-      new_end_pts[0] = end_pts[0];
-      new_end_pts[1] = start_pt;
-      new_vect_at_end_pts[0] = vect_at_end_pts[0];
-      new_vect_at_end_pts[1] = vec;
-      findIntersection (level + 1, new_end_pts, new_vect_at_end_pts, new_start_pt, pt_union_indices, intersection);
-      return;
-    }
-    if (vec.dot (vect_at_end_pts[1]) < 0)
-    {
-      Eigen::Vector4f new_start_pt = start_pt + (end_pts[1] - start_pt) * 0.5;
-      new_end_pts[0] = start_pt;
-      new_end_pts[1] = end_pts[1];
-      new_vect_at_end_pts[0] = vec;
-      new_vect_at_end_pts[1] = vect_at_end_pts[1];
-      findIntersection (level + 1, new_end_pts, new_vect_at_end_pts, new_start_pt, pt_union_indices, intersection);
-      return;
-    }
-    intersection = start_pt;
+    Eigen::Vector4f new_start_pt = end_pts[0] + (start_pt - end_pts[0]) * 0.5;
+    new_end_pts[0] = end_pts[0];
+    new_end_pts[1] = start_pt;
+    new_vect_at_end_pts[0] = vect_at_end_pts[0];
+    new_vect_at_end_pts[1] = vec;
+    findIntersection (level + 1, new_end_pts, new_vect_at_end_pts, new_start_pt, pt_union_indices, intersection);
     return;
   }
+  if (vec.dot (vect_at_end_pts[1]) < 0)
+  {
+    Eigen::Vector4f new_start_pt = start_pt + (end_pts[1] - start_pt) * 0.5;
+    new_end_pts[0] = start_pt;
+    new_end_pts[1] = end_pts[1];
+    new_vect_at_end_pts[0] = vec;
+    new_vect_at_end_pts[1] = vect_at_end_pts[1];
+    findIntersection (level + 1, new_end_pts, new_vect_at_end_pts, new_start_pt, pt_union_indices, intersection);
+    return;
+  }
+  intersection = start_pt;
+  return;
 }
 
 

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -401,10 +401,7 @@ pcl::TextureMapping<PointInT>::isPointOccluded (const PointInT &pt, OctreePtr oc
    }
   }
 
-  if (nbocc == 0)
-   return (false);
-  else
-   return (true);
+  return (nbocc != 0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/surface/src/ear_clipping.cpp
+++ b/surface/src/ear_clipping.cpp
@@ -70,7 +70,7 @@ pcl::EarClipping::triangulate (const Vertices& vertices, PolygonMesh& output)
 
   if (n_vertices < 3)
     return;
-  else if (n_vertices == 3)
+  if (n_vertices == 3)
   {
     output.polygons.push_back( vertices );
     return;

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -478,16 +478,12 @@ FittingCurve2d::inverseMapping (const ON_NurbsCurve &nurbs, const Eigen::Vector2
       return current;
 
     }
-    else
-    {
-      current += delta;
+    current += delta;
 
-      if (current < minU)
-        current = minU;
-      if (current > maxU)
-        current = maxU;
-    }
-
+    if (current < minU)
+      current = minU;
+    if (current > maxU)
+      current = maxU;
   }
 
   error = r.norm ();
@@ -702,7 +698,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
 
   if (d_shortest_hint < d_shortest_elem)
     return hint;
-  else
+  
     return param;
 }
 

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -844,22 +844,15 @@ FittingCurve2dAPDM::inverseMapping (const ON_NurbsCurve &nurbs, const Eigen::Vec
 
     if (std::abs (delta) < accuracy)
     {
-
       error = r.norm ();
       return current;
-
     }
-    else
-    {
-      current += delta;
+    current += delta;
 
-      if (current < minU)
-        current = maxU - (minU - current);
-      else if (current > maxU)
-        current = minU + (current - maxU);
-
-    }
-
+    if (current < minU)
+      current = maxU - (minU - current);
+    else if (current > maxU)
+      current = minU + (current - maxU);
   }
 
   error = r.norm ();
@@ -1075,7 +1068,7 @@ FittingCurve2dAPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, cons
 
   if (d_shortest_hint < d_shortest_elem)
     return hint;
-  else
+  
     return param;
 }
 

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -606,17 +606,12 @@ FittingCurve2dPDM::inverseMapping (const ON_NurbsCurve &nurbs, const Eigen::Vect
       return current;
 
     }
-    else
-    {
-      current += delta;
+    current += delta;
 
-      if (current < minU)
-        current = maxU - (minU - current);
-      else if (current > maxU)
-        current = minU + (current - maxU);
-
-    }
-
+    if (current < minU)
+      current = maxU - (minU - current);
+    else if (current > maxU)
+      current = minU + (current - maxU);
   }
 
   error = r.norm ();
@@ -832,8 +827,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
 
   if (d_shortest_hint < d_shortest_elem)
     return hint;
-  else
-    return param;
+  return param;
 }
 
 double

--- a/surface/src/on_nurbs/fitting_curve_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_pdm.cpp
@@ -388,17 +388,12 @@ FittingCurve::inverseMapping (const ON_NurbsCurve &nurbs, const Eigen::Vector3d 
       return current;
 
     }
-    else
-    {
-      current += delta;
+    current += delta;
 
-      if (current < minU)
-        current = maxU - (minU - current);
-      else if (current > maxU)
-        current = minU + (current - maxU);
-
-    }
-
+    if (current < minU)
+      current = maxU - (minU - current);
+    else if (current > maxU)
+      current = minU + (current - maxU);
   }
 
   error = r.norm ();

--- a/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
@@ -578,20 +578,16 @@ FittingCylinder::inverseMapping (const ON_NurbsSurface &nurbs, const Vector3d &p
       return current;
 
     }
-    else
-    {
-      current += delta;
-      if (current (0) < minU)
-        current (0) = minU;
-      else if (current (0) > maxU)
-        current (0) = maxU;
+    current += delta;
+    if (current (0) < minU)
+      current (0) = minU;
+    else if (current (0) > maxU)
+      current (0) = maxU;
 
-      if (current (1) < minV)
-        current (1) = maxV - (minV - current (1));
-      else if (current (1) > maxV)
-        current (1) = minV + (current (1) - maxV);
-    }
-
+    if (current (1) < minV)
+      current (1) = maxV - (minV - current (1));
+    else if (current (1) > maxV)
+      current (1) = minV + (current (1) - maxV);
   }
 
   error = r.norm ();

--- a/surface/src/on_nurbs/fitting_sphere_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_sphere_pdm.cpp
@@ -479,20 +479,16 @@ FittingSphere::inverseMapping (const ON_NurbsSurface &nurbs, const Vector3d &pt,
       return current;
 
     }
-    else
-    {
-      current += delta;
-      if (current (0) < minU)
-        current (0) = minU;
-      else if (current (0) > maxU)
-        current (0) = maxU;
+    current += delta;
+    if (current (0) < minU)
+      current (0) = minU;
+    else if (current (0) > maxU)
+      current (0) = maxU;
 
-      if (current (1) < minV)
-        current (1) = maxV - (minV - current (1));
-      else if (current (1) > maxV)
-        current (1) = minV + (current (1) - maxV);
-    }
-
+    if (current (1) < minV)
+      current (1) = maxV - (minV - current (1));
+    else if (current (1) > maxV)
+      current (1) = minV + (current (1) - maxV);
   }
 
   error = r.norm ();

--- a/surface/src/on_nurbs/fitting_surface_im.cpp
+++ b/surface/src/on_nurbs/fitting_surface_im.cpp
@@ -604,22 +604,17 @@ FittingSurfaceIM::inverseMapping (const ON_NurbsSurface &nurbs, const Eigen::Vec
       return current;
 
     }
-    else
-    {
-      current += delta;
+    current += delta;
 
-      if (current (0) < minU)
-        current (0) = minU;
-      else if (current (0) > maxU)
-        current (0) = maxU;
+    if (current (0) < minU)
+      current (0) = minU;
+    else if (current (0) > maxU)
+      current (0) = maxU;
 
-      if (current (1) < minV)
-        current (1) = minV;
-      else if (current (1) > maxV)
-        current (1) = maxV;
-
-    }
-
+    if (current (1) < minV)
+      current (1) = minV;
+    else if (current (1) > maxV)
+      current (1) = maxV;
   }
 
   error = r.norm ();

--- a/surface/src/on_nurbs/fitting_surface_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_surface_pdm.cpp
@@ -1003,22 +1003,17 @@ FittingSurface::inverseMapping (const ON_NurbsSurface &nurbs, const Vector3d &pt
       return current;
 
     }
-    else
-    {
-      current += delta;
+    current += delta;
 
-      if (current (0) < minU)
-        current (0) = minU;
-      else if (current (0) > maxU)
-        current (0) = maxU;
+    if (current (0) < minU)
+      current (0) = minU;
+    else if (current (0) > maxU)
+      current (0) = maxU;
 
-      if (current (1) < minV)
-        current (1) = minV;
-      else if (current (1) > maxV)
-        current (1) = maxV;
-
-    }
-
+    if (current (1) < minV)
+      current (1) = minV;
+    else if (current (1) > maxV)
+      current (1) = maxV;
   }
 
   error = r.norm ();
@@ -1083,22 +1078,17 @@ FittingSurface::inverseMapping (const ON_NurbsSurface &nurbs, const Vector3d &pt
     {
       return current;
     }
-    else
-    {
-      current += delta;
+    current += delta;
 
-      if (current (0) < minU)
-        current (0) = minU;
-      else if (current (0) > maxU)
-        current (0) = maxU;
+    if (current (0) < minU)
+      current (0) = minU;
+    else if (current (0) > maxU)
+      current (0) = maxU;
 
-      if (current (1) < minV)
-        current (1) = minV;
-      else if (current (1) > maxV)
-        current (1) = maxV;
-
-    }
-
+    if (current (1) < minV)
+      current (1) = minV;
+    else if (current (1) > maxV)
+      current (1) = maxV;
   }
 
   if (!quiet)
@@ -1314,55 +1304,47 @@ FittingSurface::inverseMappingBoundary (const ON_NurbsSurface &nurbs, const Vect
       return params;
 
     }
-    else
+
+    current += delta;
+
+    bool stop = false;
+
+    switch (side)
     {
+      case WEST:
+       case EAST:
+        if (current < minV)
+        {
+          params (1) = minV;
+          stop = true;
+        }
+        else if (current > maxV)
+        {
+          params (1) = maxV;
+          stop = true;
+        }
+        break;
 
-      current += delta;
-
-      bool stop = false;
-
-      switch (side)
-      {
-
-        case WEST:
-        case EAST:
-          if (current < minV)
-          {
-            params (1) = minV;
-            stop = true;
-          }
-          else if (current > maxV)
-          {
-            params (1) = maxV;
-            stop = true;
-          }
-
-          break;
-
-        case NORTH:
-        case SOUTH:
-          if (current < minU)
-          {
-            params (0) = minU;
-            stop = true;
-          }
-          else if (current > maxU)
-          {
-            params (0) = maxU;
-            stop = true;
-          }
-
-          break;
-      }
-
-      if (stop)
-      {
-        error = r.norm ();
-        return params;
-      }
-
+      case NORTH:
+      case SOUTH:
+        if (current < minU)
+        {
+          params (0) = minU;
+          stop = true;
+        }
+        else if (current > maxU)
+        {
+          params (0) = maxU;
+          stop = true;
+        }
+        break;
     }
 
+    if (stop)
+    {
+      error = r.norm ();
+      return params;
+    }
   }
 
   error = r.norm ();


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-else-after-return' -fix`