### PR TITLE
Include pcl_config.h before checking HAVE_OPENNI2

### DIFF
--- a/io/include/pcl/io/openni2_grabber.h
+++ b/io/include/pcl/io/openni2_grabber.h
@@ -38,9 +38,10 @@
  */
 
 #pragma once
- 
-#ifdef HAVE_OPENNI2
+
 #include <pcl/pcl_config.h>
+
+#ifdef HAVE_OPENNI2
 
 #include <pcl/io/eigen.h>
 #include <pcl/io/boost.h>

--- a/io/include/pcl/io/openni_grabber.h
+++ b/io/include/pcl/io/openni_grabber.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+
 #ifdef HAVE_OPENNI
 
 #include <pcl/io/eigen.h>


### PR DESCRIPTION
Fixes an issue discovered in #3176.