### PR TITLE
Use std::cout/std::cerr/std::endl instead of just cout/cerr/end…

### DIFF
--- a/gpu/features/test/test_fpfh.cpp
+++ b/gpu/features/test/test_fpfh.cpp
@@ -56,7 +56,7 @@ TEST(PCL_FeaturesGPU, fpfh_low_level)
 
     source.estimateNormals();
     source.findRadiusNeghbors();
-    cout << "max_radius_nn_size: " << source.max_nn_size << endl;
+    std::cout << "max_radius_nn_size: " << source.max_nn_size << std::endl;
                    
     std::vector<int> data;
     source.getNeghborsArray(data);
@@ -119,7 +119,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level1)
   
     //source.generateSurface();
     //source.generateIndices();
-    cout << "!indices, !surface" << endl;
+    std::cout << "!indices, !surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
@@ -197,7 +197,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level2)
 
     //source.generateSurface();
     source.generateIndices();
-    cout << "indices, !surface" << endl;
+    std::cout << "indices, !surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
@@ -260,7 +260,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level2)
 
             //ASSERT_NEAR(gpu.histogram[j], cpu.histogram[j], 0.03f);
         }
-        //cout << i << "->"<< norm_diff/norm << endl;
+        //std::cout << i << "->"<< norm_diff/norm << std::endl;
         if (norm != 0)
             ASSERT_EQ(norm_diff/norm < 0.01f/FSize, true);
     }
@@ -274,7 +274,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level3)
   
     source.generateSurface();
     //source.generateIndices();
-    cout << "!indices, surface" << endl;
+    std::cout << "!indices, surface" << std::endl;
     
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 
@@ -337,7 +337,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level3)
 
             //ASSERT_NEAR(gpu.histogram[j], cpu.histogram[j], 0.03f);
         }
-        //cout << i << "->"<< norm_diff/norm << endl;
+        //std::cout << i << "->"<< norm_diff/norm << std::endl;
         if (norm != 0)
             ASSERT_EQ(norm_diff/norm < 0.01f/FSize, true);
     }
@@ -352,7 +352,7 @@ TEST(PCL_FeaturesGPU, fpfh_high_level4)
   
     source.generateSurface();
     source.generateIndices();
-    cout << "indices, surface" << endl;
+    std::cout << "indices, surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 

--- a/gpu/features/test/test_normals.cpp
+++ b/gpu/features/test/test_normals.cpp
@@ -50,9 +50,9 @@ using namespace pcl::gpu;
 TEST(PCL_FeaturesGPU, normals_lowlevel)
 {       
     DataSource source;
-    cout << "Cloud size: " << source.cloud->points.size() << endl;
-    cout << "Radius: " << source.radius << endl;
-    cout << "K: " << source.k << endl;
+    std::cout << "Cloud size: " << source.cloud->points.size() << std::endl;
+    std::cout << "Radius: " << source.radius << std::endl;
+    std::cout << "K: " << source.k << std::endl;
 
     //source.runCloudViewer();
 
@@ -99,11 +99,11 @@ TEST(PCL_FeaturesGPU, normals_lowlevel)
 TEST(PCL_FeaturesGPU, normals_highlevel_1)
 {       
     DataSource source;
-    cout << "Cloud size: " << source.cloud->points.size() << endl;
-    cout << "Radius: " << source.radius << endl;
-    cout << "Max_elems: " <<  source.max_elements << endl;
+    std::cout << "Cloud size: " << source.cloud->points.size() << std::endl;
+    std::cout << "Radius: " << source.radius << std::endl;
+    std::cout << "Max_elems: " <<  source.max_elements << std::endl;
 
-    cout << "!indices, !surface" << endl;
+    std::cout << "!indices, !surface" << std::endl;
     
     //source.runCloudViewer();
 
@@ -163,11 +163,11 @@ TEST(PCL_FeaturesGPU, normals_highlevel_1)
 TEST(PCL_FeaturesGPU, normals_highlevel_2)
 {       
     DataSource source;
-    cout << "Cloud size: " << source.cloud->points.size() << endl;
-    cout << "Radius: " << source.radius << endl;
-    cout << "Max_elems: " <<  source.max_elements << endl;    
+    std::cout << "Cloud size: " << source.cloud->points.size() << std::endl;
+    std::cout << "Radius: " << source.radius << std::endl;
+    std::cout << "Max_elems: " <<  source.max_elements << std::endl;    
 
-    cout << "indices, !surface" << endl;
+    std::cout << "indices, !surface" << std::endl;
     
     //source.runCloudViewer();
 
@@ -228,11 +228,11 @@ TEST(PCL_FeaturesGPU, normals_highlevel_2)
 TEST(PCL_FeaturesGPU, normals_highlevel_3)
 {       
     DataSource source;
-    cout << "Cloud size: " << source.cloud->points.size() << endl;
-    cout << "Radius: " << source.radius << endl;
-    cout << "Max_elems: " <<  source.max_elements << endl;
+    std::cout << "Cloud size: " << source.cloud->points.size() << std::endl;
+    std::cout << "Radius: " << source.radius << std::endl;
+    std::cout << "Max_elems: " <<  source.max_elements << std::endl;
 
-    cout << "!indices, surface" << endl;
+    std::cout << "!indices, surface" << std::endl;
 
     //source.runCloudViewer();
 
@@ -302,11 +302,11 @@ TEST(PCL_FeaturesGPU, normals_highlevel_3)
 TEST(PCL_FeaturesGPU, normals_highlevel_4)
 {       
     DataSource source;
-    cout << "Cloud size: " << source.cloud->points.size() << endl;
-    cout << "Radius: " << source.radius << endl;
-    cout << "Max_elems: " <<  source.max_elements << endl;
+    std::cout << "Cloud size: " << source.cloud->points.size() << std::endl;
+    std::cout << "Radius: " << source.radius << std::endl;
+    std::cout << "Max_elems: " <<  source.max_elements << std::endl;
     
-    cout << "indices, surface" << endl;
+    std::cout << "indices, surface" << std::endl;
 
     //source.runCloudViewer();
 

--- a/gpu/features/test/test_pfh.cpp
+++ b/gpu/features/test/test_pfh.cpp
@@ -57,7 +57,7 @@ TEST(PCL_FeaturesGPU, pfh_low_level)
 
     source.estimateNormals();
     source.findRadiusNeghbors();
-    cout << "max_radius_nn_size: " << source.max_nn_size << endl;
+    std::cout << "max_radius_nn_size: " << source.max_nn_size << std::endl;
                    
     std::vector<int> data;
     source.getNeghborsArray(data);
@@ -124,7 +124,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level1)
     //source.generateSurface();
     //source.generateIndices();
 
-    cout << "!indices, !surface" << endl;
+    std::cout << "!indices, !surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
@@ -202,7 +202,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level2)
     //source.generateSurface();
     source.generateIndices();
 
-    cout << "indices, !surface" << endl;
+    std::cout << "indices, !surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 
@@ -280,7 +280,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level3)
     source.generateSurface();
     //source.generateIndices();
 
-    cout << "!indices, surface" << endl;
+    std::cout << "!indices, surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 
@@ -358,7 +358,7 @@ TEST(PCL_FeaturesGPU, pfh_high_level4)
     source.generateSurface();
     source.generateIndices();
 
-    cout << "indices, surface" << endl;
+    std::cout << "indices, surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals_surface;
 
@@ -436,7 +436,7 @@ TEST(PCL_FeaturesGPU, pfhrgb)
     //source.generateSurface();
     //source.generateIndices();
 
-    cout << "!indices, !surface" << endl;
+    std::cout << "!indices, !surface" << std::endl;
 
     PointCloud<Normal>::Ptr& normals = source.normals;
 

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -172,7 +172,7 @@ void
 pcl::gpu::KinfuTracker::reset()
 {
   if (global_time_)
-    cout << "Reset" << endl;
+    std::cout << "Reset" << std::endl;
 
   global_time_ = 0;
   rmats_.clear ();
@@ -342,7 +342,7 @@ pcl::gpu::KinfuTracker::operator() (const DepthMap& depth_raw,
 
             if (std::abs (det) < 1e-15 || std::isnan (det))
             {
-              if (std::isnan (det)) cout << "qnan" << endl;
+              if (std::isnan (det)) std::cout << "qnan" << std::endl;
 
               reset ();
               return (false);

--- a/gpu/kinfu/tools/evaluation.cpp
+++ b/gpu/kinfu/tools/evaluation.cpp
@@ -50,7 +50,7 @@ const float Evaluation::cy = 239.5f;
 
 struct Evaluation::Impl {};
 
-Evaluation::Evaluation(const std::string&) { cout << "Evaluation requires OpenCV. Please enable it in cmake-file" << endl; exit(0); }
+Evaluation::Evaluation(const std::string&) { std::cout << "Evaluation requires OpenCV. Please enable it in cmake-file" << std::endl; exit(0); }
 void Evaluation::setMatchFile(const std::string&) { }
 bool Evaluation::grab (double stamp, pcl::gpu::PtrStepSz<const RGB>& rgb24) { return false; }
 bool Evaluation::grab (double stamp, pcl::gpu::PtrStepSz<const unsigned short>& depth) { return false; }
@@ -80,7 +80,7 @@ Evaluation::Evaluation(const std::string& folder) : folder_(folder), visualizati
   if (folder_[folder_.size() - 1] != '\\' && folder_[folder_.size() - 1] != '/')
       folder_.push_back('/');
 
-  cout << "Initializing evaluation from folder: " << folder_ << endl;
+  std::cout << "Initializing evaluation from folder: " << folder_ << std::endl;
   string depth_file = folder_ + "depth.txt";
   string rgb_file = folder_ + "rgb.txt";
   
@@ -94,7 +94,7 @@ void Evaluation::setMatchFile(const std::string& file)
   ifstream iff(full.c_str());  
   if(!iff)
   {
-    cout << "Can't read " << file << endl;
+    std::cout << "Can't read " << file << std::endl;
     exit(1);
   }
 
@@ -115,7 +115,7 @@ void Evaluation::readFile(const string& file, std::vector< pair<double,string> >
   ifstream iff(file.c_str());
   if(!iff)
   {
-    cout << "Can't read " << file << endl;
+    std::cout << "Can't read " << file << std::endl;
     exit(1);
   }
 
@@ -179,7 +179,7 @@ bool Evaluation::grab (double stamp, PtrStepSz<const unsigned short>& depth)
    
   if (d_img.elemSize() != sizeof(unsigned short))
   {
-    cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << endl;
+    std::cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << std::endl;
     exit(1);
   }
 
@@ -205,7 +205,7 @@ bool Evaluation::grab (double stamp, PtrStepSz<const unsigned short>& depth, Ptr
 {
   if (accociations_.empty())
   {
-    cout << "Please set match file" << endl;
+    std::cout << "Please set match file" << std::endl;
     exit(0);
   }
 
@@ -223,7 +223,7 @@ bool Evaluation::grab (double stamp, PtrStepSz<const unsigned short>& depth, Ptr
    
   if (d_img.elemSize() != sizeof(unsigned short))
   {
-    cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << endl;
+    std::cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << std::endl;
     exit(1);
   }
 
@@ -259,7 +259,7 @@ void Evaluation::saveAllPoses(const pcl::gpu::KinfuTracker& kinfu, int frame_num
 
   frame_number = std::min(frame_number, (int)kinfu.getNumberOfPoses());
 
-  cout << "Writing " << frame_number << " poses to " << logfile << endl;
+  std::cout << "Writing " << frame_number << " poses to " << logfile << std::endl;
   
   ofstream path_file_stream(logfile.c_str());
   path_file_stream.setf(ios::fixed,ios::floatfield);
@@ -274,7 +274,7 @@ void Evaluation::saveAllPoses(const pcl::gpu::KinfuTracker& kinfu, int frame_num
 
     path_file_stream << stamp << " ";
     path_file_stream << t[0] << " " << t[1] << " " << t[2] << " ";
-    path_file_stream << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << endl;
+    path_file_stream << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << std::endl;
   }
 }
 

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -189,7 +189,7 @@ std::vector<string> getPcdFilesInDir(const string& directory)
       if (fs::extension(*pos) == ".pcd")
       {
         result.push_back (pos->path ().string ());
-        cout << "added: " << result.back() << endl;
+        std::cout << "added: " << result.back() << std::endl;
       }
     
   return result;  
@@ -209,8 +209,8 @@ struct SampledScopeTime : public StopWatch
     if (i_ % EACH == 0 && i_)
     {
       boost::posix_time::ptime endtime_ = boost::posix_time::microsec_clock::local_time();
-      cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )"
-           << "( real: " << 1000.f * EACH / (endtime_-starttime_).total_milliseconds() << "fps )"  << endl;
+      std::cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )"
+           << "( real: " << 1000.f * EACH / (endtime_-starttime_).total_milliseconds() << "fps )"  << std::endl;
       time_ms_ = 0;
       starttime_ = endtime_;
     }
@@ -424,7 +424,7 @@ struct ImageView
   toggleImagePaint()
   {
     paint_image_ = !paint_image_;
-    cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << endl;
+    std::cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << std::endl;
   }
 
   int viz_;
@@ -483,7 +483,7 @@ struct SceneCloudView
     viewer_pose_ = kinfu.getCameraPose();
 
     ScopeTimeT time ("PointCloud Extraction");
-    cout << "\nGetting cloud... " << flush;
+    std::cout << "\nGetting cloud... " << flush;
 
     valid_combined_ = false;
 
@@ -523,7 +523,7 @@ struct SceneCloudView
         point_colors_ptr_->points.clear();
     }
     size_t points_size = valid_combined_ ? combined_ptr_->points.size () : cloud_ptr_->points.size ();
-    cout << "Done.  Cloud size: " << points_size / 1000 << "K" << endl;
+    std::cout << "Done.  Cloud size: " << points_size / 1000 << "K" << std::endl;
 
     if (viz_)
     {
@@ -563,9 +563,9 @@ struct SceneCloudView
 
     switch (extraction_mode_)
     {
-    case 0: cout << "Cloud exctraction mode: GPU, Connected-6" << endl; break;
-    case 1: cout << "Cloud exctraction mode: CPU, Connected-6    (requires a lot of memory)" << endl; break;
-    case 2: cout << "Cloud exctraction mode: CPU, Connected-26   (requires a lot of memory)" << endl; break;
+    case 0: std::cout << "Cloud exctraction mode: GPU, Connected-6" << std::endl; break;
+    case 1: std::cout << "Cloud exctraction mode: CPU, Connected-6    (requires a lot of memory)" << std::endl; break;
+    case 2: std::cout << "Cloud exctraction mode: CPU, Connected-26   (requires a lot of memory)" << std::endl; break;
     }
     ;
   }
@@ -574,7 +574,7 @@ struct SceneCloudView
   toggleNormals ()
   {
     compute_normals_ = !compute_normals_;
-    cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << endl;
+    std::cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << std::endl;
   }
 
   void
@@ -587,7 +587,7 @@ struct SceneCloudView
     cloud_ptr_->points.clear ();
     normals_ptr_->points.clear ();    
     if (print_message)
-      cout << "Clouds/Meshes were cleared" << endl;
+      std::cout << "Clouds/Meshes were cleared" << std::endl;
   }
 
   void
@@ -597,7 +597,7 @@ struct SceneCloudView
        return;
 
     ScopeTimeT time ("Mesh Extraction");
-    cout << "\nGetting mesh... " << flush;
+    std::cout << "\nGetting mesh... " << flush;
 
     if (!marching_cubes_)
       marching_cubes_ = MarchingCubes::Ptr( new MarchingCubes() );
@@ -609,7 +609,7 @@ struct SceneCloudView
     if (mesh_ptr_)
       cloud_viewer_->addPolygonMesh(*mesh_ptr_);
     
-    cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << endl;
+    std::cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << std::endl;
   }
     
   int viz_;
@@ -699,7 +699,7 @@ struct KinFuApp
   initRegistration ()
   {        
     registration_ = capture_.providesCallback<pcl::ONIGrabber::sig_cb_openni_image_depth_image> ();
-    cout << "Registration mode: " << (registration_ ? "On" : "Off (not supported by source)") << endl;
+    std::cout << "Registration mode: " << (registration_ ? "On" : "Off (not supported by source)") << std::endl;
     if (registration_)
       kinfu_.setDepthIntrinsics(KINFU_DEFAULT_RGB_FOCAL_X, KINFU_DEFAULT_RGB_FOCAL_Y);
   }
@@ -715,11 +715,11 @@ struct KinFuApp
         float cx = depth_intrinsics[2];
         float cy = depth_intrinsics[3];
         kinfu_.setDepthIntrinsics(fx, fy, cx, cy);
-        cout << "Depth intrinsics changed to fx="<< fx << " fy=" << fy << " cx=" << cx << " cy=" << cy << endl;
+        std::cout << "Depth intrinsics changed to fx="<< fx << " fy=" << fy << " cx=" << cx << " cy=" << cy << std::endl;
     }
     else {
         kinfu_.setDepthIntrinsics(fx, fy);
-        cout << "Depth intrinsics changed to fx="<< fx << " fy=" << fy << endl;
+        std::cout << "Depth intrinsics changed to fx="<< fx << " fy=" << fy << std::endl;
     }
   }
 
@@ -732,7 +732,7 @@ struct KinFuApp
       kinfu_.initColorIntegration(max_color_integration_weight);
       integrate_colors_ = true;      
     }    
-    cout << "Color integration: " << (integrate_colors_ ? "On" : "Off ( requires registration mode )") << endl;
+    std::cout << "Color integration: " << (integrate_colors_ ? "On" : "Off ( requires registration mode )") << std::endl;
   }
   
   void 
