### PR TITLE
Simplifying the resize logic in PCLBase

### DIFF
--- a/common/include/pcl/impl/pcl_base.hpp
+++ b/common/include/pcl/impl/pcl_base.hpp
@@ -146,6 +146,12 @@ pcl::PCLBase<PointT>::initCompute ()
   {
     fake_indices_ = true;
     indices_.reset (new std::vector<int>);
+  }
+
+  // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
+  if (fake_indices_ && indices_->size () != input_->points.size ())
+  {
+    size_t indices_size = indices_->size ();
     try
     {
       indices_->resize (input_->points.size ());
@@ -154,14 +160,6 @@ pcl::PCLBase<PointT>::initCompute ()
     {
       PCL_ERROR ("[initCompute] Failed to allocate %lu indices.\n", input_->points.size ());
     }
-    for (size_t i = 0; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
-  }
-
-  // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
-  if (fake_indices_ && indices_->size () != input_->points.size ())
-  {
-    size_t indices_size = indices_->size ();
-    indices_->resize (input_->points.size ());
     for (size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
   }
 

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -134,6 +134,12 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   {
     fake_indices_ = true;
     indices_.reset (new std::vector<int>);
+  }
+
+  // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
+  if (fake_indices_ && indices_->size () != (input_->width * input_->height))
+  {
+    size_t indices_size = indices_->size ();
     try
     {
       indices_->resize (input_->width * input_->height);
@@ -142,13 +148,6 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
     {
       PCL_ERROR ("[initCompute] Failed to allocate %lu indices.\n", (input_->width * input_->height));
     }
-    for (size_t i = 0; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
-  }
-  // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
-  if (fake_indices_ && indices_->size () != (input_->width * input_->height))
-  {
-    size_t indices_size = indices_->size ();
-    indices_->resize (input_->width * input_->height);
     for (size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
   }
 


### PR DESCRIPTION
Current path has repeated logic with dissimilar code resulting in `std::bad_alloc` not being caught in one case.