### PR TITLE
Add emplace[_back] to pcl::PointCloud

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -486,13 +486,15 @@ namespace pcl
       /** \brief Emplace a new point in the cloud, at the end of the container.
         * \note This breaks the organized structure of the cloud by setting the height to 1!
         * \param[in] args the parameters to forward to the point to construct
+        * \return reference to the emplaced point
         */
-      template <class... Args> inline void
+      template <class... Args> inline reference
       emplace_back (Args&& ...args)
       {
         points.emplace_back (std::forward<Args> (args)...);
         width = static_cast<uint32_t> (points.size ());
         height = 1;
+        return points.back();
       }
 
       /** \brief Insert a new point in the cloud, given an iterator.

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -47,6 +47,7 @@
 #include <pcl/PCLHeader.h>
 #include <pcl/exceptions.h>
 #include <pcl/point_traits.h>
+#include <utility>
 
 namespace pcl
 {

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -483,6 +483,18 @@ namespace pcl
         height = 1;
       }
 
+      /** \brief Emplace a new point in the cloud, at the end of the container.
+        * \note This breaks the organized structure of the cloud by setting the height to 1!
+        * \param[in] args the parameters to forward to the point to construct
+        */
+      template <class... Args> inline void
+      emplace_back (Args&& ...args)
+      {
+        points.emplace_back (std::forward<Args> (args)...);
+        width = static_cast<uint32_t> (points.size ());
+        height = 1;
+      }
+
       /** \brief Insert a new point in the cloud, given an iterator.
         * \note This breaks the organized structure of the cloud by setting the height to 1!
         * \param[in] position where to insert the point
@@ -524,6 +536,21 @@ namespace pcl
         points.insert (position, first, last);
         width = static_cast<uint32_t> (points.size ());
         height = 1;
+      }
+
+      /** \brief Emplace a new point in the cloud, given an iterator.
+        * \note This breaks the organized structure of the cloud by setting the height to 1!
+        * \param[in] position iterator before which the point will be emplaced
+        * \param[in] args the parameters to forward to the point to construct
+        * \return returns the new position iterator
+        */
+      template <class... Args> inline iterator
+      emplace (iterator position, Args&& ...args)
+      {
+        iterator it = points.emplace (position, std::forward<Args> (args)...);
+        width = static_cast<uint32_t> (points.size ());
+        height = 1;
+        return (it);
       }
 
       /** \brief Erase a point in the cloud.

--- a/test/common/test_common.cpp
+++ b/test/common/test_common.cpp
@@ -279,9 +279,11 @@ TEST (PCL, PointCloud)
   EXPECT_EQ (cloud.isOrganized (), false);
   EXPECT_EQ (cloud.width, 1);
 
-  cloud.emplace_back (1, 1, 1);
+  auto& new_point = cloud.emplace_back (1, 1, 1);
   EXPECT_EQ (cloud.isOrganized (), false);
   EXPECT_EQ (cloud.width, 2);
+  EXPECT_EQ (new_point, cloud.back ());
+  EXPECT_EQ (&new_point, &cloud.back ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/common/test_common.cpp
+++ b/test/common/test_common.cpp
@@ -282,7 +282,6 @@ TEST (PCL, PointCloud)
   auto& new_point = cloud.emplace_back (1, 1, 1);
   EXPECT_EQ (cloud.isOrganized (), false);
   EXPECT_EQ (cloud.width, 2);
-  EXPECT_EQ (new_point, cloud.back ());
   EXPECT_EQ (&new_point, &cloud.back ());
 }
 

--- a/test/common/test_common.cpp
+++ b/test/common/test_common.cpp
@@ -89,8 +89,8 @@ TEST (PCL, PointXYZRGBNormal)
   PointXYZRGBNormal p;
 
   uint8_t r = 127, g = 64, b = 254;
-  uint32_t rgb = (static_cast<uint32_t> (r) << 16 | 
-                  static_cast<uint32_t> (g) << 8 | 
+  uint32_t rgb = (static_cast<uint32_t> (r) << 16 |
+                  static_cast<uint32_t> (g) << 8 |
                   static_cast<uint32_t> (b));
   p.rgba = rgb;
 
@@ -217,7 +217,7 @@ TEST (PCL, PointCloud)
     EXPECT_EQ (mat_xyz (0, 0), 0);
     EXPECT_EQ (mat_xyz (2, cloud.width - 1), 3 * cloud.width - 1);    // = 29
   }
-  
+
 #ifdef NDEBUG
   if (Eigen::MatrixXf::Flags & Eigen::RowMajorBit)
   {
@@ -274,6 +274,14 @@ TEST (PCL, PointCloud)
   cloud.erase (cloud.begin (), cloud.end ());
   EXPECT_EQ (cloud.isOrganized (), false);
   EXPECT_EQ (cloud.width, 0);
+
+  cloud.emplace (cloud.end (), 1, 1, 1);
+  EXPECT_EQ (cloud.isOrganized (), false);
+  EXPECT_EQ (cloud.width, 1);
+
+  cloud.emplace_back (1, 1, 1);
+  EXPECT_EQ (cloud.isOrganized (), false);
+  EXPECT_EQ (cloud.width, 2);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -391,7 +399,7 @@ TEST (PCL, CopyIfFieldExists)
   p.normal_x = 1.0; p.normal_y = 0.0; p.normal_z = 0.0;
 
   using FieldList = pcl::traits::fieldList<PointXYZRGBNormal>::type;
-  bool is_x = false, is_y = false, is_z = false, is_rgb = false, 
+  bool is_x = false, is_y = false, is_z = false, is_rgb = false,
        is_normal_x = false, is_normal_y = false, is_normal_z = false;
 
   float x_val, y_val, z_val, normal_x_val, normal_y_val, normal_z_val, rgb_val;
@@ -422,7 +430,7 @@ TEST (PCL, CopyIfFieldExists)
   pcl::for_each_type<FieldList> (CopyIfFieldExists<PointXYZRGBNormal, float> (p, "normal_z", is_normal_z, normal_z_val));
   EXPECT_EQ (is_normal_z, true);
   EXPECT_EQ (normal_z_val, 0.0);
-  
+
   pcl::for_each_type<FieldList> (CopyIfFieldExists<PointXYZRGBNormal, float> (p, "x", x_val));
   EXPECT_EQ (x_val, 1.0);
 
@@ -479,7 +487,7 @@ TEST (PCL, IsSamePointType)
   EXPECT_FALSE (status);
   status = isSamePointType<PointXYZRGB, PointXYZRGB> ();
   EXPECT_TRUE (status);
-  
+
   // Even though it's the "same" type, rgb != rgba
   status = isSamePointType<PointXYZRGB, PointXYZRGBA> ();
   EXPECT_FALSE (status);


### PR DESCRIPTION
Here is the pull request to implement #3204. It's my first time contributing to PCL, so I opened this pull request quite soon to ask questions about contribution. First of all, I haven't run the tests because I'm not sure how to run the test suite just yet, I merely know that it uses Google Test, and I suppose that there is an option in the CMakeLists.txt to run the test (consider it untested code pushed for the sake of the pull request). Anyway, here are my more specific questions & remarks:
* I couldn't find any variadic templates in PCL so far, is the formatting ok or would you like the spaces in other places.
* Is the documentation enough?
* Since C++17, `std::vector::emplace_back` returns a reference to the inserted element, but since the next version of PCL targets C++14, I couldn't really implement that short of querying the emplaced element before returning it. Is it okay or do you want the function to return a reference?
* I hesitated to `#include <utility>` but it seems that the whole file doesn't care much about include standard or Boost headers, so I decided to leave it out.
* Have I missed anything?

That's pretty much it. My IDE automatically removes the blank characters at the end of lines, I hope that it isn't too much noise.