### PR TITLE
Add process to add/remove VTK path in PCL All-in-one Installer

### DIFF
--- a/cmake/Modules/NSIS.template.in
+++ b/cmake/Modules/NSIS.template.in
@@ -735,6 +735,13 @@ Section "-Add to path"
   StrCmp $DO_NOT_ADD_TO_PATH "1" doNotAddToPath 0
     Call AddToPath
   doNotAddToPath:
+  ; This is temporary solution for issue #1601.
+  Push $INSTDIR\3rdParty\VTK\bin
+  StrCmp "ON" "ON" 0 doNotAddVTKToPath
+  StrCmp $DO_NOT_ADD_TO_PATH "1" doNotAddVTKToPath 0
+  StrCmp $VTK_selected "0" doNotAddVTKToPath 0
+    Call AddToPath
+  doNotAddVTKToPath:
 SectionEnd
 
 ;--------------------------------
@@ -900,6 +907,12 @@ Section "Uninstall"
   StrCmp $DO_NOT_ADD_TO_PATH "1" doNotRemoveFromPath 0
     Call un.RemoveFromPath
   doNotRemoveFromPath:
+  ; This is temporary solution for issue #1601.
+  Push $INSTDIR\3rdParty\VTK\bin
+  StrCmp $DO_NOT_ADD_TO_PATH "1" doNotRemoveVTKFromPath 0
+  StrCmp $VTK_was_installed "0" doNotRemoveVTKFromPath 0
+    Call un.RemoveFromPath
+  doNotRemoveVTKFromPath:
 SectionEnd
 
 ;--------------------------------

--- a/cmake/Modules/NSIS.template.in
+++ b/cmake/Modules/NSIS.template.in
@@ -897,7 +897,7 @@ Section "Uninstall"
   DeleteRegValue SHCTX "Software\Kitware\CMake\Packages\@CPACK_PACKAGE_NAME@" "@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@"
 
   Push $INSTDIR\bin
-  StrCmp $DO_NOT_ADD_TO_PATH_ "1" doNotRemoveFromPath 0
+  StrCmp $DO_NOT_ADD_TO_PATH "1" doNotRemoveFromPath 0
     Call un.RemoveFromPath
   doNotRemoveFromPath:
 SectionEnd


### PR DESCRIPTION
This pull request has two changes.

* Fix uninstall process to remove environment variable.
  The variable name contained an unnecessary underscore.
  The conditional expression is always false and always runing process to remove variable.
  (It has not been a problem so far, because the remove path process that are not included in environment variables as there is virtually no change.)
  ```patch
  - StrCmp $DO_NOT_ADD_TO_PATH_ "1" doNotRemoveFromPath 0
  + StrCmp $DO_NOT_ADD_TO_PATH "1" doNotRemoveFromPath 0
  ```

* Add install and uninstall process to add and remove VTK path to environment variables PATH.
  This installer change for a temporary solution (It can be avoided by changing to dynamic linked VTK) for issue #1601. It just add/remove the VTK path in addition to the PCL path.
  I have already tested this installer/uninstaller on my environment. It works correctly without problem which option choose. It means we are ready to generate and publish the PCL 1.10.0 All-In-One Installer (that include pre-built PCL with dynamic linked VTK as a temporary solution for this issue).
  ```
  C:\Program Files\PCL\bin
  C:\Program Files\PCL\3rdParty\VTK\bin
  ```
  Note: This change should be undone once the issue #1601 is resolved.