### PR TITLE
Remove else after return statement [test, tools, tracking, visualization]

### DIFF
--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -208,7 +208,7 @@ testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, con
       validness = false;
       break;
     }
-    else if (!nan_mask [index])
+    if (!nan_mask [index])
     {
 #if DEBUG_OUT
       cerr << name << ": result contains an invalid point: " << index << " = NaN (" << point_cloud->points [index].x << " , " 

--- a/tools/image_grabber_viewer.cpp
+++ b/tools/image_grabber_viewer.cpp
@@ -258,7 +258,7 @@ main (int argc, char** argv)
       std::this_thread::sleep_for(10ms);
       continue;
     }
-    else if (mutex_.try_lock ())
+    if (mutex_.try_lock ())
     {
       pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr temp_cloud;
       temp_cloud.swap (cloud_);

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -434,8 +434,7 @@ private:
       extractPointsAtLevel(displayedDepth);
       return true;
     }
-    else
-      return false;
+    return false;
   }
 
   /* \brief Helper function to decrease the octree display level by one

--- a/tools/openni2_viewer.cpp
+++ b/tools/openni2_viewer.cpp
@@ -297,7 +297,7 @@ main (int argc, char** argv)
       printHelp (argc, argv);
       return 0;
     }
-    else if (device_id == "-l")
+    if (device_id == "-l")
     {
       if (argc >= 3)
       {

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -77,10 +77,7 @@ getTotalSystemMemory ()
   {
     return std::numeric_limits<size_t>::max ();
   }
-  else
-  {
-    return size_t (pages * page_size);
-  }
+  return size_t (pages * page_size);
 }
 
 const int BUFFER_SIZE = int (getTotalSystemMemory () / (640 * 480) / 2);
@@ -690,7 +687,7 @@ main (int argc, char ** argv)
       usage (argv);
       return (0);
     }
-    else if (device_id == "-l")
+    if (device_id == "-l")
     {
       if (argc >= 3)
       {

--- a/tools/openni_save_image.cpp
+++ b/tools/openni_save_image.cpp
@@ -237,7 +237,7 @@ main(int argc, char ** argv)
       usage(argv);
       return 0;
     }
-    else if (device_id == "-l")
+    if (device_id == "-l")
     {
       if (argc >= 3)
       {

--- a/tools/openni_viewer.cpp
+++ b/tools/openni_viewer.cpp
@@ -289,7 +289,7 @@ main (int argc, char** argv)
       printHelp(argc, argv);
       return 0;
     }
-    else if (device_id == "-l")
+    if (device_id == "-l")
     {
       if (argc >= 3)
       {

--- a/tools/pcd_grabber_viewer.cpp
+++ b/tools/pcd_grabber_viewer.cpp
@@ -242,7 +242,7 @@ main (int argc, char** argv)
       std::this_thread::sleep_for(10ms);
       continue;
     }
-    else if (mutex_.try_lock ())
+    if (mutex_.try_lock ())
     {
       pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr temp_cloud;
       temp_cloud.swap (cloud_);

--- a/tools/tiff2pcd.cpp
+++ b/tools/tiff2pcd.cpp
@@ -351,7 +351,7 @@ int main(int argc, char ** argv)
       //std::cout << "RGB Time: " << rgb_time << std::endl;
 
       // Try to read the depth file
-      int found = 0; // indicates if a corresponding depth file was found
+      bool found = false; // indicates if a corresponding depth file was found
       // Find the correct file name
       for(size_t j = 0; j < tiff_depth_paths.size(); j++)
       {
@@ -361,7 +361,7 @@ int main(int argc, char ** argv)
         if(depth_time == rgb_time) // found the correct depth
         {
           //std::cout << "Depth Time: " << depth_time << std::endl;
-          found = 1;
+          found = true;
 
           // Process here!
 
@@ -389,16 +389,13 @@ int main(int argc, char ** argv)
           // TODO: remove this depth entry from vector before break > speed up search time
           break;
         }
-        else
-        {
-          // Continue with the next depth entry
-          continue;
-        }
-        if(found == 0)
-        {
-          std::cout << "We couldn't find a Depth file for this RGB image" << std::endl;
-        }
+        // Continue with the next depth entry
+        continue;
       } //for depth_paths
+      if(!found)
+      {
+        std::cout << "We couldn't find a Depth file for this RGB image" << std::endl;
+      }
     } //if ret = 2 or 3
   } //for rgb paths
   return 0;

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -84,18 +84,15 @@ loadDataSet (const char* file_name)
     reader->Update ();
     return (reader->GetOutput ());
   }
-  else if (extension == ".vtk")
+  if (extension == ".vtk")
   {
     vtkPolyDataReader* reader = vtkPolyDataReader::New ();
     reader->SetFileName (file_name);
     reader->Update ();
     return (reader->GetOutput ());
   }
-  else
-  {
-    PCL_ERROR ("Needs a VTK/PLY file to continue.\n");
-    return (nullptr);
-  }
+  PCL_ERROR ("Needs a VTK/PLY file to continue.\n");
+  return (nullptr);
 }
 
 int

--- a/tracking/include/pcl/tracking/impl/normal_coherence.hpp
+++ b/tracking/include/pcl/tracking/impl/normal_coherence.hpp
@@ -12,22 +12,18 @@ pcl::tracking::NormalCoherence<PointInT>::computeCoherence (PointInT &source, Po
     Eigen::Vector4f n_dash = target.getNormalVector4fMap ();
     if ( n.norm () <= 1e-5 || n_dash.norm () <= 1e-5 )
     {
-        PCL_ERROR("norm might be ZERO!\n");
-        std::cout << "source: " << source << std::endl;
-        std::cout << "target: " << target << std::endl;
-        exit (1);
-        return 0.0;
+      PCL_ERROR("norm might be ZERO!\n");
+      std::cout << "source: " << source << std::endl;
+      std::cout << "target: " << target << std::endl;
+      exit (1);
+      return 0.0;
     }
-    else
-    {
-        n.normalize ();
-        n_dash.normalize ();
-        double theta = pcl::getAngle3D (n, n_dash);
-        if (!std::isnan (theta))
-            return 1.0 / (1.0 + weight_ * theta * theta);
-        else
-            return 0.0;
-    }
+    n.normalize ();
+    n_dash.normalize ();
+    double theta = pcl::getAngle3D (n, n_dash);
+    if (!std::isnan (theta))
+      return 1.0 / (1.0 + weight_ * theta * theta);
+    return 0.0;
 }
 
 

--- a/tracking/include/pcl/tracking/impl/particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/particle_filter.hpp
@@ -49,8 +49,7 @@ pcl::tracking::ParticleFilterTracker<PointInT, StateT>::sampleWithReplacement
   rU -= k;    /* rU - [rU] */
   if ( rU < q[k] )
     return k;
