### PR TITLE
Use std::vector instead of just vector

### DIFF
--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -264,7 +264,7 @@ class NILinemod
       euclidean_segmentation.setInputCloud (cloud);
 
       PointCloud<Label> euclidean_labels;
-      vector<PointIndices> euclidean_label_indices;
+      std::vector<PointIndices> euclidean_label_indices;
       euclidean_segmentation.segment (euclidean_labels, euclidean_label_indices);
 
       // For each cluster found
@@ -313,12 +313,12 @@ class NILinemod
       mps_.setInputCloud (search_.getInputCloud ());
 
       // Use one of the overloaded segmentAndRefine calls to get all the information that we want out
-      vector<PlanarRegion<PointT>, Eigen::aligned_allocator<PlanarRegion<PointT> > > regions;
-      vector<ModelCoefficients> model_coefficients;
-      vector<PointIndices> inlier_indices;  
+      std::vector<PlanarRegion<PointT>, Eigen::aligned_allocator<PlanarRegion<PointT> > > regions;
+      std::vector<ModelCoefficients> model_coefficients;
+      std::vector<PointIndices> inlier_indices;  
       PointCloud<Label>::Ptr labels (new PointCloud<Label>);
-      vector<PointIndices> label_indices;
-      vector<PointIndices> boundary_indices;
+      std::vector<PointIndices> label_indices;
+      std::vector<PointIndices> boundary_indices;
       mps_.segmentAndRefine (regions, model_coefficients, inlier_indices, labels, label_indices, boundary_indices);
       PCL_DEBUG ("Number of planar regions detected: %lu for a cloud of %lu points and %lu normals.\n", regions.size (), search_.getInputCloud ()->points.size (), normal_cloud->points.size ());
 
@@ -370,8 +370,8 @@ class NILinemod
       if (idx == -1)
         return;
 
-      vector<int> indices (1);
-      vector<float> distances (1);
+      std::vector<int> indices (1);
+      std::vector<float> distances (1);
 
       // Use mutices to make sure we get the right cloud
       std::lock_guard<std::mutex> lock1 (cloud_mutex_);

--- a/apps/src/openni_organized_compression.cpp
+++ b/apps/src/openni_organized_compression.cpp
@@ -218,8 +218,8 @@ struct EventHelper
                   const openni_wrapper::DepthImage::Ptr &depth_image, float)
   {
 
-    vector<uint16_t> disparity_data;
-    vector<uint8_t> rgb_data;
+    std::vector<uint16_t> disparity_data;
+    std::vector<uint8_t> rgb_data;
 
     uint32_t width=depth_image->getWidth ();
     uint32_t height=depth_image->getHeight ();

--- a/apps/src/openni_shift_to_depth_conversion.cpp
+++ b/apps/src/openni_shift_to_depth_conversion.cpp
@@ -81,10 +81,10 @@ class SimpleOpenNIViewer
                     const openni_wrapper::DepthImage::Ptr &depth_image, float)
     {
 
-      vector<uint16_t> raw_shift_data;
-      vector<uint16_t> raw_depth_data;
+      std::vector<uint16_t> raw_shift_data;
+      std::vector<uint16_t> raw_depth_data;
 
-      vector<uint8_t> rgb_data;
+      std::vector<uint8_t> rgb_data;
 
       uint32_t width=depth_image->getWidth ();
       uint32_t height=depth_image->getHeight ();

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -192,7 +192,7 @@ class ObjectSelection
       exppd.setHeightLimits (0.001, 0.5);           // up to half a meter
       exppd.segment (*points_above_plane);
 
-      vector<PointIndices> euclidean_label_indices;
+      std::vector<PointIndices> euclidean_label_indices;
       // Prefer a faster method if the cloud is organized, over EuclidanClusterExtraction
       if (cloud_->isOrganized ())
       {
@@ -262,9 +262,9 @@ class ObjectSelection
       object.reset ();
 
       // Segment out all planes
-      vector<ModelCoefficients> model_coefficients;
-      vector<PointIndices> inlier_indices, boundary_indices;
-      vector<PlanarRegion<PointT>, Eigen::aligned_allocator<PlanarRegion<PointT> > > regions;
+      std::vector<ModelCoefficients> model_coefficients;
+      std::vector<PointIndices> inlier_indices, boundary_indices;
+      std::vector<PlanarRegion<PointT>, Eigen::aligned_allocator<PlanarRegion<PointT> > > regions;
 
       // Prefer a faster method if the cloud is organized, over RANSAC
       if (cloud_->isOrganized ())
@@ -288,7 +288,7 @@ class ObjectSelection
 
         // Use one of the overloaded segmentAndRefine calls to get all the information that we want out
         PointCloud<Label>::Ptr labels (new PointCloud<Label>);
-        vector<PointIndices> label_indices;
+        std::vector<PointIndices> label_indices;
         mps.segmentAndRefine (regions, model_coefficients, inlier_indices, labels, label_indices, boundary_indices);
       }
       else
@@ -417,8 +417,8 @@ class ObjectSelection
       if (idx == -1)
         return;
 
-      vector<int> indices (1);
-      vector<float> distances (1);
+      std::vector<int> indices (1);
+      std::vector<float> distances (1);
 
       // Get the point that was picked
       PointT picked_pt;
@@ -527,7 +527,7 @@ class ObjectSelection
       if (cloud_->isOrganized ())
       {
         // If the dataset is organized, and has RGB data, create an image viewer
-        vector<pcl::PCLPointField> fields;
+        std::vector<pcl::PCLPointField> fields;
         int rgba_index = -1;
         rgba_index = getFieldIndex (*cloud_, "rgba", fields);
        

--- a/apps/src/ppf_object_recognition.cpp
+++ b/apps/src/ppf_object_recognition.cpp
@@ -63,7 +63,7 @@ main (int argc, char** argv)
   PCL_INFO ("Scene read: %s\n", argv[2]);
 
   PCL_INFO ("Reading models ...\n");
-  vector<PointCloud<PointXYZ>::Ptr > cloud_models;
+  std::vector<PointCloud<PointXYZ>::Ptr > cloud_models;
   ifstream pcd_file_list (argv[1]);
   while (!pcd_file_list.eof())
   {
@@ -99,10 +99,10 @@ main (int argc, char** argv)
   }
 
   PointCloud<PointNormal>::Ptr cloud_scene_input = subsampleAndCalculateNormals (cloud_scene);
-  vector<PointCloud<PointNormal>::Ptr > cloud_models_with_normals;
+  std::vector<PointCloud<PointNormal>::Ptr > cloud_models_with_normals;
 
   PCL_INFO ("Training models ...\n");
-  vector<PPFHashMapSearch::Ptr> hashmap_search_vector;
+  std::vector<PPFHashMapSearch::Ptr> hashmap_search_vector;
   for (const auto &cloud_model : cloud_models)
   {
     PointCloud<PointNormal>::Ptr cloud_model_input = subsampleAndCalculateNormals (cloud_model);

--- a/apps/src/pyramid_surface_matching.cpp
+++ b/apps/src/pyramid_surface_matching.cpp
@@ -82,7 +82,7 @@ main (int argc, char **argv)
   PCL_INFO ("Feature cloud sizes: %u , %u\n", ppf_signature_a->points.size (), ppf_signature_b->points.size ());
 
   PCL_INFO ("Finished calculating the features ...\n");
-  vector<pair<float, float> > dim_range_input, dim_range_target;
+  std::vector<pair<float, float> > dim_range_input, dim_range_target;
   for (size_t i = 0; i < 3; ++i) dim_range_input.emplace_back(float (-M_PI), float (M_PI));
   dim_range_input.emplace_back(0.0f, 1.0f);
   for (size_t i = 0; i < 3; ++i) dim_range_target.emplace_back(float (-M_PI) * 10.0f, float (M_PI) * 10.0f);

--- a/apps/src/test_search.cpp
+++ b/apps/src/test_search.cpp
@@ -58,10 +58,10 @@ main (int argc, char ** argv)
   query.y = 0.5;
   query.z = 0.5;
 
-  vector<int> kd_indices;
-  vector<float> kd_distances;
-  vector<int> bf_indices;
-  vector<float> bf_distances;
+  std::vector<int> kd_indices;
+  std::vector<float> kd_distances;
+  std::vector<int> bf_indices;
+  std::vector<float> bf_distances;
 
   double start, stop;
   double kd_setup;

--- a/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model.h
+++ b/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model.h
@@ -103,7 +103,7 @@ namespace pcl
         using CoefficientsConstPtr = boost::shared_ptr <const Coefficients>;
 
         using Hypotheses = typename Storage<float4>::type;
-        //TODO: should be vector<int> instead of int. but currently, only 1point plane model supports this
+        //TODO: should be std::vector<int> instead of int. but currently, only 1point plane model supports this
         using Samples = typename Storage<int>::type;
 
       private:

--- a/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model_plane.h
+++ b/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model_plane.h
@@ -132,7 +132,7 @@ namespace pcl
         virtual bool 
         generateModelHypotheses (Hypotheses &h, Samples &s, int max_iterations)
         {
-          // TODO: hack.. Samples should be vector<int>, not int..
+          // TODO: hack.. Samples should be std::vector<int>, not int..
           return generateModelHypotheses (h, max_iterations);
         };
 

--- a/cuda/segmentation/include/pcl/cuda/segmentation/mssegmentation.h
+++ b/cuda/segmentation/include/pcl/cuda/segmentation/mssegmentation.h
@@ -74,9 +74,9 @@ public:
 
     void init (int n);
 
-    vector<int> parent;
-    vector<int> rank;
-    vector<int> size;
+    std::vector<int> parent;
+    std::vector<int> rank;
+    std::vector<int> size;
 private:
     DjSets(const DjSets&);
     void operator =(const DjSets&);
@@ -104,8 +104,8 @@ public:
 
     void addEdge(int from, int to, const T& val=T());
 
-    vector<int> start;
-    vector<Edge> edges;
+    std::vector<int> start;
+    std::vector<Edge> edges;
 
     int numv;
     int nume_max;

--- a/cuda/segmentation/src/mssegmentation.cpp
+++ b/cuda/segmentation/src/mssegmentation.cpp
@@ -159,7 +159,7 @@ void meanShiftSegmentation(const GpuMat& src, Mat& dst, int sp, int sr, int mins
         }
     }
 
-    vector<SegmLink> edges;
+    std::vector<SegmLink> edges;
     edges.reserve(g.numv);
 
     // Prepare edges connecting different components
@@ -188,7 +188,7 @@ void meanShiftSegmentation(const GpuMat& src, Mat& dst, int sp, int sr, int mins
 
     // Compute sum of the pixel's colors which are in the same segment
     Mat h_src = (Mat)src;
-    vector<Vec4i> sumcols(nrows * ncols, Vec4i(0, 0, 0, 0));
+    std::vector<Vec4i> sumcols(nrows * ncols, Vec4i(0, 0, 0, 0));
     for (int y = 0; y < nrows; ++y)
     {
         Vec4b* h_srcy = h_src.ptr<Vec4b>(y);

--- a/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
+++ b/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
@@ -329,7 +329,7 @@ int main(int argc, char** argv)
   pcl::Grabber::Ptr capture (new pcl::OpenNIGrabber());
 
   //selecting tree files
-  vector<string> tree_files;
+  std::vector<string> tree_files;
   tree_files.push_back("Data/forest1/tree_20.txt");
   tree_files.push_back("Data/forest2/tree_20.txt");
   tree_files.push_back("Data/forest3/tree_20.txt");

--- a/doc/tutorials/content/sources/pcl_plotter/pcl_plotter_demo.cpp
+++ b/doc/tutorials/content/sources/pcl_plotter/pcl_plotter_demo.cpp
@@ -68,9 +68,9 @@ main (int argc, char * argv [])
   plotter->setYRange (-10, 10);
 
   //defining polynomials
-  vector<double> func1 (1, 0);
+  std::vector<double> func1 (1, 0);
   func1[0] = 1; //y = 1
-  vector<double> func2 (3, 0);
+  std::vector<double> func2 (3, 0);
   func2[2] = 1; //y = x^2
 
   plotter->addPlotData (std::make_pair (func1, func2), -10, 10, "y = 1/x^2", 100, vtkChart::POINTS);
@@ -92,7 +92,7 @@ main (int argc, char * argv [])
   plotter->clearPlots ();
 
   //........................A simple animation..............................
-  vector<double> fsq (3, 0);
+  std::vector<double> fsq (3, 0);
   fsq[2] = -100; //y = x^2
   while (!plotter->wasStopped ())
   {

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -256,7 +256,7 @@ Narf::extractFromRangeImageWithBestRotation (const RangeImage& range_image, cons
                                              int descriptor_size, float support_size)
 {
   extractFromRangeImage(range_image, interest_point, descriptor_size, support_size);
-  vector<float> rotations, strengths;
+  std::vector<float> rotations, strengths;
   getRotations(rotations, strengths);
   if (rotations.empty())
     return false;
@@ -353,7 +353,7 @@ Narf::extractFromRangeImageAndAddToList (const RangeImage& range_image, const Ei
     feature_list.push_back(feature);
     return;
   }
-  vector<float> rotations, strengths;
+  std::vector<float> rotations, strengths;
   feature->getRotations(rotations, strengths);
   feature->getRotatedVersions(range_image, rotations, feature_list);
   delete feature;
@@ -397,7 +397,7 @@ Narf::extractForInterestPoints (const RangeImage& range_image, const PointCloud<
         }
       }
       else {
-        vector<float> rotations, strengths;
+        std::vector<float> rotations, strengths;
         feature->getRotations(rotations, strengths);
         {
           //feature->getRotatedVersions(range_image, rotations, feature_list);

--- a/filters/src/statistical_outlier_removal.cpp
+++ b/filters/src/statistical_outlier_removal.cpp
@@ -67,7 +67,7 @@ pcl::StatisticalOutlierRemoval<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2
   double mean;
   double variance;
   double stddev;
-  vector<float> distances;
+  std::vector<float> distances;
   generateStatistics (mean, variance, stddev, distances);
   double const distance_threshold = mean + std_mul_ * stddev; // a distance that is bigger than this signals an outlier
 
@@ -157,7 +157,7 @@ pcl::StatisticalOutlierRemoval<pcl::PCLPointCloud2>::applyFilter (vector<int>& i
   double mean;
   double variance;
   double stddev;
-  vector<float> distances;
+  std::vector<float> distances;
   generateStatistics(mean, variance, stddev, distances);
   double const distance_threshold = mean + std_mul_ * stddev; // a distance that is bigger than this signals an outlier
 

--- a/gpu/features/test/test_fpfh.cpp
+++ b/gpu/features/test/test_fpfh.cpp
@@ -58,9 +58,9 @@ TEST(PCL_FeaturesGPU, fpfh_low_level)
     source.findRadiusNeghbors();
     cout << "max_radius_nn_size: " << source.max_nn_size << endl;
                    
-    vector<int> data;
+    std::vector<int> data;
     source.getNeghborsArray(data);
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
     
     //uploading data to GPU
@@ -79,7 +79,7 @@ TEST(PCL_FeaturesGPU, fpfh_low_level)
     fpfh_gpu.compute(cloud_gpu, normals_gpu, indices, fpfh33_features);
 
     int stub;
-    vector<FPFHSignature33> downloaded;
+    std::vector<FPFHSignature33> downloaded;
     fpfh33_features.download(downloaded, stub);
 
     pcl::FPFHEstimation<PointXYZ, Normal, FPFHSignature33> fe;
@@ -123,7 +123,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level1)
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -164,7 +164,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level1)
     fe.compute (fpfhs);
 
     int stub;
-    vector<FPFHSignature33> downloaded;
+    std::vector<FPFHSignature33> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -201,7 +201,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level2)
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -242,7 +242,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level2)
     fe.compute (fpfhs);
 
     int stub;
-    vector<FPFHSignature33> downloaded;
+    std::vector<FPFHSignature33> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -278,7 +278,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level3)
     
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -319,7 +319,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level3)
     fe.compute (fpfhs);
 
     int stub;
-    vector<FPFHSignature33> downloaded;
+    std::vector<FPFHSignature33> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -356,7 +356,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level4)
 
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -397,7 +397,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level4)
     fe.compute (fpfhs);
 
     int stub;
