### PR TITLE
Use std::cout/std::cerr/std::endl instead of just cout/cerr/endl [io-visualization]

### DIFF
--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -181,7 +181,7 @@ PCDBuffer<PointT>::getFront ()
         break;
       {
         std::lock_guard<std::mutex> io_lock (io_mutex);
-        //cerr << "No data in buffer_ yet or buffer is empty." << endl;
+        //std::cerr << "No data in buffer_ yet or buffer is empty." << std::endl;
       }
       buff_empty_.wait (buff_lock);
     }
@@ -200,7 +200,7 @@ do \
     ++count; \
     if (now - last >= 1.0) \
     { \
-      cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff.getSize () << "\n"; \
+      std::cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff.getSize () << "\n"; \
       count = 0; \
       last = now; \
     } \
@@ -401,20 +401,20 @@ main (int argc, char** argv)
       {
         pcl::OpenNIGrabber grabber (argv[2]);
         openni_wrapper::OpenNIDevice::Ptr device = grabber.getDevice ();
-        cout << "Supported depth modes for device: " << device->getVendorName () << " , " << device->getProductName () << endl;
+        std::cout << "Supported depth modes for device: " << device->getVendorName () << " , " << device->getProductName () << std::endl;
         std::vector<std::pair<int, XnMapOutputMode > > modes = grabber.getAvailableDepthModes ();
         for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin (); it != modes.end (); ++it)
         {
-          cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+          std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
         }
 
         if (device->hasImageStream ())
         {
-          cout << endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << endl;
+          std::cout << std::endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << std::endl;
           modes = grabber.getAvailableImageModes ();
           for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin (); it != modes.end (); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         }
       }
@@ -425,15 +425,15 @@ main (int argc, char** argv)
         {
           for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
           {
-            cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus(deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
+            std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus(deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
 
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return 0;
     }
@@ -442,7 +442,7 @@ main (int argc, char** argv)
   {
     openni_wrapper::OpenNIDriver& driver = openni_wrapper::OpenNIDriver::getInstance ();
     if (driver.getNumberDevices () > 0)
-      cout << "Device Id not set, using first device." << endl;
+      std::cout << "Device Id not set, using first device." << std::endl;
   }
 
   bool just_xyz = find_switch (argc, argv, "-xyz");

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -1070,7 +1070,7 @@ namespace pcl
           double c = planes[(i*4)+2];
           double d = planes[(i*4)+3];
 
-          //cout << i << ": " << a << "x + " << b << "y + " << c << "z + " << d << endl;
+          //std::cout << i << ": " << a << "x + " << b << "y + " << c << "z + " << d << std::endl;
 
           Eigen::Vector3d normal(a, b, c);
 
@@ -1099,8 +1099,8 @@ namespace pcl
   //        Eigen::Vector3d n_vertex; //neg vertex
   //        get_np_vertices(normal, p_vertex, n_vertex, min_bb, max_bb);
   //
-  //        cout << "n_vertex: " << n_vertex.x () << ", " << n_vertex.y () << ", " << n_vertex.z () << endl;
-  //        cout << "p_vertex: " << p_vertex.x () << ", " << p_vertex.y () << ", " << p_vertex.z () << endl;
+  //        std::cout << "n_vertex: " << n_vertex.x () << ", " << n_vertex.y () << ", " << n_vertex.z () << std::endl;
+  //        std::cout << "p_vertex: " << p_vertex.x () << ", " << p_vertex.y () << ", " << p_vertex.z () << std::endl;
 
           // is the positive vertex outside?
   //        if (pl[i].distance(b.getVertexP(pl[i].normal)) < 0)
@@ -1128,14 +1128,14 @@ namespace pcl
 
           // This should be the same as above
   //        double m = (a * n_vertex.x ()) + (b * n_vertex.y ()) + (c * n_vertex.z ());
-  //        cout << "m = " << m << endl;
+  //        std::cout << "m = " << m << std::endl;
   //        if (m > -d)
   //        {
   //          result = OUTSIDE;
   //        }
   //
   //        double n = (a * p_vertex.x ()) + (b * p_vertex.y ()) + (c * p_vertex.z ());
-  //        cout << "n = " << n << endl;
+  //        std::cout << "n = " << n << std::endl;
   //        if (n > -d)
   //        {
   //          result = INTERSECT;
@@ -1150,13 +1150,13 @@ namespace pcl
 
 //      switch(result){
 //        case OUTSIDE:
-//          //cout << this->depth_ << " [OUTSIDE]: " << node_metadata_->getPCDFilename() << endl;
+//          //std::cout << this->depth_ << " [OUTSIDE]: " << node_metadata_->getPCDFilename() << std::endl;
 //          return;
 //        case INTERSECT:
-//          //cout << this->depth_ << " [INTERSECT]: " << node_metadata_->getPCDFilename() << endl;
+//          //std::cout << this->depth_ << " [INTERSECT]: " << node_metadata_->getPCDFilename() << std::endl;
 //          break;
 //        case INSIDE:
-//          //cout << this->depth_ << " [INSIDE]: " << node_metadata_->getPCDFilename() << endl;
+//          //std::cout << this->depth_ << " [INSIDE]: " << node_metadata_->getPCDFilename() << std::endl;
 //          break;
 //      }
 
@@ -1223,7 +1223,7 @@ namespace pcl
           double c = planes[(i*4)+2];
           double d = planes[(i*4)+3];
 
-          //cout << i << ": " << a << "x + " << b << "y + " << c << "z + " << d << endl;
+          //std::cout << i << ": " << a << "x + " << b << "y + " << c << "z + " << d << std::endl;
 
           Eigen::Vector3d normal(a, b, c);
 

--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -234,7 +234,7 @@ class OutofcoreCloud : public Object
         value = 100;
 
       lod_pixel_threshold_ += value;
-      std::cout << "Increasing lod pixel threshold: " << lod_pixel_threshold_ << endl;
+      std::cout << "Increasing lod pixel threshold: " << lod_pixel_threshold_ << std::endl;
     }
 
     void
@@ -252,7 +252,7 @@ class OutofcoreCloud : public Object
 
       if (lod_pixel_threshold_ < 100)
         lod_pixel_threshold_ = 100;
-      std::cout << "Decreasing lod pixel threshold: " << lod_pixel_threshold_ << endl;
+      std::cout << "Decreasing lod pixel threshold: " << lod_pixel_threshold_ << std::endl;
     }
 
     void

--- a/outofcore/src/visualization/outofcore_cloud.cpp
+++ b/outofcore/src/visualization/outofcore_cloud.cpp
@@ -213,7 +213,7 @@ OutofcoreCloud::render (vtkRenderer* renderer)
 
 //      for (int i=0; i < node->getDepth(); i++)
 //        std::cout << " ";
-//      std::cout << coverage << "-" << pcd_file << endl;//" : " << (coverage > (size[0] * size[1])) << endl;
+//      std::cout << coverage << "-" << pcd_file << std::endl;//" : " << (coverage > (size[0] * size[1])) << std::endl;
 
       std::string pcd_file = node->getPCDFilename ().string ();
 

--- a/outofcore/tools/outofcore_viewer.cpp
+++ b/outofcore/tools/outofcore_viewer.cpp
@@ -158,7 +158,7 @@ public:
     std::string key (interactor->GetKeySym ());
     bool shift_down = interactor->GetShiftKey();
 
-    cout << "Key Pressed: " << key << endl;
+    std::cout << "Key Pressed: " << key << std::endl;
 
     Scene *scene = Scene::instance ();
     OutofcoreCloud *cloud = static_cast<OutofcoreCloud*> (scene->getObjectByName ("my_octree"));
@@ -225,7 +225,7 @@ renderEndCallback(vtkObject* vtkNotUsed(caller), unsigned long int vtkNotUsed(ev
 int
 outofcoreViewer (boost::filesystem::path tree_root, int depth, bool display_octree=true, unsigned int gpu_cache_size=512)
 {
-  cout << boost::filesystem::absolute (tree_root) << endl;
+  std::cout << boost::filesystem::absolute (tree_root) << std::endl;
 
   // Create top level scene
   Scene *scene = Scene::instance ();

--- a/people/apps/main_ground_based_people_detection.cpp
+++ b/people/apps/main_ground_based_people_detection.cpp
@@ -71,15 +71,15 @@ enum { COLS = 640, ROWS = 480 };
 
 int print_help()
 {
-  cout << "*******************************************************" << std::endl;
-  cout << "Ground based people detection app options:" << std::endl;
-  cout << "   --help    <show_this_help>" << std::endl;
-  cout << "   --svm     <path_to_svm_file>" << std::endl;
-  cout << "   --conf    <minimum_HOG_confidence (default = -1.5)>" << std::endl;
-  cout << "   --min_h   <minimum_person_height (default = 1.3)>" << std::endl;
-  cout << "   --max_h   <maximum_person_height (default = 2.3)>" << std::endl;
-  cout << "   --sample  <sampling_factor (default = 1)>" << std::endl;
-  cout << "*******************************************************" << std::endl;
+  std::cout << "*******************************************************" << std::endl;
+  std::cout << "Ground based people detection app options:" << std::endl;
+  std::cout << "   --help    <show_this_help>" << std::endl;
+  std::cout << "   --svm     <path_to_svm_file>" << std::endl;
+  std::cout << "   --conf    <minimum_HOG_confidence (default = -1.5)>" << std::endl;
+  std::cout << "   --min_h   <minimum_person_height (default = 1.3)>" << std::endl;
+  std::cout << "   --max_h   <maximum_person_height (default = 2.3)>" << std::endl;
+  std::cout << "   --sample  <sampling_factor (default = 1)>" << std::endl;
+  std::cout << "*******************************************************" << std::endl;
   return 0;
 }
 

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -175,7 +175,7 @@ pcl::recognition::ObjRecRANSAC::sampleOrientedPointPairs (int num_iterations, co
   if ( !num_full_leaves )
   {
 #ifdef OBJ_REC_RANSAC_VERBOSE
-    cout << "done [" << num_of_opps << " opps].\n";
+    std::cout << "done [" << num_of_opps << " opps].\n";
 #endif
     return;
   }
@@ -229,7 +229,7 @@ pcl::recognition::ObjRecRANSAC::sampleOrientedPointPairs (int num_iterations, co
   }
 
 #ifdef OBJ_REC_RANSAC_VERBOSE
-  cout << "done [" << num_of_opps << " opps].\n";
+  std::cout << "done [" << num_of_opps << " opps].\n";
 #endif
 }
 

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -125,22 +125,22 @@ display_tic_toc (vector<double> &tic_toc,const string &fun_name)
 
   double percent_tic_toc_last = 0;
   double dtime = tic_toc[tic_toc_size-1] - tic_toc[0];
-  cout << "fraction_" << fun_name << ",";
+  std::cout << "fraction_" << fun_name << ",";
   for (size_t i = 0; i < tic_toc_size; i++)
   {
     double percent_tic_toc =  (tic_toc[i] - tic_toc[0])/(tic_toc[tic_toc_size-1] - tic_toc[0]);
-    cout <<  percent_tic_toc - percent_tic_toc_last << ", ";
+    std::cout <<  percent_tic_toc - percent_tic_toc_last << ", ";
     percent_tic_toc_last = percent_tic_toc;
   }
-  cout << "\ntime_" << fun_name << ",";
+  std::cout << "\ntime_" << fun_name << ",";
   double time_tic_toc_last = 0;
   for (size_t i = 0; i < tic_toc_size; i++)
   {
     double percent_tic_toc = (tic_toc[i] - tic_toc[0])/(tic_toc[tic_toc_size-1] - tic_toc[0]);
-    cout <<  percent_tic_toc*dtime - time_tic_toc_last << ", ";
+    std::cout <<  percent_tic_toc*dtime - time_tic_toc_last << ", ";
     time_tic_toc_last = percent_tic_toc*dtime;
   }
-  cout << "\ntotal_time_" << fun_name << " " << dtime << "\n";
+  std::cout << "\ntotal_time_" << fun_name << " " << dtime << "\n";
 }
 
 pcl::simulation::RangeLikelihood::RangeLikelihood (int rows, int cols, int row_height, int col_width, Scene::Ptr scene) :
@@ -810,7 +810,7 @@ pcl::simulation::RangeLikelihood::addNoise ()
   {
     depth_buffer_[i] =  std::ceil (depth_buffer_[i]*bins)/bins;
   }
-  cout << "in add noise\n";
+  std::cout << "in add noise\n";
 }
 
 void

--- a/simulation/tools/sim_terminal_demo.cpp
+++ b/simulation/tools/sim_terminal_demo.cpp
@@ -63,7 +63,7 @@ void write_sim_output(const string &fname_root){
     pcl::PCDWriter writer;
     //writer.write ( string (fname_root + ".pcd"), *pc_out,	false);  /// ASCII
     writer.writeBinary (  string (fname_root + ".pcd")  , *pc_out);
-    //cout << "finished writing file\n";
+    //std::cout << "finished writing file\n";
   }else{
     std::cout << pc_out->points.size() << " points in cloud, not written\n";
   }
@@ -202,10 +202,10 @@ main (int argc, char** argv)
     simexample->doSim(poses[i]);
     
     write_sim_output(ss.str());
-    cout << (getTime() -tic) << " sec\n";
+    std::cout << (getTime() -tic) << " sec\n";
   }
-  cout << poses.size() << " poses simulated in " << (getTime() -tic_main) << "seconds\n";
-  cout << (poses.size()/ (getTime() -tic_main) ) << "Hz on average\n";
+  std::cout << poses.size() << " poses simulated in " << (getTime() -tic_main) << "seconds\n";
+  std::cout << (poses.size()/ (getTime() -tic_main) ) << "Hz on average\n";
   
   return 0;
 }

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -401,7 +401,7 @@ void display ()
     
     pcl::PCDWriter writer;
     writer.write ("simulated_range_image.pcd", *pc_out,	false);  
