### PR TITLE
Prefer C++ method std::acos over C method acos

### DIFF
--- a/apps/in_hand_scanner/src/visibility_confidence.cpp
+++ b/apps/in_hand_scanner/src/visibility_confidence.cpp
@@ -114,7 +114,7 @@ pcl::ihs::addDirection (const Eigen::Vector4f& normal,
   // TODO: The threshold is hard coded for a frequency=3.
   //       It can be calculated with
   //       - max_z = maximum z value of the dome vertices (excluding [0; 0; 1])
-  //       - thresh = cos (acos (max_z) / 2)
+  //       - thresh = cos (std::acos (max_z) / 2)
   //       - always round up!
   //       - with max_z = 0.939 -> thresh = 0.9847 ~ 0.985
   if (dot <= .985f)
@@ -134,7 +134,7 @@ pcl::ihs::addDirection (const Eigen::Vector4f& normal,
 
   // Find the closest viewing direction
   // NOTE: cos (0deg) = 1 = max
-  //       acos (angle) = dot (a, b) / (norm (a) * norm (b)
+  //       std::acos (angle) = dot (a, b) / (norm (a) * norm (b)
   //       m_sphere_vertices are already normalized
   unsigned int index = 0;
   aligned_direction.transpose ().lazyProduct (pcl::ihs::dome.getVertices ()).maxCoeff (&index);

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -51,7 +51,7 @@ pcl::getAngle3D (const Eigen::Vector4f &v1, const Eigen::Vector4f &v2, const boo
     rad = -1.0;
   else if (rad >  1.0)
     rad = 1.0;
-  return (in_degree ? acos (rad) * 180.0 / M_PI : acos (rad));
+  return (in_degree ? std::acos (rad) * 180.0 / M_PI : std::acos (rad));
 }
 
 inline double
@@ -63,7 +63,7 @@ pcl::getAngle3D (const Eigen::Vector3f &v1, const Eigen::Vector3f &v2, const boo
     rad = -1.0;
   else if (rad >  1.0)
     rad = 1.0;
-  return (in_degree ? acos (rad) * 180.0 / M_PI : acos (rad));
+  return (in_degree ? std::acos (rad) * 180.0 / M_PI : std::acos (rad));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -230,7 +230,7 @@ inline void
   else
   {
     double tmp1 = sqrt (- (4.0/3.0)*alpha),
-           tmp2 = acos (-sqrt (-27.0/alpha3)*0.5*beta)/3.0;
+           tmp2 = std::acos (-sqrt (-27.0/alpha3)*0.5*beta)/3.0;
     roots.push_back (tmp1*cos (tmp2) - resubValue);
     roots.push_back (-tmp1*cos (tmp2 + M_PI/3.0) - resubValue);
     roots.push_back (-tmp1*cos (tmp2 - M_PI/3.0) - resubValue);

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -635,7 +635,7 @@ RangeImage::getImpactAngle (const PointWithRange& point1, const PointWithRange& 
           d     = std::sqrt (dSqr);
     float cos_impact_angle = (r2Sqr + dSqr - r1Sqr)/ (2.0f*r2*d);
     cos_impact_angle = (std::max) (0.0f, (std::min) (1.0f, cos_impact_angle));
-    impact_angle = acosf (cos_impact_angle);  // Using the cosine rule
+    impact_angle = std::acos (cos_impact_angle);  // Using the cosine rule
   }
   
   if (point1.range > point2.range)
@@ -715,7 +715,7 @@ RangeImage::getSurfaceAngleChange (int x, int y, int radius, float& angle_change
     }
     angle_change_x = transformed_left.dot (transformed_right);
     angle_change_x = (std::max) (0.0f, (std::min) (1.0f, angle_change_x));
-    angle_change_x = acosf (angle_change_x);
+    angle_change_x = std::acos (angle_change_x);
   }
   
   if (isObserved (x, y-radius) && isObserved (x, y+radius))
@@ -747,7 +747,7 @@ RangeImage::getSurfaceAngleChange (int x, int y, int radius, float& angle_change
     }
     angle_change_y = transformed_top.dot (transformed_bottom);
     angle_change_y = (std::max) (0.0f, (std::min) (1.0f, angle_change_y));
-    angle_change_y = acosf (angle_change_y);
+    angle_change_y = std::acos (angle_change_y);
   }
 }
 
@@ -761,10 +761,10 @@ RangeImage::getSurfaceAngleChange (int x, int y, int radius, float& angle_change
     //if (std::isinf (neighbor2.range))
       //return 0.0f;
     //else
-      //return acosf ( (Eigen::Vector3f (point.x, point.y, point.z)-getSensorPos ()).normalized ().dot ( (Eigen::Vector3f (neighbor2.x, neighbor2.y, neighbor2.z)-Eigen::Vector3f (point.x, point.y, point.z)).normalized ()));
+      //return std::acos ( (Eigen::Vector3f (point.x, point.y, point.z)-getSensorPos ()).normalized ().dot ( (Eigen::Vector3f (neighbor2.x, neighbor2.y, neighbor2.z)-Eigen::Vector3f (point.x, point.y, point.z)).normalized ()));
   //}
   //if (std::isinf (neighbor2.range))
-    //return acosf ( (Eigen::Vector3f (point.x, point.y, point.z)-getSensorPos ()).normalized ().dot ( (Eigen::Vector3f (neighbor1.x, neighbor1.y, neighbor1.z)-Eigen::Vector3f (point.x, point.y, point.z)).normalized ()));
+    //return std::acos ( (Eigen::Vector3f (point.x, point.y, point.z)-getSensorPos ()).normalized ().dot ( (Eigen::Vector3f (neighbor1.x, neighbor1.y, neighbor1.z)-Eigen::Vector3f (point.x, point.y, point.z)).normalized ()));
   
   //float d1_squared = squaredEuclideanDistance (point, neighbor1),
         //d1 = std::sqrt (d1_squared),
@@ -772,7 +772,7 @@ RangeImage::getSurfaceAngleChange (int x, int y, int radius, float& angle_change
         //d2 = std::sqrt (d2_squared),
         //d3_squared = squaredEuclideanDistance (neighbor1, neighbor2);
   //float cos_surface_change = (d1_squared + d2_squared - d3_squared)/ (2.0f*d1*d2),
-        //surface_change = acosf (cos_surface_change);
+        //surface_change = std::acos (cos_surface_change);
   //if (std::isnan (surface_change))
     //surface_change = static_cast<float> (M_PI);
   ////std::cout << PVARN (point)<<PVARN (neighbor1)<<PVARN (neighbor2)<<PVARN (cos_surface_change)<<PVARN (surface_change)<<PVARN (d1)<<PVARN (d2)<<PVARN (d1_squared)<<PVARN (d2_squared)<<PVARN (d3_squared);
@@ -887,7 +887,7 @@ RangeImage::getImpactAngleBasedOnLocalNormal (int x, int y, int radius) const
   Eigen::Vector3f normal;
   if (!getNormalForClosestNeighbors (x, y, radius, point, no_of_nearest_neighbors, normal, 1))
     return -std::numeric_limits<float>::infinity ();
-  return deg2rad (90.0f) - acosf (normal.dot ( (getSensorPos ()-getEigenVector3f (point)).normalized ()));
+  return deg2rad (90.0f) - std::acos (normal.dot ( (getSensorPos ()-getEigenVector3f (point)).normalized ()));
 }
 
 

--- a/common/src/bearing_angle_image.cpp
+++ b/common/src/bearing_angle_image.cpp
@@ -80,7 +80,7 @@ BearingAngleImage::getAngle (const PointXYZ &point1, const PointXYZ &point2)
 
   if (a != 0 && b != 0)
   {
-    theta = acos ((a + b - c) / (2 * sqrt (a) * sqrt (b))) * 180 / M_PI;
+    theta = std::acos ((a + b - c) / (2 * sqrt (a) * sqrt (b))) * 180 / M_PI;
   }
   else
   {

--- a/cuda/sample_consensus/src/sac_model_1point_plane.cu
+++ b/cuda/sample_consensus/src/sac_model_1point_plane.cu
@@ -485,9 +485,9 @@ namespace pcl
       if ((fabs (actual_disparity - orig_disparity) <= 1.0/2.0) & (idx != -1)
           &
             (
-              fabs (acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
+              fabs (std::acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
               |
-              fabs (acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
+              fabs (std::acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
             )
          )
         return (idx);
@@ -510,9 +510,9 @@ namespace pcl
                 pt.z * coefficients.z + coefficients.w) < threshold
           &
             (
-              fabs (acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
+              fabs (std::acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
               |
-              fabs (acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
+              fabs (std::acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
             )
           )
         // If inlier, return its position in the vector

--- a/doc/tutorials/content/sources/registration_api/example1.cpp
+++ b/doc/tutorials/content/sources/registration_api/example1.cpp
@@ -77,7 +77,7 @@ rejectBadCorrespondences (const CorrespondencesPtr &all_correspondences,
 
   // Reject if the angle between the normals is really off
   CorrespondenceRejectorSurfaceNormal rej_normals;
-  rej_normals.setThreshold (acos (deg2rad (45.0)));
+  rej_normals.setThreshold (std::acos (deg2rad (45.0)));
   rej_normals.initializeDataContainer<PointT, PointT> ();
   rej_normals.setInputCloud<PointT> (src);
   rej_normals.setInputNormals<PointT, PointT> (src);

--- a/features/include/pcl/features/impl/3dsc.hpp
+++ b/features/include/pcl/features/impl/3dsc.hpp
@@ -212,7 +212,7 @@ pcl::ShapeContext3DEstimation<PointInT, PointNT, PointOutT>::computePoint (
     Eigen::Vector3f no = neighbour - origin;
     no.normalize ();
     float theta = normal.dot (no);
-    theta = pcl::rad2deg (acosf (std::min (1.0f, std::max (-1.0f, theta))));
+    theta = pcl::rad2deg (std::acos (std::min (1.0f, std::max (-1.0f, theta))));
 
     // Bin (j, k, l)
     size_t j = 0;

--- a/features/include/pcl/features/impl/board.hpp
+++ b/features/include/pcl/features/impl/board.hpp
@@ -88,7 +88,7 @@ pcl::BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT>::getAngleB
 {
   Eigen::Vector3f angle_orientation;
   angle_orientation = v1.cross (v2);
-  float angle_radians = acosf (std::max (-1.0f, std::min (1.0f, v1.dot (v2))));
+  float angle_radians = std::acos (std::max (-1.0f, std::min (1.0f, v1.dot (v2))));
 
   angle_radians = angle_orientation.dot (axis) < 0.f ? (2 * static_cast<float> (M_PI) - angle_radians) : angle_radians;
 

--- a/features/include/pcl/features/impl/cppf.hpp
+++ b/features/include/pcl/features/impl/cppf.hpp
@@ -88,7 +88,7 @@ pcl::CPPFEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
           Eigen::Vector3f model_reference_point = input_->points[i].getVector3fMap (),
                           model_reference_normal = normals_->points[i].getNormalVector3fMap (),
                           model_point = input_->points[j].getVector3fMap ();
-          Eigen::AngleAxisf rotation_mg (acosf (model_reference_normal.dot (Eigen::Vector3f::UnitX ())),
+          Eigen::AngleAxisf rotation_mg (std::acos (model_reference_normal.dot (Eigen::Vector3f::UnitX ())),
                                          model_reference_normal.cross (Eigen::Vector3f::UnitX ()).normalized ());
           Eigen::Affine3f transform_mg = Eigen::Translation3f ( rotation_mg * ((-1) * model_reference_point)) * rotation_mg;
 

--- a/features/include/pcl/features/impl/cvfh.hpp
+++ b/features/include/pcl/features/impl/cvfh.hpp
@@ -130,7 +130,7 @@ pcl::CVFHEstimation<PointInT, PointNT, PointOutT>::extractEuclideanClustersSmoot
                      + normals.points[seed_queue[sq_idx]].normal[1] * normals.points[nn_indices[j]].normal[1]
                      + normals.points[seed_queue[sq_idx]].normal[2] * normals.points[nn_indices[j]].normal[2];
 
-        if (fabs (acos (dot_p)) < eps_angle)
+        if (fabs (std::acos (dot_p)) < eps_angle)
         {
           processed[nn_indices[j]] = true;
           seed_queue.push_back (nn_indices[j]);

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -118,9 +118,9 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
     v23.normalize ();
 
     //TODO: .dot gives nan's
-    th1 = static_cast<int> (pcl_round (acos (fabs (v21.dot (v31))) / pih * (binsize-1)));
-    th2 = static_cast<int> (pcl_round (acos (fabs (v23.dot (v31))) / pih * (binsize-1)));
-    th3 = static_cast<int> (pcl_round (acos (fabs (v23.dot (v21))) / pih * (binsize-1)));
+    th1 = static_cast<int> (pcl_round (std::acos (fabs (v21.dot (v31))) / pih * (binsize-1)));
+    th2 = static_cast<int> (pcl_round (std::acos (fabs (v23.dot (v31))) / pih * (binsize-1)));
+    th3 = static_cast<int> (pcl_round (std::acos (fabs (v23.dot (v21))) / pih * (binsize-1)));
     if (th1 < 0 || th1 >= binsize)
     {
       nn_idx--;

--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -129,7 +129,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::extractEuclideanClustersSm
             + normals.points[seed_queue[sq_idx]].normal[1] * normals.points[nn_indices[j]].normal[1] + normals.points[seed_queue[sq_idx]].normal[2]
             * normals.points[nn_indices[j]].normal[2];
 
-        if (fabs (acos (dot_p)) < eps_angle)
+        if (fabs (std::acos (dot_p)) < eps_angle)
         {
           processed[nn_indices[j]] = true;
           seed_queue.push_back (nn_indices[j]);
@@ -641,7 +641,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
       {
         //decide if normal should be added
         double dot_p = avg_normal.dot (normals_filtered_cloud->points[index].getNormalVector4fMap ());
-        if (fabs (acos (dot_p)) < (eps_angle_threshold_ * refine_clusters_))
+        if (fabs (std::acos (dot_p)) < (eps_angle_threshold_ * refine_clusters_))
         {
           clusters_[cluster_filtered_idx].indices.push_back (indices_from_nfc_to_indices[index]);
           clusters_filtered[cluster_filtered_idx].indices.push_back (index);

--- a/features/include/pcl/features/impl/ppf.hpp
+++ b/features/include/pcl/features/impl/ppf.hpp
@@ -85,7 +85,7 @@ pcl::PPFEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
           Eigen::Vector3f model_reference_point = input_->points[i].getVector3fMap (),
                           model_reference_normal = normals_->points[i].getNormalVector3fMap (),
                           model_point = input_->points[j].getVector3fMap ();
-          float rotation_angle = acosf (model_reference_normal.dot (Eigen::Vector3f::UnitX ()));
+          float rotation_angle = std::acos (model_reference_normal.dot (Eigen::Vector3f::UnitX ()));
           bool parallel_to_x = (model_reference_normal.y() == 0.0f && model_reference_normal.z() == 0.0f);
           Eigen::Vector3f rotation_axis = (parallel_to_x)?(Eigen::Vector3f::UnitY ()):(model_reference_normal.cross (Eigen::Vector3f::UnitX ()). normalized());
           Eigen::AngleAxisf rotation_mg (rotation_angle, rotation_axis);

--- a/features/include/pcl/features/impl/ppfrgb.hpp
+++ b/features/include/pcl/features/impl/ppfrgb.hpp
@@ -80,7 +80,7 @@ pcl::PPFRGBEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudO
           Eigen::Vector3f model_reference_point = input_->points[i].getVector3fMap (),
               model_reference_normal = normals_->points[i].getNormalVector3fMap (),
               model_point = input_->points[j].getVector3fMap ();
-          Eigen::AngleAxisf rotation_mg (acosf (model_reference_normal.dot (Eigen::Vector3f::UnitX ())),
+          Eigen::AngleAxisf rotation_mg (std::acos (model_reference_normal.dot (Eigen::Vector3f::UnitX ())),
                                          model_reference_normal.cross (Eigen::Vector3f::UnitX ()).normalized ());
           Eigen::Affine3f transform_mg = Eigen::Translation3f ( rotation_mg * ((-1) * model_reference_point)) * rotation_mg;
 

--- a/features/include/pcl/features/impl/range_image_border_extractor.hpp
+++ b/features/include/pcl/features/impl/range_image_border_extractor.hpp
@@ -388,8 +388,8 @@ bool RangeImageBorderExtractor::calculateMainPrincipalCurvature(int x, int y, in
     //magnitude = -std::numeric_limits<float>::infinity ();
     //return false;
   //}
-  //float angle2 = acosf(surface_structure_[y*range_image_->width+x+1]->normal.dot(local_surface->normal)),
-        //angle1 = acosf(surface_structure_[y*range_image_->width+x-1]->normal.dot(local_surface->normal));
+  //float angle2 = std::acos(surface_structure_[y*range_image_->width+x+1]->normal.dot(local_surface->normal)),
+        //angle1 = std::acos(surface_structure_[y*range_image_->width+x-1]->normal.dot(local_surface->normal));
   //magnitude = angle2-angle1;
 
   return std::isfinite(magnitude);

--- a/features/include/pcl/features/impl/rift.hpp
+++ b/features/include/pcl/features/impl/rift.hpp
@@ -72,7 +72,7 @@ pcl::RIFTEstimation<PointInT, GradientT, PointOutT>::computeRIFT (
     Eigen::Map<const Eigen::Vector3f> gradient_vector (& (gradient.points[indices[idx]].gradient[0]));
 
     float gradient_magnitude = gradient_vector.norm ();
-    float gradient_angle_from_center = acosf (gradient_vector.dot ((point - p0).normalized ()) / gradient_magnitude);
+    float gradient_angle_from_center = std::acos (gradient_vector.dot ((point - p0).normalized ()) / gradient_magnitude);
     if (!std::isfinite (gradient_angle_from_center))
       gradient_angle_from_center = 0.0;
 

--- a/features/include/pcl/features/impl/rsd.hpp
+++ b/features/include/pcl/features/impl/rsd.hpp
@@ -84,7 +84,7 @@ pcl::computeRSD (const pcl::PointCloud<PointInT> &surface, const pcl::PointCloud
                     normals.points[*i].normal[2] * normals.points[*begin].normal[2];
     if (cosine > 1) cosine = 1;
     if (cosine < -1) cosine = -1;
-    double angle  = acos (cosine);
+    double angle  = std::acos (cosine);
     if (angle > M_PI/2) angle = M_PI - angle; /// \note: orientation is neglected!
 
     // Compute point to point distance
@@ -185,7 +185,7 @@ pcl::computeRSD (const pcl::PointCloud<PointNT> &normals,
                     normals.points[*i].normal[2] * normals.points[*begin].normal[2];
     if (cosine > 1) cosine = 1;
     if (cosine < -1) cosine = -1;
-    double angle  = acos (cosine);
+    double angle  = std::acos (cosine);
     if (angle > M_PI/2) angle = M_PI - angle; /// \note: orientation is neglected!
 
     // Compute point to point distance

--- a/features/include/pcl/features/impl/shot.hpp
+++ b/features/include/pcl/features/impl/shot.hpp
@@ -359,7 +359,7 @@ pcl::SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSing
     if (inclinationCos > 1.0)
       inclinationCos = 1.0;
 
-    double inclination = acos (inclinationCos);
+    double inclination = std::acos (inclinationCos);
 
     assert (inclination >= 0.0 && inclination <= PST_RAD_180);
 
@@ -558,7 +558,7 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::interpolateDou
     if (inclinationCos > 1.0)
       inclinationCos = 1.0;
 
-    double inclination = acos (inclinationCos);
+    double inclination = std::acos (inclinationCos);
 
     assert (inclination >= 0.0 && inclination <= PST_RAD_180);
 

--- a/features/include/pcl/features/impl/spin_image.hpp
+++ b/features/include/pcl/features/impl/spin_image.hpp
@@ -211,10 +211,10 @@ pcl::SpinImageEstimation<PointInT, PointNT, PointOutT>::computeSiForPoint (int i
 
     if (is_angular_)
     {
-      m_averAngles (alpha_bin, beta_bin) += (1-a) * (1-b) * acos (cos_between_normals); 
-      m_averAngles (alpha_bin+1, beta_bin) += a * (1-b) * acos (cos_between_normals);
-      m_averAngles (alpha_bin, beta_bin+1) += (1-a) * b * acos (cos_between_normals);
-      m_averAngles (alpha_bin+1, beta_bin+1) += a * b * acos (cos_between_normals);
+      m_averAngles (alpha_bin, beta_bin) += (1-a) * (1-b) * std::acos (cos_between_normals); 
+      m_averAngles (alpha_bin+1, beta_bin) += a * (1-b) * std::acos (cos_between_normals);
+      m_averAngles (alpha_bin, beta_bin+1) += (1-a) * b * std::acos (cos_between_normals);
+      m_averAngles (alpha_bin+1, beta_bin+1) += a * b * std::acos (cos_between_normals);
     }
   }
 

--- a/features/include/pcl/features/impl/usc.hpp
+++ b/features/include/pcl/features/impl/usc.hpp
@@ -186,7 +186,7 @@ pcl::UniqueShapeContext<PointInT, PointOutT, PointRFT>::computePointDescriptor (
     Eigen::Vector3f no = neighbour - origin;
     no.normalize ();
     float theta = normal.dot (no);
-    theta = pcl::rad2deg (acosf (std::min (1.0f, std::max (-1.0f, theta))));
+    theta = pcl::rad2deg (std::acos (std::min (1.0f, std::max (-1.0f, theta))));
 
     /// Bin (j, k, l)
     size_t j = 0;

--- a/features/src/pfh.cpp
+++ b/features/src/pfh.cpp
@@ -64,7 +64,7 @@ pcl::computePairFeatures (const Eigen::Vector4f &p1, const Eigen::Vector4f &n1,
 
   // Make sure the same point is selected as 1 and 2 for each pair
   float angle2 = n2_copy.dot (dp2p1) / f4;
-  if (acos (std::fabs (angle1)) > acos (std::fabs (angle2)))
+  if (std::acos (std::fabs (angle1)) > std::acos (std::fabs (angle2)))
   {
     // switch p1 and p2
     n1_copy = n2;

--- a/gpu/features/include/pcl/gpu/features/device/pair_features.hpp
+++ b/gpu/features/include/pcl/gpu/features/device/pair_features.hpp
@@ -60,7 +60,7 @@ namespace pcl
             
 
             float angle2 = dot(n2_copy, dp2p1) / f4;
-            if (acos (fabs (angle1)) > acos (fabs (angle2)))
+            if (std::acos (fabs (angle1)) > std::acos (fabs (angle2)))
             {
               // switch p1 and p2
               n1_copy = n2;
@@ -179,7 +179,7 @@ namespace pcl
          __device__ __host__ __forceinline__ void computeAlfaM(const float3& model_reference_point, const float3& model_reference_normal, 
             const float3& model_point, float& alpha_m)
         {
-            float acos_value = acos (model_reference_normal.x);
+            float acos_value = std::acos (model_reference_normal.x);
 
             //float3 cross_vector = cross(model_reference_normal, Eigen::Vector3f::UnitX);
             float3 cross_vector = make_float3(0, model_reference_normal.z, - model_reference_normal.y);

--- a/gpu/features/src/spinimages.cu
+++ b/gpu/features/src/spinimages.cu
@@ -227,7 +227,7 @@ namespace pcl
 
 					if (angular)
 					{
-						float anlge_betwwn_normals = acos(cos_between_normals);						
+						float anlge_betwwn_normals = std::acos(cos_between_normals);						
 						incAngle(alpha_bin,   beta_bin,   anlge_betwwn_normals * (1-a) * (1-b)); 
 						incAngle(alpha_bin+1, beta_bin,   anlge_betwwn_normals *    a  * (1-b));
 						incAngle(alpha_bin,   beta_bin+1, anlge_betwwn_normals * (1-a) *    b );

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -589,7 +589,7 @@ namespace pcl
       double c = (R.trace() - 1) * 0.5;
       c = c > 1. ? 1. : c < -1. ? -1. : c;
 
-      double theta = acos(c);
+      double theta = std::acos(c);
 
       if( s < 1e-5 )
       {

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -870,7 +870,7 @@ namespace pcl
         double c = (R.trace() - 1) * 0.5;
         c = c > 1. ? 1. : c < -1. ? -1. : c;
 
-        double theta = acos(c);
+        double theta = std::acos(c);
 
         if( s < 1e-5 )
         {

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -146,7 +146,7 @@ namespace
     Eigen::Vector3f rotated_direction = rotation*direction;
     Eigen::Vector2f direction_vector (rotated_direction[0], rotated_direction[1]);
     direction_vector.normalize ();
-    float angle = 0.5f*normAngle (2.0f*acosf (direction_vector[0]));
+    float angle = 0.5f*normAngle (2.0f*std::acos (direction_vector[0]));
     return (angle);
   }
   

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -112,7 +112,7 @@ inline void extractEuclideanClustersSmooth(const typename pcl::PointCloud<PointT
             + normals.points[seed_queue[sq_idx]].normal[1] * normals.points[nn_indices[j]].normal[1]
             + normals.points[seed_queue[sq_idx]].normal[2] * normals.points[nn_indices[j]].normal[2];
 
-        if (fabs (acos (dot_p)) < eps_angle)
+        if (fabs (std::acos (dot_p)) < eps_angle)
         {
           processed[nn_indices[j]] = true;
           seed_queue.push_back (nn_indices[j]);

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -92,7 +92,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
     Eigen::Vector3f scene_reference_point = target_->points[scene_reference_index].getVector3fMap (),
         scene_reference_normal = target_->points[scene_reference_index].getNormalVector3fMap ();
 
-    float rotation_angle_sg = acosf (scene_reference_normal.dot (Eigen::Vector3f::UnitX ()));
+    float rotation_angle_sg = std::acos (scene_reference_normal.dot (Eigen::Vector3f::UnitX ()));
     bool parallel_to_x_sg = (scene_reference_normal.y() == 0.0f && scene_reference_normal.z() == 0.0f);
     Eigen::Vector3f rotation_axis_sg = (parallel_to_x_sg)?(Eigen::Vector3f::UnitY ()):(scene_reference_normal.cross (Eigen::Vector3f::UnitX ()). normalized());
     Eigen::AngleAxisf rotation_sg (rotation_angle_sg, rotation_axis_sg);
@@ -162,7 +162,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation (PointClou
 
     Eigen::Vector3f model_reference_point = input_->points[max_votes_i].getVector3fMap (),
         model_reference_normal = input_->points[max_votes_i].getNormalVector3fMap ();
-    float rotation_angle_mg = acosf (model_reference_normal.dot (Eigen::Vector3f::UnitX ()));
+    float rotation_angle_mg = std::acos (model_reference_normal.dot (Eigen::Vector3f::UnitX ()));
     bool parallel_to_x_mg = (model_reference_normal.y() == 0.0f && model_reference_normal.z() == 0.0f);
     Eigen::Vector3f rotation_axis_mg = (parallel_to_x_mg)?(Eigen::Vector3f::UnitY ()):(model_reference_normal.cross (Eigen::Vector3f::UnitX ()). normalized());
     Eigen::AngleAxisf rotation_mg (rotation_angle_mg, rotation_axis_mg);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -110,7 +110,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::computeModelCoefficients (
   ap3.normalize ();
 
   //compute opening angle
-  float opening_angle = ( acosf (ap1.dot (axis_dir)) + acosf (ap2.dot (axis_dir)) + acosf (ap3.dot (axis_dir)) ) / 3.0f;
+  float opening_angle = ( std::acos (ap1.dot (axis_dir)) + std::acos (ap2.dot (axis_dir)) + std::acos (ap3.dot (axis_dir)) ) / 3.0f;
 
   model_coefficients.resize (7);
   // model_coefficients.template head<3> ()    = line_pt.template head<3> ();

--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -149,7 +149,7 @@ namespace pcl
           double dot_p = normals.points[i].normal[0] * normals.points[nn_indices[j]].normal[0] +
                          normals.points[i].normal[1] * normals.points[nn_indices[j]].normal[1] +
                          normals.points[i].normal[2] * normals.points[nn_indices[j]].normal[2];
-          if ( fabs (acos (dot_p)) < eps_angle )
+          if ( fabs (std::acos (dot_p)) < eps_angle )
           {
             processed[nn_indices[j]] = true;
             seed_queue.push_back (nn_indices[j]);
@@ -255,7 +255,7 @@ namespace pcl
             normals.points[indices[i]].normal[0] * normals.points[indices[nn_indices[j]]].normal[0] +
             normals.points[indices[i]].normal[1] * normals.points[indices[nn_indices[j]]].normal[1] +
             normals.points[indices[i]].normal[2] * normals.points[indices[nn_indices[j]]].normal[2];
-          if ( fabs (acos (dot_p)) < eps_angle )
+          if ( fabs (std::acos (dot_p)) < eps_angle )
           {
             processed[nn_indices[j]] = true;
             seed_queue.push_back (nn_indices[j]);

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -181,7 +181,7 @@ namespace pcl
       inline float
       getAngularThreshold () const
       {
-        return (acosf (angular_threshold_) );
+        return (std::acos (angular_threshold_) );
       }
 
       /** \brief Set the tolerance in meters for difference in perpendicular distance (d component of plane equation) to the plane between neighboring points, to be considered part of the same plane.

--- a/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
@@ -156,7 +156,7 @@ namespace pcl
       inline float
       getAngularThreshold () const
       {
-        return (acosf (angular_threshold_) );
+        return (std::acos (angular_threshold_) );
       }
 
       /** \brief Set the tolerance in meters for difference in perpendicular distance (d component of plane equation) to the plane between neighboring points, to be considered part of the same plane.

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -378,7 +378,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
         double cosine = nc.dot (neighbor_normal);
         if (cosine > 1) cosine = 1;
         if (cosine < -1) cosine = -1;
-        double angle = acos (cosine);
+        double angle = std::acos (cosine);
         if ((!consistent_) && (angle > M_PI/2))
           angle = M_PI - angle;
         if (angle > eps_angle_)

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -682,7 +682,7 @@ double q[4];
   q[2] = qx.y();
   q[3] = qx.z();
 
-    double halftheta = acos (q[0]);
+    double halftheta = std::acos (q[0]);
     theta = halftheta * 2;
     double sinhalftheta = sin (halftheta);
     if (feq (halftheta, 0)) {


### PR DESCRIPTION
This fix Clang-tidy warning `call to 'acos' promotes float to double` in 
https://github.com/PointCloudLibrary/pcl/blob/816391762918f3a026b1822fe42c74bb83129eb4/features/src/pfh.cpp#L67

This issues seem to be missed in #3087.