-    vector<FPFHSignature33> downloaded;
+    std::vector<FPFHSignature33> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)

--- a/gpu/features/test/test_normals.cpp
+++ b/gpu/features/test/test_normals.cpp
@@ -63,7 +63,7 @@ TEST(PCL_FeaturesGPU, normals_lowlevel)
     cloud.upload(source.cloud->points);
 
     // convert to single array format
-    vector<int> neighbors_all(source.max_nn_size * cloud.size());
+    std::vector<int> neighbors_all(source.max_nn_size * cloud.size());
     PtrStep<int> ps(&neighbors_all[0], source.max_nn_size * PtrStep<int>::elem_size);    
     for(size_t i = 0; i < cloud.size(); ++i)
         copy(source.neighbors_all[i].begin(), source.neighbors_all[i].end(), ps.ptr(i));
@@ -75,7 +75,7 @@ TEST(PCL_FeaturesGPU, normals_lowlevel)
     gpu::NormalEstimation::computeNormals(cloud, indices, normals);
     gpu::NormalEstimation::flipNormalTowardsViewpoint(cloud, 0.f, 0.f, 0.f, normals);
 
-    vector<PointXYZ> downloaded;
+    std::vector<PointXYZ> downloaded;
     normals.download(downloaded);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -139,7 +139,7 @@ TEST(PCL_FeaturesGPU, normals_highlevel_1)
     pcl::gpu::NormalEstimation::Normals normals_device;
     ne_device.compute(normals_device);
 
-    vector<PointXYZ> downloaded;
+    std::vector<PointXYZ> downloaded;
     normals_device.download(downloaded);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -204,7 +204,7 @@ TEST(PCL_FeaturesGPU, normals_highlevel_2)
     pcl::gpu::NormalEstimation::Normals normals_device;
     ne_device.compute(normals_device);
 
-    vector<PointXYZ> downloaded;
+    std::vector<PointXYZ> downloaded;
     normals_device.download(downloaded);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -269,7 +269,7 @@ TEST(PCL_FeaturesGPU, normals_highlevel_3)
     pcl::gpu::NormalEstimation::Normals normals_device;
     ne_device.compute(normals_device);
 
-    vector<PointXYZ> downloaded;
+    std::vector<PointXYZ> downloaded;
     normals_device.download(downloaded);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -343,7 +343,7 @@ TEST(PCL_FeaturesGPU, normals_highlevel_4)
     pcl::gpu::NormalEstimation::Normals normals_device;
     ne_device.compute(normals_device);
 
-    vector<PointXYZ> downloaded;
+    std::vector<PointXYZ> downloaded;
     normals_device.download(downloaded);
 
    for(size_t i = 0; i < downloaded.size(); ++i)

--- a/gpu/features/test/test_pfh.cpp
+++ b/gpu/features/test/test_pfh.cpp
@@ -59,9 +59,9 @@ TEST(PCL_FeaturesGPU, pfh_low_level)
     source.findRadiusNeghbors();
     cout << "max_radius_nn_size: " << source.max_nn_size << endl;
                    
-    vector<int> data;
+    std::vector<int> data;
     source.getNeghborsArray(data);
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
     
     //uploading data to GPU
@@ -80,7 +80,7 @@ TEST(PCL_FeaturesGPU, pfh_low_level)
     pfh_gpu.compute(cloud_gpu, normals_gpu, indices, pfh125_features);
 
     int stub;
-    vector<PFHSignature125> downloaded;
+    std::vector<PFHSignature125> downloaded;
     pfh125_features.download(downloaded, stub);
 
     pcl::PFHEstimation<PointXYZ, Normal, PFHSignature125> fe;
@@ -128,7 +128,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level1)
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -169,7 +169,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level1)
     fe.compute (fpfhs);
 
     int stub;
-    vector<PFHSignature125> downloaded;
+    std::vector<PFHSignature125> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -206,7 +206,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level2)
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -247,7 +247,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level2)
     fe.compute (fpfhs);
 
     int stub;
-    vector<PFHSignature125> downloaded;
+    std::vector<PFHSignature125> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -284,7 +284,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level3)
 
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -325,7 +325,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level3)
     fe.compute (fpfhs);
 
     int stub;
-    vector<PFHSignature125> downloaded;
+    std::vector<PFHSignature125> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -362,7 +362,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level4)
 
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -403,7 +403,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level4)
     fe.compute (fpfhs);
 
     int stub;
-    vector<PFHSignature125> downloaded;
+    std::vector<PFHSignature125> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 0; i < downloaded.size(); ++i)
@@ -440,7 +440,7 @@ TEST(PCL_FeaturesGPU, pfhrgb)
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(normals->points.begin(), normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
 
     //uploading data to GPU
@@ -502,7 +502,7 @@ TEST(PCL_FeaturesGPU, pfhrgb)
     fe.compute (fpfhs);
 
     int stub;
-    vector<PFHRGBSignature250> downloaded;
+    std::vector<PFHRGBSignature250> downloaded;
     fpfhs_gpu.download(downloaded, stub);
 
     for(size_t i = 170; i < downloaded.size(); ++i)

--- a/gpu/features/test/test_ppf.cpp
+++ b/gpu/features/test/test_ppf.cpp
@@ -57,7 +57,7 @@ TEST(PCL_FeaturesGPU, ppf)
     source.generateIndices();
     source.estimateNormals();
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
     
     //uploading data to GPU
@@ -82,7 +82,7 @@ TEST(PCL_FeaturesGPU, ppf)
     pph_gpu.compute(ppf_features);
 
 
-    vector<PPFSignature> downloaded;
+    std::vector<PPFSignature> downloaded;
     ppf_features.download(downloaded);
 
     pcl::PPFEstimation<PointXYZ, Normal, PPFSignature> fe;
@@ -116,7 +116,7 @@ TEST(PCL_FeaturesGPU, ppfrgb)
     source.generateIndices();
     source.estimateNormals();
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
     
     //uploading data to GPU
@@ -140,7 +140,7 @@ TEST(PCL_FeaturesGPU, ppfrgb)
     pph_gpu.setIndices(indices_gpu);
     pph_gpu.compute(ppf_features);
 
-    vector<PPFRGBSignature> downloaded;
+    std::vector<PPFRGBSignature> downloaded;
     ppf_features.download(downloaded);
 
     pcl::PPFRGBEstimation<PointXYZRGB, Normal, PPFRGBSignature> fe;
@@ -204,7 +204,7 @@ TEST(PCL_FeaturesGPU, ppfrgb_region)
 
     source.estimateNormals();
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
     
     //uploading data to GPU
@@ -230,7 +230,7 @@ TEST(PCL_FeaturesGPU, ppfrgb_region)
 
     pph_gpu.compute(ppf_features);
 
-    vector<PPFRGBSignature> downloaded;
+    std::vector<PPFRGBSignature> downloaded;
     ppf_features.download(downloaded);
 
     pcl::PPFRGBRegionEstimation<PointXYZRGB, Normal, PPFRGBSignature> fe;

--- a/gpu/features/test/test_principal_curvatures.cpp
+++ b/gpu/features/test/test_principal_curvatures.cpp
@@ -53,7 +53,7 @@ TEST(PCL_FeaturesGPU, PrincipalCurvatures)
     
     source.estimateNormals();
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());
     
     //uploading data to GPU
@@ -74,7 +74,7 @@ TEST(PCL_FeaturesGPU, PrincipalCurvatures)
     pc_gpu.setRadiusSearch(source.radius, source.max_elements);
     pc_gpu.compute(pc_features);
 
-    vector<PrincipalCurvatures> downloaded;
+    std::vector<PrincipalCurvatures> downloaded;
     pc_features.download(downloaded);
 
     pcl::PrincipalCurvaturesEstimation<PointXYZ, Normal, PrincipalCurvatures> fe;

--- a/gpu/features/test/test_spinimages.cpp
+++ b/gpu/features/test/test_spinimages.cpp
@@ -61,7 +61,7 @@ TEST(PCL_FeaturesGPU, spinImages_rectangular)
 
 	const int min_beighbours = 15;
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
     //uploading data to GPU
@@ -92,8 +92,8 @@ TEST(PCL_FeaturesGPU, spinImages_rectangular)
     }
 
 	int c;
-    vector<SpinImage> downloaded;
-	vector<unsigned char> downloaded_mask;
+    std::vector<SpinImage> downloaded;
+	std::vector<unsigned char> downloaded_mask;
     spin_images_device.download(downloaded, c);
 	mask_device.download(downloaded_mask);
 
@@ -150,7 +150,7 @@ TEST(PCL_FeaturesGPU, spinImages_radial)
 
 	const int min_beighbours = 15;
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
 
@@ -182,8 +182,8 @@ TEST(PCL_FeaturesGPU, spinImages_radial)
     }
 
 	int c;
-    vector<SpinImage> downloaded;
-	vector<unsigned char> downloaded_mask;
+    std::vector<SpinImage> downloaded;
+	std::vector<unsigned char> downloaded_mask;
     spin_images_device.download(downloaded, c);
 	mask_device.download(downloaded_mask);
 
@@ -240,7 +240,7 @@ TEST(PCL_FeaturesGPU, spinImages_rectangular_angular)
 
 	const int min_beighbours = 15;
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
 
@@ -272,8 +272,8 @@ TEST(PCL_FeaturesGPU, spinImages_rectangular_angular)
     }
 
 	int c;
-    vector<SpinImage> downloaded;
-	vector<unsigned char> downloaded_mask;
+    std::vector<SpinImage> downloaded;
+	std::vector<unsigned char> downloaded_mask;
     spin_images_device.download(downloaded, c);
 	mask_device.download(downloaded_mask);
 
@@ -330,7 +330,7 @@ TEST(PCL_FeaturesGPU, spinImages_radial_angular)
 
 	const int min_beighbours = 15;
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
 
@@ -362,8 +362,8 @@ TEST(PCL_FeaturesGPU, spinImages_radial_angular)
     }
 
 	int c;
-    vector<SpinImage> downloaded;
-	vector<unsigned char> downloaded_mask;
+    std::vector<SpinImage> downloaded;
+	std::vector<unsigned char> downloaded_mask;
     spin_images_device.download(downloaded, c);
 	mask_device.download(downloaded_mask);
 