-    cout << "finished writing file\n";
+    std::cout << "finished writing file\n";
     
 //     pcl::visualization::CloudViewer viewer ("Simple Cloud Viewer");
 //     viewer.showCloud (pc_out);
@@ -420,7 +420,7 @@ void display ()
 //    viewer.reset();
     
     
-    cout << "done\n";
+    std::cout << "done\n";
     // Problem: vtk and opengl don't seem to play very well together
     // vtk seems to misbehave after a little while and won't keep the window on the screen
 
@@ -430,7 +430,7 @@ void display ()
     
     // method2: eventually starts ignoring cin and pops up on screen and closes almost 
     // immediately
-    //  cout << "enter 1 to cont\n";
+    //  std::cout << "enter 1 to cont\n";
     //  cin >> pause;
     //  viewer.wasStopped ();
     
@@ -569,7 +569,7 @@ initialize (int, char** argv)
   camera_->setPitch(0.20944); // not sure why this is here: 
   //camera_->set(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
   
-  cout << "About to read: " << argv[1] << endl;
+  std::cout << "About to read: " << argv[1] << std::endl;
   load_PolygonMesh_model (argv[1]);
     
   paused_ = false;

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -333,7 +333,7 @@ void simulate_callback (const pcl::visualization::KeyboardEvent &event,
       std::cout << "n cams not 1 exiting\n"; // for now in case ...
      return; 
     }
-   // cout << "n cams: " << cams.size() << "\n";
+   // std::cout << "n cams: " << cams.size() << "\n";
     pcl::visualization::Camera cam = cams[0];
     
 
