### PR TITLE
Export SDK version of MacOS  to prevent some linker warnings

### DIFF
--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -37,6 +37,8 @@ jobs:
             -DBUILD_apps_point_cloud_editor=ON
         displayName: 'CMake Configuration'
       - script: |
+          # Following export is to prevent messages like warning: text-based stub file <...> and library file <...> are out of sync. Falling back to library file for linking.
+          export SDKROOT=macosx10.13
           cd $BUILD_DIR
           # Compiling some of the test targets with -j2 option leads to pipeline failures
           # (presumably out of memory error). Thus we make them separately in a single

--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -38,6 +38,7 @@ jobs:
         displayName: 'CMake Configuration'
       - script: |
           # Following export is to prevent messages like warning: text-based stub file <...> and library file <...> are out of sync. Falling back to library file for linking.
+          xcrun --show-sdk-path
           export SDKROOT=macosx10.13
           cd $BUILD_DIR
           # Compiling some of the test targets with -j2 option leads to pipeline failures

--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -39,7 +39,7 @@ jobs:
       - script: |
           # Following export is to prevent messages like warning: text-based stub file <...> and library file <...> are out of sync. Falling back to library file for linking.
           xcrun --show-sdk-path
-          export SDKROOT=macosx10.13
+          export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
           cd $BUILD_DIR
           # Compiling some of the test targets with -j2 option leads to pipeline failures
           # (presumably out of memory error). Thus we make them separately in a single


### PR DESCRIPTION
Found this [here](https://stackoverflow.com/questions/51314888/ld-warning-text-based-stub-file-are-out-of-sync-falling-back-to-library-file). I don't believe it fixes #3288, but its worth a try ;)