### PR TITLE
Use std::cout/std::cerr/std::endl instead of just cout/cerr/end…

### DIFF
--- a/apps/src/feature_matching.cpp
+++ b/apps/src/feature_matching.cpp
@@ -172,7 +172,7 @@ ICCVTutorial<FeatureType>::ICCVTutorial(pcl::Keypoint<pcl::PointXYZRGB, pcl::Poi
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::segmentation (const typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& source, const typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr& segmented) const
 {
-  cout << "segmentation..." << std::flush;
+  std::cout << "segmentation..." << std::flush;
   // fit plane and keep points above that plane
   pcl::ModelCoefficients::Ptr coefficients (new pcl::ModelCoefficients);
   pcl::PointIndices::Ptr inliers (new pcl::PointIndices);
@@ -196,9 +196,9 @@ void ICCVTutorial<FeatureType>::segmentation (const typename pcl::PointCloud<pcl
   extract.filter (*segmented);
   std::vector<int> indices;
   pcl::removeNaNFromPointCloud(*segmented, *segmented, indices);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 
-  cout << "clustering..." << std::flush;
+  std::cout << "clustering..." << std::flush;
   // euclidean clustering
   typename pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZRGB>);
   tree->setInputCloud (segmented);
@@ -214,10 +214,10 @@ void ICCVTutorial<FeatureType>::segmentation (const typename pcl::PointCloud<pcl
 
   if (!cluster_indices.empty ())//use largest cluster
   {
-    cout << cluster_indices.size() << " clusters found";
+    std::cout << cluster_indices.size() << " clusters found";
     if (cluster_indices.size() > 1)
-      cout <<" Using largest one...";
-    cout << endl;
+      std::cout <<" Using largest one...";
+    std::cout << std::endl;
     typename pcl::IndicesPtr indices (new std::vector<int>);
     *indices = cluster_indices[0].indices;
     extract.setInputCloud (segmented);
@@ -231,10 +231,10 @@ void ICCVTutorial<FeatureType>::segmentation (const typename pcl::PointCloud<pcl
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::detectKeypoints (const typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& input, const pcl::PointCloud<pcl::PointXYZI>::Ptr& keypoints) const
 {
-  cout << "keypoint detection..." << std::flush;
+  std::cout << "keypoint detection..." << std::flush;
   keypoint_detector_->setInputCloud(input);
   keypoint_detector_->compute(*keypoints);
-  cout << "OK. keypoints found: " << keypoints->points.size() << endl;
+  std::cout << "OK. keypoints found: " << keypoints->points.size() << std::endl;
 }
 
 template<typename FeatureType>
@@ -253,7 +253,7 @@ void ICCVTutorial<FeatureType>::extractDescriptors (typename pcl::PointCloud<pcl
   if (feature_from_normals)
   //if (boost::dynamic_pointer_cast<typename pcl::FeatureFromNormals<pcl::PointXYZRGB, pcl::Normal, FeatureType> > (feature_extractor_))
   {
-    cout << "normal estimation..." << std::flush;
+    std::cout << "normal estimation..." << std::flush;
     typename pcl::PointCloud<pcl::Normal>::Ptr normals (new  pcl::PointCloud<pcl::Normal>);
     pcl::NormalEstimation<pcl::PointXYZRGB, pcl::Normal> normal_estimation;
     normal_estimation.setSearchMethod (pcl::search::Search<pcl::PointXYZRGB>::Ptr (new pcl::search::KdTree<pcl::PointXYZRGB>));
@@ -261,18 +261,18 @@ void ICCVTutorial<FeatureType>::extractDescriptors (typename pcl::PointCloud<pcl
     normal_estimation.setInputCloud (input);
     normal_estimation.compute (*normals);
     feature_from_normals->setInputNormals(normals);
-    cout << "OK" << endl;
+    std::cout << "OK" << std::endl;
   }
 
-  cout << "descriptor extraction..." << std::flush;
+  std::cout << "descriptor extraction..." << std::flush;
   feature_extractor_->compute (*features);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::findCorrespondences (typename pcl::PointCloud<FeatureType>::Ptr source, typename pcl::PointCloud<FeatureType>::Ptr target, std::vector<int>& correspondences) const
 {
-  cout << "correspondence assignment..." << std::flush;
+  std::cout << "correspondence assignment..." << std::flush;
   correspondences.resize (source->size());
 
   // Use a KdTree to search for the nearest matches in feature space
@@ -288,13 +288,13 @@ void ICCVTutorial<FeatureType>::findCorrespondences (typename pcl::PointCloud<Fe
     descriptor_kdtree.nearestKSearch (*source, i, k, k_indices, k_squared_distances);
     correspondences[i] = k_indices[0];
   }
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::filterCorrespondences ()
 {
-  cout << "correspondence rejection..." << std::flush;
+  std::cout << "correspondence rejection..." << std::flush;
   std::vector<std::pair<unsigned, unsigned> > correspondences;
   for (size_t cIdx = 0; cIdx < source2target_.size (); ++cIdx)
     if (target2source_[source2target_[cIdx]] == static_cast<int> (cIdx))
@@ -312,25 +312,25 @@ void ICCVTutorial<FeatureType>::filterCorrespondences ()
   rejector.setInputTarget (target_keypoints_);
   rejector.setInputCorrespondences(correspondences_);
   rejector.getCorrespondences(*correspondences_);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::determineInitialTransformation ()
 {
-  cout << "initial alignment..." << std::flush;
+  std::cout << "initial alignment..." << std::flush;
   pcl::registration::TransformationEstimation<pcl::PointXYZI, pcl::PointXYZI>::Ptr transformation_estimation (new pcl::registration::TransformationEstimationSVD<pcl::PointXYZI, pcl::PointXYZI>);
 
   transformation_estimation->estimateRigidTransformation (*source_keypoints_, *target_keypoints_, *correspondences_, initial_transformation_matrix_);
 
   pcl::transformPointCloud(*source_segmented_, *source_transformed_, initial_transformation_matrix_);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::determineFinalTransformation ()
 {
-  cout << "final registration..." << std::flush;
+  std::cout << "final registration..." << std::flush;
   pcl::Registration<pcl::PointXYZRGB, pcl::PointXYZRGB>::Ptr registration (new pcl::IterativeClosestPoint<pcl::PointXYZRGB, pcl::PointXYZRGB>);
   registration->setInputSource (source_transformed_);
   //registration->setInputSource (source_segmented_);
@@ -341,13 +341,13 @@ void ICCVTutorial<FeatureType>::determineFinalTransformation ()
   registration->setMaximumIterations (1000);
   registration->align(*source_registered_);
   transformation_matrix_ = registration->getFinalTransformation();
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::reconstructSurface ()
 {
-  cout << "surface reconstruction..." << std::flush;
+  std::cout << "surface reconstruction..." << std::flush;
   // merge the transformed and the target point cloud
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr merged (new pcl::PointCloud<pcl::PointXYZRGB>);
   *merged = *source_registered_;
@@ -375,7 +375,7 @@ void ICCVTutorial<FeatureType>::reconstructSurface ()
   surface_reconstructor_->setSearchMethod(tree);
   surface_reconstructor_->setInputCloud(vertices);
   surface_reconstructor_->reconstruct(surface_);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -180,13 +180,13 @@ class NILinemod
     keyboard_callback (const visualization::KeyboardEvent&, void*)
     {
       //if (event.getKeyCode())
-      //  cout << "the key \'" << event.getKeyCode() << "\' (" << event.getKeyCode() << ") was";
+      //  std::cout << "the key \'" << event.getKeyCode() << "\' (" << event.getKeyCode() << ") was";
       //else
-      //  cout << "the special key \'" << event.getKeySym() << "\' was";
+      //  std::cout << "the special key \'" << event.getKeySym() << "\' was";
       //if (event.keyDown())
-      //  cout << " pressed" << endl;
+      //  std::cout << " pressed" << std::endl;
       //else
-      //  cout << " released" << endl;
+      //  std::cout << " released" << std::endl;
     }
     
     /////////////////////////////////////////////////////////////////////////
@@ -195,7 +195,7 @@ class NILinemod
     {
       //if (mouse_event.getType() == visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == visualization::MouseEvent::LeftButton)
       //{
-      //  cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+      //  std::cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
       //}
     }
 

--- a/apps/src/openni_3d_concave_hull.cpp
+++ b/apps/src/openni_3d_concave_hull.cpp
@@ -177,15 +177,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int

--- a/apps/src/openni_3d_convex_hull.cpp
+++ b/apps/src/openni_3d_convex_hull.cpp
@@ -175,15 +175,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int

--- a/apps/src/openni_boundary_estimation.cpp
+++ b/apps/src/openni_boundary_estimation.cpp
@@ -196,15 +196,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int 

--- a/apps/src/openni_color_filter.cpp
+++ b/apps/src/openni_color_filter.cpp
@@ -83,7 +83,7 @@ class OpenNIPassthrough
        if (lookup[i])
         ++set;
         
-      cout << "used colors: " << set << endl;
+      std::cout << "used colors: " << set << std::endl;
       
       color_filter_.setLookUpTable (lookup);
     }
@@ -158,15 +158,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << (int)driver.getBus (deviceIdx) << " @ " << (int)driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << (int)driver.getBus (deviceIdx) << " @ " << (int)driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int
@@ -192,7 +192,7 @@ main (int argc, char ** argv)
 
   if (pcl::console::parse_3x_arguments (argc, argv, "-rgb", rr, gg, bb, true) != -1 )
   {
-    cout << "-rgb present" << endl;
+    std::cout << "-rgb present" << std::endl;
     int rad;
     int idx = pcl::console::parse_argument (argc, argv, "-radius", rad);
     if (idx != -1)
@@ -217,7 +217,7 @@ main (int argc, char ** argv)
   }
   else
   {
-    cout << "device does not provide rgb stream" << endl;
+    std::cout << "device does not provide rgb stream" << std::endl;
   }
 
   return (0);

--- a/apps/src/openni_fast_mesh.cpp
+++ b/apps/src/openni_fast_mesh.cpp
@@ -162,15 +162,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int

--- a/apps/src/openni_feature_persistence.cpp
+++ b/apps/src/openni_feature_persistence.cpp
@@ -242,15 +242,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int

--- a/apps/src/openni_grab_images.cpp
+++ b/apps/src/openni_grab_images.cpp
@@ -250,7 +250,7 @@ class OpenNIGrabFrame
             writer_->SetFileName (ss.str ().c_str ());
             writer_->SetInputConnection (flipper_->GetOutputPort ());
             writer_->Write ();
-            cout << "writing rgb frame: " << ss.str () << endl;
+            std::cout << "writing rgb frame: " << ss.str () << std::endl;
           }
         } // if (image_)
         
@@ -282,7 +282,7 @@ class OpenNIGrabFrame
             writer_->SetFileName (ss.str ().c_str ());
             writer_->SetInputConnection (flipper_->GetOutputPort ());
             writer_->Write ();
-            cout << "writing depth frame: " << ss.str () << endl;
+            std::cout << "writing depth frame: " << ss.str () << std::endl;
           }
         }
         trigger_ = false;
@@ -314,35 +314,35 @@ class OpenNIGrabFrame
 void
 usage (char ** argv)
 {
-  cout << "usage: " << argv[0] << " [((<device_id> | <path-to-oni-file>) [-imagemode <mode>] [-depthformat <format>] [-paused] | -l [<device_id>]| -h | --help)]" << endl;
-  cout << argv[0] << " -h | --help : shows this help" << endl;
-  cout << argv[0] << " -l : list all available devices" << endl;
-  cout << argv[0] << " -l <device-id> : list all available modes for specified device" << endl;
+  std::cout << "usage: " << argv[0] << " [((<device_id> | <path-to-oni-file>) [-imagemode <mode>] [-depthformat <format>] [-paused] | -l [<device_id>]| -h | --help)]" << std::endl;
+  std::cout << argv[0] << " -h | --help : shows this help" << std::endl;
+  std::cout << argv[0] << " -l : list all available devices" << std::endl;
+  std::cout << argv[0] << " -l <device-id> : list all available modes for specified device" << std::endl;
 
-  cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
+  std::cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
 #ifndef _WIN32
-       << " or" << endl
-       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << endl
+       << " or" << std::endl
+       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << std::endl
        << "                 <serial-number>"
 #endif
-       << endl;
-  cout << "                 -paused : start grabber in paused mode. Toggle pause by pressing the space bar\n";
-  cout << "                           or grab single frames by just pressing the left mouse button.\n";
-  cout << endl;
-  cout << "examples:" << endl;
-  cout << argv[0] << " \"#1\"" << endl;
-  cout << "    uses the first device." << endl;
-  cout << argv[0] << " \"./temp/test.oni\"" << endl;
-  cout << "    uses the oni-player device to play back oni file given by path." << endl;
-  cout << argv[0] << " -l" << endl;
-  cout << "    lists all available devices." << endl;
-  cout << argv[0] << " -l \"#2\"" << endl;
-  cout << "    lists all available modes for the second device" << endl;
+       << std::endl;
+  std::cout << "                 -paused : start grabber in paused mode. Toggle pause by pressing the space bar\n";
+  std::cout << "                           or grab single frames by just pressing the left mouse button.\n";
+  std::cout << std::endl;
+  std::cout << "examples:" << std::endl;
+  std::cout << argv[0] << " \"#1\"" << std::endl;
+  std::cout << "    uses the first device." << std::endl;
+  std::cout << argv[0] << " \"./temp/test.oni\"" << std::endl;
+  std::cout << "    uses the oni-player device to play back oni file given by path." << std::endl;
+  std::cout << argv[0] << " -l" << std::endl;
+  std::cout << "    lists all available devices." << std::endl;
+  std::cout << argv[0] << " -l \"#2\"" << std::endl;
+  std::cout << "    lists all available modes for the second device" << std::endl;
 #ifndef _WIN32
-  cout << argv[0] << " A00361800903049A" << endl;
-  cout << "    uses the device with the serial number \'A00361800903049A\'." << endl;
-  cout << argv[0] << " 1@16" << endl;
-  cout << "    uses the device on address 16 at USB bus 1." << endl;
+  std::cout << argv[0] << " A00361800903049A" << std::endl;
+  std::cout << "    uses the device with the serial number \'A00361800903049A\'." << std::endl;
+  std::cout << argv[0] << " 1@16" << std::endl;
+  std::cout << "    uses the device on address 16 at USB bus 1." << std::endl;
 #endif  
 }
 
@@ -370,11 +370,11 @@ main (int argc, char** argv)
 
         if (device->hasImageStream ())
         {
-          cout << endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << endl;
+          std::cout << std::endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << std::endl;
           modes = grabber.getAvailableImageModes ();
           for (std::vector<std::pair<int, XnMapOutputMode> >::const_iterator it = modes.begin (); it != modes.end (); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         }
       }
@@ -385,15 +385,15 @@ main (int argc, char** argv)
         {
           for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
           {
-            cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
+            std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
         
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return (0);
     }
@@ -402,7 +402,7 @@ main (int argc, char** argv)
   {
     openni_wrapper::OpenNIDriver& driver = openni_wrapper::OpenNIDriver::getInstance ();
     if (driver.getNumberDevices() > 0)
-      cout << "Device Id not set, using first device." << endl;
+      std::cout << "Device Id not set, using first device." << std::endl;
   }
   
   unsigned mode;

--- a/apps/src/openni_ii_normal_estimation.cpp
+++ b/apps/src/openni_ii_normal_estimation.cpp
@@ -198,15 +198,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int

--- a/apps/src/openni_klt.cpp
+++ b/apps/src/openni_klt.cpp
@@ -196,7 +196,7 @@ class OpenNIViewer
     {
       if (mouse_event.getType() == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == pcl::visualization::MouseEvent::LeftButton)
       {
-        cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+        std::cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
       }
     }
 
@@ -336,20 +336,20 @@ main (int argc, char** argv)
       {
         pcl::OpenNIGrabber grabber(argv[2]);
         auto device = grabber.getDevice();
-        cout << "Supported depth modes for device: " << device->getVendorName() << " , " << device->getProductName() << endl;
+        std::cout << "Supported depth modes for device: " << device->getVendorName() << " , " << device->getProductName() << std::endl;
         std::vector<std::pair<int, XnMapOutputMode > > modes = grabber.getAvailableDepthModes();
         for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin(); it != modes.end(); ++it)
         {
-          cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+          std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
         }
 
         if (device->hasImageStream ())
         {
-          cout << endl << "Supported image modes for device: " << device->getVendorName() << " , " << device->getProductName() << endl;
+          std::cout << std::endl << "Supported image modes for device: " << device->getVendorName() << " , " << device->getProductName() << std::endl;
           modes = grabber.getAvailableImageModes();
           for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin(); it != modes.end(); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         }
       }
@@ -360,15 +360,15 @@ main (int argc, char** argv)
         {
           for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices(); ++deviceIdx)
           {
-            cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName(deviceIdx) << ", product: " << driver.getProductName(deviceIdx)
-              << ", connected: " << driver.getBus(deviceIdx) << " @ " << driver.getAddress(deviceIdx) << ", serial number: \'" << driver.getSerialNumber(deviceIdx) << "\'" << endl;
+            std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName(deviceIdx) << ", product: " << driver.getProductName(deviceIdx)
+              << ", connected: " << driver.getBus(deviceIdx) << " @ " << driver.getAddress(deviceIdx) << ", serial number: \'" << driver.getSerialNumber(deviceIdx) << "\'" << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
 
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return 0;
     }
@@ -377,7 +377,7 @@ main (int argc, char** argv)
   {
     openni_wrapper::OpenNIDriver& driver = openni_wrapper::OpenNIDriver::getInstance();
     if (driver.getNumberDevices() > 0)
-      cout << "Device Id not set, using first device." << endl;
+      std::cout << "Device Id not set, using first device." << std::endl;
   }
 
   unsigned mode;

--- a/apps/src/openni_mls_smoothing.cpp
+++ b/apps/src/openni_mls_smoothing.cpp
@@ -184,15 +184,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int

--- a/apps/src/openni_organized_edge_detection.cpp
+++ b/apps/src/openni_organized_edge_detection.cpp
@@ -259,15 +259,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int

--- a/apps/src/openni_planar_convex_hull.cpp
+++ b/apps/src/openni_planar_convex_hull.cpp
@@ -160,15 +160,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (wotks only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (wotks only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int 

--- a/apps/src/openni_planar_segmentation.cpp
+++ b/apps/src/openni_planar_segmentation.cpp
@@ -154,15 +154,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int 

--- a/apps/src/openni_uniform_sampling.cpp
+++ b/apps/src/openni_uniform_sampling.cpp
@@ -157,15 +157,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int 

--- a/apps/src/openni_voxel_grid.cpp
+++ b/apps/src/openni_voxel_grid.cpp
@@ -152,15 +152,15 @@ usage (char ** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
-      cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << endl
-           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << endl
-           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << endl;
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
+      std::cout << "device_id may be #1, #2, ... for the first second etc device in the list or" << std::endl
+           << "                 bus@address for the device connected to a specific usb-bus / address combination (works only in Linux) or" << std::endl
+           << "                 <serial-number> (only in Linux and for devices which provide serial numbers)"  << std::endl;
     }
   }
   else
-    cout << "No devices connected." << endl;
+    std::cout << "No devices connected." << std::endl;
 }
 
 int 

--- a/apps/src/pcd_select_object_plane.cpp
+++ b/apps/src/pcd_select_object_plane.cpp
@@ -129,13 +129,13 @@ class ObjectSelection
     keyboard_callback (const visualization::KeyboardEvent&, void*)
     {
       //if (event.getKeyCode())
-      //  cout << "the key \'" << event.getKeyCode() << "\' (" << event.getKeyCode() << ") was";
+      //  std::cout << "the key \'" << event.getKeyCode() << "\' (" << event.getKeyCode() << ") was";
       //else
-      //  cout << "the special key \'" << event.getKeySym() << "\' was";
+      //  std::cout << "the special key \'" << event.getKeySym() << "\' was";
       //if (event.keyDown())
-      //  cout << " pressed" << endl;
+      //  std::cout << " pressed" << std::endl;
       //else
-      //  cout << " released" << endl;
+      //  std::cout << " released" << std::endl;
     }
     
     /////////////////////////////////////////////////////////////////////////
@@ -144,7 +144,7 @@ class ObjectSelection
     {
       if (mouse_event.getType() == visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == visualization::MouseEvent::LeftButton)
       {
-        cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+        std::cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
       }
     }
 

--- a/apps/src/pyramid_surface_matching.cpp
+++ b/apps/src/pyramid_surface_matching.cpp
@@ -34,7 +34,7 @@ subsampleAndCalculateNormals (PointCloud<PointXYZ>::Ptr &cloud,
   normal_estimation_filter.setRadiusSearch (normal_estimation_search_radius);
   normal_estimation_filter.compute (*cloud_subsampled_normals);
 
-  cerr << "Before -> After subsampling: " << cloud->points.size () << " -> " << cloud_subsampled->points.size () << endl;
+  std::cerr << "Before -> After subsampling: " << cloud->points.size () << " -> " << cloud_subsampled->points.size () << std::endl;
 }
 
 

--- a/apps/src/statistical_multiscale_interest_region_extraction_example.cpp
+++ b/apps/src/statistical_multiscale_interest_region_extraction_example.cpp
@@ -56,14 +56,14 @@ main (int, char **argv)
   PCDReader reader;
   reader.read (argv[1], *cloud);
   PCL_INFO ("Cloud read: %s\n", argv[1]);
-  cerr << "cloud has #points: " << cloud->points.size () << endl;
+  std::cerr << "cloud has #points: " << cloud->points.size () << std::endl;
 
   PointCloud<PointXYZ>::Ptr cloud_subsampled (new PointCloud<PointXYZ> ());
   VoxelGrid<PointXYZ> subsampling_filter;
   subsampling_filter.setInputCloud (cloud);
   subsampling_filter.setLeafSize (subsampling_leaf_size, subsampling_leaf_size, subsampling_leaf_size);
   subsampling_filter.filter (*cloud_subsampled);
-  cerr << "subsampled cloud has #points: " << cloud_subsampled->points.size () << endl;
+  std::cerr << "subsampled cloud has #points: " << cloud_subsampled->points.size () << std::endl;
 
   StatisticalMultiscaleInterestRegionExtraction<PointXYZ> region_extraction;
   std::vector<float> scale_vector;

--- a/apps/src/test_search.cpp
+++ b/apps/src/test_search.cpp
@@ -33,7 +33,7 @@ main (int argc, char ** argv)
 
   if (radius < 0 && k < 0)
   {
-    cout << "please specify at least one of the options -radius and -knn" << endl;
+    std::cout << "please specify at least one of the options -radius and -knn" << std::endl;
     return (1);
   }
 
@@ -74,64 +74,64 @@ main (int argc, char ** argv)
     start = pcl::getTime ();
     tree.setInputCloud (cloud);
     stop = pcl::getTime ();
-    cout << "setting up kd tree: " << (kd_setup = stop - start) << endl;
+    std::cout << "setting up kd tree: " << (kd_setup = stop - start) << std::endl;
 
     start = pcl::getTime ();
     tree.nearestKSearchT (query, k, kd_indices, kd_distances);
     stop = pcl::getTime ();
-    cout << "single search with kd tree; " << (kd_search = stop - start) << " :: " << kd_indices[0] << " , " << kd_distances [0] << endl;
+    std::cout << "single search with kd tree; " << (kd_search = stop - start) << " :: " << kd_indices[0] << " , " << kd_distances [0] << std::endl;
 
     pcl::search::BruteForce<pcl::PointXYZRGB> brute_force;
     start = pcl::getTime ();
     brute_force.setInputCloud (cloud);
     stop = pcl::getTime ();
-    cout << "setting up brute force search: " << (bf_setup = stop - start) << endl;
+    std::cout << "setting up brute force search: " << (bf_setup = stop - start) << std::endl;
 
     start = pcl::getTime ();
     brute_force.nearestKSearchT (query, k, bf_indices, bf_distances);
     stop = pcl::getTime ();
-    cout << "single search with brute force; " << (bf_search = stop - start) << " :: " << bf_indices[0] << " , " << bf_distances [0] << endl;
-    cout << "amortization after searches: " << (kd_setup - bf_setup) / (bf_search - kd_search) << endl;
+    std::cout << "single search with brute force; " << (bf_search = stop - start) << " :: " << bf_indices[0] << " , " << bf_distances [0] << std::endl;
+    std::cout << "amortization after searches: " << (kd_setup - bf_setup) / (bf_search - kd_search) << std::endl;
   }
   else
   {
     start = pcl::getTime ();
     tree.setInputCloud (cloud);
     stop = pcl::getTime ();
-    cout << "setting up kd tree: " << (kd_setup = stop - start) << endl;
+    std::cout << "setting up kd tree: " << (kd_setup = stop - start) << std::endl;
 
     start = pcl::getTime ();
     tree.radiusSearch (query, radius, kd_indices, kd_distances, k);
     stop = pcl::getTime ();
-    cout << "single search with kd tree; " << (kd_search = stop - start) << " :: " << kd_indices[0] << " , " << kd_distances [0] << endl;
+    std::cout << "single search with kd tree; " << (kd_search = stop - start) << " :: " << kd_indices[0] << " , " << kd_distances [0] << std::endl;
 
     pcl::search::BruteForce<pcl::PointXYZRGB> brute_force;
     start = pcl::getTime ();
     brute_force.setInputCloud (cloud);
     stop = pcl::getTime ();
-    cout << "setting up brute force search: " << (bf_setup = stop - start) << endl;
+    std::cout << "setting up brute force search: " << (bf_setup = stop - start) << std::endl;
 
     start = pcl::getTime ();
     brute_force.radiusSearch (query, radius, bf_indices, bf_distances, k);
     stop = pcl::getTime ();
-    cout << "single search with brute force; " << (bf_search = stop - start) << " :: " << bf_indices[0] << " , " << bf_distances [0] << endl;
-    cout << "amortization after searches: " << (kd_setup - bf_setup) / (bf_search - kd_search) << endl;
+    std::cout << "single search with brute force; " << (bf_search = stop - start) << " :: " << bf_indices[0] << " , " << bf_distances [0] << std::endl;
+    std::cout << "amortization after searches: " << (kd_setup - bf_setup) / (bf_search - kd_search) << std::endl;
   }
 
   if (kd_indices.size () != bf_indices.size ())
   {
-    cerr << "size of results do not match " <<kd_indices.size () << " vs. " << bf_indices.size () << endl;
+    std::cerr << "size of results do not match " <<kd_indices.size () << " vs. " << bf_indices.size () << std::endl;
   }
   else
   {
-    cerr << "size of result: " <<kd_indices.size () << endl;
+    std::cerr << "size of result: " <<kd_indices.size () << std::endl;
     for (size_t idx = 0; idx < kd_indices.size (); ++idx)
     {
       if (kd_indices[idx] != bf_indices[idx] && kd_distances[idx] != bf_distances[idx])
       {
-        cerr << "results do not match: " << idx << " nearest neighbor: "
+        std::cerr << "results do not match: " << idx << " nearest neighbor: "
                 << kd_indices[idx] << " with distance: " << kd_distances[idx] << " vs. "
-                << bf_indices[idx] << " with distance: " << bf_distances[idx] << endl;
+                << bf_indices[idx] << " with distance: " << bf_distances[idx] << std::endl;
       }
     }
   }

--- a/common/include/pcl/common/impl/file_io.hpp
+++ b/common/include/pcl/common/impl/file_io.hpp
@@ -62,7 +62,7 @@ namespace pcl
     closedir(dp);
     std::sort(file_names.begin(), file_names.end());
     //for (unsigned int i=0; i<file_names.size(); ++i)
-      //cout << file_names[i]<<"\n";
+      //std::cout << file_names[i]<<"\n";
   }
 #endif
 

--- a/common/include/pcl/common/impl/piecewise_linear_function.hpp
+++ b/common/include/pcl/common/impl/piecewise_linear_function.hpp
@@ -48,7 +48,7 @@ inline float PiecewiseLinearFunction::getValue(float point) const
   float floored_vector_pos = std::floor(vector_pos);
   float interpolation_size = vector_pos-floored_vector_pos;
   int data_point_before = (std::max)(0, (std::min)(int(data_points_.size())-2, int(lrint(floored_vector_pos))));
-  //cout << "Interpolating between "<<data_point_before<<" and "<<data_point_before+1<<" with value "
+  //std::cout << "Interpolating between "<<data_point_before<<" and "<<data_point_before+1<<" with value "
        //<< interpolation_size<<" (vector size is "<<data_points_.size()<<").\n";
   return data_points_[data_point_before]+interpolation_size*(data_points_[data_point_before+1]-data_points_[data_point_before]);
 }

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -68,7 +68,7 @@ template <typename real>
 inline void
   pcl::PolynomialCalculationsT<real>::solveLinearEquation (real a, real b, std::vector<real>& roots) const
 {
-  //cout << "Trying to solve "<<a<<"x + "<<b<<" = 0\n";
+  //std::cout << "Trying to solve "<<a<<"x + "<<b<<" = 0\n";
 
   if (isNearlyZero (b))
   {
@@ -80,17 +80,17 @@ inline void
   }
 
 #if 0
-  cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
+  std::cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
   for (unsigned int i=0; i<roots.size (); i++)
   {
     real x=roots[i];
     real result = a*x + b;
     if (!isNearlyZero (result))
     {
-      cout << "Something went wrong during solving of polynomial "<<a<<"x + "<<b<<" = 0\n";
+      std::cout << "Something went wrong during solving of polynomial "<<a<<"x + "<<b<<" = 0\n";
       //roots.clear ();
     }
-    cout << "Root "<<i<<" = "<<roots[i]<<". ("<<a<<"x^ + "<<b<<" = "<<result<<")\n";
+    std::cout << "Root "<<i<<" = "<<roots[i]<<". ("<<a<<"x^ + "<<b<<" = "<<result<<")\n";
   }
 #endif
 }
@@ -101,11 +101,11 @@ template <typename real>
 inline void
   pcl::PolynomialCalculationsT<real>::solveQuadraticEquation (real a, real b, real c, std::vector<real>& roots) const
 {
-  //cout << "Trying to solve "<<a<<"x^2 + "<<b<<"x + "<<c<<" = 0\n";
+  //std::cout << "Trying to solve "<<a<<"x^2 + "<<b<<"x + "<<c<<" = 0\n";
 
   if (isNearlyZero (a))
   {
-    //cout << "Highest order element is 0 => Calling solveLineaqrEquation.\n";
+    //std::cout << "Highest order element is 0 => Calling solveLineaqrEquation.\n";
     solveLinearEquation (b, c, roots);
     return;
   }
@@ -113,7 +113,7 @@ inline void
   if (isNearlyZero (c))
   {
     roots.push_back (0.0);
-    //cout << "Constant element is 0 => Adding root 0 and calling solveLinearEquation.\n";
+    //std::cout << "Constant element is 0 => Adding root 0 and calling solveLinearEquation.\n";
     std::vector<real> tmpRoots;
     solveLinearEquation (a, b, tmpRoots);
     for (unsigned int i=0; i<tmpRoots.size (); i++)
@@ -136,17 +136,17 @@ inline void
   }
 
 #if 0
-  cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
+  std::cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
   for (unsigned int i=0; i<roots.size (); i++)
   {
     real x=roots[i], x2=x*x;
     real result = a*x2 + b*x + c;
     if (!isNearlyZero (result))
     {
-      cout << "Something went wrong during solving of polynomial "<<a<<"x^2 + "<<b<<"x + "<<c<<" = 0\n";
+      std::cout << "Something went wrong during solving of polynomial "<<a<<"x^2 + "<<b<<"x + "<<c<<" = 0\n";
       //roots.clear ();
     }
-    //cout << "Root "<<i<<" = "<<roots[i]<<". ("<<a<<"x^2 + "<<b<<"x + "<<c<<" = "<<result<<")\n";
+    //std::cout << "Root "<<i<<" = "<<roots[i]<<". ("<<a<<"x^2 + "<<b<<"x + "<<c<<" = "<<result<<")\n";
   }
 #endif
 }
@@ -157,11 +157,11 @@ template<typename real>
 inline void
   pcl::PolynomialCalculationsT<real>::solveCubicEquation (real a, real b, real c, real d, std::vector<real>& roots) const
 {
-  //cout << "Trying to solve "<<a<<"x^3 + "<<b<<"x^2 + "<<c<<"x + "<<d<<" = 0\n";
+  //std::cout << "Trying to solve "<<a<<"x^3 + "<<b<<"x^2 + "<<c<<"x + "<<d<<" = 0\n";
 
   if (isNearlyZero (a))
   {
-    //cout << "Highest order element is 0 => Calling solveQuadraticEquation.\n";
+    //std::cout << "Highest order element is 0 => Calling solveQuadraticEquation.\n";
     solveQuadraticEquation (b, c, d, roots);
     return;
   }
@@ -169,7 +169,7 @@ inline void
   if (isNearlyZero (d))
   {
     roots.push_back (0.0);
-    //cout << "Constant element is 0 => Adding root 0 and calling solveQuadraticEquation.\n";
+    //std::cout << "Constant element is 0 => Adding root 0 and calling solveQuadraticEquation.\n";
     std::vector<real> tmpRoots;
     solveQuadraticEquation (a, b, c, tmpRoots);
     for (unsigned int i=0; i<tmpRoots.size (); i++)
@@ -191,11 +191,11 @@ inline void
   // Value for resubstitution:
   double resubValue = b/ (3*a);
 
-  //cout << "Trying to solve y^3 + "<<alpha<<"y + "<<beta<<"\n";
+  //std::cout << "Trying to solve y^3 + "<<alpha<<"y + "<<beta<<"\n";
 
   double discriminant = (alpha3/27.0) + 0.25*beta2;
 
-  //cout << "Discriminant is "<<discriminant<<"\n";
+  //std::cout << "Discriminant is "<<discriminant<<"\n";
 
   if (isNearlyZero (discriminant))
   {
@@ -224,7 +224,7 @@ inline void
     else
       d2 = pow (d2, 1.0/3.0);
 
-    //cout << PVAR (d1)<<", "<<PVAR (d2)<<"\n";
+    //std::cout << PVAR (d1)<<", "<<PVAR (d2)<<"\n";
     roots.push_back (d1 + d2 - resubValue);
   }
   else
@@ -237,19 +237,19 @@ inline void
   }
 
 #if 0
-  cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
+  std::cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
   for (unsigned int i=0; i<roots.size (); i++)
   {
     real x=roots[i], x2=x*x, x3=x2*x;
     real result = a*x3 + b*x2 + c*x + d;
     if (std::abs (result) > 1e-4)
     {
-      cout << "Something went wrong:\n";
+      std::cout << "Something went wrong:\n";
       //roots.clear ();
     }
-    cout << "Root "<<i<<" = "<<roots[i]<<". ("<<a<<"x^3 + "<<b<<"x^2 + "<<c<<"x + "<<d<<" = "<<result<<")\n";
+    std::cout << "Root "<<i<<" = "<<roots[i]<<". ("<<a<<"x^3 + "<<b<<"x^2 + "<<c<<"x + "<<d<<" = "<<result<<")\n";
   }
-  cout << "\n\n";
+  std::cout << "\n\n";
 #endif
 }
 
@@ -260,11 +260,11 @@ inline void
   pcl::PolynomialCalculationsT<real>::solveQuarticEquation (real a, real b, real c, real d, real e,
                                                             std::vector<real>& roots) const
 {
-  //cout << "Trying to solve "<<a<<"x^4 + "<<b<<"x^3 + "<<c<<"x^2 + "<<d<<"x + "<<e<<" = 0\n";
+  //std::cout << "Trying to solve "<<a<<"x^4 + "<<b<<"x^3 + "<<c<<"x^2 + "<<d<<"x + "<<e<<" = 0\n";
 
   if (isNearlyZero (a))
   {
-    //cout << "Highest order element is 0 => Calling solveCubicEquation.\n";
+    //std::cout << "Highest order element is 0 => Calling solveCubicEquation.\n";
     solveCubicEquation (b, c, d, e, roots);
     return;
   }
@@ -272,7 +272,7 @@ inline void
   if (isNearlyZero (e))
   {
     roots.push_back (0.0);
-    //cout << "Constant element is 0 => Adding root 0 and calling solveCubicEquation.\n";
+    //std::cout << "Constant element is 0 => Adding root 0 and calling solveCubicEquation.\n";
     std::vector<real> tmpRoots;
     solveCubicEquation (a, b, c, d, tmpRoots);
     for (unsigned int i=0; i<tmpRoots.size (); i++)
@@ -296,11 +296,11 @@ inline void
   // Value for resubstitution:
   double resubValue = b/ (4*a);
 
-  //cout << "Trying to solve y^4 + "<<alpha<<"y^2 + "<<beta<<"y + "<<gamma<<"\n";
+  //std::cout << "Trying to solve y^4 + "<<alpha<<"y^2 + "<<beta<<"y + "<<gamma<<"\n";
 
   if (isNearlyZero (beta))
   {  // y^4 + alpha*y^2 + gamma\n";
-    //cout << "Using beta=0 condition\n";
+    //std::cout << "Using beta=0 condition\n";
     std::vector<real> tmpRoots;
     solveQuadraticEquation (1.0, alpha, gamma, tmpRoots);
     for (unsigned int i=0; i<tmpRoots.size (); i++)
@@ -320,7 +320,7 @@ inline void
   }
   else
   {
-    //cout << "beta != 0\n";
+    //std::cout << "beta != 0\n";
     double alpha3 = alpha2*alpha,
            beta2 = beta*beta,
            p = (-alpha2/12.0)-gamma,
@@ -351,7 +351,7 @@ inline void
     }
     else
     {
-      //cout << "Found no roots\n";
+      //std::cout << "Found no roots\n";
       return;
     }
 
@@ -386,24 +386,24 @@ inline void
       roots.push_back (root3);
     }
 
-    //cout << "Test: " << alpha<<", "<<beta<<", "<<gamma<<", "<<p<<", "<<q<<", "<<u <<", "<<y<<", "<<w<<"\n";
+    //std::cout << "Test: " << alpha<<", "<<beta<<", "<<gamma<<", "<<p<<", "<<q<<", "<<u <<", "<<y<<", "<<w<<"\n";
   }
 
 #if 0
-  cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
+  std::cout << __PRETTY_FUNCTION__ << ": Found "<<roots.size ()<<" roots.\n";
   for (unsigned int i=0; i<roots.size (); i++)
   {
     real x=roots[i], x2=x*x, x3=x2*x, x4=x2*x2;
     real result = a*x4 + b*x3 + c*x2 + d*x + e;
     if (std::abs (result) > 1e-4)
     {
-      cout << "Something went wrong:\n";
+      std::cout << "Something went wrong:\n";
       //roots.clear ();
     }
-    cout << "Root "<<i<<" = "<<roots[i]
+    std::cout << "Root "<<i<<" = "<<roots[i]
          << ". ("<<a<<"x^4 + "<<b<<"x^3 + "<<c<<"x^2 + "<<d<<"x + "<<e<<" = "<<result<<")\n";
   }
-  cout << "\n\n";
+  std::cout << "\n\n";
 #endif
 }
 
@@ -429,9 +429,9 @@ inline bool
 {
   //MEASURE_FUNCTION_TIME;
   unsigned int parameters_size = BivariatePolynomialT<real>::getNoOfParametersFromDegree (polynomial_degree);
-  //cout << PVARN (parameters_size);
+  //std::cout << PVARN (parameters_size);
 
-  //cout << "Searching for the "<<parameters_size<<" parameters for the bivariate polynom of degree "
+  //std::cout << "Searching for the "<<parameters_size<<" parameters for the bivariate polynom of degree "
   //     << polynomial_degree<<" using "<<samplePoints.size ()<<" points.\n";
 
   if (parameters_size > samplePoints.size ()) // Too many parameters for this number of equations (points)?
@@ -440,7 +440,7 @@ inline bool
     // Reduce degree of polynomial
     //polynomial_degree = (unsigned int) (0.5f* (std::sqrt (8*samplePoints.size ()+1) - 3));
     //parameters_size = BivariatePolynomialT<real>::getNoOfParametersFromDegree (polynomial_degree);
-    //cout << "Not enough points, so degree of polynomial was decreased to "<<polynomial_degree
+    //std::cout << "Not enough points, so degree of polynomial was decreased to "<<polynomial_degree
     //     << " ("<<samplePoints.size ()<<" points => "<<parameters_size<<" parameters)\n";
   }
 
@@ -459,7 +459,7 @@ inline bool
        it!=samplePoints.end (); ++it)
   {
     currentX= (*it)[0]; currentY= (*it)[1]; currentZ= (*it)[2];
-    //cout << "current point: "<<currentX<<","<<currentY<<" => "<<currentZ<<"\n";
+    //std::cout << "current point: "<<currentX<<","<<currentY<<" => "<<currentZ<<"\n";
     //unsigned int posInC = parameters_size-1;
     real* tmpCPtr = tmpCEndPtr;
     tmpX = 1.0;
@@ -469,7 +469,7 @@ inline bool
       for (unsigned int yDegree=0; yDegree<=polynomial_degree-xDegree; ++yDegree)
       {
         * (tmpCPtr--) = tmpX*tmpY;
-        //cout << "x="<<currentX<<", y="<<currentY<<", Pos "<<posInC--<<": "<<tmpX<<"*"<<tmpY<<"="<<tmpC[posInC]<<"\n";
+        //std::cout << "x="<<currentX<<", y="<<currentY<<", Pos "<<posInC--<<": "<<tmpX<<"*"<<tmpY<<"="<<tmpC[posInC]<<"\n";
         tmpY *= currentY;
       }
       tmpX *= currentX;
@@ -493,9 +493,9 @@ inline bool
     //A += DMatrix<real>::outProd (tmpC);
     //b += currentZ * tmpC;
   }
-  //cout << "Calculating matrix A and vector b (size "<<b.size ()<<") from "<<samplePoints.size ()<<" points took "
+  //std::cout << "Calculating matrix A and vector b (size "<<b.size ()<<") from "<<samplePoints.size ()<<" points took "
        //<< (coeffStuffStartTime+get_time ())*1000<<"ms using constant memory.\n";
-    //cout << PVARC (A)<<PVARN (b);
+    //std::cout << PVARC (A)<<PVARN (b);
 
 
   //double coeffStuffStartTime=-get_time ();
@@ -509,7 +509,7 @@ inline bool
   //     it!=samplePoints.end (); ++it)
   //{
     //currentX= (*it)[0]; currentY= (*it)[1]; currentZ= (*it)[2];
-    ////cout << "x="<<currentX<<", y="<<currentY<<"\n";
+    ////std::cout << "x="<<currentX<<", y="<<currentY<<"\n";
     //posInC = parameters_size-1;
     //tmpX = 1.0;
     //for (unsigned int xDegree=0; xDegree<=polynomial_degree; xDegree++)
@@ -518,7 +518,7 @@ inline bool
       //for (unsigned int yDegree=0; yDegree<=polynomial_degree-xDegree; yDegree++)
       //{
         //tmpC[posInC] = tmpX*tmpY;
-        ////cout << "x="<<currentX<<", y="<<currentY<<", Pos "<<posInC<<": "<<tmpX<<"*"<<tmpY<<"="<<tmpC[posInC]<<"\n";
+        ////std::cout << "x="<<currentX<<", y="<<currentY<<", Pos "<<posInC<<": "<<tmpX<<"*"<<tmpY<<"="<<tmpC[posInC]<<"\n";
         //tmpY *= currentY;
         //posInC--;
       //}
@@ -527,31 +527,31 @@ inline bool
     //A += DMatrix<real>::outProd (tmpC);
     //b += currentZ * tmpC;
   //}
-  //cout << "Calculating matrix A and vector b (size "<<b.size ()<<") from "<<samplePoints.size ()<<" points took "
+  //std::cout << "Calculating matrix A and vector b (size "<<b.size ()<<") from "<<samplePoints.size ()<<" points took "
        //<< (coeffStuffStartTime+get_time ())*1000<<"ms.\n";
 
   Eigen::Matrix<real, Eigen::Dynamic, 1> parameters;
   //double choleskyStartTime=-get_time ();
   //parameters = A.choleskySolve (b);
-  //cout << "Cholesky took "<< (choleskyStartTime+get_time ())*1000<<"ms.\n";
+  //std::cout << "Cholesky took "<< (choleskyStartTime+get_time ())*1000<<"ms.\n";
 
   //double invStartTime=-get_time ();
   parameters = A.inverse () * b;
-  //cout << "Inverse took "<< (invStartTime+get_time ())*1000<<"ms.\n";
+  //std::cout << "Inverse took "<< (invStartTime+get_time ())*1000<<"ms.\n";
 
-  //cout << PVARC (A)<<PVARC (b)<<PVARN (parameters);
+  //std::cout << PVARC (A)<<PVARC (b)<<PVARN (parameters);
 
   real inversionCheckResult = (A*parameters - b).norm ();
   if (inversionCheckResult > 1e-5)
   {
-    //cout << "Inversion result: "<< inversionCheckResult<<" for matrix "<<A<<"\n";
+    //std::cout << "Inversion result: "<< inversionCheckResult<<" for matrix "<<A<<"\n";
     return false;
   }
 
   for (unsigned int i=0; i<parameters_size; i++)
     ret.parameters[i] = parameters[i];
 
-  //cout << "Resulting polynomial is "<<ret<<"\n";
+  //std::cout << "Resulting polynomial is "<<ret<<"\n";
 
   //Test of gradient: ret.calculateGradient ();
 

--- a/common/include/pcl/common/impl/vector_average.hpp
+++ b/common/include/pcl/common/impl/vector_average.hpp
@@ -74,7 +74,7 @@ namespace pcl
 
     //if (std::isnan(covariance_(0,0)))
     //{
-      //cout << PVARN(weight);
+      //std::cout << PVARN(weight);
       //exit(0);
     //}
   }
@@ -90,9 +90,9 @@ namespace pcl
     //eigen_values = ei_symm.eigenvalues().template cast<real>();
     //Eigen::Matrix<real, dimension, dimension> eigen_vectors = ei_symm.eigenvectors().template cast<real>();
 
-    //cout << "My covariance is \n"<<covariance_<<"\n";
-    //cout << "My mean is \n"<<mean_<<"\n";
-    //cout << "My Eigenvectors \n"<<eigen_vectors<<"\n";
+    //std::cout << "My covariance is \n"<<covariance_<<"\n";
+    //std::cout << "My mean is \n"<<mean_<<"\n";
+    //std::cout << "My Eigenvectors \n"<<eigen_vectors<<"\n";
 
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix<real, dimension, dimension> > ei_symm(covariance_);
     eigen_values = ei_symm.eigenvalues();
@@ -126,9 +126,9 @@ namespace pcl
     //eigen_values = ei_symm.eigenvalues().template cast<real>();
     //Eigen::Matrix<real, dimension, dimension> eigen_vectors = ei_symm.eigenvectors().template cast<real>();
 
-    //cout << "My covariance is \n"<<covariance_<<"\n";
-    //cout << "My mean is \n"<<mean_<<"\n";
-    //cout << "My Eigenvectors \n"<<eigen_vectors<<"\n";
+    //std::cout << "My covariance is \n"<<covariance_<<"\n";
+    //std::cout << "My mean is \n"<<mean_<<"\n";
+    //std::cout << "My Eigenvectors \n"<<eigen_vectors<<"\n";
 
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix<real, dimension, dimension> > ei_symm(covariance_);
     Eigen::Matrix<real, dimension, dimension> eigen_vectors = ei_symm.eigenvectors();
@@ -146,7 +146,7 @@ namespace pcl
   inline void VectorAverage<float, 3>::doPCA(Eigen::Matrix<float, 3, 1>& eigen_values, Eigen::Matrix<float, 3, 1>& eigen_vector1,
                                             Eigen::Matrix<float, 3, 1>& eigen_vector2, Eigen::Matrix<float, 3, 1>& eigen_vector3) const
   {
-    //cout << "Using specialized 3x3 version of doPCA!\n";
+    //std::cout << "Using specialized 3x3 version of doPCA!\n";
     Eigen::Matrix<float, 3, 3> eigen_vectors;
     eigen33(covariance_, eigen_vectors, eigen_values);
     eigen_vector1 = eigen_vectors.col(0);
@@ -156,13 +156,13 @@ namespace pcl
   template <>
   inline void VectorAverage<float, 3>::doPCA(Eigen::Matrix<float, 3, 1>& eigen_values) const
   {
-    //cout << "Using specialized 3x3 version of doPCA!\n";
+    //std::cout << "Using specialized 3x3 version of doPCA!\n";
     computeRoots (covariance_, eigen_values);
   }
   template <>
   inline void VectorAverage<float, 3>::getEigenVector1(Eigen::Matrix<float, 3, 1>& eigen_vector1) const
   {
-    //cout << "Using specialized 3x3 version of doPCA!\n";
+    //std::cout << "Using specialized 3x3 version of doPCA!\n";
     Eigen::Vector3f::Scalar eigen_value;
     Eigen::Vector3f eigen_vector;
     eigen33(covariance_, eigen_value, eigen_vector);
@@ -176,7 +176,7 @@ namespace pcl
   inline void VectorAverage<double, 3>::doPCA(Eigen::Matrix<double, 3, 1>& eigen_values, Eigen::Matrix<double, 3, 1>& eigen_vector1,
                                             Eigen::Matrix<double, 3, 1>& eigen_vector2, Eigen::Matrix<double, 3, 1>& eigen_vector3) const
   {
-    //cout << "Using specialized 3x3 version of doPCA!\n";
+    //std::cout << "Using specialized 3x3 version of doPCA!\n";
     Eigen::Matrix<double, 3, 3> eigen_vectors;
     eigen33(covariance_, eigen_vectors, eigen_values);
     eigen_vector1 = eigen_vectors.col(0);
@@ -186,13 +186,13 @@ namespace pcl
   template <>
   inline void VectorAverage<double, 3>::doPCA(Eigen::Matrix<double, 3, 1>& eigen_values) const
   {
-    //cout << "Using specialized 3x3 version of doPCA!\n";
+    //std::cout << "Using specialized 3x3 version of doPCA!\n";
     computeRoots (covariance_, eigen_values);
   }
   template <>
   inline void VectorAverage<double, 3>::getEigenVector1(Eigen::Matrix<double, 3, 1>& eigen_vector1) const
   {
-    //cout << "Using specialized 3x3 version of doPCA!\n";
+    //std::cout << "Using specialized 3x3 version of doPCA!\n";
     Eigen::Vector3d::Scalar eigen_value;
     Eigen::Vector3d eigen_vector;
     eigen33(covariance_, eigen_value, eigen_vector);

--- a/common/include/pcl/range_image/impl/range_image_planar.hpp
+++ b/common/include/pcl/range_image/impl/range_image_planar.hpp
@@ -91,7 +91,7 @@ RangeImagePlanar::createFromPointCloudWithFixedSize (const PointCloudType& point
 void
 RangeImagePlanar::calculate3DPoint (float image_x, float image_y, float range, Eigen::Vector3f& point) const
 {
-  //cout << __PRETTY_FUNCTION__ << " called.\n";
+  //std::cout << __PRETTY_FUNCTION__ << " called.\n";
   float delta_x = (image_x+static_cast<float> (image_offset_x_)-center_x_)*focal_length_x_reciprocal_,
         delta_y = (image_y+static_cast<float> (image_offset_y_)-center_y_)*focal_length_y_reciprocal_;
   point[2] = range / (std::sqrt (delta_x*delta_x + delta_y*delta_y + 1));

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -76,7 +76,7 @@ namespace pcl
     center_y_ = static_cast<float> (di_height) / static_cast<float> (2 * skip);
     points.resize (width*height);
     
-    //cout << PVARN (*this);
+    //std::cout << PVARN (*this);
     
     float normalization_factor = static_cast<float> (skip) * focal_length_x_ * base_line;
     for (int y=0; y < static_cast<int> (height); ++y)
@@ -95,18 +95,18 @@ namespace pcl
         point.x = (static_cast<float> (x) - center_x_) * point.z * focal_length_x_reciprocal_;
         point.y = (static_cast<float> (y) - center_y_) * point.z * focal_length_y_reciprocal_;
         point.range = point.getVector3fMap ().norm ();
-        //cout << point<<std::flush;
+        //std::cout << point<<std::flush;
         
         //// Just a test:
         //PointWithRange test_point1;
         //calculate3DPoint (float (x), float (y), point.range, test_point1);
         //if ( (point.getVector3fMap ()-test_point1.getVector3fMap ()).norm () > 1e-5)
-          //cerr << "Something's wrong here...\n";
+          //std::cerr << "Something's wrong here...\n";
         
         //float image_x, image_y;
         //getImagePoint (point.getVector3fMap (), image_x, image_y);
         //if (std::abs (image_x-x)+std::abs (image_y-y)>1e-4)
-          //cerr << PVARC (x)<<PVARC (y)<<PVARC (image_x)<<PVARN (image_y);
+          //std::cerr << PVARC (x)<<PVARC (y)<<PVARC (image_x)<<PVARN (image_y);
       }
     }
   }

--- a/doc/tutorials/content/narf_feature_extraction.rst
+++ b/doc/tutorials/content/narf_feature_extraction.rst
@@ -48,7 +48,7 @@ Here we copy the indices to the vector used as input for the feature.
   narf_descriptor.getParameters().rotation_invariant = rotation_invariant;
   pcl::PointCloud<pcl::Narf36> narf_descriptors;
   narf_descriptor.compute(narf_descriptors);
-  cout << "Extracted "<<narf_descriptors.size()<<" descriptors for "<<keypoint_indices.points.size()<< " keypoints.\n";
+  std::cout << "Extracted "<<narf_descriptors.size()<<" descriptors for "<<keypoint_indices.points.size()<< " keypoints.\n";
   ...
 
 This code does the actual calculation of the descriptors. It first creates the

--- a/doc/tutorials/content/sources/don_segmentation/don_segmentation.cpp
+++ b/doc/tutorials/content/sources/don_segmentation/don_segmentation.cpp
@@ -37,7 +37,7 @@ main (int argc, char *argv[])
 
   if (argc < 6)
   {
-    cerr << "usage: " << argv[0] << " inputfile smallscale largescale threshold segradius" << endl;
+    std::cerr << "usage: " << argv[0] << " inputfile smallscale largescale threshold segradius" << std::endl;
     exit (EXIT_FAILURE);
   }
 
@@ -72,7 +72,7 @@ main (int argc, char *argv[])
 
   if (scale1 >= scale2)
   {
-    cerr << "Error: Large scale must be > small scale!" << endl;
+    std::cerr << "Error: Large scale must be > small scale!" << std::endl;
     exit (EXIT_FAILURE);
   }
 
@@ -88,14 +88,14 @@ main (int argc, char *argv[])
   ne.setViewPoint (std::numeric_limits<float>::max (), std::numeric_limits<float>::max (), std::numeric_limits<float>::max ());
 
   // calculate normals with the small scale
-  cout << "Calculating normals for scale..." << scale1 << endl;
+  std::cout << "Calculating normals for scale..." << scale1 << std::endl;
   pcl::PointCloud<PointNormal>::Ptr normals_small_scale (new pcl::PointCloud<PointNormal>);
 
   ne.setRadiusSearch (scale1);
   ne.compute (*normals_small_scale);
 
   // calculate normals with the large scale
-  cout << "Calculating normals for scale..." << scale2 << endl;
+  std::cout << "Calculating normals for scale..." << scale2 << std::endl;
   pcl::PointCloud<PointNormal>::Ptr normals_large_scale (new pcl::PointCloud<PointNormal>);
 
   ne.setRadiusSearch (scale2);
@@ -105,7 +105,7 @@ main (int argc, char *argv[])
   PointCloud<PointNormal>::Ptr doncloud (new pcl::PointCloud<PointNormal>);
   copyPointCloud<PointXYZRGB, PointNormal>(*cloud, *doncloud);
 
-  cout << "Calculating DoN... " << endl;
+  std::cout << "Calculating DoN... " << std::endl;
   // Create DoN operator
   pcl::DifferenceOfNormalsEstimation<PointXYZRGB, PointNormal, PointNormal> don;
   don.setInputCloud (cloud);
@@ -126,7 +126,7 @@ main (int argc, char *argv[])
   writer.write<pcl::PointNormal> ("don.pcd", *doncloud, false); 
 
   // Filter by magnitude
-  cout << "Filtering out DoN mag <= " << threshold << "..." << endl;
+  std::cout << "Filtering out DoN mag <= " << threshold << "..." << std::endl;
 
   // Build the condition for filtering
   pcl::ConditionOr<PointNormal>::Ptr range_cond (
@@ -153,7 +153,7 @@ main (int argc, char *argv[])
   writer.write<pcl::PointNormal> ("don_filtered.pcd", *doncloud, false); 
 
   // Filter by magnitude
-  cout << "Clustering using EuclideanClusterExtraction with tolerance <= " << segradius << "..." << endl;
+  std::cout << "Clustering using EuclideanClusterExtraction with tolerance <= " << segradius << "..." << std::endl;
 
   pcl::search::KdTree<PointNormal>::Ptr segtree (new pcl::search::KdTree<PointNormal>);
   segtree->setInputCloud (doncloud);
@@ -182,7 +182,7 @@ main (int argc, char *argv[])
     cloud_cluster_don->is_dense = true;
 
     //Save cluster
-    cout << "PointCloud representing the Cluster: " << cloud_cluster_don->points.size () << " data points." << std::endl;
+    std::cout << "PointCloud representing the Cluster: " << cloud_cluster_don->points.size () << " data points." << std::endl;
     stringstream ss;
     ss << "don_cluster_" << j << ".pcd";
     writer.write<pcl::PointNormal> (ss.str (), *cloud_cluster_don, false);

--- a/doc/tutorials/content/sources/global_hypothesis_verification/global_hypothesis_verification.cpp
+++ b/doc/tutorials/content/sources/global_hypothesis_verification/global_hypothesis_verification.cpp
@@ -376,12 +376,12 @@ main (int argc,
    */
   if (rototranslations.size () <= 0)
   {
-    cout << "*** No instances found! ***" << endl;
+    std::cout << "*** No instances found! ***" << std::endl;
     return (0);
   }
   else
   {
-    cout << "Recognized Instances: " << rototranslations.size () << endl << endl;
+    std::cout << "Recognized Instances: " << rototranslations.size () << std::endl << std::endl;
   }
 
   /**
@@ -402,7 +402,7 @@ main (int argc,
   std::vector<pcl::PointCloud<PointType>::ConstPtr> registered_instances;
   if (true)
   {
-    cout << "--- ICP ---------" << endl;
+    std::cout << "--- ICP ---------" << std::endl;
 
     for (size_t i = 0; i < rototranslations.size (); ++i)
     {
@@ -414,24 +414,24 @@ main (int argc,
       pcl::PointCloud<PointType>::Ptr registered (new pcl::PointCloud<PointType>);
       icp.align (*registered);
       registered_instances.push_back (registered);
-      cout << "Instance " << i << " ";
+      std::cout << "Instance " << i << " ";
       if (icp.hasConverged ())
       {
-        cout << "Aligned!" << endl;
+        std::cout << "Aligned!" << std::endl;
       }
       else
       {
-        cout << "Not Aligned!" << endl;
+        std::cout << "Not Aligned!" << std::endl;
       }
     }
 
-    cout << "-----------------" << endl << endl;
+    std::cout << "-----------------" << std::endl << std::endl;
   }
 
   /**
    * Hypothesis Verification
    */
-  cout << "--- Hypotheses Verification ---" << endl;
+  std::cout << "--- Hypotheses Verification ---" << std::endl;
   std::vector<bool> hypotheses_mask;  // Mask Vector to identify positive hypotheses
 
   pcl::GlobalHypothesesVerification<PointType, PointType> GoHv;
@@ -455,14 +455,14 @@ main (int argc,
   {
     if (hypotheses_mask[i])
     {
-      cout << "Instance " << i << " is GOOD! <---" << endl;
+      std::cout << "Instance " << i << " is GOOD! <---" << std::endl;
     }
     else
     {
-      cout << "Instance " << i << " is bad!" << endl;
+      std::cout << "Instance " << i << " is bad!" << std::endl;
     }
   }
-  cout << "-------------------------------" << endl;
+  std::cout << "-------------------------------" << std::endl;
 
   /**
    *  Visualization
@@ -511,7 +511,7 @@ main (int argc,
     viewer.setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, clusterStyle.size, ss_instance.str ());
 
     CloudStyle registeredStyles = hypotheses_mask[i] ? style_green : style_cyan;
-    ss_instance << "_registered" << endl;
+    ss_instance << "_registered" << std::endl;
     pcl::visualization::PointCloudColorHandlerCustom<PointType> registered_instance_color_handler (registered_instances[i], registeredStyles.r,
                                                                                                    registeredStyles.g, registeredStyles.b);
     viewer.addPointCloud (registered_instances[i], registered_instance_color_handler, ss_instance.str ());

--- a/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
+++ b/doc/tutorials/content/sources/gpu/people_detect/src/people_detect.cpp
@@ -74,7 +74,7 @@ struct SampledScopeTime : public StopWatch
     time_ms_ += getTime ();
     if (i_ % EACH == 0 && i_)
     {
-      cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << endl;
+      std::cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << std::endl;
       time_ms_ = 0;
     }
     ++i_;
@@ -280,8 +280,8 @@ class PeoplePCDApp
           }
           final_view_.spinOnce (3);
         }
-        catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; }
-        catch (const std::exception& /*e*/) { cout << "Exception" << endl; }
+        catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; }
+        catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; }
 
         capture_.stop ();
       }
@@ -345,7 +345,7 @@ int main(int argc, char** argv)
 
   tree_files.resize(num_trees);
   if (num_trees == 0 || num_trees > 4)
-    return cout << "Invalid number of trees" << endl, -1;
+    return std::cout << "Invalid number of trees" << std::endl, -1;
 
   try
   {
@@ -361,10 +361,10 @@ int main(int argc, char** argv)
     // executing
     app.startMainLoop ();
   }
-  catch (const pcl::PCLException& e) { cout << "PCLException: " << e.detailedMessage() << endl; }  
-  catch (const std::runtime_error& e) { cout << e.what() << endl; }
-  catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; }
-  catch (const std::exception& /*e*/) { cout << "Exception" << endl; }
+  catch (const pcl::PCLException& e) { std::cout << "PCLException: " << e.detailedMessage() << std::endl; }  
+  catch (const std::runtime_error& e) { std::cout << e.what() << std::endl; }
+  catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; }
+  catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; }
 
   return 0;
 }