--- a/gpu/features/test/test_vfh.cpp
+++ b/gpu/features/test/test_vfh.cpp
@@ -55,7 +55,7 @@ TEST(PCL_FeaturesGPU, vfh1)
     source.estimateNormals();
     source.generateIndices(3);
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
     //uploading data to GPU
@@ -84,7 +84,7 @@ TEST(PCL_FeaturesGPU, vfh1)
         pc_gpu.compute(vfh_features);
     }
 
-    vector<VFHSignature308> downloaded;
+    std::vector<VFHSignature308> downloaded;
     vfh_features.download(downloaded);
 
     pcl::VFHEstimation<PointXYZ, Normal, VFHSignature308> fe;
@@ -127,7 +127,7 @@ TEST(PCL_FeaturesGPU, vfh_norm_bins_false)
     source.estimateNormals();
     source.generateIndices(3);
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
     //uploading data to GPU
@@ -153,7 +153,7 @@ TEST(PCL_FeaturesGPU, vfh_norm_bins_false)
     DeviceArray<VFHSignature308> vfh_features;
     pc_gpu.compute(vfh_features);
 
-    vector<VFHSignature308> downloaded;
+    std::vector<VFHSignature308> downloaded;
     vfh_features.download(downloaded);
 
     pcl::VFHEstimation<PointXYZ, Normal, VFHSignature308> fe;
@@ -194,7 +194,7 @@ TEST(PCL_FeaturesGPU, vfh_norm_distance_true)
     source.estimateNormals();
     source.generateIndices(3);
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
     //uploading data to GPU
@@ -220,7 +220,7 @@ TEST(PCL_FeaturesGPU, vfh_norm_distance_true)
     DeviceArray<VFHSignature308> vfh_features;
     pc_gpu.compute(vfh_features);
 
-    vector<VFHSignature308> downloaded;
+    std::vector<VFHSignature308> downloaded;
     vfh_features.download(downloaded);
 
     pcl::VFHEstimation<PointXYZ, Normal, VFHSignature308> fe;
@@ -262,7 +262,7 @@ TEST(PCL_FeaturesGPU, vfh_fill_size_component_true)
     source.estimateNormals();
     source.generateIndices(3);
                    
-    vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
+    std::vector<PointXYZ> normals_for_gpu(source.normals->points.size());    
     std::transform(source.normals->points.begin(), source.normals->points.end(), normals_for_gpu.begin(), DataSource::Normal2PointXYZ());        
     
     //uploading data to GPU
@@ -288,7 +288,7 @@ TEST(PCL_FeaturesGPU, vfh_fill_size_component_true)
     DeviceArray<VFHSignature308> vfh_features;
     pc_gpu.compute(vfh_features);
 
-    vector<VFHSignature308> downloaded;
+    std::vector<VFHSignature308> downloaded;
     vfh_features.download(downloaded);
 
     pcl::VFHEstimation<PointXYZ, Normal, VFHSignature308> fe;

--- a/gpu/kinfu/tools/evaluation.cpp
+++ b/gpu/kinfu/tools/evaluation.cpp
@@ -107,10 +107,10 @@ void Evaluation::setMatchFile(const std::string& file)
   }  
 }
 
-void Evaluation::readFile(const string& file, vector< pair<double,string> >& output)
+void Evaluation::readFile(const string& file, std::vector< pair<double,string> >& output)
 {
   char buffer[4096];
-  vector< pair<double,string> > tmp;
+  std::vector< pair<double,string> > tmp;
   
   ifstream iff(file.c_str());
   if(!iff)

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -171,7 +171,7 @@ namespace pcl
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-vector<string> getPcdFilesInDir(const string& directory)
+std::vector<string> getPcdFilesInDir(const string& directory)
 {
   namespace fs = boost::filesystem;
   fs::path dir(directory);
@@ -180,7 +180,7 @@ vector<string> getPcdFilesInDir(const string& directory)
   if (directory.empty() || !fs::exists(dir) || !fs::is_directory(dir))
     PCL_THROW_EXCEPTION (pcl::IOException, "No valid PCD directory given!\n");
     
-  vector<string> result;
+  std::vector<string> result;
   fs::directory_iterator pos(dir);
   fs::directory_iterator end;           
 
@@ -413,7 +413,7 @@ struct ImageView
     raycaster_ptr_->generateDepthImage(generated_depth_);    
 
     int c;
-    vector<unsigned short> data;
+    std::vector<unsigned short> data;
     generated_depth_.download(data, c);
 
     if (viz_)
@@ -437,14 +437,14 @@ struct ImageView
 
   KinfuTracker::View view_device_;
   KinfuTracker::View colors_device_;
-  vector<KinfuTracker::PixelRGB> view_host_;
+  std::vector<KinfuTracker::PixelRGB> view_host_;
 
   RayCaster::Ptr raycaster_ptr_;
 
   KinfuTracker::DepthMap generated_depth_;
   
 #ifdef HAVE_OPENCV
-  vector<cv::Mat> views_;
+  std::vector<cv::Mat> views_;
 #endif
 };
 
@@ -1268,7 +1268,7 @@ main (int argc, char* argv[])
       float fps_pcd = 15.0f;
       pc::parse_argument (argc, argv, "-pcd_fps", fps_pcd);
 
-      vector<string> pcd_files = getPcdFilesInDir(pcd_dir);    
+      std::vector<string> pcd_files = getPcdFilesInDir(pcd_dir);    
 
       // Sort the read files by name
       sort (pcd_files.begin (), pcd_files.end ());

--- a/gpu/kinfu/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu/tools/kinfu_app_sim.cpp
@@ -671,7 +671,7 @@ struct ImageView
     raycaster_ptr_->generateDepthImage(generated_depth_);
 
     int c;
-    vector<unsigned short> data;
+    std::vector<unsigned short> data;
     generated_depth_.download(data, c);
 
     viewerDepth_.showShortImage (&data[0], generated_depth_.cols(), generated_depth_.rows(), 0, 5000, true);
@@ -693,14 +693,14 @@ struct ImageView
 
   KinfuTracker::View view_device_;
   KinfuTracker::View colors_device_;
-  vector<KinfuTracker::PixelRGB> view_host_;
+  std::vector<KinfuTracker::PixelRGB> view_host_;
 
   RayCaster::Ptr raycaster_ptr_;
 
   KinfuTracker::DepthMap generated_depth_;
 
 #ifdef HAVE_OPENCV
-  vector<cv::Mat> views_;
+  std::vector<cv::Mat> views_;
 #endif
 };
 
@@ -1054,7 +1054,7 @@ struct KinFuApp
     // loop though and create the mesh:
     for (int i = 0; !exit_; ++i)
     {
-      vector<double> tic_toc;
+      std::vector<double> tic_toc;
       tic_toc.push_back(getTime());
       double tic_main = getTime();
 

--- a/gpu/kinfu/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu/tools/record_tsdfvolume.cpp
@@ -176,8 +176,8 @@ DeviceVolume::getVolume (pcl::TSDFVolume<VoxelT, WeightT>::Ptr &volume)
     return false;
   }
 
-  vector<VoxelT>&  volume_vec  = volume->volumeWriteable();
-  vector<WeightT>& weights_vec = volume->weightsWriteable();
+  std::vector<VoxelT>&  volume_vec  = volume->volumeWriteable();
+  std::vector<WeightT>& weights_vec = volume->weightsWriteable();
 
   device_volume_.download (&volume_vec[0], device_volume_.cols() * sizeof(int));
 

--- a/gpu/kinfu_large_scale/tools/evaluation.cpp
+++ b/gpu/kinfu_large_scale/tools/evaluation.cpp
@@ -107,10 +107,10 @@ void Evaluation::setMatchFile(const std::string& file)
   }  
 }
 
-void Evaluation::readFile(const string& file, vector< pair<double,string> >& output)
+void Evaluation::readFile(const string& file, std::vector< pair<double,string> >& output)
 {
   char buffer[4096];
-  vector< pair<double,string> > tmp;
+  std::vector< pair<double,string> > tmp;
   
   ifstream iff(file.c_str());
   if(!iff)

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -114,7 +114,7 @@ namespace pcl
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-vector<string> getPcdFilesInDir(const string& directory)
+std::vector<string> getPcdFilesInDir(const string& directory)
 {
   namespace fs = boost::filesystem;
   fs::path dir(directory);
@@ -123,7 +123,7 @@ vector<string> getPcdFilesInDir(const string& directory)
   if (directory.empty() || !fs::exists(dir) || !fs::is_directory(dir))
           PCL_THROW_EXCEPTION (pcl::IOException, "No valid PCD directory given!\n");
 
-  vector<string> result;
+  std::vector<string> result;
   fs::directory_iterator pos(dir);
   fs::directory_iterator end;           
 
@@ -349,7 +349,7 @@ struct ImageView
     raycaster_ptr_->generateDepthImage(generated_depth_);    
 
     int c;
-    vector<unsigned short> data;
+    std::vector<unsigned short> data;
     generated_depth_.download(data, c);
 
     viewerDepth_.showShortImage (&data[0], generated_depth_.cols(), generated_depth_.rows(), 0, 5000, true);
@@ -371,14 +371,14 @@ struct ImageView
 
   KinfuTracker::View view_device_;
   KinfuTracker::View colors_device_;
-  vector<pcl::gpu::kinfuLS::PixelRGB> view_host_;
+  std::vector<pcl::gpu::kinfuLS::PixelRGB> view_host_;
 
   RayCaster::Ptr raycaster_ptr_;
 
   KinfuTracker::DepthMap generated_depth_;
 
 #ifdef HAVE_OPENCV
-  vector<cv::Mat> views_;
+  std::vector<cv::Mat> views_;
 #endif
 };
 
@@ -1286,7 +1286,7 @@ main (int argc, char* argv[])
       float fps_pcd = 15.0f;
       pc::parse_argument (argc, argv, "-pcd_fps", fps_pcd);
 
-      vector<string> pcd_files = getPcdFilesInDir(pcd_dir);    
+      std::vector<string> pcd_files = getPcdFilesInDir(pcd_dir);    
       // Sort the read files by name
       sort (pcd_files.begin (), pcd_files.end ());
       capture.reset (new pcl::PCDGrabber<pcl::PointXYZRGBA> (pcd_files, fps_pcd, false));

--- a/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
@@ -669,7 +669,7 @@ struct ImageView
     raycaster_ptr_->generateDepthImage(generated_depth_);    
 
     int c;
-    vector<unsigned short> data;
+    std::vector<unsigned short> data;
     generated_depth_.download(data, c);
 
     viewerDepth_.showShortImage (&data[0], generated_depth_.cols(), generated_depth_.rows(), 0, 5000, true);
@@ -691,14 +691,14 @@ struct ImageView
 
   KinfuTracker::View view_device_;
   KinfuTracker::View colors_device_;
-  vector<KinfuTracker::PixelRGB> view_host_;
+  std::vector<KinfuTracker::PixelRGB> view_host_;
 
   RayCaster::Ptr raycaster_ptr_;
 
   KinfuTracker::DepthMap generated_depth_;
   
 #ifdef HAVE_OPENCV
-  vector<cv::Mat> views_;
+  std::vector<cv::Mat> views_;
 #endif
 };
 
@@ -1052,7 +1052,7 @@ struct KinFuApp
     // loop though and create the mesh:
     for (int i = 0; !exit_; ++i)
     { 
-      vector<double> tic_toc;
+      std::vector<double> tic_toc;
       tic_toc.push_back(getTime());
       double tic_main = getTime();
 

--- a/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
@@ -174,8 +174,8 @@ DeviceVolume::getVolume (pcl::TSDFVolume<VoxelT, WeightT>::Ptr &volume)
     return false;
   }
 
-  vector<VoxelT>&  volume_vec  = volume->volumeWriteable();
-  vector<WeightT>& weights_vec = volume->weightsWriteable();
+  std::vector<VoxelT>&  volume_vec  = volume->volumeWriteable();
+  std::vector<WeightT>& weights_vec = volume->weightsWriteable();
 
   device_volume_.download (&volume_vec[0], device_volume_.cols() * sizeof(int));
 

--- a/gpu/octree/src/cuda/octree_host.cu
+++ b/gpu/octree/src/cuda/octree_host.cu
@@ -144,7 +144,7 @@ namespace
 
 }
 