@@ -745,7 +745,7 @@ struct KinFuApp
   toggleIndependentCamera()
   {
     independent_camera_ = !independent_camera_;
-    cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << endl;
+    std::cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << std::endl;
   }
   
   void
@@ -797,17 +797,17 @@ struct KinFuApp
                     
       if (scan_volume_)
       {                
-        cout << "Downloading TSDF volume from device ... " << flush;
+        std::cout << "Downloading TSDF volume from device ... " << flush;
         kinfu_.volume().downloadTsdfAndWeighs (tsdf_volume_.volumeWriteable (), tsdf_volume_.weightsWriteable ());
         tsdf_volume_.setHeader (Eigen::Vector3i (pcl::device::VOLUME_X, pcl::device::VOLUME_Y, pcl::device::VOLUME_Z), kinfu_.volume().getSize ());
-        cout << "done [" << tsdf_volume_.size () << " voxels]" << endl << endl;
+        std::cout << "done [" << tsdf_volume_.size () << " voxels]" << std::endl << std::endl;
                 
-        cout << "Converting volume to TSDF cloud ... " << flush;
+        std::cout << "Converting volume to TSDF cloud ... " << flush;
         tsdf_volume_.convertToTsdfCloud (tsdf_cloud_ptr_);
-        cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << endl << endl;        
+        std::cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << std::endl << std::endl;        
       }
       else
-        cout << "[!] tsdf volume download is disabled" << endl << endl;
+        std::cout << "[!] tsdf volume download is disabled" << std::endl << std::endl;
     }
 
     if (scan_mesh_)
@@ -1006,8 +1006,8 @@ struct KinFuApp
         bool has_data = (data_ready_cond_.wait_for(lock, 100ms) == std::cv_status::no_timeout);
                        
         try { this->execute (depth_, rgb24_, has_data); }
-        catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; break; }
-        catch (const std::exception& /*e*/) { cout << "Exception" << endl; break; }
+        catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; break; }
+        catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; break; }
         
         if (viz_)
             scene_cloud_view_.cloud_viewer_->spinOnce (3);
@@ -1029,7 +1029,7 @@ struct KinFuApp
     // If none have points, we have nothing to export.
     if (view.cloud_ptr_->points.empty () && view.combined_ptr_->points.empty ())
     {
-      cout << "Not writing cloud: Cloud is empty" << endl;
+      std::cout << "Not writing cloud: Cloud is empty" << std::endl;
     }
     else
     {
@@ -1062,23 +1062,23 @@ struct KinFuApp
   void
   printHelp ()
   {
-    cout << endl;
-    cout << "KinFu app hotkeys" << endl;
-    cout << "=================" << endl;
-    cout << "    H    : print this help" << endl;
-    cout << "   Esc   : exit" << endl;
-    cout << "    T    : take cloud" << endl;
-    cout << "    A    : take mesh" << endl;
-    cout << "    M    : toggle cloud exctraction mode" << endl;
-    cout << "    N    : toggle normals exctraction" << endl;
-    cout << "    I    : toggle independent camera mode" << endl;
-    cout << "    B    : toggle volume bounds" << endl;
-    cout << "    *    : toggle scene view painting ( requires registration mode )" << endl;
-    cout << "    C    : clear clouds" << endl;    
-    cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << endl;
-    cout << "    7,8  : save mesh to PLY, VTK" << endl;
-    cout << "   X, V  : TSDF volume utility" << endl;
-    cout << endl;
+    std::cout << std::endl;
+    std::cout << "KinFu app hotkeys" << std::endl;
+    std::cout << "=================" << std::endl;
+    std::cout << "    H    : print this help" << std::endl;
+    std::cout << "   Esc   : exit" << std::endl;
+    std::cout << "    T    : take cloud" << std::endl;
+    std::cout << "    A    : take mesh" << std::endl;
+    std::cout << "    M    : toggle cloud exctraction mode" << std::endl;
+    std::cout << "    N    : toggle normals exctraction" << std::endl;
+    std::cout << "    I    : toggle independent camera mode" << std::endl;
+    std::cout << "    B    : toggle volume bounds" << std::endl;
+    std::cout << "    *    : toggle scene view painting ( requires registration mode )" << std::endl;
+    std::cout << "    C    : clear clouds" << std::endl;    
+    std::cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << std::endl;
+    std::cout << "    7,8  : save mesh to PLY, VTK" << std::endl;
+    std::cout << "   X, V  : TSDF volume utility" << std::endl;
+    std::cout << std::endl;
   }  
 
   bool exit_;
@@ -1146,15 +1146,15 @@ struct KinFuApp
 
       case (int)'x': case (int)'X':
         app->scan_volume_ = !app->scan_volume_;
-        cout << endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << endl << endl;
+        std::cout << std::endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << std::endl << std::endl;
         break;
       case (int)'v': case (int)'V':
-        cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
+        std::cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
         app->tsdf_volume_.save ("tsdf_volume.dat", true);
-        cout << "done [" << app->tsdf_volume_.size () << " voxels]" << endl;
-        cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
+        std::cout << "done [" << app->tsdf_volume_.size () << " voxels]" << std::endl;
+        std::cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
         pcl::io::savePCDFile<pcl::PointXYZI> ("tsdf_cloud.pcd", *app->tsdf_cloud_ptr_, true);
-        cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << endl;
+        std::cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << std::endl;
         break;
 
       default:
@@ -1169,22 +1169,22 @@ writeCloudFile (int format, const CloudPtr& cloud_prt)
 {
   if (format == KinFuApp::PCD_BIN)
   {
-    cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
+    std::cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
     pcl::io::savePCDFile ("cloud_bin.pcd", *cloud_prt, true);
   }
   else
   if (format == KinFuApp::PCD_ASCII)
   {
-    cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
     pcl::io::savePCDFile ("cloud.pcd", *cloud_prt, false);
   }
   else   /* if (format == KinFuApp::PLY) */
   {
-    cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
     pcl::io::savePLYFileASCII ("cloud.ply", *cloud_prt);
   
   }
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1194,15 +1194,15 @@ writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 {
   if (format == KinFuApp::MESH_PLY)
   {
-    cout << "Saving mesh to to 'mesh.ply'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.ply'... " << flush;
     pcl::io::savePLYFile("mesh.ply", mesh);		
   }
   else /* if (format == KinFuApp::MESH_VTK) */
   {
-    cout << "Saving mesh to to 'mesh.vtk'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.vtk'... " << flush;
     pcl::io::saveVTKFile("mesh.vtk", mesh);    
   }  
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1210,21 +1210,21 @@ writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 int
 print_cli_help ()
 {
-  cout << "\nKinFu parameters:" << endl;
-  cout << "    --help, -h                              : print this message" << endl;  
-  cout << "    --registration, -r                      : try to enable registration (source needs to support this)" << endl;
-  cout << "    --current-cloud, -cc                    : show current frame cloud" << endl;
-  cout << "    --save-views, -sv                       : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << endl;  
-  cout << "    --integrate-colors, -ic                 : enable color integration mode (allows to get cloud with colors)" << endl;   
-  cout << "    --scale-truncation, -st                 : scale the truncation distance and raycaster based on the volume size" << endl;
-  cout << "    -volume_size <size_in_meters>           : define integration volume size" << endl;
-  cout << "    --depth-intrinsics <fx>,<fy>[,<cx>,<cy> : set the intrinsics of the depth camera" << endl;
-  cout << "    -save_pose <pose_file.csv>              : write tracked camera positions to the specified file" << endl;
-  cout << "Valid depth data sources:" << endl; 
-  cout << "    -dev <device> (default), -oni <oni_file>, -pcd <pcd_file or directory>" << endl;
-  cout << "";
-  cout << " For RGBD benchmark (Requires OpenCV):" << endl; 
-  cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl;
+  std::cout << "\nKinFu parameters:" << std::endl;
+  std::cout << "    --help, -h                              : print this message" << std::endl;  
+  std::cout << "    --registration, -r                      : try to enable registration (source needs to support this)" << std::endl;
+  std::cout << "    --current-cloud, -cc                    : show current frame cloud" << std::endl;
+  std::cout << "    --save-views, -sv                       : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << std::endl;  
+  std::cout << "    --integrate-colors, -ic                 : enable color integration mode (allows to get cloud with colors)" << std::endl;   
+  std::cout << "    --scale-truncation, -st                 : scale the truncation distance and raycaster based on the volume size" << std::endl;
+  std::cout << "    -volume_size <size_in_meters>           : define integration volume size" << std::endl;
+  std::cout << "    --depth-intrinsics <fx>,<fy>[,<cx>,<cy> : set the intrinsics of the depth camera" << std::endl;
+  std::cout << "    -save_pose <pose_file.csv>              : write tracked camera positions to the specified file" << std::endl;
+  std::cout << "Valid depth data sources:" << std::endl; 
+  std::cout << "    -dev <device> (default), -oni <oni_file>, -pcd <pcd_file or directory>" << std::endl;
+  std::cout << "";
+  std::cout << " For RGBD benchmark (Requires OpenCV):" << std::endl; 
+  std::cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << std::endl;
     
   return 0;
 }
@@ -1243,7 +1243,7 @@ main (int argc, char* argv[])
   pcl::gpu::printShortCudaDeviceInfo (device);
 
 //  if (checkIfPreFermiGPU(device))
-//    return cout << endl << "Kinfu is supported only for Fermi and Kepler arhitectures. It is not even compiled for pre-Fermi by default. Exiting..." << endl, 1;
+//    return std::cout << std::endl << "Kinfu is supported only for Fermi and Kepler arhitectures. It is not even compiled for pre-Fermi by default. Exiting..." << std::endl, 1;
   
   boost::shared_ptr<pcl::Grabber> capture;
   
@@ -1292,7 +1292,7 @@ main (int argc, char* argv[])
       //triggered_capture = true; capture.reset( new pcl::ONIGrabber("d:/onis/20111013-224719.oni", true, ! triggered_capture) );    
     }
   }
-  catch (const pcl::PCLException& /*e*/) { return cout << "Can't open depth source" << endl, -1; }
+  catch (const pcl::PCLException& /*e*/) { return std::cout << "Can't open depth source" << std::endl, -1; }
 
   float volume_size = 3.f;
   pc::parse_argument (argc, argv, "-volume_size", volume_size);
@@ -1353,18 +1353,18 @@ main (int argc, char* argv[])
 
   // executing
   try { app.startMainLoop (triggered_capture); }
-  catch (const pcl::PCLException& /*e*/) { cout << "PCLException" << endl; }
-  catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; }
-  catch (const std::exception& /*e*/) { cout << "Exception" << endl; }
+  catch (const pcl::PCLException& /*e*/) { std::cout << "PCLException" << std::endl; }
+  catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; }
+  catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; }
 
 #ifdef HAVE_OPENCV
   for (size_t t = 0; t < app.image_view_.views_.size (); ++t)
   {
     if (t == 0)
     {
-      cout << "Saving depth map of first view." << endl;
+      std::cout << "Saving depth map of first view." << std::endl;
       cv::imwrite ("./depthmap_1stview.png", app.image_view_.views_[0]);
-      cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << endl;
+      std::cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << std::endl;
     }
     char buf[4096];
     sprintf (buf, "./%06d.png", (int)t);

--- a/gpu/kinfu/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu/tools/kinfu_app_sim.cpp
@@ -162,7 +162,7 @@ struct SampledScopeTime : public StopWatch
     time_ms_ += stopWatch_.getTime ();
     if (i_ % EACH == 0 && i_)
     {
-      cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << endl;
+      std::cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << std::endl;
       time_ms_ = 0;
     }
   }