--- a/doc/tutorials/content/sources/ground_based_rgbd_people_detection/src/main_ground_based_people_detection.cpp
+++ b/doc/tutorials/content/sources/ground_based_rgbd_people_detection/src/main_ground_based_people_detection.cpp
@@ -72,14 +72,14 @@ enum { COLS = 640, ROWS = 480 };
 
 int print_help()
 {
-  cout << "*******************************************************" << std::endl;
-  cout << "Ground based people detection app options:" << std::endl;
-  cout << "   --help    <show_this_help>" << std::endl;
-  cout << "   --svm     <path_to_svm_file>" << std::endl;
-  cout << "   --conf    <minimum_HOG_confidence (default = -1.5)>" << std::endl;
-  cout << "   --min_h   <minimum_person_height (default = 1.3)>" << std::endl;
-  cout << "   --max_h   <maximum_person_height (default = 2.3)>" << std::endl;
-  cout << "*******************************************************" << std::endl;
+  std::cout << "*******************************************************" << std::endl;
+  std::cout << "Ground based people detection app options:" << std::endl;
+  std::cout << "   --help    <show_this_help>" << std::endl;
+  std::cout << "   --svm     <path_to_svm_file>" << std::endl;
+  std::cout << "   --conf    <minimum_HOG_confidence (default = -1.5)>" << std::endl;
+  std::cout << "   --min_h   <minimum_person_height (default = 1.3)>" << std::endl;
+  std::cout << "   --max_h   <maximum_person_height (default = 2.3)>" << std::endl;
+  std::cout << "*******************************************************" << std::endl;
   return 0;
 }
 

