### PR TITLE
Enable building Ensenso tutorial on Azure

### DIFF
--- a/.ci/azure-pipelines/tutorials.yml
+++ b/.ci/azure-pipelines/tutorials.yml
@@ -14,7 +14,7 @@ jobs:
       BUILD_DIR: '$(Agent.BuildDirectory)/build'
       INSTALL_DIR: '$(Agent.BuildDirectory)/install'
       CMAKE_CXX_FLAGS: '-Wall -Wextra -Wabi -O2'
-      EXCLUDE_TUTORIALS: 'davidsdk,ensenso_cameras,gpu'
+      EXCLUDE_TUTORIALS: 'davidsdk,gpu'
     steps:
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR


### PR DESCRIPTION
I've pushed an updated Docker image with EnsensoSDK. Grabber build is enabled by default, so this PR only turns on the corresponding tutorial.

Closes  #3221.