@@ -345,7 +345,7 @@ depthBufferToMM(const float* depth_buffer,unsigned short* depth_img)
       else if (z_new>5000) z_new = 0;
 
       //      if ( z_new < 18000){
-//          cout << z_new << " " << d << " " << x << "\n";
+//          std::cout << z_new << " " << d << " " << x << "\n";
 //      }
       depth_img[i] = z_new;
     }
@@ -374,22 +374,22 @@ display_tic_toc (vector<double> &tic_toc,const string &fun_name)
 
   double percent_tic_toc_last = 0;
   double dtime = tic_toc[tic_toc_size-1] - tic_toc[0];
-  cout << "fraction_" << fun_name << ",";
+  std::cout << "fraction_" << fun_name << ",";
   for (size_t i = 0; i < tic_toc_size; i++)
   {
     double percent_tic_toc =  (tic_toc[i] - tic_toc[0])/(tic_toc[tic_toc_size-1] - tic_toc[0]);
-    cout <<  percent_tic_toc - percent_tic_toc_last << ", ";
+    std::cout <<  percent_tic_toc - percent_tic_toc_last << ", ";
     percent_tic_toc_last = percent_tic_toc;
   }
-  cout << "\ntime_" << fun_name << ",";
+  std::cout << "\ntime_" << fun_name << ",";
   double time_tic_toc_last = 0;
   for (size_t i = 0; i < tic_toc_size; i++)
   {
     double percent_tic_toc = (tic_toc[i] - tic_toc[0])/(tic_toc[tic_toc_size-1] - tic_toc[0]);
-    cout <<  percent_tic_toc*dtime - time_tic_toc_last << ", ";
+    std::cout <<  percent_tic_toc*dtime - time_tic_toc_last << ", ";
     time_tic_toc_last = percent_tic_toc*dtime;
   }
-  cout << "\ntotal_time_" << fun_name << " " << dtime << "\n";
+  std::cout << "\ntotal_time_" << fun_name << " " << dtime << "\n";
 }
 
 void
@@ -453,7 +453,7 @@ capture (Eigen::Isometry3d pose_in,unsigned short* depth_buffer_mm,const uint8_t
     pcl::PCDWriter writer;
     //writer.write (point_cloud_fname, *pc_out, false);  /// ASCII
     writer.writeBinary (point_cloud_fname, *pc_out);
-    //cout << "finished writing file\n";
+    //std::cout << "finished writing file\n";
   }
   */
 
@@ -566,7 +566,7 @@ boost::shared_ptr<pcl::PolygonMesh> convertToMesh(const DeviceArray<PointXYZ>& t
   }
   return mesh_ptr;
 
-  cout << mesh_ptr->polygons.size () << " plys\n";
+  std::cout << mesh_ptr->polygons.size () << " plys\n";
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -681,7 +681,7 @@ struct ImageView
   toggleImagePaint()
   {
     paint_image_ = !paint_image_;
-    cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << endl;
+    std::cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << std::endl;
   }
 
   bool paint_image_;
@@ -734,7 +734,7 @@ struct SceneCloudView
     viewer_pose_ = kinfu.getCameraPose();
 
     ScopeTimeT time ("PointCloud Extraction");
-    cout << "\nGetting cloud... " << flush;
+    std::cout << "\nGetting cloud... " << flush;
 
     valid_combined_ = false;
 
@@ -774,7 +774,7 @@ struct SceneCloudView
         point_colors_ptr_->points.clear();
     }
     size_t points_size = valid_combined_ ? combined_ptr_->points.size () : cloud_ptr_->points.size ();
-    cout << "Done.  Cloud size: " << points_size / 1000 << "K" << endl;
+    std::cout << "Done.  Cloud size: " << points_size / 1000 << "K" << std::endl;
 
     cloud_viewer_.removeAllPointClouds ();
     if (valid_combined_)
@@ -808,9 +808,9 @@ struct SceneCloudView
 
     switch (extraction_mode_)
     {
-    case 0: cout << "Cloud exctraction mode: GPU, Connected-6" << endl; break;
-    case 1: cout << "Cloud exctraction mode: CPU, Connected-6    (requires a lot of memory)" << endl; break;
-    case 2: cout << "Cloud exctraction mode: CPU, Connected-26   (requires a lot of memory)" << endl; break;
+    case 0: std::cout << "Cloud exctraction mode: GPU, Connected-6" << std::endl; break;
+    case 1: std::cout << "Cloud exctraction mode: CPU, Connected-6    (requires a lot of memory)" << std::endl; break;
+    case 2: std::cout << "Cloud exctraction mode: CPU, Connected-26   (requires a lot of memory)" << std::endl; break;
     }
     ;
   }
@@ -819,7 +819,7 @@ struct SceneCloudView
   toggleNormals ()
   {
     compute_normals_ = !compute_normals_;
-    cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << endl;
+    std::cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << std::endl;
   }
 
   void
@@ -829,14 +829,14 @@ struct SceneCloudView
     cloud_ptr_->points.clear ();
     normals_ptr_->points.clear ();
     if (print_message)
-      cout << "Clouds/Meshes were cleared" << endl;
+      std::cout << "Clouds/Meshes were cleared" << std::endl;
   }
 
   void
   showMesh(KinfuTracker& kinfu, bool /*integrate_colors*/)
   {
     ScopeTimeT time ("Mesh Extraction");
-    cout << "\nGetting mesh... " << flush;
+    std::cout << "\nGetting mesh... " << flush;
 
     if (!marching_cubes_)
       marching_cubes_ = MarchingCubes::Ptr( new MarchingCubes() );
@@ -847,12 +847,12 @@ struct SceneCloudView
     cloud_viewer_.removeAllPointClouds ();
     if (mesh_ptr_){
       cloud_viewer_.addPolygonMesh(*mesh_ptr_);
-      cout << "mesh ptr exist\n";
+      std::cout << "mesh ptr exist\n";
     }else{
-      cout << "mesh ptr no exist\n";
+      std::cout << "mesh ptr no exist\n";
     }
 
-    cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << endl;
+    std::cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << std::endl;
   }
 
   int extraction_mode_;
@@ -941,7 +941,7 @@ struct KinFuApp
   tryRegistrationInit ()
   {
     registration_ = capture_.setRegistration (true);
-    cout << "Registration mode: " << (registration_ ?  "On" : "Off (not supported by source)") << endl;
+    std::cout << "Registration mode: " << (registration_ ?  "On" : "Off (not supported by source)") << std::endl;
   }
 
   void
@@ -953,14 +953,14 @@ struct KinFuApp
       kinfu_.initColorIntegration(max_color_integration_weight);
       integrate_colors_ = true;
     }
-    cout << "Color integration: " << (integrate_colors_ ? "On" : "Off (not supported by source)") << endl;
+    std::cout << "Color integration: " << (integrate_colors_ ? "On" : "Off (not supported by source)") << std::endl;
   }
 
   void
   toggleIndependentCamera()
   {
     independent_camera_ = !independent_camera_;
-    cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << endl;
+    std::cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << std::endl;
   }
 
   void
@@ -1032,7 +1032,7 @@ struct KinFuApp
     camera_->set(0.471703, 1.59862, 3.10937, 0, 0.418879, -12.2129);
     camera_->set_pitch(0.418879); // not sure why this is here:
 
-    cout << "About to read: "<< plyfile << endl;
+    std::cout << "About to read: "<< plyfile << std::endl;
     load_PolygonMesh_model (plyfile);
 
     // Generate a series of poses:
@@ -1068,14 +1068,14 @@ struct KinFuApp
       capture (poses[i],disparity_buf_, color_buf_uint);//,ss.str());
       const KinfuTracker::PixelRGB* color_buf_ = (const KinfuTracker::PixelRGB*) color_buf_uint;
       PtrStepSz<const unsigned short> depth_sim = PtrStepSz<const unsigned short>(height, width, disparity_buf_, 2*width);
-      //cout << depth_sim.rows << " by " << depth_sim.cols << " | s: " << depth_sim.step << "\n";
+      //std::cout << depth_sim.rows << " by " << depth_sim.cols << " | s: " << depth_sim.step << "\n";
       // RGB-KinFu currently disabled for now - problems with color in KinFu apparently
       // but this constructor might not  be right either: not sure about step size
       integrate_colors_=false;
       PtrStepSz<const KinfuTracker::PixelRGB> rgb24_sim = PtrStepSz<const KinfuTracker::PixelRGB>(height, width, color_buf_, width);
       tic_toc.push_back (getTime ());
 
-      cout << " color: " << integrate_colors_ << "\n"; // integrate_colors_ seems to be zero
+      std::cout << " color: " << integrate_colors_ << "\n"; // integrate_colors_ seems to be zero
       depth_device_.upload (depth_sim.data, depth_sim.step, depth_sim.rows, depth_sim.cols);
       if (integrate_colors_){
           image_view_.colors_device_.upload (rgb24_sim.data, rgb24_sim.step, rgb24_sim.rows, rgb24_sim.cols);
@@ -1107,7 +1107,7 @@ struct KinFuApp
       // Everything below this is Visualization or I/O:
       if (i >n_pose_stop){
         int pause;
-        cout << "Enter a key to write Mesh file\n";
+        std::cout << "Enter a key to write Mesh file\n";
         cin >> pause;
 
         scene_cloud_view_.showMesh(kinfu_, integrate_colors_);
@@ -1124,20 +1124,20 @@ struct KinFuApp
             // download tsdf volume
             {
               ScopeTimeT time ("tsdf volume download");
-              cout << "Downloading TSDF volume from device ... " << flush;
+              std::cout << "Downloading TSDF volume from device ... " << flush;
               kinfu_.volume().downloadTsdfAndWeighs (tsdf_volume_.volumeWriteable (), tsdf_volume_.weightsWriteable ());
               tsdf_volume_.setHeader (Eigen::Vector3i (pcl::device::VOLUME_X, pcl::device::VOLUME_Y, pcl::device::VOLUME_Z), kinfu_.volume().getSize ());
-              cout << "done [" << tsdf_volume_.size () << " voxels]" << endl << endl;
+              std::cout << "done [" << tsdf_volume_.size () << " voxels]" << std::endl << std::endl;
             }
             {
               ScopeTimeT time ("converting");
-              cout << "Converting volume to TSDF cloud ... " << flush;
+              std::cout << "Converting volume to TSDF cloud ... " << flush;
               tsdf_volume_.convertToTsdfCloud (tsdf_cloud_ptr_);
-              cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << endl << endl;
+              std::cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << std::endl << std::endl;
             }
           }
           else
-            cout << "[!] tsdf volume download is disabled" << endl << endl;
+            std::cout << "[!] tsdf volume download is disabled" << std::endl << std::endl;
         }
 
         if (scan_mesh_)
@@ -1166,11 +1166,11 @@ struct KinFuApp
         scene_cloud_view_.cloud_viewer_.spinOnce (3);
 
         // As of April 2012, entering a key will end this program...
-        cout << "Paused after view\n";
+        std::cout << "Paused after view\n";
         cin >> pause;
       }
       double elapsed = (getTime() -tic_main);
-      cout << elapsed << " sec elapsed [" << (1/elapsed) << "]\n";
+      std::cout << elapsed << " sec elapsed [" << (1/elapsed) << "]\n";
       tic_toc.push_back (getTime ());
       display_tic_toc (tic_toc, "kinfu_app_sim");
     }
@@ -1211,23 +1211,23 @@ struct KinFuApp
   void
   printHelp ()
   {
-    cout << endl;
-    cout << "KinFu app hotkeys" << endl;
-    cout << "=================" << endl;
-    cout << "    H    : print this help" << endl;
-    cout << "   Esc   : exit" << endl;
-    cout << "    T    : take cloud" << endl;
-    cout << "    A    : take mesh" << endl;
-    cout << "    M    : toggle cloud exctraction mode" << endl;
-    cout << "    N    : toggle normals exctraction" << endl;
-    cout << "    I    : toggle independent camera mode" << endl;
-    cout << "    B    : toggle volume bounds" << endl;
-    cout << "    *    : toggle scene view painting ( requires registration mode )" << endl;
-    cout << "    C    : clear clouds" << endl;
-    cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << endl;
-    cout << "    7,8  : save mesh to PLY, VTK" << endl;
-    cout << "   X, V  : TSDF volume utility" << endl;
-    cout << endl;
+    std::cout << std::endl;
+    std::cout << "KinFu app hotkeys" << std::endl;
+    std::cout << "=================" << std::endl;
+    std::cout << "    H    : print this help" << std::endl;
+    std::cout << "   Esc   : exit" << std::endl;
+    std::cout << "    T    : take cloud" << std::endl;
+    std::cout << "    A    : take mesh" << std::endl;
+    std::cout << "    M    : toggle cloud exctraction mode" << std::endl;
+    std::cout << "    N    : toggle normals exctraction" << std::endl;
+    std::cout << "    I    : toggle independent camera mode" << std::endl;
+    std::cout << "    B    : toggle volume bounds" << std::endl;
+    std::cout << "    *    : toggle scene view painting ( requires registration mode )" << std::endl;
+    std::cout << "    C    : clear clouds" << std::endl;
+    std::cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << std::endl;
+    std::cout << "    7,8  : save mesh to PLY, VTK" << std::endl;
+    std::cout << "   X, V  : TSDF volume utility" << std::endl;
+    std::cout << std::endl;
   }
 
   bool exit_;
@@ -1279,15 +1279,15 @@ struct KinFuApp
 
       case (int)'x': case (int)'X':
         app->scan_volume_ = !app->scan_volume_;
-        cout << endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << endl << endl;
+        std::cout << std::endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << std::endl << std::endl;
         break;
       case (int)'v': case (int)'V':
-        cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
+        std::cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
         app->tsdf_volume_.save ("tsdf_volume.dat", true);
-        cout << "done [" << app->tsdf_volume_.size () << " voxels]" << endl;
-        cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
+        std::cout << "done [" << app->tsdf_volume_.size () << " voxels]" << std::endl;
+        std::cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
         pcl::io::savePCDFile<pcl::PointXYZI> ("tsdf_cloud.pcd", *app->tsdf_cloud_ptr_, true);
-        cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << endl;
+        std::cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << std::endl;
         break;
 
       default:
