### PR TITLE
Navigate to test folder before running ctest in Windows jobs on Azure

### DIFF
--- a/.ci/azure-pipelines/build-windows.yml
+++ b/.ci/azure-pipelines/build-windows.yml
@@ -37,7 +37,7 @@ jobs:
         displayName: 'CMake Configuration'
       - script: cd %BUILD_DIR% && cmake --build . --config %CONFIGURATION%
         displayName: 'Build Library'
-      - script: cd %BUILD_DIR% && ctest -C %CONFIGURATION% -V -T Test
+      - script: cd %BUILD_DIR%/test && ctest -C %CONFIGURATION% -V -T Test
         displayName: 'Run Unit Tests'
       - task: PublishTestResults@2
         inputs:


### PR DESCRIPTION
The unit tests are not run in our CI Windows jobs. We had similar issue with OSX and Ubuntu jobs before and fixed it with #3201. This PR applies the same fix to the Windows job.