### PR TITLE
Add new overload of `PointCloudColorHandler::getColor()`

### DIFF
--- a/apps/modeler/src/cloud_mesh.cpp
+++ b/apps/modeler/src/cloud_mesh.cpp
@@ -141,19 +141,19 @@ pcl::modeler::CloudMesh::getColorScalarsFromField(vtkSmartPointer<vtkDataArray> 
   if (field == "rgb" || field == "rgba")
   {
     pcl::visualization::PointCloudColorHandlerRGBField<PointT> color_handler(cloud_);
-    color_handler.getColor(scalars);
+    scalars = color_handler.getColor();
     return;
   }
 
   if (field == "random")
   {
     pcl::visualization::PointCloudColorHandlerRandom<PointT> color_handler(cloud_);
-    color_handler.getColor(scalars);
+    scalars = color_handler.getColor();
     return;
   }
 
   pcl::visualization::PointCloudColorHandlerGenericField<PointT> color_handler(cloud_, field);
-  color_handler.getColor(scalars);
+  scalars = color_handler.getColor();
 
   return;
 }

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1307,8 +1307,7 @@ pcl::visualization::PCLVisualizer::fromHandlersToScreen (
   // Get the colors from the handler
   bool has_colors = false;
   double minmax[2];
-  vtkSmartPointer<vtkDataArray> scalars;
-  if (color_handler.getColor (scalars))
+  if (auto scalars = color_handler.getColor ())
   {
     polydata->GetPointData ()->SetScalars (scalars);
     scalars->GetRange (minmax);
@@ -1370,8 +1369,7 @@ pcl::visualization::PCLVisualizer::fromHandlersToScreen (
   // Get the colors from the handler
   bool has_colors = false;
   double minmax[2];
-  vtkSmartPointer<vtkDataArray> scalars;
-  if (color_handler->getColor (scalars))
+  if (auto scalars = color_handler->getColor ())
   {
     polydata->GetPointData ()->SetScalars (scalars);
     scalars->GetRange (minmax);
@@ -1434,8 +1432,7 @@ pcl::visualization::PCLVisualizer::fromHandlersToScreen (
   // Get the colors from the handler
   bool has_colors = false;
   double minmax[2];
-  vtkSmartPointer<vtkDataArray> scalars;
-  if (color_handler.getColor (scalars))
+  if (auto scalars = color_handler.getColor ())
   {
     polydata->GetPointData ()->SetScalars (scalars);
     scalars->GetRange (minmax);
@@ -1590,8 +1587,7 @@ pcl::visualization::PCLVisualizer::updatePointCloud (const typename pcl::PointCl
   // Get the colors from the handler
   bool has_colors = false;
   double minmax[2];
-  vtkSmartPointer<vtkDataArray> scalars;
-  if (color_handler.getColor (scalars))
+  if (auto scalars = color_handler.getColor ())
   {
     // Update the data
     polydata->GetPointData ()->SetScalars (scalars);

--- a/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
+++ b/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
@@ -45,18 +45,17 @@
 #include <pcl/common/colors.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> bool
-pcl::visualization::PointCloudColorHandlerCustom<PointT>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+template <typename PointT> vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerCustom<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
-  
+
   vtkIdType nr_points = cloud_->points.size ();
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
 
   // Get a random color
   unsigned char* colors = new unsigned char[nr_points * 3];
@@ -68,23 +67,22 @@ pcl::visualization::PointCloudColorHandlerCustom<PointT>::getColor (vtkSmartPoin
     colors[cp * 3 + 1] = static_cast<unsigned char> (g_);
     colors[cp * 3 + 2] = static_cast<unsigned char> (b_);
   }
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
-  return (true);
+  scalars->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> bool
-pcl::visualization::PointCloudColorHandlerRandom<PointT>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+template <typename PointT> vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerRandom<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
-  
+
   vtkIdType nr_points = cloud_->points.size ();
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
 
   // Get a random color
   unsigned char* colors = new unsigned char[nr_points * 3];
@@ -102,8 +100,8 @@ pcl::visualization::PointCloudColorHandlerRandom<PointT>::getColor (vtkSmartPoin
     colors[cp * 3 + 1] = static_cast<unsigned char> (g_);
     colors[cp * 3 + 2] = static_cast<unsigned char> (b_);
   }
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
-  return (true);
+  scalars->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -130,12 +128,12 @@ pcl::visualization::PointCloudColorHandlerRGBField<PointT>::setInputCloud (
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> bool
-pcl::visualization::PointCloudColorHandlerRGBField<PointT>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+template <typename PointT> vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerRGBField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
-  
+    return nullptr;
+
    // Get the RGB field index
   std::vector<pcl::PCLPointField> fields;
   int rgba_index = -1;
@@ -145,13 +143,12 @@ pcl::visualization::PointCloudColorHandlerRGBField<PointT>::getColor (vtkSmartPo
 
   int rgba_offset = fields[rgba_index].offset;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
 
   vtkIdType nr_points = cloud_->points.size ();
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
-  unsigned char* colors = reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->GetPointer (0);
+  scalars->SetNumberOfTuples (nr_points);
+  unsigned char* colors = scalars->GetPointer (0);
 
   int j = 0;
   // If XYZ present, check if the points are invalid
@@ -191,7 +188,7 @@ pcl::visualization::PointCloudColorHandlerRGBField<PointT>::getColor (vtkSmartPo
       colors[idx + 2] = rgb.b;
     }
   }
-  return (true);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -226,19 +223,18 @@ pcl::visualization::PointCloudColorHandlerHSVField<PointT>::PointCloudColorHandl
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> bool
-pcl::visualization::PointCloudColorHandlerHSVField<PointT>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+template <typename PointT> vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerHSVField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
 
   vtkIdType nr_points = cloud_->points.size ();
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
-  unsigned char* colors = reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->GetPointer (0);
+  scalars->SetNumberOfTuples (nr_points);
+  unsigned char* colors = scalars->GetPointer (0);
 
   int idx = 0;
   // If XYZ present, check if the points are invalid
@@ -360,7 +356,7 @@ pcl::visualization::PointCloudColorHandlerHSVField<PointT>::getColor (vtkSmartPo
       idx +=3;
     }
   }
-  return (true);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -377,18 +373,17 @@ pcl::visualization::PointCloudColorHandlerGenericField<PointT>::setInputCloud (
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> bool
-pcl::visualization::PointCloudColorHandlerGenericField<PointT>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+template <typename PointT> vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerGenericField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkFloatArray>::New ();
+  auto scalars = vtkSmartPointer<vtkFloatArray>::New ();
   scalars->SetNumberOfComponents (1);
 
   vtkIdType nr_points = cloud_->points.size ();
-  reinterpret_cast<vtkFloatArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
 
   using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
@@ -433,8 +428,8 @@ pcl::visualization::PointCloudColorHandlerGenericField<PointT>::getColor (vtkSma
       j++;
     }
   }
-  reinterpret_cast<vtkFloatArray*>(&(*scalars))->SetArray (colors, j, 0, vtkFloatArray::VTK_DATA_ARRAY_DELETE);
-  return (true);
+  scalars->SetArray (colors, j, 0, vtkFloatArray::VTK_DATA_ARRAY_DELETE);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -452,19 +447,18 @@ pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::setInputCloud (
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> bool
-pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+template <typename PointT> vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (4);
 
   vtkIdType nr_points = cloud_->points.size ();
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
-  unsigned char* colors = reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->GetPointer (0);
+  scalars->SetNumberOfTuples (nr_points);
+  unsigned char* colors = scalars->GetPointer (0);
 
   int j = 0;
   // If XYZ present, check if the points are invalid
@@ -503,7 +497,7 @@ pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::getColor (vtkSmartP
       colors[idx + 3] = cloud_->points[cp].a;
     }
   }
-  return (true);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -520,19 +514,18 @@ pcl::visualization::PointCloudColorHandlerLabelField<PointT>::setInputCloud (con
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> bool
-pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+template <typename PointT> vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
 
   vtkIdType nr_points = cloud_->points.size ();
-  reinterpret_cast<vtkUnsignedCharArray*> (&(*scalars))->SetNumberOfTuples (nr_points);
-  unsigned char* colors = reinterpret_cast<vtkUnsignedCharArray*> (&(*scalars))->GetPointer (0);
+  scalars->SetNumberOfTuples (nr_points);
+  unsigned char* colors = scalars->GetPointer (0);
 
 
   std::map<uint32_t, pcl::RGB> colormap;
@@ -562,7 +555,7 @@ pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor (vtkSmart
     }
   }
 
-  return (true);
+  return scalars;
 }
 
 #endif      // PCL_POINT_CLOUD_COLOR_HANDLERS_IMPL_HPP_

--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -96,13 +96,29 @@ namespace pcl
         virtual std::string
         getFieldName () const = 0;
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
+        /** Obtain the actual color for the input dataset as a VTK data array.
+          * Deriving handlers should override this method. The default implementation is
+          * provided only for backwards compatibility with handlers that were written
+          * before PCL 1.10.0 and will be removed in future.
+          * \return smart pointer to VTK array if the operation was successful (the
+          * handler is capable and the input cloud was given), a null pointer otherwise */
+        virtual vtkSmartPointer<vtkDataArray>
+        getColor () const {
+          vtkSmartPointer<vtkDataArray> scalars;
+          getColor (scalars);
+          return scalars;
+        }
+
+        /** Obtain the actual color for the input dataset as a VTK data array.
+          * This virtual method should not be overriden or used. The default implementation
+          * is provided only for backwards compatibility with handlers that were written
+          * before PCL 1.10.0 and will be removed in future. */
+        [[deprecated("use getColor() without parameters instead")]]
         virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const = 0;
+        getColor (vtkSmartPointer<vtkDataArray> &scalars) const {
+          scalars = getColor ();
+          return scalars.Get() != nullptr;
+        }
 
         /** \brief Set the input cloud to be used.
           * \param[in] cloud the input cloud to be used by the handler
@@ -167,13 +183,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return ("[random]"); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<PointT>::getColor;
 
       protected:
         // Members derived from the base class
@@ -230,13 +243,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return (""); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<PointT>::getColor;
 
       protected:
         // Members derived from the base class
@@ -284,13 +294,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return ("rgb"); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<PointT>::getColor;
 
         /** \brief Set the input cloud to be used.
           * \param[in] cloud the input cloud to be used by the handler
@@ -337,13 +344,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return ("hsv"); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<PointT>::getColor;
 
       protected:
         /** \brief Class getName method. */
@@ -402,13 +406,10 @@ namespace pcl
         /** \brief Get the name of the field used. */
         virtual std::string getFieldName () const { return (field_name_); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<PointT>::getColor;
 
         /** \brief Set the input cloud to be used.
           * \param[in] cloud the input cloud to be used by the handler
@@ -469,13 +470,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return ("rgba"); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<PointT>::getColor;
 
         /** \brief Set the input cloud to be used.
           * \param[in] cloud the input cloud to be used by the handler
@@ -539,13 +537,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return ("label"); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<PointT>::getColor;
 
         /** \brief Set the input cloud to be used.
           * \param[in] cloud the input cloud to be used by the handler
@@ -603,13 +598,29 @@ namespace pcl
         virtual std::string
         getFieldName () const = 0;
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
+        /** Obtain the actual color for the input dataset as a VTK data array.
+          * Deriving handlers should override this method. The default implementation is
+          * provided only for backwards compatibility with handlers that were written
+          * before PCL 1.10.0 and will be removed in future.
+          * \return smart pointer to VTK array if the operation was successful (the
+          * handler is capable and the input cloud was given), a null pointer otherwise */
+        virtual vtkSmartPointer<vtkDataArray>
+        getColor () const {
+          vtkSmartPointer<vtkDataArray> scalars;
+          getColor (scalars);
+          return scalars;
+        }
+
+        /** Obtain the actual color for the input dataset as a VTK data array.
+          * This virtual method should not be overriden or used. The default implementation
+          * is provided only for backwards compatibility with handlers that were written
+          * before PCL 1.10.0 and will be removed in future. */
+        [[deprecated("use getColor() without parameters instead")]]
         virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const = 0;
+        getColor (vtkSmartPointer<vtkDataArray> &scalars) const {
+          scalars = getColor ();
+          return scalars.Get() != nullptr;
+        }
 
         /** \brief Set the input cloud to be used.
           * \param[in] cloud the input cloud to be used by the handler
@@ -667,13 +678,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return ("[random]"); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<pcl::PCLPointCloud2>::getColor;
     };
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -710,13 +718,10 @@ namespace pcl
         virtual std::string
         getFieldName () const { return (""); }
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<pcl::PCLPointCloud2>::getColor;
 
       protected:
         /** \brief Internal R, G, B holding the values given by the user. */
@@ -746,13 +751,10 @@ namespace pcl
         /** \brief Empty destructor */
         virtual ~PointCloudColorHandlerRGBField () {}
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<pcl::PCLPointCloud2>::getColor;
 
       protected:
         /** \brief Get the name of the class. */
@@ -786,13 +788,10 @@ namespace pcl
         /** \brief Empty destructor */
         virtual ~PointCloudColorHandlerHSVField () {}
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<pcl::PCLPointCloud2>::getColor;
 
       protected:
         /** \brief Get the name of the class. */
@@ -834,13 +833,10 @@ namespace pcl
         /** \brief Empty destructor */
         virtual ~PointCloudColorHandlerGenericField () {}
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and 
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<pcl::PCLPointCloud2>::getColor;
 
       protected:
         /** \brief Get the name of the class. */
@@ -879,13 +875,10 @@ namespace pcl
         /** \brief Empty destructor */
         virtual ~PointCloudColorHandlerRGBAField () {}
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<pcl::PCLPointCloud2>::getColor;
 
       protected:
         /** \brief Get the name of the class. */
@@ -922,13 +915,10 @@ namespace pcl
         /** \brief Empty destructor */
         virtual ~PointCloudColorHandlerLabelField () {}
 
-        /** \brief Obtain the actual color for the input dataset as vtk scalars.
-          * \param[out] scalars the output scalars containing the color for the dataset
-          * \return true if the operation was successful (the handler is capable and
-          * the input cloud was given as a valid pointer), false otherwise
-          */
-        virtual bool
-        getColor (vtkSmartPointer<vtkDataArray> &scalars) const;
+        vtkSmartPointer<vtkDataArray>
+        getColor () const override;
+
+        using PointCloudColorHandler<pcl::PCLPointCloud2>::getColor;
 
       protected:
         /** \brief Get the name of the class. */

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -699,8 +699,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         // Get the new color
         PointCloudColorHandler<pcl::PCLPointCloud2>::ConstPtr color_handler = act.color_handlers[index];
 
-        vtkSmartPointer<vtkDataArray> scalars;
-        color_handler->getColor (scalars);
+        auto scalars = color_handler->getColor ();
         double minmax[2];
         scalars->GetRange (minmax);
         // Update the data

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -2933,8 +2933,7 @@ pcl::visualization::PCLVisualizer::updateColorHandlerIndex (const std::string &i
   // Get the handler
   PointCloudColorHandler<pcl::PCLPointCloud2>::ConstPtr color_handler = am_it->second.color_handlers[index];
 
-  vtkSmartPointer<vtkDataArray> scalars;
-  color_handler->getColor (scalars);
+  auto scalars = color_handler->getColor ();
   double minmax[2];
   scalars->GetRange (minmax);
   // Update the data
@@ -4052,8 +4051,7 @@ pcl::visualization::PCLVisualizer::fromHandlersToScreen (
   // Get the colors from the handler
   bool has_colors = false;
   double minmax[2];
-  vtkSmartPointer<vtkDataArray> scalars;
-  if (color_handler->getColor (scalars))
+  if (auto scalars = color_handler->getColor ())
   {
     polydata->GetPointData ()->SetScalars (scalars);
     scalars->GetRange (minmax);

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -44,19 +44,18 @@
 #include <pcl/point_types.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl::visualization::PointCloudColorHandlerCustom<pcl::PCLPointCloud2>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerCustom<pcl::PCLPointCloud2>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
-  
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+    return nullptr;
+
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
-  
+
   vtkIdType nr_points = cloud_->width * cloud_->height;
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
-  
+  scalars->SetNumberOfTuples (nr_points);
+
   // Get a random color
   unsigned char* colors = new unsigned char[nr_points * 3];
   
@@ -67,23 +66,22 @@ pcl::visualization::PointCloudColorHandlerCustom<pcl::PCLPointCloud2>::getColor 
     colors[cp * 3 + 1] = static_cast<unsigned char> (g_);
     colors[cp * 3 + 2] = static_cast<unsigned char> (b_);
   }
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
-  return (true);
+  scalars->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl::visualization::PointCloudColorHandlerRandom<pcl::PCLPointCloud2>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerRandom<pcl::PCLPointCloud2>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
-  
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+    return nullptr;
+
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
-  
+
   vtkIdType nr_points = cloud_->width * cloud_->height;
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
   
   // Get a random color
   unsigned char* colors = new unsigned char[nr_points * 3];
@@ -99,8 +97,8 @@ pcl::visualization::PointCloudColorHandlerRandom<pcl::PCLPointCloud2>::getColor 
     colors[cp * 3 + 1] = static_cast<unsigned char> (g_);
     colors[cp * 3 + 2] = static_cast<unsigned char> (b_);
   }
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
-  return (true);
+  scalars->SetArray (colors, 3 * nr_points, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -126,18 +124,17 @@ pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2>::PointCl
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
 
   vtkIdType nr_points = cloud_->width * cloud_->height;
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
   // Allocate enough memory to hold all colors
   unsigned char* colors = new unsigned char[nr_points * 3];
 
@@ -189,11 +186,11 @@ pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2>::getColo
     }
   }
   if (j != 0)
-    reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+    scalars->SetArray (colors, j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
   else
-    reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (0);
+    scalars->SetNumberOfTuples (0);
   //delete [] colors;
-  return (true);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -229,18 +226,17 @@ pcl::visualization::PointCloudColorHandlerHSVField<pcl::PCLPointCloud2>::PointCl
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl::visualization::PointCloudColorHandlerHSVField<pcl::PCLPointCloud2>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerHSVField<pcl::PCLPointCloud2>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
 
   vtkIdType nr_points = cloud_->width * cloud_->height;
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
 
   // Allocate enough memory to hold all colors
   // colors is taken over by SetArray (line 419)
@@ -416,8 +412,8 @@ pcl::visualization::PointCloudColorHandlerHSVField<pcl::PCLPointCloud2>::getColo
     }
   }
   // Set array takes over allocation (Set save to 1 to keep the class from deleting the array when it cleans up or reallocates memory.)
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, 3 * j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
-  return (true);
+  scalars->SetArray (colors, 3 * j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -435,18 +431,17 @@ pcl::visualization::PointCloudColorHandlerGenericField<pcl::PCLPointCloud2>::Poi
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl::visualization::PointCloudColorHandlerGenericField<pcl::PCLPointCloud2>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerGenericField<pcl::PCLPointCloud2>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkFloatArray>::New ();
+  auto scalars = vtkSmartPointer<vtkFloatArray>::New ();
   scalars->SetNumberOfComponents (1);
 
   vtkIdType nr_points = cloud_->width * cloud_->height;
-  reinterpret_cast<vtkFloatArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
 
   float* colors = new float[nr_points];
   float field_data;
@@ -493,8 +488,8 @@ pcl::visualization::PointCloudColorHandlerGenericField<pcl::PCLPointCloud2>::get
       j++;
     }
   }
-  reinterpret_cast<vtkFloatArray*>(&(*scalars))->SetArray (colors, j, 0, vtkFloatArray::VTK_DATA_ARRAY_DELETE);
-  return (true);
+  scalars->SetArray (colors, j, 0, vtkFloatArray::VTK_DATA_ARRAY_DELETE);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -511,18 +506,17 @@ pcl::visualization::PointCloudColorHandlerRGBAField<pcl::PCLPointCloud2>::PointC
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl::visualization::PointCloudColorHandlerRGBAField<pcl::PCLPointCloud2>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerRGBAField<pcl::PCLPointCloud2>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (4);
 
   vtkIdType nr_points = cloud_->width * cloud_->height;
-  reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
   // Allocate enough memory to hold all colors
   unsigned char* colors = new unsigned char[nr_points * 4];
 
@@ -576,11 +570,11 @@ pcl::visualization::PointCloudColorHandlerRGBAField<pcl::PCLPointCloud2>::getCol
     }
   }
   if (j != 0)
-    reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+    scalars->SetArray (colors, j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
   else
-    reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (0);
+    scalars->SetNumberOfTuples (0);
   //delete [] colors;
-  return (true);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -597,18 +591,17 @@ pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::Point
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getColor (vtkSmartPointer<vtkDataArray> &scalars) const
+vtkSmartPointer<vtkDataArray>
+pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getColor () const
 {
   if (!capable_ || !cloud_)
-    return (false);
+    return nullptr;
 
-  if (!scalars)
-    scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
+  auto scalars = vtkSmartPointer<vtkUnsignedCharArray>::New ();
   scalars->SetNumberOfComponents (3);
 
   vtkIdType nr_points = cloud_->width * cloud_->height;
-  reinterpret_cast<vtkUnsignedCharArray*> (&(*scalars))->SetNumberOfTuples (nr_points);
+  scalars->SetNumberOfTuples (nr_points);
   // Allocate enough memory to hold all colors
   unsigned char* colors = new unsigned char[nr_points * 3];
 
@@ -679,11 +672,11 @@ pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getCo
     }
   }
   if (j != 0)
-    reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetArray (colors, j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
+    scalars->SetArray (colors, j, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
   else
-    reinterpret_cast<vtkUnsignedCharArray*>(&(*scalars))->SetNumberOfTuples (0);
+    scalars->SetNumberOfTuples (0);
   //delete [] colors;
-  return (true);
+  return scalars;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add `PointCloudColorHandler::getColor()` that returns VTK data array and deprecate old `getColor(vtkSmartPointer<vtkUnsignedCharArray>&)` in its favor. Follow-up to the discussion in #3176.

In the process of implementing my propsal from #3176 I realized that we can not change the signature to use `vtkSmartPointer<vtkUnsignedCharArray>` since some of the handlers actually produce arrays of `float`s. However, the idea to always allocate data array inside `getColor()` and return it as a smart pointer was implementable, so here we go.

Note the two default implementations of `getColor` in the base that are provided for backwards compatibility. They use each other, which may seem like a circular reference, however in practice should not be a problem. The reason to implement them this way is to support two use-cases in downstream projects:
 1. Custom user-defined handlers. Such handlers certainly override the "old" `getColor` (because it was pure virtual, thus required to be overriden). Therefore the "new" `getColor` calls these implementations, and there is no circular reference.
 2. Usage of now-deprecated `getColor` in user code. In case it's a PCL color handler, the default implementation of "old" `getColor` will call the new `getColor`, which is overriden in every PCL color handler, so again no circular reference. In case it's a user color handler, according to item 1 it will again have its own override of the "old" `getColor`, so no circular references.