@@ -1303,22 +1303,22 @@ writeCloudFile (int format, const CloudPtr& cloud_prt)
 {
   if (format == KinFuApp::PCD_BIN)
   {
-    cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
+    std::cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
     pcl::io::savePCDFile ("cloud_bin.pcd", *cloud_prt, true);
   }
   else
   if (format == KinFuApp::PCD_ASCII)
   {
-    cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
     pcl::io::savePCDFile ("cloud.pcd", *cloud_prt, false);
   }
   else   /* if (format == KinFuApp::PLY) */
   {
-    cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
     pcl::io::savePLYFileASCII ("cloud.ply", *cloud_prt);
 
   }
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1326,19 +1326,19 @@ writeCloudFile (int format, const CloudPtr& cloud_prt)
 void
 writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 {
-    cout << "writePolygonMeshFile mf" << endl;
+    std::cout << "writePolygonMeshFile mf" << std::endl;
 
   if (format == KinFuApp::MESH_PLY)
   {
-    cout << "Saving mesh to to 'mesh.ply'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.ply'... " << flush;
     pcl::io::savePLYFile("mesh.ply", mesh);
   }
   else /* if (format == KinFuApp::MESH_VTK) */
   {
-    cout << "Saving mesh to to 'mesh.vtk'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.vtk'... " << flush;
     pcl::io::saveVTKFile("mesh.vtk", mesh);
   }
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1346,20 +1346,20 @@ writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 int
 print_cli_help ()
 {
-  cout << "\nKinfu app concole parameters help:" << endl;
-  cout << "    --help, -h                      : print this message" << endl;
-  cout << "    --registration, -r              : try to enable registration ( requires source to support this )" << endl;
-  cout << "    --current-cloud, -cc            : show current frame cloud" << endl;
-  cout << "    --save-views, -sv               : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << endl;
-  cout << "    --registration, -r              : enable registration mode" << endl;
-  cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << endl;
-  cout << "    -volume_suze <size_in_meters>   : define integration volume size" << endl;
-  cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
-  cout << "";
-  cout << " For RGBD benchmark (Requires OpenCV):" << endl;
-  cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl;
-  cout << " For Simuation (Requires pcl::simulation):" << endl;
-  cout << "    -plyfile                        : path to ply file for simulation testing " << endl;
+  std::cout << "\nKinfu app concole parameters help:" << std::endl;
+  std::cout << "    --help, -h                      : print this message" << std::endl;
+  std::cout << "    --registration, -r              : try to enable registration ( requires source to support this )" << std::endl;
+  std::cout << "    --current-cloud, -cc            : show current frame cloud" << std::endl;
+  std::cout << "    --save-views, -sv               : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << std::endl;
+  std::cout << "    --registration, -r              : enable registration mode" << std::endl;
+  std::cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << std::endl;
+  std::cout << "    -volume_suze <size_in_meters>   : define integration volume size" << std::endl;
+  std::cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << std::endl;
+  std::cout << "";
+  std::cout << " For RGBD benchmark (Requires OpenCV):" << std::endl;
+  std::cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << std::endl;
+  std::cout << " For Simuation (Requires pcl::simulation):" << std::endl;
+  std::cout << "    -plyfile                        : path to ply file for simulation testing " << std::endl;
 
   return 0;
 }
@@ -1378,7 +1378,7 @@ main (int argc, char* argv[])
   pcl::gpu::printShortCudaDeviceInfo (device);
 
   if(checkIfPreFermiGPU(device))
-    return cout << endl << "Kinfu is not supported for pre-Fermi GPU architectures, and not built for them by default. Exiting..." << endl, 1;
+    return std::cout << std::endl << "Kinfu is not supported for pre-Fermi GPU architectures, and not built for them by default. Exiting..." << std::endl, 1;
 
   CaptureOpenNI capture;
 
@@ -1443,17 +1443,17 @@ main (int argc, char* argv[])
 
   // executing
   try { app.execute (argc, argv,plyfile); }
-  catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; }
-  catch (const std::exception& /*e*/) { cout << "Exception" << endl; }
+  catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; }
+  catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; }
 
 #ifdef HAVE_OPENCV
   for (size_t t = 0; t < app.image_view_.views_.size (); ++t)
   {
     if (t == 0)
     {
-      cout << "Saving depth map of first view." << endl;
+      std::cout << "Saving depth map of first view." << std::endl;
       cv::imwrite ("./depthmap_1stview.png", app.image_view_.views_[0]);
-      cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << endl;
+      std::cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << std::endl;
     }
     char buf[4096];
     sprintf (buf, "./%06d.png", (int)t);

--- a/gpu/kinfu/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu/tools/record_tsdfvolume.cpp
@@ -320,11 +320,11 @@ keyboard_callback (const pcl::visualization::KeyboardEvent &event, void *cookie)
       case 27:
       case (int)'q': case (int)'Q':
       case (int)'e': case (int)'E':
-        cout << "Exiting program" << endl;
+        std::cout << "Exiting program" << std::endl;
         quit = true;
         break;
       case (int)'s': case (int)'S':
-        cout << "Saving volume and cloud" << endl;
+        std::cout << "Saving volume and cloud" << std::endl;
         save = true;
         break;
       default:
@@ -450,7 +450,7 @@ main (int argc, char* argv[])
 
 
   // integrate depth in device volume
-  pc::print_highlight ("Converting depth map to volume ... "); cout << flush;
+  pc::print_highlight ("Converting depth map to volume ... "); std::cout << flush;
   device_volume->createFromDepth (depth, intr);
 
   // get volume from device
@@ -463,7 +463,7 @@ main (int argc, char* argv[])
 
 
   // generating TSDF cloud
-  pc::print_highlight ("Generating tsdf volume cloud ... "); cout << flush;
+  pc::print_highlight ("Generating tsdf volume cloud ... "); std::cout << flush;
   pcl::PointCloud<pcl::PointXYZI>::Ptr tsdf_cloud (new pcl::PointCloud<pcl::PointXYZI>);
   volume->convertToTsdfCloud (tsdf_cloud);
   pc::print_info ("done [%d points]\n", tsdf_cloud->size());
@@ -473,7 +473,7 @@ main (int argc, char* argv[])
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_volume (new pcl::PointCloud<pcl::PointXYZ>);
   if (extract_cloud_volume)
   {
-    pc::print_highlight ("Generating cloud from volume ... "); cout << flush;
+    pc::print_highlight ("Generating cloud from volume ... "); std::cout << flush;
     if (!device_volume->getCloud (cloud_volume))
     {
       pc::print_error ("Cloudn't get cloud from device volume!\n");
@@ -493,7 +493,7 @@ main (int argc, char* argv[])
   pc::print_info ("Saving captured cloud to "); pc::print_value ("%s", cloud_file.c_str()); pc::print_info (" ... ");
   if (pcl::io::savePCDFile (cloud_file, *cloud, true) < 0)
   {
-    cout << endl;
+    std::cout << std::endl;
     pc::print_error ("Cloudn't save the point cloud to file %s.\n", cloud_file.c_str());
   }
   else
@@ -508,7 +508,7 @@ main (int argc, char* argv[])
   pc::print_info ("Saving volume cloud to "); pc::print_value ("%s", tsdf_cloud_file.c_str()); pc::print_info (" ... ");
   if (pcl::io::savePCDFile (tsdf_cloud_file, *tsdf_cloud, true) < 0)
   {
-    cout << endl;
+    std::cout << std::endl;
     pc::print_error ("Cloudn't save the volume point cloud to file %s.\n", tsdf_cloud_file.c_str());
   }
   else
@@ -521,7 +521,7 @@ main (int argc, char* argv[])
     pc::print_info ("Saving cloud from volume to "); pc::print_value ("%s", cloud_volume_file.c_str()); pc::print_info (" ... ");
     if (pcl::io::savePCDFile (cloud_volume_file, *cloud_volume, true) < 0)
     {
-      cout << endl;
+      std::cout << std::endl;
       pc::print_error ("Cloudn't save the point cloud to file %s.\n", cloud_volume_file.c_str());
     }
     else

--- a/gpu/kinfu_large_scale/src/kinfu.cpp
+++ b/gpu/kinfu_large_scale/src/kinfu.cpp
@@ -205,7 +205,7 @@ pcl::gpu::kinfuLS::KinfuTracker::extractAndSaveWorld ()
 void
 pcl::gpu::kinfuLS::KinfuTracker::reset ()
 {
-  cout << "in reset function!" << std::endl;
+  std::cout << "in reset function!" << std::endl;
   
   if (global_time_)
     PCL_WARN ("Reset\n");
@@ -431,7 +431,7 @@ pcl::gpu::kinfuLS::KinfuTracker::performICP(const Intr& cam_intrinsics, Matrix3f
     
         if ( std::abs (det) < 100000 /*1e-15*/ || std::isnan (det) ) //TODO find a threshold that makes ICP track well, but prevents it from generating wrong transforms
         {
-          if (std::isnan (det)) cout << "qnan" << endl;
+          if (std::isnan (det)) std::cout << "qnan" << std::endl;
           if(!lost_)
             PCL_ERROR ("ICP LOST... PLEASE COME BACK TO THE LAST VALID POSE (green)\n");
           //reset (); //GUI will now show the user that ICP is lost. User needs to press "R" to reset the volume
@@ -516,7 +516,7 @@ pcl::gpu::kinfuLS::KinfuTracker::performPairWiseICP(const Intr cam_intrinsics, M
         
         if ( std::abs (det) < 1e-15 || std::isnan (det) )
         {
-          if (std::isnan (det)) cout << "qnan" << endl;
+          if (std::isnan (det)) std::cout << "qnan" << std::endl;
                     
           PCL_WARN ("ICP PairWise LOST...\n");
           //reset ();

--- a/gpu/kinfu_large_scale/tools/evaluation.cpp
+++ b/gpu/kinfu_large_scale/tools/evaluation.cpp
@@ -50,7 +50,7 @@ const float Evaluation::cy = 239.5f;
 
 struct Evaluation::Impl {};
 
-Evaluation::Evaluation(const std::string&) { cout << "Evaluation requires OpenCV. Please enable it in cmake-file" << endl; exit(0); }
+Evaluation::Evaluation(const std::string&) { std::cout << "Evaluation requires OpenCV. Please enable it in cmake-file" << std::endl; exit(0); }
 void Evaluation::setMatchFile(const std::string&) { }
 bool Evaluation::grab (double stamp, pcl::gpu::PtrStepSz<const RGB>& rgb24) { return false; }
 bool Evaluation::grab (double stamp, pcl::gpu::PtrStepSz<const unsigned short>& depth) { return false; }
@@ -80,7 +80,7 @@ Evaluation::Evaluation(const std::string& folder) : folder_(folder), visualizati
   if (folder_[folder_.size() - 1] != '\\' && folder_[folder_.size() - 1] != '/')
       folder_.push_back('/');
 
-  cout << "Initializing evaluation from folder: " << folder_ << endl;
+  std::cout << "Initializing evaluation from folder: " << folder_ << std::endl;
   string depth_file = folder_ + "depth.txt";
   string rgb_file = folder_ + "rgb.txt";
   
@@ -94,7 +94,7 @@ void Evaluation::setMatchFile(const std::string& file)
   ifstream iff(full.c_str());  
   if(!iff)
   {
-    cout << "Can't read " << file << endl;
+    std::cout << "Can't read " << file << std::endl;
     exit(1);
   }
 
@@ -115,7 +115,7 @@ void Evaluation::readFile(const string& file, std::vector< pair<double,string> >
   ifstream iff(file.c_str());
   if(!iff)
   {
-    cout << "Can't read " << file << endl;
+    std::cout << "Can't read " << file << std::endl;
     exit(1);
   }
 
@@ -179,7 +179,7 @@ bool Evaluation::grab (double stamp, PtrStepSz<const unsigned short>& depth)
    
   if (d_img.elemSize() != sizeof(unsigned short))
   {
-    cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << endl;
+    std::cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << std::endl;
     exit(1);
   }
 
@@ -205,7 +205,7 @@ bool Evaluation::grab (double stamp, PtrStepSz<const unsigned short>& depth, Ptr
 {
   if (accociations_.empty())
   {
-    cout << "Please set match file" << endl;
+    std::cout << "Please set match file" << std::endl;
     exit(0);
   }
 
@@ -223,7 +223,7 @@ bool Evaluation::grab (double stamp, PtrStepSz<const unsigned short>& depth, Ptr
    
   if (d_img.elemSize() != sizeof(unsigned short))
   {
-    cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << endl;
+    std::cout << "Image was not opend in 16-bit format. Please use OpenCV 2.3.1 or higher" << std::endl;
     exit(1);
   }
 
@@ -259,7 +259,7 @@ void Evaluation::saveAllPoses(const pcl::gpu::KinfuTracker& kinfu, int frame_num
 
   frame_number = std::min(frame_number, (int)kinfu.getNumberOfPoses());
 
-  cout << "Writing " << frame_number << " poses to " << logfile << endl;
+  std::cout << "Writing " << frame_number << " poses to " << logfile << std::endl;
   
   ofstream path_file_stream(logfile.c_str());
   path_file_stream.setf(ios::fixed,ios::floatfield);
@@ -274,7 +274,7 @@ void Evaluation::saveAllPoses(const pcl::gpu::KinfuTracker& kinfu, int frame_num
 
     path_file_stream << stamp << " ";
     path_file_stream << t[0] << " " << t[1] << " " << t[2] << " ";
-    path_file_stream << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << endl;
+    path_file_stream << q.x() << " " << q.y() << " " << q.z() << " " << q.w() << std::endl;
   }
 }
 

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -132,7 +132,7 @@ std::vector<string> getPcdFilesInDir(const string& directory)
       if (fs::extension(*pos) == ".pcd")
       {
         result.push_back (pos->path ().string ());
-        cout << "added: " << result.back() << endl;
+        std::cout << "added: " << result.back() << std::endl;
       }
 
   return result;  
@@ -152,8 +152,8 @@ struct SampledScopeTime : public StopWatch
     if (i_ % EACH == 0 && i_)
     {
       boost::posix_time::ptime endtime_ = boost::posix_time::microsec_clock::local_time();
-      cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )"
-           << "( real: " << 1000.f * EACH / (endtime_-starttime_).total_milliseconds() << "fps )"  << endl;
+      std::cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )"
+           << "( real: " << 1000.f * EACH / (endtime_-starttime_).total_milliseconds() << "fps )"  << std::endl;
       time_ms_ = 0;
       starttime_ = endtime_;
     }
@@ -359,7 +359,7 @@ struct ImageView
   toggleImagePaint()
   {
     paint_image_ = !paint_image_;
-    cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << endl;
+    std::cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << std::endl;
   }
 
   bool paint_image_;
@@ -530,7 +530,7 @@ struct SceneCloudView
       
       
       
-//       cout << "current estimated pose: " << kinfu.getLastEstimatedPose().translation() << std::endl << kinfu.getLastEstimatedPose().linear() << std::endl;
+//       std::cout << "current estimated pose: " << kinfu.getLastEstimatedPose().translation() << std::endl << kinfu.getLastEstimatedPose().linear() << std::endl;
 //     
   }
   
@@ -540,7 +540,7 @@ struct SceneCloudView
     viewer_pose_ = kinfu.getCameraPose();
 
     ScopeTimeT time ("PointCloud Extraction");
-    cout << "\nGetting cloud... " << flush;
+    std::cout << "\nGetting cloud... " << flush;
 
     valid_combined_ = false;
 
@@ -580,7 +580,7 @@ struct SceneCloudView
         point_colors_ptr_->points.clear();
     }
     size_t points_size = valid_combined_ ? combined_ptr_->points.size () : cloud_ptr_->points.size ();
-    cout << "Done.  Cloud size: " << points_size / 1000 << "K" << endl;
+    std::cout << "Done.  Cloud size: " << points_size / 1000 << "K" << std::endl;
 
     cloud_viewer_.removeAllPointClouds ();    
     if (valid_combined_)
@@ -613,9 +613,9 @@ struct SceneCloudView
     extraction_mode_ = (extraction_mode_ + 1) % 3;
     switch (extraction_mode_)
     {
-      case 0: cout << "Cloud extraction mode: GPU, Connected-6" << endl; break;
-      case 1: cout << "Cloud extraction mode: CPU, Connected-6    (requires a lot of memory)" << endl; break;
-      case 2: cout << "Cloud extraction mode: CPU, Connected-26   (requires a lot of memory)" << endl; break;
+      case 0: std::cout << "Cloud extraction mode: GPU, Connected-6" << std::endl; break;
+      case 1: std::cout << "Cloud extraction mode: CPU, Connected-6    (requires a lot of memory)" << std::endl; break;
+      case 2: std::cout << "Cloud extraction mode: CPU, Connected-26   (requires a lot of memory)" << std::endl; break;
     }         
   }
 
@@ -623,7 +623,7 @@ struct SceneCloudView
   toggleNormals ()
   {
     compute_normals_ = !compute_normals_;
-    cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << endl;
+    std::cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << std::endl;
   }
 
   void
@@ -633,14 +633,14 @@ struct SceneCloudView
     cloud_ptr_->points.clear ();
     normals_ptr_->points.clear ();    
     if (print_message)
-      cout << "Clouds/Meshes were cleared" << endl;
+      std::cout << "Clouds/Meshes were cleared" << std::endl;
   }
 
   void
   showMesh(KinfuTracker& kinfu, bool /*integrate_colors*/)
   {
     ScopeTimeT time ("Mesh Extraction");
-    cout << "\nGetting mesh... " << flush;
+    std::cout << "\nGetting mesh... " << flush;
 
     if (!marching_cubes_)
       marching_cubes_ = MarchingCubes::Ptr( new MarchingCubes() );
@@ -652,7 +652,7 @@ struct SceneCloudView
     if (mesh_ptr_)
       cloud_viewer_.addPolygonMesh(*mesh_ptr_);	
 
-    cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << endl;
+    std::cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << std::endl;
   }
 
   int extraction_mode_;
@@ -766,7 +766,7 @@ struct KinFuLSApp
   initRegistration ()
   {        
     registration_ = capture_.providesCallback<pcl::ONIGrabber::sig_cb_openni_image_depth_image> ();
-    cout << "Registration mode: " << (registration_ ? "On" : "Off (not supported by source)") << endl;
+    std::cout << "Registration mode: " << (registration_ ? "On" : "Off (not supported by source)") << std::endl;
   }
 
   void 
@@ -778,14 +778,14 @@ struct KinFuLSApp
       kinfu_->initColorIntegration(max_color_integration_weight);
       integrate_colors_ = true;      
     }    
-    cout << "Color integration: " << (integrate_colors_ ? "On" : "Off ( requires registration mode )") << endl;
+    std::cout << "Color integration: " << (integrate_colors_ ? "On" : "Off ( requires registration mode )") << std::endl;
   }
 
   void
   toggleIndependentCamera()
   {
     independent_camera_ = !independent_camera_;
-    cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << endl;
+    std::cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << std::endl;
   }
 
   void
@@ -834,22 +834,22 @@ struct KinFuLSApp
 
       if (scan_volume_)
       {                
-        cout << "Downloading TSDF volume from device ... " << flush;
+        std::cout << "Downloading TSDF volume from device ... " << flush;
         // kinfu_->volume().downloadTsdfAndWeighs (tsdf_volume_.volumeWriteable (), tsdf_volume_.weightsWriteable ());
         kinfu_->volume ().downloadTsdfAndWeightsLocal ();
         // tsdf_volume_.setHeader (Eigen::Vector3i (pcl::device::kinfuLS::VOLUME_X, pcl::device::kinfuLS::VOLUME_Y, pcl::device::kinfuLS::VOLUME_Z), kinfu_->volume().getSize ());
         kinfu_->volume ().setHeader (Eigen::Vector3i (pcl::device::kinfuLS::VOLUME_X, pcl::device::kinfuLS::VOLUME_Y, pcl::device::kinfuLS::VOLUME_Z), kinfu_->volume().getSize ());
-        // cout << "done [" << tsdf_volume_.size () << " voxels]" << endl << endl;
-        cout << "done [" << kinfu_->volume ().size () << " voxels]" << endl << endl;
+        // std::cout << "done [" << tsdf_volume_.size () << " voxels]" << std::endl << std::endl;
+        std::cout << "done [" << kinfu_->volume ().size () << " voxels]" << std::endl << std::endl;
 
-        cout << "Converting volume to TSDF cloud ... " << flush;
+        std::cout << "Converting volume to TSDF cloud ... " << flush;
         // tsdf_volume_.convertToTsdfCloud (tsdf_cloud_ptr_);
         kinfu_->volume ().convertToTsdfCloud (tsdf_cloud_ptr_);
-        // cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << endl << endl;        
-        cout << "done [" << kinfu_->volume ().size () << " points]" << endl << endl;
+        // std::cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << std::endl << std::endl;        
+        std::cout << "done [" << kinfu_->volume ().size () << " points]" << std::endl << std::endl;
       }
       else
-        cout << "[!] tsdf volume download is disabled" << endl << endl;
+        std::cout << "[!] tsdf volume download is disabled" << std::endl << std::endl;
     }
     
 
@@ -1015,11 +1015,11 @@ struct KinFuLSApp
         bool has_data = (data_ready_cond_.wait_for(lock, 100ms) == std::cv_status::no_timeout);
 
         try { this->execute (depth_, rgb24_, has_data); }
-        catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; break; }
-        catch (const std::exception& /*e*/) { cout << "Exception" << endl; break; }
+        catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; break; }
+        catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; break; }
 
         scene_cloud_view_.cloud_viewer_.spinOnce (3);
