### PR TITLE
[ci] Navigate to test folder before running ctest

### DIFF
--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -46,7 +46,7 @@ jobs:
           cmake --build . -- test_filters test_registration test_registration_api
           cmake --build . -- -j2
         displayName: 'Build Library'
-      - script: cd $BUILD_DIR && ctest -V -T Test
+      - script: cd $BUILD_DIR/test && ctest -V -T Test
         displayName: 'Run Unit Tests'
       - task: PublishTestResults@2
         inputs:

--- a/.ci/azure-pipelines/build-ubuntu.yml
+++ b/.ci/azure-pipelines/build-ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
           cmake --build . -- -j2
         displayName: 'Build Library'
       - script: |
-          cd $BUILD_DIR
+          cd $BUILD_DIR/test
           ctest -V -T Test
         displayName: 'Run Unit Tests'
       - task: PublishTestResults@2


### PR DESCRIPTION
Hopefully, it fixes #3200. In my platform, invoking `ctest` from the build folder also produces the same results. We need to navigate to `build/test` first.
