### PR TITLE
Add missing std::move or const reference for parameter [apps]

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/persistence_utils.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/persistence_utils.h
@@ -11,7 +11,7 @@ namespace pcl
     {
 
       inline bool
-      writeCentroidToFile (std::string file, Eigen::Vector3f & centroid)
+      writeCentroidToFile (const std::string& file, Eigen::Vector3f & centroid)
       {
         std::ofstream out (file.c_str ());
         if (!out)
@@ -27,7 +27,7 @@ namespace pcl
       }
 
       inline bool
-      getCentroidFromFile (std::string file, Eigen::Vector3f & centroid)
+      getCentroidFromFile (const std::string& file, Eigen::Vector3f & centroid)
       {
         std::ifstream in;
         in.open (file.c_str (), std::ifstream::in);
@@ -45,7 +45,7 @@ namespace pcl
       }
 
       inline bool
-      writeMatrixToFile (std::string file, Eigen::Matrix4f & matrix)
+      writeMatrixToFile (const std::string& file, Eigen::Matrix4f & matrix)
       {
         std::ofstream out (file.c_str ());
         if (!out)
@@ -69,7 +69,7 @@ namespace pcl
       }
 
       inline bool
-      writeFloatToFile (std::string file, float value)
+      writeFloatToFile (const std::string& file, float value)
       {
         std::ofstream out (file.c_str ());
         if (!out)
@@ -100,7 +100,7 @@ namespace pcl
       }
 
       inline bool
-      readFloatFromFile (std::string dir, std::string file, float& value)
+      readFloatFromFile (const std::string& dir, std::string file, float& value)
       {
 
         std::vector < std::string > strs;
@@ -126,7 +126,7 @@ namespace pcl
       }
 
       inline bool
-      readFloatFromFile (std::string file, float& value)
+      readFloatFromFile (const std::string& file, float& value)
       {
 
         std::ifstream in;
@@ -191,7 +191,7 @@ namespace pcl
       }
 
       inline bool
-      readMatrixFromFile (std::string file, Eigen::Matrix4f & matrix)
+      readMatrixFromFile (const std::string& file, Eigen::Matrix4f & matrix)
       {
 
         std::ifstream in;
@@ -212,7 +212,7 @@ namespace pcl
       }
 
       inline bool
-      readMatrixFromFile2 (std::string file, Eigen::Matrix4f & matrix)
+      readMatrixFromFile2 (const std::string& file, Eigen::Matrix4f & matrix)
       {
 
         std::ifstream in;

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/vtk_model_sampling.h
@@ -76,7 +76,7 @@ namespace pcl
 
     template<typename PointT>
       inline void
-      uniform_sampling (vtkSmartPointer<vtkPolyData> polydata, size_t n_samples, typename pcl::PointCloud<PointT> & cloud_out)
+      uniform_sampling (const vtkSmartPointer<vtkPolyData>& polydata, size_t n_samples, typename pcl::PointCloud<PointT> & cloud_out)
       {
         polydata->BuildCells ();
         vtkSmartPointer < vtkCellArray > cells = polydata->GetPolys ();
@@ -142,7 +142,7 @@ namespace pcl
       }
 
     inline void
-    getVerticesAsPointCloud (vtkSmartPointer<vtkPolyData> polydata, pcl::PointCloud<pcl::PointXYZ> & cloud_out)
+    getVerticesAsPointCloud (const vtkSmartPointer<vtkPolyData>& polydata, pcl::PointCloud<pcl::PointXYZ> & cloud_out)
     {
       vtkPoints *points = polydata->GetPoints ();
       cloud_out.points.resize (points->GetNumberOfPoints ());

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/commands.h
@@ -81,7 +81,7 @@ namespace pcl
         inline void
         setInputData (ConstItemList input_data)
         {
-          original_data_ = input_data;
+          original_data_ = std::move(input_data);
         }
       protected:
         /** \brief Removes the original item(s) from the model and replaces with the replacement(s)
@@ -89,11 +89,11 @@ namespace pcl
          *  This stores the removed items in removed_items_
          */
         bool 
-        replaceOriginalWithNew (QList <const CloudComposerItem*> originals, QList <CloudComposerItem*> new_items);
+        replaceOriginalWithNew (const QList <const CloudComposerItem*>& originals, const QList <CloudComposerItem*>& new_items);
         
         /** \brief This removes new_items from the model and restores originals */
         bool
-        restoreOriginalRemoveNew (QList <const CloudComposerItem*> originals, QList <CloudComposerItem*> new_items);
+        restoreOriginalRemoveNew (const QList <const CloudComposerItem*>& originals, const QList <CloudComposerItem*>& new_items);
         
         ConstItemList original_data_;
         
@@ -206,7 +206,7 @@ namespace pcl
         redo () override;
         
         inline void
-        setSelectedIndicesMap( const QMap <CloudItem*, pcl::PointIndices::Ptr > selected_item_index_map)
+        setSelectedIndicesMap( const QMap <CloudItem*, pcl::PointIndices::Ptr >& selected_item_index_map)
         {
           selected_item_index_map_ = selected_item_index_map;
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/cloud_item.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/cloud_item.hpp
@@ -64,7 +64,7 @@ pcl::cloud_composer::CloudItem::printNumPoints () const
 
 
 template <typename PointT> pcl::cloud_composer::CloudItem* 
-pcl::cloud_composer::CloudItem::createCloudItemFromTemplate (const QString name, typename PointCloud<PointT>::Ptr cloud_ptr)
+pcl::cloud_composer::CloudItem::createCloudItemFromTemplate (const QString& name, typename PointCloud<PointT>::Ptr cloud_ptr)
 {
   pcl::PCLPointCloud2::Ptr cloud_blob = boost::make_shared <pcl::PCLPointCloud2> ();
   toPCLPointCloud2 (*cloud_ptr, *cloud_blob);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/merge_selection.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/merge_selection.hpp
@@ -43,7 +43,7 @@
 #include <pcl/apps/cloud_composer/impl/cloud_item.hpp>
 
 template <typename PointT> QList <pcl::cloud_composer::CloudComposerItem*>
-pcl::cloud_composer::MergeSelection::performTemplatedAction (QList <const CloudComposerItem*> input_data)
+pcl::cloud_composer::MergeSelection::performTemplatedAction (const QList <const CloudComposerItem*>& input_data)
 {
   QList <CloudComposerItem*> output;  
   

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/transform_clouds.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/impl/transform_clouds.hpp
@@ -44,7 +44,7 @@
 #include <pcl/common/transforms.h>
 
 template <typename PointT> QList <pcl::cloud_composer::CloudComposerItem*>
-pcl::cloud_composer::TransformClouds::performTemplatedAction (QList <const CloudComposerItem*> input_data)
+pcl::cloud_composer::TransformClouds::performTemplatedAction (const QList <const CloudComposerItem*>& input_data)
 {
   QList <CloudComposerItem*> output;  
   

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
@@ -81,7 +81,7 @@ namespace pcl
           FPFH_ITEM
         };
 
-        CloudComposerItem (const QString name = "default item");
+        CloudComposerItem (const QString& name = "default item");
         CloudComposerItem (const CloudComposerItem& to_copy);
         ~CloudComposerItem ();
         
@@ -145,7 +145,7 @@ namespace pcl
     template <class T> class VPtr
     {
       public:
-        static T* asPtr (QVariant v)
+        static T* asPtr (const QVariant& v)
         {
           return (static_cast<T *> (v.value<void *> ()));
         }

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_item.h
@@ -73,7 +73,7 @@ namespace pcl
         PCL_MAKE_ALIGNED_OPERATOR_NEW
         
         CloudItem (const QString name,
-                   const pcl::PCLPointCloud2::Ptr cloud_ptr,
+                   const pcl::PCLPointCloud2::Ptr& cloud_ptr,
                    const Eigen::Vector4f& origin = Eigen::Vector4f (),
                    const Eigen::Quaternionf& orientation = Eigen::Quaternionf (),
                    bool make_templated_cloud = true);
@@ -84,7 +84,7 @@ namespace pcl
         /** \brief This creates a CloudItem from a templated cloud type */
         template <typename PointT>
         static CloudItem*
-        createCloudItemFromTemplate (const QString name, typename PointCloud<PointT>::Ptr cloud_ptr);
+        createCloudItemFromTemplate (const QString& name, typename PointCloud<PointT>::Ptr cloud_ptr);
         
         /** \brief virtual data getter which calls QStandardItem::data; used to create template cloud if not created yet
          *    WARNING : This function modifies "this" - it sets up the templated type if you request one when it doesn't exist yet!

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/fpfh_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/fpfh_item.h
@@ -55,7 +55,7 @@ namespace pcl
       public:
 
         FPFHItem (QString name, 
-                     pcl::PointCloud<pcl::FPFHSignature33>::Ptr fpfh_ptr,
+                     const pcl::PointCloud<pcl::FPFHSignature33>::Ptr& fpfh_ptr,
                      double radius);
         FPFHItem (const FPFHItem& to_copy);
         ~FPFHItem ();

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/normals_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/normals_item.h
@@ -52,7 +52,7 @@ namespace pcl
       public:
 
         NormalsItem (QString name, 
-                     pcl::PointCloud<pcl::Normal>::Ptr normals_ptr,
+                     const pcl::PointCloud<pcl::Normal>::Ptr& normals_ptr,
                      double radius);
         NormalsItem (const NormalsItem& to_copy);
         ~NormalsItem ();

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/merge_selection.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/merge_selection.h
@@ -60,7 +60,7 @@ namespace pcl
         getSelectedItems () { return selected_item_index_map_.keys ();}
         
         template <typename PointT> QList <CloudComposerItem*>
-        performTemplatedAction (QList <const CloudComposerItem*> input_data);
+        performTemplatedAction (const QList <const CloudComposerItem*>& input_data);
         
       private:
         QMap <const CloudItem*, pcl::PointIndices::ConstPtr > selected_item_index_map_;

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/manipulation_event.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/manipulation_event.h
@@ -56,7 +56,7 @@ namespace pcl
         ~ManipulationEvent ();
         
         void
-        addManipulation (QString id, vtkSmartPointer<vtkMatrix4x4> start, vtkSmartPointer<vtkMatrix4x4> end);
+        addManipulation (const QString& id, const vtkSmartPointer<vtkMatrix4x4>& start, const vtkSmartPointer<vtkMatrix4x4>& end);
         
         inline QMap <QString, vtkSmartPointer<vtkMatrix4x4> >
         getStartMap () const { return id_start_map_;}

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selection_event.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/selection_event.h
@@ -51,10 +51,10 @@ namespace pcl
       
       public:
         SelectionEvent (vtkSmartPointer <vtkPolyData> selected_points, vtkSmartPointer<vtkActor> selected_actor, vtkSmartPointer<vtkDataSetMapper> selected_mapper, QMap < QString, vtkPolyData* > id_selected_map, vtkRenderer* renderer) 
-        : selected_points_ (selected_points) 
-        , selected_actor_ (selected_actor)
-        , selected_mapper_ (selected_mapper)
-        , id_selected_data_map_ (id_selected_map)
+        : selected_points_ (std::move(selected_points)) 
+        , selected_actor_ (std::move(selected_actor))
+        , selected_mapper_ (std::move(selected_mapper))
+        , id_selected_data_map_ (std::move(id_selected_map))
         , renderer_ (renderer) 
         {}
         
@@ -73,7 +73,7 @@ namespace pcl
         getActor () const { return selected_actor_; }
         
         void
-        findIndicesInItem (CloudItem* cloud_item, pcl::PointIndices::Ptr indices);
+        findIndicesInItem (CloudItem* cloud_item, const pcl::PointIndices::Ptr& indices);
         
       private:
       

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/project_model.h
@@ -82,7 +82,7 @@ namespace pcl
         
         /** \brief Sets the name of the project using the horizontalHeaderItem         */
         void 
-        setName (QString new_name);     
+        setName (const QString& new_name);
         
         /** \brief Returns the selection model which is used for this project */
         inline QItemSelectionModel*
@@ -107,11 +107,11 @@ namespace pcl
         
         /** \brief This sets the selection for points which have been selected in the QVTKWindow */
         void 
-        setPointSelection (boost::shared_ptr<SelectionEvent> selected_event);
+        setPointSelection (const boost::shared_ptr<SelectionEvent>& selected_event);
         
         /** \brief This is invoked to perform the manipulations specified on the model */
         void
-        manipulateClouds (boost::shared_ptr<ManipulationEvent> manip_event);
+        manipulateClouds (const boost::shared_ptr<ManipulationEvent>& manip_event);
       public Q_SLOTS:
         void 
         commandCompleted (CloudCommand* command);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/properties_model.h
@@ -60,15 +60,15 @@ namespace pcl
         
         /** \brief Helper function for adding a new property */
         void
-        addProperty (const QString prop_name, const QVariant value, const Qt::ItemFlags flags = Qt::ItemIsSelectable, const QString category = "");
+        addProperty (const QString& prop_name, const QVariant& value, const Qt::ItemFlags flags = Qt::ItemIsSelectable, const QString& category = "");
         
         /** \brief Helper function for adding a new property category */
         void
-        addCategory (const QString category_name);
+        addCategory (const QString& category_name);
         
         /** \brief Helper function to get a property */
         QVariant 
-        getProperty (const QString prop_name) const;
+        getProperty (const QString& prop_name) const;
         
         void 
         copyProperties (const PropertiesModel* to_copy);

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/abstract_tool.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tool_interface/abstract_tool.h
@@ -73,7 +73,7 @@ namespace pcl
         getActionText () const {return action_text_;}
         
         void
-        setActionText (const QString text) { action_text_ = text; }
+        setActionText (const QString& text) { action_text_ = text; }
               
         virtual QString
         getToolName () const = 0;

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/toolbox_model.h
@@ -107,7 +107,7 @@ namespace pcl
       
     private:
       QStandardItem* 
-      addToolGroup (QString tool_group_name);
+      addToolGroup (const QString& tool_group_name);
       
       QTreeView* tool_view_;
       QTreeView* parameter_view_;

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -53,7 +53,7 @@
  
  
  template <typename PointT> QList <pcl::cloud_composer::CloudComposerItem*>
- pcl::cloud_composer::OrganizedSegmentationTool::performTemplatedAction (QList <const CloudComposerItem*> input_data)
+ pcl::cloud_composer::OrganizedSegmentationTool::performTemplatedAction (const QList <const CloudComposerItem*>& input_data)
  {
    QList <CloudComposerItem*> output;  
    

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/supervoxels.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/supervoxels.hpp
@@ -46,7 +46,7 @@
 
 
 template <typename PointT> QList <pcl::cloud_composer::CloudComposerItem*>
-pcl::cloud_composer::SupervoxelsTool::performTemplatedAction (QList <const CloudComposerItem*> input_data)
+pcl::cloud_composer::SupervoxelsTool::performTemplatedAction (const QList <const CloudComposerItem*>& input_data)
 {
   QList <CloudComposerItem*> output;  
   

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/organized_segmentation.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/organized_segmentation.h
@@ -56,7 +56,7 @@
        performAction (QList <const CloudComposerItem*> input_data, PointTypeFlags::PointType type = PointTypeFlags::NONE) override;
        
        template <typename PointT> QList <CloudComposerItem*>
-       performTemplatedAction (QList <const CloudComposerItem*> input_data);
+       performTemplatedAction (const QList <const CloudComposerItem*>& input_data);
        
        inline QString
        getToolName () const override { return "Organized Segmenation Tool";}

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/supervoxels.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/supervoxels.h
@@ -56,7 +56,7 @@
        performAction (QList <const CloudComposerItem*> input_data, PointTypeFlags::PointType type = PointTypeFlags::NONE) override;
        
        template <typename PointT> QList <CloudComposerItem*>
-       performTemplatedAction (QList <const CloudComposerItem*> input_data);
+       performTemplatedAction (const QList <const CloudComposerItem*>& input_data);
        
        inline QString
        getToolName () const override { return "Voxel Superpixels Tool";}

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/transform_clouds.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/transform_clouds.h
@@ -57,7 +57,7 @@ namespace pcl
         getToolName () const override { return "Transform Clouds Tool";}
        
         template <typename PointT> QList <CloudComposerItem*>
-        performTemplatedAction (QList <const CloudComposerItem*> input_data);
+        performTemplatedAction (const QList <const CloudComposerItem*>& input_data);
         
       private:
         QMap <QString, vtkSmartPointer<vtkMatrix4x4> > transform_map_;

--- a/apps/cloud_composer/src/commands.cpp
+++ b/apps/cloud_composer/src/commands.cpp
@@ -5,7 +5,7 @@
 
 pcl::cloud_composer::CloudCommand::CloudCommand (QList <const CloudComposerItem*> input_data, QUndoCommand* parent)
   : QUndoCommand (parent)
-  , original_data_ (input_data)
+  , original_data_ (std::move(input_data))
   , can_use_templates_(false)
   , template_type_ (-1)
 {
@@ -115,7 +115,7 @@ pcl::cloud_composer::CloudCommand::executeToolOnTemplateCloud (AbstractTool* too
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool 
-pcl::cloud_composer::CloudCommand::replaceOriginalWithNew (QList <const CloudComposerItem*> originals, QList <CloudComposerItem*> new_items)
+pcl::cloud_composer::CloudCommand::replaceOriginalWithNew (const QList <const CloudComposerItem*>& originals, const QList <CloudComposerItem*>& new_items)
 { 
   //Find the input item's parent
   if (originals.empty ())
@@ -161,7 +161,7 @@ pcl::cloud_composer::CloudCommand::replaceOriginalWithNew (QList <const CloudCom
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool 
-pcl::cloud_composer::CloudCommand::restoreOriginalRemoveNew (QList <const CloudComposerItem*> originals, QList <CloudComposerItem*> new_items)
+pcl::cloud_composer::CloudCommand::restoreOriginalRemoveNew (const QList <const CloudComposerItem*>& originals, const QList <CloudComposerItem*>& new_items)
 { 
   
   //Now remove all the new items
@@ -205,7 +205,7 @@ pcl::cloud_composer::CloudCommand::restoreOriginalRemoveNew (QList <const CloudC
 //////////// MODIFY CLOUD COMMAND
 
 pcl::cloud_composer::ModifyItemCommand::ModifyItemCommand (QList <const CloudComposerItem*> input_data, QUndoCommand* parent)
-  : CloudCommand (input_data, parent)
+  : CloudCommand (std::move(input_data), parent)
 { 
   
 }
@@ -280,7 +280,7 @@ pcl::cloud_composer::ModifyItemCommand::redo ()
 //////////// New Item CLOUD COMMAND ///////////////////////////////////////////////////////////////////////////
 
 pcl::cloud_composer::NewItemCloudCommand::NewItemCloudCommand (QList <const CloudComposerItem*> input_data, QUndoCommand* parent)
-  : CloudCommand (input_data, parent)
+  : CloudCommand (std::move(input_data), parent)
 {
   
 }
@@ -383,7 +383,7 @@ pcl::cloud_composer::NewItemCloudCommand::redo ()
 //////////// Split CLOUD COMMAND ///////////////////////////////////////////////////////////////////////////
 
 pcl::cloud_composer::SplitCloudCommand::SplitCloudCommand (QList <const CloudComposerItem*> input_data, QUndoCommand* parent)
-  : CloudCommand (input_data, parent)
+  : CloudCommand (std::move(input_data), parent)
 {
   
 }
@@ -458,7 +458,7 @@ pcl::cloud_composer::SplitCloudCommand::redo ()
 //////////// Delete CLOUD COMMAND ///////////////////////////////////////////////////////////////////////////
 
 pcl::cloud_composer::DeleteItemCommand::DeleteItemCommand (QList <const CloudComposerItem*> input_data, QUndoCommand* parent)
-  : CloudCommand (input_data, parent)
+  : CloudCommand (std::move(input_data), parent)
 {
   
 }
@@ -516,7 +516,7 @@ pcl::cloud_composer::DeleteItemCommand::redo ()
 //////////// MERGE CLOUD COMMAND ///////////////////////////////////////////////////////////////////////////
 
 pcl::cloud_composer::MergeCloudCommand::MergeCloudCommand (ConstItemList input_data, QUndoCommand* parent)
-  : CloudCommand (input_data, parent)
+  : CloudCommand (std::move(input_data), parent)
 {
   
 }

--- a/apps/cloud_composer/src/items/cloud_composer_item.cpp
+++ b/apps/cloud_composer/src/items/cloud_composer_item.cpp
@@ -2,7 +2,7 @@
 
 #include <QDebug>
 
-pcl::cloud_composer::CloudComposerItem::CloudComposerItem (QString name)
+pcl::cloud_composer::CloudComposerItem::CloudComposerItem (const QString& name)
   : QStandardItem(name)
 {
   //Set up the properties, store pointer locally for convenience

--- a/apps/cloud_composer/src/items/cloud_item.cpp
+++ b/apps/cloud_composer/src/items/cloud_item.cpp
@@ -8,11 +8,11 @@
 #include <QMessageBox>
 
 pcl::cloud_composer::CloudItem::CloudItem (QString name,
-                                           pcl::PCLPointCloud2::Ptr cloud_ptr,
+                                           const pcl::PCLPointCloud2::Ptr& cloud_ptr,
                                            const Eigen::Vector4f& origin, 
                                            const Eigen::Quaternionf& orientation,
                                            bool make_templated_cloud)
-  : CloudComposerItem (name)
+  : CloudComposerItem (std::move(name))
   , origin_ (origin)
   , orientation_ (orientation)
   , template_cloud_set_ (false)

--- a/apps/cloud_composer/src/items/fpfh_item.cpp
+++ b/apps/cloud_composer/src/items/fpfh_item.cpp
@@ -5,8 +5,8 @@
 
 #include <QVTKWidget.h>
 
-pcl::cloud_composer::FPFHItem::FPFHItem (QString name, pcl::PointCloud<pcl::FPFHSignature33>::Ptr fpfh_ptr, double radius)
-  : CloudComposerItem (name)
+pcl::cloud_composer::FPFHItem::FPFHItem (QString name, const pcl::PointCloud<pcl::FPFHSignature33>::Ptr& fpfh_ptr, double radius)
+  : CloudComposerItem (std::move(name))
   , fpfh_ptr_ (fpfh_ptr)
   , radius_ (radius)
 

--- a/apps/cloud_composer/src/items/normals_item.cpp
+++ b/apps/cloud_composer/src/items/normals_item.cpp
@@ -3,8 +3,8 @@
 
 #include <QDebug>
 
-pcl::cloud_composer::NormalsItem::NormalsItem (QString name, pcl::PointCloud<pcl::Normal>::Ptr normals_ptr, double radius)
-  : CloudComposerItem (name)
+pcl::cloud_composer::NormalsItem::NormalsItem (QString name, const pcl::PointCloud<pcl::Normal>::Ptr& normals_ptr, double radius)
+  : CloudComposerItem (std::move(name))
   , normals_ptr_ (normals_ptr)
 
 {

--- a/apps/cloud_composer/src/merge_selection.cpp
+++ b/apps/cloud_composer/src/merge_selection.cpp
@@ -8,7 +8,7 @@
 
 pcl::cloud_composer::MergeSelection::MergeSelection (QMap <const CloudItem*, pcl::PointIndices::ConstPtr > selected_item_index_map, QObject* parent)
   : MergeCloudTool (nullptr, parent)
-  , selected_item_index_map_ (selected_item_index_map)
+  , selected_item_index_map_ (std::move(selected_item_index_map))
 {
   
 }

--- a/apps/cloud_composer/src/point_selectors/interactor_style_switch.cpp
+++ b/apps/cloud_composer/src/point_selectors/interactor_style_switch.cpp
@@ -44,7 +44,7 @@ void
 pcl::cloud_composer::InteractorStyleSwitch::initializeInteractorStyles (pcl::visualization::PCLVisualizer::Ptr vis, ProjectModel* model)
 {
   qDebug () << "Initializing Interactor Styles";
-  vis_ = vis;
+  vis_ = std::move(vis);
   project_model_ = model;
   
   pcl_vis_style_->Initialize ();

--- a/apps/cloud_composer/src/point_selectors/manipulation_event.cpp
+++ b/apps/cloud_composer/src/point_selectors/manipulation_event.cpp
@@ -7,7 +7,7 @@ pcl::cloud_composer::ManipulationEvent::~ManipulationEvent ()
 }
 
 void
-pcl::cloud_composer::ManipulationEvent::addManipulation (QString id, vtkSmartPointer<vtkMatrix4x4> start, vtkSmartPointer<vtkMatrix4x4> end)
+pcl::cloud_composer::ManipulationEvent::addManipulation (const QString& id, const vtkSmartPointer<vtkMatrix4x4>& start, const vtkSmartPointer<vtkMatrix4x4>& end)
 {
   id_start_map_.insert (id, start);
   id_end_map_.insert (id, end);

--- a/apps/cloud_composer/src/point_selectors/selection_event.cpp
+++ b/apps/cloud_composer/src/point_selectors/selection_event.cpp
@@ -9,7 +9,7 @@ pcl::cloud_composer::SelectionEvent::~SelectionEvent ()
 
 
 void
-pcl::cloud_composer::SelectionEvent::findIndicesInItem (CloudItem* cloud_item, pcl::PointIndices::Ptr indices)
+pcl::cloud_composer::SelectionEvent::findIndicesInItem (CloudItem* cloud_item, const pcl::PointIndices::Ptr& indices)
 {
   // WE DON'T NEED TO DO THIS SEARCH BECAUSE WE HAVE A 1-1 CORRESPONDENCE VTK TO PCL
   // THIS IS ONLY THE CASE FOR CLOUDS WITH NO NANs

--- a/apps/cloud_composer/src/project_model.cpp
+++ b/apps/cloud_composer/src/project_model.cpp
@@ -68,11 +68,11 @@ pcl::cloud_composer::ProjectModel::ProjectModel (QString project_name, QObject* 
 : QStandardItemModel (parent)
 {
   selection_model_ = new QItemSelectionModel(this);
-  setName (project_name);
+  setName (std::move(project_name));
 }
 
 void 
-pcl::cloud_composer::ProjectModel::setName (QString new_name)
+pcl::cloud_composer::ProjectModel::setName (const QString& new_name)
 { 
   //If it hasn't been set yet
   if (!horizontalHeaderItem (0))
@@ -94,7 +94,7 @@ pcl::cloud_composer::ProjectModel::setCloudView (CloudView* view)
 }
 
 void
-pcl::cloud_composer::ProjectModel::setPointSelection (boost::shared_ptr<SelectionEvent> selected_event)
+pcl::cloud_composer::ProjectModel::setPointSelection (const boost::shared_ptr<SelectionEvent>& selected_event)
 {
   selection_event_ = selected_event;
   //Get all the items in this project that are clouds
@@ -124,7 +124,7 @@ pcl::cloud_composer::ProjectModel::setPointSelection (boost::shared_ptr<Selectio
 }
 
 void
-pcl::cloud_composer::ProjectModel::manipulateClouds (boost::shared_ptr<ManipulationEvent> manip_event)
+pcl::cloud_composer::ProjectModel::manipulateClouds (const boost::shared_ptr<ManipulationEvent>& manip_event)
 {
   
   //Get all the items in this project that are clouds

--- a/apps/cloud_composer/src/properties_model.cpp
+++ b/apps/cloud_composer/src/properties_model.cpp
@@ -43,7 +43,7 @@ pcl::cloud_composer::PropertiesModel::~PropertiesModel ()
 }
 
 void
-pcl::cloud_composer::PropertiesModel::addProperty (const QString prop_name, QVariant value,  Qt::ItemFlags flags, QString category)
+pcl::cloud_composer::PropertiesModel::addProperty (const QString& prop_name, const QVariant& value,  Qt::ItemFlags flags, const QString& category)
 {
   QStandardItem* parent_item = invisibleRootItem ();
   if (category.size () > 0)
@@ -71,14 +71,14 @@ pcl::cloud_composer::PropertiesModel::addProperty (const QString prop_name, QVar
 }
 
 void
-pcl::cloud_composer::PropertiesModel::addCategory (const QString category_name)
+pcl::cloud_composer::PropertiesModel::addCategory (const QString& category_name)
 {
   QStandardItem* new_category = new QStandardItem (category_name);
   appendRow (new_category);
 }
 
 QVariant 
-pcl::cloud_composer::PropertiesModel::getProperty (const QString prop_name) const
+pcl::cloud_composer::PropertiesModel::getProperty (const QString& prop_name) const
 {
   //qDebug () << "Searching for property " << prop_name;
   QList<QStandardItem*> items = findItems (prop_name, Qt::MatchExactly | Qt::MatchRecursive, 0);

--- a/apps/cloud_composer/src/toolbox_model.cpp
+++ b/apps/cloud_composer/src/toolbox_model.cpp
@@ -48,7 +48,7 @@ pcl::cloud_composer::ToolBoxModel::setSelectionModel (QItemSelectionModel* selec
 }
   
 QStandardItem*
-pcl::cloud_composer::ToolBoxModel::addToolGroup (QString tool_group_name)
+pcl::cloud_composer::ToolBoxModel::addToolGroup (const QString& tool_group_name)
 {
   QList <QStandardItem*> matches_name = findItems (tool_group_name);
   if (matches_name.empty ())

--- a/apps/cloud_composer/src/transform_clouds.cpp
+++ b/apps/cloud_composer/src/transform_clouds.cpp
@@ -8,7 +8,7 @@
 
 pcl::cloud_composer::TransformClouds::TransformClouds (QMap <QString, vtkSmartPointer<vtkMatrix4x4> > transform_map, QObject* parent)
   : ModifyItemTool (nullptr, parent)
-  , transform_map_ (transform_map)
+  , transform_map_ (std::move(transform_map))
 {
   
 }

--- a/apps/cloud_composer/src/work_queue.cpp
+++ b/apps/cloud_composer/src/work_queue.cpp
@@ -21,7 +21,7 @@ pcl::cloud_composer::WorkQueue::enqueueNewAction (AbstractTool* new_tool, ConstI
 {
   ActionPair new_action;
   //Create a command which will manage data for the tool
-  new_action.command = new_tool->createCommand (input_data);
+  new_action.command = new_tool->createCommand (std::move(input_data));
   new_action.tool = new_tool;
  
   work_queue_.enqueue (new_action);

--- a/apps/cloud_composer/tools/supervoxels.cpp
+++ b/apps/cloud_composer/tools/supervoxels.cpp
@@ -41,8 +41,8 @@ pcl::cloud_composer::SupervoxelsTool::performAction (ConstItemList input_data, P
   return output;
 } 
 
-template QList <pcl::cloud_composer::CloudComposerItem*> pcl::cloud_composer::SupervoxelsTool::performTemplatedAction <pcl::PointXYZRGB> (QList <const CloudComposerItem*>);
-//template QList <pcl::cloud_composer::CloudComposerItem*> pcl::cloud_composer::SupervoxelsTool::performTemplatedAction <pcl::PointXYZRGBA> (QList <const CloudComposerItem*>);
+template QList <pcl::cloud_composer::CloudComposerItem*> pcl::cloud_composer::SupervoxelsTool::performTemplatedAction <pcl::PointXYZRGB> (const QList <const CloudComposerItem*>&);
+//template QList <pcl::cloud_composer::CloudComposerItem*> pcl::cloud_composer::SupervoxelsTool::performTemplatedAction <pcl::PointXYZRGBA> (const QList <const CloudComposerItem*>&);
 
 
 /////////////////// PARAMETER MODEL /////////////////////////////////

--- a/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
+++ b/apps/in_hand_scanner/include/pcl/apps/in_hand_scanner/offline_integration.h
@@ -153,8 +153,8 @@ namespace pcl
           * \return True if success.
           */
         bool
-        getFilesFromDirectory (const std::string          path_dir,
-                               const std::string          extension,
+        getFilesFromDirectory (const std::string&          path_dir,
+                               const std::string&          extension,
                                std::vector <std::string>& files) const;
 
         /** \brief Load the transformation matrix from the given file.

--- a/apps/in_hand_scanner/src/offline_integration.cpp
+++ b/apps/in_hand_scanner/src/offline_integration.cpp
@@ -181,8 +181,8 @@ pcl::ihs::OfflineIntegration::computationThread ()
 ////////////////////////////////////////////////////////////////////////////////
 
 bool
-pcl::ihs::OfflineIntegration::getFilesFromDirectory (const std::string          path_dir,
-                                                     const std::string          extension,
+pcl::ihs::OfflineIntegration::getFilesFromDirectory (const std::string&          path_dir,
+                                                     const std::string&          extension,
                                                      std::vector <std::string>& files) const
 {
   if (path_dir.empty() || !boost::filesystem::exists (path_dir))

--- a/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
+++ b/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
@@ -9,7 +9,7 @@
 
 namespace face_detection_apps_utils
 {
-  inline bool readMatrixFromFile(std::string file, Eigen::Matrix4f & matrix)
+  inline bool readMatrixFromFile(const std::string& file, Eigen::Matrix4f & matrix)
   {
 
     std::ifstream in;

--- a/apps/include/pcl/apps/manual_registration.h
+++ b/apps/include/pcl/apps/manual_registration.h
@@ -101,13 +101,13 @@ class ManualRegistration : public QMainWindow
     void
     setSrcCloud (pcl::PointCloud<pcl::PointXYZRGBA>::Ptr cloud_src)
     {
-      cloud_src_ = cloud_src;
+      cloud_src_ = std::move(cloud_src);
       cloud_src_present_ = true;
     }
     void
     setDstCloud (pcl::PointCloud<pcl::PointXYZRGBA>::Ptr cloud_dst)
     {
-      cloud_dst_ = cloud_dst;
+      cloud_dst_ = std::move(cloud_dst);
       cloud_dst_present_ = true;
     }
 

--- a/apps/include/pcl/apps/nn_classification.h
+++ b/apps/include/pcl/apps/nn_classification.h
@@ -133,7 +133,7 @@ namespace pcl
         * \return true on success, false on failure (read error or number of entries don't match)
         */
       bool 
-      loadTrainingFeatures(std::string file_name, std::string labels_file_name)
+      loadTrainingFeatures(const std::string& file_name, const std::string& labels_file_name)
       {
         typename pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
         if (pcl::io::loadPCDFile (file_name.c_str (), *cloud) != 0)
@@ -157,7 +157,7 @@ namespace pcl
         * \return true on success, false on failure (write error or number of entries don't match)
         */
       bool 
-      saveTrainingFeatures (std::string file_name, std::string labels_file_name)
+      saveTrainingFeatures (const std::string& file_name, const std::string& labels_file_name)
       {
         typename pcl::PointCloud<PointT>::ConstPtr training_features = tree_->getInputCloud ();
         if (labels_idx_.size () == training_features->points.size ())

--- a/apps/include/pcl/apps/vfh_nn_classifier.h
+++ b/apps/include/pcl/apps/vfh_nn_classifier.h
@@ -146,7 +146,7 @@ namespace pcl
         * \param labels_file_name file name for writing the class label for each training example
         * \return true on success, false on failure (write error or number of entries don't match)
         */
-      bool saveTrainingFeatures(std::string file_name, std::string labels_file_name)
+      bool saveTrainingFeatures(const std::string& file_name, const std::string& labels_file_name)
       {
         if (labels_.size () == training_features_->points.size ())
         {
@@ -166,7 +166,7 @@ namespace pcl
         * \param labels the class label for each training example
         * \return true on success, false on failure (number of entries don't match)
         */
-      bool addTrainingFeatures (const FeatureCloudPtr training_features, const std::vector<std::string> &labels)
+      bool addTrainingFeatures (const FeatureCloudPtr& training_features, const std::vector<std::string> &labels)
       {
         if (labels.size () == training_features->points.size ())
         {
@@ -189,7 +189,7 @@ namespace pcl
         * \param labels_file_name the class label for each training example
         * \return true on success, false on failure (read error or number of entries don't match)
         */
-      bool loadTrainingFeatures(std::string file_name, std::string labels_file_name)
+      bool loadTrainingFeatures(const std::string& file_name, const std::string& labels_file_name)
       {
         FeatureCloudPtr cloud (new FeatureCloud);
         if (pcl::io::loadPCDFile (file_name.c_str (), *cloud) != 0)
@@ -210,7 +210,7 @@ namespace pcl
         * \param label the class label for the training example
         * \return true on success, false on failure (read error or number of entries don't match)
         */
-      bool loadTrainingData (std::string file_name, std::string label)
+      bool loadTrainingData (const std::string& file_name, std::string label)
       {
         pcl::PCLPointCloud2 cloud_blob;
         if (pcl::io::loadPCDFile (file_name.c_str (), cloud_blob) != 0)

--- a/apps/modeler/include/pcl/apps/modeler/parameter.h
+++ b/apps/modeler/include/pcl/apps/modeler/parameter.h
@@ -252,7 +252,7 @@ namespace pcl
     class ColorParameter : public Parameter
     {
       public:
-        ColorParameter(const std::string& name, const std::string& description, QColor value):
+        ColorParameter(const std::string& name, const std::string& description, const QColor& value):
           Parameter(name, description, value){}
         ~ColorParameter(){}
 

--- a/apps/modeler/src/cloud_mesh.cpp
+++ b/apps/modeler/src/cloud_mesh.cpp
@@ -56,7 +56,7 @@ pcl::modeler::CloudMesh::CloudMesh()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 pcl::modeler::CloudMesh::CloudMesh(PointCloudPtr cloud)
-  :cloud_(cloud),
+  :cloud_(std::move(cloud)),
   vtk_points_(vtkSmartPointer<vtkPoints>::New()),
   vtk_polygons_(vtkSmartPointer<vtkCellArray>::New())
 {

--- a/apps/modeler/src/cloud_mesh_item.cpp
+++ b/apps/modeler/src/cloud_mesh_item.cpp
@@ -68,7 +68,7 @@ pcl::modeler::CloudMeshItem::CloudMeshItem (QTreeWidgetItem* parent, const std::
 pcl::modeler::CloudMeshItem::CloudMeshItem (QTreeWidgetItem* parent, CloudMesh::PointCloudPtr cloud)
   :QTreeWidgetItem(parent),
   filename_("unnamed point cloud"),
-  cloud_mesh_(new CloudMesh (cloud)),
+  cloud_mesh_(new CloudMesh (std::move(cloud))),
   translation_x_(new DoubleParameter("Translation X", "Translation X", 0.0, -1.0, 1.0)),
   translation_y_(new DoubleParameter("Translation Y", "Translation Y", 0.0, -1.0, 1.0)),
   translation_z_(new DoubleParameter("Translation Z", "Translation Z", 0.0, -1.0, 1.0)),

--- a/apps/modeler/src/icp_registration_worker.cpp
+++ b/apps/modeler/src/icp_registration_worker.cpp
@@ -45,7 +45,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 pcl::modeler::ICPRegistrationWorker::ICPRegistrationWorker(CloudMesh::PointCloudPtr cloud, const QList<CloudMeshItem*>& cloud_mesh_items, QWidget* parent)
   : AbstractWorker(cloud_mesh_items, parent),
-  cloud_(cloud),
+  cloud_(std::move(cloud)),
   x_min_(std::numeric_limits<double>::max()), x_max_(std::numeric_limits<double>::min()),
   y_min_(std::numeric_limits<double>::max()), y_max_(std::numeric_limits<double>::min()),
   z_min_(std::numeric_limits<double>::max()), z_max_(std::numeric_limits<double>::min()),

--- a/apps/modeler/src/render_window_item.cpp
+++ b/apps/modeler/src/render_window_item.cpp
@@ -81,7 +81,7 @@ pcl::modeler::RenderWindowItem::openPointCloud(const QString& filename)
 pcl::modeler::CloudMeshItem*
 pcl::modeler::RenderWindowItem::addPointCloud(CloudMesh::PointCloudPtr cloud)
 {
-  CloudMeshItem* cloud_mesh_item = new CloudMeshItem(this, cloud);
+  CloudMeshItem* cloud_mesh_item = new CloudMeshItem(this, std::move(cloud));
   addChild(cloud_mesh_item);
 
   treeWidget()->setCurrentItem(cloud_mesh_item);

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
@@ -201,7 +201,7 @@ class Cloud : public Statistics
     /// a faster rendering mode; this also occurs if the selection object is
     /// empty.
     void
-    setSelection (SelectionPtr selection_ptr);
+    setSelection (const SelectionPtr& selection_ptr);
 
     /// @brief Sets the RGB values for coloring points in COLOR_BY_PURE mode.
     /// @param r the value for red color

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
@@ -73,7 +73,7 @@ class CommandQueue
     /// @param command_ptr a shared pointer pointing to a command object whose
     /// execute function will be invoked by this object.
     void
-    execute (CommandPtr);
+    execute (const CommandPtr&);
 
     /// @brief Undoes the last command by popping the tail of the queue, invoke
     /// the undo function of the command.

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyBuffer.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyBuffer.h
@@ -66,7 +66,7 @@ class CopyBuffer : public Statistics
     /// copied
     /// @param selection a const reference to the selected points object
     void
-    set (ConstCloudPtr cloud_ptr, const Selection& selection);
+    set (const ConstCloudPtr& cloud_ptr, const Selection& selection);
 
     /// @brief Returns the points stored in the internal buffer as a const Cloud
     const Cloud&

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/copyCommand.h
@@ -54,8 +54,8 @@ class CopyCommand : public Command
     CopyCommand (CopyBufferPtr copy_buffer_ptr,
                  ConstSelectionPtr selection_ptr,
                  ConstCloudPtr cloud_ptr)
-      : copy_buffer_ptr_(copy_buffer_ptr), selection_ptr_(selection_ptr),
-        cloud_ptr_(cloud_ptr)
+      : copy_buffer_ptr_(std::move(copy_buffer_ptr)), selection_ptr_(std::move(selection_ptr)),
+        cloud_ptr_(std::move(cloud_ptr))
     {
       has_undo_ = false;
     }

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cutCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cutCommand.h
@@ -54,7 +54,7 @@ class CutCommand : public Command
     /// @param cloud_ptr a shared pointer pointing to the cloud object.
     CutCommand (CopyBufferPtr copy_buffer_ptr,
                 SelectionPtr selection_ptr,
-                CloudPtr cloud_ptr);
+                const CloudPtr& cloud_ptr);
 
     /// @brief Copy constructor - commands are non-copyable
     CutCommand (const CutCommand&) = delete;

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/deleteCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/deleteCommand.h
@@ -51,7 +51,7 @@ class DeleteCommand : public Command
     /// @brief Constructor
     /// @param selection_ptr A shared pointer pointing to the selection object.
     /// @param cloud_ptr A shared pointer pointing to the cloud object.
-    DeleteCommand (SelectionPtr selection_ptr, CloudPtr cloud_ptr);
+    DeleteCommand (SelectionPtr selection_ptr, const CloudPtr& cloud_ptr);
 
     /// @brief Copy constructor - commands are non-copyable
     DeleteCommand (const DeleteCommand& c) = delete;

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseCommand.h
@@ -55,9 +55,9 @@ public:
   /// @param cloud_ptr a shared pointer pointing to the cloud object.
   /// @param mean the number of points to use for mean distance estimation.
   /// @param threshold the standard deviation multiplier threshold
-  DenoiseCommand (SelectionPtr selection_ptr, CloudPtr cloud_ptr,
+  DenoiseCommand (SelectionPtr selection_ptr, const CloudPtr& cloud_ptr,
                   float mean, float threshold)
-    : selection_ptr_(selection_ptr), cloud_ptr_(cloud_ptr), mean_(mean),
+    : selection_ptr_(std::move(selection_ptr)), cloud_ptr_(cloud_ptr), mean_(mean),
       threshold_(threshold), removed_indices_(cloud_ptr)
   {
   }

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selection.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selection.h
@@ -54,7 +54,7 @@ class Selection : public Statistics
     /// @param cloud_ptr A pointer to the const cloud object for which this
     /// object is to maintain selections.
     Selection (ConstCloudPtr cloud_ptr, bool register_stats=false)
-      : cloud_ptr_(cloud_ptr)
+      : cloud_ptr_(std::move(cloud_ptr))
     {
       if (register_stats)
         registerStats();

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/transformCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/transformCommand.h
@@ -52,7 +52,7 @@ class TransformCommand : public Command
     /// @param cloud_ptr a shared pointer pointing to the cloud object.
     /// @param matrix a (4x4) transform matrix following OpenGL's format.
     /// @pre Assumes the selection_ptr is valid, non-NULL.
-    TransformCommand (ConstSelectionPtr selection_ptr, CloudPtr cloud_ptr,
+    TransformCommand (const ConstSelectionPtr& selection_ptr, CloudPtr cloud_ptr,
                       const float* matrix, float translate_x,
                       float translate_y, float translate_z);
 
@@ -78,7 +78,7 @@ class TransformCommand : public Command
     /// @param sel_ptr A pointer to the selection object whose points are to be
     /// transformed.
     void
-    applyTransform(ConstSelectionPtr sel_ptr);
+    applyTransform(const ConstSelectionPtr& sel_ptr);
 
     /// pointers to constructor params
     ConstSelectionPtr selection_ptr_;

--- a/apps/point_cloud_editor/src/cloud.cpp
+++ b/apps/point_cloud_editor/src/cloud.cpp
@@ -182,7 +182,7 @@ Cloud::setSelectionTranslation (float dx, float dy, float dz)
 }
 
 void
-Cloud::setSelection (SelectionPtr selection_ptr)
+Cloud::setSelection (const SelectionPtr& selection_ptr)
 {
   selection_wk_ptr_ = selection_ptr;
   if (!selection_ptr || selection_ptr->empty())

--- a/apps/point_cloud_editor/src/cloudTransformTool.cpp
+++ b/apps/point_cloud_editor/src/cloudTransformTool.cpp
@@ -48,7 +48,7 @@ const float CloudTransformTool::DEFAULT_TRANSLATE_FACTOR_ = 0.001f;
 
 
 CloudTransformTool::CloudTransformTool (CloudPtr cloud_ptr)
-  : cloud_ptr_(cloud_ptr), x_(0), y_(0), scale_factor_(DEFAULT_SCALE_FACTOR_),
+  : cloud_ptr_(std::move(cloud_ptr)), x_(0), y_(0), scale_factor_(DEFAULT_SCALE_FACTOR_),
     translate_factor_(DEFAULT_TRANSLATE_FACTOR_)
 {
   setIdentity(transform_matrix_);

--- a/apps/point_cloud_editor/src/commandQueue.cpp
+++ b/apps/point_cloud_editor/src/commandQueue.cpp
@@ -58,7 +58,7 @@ CommandQueue::enforceDequeLimit ()
 }
 
 void
-CommandQueue::execute (CommandPtr command_ptr)
+CommandQueue::execute (const CommandPtr& command_ptr)
 {
   if (!command_ptr)
     return;

--- a/apps/point_cloud_editor/src/copyBuffer.cpp
+++ b/apps/point_cloud_editor/src/copyBuffer.cpp
@@ -43,7 +43,7 @@
 #include <pcl/apps/point_cloud_editor/common.h>
 
 void
-CopyBuffer::set (ConstCloudPtr cloud_ptr, const Selection& selection)
+CopyBuffer::set (const ConstCloudPtr& cloud_ptr, const Selection& selection)
 {
   clean();
   if (!cloud_ptr)

--- a/apps/point_cloud_editor/src/cutCommand.cpp
+++ b/apps/point_cloud_editor/src/cutCommand.cpp
@@ -44,9 +44,9 @@
 
 CutCommand::CutCommand (CopyBufferPtr copy_buffer_ptr,
                         SelectionPtr selection_ptr,
-                        CloudPtr cloud_ptr)
-  : selection_ptr_(selection_ptr), cloud_ptr_(cloud_ptr),
-    copy_buffer_ptr_(copy_buffer_ptr), cut_selection_(cloud_ptr)
+                        const CloudPtr& cloud_ptr)
+  : selection_ptr_(std::move(selection_ptr)), cloud_ptr_(cloud_ptr),
+    copy_buffer_ptr_(std::move(copy_buffer_ptr)), cut_selection_(cloud_ptr)
 {
 }
 

--- a/apps/point_cloud_editor/src/deleteCommand.cpp
+++ b/apps/point_cloud_editor/src/deleteCommand.cpp
@@ -43,8 +43,8 @@
 #include <pcl/apps/point_cloud_editor/selection.h>
 
 DeleteCommand::DeleteCommand (SelectionPtr selection_ptr,
-                              CloudPtr cloud_ptr)
-  : cloud_ptr_(cloud_ptr), selection_ptr_(selection_ptr), deleted_selection_(cloud_ptr) {}
+                              const CloudPtr& cloud_ptr)
+  : cloud_ptr_(cloud_ptr), selection_ptr_(std::move(selection_ptr)), deleted_selection_(cloud_ptr) {}
 
 void
 DeleteCommand::execute ()

--- a/apps/point_cloud_editor/src/pasteCommand.cpp
+++ b/apps/point_cloud_editor/src/pasteCommand.cpp
@@ -46,8 +46,8 @@
 PasteCommand::PasteCommand (ConstCopyBufferPtr copy_buffer_ptr,
                             SelectionPtr selection_ptr,
                             CloudPtr cloud_ptr)
-  : copy_buffer_ptr_(copy_buffer_ptr), selection_ptr_(selection_ptr),
-    cloud_ptr_(cloud_ptr)
+  : copy_buffer_ptr_(std::move(copy_buffer_ptr)), selection_ptr_(std::move(selection_ptr)),
+    cloud_ptr_(std::move(cloud_ptr))
 {
 }
 

--- a/apps/point_cloud_editor/src/select1DTool.cpp
+++ b/apps/point_cloud_editor/src/select1DTool.cpp
@@ -45,7 +45,7 @@
 #include <pcl/apps/point_cloud_editor/localTypes.h>
 
 Select1DTool::Select1DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr)
-  : selection_ptr_(selection_ptr), cloud_ptr_(cloud_ptr)
+  : selection_ptr_(std::move(selection_ptr)), cloud_ptr_(std::move(cloud_ptr))
 {
 }
 

--- a/apps/point_cloud_editor/src/select2DTool.cpp
+++ b/apps/point_cloud_editor/src/select2DTool.cpp
@@ -49,7 +49,7 @@ const float Select2DTool::DEFAULT_TOOL_DISPLAY_COLOR_BLUE_ = 1.0f;
 
 
 Select2DTool::Select2DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr)
-  : selection_ptr_(selection_ptr), cloud_ptr_(cloud_ptr), display_box_(false)
+  : selection_ptr_(std::move(selection_ptr)), cloud_ptr_(std::move(cloud_ptr)), display_box_(false)
 {
 }
 

--- a/apps/point_cloud_editor/src/selectionTransformTool.cpp
+++ b/apps/point_cloud_editor/src/selectionTransformTool.cpp
@@ -50,9 +50,9 @@ const float SelectionTransformTool::DEFAULT_TRANSLATE_FACTOR_ = 0.001;
 SelectionTransformTool::SelectionTransformTool (ConstSelectionPtr selection_ptr,
                                                 CloudPtr cloud_ptr,
                                                 CommandQueuePtr command_queue_ptr)
-  : selection_ptr_(selection_ptr),
-    cloud_ptr_(cloud_ptr),
-    command_queue_ptr_(command_queue_ptr),
+  : selection_ptr_(std::move(selection_ptr)),
+    cloud_ptr_(std::move(cloud_ptr)),
+    command_queue_ptr_(std::move(command_queue_ptr)),
     translate_factor_(DEFAULT_TRANSLATE_FACTOR_)
 {
   std::fill_n(center_xyz_, XYZ_SIZE, 0);

--- a/apps/point_cloud_editor/src/transformCommand.cpp
+++ b/apps/point_cloud_editor/src/transformCommand.cpp
@@ -42,13 +42,13 @@
 #include <pcl/apps/point_cloud_editor/selection.h>
 #include <pcl/apps/point_cloud_editor/common.h>
 
-TransformCommand::TransformCommand(ConstSelectionPtr selection_ptr,
+TransformCommand::TransformCommand(const ConstSelectionPtr& selection_ptr,
                                    CloudPtr cloud_ptr,
                                    const float *matrix,
                                    float translate_x,
                                    float translate_y,
                                    float translate_z)
-  : selection_ptr_(selection_ptr), cloud_ptr_(cloud_ptr),
+  : selection_ptr_(selection_ptr), cloud_ptr_(std::move(cloud_ptr)),
     translate_x_(translate_x), translate_y_(translate_y),
     translate_z_(translate_z)
 {
@@ -125,7 +125,7 @@ TransformCommand::undo()
 }
 
 void
-TransformCommand::applyTransform(ConstSelectionPtr sel_ptr)
+TransformCommand::applyTransform(const ConstSelectionPtr& sel_ptr)
 {
   // now modify the selected points' coordinates
   for(const unsigned int &index : *sel_ptr)

--- a/apps/src/feature_matching.cpp
+++ b/apps/src/feature_matching.cpp
@@ -45,14 +45,14 @@ class ICCVTutorial
      * @param input the input point cloud
      * @param segmented the resulting segmented point cloud containing only points of the largest cluster
      */
-    void segmentation (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr segmented) const;
+    void segmentation (const typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& input, const typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr& segmented) const;
 
     /**
      * @brief Detects key points in the input point cloud
      * @param input the input point cloud
      * @param keypoints the resulting key points. Note that they are not necessarily a subset of the input cloud
      */
-    void detectKeypoints (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, pcl::PointCloud<pcl::PointXYZI>::Ptr keypoints) const;
+    void detectKeypoints (const typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& input, const pcl::PointCloud<pcl::PointXYZI>::Ptr& keypoints) const;
 
     /**
      * @brief extract descriptors for given key points
@@ -60,7 +60,7 @@ class ICCVTutorial
      * @param keypoints locations where descriptors are to be extracted
      * @param features resulting descriptors
      */
-    void extractDescriptors (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, typename pcl::PointCloud<pcl::PointXYZI>::Ptr keypoints, typename pcl::PointCloud<FeatureType>::Ptr features);
+    void extractDescriptors (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, const typename pcl::PointCloud<pcl::PointXYZI>::Ptr& keypoints, typename pcl::PointCloud<FeatureType>::Ptr features);
 
     /**
      * @brief find corresponding features based on some metric
@@ -131,11 +131,11 @@ ICCVTutorial<FeatureType>::ICCVTutorial(pcl::Keypoint<pcl::PointXYZRGB, pcl::Poi
                                         pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr target)
 : source_keypoints_ (new pcl::PointCloud<pcl::PointXYZI> ())
 , target_keypoints_ (new pcl::PointCloud<pcl::PointXYZI> ())
-, keypoint_detector_ (keypoint_detector)
+, keypoint_detector_ (std::move(keypoint_detector))
 , feature_extractor_ (feature_extractor)
-, surface_reconstructor_ (surface_reconstructor)
-, source_ (source)
-, target_ (target)
+, surface_reconstructor_ (std::move(surface_reconstructor))
+, source_ (std::move(source))
+, target_ (std::move(target))
 , source_segmented_ (new pcl::PointCloud<pcl::PointXYZRGB>)
 , target_segmented_ (new pcl::PointCloud<pcl::PointXYZRGB>)
 , source_transformed_ (new pcl::PointCloud<pcl::PointXYZRGB>)
@@ -170,7 +170,7 @@ ICCVTutorial<FeatureType>::ICCVTutorial(pcl::Keypoint<pcl::PointXYZRGB, pcl::Poi
 }
 
 template<typename FeatureType>
-void ICCVTutorial<FeatureType>::segmentation (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr source, typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr segmented) const
+void ICCVTutorial<FeatureType>::segmentation (const typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& source, const typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr& segmented) const
 {
   cout << "segmentation..." << std::flush;
   // fit plane and keep points above that plane
@@ -229,7 +229,7 @@ void ICCVTutorial<FeatureType>::segmentation (typename pcl::PointCloud<pcl::Poin
 }
 
 template<typename FeatureType>
-void ICCVTutorial<FeatureType>::detectKeypoints (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, pcl::PointCloud<pcl::PointXYZI>::Ptr keypoints) const
+void ICCVTutorial<FeatureType>::detectKeypoints (const typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& input, const pcl::PointCloud<pcl::PointXYZI>::Ptr& keypoints) const
 {
   cout << "keypoint detection..." << std::flush;
   keypoint_detector_->setInputCloud(input);
@@ -238,7 +238,7 @@ void ICCVTutorial<FeatureType>::detectKeypoints (typename pcl::PointCloud<pcl::P
 }
 
 template<typename FeatureType>
-void ICCVTutorial<FeatureType>::extractDescriptors (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, typename pcl::PointCloud<pcl::PointXYZI>::Ptr keypoints, typename pcl::PointCloud<FeatureType>::Ptr features)
+void ICCVTutorial<FeatureType>::extractDescriptors (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, const typename pcl::PointCloud<pcl::PointXYZI>::Ptr& keypoints, typename pcl::PointCloud<FeatureType>::Ptr features)
 {
   typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr kpts(new pcl::PointCloud<pcl::PointXYZRGB>);
   kpts->points.resize(keypoints->points.size());

--- a/apps/src/openni_mobile_server.cpp
+++ b/apps/src/openni_mobile_server.cpp
@@ -58,7 +58,7 @@ struct PointCloudBuffers
 };
 
 void
-CopyPointCloudToBuffers (pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr cloud, PointCloudBuffers& cloud_buffers)
+CopyPointCloudToBuffers (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& cloud, PointCloudBuffers& cloud_buffers)
 {
   const size_t nr_points = cloud->points.size ();
 

--- a/apps/src/openni_organized_edge_detection.cpp
+++ b/apps/src/openni_organized_edge_detection.cpp
@@ -63,7 +63,7 @@ class OpenNIOrganizedEdgeDetection
     }
 
     pcl::visualization::PCLVisualizer::Ptr
-    initCloudViewer (pcl::PointCloud<PointT>::ConstPtr cloud)
+    initCloudViewer (const pcl::PointCloud<PointT>::ConstPtr& cloud)
     {
       viewer->setSize (640, 480);
       viewer->addPointCloud<PointT> (cloud, "cloud");

--- a/apps/src/openni_organized_multi_plane_segmentation.cpp
+++ b/apps/src/openni_organized_multi_plane_segmentation.cpp
@@ -68,7 +68,7 @@ class OpenNIOrganizedMultiPlaneSegmentation
     }
 
     pcl::visualization::PCLVisualizer::Ptr
-    cloudViewer (pcl::PointCloud<PointT>::ConstPtr cloud)
+    cloudViewer (const pcl::PointCloud<PointT>::ConstPtr& cloud)
     {
       pcl::visualization::PCLVisualizer::Ptr viewer (new pcl::visualization::PCLVisualizer ("Viewer"));
       viewer->setBackgroundColor (0, 0, 0);

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -13,7 +13,7 @@
 
 void
 displayPlanarRegions (std::vector<pcl::PlanarRegion<PointT>, Eigen::aligned_allocator<pcl::PlanarRegion<PointT> > > &regions,
-                      pcl::visualization::PCLVisualizer::Ptr viewer)
+                      const pcl::visualization::PCLVisualizer::Ptr& viewer)
 {
   char name[1024];
   unsigned char red [6] = {255,   0,   0, 255, 255,   0};
@@ -44,7 +44,7 @@ displayPlanarRegions (std::vector<pcl::PlanarRegion<PointT>, Eigen::aligned_allo
 
 void
 displayEuclideanClusters (const pcl::PointCloud<PointT>::CloudVectorType &clusters,
-                          pcl::visualization::PCLVisualizer::Ptr viewer)
+                          const pcl::visualization::PCLVisualizer::Ptr& viewer)
 {
   char name[1024];
   unsigned char red [6] = {255,   0,   0, 255, 255,   0};
@@ -64,7 +64,7 @@ displayEuclideanClusters (const pcl::PointCloud<PointT>::CloudVectorType &cluste
 }
 
 void
-displayCurvature (pcl::PointCloud<PointT>& cloud, pcl::PointCloud<pcl::Normal>& normals, pcl::visualization::PCLVisualizer::Ptr viewer)
+displayCurvature (pcl::PointCloud<PointT>& cloud, pcl::PointCloud<pcl::Normal>& normals, const pcl::visualization::PCLVisualizer::Ptr& viewer)
 {
   pcl::PointCloud<pcl::PointXYZRGBA> curvature_cloud = cloud;
   for (size_t i  = 0; i < cloud.points.size (); i++)
@@ -88,7 +88,7 @@ displayCurvature (pcl::PointCloud<PointT>& cloud, pcl::PointCloud<pcl::Normal>& 
 }
 
 void
-displayDistanceMap (pcl::PointCloud<PointT>& cloud, float* distance_map, pcl::visualization::PCLVisualizer::Ptr viewer)
+displayDistanceMap (pcl::PointCloud<PointT>& cloud, float* distance_map, const pcl::visualization::PCLVisualizer::Ptr& viewer)
 {
   pcl::PointCloud<pcl::PointXYZRGBA> distance_map_cloud = cloud;
   for (size_t i  = 0; i < cloud.points.size (); i++)
@@ -112,7 +112,7 @@ displayDistanceMap (pcl::PointCloud<PointT>& cloud, float* distance_map, pcl::vi
 }
 
 void
-removePreviousDataFromScreen (size_t prev_models_size, size_t prev_clusters_size, pcl::visualization::PCLVisualizer::Ptr viewer)
+removePreviousDataFromScreen (size_t prev_models_size, size_t prev_clusters_size, const pcl::visualization::PCLVisualizer::Ptr& viewer)
 {
   char name[1024];
   for (size_t i = 0; i < prev_models_size; i++)

--- a/apps/src/ppf_object_recognition.cpp
+++ b/apps/src/ppf_object_recognition.cpp
@@ -22,7 +22,7 @@ const float normal_estimation_search_radius = 0.05f;
 
 
 PointCloud<PointNormal>::Ptr
-subsampleAndCalculateNormals (PointCloud<PointXYZ>::Ptr cloud)
+subsampleAndCalculateNormals (const PointCloud<PointXYZ>::Ptr& cloud)
 {
   PointCloud<PointXYZ>::Ptr cloud_subsampled (new PointCloud<PointXYZ> ());
   VoxelGrid<PointXYZ> subsampling_filter;


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,performance-unnecessary-value-param' -fix`