-        //~ cout << "In main loop" << endl;                  
+        //~ std::cout << "In main loop" << std::endl;                  
       } 
       exit_ = true;
       std::this_thread::sleep_for(100ms);
@@ -1067,25 +1067,25 @@ struct KinFuLSApp
   void
   printHelp ()
   {
-    cout << endl;
-    cout << "KinFu app hotkeys" << endl;
-    cout << "=================" << endl;
-    cout << "    H    : print this help" << endl;
-    cout << "   Esc   : exit" << endl;
-    cout << "    T    : take cloud" << endl;
-    cout << "    A    : take mesh" << endl;
-    cout << "    M    : toggle cloud exctraction mode" << endl;
-    cout << "    N    : toggle normals exctraction" << endl;
-    cout << "    I    : toggle independent camera mode" << endl;
-    cout << "    B    : toggle volume bounds" << endl;
-    cout << "    *    : toggle scene view painting ( requires registration mode )" << endl;
-    cout << "    C    : clear clouds" << endl;    
-    cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << endl;
-    cout << "    7,8  : save mesh to PLY, VTK" << endl;
-    cout << "   X, V  : TSDF volume utility" << endl;
-    cout << "   L, l  : On the next shift, KinFu will extract the whole current cube, extract the world and stop" << endl;
-    cout << "   S, s  : On the next shift, KinFu will extract the world and stop" << endl;
-    cout << endl;
+    std::cout << std::endl;
+    std::cout << "KinFu app hotkeys" << std::endl;
+    std::cout << "=================" << std::endl;
+    std::cout << "    H    : print this help" << std::endl;
+    std::cout << "   Esc   : exit" << std::endl;
+    std::cout << "    T    : take cloud" << std::endl;
+    std::cout << "    A    : take mesh" << std::endl;
+    std::cout << "    M    : toggle cloud exctraction mode" << std::endl;
+    std::cout << "    N    : toggle normals exctraction" << std::endl;
+    std::cout << "    I    : toggle independent camera mode" << std::endl;
+    std::cout << "    B    : toggle volume bounds" << std::endl;
+    std::cout << "    *    : toggle scene view painting ( requires registration mode )" << std::endl;
+    std::cout << "    C    : clear clouds" << std::endl;    
+    std::cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << std::endl;
+    std::cout << "    7,8  : save mesh to PLY, VTK" << std::endl;
+    std::cout << "   X, V  : TSDF volume utility" << std::endl;
+    std::cout << "   L, l  : On the next shift, KinFu will extract the whole current cube, extract the world and stop" << std::endl;
+    std::cout << "   S, s  : On the next shift, KinFu will extract the world and stop" << std::endl;
+    std::cout << std::endl;
   }  
 
   bool exit_;
@@ -1162,17 +1162,17 @@ struct KinFuLSApp
 
       case (int)'x': case (int)'X':
         app->scan_volume_ = !app->scan_volume_;
-        cout << endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << endl << endl;
+        std::cout << std::endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << std::endl << std::endl;
         break;
       case (int)'v': case (int)'V':
-        cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
+        std::cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
         // app->tsdf_volume_.save ("tsdf_volume.dat", true);
         app->kinfu_->volume ().save ("tsdf_volume.dat", true);
-        // cout << "done [" << app->tsdf_volume_.size () << " voxels]" << endl;
-        cout << "done [" << app->kinfu_->volume ().size () << " voxels]" << endl;
-        cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
+        // std::cout << "done [" << app->tsdf_volume_.size () << " voxels]" << std::endl;
+        std::cout << "done [" << app->kinfu_->volume ().size () << " voxels]" << std::endl;
+        std::cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
         pcl::io::savePCDFile<pcl::PointXYZI> ("tsdf_cloud.pcd", *app->tsdf_cloud_ptr_, true);
-        cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << endl;
+        std::cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << std::endl;
         break;
       default:
         break;
@@ -1187,21 +1187,21 @@ writeCloudFile (int format, const CloudPtr& cloud_prt)
 {
   if (format == KinFuLSApp::PCD_BIN)
   {
-    cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
+    std::cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
     pcl::io::savePCDFile ("cloud_bin.pcd", *cloud_prt, true);
   }
   else if (format == KinFuLSApp::PCD_ASCII)
   {
-    cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
     pcl::io::savePCDFile ("cloud.pcd", *cloud_prt, false);
   }
   else   /* if (format == KinFuLSApp::PLY) */
   {
-    cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
     pcl::io::savePLYFileASCII ("cloud.ply", *cloud_prt);
 
   }
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1211,15 +1211,15 @@ writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 {
   if (format == KinFuLSApp::MESH_PLY)
   {
-    cout << "Saving mesh to to 'mesh.ply'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.ply'... " << flush;
     pcl::io::savePLYFile("mesh.ply", mesh);		
   }
   else /* if (format == KinFuLSApp::MESH_VTK) */
   {
-    cout << "Saving mesh to to 'mesh.vtk'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.vtk'... " << flush;
     pcl::io::saveVTKFile("mesh.vtk", mesh);    
   }  
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1227,23 +1227,23 @@ writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 int
 print_cli_help ()
 {
-  cout << "\nKinFu parameters:" << endl;
-  cout << "    --help, -h                          : print this message" << endl;  
-  cout << "    --registration, -r                  : try to enable registration (source needs to support this)" << endl;
-  cout << "    --current-cloud, -cc                : show current frame cloud" << endl;
-  cout << "    --save-views, -sv                   : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << endl;  
-  cout << "    --registration, -r                  : enable registration mode" << endl; 
-  cout << "    --integrate-colors, -ic             : enable color integration mode (allows to get cloud with colors)" << endl;
-  cout << "    --extract-textures, -et             : extract RGB PNG images to KinFuSnapshots folder." << endl;
-  cout << "    --volume_size <in_meters>, -vs      : define integration volume size" << endl;
-  cout << "    --shifting_distance <in_meters>, -sd : define shifting threshold (distance target-point / cube center)" << endl;
-  cout << "    --snapshot_rate <X_frames>, -sr     : Extract RGB textures every <X_frames>. Default: 45  " << endl;
-  cout << endl << "";
-  cout << "Valid depth data sources:" << endl; 
-  cout << "    -dev <device> (default), -oni <oni_file>, -pcd <pcd_file or directory>" << endl;
-  cout << endl << "";
-  cout << " For RGBD benchmark (Requires OpenCV):" << endl; 
-  cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl << endl;
+  std::cout << "\nKinFu parameters:" << std::endl;
+  std::cout << "    --help, -h                          : print this message" << std::endl;  
+  std::cout << "    --registration, -r                  : try to enable registration (source needs to support this)" << std::endl;
+  std::cout << "    --current-cloud, -cc                : show current frame cloud" << std::endl;
+  std::cout << "    --save-views, -sv                   : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << std::endl;  
+  std::cout << "    --registration, -r                  : enable registration mode" << std::endl; 
+  std::cout << "    --integrate-colors, -ic             : enable color integration mode (allows to get cloud with colors)" << std::endl;
+  std::cout << "    --extract-textures, -et             : extract RGB PNG images to KinFuSnapshots folder." << std::endl;
+  std::cout << "    --volume_size <in_meters>, -vs      : define integration volume size" << std::endl;
+  std::cout << "    --shifting_distance <in_meters>, -sd : define shifting threshold (distance target-point / cube center)" << std::endl;
+  std::cout << "    --snapshot_rate <X_frames>, -sr     : Extract RGB textures every <X_frames>. Default: 45  " << std::endl;
+  std::cout << std::endl << "";
+  std::cout << "Valid depth data sources:" << std::endl; 
+  std::cout << "    -dev <device> (default), -oni <oni_file>, -pcd <pcd_file or directory>" << std::endl;
+  std::cout << std::endl << "";
+  std::cout << " For RGBD benchmark (Requires OpenCV):" << std::endl; 
+  std::cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << std::endl << std::endl;
 
   return 0;
 }
@@ -1262,7 +1262,7 @@ main (int argc, char* argv[])
   pcl::gpu::printShortCudaDeviceInfo (device);
 
   //  if (checkIfPreFermiGPU(device))
-  //    return cout << endl << "Kinfu is supported only for Fermi and Kepler arhitectures. It is not even compiled for pre-Fermi by default. Exiting..." << endl, 1;
+  //    return std::cout << std::endl << "Kinfu is supported only for Fermi and Kepler arhitectures. It is not even compiled for pre-Fermi by default. Exiting..." << std::endl, 1;
 
   boost::shared_ptr<pcl::Grabber> capture;
   bool triggered_capture = false;
@@ -1309,7 +1309,7 @@ main (int argc, char* argv[])
       //capture.reset( new pcl::ONIGrabber("d:/onis/20111013-224719.oni", true, true) );    
     }
   }