@@ -351,9 +351,9 @@ void simulate_callback (const pcl::visualization::KeyboardEvent &event,
 	     m =pose.rotation();
 	     //All axies use right hand rule. x=red axis, y=green axis, z=blue axis z direction is point into the screen. z \ \ \ -----------> x | | | | | | y 
 	      
- cout << pose(0,0)  << " " << pose(0,1) << " " << pose(0,2)  << " " << pose(0,3) << " x0\n";
- cout << pose(1,0) << " " << pose(1,1) << " " << pose(1,2) << " " << pose(1,3) << " x1\n";
-  cout << pose(2,0) << " " << pose(2,1)  << " " << pose(2,2) << " " << pose(2,3)<< "x2\n";
+ std::cout << pose(0,0)  << " " << pose(0,1) << " " << pose(0,2)  << " " << pose(0,3) << " x0\n";
+ std::cout << pose(1,0) << " " << pose(1,1) << " " << pose(1,2) << " " << pose(1,3) << " x1\n";
+  std::cout << pose(2,0) << " " << pose(2,1)  << " " << pose(2,2) << " " << pose(2,3)<< "x2\n";
 
   double yaw,pitch, roll;
   wRo_to_euler(m,yaw,pitch,roll);
@@ -362,9 +362,9 @@ void simulate_callback (const pcl::visualization::KeyboardEvent &event,
 
 // matrix->GetElement(1,0);
   
- cout << m(0,0)  << " " << m(0,1) << " " << m(0,2)  << " "  << " x0\n";
- cout << m(1,0) << " " << m(1,1) << " " << m(1,2) << " "  << " x1\n";
-  cout << m(2,0) << " " << m(2,1)  << " " << m(2,2) << " "<< "x2\n\n";
+ std::cout << m(0,0)  << " " << m(0,1) << " " << m(0,2)  << " "  << " x0\n";
+ std::cout << m(1,0) << " " << m(1,1) << " " << m(1,2) << " "  << " x1\n";
+  std::cout << m(2,0) << " " << m(2,1)  << " " << m(2,2) << " "<< "x2\n\n";
   
   Eigen::Quaternionf rf;
   rf = Eigen::Quaternionf(m);
@@ -395,7 +395,7 @@ void simulate_callback (const pcl::visualization::KeyboardEvent &event,
     ss2.precision(20);
     ss2 << "simulated_pcl_" << tic << ".pcd";
     capture(init_pose);
-    cout << (getTime() -tic) << " sec\n";  
+    std::cout << (getTime() -tic) << " sec\n";  
   }
 }
 

--- a/simulation/tools/simulation_io.cpp
+++ b/simulation/tools/simulation_io.cpp
@@ -268,7 +268,7 @@ pcl::simulation::SimExample::write_depth_image_uint(const float* depth_buffer, s
       if (z_new>65535) z_new = 65535;
       
       if ( z_new < 18000){
-	  cout << z_new << " " << d << " " << x << "\n";  
+	  std::cout << z_new << " " << d << " " << x << "\n";  
       }
 
       depth_img[i] = z_new;

--- a/test/features/test_ii_normals.cpp
+++ b/test/features/test_ii_normals.cpp
@@ -86,7 +86,7 @@ TEST(PCL, IntegralImage1D)
       {
         for(unsigned xIdx = 0; xIdx < width - window_width; ++xIdx)
         {
-          //cout << xIdx << " : " << yIdx << " - " << window_width << " x " << window_height << " :: " << integral_image1.getFirstOrderSum (xIdx, yIdx, window_width, window_height) * 2 << endl;
+          //std::cout << xIdx << " : " << yIdx << " - " << window_width << " x " << window_height << " :: " << integral_image1.getFirstOrderSum (xIdx, yIdx, window_width, window_height) * 2 << std::endl;
           EXPECT_EQ (window_height * window_width * (window_width + 2 * xIdx - 1), integral_image1.getFirstOrderSum (xIdx, yIdx, window_width, window_height) * 2);
           EXPECT_EQ (window_height * window_width * (window_width + 2 * xIdx - 1), integral_image2.getFirstOrderSum (xIdx, yIdx, window_width, window_height) * 2);
           EXPECT_EQ (window_height * window_width, integral_image1.getFiniteElementsCount (xIdx, yIdx, window_width, window_height));

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -67,7 +67,7 @@ TEST (PCL, computePointNormal)
   c.push_back (p11); c.push_back (p21); c.push_back (p31);
 
   computePointNormal (cloud, plane_parameters, curvature);
-//  cerr << plane_parameters << "\n";
+//  std::cerr << plane_parameters << "\n";
   
   c.clear ();
   PointXYZ p12 (-439747.72f, -43597.250f, 0.0000000f),
@@ -77,7 +77,7 @@ TEST (PCL, computePointNormal)
   c.push_back (p12); c.push_back (p22); c.push_back (p32);
 
   computePointNormal (cloud, plane_parameters, curvature);
-//  cerr << plane_parameters << "\n";
+//  std::cerr << plane_parameters << "\n";
 
   c.clear ();
   PointXYZ p13 (567011.56f, -7741.8179f, 0.00000000f),
@@ -87,7 +87,7 @@ TEST (PCL, computePointNormal)
   c.push_back (p13); c.push_back (p23); c.push_back (p33);
 
   computePointNormal (cloud, plane_parameters, curvature);
-//  cerr << plane_parameters << "\n";
+//  std::cerr << plane_parameters << "\n";
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -100,23 +100,23 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
   std::vector<float> k_distances;
   kdtree.radiusSearch (test_point, max_dist, k_indices, k_distances, 100);
   
-  //cout << k_indices.size()<<"=="<<brute_force_result.size()<<"?\n";
+  //std::cout << k_indices.size()<<"=="<<brute_force_result.size()<<"?\n";
   
   for (const int &k_index : k_indices)
   {
     set<int>::iterator brute_force_result_it = brute_force_result.find (k_index);
     bool ok = brute_force_result_it != brute_force_result.end ();
-    //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
-    //else      cerr << k_indices[i] << " is correct...\n";
+    //if (!ok)  std::cerr << k_indices[i] << " is not correct...\n";
+    //else      std::cerr << k_indices[i] << " is correct...\n";
     EXPECT_EQ (ok, true);
     if (ok)
       brute_force_result.erase (brute_force_result_it);
   }
   //for (set<int>::const_iterator it=brute_force_result.begin(); it!=brute_force_result.end(); ++it)
-  //cerr << "FLANN missed "<<*it<<"\n";
+  //std::cerr << "FLANN missed "<<*it<<"\n";
   
   bool error = !brute_force_result.empty ();
-  //if (error)  cerr << "Missed too many neighbors!\n";
+  //if (error)  std::cerr << "Missed too many neighbors!\n";
   EXPECT_EQ (error, false);
 
   {
@@ -180,7 +180,7 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
   std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
   kdtree.nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);
-  //if (k_indices.size() != no_of_neighbors)  cerr << "Found "<<k_indices.size()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
+  //if (k_indices.size() != no_of_neighbors)  std::cerr << "Found "<<k_indices.size()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
@@ -190,8 +190,8 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
       ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
-    //if (!ok)  cerr << k_index << " is not correct...\n";
-    //else      cerr << k_index << " is correct...\n";
+    //if (!ok)  std::cerr << k_index << " is not correct...\n";
+    //else      std::cerr << k_index << " is correct...\n";
     EXPECT_EQ (ok, true);
   }
 

--- a/test/people/test_people_groundBasedPeopleDetectionApp.cpp
+++ b/test/people/test_people_groundBasedPeopleDetectionApp.cpp
@@ -102,20 +102,20 @@ int main (int argc, char** argv)
 {
   if (argc < 2)
   {
-    cerr << "No svm filename provided. Please download `trainedLinearSVMForPeopleDetectionWithHOG.yaml` and pass its path to the test." << endl;
+    std::cerr << "No svm filename provided. Please download `trainedLinearSVMForPeopleDetectionWithHOG.yaml` and pass its path to the test." << std::endl;
     return (-1);
   }
   	
   if (argc < 3)
   {
-    cerr << "No test file given. Please download 'five_people.pcd` and pass its path to the test." << endl;
+    std::cerr << "No test file given. Please download 'five_people.pcd` and pass its path to the test." << std::endl;
     return (-1);
   }
 
   cloud = PointCloudT::Ptr (new PointCloudT);
   if (pcl::io::loadPCDFile (argv[2], *cloud) < 0)
   {
-    cerr << "Failed to read test file. Please download `five_people.pcd` and pass its path to the test." << endl;
+    std::cerr << "Failed to read test file. Please download `five_people.pcd` and pass its path to the test." << std::endl;
     return (-1);
   }	
 	

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -166,19 +166,19 @@ main (int argc, char** argv)
 {
   if (argc < 3)
   {
-    cerr << "No test file given. Please download `milk.pcd` and `milk_cartoon_all_small_clorox.pcd` and pass their paths to the test." << endl;
+    std::cerr << "No test file given. Please download `milk.pcd` and `milk_cartoon_all_small_clorox.pcd` and pass their paths to the test." << std::endl;
     return (-1);
   }
 
   if (loadPCDFile (argv[1], *model_) < 0)
   {
-    cerr << "Failed to read test file. Please download `milk.pcd` and pass its path to the test." << endl;
+    std::cerr << "Failed to read test file. Please download `milk.pcd` and pass its path to the test." << std::endl;
     return (-1);
   }
 
   if (loadPCDFile (argv[2], *scene_) < 0)
   {
-    cerr << "Failed to read test file. Please download `milk_cartoon_all_small_clorox.pcd` and pass its path to the test." << endl;
+    std::cerr << "Failed to read test file. Please download `milk_cartoon_all_small_clorox.pcd` and pass its path to the test." << std::endl;
     return (-1);
   }
 

--- a/test/search/test_auto_search.cpp
+++ b/test/search/test_auto_search.cpp
@@ -294,8 +294,8 @@ TEST (PCL, KdTreeWrapper_nearestKSearch)
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
       ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
-    //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
-    //else      cerr << k_indices[i] << " is correct...\n";
+    //if (!ok)  std::cerr << k_indices[i] << " is not correct...\n";
+    //else      std::cerr << k_indices[i] << " is correct...\n";
     EXPECT_EQ (ok, true);
   }
 

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -102,7 +102,7 @@ TEST (PCL, FlannSearch_nearestKSearch)
 
   FlannSearch->nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);
 
-  //if (k_indices.size () != no_of_neighbors)  cerr << "Found "<<k_indices.size ()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
+  //if (k_indices.size () != no_of_neighbors)  std::cerr << "Found "<<k_indices.size ()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
@@ -112,8 +112,8 @@ TEST (PCL, FlannSearch_nearestKSearch)
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
     ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
-    //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
-    //else      cerr << k_indices[i] << " is correct...\n";
+    //if (!ok)  std::cerr << k_indices[i] << " is not correct...\n";
+    //else      std::cerr << k_indices[i] << " is correct...\n";
     EXPECT_EQ (ok, true);
   }
 

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -97,7 +97,7 @@ init ()
 
   kdtree->nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);
 
-  //if (k_indices.size () != no_of_neighbors)  cerr << "Found "<<k_indices.size ()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
+  //if (k_indices.size () != no_of_neighbors)  std::cerr << "Found "<<k_indices.size ()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
   EXPECT_EQ (k_indices.size (), no_of_neighbors);
 
   // Check if all found neighbors have distance smaller than max_dist
@@ -107,8 +107,8 @@ init ()
     bool ok = euclideanDistance (test_point, point) <= max_dist;
     if (!ok)
     ok = (std::abs (euclideanDistance (test_point, point)) - max_dist) <= 1e-6;
-    //if (!ok)  cerr << k_indices[i] << " is not correct...\n";
-    //else      cerr << k_indices[i] << " is correct...\n";
+    //if (!ok)  std::cerr << k_indices[i] << " is not correct...\n";
+    //else      std::cerr << k_indices[i] << " is correct...\n";
     EXPECT_EQ (ok, true);
   }
 

--- a/test/search/test_organized_index.cpp
+++ b/test/search/test_organized_index.cpp
@@ -492,7 +492,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
 	  if(cloudIn->points[randomIdx].z <100)break;
   }
 