-void pcl::device::OctreeImpl::radiusSearchHost(const PointType& query, float radius, vector<int>& out, int max_nn) const
+void pcl::device::OctreeImpl::radiusSearchHost(const PointType& query, float radius, std::vector<int>& out, int max_nn) const
 {            
     out.clear();  
 

--- a/gpu/octree/test/perfomance.cpp
+++ b/gpu/octree/test/perfomance.cpp
@@ -133,7 +133,7 @@ TEST(PCL_OctreeGPU, performance)
 #ifdef HAVE_OPENCV
     cv::Octree octree_opencv;
     const static int opencv_octree_points_per_leaf = 32;    
-    vector<cv::Point3f> opencv_points(data.points.size());
+    std::vector<cv::Point3f> opencv_points(data.points.size());
     std::transform(data.points.begin(), data.points.end(), opencv_points.begin(), DataGenerator::ConvPoint<cv::Point3f>());
         
     {        
@@ -149,10 +149,10 @@ TEST(PCL_OctreeGPU, performance)
     int inds;
 
     //host buffers
-    vector<int> indeces;
-    vector<float> pointRadiusSquaredDistance;
+    std::vector<int> indeces;
+    std::vector<float> pointRadiusSquaredDistance;
 #ifdef HAVE_OPENCV  
-    vector<cv::Point3f> opencv_results;
+    std::vector<cv::Point3f> opencv_results;
 #endif
 
     //reserve

--- a/gpu/octree/test/test_approx_nearest.cpp
+++ b/gpu/octree/test/test_approx_nearest.cpp
@@ -107,15 +107,15 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
         
     //prepare output buffers on device
     pcl::gpu::NeighborIndices result_device(data.tests_num, 1);
-    vector<int> result_host_pcl(data.tests_num);
-    vector<int> result_host_gpu(data.tests_num);
-    vector<float> dists_pcl(data.tests_num);
-    vector<float> dists_gpu(data.tests_num);
+    std::vector<int> result_host_pcl(data.tests_num);
+    std::vector<int> result_host_gpu(data.tests_num);
+    std::vector<float> dists_pcl(data.tests_num);
+    std::vector<float> dists_gpu(data.tests_num);
     
     //search GPU shared
     octree_device.approxNearestSearch(queries_device, result_device);
 
-    vector<int> downloaded;
+    std::vector<int> downloaded;
     result_device.data.download(downloaded);
                 
     for(size_t i = 0; i < data.tests_num; ++i)

--- a/gpu/octree/test/test_bfrs_gpu.cpp
+++ b/gpu/octree/test/test_bfrs_gpu.cpp
@@ -81,8 +81,8 @@ TEST (PCL_GPU, bruteForceRadiusSeachGPU)
     
     pcl::gpu::DeviceArray<int> results_device, buffer(cloud_device.size());
     
-    vector<int> results_host;
-    vector<size_t> sizes;
+    std::vector<int> results_host;
+    std::vector<size_t> sizes;
     for(size_t i = 0; i < data.tests_num; ++i)
     {
         pcl::gpu::bruteForceRadiusSearchGPU(cloud_device, data.queries[i], data.radiuses[i], results_device, buffer);

--- a/gpu/octree/test/test_host_radius_search.cpp
+++ b/gpu/octree/test/test_host_radius_search.cpp
@@ -104,19 +104,19 @@ TEST(PCL_OctreeGPU, hostRadiusSearch)
     //perform bruteForceSearch    
     data.bruteForceSearch(true);    
     
-    vector<int> sizes;
+    std::vector<int> sizes;
     sizes.reserve(data.tests_num);
     octree_device.internalDownload();
              
     for(size_t i = 0; i < data.tests_num; ++i)
     {
         //search host on octree that was built on device
-        vector<int> results_host_gpu; //host search
+        std::vector<int> results_host_gpu; //host search
         octree_device.radiusSearchHost(data.queries[i], data.radiuses[i], results_host_gpu);                        
         
         //search host
-        vector<float> dists;
-        vector<int> results_host;                
+        std::vector<float> dists;
+        std::vector<int> results_host;                
         octree_host.radiusSearch(pcl::PointXYZ(data.queries[i].x, data.queries[i].y, data.queries[i].z), data.radiuses[i], results_host, dists);                        
         
         std::sort(results_host_gpu.begin(), results_host_gpu.end());

--- a/gpu/octree/test/test_knn_search.cpp
+++ b/gpu/octree/test/test_knn_search.cpp
@@ -118,8 +118,8 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     pcl::gpu::NeighborIndices result_device(data.tests_num, k);    
 
     //prepare output buffers on host
-    vector<vector<  int> > result_host(data.tests_num);   
-    vector<vector<float> >  dists_host(data.tests_num);    
+    std::vector<vector<  int> > result_host(data.tests_num);   
+    std::vector<vector<float> >  dists_host(data.tests_num);    
     for(size_t i = 0; i < data.tests_num; ++i)
     {
         result_host[i].reserve(k);
@@ -132,7 +132,7 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
         octree_device.nearestKSearchBatch(queries_device, k, result_device);
     }
 
-    vector<int> downloaded, downloaded_cur;
+    std::vector<int> downloaded, downloaded_cur;
     result_device.data.download(downloaded);
                  
     {
@@ -145,16 +145,16 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     for(size_t i = 0; i < data.tests_num; ++i)    
     {           
         //cout << i << endl;
-        vector<int>&   results_host_cur = result_host[i];
-        vector<float>&   dists_host_cur = dists_host[i];
+        std::vector<int>&   results_host_cur = result_host[i];
+        std::vector<float>&   dists_host_cur = dists_host[i];
                 
         int beg = i * k;
         int end = beg + k;
 
         downloaded_cur.assign(downloaded.begin() + beg, downloaded.begin() + end);
         
-        vector<PriorityPair> pairs_host;
-        vector<PriorityPair> pairs_gpu;
+        std::vector<PriorityPair> pairs_host;
+        std::vector<PriorityPair> pairs_gpu;
         for(int n = 0; n < k; ++n)
         {
             PriorityPair host;

--- a/gpu/octree/test/test_radius_search.cpp
+++ b/gpu/octree/test/test_radius_search.cpp
@@ -97,8 +97,8 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
     pcl::gpu::NeighborIndices result_device3(data.indices.size(), max_answers);
             
     //prepare output buffers on host
-    vector< vector<int> > host_search1(data.tests_num);
-    vector< vector<int> > host_search2(data.tests_num);
+    std::vector< std::vector<int> > host_search1(data.tests_num);
+    std::vector< std::vector<int> > host_search2(data.tests_num);
     for(size_t i = 0; i < data.tests_num; ++i)
     {
         host_search1[i].reserve(max_answers);
@@ -125,14 +125,14 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
     }
     
     //download results
-    vector<int> sizes1;
-    vector<int> sizes2;
-    vector<int> sizes3;
+    std::vector<int> sizes1;
+    std::vector<int> sizes2;
+    std::vector<int> sizes3;
     result_device1.sizes.download(sizes1);
     result_device2.sizes.download(sizes2);
     result_device3.sizes.download(sizes3);
 
-    vector<int> downloaded_buffer1, downloaded_buffer2, downloaded_buffer3, results_batch;    
+    std::vector<int> downloaded_buffer1, downloaded_buffer2, downloaded_buffer3, results_batch;    
     result_device1.data.download(downloaded_buffer1);
     result_device2.data.download(downloaded_buffer2);
     result_device3.data.download(downloaded_buffer3);
@@ -142,7 +142,7 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
     //verify results    
     for(size_t i = 0; i < data.tests_num; ++i)
     {        
-        vector<int>& results_host = host_search1[i];        
+        std::vector<int>& results_host = host_search1[i];        
         
         int beg = i * max_answers;
         int end = beg + sizes1[i];
@@ -171,7 +171,7 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
     //verify results    
     for(size_t i = 0; i < data.tests_num; ++i)
     {        
-        vector<int>& results_host = host_search2[i];        
+        std::vector<int>& results_host = host_search2[i];        
         
         int beg = i * max_answers;
         int end = beg + sizes2[i];
@@ -200,7 +200,7 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
     //verify results    
     for(size_t i = 0; i < data.tests_num; i+=2)
     {                
-        vector<int>& results_host = host_search1[i];        
+        std::vector<int>& results_host = host_search1[i];        
         
         int beg = i/2 * max_answers;
         int end = beg + sizes3[i/2];

--- a/gpu/people/src/bodyparts_detector.cpp
+++ b/gpu/people/src/bodyparts_detector.cpp
@@ -54,7 +54,7 @@ using namespace std;
 const int MAX_CLUST_SIZE = 25000;
 const float CLUST_TOL = 0.05f;
 
-pcl::gpu::people::RDFBodyPartsDetector::RDFBodyPartsDetector( const vector<string>& tree_files, int rows, int cols)    
+pcl::gpu::people::RDFBodyPartsDetector::RDFBodyPartsDetector( const std::vector<string>& tree_files, int rows, int cols)    
 : max_cluster_size_(MAX_CLUST_SIZE), cluster_tolerance_(CLUST_TOL)
 {
   PCL_DEBUG("[pcl::gpu::people::RDFBodyPartsDetector::RDFBodyPartsDetector] : (D) : Constructor called\n");
@@ -66,8 +66,8 @@ pcl::gpu::people::RDFBodyPartsDetector::RDFBodyPartsDetector( const vector<strin
   for(const auto &tree_file : tree_files)
   {
     // load the tree file
-    vector<trees::Node>  nodes;
-    vector<trees::Label> leaves;
+    std::vector<trees::Node>  nodes;
+    std::vector<trees::Label> leaves;
 
     // this might throw but we haven't done any malloc yet
     int height = loadTree (tree_file, nodes, leaves );

--- a/gpu/people/src/colormap.cpp
+++ b/gpu/people/src/colormap.cpp
@@ -81,7 +81,7 @@ void pcl::gpu::people::colorLMap (const pcl::PointCloud<pcl::Label>& cloud_in, p
 void pcl::gpu::people::uploadColorMap(DeviceArray<pcl::RGB>& color_map)
 {
   // Copy the list of label colors into the devices
-  vector<pcl::RGB> rgba(LUT_COLOR_LABEL_LENGTH);
+  std::vector<pcl::RGB> rgba(LUT_COLOR_LABEL_LENGTH);
   for(int i = 0; i < LUT_COLOR_LABEL_LENGTH; ++i)
   {
     // !!!! generate in RGB format, not BGR

--- a/gpu/people/src/cuda/multi_tree.cu
+++ b/gpu/people/src/cuda/multi_tree.cu
@@ -355,7 +355,7 @@ namespace pcl
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pcl::device::CUDATree::CUDATree (int treeHeight_arg, const vector<Node>& nodes, const vector<Label>& leaves)
+pcl::device::CUDATree::CUDATree (int treeHeight_arg, const std::vector<Node>& nodes, const std::vector<Label>& leaves)
 {
   treeHeight = treeHeight_arg;
   numNodes = (1 << treeHeight) - 1;

--- a/gpu/people/src/cuda/shs.cu
+++ b/gpu/people/src/cuda/shs.cu
@@ -174,7 +174,7 @@ void optimized_shs5(const PointCloud<PointXYZRGB> &cloud, float tolerance, const
     SearchD search;    
     search.setInputCloud(cloud.makeShared());
 
-    vector< vector<int> > storage(100);
+    std::vector< std::vector<int> > storage(100);
 
     //  omp_set_num_threads(1);
     // Process all points in the indices vector

--- a/gpu/people/tools/people_app.cpp
+++ b/gpu/people/tools/people_app.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-vector<string> getPcdFilesInDir(const string& directory)
+std::vector<string> getPcdFilesInDir(const string& directory)
 {
   namespace fs = boost::filesystem;
   fs::path dir(directory);
@@ -75,7 +75,7 @@ vector<string> getPcdFilesInDir(const string& directory)
   if (!fs::exists(dir) || !fs::is_directory(dir))
     PCL_THROW_EXCEPTION(pcl::IOException, "Wrong PCD directory");
     
-  vector<string> result;
+  std::vector<string> result;
   fs::directory_iterator pos(dir);
   fs::directory_iterator end;           
 
@@ -409,7 +409,7 @@ int main(int argc, char** argv)
     else
     if (pc::parse_argument (argc, argv, "-pcd_folder", pcd_folder) > 0)
     {         
-      vector<string> pcd_files = getPcdFilesInDir(pcd_folder);       
+      std::vector<string> pcd_files = getPcdFilesInDir(pcd_folder);       
       capture.reset( new pcl::PCDGrabber<PointXYZRGBA>(pcd_files, 30, true) );
     }    
     else
@@ -426,7 +426,7 @@ int main(int argc, char** argv)
   catch (const pcl::PCLException& /*e*/) { return cout << "Can't open depth source" << endl, -1; }
     
   //selecting tree files
-  vector<string> tree_files;
+  std::vector<string> tree_files;
   tree_files.emplace_back("Data/forest1/tree_20.txt");
   tree_files.emplace_back("Data/forest2/tree_20.txt");
   tree_files.emplace_back("Data/forest3/tree_20.txt");

--- a/gpu/people/tools/people_pcd_prob.cpp
+++ b/gpu/people/tools/people_pcd_prob.cpp
@@ -341,7 +341,7 @@ int main(int argc, char** argv)
   // loading trees
   using pcl::gpu::people::RDFBodyPartsDetector;
 
-  vector<string> names_vector(treeFilenames, treeFilenames + numTrees);
+  std::vector<string> names_vector(treeFilenames, treeFilenames + numTrees);
   PCL_DEBUG("[Main] : (D) : Trees collected\n");
   RDFBodyPartsDetector::Ptr rdf(new RDFBodyPartsDetector(names_vector));
   PCL_DEBUG("[Main] : (D) : Loaded files into rdf\n");

--- a/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
@@ -224,7 +224,7 @@ namespace pcl
        {
          if (convertToMono)
          {
-           vector<uint8_t> monoImage;
+           std::vector<uint8_t> monoImage;
            size_t size = width_arg*height_arg;
 
            monoImage.reserve(size);

--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -498,7 +498,7 @@ OpenNI2VideoMode
 pcl::io::openni2::OpenNI2Device::getDefaultIRMode () const
 {
   // Search for and return VGA@30 Hz mode
-  vector<OpenNI2VideoMode> modeList = getSupportedIRVideoModes ();
+  std::vector<OpenNI2VideoMode> modeList = getSupportedIRVideoModes ();
   for (const auto &mode : modeList)
   {
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
@@ -511,7 +511,7 @@ OpenNI2VideoMode
 pcl::io::openni2::OpenNI2Device::getDefaultColorMode () const
 {
   // Search for and return VGA@30 Hz mode
-  vector<OpenNI2VideoMode> modeList = getSupportedColorVideoModes ();
+  std::vector<OpenNI2VideoMode> modeList = getSupportedColorVideoModes ();
   for (const auto &mode : modeList)
   {
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
@@ -524,7 +524,7 @@ OpenNI2VideoMode
 pcl::io::openni2::OpenNI2Device::getDefaultDepthMode () const
 {
   // Search for and return VGA@30 Hz mode
-  vector<OpenNI2VideoMode> modeList = getSupportedDepthVideoModes ();
+  std::vector<OpenNI2VideoMode> modeList = getSupportedDepthVideoModes ();
   for (const auto &mode : modeList)
   {
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )

--- a/recognition/src/ransac_based/model_library.cpp
+++ b/recognition/src/ransac_based/model_library.cpp
@@ -123,7 +123,7 @@ ModelLibrary::addModel (const PointCloudIn& points, const PointCloudN& normals, 
   result.first->second = new_model;
 
   const ORROctree& octree = new_model->getOctree ();
-  const vector<ORROctree::Node*> &full_leaves = octree.getFullLeaves ();
+  const std::vector<ORROctree::Node*> &full_leaves = octree.getFullLeaves ();
   list<ORROctree::Node*> inter_leaves;
   int num_of_pairs = 0;
 

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -92,7 +92,7 @@ pcl::recognition::ObjRecRANSAC::recognize (const PointCloudIn& scene, const Poin
     success_probability = 0.99;
 
   // Compute the number of iterations
-  vector<ORROctree::Node*>& full_leaves = scene_octree_.getFullLeaves();
+  std::vector<ORROctree::Node*>& full_leaves = scene_octree_.getFullLeaves();
   int num_iterations = this->computeNumberOfIterations(success_probability), num_full_leaves = static_cast<int> (full_leaves.size ());
 
   // Make sure that there are not more iterations than full leaves
@@ -130,11 +130,11 @@ pcl::recognition::ObjRecRANSAC::recognize (const PointCloudIn& scene, const Poin
     return;
 
   // Create and initialize a vector of bounded objects needed for the bounding volume hierarchy (BVH)
-  vector<BVHH::BoundedObject*> bounded_objects (accepted_hypotheses_.size ());
+  std::vector<BVHH::BoundedObject*> bounded_objects (accepted_hypotheses_.size ());
   int i = 0;
 
   // Initialize the vector with bounded objects
-  for ( vector<Hypothesis>::iterator hypo = accepted_hypotheses_.begin () ; hypo != accepted_hypotheses_.end () ; ++hypo, ++i )
+  for ( std::vector<Hypothesis>::iterator hypo = accepted_hypotheses_.begin () ; hypo != accepted_hypotheses_.end () ; ++hypo, ++i )
   {
     // Create, initialize and save a bounded object based on the hypothesis
     BVHH::BoundedObject *bounded_object = new BVHH::BoundedObject (&(*hypo));
@@ -162,7 +162,7 @@ pcl::recognition::ObjRecRANSAC::recognize (const PointCloudIn& scene, const Poin
 //===============================================================================================================================================
 
 void
-pcl::recognition::ObjRecRANSAC::sampleOrientedPointPairs (int num_iterations, const vector<ORROctree::Node*>& full_scene_leaves,
+pcl::recognition::ObjRecRANSAC::sampleOrientedPointPairs (int num_iterations, const std::vector<ORROctree::Node*>& full_scene_leaves,
     list<OrientedPointPair>& output) const
 {
 #ifdef OBJ_REC_RANSAC_VERBOSE
@@ -184,7 +184,7 @@ pcl::recognition::ObjRecRANSAC::sampleOrientedPointPairs (int num_iterations, co
   UniformGenerator<int> randgen (0, num_full_leaves - 1, static_cast<uint32_t> (time (nullptr)));
 
   // Init the vector with the ids
-  vector<int> ids (num_full_leaves);
+  std::vector<int> ids (num_full_leaves);
   for ( int i = 0 ; i < num_full_leaves ; ++i )
     ids[i] = i;
 
@@ -419,18 +419,18 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfCloseHypotheses (HypothesisOctree& h
   printf ("ObjRecRANSAC::%s(): building the graph ... ", __func__); fflush (stdout);
 #endif
 
-  vector<HypothesisOctree::Node*> hypo_leaves = hypotheses.getFullLeaves ();
+  std::vector<HypothesisOctree::Node*> hypo_leaves = hypotheses.getFullLeaves ();
   int i = 0;
 
   graph.resize (static_cast<int> (hypo_leaves.size ()));
 
-  for ( vector<HypothesisOctree::Node*>::iterator hypo = hypo_leaves.begin () ; hypo != hypo_leaves.end () ; ++hypo, ++i )
+  for ( std::vector<HypothesisOctree::Node*>::iterator hypo = hypo_leaves.begin () ; hypo != hypo_leaves.end () ; ++hypo, ++i )
     (*hypo)->getData ().setLinearId (i);
 
   i = 0;
 
   // Now create the graph connectivity such that each two neighboring rotation spaces are neighbors in the graph
-  for ( vector<HypothesisOctree::Node*>::const_iterator hypo = hypo_leaves.begin () ; hypo != hypo_leaves.end () ; ++hypo, ++i )
+  for ( std::vector<HypothesisOctree::Node*>::const_iterator hypo = hypo_leaves.begin () ; hypo != hypo_leaves.end () ; ++hypo, ++i )
   {
     // Compute the fitness of the graph node
     graph.getNodes ()[i]->setFitness (static_cast<int> ((*hypo)->getData ().explained_pixels_.size ()));
@@ -478,7 +478,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
   printf ("ObjRecRANSAC::%s(): building the conflict graph ... ", __func__); fflush (stdout);
 #endif
 
-  const vector<BVHH::BoundedObject*>* bounded_objects = bvh.getInputObjects ();
+  const std::vector<BVHH::BoundedObject*>* bounded_objects = bvh.getInputObjects ();
 
   if ( !bounded_objects )
   {
@@ -494,7 +494,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
   graph.resize (static_cast<int> (bounded_objects->size ()));
 
   // Setup the hypotheses' ids
-  for ( vector<BVHH::BoundedObject*>::const_iterator obj = bounded_objects->begin () ; obj != bounded_objects->end () ; ++obj, ++lin_id )
+  for ( std::vector<BVHH::BoundedObject*>::const_iterator obj = bounded_objects->begin () ; obj != bounded_objects->end () ; ++obj, ++lin_id )
   {
     (*obj)->getData ()->setLinearId (lin_id);
     graph.getNodes ()[lin_id]->setData ((*obj)->getData ());
@@ -576,7 +576,7 @@ pcl::recognition::ObjRecRANSAC::filterGraphOfConflictingHypotheses (ORRGraph<Hyp
   printf ("ObjRecRANSAC::%s(): filtering the conflict graph ... ", __func__); fflush (stdout);
 #endif
 
-  vector<ORRGraph<Hypothesis*>::Node*> &nodes = graph.getNodes ();
+  std::vector<ORRGraph<Hypothesis*>::Node*> &nodes = graph.getNodes ();
 
   // Compute the penalty for each graph node
   for (auto &node : nodes)

--- a/recognition/src/ransac_based/orr_octree.cpp
+++ b/recognition/src/ransac_based/orr_octree.cpp
@@ -330,7 +330,7 @@ pcl::recognition::ORROctree::getFullLeavesIntersectedBySphere (const float* p, f
 ORROctree::Node*
 pcl::recognition::ORROctree::getRandomFullLeafOnSphere (const float* p, float radius) const
 {
-  vector<int> tmp_ids;
+  std::vector<int> tmp_ids;
   tmp_ids.reserve (8);
 
   pcl::common::UniformGenerator<int> randgen (0, 1, static_cast<uint32_t> (time (nullptr)));
@@ -418,7 +418,7 @@ pcl::recognition::ORROctree::getFullLeavesPoints (PointCloudOut& out) const
   size_t i = 0;
 
   // Now iterate over all full leaves and compute the normals and average points
-  for ( vector<ORROctree::Node*>::const_iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
+  for ( std::vector<ORROctree::Node*>::const_iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
   {
     out[i].x = (*it)->getData ()->getPoint ()[0];
     out[i].y = (*it)->getData ()->getPoint ()[1];
@@ -435,7 +435,7 @@ pcl::recognition::ORROctree::getNormalsOfFullLeaves (PointCloudN& out) const
   size_t i = 0;
 
   // Now iterate over all full leaves and compute the normals and average points
-  for ( vector<ORROctree::Node*>::const_iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
+  for ( std::vector<ORROctree::Node*>::const_iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
   {
     out[i].normal_x = (*it)->getData ()->getNormal ()[0];
     out[i].normal_y = (*it)->getData ()->getNormal ()[1];

--- a/recognition/src/ransac_based/orr_octree_zprojection.cpp
+++ b/recognition/src/ransac_based/orr_octree_zprojection.cpp
@@ -98,7 +98,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   this->clear();
 
   // Compute the bounding box of the full leaves
-  const vector<ORROctree::Node*>& full_leaves = input.getFullLeaves ();
+  const std::vector<ORROctree::Node*>& full_leaves = input.getFullLeaves ();
   std::array<float, 4> full_leaves_bounds;
 
   if ( full_leaves.empty() )

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -819,7 +819,7 @@ RangeLikelihood::computeLikelihoods (float* reference,
                                      std::vector<float> & scores)
 {
   #if DO_TIMING_PROFILE
-    vector<double> tic_toc;
+    std::vector<double> tic_toc;
     tic_toc.push_back(getTime());
   #endif  
   

--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -96,7 +96,7 @@ TEST (PCL, copyPointCloud)
     EXPECT_EQ (cloud_xyz_rgba[i].rgba, cloud_xyz_rgb_normal[i].rgba);
   }
 
-  vector<int> indices;
+  std::vector<int> indices;
   indices.push_back (0); indices.push_back (1); 
   pcl::copyPointCloud (cloud_xyz_rgba, indices, cloud_xyz_rgb_normal);
   ASSERT_EQ (int (cloud_xyz_rgb_normal.size ()), 2);
@@ -107,7 +107,7 @@ TEST (PCL, copyPointCloud)
     EXPECT_EQ (cloud_xyz_rgba[i].rgba, cloud_xyz_rgb_normal[i].rgba);
   }
 
-  vector<int, Eigen::aligned_allocator<int> > indices_aligned;
+  std::vector<int, Eigen::aligned_allocator<int> > indices_aligned;
   indices_aligned.push_back (1); indices_aligned.push_back (2); indices_aligned.push_back (3); 
   pcl::copyPointCloud (cloud_xyz_rgba, indices_aligned, cloud_xyz_rgb_normal);
   ASSERT_EQ (int (cloud_xyz_rgb_normal.size ()), 3);

--- a/test/features/test_base_feature.cpp
+++ b/test/features/test_base_feature.cpp
@@ -50,7 +50,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_board_estimation.cpp
+++ b/test/features/test_board_estimation.cpp
@@ -52,7 +52,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_boundary_estimation.cpp
+++ b/test/features/test_boundary_estimation.cpp
@@ -50,7 +50,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_curvatures_estimation.cpp
+++ b/test/features/test_curvatures_estimation.cpp
@@ -50,7 +50,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_cvfh_estimation.cpp
+++ b/test/features/test_cvfh_estimation.cpp
@@ -52,7 +52,7 @@ using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 using CloudPtr = PointCloud<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 CloudPtr cloud_milk;

--- a/test/features/test_grsd_estimation.cpp
+++ b/test/features/test_grsd_estimation.cpp
@@ -50,7 +50,7 @@ using namespace std;
 
 search::KdTree<PointXYZ>::Ptr tree (new search::KdTree<PointXYZ> ());
 PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ> ());
-vector<int> indices;
+std::vector<int> indices;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, GRSDEstimation)

--- a/test/features/test_invariants_estimation.cpp
+++ b/test/features/test_invariants_estimation.cpp
@@ -49,7 +49,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -50,7 +50,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_rsd_estimation.cpp
+++ b/test/features/test_rsd_estimation.cpp
@@ -50,7 +50,7 @@ using namespace std;
 
 search::KdTree<PointXYZ>::Ptr tree (new search::KdTree<PointXYZ> ());
 PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ> ());
-vector<int> indices;
+std::vector<int> indices;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, RSDEstimation)

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -54,7 +54,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_shot_lrf_estimation.cpp
+++ b/test/features/test_shot_lrf_estimation.cpp
@@ -51,7 +51,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/features/test_spin_estimation.cpp
+++ b/test/features/test_spin_estimation.cpp
@@ -51,7 +51,7 @@ using namespace std;
 using KdTreePtr = search::KdTree<PointXYZ>::Ptr;
 
 PointCloud<PointXYZ> cloud;
-vector<int> indices;
+std::vector<int> indices;
 KdTreePtr tree;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/filters/test_clipper.cpp
+++ b/test/filters/test_clipper.cpp
@@ -70,7 +70,7 @@ TEST (BoxClipper3D, Filters)
   input->push_back (PointXYZ (-0.9f, -0.9f, -0.9f));
 
   ExtractIndices<PointXYZ> extract_indices;
-  vector<int> indices;
+  std::vector<int> indices;
 
   BoxClipper3D<PointXYZ> boxClipper3D (Affine3f::Identity ());
   boxClipper3D.clipPointCloud3D (*input, indices);
@@ -143,7 +143,7 @@ TEST (CropBox, Filters)
   cropBoxFilter.setMax (max_pt);
 
   // Indices
-  vector<int> indices;
+  std::vector<int> indices;
   cropBoxFilter.filter (indices);
 
   // Cloud
@@ -303,7 +303,7 @@ TEST (CropBox, Filters)
   cropBoxFilter2.setMax (max_pt);
 
   // Indices
-  vector<int> indices2;
+  std::vector<int> indices2;
   cropBoxFilter2.filter (indices2);
 
   // Cloud

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -70,7 +70,7 @@ using namespace Eigen;
 
 PCLPointCloud2::Ptr cloud_blob (new PCLPointCloud2);
 PointCloud<PointXYZ>::Ptr cloud (new PointCloud<PointXYZ>);
-vector<int> indices_;
+std::vector<int> indices_;
 
 PointCloud<PointXYZRGB>::Ptr cloud_organized (new PointCloud<PointXYZRGB>);
 
@@ -632,7 +632,7 @@ TEST (VoxelGrid, Filters)
 
   // neighboring centroid should be in the right position
   Eigen::MatrixXi directions = Eigen::Vector3i (0, 0, 1);
-  vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[195], directions);
+  std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[195], directions);
   EXPECT_EQ (neighbors.size (), size_t (directions.cols ()));
   EXPECT_NE (neighbors.at (0), -1);
   EXPECT_LE (fabs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
@@ -714,7 +714,7 @@ TEST (VoxelGrid, Filters)
 
   // neighboring centroid should be in the right position
   Eigen::MatrixXi directions2 = Eigen::Vector3i (0, 0, 1);
-  vector<int> neighbors2 = grid2.getNeighborCentroidIndices (0.048722f, 0.073760f, 0.017434f, directions2);
+  std::vector<int> neighbors2 = grid2.getNeighborCentroidIndices (0.048722f, 0.073760f, 0.017434f, directions2);
   EXPECT_EQ (neighbors2.size (), size_t (directions2.cols ()));
   EXPECT_NE (neighbors2.at (0), -1);
   EXPECT_LE (fabs (output.points[neighbors2.at (0)].x - output.points[centroidIdx2].x), 0.02);
@@ -785,7 +785,7 @@ TEST (VoxelGrid_No_DownsampleAllData, Filters)
 
   // neighboring centroid should be in the right position
   Eigen::MatrixXi directions = Eigen::Vector3i (0, 0, 1);
-  vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[195], directions);
+  std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[195], directions);
   EXPECT_EQ (neighbors.size (), size_t (directions.cols ()));
   EXPECT_NE (neighbors.at (0), -1);
   EXPECT_LE (fabs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
@@ -860,7 +860,7 @@ TEST (VoxelGrid_No_DownsampleAllData, Filters)
 
   // neighboring centroid should be in the right position
   Eigen::MatrixXi directions2 = Eigen::Vector3i (0, 0, 1);
-  vector<int> neighbors2 = grid2.getNeighborCentroidIndices (0.048722f, 0.073760f, 0.017434f, directions2);
+  std::vector<int> neighbors2 = grid2.getNeighborCentroidIndices (0.048722f, 0.073760f, 0.017434f, directions2);
   EXPECT_EQ (neighbors2.size (), size_t (directions2.cols ()));
   EXPECT_NE (neighbors2.at (0), -1);
   EXPECT_LE (fabs (output.points[neighbors2.at (0)].x - output.points[centroidIdx2].x), 0.02);
@@ -1287,7 +1287,7 @@ TEST (VoxelGridCovariance, Filters)
 
   // neighboring centroid should be in the right position
   Eigen::MatrixXi directions = Eigen::Vector3i (0, 1, 0);
-  vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[38], directions);
+  std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[38], directions);
   EXPECT_EQ (neighbors.size (), size_t (directions.cols ()));
   EXPECT_NE (neighbors.at (0), -1);
   EXPECT_LE (fabs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
@@ -1299,8 +1299,8 @@ TEST (VoxelGridCovariance, Filters)
   grid.filter (output, true);
 
   // testing k nearest neighbors search
-  vector<VoxelGridCovariance<pcl::PointXYZ>::LeafConstPtr> leaves;
-  vector<float> distances;
+  std::vector<VoxelGridCovariance<pcl::PointXYZ>::LeafConstPtr> leaves;
+  std::vector<float> distances;
   grid.nearestKSearch (PointXYZ(0,1,0), 1, leaves, distances);
 
   EXPECT_EQ (int (leaves.size ()), 1);

--- a/test/io/test_grabbers.cpp
+++ b/test/io/test_grabbers.cpp
@@ -18,8 +18,8 @@ using CloudT = pcl::PointCloud<PointT>;
 string tiff_dir_;
 string pclzf_dir_;
 string pcd_dir_;
-vector<CloudT::ConstPtr> pcds_;
-vector<std::string> pcd_files_;
+std::vector<CloudT::ConstPtr> pcds_;
+std::vector<std::string> pcd_files_;
 
 
 // Helper function for grabbing a cloud
@@ -36,7 +36,7 @@ TEST (PCL, PCDGrabber)
 {
   pcl::PCDGrabber<PointT> grabber (pcd_files_, 10, false); // TODO add directory functionality
   EXPECT_EQ (grabber.size (), pcds_.size ());
-  vector<CloudT::ConstPtr> grabbed_clouds;
+  std::vector<CloudT::ConstPtr> grabbed_clouds;
   std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)>
     fxn = [&] (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& input_cloud) { grabbed_clouds.push_back (input_cloud); };
   grabber.registerCallback (fxn);
@@ -105,7 +105,7 @@ TEST (PCL, ImageGrabberTIFF)
 {
   // Get all clouds from the grabber
   pcl::ImageGrabber<PointT> grabber (tiff_dir_, 0, false, false);
-  vector<CloudT::ConstPtr> tiff_clouds;
+  std::vector<CloudT::ConstPtr> tiff_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
   std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)>
@@ -188,7 +188,7 @@ TEST (PCL, ImageGrabberPCLZF)
 {
   // Get all clouds from the grabber
   pcl::ImageGrabber<PointT> grabber (pclzf_dir_, 0, false, true);
-  vector <CloudT::ConstPtr> pclzf_clouds;
+  std::vector <CloudT::ConstPtr> pclzf_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
   std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)>
@@ -267,7 +267,7 @@ TEST (PCL, ImageGrabberOMP)
 {
   // Get all clouds from the grabber
   pcl::ImageGrabber<PointT> grabber (pclzf_dir_, 0, false, true);
-  vector <CloudT::ConstPtr> pclzf_clouds;
+  std::vector <CloudT::ConstPtr> pclzf_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
   std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)>
@@ -360,7 +360,7 @@ TEST (PCL, ImageGrabberSetIntrinsicsTIFF)
   pcl::ImageGrabber<PointT> grabber (tiff_dir_, 0, false, false);
 
   // Get all clouds from the grabber
-  vector <CloudT::ConstPtr> tiff_clouds;
+  std::vector <CloudT::ConstPtr> tiff_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
   std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)>
@@ -438,7 +438,7 @@ TEST (PCL, ImageGrabberSetIntrinsicsPCLZF)
   pcl::ImageGrabber<PointT> grabber (pclzf_dir_, 0, false, true);
 
   // Get all clouds from the grabber
-  vector <CloudT::ConstPtr> pclzf_clouds;
+  std::vector <CloudT::ConstPtr> pclzf_clouds;
   CloudT::ConstPtr cloud_buffer;
   bool signal_received = false;
   std::function<void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&)>

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -96,8 +96,8 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
   for (size_t i=0; i < cloud.points.size(); ++i)
     if (euclideanDistance(cloud.points[i], test_point) < max_dist)
       brute_force_result.insert(i);
-  vector<int> k_indices;
-  vector<float> k_distances;
+  std::vector<int> k_indices;
+  std::vector<float> k_distances;
   kdtree.radiusSearch (test_point, max_dist, k_indices, k_distances, 100);
   
   //cout << k_indices.size()<<"=="<<brute_force_result.size()<<"?\n";
@@ -175,9 +175,9 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
     ++counter;
   }
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
   kdtree.nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);
   //if (k_indices.size() != no_of_neighbors)  cerr << "Found "<<k_indices.size()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
@@ -240,8 +240,8 @@ TEST (PCL, KdTreeFLANN_setPointRepresentation)
   
   // Find k nearest neighbors
   const int k = 10;
-  vector<int> k_indices (k);
-  vector<float> k_distances (k);
+  std::vector<int> k_indices (k);
+  std::vector<float> k_distances (k);
   kdtree.nearestKSearch (p, k, k_indices, k_distances);
   for (int i = 0; i < k; ++i)
   {

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -1011,7 +1011,7 @@ TEST (PCL, Octree_Pointcloud_Change_Detector_Test)
         cloudIn);
   }
 
-  vector<int> newPointIdxVector;
+  std::vector<int> newPointIdxVector;
 
   // get a vector of new points, which did not exist in previous buffer
   octree.getPointIndicesFromNewVoxels (newPointIdxVector);
@@ -1404,7 +1404,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
     double searchRadius = 5.0 * static_cast<float> (rand () / RAND_MAX);
 
     // bruteforce radius search
-    vector<int> cloudSearchBruteforce;
+    std::vector<int> cloudSearchBruteforce;
     for (size_t i = 0; i < cloudIn->points.size (); i++)
     {
       pointDist = sqrt (
@@ -1419,8 +1419,8 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
       }
     }
 
-    vector<int> cloudNWRSearch;
-    vector<float> cloudNWRRadius;
+    std::vector<int> cloudNWRSearch;
+    std::vector<float> cloudNWRRadius;
 
     // execute octree radius search
     octree.radiusSearch (searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius);

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -80,8 +80,8 @@ computeRmsE (const PointCloud<PointType>::ConstPtr &model, const PointCloud<Poin
   double sqr_norm_sum = 0;
   int found_points = 0;
 
-  vector<int> neigh_indices (1);
-  vector<float> neigh_sqr_dists (1);
+  std::vector<int> neigh_indices (1);
+  std::vector<float> neigh_sqr_dists (1);
   for (const auto &model : transformed_model)
   {
 
@@ -118,7 +118,7 @@ TEST (PCL, Hough3DGrouping)
   rf_est.setSearchSurface (scene_);
   rf_est.compute (*scene_rf);
 
-  vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > rototranslations;
+  std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > rototranslations;
 
   //Actual CG
   Hough3DGrouping<PointType, PointType, RFType, RFType> clusterer;
@@ -144,7 +144,7 @@ TEST (PCL, Hough3DGrouping)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, GeometricConsistencyGrouping)
 {
-  vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > rototranslations;
+  std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > rototranslations;
 
   GeometricConsistencyGrouping<PointType, PointType> clusterer;
   clusterer.setInputCloud (model_downsampled_);
@@ -222,8 +222,8 @@ main (int argc, char** argv)
   {
     if ( std::isfinite( scene_descriptors_->at (i).descriptor[0] ) )
     {
-      vector<int> neigh_indices (1);
-      vector<float> neigh_sqr_dists (1);
+      std::vector<int> neigh_indices (1);
+      std::vector<float> neigh_sqr_dists (1);
       int found_neighs = match_search.nearestKSearch (scene_descriptors_->at (i), 1, neigh_indices, neigh_sqr_dists);
       if(found_neighs == 1 && neigh_sqr_dists[0] < 0.25f)
       {

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -622,7 +622,7 @@ TEST (PCL, PyramidFeatureHistogram)
   ppf_estimator.compute (*ppf_signature_target);
 
 
-  vector<pair<float, float> > dim_range_input, dim_range_target;
+  std::vector<pair<float, float> > dim_range_input, dim_range_target;
   for (size_t i = 0; i < 3; ++i) dim_range_input.emplace_back(static_cast<float> (-M_PI), static_cast<float> (M_PI));
   dim_range_input.emplace_back(0.0f, 1.0f);
   for (size_t i = 0; i < 3; ++i) dim_range_target.emplace_back(static_cast<float> (-M_PI) * 10.0f, static_cast<float> (M_PI) * 10.0f);
@@ -644,7 +644,7 @@ TEST (PCL, PyramidFeatureHistogram)
   float similarity_value = PyramidFeatureHistogram<PPFSignature>::comparePyramidFeatureHistograms (pyramid_source, pyramid_target);
   EXPECT_NEAR (similarity_value, 0.74101555347442627, 1e-4);
 
-  vector<pair<float, float> > dim_range_target2;
+  std::vector<pair<float, float> > dim_range_target2;
   for (size_t i = 0; i < 3; ++i) dim_range_target2.emplace_back(static_cast<float> (-M_PI) * 5.0f, static_cast<float> (M_PI) * 5.0f);
     dim_range_target2.emplace_back(0.0f, 20.0f);
 
@@ -658,7 +658,7 @@ TEST (PCL, PyramidFeatureHistogram)
   EXPECT_NEAR (similarity_value2, 0.80097091197967529, 1e-4);
 
 
-  vector<pair<float, float> > dim_range_target3;
+  std::vector<pair<float, float> > dim_range_target3;
   for (size_t i = 0; i < 3; ++i) dim_range_target3.emplace_back(static_cast<float> (-M_PI) * 2.0f, static_cast<float> (M_PI) * 2.0f);
   dim_range_target3.emplace_back(0.0f, 10.0f);
 

--- a/test/search/test_auto_search.cpp
+++ b/test/search/test_auto_search.cpp
@@ -278,9 +278,9 @@ TEST (PCL, KdTreeWrapper_nearestKSearch)
     ++counter;
   }
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   kdtree->nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -95,9 +95,9 @@ TEST (PCL, FlannSearch_nearestKSearch)
     ++counter;
   }
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   FlannSearch->nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);
@@ -147,9 +147,9 @@ TEST (PCL, FlannSearch_differentPointT)
   std::vector< std::vector< int > > indices;
   FlannSearch->nearestKSearchT (cloud_rgb, std::vector<int> (),no_of_neighbors,indices,dists);
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   //vector<int> k_indices_t;
@@ -188,9 +188,9 @@ TEST (PCL, FlannSearch_multipointKnnSearch)
   std::vector< std::vector< int > > indices;
   FlannSearch->nearestKSearch (cloud_big, std::vector<int>(),no_of_neighbors,indices,dists);
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   for (size_t i = 0; i < cloud_big.points.size (); ++i)
@@ -226,9 +226,9 @@ TEST (PCL, FlannSearch_knnByIndex)
   }
   flann_search->nearestKSearch (cloud_big, query_indices,no_of_neighbors,indices,dists);
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   for (size_t i = 0; i < query_indices.size (); ++i)
@@ -257,9 +257,9 @@ TEST (PCL, FlannSearch_compareToKdTreeFlann)
 {
 
   int no_of_neighbors=3;
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   pcl::search::Search<PointXYZ> *flann_search, *kdtree_search;
@@ -290,10 +290,10 @@ TEST (PCL, FlannSearch_compareToKdTreeFlann)
       kdtree_search->nearestKSearch (point, no_of_neighbors, k_indices, k_distances);
   }
 
-  vector<vector<int> > indices_flann;
-  vector<vector<float> > dists_flann;
-  vector<vector<int> > indices_tree;
-  vector<vector<float> > dists_tree;
+  std::vector<vector<int> > indices_flann;
+  std::vector<vector<float> > dists_flann;
+  std::vector<vector<int> > indices_tree;
+  std::vector<vector<float> > dists_tree;
   indices_flann.resize (cloud_big.size ());
   dists_flann.resize (cloud_big.size ());
   indices_tree.resize (cloud_big.size ());
@@ -333,7 +333,7 @@ TEST (PCL, FlannSearch_compareToKdTreeFlann)
   }
 
 
-  vector<int> query_indices;
+  std::vector<int> query_indices;
   for (size_t i = 0; i<cloud_big.size (); i+=2)
     query_indices.push_back (int (i));
 

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -90,9 +90,9 @@ init ()
     ++counter;
   }
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   kdtree->nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);
@@ -140,14 +140,14 @@ TEST (PCL, KdTree_differentPointT)
   std::vector< std::vector< int > > indices;
   kdtree->nearestKSearchT (cloud_rgb, std::vector<int> (),no_of_neighbors,indices,dists);
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
-  vector<int> k_indices_t;
+  std::vector<int> k_indices_t;
   k_indices_t.resize (no_of_neighbors);
-  vector<float> k_distances_t;
+  std::vector<float> k_distances_t;
   k_distances_t.resize (no_of_neighbors);
 
   for (size_t i = 0; i < cloud_rgb.points.size (); ++i)
@@ -178,9 +178,9 @@ TEST (PCL, KdTree_multipointKnnSearch)
   std::vector< std::vector< int > > indices;
   kdtree->nearestKSearch (cloud_big, std::vector<int> (),no_of_neighbors,indices,dists);
 
-  vector<int> k_indices;
+  std::vector<int> k_indices;
   k_indices.resize (no_of_neighbors);
-  vector<float> k_distances;
+  std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
 
   for (size_t i = 0; i < cloud_big.points.size (); ++i)

--- a/test/search/test_octree.cpp
+++ b/test/search/test_octree.cpp
@@ -257,7 +257,7 @@ TEST (PCL, Octree_RadiusSearch_GPU)
   point.push_back(searchPoint);
   double searchRadius = 5.0 * ((double)rand () / (double)RAND_MAX);
   double radius =5;
-  vector < double > radiuses;
+  std::vector < double > radiuses;
   radiuses.push_back(radius);
   radiuses.push_back(radius);
   radiuses.push_back(radius);
@@ -305,7 +305,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
     double searchRadius = 5.0 * rand () / static_cast<double> (RAND_MAX);
     
     // bruteforce radius search
-    vector<int> cloudSearchBruteforce;
+    std::vector<int> cloudSearchBruteforce;
     for (size_t i = 0; i < cloudIn->points.size (); i++)
     {
       pointDist = sqrt (
@@ -320,8 +320,8 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
       }
     }
 
-    vector<int> cloudNWRSearch;
-    vector<float> cloudNWRRadius;
+    std::vector<int> cloudNWRSearch;
+    std::vector<float> cloudNWRRadius;
 
     // execute octree radius search
     octree->setInputCloud (cloudIn);

--- a/test/search/test_organized.cpp
+++ b/test/search/test_organized.cpp
@@ -230,7 +230,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Neighbours_Within_Radius_Search)
     double searchRadius = 1.0 * (double (rand ()) / double (RAND_MAX));
 
     // bruteforce radius search
-    vector<int> cloudSearchBruteforce;
+    std::vector<int> cloudSearchBruteforce;
     cloudSearchBruteforce.clear();
 
     for (size_t i = 0; i < cloudIn->points.size (); i++)

--- a/test/search/test_organized_index.cpp
+++ b/test/search/test_organized_index.cpp
@@ -308,7 +308,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search)
 //   double searchRadius = 1/10;
 
     // bruteforce radius search
-    vector<int> cloudSearchBruteforce;
+    std::vector<int> cloudSearchBruteforce;
     cloudSearchBruteforce.clear();
 
     for (size_t i = 0; i < cloudIn->points.size (); i++)
@@ -324,8 +324,8 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search)
       }
     }
 
-    vector<int> cloudNWRSearch;
-    vector<float> cloudNWRRadius;
+    std::vector<int> cloudNWRSearch;
+    std::vector<float> cloudNWRRadius;
 
     organizedNeighborSearch->setInputCloud (cloudIn);
 
@@ -425,7 +425,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
     const double searchRadius = 1.0 * ((double)rand () / (double)RAND_MAX);
 
     // bruteforce radius search
-    vector<int> cloudSearchBruteforce;
+    std::vector<int> cloudSearchBruteforce;
     cloudSearchBruteforce.clear();
 
     for (size_t i = 0; i < cloudIn->points.size (); i++)
@@ -442,8 +442,8 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
     }
 
 
-    vector<int> cloudNWRSearch;
-    vector<float> cloudNWRRadius;
+    std::vector<int> cloudNWRSearch;
+    std::vector<float> cloudNWRRadius;
     
     double check_time = getTime();
     organizedNeighborSearch->setInputCloud (cloudIn);
@@ -505,11 +505,11 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
     double searchRadius = 1.0 * (test_id*1.0/10*1.0);
     double sum_time = 0, sum_time2 = 0;
 
-    vector<int> cloudNWRSearch;
-    vector<float> cloudNWRRadius;
+    std::vector<int> cloudNWRSearch;
+    std::vector<float> cloudNWRRadius;
 
-    vector<int> cloudNWRSearch2;
-    vector<float> cloudNWRRadius2;
+    std::vector<int> cloudNWRSearch2;
+    std::vector<float> cloudNWRRadius2;
 
     for (int iter = 0; iter < 100; iter++)
     {
@@ -548,7 +548,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
     const PointXYZ& searchPoint = cloudIn->points[randomIdx];
 
     // bruteforce radius search
-    vector<int> cloudSearchBruteforce;
+    std::vector<int> cloudSearchBruteforce;
     cloudSearchBruteforce.clear();
 
     for (size_t i = 0; i < cloudIn->points.size (); i++)

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -121,22 +121,22 @@ pcl::search::Octree<pcl::PointXYZ> octree_search (0.1);
 pcl::search::OrganizedNeighbor<pcl::PointXYZ> organized;
 
 /** \brief list of search methods for unorganized search test*/
-vector<search::Search<PointXYZ>* > unorganized_search_methods;
+std::vector<search::Search<PointXYZ>* > unorganized_search_methods;
 
 /** \brief list of search methods for organized search test*/
-vector<search::Search<PointXYZ>* > organized_search_methods;
+std::vector<search::Search<PointXYZ>* > organized_search_methods;
 
 /** \brief lists of indices to be used as query points for various search methods and different cloud types*/
-vector<int> unorganized_dense_cloud_query_indices;
-vector<int> unorganized_sparse_cloud_query_indices;
-vector<int> organized_sparse_query_indices;
+std::vector<int> unorganized_dense_cloud_query_indices;
+std::vector<int> unorganized_sparse_cloud_query_indices;
+std::vector<int> organized_sparse_query_indices;
 
 /** \briet test whether the result of a search contains unique point ids or not
   * @param indices resulting indices from a search
   * @param name name of the search method that returned these distances
   * @return true if indices are unique, false otherwise
   */
-bool testUniqueness (const vector<int>& indices, const string& name)
+bool testUniqueness (const std::vector<int>& indices, const string& name)
 {
   bool uniqueness = true;
   for (unsigned idx1 = 1; idx1 < indices.size () && uniqueness; ++idx1)
@@ -164,7 +164,7 @@ bool testUniqueness (const vector<int>& indices, const string& name)
   * \param name name of the search method that returned these distances
   * \return true if distances in weak ascending order, false otherwise
   */
-bool testOrder (const vector<float>& distances, const string& name)
+bool testOrder (const std::vector<float>& distances, const string& name)
 {
   bool ordered = true;
   for (size_t idx1 = 1; idx1 < distances.size (); ++idx1)
@@ -191,7 +191,7 @@ bool testOrder (const vector<float>& distances, const string& name)
  * @return true if result is valid, false otherwise
  */
 template<typename PointT> bool
-testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, const vector<bool>& indices_mask, const vector<bool>& nan_mask, const vector<int>& indices, const vector<int>& /*input_indices*/, const string& name)
+testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, const std::vector<bool>& indices_mask, const std::vector<bool>& nan_mask, const std::vector<int>& indices, const std::vector<int>& /*input_indices*/, const string& name)
 {
   bool validness = true;
   for (const int &index : indices)
@@ -281,15 +281,15 @@ bool compareResults (const std::vector<int>& indices1, const::vector<float>& dis
   * \param input_indices indices defining a subset of the point cloud.
   */
 template<typename PointT> void
-testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search::Search<PointT>*> search_methods,
-                const vector<int>& query_indices, const vector<int>& input_indices = vector<int> () )
+testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector<search::Search<PointT>*> search_methods,
+                const std::vector<int>& query_indices, const std::vector<int>& input_indices = std::vector<int> () )
 {
-  vector< vector<int> >indices (search_methods.size ());
-  vector< vector<float> >distances (search_methods.size ());
-  vector<bool> passed (search_methods.size (), true);
+  std::vector< std::vector<int> >indices (search_methods.size ());
+  std::vector< std::vector<float> >distances (search_methods.size ());
+  std::vector<bool> passed (search_methods.size (), true);
   
-  vector<bool> indices_mask (point_cloud->size (), true);
-  vector<bool> nan_mask (point_cloud->size (), true);
+  std::vector<bool> indices_mask (point_cloud->size (), true);
+  std::vector<bool> nan_mask (point_cloud->size (), true);
   
   if (!input_indices.empty ())
   {
@@ -352,14 +352,14 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search:
   * \param input_indices indices defining a subset of the point cloud.
   */
 template<typename PointT> void
-testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, vector<search::Search<PointT>*> search_methods, 
-                   const vector<int>& query_indices, const vector<int>& input_indices = vector<int> ())
+testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector<search::Search<PointT>*> search_methods, 
+                   const std::vector<int>& query_indices, const std::vector<int>& input_indices = std::vector<int> ())
 {
-  vector< vector<int> >indices (search_methods.size ());
-  vector< vector<float> >distances (search_methods.size ());
-  vector <bool> passed (search_methods.size (), true);
-  vector<bool> indices_mask (point_cloud->size (), true);
-  vector<bool> nan_mask (point_cloud->size (), true);
+  std::vector< std::vector<int> >indices (search_methods.size ());
+  std::vector< std::vector<float> >distances (search_methods.size ());
+  std::vector<bool> passed (search_methods.size (), true);
+  std::vector<bool> indices_mask (point_cloud->size (), true);
+  std::vector<bool> nan_mask (point_cloud->size (), true);
   
   if (!input_indices.empty ())
   {
@@ -459,7 +459,7 @@ TEST (PCL, unorganized_dense_cloud_Complete_Radius)
 // Test search on unorganized point clouds in a grid
 TEST (PCL, unorganized_grid_cloud_Complete_Radius)
 {
-  vector<int> query_indices;
+  std::vector<int> query_indices;
   query_indices.reserve (query_count);
   
   unsigned skip = static_cast<unsigned> (unorganized_grid_cloud->size ()) / query_count;

--- a/test/test_recognition_ransac_based_ORROctree.cpp
+++ b/test/test_recognition_ransac_based_ORROctree.cpp
@@ -97,11 +97,11 @@ TEST (ORROctreeTest, OctreeSphereIntersection)
   ModelLibrary::Model* new_model = new ModelLibrary::Model (*model_cloud, *model_cloud_normals, voxel_size, object_name, frac_of_points_for_registration);
 
   const ORROctree& octree = new_model->getOctree ();
-  const vector<ORROctree::Node*> &full_leaves = octree.getFullLeaves ();
+  const std::vector<ORROctree::Node*> &full_leaves = octree.getFullLeaves ();
   list<ORROctree::Node*> inter_leaves;
 
   // Run through all full leaves
-  for ( vector<ORROctree::Node*>::const_iterator leaf1 = full_leaves.begin () ; leaf1 != full_leaves.end () ; ++leaf1 )
+  for ( std::vector<ORROctree::Node*>::const_iterator leaf1 = full_leaves.begin () ; leaf1 != full_leaves.end () ; ++leaf1 )
   {
     const ORROctree::Node::Data* node_data1 = (*leaf1)->getData ();
     // Get all full leaves at the right distance to the current leaf

--- a/tools/compute_hull.cpp
+++ b/tools/compute_hull.cpp
@@ -105,7 +105,7 @@ main (int argc, char** argv)
   if (parse_argument (argc, argv, "-alpha", alpha) != -1)
     convex_concave_hull = true;
 
-  vector<int> pcd_file_indices;
+  std::vector<int> pcd_file_indices;
   pcd_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
   if (pcd_file_indices.size () != 1)
   {
@@ -113,7 +113,7 @@ main (int argc, char** argv)
     return (-1);
   }
 
-  vector<int> vtk_file_indices;
+  std::vector<int> vtk_file_indices;
   vtk_file_indices = parse_file_extension_argument (argc, argv, ".vtk");
   if (vtk_file_indices.size () != 1)
   {

--- a/tools/fast_bilateral_filter.cpp
+++ b/tools/fast_bilateral_filter.cpp
@@ -110,7 +110,7 @@ saveCloud (const string &filename, const pcl::PCLPointCloud2 &output,
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir, float sigma_s, float sigma_r)
+batchProcess (const std::vector<string> &pcd_files, string &output_dir, float sigma_s, float sigma_r)
 {
 #if _OPENMP
 #pragma omp parallel for
@@ -131,7 +131,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir, float sigma_s
     // Prepare output file name
     string filename = pcd_files[i];
     boost::trim (filename);
-    vector<string> st;
+    std::vector<string> st;
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
@@ -178,7 +178,7 @@ main (int argc, char** argv)
   if (!batch_mode)
   {
     // Parse the command line arguments for .pcd files
-    vector<int> p_file_indices;
+    std::vector<int> p_file_indices;
     p_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
     if (p_file_indices.size () != 2)
     {
@@ -207,7 +207,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/grid_min.cpp
+++ b/tools/grid_min.cpp
@@ -113,10 +113,10 @@ saveCloud (const std::string &filename, const Cloud &output)
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir,
+batchProcess (const std::vector<string> &pcd_files, string &output_dir,
               float resolution)
 {
-  vector<string> st;
+  std::vector<string> st;
   for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
@@ -200,7 +200,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/local_max.cpp
+++ b/tools/local_max.cpp
@@ -114,10 +114,10 @@ saveCloud (const std::string &filename, const Cloud &output)
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir,
+batchProcess (const std::vector<string> &pcd_files, string &output_dir,
               float radius)
 {
-  vector<string> st;
+  std::vector<string> st;
   for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
@@ -201,7 +201,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/morph.cpp
+++ b/tools/morph.cpp
@@ -135,10 +135,10 @@ saveCloud (const std::string &filename, const Cloud &output)
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir,
+batchProcess (const std::vector<string> &pcd_files, string &output_dir,
               float resolution, const std::string &method)
 {
-  vector<string> st;
+  std::vector<string> st;
   for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
@@ -224,7 +224,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/normal_estimation.cpp
+++ b/tools/normal_estimation.cpp
@@ -129,7 +129,7 @@ saveCloud (const string &filename, const pcl::PCLPointCloud2 &output,
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir, int k, double radius)
+batchProcess (const std::vector<string> &pcd_files, string &output_dir, int k, double radius)
 {
 #if _OPENMP
 #pragma omp parallel for
@@ -150,7 +150,7 @@ batchProcess (const vector<string> &pcd_files, string &output_dir, int k, double
     // Prepare output file name
     string filename = pcd_files[i];
     boost::trim (filename);
-    vector<string> st;
+    std::vector<string> st;
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
@@ -197,7 +197,7 @@ main (int argc, char** argv)
   if (!batch_mode)
   {
     // Parse the command line arguments for .pcd files
-    vector<int> p_file_indices;
+    std::vector<int> p_file_indices;
     p_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
     if (p_file_indices.size () != 2)
     {
@@ -226,7 +226,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -297,7 +297,7 @@ update (CallbackParameters* params)
 #endif
 
   // Now show some of the accepted hypotheses
-  vector<Hypothesis> accepted_hypotheses;
+  std::vector<Hypothesis> accepted_hypotheses;
   params->objrec_.getAcceptedHypotheses (accepted_hypotheses);
   int i = 0;
 
@@ -305,7 +305,7 @@ update (CallbackParameters* params)
   std::sort(accepted_hypotheses.begin (), accepted_hypotheses.end (), compareHypotheses);
 
   // Show the hypotheses
-  for ( vector<Hypothesis>::iterator acc_hypo = accepted_hypotheses.begin () ; i < params->num_hypotheses_to_show_ && acc_hypo != accepted_hypotheses.end () ; ++i, ++acc_hypo )
+  for ( std::vector<Hypothesis>::iterator acc_hypo = accepted_hypotheses.begin () ; i < params->num_hypotheses_to_show_ && acc_hypo != accepted_hypotheses.end () ; ++i, ++acc_hypo )
   {
     // Visualize the orientation as a tripod
     char frame_name[128];

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -501,7 +501,7 @@ class Viewer
           if (frame->image)
           {
             // Copy RGB data for visualization
-            static vector<unsigned char> rgb_data (frame->image->getWidth () * frame->image->getHeight () * 3);
+            static std::vector<unsigned char> rgb_data (frame->image->getWidth () * frame->image->getHeight () * 3);
             if (frame->image->getEncoding () != openni_wrapper::Image::RGB)
             {
               frame->image->fillRGB (frame->image->getWidth (), 
@@ -699,7 +699,7 @@ main (int argc, char ** argv)
       {
         OpenNIGrabber grabber (argv[2]);
         auto device = grabber.getDevice ();
-        vector<pair<int, XnMapOutputMode> > modes;
+        std::vector<pair<int, XnMapOutputMode> > modes;
 
         if (device->hasImageStream ())
         {

--- a/tools/passthrough_filter.cpp
+++ b/tools/passthrough_filter.cpp
@@ -124,10 +124,10 @@ saveCloud (const std::string &filename, const pcl::PCLPointCloud2 &output)
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir,
+batchProcess (const std::vector<string> &pcd_files, string &output_dir,
               const std::string &field_name, float min, float max, bool inside, bool keep_organized)
 {
-  vector<string> st;
+  std::vector<string> st;
   for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
@@ -218,7 +218,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/progressive_morphological_filter.cpp
+++ b/tools/progressive_morphological_filter.cpp
@@ -173,9 +173,9 @@ saveCloud (const std::string &filename, const Cloud &output)
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir, int max_window_size, float slope, float max_distance, float initial_distance, float cell_size, float base, bool exponential, bool approximate)
+batchProcess (const std::vector<string> &pcd_files, string &output_dir, int max_window_size, float slope, float max_distance, float initial_distance, float cell_size, float base, bool exponential, bool approximate)
 {
-  vector<string> st;
+  std::vector<string> st;
   for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
@@ -302,7 +302,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -108,7 +108,7 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
   sac.setMaxIterations (max_iterations);
   bool res = sac.computeModel ();
   
-  vector<int> inliers;
+  std::vector<int> inliers;
   sac.getInliers (inliers);
   Eigen::VectorXf coefficients;
   sac.getModelCoefficients (coefficients);
@@ -142,7 +142,7 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
                     inserter (everything_but_the_plane->indices, everything_but_the_plane->indices.begin ()));
 
     // Extract largest cluster minus the plane
-    vector<PointIndices> cluster_indices;
+    std::vector<PointIndices> cluster_indices;
     EuclideanClusterExtraction<PointXYZ> ec;
     ec.setClusterTolerance (0.02); // 2cm
     ec.setMinClusterSize (100);
@@ -176,9 +176,9 @@ saveCloud (const string &filename, const pcl::PCLPointCloud2 &output)
 }
 
 int
-batchProcess (const vector<string> &pcd_files, string &output_dir, int max_it, double thresh, bool negative)
+batchProcess (const std::vector<string> &pcd_files, string &output_dir, int max_it, double thresh, bool negative)
 {
-  vector<string> st;
+  std::vector<string> st;
   for (const auto &pcd_file : pcd_files)
   {
     // Load the first file
@@ -251,7 +251,7 @@ main (int argc, char** argv)
   if (!batch_mode)
   {
     // Parse the command line arguments for .pcd files
-    vector<int> p_file_indices;
+    std::vector<int> p_file_indices;
     p_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
     if (p_file_indices.size () != 2)
     {
@@ -281,7 +281,7 @@ main (int argc, char** argv)
   {
     if (!input_dir.empty() && boost::filesystem::exists (input_dir))
     {
-      vector<string> pcd_files;
+      std::vector<string> pcd_files;
       boost::filesystem::directory_iterator end_itr;
       for (boost::filesystem::directory_iterator itr (input_dir); itr != end_itr; ++itr)
       {

--- a/tools/uniform_sampling.cpp
+++ b/tools/uniform_sampling.cpp
@@ -151,8 +151,8 @@ main (int argc, char** argv)
   }
 
   // Parse the command line arguments for .pcd files
-  vector<int> p_file_indices;
-  vector<std::string> extension;
+  std::vector<int> p_file_indices;
+  std::vector<std::string> extension;
   extension.emplace_back(".pcd");
   extension.emplace_back(".ply");
   extension.emplace_back(".vtk");

--- a/tools/xyz2pcd.cpp
+++ b/tools/xyz2pcd.cpp
@@ -63,7 +63,7 @@ loadCloud (const string &filename, PointCloud<PointXYZ> &cloud)
   }
   
   string line;
-  vector<string> st;
+  std::vector<string> st;
 
   while (!fs.eof ())
   {
@@ -100,8 +100,8 @@ main (int argc, char** argv)
   }
 
   // Parse the command line arguments for .pcd and .ply files
-  vector<int> pcd_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
-  vector<int> xyz_file_indices = parse_file_extension_argument (argc, argv, ".xyz");
+  std::vector<int> pcd_file_indices = parse_file_extension_argument (argc, argv, ".pcd");
+  std::vector<int> xyz_file_indices = parse_file_extension_argument (argc, argv, ".xyz");
   if (pcd_file_indices.size () != 1 || xyz_file_indices.size () != 1)
   {
     print_error ("Need one input XYZ file and one output PCD file.\n");

--- a/visualization/include/pcl/visualization/pcl_painter2D.h
+++ b/visualization/include/pcl/visualization/pcl_painter2D.h
@@ -413,7 +413,7 @@ namespace pcl
       void spin ();
 
     private:
-      //std::map< int, std::vector< std::vector<float> > > figures_; //FIG_TYPE -> vector<array>
+      //std::map< int, std::vector< std::vector<float> > > figures_; //FIG_TYPE -> std::vector<array>
 
       //All the figures drawn till now gets stored here
       std::vector<Figure2D *> figures_;

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -251,7 +251,7 @@ pcl::visualization::PCLPlotter::addPlotData (
   getline (fin, line);
   stringstream ss(line);
   
-  vector<string> pnames;       //plot names
+  std::vector<string> pnames;       //plot names
   string xname, temp;         //plot name of X axis
   
   //checking X axis name
@@ -262,8 +262,8 @@ pcl::visualization::PCLPlotter::addPlotData (
     
   int nop = int (pnames.size ());// number of plots (y coordinate vectors)  
   
-  vector<double> xarray;      //array of X coordinates
-  vector< vector<double> > yarrays (nop); //a set of array of Y coordinates
+  std::vector<double> xarray;      //array of X coordinates
+  std::vector< std::vector<double> > yarrays (nop); //a set of array of Y coordinates
   
   //reading the entire table
   double x, y;


### PR DESCRIPTION
Use `std::vector` instead of just `vector` in preparation for #3235.