### PR TITLE
Removed boost::chrono from module [io]

### DIFF
--- a/cmake/pcl_find_boost.cmake
+++ b/cmake/pcl_find_boost.cmake
@@ -29,13 +29,8 @@ if(Boost_SERIALIZATION_FOUND)
 endif()
 
 # Required boost modules
-if(WITH_OPENNI2)
-set(BOOST_REQUIRED_MODULES filesystem date_time iostreams chrono system)
-find_package(Boost 1.55.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_MODULES})
-else()
 set(BOOST_REQUIRED_MODULES filesystem date_time iostreams system)
 find_package(Boost 1.55.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_MODULES})
-endif()
 
 if(Boost_FOUND)
   set(BOOST_FOUND TRUE)

--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -56,7 +56,6 @@
 #include <boost/mpl/transform.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/chrono.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
 #include <boost/shared_array.hpp>

--- a/io/include/pcl/io/image.h
+++ b/io/include/pcl/io/image.h
@@ -36,11 +36,11 @@
  
 #pragma once
 
-#include <pcl/pcl_config.h>
+#include <chrono>
 
+#include <pcl/pcl_config.h>
 #include <pcl/pcl_exports.h>
 #include <pcl/io/boost.h>
-#include <boost/chrono.hpp>
 
 #include <pcl/io/image_metadata_wrapper.h>
 
@@ -60,8 +60,8 @@ namespace pcl
         using Ptr = boost::shared_ptr<Image>;
         using ConstPtr = boost::shared_ptr<const Image>;
 
-        using Clock = boost::chrono::high_resolution_clock;
-        using Timestamp = boost::chrono::high_resolution_clock::time_point;
+        using Clock = std::chrono::high_resolution_clock;
+        using Timestamp = std::chrono::high_resolution_clock::time_point;
 
         enum Encoding
         {

--- a/io/include/pcl/io/image_depth.h
+++ b/io/include/pcl/io/image_depth.h
@@ -38,11 +38,11 @@
 
 #pragma once
 
-#include <pcl/pcl_config.h>
+#include <chrono>
 
+#include <pcl/pcl_config.h>
 #include <pcl/pcl_exports.h>
 #include <pcl/io/boost.h>
-#include <boost/chrono.hpp>
 
 #include<pcl/io/image_metadata_wrapper.h>
 
@@ -58,8 +58,8 @@ namespace pcl
         using Ptr = boost::shared_ptr<DepthImage>;
         using ConstPtr = boost::shared_ptr<const DepthImage>;
 
-        using Clock = boost::chrono::high_resolution_clock;
-        using Timestamp = boost::chrono::high_resolution_clock::time_point;
+        using Clock = std::chrono::high_resolution_clock;
+        using Timestamp = std::chrono::high_resolution_clock::time_point;
 
         /** \brief Constructor
           * \param[in] depth_metadata the actual data from the OpenNI library

--- a/io/include/pcl/io/image_ir.h
+++ b/io/include/pcl/io/image_ir.h
@@ -36,6 +36,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include <pcl/pcl_macros.h>
 #include <pcl/io/boost.h>
 
@@ -55,8 +57,8 @@ namespace pcl
         using Ptr = boost::shared_ptr<IRImage>;
         using ConstPtr = boost::shared_ptr<const IRImage>;
 
-        using Clock = boost::chrono::high_resolution_clock;
-        using Timestamp = boost::chrono::high_resolution_clock::time_point;
+        using Clock = std::chrono::high_resolution_clock;
+        using Timestamp = std::chrono::high_resolution_clock::time_point;
 
         IRImage (FrameWrapper::Ptr ir_metadata);
         IRImage (FrameWrapper::Ptr ir_metadata, Timestamp time);

--- a/io/include/pcl/io/image_rgb24.h
+++ b/io/include/pcl/io/image_rgb24.h
@@ -37,9 +37,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
-
 #include <pcl/pcl_macros.h>
-#include <boost/chrono.hpp>
 
 #include <pcl/io/image.h>
 

--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -33,7 +33,6 @@
 #include <PS1080.h> // For XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE property
 
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/chrono.hpp>
 
 #include "pcl/io/openni2/openni2_device.h"
 #include "pcl/io/openni2/openni2_convert.h"
@@ -48,8 +47,6 @@ using namespace pcl::io::openni2;
 
 using openni::VideoMode;
 using std::vector;
-
-using hr_clock = boost::chrono::high_resolution_clock;
 
 pcl::io::openni2::OpenNI2Device::OpenNI2Device (const std::string& device_URI) :
   ir_video_started_(false),


### PR DESCRIPTION
Last bit of `boost::chrono` left. Removed some dead-code too.

I've left the requirement of `boost::chrono` for OpenNI2 in the cmake

Adds one check-mark in the list of #2772