### PR TITLE
Add surface module to the list of dependencies of examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SUBSYS_NAME examples)
 set(SUBSYS_DESC "PCL examples")
-set(SUBSYS_DEPS common io features search kdtree octree filters keypoints segmentation sample_consensus outofcore stereo geometry)
+set(SUBSYS_DEPS common io features search kdtree octree filters keypoints segmentation sample_consensus outofcore stereo geometry surface)
 
 set(DEFAULT FALSE)
 set(REASON "Code examples are disabled by default.")


### PR DESCRIPTION
This fixes the Ubuntu CI job issue mentioned in #3288.