-  cout << "**Search Point:** " << cloudIn->points[randomIdx].x << " " << cloudIn->points[randomIdx].y << " " << cloudIn->points[randomIdx].z << endl;
+  std::cout << "**Search Point:** " << cloudIn->points[randomIdx].x << " " << cloudIn->points[randomIdx].y << " " << cloudIn->points[randomIdx].z << std::endl;
 
   std::cout << "+--------+-----------------+----------------+-------------------+" << std::endl;
   std::cout << "| Search | Organized       | Organized      | Number of         |" << std::endl;

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -199,11 +199,11 @@ testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, con
     if (!indices_mask [index])
     {
 #if DEBUG_OUT
-      cerr << name << ": result contains an invalid point: " << index << " not in indices list.\n";
+      std::cerr << name << ": result contains an invalid point: " << index << " not in indices list.\n";
       
 //      for (vector<int>::const_iterator iIt2 = input_indices.begin (); iIt2 != input_indices.end (); ++iIt2)
-//        cout << *iIt2 << "  ";
-//      cout << endl;
+//        std::cout << *iIt2 << "  ";
+//      std::cout << std::endl;
 #endif
       validness = false;
       break;
@@ -211,7 +211,7 @@ testResultValidity (const typename PointCloud<PointT>::ConstPtr point_cloud, con
     if (!nan_mask [index])
     {
 #if DEBUG_OUT
-      cerr << name << ": result contains an invalid point: " << index << " = NaN (" << point_cloud->points [index].x << " , " 
+      std::cerr << name << ": result contains an invalid point: " << index << " = NaN (" << point_cloud->points [index].x << " , " 
                                                                                     << point_cloud->points [index].y << " , " 
                                                                                     << point_cloud->points [index].z << ")\n";
 #endif
@@ -240,17 +240,17 @@ bool compareResults (const std::vector<int>& indices1, const::vector<float>& dis
   if (indices1.size () != indices2.size ())
   {
 #if DEBUG_OUT
-    cerr << "size of results between " << name1 << " search and " << name2 << " search do not match " <<indices1.size () << " vs. " << indices2.size () << endl;
+    std::cerr << "size of results between " << name1 << " search and " << name2 << " search do not match " <<indices1.size () << " vs. " << indices2.size () << std::endl;
 //    for (unsigned idx = 0; idx < std::min (indices1.size (), indices2.size ()); ++idx)
 //    {
-//      cout << idx <<".\t" << indices1[idx] << "\t(" << distances1[idx] << "),\t" << indices2[idx] << "\t(" << distances2[idx] << ")\n";
+//      std::cout << idx <<".\t" << indices1[idx] << "\t(" << distances1[idx] << "),\t" << indices2[idx] << "\t(" << distances2[idx] << ")\n";
 //    }    
 //    for (unsigned idx = std::min (indices1.size (), indices2.size ()); idx < std::max (indices1.size (), indices2.size ()); ++idx)
 //    {
 //      if (idx >= indices1.size ())
-//        cout << idx <<".\t     \t      ,\t" << indices2[idx] << "\t(" << distances2[idx] << ")\n";
+//        std::cout << idx <<".\t     \t      ,\t" << indices2[idx] << "\t(" << distances2[idx] << ")\n";
 //      else
-//        cout << idx <<".\t" << indices1[idx] << "\t(" << distances1[idx] << ")\n";
+//        std::cout << idx <<".\t" << indices1[idx] << "\t(" << distances1[idx] << ")\n";
 //    }
 #endif
     equal = false;
@@ -262,9 +262,9 @@ bool compareResults (const std::vector<int>& indices1, const::vector<float>& dis
       if (indices1[idx] != indices2[idx] && std::abs (distances1[idx] - distances2[idx]) > eps)
       {
 #if DEBUG_OUT
-        cerr << "results between " << name1 << " search and " << name2 << " search do not match: " << idx << " nearest neighbor: "
+        std::cerr << "results between " << name1 << " search and " << name2 << " search do not match: " << idx << " nearest neighbor: "
                 << indices1[idx] << " with distance: " << distances1[idx] << " vs. "
-                << indices2[idx] << " with distance: " << distances2[idx] << endl;
+                << indices2[idx] << " with distance: " << distances2[idx] << std::endl;
 #endif
         equal = false;
         break;
@@ -340,7 +340,7 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector<se
   }
   for (size_t sIdx = 0; sIdx < search_methods.size (); ++sIdx)
   {
-    cout << search_methods [sIdx]->getName () << ": " << (passed[sIdx]?"passed":"failed") << endl;
+    std::cout << search_methods [sIdx]->getName () << ": " << (passed[sIdx]?"passed":"failed") << std::endl;
     EXPECT_TRUE (passed [sIdx]);
   }
 }
@@ -387,7 +387,7 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector
   // test radii 0.01, 0.02, 0.04, 0.08
   for (float radius = 0.01f; radius < 0.1f; radius *= 2.0f)
   {
-    //cout << radius << endl;
+    //std::cout << radius << std::endl;
     // find nn for each point in the cloud
     for (const int &query_index : query_indices)
     {
@@ -411,7 +411,7 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector
   }
   for (size_t sIdx = 0; sIdx < search_methods.size (); ++sIdx)
   {
-    cout << search_methods [sIdx]->getName () << ": " << (passed[sIdx]?"passed":"failed") << endl;
+    std::cout << search_methods [sIdx]->getName () << ": " << (passed[sIdx]?"passed":"failed") << std::endl;
     EXPECT_TRUE (passed [sIdx]);
   }
 }

--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -107,7 +107,7 @@ TEST (PCL, PCLVisualizer_camera)
 //  visualizer.spinOnce ();
 //  viewer_pose = visualizer.getViewerPose ().matrix ();
 
-//  cerr << "reset camera viewer pose:" << endl << viewer_pose << endl;
+//  std::cerr << "reset camera viewer pose:" << std::endl << viewer_pose << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tools/hdl_viewer_simple.cpp
+++ b/tools/hdl_viewer_simple.cpp
@@ -135,7 +135,7 @@ class SimpleHDLViewer
       if (mouse_event.getType () == MouseEvent::MouseButtonPress && 
           mouse_event.getButton () == MouseEvent::LeftButton)
       {
-        cout << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+        std::cout << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
       }
     }
 
@@ -200,10 +200,10 @@ class SimpleHDLViewer
 void
 usage (char ** argv)
 {
-  cout << "usage: " << argv[0]
+  std::cout << "usage: " << argv[0]
       << " [-hdlCalibration <path-to-calibration-file>] [-pcapFile <path-to-pcap-file>] [-h | --help] [-format XYZ(default)|XYZI|XYZRGB]"
-      << endl;
-  cout << argv[0] << " -h | --help : shows this help" << endl;
+      << std::endl;
+  std::cout << argv[0] << " -h | --help : shows this help" << std::endl;
   return;
 }
 
@@ -225,7 +225,7 @@ main (int argc, char ** argv)
 
   HDLGrabber grabber (hdlCalibration, pcapFile);
 
-  cout << "viewer format:" << format << endl;
+  std::cout << "viewer format:" << format << std::endl;
   if (boost::iequals (format, std::string ("XYZ")))
   {
     std::vector<double> fcolor (3); fcolor[0] = fcolor[1] = fcolor[2] = 255.0;

--- a/tools/image_grabber_viewer.cpp
+++ b/tools/image_grabber_viewer.cpp
@@ -122,7 +122,7 @@ mouse_callback (const pcl::visualization::MouseEvent& mouse_event, void* cookie)
   std::string* message = static_cast<std::string*> (cookie);
   if (mouse_event.getType() == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == pcl::visualization::MouseEvent::LeftButton)
   {
-    cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+    std::cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
   }
 }
 

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -340,7 +340,7 @@ update (CallbackParameters* params)
     params->model_actors_.push_back (vtk_actor);
 
     // Compose the model's id
-    cout << acc_hypo->obj_model_->getObjectName () << "_" << i+1 << " has a confidence value of " << acc_hypo->match_confidence_ << ";  ";
+    std::cout << acc_hypo->obj_model_->getObjectName () << "_" << i+1 << " has a confidence value of " << acc_hypo->match_confidence_ << ";  ";
   }
 
   // Show the bounds of the scene octree
@@ -363,8 +363,8 @@ update (CallbackParameters* params)
   axis(1,0) /=len;
   axis(2,0) /=len;
 
-  cout << "Input angle = " << angle << endl;
-  cout << "Input axis = \n" << axis << endl;
+  std::cout << "Input angle = " << angle << std::endl;
+  std::cout << "Input axis = \n" << axis << std::endl;
 
   // The eigen axis-angle object
   Eigen::AngleAxis<float> angle_axis(angle, axis);
@@ -376,8 +376,8 @@ update (CallbackParameters* params)
   // Now compute back the angle and the axis based on eigen
   float comp_angle, comp_axis[3];
   aux::rotationMatrixToAxisAngle (m, comp_axis, comp_angle);
-  cout << "\nComputed angle = " << comp_angle << endl;
-  cout << "Computed axis = \n" << comp_axis[0] << "\n" << comp_axis[1] << "\n" << comp_axis[2] << endl;
+  std::cout << "\nComputed angle = " << comp_angle << std::endl;
+  std::cout << "Computed axis = \n" << comp_axis[0] << "\n" << comp_axis[1] << "\n" << comp_axis[2] << std::endl;
 #endif
 }
 
@@ -482,8 +482,8 @@ main (int argc, char** argv)
 
   printf ("The following parameter values will be used:\n");
   for ( int i = 0 ; i < num_params ; ++i )
-    cout << "  " << parameter_names[i] << " = " << parameters[i] << endl;
-  cout << endl;
+    std::cout << "  " << parameter_names[i] << " = " << parameters[i] << std::endl;
+  std::cout << std::endl;
 
   run (parameters[0], parameters[1], parameters[2], static_cast<int> (parameters[3] + 0.5f));
 

--- a/tools/obj_rec_ransac_hash_table.cpp
+++ b/tools/obj_rec_ransac_hash_table.cpp
@@ -190,7 +190,7 @@ visualize (const ModelLibrary::HashTable& hash_table)
   // right scale factor for the spheres
   float s = (0.5f*spacing)/static_cast<float> (max_num_entries);
 
-  cout << "s = " << s << ", max_num_entries = " << max_num_entries << endl;
+  std::cout << "s = " << s << ", max_num_entries = " << max_num_entries << std::endl;
 
   // Now, render a sphere with the right radius at the right place
   cells = hash_table.getVoxels ();

--- a/tools/obj_rec_ransac_model_opps.cpp
+++ b/tools/obj_rec_ransac_model_opps.cpp
@@ -97,8 +97,8 @@ main (int argc, char** argv)
 
   printf ("The following parameter values will be used:\n");
   for ( int i = 0 ; i < num_params ; ++i )
-    cout << "  " << parameter_names[i] << " = " << parameters[i] << endl;
-  cout << endl;
+    std::cout << "  " << parameter_names[i] << " = " << parameters[i] << std::endl;
+  std::cout << std::endl;
 
   run (parameters[0], parameters[1], parameters[2]);
 

--- a/tools/obj_rec_ransac_orr_octree.cpp
+++ b/tools/obj_rec_ransac_orr_octree.cpp
@@ -317,7 +317,7 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz, bool show_full_leaves_o
   vtkSmartPointer<vtkPolyData> vtk_octree = vtkSmartPointer<vtkPolyData>::New ();
   vtkSmartPointer<vtkAppendPolyData> append = vtkSmartPointer<vtkAppendPolyData>::New ();
 
-  cout << "There are " << octree->getFullLeaves ().size () << " full leaves.\n";
+  std::cout << "There are " << octree->getFullLeaves ().size () << " full leaves.\n";
 
   if ( show_full_leaves_only )
   {

--- a/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+++ b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
@@ -194,7 +194,7 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz)
   vtkSmartPointer<vtkPolyData> vtk_octree = vtkSmartPointer<vtkPolyData>::New ();
   vtkSmartPointer<vtkAppendPolyData> append = vtkSmartPointer<vtkAppendPolyData>::New ();
 
-  cout << "There are " << octree->getFullLeaves ().size () << " full leaves.\n";
+  std::cout << "There are " << octree->getFullLeaves ().size () << " full leaves.\n";
 
   std::vector<ORROctree::Node*>& full_leaves = octree->getFullLeaves ();
   for (const auto &full_leaf : full_leaves)
@@ -221,7 +221,7 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz)
 
 void show_octree_zproj (ORROctreeZProjection* zproj, PCLVisualizer& viz)
 {
-  cout << "There is (are) " << zproj->getFullPixels ().size () << " full pixel(s).\n";
+  std::cout << "There is (are) " << zproj->getFullPixels ().size () << " full pixel(s).\n";
 
   vtkSmartPointer<vtkAppendPolyData> upper_bound = vtkSmartPointer<vtkAppendPolyData>::New (), lower_bound = vtkSmartPointer<vtkAppendPolyData>::New ();
   const ORROctreeZProjection::Pixel *pixel;

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -127,8 +127,8 @@ main (int argc, char** argv)
 
   printf ("The following parameter values will be used:\n");
   for ( int i = 0 ; i < num_params ; ++i )
-    cout << "  " << parameter_names[i] << " = " << parameters[i] << endl;
-  cout << endl;
+    std::cout << "  " << parameter_names[i] << " = " << parameters[i] << std::endl;
+  std::cout << std::endl;
 
   run (parameters[0], parameters[1], parameters[2]);
 }
@@ -260,7 +260,7 @@ update (CallbackParameters* params)
   // Show the hypotheses
   for ( list<ObjRecRANSAC::Output>::iterator it = rec_output.begin () ; it != rec_output.end () ; ++it, ++i )
   {
-    cout << it->object_name_ << " has a confidence value of " << it->match_confidence_ << endl;
+    std::cout << it->object_name_ << " has a confidence value of " << it->match_confidence_ << std::endl;
 
     // Make a copy of the VTK model
     vtkSmartPointer<vtkPolyData> vtk_model = vtkSmartPointer<vtkPolyData>::New ();

--- a/tools/obj_rec_ransac_scene_opps.cpp
+++ b/tools/obj_rec_ransac_scene_opps.cpp
@@ -117,8 +117,8 @@ main (int argc, char** argv)
 
   printf ("The following parameter values will be used:\n");
   for ( int i = 0 ; i < num_params ; ++i )
-    cout << "  " << parameter_names[i] << " = " << parameters[i] << endl;
-  cout << endl;
+    std::cout << "  " << parameter_names[i] << " = " << parameters[i] << std::endl;
+  std::cout << std::endl;
 
   run (parameters[0], parameters[1], parameters[2]);
 
@@ -144,7 +144,7 @@ void update (CallbackParameters* params)
 
   // Build the vtk objects visualizing the lines between the opps
   const list<ObjRecRANSAC::OrientedPointPair>& opps = params->objrec_.getSampledOrientedPointPairs ();
-  cout << "There is (are) " << opps.size () << " oriented point pair(s).\n";
+  std::cout << "There is (are) " << opps.size () << " oriented point pair(s).\n";
   // The opps points
   vtkSmartPointer<vtkPolyData> vtk_opps = vtkSmartPointer<vtkPolyData>::New ();
   vtkSmartPointer<vtkPoints> vtk_opps_points = vtkSmartPointer<vtkPoints>::New ();

--- a/tools/oni_viewer_simple.cpp
+++ b/tools/oni_viewer_simple.cpp
@@ -150,9 +150,9 @@ public:
 void
 usage(char ** argv)
 {
-  cout << "usage: " << argv[0] << " <path-to-oni-file> [framerate]\n";
-  cout << argv[0] << " -h | --help : shows this help\n";
-  cout << argv[0] << " -xyz        : enable just XYZ data display\n";
+  std::cout << "usage: " << argv[0] << " <path-to-oni-file> [framerate]\n";
+  std::cout << argv[0] << " -h | --help : shows this help\n";
+  std::cout << argv[0] << " -xyz        : enable just XYZ data display\n";
   return;
 }
 

--- a/tools/openni2_viewer.cpp
+++ b/tools/openni2_viewer.cpp
@@ -151,13 +151,13 @@ public:
   keyboard_callback (const pcl::visualization::KeyboardEvent& event, void*)
   {
     if (event.getKeyCode ())
-      cout << "the key \'" << event.getKeyCode () << "\' (" << event.getKeyCode () << ") was";
+      std::cout << "the key \'" << event.getKeyCode () << "\' (" << event.getKeyCode () << ") was";
     else
-      cout << "the special key \'" << event.getKeySym () << "\' was";
+      std::cout << "the special key \'" << event.getKeySym () << "\' was";
     if (event.keyDown ())
-      cout << " pressed" << endl;
+      std::cout << " pressed" << std::endl;
     else
-      cout << " released" << endl;
+      std::cout << " released" << std::endl;
   }
 
   void
@@ -165,7 +165,7 @@ public:
   {
     if (mouse_event.getType () == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton () == pcl::visualization::MouseEvent::LeftButton)
     {
-      cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+      std::cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
     }
   }
 
@@ -304,7 +304,7 @@ main (int argc, char** argv)
       {
         pcl::io::OpenNI2Grabber grabber (argv[2]);
         auto device = grabber.getDevice ();
-        cout << *device;		// Prints out all sensor data, including supported video modes
+        std::cout << *device;		// Prints out all sensor data, including supported video modes
       }
       else
       {
@@ -314,14 +314,14 @@ main (int argc, char** argv)
           for (size_t deviceIdx = 0; deviceIdx < deviceManager->getNumOfConnectedDevices (); ++deviceIdx)
           {
             auto device = deviceManager->getDeviceByIndex (deviceIdx);
-            cout << "Device " << device->getStringID () << "connected." << endl;
+            std::cout << "Device " << device->getStringID () << "connected." << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
 
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return 0;
     }
@@ -332,7 +332,7 @@ main (int argc, char** argv)
     if (deviceManager->getNumOfConnectedDevices () > 0)
     {
       auto device = deviceManager->getAnyDevice ();
-      cout << "Device ID not set, using default device: " << device->getStringID () << endl;
+      std::cout << "Device ID not set, using default device: " << device->getStringID () << std::endl;
     }
   }
 

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -98,7 +98,7 @@ do \
     ++count; \
     if (now - last >= 1.0) \
     { \
-      cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff.getSize () << ", number of frames written so far: " << nr_frames_total << "\n"; \
+      std::cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff.getSize () << ", number of frames written so far: " << nr_frames_total << "\n"; \
       count = 0; \
       last = now; \
     } \
@@ -113,7 +113,7 @@ do \
     ++count; \
     if (now - last >= 1.0) \
     { \
-      cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff.getSize () << "\n"; \
+      std::cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff.getSize () << "\n"; \
       count = 0; \
       last = now; \
     } \
@@ -129,9 +129,9 @@ do \
     if (now - last >= 1.0) \
     { \
       if (visualize && global_visualize) \
-        cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff1.getSize () << " (w) / " << buff2.getSize () << " (v)\n"; \
+        std::cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff1.getSize () << " (w) / " << buff2.getSize () << " (v)\n"; \
       else \
-        cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff1.getSize () << " (w)\n"; \
+        std::cerr << "Average framerate("<< _WHAT_ << "): " << double(count)/double(now - last) << " Hz. Queue size: " << buff1.getSize () << " (w)\n"; \
       count = 0; \
       last = now; \
     } \
@@ -195,7 +195,7 @@ class Buffer
             break;
           {
             std::lock_guard<std::mutex> io_lock (io_mutex);
-            //cerr << "No data in buffer_ yet or buffer is empty." << endl;
+            //std::cerr << "No data in buffer_ yet or buffer is empty." << std::endl;
           }
           buff_empty_.wait (buff_lock);
         }
@@ -627,33 +627,33 @@ class Viewer
 void
 usage (char ** argv)
 {
-  cout << "usage: " << argv[0] << " [(<device_id> [-visualize | -imagemode <mode>] | [-depthmode <mode>] | [-depthformat <format>] | -l [<device_id>]| -h | --help)]\n";
-  cout << argv[0] << " -h | --help : shows this help\n";
-  cout << argv[0] << " -l : list all available devices\n";
-  cout << argv[0] << " -buf X         : use a buffer size of X frames (default: " << buff_size << ")\n";
-  cout << argv[0] << " -visualize 0/1 : turn the visualization off/on (WARNING: when visualization is disabled, data writing is enabled by default!)\n";
-  cout << argv[0] << " -l <device-id> : list all available modes for specified device\n";
+  std::cout << "usage: " << argv[0] << " [(<device_id> [-visualize | -imagemode <mode>] | [-depthmode <mode>] | [-depthformat <format>] | -l [<device_id>]| -h | --help)]\n";
+  std::cout << argv[0] << " -h | --help : shows this help\n";
+  std::cout << argv[0] << " -l : list all available devices\n";
+  std::cout << argv[0] << " -buf X         : use a buffer size of X frames (default: " << buff_size << ")\n";
+  std::cout << argv[0] << " -visualize 0/1 : turn the visualization off/on (WARNING: when visualization is disabled, data writing is enabled by default!)\n";
+  std::cout << argv[0] << " -l <device-id> : list all available modes for specified device\n";
 
-  cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
+  std::cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
 #ifndef _WIN32
-       << " or" << endl
-       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << endl
+       << " or" << std::endl
+       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << std::endl
        << "                 <serial-number>"
 #endif
-       << endl;
-  cout << endl;
-  cout << "examples:" << endl;
-  cout << argv[0] << " \"#1\"" << endl;
-  cout << "    uses the first device." << endl;
-  cout << argv[0] << " -l" << endl;
-  cout << "    lists all available devices." << endl;
-  cout << argv[0] << " -l \"#2\"" << endl;
-  cout << "    lists all available modes for the second device" << endl;
+       << std::endl;
+  std::cout << std::endl;
+  std::cout << "examples:" << std::endl;
+  std::cout << argv[0] << " \"#1\"" << std::endl;
+  std::cout << "    uses the first device." << std::endl;
+  std::cout << argv[0] << " -l" << std::endl;
+  std::cout << "    lists all available devices." << std::endl;
+  std::cout << argv[0] << " -l \"#2\"" << std::endl;
+  std::cout << "    lists all available modes for the second device" << std::endl;
 #ifndef _WIN32
-  cout << argv[0] << " A00361800903049A" << endl;
-  cout << "    uses the device with the serial number \'A00361800903049A\'." << endl;
-  cout << argv[0] << " 1@16" << endl;
-  cout << "    uses the device on address 16 at USB bus 1." << endl;
+  std::cout << argv[0] << " A00361800903049A" << std::endl;
+  std::cout << "    uses the device with the serial number \'A00361800903049A\'." << std::endl;
+  std::cout << argv[0] << " 1@16" << std::endl;
+  std::cout << "    uses the device on address 16 at USB bus 1." << std::endl;
 #endif
 }
 
@@ -703,19 +703,19 @@ main (int argc, char ** argv)
 
         if (device->hasImageStream ())
         {
-          cout << endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << endl;
+          std::cout << std::endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << std::endl;
           modes = grabber.getAvailableImageModes ();
           for (vector<pair<int, XnMapOutputMode> >::const_iterator it = modes.begin (); it != modes.end (); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         if (device->hasDepthStream ())
         {
-          cout << endl << "Supported depth modes for device: " << device->getVendorName () << " , " << device->getProductName () << endl;
+          std::cout << std::endl << "Supported depth modes for device: " << device->getVendorName () << " , " << device->getProductName () << std::endl;
           modes = grabber.getAvailableDepthModes ();
           for (vector<pair<int, XnMapOutputMode> >::const_iterator it = modes.begin (); it != modes.end (); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         }
         }
@@ -727,15 +727,15 @@ main (int argc, char ** argv)
         {
           for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
           {
-            cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
+            std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
         
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return (0);
     }
@@ -744,7 +744,7 @@ main (int argc, char ** argv)
   {
     openni_wrapper::OpenNIDriver& driver = openni_wrapper::OpenNIDriver::getInstance ();
     if (driver.getNumberDevices() > 0)
-      cout << "Device Id not set, using first device." << endl;
+      std::cout << "Device Id not set, using first device." << std::endl;
   }
   
   unsigned mode;

--- a/tools/openni_save_image.cpp
+++ b/tools/openni_save_image.cpp
@@ -196,33 +196,33 @@ class SimpleOpenNIViewer
 void
 usage (char ** argv)
 {
-  cout << "usage: " << argv[0] << " [((<device_id> | <path-to-oni-file>) [-imagemode <mode>] | -l [<device_id>]| -h | --help)]" << endl;
-  cout << argv[0] << " -h | --help : shows this help" << endl;
-  cout << argv[0] << " -l : list all available devices" << endl;
-  cout << argv[0] << " -l <device-id> : list all available modes for specified device" << endl;
+  std::cout << "usage: " << argv[0] << " [((<device_id> | <path-to-oni-file>) [-imagemode <mode>] | -l [<device_id>]| -h | --help)]" << std::endl;
+  std::cout << argv[0] << " -h | --help : shows this help" << std::endl;
+  std::cout << argv[0] << " -l : list all available devices" << std::endl;
+  std::cout << argv[0] << " -l <device-id> : list all available modes for specified device" << std::endl;
 
-  cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
+  std::cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
 #ifndef _WIN32
-       << " or" << endl
-       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << endl
+       << " or" << std::endl
+       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << std::endl
        << "                 <serial-number>"
 #endif
-       << endl;
-  cout << endl;
-  cout << "examples:" << endl;
-  cout << argv[0] << " \"#1\"" << endl;
-  cout << "    uses the first device." << endl;
-  cout << argv[0] << " \"./temp/test.oni\"" << endl;
-  cout << "    uses the oni-player device to play back oni file given by path." << endl;
-  cout << argv[0] << " -l" << endl;
-  cout << "    lists all available devices." << endl;
-  cout << argv[0] << " -l \"#2\"" << endl;
-  cout << "    lists all available modes for the second device" << endl;
+       << std::endl;
+  std::cout << std::endl;
+  std::cout << "examples:" << std::endl;
+  std::cout << argv[0] << " \"#1\"" << std::endl;
+  std::cout << "    uses the first device." << std::endl;
+  std::cout << argv[0] << " \"./temp/test.oni\"" << std::endl;
+  std::cout << "    uses the oni-player device to play back oni file given by path." << std::endl;
+  std::cout << argv[0] << " -l" << std::endl;
+  std::cout << "    lists all available devices." << std::endl;
+  std::cout << argv[0] << " -l \"#2\"" << std::endl;
+  std::cout << "    lists all available modes for the second device" << std::endl;
 #ifndef _WIN32
-  cout << argv[0] << " A00361800903049A" << endl;
-  cout << "    uses the device with the serial number \'A00361800903049A\'." << endl;
-  cout << argv[0] << " 1@16" << endl;
-  cout << "    uses the device on address 16 at USB bus 1." << endl;
+  std::cout << argv[0] << " A00361800903049A" << std::endl;
+  std::cout << "    uses the device with the serial number \'A00361800903049A\'." << std::endl;
+  std::cout << argv[0] << " 1@16" << std::endl;
+  std::cout << "    uses the device on address 16 at USB bus 1." << std::endl;
 #endif
   return;
 }
@@ -252,11 +252,11 @@ main(int argc, char ** argv)
 
         if (device->hasImageStream ())
         {
-          cout << endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << endl;
+          std::cout << std::endl << "Supported image modes for device: " << device->getVendorName () << " , " << device->getProductName () << std::endl;
           modes = grabber.getAvailableImageModes ();
           for (std::vector<std::pair<int, XnMapOutputMode> >::const_iterator it = modes.begin (); it != modes.end (); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         }
       }
@@ -267,15 +267,15 @@ main(int argc, char ** argv)
         {
           for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices (); ++deviceIdx)
           {
-            cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
-              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << endl;
+            std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName (deviceIdx) << ", product: " << driver.getProductName (deviceIdx)
+              << ", connected: " << driver.getBus (deviceIdx) << " @ " << driver.getAddress (deviceIdx) << ", serial number: \'" << driver.getSerialNumber (deviceIdx) << "\'" << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
         
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return (0);
     }
@@ -284,7 +284,7 @@ main(int argc, char ** argv)
   {
     openni_wrapper::OpenNIDriver& driver = openni_wrapper::OpenNIDriver::getInstance ();
     if (driver.getNumberDevices () > 0)
-      cout << "Device Id not set, using first device." << endl;
+      std::cout << "Device Id not set, using first device." << std::endl;
   }
   
   unsigned imagemode;

--- a/tools/openni_viewer.cpp
+++ b/tools/openni_viewer.cpp
@@ -148,13 +148,13 @@ class OpenNIViewer
     keyboard_callback (const pcl::visualization::KeyboardEvent& event, void*)
     {
       if (event.getKeyCode ())
-        cout << "the key \'" << event.getKeyCode() << "\' (" << event.getKeyCode() << ") was";
+        std::cout << "the key \'" << event.getKeyCode() << "\' (" << event.getKeyCode() << ") was";
       else
-        cout << "the special key \'" << event.getKeySym() << "\' was";
+        std::cout << "the special key \'" << event.getKeySym() << "\' was";
       if (event.keyDown())
-        cout << " pressed" << endl;
+        std::cout << " pressed" << std::endl;
       else
-        cout << " released" << endl;
+        std::cout << " released" << std::endl;
     }
     
     void 
@@ -162,7 +162,7 @@ class OpenNIViewer
     {
       if (mouse_event.getType() == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == pcl::visualization::MouseEvent::LeftButton)
       {
-        cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+        std::cout << "left button pressed @ " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
       }
     }
 
@@ -295,20 +295,20 @@ main (int argc, char** argv)
       {
         pcl::OpenNIGrabber grabber(argv[2]);
         auto device = grabber.getDevice();
-        cout << "Supported depth modes for device: " << device->getVendorName() << " , " << device->getProductName() << endl;
+        std::cout << "Supported depth modes for device: " << device->getVendorName() << " , " << device->getProductName() << std::endl;
         std::vector<std::pair<int, XnMapOutputMode > > modes = grabber.getAvailableDepthModes();
         for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin(); it != modes.end(); ++it)
         {
-          cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+          std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
         }
 
         if (device->hasImageStream ())
         {
-          cout << endl << "Supported image modes for device: " << device->getVendorName() << " , " << device->getProductName() << endl;
+          std::cout << std::endl << "Supported image modes for device: " << device->getVendorName() << " , " << device->getProductName() << std::endl;
           modes = grabber.getAvailableImageModes();
           for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin(); it != modes.end(); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         }
       }
@@ -319,15 +319,15 @@ main (int argc, char** argv)
         {
           for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices(); ++deviceIdx)
           {
-            cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName(deviceIdx) << ", product: " << driver.getProductName(deviceIdx)
-              << ", connected: " << driver.getBus(deviceIdx) << " @ " << driver.getAddress(deviceIdx) << ", serial number: \'" << driver.getSerialNumber(deviceIdx) << "\'" << endl;
+            std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName(deviceIdx) << ", product: " << driver.getProductName(deviceIdx)
+              << ", connected: " << driver.getBus(deviceIdx) << " @ " << driver.getAddress(deviceIdx) << ", serial number: \'" << driver.getSerialNumber(deviceIdx) << "\'" << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
         
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return 0;
     }
@@ -336,7 +336,7 @@ main (int argc, char** argv)
   {
     openni_wrapper::OpenNIDriver& driver = openni_wrapper::OpenNIDriver::getInstance();
     if (driver.getNumberDevices() > 0)
-      cout << "Device Id not set, using first device." << endl;
+      std::cout << "Device Id not set, using first device." << std::endl;
   }
   
   unsigned mode;

--- a/tools/openni_viewer_simple.cpp
+++ b/tools/openni_viewer_simple.cpp
@@ -125,15 +125,15 @@ class SimpleOpenNIViewer
     keyboard_callback (const pcl::visualization::KeyboardEvent& event, void* cookie)
     {
       string* message = (string*)cookie;
-      cout << (*message) << " :: ";
+      std::cout << (*message) << " :: ";
       if (event.getKeyCode())
-        cout << "the key \'" << event.getKeyCode() << "\' (" << (int)event.getKeyCode() << ") was";
+        std::cout << "the key \'" << event.getKeyCode() << "\' (" << (int)event.getKeyCode() << ") was";
       else
-        cout << "the special key \'" << event.getKeySym() << "\' was";
+        std::cout << "the special key \'" << event.getKeySym() << "\' was";
       if (event.keyDown())
-        cout << " pressed" << endl;
+        std::cout << " pressed" << std::endl;
       else
-        cout << " released" << endl;
+        std::cout << " released" << std::endl;
     }
     
     void mouse_callback (const pcl::visualization::MouseEvent& mouse_event, void* cookie)
@@ -141,7 +141,7 @@ class SimpleOpenNIViewer
       string* message = (string*) cookie;
       if (mouse_event.getType() == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == pcl::visualization::MouseEvent::LeftButton)
       {
-        cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+        std::cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
       }
     }
     /**
@@ -241,33 +241,33 @@ class SimpleOpenNIViewer
 void
 usage(char ** argv)
 {
-  cout << "usage: " << argv[0] << " [((<device_id> | <path-to-oni-file>) [-depthmode <mode>] [-imagemode <mode>] [-xyz] | -l [<device_id>]| -h | --help)]" << endl;
-  cout << argv[0] << " -h | --help : shows this help" << endl;
-  cout << argv[0] << " -l : list all available devices" << endl;
-  cout << argv[0] << " -l <device-id> : list all available modes for specified device" << endl;
+  std::cout << "usage: " << argv[0] << " [((<device_id> | <path-to-oni-file>) [-depthmode <mode>] [-imagemode <mode>] [-xyz] | -l [<device_id>]| -h | --help)]" << std::endl;
+  std::cout << argv[0] << " -h | --help : shows this help" << std::endl;
+  std::cout << argv[0] << " -l : list all available devices" << std::endl;
+  std::cout << argv[0] << " -l <device-id> : list all available modes for specified device" << std::endl;
 
-  cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
+  std::cout << "                 device_id may be #1, #2, ... for the first, second etc device in the list"
 #ifndef _WIN32
-       << " or" << endl
-       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << endl
+       << " or" << std::endl
+       << "                 bus@address for the device connected to a specific usb-bus / address combination or" << std::endl
        << "                 <serial-number>"
 #endif
-       << endl;
-  cout << endl;
-  cout << "examples:" << endl;
-  cout << argv[0] << " \"#1\"" << endl;
-  cout << "    uses the first device." << endl;
-  cout << argv[0] << " \"./temp/test.oni\"" << endl;
-  cout << "    uses the oni-player device to play back oni file given by path." << endl;
-  cout << argv[0] << " -l" << endl;
-  cout << "    lists all available devices." << endl;
-  cout << argv[0] << " -l \"#2\"" << endl;
-  cout << "    lists all available modes for the second device" << endl;
+       << std::endl;
+  std::cout << std::endl;
+  std::cout << "examples:" << std::endl;
+  std::cout << argv[0] << " \"#1\"" << std::endl;
+  std::cout << "    uses the first device." << std::endl;
+  std::cout << argv[0] << " \"./temp/test.oni\"" << std::endl;
+  std::cout << "    uses the oni-player device to play back oni file given by path." << std::endl;
+  std::cout << argv[0] << " -l" << std::endl;
+  std::cout << "    lists all available devices." << std::endl;
+  std::cout << argv[0] << " -l \"#2\"" << std::endl;
+  std::cout << "    lists all available modes for the second device" << std::endl;
   #ifndef _WIN32
-  cout << argv[0] << " A00361800903049A" << endl;
-  cout << "    uses the device with the serial number \'A00361800903049A\'." << endl;
-  cout << argv[0] << " 1@16" << endl;
-  cout << "    uses the device on address 16 at USB bus 1." << endl;
+  std::cout << argv[0] << " A00361800903049A" << std::endl;
+  std::cout << "    uses the device with the serial number \'A00361800903049A\'." << std::endl;
+  std::cout << argv[0] << " 1@16" << std::endl;
+  std::cout << "    uses the device on address 16 at USB bus 1." << std::endl;
   #endif
   return;
 }
@@ -294,20 +294,20 @@ main(int argc, char ** argv)
       {
         pcl::OpenNIGrabber grabber(argv[2]);
         auto device = grabber.getDevice();
-        cout << "Supported depth modes for device: " << device->getVendorName() << " , " << device->getProductName() << endl;
+        std::cout << "Supported depth modes for device: " << device->getVendorName() << " , " << device->getProductName() << std::endl;
         std::vector<std::pair<int, XnMapOutputMode > > modes = grabber.getAvailableDepthModes();
         for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin(); it != modes.end(); ++it)
         {
-          cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+          std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
         }
 
         if (device->hasImageStream ())
         {
-          cout << endl << "Supported image modes for device: " << device->getVendorName() << " , " << device->getProductName() << endl;
+          std::cout << std::endl << "Supported image modes for device: " << device->getVendorName() << " , " << device->getProductName() << std::endl;
           modes = grabber.getAvailableImageModes();
           for (std::vector<std::pair<int, XnMapOutputMode > >::const_iterator it = modes.begin(); it != modes.end(); ++it)
           {
-            cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << endl;
+            std::cout << it->first << " = " << it->second.nXRes << " x " << it->second.nYRes << " @ " << it->second.nFPS << std::endl;
           }
         }
       }
@@ -318,15 +318,15 @@ main(int argc, char ** argv)
         {
           for (unsigned deviceIdx = 0; deviceIdx < driver.getNumberDevices(); ++deviceIdx)
           {
-            cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName(deviceIdx) << ", product: " << driver.getProductName(deviceIdx)
-              << ", connected: " << (int) driver.getBus(deviceIdx) << " @ " << (int) driver.getAddress(deviceIdx) << ", serial number: \'" << driver.getSerialNumber(deviceIdx) << "\'" << endl;
+            std::cout << "Device: " << deviceIdx + 1 << ", vendor: " << driver.getVendorName(deviceIdx) << ", product: " << driver.getProductName(deviceIdx)
+              << ", connected: " << (int) driver.getBus(deviceIdx) << " @ " << (int) driver.getAddress(deviceIdx) << ", serial number: \'" << driver.getSerialNumber(deviceIdx) << "\'" << std::endl;
           }
 
         }
         else
-          cout << "No devices connected." << endl;
+          std::cout << "No devices connected." << std::endl;
         
-        cout <<"Virtual Devices available: ONI player" << endl;
+        std::cout <<"Virtual Devices available: ONI player" << std::endl;
       }
       return 0;
     }
@@ -335,7 +335,7 @@ main(int argc, char ** argv)
   {
     openni_wrapper::OpenNIDriver& driver = openni_wrapper::OpenNIDriver::getInstance();
     if (driver.getNumberDevices() > 0)
-      cout << "Device Id not set, using first device." << endl;
+      std::cout << "Device Id not set, using first device." << std::endl;
   }
   
   unsigned mode;

--- a/tools/pcd_grabber_viewer.cpp
+++ b/tools/pcd_grabber_viewer.cpp
@@ -106,7 +106,7 @@ mouse_callback (const pcl::visualization::MouseEvent& mouse_event, void* cookie)
   std::string* message = static_cast<std::string*> (cookie);
   if (mouse_event.getType() == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == pcl::visualization::MouseEvent::LeftButton)
   {
-    cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << endl;
+    std::cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;
   }
 }
 

--- a/tools/timed_trigger_test.cpp
+++ b/tools/timed_trigger_test.cpp
@@ -15,7 +15,7 @@ void callback ()
   static double last_time = pcl::getTime ();
   double elapsed = pcl::getTime () - last_time;
   last_time = pcl::getTime ();
-  cout << "global fn: " << pcl::getTime () - global_time << " :: " << elapsed << endl;
+  std::cout << "global fn: " << pcl::getTime () - global_time << " :: " << elapsed << std::endl;
 
   std::this_thread::sleep_for(1ms);
 }
@@ -28,7 +28,7 @@ class Dummy
       static double last_time = pcl::getTime ();
       double elapsed = pcl::getTime () - last_time;
       last_time = pcl::getTime ();
-      cout << "member fn: " << pcl::getTime () - global_time << " :: " << elapsed << endl;
+      std::cout << "member fn: " << pcl::getTime () - global_time << " :: " << elapsed << std::endl;
     }
 };
 

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -302,10 +302,10 @@ main (int argc, char** argv)
       up[2] /= up_len;
     
       // Output resulting vectors
-      cerr << "Viewray Right Up:" << endl;
-      cerr << viewray[0] << " " << viewray[1] << " " << viewray[2] << " " << endl;
-      cerr << right[0] << " " << right[1] << " " << right[2] << " " << endl;
-      cerr << up[0] << " " << up[1] << " " << up[2] << " " << endl;
+      std::cerr << "Viewray Right Up:" << std::endl;
+      std::cerr << viewray[0] << " " << viewray[1] << " " << viewray[2] << " " << std::endl;
+      std::cerr << right[0] << " " << right[1] << " " << right[2] << " " << std::endl;
+      std::cerr << up[0] << " " << up[1] << " " << up[2] << " " << std::endl;
     }
 
     // Create a transformation

--- a/tools/vlp_viewer.cpp
+++ b/tools/vlp_viewer.cpp
@@ -210,8 +210,8 @@ class SimpleVLPViewer
 void
 usage (char ** argv)
 {
-  cout << "usage: " << argv[0] << " [-pcapFile <path-to-pcap-file>] [-h | --help]" << endl;
-  cout << argv[0] << " -h | --help : shows this help" << endl;
+  std::cout << "usage: " << argv[0] << " [-pcapFile <path-to-pcap-file>] [-h | --help]" << std::endl;
+  std::cout << argv[0] << " -h | --help : shows this help" << std::endl;
   return;
 }
 

--- a/visualization/src/common/common.cpp
+++ b/visualization/src/common/common.cpp
@@ -160,7 +160,7 @@ pcl::visualization::cullFrustum (double frustum[24], const Eigen::Vector3d &min_
     double c = frustum[(i*4)+2];
     double d = frustum[(i*4)+3];
 
-    //cout << i << ": " << a << "x + " << b << "y + " << c << "z + " << d << endl;
+    //std::cout << i << ": " << a << "x + " << b << "y + " << c << "z + " << d << std::endl;
 
     //  Basic VFC algorithm
     Eigen::Vector3d center ((max_bb.x () - min_bb.x ()) / 2 + min_bb.x (),
@@ -291,54 +291,54 @@ pcl::visualization::viewScreenArea (
     //return 0.0;
 
 
-//  cout << "eye: " << eye.x() << " " << eye.y() << " " << eye.z() << endl;
-//  cout << "min: " << bounding_box[0].x() << " " << bounding_box[0].y() << " " << bounding_box[0].z() << endl;
+//  std::cout << "eye: " << eye.x() << " " << eye.y() << " " << eye.z() << std::endl;
+//  std::cout << "min: " << bounding_box[0].x() << " " << bounding_box[0].y() << " " << bounding_box[0].z() << std::endl;
 //
-//  cout << "pos: " << pos << " ";
+//  std::cout << "pos: " << pos << " ";
 //  switch(pos){
-//    case 0:  cout << "inside" << endl; break;
-//    case 1:  cout << "left" << endl; break;
-//    case 2:  cout << "right" << endl; break;
+//    case 0:  std::cout << "inside" << std::endl; break;
+//    case 1:  std::cout << "left" << std::endl; break;
+//    case 2:  std::cout << "right" << std::endl; break;
 //    case 3:
-//    case 4:  cout << "bottom" << endl; break;
-//    case 5:  cout << "bottom, left" << endl; break;
-//    case 6:  cout << "bottom, right" << endl; break;
+//    case 4:  std::cout << "bottom" << std::endl; break;
+//    case 5:  std::cout << "bottom, left" << std::endl; break;
+//    case 6:  std::cout << "bottom, right" << std::endl; break;
 //    case 7:
-//    case 8:  cout << "top" << endl; break;
-//    case 9:  cout << "top, left" << endl; break;
-//    case 10:  cout << "top, right" << endl; break;
+//    case 8:  std::cout << "top" << std::endl; break;
+//    case 9:  std::cout << "top, left" << std::endl; break;
+//    case 10:  std::cout << "top, right" << std::endl; break;
 //    case 11:
 //    case 12:
 //    case 13:
 //    case 14:
 //    case 15:
-//    case 16:  cout << "front" << endl; break;
-//    case 17:  cout << "front, left" << endl; break;
-//    case 18:  cout << "front, right" << endl; break;
+//    case 16:  std::cout << "front" << std::endl; break;
+//    case 17:  std::cout << "front, left" << std::endl; break;
+//    case 18:  std::cout << "front, right" << std::endl; break;
 //    case 19:
-//    case 20:  cout << "front, bottom" << endl; break;
-//    case 21:  cout << "front, bottom, left" << endl; break;
+//    case 20:  std::cout << "front, bottom" << std::endl; break;
+//    case 21:  std::cout << "front, bottom, left" << std::endl; break;
 //    case 22:
 //    case 23:
-//    case 24:  cout << "front, top" << endl; break;
-//    case 25:  cout << "front, top, left" << endl; break;
-//    case 26:  cout << "front, top, right" << endl; break;
+//    case 24:  std::cout << "front, top" << std::endl; break;
+//    case 25:  std::cout << "front, top, left" << std::endl; break;
+//    case 26:  std::cout << "front, top, right" << std::endl; break;
 //    case 27:
 //    case 28:
 //    case 29:
 //    case 30:
 //    case 31:
-//    case 32:  cout << "back" << endl; break;
-//    case 33:  cout << "back, left" << endl; break;
-//    case 34:  cout << "back, right" << endl; break;
+//    case 32:  std::cout << "back" << std::endl; break;
+//    case 33:  std::cout << "back, left" << std::endl; break;
+//    case 34:  std::cout << "back, right" << std::endl; break;
 //    case 35:
-//    case 36:  cout << "back, bottom" << endl; break;
-//    case 37:  cout << "back, bottom, left" << endl; break;
-//    case 38:  cout << "back, bottom, right" << endl; break;
+//    case 36:  std::cout << "back, bottom" << std::endl; break;
+//    case 37:  std::cout << "back, bottom, left" << std::endl; break;
+//    case 38:  std::cout << "back, bottom, right" << std::endl; break;
 //    case 39:
-//    case 40:  cout << "back, top" << endl; break;
-//    case 41:  cout << "back, top, left" << endl; break;
-//    case 42:  cout << "back, top, right" << endl; break;
+//    case 40:  std::cout << "back, top" << std::endl; break;
+//    case 41:  std::cout << "back, top, left" << std::endl; break;
+//    case 42:  std::cout << "back, top, right" << std::endl; break;
 //  }
 
   //return -1 if inside
@@ -347,7 +347,7 @@ pcl::visualization::viewScreenArea (
   {
     Eigen::Vector4d world_pt = bounding_box[hull_vertex_table[pos][i]];
     Eigen::Vector2i screen_pt = pcl::visualization::worldToView(world_pt, view_projection_matrix, width, height);
-//    cout << "point[" << i << "]: " << screen_pt.x() << " " << screen_pt.y() << endl;
+//    std::cout << "point[" << i << "]: " << screen_pt.x() << " " << screen_pt.y() << std::endl;
     dst[i] = Eigen::Vector2d(screen_pt.x (), screen_pt.y ());
   }
 

--- a/visualization/src/common/float_image_utils.cpp
+++ b/visualization/src/common/float_image_utils.cpp
@@ -145,7 +145,7 @@ pcl::visualization::FloatImageUtils::getColorForAngle (float value, unsigned cha
   {  // green -> black
     g = static_cast<unsigned char> (255-pcl_lrint(255*(value-M_PI/2.0f)/(float(M_PI)/2.0f)));
   }
-  //cout << 180.0f*value/M_PI<<"deg => "<<(int)r<<", "<<(int)g<<", "<<(int)b<<"\n";
+  //std::cout << 180.0f*value/M_PI<<"deg => "<<(int)r<<", "<<(int)g<<", "<<(int)b<<"\n";
 }
 
 void 
@@ -159,7 +159,7 @@ pcl::visualization::FloatImageUtils::getVisualImage (const float* float_image, i
 {
   //MEASURE_FUNCTION_TIME;
   
-  //cout << "Image is of size "<<width<<"x"<<height<<"\n";
+  //std::cout << "Image is of size "<<width<<"x"<<height<<"\n";
   int size = width*height;
   int arraySize = 3 * size;
   unsigned char* data = new unsigned char[arraySize];
@@ -180,7 +180,7 @@ pcl::visualization::FloatImageUtils::getVisualImage (const float* float_image, i
       if (recalculateMaxValue)  max_value = (std::max)(max_value, value);
     }
   }
-  //cout << "min_value is "<<min_value<<" and max_value is "<<max_value<<".\n";
+  //std::cout << "min_value is "<<min_value<<" and max_value is "<<max_value<<".\n";
   float factor = 1.0f / (max_value-min_value), offset = -min_value;
   
   for (int i=0; i<size; ++i) 
@@ -206,7 +206,7 @@ pcl::visualization::FloatImageUtils::getVisualImage (const float* float_image, i
     {
       getColorForFloat(value, r, g, b);
     }
-    //cout << "Setting pixel "<<i<<" to "<<(int)r<<", "<<(int)g<<", "<<(int)b<<".\n";
+    //std::cout << "Setting pixel "<<i<<" to "<<(int)r<<", "<<(int)g<<", "<<(int)b<<".\n";
   }
   
   return data;
@@ -219,7 +219,7 @@ pcl::visualization::FloatImageUtils::getVisualImage (const unsigned short* short
 {
   //MEASURE_FUNCTION_TIME;
   
-  //cout << "Image is of size "<<width<<"x"<<height<<"\n";
+  //std::cout << "Image is of size "<<width<<"x"<<height<<"\n";
   int size = width*height;
   int arraySize = 3 * size;
   unsigned char* data = new unsigned char[arraySize];
@@ -244,7 +244,7 @@ pcl::visualization::FloatImageUtils::getVisualImage (const unsigned short* short
     {
       getColorForFloat(value, r, g, b);
     }
-    //cout << "Setting pixel "<<i<<" to "<<(int)r<<", "<<(int)g<<", "<<(int)b<<".\n";
+    //std::cout << "Setting pixel "<<i<<" to "<<(int)r<<", "<<(int)g<<", "<<(int)b<<".\n";
   }
   
   return data;

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -154,7 +154,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::saveCameraParameters (const st
   ofs_cam << clip[0]  << "," << clip[1]  << "/" << focal[0] << "," << focal[1] << "," << focal[2] << "/" <<
              pos[0]   << "," << pos[1]   << "," << pos[2]   << "/" << view[0]  << "," << view[1]  << "," << view[2] << "/" <<
              cam->GetViewAngle () / 180.0 * M_PI  << "/" << win_size[0] << "," << win_size[1] << "/" << win_pos[0] << "," << win_pos[1]
-          << endl;
+          << std::endl;
   ofs_cam.close ();
 
   return (true);
@@ -867,13 +867,13 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
     case 'c': case 'C':
     {
       Camera cam (*CurrentRenderer->GetActiveCamera (), *Interactor->GetRenderWindow ());
-      std::cerr <<  "Clipping plane [near,far] "  << cam.clip[0] << ", " << cam.clip[1] << endl <<
-                    "Focal point [x,y,z] " << cam.focal[0] << ", " << cam.focal[1] << ", " << cam.focal[2] << endl <<
-                    "Position [x,y,z] " << cam.pos[0] << ", " << cam.pos[1] << ", " << cam.pos[2] << endl <<
-                    "View up [x,y,z] " << cam.view[0]  << ", " << cam.view[1]  << ", " << cam.view[2] << endl <<
-                    "Camera view angle [degrees] " << rad2deg (cam.fovy) << endl <<
-                    "Window size [x,y] " << cam.window_size[0] << ", " << cam.window_size[1] << endl <<
-                    "Window position [x,y] " << cam.window_pos[0] << ", " << cam.window_pos[1] << endl;
+      std::cerr <<  "Clipping plane [near,far] "  << cam.clip[0] << ", " << cam.clip[1] << std::endl <<
+                    "Focal point [x,y,z] " << cam.focal[0] << ", " << cam.focal[1] << ", " << cam.focal[2] << std::endl <<
+                    "Position [x,y,z] " << cam.pos[0] << ", " << cam.pos[1] << ", " << cam.pos[2] << std::endl <<
+                    "View up [x,y,z] " << cam.view[0]  << ", " << cam.view[1]  << ", " << cam.view[2] << std::endl <<
+                    "Camera view angle [degrees] " << rad2deg (cam.fovy) << std::endl <<
+                    "Window size [x,y] " << cam.window_size[0] << ", " << cam.window_size[1] << std::endl <<
+                    "Window position [x,y] " << cam.window_pos[0] << ", " << cam.window_pos[1] << std::endl;
       break;
     }
     case '=':

--- a/visualization/src/range_image_visualizer.cpp
+++ b/visualization/src/range_image_visualizer.cpp
@@ -144,7 +144,7 @@ pcl::visualization::RangeImageVisualizer::getInterestPointsWidget (
     float image_x, image_y;
     range_image.getImagePoint (interest_point.x, interest_point.y, interest_point.z, image_x, image_y);
     widget->markPoint (static_cast<size_t> (image_x), static_cast<size_t> (image_y), green_color, red_color);
-    //cout << "Marking point "<<image_x<<","<<image_y<<"\n";
+    //std::cout << "Marking point "<<image_x<<","<<image_y<<"\n";
   }
   return widget;
 }

--- a/visualization/test/test.cpp
+++ b/visualization/test/test.cpp
@@ -84,7 +84,7 @@ int
   while (!p.wasStopped())
   {
     static int counter = 0;
-    cout << "spinOnce was called "<<++counter<<" times.\n";
+    std::cout << "spinOnce was called "<<++counter<<" times.\n";
     p.spinOnce(1000);  // Give the GUI 1000ms to handle events, then return
   }
 


### PR DESCRIPTION
Use `std::cout`/`std::cerr`/`std::endl` instead of just `cout`/`cerr`/`endl` in preparation for #3235.