### PR TITLE
Supress -Wformat-security warnings.

### DIFF
--- a/gpu/kinfu/tools/capture.cpp
+++ b/gpu/kinfu/tools/capture.cpp
@@ -136,8 +136,8 @@ pcl::gpu::CaptureOpenNI::open (int device)
   XnLicense license;
   const char* vendor = "PrimeSense";
   const char* key = "0KOIk2JeIBYClPWVnMoRKn5cdY4=";
-  sprintf (license.strKey, key);
-  sprintf (license.strVendor, vendor);
+  strncpy (license.strKey, key, sizeof (license.strKey));
+  strncpy (license.strVendor, vendor, sizeof (license.strVendor));
 
   rc = impl_->context.AddLicense (license);
   if (rc != XN_STATUS_OK)

--- a/gpu/kinfu_large_scale/tools/capture.cpp
+++ b/gpu/kinfu_large_scale/tools/capture.cpp
@@ -136,8 +136,8 @@ pcl::gpu::kinfuLS::CaptureOpenNI::open (int device)
   XnLicense license;
   const char* vendor = "PrimeSense";
   const char* key = "0KOIk2JeIBYClPWVnMoRKn5cdY4=";
-  sprintf (license.strKey, key);
-  sprintf (license.strVendor, vendor);
+  strncpy (license.strKey, key, sizeof (license.strKey));
+  strncpy (license.strVendor, vendor, sizeof (license.strVendor));
 
   rc = impl_->context.AddLicense (license);
   if (rc != XN_STATUS_OK)


### PR DESCRIPTION
This PR suppresses the following warnings
```
[229/437] Building CXX object gpu/kinfu/tools/CMakeFiles/pcl_record_tsdfvolume.dir/capture.cpp.o
../gpu/kinfu/tools/capture.cpp:139:28: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  sprintf (license.strKey, key);
                           ^~~
../gpu/kinfu/tools/capture.cpp:139:28: note: treat the string as an argument to avoid this
  sprintf (license.strKey, key);
                           ^
                           "%s", 
../gpu/kinfu/tools/capture.cpp:140:31: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  sprintf (license.strVendor, vendor);
                              ^~~~~~
../gpu/kinfu/tools/capture.cpp:140:31: note: treat the string as an argument to avoid this
  sprintf (license.strVendor, vendor);
                              ^
                              "%s", 
2 warnings generated.
[251/437] Building NVCC (Device) object gpu/kinfu_large_scale/CMakeFiles/cuda_compile_1.dir/src/cuda/cuda_compile_1_generated_pointer_shift.cu.o
/Users/neglective/Development/3rdparty/pcl/gpu/kinfu_large_scale/src/cuda/pointer_shift.cu(4): warning: function "shift_tsdf_pointer" was declared but never referenced

[294/437] Building CXX object gpu/kinfu_large_scale/tools/CMakeFiles/pcl_kinfu_largeScale.dir/capture.cpp.o
../gpu/kinfu_large_scale/tools/capture.cpp:139:28: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  sprintf (license.strKey, key);
                           ^~~
../gpu/kinfu_large_scale/tools/capture.cpp:139:28: note: treat the string as an argument to avoid this
  sprintf (license.strKey, key);
                           ^
                           "%s", 
../gpu/kinfu_large_scale/tools/capture.cpp:140:31: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  sprintf (license.strVendor, vendor);
                              ^~~~~~
../gpu/kinfu_large_scale/tools/capture.cpp:140:31: note: treat the string as an argument to avoid this
  sprintf (license.strVendor, vendor);
                              ^
                              "%s", 
2 warnings generated.
```
According to https://documentation.help/OpenNI/struct_xn_license.html, both `XnLicense::strKey` and `XnLicense::strVendor` are fixed sized char arrays. 