### PR TITLE
Adding support for compilation target 'format'

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+---
+AlwaysBreakAfterReturnType: All
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterFunction: true
+  AfterClass: false
+  AfterStruct: false
+  BeforeElse: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBraces: Custom
+BreakConstructorInitializers: BeforeComma
+ColumnLimit: 88
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 0
+Language: Cpp
+PointerAlignment: Left
+Standard: Cpp11
+TabWidth: 2
+UseTab: Never

--- a/.dev/format.sh
+++ b/.dev/format.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env sh
+
+# sample command line usage: $0 clang-format(version >= 6.0) $PCL_SOURCE_DIR
+# $ sh ./.dev/format.sh `which clang-format` ./
+# $ sh format.sh `which clang-format` ../
+# $ sh ~/pcl/format.sh `which clang-format` ~/pcl
+# $ sh /pcl/format.sh `which clang-format` /pcl
+
+format() {
+    # don't use a directory with whitespace
+    local whitelist="2d cuda gpu ml simulation stereo tracking"
+
+    local PCL_DIR="${2}"
+    local formatter="${1}"
+
+    if [ ! -f "${formatter}" ]; then
+        echo "Could not find a clang-format. Please specify one as the first argument"
+        exit 166
+    fi
+
+    # check for self
+    if [ ! -f "${PCL_DIR}/.dev/format.sh" ]; then
+        echo "Please ensure that PCL_SOURCE_DIR is passed as the second argument"
+        exit 166
+    fi
+
+    for dir in ${whitelist}; do
+        path=${PCL_DIR}/${dir}
+        find ${path} -type f -iname *.[ch] -o -iname *.[ch]pp -o -iname *.[ch]xx \
+            -iname *.cu | xargs -n1 ${formatter} -i -style=file
+    done
+}
+
+format $@

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ endif()
 include("${PCL_SOURCE_DIR}/cmake/pcl_verbosity.cmake")
 include("${PCL_SOURCE_DIR}/cmake/pcl_targets.cmake")
 include("${PCL_SOURCE_DIR}/cmake/pcl_options.cmake")
+include("${PCL_SOURCE_DIR}/cmake/clang-format.cmake")
 
 # Enable verbose timing display?
 if(CMAKE_TIMING_VERBOSE AND UNIX)

--- a/cmake/Modules/FindClangFormat.cmake
+++ b/cmake/Modules/FindClangFormat.cmake
@@ -1,0 +1,72 @@
+#
+# .rst: FindClangFormat
+# ---------------
+#
+# The module defines the following variables
+#
+# ``ClangFormat_EXECUTABLE`` Path to clang-format executable
+# ``ClangFormat_FOUND`` True if the clang-format executable was found.
+# ``ClangFormat_VERSION`` The version of clang-format found
+#
+# Example usage:
+#
+# .. code-block:: cmake
+#
+# find_package(ClangFormat) 
+# if(ClangFormat_FOUND)
+# message("clang-format executable found: ${ClangFormat_EXECUTABLE}\n"
+#         "version: ${ClangFormat_VERSION}") 
+# endif()
+
+find_program(ClangFormat_EXECUTABLE
+             NAMES
+                   clang-format-9
+                   clang-format-9.0
+                   clang-format-8
+                   clang-format-8.0
+                   clang-format-7
+                   clang-format-7.0
+                   clang-format-6.0
+                   clang-format-5.0
+                   clang-format-4.0
+                   clang-format-3.9
+                   clang-format-3.8
+                   clang-format-3.7
+                   clang-format-3.6
+                   clang-format-3.5
+                   clang-format-3.4
+                   clang-format-3.3
+                   clang-format  # least priority
+             DOC "clang-format executable")
+mark_as_advanced(ClangFormat_EXECUTABLE)
+
+# Extract version from command "clang-format -version"
+if(ClangFormat_EXECUTABLE)
+  execute_process(COMMAND ${ClangFormat_EXECUTABLE} -version
+                  OUTPUT_VARIABLE clang_format_version
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+set(version_regex "^.*clang-format version ([.0-9]+).*")
+if(clang_format_version MATCHES ${version_regex})
+  # clang_format_version samples:
+  # * clang-format version 3.9.1-4ubuntu3~16.04.1 (tags/RELEASE_391/rc2)
+  # * Alpine clang-format version 8.0.0 (tags/RELEASE_800/final) (based on LLVM 8.0.0)
+  string(REGEX
+          REPLACE ${version_regex}
+                  "\\1"
+                  ClangFormat_VERSION
+                  "${clang_format_version}")
+  # ClangFormat_VERSION sample: "3.9.1", "8.0.0"
+endif()
+unset(clang_format_version)
+unset(version_regex)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  ClangFormat
+  REQUIRED_VARS
+    ClangFormat_EXECUTABLE
+    ClangFormat_VERSION
+  VERSION_VAR
+    ClangFormat_VERSION
+)

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,0 +1,12 @@
+find_package(ClangFormat 6)
+# search for version number in clang-format without version number
+if(ClangFormat_FOUND)
+  message(STATUS "Adding target 'format'")
+  add_custom_target(
+  format
+  COMMAND sh 
+    ${PCL_SOURCE_DIR}/.dev/format.sh
+    ${ClangFormat_EXECUTABLE}
+    ${PCL_SOURCE_DIR}
+  )
+endif()


### PR DESCRIPTION
* `.clang-format` file added from details gleaned via website. PTAL
* Added cmake file to keep clang-format detection an target addition separate
* Changed main CMakeLists.txt to include said cmake file

TODO:
Compile and test on:
* [x] ubuntu:18.04 + make
* [x] ubuntu:18.04 + ninja (Not a blocker. Makes incremental builds faster, and I like it)
* [ ] alpine:edge (CMake config currently failing)
* [ ] any others?

Please run `cmake` and check if `make format` is correct as per the standards.

It modifies all the files, including `doc`, `tools`, `test`, `outofcore`, `examples`, .... `*/3rd_party` so that might not be the desired behavior or whatever reason. Though we do own all code in the repo and it should be ok to format it as per the guidelines.

## Executive summary

This PR adds:
  * A new clang-format config decided upon in #3190. This config defines the new PCL style guide. The [old document](http://www.pointclouds.org/documentation/advanced/pcl_style_guide.php) with "verbal" description of the style is thus obsoleted and has to be updated.
  * A shell script that formats PCL codebase using `clang-format`. This is not intended to be used by developers directly.
  * A make target `format` that formats PCL codebase. This is to be used by developers.

At the moment formatting will only be applied to a selected list of PCL modules. This while listing will be removed after the "testing period" is over.

Closes #3190, #2106, and #2376 (obsoleted).