--- a/doc/tutorials/content/sources/iccv2011/src/tutorial.cpp
+++ b/doc/tutorials/content/sources/iccv2011/src/tutorial.cpp
@@ -181,7 +181,7 @@ ICCVTutorial<FeatureType>::ICCVTutorial(pcl::Keypoint<pcl::PointXYZRGB, pcl::Poi
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::segmentation (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr source, typename pcl::PointCloud<pcl::PointXYZRGB>::Ptr segmented) const
 {
-  cout << "segmentation..." << std::flush;
+  std::cout << "segmentation..." << std::flush;
   // fit plane and keep points above that plane
   pcl::ModelCoefficients::Ptr coefficients (new pcl::ModelCoefficients);
   pcl::PointIndices::Ptr inliers (new pcl::PointIndices);
@@ -205,9 +205,9 @@ void ICCVTutorial<FeatureType>::segmentation (typename pcl::PointCloud<pcl::Poin
   extract.filter (*segmented);
   std::vector<int> indices;
   pcl::removeNaNFromPointCloud(*segmented, *segmented, indices);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
   
-  cout << "clustering..." << std::flush;
+  std::cout << "clustering..." << std::flush;
   // euclidean clustering
   typename pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZRGB>);
   tree->setInputCloud (segmented);
@@ -223,10 +223,10 @@ void ICCVTutorial<FeatureType>::segmentation (typename pcl::PointCloud<pcl::Poin
   
   if (cluster_indices.size() > 0)//use largest cluster
   {
-    cout << cluster_indices.size() << " clusters found";
+    std::cout << cluster_indices.size() << " clusters found";
     if (cluster_indices.size() > 1)
-      cout <<" Using largest one...";
-    cout << endl;
+      std::cout <<" Using largest one...";
+    std::cout << std::endl;
     typename pcl::IndicesPtr indices (new std::vector<int>);
     *indices = cluster_indices[0].indices;
     extract.setInputCloud (segmented);
@@ -240,11 +240,11 @@ void ICCVTutorial<FeatureType>::segmentation (typename pcl::PointCloud<pcl::Poin
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::detectKeypoints (typename pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr input, pcl::PointCloud<pcl::PointXYZI>::Ptr keypoints) const
 {
-  cout << "keypoint detection..." << std::flush;
+  std::cout << "keypoint detection..." << std::flush;
   keypoint_detector_->setInputCloud(input);
   keypoint_detector_->setSearchSurface(input);
   keypoint_detector_->compute(*keypoints);
-  cout << "OK. keypoints found: " << keypoints->points.size() << endl;
+  std::cout << "OK. keypoints found: " << keypoints->points.size() << std::endl;
 }
 
 template<typename FeatureType>
@@ -263,7 +263,7 @@ void ICCVTutorial<FeatureType>::extractDescriptors (typename pcl::PointCloud<pcl
   if (feature_from_normals)
   //if (boost::dynamic_pointer_cast<typename pcl::FeatureFromNormals<pcl::PointXYZRGB, pcl::Normal, FeatureType> > (feature_extractor_))
   {
-    cout << "normal estimation..." << std::flush;
+    std::cout << "normal estimation..." << std::flush;
     typename pcl::PointCloud<pcl::Normal>::Ptr normals (new  pcl::PointCloud<pcl::Normal>);
     pcl::NormalEstimation<pcl::PointXYZRGB, pcl::Normal> normal_estimation;
     normal_estimation.setSearchMethod (pcl::search::Search<pcl::PointXYZRGB>::Ptr (new pcl::search::KdTree<pcl::PointXYZRGB>));
@@ -271,18 +271,18 @@ void ICCVTutorial<FeatureType>::extractDescriptors (typename pcl::PointCloud<pcl
     normal_estimation.setInputCloud (input);
     normal_estimation.compute (*normals);
     feature_from_normals->setInputNormals(normals);
-    cout << "OK" << endl;
+    std::cout << "OK" << std::endl;
   }
 
-  cout << "descriptor extraction..." << std::flush;
+  std::cout << "descriptor extraction..." << std::flush;
   feature_extractor_->compute (*features);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::findCorrespondences (typename pcl::PointCloud<FeatureType>::Ptr source, typename pcl::PointCloud<FeatureType>::Ptr target, std::vector<int>& correspondences) const
 {
-  cout << "correspondence assignment..." << std::flush;
+  std::cout << "correspondence assignment..." << std::flush;
   correspondences.resize (source->size());
 
   // Use a KdTree to search for the nearest matches in feature space
@@ -298,13 +298,13 @@ void ICCVTutorial<FeatureType>::findCorrespondences (typename pcl::PointCloud<Fe
     descriptor_kdtree.nearestKSearch (*source, i, k, k_indices, k_squared_distances);
     correspondences[i] = k_indices[0];
   }
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::filterCorrespondences ()
 {
-  cout << "correspondence rejection..." << std::flush;
+  std::cout << "correspondence rejection..." << std::flush;
   std::vector<std::pair<unsigned, unsigned> > correspondences;
   for (unsigned cIdx = 0; cIdx < source2target_.size (); ++cIdx)
     if (target2source_[source2target_[cIdx]] == cIdx)
@@ -322,25 +322,25 @@ void ICCVTutorial<FeatureType>::filterCorrespondences ()
   rejector.setInputTarget(target_keypoints_);
   rejector.setInputCorrespondences(correspondences_);
   rejector.getCorrespondences(*correspondences_);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::determineInitialTransformation ()
 {
-  cout << "initial alignment..." << std::flush;
+  std::cout << "initial alignment..." << std::flush;
   pcl::registration::TransformationEstimation<pcl::PointXYZI, pcl::PointXYZI>::Ptr transformation_estimation (new pcl::registration::TransformationEstimationSVD<pcl::PointXYZI, pcl::PointXYZI>);
   
   transformation_estimation->estimateRigidTransformation (*source_keypoints_, *target_keypoints_, *correspondences_, initial_transformation_matrix_);
   
   pcl::transformPointCloud(*source_segmented_, *source_transformed_, initial_transformation_matrix_);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::determineFinalTransformation ()
 {
-  cout << "final registration..." << std::flush;
+  std::cout << "final registration..." << std::flush;
   pcl::Registration<pcl::PointXYZRGB, pcl::PointXYZRGB>::Ptr registration (new pcl::IterativeClosestPoint<pcl::PointXYZRGB, pcl::PointXYZRGB>);
   registration->setInputCloud(source_transformed_);
   //registration->setInputCloud(source_segmented_);
@@ -351,13 +351,13 @@ void ICCVTutorial<FeatureType>::determineFinalTransformation ()
   registration->setMaximumIterations (1000);
   registration->align(*source_registered_);
   transformation_matrix_ = registration->getFinalTransformation();
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>
 void ICCVTutorial<FeatureType>::reconstructSurface ()
 {
-  cout << "surface reconstruction..." << std::flush;
+  std::cout << "surface reconstruction..." << std::flush;
   // merge the transformed and the target point cloud
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr merged (new pcl::PointCloud<pcl::PointXYZRGB>);
   *merged = *source_transformed_;
@@ -385,7 +385,7 @@ void ICCVTutorial<FeatureType>::reconstructSurface ()
   surface_reconstructor_->setSearchMethod(tree);
   surface_reconstructor_->setInputCloud(vertices);
   surface_reconstructor_->reconstruct(surface_);
-  cout << "OK" << endl;
+  std::cout << "OK" << std::endl;
 }
 
 template<typename FeatureType>

--- a/doc/tutorials/content/sources/narf_feature_extraction/narf_feature_extraction.cpp
+++ b/doc/tutorials/content/sources/narf_feature_extraction/narf_feature_extraction.cpp
@@ -70,20 +70,20 @@ main (int argc, char** argv)
   if (pcl::console::find_argument (argc, argv, "-m") >= 0)
   {
     setUnseenToMaxRange = true;
-    cout << "Setting unseen values in range image to maximum range readings.\n";
+    std::cout << "Setting unseen values in range image to maximum range readings.\n";
   }
   if (pcl::console::parse (argc, argv, "-o", rotation_invariant) >= 0)
-    cout << "Switching rotation invariant feature version "<< (rotation_invariant ? "on" : "off")<<".\n";
+    std::cout << "Switching rotation invariant feature version "<< (rotation_invariant ? "on" : "off")<<".\n";
   int tmp_coordinate_frame;
   if (pcl::console::parse (argc, argv, "-c", tmp_coordinate_frame) >= 0)
   {
     coordinate_frame = pcl::RangeImage::CoordinateFrame (tmp_coordinate_frame);
-    cout << "Using coordinate frame "<< (int)coordinate_frame<<".\n";
+    std::cout << "Using coordinate frame "<< (int)coordinate_frame<<".\n";
   }
   if (pcl::console::parse (argc, argv, "-s", support_size) >= 0)
-    cout << "Setting support size to "<<support_size<<".\n";
+    std::cout << "Setting support size to "<<support_size<<".\n";
   if (pcl::console::parse (argc, argv, "-r", angular_resolution) >= 0)
-    cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
+    std::cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
   angular_resolution = pcl::deg2rad (angular_resolution);
   
   // ------------------------------------------------------------------
@@ -99,7 +99,7 @@ main (int argc, char** argv)
     std::string filename = argv[pcd_filename_indices[0]];
     if (pcl::io::loadPCDFile (filename, point_cloud) == -1)
     {
-      cerr << "Was not able to open file \""<<filename<<"\".\n";
+      std::cerr << "Was not able to open file \""<<filename<<"\".\n";
       printUsage (argv[0]);
       return 0;
     }
@@ -114,7 +114,7 @@ main (int argc, char** argv)
   else
   {
     setUnseenToMaxRange = true;
-    cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
+    std::cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
     for (float x=-0.5f; x<=0.5f; x+=0.01f)
     {
       for (float y=-0.5f; y<=0.5f; y+=0.01f)
@@ -204,7 +204,7 @@ main (int argc, char** argv)
   narf_descriptor.getParameters ().rotation_invariant = rotation_invariant;
   pcl::PointCloud<pcl::Narf36> narf_descriptors;
   narf_descriptor.compute (narf_descriptors);
-  cout << "Extracted "<<narf_descriptors.size ()<<" descriptors for "
+  std::cout << "Extracted "<<narf_descriptors.size ()<<" descriptors for "
                       <<keypoint_indices.points.size ()<< " keypoints.\n";
   
   //--------------------

--- a/doc/tutorials/content/sources/narf_keypoint_extraction/narf_keypoint_extraction.cpp
+++ b/doc/tutorials/content/sources/narf_keypoint_extraction/narf_keypoint_extraction.cpp
@@ -66,18 +66,18 @@ main (int argc, char** argv)
   if (pcl::console::find_argument (argc, argv, "-m") >= 0)
   {
     setUnseenToMaxRange = true;
-    cout << "Setting unseen values in range image to maximum range readings.\n";
+    std::cout << "Setting unseen values in range image to maximum range readings.\n";
   }
   int tmp_coordinate_frame;
   if (pcl::console::parse (argc, argv, "-c", tmp_coordinate_frame) >= 0)
   {
     coordinate_frame = pcl::RangeImage::CoordinateFrame (tmp_coordinate_frame);
-    cout << "Using coordinate frame "<< (int)coordinate_frame<<".\n";
+    std::cout << "Using coordinate frame "<< (int)coordinate_frame<<".\n";
   }
   if (pcl::console::parse (argc, argv, "-s", support_size) >= 0)
-    cout << "Setting support size to "<<support_size<<".\n";
+    std::cout << "Setting support size to "<<support_size<<".\n";
   if (pcl::console::parse (argc, argv, "-r", angular_resolution) >= 0)
-    cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
+    std::cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
   angular_resolution = pcl::deg2rad (angular_resolution);
   
   // ------------------------------------------------------------------
@@ -93,7 +93,7 @@ main (int argc, char** argv)
     std::string filename = argv[pcd_filename_indices[0]];
     if (pcl::io::loadPCDFile (filename, point_cloud) == -1)
     {
-      cerr << "Was not able to open file \""<<filename<<"\".\n";
+      std::cerr << "Was not able to open file \""<<filename<<"\".\n";
       printUsage (argv[0]);
       return 0;
     }
@@ -108,7 +108,7 @@ main (int argc, char** argv)
   else
   {
     setUnseenToMaxRange = true;
-    cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
+    std::cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
     for (float x=-0.5f; x<=0.5f; x+=0.01f)
     {
       for (float y=-0.5f; y<=0.5f; y+=0.01f)

--- a/doc/tutorials/content/sources/openni_narf_keypoint_extraction/openni_narf_keypoint_extraction.cpp
+++ b/doc/tutorials/content/sources/openni_narf_keypoint_extraction/openni_narf_keypoint_extraction.cpp
@@ -51,7 +51,7 @@ struct EventHelper
 void
 printUsage (const char* progName)
 {
-  cout << "\n\nUsage: "<<progName<<" [options] [scene.pcd] <model.pcl> [model_2.pcl] ... [model_n.pcl]\n\n"
+  std::cout << "\n\nUsage: "<<progName<<" [options] [scene.pcd] <model.pcl> [model_2.pcl] ... [model_n.pcl]\n\n"
        << "Options:\n"
        << "-------------------------------------------\n"
        << "-d <device_id>  set the device id (default \""<<device_id<<"\")\n"
@@ -75,16 +75,16 @@ int main (int argc, char** argv)
     return 0;
   }
   if (pcl::console::parse (argc, argv, "-d", device_id) >= 0)
-    cout << "Using device id \""<<device_id<<"\".\n";
+    std::cout << "Using device id \""<<device_id<<"\".\n";
   if (pcl::console::parse (argc, argv, "-r", angular_resolution) >= 0)
-    cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
+    std::cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
   angular_resolution = pcl::deg2rad (angular_resolution);
   if (pcl::console::parse (argc, argv, "-s", support_size) >= 0)
-    cout << "Setting support size to "<<support_size<<"m.\n";
+    std::cout << "Setting support size to "<<support_size<<"m.\n";
   if (pcl::console::parse (argc, argv, "-i", min_interest_value) >= 0)
-    cout << "Setting minimum interest value to "<<min_interest_value<<".\n";
+    std::cout << "Setting minimum interest value to "<<min_interest_value<<".\n";
   if (pcl::console::parse (argc, argv, "-t", max_no_of_threads) >= 0)
-    cout << "Setting maximum number of threads to "<<max_no_of_threads<<".\n";
+    std::cout << "Setting maximum number of threads to "<<max_no_of_threads<<".\n";
   
   pcl::visualization::RangeImageVisualizer range_image_widget ("Range Image");
   
@@ -102,7 +102,7 @@ int main (int argc, char** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx)
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx)
            << ", product: " << driver.getProductName (deviceIdx) << ", connected: "
            << (int) driver.getBus (deviceIdx) << " @ " << (int) driver.getAddress (deviceIdx)
            << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'\n";
@@ -110,7 +110,7 @@ int main (int argc, char** argv)
   }
   else
   {
-    cout << "\nNo devices connected.\n\n";
+    std::cout << "\nNo devices connected.\n\n";
     return 1;
   }
   
@@ -121,9 +121,9 @@ int main (int argc, char** argv)
     [&] (const openni_wrapper::DepthImage::Ptr& depth) { event_helper.depth_image_cb (depth); };
   boost::signals2::connection c_depth_image = interface->registerCallback (f_depth_image);
   
-  cout << "Starting grabber\n";
+  std::cout << "Starting grabber\n";
   interface->start ();
-  cout << "Done\n";
+  std::cout << "Done\n";
   
   pcl::RangeImagePlanar::Ptr range_image_planar_ptr (new pcl::RangeImagePlanar);
   pcl::RangeImagePlanar& range_image_planar = *range_image_planar_ptr;

--- a/doc/tutorials/content/sources/openni_range_image_visualization/openni_range_image_visualization.cpp
+++ b/doc/tutorials/content/sources/openni_range_image_visualization/openni_range_image_visualization.cpp
@@ -37,7 +37,7 @@ struct EventHelper
 void
 printUsage (const char* progName)
 {
-  cout << "\n\nUsage: "<<progName<<" [options] [scene.pcd] <model.pcl> [model_2.pcl] ... [model_n.pcl]\n\n"
+  std::cout << "\n\nUsage: "<<progName<<" [options] [scene.pcd] <model.pcl> [model_2.pcl] ... [model_n.pcl]\n\n"
        << "Options:\n"
        << "-------------------------------------------\n"
        << "-d <device_id>  set the device id (default \""<<device_id<<"\")\n"
@@ -57,9 +57,9 @@ int main (int argc, char** argv)
     return 0;
   }
   if (pcl::console::parse (argc, argv, "-d", device_id) >= 0)
-    cout << "Using device id \""<<device_id<<"\".\n";
+    std::cout << "Using device id \""<<device_id<<"\".\n";
   if (pcl::console::parse (argc, argv, "-r", angular_resolution) >= 0)
-    cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
+    std::cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
   angular_resolution = pcl::deg2rad (angular_resolution);
   
   pcl::visualization::RangeImageVisualizer range_image_widget ("Range Image");
@@ -79,7 +79,7 @@ int main (int argc, char** argv)
   {
     for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
     {
-      cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx)
+      std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx)
            << ", product: " << driver.getProductName (deviceIdx) << ", connected: "
            << (int) driver.getBus (deviceIdx) << " @ " << (int) driver.getAddress (deviceIdx)
            << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'\n";
@@ -87,7 +87,7 @@ int main (int argc, char** argv)
   }
   else
   {
-    cout << "\nNo devices connected.\n\n";
+    std::cout << "\nNo devices connected.\n\n";
     return 1;
   }
   
@@ -98,9 +98,9 @@ int main (int argc, char** argv)
     [&] (const openni_wrapper::DepthImage::Ptr& depth) { event_helper.depth_image_cb (depth); };
   boost::signals2::connection c_depth_image = interface->registerCallback (f_depth_image);
   
-  cout << "Starting grabber\n";
+  std::cout << "Starting grabber\n";
   interface->start ();
-  cout << "Done\n";
+  std::cout << "Done\n";
   
   pcl::RangeImagePlanar::Ptr range_image_planar_ptr (new pcl::RangeImagePlanar);
   pcl::RangeImagePlanar& range_image_planar = *range_image_planar_ptr;
@@ -117,7 +117,7 @@ int main (int argc, char** argv)
       received_new_depth_data = false;
 
       int frame_id = depth_image_ptr->getFrameID ();
-      cout << "Visualizing frame "<<frame_id<<"\n";
+      std::cout << "Visualizing frame "<<frame_id<<"\n";
       const unsigned short* depth_map = depth_image_ptr->getDepthMetaData ().Data ();
       int width = depth_image_ptr->getWidth (), height = depth_image_ptr->getHeight ();
       float center_x = width/2, center_y = height/2;

--- a/doc/tutorials/content/sources/range_image_border_extraction/range_image_border_extraction.cpp
+++ b/doc/tutorials/content/sources/range_image_border_extraction/range_image_border_extraction.cpp
@@ -51,16 +51,16 @@ main (int argc, char** argv)
   if (pcl::console::find_argument (argc, argv, "-m") >= 0)
   {
     setUnseenToMaxRange = true;
-    cout << "Setting unseen values in range image to maximum range readings.\n";
+    std::cout << "Setting unseen values in range image to maximum range readings.\n";
   }
   int tmp_coordinate_frame;
   if (pcl::console::parse (argc, argv, "-c", tmp_coordinate_frame) >= 0)
   {
     coordinate_frame = pcl::RangeImage::CoordinateFrame (tmp_coordinate_frame);
-    cout << "Using coordinate frame "<< (int)coordinate_frame<<".\n";
+    std::cout << "Using coordinate frame "<< (int)coordinate_frame<<".\n";
   }
   if (pcl::console::parse (argc, argv, "-r", angular_resolution) >= 0)
-    cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
+    std::cout << "Setting angular resolution to "<<angular_resolution<<"deg.\n";
   angular_resolution = pcl::deg2rad (angular_resolution);
   
   // ------------------------------------------------------------------
@@ -76,7 +76,7 @@ main (int argc, char** argv)
     std::string filename = argv[pcd_filename_indices[0]];
     if (pcl::io::loadPCDFile (filename, point_cloud) == -1)
     {
-      cout << "Was not able to open file \""<<filename<<"\".\n";
+      std::cout << "Was not able to open file \""<<filename<<"\".\n";
       printUsage (argv[0]);
       return 0;
     }
@@ -91,7 +91,7 @@ main (int argc, char** argv)
   }
   else
   {
-    cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
+    std::cout << "\nNo *.pcd file given => Generating example point cloud.\n\n";
     for (float x=-0.5f; x<=0.5f; x+=0.01f)
     {
       for (float y=-0.5f; y<=0.5f; y+=0.01f)

--- a/doc/tutorials/content/sources/region_growing_segmentation/region_growing_segmentation.cpp
+++ b/doc/tutorials/content/sources/region_growing_segmentation/region_growing_segmentation.cpp
@@ -49,7 +49,7 @@ main (int argc, char** argv)
   reg.extract (clusters);
 
   std::cout << "Number of clusters is equal to " << clusters.size () << std::endl;
-  std::cout << "First cluster has " << clusters[0].indices.size () << " points." << endl;
+  std::cout << "First cluster has " << clusters[0].indices.size () << " points." << std::endl;
   std::cout << "These are the indices of the points of the initial" <<
     std::endl << "cloud that belong to the first cluster:" << std::endl;
   int counter = 0;

--- a/doc/tutorials/content/sources/registration_api/example1.cpp
+++ b/doc/tutorials/content/sources/registration_api/example1.cpp
@@ -235,7 +235,7 @@ main (int argc, char** argv)
 
   saveTransform (argv[p_tr_file_indices[0]], transform);
 
-  cerr.precision (15);
+  std::cerr.precision (15);
   std::cerr << transform << std::endl;
 }
 /* ]--- */

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -55,7 +55,7 @@ int main (int argc, char *argv[])
   constexpr double decimation = 100;
 
   if(argc < 2){
-    cerr << "Expected 2 arguments: inputfile outputfile" << endl;
+    std::cerr << "Expected 2 arguments: inputfile outputfile" << std::endl;
   }
 
   ///The file to read from.
@@ -69,9 +69,9 @@ int main (int argc, char *argv[])
   pcl::io::loadPCDFile (infile.c_str(), blob);
 
   pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
-        cout << "Loading point cloud...";
+        std::cout << "Loading point cloud...";
         pcl::fromPCLPointCloud2 (blob, *cloud);
-        cout << "done." << endl;
+        std::cout << "done." << std::endl;
 
   SearchPtr tree;
 
@@ -91,7 +91,7 @@ int main (int argc, char *argv[])
 
   // If we are using approximation
   if(approx){
-    cout << "Downsampling point cloud for approximation" << endl;
+    std::cout << "Downsampling point cloud for approximation" << std::endl;
 
     // Create the downsampling filtering object
     pcl::VoxelGrid<PointT> sor;
@@ -103,14 +103,14 @@ int main (int argc, char *argv[])
     float smalldownsample = static_cast<float> (scale1 / decimation);
     sor.setLeafSize (smalldownsample, smalldownsample, smalldownsample);
     sor.filter (*small_cloud_downsampled);
-    cout << "Using leaf size of " << smalldownsample << " for small scale, " << small_cloud_downsampled->size() << " points" << endl;
+    std::cout << "Using leaf size of " << smalldownsample << " for small scale, " << small_cloud_downsampled->size() << " points" << std::endl;
 
     // Create downsampled point cloud for DoN NN search with large scale
     large_cloud_downsampled = PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
     const float largedownsample = float (scale2/decimation);
     sor.setLeafSize (largedownsample, largedownsample, largedownsample);
     sor.filter (*large_cloud_downsampled);
-    cout << "Using leaf size of " << largedownsample << " for large scale, " << large_cloud_downsampled->size() << " points" << endl;
+    std::cout << "Using leaf size of " << largedownsample << " for large scale, " << large_cloud_downsampled->size() << " points" << std::endl;
   }
 
   // Compute normals using both small and large scales at each point
@@ -125,12 +125,12 @@ int main (int argc, char *argv[])
   ne.setViewPoint(std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),std::numeric_limits<float>::max());
 
   if(scale1 >= scale2){
-    cerr << "Error: Large scale must be > small scale!" << endl;
+    std::cerr << "Error: Large scale must be > small scale!" << std::endl;
     exit(EXIT_FAILURE);
   }
 
   //the normals calculated with the small scale
-  cout << "Calculating normals for scale..." << scale1 << endl;
+  std::cout << "Calculating normals for scale..." << scale1 << std::endl;
   pcl::PointCloud<PointNT>::Ptr normals_small_scale (new pcl::PointCloud<PointNT>);
 
   if(approx){
@@ -140,7 +140,7 @@ int main (int argc, char *argv[])
   ne.setRadiusSearch (scale1);
   ne.compute (*normals_small_scale);
 
-  cout << "Calculating normals for scale..." << scale2 << endl;
+  std::cout << "Calculating normals for scale..." << scale2 << std::endl;
   //the normals calculated with the large scale
   pcl::PointCloud<PointNT>::Ptr normals_large_scale (new pcl::PointCloud<PointNT>);
 
@@ -154,7 +154,7 @@ int main (int argc, char *argv[])
   PointCloud<PointOutT>::Ptr doncloud (new pcl::PointCloud<PointOutT>);
   copyPointCloud<PointT, PointOutT>(*cloud, *doncloud);
 
-  cout << "Calculating DoN... " << endl;
+  std::cout << "Calculating DoN... " << std::endl;
   // Create DoN operator
   pcl::DifferenceOfNormalsEstimation<PointT, PointNT, PointOutT> don;
   don.setInputCloud (cloud);
@@ -175,7 +175,7 @@ int main (int argc, char *argv[])
         writer.write<PointOutT> (outfile.c_str (), *doncloud, false);
 
   //Filter by magnitude
-  cout << "Filtering out DoN mag <= "<< threshold <<  "..." << endl;
+  std::cout << "Filtering out DoN mag <= "<< threshold <<  "..." << std::endl;
 
   // build the condition
   pcl::ConditionOr<PointOutT>::Ptr range_cond (new
@@ -201,7 +201,7 @@ int main (int argc, char *argv[])
   writer.write<PointOutT> (ss.str (), *doncloud, false);
 
   //Filter by magnitude
-  cout << "Clustering using EuclideanClusterExtraction with tolerance <= "<< segradius <<  "..." << endl;
+  std::cout << "Clustering using EuclideanClusterExtraction with tolerance <= "<< segradius <<  "..." << std::endl;
 
   pcl::search::KdTree<PointOutT>::Ptr segtree (new pcl::search::KdTree<PointOutT>);
   segtree->setInputCloud (doncloud);

--- a/features/include/pcl/features/impl/range_image_border_extractor.hpp
+++ b/features/include/pcl/features/impl/range_image_border_extractor.hpp
@@ -78,7 +78,7 @@ float RangeImageBorderExtractor::getNeighborDistanceChangeScore(
   {
     if (neighbor.range < 0.0f)
       return 0.0f;
-    //cout << "INF edge -> Setting to 1.0\n";
+    //std::cout << "INF edge -> Setting to 1.0\n";
     return 1.0f;  // TODO: Something more intelligent
   }
   
@@ -113,7 +113,7 @@ float RangeImageBorderExtractor::getNeighborDistanceChangeScore(
   //float ret = 1.0f - (normal_distance_to_plane_squared/distance_to_plane_squared);
   //if (shadow_side)
     //ret = -ret;
-  ////cout << PVARC(normal_distance_to_plane_squared)<<PVAR(distance_to_plane_squared)<<" => "<<ret<<"\n";
+  ////std::cout << PVARC(normal_distance_to_plane_squared)<<PVAR(distance_to_plane_squared)<<" => "<<ret<<"\n";
   //return ret;
 //}
 
@@ -139,7 +139,7 @@ bool RangeImageBorderExtractor::get3dDirection(const BorderDescription& border_d
   const PointWithRange& point = range_image_->getPoint(x, y);
   Eigen::Vector3f neighbor_point;
   range_image_->calculate3DPoint(static_cast<float> (x+delta_x), static_cast<float> (y+delta_y), point.range, neighbor_point);
-  //cout << "Neighborhood point is "<<neighbor_point[0]<<", "<<neighbor_point[1]<<", "<<neighbor_point[2]<<".\n";
+  //std::cout << "Neighborhood point is "<<neighbor_point[0]<<", "<<neighbor_point[1]<<", "<<neighbor_point[2]<<".\n";
   
   if (local_surface!=nullptr)
   {
@@ -150,9 +150,9 @@ bool RangeImageBorderExtractor::get3dDirection(const BorderDescription& border_d
     float lambda = (local_surface->normal_no_jumps.dot(local_surface->neighborhood_mean_no_jumps-sensor_pos)/
                    local_surface->normal_no_jumps.dot(viewing_direction));
     neighbor_point = lambda*viewing_direction + sensor_pos;
-    //cout << "Neighborhood point projected onto plane is "<<neighbor_point[0]<<", "<<neighbor_point[1]<<", "<<neighbor_point[2]<<".\n";
+    //std::cout << "Neighborhood point projected onto plane is "<<neighbor_point[0]<<", "<<neighbor_point[1]<<", "<<neighbor_point[2]<<".\n";
   }
-  //cout << point.x<<","<< point.y<<","<< point.z<<" -> "<< direction[0]<<","<< direction[1]<<","<< direction[2]<<"\n";
+  //std::cout << point.x<<","<< point.y<<","<< point.z<<" -> "<< direction[0]<<","<< direction[1]<<","<< direction[2]<<"\n";
   direction = neighbor_point-point.getVector3fMap();
   direction.normalize();
   
@@ -212,7 +212,7 @@ bool RangeImageBorderExtractor::changeScoreAccordingToShadowBorderValue(int x, i
   }
   if (shadow_border_idx >= 0)
   {
-    //cout << PVARC(border_score)<<PVARN(best_shadow_border_score);
+    //std::cout << PVARC(border_score)<<PVARN(best_shadow_border_score);
     //border_score *= (std::max)(0.9f, powf(-best_shadow_border_score, 0.1f));  // TODO: Something better
     border_score *= (std::max)(0.9f, 1-powf(1+best_shadow_border_score, 3));
     if (border_score>=parameters_.minimum_border_probability)

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -105,7 +105,7 @@ Narf::reset ()
 void 
 Narf::deepCopy (const Narf& other)
 {
-  //cout << __PRETTY_FUNCTION__<<" called.\n";
+  //std::cout << __PRETTY_FUNCTION__<<" called.\n";
   if (&other == this)
     return;
   
@@ -147,7 +147,7 @@ Narf::extractDescriptor (int descriptor_size)
     descriptor_ = new float[descriptor_size_];
   }
   float angle_step_size = deg2rad (360.0f) / static_cast<float> (descriptor_size_);
-  //cout << PVARN(no_of_beam_points)<<PVARN(surface_patch_pixel_size_);
+  //std::cout << PVARN(no_of_beam_points)<<PVARN(surface_patch_pixel_size_);
 
   float cell_size = surface_patch_world_size_/float(surface_patch_pixel_size_),
         cell_factor = 1.0f/cell_size,
@@ -305,7 +305,7 @@ Narf::getBlurredSurfacePatch (int new_pixel_size, int blur_radius) const
         top_value = integral_image[(y-1)*new_pixel_size+x];
       
       integral_pixel += left_value + top_value - top_left_value;
-      //cout << PVARC(x)<<PVARC(y)<<PVARC(left_value)<<PVARC(top_value)<<PVARC(top_left_value)<<PVARN(integral_pixel)<<PVARN(integral_image[y*new_pixel_size+x-1]);
+      //std::cout << PVARC(x)<<PVARC(y)<<PVARC(left_value)<<PVARC(top_value)<<PVARC(top_left_value)<<PVARN(integral_pixel)<<PVARN(integral_image[y*new_pixel_size+x-1]);
     }
   }
   
@@ -468,14 +468,14 @@ Narf::getRotations (std::vector<float>& rotations, std::vector<float>& strengths
   }
   
   //for (std::multimap<float, float>::const_iterator it=scored_orientations.begin(); it!=scored_orientations.end(); ++it)
-    //cout << "Score "<<it->first<<" for angle "<<rad2deg(it->second)<<".\n";
+    //std::cout << "Score "<<it->first<<" for angle "<<rad2deg(it->second)<<".\n";
   
   float min_score = scored_orientations.begin()->first,
         max_score = scored_orientations.rbegin()->first;
   
   float min_score_for_remaining_rotations = max_score - 0.2f*(max_score-min_score);
   scored_orientations.erase(scored_orientations.begin(), scored_orientations.upper_bound(min_score_for_remaining_rotations));
-  //cout << "There are "<<scored_orientations.size()<<" potential orientations left after filtering out bad scores.\n";
+  //std::cout << "There are "<<scored_orientations.size()<<" potential orientations left after filtering out bad scores.\n";
   
   while (!scored_orientations.empty())
   {
@@ -587,7 +587,7 @@ Narf::loadBinary (std::istream& file)
   file.read(reinterpret_cast<char*>(&descriptor_size_), sizeof(descriptor_size_));
   descriptor_ = new float[descriptor_size_];
   if (file.eof())
-    cout << ":-(\n";
+    std::cout << ":-(\n";
   file.read (reinterpret_cast<char*>(descriptor_), descriptor_size_*sizeof(*descriptor_));
 }
 

--- a/features/src/range_image_border_extractor.cpp
+++ b/features/src/range_image_border_extractor.cpp
@@ -83,7 +83,7 @@ RangeImageBorderExtractor::clearData ()
   delete[] border_scores_right_;   border_scores_right_  = nullptr;
   delete[] border_scores_top_;     border_scores_top_    = nullptr;
   delete[] border_scores_bottom_;  border_scores_bottom_ = nullptr;
-  //cout << PVARC(range_image_size_during_extraction_)<<PVARN((void*)this);
+  //std::cout << PVARC(range_image_size_during_extraction_)<<PVARN((void*)this);
   for (int i=0; i<range_image_size_during_extraction_; ++i)
   {
     if (surface_structure_!=nullptr)
@@ -108,7 +108,7 @@ RangeImageBorderExtractor::extractLocalSurfaceStructure ()
 {
   if (surface_structure_ != nullptr)
     return;
-  //cerr << __PRETTY_FUNCTION__<<" called (this="<<(void*)this<<").\n";
+  //std::cerr << __PRETTY_FUNCTION__<<" called (this="<<(void*)this<<").\n";
   //MEASURE_FUNCTION_TIME;
   
   int width  = range_image_->width,
@@ -117,7 +117,7 @@ RangeImageBorderExtractor::extractLocalSurfaceStructure ()
   int array_size = range_image_size_during_extraction_;
   surface_structure_ = new LocalSurface*[array_size];
   int step_size = (std::max)(1, parameters_.pixel_radius_plane_extraction/2);
-  //cout << PVARN(step_size);
+  //std::cout << PVARN(step_size);
   int no_of_nearest_neighbors = static_cast<int> (pow (static_cast<double> (parameters_.pixel_radius_plane_extraction/step_size + 1), 2.0));
   
 # pragma omp parallel for num_threads(parameters_.max_no_of_threads) default(shared) schedule(dynamic, 10)
@@ -133,7 +133,7 @@ RangeImageBorderExtractor::extractLocalSurfaceStructure ()
       local_surface = new LocalSurface;
       Eigen::Vector3f point;
       range_image_->getPoint(x, y, point);
-      //cout << PVARN(point);
+      //std::cout << PVARN(point);
       if (!range_image_->getSurfaceInformation(x, y, parameters_.pixel_radius_plane_extraction, point,
                                   no_of_nearest_neighbors, step_size, local_surface->max_neighbor_distance_squared,
                                   local_surface->normal_no_jumps, local_surface->neighborhood_mean_no_jumps,
@@ -144,7 +144,7 @@ RangeImageBorderExtractor::extractLocalSurfaceStructure ()
         local_surface = nullptr;
       }
       
-      //cout << x<<","<<y<<": ("<<local_surface->normal_no_jumps[0]<<","<<local_surface->normal_no_jumps[1]<<","<<local_surface->normal_no_jumps[2]<<")\n";
+      //std::cout << x<<","<<y<<": ("<<local_surface->normal_no_jumps[0]<<","<<local_surface->normal_no_jumps[1]<<","<<local_surface->normal_no_jumps[2]<<")\n";
     }
   }
 }
@@ -429,7 +429,7 @@ RangeImageBorderExtractor::classifyBorders ()
         shadow_traits[BORDER_TRAIT__SHADOW_BORDER] = shadow_traits[BORDER_TRAIT__SHADOW_BORDER_BOTTOM] = true;
         for (int index3=index-width; index3>shadow_border_index; index3-=width)
         {
-          //cout << "Adding veil point at "<<(index3-index)%width<<","<<(index3-index)/width<<".\n";
+          //std::cout << "Adding veil point at "<<(index3-index)%width<<","<<(index3-index)/width<<".\n";
           BorderTraits& veil_point = border_descriptions_->points[index3].traits;
           veil_point[BORDER_TRAIT__VEIL_POINT] = veil_point[BORDER_TRAIT__VEIL_POINT_BOTTOM] = true;
         }
@@ -443,7 +443,7 @@ RangeImageBorderExtractor::classifyBorders ()
         shadow_traits[BORDER_TRAIT__SHADOW_BORDER] = shadow_traits[BORDER_TRAIT__SHADOW_BORDER_TOP] = true;
         for (int index3=index+width; index3<shadow_border_index; index3+=width)
         {
-          //cout << "Adding veil point at "<<(index3-index)%width<<","<<(index3-index)/width<<".\n";
+          //std::cout << "Adding veil point at "<<(index3-index)%width<<","<<(index3-index)/width<<".\n";
           BorderTraits& veil_point = border_descriptions_->points[index3].traits;
           veil_point[BORDER_TRAIT__VEIL_POINT] = veil_point[BORDER_TRAIT__VEIL_POINT_TOP] = true;
         }
@@ -508,11 +508,11 @@ RangeImageBorderExtractor::calculateBorderDirections ()
           float cos_angle = neighbor_border_direction->dot(*border_direction);
           if (cos_angle<min_cos_angle)
           {
-            //cout << "Reject. "<<PVARC(min_cos_angle)<<PVARC(cos_angle)<<PVARAN(acosf(cos_angle));
+            //std::cout << "Reject. "<<PVARC(min_cos_angle)<<PVARC(cos_angle)<<PVARAN(acosf(cos_angle));
             continue;
           }
           //else
-            //cout << "No reject\n";
+            //std::cout << "No reject\n";
           
           // Border in between?
           float border_between_points_score = getNeighborDistanceChangeScore(*surface_structure_[index], x, y, x2-x,  y2-y, 1);
@@ -629,7 +629,7 @@ RangeImageBorderExtractor::blurSurfaceChanges ()
           {
             Eigen::Vector3f& neighbor = surface_change_directions_[index2];
             //if (std::abs(neighbor.norm()-1) > 1e-4)
-              //cerr<<PVARN(neighbor)<<PVARN(score);
+              //std::cerr<<PVARN(neighbor)<<PVARN(score);
             if (point.dot(neighbor)<0.0f)
               neighbor *= -1.0f;
             new_point += score*neighbor;

--- a/filters/include/pcl/filters/impl/plane_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/plane_clipper3D.hpp
@@ -209,9 +209,9 @@ pcl::PlaneClipper3D<PointT>::clipPointCloud3D (const pcl::PointCloud<PointT>& cl
 
 #endif
 
-    //cout << "points   : " << points.rows () << " x " << points.cols () << " * " << plane_params_.transpose ().rows () << " x " << plane_params_.transpose ().cols () << endl;
+    //std::cout << "points   : " << points.rows () << " x " << points.cols () << " * " << plane_params_.transpose ().rows () << " x " << plane_params_.transpose ().cols () << std::endl;
 
-    //cout << "distances: " << distances.rows () << " x " << distances.cols () << endl;
+    //std::cout << "distances: " << distances.rows () << " x " << distances.cols () << std::endl;
     /*/
     for (unsigned pIdx = 0; pIdx < cloud_in.size (); ++pIdx)
       if (clipPoint3D (cloud_in[pIdx]))


### PR DESCRIPTION
Use `std::cout`/`std::cerr`/`std::endl` instead of just `cout`/`cerr`/`endl` in preparation for #3235.