### PR TITLE
Add cloexec option to fopen (part 2)

### DIFF
--- a/gpu/people/src/face_detector.cpp
+++ b/gpu/people/src/face_detector.cpp
@@ -379,7 +379,7 @@ pcl::gpu::people::FaceDetector::loadFromNVBIN(const std::string &filename,
                                std::vector<HaarFeature64> &haar_features)
 {
     size_t readCount;
-    FILE *fp = fopen(filename.c_str(), "rb");
+    FILE *fp = fopen(filename.c_str(), "rbe");
     ncvAssertReturn(fp != nullptr, NCV_FILE_ERROR);
     Ncv32u fileVersion;
     readCount = fread(&fileVersion, sizeof(Ncv32u), 1, fp);
@@ -500,7 +500,7 @@ pcl::gpu::people::FaceDetector::ncvHaarGetClassifierSize(const std::string &file
 
     if (fext == "nvbin")
     {
-        FILE *fp = fopen(filename.c_str(), "rb");
+        FILE *fp = fopen(filename.c_str(), "rbe");
         PCL_ASSERT_ERROR_PRINT_RETURN(fp != nullptr, "Return NCV_FILE_ERROR", NCV_FILE_ERROR);
         Ncv32u fileVersion;
         size_t readCount = fread(&fileVersion, sizeof(Ncv32u), 1, fp);


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,android-cloexec-fopen' -fix`

I don't know why this wasn't found in #2755 (maybe because I use clang-tidy-8 instead of clang-tidy-6 now). Found this during running all android checks again, because there are two new checks in official list.