-  catch (const pcl::PCLException& /*e*/) { return cout << "Can't open depth source" << endl, -1; }
+  catch (const pcl::PCLException& /*e*/) { return std::cout << "Can't open depth source" << std::endl, -1; }
 
   float volume_size = pcl::device::kinfuLS::VOLUME_SIZE;
   pc::parse_argument (argc, argv, "--volume_size", volume_size);
@@ -1358,18 +1358,18 @@ main (int argc, char* argv[])
   // set verbosity level
   pcl::console::setVerbosityLevel(pcl::console::L_VERBOSE);
   try { app.startMainLoop (triggered_capture); }  
-  catch (const pcl::PCLException& /*e*/) { cout << "PCLException" << endl; }
-  catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; }
-  catch (const std::exception& /*e*/) { cout << "Exception" << endl; }
+  catch (const pcl::PCLException& /*e*/) { std::cout << "PCLException" << std::endl; }
+  catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; }
+  catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; }
 
   //~ #ifdef HAVE_OPENCV
   //~ for (size_t t = 0; t < app.image_view_.views_.size (); ++t)
   //~ {
   //~ if (t == 0)
   //~ {
-  //~ cout << "Saving depth map of first view." << endl;
+  //~ std::cout << "Saving depth map of first view." << std::endl;
   //~ cv::imwrite ("./depthmap_1stview.png", app.image_view_.views_[0]);
-  //~ cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << endl;
+  //~ std::cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << std::endl;
   //~ }
   //~ char buf[4096];
   //~ sprintf (buf, "./%06d.png", (int)t);

--- a/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
@@ -160,7 +160,7 @@ struct SampledScopeTime : public StopWatch
     time_ms_ += stopWatch_.getTime ();        
     if (i_ % EACH == 0 && i_)
     {
-      cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << endl;
+      std::cout << "Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << std::endl;
       time_ms_ = 0;        
     }
   }
@@ -343,7 +343,7 @@ depthBufferToMM(const float* depth_buffer,unsigned short* depth_img)
       else if (z_new>5000) z_new = 0;
 
       //      if ( z_new < 18000){
-//	  cout << z_new << " " << d << " " << x << "\n";  
+//	  std::cout << z_new << " " << d << " " << x << "\n";  
 //      }
       depth_img[i] = z_new;
     }
@@ -372,22 +372,22 @@ display_tic_toc (vector<double> &tic_toc,const string &fun_name)
 
   double percent_tic_toc_last = 0;
   double dtime = tic_toc[tic_toc_size-1] - tic_toc[0];
-  cout << "fraction_" << fun_name << ",";
+  std::cout << "fraction_" << fun_name << ",";
   for (size_t i = 0; i < tic_toc_size; i++)
   {
     double percent_tic_toc =  (tic_toc[i] - tic_toc[0])/(tic_toc[tic_toc_size-1] - tic_toc[0]);
-    cout <<  percent_tic_toc - percent_tic_toc_last << ", ";
+    std::cout <<  percent_tic_toc - percent_tic_toc_last << ", ";
     percent_tic_toc_last = percent_tic_toc;
   }
-  cout << "\ntime_" << fun_name << ",";
+  std::cout << "\ntime_" << fun_name << ",";
   double time_tic_toc_last = 0;
   for (size_t i = 0; i < tic_toc_size; i++)
   {
     double percent_tic_toc = (tic_toc[i] - tic_toc[0])/(tic_toc[tic_toc_size-1] - tic_toc[0]);
-    cout <<  percent_tic_toc*dtime - time_tic_toc_last << ", ";
+    std::cout <<  percent_tic_toc*dtime - time_tic_toc_last << ", ";
     time_tic_toc_last = percent_tic_toc*dtime;
   }
-  cout << "\ntotal_time_" << fun_name << " " << dtime << "\n";
+  std::cout << "\ntotal_time_" << fun_name << " " << dtime << "\n";
 }
 
 void
@@ -451,7 +451,7 @@ capture (Eigen::Isometry3d pose_in,unsigned short* depth_buffer_mm,const uint8_t
     pcl::PCDWriter writer;
     //writer.write (point_cloud_fname, *pc_out,	false);  /// ASCII
     writer.writeBinary (point_cloud_fname, *pc_out);
-    //cout << "finished writing file\n";
+    //std::cout << "finished writing file\n";
   }
   */
 
@@ -564,7 +564,7 @@ boost::shared_ptr<pcl::PolygonMesh> convertToMesh(const DeviceArray<PointXYZ>& t
   }    
   return mesh_ptr;
   
-  cout << mesh_ptr->polygons.size () << " plys\n";
+  std::cout << mesh_ptr->polygons.size () << " plys\n";
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -679,7 +679,7 @@ struct ImageView
   toggleImagePaint()
   {
     paint_image_ = !paint_image_;
-    cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << endl;
+    std::cout << "Paint image: " << (paint_image_ ? "On   (requires registration mode)" : "Off") << std::endl;
   }
 
   bool paint_image_;
@@ -732,7 +732,7 @@ struct SceneCloudView
     viewer_pose_ = kinfu.getCameraPose();
 
     ScopeTimeT time ("PointCloud Extraction");
-    cout << "\nGetting cloud... " << flush;
+    std::cout << "\nGetting cloud... " << flush;
 
     valid_combined_ = false;
 
@@ -772,7 +772,7 @@ struct SceneCloudView
         point_colors_ptr_->points.clear();
     }
     size_t points_size = valid_combined_ ? combined_ptr_->points.size () : cloud_ptr_->points.size ();
-    cout << "Done.  Cloud size: " << points_size / 1000 << "K" << endl;
+    std::cout << "Done.  Cloud size: " << points_size / 1000 << "K" << std::endl;
 
     cloud_viewer_.removeAllPointClouds ();    
     if (valid_combined_)
@@ -806,9 +806,9 @@ struct SceneCloudView
 
     switch (extraction_mode_)
     {
-    case 0: cout << "Cloud exctraction mode: GPU, Connected-6" << endl; break;
-    case 1: cout << "Cloud exctraction mode: CPU, Connected-6    (requires a lot of memory)" << endl; break;
-    case 2: cout << "Cloud exctraction mode: CPU, Connected-26   (requires a lot of memory)" << endl; break;
+    case 0: std::cout << "Cloud exctraction mode: GPU, Connected-6" << std::endl; break;
+    case 1: std::cout << "Cloud exctraction mode: CPU, Connected-6    (requires a lot of memory)" << std::endl; break;
+    case 2: std::cout << "Cloud exctraction mode: CPU, Connected-26   (requires a lot of memory)" << std::endl; break;
     }
     ;
   }
@@ -817,7 +817,7 @@ struct SceneCloudView
   toggleNormals ()
   {
     compute_normals_ = !compute_normals_;
-    cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << endl;
+    std::cout << "Compute normals: " << (compute_normals_ ? "On" : "Off") << std::endl;
   }
 
   void
@@ -827,14 +827,14 @@ struct SceneCloudView
     cloud_ptr_->points.clear ();
     normals_ptr_->points.clear ();    
     if (print_message)
-      cout << "Clouds/Meshes were cleared" << endl;
+      std::cout << "Clouds/Meshes were cleared" << std::endl;
   }
 
   void
   showMesh(KinfuTracker& kinfu, bool /*integrate_colors*/)
   {
     ScopeTimeT time ("Mesh Extraction");
-    cout << "\nGetting mesh... " << flush;
+    std::cout << "\nGetting mesh... " << flush;
 
     if (!marching_cubes_)
       marching_cubes_ = MarchingCubes::Ptr( new MarchingCubes() );
@@ -845,12 +845,12 @@ struct SceneCloudView
     cloud_viewer_.removeAllPointClouds ();
     if (mesh_ptr_){
       cloud_viewer_.addPolygonMesh(*mesh_ptr_);	
-      cout << "mesh ptr exist\n";
+      std::cout << "mesh ptr exist\n";
     }else{
-      cout << "mesh ptr no exist\n";
+      std::cout << "mesh ptr no exist\n";
     }
     
-    cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << endl;
+    std::cout << "Done.  Triangles number: " << triangles_device.size() / MarchingCubes::POINTS_PER_TRIANGLE / 1000 << "K" << std::endl;
   }
     
   int extraction_mode_;
@@ -939,7 +939,7 @@ struct KinFuApp
   tryRegistrationInit ()
   {
     registration_ = capture_.setRegistration (true);
-    cout << "Registration mode: " << (registration_ ?  "On" : "Off (not supported by source)") << endl;
+    std::cout << "Registration mode: " << (registration_ ?  "On" : "Off (not supported by source)") << std::endl;
   }
 
   void 
@@ -951,14 +951,14 @@ struct KinFuApp
       kinfu_.initColorIntegration(max_color_integration_weight);
       integrate_colors_ = true;      
     }
-    cout << "Color integration: " << (integrate_colors_ ? "On" : "Off (not supported by source)") << endl;
+    std::cout << "Color integration: " << (integrate_colors_ ? "On" : "Off (not supported by source)") << std::endl;
   }
 
   void
   toggleIndependentCamera()
   {
     independent_camera_ = !independent_camera_;
-    cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << endl;
+    std::cout << "Camera mode: " << (independent_camera_ ?  "Independent" : "Bound to Kinect pose") << std::endl;
   }
   
   void
@@ -1030,7 +1030,7 @@ struct KinFuApp
     camera_->set(0.471703, 1.59862, 3.10937, 0, 0.418879, -12.2129);
     camera_->set_pitch(0.418879); // not sure why this is here:
 
-    cout << "About to read: "<< plyfile << endl;   
+    std::cout << "About to read: "<< plyfile << std::endl;   
     load_PolygonMesh_model (plyfile);  
     
     // Generate a series of poses:
@@ -1066,7 +1066,7 @@ struct KinFuApp
       capture (poses[i],disparity_buf_, color_buf_uint);//,ss.str());
       const KinfuTracker::PixelRGB* color_buf_ = (const KinfuTracker::PixelRGB*) color_buf_uint;
       PtrStepSz<const unsigned short> depth_sim = PtrStepSz<const unsigned short>(height, width, disparity_buf_, 2*width);
-      //cout << depth_sim.rows << " by " << depth_sim.cols << " | s: " << depth_sim.step << "\n";
+      //std::cout << depth_sim.rows << " by " << depth_sim.cols << " | s: " << depth_sim.step << "\n";
       // RGB-KinFu currently disabled for now - problems with color in KinFu apparently
       // but this constructor might not  be right either: not sure about step size
       integrate_colors_=false;
@@ -1077,7 +1077,7 @@ struct KinFuApp
 	bool has_frame = evaluation_ptr_ ? evaluation_ptr_->grab(i, depth) : capture_.grab (depth, rgb24);      
 	if (!has_frame)
 	{
-	  cout << "Can't grab" << endl;
+	  std::cout << "Can't grab" << std::endl;
 	  break;
 	}
 
@@ -1096,7 +1096,7 @@ struct KinFuApp
 	}
       }else{ //simulate:
 
-	cout << " color: " << integrate_colors_ << "\n"; // integrate_colors_ seems to be zero
+	std::cout << " color: " << integrate_colors_ << "\n"; // integrate_colors_ seems to be zero
 	depth_device_.upload (depth_sim.data, depth_sim.step, depth_sim.rows, depth_sim.cols);
 	if (integrate_colors_){
 	    image_view_.colors_device_.upload (rgb24_sim.data, rgb24_sim.step, rgb24_sim.rows, rgb24_sim.cols);
@@ -1130,7 +1130,7 @@ struct KinFuApp
       // Everything below this is Visualization or I/O:
       if (i >n_pose_stop){
 	int pause;
-	cout << "Enter a key to write Mesh file\n";
+	std::cout << "Enter a key to write Mesh file\n";
 	cin >> pause;
 
 	scene_cloud_view_.showMesh(kinfu_, integrate_colors_);
@@ -1147,24 +1147,24 @@ struct KinFuApp
 	    // download tsdf volume
 	    {
 	      ScopeTimeT time ("tsdf volume download");
-	      cout << "Downloading TSDF volume from device ... " << flush;
+	      std::cout << "Downloading TSDF volume from device ... " << flush;
 	      // kinfu_.volume().downloadTsdfAndWeighs (tsdf_volume_.volumeWriteable (), tsdf_volume_.weightsWriteable ());
               kinfu_.volume ().downloadTsdfAndWeighsLocal ();
 	      // tsdf_volume_.setHeader (Eigen::Vector3i (pcl::device::VOLUME_X, pcl::device::VOLUME_Y, pcl::device::VOLUME_Z), kinfu_.volume().getSize ());
               kinfu_.volume ().setHeader (Eigen::Vector3i (pcl::device::VOLUME_X, pcl::device::VOLUME_Y, pcl::device::VOLUME_Z), kinfu_.volume().getSize ());
-	      // cout << "done [" << tsdf_volume_.size () << " voxels]" << endl << endl;
-              cout << "done [" << kinfu_.volume ().size () << " voxels]" << endl << endl;
+	      // std::cout << "done [" << tsdf_volume_.size () << " voxels]" << std::endl << std::endl;
+              std::cout << "done [" << kinfu_.volume ().size () << " voxels]" << std::endl << std::endl;
 	    }
 	    {
 	      ScopeTimeT time ("converting");
-	      cout << "Converting volume to TSDF cloud ... " << flush;
+	      std::cout << "Converting volume to TSDF cloud ... " << flush;
 	      // tsdf_volume_.convertToTsdfCloud (tsdf_cloud_ptr_);
               kinfu_.volume ().convertToTsdfCloud (tsdf_cloud_ptr_);
-	      cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << endl << endl;
+	      std::cout << "done [" << tsdf_cloud_ptr_->size () << " points]" << std::endl << std::endl;
 	    }
 	  }
 	  else
-	    cout << "[!] tsdf volume download is disabled" << endl << endl;
+	    std::cout << "[!] tsdf volume download is disabled" << std::endl << std::endl;
 	}
 
 	if (scan_mesh_)
@@ -1193,11 +1193,11 @@ struct KinFuApp
 	scene_cloud_view_.cloud_viewer_.spinOnce (3);    
 	
 	// As of April 2012, entering a key will end this program...
-	cout << "Paused after view\n";
+	std::cout << "Paused after view\n";
 	cin >> pause;      
       }
       double elapsed = (getTime() -tic_main);
