### PR TITLE
Support AppleClang in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
 # Compiler identification
 # Define a variable CMAKE_COMPILER_IS_X where X is the compiler short name.
 # Note: CMake automatically defines one for GNUCXX, nothing to do in this case.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANG 1)
 elseif(__COMPILER_PATHSCALE)
   set(CMAKE_COMPILER_IS_PATHSCALE 1)


### PR DESCRIPTION
Changing this option makes sure that `CMAKE_COMPILER_IS_CLANG` is defined not matter whether the compiler used is regular Clang or AppleClang (see https://stackoverflow.com/a/10055571/1364752).

Apparently when the `STREQUAL` check was introduced, the required CMake version was < 3.0, so it didn't make a difference between Clang and AppleClang. This should notably enable again some SEE optimizations on OSX.