-  else
-    return a[k];
+  return a[k];
 }
 
 template <typename PointInT, typename StateT> void

--- a/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
+++ b/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
@@ -154,8 +154,7 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::initCompute ()
     computePyramids (ref_, ref_pyramid_, pcl::BORDER_REFLECT_101);
     return (true);
   }
-  else
-    initialized_ = true;
+  initialized_ = true;
 
   return (true);
 }

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1155,7 +1155,8 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   {
     PCL_WARN ("[addCorrespondences] A set of correspondences with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
     return (false);
-  } else if (am_it == shape_actor_map_->end () && overwrite)
+  }
+  if (am_it == shape_actor_map_->end () && overwrite)
   {
     overwrite = false; // Correspondences doesn't exist, add them instead of updating them
   }

--- a/visualization/src/common/io.cpp
+++ b/visualization/src/common/io.cpp
@@ -127,8 +127,7 @@ pcl::visualization::savePointData (vtkPolyData* data, const std::string &out_fil
       pcl::console::print_error (stdout, "[failed]\n");
       return (false);
     }
-    else
-      pcl::console::print_debug ("[success]\n");
+    pcl::console::print_debug ("[success]\n");
  
     pcl::PointCloud<pcl::PointXYZ> cloud_xyz;
     pcl::fromPCLPointCloud2 (cloud, cloud_xyz);
@@ -148,8 +147,7 @@ pcl::visualization::savePointData (vtkPolyData* data, const std::string &out_fil
       pcl::console::print_error (stdout, "[failed]\n");
       return (false);
     }
-    else
-      pcl::console::print_debug ("[success]\n");
+    pcl::console::print_debug ("[success]\n");
   }
 
   return (true);

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -655,8 +655,7 @@ pcl::visualization::PCLPlotter::wasStopped () const
 {
   if (view_->GetInteractor()) 
     return (stopped_); 
-  else 
-    return (true);
+  return (true);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1945,8 +1945,7 @@ pcl::visualization::PCLVisualizer::updateShapePose (const std::string &id, const
 
   if (am_it == shape_actor_map_->end ())
     return (false);
-  else
-    actor = vtkLODActor::SafeDownCast (am_it->second);
+  actor = vtkLODActor::SafeDownCast (am_it->second);
 
   if (!actor)
     return (false);
@@ -1971,8 +1970,7 @@ pcl::visualization::PCLVisualizer::updateCoordinateSystemPose (const std::string
 
   if (am_it == coordinate_actor_map_->end ())
     return (false);
-  else
-    actor = vtkLODActor::SafeDownCast (am_it->second);
+  actor = vtkLODActor::SafeDownCast (am_it->second);
 
   if (!actor)
     return (false);
@@ -2227,11 +2225,8 @@ pcl::visualization::PCLVisualizer::getCameraParameters (int argc, char **argv)
         boost::split (camera, argv[i], boost::is_any_of ("/"), boost::token_compress_on);
         return (style_->getCameraParameters (camera));
       }
-      else
-      {
-        // Assume that if we don't have clip/focal/pos/view, a filename.cam was given as a parameter
-        return (style_->loadCameraParameters (camfile));
-      }
+      // Assume that if we don't have clip/focal/pos/view, a filename.cam was given as a parameter
+      return (style_->loadCameraParameters (camfile));
     }
   }
   return (false);
@@ -2709,7 +2704,7 @@ pcl::visualization::PCLVisualizer::createViewPortCamera (const int viewport)
   {
     if (viewport == 0)
       continue;
-    else if (viewport == i)
+    if (viewport == i)
     {
       renderer->SetActiveCamera (cam);
       renderer->ResetCamera ();

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -115,14 +115,8 @@ pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2>::PointCl
     capable_ = true;
     return;
   }
-  else
-  {
-    field_idx_ = pcl::getFieldIndex (*cloud, "rgba");
-    if (field_idx_ != -1)
-      capable_ = true;
-    else
-      capable_ = false;
-  }
+  field_idx_ = pcl::getFieldIndex (*cloud, "rgba");
+  capable_ = (field_idx_ != -1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-else-after-return' -fix`