-      cout << elapsed << " sec elapsed [" << (1/elapsed) << "]\n";          
+      std::cout << elapsed << " sec elapsed [" << (1/elapsed) << "]\n";          
       tic_toc.push_back (getTime ());
       display_tic_toc (tic_toc, "kinfu_app_sim");
     }
@@ -1238,23 +1238,23 @@ struct KinFuApp
   void
   printHelp ()
   {
-    cout << endl;
-    cout << "KinFu app hotkeys" << endl;
-    cout << "=================" << endl;
-    cout << "    H    : print this help" << endl;
-    cout << "   Esc   : exit" << endl;
-    cout << "    T    : take cloud" << endl;
-    cout << "    A    : take mesh" << endl;
-    cout << "    M    : toggle cloud exctraction mode" << endl;
-    cout << "    N    : toggle normals exctraction" << endl;
-    cout << "    I    : toggle independent camera mode" << endl;
-    cout << "    B    : toggle volume bounds" << endl;
-    cout << "    *    : toggle scene view painting ( requires registration mode )" << endl;
-    cout << "    C    : clear clouds" << endl;    
-    cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << endl;
-    cout << "    7,8  : save mesh to PLY, VTK" << endl;
-    cout << "   X, V  : TSDF volume utility" << endl;
-    cout << endl;
+    std::cout << std::endl;
+    std::cout << "KinFu app hotkeys" << std::endl;
+    std::cout << "=================" << std::endl;
+    std::cout << "    H    : print this help" << std::endl;
+    std::cout << "   Esc   : exit" << std::endl;
+    std::cout << "    T    : take cloud" << std::endl;
+    std::cout << "    A    : take mesh" << std::endl;
+    std::cout << "    M    : toggle cloud exctraction mode" << std::endl;
+    std::cout << "    N    : toggle normals exctraction" << std::endl;
+    std::cout << "    I    : toggle independent camera mode" << std::endl;
+    std::cout << "    B    : toggle volume bounds" << std::endl;
+    std::cout << "    *    : toggle scene view painting ( requires registration mode )" << std::endl;
+    std::cout << "    C    : clear clouds" << std::endl;    
+    std::cout << "   1,2,3 : save cloud to PCD(binary), PCD(ASCII), PLY(ASCII)" << std::endl;
+    std::cout << "    7,8  : save mesh to PLY, VTK" << std::endl;
+    std::cout << "   X, V  : TSDF volume utility" << std::endl;
+    std::cout << std::endl;
   }  
 
   bool exit_;
@@ -1306,17 +1306,17 @@ struct KinFuApp
 
       case (int)'x': case (int)'X':
         app->scan_volume_ = !app->scan_volume_;
-        cout << endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << endl << endl;
+        std::cout << std::endl << "Volume scan: " << (app->scan_volume_ ? "enabled" : "disabled") << std::endl << std::endl;
         break;
       case (int)'v': case (int)'V':
-        cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
+        std::cout << "Saving TSDF volume to tsdf_volume.dat ... " << flush;
         // app->tsdf_volume_.save ("tsdf_volume.dat", true);
         app->kinfu_.volume ().save ("tsdf_volume.dat", true);
-        //cout << "done [" << app->tsdf_volume_.size () << " voxels]" << endl;
-        cout << "done [" << app->app->kinfu_.volume ().size () << " voxels]" << endl;
-        cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
+        //std::cout << "done [" << app->tsdf_volume_.size () << " voxels]" << std::endl;
+        std::cout << "done [" << app->app->kinfu_.volume ().size () << " voxels]" << std::endl;
+        std::cout << "Saving TSDF volume cloud to tsdf_cloud.pcd ... " << flush;
         pcl::io::savePCDFile<pcl::PointXYZI> ("tsdf_cloud.pcd", *app->tsdf_cloud_ptr_, true);
-        cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << endl;
+        std::cout << "done [" << app->tsdf_cloud_ptr_->size () << " points]" << std::endl;
         break;
 
       default:
@@ -1332,22 +1332,22 @@ writeCloudFile (int format, const CloudPtr& cloud_prt)
 {
   if (format == KinFuApp::PCD_BIN)
   {
-    cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
+    std::cout << "Saving point cloud to 'cloud_bin.pcd' (binary)... " << flush;
     pcl::io::savePCDFile ("cloud_bin.pcd", *cloud_prt, true);
   }
   else
   if (format == KinFuApp::PCD_ASCII)
   {
-    cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.pcd' (ASCII)... " << flush;
     pcl::io::savePCDFile ("cloud.pcd", *cloud_prt, false);
   }
   else   /* if (format == KinFuApp::PLY) */
   {
-    cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
+    std::cout << "Saving point cloud to 'cloud.ply' (ASCII)... " << flush;
     pcl::io::savePLYFileASCII ("cloud.ply", *cloud_prt);
   
   }
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1355,19 +1355,19 @@ writeCloudFile (int format, const CloudPtr& cloud_prt)
 void
 writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 {
-    cout << "writePolygonMeshFile mf" << endl;
+    std::cout << "writePolygonMeshFile mf" << std::endl;
 
   if (format == KinFuApp::MESH_PLY)
   {
-    cout << "Saving mesh to to 'mesh.ply'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.ply'... " << flush;
     pcl::io::savePLYFile("mesh.ply", mesh);		
   }
   else /* if (format == KinFuApp::MESH_VTK) */
   {
-    cout << "Saving mesh to to 'mesh.vtk'... " << flush;
+    std::cout << "Saving mesh to to 'mesh.vtk'... " << flush;
     pcl::io::saveVTKFile("mesh.vtk", mesh);    
   }  
-  cout << "Done" << endl;
+  std::cout << "Done" << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1375,20 +1375,20 @@ writePolygonMeshFile (int format, const pcl::PolygonMesh& mesh)
 int
 print_cli_help ()
 {
-  cout << "\nKinfu app concole parameters help:" << endl;
-  cout << "    --help, -h                      : print this message" << endl;  
-  cout << "    --registration, -r              : try to enable registration ( requires source to support this )" << endl;
-  cout << "    --current-cloud, -cc            : show current frame cloud" << endl;
-  cout << "    --save-views, -sv               : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << endl;  
-  cout << "    --registration, -r              : enable registration mode" << endl; 
-  cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << endl;   
-  cout << "    -volume_suze <size_in_meters>   : define integration volume size" << endl;   
-  cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << endl;
-  cout << "";
-  cout << " For RGBD benchmark (Requires OpenCV):" << endl; 
-  cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << endl;
-  cout << " For Simuation (Requires pcl::simulation):" << endl; 
-  cout << "    -plyfile                        : path to ply file for simulation testing " << endl;
+  std::cout << "\nKinfu app concole parameters help:" << std::endl;
+  std::cout << "    --help, -h                      : print this message" << std::endl;  
+  std::cout << "    --registration, -r              : try to enable registration ( requires source to support this )" << std::endl;
+  std::cout << "    --current-cloud, -cc            : show current frame cloud" << std::endl;
+  std::cout << "    --save-views, -sv               : accumulate scene view and save in the end ( Requires OpenCV. Will cause 'bad_alloc' after some time )" << std::endl;  
+  std::cout << "    --registration, -r              : enable registration mode" << std::endl; 
+  std::cout << "    --integrate-colors, -ic         : enable color integration mode ( allows to get cloud with colors )" << std::endl;   
+  std::cout << "    -volume_suze <size_in_meters>   : define integration volume size" << std::endl;   
+  std::cout << "    -dev <device>, -oni <oni_file>  : select depth source. Default will be selected if not specified" << std::endl;
+  std::cout << "";
+  std::cout << " For RGBD benchmark (Requires OpenCV):" << std::endl; 
+  std::cout << "    -eval <eval_folder> [-match_file <associations_file_in_the_folder>]" << std::endl;
+  std::cout << " For Simuation (Requires pcl::simulation):" << std::endl; 
+  std::cout << "    -plyfile                        : path to ply file for simulation testing " << std::endl;
     
   return 0;
 }
@@ -1407,7 +1407,7 @@ main (int argc, char* argv[])
   pcl::gpu::printShortCudaDeviceInfo (device);
 
   if(checkIfPreFermiGPU(device))
-    return cout << endl << "Kinfu is not supported for pre-Fermi GPU architectures, and not built for them by default. Exiting..." << endl, 1;
+    return std::cout << std::endl << "Kinfu is not supported for pre-Fermi GPU architectures, and not built for them by default. Exiting..." << std::endl, 1;
 
   CaptureOpenNI capture;
   
@@ -1472,17 +1472,17 @@ main (int argc, char* argv[])
   
   // executing
   try { app.execute (argc, argv,plyfile); }
-  catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; }
-  catch (const std::exception& /*e*/) { cout << "Exception" << endl; }
+  catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; }
+  catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; }
 
 #ifdef HAVE_OPENCV
   for (size_t t = 0; t < app.image_view_.views_.size (); ++t)
   {
     if (t == 0)
     {
-      cout << "Saving depth map of first view." << endl;
+      std::cout << "Saving depth map of first view." << std::endl;
       cv::imwrite ("./depthmap_1stview.png", app.image_view_.views_[0]);
-      cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << endl;
+      std::cout << "Saving sequence of (" << app.image_view_.views_.size () << ") views." << std::endl;
     }
     char buf[4096];
     sprintf (buf, "./%06d.png", (int)t);

--- a/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
@@ -318,11 +318,11 @@ keyboard_callback (const pcl::visualization::KeyboardEvent &event, void *cookie)
       case 27:
       case (int)'q': case (int)'Q':
       case (int)'e': case (int)'E':
-        cout << "Exiting program" << endl;
+        std::cout << "Exiting program" << std::endl;
         quit = true;
         break;
       case (int)'s': case (int)'S':
-        cout << "Saving volume and cloud" << endl;
+        std::cout << "Saving volume and cloud" << std::endl;
         save = true;
         break;
       default:
@@ -448,7 +448,7 @@ main (int argc, char* argv[])
 
 
   // integrate depth in device volume
-  pc::print_highlight ("Converting depth map to volume ... "); cout << flush;
+  pc::print_highlight ("Converting depth map to volume ... "); std::cout << flush;
   device_volume->createFromDepth (depth, intr);
 
   // get volume from device
@@ -461,7 +461,7 @@ main (int argc, char* argv[])
 
 
   // generating TSDF cloud
-  pc::print_highlight ("Generating tsdf volume cloud ... "); cout << flush;
+  pc::print_highlight ("Generating tsdf volume cloud ... "); std::cout << flush;
   pcl::PointCloud<pcl::PointXYZI>::Ptr tsdf_cloud (new pcl::PointCloud<pcl::PointXYZI>);
   volume->convertToTsdfCloud (tsdf_cloud);
   pc::print_info ("done [%d points]\n", tsdf_cloud->size());
@@ -471,7 +471,7 @@ main (int argc, char* argv[])
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_volume (new pcl::PointCloud<pcl::PointXYZ>);
   if (extract_cloud_volume)
   {
-    pc::print_highlight ("Generating cloud from volume ... "); cout << flush;
+    pc::print_highlight ("Generating cloud from volume ... "); std::cout << flush;
     if (!device_volume->getCloud (cloud_volume))
     {
       pc::print_error ("Cloudn't get cloud from device volume!\n");
@@ -491,7 +491,7 @@ main (int argc, char* argv[])
   pc::print_info ("Saving captured cloud to "); pc::print_value ("%s", cloud_file.c_str()); pc::print_info (" ... ");
   if (pcl::io::savePCDFile (cloud_file, *cloud, true) < 0)
   {
-    cout << endl;
+    std::cout << std::endl;
     pc::print_error ("Cloudn't save the point cloud to file %s.\n", cloud_file.c_str());
   }
   else
@@ -506,7 +506,7 @@ main (int argc, char* argv[])
   pc::print_info ("Saving volume cloud to "); pc::print_value ("%s", tsdf_cloud_file.c_str()); pc::print_info (" ... ");
   if (pcl::io::savePCDFile (tsdf_cloud_file, *tsdf_cloud, true) < 0)
   {
-    cout << endl;
+    std::cout << std::endl;
     pc::print_error ("Cloudn't save the volume point cloud to file %s.\n", tsdf_cloud_file.c_str());
   }
   else
@@ -519,7 +519,7 @@ main (int argc, char* argv[])
     pc::print_info ("Saving cloud from volume to "); pc::print_value ("%s", cloud_volume_file.c_str()); pc::print_info (" ... ");
     if (pcl::io::savePCDFile (cloud_volume_file, *cloud_volume, true) < 0)
     {
-      cout << endl;
+      std::cout << std::endl;
       pc::print_error ("Cloudn't save the point cloud to file %s.\n", cloud_volume_file.c_str());
     }
     else

--- a/gpu/octree/test/perfomance.cpp
+++ b/gpu/octree/test/perfomance.cpp
@@ -82,8 +82,8 @@ TEST(PCL_OctreeGPU, performance)
 
     //const int k = 32;
 
-    cout << "sizeof(pcl::gpu::Octree::PointType): " << sizeof(pcl::gpu::Octree::PointType) << endl;    
-    //cout << "k = " << k << endl;
+    std::cout << "sizeof(pcl::gpu::Octree::PointType): " << sizeof(pcl::gpu::Octree::PointType) << std::endl;    
+    //std::cout << "k = " << k << std::endl;
     //generate data
     data();
 
@@ -106,9 +106,9 @@ TEST(PCL_OctreeGPU, performance)
 
     float host_octree_resolution = 25.f;    
     
-    cout << "[!] Host octree resolution: " << host_octree_resolution << endl << endl;    
+    std::cout << "[!] Host octree resolution: " << host_octree_resolution << std::endl << std::endl;    
 
-    cout << "======  Build performance =====" << endl;
+    std::cout << "======  Build performance =====" << std::endl;
     // build device octree
     pcl::gpu::Octree octree_device;                
     octree_device.setCloud(cloud_device);	    
@@ -169,7 +169,7 @@ TEST(PCL_OctreeGPU, performance)
     //pcl::gpu::Octree::BatchResult          distsKNN_device(queries_device.size() * k);
     //pcl::gpu::Octree::BatchResultSqrDists  indsKNN_device(queries_device.size() * k);
         
-    cout << "======  Separate radius for each query =====" << endl;
+    std::cout << "======  Separate radius for each query =====" << std::endl;
 
     {
         ScopeTime up("gpu--radius-search-batch-all");	        
@@ -195,7 +195,7 @@ TEST(PCL_OctreeGPU, performance)
             pcl::gpu::bruteForceRadiusSearchGPU(cloud_device, data.queries[i], data.radiuses[i], bruteforce_results_device, buffer);
     }
 
-    cout << "======  Shared radius (" << data.shared_radius << ") =====" << endl;
+    std::cout << "======  Shared radius (" << data.shared_radius << ") =====" << std::endl;
     
     {
         ScopeTime up("gpu-radius-search-batch-all");	        
@@ -221,7 +221,7 @@ TEST(PCL_OctreeGPU, performance)
             pcl::gpu::bruteForceRadiusSearchGPU(cloud_device, data.queries[i], data.shared_radius, bruteforce_results_device, buffer);
     }
 
-    cout << "======  Approx nearest search =====" << endl;
+    std::cout << "======  Approx nearest search =====" << std::endl;
 
     {
         ScopeTime up("gpu-approx-nearest-batch-all");	        
@@ -240,7 +240,7 @@ TEST(PCL_OctreeGPU, performance)
             octree_host.approxNearestSearch(data.queries[i], inds, dist);
     }
 
- /*   cout << "======  knn search ( k fixed to " << k << " ) =====" << endl;    
+ /*   std::cout << "======  knn search ( k fixed to " << k << " ) =====" << std::endl;    
     {
         ScopeTime up("gpu-knn-batch-all");	        
         octree_device.nearestKSearchBatch(queries_device, k, distsKNN_device, indsKNN_device);                        

--- a/gpu/octree/test/test_approx_nearest.cpp
+++ b/gpu/octree/test/test_approx_nearest.cpp
@@ -142,8 +142,8 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
 
     diff_pcl_better /=count_pcl_better;
 
-    cout << "count_gpu_better: " << count_gpu_better << endl;
-    cout << "count_pcl_better: " << count_pcl_better << endl;
-    cout << "avg_diff_pcl_better: " << diff_pcl_better << endl;    
+    std::cout << "count_gpu_better: " << count_gpu_better << std::endl;
+    std::cout << "count_pcl_better: " << count_pcl_better << std::endl;
+    std::cout << "avg_diff_pcl_better: " << diff_pcl_better << std::endl;    
 
 }

--- a/gpu/octree/test/test_bfrs_gpu.cpp
+++ b/gpu/octree/test/test_bfrs_gpu.cpp
@@ -96,6 +96,6 @@ TEST (PCL_GPU, bruteForceRadiusSeachGPU)
         
     float avg_size = std::accumulate(sizes.begin(), sizes.end(), (size_t)0) * (1.f/sizes.size());;
 
-    cout << "avg_result_size = " << avg_size << endl;
+    std::cout << "avg_result_size = " << avg_size << std::endl;
     ASSERT_GT(avg_size, 5);    
 }

--- a/gpu/octree/test/test_host_radius_search.cpp
+++ b/gpu/octree/test/test_host_radius_search.cpp
@@ -96,7 +96,7 @@ TEST(PCL_OctreeGPU, hostRadiusSearch)
 
     // build host octree
     float resolution = 25.f;
-    cout << "[!]Octree resolution: " << resolution << endl;
+    std::cout << "[!]Octree resolution: " << resolution << std::endl;
     pcl::octree::OctreePointCloudSearch<pcl::PointXYZ> octree_host(resolution);
     octree_host.setInputCloud (cloud_host);
     octree_host.addPointsFromInputCloud ();
@@ -129,7 +129,7 @@ TEST(PCL_OctreeGPU, hostRadiusSearch)
 
     float avg_size = std::accumulate(sizes.begin(), sizes.end(), 0) * (1.f/sizes.size());;
 
-    cout << "avg_result_size = " << avg_size << endl;
+    std::cout << "avg_result_size = " << avg_size << std::endl;
     ASSERT_GT(avg_size, 5);    
 }
 

--- a/gpu/octree/test/test_knn_search.cpp
+++ b/gpu/octree/test/test_knn_search.cpp
@@ -144,7 +144,7 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     //verify results    
     for(size_t i = 0; i < data.tests_num; ++i)    
     {           
-        //cout << i << endl;
+        //std::cout << i << std::endl;
         std::vector<int>&   results_host_cur = result_host[i];
         std::vector<float>&   dists_host_cur = dists_host[i];
                 

--- a/gpu/octree/test/test_radius_search.cpp
+++ b/gpu/octree/test/test_radius_search.cpp
@@ -164,7 +164,7 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
 
     float avg_size1 = std::accumulate(sizes1.begin(), sizes1.end(), 0) * (1.f/sizes1.size());
 
-    cout << "avg_result_size1 = " << avg_size1 << endl;
+    std::cout << "avg_result_size1 = " << avg_size1 << std::endl;
     ASSERT_GT(avg_size1, 5);    
 
 
@@ -193,7 +193,7 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
 
     float avg_size2 = std::accumulate(sizes2.begin(), sizes2.end(), 0) * (1.f/sizes2.size());
 
-    cout << "avg_result_size2 = " << avg_size2 << endl;
+    std::cout << "avg_result_size2 = " << avg_size2 << std::endl;
     ASSERT_GT(avg_size2, 5);
 
 
@@ -222,7 +222,7 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
 
     float avg_size3 = std::accumulate(sizes3.begin(), sizes3.end(), 0) * (1.f/sizes3.size());
 
-    cout << "avg_result_size3 = " << avg_size3 << endl;
+    std::cout << "avg_result_size3 = " << avg_size3 << std::endl;
     ASSERT_GT(avg_size3, 5);
 }
 

--- a/gpu/people/src/cuda/nvidia/NCV.cu
+++ b/gpu/people/src/cuda/nvidia/NCV.cu
@@ -56,7 +56,7 @@ using namespace std;
 
 static void stdDebugOutput(const string &msg)
 {
-    cout << msg;
+    std::cout << msg;
 }
 
 

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -224,14 +224,14 @@ pcl::gpu::people::PeopleDetector::process ()
       {
         if(t2.parts_lid[f] == NO_CHILD)
         {
-          cerr << "1;";
+          std::cerr << "1;";
           par++;
         }
         else
-           cerr << "0;";
+           std::cerr << "0;";
       }*/
       //static int counter = 0; // TODO move this logging to PeopleApp
-      //cerr << t2.nr_parts << ";" << par << ";" << t2.total_dist_error << ";" << t2.norm_dist_error << ";" << counter++ << ";" << endl;
+      //std::cerr << t2.nr_parts << ";" << par << ";" << t2.total_dist_error << ";" << t2.norm_dist_error << ";" << counter++ << ";" << std::endl;
       return 2;
     }
     return 1;
@@ -375,15 +375,15 @@ pcl::gpu::people::PeopleDetector::processProb ()
       {
         if(node_type == NO_CHILD)
         {
-          cerr << "1;";
+          std::cerr << "1;";
           //par++;
         }
         else
-           cerr << "0;";
+           std::cerr << "0;";
       }
       std::cerr << std::endl;
       //static int counter = 0; // TODO move this logging to PeopleApp
-      //cerr << t2.nr_parts << ";" << par << ";" << t2.total_dist_error << ";" << t2.norm_dist_error << ";" << counter++ << ";" << endl;
+      //std::cerr << t2.nr_parts << ";" << par << ";" << t2.total_dist_error << ";" << t2.norm_dist_error << ";" << counter++ << ";" << std::endl;
       first_iteration_ = false;
       return 2;
     }

--- a/gpu/people/tools/people_app.cpp
+++ b/gpu/people/tools/people_app.cpp
@@ -99,7 +99,7 @@ struct SampledScopeTime : public StopWatch
     time_ms_ += getTime ();    
     if (i_ % EACH == 0 && i_)
     {
-      cout << "[~SampledScopeTime] : Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << endl;
+      std::cout << "[~SampledScopeTime] : Average frame time = " << time_ms_ / EACH << "ms ( " << 1000.f * EACH / time_ms_ << "fps )" << std::endl;
       time_ms_ = 0;        
     }
     ++i_;
@@ -315,8 +315,8 @@ class PeoplePCDApp
           }
           final_view_.spinOnce (3);                  
         }
