### PR TITLE
Changed prefix hint for gtest src

### DIFF
--- a/cmake/Modules/FindGTestSource.cmake
+++ b/cmake/Modules/FindGTestSource.cmake
@@ -26,7 +26,7 @@ find_path(GTEST_SRC_DIR src/gtest-all.cc
     PATHS "$ENV{PROGRAMFILES}/gtest-1.7.0" "$ENV{PROGRAMW6432}/gtest-1.7.0"
     PATH /usr/src/googletest/googletest
     PATH /usr/src/gtest
-    PATH_SUFFIXES gtest usr/src/gtest)
+    PATH_SUFFIXES gtest src/gtest googletest/googletest)
 
 set(GTEST_INCLUDE_DIRS ${GTEST_INCLUDE_DIR})
 set(CMAKE_FIND_FRAMEWORK)


### PR DESCRIPTION
* usr/src/gtest seems wrong to use, changed to src/gtest instead (based on path similarity to headers)
* added googletest/googletest to work with cloned repo as `GTEST_ROOT`