### PR TITLE
Prefer C++ method std::abs over C method abs

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/local/local_estimator.h
@@ -127,7 +127,7 @@ namespace pcl
                 PCL_ERROR("Eigen sum is not finite\n");
               }
 
-              if ((fabs (eigenValues[0] - eigenValues[1]) < 1.5e-4) || (eigsum != 0 && fabs (eigenValues[0] / eigsum) > 1.e-2))
+              if ((std::abs (eigenValues[0] - eigenValues[1]) < 1.5e-4) || (eigsum != 0 && std::abs (eigenValues[0] / eigsum) > 1.e-2))
               {
                 //region is not planar, add to filtered keypoint
                 keypoints_cloud->points[good] = keypoints_cloud->points[i];

--- a/apps/point_cloud_editor/src/select2DTool.cpp
+++ b/apps/point_cloud_editor/src/select2DTool.cpp
@@ -196,8 +196,8 @@ Select2DTool::drawRubberBand (GLint* viewport) const
 void
 Select2DTool::highlightPoints (GLint* viewport) const
 {
-  double width = abs(origin_x_ - final_x_);
-  double height = abs(origin_y_ - final_y_);
+  double width = std::abs(origin_x_ - final_x_);
+  double height = std::abs(origin_y_ - final_y_);
   glPushAttrib(GL_SCISSOR_BIT);
   {
     glEnable(GL_SCISSOR_TEST);

--- a/apps/src/openni_tracking.cpp
+++ b/apps/src/openni_tracking.cpp
@@ -476,9 +476,9 @@ public:
     for (size_t i = 0; i < cloud->points.size (); i++)
     {
       PointType point = cloud->points[i];
-      if (!(fabs(point.x) < 0.01 &&
-            fabs(point.y) < 0.01 &&
-            fabs(point.z) < 0.01) &&
+      if (!(std::abs(point.x) < 0.01 &&
+            std::abs(point.y) < 0.01 &&
+            std::abs(point.z) < 0.01) &&
           !std::isnan(point.x) &&
           !std::isnan(point.y) &&
           !std::isnan(point.z))

--- a/apps/src/organized_segmentation_demo.cpp
+++ b/apps/src/organized_segmentation_demo.cpp
@@ -140,7 +140,7 @@ compareClusterToRegion (pcl::PlanarRegion<PointT>& region, pcl::PointCloud<Point
 
   for (const auto &point : cluster.points)
   {
-    double ptp_dist = fabs (model[0] * point.x +
+    double ptp_dist = std::abs (model[0] * point.x +
                             model[1] * point.y +
                             model[2] * point.z +
                             model[3]);
@@ -156,7 +156,7 @@ comparePointToRegion (PointT& pt, pcl::ModelCoefficients& model, pcl::PointCloud
 {
   //bool dist_ok;
 
-  double ptp_dist = fabs (model.values[0] * pt.x +
+  double ptp_dist = std::abs (model.values[0] * pt.x +
                           model.values[1] * pt.y +
                           model.values[2] * pt.z +
                           model.values[3]);

--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -203,7 +203,7 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
     //If the view up is parallel to ray cam_pos - focalPoint then the transformation
     //is singular and no points are rendered...
     //make sure it is perpendicular
-    if (fabs (cam_pos_3f.dot (test)) == 1)
+    if (std::abs (cam_pos_3f.dot (test)) == 1)
     {
       //parallel, create
       test = cam_pos_3f.cross (Eigen::Vector3f::UnitX ());

--- a/common/include/pcl/common/impl/bivariate_polynomial.hpp
+++ b/common/include/pcl/common/impl/bivariate_polynomial.hpp
@@ -240,7 +240,7 @@ pcl::operator<< (std::ostream& os, const pcl::BivariatePolynomialT<real>& p)
       if (!first) 
       {
         os << (currentParameter<0.0?" - ":" + ");
-        currentParameter = fabs (currentParameter);
+        currentParameter = std::abs (currentParameter);
       }
       os << currentParameter;
       if (xDegree>0) 

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -78,7 +78,7 @@ pcl::computeRoots (const Matrix& m, Roots& roots)
         m (1, 2) * m (1, 2);
   Scalar c2 = m (0, 0) + m (1, 1) + m (2, 2);
 
-  if (fabs (c0) < Eigen::NumTraits < Scalar > ::epsilon ())  // one root is 0 -> quadratic equation
+  if (std::abs (c0) < Eigen::NumTraits < Scalar > ::epsilon ())  // one root is 0 -> quadratic equation
     computeRoots2 (c2, c1, roots);
   else
   {
@@ -127,7 +127,7 @@ pcl::eigen22 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& ei
 {
   // if diagonal matrix, the eigenvalues are the diagonal elements
   // and the eigenvectors are not unique, thus set to Identity
-  if (fabs (mat.coeff (1)) <= std::numeric_limits<typename Matrix::Scalar>::min ())
+  if (std::abs (mat.coeff (1)) <= std::numeric_limits<typename Matrix::Scalar>::min ())
   {
     if (mat.coeff (0) < mat.coeff (2))
     {
@@ -166,7 +166,7 @@ pcl::eigen22 (const Matrix& mat, Matrix& eigenvectors, Vector& eigenvalues)
 {
   // if diagonal matrix, the eigenvalues are the diagonal elements
   // and the eigenvectors are not unique, thus set to Identity
-  if (fabs (mat.coeff (1)) <= std::numeric_limits<typename Matrix::Scalar>::min ())
+  if (std::abs (mat.coeff (1)) <= std::numeric_limits<typename Matrix::Scalar>::min ())
   {
     if (mat.coeff (0) < mat.coeff (3))
     {

--- a/common/include/pcl/common/impl/intersections.hpp
+++ b/common/include/pcl/common/impl/intersections.hpp
@@ -91,9 +91,9 @@ pcl::planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
 
   // Test if planes are parallel
   double test_cos = plane_a_norm.dot (plane_b_norm);
-  double tolerance_cos = 1 - sin (fabs (angular_tolerance));
+  double tolerance_cos = 1 - sin (std::abs (angular_tolerance));
 
-  if (fabs (test_cos) > tolerance_cos)
+  if (std::abs (test_cos) > tolerance_cos)
   {
       PCL_DEBUG ("Plane A and Plane B are parallel.\n");
       return (false);
@@ -142,7 +142,7 @@ pcl::threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
   }
 
   Scalar determinant = normals_in_lines.determinant ();
-  if (fabs (determinant) < determinant_tolerance)
+  if (std::abs (determinant) < determinant_tolerance)
   {
     // det ~= 0
     PCL_DEBUG ("At least two planes are parallel.\n");

--- a/common/include/pcl/common/impl/norms.hpp
+++ b/common/include/pcl/common/impl/norms.hpp
@@ -88,7 +88,7 @@ L1_Norm (FloatVectorT a, FloatVectorT b, int dim)
 {
   float norm = 0.0f;
   for (int i = 0; i < dim; ++i)
-    norm += fabsf(a[i] - b[i]);
+    norm += std::abs(a[i] - b[i]);
   return norm;
 }
 
@@ -118,7 +118,7 @@ Linf_Norm (FloatVectorT a, FloatVectorT b, int dim)
 {
   float norm = 0.0;
   for (int i = 0; i < dim; ++i)
-    norm = (std::max)(fabsf(a[i] - b[i]), norm);
+    norm = (std::max)(std::abs(a[i] - b[i]), norm);
   return norm;
 }
 
@@ -158,7 +158,7 @@ Sublinear_Norm (FloatVectorT a, FloatVectorT b, int dim)
   float norm = 0.0;
 
   for (int i = 0; i < dim; ++i)
-    norm += std::sqrt (fabsf (a[i] - b[i]));
+    norm += std::sqrt (std::abs (a[i] - b[i]));
 
   return norm;
 }
@@ -209,7 +209,7 @@ K_Norm (FloatVectorT a, FloatVectorT b, int dim, float P1, float P2)
   float norm = 0.0;
 
   for (int i = 0; i < dim; ++i)
-    norm += fabsf (P1 * a[i] - P2 * b[i]);
+    norm += std::abs (P1 * a[i] - P2 * b[i]);
   return norm;
 }
 

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -242,7 +242,7 @@ inline void
   {
     real x=roots[i], x2=x*x, x3=x2*x;
     real result = a*x3 + b*x2 + c*x + d;
-    if (fabs (result) > 1e-4)
+    if (std::abs (result) > 1e-4)
     {
       cout << "Something went wrong:\n";
       //roots.clear ();
@@ -395,7 +395,7 @@ inline void
   {
     real x=roots[i], x2=x*x, x3=x2*x, x4=x2*x2;
     real result = a*x4 + b*x3 + c*x2 + d*x + e;
-    if (fabs (result) > 1e-4)
+    if (std::abs (result) > 1e-4)
     {
       cout << "Something went wrong:\n";
       //roots.clear ();

--- a/common/include/pcl/common/polynomial_calculations.h
+++ b/common/include/pcl/common/polynomial_calculations.h
@@ -106,18 +106,18 @@ namespace pcl
       
     protected:  
       // =====PROTECTED METHODS=====
-      //! check if fabs(d)<zeroValue
+      //! check if std::abs(d)<zeroValue
       inline bool
       isNearlyZero (real d) const 
       { 
-        return (fabs (d) < parameters_.zero_value);
+        return (std::abs (d) < parameters_.zero_value);
       }
       
-      //! check if sqrt(fabs(d))<zeroValue
+      //! check if sqrt(std::abs(d))<zeroValue
       inline bool
       sqrtIsNearlyZero (real d) const 
       { 
-        return (fabs (d) < parameters_.sqr_zero_value);
+        return (std::abs (d) < parameters_.sqr_zero_value);
       }
       
       // =====PROTECTED MEMBERS=====

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -62,7 +62,7 @@ RangeImage::atan2LookUp (float y, float x)
   if (x==0 && y==0)
     return 0;
   float ret;
-  if (fabsf (x) < fabsf (y)) 
+  if (std::abs (x) < std::abs (y)) 
   {
     ret = atan_lookup_table[
       static_cast<int> (
@@ -85,7 +85,7 @@ RangeImage::atan2LookUp (float y, float x)
 inline float
 RangeImage::cosLookUp (float value)
 {
-  int cell_idx = static_cast<int> (pcl_lrintf ( (static_cast<float> (lookup_table_size-1)) * fabsf (value) / (2.0f * static_cast<float> (M_PI))));
+  int cell_idx = static_cast<int> (pcl_lrintf ( (static_cast<float> (lookup_table_size-1)) * std::abs (value) / (2.0f * static_cast<float> (M_PI))));
   return (cos_lookup_table[cell_idx]);
 }
 
@@ -654,7 +654,7 @@ RangeImage::getAcutenessValue (const PointWithRange& point1, const PointWithRang
   float ret = 1.0f - float (std::fabs (impact_angle)/ (0.5f*M_PI));
   if (impact_angle < 0.0f)
     ret = -ret;
-  //if (fabs (ret)>1)
+  //if (std::abs (ret)>1)
     //std::cout << PVARAC (impact_angle)<<PVARN (ret);
   return ret;
 }

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -495,12 +495,12 @@ RangeImage::getInterpolatedSurfaceProjection (const Eigen::Affine3f& pose, int p
         continue;
       getPoint (x, y, point1);
       point1 = pose*point1;
-      if (fabs (point1[2]) > max_dist)
+      if (std::abs (point1[2]) > max_dist)
         continue;
       
       getPoint (x+1, y+1, point2);
       point2 = pose*point2;
-      if (fabs (point2[2]) > max_dist)
+      if (std::abs (point2[2]) > max_dist)
         continue;
       
       for (int triangle_idx=0; triangle_idx<=1; ++triangle_idx)
@@ -518,7 +518,7 @@ RangeImage::getInterpolatedSurfaceProjection (const Eigen::Affine3f& pose, int p
           getPoint (x+1, y, point3);
         }
         point3 = pose*point3;
-        if (fabs (point3[2]) > max_dist)
+        if (std::abs (point3[2]) > max_dist)
           continue;
         
         // Are all the points either left, right, on top or below the bottom of the surface patch?

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -105,7 +105,7 @@ namespace pcl
         
         //float image_x, image_y;
         //getImagePoint (point.getVector3fMap (), image_x, image_y);
-        //if (fabsf (image_x-x)+fabsf (image_y-y)>1e-4)
+        //if (std::abs (image_x-x)+std::abs (image_y-y)>1e-4)
           //cerr << PVARC (x)<<PVARC (y)<<PVARC (image_x)<<PVARN (image_y);
       }
     }

--- a/cuda/common/include/pcl/cuda/common/eigen.h
+++ b/cuda/common/include/pcl/cuda/common/eigen.h
@@ -179,7 +179,7 @@ namespace pcl
       float  c2 = m.data[0].x + m.data[1].y + m.data[2].z;
   
   
-  		if (fabs(c0) < FLT_EPSILON) // one root is 0 -> quadratic equation
+  		if (std::abs(c0) < FLT_EPSILON) // one root is 0 -> quadratic equation
   			computeRoots2 (c2, c1, roots);
   		else
   		{

--- a/cuda/features/include/pcl/cuda/features/normal_3d_kernels.h
+++ b/cuda/features/include/pcl/cuda/features/normal_3d_kernels.h
@@ -112,10 +112,10 @@ namespace pcl
         int yIdx = idx / width_;
 
         // are we at a border? are our neighbor valid points?
-        bool west_valid  = (xIdx > 1)         && !isnan (points_[idx-1].z) &&      fabs (points_[idx-1].z - query_pt.z) < 200;
-        bool east_valid  = (xIdx < width_-1)  && !isnan (points_[idx+1].z) &&      fabs (points_[idx+1].z - query_pt.z) < 200;
-        bool north_valid = (yIdx > 1)         && !isnan (points_[idx-width_].z) && fabs (points_[idx-width_].z - query_pt.z) < 200;
-        bool south_valid = (yIdx < height_-1) && !isnan (points_[idx+width_].z) && fabs (points_[idx+width_].z - query_pt.z) < 200;
+        bool west_valid  = (xIdx > 1)         && !isnan (points_[idx-1].z) &&      std::abs (points_[idx-1].z - query_pt.z) < 200;
+        bool east_valid  = (xIdx < width_-1)  && !isnan (points_[idx+1].z) &&      std::abs (points_[idx+1].z - query_pt.z) < 200;
+        bool north_valid = (yIdx > 1)         && !isnan (points_[idx-width_].z) && std::abs (points_[idx-width_].z - query_pt.z) < 200;
+        bool south_valid = (yIdx < height_-1) && !isnan (points_[idx+width_].z) && std::abs (points_[idx+width_].z - query_pt.z) < 200;
 
         float3 horiz, vert;
         if (west_valid & east_valid)
@@ -139,7 +139,7 @@ namespace pcl
         float3 normal = cross (horiz, vert);
 
         float curvature = length (normal);
-        curvature = fabs(horiz.z) > 0.04 | fabs(vert.z) > 0.04 | !west_valid | !east_valid | !north_valid | !south_valid;
+        curvature = std::abs(horiz.z) > 0.04 | std::abs(vert.z) > 0.04 | !west_valid | !east_valid | !north_valid | !south_valid;
 
         float3 mc = normalize (normal);
         if ( dot (query_pt, mc) > 0 )
@@ -182,7 +182,7 @@ namespace pcl
                      normal.z * (query_pt.z - centroid.z) / sqrt(sqr_radius_) ; 
 
 
-        //return make_float4 (normal.x*proj, normal.y*proj, normal.z*proj, clamp (fabs (proj), 0.0f, 1.0f));
+        //return make_float4 (normal.x*proj, normal.y*proj, normal.z*proj, clamp (std::abs (proj), 0.0f, 1.0f));
         return make_float4 (
            (centroid.x - query_pt.x) / sqrt(sqr_radius_) ,
            (centroid.y - query_pt.y) / sqrt(sqr_radius_) ,

--- a/cuda/io/include/pcl/cuda/io/kinect_smoothing.h
+++ b/cuda/io/include/pcl/cuda/io/kinect_smoothing.h
@@ -136,7 +136,7 @@ namespace pcl
             // ignore invalid points
             if (otherDepth == 0)
               continue;
-            if (fabs(otherDepth - depth) > 200)
+            if (std::abs(otherDepth - depth) > 200)
               continue;
 
             ++counter;

--- a/cuda/sample_consensus/src/sac_model_1point_plane.cu
+++ b/cuda/sample_consensus/src/sac_model_1point_plane.cu
@@ -388,7 +388,7 @@ namespace pcl
 
       //TODO: make threshold adaptive, depending on z
 
-      return (fabs (thrust::raw_reference_cast(thrust::get<0>(t)).x * coefficients.x +
+      return (std::abs (thrust::raw_reference_cast(thrust::get<0>(t)).x * coefficients.x +
                     thrust::raw_reference_cast(thrust::get<0>(t)).y * coefficients.y +
                     thrust::raw_reference_cast(thrust::get<0>(t)).z * coefficients.z + coefficients.w) < threshold);
     }
@@ -405,7 +405,7 @@ namespace pcl
       if (isnan (p.x))
         return -1;
 
-      if (fabs (p.x * coefficients.x +
+      if (std::abs (p.x * coefficients.x +
                 p.y * coefficients.y +
                 p.z * coefficients.z + coefficients.w) < threshold)
         // If inlier, return its position in the vector
@@ -432,7 +432,7 @@ namespace pcl
 
       //TODO: make threshold adaptive, depending on z
 
-      if (fabs (dot (pt, coefficients)) < threshold)
+      if (std::abs (dot (pt, coefficients)) < threshold)
         // If inlier, return its position in the vector
         return (thrust::get<1>(t));
       else
@@ -456,7 +456,7 @@ namespace pcl
       float orig_disparity = b * f / pt.z;
       float actual_disparity = orig_disparity * length_pt / (length_pt + D);
 
-      if ((fabs (actual_disparity - orig_disparity) <= 1.0/6.0) & idx != -1)
+      if ((std::abs (actual_disparity - orig_disparity) <= 1.0/6.0) & idx != -1)
         return (idx);
       else
         return -1;
@@ -482,12 +482,12 @@ namespace pcl
       float orig_disparity = b * f / pt.z;
       float actual_disparity = orig_disparity * length_pt / (length_pt + D);
 
-      if ((fabs (actual_disparity - orig_disparity) <= 1.0/2.0) & (idx != -1)
+      if ((std::abs (actual_disparity - orig_disparity) <= 1.0/2.0) & (idx != -1)
           &
             (
-              fabs (std::acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
+              std::abs (std::acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
               |
-              fabs (std::acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
+              std::abs (std::acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
             )
          )
         return (idx);
@@ -505,14 +505,14 @@ namespace pcl
       float4 &normal = thrust::get<1>(t);
       //TODO: make threshold adaptive, depending on z
 
-      if (fabs (pt.x * coefficients.x +
+      if (std::abs (pt.x * coefficients.x +
                 pt.y * coefficients.y +
                 pt.z * coefficients.z + coefficients.w) < threshold
           &
             (
-              fabs (std::acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
+              std::abs (std::acos (normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z)) < angle_threshold
               |
-              fabs (std::acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
+              std::abs (std::acos (-(normal.x*coefficients.x + normal.y*coefficients.y + normal.z*coefficients.z))) < angle_threshold
             )
           )
         // If inlier, return its position in the vector
@@ -531,7 +531,7 @@ namespace pcl
 
       //TODO: make threshold adaptive, depending on z
 
-      if (fabs (pt.x * coefficients.x +
+      if (std::abs (pt.x * coefficients.x +
                 pt.y * coefficients.y +
                 pt.z * coefficients.z + coefficients.w) < threshold)
         // If inlier, return its position in the vector

--- a/cuda/sample_consensus/src/sac_model_plane.cu
+++ b/cuda/sample_consensus/src/sac_model_plane.cu
@@ -195,7 +195,7 @@ namespace pcl
       if (!isfinite (thrust::raw_reference_cast(thrust::get<0>(t)).x))
         return (false);
 
-      return (fabs (thrust::raw_reference_cast(thrust::get<0>(t)).x * coefficients.x +
+      return (std::abs (thrust::raw_reference_cast(thrust::get<0>(t)).x * coefficients.x +
                     thrust::raw_reference_cast(thrust::get<0>(t)).y * coefficients.y +
                     thrust::raw_reference_cast(thrust::get<0>(t)).z * coefficients.z + coefficients.w) < threshold);
     }
@@ -213,7 +213,7 @@ namespace pcl
       pt.z = thrust::get<0>(t).z;
       pt.w = 1;
 
-      if (fabs (dot (pt, coefficients)) < threshold)
+      if (std::abs (dot (pt, coefficients)) < threshold)
         // If inlier, return its position in the vector
         return (thrust::get<1>(t));
       else

--- a/doc/tutorials/content/pairwise_incremental_registration.rst
+++ b/doc/tutorials/content/pairwise_incremental_registration.rst
@@ -139,7 +139,7 @@ During each iteration, we keep track of and accumulate the transformations retur
 		for (int i = 0; i < 30; ++i)
 		{
 		 [...]
-		 if (fabs ((reg.getLastIncrementalTransformation () - prev).sum ()) < reg.getTransformationEpsilon ())
+		 if (std::abs ((reg.getLastIncrementalTransformation () - prev).sum ()) < reg.getTransformationEpsilon ())
 		   reg.setMaxCorrespondenceDistance (reg.getMaxCorrespondenceDistance () - 0.001);
      
 		 prev = reg.getLastIncrementalTransformation ();

--- a/doc/tutorials/content/sources/conditional_euclidean_clustering/conditional_euclidean_clustering.cpp
+++ b/doc/tutorials/content/sources/conditional_euclidean_clustering/conditional_euclidean_clustering.cpp
@@ -12,7 +12,7 @@ typedef pcl::PointXYZINormal PointTypeFull;
 bool
 enforceIntensitySimilarity (const PointTypeFull& point_a, const PointTypeFull& point_b, float squared_distance)
 {
-  if (fabs (point_a.intensity - point_b.intensity) < 5.0f)
+  if (std::abs (point_a.intensity - point_b.intensity) < 5.0f)
     return (true);
   else
     return (false);
@@ -22,9 +22,9 @@ bool
 enforceCurvatureOrIntensitySimilarity (const PointTypeFull& point_a, const PointTypeFull& point_b, float squared_distance)
 {
   Eigen::Map<const Eigen::Vector3f> point_a_normal = point_a.getNormalVector3fMap (), point_b_normal = point_b.getNormalVector3fMap ();
-  if (fabs (point_a.intensity - point_b.intensity) < 5.0f)
+  if (std::abs (point_a.intensity - point_b.intensity) < 5.0f)
     return (true);
-  if (fabs (point_a_normal.dot (point_b_normal)) < 0.05)
+  if (std::abs (point_a_normal.dot (point_b_normal)) < 0.05)
     return (true);
   return (false);
 }
@@ -35,14 +35,14 @@ customRegionGrowing (const PointTypeFull& point_a, const PointTypeFull& point_b,
   Eigen::Map<const Eigen::Vector3f> point_a_normal = point_a.getNormalVector3fMap (), point_b_normal = point_b.getNormalVector3fMap ();
   if (squared_distance < 10000)
   {
-    if (fabs (point_a.intensity - point_b.intensity) < 8.0f)
+    if (std::abs (point_a.intensity - point_b.intensity) < 8.0f)
       return (true);
-    if (fabs (point_a_normal.dot (point_b_normal)) < 0.06)
+    if (std::abs (point_a_normal.dot (point_b_normal)) < 0.06)
       return (true);
   }
   else
   {
-    if (fabs (point_a.intensity - point_b.intensity) < 3.0f)
+    if (std::abs (point_a.intensity - point_b.intensity) < 3.0f)
       return (true);
   }
   return (false);

--- a/doc/tutorials/content/sources/pairwise_incremental_registration/pairwise_incremental_registration.cpp
+++ b/doc/tutorials/content/sources/pairwise_incremental_registration/pairwise_incremental_registration.cpp
@@ -284,7 +284,7 @@ void pairAlign (const PointCloud::Ptr cloud_src, const PointCloud::Ptr cloud_tgt
 		//if the difference between this transformation and the previous one
 		//is smaller than the threshold, refine the process by reducing
 		//the maximal correspondence distance
-    if (fabs ((reg.getLastIncrementalTransformation () - prev).sum ()) < reg.getTransformationEpsilon ())
+    if (std::abs ((reg.getLastIncrementalTransformation () - prev).sum ()) < reg.getTransformationEpsilon ())
       reg.setMaxCorrespondenceDistance (reg.getMaxCorrespondenceDistance () - 0.001);
     
     prev = reg.getLastIncrementalTransformation ();

--- a/doc/tutorials/content/sources/pcl_plotter/pcl_plotter_demo.cpp
+++ b/doc/tutorials/content/sources/pcl_plotter/pcl_plotter_demo.cpp
@@ -5,7 +5,7 @@
 #include<iostream>
 #include<vector>
 #include<utility>
-#include<math.h>  //for abs()
+#include<cmath>  //for std::abs()
 
 using namespace std;
 using namespace pcl::visualization;
@@ -83,7 +83,7 @@ main (int argc, char * argv [])
   plotter->addPlotData (identity, -10, 10, "identity");
   plotter->spinOnce (2000);
 
-  plotter->addPlotData (abs, -10, 10, "abs");
+  plotter->addPlotData (std::abs, -10, 10, "abs");
   plotter->spinOnce (2000);
 
   plotter->addPlotData (step, -10, 10, "step", 100, vtkChart::POINTS);

--- a/doc/tutorials/content/writing_new_classes.rst
+++ b/doc/tutorials/content/writing_new_classes.rst
@@ -128,7 +128,7 @@ and save the results to disk.
         {
           float id = k_indices.at (n_id);
           float dist = sqrt (k_distances.at (n_id));
-          float intensity_dist = abs (cloud->points[point_id].intensity - cloud->points[id].intensity);
+          float intensity_dist = std::abs (cloud->points[point_id].intensity - cloud->points[id].intensity);
 
           float w_a = G (dist, sigma_s);
           float w_b = G (intensity_dist, sigma_r);
@@ -607,7 +607,7 @@ There're two methods that we need to implement here, namely `applyFilter` and
       {
         double id = indices[n_id];
         double dist = std::sqrt (distances[n_id]);
-        double intensity_dist = abs (input_->points[pid].intensity - input_->points[id].intensity);
+        double intensity_dist = std::abs (input_->points[pid].intensity - input_->points[id].intensity);
 
         double weight = kernel (dist, sigma_s_) * kernel (intensity_dist, sigma_r_);
 
@@ -728,7 +728,7 @@ The implementation file header thus becomes:
       {
         double id = indices[n_id];
         double dist = std::sqrt (distances[n_id]);
-        double intensity_dist = abs (input_->points[pid].intensity - input_->points[id].intensity);
+        double intensity_dist = std::abs (input_->points[pid].intensity - input_->points[id].intensity);
 
         double weight = kernel (dist, sigma_s_) * kernel (intensity_dist, sigma_r_);
 
@@ -843,7 +843,7 @@ The implementation file header thus becomes:
       {
         double id = indices[n_id];
         double dist = std::sqrt (distances[n_id]);
-        double intensity_dist = abs (input_->points[pid].intensity - input_->points[id].intensity);
+        double intensity_dist = std::abs (input_->points[pid].intensity - input_->points[id].intensity);
 
         double weight = kernel (dist, sigma_s_) * kernel (intensity_dist, sigma_r_);
 
@@ -1195,7 +1195,7 @@ And the *bilateral.hpp* likes:
       {
         double id = indices[n_id];
         // Compute the difference in intensity
-        double intensity_dist = abs (input_->points[pid].intensity - input_->points[id].intensity);
+        double intensity_dist = std::abs (input_->points[pid].intensity - input_->points[id].intensity);
 
         // Compute the Gaussian intensity weights both in Euclidean and in intensity space
         double dist = std::sqrt (distances[n_id]);

--- a/features/include/pcl/features/impl/cvfh.hpp
+++ b/features/include/pcl/features/impl/cvfh.hpp
@@ -130,7 +130,7 @@ pcl::CVFHEstimation<PointInT, PointNT, PointOutT>::extractEuclideanClustersSmoot
                      + normals.points[seed_queue[sq_idx]].normal[1] * normals.points[nn_indices[j]].normal[1]
                      + normals.points[seed_queue[sq_idx]].normal[2] * normals.points[nn_indices[j]].normal[2];
 
-        if (fabs (std::acos (dot_p)) < eps_angle)
+        if (std::abs (std::acos (dot_p)) < eps_angle)
         {
           processed[nn_indices[j]] = true;
           seed_queue.push_back (nn_indices[j]);

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -118,9 +118,9 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
     v23.normalize ();
 
     //TODO: .dot gives nan's
-    th1 = static_cast<int> (pcl_round (std::acos (fabs (v21.dot (v31))) / pih * (binsize-1)));
-    th2 = static_cast<int> (pcl_round (std::acos (fabs (v23.dot (v31))) / pih * (binsize-1)));
-    th3 = static_cast<int> (pcl_round (std::acos (fabs (v23.dot (v21))) / pih * (binsize-1)));
+    th1 = static_cast<int> (pcl_round (std::acos (std::abs (v21.dot (v31))) / pih * (binsize-1)));
+    th2 = static_cast<int> (pcl_round (std::acos (std::abs (v23.dot (v31))) / pih * (binsize-1)));
+    th3 = static_cast<int> (pcl_round (std::acos (std::abs (v23.dot (v21))) / pih * (binsize-1)));
     if (th1 < 0 || th1 >= binsize)
     {
       nn_idx--;
@@ -322,17 +322,17 @@ pcl::ESFEstimation<PointInT, PointOutT>::lci (
     x_inc = -1;
   else
     x_inc = 1;
-  int l = abs (dx);
+  int l = std::abs (dx);
   if (dy < 0)
     y_inc = -1 ;
   else
     y_inc = 1;
-  int m = abs (dy);
+  int m = std::abs (dy);
   if (dz < 0)
     z_inc = -1 ;
   else
     z_inc = 1;
-  int n = abs (dz);
+  int n = std::abs (dz);
   int dx2 = 2 * l;
   int dy2 = 2 * m;
   int dz2 = 2 * n;

--- a/features/include/pcl/features/impl/feature.hpp
+++ b/features/include/pcl/features/impl/feature.hpp
@@ -81,7 +81,7 @@ pcl::solvePlaneParameters (const Eigen::Matrix3f &covariance_matrix,
   // Compute the curvature surface change
   float eig_sum = covariance_matrix.coeff (0) + covariance_matrix.coeff (4) + covariance_matrix.coeff (8);
   if (eig_sum != 0)
-    curvature = fabsf (eigen_value / eig_sum);
+    curvature = std::abs (eigen_value / eig_sum);
   else
     curvature = 0;
 }

--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -244,7 +244,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
 
     // Compute the curvature surface change
     if (eigen_value > 0.0)
-      normal.curvature = fabsf (eigen_value / (covariance_matrix.coeff (0) + covariance_matrix.coeff (4) + covariance_matrix.coeff (8)));
+      normal.curvature = std::abs (eigen_value / (covariance_matrix.coeff (0) + covariance_matrix.coeff (4) + covariance_matrix.coeff (8)));
     else
       normal.curvature = 0;
 
@@ -532,7 +532,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormalMirro
 
     // Compute the curvature surface change
     if (eigen_value > 0.0)
-      normal.curvature = fabsf (eigen_value / (covariance_matrix.coeff (0) + covariance_matrix.coeff (4) + covariance_matrix.coeff (8)));
+      normal.curvature = std::abs (eigen_value / (covariance_matrix.coeff (0) + covariance_matrix.coeff (4) + covariance_matrix.coeff (8)));
     else
       normal.curvature = 0;
 
@@ -750,8 +750,8 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
       const float depthR = input_->points [index + 1].z;
       const float depthD = input_->points [index + input_->width].z;
 
-      //const float depthDependendDepthChange = (max_depth_change_factor_ * (fabs(depth)+1.0f))/(500.0f*0.001f);
-      const float depthDependendDepthChange = (max_depth_change_factor_ * (fabsf (depth) + 1.0f) * 2.0f);
+      //const float depthDependendDepthChange = (max_depth_change_factor_ * (std::abs(depth)+1.0f))/(500.0f*0.001f);
+      const float depthDependendDepthChange = (max_depth_change_factor_ * (std::abs (depth) + 1.0f) * 2.0f);
 
       if (std::fabs (depth - depthR) > depthDependendDepthChange
         || !std::isfinite (depth) || !std::isfinite (depthR))

--- a/features/include/pcl/features/impl/linear_least_squares_normal.hpp
+++ b/features/include/pcl/features/impl/linear_least_squares_normal.hpp
@@ -218,11 +218,11 @@ pcl::LinearLeastSquaresNormalEstimation<PointInT, PointOutT>::computeFeature (Po
           const float i = qx - px;
           const float j = qy - py;
 
-          const float depthDependendDepthChange = (max_depth_change_factor_ * (fabsf (pz) + 1.0f) * 2.0f);
+          const float depthDependendDepthChange = (max_depth_change_factor_ * (std::abs (pz) + 1.0f) * 2.0f);
           const float f = std::fabs(delta) > depthDependendDepthChange ? 0 : 1;
 
-          //float f = fabs(delta) > (pz * 0.05f - 0.3f) ? 0 : 1;
-          //const float f = fabs(delta) > (pz*pz * 0.05f * max_depth_change_factor_) ? 0 : 1;
+          //float f = std::abs(delta) > (pz * 0.05f - 0.3f) ? 0 : 1;
+          //const float f = std::abs(delta) > (pz*pz * 0.05f * max_depth_change_factor_) ? 0 : 1;
           //float f = Math.Abs(delta) > (depth * Math.Log(depth + 1.0) * 0.02f - 0.2f) ? 0 : 1;
 
           matA0 += f * i * i;

--- a/features/include/pcl/features/impl/narf.hpp
+++ b/features/include/pcl/features/impl/narf.hpp
@@ -70,7 +70,7 @@ inline void Narf::copyToNarf36(Narf36& narf36) const
   //const float* descriptor2_ptr = other.getDescriptor();
   //float ret = 0;
   //for (int i=0; i<descriptor_size_; ++i) {
-    //float diff = fabsf(*(descriptor2_ptr++) - *(descriptor1_ptr++));
+    //float diff = std::abs(*(descriptor2_ptr++) - *(descriptor1_ptr++));
     //if (diff < middle_value)
     //{
       //diff = diff*normalization_factor1;
@@ -98,7 +98,7 @@ inline void Narf::copyToNarf36(Narf36& narf36) const
   //const float* descriptor2_ptr = other.getDescriptor();
   //float ret = 0;
   //for (int i=0; i<descriptor_size_; ++i) {
-    //ret += (std::min)(max_diff_between_cells, fabsf(*(descriptor2_ptr++) - *(descriptor1_ptr++)));
+    //ret += (std::min)(max_diff_between_cells, std::abs(*(descriptor2_ptr++) - *(descriptor1_ptr++)));
   //}
   //ret /= descriptor_size_*max_diff_between_cells;
   //return ret;

--- a/features/include/pcl/features/impl/normal_based_signature.hpp
+++ b/features/include/pcl/features/impl/normal_based_signature.hpp
@@ -78,7 +78,7 @@ pcl::NormalBasedSignatureEstimation<PointT, PointNT, PointFeature>::computeFeatu
         Eigen::Vector4f normal_u = Eigen::Vector4f::Zero ();
         Eigen::Vector4f normal_v = Eigen::Vector4f::Zero ();
 
-        if (fabs (normal.x ()) > 0.0001f)
+        if (std::abs (normal.x ()) > 0.0001f)
         {
           normal_u.x () = - normal.y () / normal.x ();
           normal_u.y () = 1.0f;
@@ -86,7 +86,7 @@ pcl::NormalBasedSignatureEstimation<PointT, PointNT, PointFeature>::computeFeatu
           normal_u.normalize ();
 
         }
-        else if (fabs (normal.y ()) > 0.0001f)
+        else if (std::abs (normal.y ()) > 0.0001f)
         {
           normal_u.x () = 1.0f;
           normal_u.y () = - normal.x () / normal.y ();

--- a/features/include/pcl/features/impl/organized_edge_detection.hpp
+++ b/features/include/pcl/features/impl/organized_edge_detection.hpp
@@ -107,7 +107,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
         if (!std::isfinite (input_->points[curr_idx].z))
           continue;
 
-        float curr_depth = fabsf (input_->points[curr_idx].z);
+        float curr_depth = std::abs (input_->points[curr_idx].z);
 
         // Calculate depth distances between current point and neighboring points
         std::vector<float> nghr_dist;
@@ -122,7 +122,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
             found_invalid_neighbor = true;
             break;
           }
-          nghr_dist[d_idx] = curr_depth - fabsf (input_->points[nghr_idx].z);
+          nghr_dist[d_idx] = curr_depth - std::abs (input_->points[nghr_idx].z);
         }
 
         if (!found_invalid_neighbor)
@@ -132,8 +132,8 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
           std::vector<float>::iterator max_itr = std::max_element (nghr_dist.begin (), nghr_dist.end ());
           float nghr_dist_min = *min_itr;
           float nghr_dist_max = *max_itr;
-          float dist_dominant = fabsf (nghr_dist_min) > fabsf (nghr_dist_max) ? nghr_dist_min : nghr_dist_max;
-          if (fabsf (dist_dominant) > th_depth_discon_*fabsf (curr_depth))
+          float dist_dominant = std::abs (nghr_dist_min) > std::abs (nghr_dist_max) ? nghr_dist_min : nghr_dist_max;
+          if (std::abs (dist_dominant) > th_depth_discon_*std::abs (curr_depth))
           {
             // Found a depth discontinuity
             if (dist_dominant > 0.f)
@@ -185,7 +185,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
 
             if (std::isfinite (input_->points[s_row*int(input_->width)+s_col].z))
             {
-              corr_depth = fabsf (input_->points[s_row*int(input_->width)+s_col].z);
+              corr_depth = std::abs (input_->points[s_row*int(input_->width)+s_col].z);
               break;
             }
           }
@@ -194,7 +194,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
           {
             // Found a corresponding point
             float dist = curr_depth - corr_depth;
-            if (fabsf (dist) > th_depth_discon_*fabsf (curr_depth))
+            if (std::abs (dist) > th_depth_discon_*std::abs (curr_depth))
             {
               // Found a depth discontinuity
               if (dist > 0.f)

--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -129,7 +129,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::extractEuclideanClustersSm
             + normals.points[seed_queue[sq_idx]].normal[1] * normals.points[nn_indices[j]].normal[1] + normals.points[seed_queue[sq_idx]].normal[2]
             * normals.points[nn_indices[j]].normal[2];
 
-        if (fabs (std::acos (dot_p)) < eps_angle)
+        if (std::abs (std::acos (dot_p)) < eps_angle)
         {
           processed[nn_indices[j]] = true;
           seed_queue.push_back (nn_indices[j]);
@@ -641,7 +641,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
       {
         //decide if normal should be added
         double dot_p = avg_normal.dot (normals_filtered_cloud->points[index].getNormalVector4fMap ());
-        if (fabs (std::acos (dot_p)) < (eps_angle_threshold_ * refine_clusters_))
+        if (std::abs (std::acos (dot_p)) < (eps_angle_threshold_ * refine_clusters_))
         {
           clusters_[cluster_filtered_idx].indices.push_back (indices_from_nfc_to_indices[index]);
           clusters_filtered[cluster_filtered_idx].indices.push_back (index);

--- a/features/include/pcl/features/impl/range_image_border_extractor.hpp
+++ b/features/include/pcl/features/impl/range_image_border_extractor.hpp
@@ -249,7 +249,7 @@ float RangeImageBorderExtractor::updatedScoreAccordingToNeighborValues(int x, in
   if (average_neighbor_score*border_score < 0.0f)
     return border_score;
   
-  float new_border_score = border_score + max_score_bonus * average_neighbor_score * (1.0f-fabsf(border_score));
+  float new_border_score = border_score + max_score_bonus * average_neighbor_score * (1.0f-std::abs(border_score));
   
   //std::cout << PVARC(border_score)<<PVARN(new_border_score);
   return new_border_score;

--- a/features/include/pcl/features/impl/rift.hpp
+++ b/features/include/pcl/features/impl/rift.hpp
@@ -96,7 +96,7 @@ pcl::RIFTEstimation<PointInT, GradientT, PointOutT>::computeRIFT (
       for (int d_idx = d_idx_min; d_idx <= d_idx_max; ++d_idx)
       {
         // To avoid boundary effects, use linear interpolation when updating each bin 
-        float w = (1.0f - fabsf (d - static_cast<float> (d_idx))) * (1.0f - fabsf (g - static_cast<float> (g_idx)));
+        float w = (1.0f - std::abs (d - static_cast<float> (d_idx))) * (1.0f - std::abs (g - static_cast<float> (g_idx)));
 
         rift_descriptor (d_idx, g_idx_wrapped) += w * gradient_magnitude;
       }

--- a/features/include/pcl/features/impl/shot.hpp
+++ b/features/include/pcl/features/impl/shot.hpp
@@ -67,7 +67,7 @@ const float zeroFloatEps8 = 1E-8f;
 inline bool
 areEquals (double val1, double val2, double zeroDoubleEps = zeroDoubleEps15)
 {
-  return (fabs (val1 - val2)<zeroDoubleEps);
+  return (std::abs (val1 - val2)<zeroDoubleEps);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -286,11 +286,11 @@ pcl::SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSing
     double zInFeatRef = delta.dot (current_frame_z);
 
     // To avoid numerical problems afterwards
-    if (fabs (yInFeatRef) < 1E-30)
+    if (std::abs (yInFeatRef) < 1E-30)
       yInFeatRef  = 0;
-    if (fabs (xInFeatRef) < 1E-30)
+    if (std::abs (xInFeatRef) < 1E-30)
       xInFeatRef  = 0;
-    if (fabs (zInFeatRef) < 1E-30)
+    if (std::abs (zInFeatRef) < 1E-30)
       zInFeatRef  = 0;
 
 
@@ -304,9 +304,9 @@ pcl::SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSing
     desc_index = desc_index << 1;
 
     if ((xInFeatRef * yInFeatRef > 0) || (xInFeatRef == 0.0))
-      desc_index += (fabs (xInFeatRef) >= fabs (yInFeatRef)) ? 0 : 4;
+      desc_index += (std::abs (xInFeatRef) >= std::abs (yInFeatRef)) ? 0 : 4;
     else
-      desc_index += (fabs (xInFeatRef) > fabs (yInFeatRef)) ? 4 : 0;
+      desc_index += (std::abs (xInFeatRef) > std::abs (yInFeatRef)) ? 4 : 0;
 
     desc_index += zInFeatRef > 0 ? 1 : 0;
 
@@ -318,7 +318,7 @@ pcl::SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSing
 
     //Interpolation on the cosine (adjacent bins in the histogram)
     binDistance[i_idx] -= step_index;
-    double intWeight = (1- fabs (binDistance[i_idx]));
+    double intWeight = (1- std::abs (binDistance[i_idx]));
 
     if (binDistance[i_idx] > 0)
       shot[volume_index + ((step_index+1) % nr_bins)] += static_cast<float> (binDistance[i_idx]);
@@ -363,7 +363,7 @@ pcl::SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSing
 
     assert (inclination >= 0.0 && inclination <= PST_RAD_180);
 
-    if (inclination > PST_RAD_90 || (fabs (inclination - PST_RAD_90) < 1e-30 && zInFeatRef <= 0))
+    if (inclination > PST_RAD_90 || (std::abs (inclination - PST_RAD_90) < 1e-30 && zInFeatRef <= 0))
     {
       double inclinationDistance = (inclination - PST_RAD_135) / PST_RAD_90;
       if (inclination > PST_RAD_135)
@@ -465,11 +465,11 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::interpolateDou
     double zInFeatRef = delta.dot (current_frame_z);
 
     // To avoid numerical problems afterwards
-    if (fabs (yInFeatRef) < 1E-30)
+    if (std::abs (yInFeatRef) < 1E-30)
       yInFeatRef  = 0;
-    if (fabs (xInFeatRef) < 1E-30)
+    if (std::abs (xInFeatRef) < 1E-30)
       xInFeatRef  = 0;
-    if (fabs (zInFeatRef) < 1E-30)
+    if (std::abs (zInFeatRef) < 1E-30)
       zInFeatRef  = 0;
 
     unsigned char bit4 = ((yInFeatRef > 0) || ((yInFeatRef == 0.0) && (xInFeatRef < 0))) ? 1 : 0;
@@ -482,9 +482,9 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::interpolateDou
     desc_index = desc_index << 1;
 
     if ((xInFeatRef * yInFeatRef > 0) || (xInFeatRef == 0.0))
-      desc_index += (fabs (xInFeatRef) >= fabs (yInFeatRef)) ? 0 : 4;
+      desc_index += (std::abs (xInFeatRef) >= std::abs (yInFeatRef)) ? 0 : 4;
     else
-      desc_index += (fabs (xInFeatRef) > fabs (yInFeatRef)) ? 4 : 0;
+      desc_index += (std::abs (xInFeatRef) > std::abs (yInFeatRef)) ? 4 : 0;
 
     desc_index += zInFeatRef > 0 ? 1 : 0;
 
@@ -501,8 +501,8 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::interpolateDou
     binDistanceShape[i_idx] -= step_index_shape;
     binDistanceColor[i_idx] -= step_index_color;
 
-    double intWeightShape = (1- fabs (binDistanceShape[i_idx]));
-    double intWeightColor = (1- fabs (binDistanceColor[i_idx]));
+    double intWeightShape = (1- std::abs (binDistanceShape[i_idx]));
+    double intWeightColor = (1- std::abs (binDistanceColor[i_idx]));
 
     if (binDistanceShape[i_idx] > 0)
       shot[volume_index_shape + ((step_index_shape + 1) % nr_bins_shape)] += static_cast<float> (binDistanceShape[i_idx]);
@@ -562,7 +562,7 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::interpolateDou
 
     assert (inclination >= 0.0 && inclination <= PST_RAD_180);
 
-    if (inclination > PST_RAD_90 || (fabs (inclination - PST_RAD_90) < 1e-30 && zInFeatRef <= 0))
+    if (inclination > PST_RAD_90 || (std::abs (inclination - PST_RAD_90) < 1e-30 && zInFeatRef <= 0))
     {
       double inclinationDistance = (inclination - PST_RAD_135) / PST_RAD_90;
       if (inclination > PST_RAD_135)

--- a/features/include/pcl/features/impl/spin_image.hpp
+++ b/features/include/pcl/features/impl/spin_image.hpp
@@ -116,7 +116,7 @@ pcl::SpinImageEstimation<PointInT, PointNT, PointOutT>::computeSiForPoint (int i
     if (support_angle_cos_ > 0.0 || is_angular_) // not bogus
     {
       cos_between_normals = origin_normal.dot (input_normals_->points[nn_indices[i_neigh]].getNormalVector3fMap ());
-      if (fabs (cos_between_normals) > (1.0 + 10*std::numeric_limits<float>::epsilon ())) // should be okay for numeric stability
+      if (std::abs (cos_between_normals) > (1.0 + 10*std::numeric_limits<float>::epsilon ())) // should be okay for numeric stability
       {      
         PCL_ERROR ("[pcl::%s::computeSiForPoint] Normal for the point %d and/or the point %d are not normalized, dot ptoduct is %f.\n", 
           getClassName ().c_str (), nn_indices[i_neigh], index, cos_between_normals);
@@ -125,7 +125,7 @@ pcl::SpinImageEstimation<PointInT, PointNT, PointOutT>::computeSiForPoint (int i
       }
       cos_between_normals = std::max (-1.0, std::min (1.0, cos_between_normals));
 
-      if (fabs (cos_between_normals) < support_angle_cos_ )    // allow counter-directed normals
+      if (std::abs (cos_between_normals) < support_angle_cos_ )    // allow counter-directed normals
       {
         continue;
       }
@@ -140,13 +140,13 @@ pcl::SpinImageEstimation<PointInT, PointNT, PointOutT>::computeSiForPoint (int i
     const Eigen::Vector3f direction (
       surface_->points[nn_indices[i_neigh]].getVector3fMap () - origin_point);
     const double direction_norm = direction.norm ();
-    if (fabs(direction_norm) < 10*std::numeric_limits<double>::epsilon ())  
+    if (std::abs(direction_norm) < 10*std::numeric_limits<double>::epsilon ())  
       continue;  // ignore the point itself; it does not contribute really
     assert (direction_norm > 0.0);
 
     // the angle between the normal vector and the direction to the point
     double cos_dir_axis = direction.dot(rotation_axis) / direction_norm;
-    if (fabs(cos_dir_axis) > (1.0 + 10*std::numeric_limits<float>::epsilon())) // should be okay for numeric stability
+    if (std::abs(cos_dir_axis) > (1.0 + 10*std::numeric_limits<float>::epsilon())) // should be okay for numeric stability
     {      
       PCL_ERROR ("[pcl::%s::computeSiForPoint] Rotation axis for the point %d are not normalized, dot ptoduct is %f.\n", 
         getClassName ().c_str (), index, cos_dir_axis);
@@ -168,7 +168,7 @@ pcl::SpinImageEstimation<PointInT, PointNT, PointOutT>::computeSiForPoint (int i
       beta = direction_norm * cos_dir_axis;
       alpha = direction_norm * sqrt (1.0 - cos_dir_axis*cos_dir_axis);
 
-      if (fabs (beta) >= bin_size * image_width_ || alpha >= bin_size * image_width_)
+      if (std::abs (beta) >= bin_size * image_width_ || alpha >= bin_size * image_width_)
       {
         continue;  // outside the cylinder
       }

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -459,7 +459,7 @@ Narf::getRotations (std::vector<float>& rotations, std::vector<float>& strengths
     {
       float value = descriptor_[descriptor_value_idx];
       float angle2 = static_cast<float> (descriptor_value_idx) * angle_step_size2;
-      float distance_weight = powf (1.0f - fabsf (normAngle (angle - angle2)) / deg2rad (180.0f), 2.0f);
+      float distance_weight = powf (1.0f - std::abs (normAngle (angle - angle2)) / deg2rad (180.0f), 2.0f);
       
       score += value * distance_weight;
     }

--- a/features/src/range_image_border_extractor.cpp
+++ b/features/src/range_image_border_extractor.cpp
@@ -516,7 +516,7 @@ RangeImageBorderExtractor::calculateBorderDirections ()
           
           // Border in between?
           float border_between_points_score = getNeighborDistanceChangeScore(*surface_structure_[index], x, y, x2-x,  y2-y, 1);
-          if (fabsf(border_between_points_score) >= 0.95f*parameters_.minimum_border_probability)
+          if (std::abs(border_between_points_score) >= 0.95f*parameters_.minimum_border_probability)
             continue;
           
           *average_border_direction += *neighbor_border_direction;
@@ -628,7 +628,7 @@ RangeImageBorderExtractor::blurSurfaceChanges ()
           if (score > 0.0f)
           {
             Eigen::Vector3f& neighbor = surface_change_directions_[index2];
-            //if (fabs(neighbor.norm()-1) > 1e-4)
+            //if (std::abs(neighbor.norm()-1) > 1e-4)
               //cerr<<PVARN(neighbor)<<PVARN(score);
             if (point.dot(neighbor)<0.0f)
               neighbor *= -1.0f;

--- a/filters/include/pcl/filters/impl/bilateral.hpp
+++ b/filters/include/pcl/filters/impl/bilateral.hpp
@@ -55,7 +55,7 @@ pcl::BilateralFilter<PointT>::computePointWeight (const int pid,
   {
     int id = indices[n_id];
     // Compute the difference in intensity
-    double intensity_dist = fabs (input_->points[pid].intensity - input_->points[id].intensity);
+    double intensity_dist = std::abs (input_->points[pid].intensity - input_->points[id].intensity);
 
     // Compute the Gaussian intensity weights both in Euclidean and in intensity space
     double dist = std::sqrt (distances[n_id]);

--- a/filters/include/pcl/filters/impl/box_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/box_clipper3D.hpp
@@ -128,8 +128,8 @@ pcl::BoxClipper3D<PointT>::clipLineSegment3D (PointT&, PointT&) const
   transformPoint (point2, pt2);
 
   //
-  bool pt1InBox = (fabs(pt1.x) <= 1.0 && fabs (pt1.y) <= 1.0 && fabs (pt1.z) <= 1.0);
-  bool pt2InBox = (fabs(pt2.x) <= 1.0 && fabs (pt2.y) <= 1.0 && fabs (pt2.z) <= 1.0);
+  bool pt1InBox = (std::abs(pt1.x) <= 1.0 && std::abs (pt1.y) <= 1.0 && std::abs (pt1.z) <= 1.0);
+  bool pt2InBox = (std::abs(pt2.x) <= 1.0 && std::abs (pt2.y) <= 1.0 && std::abs (pt2.z) <= 1.0);
 
   // one is outside the other one inside the box
   //if (pt1InBox ^ pt2InBox)

--- a/filters/include/pcl/filters/impl/covariance_sampling.hpp
+++ b/filters/include/pcl/filters/impl/covariance_sampling.hpp
@@ -163,7 +163,7 @@ pcl::CovarianceSampling<PointT, PointNT>::applyFilter (std::vector<int> &sampled
   for (size_t i = 0; i < 6; ++i)
   {
     for (size_t p_i = 0; p_i < candidate_indices.size (); ++p_i)
-      L[i].push_back (std::make_pair (p_i, fabs (v[p_i].dot (x.block<6, 1> (0, i)))));
+      L[i].push_back (std::make_pair (p_i, std::abs (v[p_i].dot (x.block<6, 1> (0, i)))));
 
     // Sort in decreasing order
     L[i].sort (sort_dot_list_function);

--- a/filters/include/pcl/filters/impl/median_filter.hpp
+++ b/filters/include/pcl/filters/impl/median_filter.hpp
@@ -80,11 +80,11 @@ pcl::MedianFilter<PointT>::applyFilter (PointCloud &output)
         partial_sort (vals.begin (), vals.begin () + vals.size () / 2 + 1, vals.end ());
         float new_depth = vals[vals.size () / 2];
         // Do not allow points to move more than the set max_allowed_movement_
-        if (fabs (new_depth - (*input_)(x, y).z) < max_allowed_movement_)
+        if (std::abs (new_depth - (*input_)(x, y).z) < max_allowed_movement_)
           output (x, y).z = new_depth;
         else
           output (x, y).z = (*input_)(x, y).z +
-                            max_allowed_movement_ * (new_depth - (*input_)(x, y).z) / fabsf (new_depth - (*input_)(x, y).z);
+                            max_allowed_movement_ * (new_depth - (*input_)(x, y).z) / std::abs (new_depth - (*input_)(x, y).z);
       }
 }
 

--- a/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
+++ b/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
@@ -287,7 +287,7 @@ pcl::SamplingSurfaceNormal<PointT>::solvePlaneParameters (const Eigen::Matrix3f 
   // Compute the curvature surface change
   float eig_sum = covariance_matrix.coeff (0) + covariance_matrix.coeff (4) + covariance_matrix.coeff (8);
   if (eig_sum != 0)
-    curvature = fabsf (eigen_value / eig_sum);
+    curvature = std::abs (eigen_value / eig_sum);
   else
     curvature = 0;
 }

--- a/filters/include/pcl/filters/impl/shadowpoints.hpp
+++ b/filters/include/pcl/filters/impl/shadowpoints.hpp
@@ -57,7 +57,7 @@ pcl::ShadowPoints<PointT, NormalT>::applyFilter (PointCloud &output)
   {
     const NormalT &normal = input_normals_->points[i];
     const PointT &pt = input_->points[i];
-    const float val = fabsf (normal.normal_x * pt.x + normal.normal_y * pt.y + normal.normal_z * pt.z);
+    const float val = std::abs (normal.normal_x * pt.x + normal.normal_y * pt.y + normal.normal_z * pt.z);
 
     if ( (val >= threshold_) ^ negative_)
       output.points[cp++] = pt;
@@ -95,7 +95,7 @@ pcl::ShadowPoints<PointT, NormalT>::applyFilter (std::vector<int> &indices)
     const NormalT &normal = input_normals_->points[*idx];
     const PointT &pt = input_->points[*idx];
     
-    float val = fabsf (normal.normal_x * pt.x + normal.normal_y * pt.y + normal.normal_z * pt.z);
+    float val = std::abs (normal.normal_x * pt.x + normal.normal_y * pt.y + normal.normal_z * pt.z);
 
     if ( (val >= threshold_) ^ negative_)
       indices[k++] = *idx;

--- a/filters/include/pcl/filters/impl/voxel_grid_occlusion_estimation.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_occlusion_estimation.hpp
@@ -292,9 +292,9 @@ pcl::VoxelGridOcclusionEstimation<PointT>::rayTraversal (const Eigen::Vector3i& 
   float t_max_y = t_min + (voxel_max[1] - start[1]) / direction[1];
   float t_max_z = t_min + (voxel_max[2] - start[2]) / direction[2];
      
-  float t_delta_x = leaf_size_[0] / static_cast<float> (fabs (direction[0]));
-  float t_delta_y = leaf_size_[1] / static_cast<float> (fabs (direction[1]));
-  float t_delta_z = leaf_size_[2] / static_cast<float> (fabs (direction[2]));
+  float t_delta_x = leaf_size_[0] / static_cast<float> (std::abs (direction[0]));
+  float t_delta_y = leaf_size_[1] / static_cast<float> (std::abs (direction[1]));
+  float t_delta_z = leaf_size_[2] / static_cast<float> (std::abs (direction[2]));
 
   // index of the point in the point cloud
   int index;
@@ -392,9 +392,9 @@ pcl::VoxelGridOcclusionEstimation<PointT>::rayTraversal (std::vector<Eigen::Vect
   float t_max_y = t_min + (voxel_max[1] - start[1]) / direction[1];
   float t_max_z = t_min + (voxel_max[2] - start[2]) / direction[2];
      
-  float t_delta_x = leaf_size_[0] / static_cast<float> (fabs (direction[0]));
-  float t_delta_y = leaf_size_[1] / static_cast<float> (fabs (direction[1]));
-  float t_delta_z = leaf_size_[2] / static_cast<float> (fabs (direction[2]));
+  float t_delta_x = leaf_size_[0] / static_cast<float> (std::abs (direction[0]));
+  float t_delta_y = leaf_size_[1] / static_cast<float> (std::abs (direction[1]));
+  float t_delta_z = leaf_size_[2] / static_cast<float> (std::abs (direction[2]));
 
   // the index of the cloud (-1 if empty)
   int index = -1;

--- a/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
+++ b/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
@@ -147,9 +147,9 @@ namespace pcl
       getCentroidCoordinate (const Eigen::Vector3i& ijk)
       {
         int i,j,k;
-        i = ((b_min_[0] < 0) ? (abs (min_b_[0]) + ijk[0]) : (ijk[0] - min_b_[0]));
-        j = ((b_min_[1] < 0) ? (abs (min_b_[1]) + ijk[1]) : (ijk[1] - min_b_[1]));
-        k = ((b_min_[2] < 0) ? (abs (min_b_[2]) + ijk[2]) : (ijk[2] - min_b_[2]));
+        i = ((b_min_[0] < 0) ? (std::abs (min_b_[0]) + ijk[0]) : (ijk[0] - min_b_[0]));
+        j = ((b_min_[1] < 0) ? (std::abs (min_b_[1]) + ijk[1]) : (ijk[1] - min_b_[1]));
+        k = ((b_min_[2] < 0) ? (std::abs (min_b_[2]) + ijk[2]) : (ijk[2] - min_b_[2]));
 
         Eigen::Vector4f xyz;
         xyz[0] = b_min_[0] + (leaf_size_[0] * 0.5f) + (static_cast<float> (i) * leaf_size_[0]);

--- a/geometry/include/pcl/geometry/impl/polygon_operations.hpp
+++ b/geometry/include/pcl/geometry/impl/polygon_operations.hpp
@@ -144,7 +144,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
     {
       for (size_t idx = first_index; idx < polygon.size(); idx++)
       {
-        float distance = fabsf (line_x * polygon[idx].x + line_y * polygon[idx].y + line_d);
+        float distance = std::abs (line_x * polygon[idx].x + line_y * polygon[idx].y + line_d);
         if (distance > max_distance)
         {
           max_distance = distance;
@@ -156,7 +156,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
 
     for (unsigned int idx = first_index; idx < currentInterval.second; idx++)
     {
-      float distance = fabsf (line_x * polygon[idx].x + line_y * polygon[idx].y + line_d);
+      float distance = std::abs (line_x * polygon[idx].x + line_y * polygon[idx].y + line_d);
       if (distance > max_distance)
       {
         max_distance = distance;
@@ -235,7 +235,7 @@ pcl::approximatePolygon2D (const typename pcl::PointCloud<PointT>::VectorType &p
       direction [1] = polygon[result[nIdx]].y - polygon[result[rIdx]].y;
       direction.normalize ();
       
-      if (fabs (direction.dot (normal)) > float(M_SQRT1_2))
+      if (std::abs (direction.dot (normal)) > float(M_SQRT1_2))
       {
         std::swap (normal [0], normal [1]);
         normal [0] = -normal [0];

--- a/gpu/features/include/pcl/gpu/features/device/eigen.hpp
+++ b/gpu/features/include/pcl/gpu/features/device/eigen.hpp
@@ -113,7 +113,7 @@ namespace pcl
 
         __device__ __forceinline__ void computeRoots3(float c0, float c1, float c2, float3& roots)
         {
-            if ( fabsf(c0) < numeric_limits<float>::epsilon())// one root is 0 -> quadratic equation
+            if ( std::abs(c0) < numeric_limits<float>::epsilon())// one root is 0 -> quadratic equation
             {
                 computeRoots2 (c2, c1, roots);
             }
@@ -211,9 +211,9 @@ namespace pcl
                 // Scale the matrix so its entries are in [-1,1].  The scaling is applied
                 // only when at least one matrix entry has magnitude larger than 1.
 
-                float max01 = fmaxf( fabsf(mat_pkg[0]), fabsf(mat_pkg[1]) );
-                float max23 = fmaxf( fabsf(mat_pkg[2]), fabsf(mat_pkg[3]) );
-                float max45 = fmaxf( fabsf(mat_pkg[4]), fabsf(mat_pkg[5]) );
+                float max01 = fmaxf( std::abs(mat_pkg[0]), std::abs(mat_pkg[1]) );
+                float max23 = fmaxf( std::abs(mat_pkg[2]), std::abs(mat_pkg[3]) );
+                float max45 = fmaxf( std::abs(mat_pkg[4]), std::abs(mat_pkg[5]) );
                 float m0123 = fmaxf( max01, max23);
                 float scale = fmaxf( max45, m0123);
 

--- a/gpu/features/include/pcl/gpu/features/device/pair_features.hpp
+++ b/gpu/features/include/pcl/gpu/features/device/pair_features.hpp
@@ -60,7 +60,7 @@ namespace pcl
             
 
             float angle2 = dot(n2_copy, dp2p1) / f4;
-            if (std::acos (fabs (angle1)) > std::acos (fabs (angle2)))
+            if (std::acos (std::abs (angle1)) > std::acos (std::abs (angle2)))
             {
               // switch p1 and p2
               n1_copy = n2;

--- a/gpu/features/src/normal_3d.cu
+++ b/gpu/features/src/normal_3d.cu
@@ -156,7 +156,7 @@ namespace pcl
 
                     // Compute the curvature surface change
                     float eig_sum = evals.x + evals.y + evals.z;
-                    float curvature = (eig_sum == 0) ? 0 : fabsf( evals.x / eig_sum );
+                    float curvature = (eig_sum == 0) ? 0 : std::abs( evals.x / eig_sum );
 
                     NormalType output;
                     output.w = curvature;

--- a/gpu/features/src/spinimages.cu
+++ b/gpu/features/src/spinimages.cu
@@ -160,10 +160,10 @@ namespace pcl
 						cos_between_normals = dot(origin_normal, normal);						
 						cos_between_normals = fmax (-1.f, fmin (1.f, cos_between_normals));
 
-						if (fabs(cos_between_normals) < support_angle_cos)    // allow counter-directed normals
+						if (std::abs(cos_between_normals) < support_angle_cos)    // allow counter-directed normals
 							continue;
 
-						cos_between_normals = fabs(cos_between_normals); // the normal is not used explicitly from now						
+						cos_between_normals = std::abs(cos_between_normals); // the normal is not used explicitly from now						
 					}
 
 					// now compute the coordinate in cylindric coordinate system associated with the origin point
@@ -192,7 +192,7 @@ namespace pcl
 						beta  = direction_norm * cos_dir_axis;
 						alpha = direction_norm * sqrt (1.0 - cos_dir_axis*cos_dir_axis);
 
-						if (fabs (beta) >= bin_size * image_width || alpha >= bin_size * image_width)
+						if (std::abs (beta) >= bin_size * image_width || alpha >= bin_size * image_width)
 							continue;  // outside the cylinder
 					}
 

--- a/gpu/kinfu/src/cuda/bilateral_pyrdown.cu
+++ b/gpu/kinfu/src/cuda/bilateral_pyrdown.cu
@@ -117,10 +117,10 @@ namespace pcl
           {
               int val = src.ptr (2*y + yi)[2*x + xi];
 
-              if (abs (val - center) < 3 * sigma_color)
+              if (std::abs (val - center) < 3 * sigma_color)
               {                                 
-                sum += val * weights[abs(xi)] * weights[abs(yi)];
-                wall += weights[abs(xi)] * weights[abs(yi)];
+                sum += val * weights[std::abs(xi)] * weights[std::abs(yi)];
+                wall += weights[std::abs(xi)] * weights[std::abs(yi)];
               }
           }
 
@@ -153,7 +153,7 @@ namespace pcl
         for (int cx = max (0, 2 * x - D / 2); cx < tx; ++cx)
         {
           int val = src.ptr (cy)[cx];
-          if (abs (val - center) < 3 * sigma_color)
+          if (std::abs (val - center) < 3 * sigma_color)
           {
             sum += val;
             ++count;

--- a/gpu/kinfu/src/cuda/extract.cu
+++ b/gpu/kinfu/src/cuda/extract.cu
@@ -130,8 +130,8 @@ namespace pcl
 
                     float Vnx = V.x + cell_size.x;
 
-                    float d_inv = 1.f / (fabs (F) + fabs (Fn));
-                    p.x = (V.x * fabs (Fn) + Vnx * fabs (F)) * d_inv;
+                    float d_inv = 1.f / (std::abs (F) + std::abs (Fn));
+                    p.x = (V.x * std::abs (Fn) + Vnx * std::abs (F)) * d_inv;
 
                     points[local_count++] = p;
                   }
@@ -152,8 +152,8 @@ namespace pcl
 
                     float Vny = V.y + cell_size.y;
 
-                    float d_inv = 1.f / (fabs (F) + fabs (Fn));
-                    p.y = (V.y * fabs (Fn) + Vny * fabs (F)) * d_inv;
+                    float d_inv = 1.f / (std::abs (F) + std::abs (Fn));
+                    p.y = (V.y * std::abs (Fn) + Vny * std::abs (F)) * d_inv;
 
                     points[local_count++] = p;
                   }
@@ -174,8 +174,8 @@ namespace pcl
 
                     float Vnz = V.z + cell_size.z;
 
-                    float d_inv = 1.f / (fabs (F) + fabs (Fn));
-                    p.z = (V.z * fabs (Fn) + Vnz * fabs (F)) * d_inv;
+                    float d_inv = 1.f / (std::abs (F) + std::abs (Fn));
+                    p.z = (V.z * std::abs (Fn) + Vnz * std::abs (F)) * d_inv;
 
                     points[local_count++] = p;
                   }

--- a/gpu/kinfu/src/cuda/image_generator.cu
+++ b/gpu/kinfu/src/cuda/image_generator.cu
@@ -86,7 +86,7 @@ namespace pcl
           {
             float3 vec = normalized (light.pos[i] - v);
 
-            weight *= fabs (dot (vec, n));
+            weight *= std::abs (dot (vec, n));
           }
 
           int br = (int)(205 * weight) + 50;

--- a/gpu/kinfu/src/cuda/utils.hpp
+++ b/gpu/kinfu/src/cuda/utils.hpp
@@ -142,7 +142,7 @@ namespace pcl
      __device__ __forceinline__ void 
      computeRoots3(float c0, float c1, float c2, float3& roots)
      {
-       if ( fabsf(c0) < numeric_limits<float>::epsilon())// one root is 0 -> quadratic equation
+       if ( std::abs(c0) < numeric_limits<float>::epsilon())// one root is 0 -> quadratic equation
        {
          computeRoots2 (c2, c1, roots);
        }
@@ -243,9 +243,9 @@ namespace pcl
          // Scale the matrix so its entries are in [-1,1].  The scaling is applied
          // only when at least one matrix entry has magnitude larger than 1.
 
-         float max01 = fmaxf( fabsf(mat_pkg[0]), fabsf(mat_pkg[1]) );
-         float max23 = fmaxf( fabsf(mat_pkg[2]), fabsf(mat_pkg[3]) );
-         float max45 = fmaxf( fabsf(mat_pkg[4]), fabsf(mat_pkg[5]) );
+         float max01 = fmaxf( std::abs(mat_pkg[0]), std::abs(mat_pkg[1]) );
+         float max23 = fmaxf( std::abs(mat_pkg[2]), std::abs(mat_pkg[3]) );
+         float max45 = fmaxf( std::abs(mat_pkg[4]), std::abs(mat_pkg[5]) );
          float m0123 = fmaxf( max01, max23);
          float scale = fmaxf( max45, m0123);
 

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -340,7 +340,7 @@ pcl::gpu::KinfuTracker::operator() (const DepthMap& depth_raw,
             //checking nullspace
             double det = A.determinant ();
 
-            if (fabs (det) < 1e-15 || std::isnan (det))
+            if (std::abs (det) < 1e-15 || std::isnan (det))
             {
               if (std::isnan (det)) cout << "qnan" << endl;
 
@@ -605,7 +605,7 @@ namespace pcl
           t = (R(2, 2) + 1)*0.5;
           rz = sqrt( std::max(t, 0.0) ) * (R(0, 2) < 0 ? -1.0 : 1.0);
 
-          if( fabs(rx) < fabs(ry) && fabs(rx) < fabs(rz) && (R(1, 2) > 0) != (ry*rz > 0) )
+          if( std::abs(rx) < std::abs(ry) && std::abs(rx) < std::abs(rz) && (R(1, 2) > 0) != (ry*rz > 0) )
             rz = -rz;
           theta /= sqrt(rx*rx + ry*ry + rz*rz);
           rx *= theta;

--- a/gpu/kinfu/src/tsdf_volume.cpp
+++ b/gpu/kinfu/src/tsdf_volume.cpp
@@ -189,7 +189,7 @@ pcl::gpu::TsdfVolume::fetchCloudHost (PointCloud<PointType>& cloud, bool connect
               if ((F > 0 && Fn < 0) || (F < 0 && Fn > 0))
               {
                 Vector3f Vn = ((Array3i (x+dx, y+dy, z+dz).cast<float>() + 0.5f) * cell_size).matrix ();
-                Vector3f point = (V * (float)abs (Fn) + Vn * (float)abs (F)) / (float)(abs (F) + abs (Fn));
+                Vector3f point = (V * (float)std::abs (Fn) + Vn * (float)std::abs (F)) / (float)(std::abs (F) + std::abs (Fn));
 
                 pcl::PointXYZ xyz;
                 xyz.x = point (0);
@@ -213,7 +213,7 @@ pcl::gpu::TsdfVolume::fetchCloudHost (PointCloud<PointType>& cloud, bool connect
               if ((F > 0 && Fn < 0) || (F < 0 && Fn > 0))
               {
                 Vector3f Vn = ((Array3i (x+dx, y+dy, z+dz).cast<float>() + 0.5f) * cell_size).matrix ();
-                Vector3f point = (V * (float)abs(Fn) + Vn * (float)abs(F))/(float)(abs(F) + abs (Fn));
+                Vector3f point = (V * (float)std::abs(Fn) + Vn * (float)std::abs(F))/(float)(std::abs(F) + std::abs (Fn));
 
                 pcl::PointXYZ xyz;
                 xyz.x = point (0);
@@ -245,7 +245,7 @@ pcl::gpu::TsdfVolume::fetchCloudHost (PointCloud<PointType>& cloud, bool connect
             if ((F > 0 && Fn < 0) || (F < 0 && Fn > 0))
             {
               Vector3f Vn = ((Array3i (x+dx, y+dy, z+dz).cast<float>() + 0.5f) * cell_size).matrix ();
-              Vector3f point = (V * (float)abs (Fn) + Vn * (float)abs (F)) / (float)(abs (F) + abs (Fn));
+              Vector3f point = (V * (float)std::abs (Fn) + Vn * (float)std::abs (F)) / (float)(std::abs (F) + std::abs (Fn));
 
               pcl::PointXYZ xyz;
               xyz.x = point (0);

--- a/gpu/kinfu_large_scale/src/cuda/bilateral_pyrdown.cu
+++ b/gpu/kinfu_large_scale/src/cuda/bilateral_pyrdown.cu
@@ -114,7 +114,7 @@ namespace pcl
           for (int cx = max (0, 2 * x - D / 2); cx < tx; ++cx)
           {
             int val = src.ptr (cy)[cx];
-            if (abs (val - center) < 3 * sigma_color)
+            if (std::abs (val - center) < 3 * sigma_color)
             {
               sum += val;
               ++count;

--- a/gpu/kinfu_large_scale/src/cuda/extract.cu
+++ b/gpu/kinfu_large_scale/src/cuda/extract.cu
@@ -148,8 +148,8 @@ namespace pcl
 
                       float Vnx = V.x + cell_size.x;
 
-                      float d_inv = 1.f / (fabs (F) + fabs (Fn));
-                      p.x = (V.x * fabs (Fn) + Vnx * fabs (F)) * d_inv;
+                      float d_inv = 1.f / (std::abs (F) + std::abs (Fn));
+                      p.x = (V.x * std::abs (Fn) + Vnx * std::abs (F)) * d_inv;
 
                       points[local_count++] = p;
                     }
@@ -170,8 +170,8 @@ namespace pcl
 
                       float Vny = V.y + cell_size.y;
 
-                      float d_inv = 1.f / (fabs (F) + fabs (Fn));
-                      p.y = (V.y * fabs (Fn) + Vny * fabs (F)) * d_inv;
+                      float d_inv = 1.f / (std::abs (F) + std::abs (Fn));
+                      p.y = (V.y * std::abs (Fn) + Vny * std::abs (F)) * d_inv;
 
                       points[local_count++] = p;
                     }
@@ -192,8 +192,8 @@ namespace pcl
 
                       float Vnz = V.z + cell_size.z;
 
-                      float d_inv = 1.f / (fabs (F) + fabs (Fn));
-                      p.z = (V.z * fabs (Fn) + Vnz * fabs (F)) * d_inv;
+                      float d_inv = 1.f / (std::abs (F) + std::abs (Fn));
+                      p.z = (V.z * std::abs (Fn) + Vnz * std::abs (F)) * d_inv;
 
                       points[local_count++] = p;
                     }

--- a/gpu/kinfu_large_scale/src/cuda/image_generator.cu
+++ b/gpu/kinfu_large_scale/src/cuda/image_generator.cu
@@ -87,7 +87,7 @@ namespace pcl
             {
               float3 vec = normalized (light.pos[i] - v);
 
-              weight *= fabs (dot (vec, n));
+              weight *= std::abs (dot (vec, n));
             }
 
             int br = (int)(205 * weight) + 50;

--- a/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
+++ b/gpu/kinfu_large_scale/src/cuda/tsdf_volume.cu
@@ -136,7 +136,7 @@ namespace pcl
                 if(pos < buffer.tsdf_memory_start)
                     pos += size;
 
-                int nbSteps = abs(maxBounds.z);
+                int nbSteps = std::abs(maxBounds.z);
                 
             #pragma unroll				
                 for(int z = 0; z < nbSteps; ++z, pos+=z_step)

--- a/gpu/kinfu_large_scale/src/cuda/utils.hpp
+++ b/gpu/kinfu_large_scale/src/cuda/utils.hpp
@@ -144,7 +144,7 @@ namespace pcl
       __device__ __forceinline__ void 
       computeRoots3(float c0, float c1, float c2, float3& roots)
       {
-        if ( fabsf(c0) < numeric_limits<float>::epsilon())// one root is 0 -> quadratic equation
+        if ( std::abs(c0) < numeric_limits<float>::epsilon())// one root is 0 -> quadratic equation
         {
           computeRoots2 (c2, c1, roots);
         }
@@ -245,9 +245,9 @@ namespace pcl
           // Scale the matrix so its entries are in [-1,1].  The scaling is applied
           // only when at least one matrix entry has magnitude larger than 1.
 
-          float max01 = fmaxf( fabsf(mat_pkg[0]), fabsf(mat_pkg[1]) );
-          float max23 = fmaxf( fabsf(mat_pkg[2]), fabsf(mat_pkg[3]) );
-          float max45 = fmaxf( fabsf(mat_pkg[4]), fabsf(mat_pkg[5]) );
+          float max01 = fmaxf( std::abs(mat_pkg[0]), std::abs(mat_pkg[1]) );
+          float max23 = fmaxf( std::abs(mat_pkg[2]), std::abs(mat_pkg[3]) );
+          float max45 = fmaxf( std::abs(mat_pkg[4]), std::abs(mat_pkg[5]) );
           float m0123 = fmaxf( max01, max23);
           float scale = fmaxf( max45, m0123);
 

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -429,7 +429,7 @@ pcl::gpu::kinfuLS::KinfuTracker::performICP(const Intr& cam_intrinsics, Matrix3f
         // checking nullspace 
         double det = A.determinant ();
     
-        if ( fabs (det) < 100000 /*1e-15*/ || std::isnan (det) ) //TODO find a threshold that makes ICP track well, but prevents it from generating wrong transforms
+        if ( std::abs (det) < 100000 /*1e-15*/ || std::isnan (det) ) //TODO find a threshold that makes ICP track well, but prevents it from generating wrong transforms
         {
           if (std::isnan (det)) cout << "qnan" << endl;
           if(!lost_)
@@ -514,7 +514,7 @@ pcl::gpu::kinfuLS::KinfuTracker::performPairWiseICP(const Intr cam_intrinsics, M
         // checking nullspace 
         double det = A.determinant ();
         
-        if ( fabs (det) < 1e-15 || std::isnan (det) )
+        if ( std::abs (det) < 1e-15 || std::isnan (det) )
         {
           if (std::isnan (det)) cout << "qnan" << endl;
                     
@@ -886,7 +886,7 @@ namespace pcl
             t = (R(2, 2) + 1)*0.5;
             rz = sqrt( std::max(t, 0.0) ) * (R(0, 2) < 0 ? -1.0 : 1.0);
 
-            if( fabs(rx) < fabs(ry) && fabs(rx) < fabs(rz) && (R(1, 2) > 0) != (ry*rz > 0) )
+            if( std::abs(rx) < std::abs(ry) && std::abs(rx) < std::abs(rz) && (R(1, 2) > 0) != (ry*rz > 0) )
               rz = -rz;
             theta /= sqrt(rx*rx + ry*ry + rz*rz);
             rx *= theta;

--- a/gpu/kinfu_large_scale/src/tsdf_volume.cpp
+++ b/gpu/kinfu_large_scale/src/tsdf_volume.cpp
@@ -200,7 +200,7 @@ pcl::gpu::kinfuLS::TsdfVolume::fetchCloudHost (PointCloud<PointType>& cloud, boo
               if ((F > 0 && Fn < 0) || (F < 0 && Fn > 0))
               {
                 Vector3f Vn = ((Array3f (x+dx, y+dy, z+dz) + 0.5f) * cell_size).matrix ();
-                Vector3f point = (V * abs (Fn) + Vn * abs (F)) / (abs (F) + abs (Fn));
+                Vector3f point = (V * std::abs (Fn) + Vn * std::abs (F)) / (std::abs (F) + std::abs (Fn));
 
                 pcl::PointXYZ xyz;
                 xyz.x = point (0);
@@ -224,7 +224,7 @@ pcl::gpu::kinfuLS::TsdfVolume::fetchCloudHost (PointCloud<PointType>& cloud, boo
               if ((F > 0 && Fn < 0) || (F < 0 && Fn > 0))
               {
                 Vector3f Vn = ((Array3f (x+dx, y+dy, z+dz) + 0.5f) * cell_size).matrix ();
-                Vector3f point = (V * abs(Fn) + Vn * abs(F))/(abs(F) + abs (Fn));
+                Vector3f point = (V * std::abs(Fn) + Vn * std::abs(F))/(std::abs(F) + std::abs (Fn));
 
                 pcl::PointXYZ xyz;
                 xyz.x = point (0);
@@ -256,7 +256,7 @@ pcl::gpu::kinfuLS::TsdfVolume::fetchCloudHost (PointCloud<PointType>& cloud, boo
             if ((F > 0 && Fn < 0) || (F < 0 && Fn > 0))
             {
               Vector3f Vn = ((Array3f (x+dx, y+dy, z+dz) + 0.5f) * cell_size).matrix ();
-              Vector3f point = (V * abs (Fn) + Vn * abs (F)) / (abs (F) + abs (Fn));
+              Vector3f point = (V * std::abs (Fn) + Vn * std::abs (F)) / (std::abs (F) + std::abs (Fn));
 
               pcl::PointXYZ xyz;
               xyz.x = point (0);

--- a/gpu/octree/test/test_approx_nearest.cpp
+++ b/gpu/octree/test/test_approx_nearest.cpp
@@ -137,7 +137,7 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
         ++(gpu_better ? count_gpu_better : count_pcl_better);
 
         if (!gpu_better)
-            diff_pcl_better +=fabs(diff);
+            diff_pcl_better +=std::abs(diff);
     }
 
     diff_pcl_better /=count_pcl_better;

--- a/gpu/people/include/pcl/gpu/people/label_segment.h
+++ b/gpu/people/include/pcl/gpu/people/label_segment.h
@@ -118,7 +118,7 @@ namespace pcl
         //          // get the depth of this part of the patch
         //          short depth_l = dmap.at<short>(h_l,w_l);
         //          // evaluate the difference to the centroid 
-        //          if(abs(depth - depth_l) < static_cast<int> (depthThres))
+        //          if(std::abs(depth - depth_l) < static_cast<int> (depthThres))
         //          {
         //            char label = lmap_in.at<char>(h_l,w_l);
         //            if(label >= 0 && label < NUM_PARTS)
@@ -200,7 +200,7 @@ namespace pcl
         //          // get the depth of this part of the patch
         //          short depth_l = dmap.at<short>(h_l,w_l);
         //          // evaluate the difference to the centroid 
-        //          if(abs(depth - depth_l) < static_cast<int> (depthThres))
+        //          if(std::abs(depth - depth_l) < static_cast<int> (depthThres))
         //          {
         //            char label = lmap_in.at<char>(h_l,w_l);
         //            if(label >= 0 && label < NUM_PARTS)
@@ -296,7 +296,7 @@ namespace pcl
                   // get the depth of this part of the patch
                   depth_l = drow_offset[w_l];
                   // evaluate the difference to the centroid 
-                  if(abs(depth - depth_l) < static_cast<int> (depthThres))
+                  if(std::abs(depth - depth_l) < static_cast<int> (depthThres))
                   {
                     label = lrow_offset[w_l];
                     votes[static_cast<unsigned int>(label)]++;

--- a/gpu/people/src/cuda/multi_tree.cu
+++ b/gpu/people/src/cuda/multi_tree.cu
@@ -268,7 +268,7 @@ namespace pcl
             char4 labels_neighbor = tex2D(multilabelTex, u+i,v+j); 
             char* bob = (char*)&labels_neighbor; //horrible but char4's have xyzw members
             //TODO: redo this part
-            int weight = abs(depth-depth_neighbor) < 50 ? 1:0; // 5cms
+            int weight = std::abs(depth-depth_neighbor) < 50 ? 1:0; // 5cms
             for(int ti = 0; ti < numTrees; ++ti)
               bins[ bob[ti] ] += weight;
           }

--- a/gpu/people/src/cuda/nvidia/NPP_staging.cu
+++ b/gpu/people/src/cuda/nvidia/NPP_staging.cu
@@ -2404,7 +2404,7 @@ __global__ void resizeSuperSample_32f(NcvSize32u srcSize,
 __forceinline__
 __device__ float bicubicCoeff(float x_)
 {
-    float x = fabsf(x_);
+    float x = std::abs(x_);
     if (x <= 1.0f)
     {
         return x * x * (1.5f * x - 2.5f) + 1.0f;

--- a/gpu/people/src/cuda/shs.cu
+++ b/gpu/people/src/cuda/shs.cu
@@ -233,7 +233,7 @@ void optimized_shs5(const PointCloud<PointXYZRGB> &cloud, float tolerance, const
                     {
                         float h_l = hue[idx];
 
-                        if (fabs(h_l - h) < delta_hue)
+                        if (std::abs(h_l - h) < delta_hue)
                         {
                             if(idx & 1)
                                 seed_queue.push_back (idx);

--- a/gpu/people/src/cuda/smooth.cu
+++ b/gpu/people/src/cuda/smooth.cu
@@ -72,7 +72,7 @@ namespace pcl
 
             for (int dx = 0; dx < patch; ++dx)
             {
-                if (abs(d[dx+x] - depth_center) < depthThres)
+                if (std::abs(d[dx+x] - depth_center) < depthThres)
                 {
                     int l = s[dx+x];
                     if (l < num_parts)

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -536,7 +536,7 @@ pcl::gpu::people::PeopleDetector::shs5(const pcl::PointCloud<PointT> &cloud, con
           {
             float h_l = hue[idx];
 
-            if (fabs(h_l - h) < DELTA_HUE_SHS)
+            if (std::abs(h_l - h) < DELTA_HUE_SHS)
             {                   
               seed_queue.push_back (idx);
               mask[idx] = 255;

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_seeded_hue_segmentation.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_seeded_hue_segmentation.hpp
@@ -117,7 +117,7 @@ seededHueSegmentation (const boost::shared_ptr<pcl::PointCloud<pcl::PointXYZRGB>
           PointXYZHSV h_l;
           PointXYZRGBtoXYZHSV(p_l, h_l);
 
-          if (fabs(h_l.h - h.h) < delta_hue)
+          if (std::abs(h_l.h - h.h) < delta_hue)
           {
             processed[data[qp_r + qp * max_answers]] = true;
             queries_host.push_back (host_cloud_->points[data[qp_r + qp * max_answers]]);

--- a/gpu/surface/src/cuda/convex_hull.cu
+++ b/gpu/surface/src/cuda/convex_hull.cu
@@ -134,7 +134,7 @@ namespace pcl
 		  thrust::tuple<float, int> operator()(const thrust::tuple<PointType, int>& in) const
 		  {
 			  float3 x0 = tr(in.get<0>());
-              float dist = fabs(dot(n, x0 - x1));
+              float dist = std::abs(dot(n, x0 - x1));
 			  return thrust::tuple<float, int>(dist, in.get<1>());
 		  }
 	  };
@@ -291,7 +291,7 @@ namespace pcl
              int i1 = negs_inds[1];
              int i2 = negs_inds[2];
              
-             int ir = fabs(dists[i1]) < fabs(dists[i2]) ? i2 : i1;
+             int ir = std::abs(dists[i1]) < std::abs(dists[i2]) ? i2 : i1;
              negs_inds[1] = ir;
              --neg_count;
           }
@@ -301,7 +301,7 @@ namespace pcl
              int i1 = negs_inds[0];
              int i2 = negs_inds[1];
              
-             int ir = fabs(dists[i1]) < fabs(dists[i2]) ? i2 : i1;
+             int ir = std::abs(dists[i1]) < std::abs(dists[i2]) ? i2 : i1;
              negs_inds[0] = ir;
              --neg_count;              
           }
@@ -309,7 +309,7 @@ namespace pcl
           if (neg_count == 1)
           {
             idx = negs_inds[0];
-            dist = diag - fabs(dists[idx]); // to ensure that sorting order is inverse, i.e. distant points go first
+            dist = diag - std::abs(dists[idx]); // to ensure that sorting order is inverse, i.e. distant points go first
           }
 
           //if (neg_count == 0)
@@ -665,7 +665,7 @@ namespace pcl
               int i1 = negs_inds[1];
               int i2 = negs_inds[2];
            
-              int ir = fabs(dists[i1]) < fabs(dists[i2]) ? i2 : i1;
+              int ir = std::abs(dists[i1]) < std::abs(dists[i2]) ? i2 : i1;
               negs_inds[1] = ir;
               --neg_count;
             }
@@ -675,7 +675,7 @@ namespace pcl
               int i1 = negs_inds[0];
               int i2 = negs_inds[1];
            
-              int ir = fabs(dists[i1]) < fabs(dists[i2]) ? i2 : i1;
+              int ir = std::abs(dists[i1]) < std::abs(dists[i2]) ? i2 : i1;
               negs_inds[0] = ir;
               --neg_count;              
             }
@@ -683,7 +683,7 @@ namespace pcl
             if (neg_count == 1)
             {
               new_idx = negs_inds[0];
-              dist = diag - fabs(dists[new_idx]); // to ensure that sorting order is inverse, i.e. distant points go first
+              dist = diag - std::abs(dists[new_idx]); // to ensure that sorting order is inverse, i.e. distant points go first
               new_idx = indeces[new_idx];
             }
 

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -77,7 +77,7 @@ pcl::PCDWriter::generateHeader (const pcl::PointCloud<PointT> &cloud, const int 
       field_types << " " << "U";
     else
       field_types << " " << pcl::getFieldType (field.datatype);
-    int count = abs (static_cast<int> (field.count));
+    int count = std::abs (static_cast<int> (field.count));
     if (count == 0) count = 1;  // check for 0 counts (coming from older converter code)
     field_counts << " " << count;
   }

--- a/io/src/debayer.cpp
+++ b/io/src/debayer.cpp
@@ -601,8 +601,8 @@ pcl::io::DeBayer::debayerEdgeAware (
       //  line_step    g b g b
       // line_step2    r g r g
 
-      int dh = abs (bayer_pixel[0] - bayer_pixel[2]);
-      int dv = abs (bayer_pixel[-bayer_line_step + 1] - bayer_pixel[bayer_line_step + 1]);
+      int dh = std::abs (bayer_pixel[0] - bayer_pixel[2]);
+      int dv = std::abs (bayer_pixel[-bayer_line_step + 1] - bayer_pixel[bayer_line_step + 1]);
 
       if (dh > dv)
         rgb_buffer[4] = AVG (bayer_pixel[-bayer_line_step + 1], bayer_pixel[bayer_line_step + 1]);
@@ -623,8 +623,8 @@ pcl::io::DeBayer::debayerEdgeAware (
       rgb_buffer[rgb_line_step ] = AVG4 (bayer_pixel[1], bayer_pixel[bayer_line_step2 + 1], bayer_pixel[-1], bayer_pixel[bayer_line_step2 - 1]);
       rgb_buffer[rgb_line_step + 2] = bayer_pixel[bayer_line_step];
 
-      dv = abs (bayer_pixel[0] - bayer_pixel[bayer_line_step2]);
-      dh = abs (bayer_pixel[bayer_line_step - 1] - bayer_pixel[bayer_line_step + 1]);
+      dv = std::abs (bayer_pixel[0] - bayer_pixel[bayer_line_step2]);
+      dh = std::abs (bayer_pixel[bayer_line_step - 1] - bayer_pixel[bayer_line_step + 1]);
 
       if (dv > dh)
         rgb_buffer[rgb_line_step + 1] = AVG (bayer_pixel[bayer_line_step - 1], bayer_pixel[bayer_line_step + 1]);
@@ -987,8 +987,8 @@ pcl::io::DeBayer::debayerEdgeAwareWeighted (
       //  line_step    g b g b
       // line_step2    r g r g
 
-      int dh = abs (bayer_pixel[0] - bayer_pixel[2]);
-      int dv = abs (bayer_pixel[-bayer_line_step + 1] - bayer_pixel[bayer_line_step + 1]);
+      int dh = std::abs (bayer_pixel[0] - bayer_pixel[2]);
+      int dv = std::abs (bayer_pixel[-bayer_line_step + 1] - bayer_pixel[bayer_line_step + 1]);
 
       if (dv == 0 && dh == 0)
         rgb_buffer[4] = AVG4 (bayer_pixel[1 - bayer_line_step], bayer_pixel[1 + bayer_line_step], bayer_pixel[0], bayer_pixel[2]);
@@ -1006,8 +1006,8 @@ pcl::io::DeBayer::debayerEdgeAwareWeighted (
       rgb_buffer[rgb_line_step ] = AVG4 (bayer_pixel[1], bayer_pixel[bayer_line_step2 + 1], bayer_pixel[-1], bayer_pixel[bayer_line_step2 - 1]);
       rgb_buffer[rgb_line_step + 2] = bayer_pixel[bayer_line_step];
 
-      dv = abs (bayer_pixel[0] - bayer_pixel[bayer_line_step2]);
-      dh = abs (bayer_pixel[bayer_line_step - 1] - bayer_pixel[bayer_line_step + 1]);
+      dv = std::abs (bayer_pixel[0] - bayer_pixel[bayer_line_step2]);
+      dh = std::abs (bayer_pixel[bayer_line_step - 1] - bayer_pixel[bayer_line_step + 1]);
 
       if (dv == 0 && dh == 0)
         rgb_buffer[rgb_line_step + 1] = AVG4 (bayer_pixel[0], bayer_pixel[bayer_line_step2], bayer_pixel[bayer_line_step - 1], bayer_pixel[bayer_line_step + 1]);

--- a/io/src/openni_camera/openni_image_bayer_grbg.cpp
+++ b/io/src/openni_camera/openni_image_bayer_grbg.cpp
@@ -161,8 +161,8 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
         bayer_pixel += 2;
         for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
-          dv = abs (bayer_pixel[-line_skip] - bayer_pixel[line_skip]);
-          dh = abs (bayer_pixel[-1] - bayer_pixel[1]);
+          dv = std::abs (bayer_pixel[-line_skip] - bayer_pixel[line_skip]);
+          dh = std::abs (bayer_pixel[-1] - bayer_pixel[1]);
           if (dh > dv)
             gray_buffer[0] = AVG (bayer_pixel[-line_skip], bayer_pixel[line_skip]);
           else if (dv > dh)
@@ -179,8 +179,8 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
         {
           gray_buffer[0] = bayer_pixel[0];
 
-          dv = abs (bayer_pixel[1 - line_skip] - bayer_pixel[1 + line_skip]);
-          dh = abs (bayer_pixel[0] - bayer_pixel[2]);
+          dv = std::abs (bayer_pixel[1 - line_skip] - bayer_pixel[1 + line_skip]);
+          dh = std::abs (bayer_pixel[0] - bayer_pixel[2]);
           if (dh > dv)
             gray_buffer[1] = AVG (bayer_pixel[1 - line_skip], bayer_pixel[1 + line_skip]);
           else if (dv > dh)
@@ -228,8 +228,8 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
         bayer_pixel += 2;
         for (unsigned xIdx = 2; xIdx < width; xIdx += 2, gray_buffer += 2, bayer_pixel += 2)
         {
-          dv = abs (bayer_pixel[-line_skip] - bayer_pixel[line_skip]);
-          dh = abs (bayer_pixel[-1] - bayer_pixel[1]);
+          dv = std::abs (bayer_pixel[-line_skip] - bayer_pixel[line_skip]);
+          dh = std::abs (bayer_pixel[-1] - bayer_pixel[1]);
 
           if (dv == 0 && dh == 0)
             gray_buffer[0] = AVG4 (bayer_pixel[-line_skip], bayer_pixel[line_skip], bayer_pixel[-1], bayer_pixel[1]);
@@ -246,8 +246,8 @@ openni_wrapper::ImageBayerGRBG::fillGrayscale (
         {
           gray_buffer[0] = bayer_pixel[0];
 
-          dv = abs (bayer_pixel[1 - line_skip] - bayer_pixel[1 + line_skip]);
-          dh = abs (bayer_pixel[0] - bayer_pixel[2]);
+          dv = std::abs (bayer_pixel[1 - line_skip] - bayer_pixel[1 + line_skip]);
+          dh = std::abs (bayer_pixel[0] - bayer_pixel[2]);
 
           if (dv == 0 && dh == 0)
             gray_buffer[1] = AVG4 (bayer_pixel[1 - line_skip], bayer_pixel[1 + line_skip], bayer_pixel[0], bayer_pixel[2]);

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -929,7 +929,7 @@ pcl::PCDWriter::generateHeaderASCII (const pcl::PCLPointCloud2 &cloud,
     // Ignore invalid padded dimensions that are inherited from binary data
     if (cloud.fields[d].name == "_")
       continue;
-    int count = abs (static_cast<int> (cloud.fields[d].count));
+    int count = std::abs (static_cast<int> (cloud.fields[d].count));
     if (count == 0)
       count = 1;          // we simply cannot tolerate 0 counts (coming from older converter code)
 
@@ -938,7 +938,7 @@ pcl::PCDWriter::generateHeaderASCII (const pcl::PCLPointCloud2 &cloud,
   // Ignore invalid padded dimensions that are inherited from binary data
   if (cloud.fields[cloud.fields.size () - 1].name != "_")
   {
-    int count = abs (static_cast<int> (cloud.fields[cloud.fields.size () - 1].count));
+    int count = std::abs (static_cast<int> (cloud.fields[cloud.fields.size () - 1].count));
     if (count == 0)
       count = 1;
 
@@ -1013,7 +1013,7 @@ pcl::PCDWriter::generateHeaderBinary (const pcl::PCLPointCloud2 &cloud,
     field_names << " " << cloud.fields[i].name;
     field_sizes << " " << pcl::getFieldSize (cloud.fields[i].datatype);
     field_types << " " << pcl::getFieldType (cloud.fields[i].datatype);
-    int count = abs (static_cast<int> (cloud.fields[i].count));
+    int count = std::abs (static_cast<int> (cloud.fields[i].count));
     if (count == 0) count = 1;  // check for 0 counts (coming from older converter code)
     field_counts << " " << count;
   }
@@ -1074,7 +1074,7 @@ pcl::PCDWriter::generateHeaderBinaryCompressed (std::ostream &os,
     field_names << " " << field.name;
     field_sizes << " " << pcl::getFieldSize (field.datatype);
     field_types << " " << pcl::getFieldType (field.datatype);
-    int count = abs (static_cast<int> (field.count));
+    int count = std::abs (static_cast<int> (field.count));
     if (count == 0) count = 1;  // check for 0 counts (coming from older converter code)
     field_counts << " " << count;
   }

--- a/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
@@ -297,7 +297,7 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::findScaleSpaceExtrema (
       const float &val = diff_of_gauss (i_point, i_scale);
 
       // Does the point have sufficient contrast?
-      if (fabs (val) >= min_contrast_)
+      if (std::abs (val) >= min_contrast_)
       {
         // Is it a local minimum?
         if ((val == min_val[i_scale]) && 

--- a/keypoints/include/pcl/keypoints/impl/susan.hpp
+++ b/keypoints/include/pcl/keypoints/impl/susan.hpp
@@ -279,7 +279,7 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::isWithinNucleusCen
 // template <typename PointInT, typename PointOutT, typename NormalT, typename IntensityT> bool
 // pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::isWithinSusan2D (int nucleus, int neighbor) const
 // {
-//   return (fabs (intensity_ (surface_->points[nucleus]) - 
+//   return (std::abs (intensity_ (surface_->points[nucleus]) - 
 //                 intensity_ (surface_->points[neighbor])) <= intensity_threshold_);
 // }
 
@@ -295,7 +295,7 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::isWithinNucleusCen
 // {
 //   Eigen::Vector3f nucleus_normal = normals_->point[nucleus].getVector3fMap ();
 //   return ((1 - nucleus_normal.dot (normals_->points[*index].getNormalVector3fMap ()) <= angular_threshold_) || 
-//           (fabs (intensity_ (surface_->points[nucleus]) - intensity_ (surface_->points[neighbor])) <= intensity_threshold_));
+//           (std::abs (intensity_ (surface_->points[nucleus]) - intensity_ (surface_->points[neighbor])) <= intensity_threshold_));
 // }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -334,7 +334,7 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
       if ((*index != point_index) && std::isfinite (normals_->points[*index].normal_x))
       {
         // if the point fulfill condition
-        if ((fabs (nucleus_intensity - intensity_ (input_->points[*index])) <= intensity_threshold_) ||
+        if ((std::abs (nucleus_intensity - intensity_ (input_->points[*index])) <= intensity_threshold_) ||
             (1 - nucleus_normal.dot (normals_->points[*index].getNormalVector3fMap ()) <= angular_threshold_))
         {
           ++area;

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -330,7 +330,7 @@ NarfKeypoint::calculateCompleteInterestImage ()
             x2 = index2 - y2*range_image.width;
         const PointWithRange& point2 = range_image.getPoint (index2);
         
-        float pixelDistance = static_cast<float> (std::max (abs (x2-x), abs (y2-y)));
+        float pixelDistance = static_cast<float> (std::max (std::abs (x2-x), std::abs (y2-y)));
         float distance_squared = squaredEuclideanDistance (point, point2);
         if (pixelDistance > 2.0f)  // Always consider immediate neighbors, even if to far away
         {
@@ -513,7 +513,7 @@ NarfKeypoint::calculateSparseInterestImage ()
           x2 = index2 - y2*range_image.width;
       const PointWithRange& point2 = range_image.getPoint (index2);
       
-      float pixelDistance = static_cast<float> (std::max (abs (x2-x), abs (y2-y)));
+      float pixelDistance = static_cast<float> (std::max (std::abs (x2-x), std::abs (y2-y)));
 
       float distance_squared = squaredEuclideanDistance (point, point2);
       if (distance_squared <= radius_overhead_squared) 
@@ -647,7 +647,7 @@ NarfKeypoint::calculateSparseInterestImage ()
             const PointWithRange& point3 = range_image.getPoint (index3);
             float surface_change_score = relevent_point_index.second;
             
-            float pixelDistance = static_cast<float> (std::max (abs (x3-x2), abs (y3-y2)));
+            float pixelDistance = static_cast<float> (std::max (std::abs (x3-x2), std::abs (y3-y2)));
             float distance = (point3.getVector3fMap ()-point2.getVector3fMap ()).norm ();
             float distance_factor = radius_reciprocal*distance;
             float positive_score, current_negative_score;

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -1833,7 +1833,7 @@ static void solve_epsilon_svr (
   for (int i = 0; i < l; i++)
   {
     alpha[i] = alpha2[i] - alpha2[i+l];
-    sum_alpha += fabs (alpha[i]);
+    sum_alpha += std::abs (alpha[i]);
   }
 
   info ("nu = %f\n", sum_alpha / (param->C*l));
@@ -1934,18 +1934,18 @@ static decision_function svm_train_one (
 
   for (int i = 0;i < prob->l;i++)
   {
-    if (fabs (alpha[i]) > 0)
+    if (std::abs (alpha[i]) > 0)
     {
       ++nSV;
 
       if (prob->y[i] > 0)
       {
-        if (fabs (alpha[i]) >= si.upper_bound_p)
+        if (std::abs (alpha[i]) >= si.upper_bound_p)
           ++nBSV;
       }
       else
       {
-        if (fabs (alpha[i]) >= si.upper_bound_n)
+        if (std::abs (alpha[i]) >= si.upper_bound_n)
           ++nBSV;
       }
     }
@@ -2045,7 +2045,7 @@ static void sigmoid_train (
     }
 
     // Stopping Criteria
-    if (fabs (g1) < eps && fabs (g2) < eps)
+    if (std::abs (g1) < eps && std::abs (g2) < eps)
       break;
 
     // Finding Newton direction: -inv(H') * g
@@ -2159,7 +2159,7 @@ static void multiclass_probability (int k, double **r, double *p)
 
     for (int t = 0;t < k;t++)
     {
-      double error = fabs (Qp[t] - pQp);
+      double error = std::abs (Qp[t] - pQp);
 
       if (error > max_error)
         max_error = error;
@@ -2312,7 +2312,7 @@ static double svm_svr_probability (
   for (int i = 0; i < prob->l; i++)
   {
     ymv[i] = prob->y[i] - ymv[i];
-    mae += fabs (ymv[i]);
+    mae += std::abs (ymv[i]);
   }
 
   mae /= prob->l;
@@ -2322,10 +2322,10 @@ static double svm_svr_probability (
   mae = 0;
 
   for (int i = 0; i < prob->l; i++)
-    if (fabs (ymv[i]) > 5*std)
+    if (std::abs (ymv[i]) > 5*std)
       count += 1;
     else
-      mae += fabs (ymv[i]);
+      mae += std::abs (ymv[i]);
 
   mae /= (prob->l - count);
 
@@ -2448,7 +2448,7 @@ svm_model *svm_train (const svm_problem *prob, const svm_parameter *param)
     int nSV = 0;
 
     for (int i = 0; i < prob->l; i++)
-      if (fabs (f.alpha[i]) > 0)
+      if (std::abs (f.alpha[i]) > 0)
         ++nSV;
 
     model->l = nSV;
@@ -2460,7 +2460,7 @@ svm_model *svm_train (const svm_problem *prob, const svm_parameter *param)
     int j = 0;
 
     for (int i = 0; i < prob->l; i++)
-      if (fabs (f.alpha[i]) > 0)
+      if (std::abs (f.alpha[i]) > 0)
       {
         model->SV[j] = prob->x[i];
         model->sv_coef[0][j] = f.alpha[i];
@@ -2558,11 +2558,11 @@ svm_model *svm_train (const svm_problem *prob, const svm_parameter *param)
         f[p] = svm_train_one (&sub_prob, param, weighted_C[i], weighted_C[j]);
 
         for (int k = 0; k < ci; k++)
-          if (!nonzero[si+k] && fabs (f[p].alpha[k]) > 0)
+          if (!nonzero[si+k] && std::abs (f[p].alpha[k]) > 0)
             nonzero[si+k] = true;
 
         for (int k = 0; k < cj; k++)
-          if (!nonzero[sj+k] && fabs (f[p].alpha[ci+k]) > 0)
+          if (!nonzero[sj+k] && std::abs (f[p].alpha[ci+k]) > 0)
             nonzero[sj+k] = true;
 
         free (sub_prob.x);

--- a/outofcore/include/pcl/outofcore/impl/octree_base.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base.hpp
@@ -717,7 +717,7 @@ namespace pcl
       assert (diff[2] > 0);
       Eigen::Vector3d center = (bb_max + bb_min)/2.0;
 
-      double max_sidelength = std::max (std::max (fabs (diff[0]), fabs (diff[1])), fabs (diff[2]));
+      double max_sidelength = std::max (std::max (std::abs (diff[0]), std::abs (diff[1])), std::abs (diff[2]));
       assert (max_sidelength > 0);
       bb_min = center - Eigen::Vector3d (1.0, 1.0, 1.0)*(max_sidelength/2.0);
       bb_max = center + Eigen::Vector3d (1.0, 1.0, 1.0)*(max_sidelength/2.0);

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -1080,12 +1080,12 @@ namespace pcl
 
           //  Basic VFC algorithm
           Eigen::Vector3d center = node_metadata_->getVoxelCenter();
-          Eigen::Vector3d radius (fabs (static_cast<double> (max_bb.x () - center.x ())),
-                                  fabs (static_cast<double> (max_bb.y () - center.y ())),
-                                  fabs (static_cast<double> (max_bb.z () - center.z ())));
+          Eigen::Vector3d radius (std::abs (static_cast<double> (max_bb.x () - center.x ())),
+                                  std::abs (static_cast<double> (max_bb.y () - center.y ())),
+                                  std::abs (static_cast<double> (max_bb.z () - center.z ())));
 
           double m = (center.x () * a) + (center.y () * b) + (center.z () * c) + d;
-          double n = (radius.x () * fabs(a)) + (radius.y () * fabs(b)) + (radius.z () * fabs(c));
+          double n = (radius.x () * std::abs(a)) + (radius.y () * std::abs(b)) + (radius.z () * std::abs(c));
 
           if (m + n < 0){
             result = OUTSIDE;
@@ -1229,12 +1229,12 @@ namespace pcl
 
           //  Basic VFC algorithm
           Eigen::Vector3d center = node_metadata_->getVoxelCenter();
-          Eigen::Vector3d radius (fabs (static_cast<double> (max_bb.x () - center.x ())),
-                                  fabs (static_cast<double> (max_bb.y () - center.y ())),
-                                  fabs (static_cast<double> (max_bb.z () - center.z ())));
+          Eigen::Vector3d radius (std::abs (static_cast<double> (max_bb.x () - center.x ())),
+                                  std::abs (static_cast<double> (max_bb.y () - center.y ())),
+                                  std::abs (static_cast<double> (max_bb.z () - center.z ())));
 
           double m = (center.x () * a) + (center.y () * b) + (center.z () * c) + d;
-          double n = (radius.x () * fabs(a)) + (radius.y () * fabs(b)) + (radius.z () * fabs(c));
+          double n = (radius.x () * std::abs(a)) + (radius.y () * std::abs(b)) + (radius.z () * std::abs(c));
 
           if (m + n < 0){
             result = OUTSIDE;

--- a/outofcore/src/cJSON.cpp
+++ b/outofcore/src/cJSON.cpp
@@ -124,7 +124,7 @@ static char *print_number(cJSON *item)
 {
 	char *str;
 	double d=item->valuedouble;
-	if (fabs((static_cast<double>(item->valueint)-d))<=DBL_EPSILON && d<=INT_MAX && d>=INT_MIN)
+	if (std::abs((static_cast<double>(item->valueint)-d))<=DBL_EPSILON && d<=INT_MAX && d>=INT_MIN)
 	{
 		str=static_cast<char*>(cJSON_malloc(21));	/* 2^64+1 can be represented in 21 chars. */
 		if (str) sprintf(str,"%d",item->valueint);
@@ -134,7 +134,7 @@ static char *print_number(cJSON *item)
 		str=static_cast<char*>(cJSON_malloc(64));	/* This is a nice tradeoff. */
 		if (str)
 		{
-			if (fabs(floor(d)-d)<=DBL_EPSILON)			sprintf(str,"%.0f",d);
+			if (std::abs(floor(d)-d)<=DBL_EPSILON)			sprintf(str,"%.0f",d);
 			else sprintf(str,"%.16g",d);
 		}
 	}

--- a/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
@@ -116,7 +116,7 @@ pcl::GeometricConsistencyGrouping<PointModelT, PointSceneT>::clusterCorresponden
           dist_ref = scene_point_k - scene_point_j;
           dist_trg = model_point_k - model_point_j;
 
-          double distance = fabs (dist_ref.norm () - dist_trg.norm ());
+          double distance = std::abs (dist_ref.norm () - dist_trg.norm ());
 
           if (distance > gc_size_)
           {

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -112,7 +112,7 @@ inline void extractEuclideanClustersSmooth(const typename pcl::PointCloud<PointT
             + normals.points[seed_queue[sq_idx]].normal[1] * normals.points[nn_indices[j]].normal[1]
             + normals.points[seed_queue[sq_idx]].normal[2] * normals.points[nn_indices[j]].normal[2];
 
-        if (fabs (std::acos (dot_p)) < eps_angle)
+        if (std::abs (std::acos (dot_p)) < eps_angle)
         {
           processed[nn_indices[j]] = true;
           seed_queue.push_back (nn_indices[j]);

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -767,7 +767,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::applyProjectiveDepthICPOnDetections ()
       size_t nr_inliers = 0;
       for (size_t match_index = 0; match_index < nr_matches; ++match_index)
       {
-        const float error = fabsf (depth_matches[match_index].first + z_translation - depth_matches[match_index].second);
+        const float error = std::abs (depth_matches[match_index].first + z_translation - depth_matches[match_index].second);
 
         if (error <= inlier_threshold)
         {
@@ -786,7 +786,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::applyProjectiveDepthICPOnDetections ()
     size_t average_counter = 0;
     for (size_t match_index = 0; match_index < nr_matches; ++match_index)
     {
-      const float error = fabsf (depth_matches[match_index].first + best_z_translation - depth_matches[match_index].second);
+      const float error = std::abs (depth_matches[match_index].first + best_z_translation - depth_matches[match_index].second);
 
       if (error <= inlier_threshold)
       {

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -242,7 +242,7 @@ namespace pcl
                                      normal.y * ref_normals[normal_index].y +
                                      normal.z * ref_normals[normal_index].z;
 
-              const float abs_response = fabsf (response);
+              const float abs_response = std::abs (response);
               if (max_response < abs_response)
               {
                 max_response = abs_response;
@@ -630,7 +630,7 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals ()
           const float i = qx - px;
           const float j = qy - py;
 
-          const float f = fabs(delta) < 0.05f ? 1.0f : 0.0f;
+          const float f = std::abs(delta) < 0.05f ? 1.0f : 0.0f;
 
           matA0 += f * i * i;
           matA1 += f * i * j;
@@ -901,7 +901,7 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
 
           surface_normal_orientations_ (l_x, l_y) = angle;
 
-          //*lp_norm = fabs(l_nz)*255;
+          //*lp_norm = std::abs(l_nz)*255;
 
           //int l_val1 = static_cast<int>(l_nx * l_offsetx + l_offsetx);
           //int l_val2 = static_cast<int>(l_ny * l_offsety + l_offsety);

--- a/recognition/src/cg/hough_3d.cpp
+++ b/recognition/src/cg/hough_3d.cpp
@@ -136,7 +136,7 @@ pcl::recognition::HoughSpace3D::voteInt (const Eigen::Vector3d &single_vote_coor
     bin_centroid[d] = static_cast<float> ((2 * static_cast<double> (central_bin_coord[d]) * bin_size_[d] + bin_size_[d]) / 2.0 );
 
     // Compute interpolated weight for each coordinate of the central bin
-    central_bin_weight[d] = static_cast<float> (1 - (fabs (single_vote_coord[d] - min_coord_[d] - bin_centroid[d]) / bin_size_[d] ) );
+    central_bin_weight[d] = static_cast<float> (1 - (std::abs (single_vote_coord[d] - min_coord_[d] - bin_centroid[d]) / bin_size_[d] ) );
 
     // Compute the neighbor bins where the weight has to be interpolated
     if ((single_vote_coord[d] - min_coord_[d]) < bin_centroid[d])

--- a/recognition/src/ransac_based/orr_octree.cpp
+++ b/recognition/src/ransac_based/orr_octree.cpp
@@ -302,7 +302,7 @@ pcl::recognition::ORROctree::getFullLeavesIntersectedBySphere (const float* p, f
     nodes.pop_back ();
 
     // Check if the sphere intersects the current node
-    if ( fabs (radius - aux::distance3<float> (p, node->getCenter ())) <= node->getRadius () )
+    if ( std::abs (radius - aux::distance3<float> (p, node->getCenter ())) <= node->getRadius () )
     {
       // We have an intersection -> push back the children of the current node
       if ( node->hasChildren () )
@@ -346,7 +346,7 @@ pcl::recognition::ORROctree::getRandomFullLeafOnSphere (const float* p, float ra
     nodes.pop_back ();
 
     // Check if the sphere intersects the current node
-    if ( fabs (radius - aux::distance3<float> (p, node->getCenter ())) <= node->getRadius () )
+    if ( std::abs (radius - aux::distance3<float> (p, node->getCenter ())) <= node->getRadius () )
     {
       // We have an intersection -> push back the children of the current node
       if ( node->hasChildren () )

--- a/registration/include/pcl/registration/bfgs.h
+++ b/registration/include/pcl/registration/bfgs.h
@@ -340,11 +340,11 @@ BFGS<FunctorType>::minimizeOneStep(FVectorType  &x)
 
   if (delta_f < 0)
   {
-    Scalar del = std::max (-delta_f, 10 * std::numeric_limits<Scalar>::epsilon() * fabs(f0));
+    Scalar del = std::max (-delta_f, 10 * std::numeric_limits<Scalar>::epsilon() * std::abs(f0));
     alpha1 = std::min (1.0, 2.0 * del / (-fp0));
   }
   else
-    alpha1 = fabs(parameters.step_size);
+    alpha1 = std::abs(parameters.step_size);
 
   BFGSSpace::Status status = lineSearch(parameters.rho, parameters.sigma, 
                                         parameters.tau1, parameters.tau2, parameters.tau3, 
@@ -539,7 +539,7 @@ BFGS<FunctorType>::lineSearch(Scalar rho, Scalar sigma,
     fpalpha = applyDF (alpha);
 
     /* Fletcher's sigma test */
-    if (fabs (fpalpha) <= -sigma * fp0)
+    if (std::abs (fpalpha) <= -sigma * fp0)
     {
       alpha_new = alpha;
       return BFGSSpace::Success;
@@ -594,7 +594,7 @@ BFGS<FunctorType>::lineSearch(Scalar rho, Scalar sigma,
     {
       fpalpha = applyDF (alpha);
           
-      if (fabs(fpalpha) <= -sigma * fp0)
+      if (std::abs(fpalpha) <= -sigma * fp0)
       {
         alpha_new = alpha;
         return BFGSSpace::Success;  /* terminate */

--- a/registration/include/pcl/registration/distances.h
+++ b/registration/include/pcl/registration/distances.h
@@ -107,7 +107,7 @@ namespace pcl
     inline double
     gedikli (double val, double clipping, double slope = 4) 
     {
-      return (1.0 / (1.0 + pow (fabs(val) / clipping, slope)));
+      return (1.0 / (1.0 + pow (std::abs(val) / clipping, slope)));
     }
 
     /** \brief Compute the Manhattan distance between two eigen vectors.

--- a/registration/include/pcl/registration/impl/correspondence_estimation_organized_projection.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_organized_projection.hpp
@@ -100,7 +100,7 @@ pcl::registration::CorrespondenceEstimationOrganizedProjection<PointSource, Poin
         if (!isFinite (pt_tgt))
           continue;
         /// Check if the depth difference is larger than the threshold
-        if (fabs (uv[2] - pt_tgt.z) > depth_threshold_)
+        if (std::abs (uv[2] - pt_tgt.z) > depth_threshold_)
           continue;
 
         double dist = (p_src3 - pt_tgt.getVector3fMap ()).norm ();

--- a/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
+++ b/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
@@ -89,7 +89,7 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
 
   // 3. The relative sum of Euclidean squared errors is smaller than a user defined threshold
   // Absolute
-  if (fabs (correspondences_cur_mse_ - correspondences_prev_mse_) < mse_threshold_absolute_)
+  if (std::abs (correspondences_cur_mse_ - correspondences_prev_mse_) < mse_threshold_absolute_)
   {
     if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {
@@ -100,7 +100,7 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   }
   
   // Relative
-  if (fabs (correspondences_cur_mse_ - correspondences_prev_mse_) / correspondences_prev_mse_ < mse_threshold_relative_)
+  if (std::abs (correspondences_cur_mse_ - correspondences_prev_mse_) / correspondences_prev_mse_ < mse_threshold_relative_)
   {
     if (iterations_similar_transforms_ >= max_iterations_similar_transforms_)
     {

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -434,7 +434,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransfor
             ratio = 1./rotation_epsilon_;
           else
             ratio = 1./transformation_epsilon_;
-          double c_delta = ratio*fabs(previous_transformation_(k,l) - transformation_(k,l));
+          double c_delta = ratio*std::abs(previous_transformation_(k,l) - transformation_(k,l));
           if(c_delta > delta)
             delta = c_delta;
         }

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -235,7 +235,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivat
 {
   // Simplified math for near 0 angles
   double cx, cy, cz, sx, sy, sz;
-  if (fabs (p (3)) < 10e-5)
+  if (std::abs (p (3)) < 10e-5)
   {
     //p(3) = 0;
     cx = 1.0;
@@ -246,7 +246,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivat
     cx = std::cos (p (3));
     sx = sin (p (3));
   }
-  if (fabs (p (4)) < 10e-5)
+  if (std::abs (p (4)) < 10e-5)
   {
     //p(4) = 0;
     cy = 1.0;
@@ -258,7 +258,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivat
     sy = sin (p (4));
   }
 
-  if (fabs (p (5)) < 10e-5)
+  if (std::abs (p (5)) < 10e-5)
   {
     //p(5) = 0;
     cz = 1.0;

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -473,7 +473,7 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
     if (update_visualizer_)
       update_visualizer_ (output, *indices_, *target_, *indices_);
 
-    //std::cout << "eps=" << fabs ((transformation - previous_transformation_).sum ()) << std::endl;
+    //std::cout << "eps=" << std::abs ((transformation - previous_transformation_).sum ()) << std::endl;
 
     Eigen::Matrix4f transformation_delta = transformation.inverse() * previous_transformation_;
     double cos_angle = 0.5 * (transformation_delta.coeff (0, 0) + transformation_delta.coeff (1, 1) + transformation_delta.coeff (2, 2) - 1);

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -261,7 +261,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::posesWithinErrorBounds (Eigen::A
   float position_diff = (pose1.translation () - pose2.translation ()).norm ();
   Eigen::AngleAxisf rotation_diff_mat ((pose1.rotation ().inverse ().lazyProduct (pose2.rotation ()).eval()));
 
-  float rotation_diff_angle = fabsf (rotation_diff_mat.angle ());
+  float rotation_diff_angle = std::abs (rotation_diff_mat.angle ());
 
   return (position_diff < clustering_position_diff_threshold_ && rotation_diff_angle < clustering_rotation_diff_threshold_);
 }

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -282,7 +282,7 @@ namespace pcl
             else
               ratio = 1. / transformation_epsilon_;
             double c_delta = ratio
-                * fabs (
+                * std::abs (
                     previous_transformation_ (k, l) - transformation_ (k, l));
             if (c_delta > delta)
               delta = c_delta;

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -116,7 +116,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::getDistancesToModel (const Eigen::Vec
   for (size_t i = 0; i < indices_->size (); ++i)
     // Calculate the distance from the point to the circle as the difference between
     // dist(point,circle_origin) and circle_radius
-    distances[i] = fabsf (std::sqrt (
+    distances[i] = std::abs (std::sqrt (
                                     ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                                     ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -146,7 +146,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::selectWithinDistance (
   {
     // Calculate the distance from the point to the sphere as the difference between
     // dist(point,sphere_origin) and sphere_radius
-    float distance = fabsf (std::sqrt (
+    float distance = std::abs (std::sqrt (
                                       ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                                       ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -180,7 +180,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::countWithinDistance (
   {
     // Calculate the distance from the point to the sphere as the difference between
     // dist(point,sphere_origin) and sphere_radius
-    float distance = fabsf (std::sqrt (
+    float distance = std::abs (std::sqrt (
                                       ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                                       ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -306,7 +306,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
   for (const int &index : indices)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
-    if (fabsf (std::sqrt (
+    if (std::abs (std::sqrt (
                          ( input_->points[index].x - model_coefficients[0] ) *
                          ( input_->points[index].x - model_coefficients[0] ) +
                          ( input_->points[index].y - model_coefficients[1] ) *

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -174,13 +174,13 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::getDistancesToModel (
 
     // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
-    double d_euclid = fabs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
+    double d_euclid = std::abs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
 
     // Calculate the angular distance between the point normal and the (dir=pt_proj->pt) vector
-    double d_normal = fabs (getAngle3D (n, cone_normal));
+    double d_normal = std::abs (getAngle3D (n, cone_normal));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    distances[i] = fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
+    distances[i] = std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
   }
 }
 
@@ -230,13 +230,13 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::selectWithinDistance (
 
     // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
-    double d_euclid = fabs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
+    double d_euclid = std::abs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
 
     // Calculate the angular distance between the point normal and the (dir=pt_proj->pt) vector
-    double d_normal = fabs (getAngle3D (n, cone_normal));
+    double d_normal = std::abs (getAngle3D (n, cone_normal));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    double distance = fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
+    double distance = std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
     
     if (distance < threshold)
     {
@@ -292,13 +292,13 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::countWithinDistance (
 
     // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
-    double d_euclid = fabs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
+    double d_euclid = std::abs (pointToAxisDistance (pt, model_coefficients) - actual_cone_radius);
 
     // Calculate the angular distance between the point normal and the (dir=pt_proj->pt) vector
-    double d_normal = fabs (getAngle3D (n, cone_normal));
+    double d_normal = std::abs (getAngle3D (n, cone_normal));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    if (fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid) < threshold)
+    if (std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid) < threshold)
       nr_p++;
   }
   return (nr_p);
@@ -473,7 +473,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::doSamplesVerifyModel (
 
     // Approximate the distance from the point to the cone as the difference between
     // dist(point,cone_axis) and actual cone radius
-    if (fabs (static_cast<double>(pointToAxisDistance (pt, model_coefficients) - actual_cone_radius)) > threshold)
+    if (std::abs (static_cast<double>(pointToAxisDistance (pt, model_coefficients) - actual_cone_radius)) > threshold)
       return (false);
   }
 
@@ -508,7 +508,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::isModelValid (const Eigen::Vecto
     coeff[3] = 0;
 
     Eigen::Vector4f axis (axis_[0], axis_[1], axis_[2], 0);
-    double angle_diff = fabs (getAngle3D (axis, coeff));
+    double angle_diff = std::abs (getAngle3D (axis, coeff));
     angle_diff = (std::min) (angle_diff, M_PI - angle_diff);
     // Check whether the current cone model satisfies our angle threshold criterion with respect to the given axis
     if (angle_diff > eps_angle_)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -70,9 +70,9 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::computeModelCoefficients (
     return (false);
   }
 
-  if (fabs (input_->points[samples[0]].x - input_->points[samples[1]].x) <= std::numeric_limits<float>::epsilon () && 
-      fabs (input_->points[samples[0]].y - input_->points[samples[1]].y) <= std::numeric_limits<float>::epsilon () && 
-      fabs (input_->points[samples[0]].z - input_->points[samples[1]].z) <= std::numeric_limits<float>::epsilon ()) 
+  if (std::abs (input_->points[samples[0]].x - input_->points[samples[1]].x) <= std::numeric_limits<float>::epsilon () && 
+      std::abs (input_->points[samples[0]].y - input_->points[samples[1]].y) <= std::numeric_limits<float>::epsilon () && 
+      std::abs (input_->points[samples[0]].z - input_->points[samples[1]].z) <= std::numeric_limits<float>::epsilon ()) 
   {
     return (false);
   }
@@ -153,7 +153,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::getDistancesToModel (
     Eigen::Vector4f pt (input_->points[(*indices_)[i]].x, input_->points[(*indices_)[i]].y, input_->points[(*indices_)[i]].z, 0);
     Eigen::Vector4f n  (normals_->points[(*indices_)[i]].normal[0], normals_->points[(*indices_)[i]].normal[1], normals_->points[(*indices_)[i]].normal[2], 0);
 
-    double d_euclid = fabs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]);
+    double d_euclid = std::abs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]);
 
     // Calculate the point's projection on the cylinder axis
     float k = (pt.dot (line_dir) - ptdotdir) * dirdotdir;
@@ -162,10 +162,10 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::getDistancesToModel (
     dir.normalize ();
 
     // Calculate the angular distance between the point normal and the (dir=pt_proj->pt) vector
-    double d_normal = fabs (getAngle3D (n, dir));
+    double d_normal = std::abs (getAngle3D (n, dir));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    distances[i] = fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
+    distances[i] = std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
   }
 }
 
@@ -196,7 +196,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::selectWithinDistance (
     // dist(point,cylinder_axis) and cylinder radius
     Eigen::Vector4f pt (input_->points[(*indices_)[i]].x, input_->points[(*indices_)[i]].y, input_->points[(*indices_)[i]].z, 0);
     Eigen::Vector4f n  (normals_->points[(*indices_)[i]].normal[0], normals_->points[(*indices_)[i]].normal[1], normals_->points[(*indices_)[i]].normal[2], 0);
-    double d_euclid = fabs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]);
+    double d_euclid = std::abs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]);
 
     // Calculate the point's projection on the cylinder axis
     float k = (pt.dot (line_dir) - ptdotdir) * dirdotdir;
@@ -205,10 +205,10 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::selectWithinDistance (
     dir.normalize ();
 
     // Calculate the angular distance between the point normal and the (dir=pt_proj->pt) vector
-    double d_normal = fabs (getAngle3D (n, dir));
+    double d_normal = std::abs (getAngle3D (n, dir));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    double distance = fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid); 
+    double distance = std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid); 
     if (distance < threshold)
     {
       // Returns the indices of the points whose distances are smaller than the threshold
@@ -243,7 +243,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::countWithinDistance (
     // dist(point,cylinder_axis) and cylinder radius
     Eigen::Vector4f pt (input_->points[(*indices_)[i]].x, input_->points[(*indices_)[i]].y, input_->points[(*indices_)[i]].z, 0);
     Eigen::Vector4f n  (normals_->points[(*indices_)[i]].normal[0], normals_->points[(*indices_)[i]].normal[1], normals_->points[(*indices_)[i]].normal[2], 0);
-    double d_euclid = fabs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]);
+    double d_euclid = std::abs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]);
 
     // Calculate the point's projection on the cylinder axis
     float k = (pt.dot (line_dir) - ptdotdir) * dirdotdir;
@@ -252,10 +252,10 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::countWithinDistance (
     dir.normalize ();
 
     // Calculate the angular distance between the point normal and the (dir=pt_proj->pt) vector
-    double d_normal = fabs (getAngle3D (n, dir));
+    double d_normal = std::abs (getAngle3D (n, dir));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    if (fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid) < threshold)
+    if (std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid) < threshold)
       nr_p++;
   }
   return (nr_p);
@@ -402,7 +402,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::doSamplesVerifyModel (
     // dist(point,cylinder_axis) and cylinder radius
     // @note need to revise this.
     Eigen::Vector4f pt (input_->points[index].x, input_->points[index].y, input_->points[index].z, 0);
-    if (fabs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]) > threshold)
+    if (std::abs (pointToLineDistance (pt, model_coefficients) - model_coefficients[6]) > threshold)
       return (false);
   }
 
@@ -455,7 +455,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::isModelValid (const Eigen::V
     coeff[3] = 0;
 
     Eigen::Vector4f axis (axis_[0], axis_[1], axis_[2], 0);
-    double angle_diff = fabs (getAngle3D (axis, coeff));
+    double angle_diff = std::abs (getAngle3D (axis, coeff));
     angle_diff = (std::min) (angle_diff, M_PI - angle_diff);
     // Check whether the current cylinder model satisfies our angle threshold criterion with respect to the given axis
     if (angle_diff > eps_angle_)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -75,9 +75,9 @@ pcl::SampleConsensusModelLine<PointT>::computeModelCoefficients (
     return (false);
   }
 
-  if (fabs (input_->points[samples[0]].x - input_->points[samples[1]].x) <= std::numeric_limits<float>::epsilon () && 
-      fabs (input_->points[samples[0]].y - input_->points[samples[1]].y) <= std::numeric_limits<float>::epsilon () && 
-      fabs (input_->points[samples[0]].z - input_->points[samples[1]].z) <= std::numeric_limits<float>::epsilon ())
+  if (std::abs (input_->points[samples[0]].x - input_->points[samples[1]].x) <= std::numeric_limits<float>::epsilon () && 
+      std::abs (input_->points[samples[0]].y - input_->points[samples[1]].y) <= std::numeric_limits<float>::epsilon () && 
+      std::abs (input_->points[samples[0]].z - input_->points[samples[1]].z) <= std::numeric_limits<float>::epsilon ())
   {
     return (false);
   }

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_parallel_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_parallel_plane.hpp
@@ -58,13 +58,13 @@ pcl::SampleConsensusModelNormalParallelPlane<PointT, PointNT>::isModelValid (con
     coeff[3] = 0;
     coeff.normalize ();
 
-    if (fabs (axis_.dot (coeff)) < cos_angle_)
+    if (std::abs (axis_.dot (coeff)) < cos_angle_)
       return  (false);
   }
 
   if (eps_dist_ > 0.0)
   {
-    if (fabs (-model_coefficients[3] - distance_from_origin_) > eps_dist_)
+    if (std::abs (-model_coefficients[3] - distance_from_origin_) > eps_dist_)
       return (false);
   }
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_plane.hpp
@@ -79,16 +79,16 @@ pcl::SampleConsensusModelNormalPlane<PointT, PointNT>::selectWithinDistance (
     // D = (P-A).N/|N|
     Eigen::Vector4f p (pt.x, pt.y, pt.z, 0);
     Eigen::Vector4f n (nt.normal_x, nt.normal_y, nt.normal_z, 0);
-    double d_euclid = fabs (coeff.dot (p) + model_coefficients[3]);
+    double d_euclid = std::abs (coeff.dot (p) + model_coefficients[3]);
 
     // Calculate the angular distance between the point normal and the plane normal
-    double d_normal = fabs (getAngle3D (n, coeff));
+    double d_normal = std::abs (getAngle3D (n, coeff));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
     // Weight with the point curvature. On flat surfaces, curvature -> 0, which means the normal will have a higher influence
     double weight = normal_distance_weight_ * (1.0 - nt.curvature);
 
-    double distance = fabs (weight * d_normal + (1.0 - weight) * d_euclid); 
+    double distance = std::abs (weight * d_normal + (1.0 - weight) * d_euclid); 
     if (distance < threshold)
     {
       // Returns the indices of the points whose distances are smaller than the threshold
@@ -131,16 +131,16 @@ pcl::SampleConsensusModelNormalPlane<PointT, PointNT>::countWithinDistance (
     // D = (P-A).N/|N|
     Eigen::Vector4f p (pt.x, pt.y, pt.z, 0);
     Eigen::Vector4f n (nt.normal_x, nt.normal_y, nt.normal_z, 0);
-    double d_euclid = fabs (coeff.dot (p) + model_coefficients[3]);
+    double d_euclid = std::abs (coeff.dot (p) + model_coefficients[3]);
 
     // Calculate the angular distance between the point normal and the plane normal
-    double d_normal = fabs (getAngle3D (n, coeff));
+    double d_normal = std::abs (getAngle3D (n, coeff));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
     // Weight with the point curvature. On flat surfaces, curvature -> 0, which means the normal will have a higher influence
     double weight = normal_distance_weight_ * (1.0 - nt.curvature);
 
-    if (fabs (weight * d_normal + (1.0 - weight) * d_euclid) < threshold)
+    if (std::abs (weight * d_normal + (1.0 - weight) * d_euclid) < threshold)
       nr_p++;
   }
   return (nr_p);
@@ -179,16 +179,16 @@ pcl::SampleConsensusModelNormalPlane<PointT, PointNT>::getDistancesToModel (
     // D = (P-A).N/|N|
     Eigen::Vector4f p (pt.x, pt.y, pt.z, 0);
     Eigen::Vector4f n (nt.normal_x, nt.normal_y, nt.normal_z, 0);
-    double d_euclid = fabs (coeff.dot (p) + model_coefficients[3]);
+    double d_euclid = std::abs (coeff.dot (p) + model_coefficients[3]);
 
     // Calculate the angular distance between the point normal and the plane normal
-    double d_normal = fabs (getAngle3D (n, coeff));
+    double d_normal = std::abs (getAngle3D (n, coeff));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
     // Weight with the point curvature. On flat surfaces, curvature -> 0, which means the normal will have a higher influence
     double weight = normal_distance_weight_ * (1.0 - nt.curvature);
 
-    distances[i] = fabs (weight * d_normal + (1.0 - weight) * d_euclid);
+    distances[i] = std::abs (weight * d_normal + (1.0 - weight) * d_euclid);
   }
 }
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
@@ -86,13 +86,13 @@ pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::selectWithinDistance (
                        0);
 
     Eigen::Vector4f n_dir = p - center;
-    double d_euclid = fabs (n_dir.norm () - model_coefficients[3]);
+    double d_euclid = std::abs (n_dir.norm () - model_coefficients[3]);
 
     // Calculate the angular distance between the point normal and the plane normal
-    double d_normal = fabs (getAngle3D (n, n_dir));
+    double d_normal = std::abs (getAngle3D (n, n_dir));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    double distance = fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid); 
+    double distance = std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid); 
     if (distance < threshold)
     {
       // Returns the indices of the points whose distances are smaller than the threshold
@@ -143,13 +143,13 @@ pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::countWithinDistance (
                        0);
 
     Eigen::Vector4f n_dir = (p-center);
-    double d_euclid = fabs (n_dir.norm () - model_coefficients[3]);
+    double d_euclid = std::abs (n_dir.norm () - model_coefficients[3]);
     //
     // Calculate the angular distance between the point normal and the plane normal
-    double d_normal = fabs (getAngle3D (n, n_dir));
+    double d_normal = std::abs (getAngle3D (n, n_dir));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    if (fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid) < threshold)
+    if (std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid) < threshold)
       nr_p++;
   }
   return (nr_p);
@@ -195,13 +195,13 @@ pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::getDistancesToModel (
                        0);
 
     Eigen::Vector4f n_dir = (p-center);
-    double d_euclid = fabs (n_dir.norm () - model_coefficients[3]);
+    double d_euclid = std::abs (n_dir.norm () - model_coefficients[3]);
     //
     // Calculate the angular distance between the point normal and the plane normal
-    double d_normal = fabs (getAngle3D (n, n_dir));
+    double d_normal = std::abs (getAngle3D (n, n_dir));
     d_normal = (std::min) (d_normal, M_PI - d_normal);
 
-    distances[i] = fabs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
+    distances[i] = std::abs (normal_distance_weight_ * d_normal + (1 - normal_distance_weight_) * d_euclid);
   }
 }
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
@@ -100,7 +100,7 @@ pcl::SampleConsensusModelParallelLine<PointT>::isModelValid (const Eigen::Vector
     Eigen::Vector4f line_dir (model_coefficients[3], model_coefficients[4], model_coefficients[5], 0);
 
     Eigen::Vector4f axis (axis_[0], axis_[1], axis_[2], 0);
-    double angle_diff = fabs (getAngle3D (axis, line_dir));
+    double angle_diff = std::abs (getAngle3D (axis, line_dir));
     angle_diff = (std::min) (angle_diff, M_PI - angle_diff);
     // Check whether the current line model satisfies our angle threshold criterion with respect to the given axis
     if (angle_diff > eps_angle_)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
@@ -101,7 +101,7 @@ pcl::SampleConsensusModelParallelPlane<PointT>::isModelValid (const Eigen::Vecto
     coeff.normalize ();
 
     Eigen::Vector4f axis (axis_[0], axis_[1], axis_[2], 0);
-    if (fabs (axis.dot (coeff)) > sin_angle_)
+    if (std::abs (axis.dot (coeff)) > sin_angle_)
       return  (false);
   }
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
@@ -100,7 +100,7 @@ pcl::SampleConsensusModelPerpendicularPlane<PointT>::isModelValid (const Eigen::
     coeff[3] = 0;
 
     Eigen::Vector4f axis (axis_[0], axis_[1], axis_[2], 0);
-    double angle_diff = fabs (getAngle3D (axis, coeff));
+    double angle_diff = std::abs (getAngle3D (axis, coeff));
     angle_diff = (std::min) (angle_diff, M_PI - angle_diff);
     // Check whether the current plane model satisfies our angle threshold criterion with respect to the given axis
     if (angle_diff > eps_angle_)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
@@ -126,7 +126,7 @@ pcl::SampleConsensusModelPlane<PointT>::getDistancesToModel (
   {
     // Calculate the distance from the point to the plane normal as the dot product
     // D = (P-A).N/|N|
-    /*distances[i] = fabs (model_coefficients[0] * input_->points[(*indices_)[i]].x +
+    /*distances[i] = std::abs (model_coefficients[0] * input_->points[(*indices_)[i]].x +
                          model_coefficients[1] * input_->points[(*indices_)[i]].y +
                          model_coefficients[2] * input_->points[(*indices_)[i]].z +
                          model_coefficients[3]);*/
@@ -134,7 +134,7 @@ pcl::SampleConsensusModelPlane<PointT>::getDistancesToModel (
                         input_->points[(*indices_)[i]].y,
                         input_->points[(*indices_)[i]].z,
                         1);
-    distances[i] = fabs (model_coefficients.dot (pt));
+    distances[i] = std::abs (model_coefficients.dot (pt));
   }
 }
 
@@ -164,7 +164,7 @@ pcl::SampleConsensusModelPlane<PointT>::selectWithinDistance (
                         input_->points[(*indices_)[i]].z,
                         1);
     
-    float distance = fabsf (model_coefficients.dot (pt));
+    float distance = std::abs (model_coefficients.dot (pt));
     
     if (distance < threshold)
     {
@@ -201,7 +201,7 @@ pcl::SampleConsensusModelPlane<PointT>::countWithinDistance (
                         input_->points[(*indices_)[i]].y,
                         input_->points[(*indices_)[i]].z,
                         1);
-    if (fabs (model_coefficients.dot (pt)) < threshold)
+    if (std::abs (model_coefficients.dot (pt)) < threshold)
       nr_p++;
   }
   return (nr_p);
@@ -358,7 +358,7 @@ pcl::SampleConsensusModelPlane<PointT>::doSamplesVerifyModel (
                         input_->points[index].y,
                         input_->points[index].z,
                         1);
-    if (fabs (model_coefficients.dot (pt)) > threshold)
+    if (std::abs (model_coefficients.dot (pt)) > threshold)
       return (false);
   }
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
@@ -134,7 +134,7 @@ pcl::SampleConsensusModelSphere<PointT>::getDistancesToModel (
   for (size_t i = 0; i < indices_->size (); ++i)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
-    distances[i] = fabs (std::sqrt (
+    distances[i] = std::abs (std::sqrt (
                                ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                                ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -165,7 +165,7 @@ pcl::SampleConsensusModelSphere<PointT>::selectWithinDistance (
   // Iterate through the 3d points and calculate the distances from them to the sphere
   for (size_t i = 0; i < indices_->size (); ++i)
   {
-    double distance = fabs (std::sqrt (
+    double distance = std::abs (std::sqrt (
                           ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                           ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -205,7 +205,7 @@ pcl::SampleConsensusModelSphere<PointT>::countWithinDistance (
   {
     // Calculate the distance from the point to the sphere as the difference between
     // dist(point,sphere_origin) and sphere_radius
-    if (fabs (std::sqrt (
+    if (std::abs (std::sqrt (
                         ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) *
                         ( input_->points[(*indices_)[i]].x - model_coefficients[0] ) +
 
@@ -289,7 +289,7 @@ pcl::SampleConsensusModelSphere<PointT>::doSamplesVerifyModel (
   for (const int &index : indices)
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius
-    if (fabs (sqrt (
+    if (std::abs (sqrt (
                     ( input_->points[index].x - model_coefficients[0] ) *
                     ( input_->points[index].x - model_coefficients[0] ) +
                     ( input_->points[index].y - model_coefficients[1] ) *

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -156,7 +156,7 @@ namespace pcl
         * \note You need to specify an angle > 0 in order to activate the axis-angle constraint!
         */
       inline void
-      setEpsAngle (const double ea) { eps_angle_ = ea; cos_angle_ = fabs (std::cos (ea));}
+      setEpsAngle (const double ea) { eps_angle_ = ea; cos_angle_ = std::abs (std::cos (ea));}
 
       /** \brief Get the angle epsilon (delta) threshold. */
       inline double

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -125,7 +125,7 @@ namespace pcl
         * \note You need to specify an angle > 0 in order to activate the axis-angle constraint!
         */
       inline void
-      setEpsAngle (const double ea) { eps_angle_ = ea; sin_angle_ = fabs (sin (ea));}
+      setEpsAngle (const double ea) { eps_angle_ = ea; sin_angle_ = std::abs (sin (ea));}
 
       /** \brief Get the angle epsilon (delta) threshold. */
       inline double

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -106,7 +106,7 @@ namespace pcl
   template <typename Point> inline double
   pointToPlaneDistance (const Point &p, double a, double b, double c, double d)
   {
-    return (fabs (pointToPlaneDistanceSigned (p, a, b, c, d)) );
+    return (std::abs (pointToPlaneDistanceSigned (p, a, b, c, d)) );
   }
 
   /** \brief Get the distance from a point to a plane (unsigned) defined by ax+by+cz+d=0
@@ -117,7 +117,7 @@ namespace pcl
   template <typename Point> inline double
   pointToPlaneDistance (const Point &p, const Eigen::Vector4f &plane_coefficients)
   {
-    return ( fabs (pointToPlaneDistanceSigned (p, plane_coefficients)) );
+    return ( std::abs (pointToPlaneDistanceSigned (p, plane_coefficients)) );
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -363,7 +363,7 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
 
   double residual_sqr = pcl::estimateProjectionMatrix<PointT> (input_, projection_matrix_, indices);
   
-  if (fabs (residual_sqr) > eps_ * float (indices.size ()))
+  if (std::abs (residual_sqr) > eps_ * float (indices.size ()))
   {
     PCL_ERROR ("[pcl::%s::radiusSearch] Input dataset is not from a projective device!\nResidual (MSE) %f, using %d valid points\n", this->getName ().c_str (), residual_sqr / double (indices.size()), indices.size ());
     return;

--- a/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
+++ b/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
@@ -55,7 +55,7 @@ namespace pcl
     * bool
     * enforceIntensitySimilarity (const pcl::PointXYZI& point_a, const pcl::PointXYZI& point_b, float squared_distance)
     * {
-    *   if (fabs (point_a.intensity - point_b.intensity) < 0.1f)
+    *   if (std::abs (point_a.intensity - point_b.intensity) < 0.1f)
     *     return (true);
     *   else
     *     return (false);

--- a/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
@@ -194,7 +194,7 @@ namespace pcl
         bool dist_ok = (dist < euclidean_dist_threshold);
 
         bool curvature_ok = normals_->points[idx1].curvature < curvature_threshold_;
-        bool plane_d_ok = fabs ((*plane_coeff_d_)[idx1] - (*plane_coeff_d_)[idx2]) < dist_threshold;
+        bool plane_d_ok = std::abs ((*plane_coeff_d_)[idx1] - (*plane_coeff_d_)[idx2]) < dist_threshold;
         
         if (distance_map_[idx1] < distance_map_threshold_)    
           curvature_ok = false;

--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -149,7 +149,7 @@ namespace pcl
           double dot_p = normals.points[i].normal[0] * normals.points[nn_indices[j]].normal[0] +
                          normals.points[i].normal[1] * normals.points[nn_indices[j]].normal[1] +
                          normals.points[i].normal[2] * normals.points[nn_indices[j]].normal[2];
-          if ( fabs (std::acos (dot_p)) < eps_angle )
+          if ( std::abs (std::acos (dot_p)) < eps_angle )
           {
             processed[nn_indices[j]] = true;
             seed_queue.push_back (nn_indices[j]);
@@ -255,7 +255,7 @@ namespace pcl
             normals.points[indices[i]].normal[0] * normals.points[indices[nn_indices[j]]].normal[0] +
             normals.points[indices[i]].normal[1] * normals.points[indices[nn_indices[j]]].normal[1] +
             normals.points[indices[i]].normal[2] * normals.points[indices[nn_indices[j]]].normal[2];
-          if ( fabs (std::acos (dot_p)) < eps_angle )
+          if ( std::abs (std::acos (dot_p)) < eps_angle )
           {
             processed[nn_indices[j]] = true;
             seed_queue.push_back (nn_indices[j]);

--- a/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
@@ -207,7 +207,7 @@ pcl::CPCSegmentation<PointT>::applyCuttingPlane (uint32_t depth_levels_left)
         {
           double index_score = weights[current_index];
           if (use_directed_weights_)
-            index_score *= 1.414 * (fabsf (plane_normal.dot (edge_cloud_cluster->at (current_index).getNormalVector3fMap ())));
+            index_score *= 1.414 * (std::abs (plane_normal.dot (edge_cloud_cluster->at (current_index).getNormalVector3fMap ())));
           cluster_score += index_score;
           if (weights[current_index] > 0)
             ++cluster_concave_pts;
@@ -333,7 +333,7 @@ pcl::CPCSegmentation<PointT>::WeightedRandomSampleConsensus::computeModel (int)
       double index_score = weights_[current_index];
       if (use_directed_weights_)
         // the sqrt(2) factor was used in the paper and was meant for making the scores better comparable between directed and undirected weights
-        index_score *= 1.414 * (fabsf (plane_normal.dot (point_cloud_ptr_->at (current_index).getNormalVector3fMap ())));
+        index_score *= 1.414 * (std::abs (plane_normal.dot (point_cloud_ptr_->at (current_index).getNormalVector3fMap ())));
 
       current_score += index_score;
     }

--- a/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
@@ -201,9 +201,9 @@ pcl::CrfSegmentation<PointT>::createDataVectorFromVoxelGrid ()
   //std::cout << "max_b: " << max_b.x () << " " << max_b.y () << " " << max_b.z () << std::endl;
 
   // compute the voxel grid dimensions
-  //dim_.x () = abs (max_b.x () - min_b.x ());
-  //dim_.y () = abs (max_b.y () - min_b.y ());
-  //dim_.z () = abs (max_b.z () - min_b.z ());
+  //dim_.x () = std::abs (max_b.x () - min_b.x ());
+  //dim_.y () = std::abs (max_b.y () - min_b.y ());
+  //dim_.z () = std::abs (max_b.z () - min_b.z ());
   
   //std::cout << dim_.x () * dim_.y () * dim_.z () << std::endl;
 

--- a/segmentation/include/pcl/segmentation/impl/extract_polygonal_prism_data.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_polygonal_prism_data.hpp
@@ -79,8 +79,8 @@ pcl::isPointIn2DPolygon (const PointT &point, const pcl::PointCloud<PointT> &pol
   // Create a X-Y projected representation for within bounds polygonal checking
   int k0, k1, k2;
   // Determine the best plane to project points onto
-  k0 = (fabs (model_coefficients[0] ) > fabs (model_coefficients[1])) ? 0  : 1;
-  k0 = (fabs (model_coefficients[k0]) > fabs (model_coefficients[2])) ? k0 : 2;
+  k0 = (std::abs (model_coefficients[0] ) > std::abs (model_coefficients[1])) ? 0  : 1;
+  k0 = (std::abs (model_coefficients[k0]) > std::abs (model_coefficients[2])) ? k0 : 2;
   k1 = (k0 + 1) % 3;
   k2 = (k0 + 2) % 3;
   // Project the convex hull
@@ -206,8 +206,8 @@ pcl::ExtractPolygonalPrismData<PointT>::segment (pcl::PointIndices &output)
   // Create a X-Y projected representation for within bounds polygonal checking
   int k0, k1, k2;
   // Determine the best plane to project points onto
-  k0 = (fabs (model_coefficients[0] ) > fabs (model_coefficients[1])) ? 0  : 1;
-  k0 = (fabs (model_coefficients[k0]) > fabs (model_coefficients[2])) ? k0 : 2;
+  k0 = (std::abs (model_coefficients[0] ) > std::abs (model_coefficients[1])) ? 0  : 1;
+  k0 = (std::abs (model_coefficients[k0]) > std::abs (model_coefficients[2])) ? k0 : 2;
   k1 = (k0 + 1) % 3;
   k2 = (k0 + 2) % 3;
   // Project the convex hull

--- a/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
@@ -163,7 +163,7 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segment (std::ve
       float curvature;
       float eig_sum = clust_cov.coeff (0) + clust_cov.coeff (4) + clust_cov.coeff (8);
       if (eig_sum != 0)
-        curvature = fabsf (eigen_value / eig_sum);
+        curvature = std::abs (eigen_value / eig_sum);
       else
         curvature = 0;
 

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -498,7 +498,7 @@ pcl::RegionGrowing<PointT, NormalT>::validatePoint (int initial_seed, int point,
   if (smooth_mode_flag_ == true)
   {
     Eigen::Map<Eigen::Vector3f> nghbr_normal (static_cast<float*> (normals_->points[nghbr].normal));
-    float dot_product = fabsf (nghbr_normal.dot (initial_normal));
+    float dot_product = std::abs (nghbr_normal.dot (initial_normal));
     if (dot_product < cosine_threshold)
     {
       return (false);
@@ -508,7 +508,7 @@ pcl::RegionGrowing<PointT, NormalT>::validatePoint (int initial_seed, int point,
   {
     Eigen::Map<Eigen::Vector3f> nghbr_normal (static_cast<float*> (normals_->points[nghbr].normal));
     Eigen::Map<Eigen::Vector3f> initial_seed_normal (static_cast<float*> (normals_->points[initial_seed].normal));
-    float dot_product = fabsf (nghbr_normal.dot (initial_seed_normal));
+    float dot_product = std::abs (nghbr_normal.dot (initial_seed_normal));
     if (dot_product < cosine_threshold)
       return (false);
   }
@@ -527,7 +527,7 @@ pcl::RegionGrowing<PointT, NormalT>::validatePoint (int initial_seed, int point,
   data_1[2] = input_->points[nghbr].data[2];
   data_1[3] = input_->points[nghbr].data[3];
   Eigen::Map<Eigen::Vector3f> nghbr_point (static_cast<float*> (data_1));
-  float residual = fabsf (initial_normal.dot (initial_point - nghbr_point));
+  float residual = std::abs (initial_normal.dot (initial_point - nghbr_point));
   if (residual_flag_ && residual > residual_threshold_)
     is_a_seed = false;
 

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -644,7 +644,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::validatePoint (int initial_seed, int poi
     if (smooth_mode_flag_ == true)
     {
       Eigen::Map<Eigen::Vector3f> nghbr_normal (static_cast<float*> (normals_->points[nghbr].normal));
-      float dot_product = fabsf (nghbr_normal.dot (initial_normal));
+      float dot_product = std::abs (nghbr_normal.dot (initial_normal));
       if (dot_product < cosine_threshold)
         return (false);
     }
@@ -652,7 +652,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::validatePoint (int initial_seed, int poi
     {
       Eigen::Map<Eigen::Vector3f> nghbr_normal (static_cast<float*> (normals_->points[nghbr].normal));
       Eigen::Map<Eigen::Vector3f> initial_seed_normal (static_cast<float*> (normals_->points[initial_seed].normal));
-      float dot_product = fabsf (nghbr_normal.dot (initial_seed_normal));
+      float dot_product = std::abs (nghbr_normal.dot (initial_seed_normal));
       if (dot_product < cosine_threshold)
         return (false);
     }
@@ -678,7 +678,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::validatePoint (int initial_seed, int poi
     Eigen::Map<Eigen::Vector3f> nghbr_point (static_cast<float*> (data_n));
     Eigen::Map<Eigen::Vector3f> initial_point (static_cast<float*> (data_p));
     Eigen::Map<Eigen::Vector3f> initial_normal (static_cast<float*> (normals_->points[point].normal));
-    float residual = fabsf (initial_normal.dot (initial_point - nghbr_point));
+    float residual = std::abs (initial_normal.dot (initial_point - nghbr_point));
     if (residual > residual_threshold_)
       is_a_seed = false;
   }

--- a/simulation/src/compute_score.frag
+++ b/simulation/src/compute_score.frag
@@ -21,7 +21,7 @@ void main()
   float depth_val = texture2D(DepthSampler, TexCoord0.st).r; 
   float ref_meters = 1.0 / (reference_depth_val * (1.0/f - 1.0/n) + 1.0/n);
   float depth_meters = 1.0 / (depth_val * (1.0/f - 1.0/n) + 1.0/n); 
-  float min_dist = abs(ref_meters - depth_meters);
+  float min_dist = std::abs(ref_meters - depth_meters);
  
   float likelihood = texture2D(CostSampler, vec2(clamp(min_dist/3.0, 0.0, 1.0),0.0)).r;
   float ratio = 0.99;

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -457,7 +457,7 @@ costFunction1 (float ref_val, float depth_val)
 float
 costFunction2 (float ref_val, float depth_val)
 {
-  float min_dist = abs(ref_val - 1/(1.4285f - (depth_val)*1.3788f));
+  float min_dist = std::abs(ref_val - 1/(1.4285f - (depth_val)*1.3788f));
   int lup = static_cast<int> (ceil (min_dist*100)); // has resolution of 0.01m
 
   if (lup > 300)
@@ -505,7 +505,7 @@ costFunction3 (float ref_val,float depth_val)
   }
   else
   { // working range
-    float min_dist = abs (ref_val - 0.7253f/(1.0360f - (depth_val)));
+    float min_dist = std::abs (ref_val - 0.7253f/(1.0360f - (depth_val)));
 
     int lup = static_cast<int> (ceil (min_dist*100)); // has resolution of 0.01m
     if (lup > 300)
@@ -520,14 +520,14 @@ costFunction3 (float ref_val,float depth_val)
 float
 costFunction4(float ref_val,float depth_val)
 {
-  float disparity_diff = abs( ( -0.7253f/ref_val +1.0360f ) -  depth_val );
+  float disparity_diff = std::abs( ( -0.7253f/ref_val +1.0360f ) -  depth_val );
 
   int top_lup = static_cast<int> (ceil (disparity_diff*300)); // has resolution of 0.001m
   if (top_lup > 300)
   {
     top_lup =300;
   }
-  float top = static_cast<float> (top_lookup[top_lup]);// round( abs(x-mu) *1000+1) );
+  float top = static_cast<float> (top_lookup[top_lup]);// round( std::abs(x-mu) *1000+1) );
 
   // bottom:
   //bottom = bottom_lookup(   round(mu*1000+1));
@@ -536,7 +536,7 @@ costFunction4(float ref_val,float depth_val)
   {
     bottom_lup =300;
   }
-  float bottom = bottom_lookup[bottom_lup];// round( abs(x-mu) *1000+1) );
+  float bottom = bottom_lookup[bottom_lup];// round( std::abs(x-mu) *1000+1) );
 
   float proportion = 0.999f;
   float lhood = proportion + (1-proportion)*(top/bottom);

--- a/stereo/src/stereo_adaptive_cost_so.cpp
+++ b/stereo/src/stereo_adaptive_cost_so.cpp
@@ -85,7 +85,7 @@ pcl::AdaptiveCostSOStereoMatching::compute_impl (unsigned char* ref_img, unsigne
   //spatial distance init
   float *ds = new float[ 2*radius_+1 ];
   for (int j = -radius_; j <= radius_; j++)
-    ds[j+radius_] = static_cast<float> (std::exp (- abs (j) / gamma_s_));
+    ds[j+radius_] = static_cast<float> (std::exp (- std::abs (j) / gamma_s_));
   
   //LUT for color distance weight computation
   float lut[256];
@@ -100,7 +100,7 @@ pcl::AdaptiveCostSOStereoMatching::compute_impl (unsigned char* ref_img, unsigne
     for (int x = x_off_ + max_disp_ + 1; x < width_; x++)
     {
       for (int j = -radius_; j <= radius_; j++)
-        wl[j+radius_] = lut[ abs(ref_img[(y+j)*width_+x] - ref_img[y*width_+x]) ] * ds[j+radius_];
+        wl[j+radius_] = lut[ std::abs(ref_img[(y+j)*width_+x] - ref_img[y*width_+x]) ] * ds[j+radius_];
  
       for (int d = 0; d < max_disp_; d++)
       {
@@ -109,8 +109,8 @@ pcl::AdaptiveCostSOStereoMatching::compute_impl (unsigned char* ref_img, unsigne
  
         for (int j = -radius_; j <= radius_; j++)
         {
-          float weight_r = lut[ abs(trg_img[(y+j)*width_+x-d-x_off_] - trg_img[y*width_+x-d-x_off_]) ] * ds[j+radius_];
-          int sad = abs (ref_img[(y+j)*width_+x] - trg_img[(y+j)*width_+x-d-x_off_]);
+          float weight_r = lut[ std::abs(trg_img[(y+j)*width_+x-d-x_off_] - trg_img[y*width_+x-d-x_off_]) ] * ds[j+radius_];
+          int sad = std::abs (ref_img[(y+j)*width_+x] - trg_img[(y+j)*width_+x-d-x_off_]);
           num += wl[j+radius_] * weight_r * static_cast<float> (sad);
           sumw += wl[j+radius_] * weight_r;
         }

--- a/stereo/src/stereo_block_based.cpp
+++ b/stereo/src/stereo_block_based.cpp
@@ -78,7 +78,7 @@ pcl::BlockBasedStereoMatching::compute_impl (unsigned char* ref_img, unsigned ch
     for (int d = 0; d < max_disp_; d++)
     {
       for (int y = 0; y < n; y++)
-        v[x][d] += abs (ref_img[y*width_+x] - trg_img[y*width_+x -d-x_off_]);
+        v[x][d] += std::abs (ref_img[y*width_+x] - trg_img[y*width_+x -d-x_off_]);
       //acc[d] += V[x][d];
     }
   }
@@ -90,7 +90,7 @@ pcl::BlockBasedStereoMatching::compute_impl (unsigned char* ref_img, unsigned ch
     {
       for (int y = 0; y < n; y++)
       {
-        v[x+radius_][d] += abs (ref_img[y*width_ + x+radius_] - trg_img[ y*width_ + x+radius_ -d-x_off_]);
+        v[x+radius_][d] += std::abs (ref_img[y*width_ + x+radius_] - trg_img[ y*width_ + x+radius_ -d-x_off_]);
       }
       acc[d] += v[x+radius_][d] - v[x-radius_-1][d];
     }//d
@@ -107,7 +107,7 @@ pcl::BlockBasedStereoMatching::compute_impl (unsigned char* ref_img, unsigned ch
       acc[d] = 0;
       for (int x = max_disp_ + x_off_; x < max_disp_ + x_off_ + n; x++)
       {
-        v[x][d] += abs( ref_img[ (y+radius_)*width_+x] - trg_img[ (y+radius_)*width_+x -d-x_off_] ) - abs( ref_img[ (y-radius_-1)*width_+x] - trg_img[ (y-radius_-1)*width_ +x -d-x_off_] );
+        v[x][d] += std::abs( ref_img[ (y+radius_)*width_+x] - trg_img[ (y+radius_)*width_+x -d-x_off_] ) - std::abs( ref_img[ (y-radius_-1)*width_+x] - trg_img[ (y-radius_-1)*width_ +x -d-x_off_] );
         
         acc[d] += v[x][d];
       }
@@ -130,7 +130,7 @@ pcl::BlockBasedStereoMatching::compute_impl (unsigned char* ref_img, unsigned ch
 
       for (int d = 0; d < max_disp_; d++)
       {
-        v[x+radius_][d] += abs( *lp - *rp ) - abs( *lpp - *rpp );
+        v[x+radius_][d] += std::abs( *lp - *rp ) - std::abs( *lpp - *rpp );
         rp--;
         rpp--;
         

--- a/stereo/src/stereo_matching.cpp
+++ b/stereo/src/stereo_matching.cpp
@@ -194,7 +194,7 @@ pcl::StereoMatching::leftRightCheck ()
         {
           p2 = disp_map_trg_[y * width_ + p2i] / 16;
 
-          if (abs (p1 - p2) > lr_check_th_)
+          if (std::abs (p1 - p2) > lr_check_th_)
             disp_map_[y* width_ + x] = -8;
         }
       }

--- a/surface/include/pcl/surface/impl/bilateral_upsampling.hpp
+++ b/surface/include/pcl/surface/impl/bilateral_upsampling.hpp
@@ -110,9 +110,9 @@ pcl::BilateralUpsampling<PointInT, PointOutT>::performProcessing (PointCloudOut 
                                                         static_cast<Eigen::MatrixXf::Index> (y - y_w + window_size_));
 
             Eigen::VectorXf::Index d_color = static_cast<Eigen::VectorXf::Index> (
-                abs (input_->points[y_w * input_->width + x_w].r - input_->points[y * input_->width + x].r) +
-                abs (input_->points[y_w * input_->width + x_w].g - input_->points[y * input_->width + x].g) +
-                abs (input_->points[y_w * input_->width + x_w].b - input_->points[y * input_->width + x].b));
+                std::abs (input_->points[y_w * input_->width + x_w].r - input_->points[y * input_->width + x].r) +
+                std::abs (input_->points[y_w * input_->width + x_w].g - input_->points[y * input_->width + x].g) +
+                std::abs (input_->points[y_w * input_->width + x_w].b - input_->points[y * input_->width + x].b));
 
             float val_exp_rgb = val_exp_rgb_vector (d_color);
 

--- a/surface/include/pcl/surface/impl/convex_hull.hpp
+++ b/surface/include/pcl/surface/impl/convex_hull.hpp
@@ -109,9 +109,9 @@ pcl::ConvexHull<PointInT>::performReconstruction2D (PointCloud &hull, std::vecto
   Eigen::Vector3d::Scalar eigen_value;
   Eigen::Vector3d plane_params;
   pcl::eigen33 (normal_calc_covariance, eigen_value, plane_params);
-  float theta_x = fabsf (static_cast<float> (plane_params.dot (x_axis_)));
-  float theta_y = fabsf (static_cast<float> (plane_params.dot (y_axis_)));
-  float theta_z = fabsf (static_cast<float> (plane_params.dot (z_axis_)));
+  float theta_x = std::abs (static_cast<float> (plane_params.dot (x_axis_)));
+  float theta_y = std::abs (static_cast<float> (plane_params.dot (y_axis_)));
+  float theta_z = std::abs (static_cast<float> (plane_params.dot (z_axis_)));
 
   // Check for degenerate cases of each projection
   // We must avoid projections in which the plane projects as a line

--- a/surface/include/pcl/surface/impl/grid_projection.hpp
+++ b/surface/include/pcl/surface/impl/grid_projection.hpp
@@ -519,7 +519,7 @@ pcl::GridProjection<PointNT>::findIntersection (int level,
   double d1 = getD1AtPoint (start_pt, vec, pt_union_indices);
   std::vector<Eigen::Vector4f, Eigen::aligned_allocator<Eigen::Vector4f> > new_end_pts (2);
   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > new_vect_at_end_pts (2);
-  if ((fabs (d1) < 10e-3) || (level == max_binary_search_level_))
+  if ((std::abs (d1) < 10e-3) || (level == max_binary_search_level_))
   {
     intersection = start_pt;
     return;

--- a/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
+++ b/surface/include/pcl/surface/impl/organized_fast_mesh.hpp
@@ -240,8 +240,8 @@ pcl::OrganizedFastMesh<PointInT>::makeAdaptiveCutMesh (std::vector<pcl::Vertices
 
       if (right_cut_upper && right_cut_lower && left_cut_upper && left_cut_lower)
       {
-        float dist_right_cut = fabsf (input_->points[index_down].z - input_->points[index_right].z);
-        float dist_left_cut = fabsf (input_->points[i].z - input_->points[index_down_right].z);
+        float dist_right_cut = std::abs (input_->points[index_down].z - input_->points[index_right].z);
+        float dist_left_cut = std::abs (input_->points[i].z - input_->points[index_down_right].z);
         if (dist_right_cut >= dist_left_cut)
         {
           if (store_shadowed_faces_ || !isShadowedTriangle (i, index_down_right, index_right))

--- a/surface/include/pcl/surface/organized_fast_mesh.h
+++ b/surface/include/pcl/surface/organized_fast_mesh.h
@@ -94,7 +94,7 @@ namespace pcl
       , triangulation_type_ (QUAD_MESH)
       , viewpoint_ (Eigen::Vector3f::Zero ())
       , store_shadowed_faces_ (false)
-      , cos_angle_tolerance_ (fabsf (std::cos (pcl::deg2rad (12.5f))))
+      , cos_angle_tolerance_ (std::abs (std::cos (pcl::deg2rad (12.5f))))
       , distance_tolerance_ (-1.0f)
       , distance_dependent_ (false)
       , use_depth_as_distance_(false)
@@ -203,7 +203,7 @@ namespace pcl
       setAngleTolerance(float angle_tolerance)
       {
         if (angle_tolerance > 0)
-          cos_angle_tolerance_ = fabsf (std::cos (angle_tolerance));
+          cos_angle_tolerance_ = std::abs (std::cos (angle_tolerance));
         else
           cos_angle_tolerance_ = -1.0f;
       }

--- a/surface/src/on_nurbs/fitting_surface_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_surface_pdm.cpp
@@ -1297,7 +1297,7 @@ FittingSurface::inverseMappingBoundary (const ON_NurbsSurface &nurbs, const Vect
 
     delta = -0.5 * r.dot (t) / t.dot (t);
 
-    if (fabs (delta) < accuracy)
+    if (std::abs (delta) < accuracy)
     {
 
       error = r.norm ();

--- a/test/common/test_common.cpp
+++ b/test/common/test_common.cpp
@@ -151,9 +151,9 @@ TEST (PCL, Eigen)
 
   eigen33 (mat, vec, val);
 
-  EXPECT_NEAR (fabs (vec (0, 0)), 0.168841, 1e-4); EXPECT_NEAR (fabs (vec (0, 1)), 0.161623, 1e-4); EXPECT_NEAR (fabs (vec (0, 2)), 0.972302, 1e-4);
-  EXPECT_NEAR (fabs (vec (1, 0)), 0.451632, 1e-4); EXPECT_NEAR (fabs (vec (1, 1)), 0.889498, 1e-4); EXPECT_NEAR (fabs (vec (1, 2)), 0.0694328, 1e-4);
-  EXPECT_NEAR (fabs (vec (2, 0)), 0.876082, 1e-4); EXPECT_NEAR (fabs (vec (2, 1)), 0.4274,   1e-4); EXPECT_NEAR (fabs (vec (2, 2)), 0.223178, 1e-4);
+  EXPECT_NEAR (std::abs (vec (0, 0)), 0.168841, 1e-4); EXPECT_NEAR (std::abs (vec (0, 1)), 0.161623, 1e-4); EXPECT_NEAR (std::abs (vec (0, 2)), 0.972302, 1e-4);
+  EXPECT_NEAR (std::abs (vec (1, 0)), 0.451632, 1e-4); EXPECT_NEAR (std::abs (vec (1, 1)), 0.889498, 1e-4); EXPECT_NEAR (std::abs (vec (1, 2)), 0.0694328, 1e-4);
+  EXPECT_NEAR (std::abs (vec (2, 0)), 0.876082, 1e-4); EXPECT_NEAR (std::abs (vec (2, 1)), 0.4274,   1e-4); EXPECT_NEAR (std::abs (vec (2, 2)), 0.223178, 1e-4);
 
   EXPECT_NEAR (val (0), 2.86806e-06, 1e-4); EXPECT_NEAR (val (1), 0.00037165, 1e-4); EXPECT_NEAR (val (2), 0.000556858, 1e-4);
 

--- a/test/common/test_eigen.cpp
+++ b/test/common/test_eigen.cpp
@@ -79,9 +79,9 @@ TEST (PCL, InverseGeneral3x3f)
 
     // test row-major -> row-major
     Scalar determinant = invert3x3Matrix (r_matrix, r_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      float eps = std::max (epsilon, epsilon / fabs(determinant));
+      float eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = r_inverse * r_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -96,9 +96,9 @@ TEST (PCL, InverseGeneral3x3f)
 
     // test row-major -> col-major
     determinant = invert3x3Matrix (c_matrix, c_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs(determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = c_inverse * c_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -138,9 +138,9 @@ TEST (PCL, InverseGeneral3x3d)
     c_matrix = r_matrix;
     // test row-major -> row-major
     Scalar determinant = invert3x3Matrix (r_matrix, r_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs (determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs (determinant));
 
       result = r_inverse * r_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -155,9 +155,9 @@ TEST (PCL, InverseGeneral3x3d)
 
     // test row-major -> col-major
     determinant = invert3x3Matrix (c_matrix, c_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs(determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = c_inverse * c_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -203,9 +203,9 @@ TEST (PCL, InverseSymmetric3x3f)
 
     // test row-major -> row-major
     Scalar determinant = invert3x3SymMatrix (r_matrix, r_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      float eps = std::max (epsilon, epsilon / fabs(determinant));
+      float eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = r_inverse * r_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -220,9 +220,9 @@ TEST (PCL, InverseSymmetric3x3f)
 
     // test row-major -> col-major
     determinant = invert3x3SymMatrix (c_matrix, c_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs(determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = c_inverse * c_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -268,9 +268,9 @@ TEST (PCL, InverseSymmetric3x3d)
 
     // test row-major -> row-major
     Scalar determinant = invert3x3SymMatrix (r_matrix, r_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs (determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs (determinant));
 
       result = r_inverse * r_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -285,9 +285,9 @@ TEST (PCL, InverseSymmetric3x3d)
 
     // test row-major -> col-major
     determinant = invert3x3SymMatrix (c_matrix, c_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs(determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = c_inverse * c_matrix;
       error = result - Eigen::Matrix<Scalar, 3, 3>::Identity ();
@@ -327,9 +327,9 @@ TEST (PCL, Inverse2x2f)
     c_matrix = r_matrix;
     // test row-major -> row-major
     Scalar determinant = invert2x2 (r_matrix, r_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      float eps = std::max (epsilon, epsilon / fabs(determinant));
+      float eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = r_inverse * r_matrix;
       error = result - Eigen::Matrix<Scalar, 2, 2>::Identity ();
@@ -344,9 +344,9 @@ TEST (PCL, Inverse2x2f)
 
     // test row-major -> col-major
     determinant = invert2x2 (c_matrix, c_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs(determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = c_inverse * c_matrix;
       error = result - Eigen::Matrix<Scalar, 2, 2>::Identity ();
@@ -385,9 +385,9 @@ TEST (PCL, Inverse2x2d)
     c_matrix = r_matrix;
     // test row-major -> row-major
     Scalar determinant = invert2x2 (r_matrix, r_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs (determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs (determinant));
 
       result = r_inverse * r_matrix;
       error = result - Eigen::Matrix<Scalar, 2, 2>::Identity ();
@@ -402,9 +402,9 @@ TEST (PCL, Inverse2x2d)
 
     // test row-major -> col-major
     determinant = invert2x2 (c_matrix, c_inverse);
-    if (fabs (determinant) > epsilon)
+    if (std::abs (determinant) > epsilon)
     {
-      Scalar eps = std::max (epsilon, epsilon / fabs(determinant));
+      Scalar eps = std::max (epsilon, epsilon / std::abs(determinant));
 
       result = c_inverse * c_matrix;
       error = result - Eigen::Matrix<Scalar, 2, 2>::Identity ();

--- a/test/features/test_base_feature.cpp
+++ b/test/features/test_base_feature.cpp
@@ -137,18 +137,18 @@ TEST (PCL, BaseFeature)
   Eigen::Vector4f plane_parameters;
   float curvature;
   solvePlaneParameters (covariance_matrix, centroid3, plane_parameters, curvature);
-  EXPECT_NEAR (fabs (plane_parameters[0]), 0.035592, 1e-4);
-  EXPECT_NEAR (fabs (plane_parameters[1]), 0.369596, 1e-4);
-  EXPECT_NEAR (fabs (plane_parameters[2]), 0.928511, 1e-4);
-  EXPECT_NEAR (fabs (plane_parameters[3]), 0.0622552, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[0]), 0.035592, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[1]), 0.369596, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[2]), 0.928511, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[3]), 0.0622552, 1e-4);
   EXPECT_NEAR (curvature, 0.0693136, 1e-4);
 
   // solvePlaneParameters
   float nx, ny, nz;
   solvePlaneParameters (covariance_matrix, nx, ny, nz, curvature);
-  EXPECT_NEAR (fabs (nx), 0.035592, 1e-4);
-  EXPECT_NEAR (fabs (ny), 0.369596, 1e-4);
-  EXPECT_NEAR (fabs (nz), 0.928511, 1e-4);
+  EXPECT_NEAR (std::abs (nx), 0.035592, 1e-4);
+  EXPECT_NEAR (std::abs (ny), 0.369596, 1e-4);
+  EXPECT_NEAR (std::abs (nz), 0.928511, 1e-4);
   EXPECT_NEAR (curvature, 0.0693136, 1e-4);
 }
 

--- a/test/features/test_curvatures_estimation.cpp
+++ b/test/features/test_curvatures_estimation.cpp
@@ -76,9 +76,9 @@ TEST (PCL, PrincipalCurvaturesEstimation)
 
   // computePointPrincipalCurvatures (indices)
   pc.computePointPrincipalCurvatures (*normals, 0, indices, pcx, pcy, pcz, pc1, pc2);
-  EXPECT_NEAR (fabs (pcx), 0.98509, 1e-4);
-  EXPECT_NEAR (fabs (pcy), 0.10714, 1e-4);
-  EXPECT_NEAR (fabs (pcz), 0.13462, 1e-4);
+  EXPECT_NEAR (std::abs (pcx), 0.98509, 1e-4);
+  EXPECT_NEAR (std::abs (pcy), 0.10714, 1e-4);
+  EXPECT_NEAR (std::abs (pcz), 0.13462, 1e-4);
   EXPECT_NEAR (pc1, 0.23997423052787781, 1e-4);
   EXPECT_NEAR (pc2, 0.19400238990783691, 1e-4);
 
@@ -118,11 +118,11 @@ TEST (PCL, PrincipalCurvaturesEstimation)
   EXPECT_EQ (pcs->points.size (), indices.size ());
 
   // Adjust for small numerical inconsitencies (due to nn_indices not being sorted)
-  EXPECT_NEAR (fabs (pcs->points[0].principal_curvature[0]), 0.98509, 1e-4);
-  EXPECT_NEAR (fabs (pcs->points[0].principal_curvature[1]), 0.10713, 1e-4);
-  EXPECT_NEAR (fabs (pcs->points[0].principal_curvature[2]), 0.13462, 1e-4);
-  EXPECT_NEAR (fabs (pcs->points[0].pc1), 0.23997458815574646, 1e-4);
-  EXPECT_NEAR (fabs (pcs->points[0].pc2), 0.19400238990783691, 1e-4);
+  EXPECT_NEAR (std::abs (pcs->points[0].principal_curvature[0]), 0.98509, 1e-4);
+  EXPECT_NEAR (std::abs (pcs->points[0].principal_curvature[1]), 0.10713, 1e-4);
+  EXPECT_NEAR (std::abs (pcs->points[0].principal_curvature[2]), 0.13462, 1e-4);
+  EXPECT_NEAR (std::abs (pcs->points[0].pc1), 0.23997458815574646, 1e-4);
+  EXPECT_NEAR (std::abs (pcs->points[0].pc2), 0.19400238990783691, 1e-4);
 
   EXPECT_NEAR (pcs->points[2].principal_curvature[0], 0.98079, 1e-4);
   EXPECT_NEAR (pcs->points[2].principal_curvature[1], -0.04019, 1e-4);

--- a/test/features/test_ii_normals.cpp
+++ b/test/features/test_ii_normals.cpp
@@ -360,9 +360,9 @@ TEST (PCL, NormalEstimation)
 
   for (size_t i = 0; i < cloud.points.size (); ++i)
   {
-    EXPECT_NEAR (fabs (output.points[i].normal_x),   0, 1e-2);
-    EXPECT_NEAR (fabs (output.points[i].normal_y),   0, 1e-2);
-    EXPECT_NEAR (fabs (output.points[i].normal_z), 1.0, 1e-2);
+    EXPECT_NEAR (std::abs (output.points[i].normal_x),   0, 1e-2);
+    EXPECT_NEAR (std::abs (output.points[i].normal_y),   0, 1e-2);
+    EXPECT_NEAR (std::abs (output.points[i].normal_z), 1.0, 1e-2);
   }
 }
 
@@ -387,9 +387,9 @@ TEST (PCL, IINormalEstimationCovariance)
           !std::isfinite(output (u, v).normal_z))
         continue;
 
-      EXPECT_NEAR (fabs (output (u, v).normal_x),   0, 1e-2);
-      EXPECT_NEAR (fabs (output (u, v).normal_y),   0, 1e-2);
-      EXPECT_NEAR (fabs (output (u, v).normal_z), 1.0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_x),   0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_y),   0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_z), 1.0, 1e-2);
     }
   }
 }
@@ -415,13 +415,13 @@ TEST (PCL, IINormalEstimationAverage3DGradient)
           !std::isfinite(output (u, v).normal_z))
         continue;
 
-      if (fabs(fabs (output (u, v).normal_z) - 1) > 1e-2)
+      if (std::abs(fabs (output (u, v).normal_z) - 1) > 1e-2)
       {
         std::cout << "T:" << u << " , " << v << " : " << output (u, v).normal_x << " , " << output (u, v).normal_y << " , " << output (u, v).normal_z <<std::endl;
       }
-      EXPECT_NEAR (fabs (output (u, v).normal_x),   0, 1e-2);
-      EXPECT_NEAR (fabs (output (u, v).normal_y),   0, 1e-2);
-      //EXPECT_NEAR (fabs (output (u, v).normal_z), 1.0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_x),   0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_y),   0, 1e-2);
+      //EXPECT_NEAR (std::abs (output (u, v).normal_z), 1.0, 1e-2);
     }
   }
 }
@@ -447,13 +447,13 @@ TEST (PCL, IINormalEstimationAverageDepthChange)
           !std::isfinite(output (u, v).normal_z))
         continue;
 
-      if (fabs(fabs (output (u, v).normal_z) - 1) > 1e-2)
+      if (std::abs(fabs (output (u, v).normal_z) - 1) > 1e-2)
       {
         std::cout << "T:" << u << " , " << v << " : " << output (u, v).normal_x << " , " << output (u, v).normal_y << " , " << output (u, v).normal_z <<std::endl;
       }
-      EXPECT_NEAR (fabs (output (u, v).normal_x),   0, 1e-2);
-      EXPECT_NEAR (fabs (output (u, v).normal_y),   0, 1e-2);
-      //EXPECT_NEAR (fabs (output (u, v).normal_z), 1.0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_x),   0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_y),   0, 1e-2);
+      //EXPECT_NEAR (std::abs (output (u, v).normal_z), 1.0, 1e-2);
     }
   }
 }
@@ -479,13 +479,13 @@ TEST (PCL, IINormalEstimationSimple3DGradient)
           !std::isfinite(output (u, v).normal_z))
         continue;
 
-      if (fabs(fabs (output (u, v).normal_z) - 1) > 1e-2)
+      if (std::abs(fabs (output (u, v).normal_z) - 1) > 1e-2)
       {
         std::cout << "T:" << u << " , " << v << " : " << output (u, v).normal_x << " , " << output (u, v).normal_y << " , " << output (u, v).normal_z <<std::endl;
       }
-      EXPECT_NEAR (fabs (output (u, v).normal_x),   0, 1e-2);
-      EXPECT_NEAR (fabs (output (u, v).normal_y),   0, 1e-2);
-      //EXPECT_NEAR (fabs (output (u, v).normal_z), 1.0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_x),   0, 1e-2);
+      EXPECT_NEAR (std::abs (output (u, v).normal_y),   0, 1e-2);
+      //EXPECT_NEAR (std::abs (output (u, v).normal_z), 1.0, 1e-2);
     }
   }
 }

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -100,18 +100,18 @@ TEST (PCL, NormalEstimation)
 
   // computePointNormal (indices, Vector)
   computePointNormal (cloud, indices, plane_parameters, curvature);
-  EXPECT_NEAR (fabs (plane_parameters[0]), 0.035592, 1e-4);
-  EXPECT_NEAR (fabs (plane_parameters[1]), 0.369596, 1e-4);
-  EXPECT_NEAR (fabs (plane_parameters[2]), 0.928511, 1e-4);
-  EXPECT_NEAR (fabs (plane_parameters[3]), 0.0622552, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[0]), 0.035592, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[1]), 0.369596, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[2]), 0.928511, 1e-4);
+  EXPECT_NEAR (std::abs (plane_parameters[3]), 0.0622552, 1e-4);
   EXPECT_NEAR (curvature, 0.0693136, 1e-4);
 
   float nx, ny, nz;
   // computePointNormal (indices)
   n.computePointNormal (cloud, indices, nx, ny, nz, curvature);
-  EXPECT_NEAR (fabs (nx), 0.035592, 1e-4);
-  EXPECT_NEAR (fabs (ny), 0.369596, 1e-4);
-  EXPECT_NEAR (fabs (nz), 0.928511, 1e-4);
+  EXPECT_NEAR (std::abs (nx), 0.035592, 1e-4);
+  EXPECT_NEAR (std::abs (ny), 0.369596, 1e-4);
+  EXPECT_NEAR (std::abs (nz), 0.928511, 1e-4);
   EXPECT_NEAR (curvature, 0.0693136, 1e-4);
 
   // computePointNormal (Vector)

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -622,9 +622,9 @@ TEST (VoxelGrid, Filters)
   int centroidIdx = grid.getCentroidIndex (cloud->points[195]);
 
   // for arbitrary points, the centroid should be close
-  EXPECT_LE (fabs (output.points[centroidIdx].x - cloud->points[195].x), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx].y - cloud->points[195].y), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx].z - cloud->points[195].z), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx].x - cloud->points[195].x), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx].y - cloud->points[195].y), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx].z - cloud->points[195].z), 0.02);
 
   // if getNeighborCentroidIndices works then the other helper functions work as well
   EXPECT_EQ (grid.getNeighborCentroidIndices (output.points[0], Eigen::MatrixXi::Zero(3,1))[0], 0);
@@ -635,8 +635,8 @@ TEST (VoxelGrid, Filters)
   std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[195], directions);
   EXPECT_EQ (neighbors.size (), size_t (directions.cols ()));
   EXPECT_NE (neighbors.at (0), -1);
-  EXPECT_LE (fabs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
-  EXPECT_LE (fabs (output.points[neighbors.at (0)].y - output.points[centroidIdx].y), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors.at (0)].y - output.points[centroidIdx].y), 0.02);
   EXPECT_LE ( output.points[neighbors.at (0)].z - output.points[centroidIdx].z, 0.02 * 2);
 
   // Test the pcl::PCLPointCloud2 method
@@ -704,9 +704,9 @@ TEST (VoxelGrid, Filters)
   EXPECT_NE (centroidIdx2, -1);
 
   // for arbitrary points, the centroid should be close
-  EXPECT_LE (fabs (output.points[centroidIdx2].x - 0.048722), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx2].y - 0.073760), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx2].z - 0.017434), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx2].x - 0.048722), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx2].y - 0.073760), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx2].z - 0.017434), 0.02);
 
   // if getNeighborCentroidIndices works then the other helper functions work as well
   EXPECT_EQ (grid2.getNeighborCentroidIndices (output.points[0].x, output.points[0].y, output.points[0].z, Eigen::MatrixXi::Zero(3,1))[0], 0);
@@ -717,8 +717,8 @@ TEST (VoxelGrid, Filters)
   std::vector<int> neighbors2 = grid2.getNeighborCentroidIndices (0.048722f, 0.073760f, 0.017434f, directions2);
   EXPECT_EQ (neighbors2.size (), size_t (directions2.cols ()));
   EXPECT_NE (neighbors2.at (0), -1);
-  EXPECT_LE (fabs (output.points[neighbors2.at (0)].x - output.points[centroidIdx2].x), 0.02);
-  EXPECT_LE (fabs (output.points[neighbors2.at (0)].y - output.points[centroidIdx2].y), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors2.at (0)].x - output.points[centroidIdx2].x), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors2.at (0)].y - output.points[centroidIdx2].y), 0.02);
   EXPECT_LE (output.points[neighbors2.at (0)].z - output.points[centroidIdx2].z, 0.02 * 2);
 }
 
@@ -775,9 +775,9 @@ TEST (VoxelGrid_No_DownsampleAllData, Filters)
   int centroidIdx = grid.getCentroidIndex (cloud->points[195]);
 
   // for arbitrary points, the centroid should be close
-  EXPECT_LE (fabs (output.points[centroidIdx].x - cloud->points[195].x), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx].y - cloud->points[195].y), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx].z - cloud->points[195].z), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx].x - cloud->points[195].x), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx].y - cloud->points[195].y), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx].z - cloud->points[195].z), 0.02);
 
   // if getNeighborCentroidIndices works then the other helper functions work as well
   EXPECT_EQ (grid.getNeighborCentroidIndices (output.points[0], Eigen::MatrixXi::Zero(3,1))[0], 0);
@@ -788,8 +788,8 @@ TEST (VoxelGrid_No_DownsampleAllData, Filters)
   std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[195], directions);
   EXPECT_EQ (neighbors.size (), size_t (directions.cols ()));
   EXPECT_NE (neighbors.at (0), -1);
-  EXPECT_LE (fabs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
-  EXPECT_LE (fabs (output.points[neighbors.at (0)].y - output.points[centroidIdx].y), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors.at (0)].y - output.points[centroidIdx].y), 0.02);
   EXPECT_LE ( output.points[neighbors.at (0)].z - output.points[centroidIdx].z, 0.02 * 2);
 
   // Test the pcl::PCLPointCloud2 method
@@ -850,9 +850,9 @@ TEST (VoxelGrid_No_DownsampleAllData, Filters)
   EXPECT_NE (centroidIdx2, -1);
 
   // for arbitrary points, the centroid should be close
-  EXPECT_LE (fabs (output.points[centroidIdx2].x - 0.048722), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx2].y - 0.073760), 0.02);
-  EXPECT_LE (fabs (output.points[centroidIdx2].z - 0.017434), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx2].x - 0.048722), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx2].y - 0.073760), 0.02);
+  EXPECT_LE (std::abs (output.points[centroidIdx2].z - 0.017434), 0.02);
 
   // if getNeighborCentroidIndices works then the other helper functions work as well
   EXPECT_EQ (grid2.getNeighborCentroidIndices (output.points[0].x, output.points[0].y, output.points[0].z, Eigen::MatrixXi::Zero(3,1))[0], 0);
@@ -863,8 +863,8 @@ TEST (VoxelGrid_No_DownsampleAllData, Filters)
   std::vector<int> neighbors2 = grid2.getNeighborCentroidIndices (0.048722f, 0.073760f, 0.017434f, directions2);
   EXPECT_EQ (neighbors2.size (), size_t (directions2.cols ()));
   EXPECT_NE (neighbors2.at (0), -1);
-  EXPECT_LE (fabs (output.points[neighbors2.at (0)].x - output.points[centroidIdx2].x), 0.02);
-  EXPECT_LE (fabs (output.points[neighbors2.at (0)].y - output.points[centroidIdx2].y), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors2.at (0)].x - output.points[centroidIdx2].x), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors2.at (0)].y - output.points[centroidIdx2].y), 0.02);
   EXPECT_LE (output.points[neighbors2.at (0)].z - output.points[centroidIdx2].z, 0.02 * 2);
 }
 
@@ -1290,8 +1290,8 @@ TEST (VoxelGridCovariance, Filters)
   std::vector<int> neighbors = grid.getNeighborCentroidIndices (cloud->points[38], directions);
   EXPECT_EQ (neighbors.size (), size_t (directions.cols ()));
   EXPECT_NE (neighbors.at (0), -1);
-  EXPECT_LE (fabs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
-  EXPECT_LE (fabs (output.points[neighbors.at (0)].y - output.points[centroidIdx].y), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors.at (0)].x - output.points[centroidIdx].x), 0.02);
+  EXPECT_LE (std::abs (output.points[neighbors.at (0)].y - output.points[centroidIdx].y), 0.02);
   EXPECT_LE (output.points[neighbors.at (0)].z - output.points[centroidIdx].z, 0.02 * 2);
 
   // testing search functions
@@ -2263,7 +2263,7 @@ TEST (NormalRefinement, Filters)
 
     // Estimated (need to avoid zeros and NaNs)
     const pcl::PointXYZRGBNormal& calci = cloud_organized_normal[idx];
-    if ((fabsf (calci.normal_x) + fabsf (calci.normal_y) + fabsf (calci.normal_z)) > 0.0f)
+    if ((std::abs (calci.normal_x) + std::abs (calci.normal_y) + std::abs (calci.normal_z)) > 0.0f)
     {
       tmp = 1.0f - (calci.normal_x * a + calci.normal_y * b + calci.normal_z * c);
       if (std::isfinite (tmp))
@@ -2275,7 +2275,7 @@ TEST (NormalRefinement, Filters)
 
     // Refined
     const pcl::PointXYZRGBNormal& refinedi = cloud_organized_normal_refined[idx];
-    if ((fabsf (refinedi.normal_x) + fabsf (refinedi.normal_y) + fabsf (refinedi.normal_z)) > 0.0f)
+    if ((std::abs (refinedi.normal_x) + std::abs (refinedi.normal_y) + std::abs (refinedi.normal_z)) > 0.0f)
     {
       tmp = 1.0f - (refinedi.normal_x * a + refinedi.normal_y * b + refinedi.normal_z * c);
       if (std::isfinite(tmp))

--- a/test/geometry/test_iterator.cpp
+++ b/test/geometry/test_iterator.cpp
@@ -73,7 +73,7 @@ void checkSimpleLine8 (unsigned x_start, unsigned y_start, unsigned x_end, unsig
   }
   int dx = x_end - x_start;
   int dy = y_end - y_start;
-  unsigned dmax = std::max (abs(dx), abs(dy));
+  unsigned dmax = std::max (std::abs(dx), std::abs(dy));
   
   EXPECT_EQ (dmax, idx);
   
@@ -91,7 +91,7 @@ void checkSimpleLine8 (unsigned x_start, unsigned y_start, unsigned x_end, unsig
     y_step = 0;
     x_step = (dx > 0) ? 1 : -1;
   }
-  else if (abs(dx) == abs(dy))
+  else if (std::abs(dx) == std::abs(dy))
   {
     y_step = (dy > 0) ? 1 : -1;
     x_step = (dx > 0) ? 1 : -1;
@@ -162,12 +162,12 @@ void checkGeneralLine (unsigned x_start, unsigned y_start, unsigned x_end, unsig
   
   int dx = x_end - x_start;
   int dy = y_end - y_start;
-  unsigned dmax = std::max (abs(dx), abs(dy));
+  unsigned dmax = std::max (std::abs(dx), std::abs(dy));
 
   if (neighorhood)
     EXPECT_EQ (dmax, idx);
   else
-    EXPECT_EQ (abs(dx) + abs(dy), idx);
+    EXPECT_EQ (std::abs(dx) + std::abs(dy), idx);
   
   float length = std::sqrt (float (dx * dx + dy * dy));
   float dir_x = float (dx) / length;

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -189,7 +189,7 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
     const MyPoint& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
-      ok = (fabs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
+      ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
     //if (!ok)  cerr << k_index << " is not correct...\n";
     //else      cerr << k_index << " is correct...\n";
     EXPECT_EQ (ok, true);

--- a/test/search/test_auto_search.cpp
+++ b/test/search/test_auto_search.cpp
@@ -293,7 +293,7 @@ TEST (PCL, KdTreeWrapper_nearestKSearch)
     const PointXYZ& point = cloud.points[k_indices[i]];
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
-      ok = (fabs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
+      ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
     //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
     //else      cerr << k_indices[i] << " is correct...\n";
     EXPECT_EQ (ok, true);

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -111,7 +111,7 @@ TEST (PCL, FlannSearch_nearestKSearch)
     const PointXYZ& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
-    ok = (fabs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
+    ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
     //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
     //else      cerr << k_indices[i] << " is correct...\n";
     EXPECT_EQ (ok, true);

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -106,7 +106,7 @@ init ()
     const PointXYZ& point = cloud.points[k_index];
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
-    ok = (fabs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
+    ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
     //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
     //else      cerr << k_indices[i] << " is correct...\n";
     EXPECT_EQ (ok, true);

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -259,7 +259,7 @@ bool compareResults (const std::vector<int>& indices1, const::vector<float>& dis
   {
     for (size_t idx = 0; idx < indices1.size (); ++idx)
     {
-      if (indices1[idx] != indices2[idx] && fabs (distances1[idx] - distances2[idx]) > eps)
+      if (indices1[idx] != indices2[idx] && std::abs (distances1[idx] - distances2[idx]) > eps)
       {
 #if DEBUG_OUT
         cerr << "results between " << name1 << " search and " << name2 << " search do not match: " << idx << " nearest neighbor: "

--- a/test/surface/test_convex_hull.cpp
+++ b/test/surface/test_convex_hull.cpp
@@ -357,13 +357,13 @@ TEST (PCL, ConvexHull_2dsquare)
   //Make sure they're in the plane
   for (const auto &point : hull.points)
   {
-    float dist = fabs (point.getVector4fMap ().dot (plane_normal));
+    float dist = std::abs (point.getVector4fMap ().dot (plane_normal));
     EXPECT_NEAR (dist, 0.0, 1e-2);
 
     float min_dist = std::numeric_limits<float>::infinity ();
     for (const auto &facet : facets)
     {
-      float d2 = fabs (point.getVector4fMap ().dot (facet));
+      float d2 = std::abs (point.getVector4fMap ().dot (facet));
       
       if (d2 < min_dist)
         min_dist = d2;
@@ -417,7 +417,7 @@ TEST (PCL, ConvexHull_3dcube)
     float min_dist = std::numeric_limits<float>::infinity ();
     for (const auto &facet : facets)
     {
-      float dist = fabs (point.getVector4fMap ().dot (facet));
+      float dist = std::abs (point.getVector4fMap ().dot (facet));
       
       if (dist < min_dist)
         min_dist = dist;

--- a/test/surface/test_moving_least_squares.cpp
+++ b/test/surface/test_moving_least_squares.cpp
@@ -82,9 +82,9 @@ TEST (PCL, MovingLeastSquares)
   EXPECT_NEAR (mls_normals->points[0].x, 0.005417, 1e-3);
   EXPECT_NEAR (mls_normals->points[0].y, 0.113463, 1e-3);
   EXPECT_NEAR (mls_normals->points[0].z, 0.040715, 1e-3);
-  EXPECT_NEAR (fabs (mls_normals->points[0].normal[0]), 0.111894, 1e-3);
-  EXPECT_NEAR (fabs (mls_normals->points[0].normal[1]), 0.594906, 1e-3);
-  EXPECT_NEAR (fabs (mls_normals->points[0].normal[2]), 0.795969, 1e-3);
+  EXPECT_NEAR (std::abs (mls_normals->points[0].normal[0]), 0.111894, 1e-3);
+  EXPECT_NEAR (std::abs (mls_normals->points[0].normal[1]), 0.594906, 1e-3);
+  EXPECT_NEAR (std::abs (mls_normals->points[0].normal[2]), 0.795969, 1e-3);
   EXPECT_NEAR (mls_normals->points[0].curvature, 0.012019, 1e-3);
 
 #ifdef _OPENMP
@@ -104,13 +104,13 @@ TEST (PCL, MovingLeastSquares)
   int count = 0;
   for (size_t i = 0; i < mls_normals->size (); ++i)
   {
-  	if (fabs (mls_normals->points[i].x - 0.005417) < 1e-3 &&
-	    fabs (mls_normals->points[i].y - 0.113463) < 1e-3 &&
-	    fabs (mls_normals->points[i].z - 0.040715) < 1e-3 &&
-	    fabs (fabs (mls_normals->points[i].normal[0]) - 0.111894) < 1e-3 &&
-		fabs (fabs (mls_normals->points[i].normal[1]) - 0.594906) < 1e-3 &&
-		fabs (fabs (mls_normals->points[i].normal[2]) - 0.795969) < 1e-3 &&
-		fabs (mls_normals->points[i].curvature - 0.012019) < 1e-3)
+  	if (std::abs (mls_normals->points[i].x - 0.005417) < 1e-3 &&
+	    std::abs (mls_normals->points[i].y - 0.113463) < 1e-3 &&
+	    std::abs (mls_normals->points[i].z - 0.040715) < 1e-3 &&
+	    std::abs (std::abs (mls_normals->points[i].normal[0]) - 0.111894) < 1e-3 &&
+		std::abs (std::abs (mls_normals->points[i].normal[1]) - 0.594906) < 1e-3 &&
+		std::abs (std::abs (mls_normals->points[i].normal[2]) - 0.795969) < 1e-3 &&
+		std::abs (mls_normals->points[i].curvature - 0.012019) < 1e-3)
 		count ++;
   }
 
@@ -136,9 +136,9 @@ TEST (PCL, MovingLeastSquares)
   EXPECT_NEAR (mls_normals->points[10].x, -0.000538, 1e-3);
   EXPECT_NEAR (mls_normals->points[10].y, 0.110080, 1e-3);
   EXPECT_NEAR (mls_normals->points[10].z, 0.043602, 1e-3);
-  EXPECT_NEAR (fabs (mls_normals->points[10].normal[0]), 0.022678, 1e-3);
-  EXPECT_NEAR (fabs (mls_normals->points[10].normal[1]), 0.554978, 1e-3);
-  EXPECT_NEAR (fabs (mls_normals->points[10].normal[2]), 0.831556, 1e-3);
+  EXPECT_NEAR (std::abs (mls_normals->points[10].normal[0]), 0.022678, 1e-3);
+  EXPECT_NEAR (std::abs (mls_normals->points[10].normal[1]), 0.554978, 1e-3);
+  EXPECT_NEAR (std::abs (mls_normals->points[10].normal[2]), 0.831556, 1e-3);
   EXPECT_NEAR (mls_normals->points[10].curvature, 0.012019, 1e-3);
   EXPECT_EQ (mls_normals->size (), 6352);
 
@@ -154,9 +154,9 @@ TEST (PCL, MovingLeastSquares)
 //  EXPECT_NEAR (mls_normals->points[10].x, 0.018806, 1e-3);
 //  EXPECT_NEAR (mls_normals->points[10].y, 0.114685, 1e-3);
 //  EXPECT_NEAR (mls_normals->points[10].z, 0.037500, 1e-3);
-//  EXPECT_NEAR (fabs (mls_normals->points[10].normal[0]), 0.351352, 1e-3);
-//  EXPECT_NEAR (fabs (mls_normals->points[10].normal[1]), 0.537741, 1e-3);
-//  EXPECT_NEAR (fabs (mls_normals->points[10].normal[2]), 0.766411, 1e-3);
+//  EXPECT_NEAR (std::abs (mls_normals->points[10].normal[0]), 0.351352, 1e-3);
+//  EXPECT_NEAR (std::abs (mls_normals->points[10].normal[1]), 0.537741, 1e-3);
+//  EXPECT_NEAR (std::abs (mls_normals->points[10].normal[2]), 0.766411, 1e-3);
 //  EXPECT_NEAR (mls_normals->points[10].curvature, 0.019003, 1e-3);
 //  EXPECT_EQ (mls_normals->size (), 457);
 

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -143,7 +143,7 @@ maskForegroundPoints (const PointCloudXYZRGBA::ConstPtr & input,
     if (foreground_mask[i])
     {
       const pcl::PointXYZRGBA & p = input->points[i];
-      float d = fabsf (c[0]*p.x + c[1]*p.y + c[2]*p.z + c[3]);
+      float d = std::abs (c[0]*p.x + c[1]*p.y + c[2]*p.z + c[3]);
       foreground_mask[i] = (d < max_height);
     }
   }

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -246,9 +246,9 @@ main (int argc, char** argv)
   for (int i = 0; i < number_of_points; i++)
   {
     sphere->GetPoint (i, eye);
-    if (fabs(eye[0]) < EPS) eye[0] = 0;
-    if (fabs(eye[1]) < EPS) eye[1] = 0;
-    if (fabs(eye[2]) < EPS) eye[2] = 0;
+    if (std::abs(eye[0]) < EPS) eye[0] = 0;
+    if (std::abs(eye[1]) < EPS) eye[1] = 0;
+    if (std::abs(eye[2]) < EPS) eye[2] = 0;
 
     viewray[0] = -eye[0];
     viewray[1] = -eye[1];
@@ -280,14 +280,14 @@ main (int argc, char** argv)
       vtkMath::Cross (viewray, x_axis, right);
     else
       vtkMath::Cross (viewray, z_axis, right);
-    if (fabs(right[0]) < EPS) right[0] = 0;
-    if (fabs(right[1]) < EPS) right[1] = 0;
-    if (fabs(right[2]) < EPS) right[2] = 0;
+    if (std::abs(right[0]) < EPS) right[0] = 0;
+    if (std::abs(right[1]) < EPS) right[1] = 0;
+    if (std::abs(right[2]) < EPS) right[2] = 0;
 
     vtkMath::Cross (viewray, right, up);
-    if (fabs(up[0]) < EPS) up[0] = 0;
-    if (fabs(up[1]) < EPS) up[1] = 0;
-    if (fabs(up[2]) < EPS) up[2] = 0;
+    if (std::abs(up[0]) < EPS) up[0] = 0;
+    if (std::abs(up[1]) < EPS) up[1] = 0;
+    if (std::abs(up[2]) < EPS) up[2] = 0;
 
     if (!object_coordinates)
     {

--- a/tracking/include/pcl/tracking/impl/hsv_color_coherence.hpp
+++ b/tracking/include/pcl/tracking/impl/hsv_color_coherence.hpp
@@ -155,13 +155,13 @@ namespace pcl
       RGB2HSV (target_rgb.Red, target_rgb.Blue, target_rgb.Green,
                target_h, target_s, target_v);
       // hue value is in 0 ~ 2pi, but circulated.
-      const float _h_diff = fabsf (source_h - target_h);
+      const float _h_diff = std::abs (source_h - target_h);
       // Also need to compute distance other way around circle - but need to check which is closer to 0
       float _h_diff2;
       if (source_h < target_h)
-        _h_diff2 = fabsf (1.0f + source_h - target_h); //Add 2pi to source, subtract target
+        _h_diff2 = std::abs (1.0f + source_h - target_h); //Add 2pi to source, subtract target
       else 
-        _h_diff2 = fabsf (1.0f + target_h - source_h); //Add 2pi to target, subtract source
+        _h_diff2 = std::abs (1.0f + target_h - source_h); //Add 2pi to target, subtract source
       
       float h_diff;
       //Now we need to choose the smaller distance

--- a/visualization/src/common/common.cpp
+++ b/visualization/src/common/common.cpp
@@ -167,12 +167,12 @@ pcl::visualization::cullFrustum (double frustum[24], const Eigen::Vector3d &min_
                             (max_bb.y () - min_bb.y ()) / 2 + min_bb.y (),
                             (max_bb.z () - min_bb.z ()) / 2 + min_bb.z ());
 
-    Eigen::Vector3d radius (fabs (static_cast<double> (max_bb.x () - center.x ())),
-                            fabs (static_cast<double> (max_bb.y () - center.y ())),
-                            fabs (static_cast<double> (max_bb.z () - center.z ())));
+    Eigen::Vector3d radius (std::abs (static_cast<double> (max_bb.x () - center.x ())),
+                            std::abs (static_cast<double> (max_bb.y () - center.y ())),
+                            std::abs (static_cast<double> (max_bb.z () - center.z ())));
 
     double m = (center.x () * a) + (center.y () * b) + (center.z () * c) + d;
-    double n = (radius.x () * fabs(a)) + (radius.y () * fabs(b)) + (radius.z () * fabs(c));
+    double n = (radius.x () * std::abs(a)) + (radius.y () * std::abs(b)) + (radius.z () * std::abs(c));
 
     if (m + n < 0){
       result = PCL_OUTSIDE_FRUSTUM;
@@ -357,7 +357,7 @@ pcl::visualization::viewScreenArea (
     sum += (dst[i].x () - dst[(i+1) % num].x ()) * (dst[i].y () + dst[(i+1) % num].y ());
   }
 
-  return (fabsf (float (sum * 0.5f)));
+  return (std::abs (float (sum * 0.5f)));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -670,7 +670,7 @@ pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, float x, f
 
 int
 feq (double a, double b) {
-    return fabs (a - b) < 1e-9;
+    return std::abs (a - b) < 1e-9;
 }
 
 void
@@ -3713,7 +3713,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
     //If the view up is parallel to ray cam_pos - focalPoint then the transformation
     //is singular and no points are rendered...
     //make sure it is perpendicular
-    if (fabs (cam_pos_3f.dot (test)) == 1)
+    if (std::abs (cam_pos_3f.dot (test)) == 1)
     {
       //parallel, create
       test = cam_pos_3f.cross (Eigen::Vector3f::UnitX ());


### PR DESCRIPTION
Well I think (and hope) this is the biggest PR of current math function transformation.

Btw: To use regular expression with a wrong font is sometimes a bit ugly (`l` vs `|`) xD
> ([^:\w\."])(l|ll|f)?abs(l|f)?([^\w])

vs
```
([^:\w\."])(l|ll|f)?abs(l|f)?([^\w])
```