-        catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; }
-        catch (const std::exception& /*e*/) { cout << "Exception" << endl; }
+        catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; }
+        catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; }
 
         capture_.stop ();
       }
@@ -355,19 +355,19 @@ class PeoplePCDApp
 
 void print_help()
 {
-  cout << "\nPeople tracking app options (help):" << endl;
-  cout << "\t -numTrees    \t<int> \tnumber of trees to load" << endl;
-  cout << "\t -tree0       \t<path_to_tree_file>" << endl;
-  cout << "\t -tree1       \t<path_to_tree_file>" << endl;
-  cout << "\t -tree2       \t<path_to_tree_file>" << endl;
-  cout << "\t -tree3       \t<path_to_tree_file>" << endl;
-  cout << "\t -gpu         \t<GPU_device_id>" << endl;
-  cout << "\t -w           \t<bool> \tWrite results to disk" << endl;
-  cout << "\t -h           \tPrint this help" << endl;
-  cout << "\t -dev         \t<Kinect_device_id>" << endl;  
-  cout << "\t -pcd         \t<path_to_pcd_file>" << endl;
-  cout << "\t -oni         \t<path_to_oni_file>" << endl;  
-  cout << "\t -pcd_folder  \t<path_to_folder_with_pcd_files>" << endl;
+  std::cout << "\nPeople tracking app options (help):" << std::endl;
+  std::cout << "\t -numTrees    \t<int> \tnumber of trees to load" << std::endl;
+  std::cout << "\t -tree0       \t<path_to_tree_file>" << std::endl;
+  std::cout << "\t -tree1       \t<path_to_tree_file>" << std::endl;
+  std::cout << "\t -tree2       \t<path_to_tree_file>" << std::endl;
+  std::cout << "\t -tree3       \t<path_to_tree_file>" << std::endl;
+  std::cout << "\t -gpu         \t<GPU_device_id>" << std::endl;
+  std::cout << "\t -w           \t<bool> \tWrite results to disk" << std::endl;
+  std::cout << "\t -h           \tPrint this help" << std::endl;
+  std::cout << "\t -dev         \t<Kinect_device_id>" << std::endl;  
+  std::cout << "\t -pcd         \t<path_to_pcd_file>" << std::endl;
+  std::cout << "\t -oni         \t<path_to_oni_file>" << std::endl;  
+  std::cout << "\t -pcd_folder  \t<path_to_folder_with_pcd_files>" << std::endl;
 }
 
 int main(int argc, char** argv)
@@ -423,7 +423,7 @@ int main(int argc, char** argv)
       //capture.reset( new pcl::PCDGrabber<PointXYZRGBA>(pcd_files, 30, true) );      
     }
   }
-  catch (const pcl::PCLException& /*e*/) { return cout << "Can't open depth source" << endl, -1; }
+  catch (const pcl::PCLException& /*e*/) { return std::cout << "Can't open depth source" << std::endl, -1; }
     
   //selecting tree files
   std::vector<string> tree_files;
@@ -462,10 +462,10 @@ int main(int argc, char** argv)
     // executing
     app.startMainLoop ();
   }
-  catch (const pcl::PCLException& e) { cout << "PCLException: " << e.detailedMessage() << endl; print_help();}
-  catch (const std::runtime_error& e) { cout << e.what() << endl; print_help(); }
-  catch (const std::bad_alloc& /*e*/) { cout << "Bad alloc" << endl; print_help(); }
-  catch (const std::exception& /*e*/) { cout << "Exception" << endl; print_help(); }
+  catch (const pcl::PCLException& e) { std::cout << "PCLException: " << e.detailedMessage() << std::endl; print_help();}
+  catch (const std::runtime_error& e) { std::cout << e.what() << std::endl; print_help(); }
+  catch (const std::bad_alloc& /*e*/) { std::cout << "Bad alloc" << std::endl; print_help(); }
+  catch (const std::exception& /*e*/) { std::cout << "Exception" << std::endl; print_help(); }
 
   return 0;
 }  

--- a/gpu/people/tools/people_tracking.cpp
+++ b/gpu/people/tools/people_tracking.cpp
@@ -82,12 +82,12 @@ class PeopleTrackingApp
 
 int print_help()
 {
-  cout << "\nPeople tracking app options:" << std::endl;
-  cout << "\t -numTrees \t<int> \tnumber of trees to load" << std::endl;
-  cout << "\t -tree0 \t<path_to_tree_file>" << std::endl;
-  cout << "\t -tree1 \t<path_to_tree_file>" << std::endl;
-  cout << "\t -tree2 \t<path_to_tree_file>" << std::endl;
-  cout << "\t -tree3 \t<path_to_tree_file>" << std::endl;
+  std::cout << "\nPeople tracking app options:" << std::endl;
+  std::cout << "\t -numTrees \t<int> \tnumber of trees to load" << std::endl;
+  std::cout << "\t -tree0 \t<path_to_tree_file>" << std::endl;
+  std::cout << "\t -tree1 \t<path_to_tree_file>" << std::endl;
+  std::cout << "\t -tree2 \t<path_to_tree_file>" << std::endl;
+  std::cout << "\t -tree3 \t<path_to_tree_file>" << std::endl;
   return 0;
 }
 


### PR DESCRIPTION
Use `std::cout`/`std::cerr`/`std::endl` instead of just `cout`/`cerr`/`endl` in preparation for #3235.