### PR TITLE
Add auto type casting in io

### DIFF
--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -99,6 +99,8 @@ namespace pcl
             mapping.serialized_offset = field.offset;
             mapping.struct_offset = traits::offset<PointT, Tag>::value;
             mapping.size = sizeof (typename traits::datatype<PointT, Tag>::type);
+            mapping.field = field;
+            mapping.out_type = static_cast<PCLPointField::PointFieldTypes>(traits::datatype<PointT, Tag>::value);
             map_.push_back (mapping);
             return;
           }
@@ -137,7 +139,11 @@ namespace pcl
         // This check is designed to permit padding between adjacent fields.
         /// @todo One could construct a pathological case where the struct has a
         /// field where the serialized data has padding
-        if (j->serialized_offset - i->serialized_offset == j->struct_offset - i->struct_offset)
+        if ((j->serialized_offset - i->serialized_offset == j->struct_offset - i->struct_offset)
+            &&
+            (i->out_type == i->field.datatype)
+            &&
+            (j->out_type == j->field.datatype))
         {
           i->size += (j->struct_offset + j->size) - (i->struct_offset + i->size);
           j = field_map.erase(j);
@@ -213,7 +219,9 @@ namespace pcl
           const uint8_t* msg_data = row_data + col * msg.point_step;
           BOOST_FOREACH (const detail::FieldMapping& mapping, field_map)
           {
-            memcpy (cloud_data + mapping.struct_offset, msg_data + mapping.serialized_offset, mapping.size);
+            memcpy (cloud_data + mapping.struct_offset,
+                mapping.cast(msg_data + mapping.serialized_offset),
+                mapping.size);
           }
           cloud_data += sizeof (PointT);
         }

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -59,6 +59,56 @@ namespace pcl
       size_t serialized_offset;
       size_t struct_offset;
       size_t size;
+
+      PCLPointField field;
+      PCLPointField::PointFieldTypes out_type;
+
+      pcl::uint8_t const * cast(pcl::uint8_t const * data) const {
+        if (out_type == field.datatype || field.name == "rgb" || field.name == "rgba") {
+          return data;
+        }
+        #define PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(type_idx) \
+           if (field.datatype == type_idx) { \
+             using type = typename traits::asType<type_idx>::type; \
+             type unpack_in_data = *reinterpret_cast<type const *>(data); \
+             set_buffer(out_type, unpack_in_data); \
+           }
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::INT8)
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::UINT8)
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::INT16)
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::UINT16)
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::INT32)
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::UINT32)
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::FLOAT32)
+        PCL_DETAIL_FIELD_MAPPING_CAT_SET_BUFFER(PCLPointField::PointFieldTypes::FLOAT64)
+        return _data;
+      }
+
+  private:
+    mutable pcl::uint8_t _data[8];
+
+    template <typename OutType, typename InType>
+      void set_buffer(InType unpack_in_data) const {
+        OutType unpack_out_data = static_cast<OutType>(unpack_in_data);
+        memcpy(_data, &unpack_out_data, sizeof(OutType));
+      }
+
+    template <typename InType>
+      void set_buffer(uint8_t out_type, InType unpack_in_data) const {
+        #define PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(type_idx) \
+           if (out_type == type_idx) { \
+             using type = typename traits::asType<type_idx>::type; \
+             set_buffer<type>(unpack_in_data); \
+           }
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::INT8)
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::UINT8)
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::INT16)
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::UINT16)
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::INT32)
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::UINT32)
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::FLOAT32)
+        PCL_DETAIL_FIELD_MAPPING_SET_BUFFER(PCLPointField::PointFieldTypes::FLOAT64)
+      }
     };
   } // namespace detail
 

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -45,6 +45,7 @@
 #include "pcl/pcl_macros.h"
 
 #include <pcl/PCLPointField.h>
+#include <pcl/console/print.h>
 #include <boost/mpl/assert.hpp>
 
 // This is required for the workaround at line 109
@@ -194,10 +195,14 @@ namespace pcl
   {
     bool operator() (const pcl::PCLPointField& field)
     {
-      return (field.name == traits::name<PointT, Tag>::value &&
-              field.datatype == traits::datatype<PointT, Tag>::value &&
-              (field.count == traits::datatype<PointT, Tag>::size ||
-               field.count == 0 && traits::datatype<PointT, Tag>::size == 1 /* see bug #821 */));
+      bool res = (field.name == traits::name<PointT, Tag>::value  &&
+          (field.count == traits::datatype<PointT, Tag>::size ||
+           field.count == 0 && traits::datatype<PointT, Tag>::size == 1 /* see bug #821 */));
+      if (res && field.datatype != traits::datatype<PointT, Tag>::value) {
+        PCL_WARN ("Failed to find exactly match for field '%s'. Need type casting\n",
+                  traits::name<PointT, Tag>::value);
+      }
+      return res;
     }
   };
 


### PR DESCRIPTION
   On PCL all vertices and normals exist only in float32 format. However, a lot of libraries and tools use float64 format. In original version, PCL don't recognize fields if types are not equals.

   This commit add auto type casting in conversion from pcl::PCLPointCloud2 to pcl::PointCloud<PointT>. This is allow read files, which are use float64 format.

   To reproduce test case, was written simple unit test.