### PR TITLE
Prefer C++ method std::exp over C method exp in doc files

### DIFF
--- a/doc/tutorials/content/writing_new_classes.rst
+++ b/doc/tutorials/content/writing_new_classes.rst
@@ -88,7 +88,7 @@ and save the results to disk.
     float
     G (float x, float sigma)
     {
-      return exp (- (x*x)/(2*sigma*sigma));
+      return std::exp (- (x*x)/(2*sigma*sigma));
     }
 
     int
@@ -575,7 +575,7 @@ header file becomes:
           inline double
           kernel (double x, double sigma)
           {
-            return (exp (- (x*x)/(2*sigma*sigma)));
+            return (std::exp (- (x*x)/(2*sigma*sigma)));
           }
 
           double sigma_s_;
@@ -1118,7 +1118,7 @@ class look like:
           inline double
           kernel (double x, double sigma)
           {
-            return (exp (- (x*x)/(2*sigma*sigma)));
+            return (std::exp (- (x*x)/(2*sigma*sigma)));
           }
 
           /** \brief The half size of the Gaussian bilateral filter window (e.g., spatial extents in Euclidean). */


### PR DESCRIPTION
Missed to search in `*.rst` files in previous PRs, but glad only a few `exp` changed were missing by #3256