### PR TITLE
Add header missing on  `trimmed_icp.h`

### DIFF
--- a/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
+++ b/recognition/include/pcl/recognition/ransac_based/trimmed_icp.h
@@ -52,6 +52,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/pcl_exports.h>
 #include <limits>
+#include <pcl/recognition/ransac_based/auxiliary.h>
 
 namespace pcl
 {


### PR DESCRIPTION
Fixes #3151.
Just add the header auxiliary.h which is required by line 128. 
See the issue for more details.