### PR TITLE
Apply clang-format to 2d module

### DIFF
--- a/2d/include/pcl/2d/convolution.h
+++ b/2d/include/pcl/2d/convolution.h
@@ -37,122 +37,116 @@
 
 #pragma once
 
+#include <pcl/filters/filter.h>
 #include <pcl/pcl_base.h>
 #include <pcl/pcl_macros.h>
-#include <pcl/filters/filter.h>
 #include <pcl/point_types.h>
 
-namespace pcl
-{
+namespace pcl {
+
+/// Point cloud containing edge information.
+struct EIGEN_ALIGN16 PointXYZIEdge {
+  PCL_ADD_POINT4D; // preferred way of adding a XYZ+padding
+  float magnitude;
+  float direction;
+  float magnitude_x;
+  float magnitude_y;
+  PCL_MAKE_ALIGNED_OPERATOR_NEW // make sure our new allocators are aligned
+};                              // enforce SSE padding for correct memory alignment
+
+/// A 2D convolution class.
+template <typename PointT>
+class Convolution : public Filter<PointT> {
+public:
+  using Filter<PointT>::input_;
+
   /**
-   * This typedef is used to represent a point cloud containing edge information
+   * Extra pixels are added to the input image so that convolution can be performed over
+   * the entire image.
+   *
+   * (kernel_height/2) rows are added before the first row and after the last row
+   * (kernel_width/2) columns are added before the first column and after the last
+   * column border options define what values are set for these extra rows and columns
+   *
+   * Assume that the three rows of right edge of the image looks like this:
+   *    .. 3 2 1
+   *    .. 6 5 4
+   *    .. 9 8 7
+   *
+   * BOUNDARY_OPTION_CLAMP : the extra pixels are set to the pixel value of the boundary
+   * pixel. This option makes it seem as if it were:
+   *    .. 3 2 1| 1 1 1 ..
+   *    .. 6 5 4| 4 4 4 ..
+   *    .. 9 8 7| 7 7 7 ..
+   *
+   * BOUNDARY_OPTION_MIRROR : the input image is mirrored at the boundary. This option
+   * makes it seem as if it were:
+   *    .. 3 2 1| 1 2 3 ..
+   *    .. 6 5 4| 4 5 6 ..
+   *    .. 9 8 7| 7 8 9 ..
+   *
+   * BOUNDARY_OPTION_ZERO_PADDING : the extra pixels are simply set to 0. This option
+   * makes it seem as if it were:
+   *    .. 3 2 1| 0 0 0 ..
+   *    .. 6 5 4| 0 0 0 ..
+   *    .. 9 8 7| 0 0 0 ..
+   *
+   * Note that the input image is not actually extended in size. Instead, based on these
+   * options, the convolution is performed differently at the border pixels.
    */
-  struct EIGEN_ALIGN16 PointXYZIEdge
-  {
-    PCL_ADD_POINT4D;                    // preferred way of adding a XYZ+padding
-    float magnitude;
-    float direction;
-    float magnitude_x;
-    float magnitude_y;
-    PCL_MAKE_ALIGNED_OPERATOR_NEW     // make sure our new allocators are aligned
-  };                    // enforce SSE padding for correct memory alignment
-
-  /** \brief A 2D convolution class. */
-  template <typename PointT>
-  class Convolution : public Filter<PointT>
-  {
-    public:
-      using Filter<PointT>::input_;
-
-      /**
-       * Extra pixels are added to the input image so that convolution can be performed over the entire image.
-       *
-       * (kernel_height/2) rows are added before the first row and after the last row
-       * (kernel_width/2) columns are added before the first column and after the last column
-       * border options define what values are set for these extra rows and columns
-       *
-       * Assume that the three rows of right edge of the image looks like this:
-       *    .. 3 2 1
-       *    .. 6 5 4
-       *    .. 9 8 7
-       *
-       * BOUNDARY_OPTION_CLAMP : the extra pixels are set to the pixel value of the boundary pixel
-       *    This option makes it seem as if it were:
-       *    .. 3 2 1| 1 1 1 ..
-       *    .. 6 5 4| 4 4 4 ..
-       *    .. 9 8 7| 7 7 7 ..
-       *
-       * BOUNDARY_OPTION_MIRROR : the input image is mirrored at the boundary.
-       *    This option makes it seem as if it were:
-       *    .. 3 2 1| 1 2 3 ..
-       *    .. 6 5 4| 4 5 6 ..
-       *    .. 9 8 7| 7 8 9 ..
-       *
-       * BOUNDARY_OPTION_ZERO_PADDING : the extra pixels are simply set to 0
-       *    This option makes it seem as if it were:
-       *    .. 3 2 1| 0 0 0 ..
-       *    .. 6 5 4| 0 0 0 ..
-       *    .. 9 8 7| 0 0 0 ..
-       *
-       * Note that the input image is not actually extended in size. Instead, based on these options,
-       * the convolution is performed differently at the border pixels.
-       */
-      enum BOUNDARY_OPTIONS_ENUM
-      {
-        BOUNDARY_OPTION_CLAMP,
-        BOUNDARY_OPTION_MIRROR,
-        BOUNDARY_OPTION_ZERO_PADDING
-      };
-
-      Convolution ()
-      {
-        boundary_options_ = BOUNDARY_OPTION_CLAMP;
-      }
-
-      /** \brief Sets the kernel to be used for convolution
-        * \param[in] kernel convolution kernel passed by reference
-        */
-      inline void 
-      setKernel (const pcl::PointCloud<PointT> &kernel)
-      {
-        kernel_ = kernel;
-      }
-
-      /**
-        * \param[in] boundary_options enum indicating the boundary options to be used for convolution
-        */
-      inline void 
-      setBoundaryOptions (BOUNDARY_OPTIONS_ENUM boundary_options)
-      {
-        boundary_options_ = boundary_options;
-      }
-
-      /** \brief Performs 2D convolution of the input point cloud with the kernel.
-        * Uses clamp as the default boundary option.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      filter (pcl::PointCloud<PointT> &output);
-
-    protected:
-      /** \brief This is an over-ride function for the pcl::Filter interface. */
-      void 
-      applyFilter (pcl::PointCloud<PointT> &) override {}
-
-    private:
-      BOUNDARY_OPTIONS_ENUM boundary_options_;
-      pcl::PointCloud<PointT> kernel_;
+  enum BOUNDARY_OPTIONS_ENUM {
+    BOUNDARY_OPTION_CLAMP,
+    BOUNDARY_OPTION_MIRROR,
+    BOUNDARY_OPTION_ZERO_PADDING
   };
-}
+
+  Convolution() { boundary_options_ = BOUNDARY_OPTION_CLAMP; }
+
+  /** \brief Sets the kernel to be used for convolution
+   * \param[in] kernel convolution kernel passed by reference
+   */
+  inline void
+  setKernel(const pcl::PointCloud<PointT>& kernel)
+  {
+    kernel_ = kernel;
+  }
+
+  /**
+   * \param[in] boundary_options enum indicating the boundary options to be used for
+   * convolution
+   */
+  inline void
+  setBoundaryOptions(BOUNDARY_OPTIONS_ENUM boundary_options)
+  {
+    boundary_options_ = boundary_options;
+  }
+
+  /** \brief Performs 2D convolution of the input point cloud with the kernel.
+   * Uses clamp as the default boundary option.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  filter(pcl::PointCloud<PointT>& output);
+
+protected:
+  /** \brief This is an over-ride function for the pcl::Filter interface. */
+  void
+  applyFilter(pcl::PointCloud<PointT>&) override
+  {}
+
+private:
+  BOUNDARY_OPTIONS_ENUM boundary_options_;
+  pcl::PointCloud<PointT> kernel_;
+};
+} // namespace pcl
 
 #include <pcl/2d/impl/convolution.hpp>
 
-POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::PointXYZIEdge,
-    (float, x, x)
-    (float, y, y)
-    (float, z, z)
-    (float, magnitude, magnitude)
-    (float, direction, direction)
-    (float, magnitude_x, magnitude_x)
-    (float, magnitude_y, magnitude_y)
-)
+POINT_CLOUD_REGISTER_POINT_STRUCT(pcl::PointXYZIEdge,                //
+                                  (float, x, x)                      //
+                                  (float, y, y)                      //
+                                  (float, z, z)                      //
+                                  (float, magnitude, magnitude)      //
+                                  (float, direction, direction)      //
+                                  (float, magnitude_x, magnitude_x)  //
+                                  (float, magnitude_y, magnitude_y)) //

--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -37,269 +37,277 @@
 
 #pragma once
 
-#include <pcl/pcl_base.h>
-#include <pcl/pcl_macros.h>
 #include <pcl/2d/convolution.h>
 #include <pcl/2d/kernel.h>
+#include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 
-namespace pcl
-{
-  template <typename PointInT, typename PointOutT>
-  class Edge
-  {
-    private:
-      using PointCloudIn = pcl::PointCloud<PointInT>;
-      using PointCloudInPtr = typename PointCloudIn::Ptr;
+namespace pcl {
 
-      PointCloudInPtr input_;
-      pcl::Convolution<PointInT> convolution_;
-      kernel<PointInT>  kernel_;
+template <typename PointInT, typename PointOutT>
+class Edge {
+private:
+  using PointCloudIn = pcl::PointCloud<PointInT>;
+  using PointCloudInPtr = typename PointCloudIn::Ptr;
 
-      /** \brief This function performs edge tracing for Canny Edge detector.
-        *
-        * \param[in] rowOffset row offset for direction in which the edge is to be traced
-        * \param[in] colOffset column offset for direction in which the edge is to be traced
-        * \param[in] row row location of the edge point
-        * \param[in] col column location of the edge point
-        * \param[out] maxima point cloud containing the edge information in the magnitude channel
-        */
-      inline void
-      cannyTraceEdge (int rowOffset, int colOffset, int row, int col, 
-                      pcl::PointCloud<pcl::PointXYZI> &maxima);
+  PointCloudInPtr input_;
+  pcl::Convolution<PointInT> convolution_;
+  kernel<PointInT> kernel_;
 
-      /** \brief This function discretizes the edge directions in steps of 22.5 degrees.
-        * \param thet point cloud containing the edge information in the direction channel
-        */
-      void
-      discretizeAngles (pcl::PointCloud<PointOutT> &thet);
+  /** \brief This function performs edge tracing for Canny Edge detector.
+   *
+   * \param[in] rowOffset row offset for direction in which the edge is to be traced
+   * \param[in] colOffset column offset for direction in which the edge is to be traced
+   * \param[in] row row location of the edge point
+   * \param[in] col column location of the edge point
+   * \param[out] maxima point cloud containing the edge information in the magnitude
+   * channel
+   */
+  inline void
+  cannyTraceEdge(int rowOffset,
+                 int colOffset,
+                 int row,
+                 int col,
+                 pcl::PointCloud<pcl::PointXYZI>& maxima);
 
-      /** \brief This function suppresses the edges which don't form a local maximum 
-        * in the edge direction.
-        * \param[in] edges point cloud containing all the edges
-        * \param[out] maxima point cloud containing the non-max suppressed edges
-        * \param[in] tLow
-        */
-      void
-      suppressNonMaxima (const pcl::PointCloud<PointXYZIEdge> &edges, 
-                         pcl::PointCloud<pcl::PointXYZI> &maxima, float tLow);
+  /** \brief This function discretizes the edge directions in steps of 22.5 degrees.
+   * \param thet point cloud containing the edge information in the direction channel
+   */
+  void
+  discretizeAngles(pcl::PointCloud<PointOutT>& thet);
 
-    public:
-      using Ptr = boost::shared_ptr<Edge<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const Edge<PointInT, PointOutT> >;
+  /** \brief This function suppresses the edges which don't form a local maximum
+   * in the edge direction.
+   * \param[in] edges point cloud containing all the edges
+   * \param[out] maxima point cloud containing the non-max suppressed edges
+   * \param[in] tLow
+   */
+  void
+  suppressNonMaxima(const pcl::PointCloud<PointXYZIEdge>& edges,
+                    pcl::PointCloud<pcl::PointXYZI>& maxima,
+                    float tLow);
 
-      enum OUTPUT_TYPE
-      {
-        OUTPUT_Y,
-        OUTPUT_X,
-        OUTPUT_X_Y,
-        OUTPUT_MAGNITUDE,
-        OUTPUT_DIRECTION,
-        OUTPUT_MAGNITUDE_DIRECTION,
-        OUTPUT_ALL
-      };
+public:
+  using Ptr = boost::shared_ptr<Edge<PointInT, PointOutT>>;
+  using ConstPtr = boost::shared_ptr<const Edge<PointInT, PointOutT>>;
 
-      enum DETECTOR_KERNEL_TYPE
-      {
-        CANNY,
-        SOBEL,
-        PREWITT,
-        ROBERTS,
-        LOG,
-        DERIVATIVE_CENTRAL,
-        DERIVATIVE_FORWARD,
-        DERIVATIVE_BACKWARD
-      };
-
-    private:
-      OUTPUT_TYPE output_type_;
-      DETECTOR_KERNEL_TYPE detector_kernel_type_;
-      bool non_maximal_suppression_;
-      bool hysteresis_thresholding_;
-
-      float hysteresis_threshold_low_;
-      float hysteresis_threshold_high_;
-      float non_max_suppression_radius_x_;
-      float non_max_suppression_radius_y_;
-
-    public:
-      Edge () :
-        output_type_ (OUTPUT_X),
-        detector_kernel_type_ (SOBEL),
-        non_maximal_suppression_ (false),
-        hysteresis_thresholding_ (false),
-        hysteresis_threshold_low_ (20),
-        hysteresis_threshold_high_ (80),
-        non_max_suppression_radius_x_ (3),
-        non_max_suppression_radius_y_ (3)
-      {
-      }
-
-      /** \brief Set the output type.
-        * \param[in] output_type the output type
-        */
-      void
-      setOutputType (OUTPUT_TYPE output_type)
-      {
-        output_type_ = output_type;
-      }
-
-      void
-      setHysteresisThresholdLow (float threshold)
-      {
-        hysteresis_threshold_low_ = threshold;
-      }
-
-      void
-      setHysteresisThresholdHigh (float threshold)
-      {
-        hysteresis_threshold_high_ = threshold;
-      }
-
-      /**
-        * \param[in] input_x
-        * \param[in] input_y
-        * \param[out] output
-        */
-      void 
-      sobelMagnitudeDirection (const pcl::PointCloud<PointInT> &input_x, 
-                               const pcl::PointCloud<PointInT> &input_y,
-                               pcl::PointCloud<PointOutT> &output);
-
-
-      /** \brief Perform Canny edge detection with two separated input images for 
-        * horizontal and vertical derivatives.
-        * All edges of magnitude above t_high are always classified as edges. All edges 
-        * below t_low are discarded. Edge values between t_low and t_high are classified 
-        * as edges only if they are connected to edges having magnitude > t_high and are 
-        * located in a direction perpendicular to that strong edge.
-        *
-        * \param[in] input_x Input point cloud passed by reference for the first derivative in the horizontal direction
-        * \param[in] input_y Input point cloud passed by reference for the first derivative in the vertical direction
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      canny (const pcl::PointCloud<PointInT> &input_x, 
-             const pcl::PointCloud<PointInT> &input_y,
-             pcl::PointCloud<PointOutT> &output);
-
-      /** \brief This is a convenience function which performs edge detection based on 
-        * the variable detector_kernel_type_
-        * \param[out] output
-        */
-      void 
-      detectEdge (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief All edges of magnitude above t_high are always classified as edges. 
-        * All edges below t_low are discarded.
-        * Edge values between t_low and t_high are classified as edges only if they are 
-        * connected to edges having magnitude > t_high and are located in a direction 
-        * perpendicular to that strong edge.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      detectEdgeCanny (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Uses the Sobel kernel for edge detection.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      detectEdgeSobel (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Uses the Prewitt kernel for edge detection.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      detectEdgePrewitt (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Uses the Roberts kernel for edge detection.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      detectEdgeRoberts (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Uses the LoG kernel for edge detection.
-        * Zero crossings of the Laplacian operator applied on an image indicate edges.
-        * Gaussian kernel is used to smoothen the image prior to the Laplacian.
-        * This is because Laplacian uses the second order derivative of the image and hence, is very sensitive to noise.
-        * The implementation is not two-step but rather applies the LoG kernel directly.
-        *
-        * \param[in] kernel_sigma variance of the LoG kernel used.
-        * \param[in] kernel_size a LoG kernel of dimensions kernel_size x kernel_size is used.
-        * \param[out] output Output point cloud passed by reference.
-        */
-      void 
-      detectEdgeLoG (const float kernel_sigma, const float kernel_size,
-                     pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Computes the image derivatives in X direction using the kernel kernel::derivativeYCentralKernel.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      computeDerivativeXCentral (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Computes the image derivatives in Y direction using the kernel kernel::derivativeYCentralKernel.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      computeDerivativeYCentral (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Computes the image derivatives in X direction using the kernel kernel::derivativeYForwardKernel.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      computeDerivativeXForward (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Computes the image derivatives in Y direction using the kernel kernel::derivativeYForwardKernel.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      computeDerivativeYForward (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Computes the image derivatives in X direction using the kernel kernel::derivativeXBackwardKernel.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param output Output point cloud passed by reference
-        */
-      void 
-      computeDerivativeXBackward (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Computes the image derivatives in Y direction using the kernel kernel::derivativeYBackwardKernel.
-        * This function does NOT include a smoothing step.
-        * The image should be smoothed before using this function to reduce noise.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      computeDerivativeYBackward (pcl::PointCloud<PointOutT> &output);
-
-      /** \brief Override function to implement the pcl::Filter interface
-        */
-      void 
-      applyFilter (pcl::PointCloud<PointOutT>& /*output*/) {}
-
-      /** \brief Set the input point cloud pointer
-        * \param[in] input pointer to input point cloud
-        */
-      void 
-      setInputCloud (PointCloudInPtr input)
-      {
-        input_ = input;
-      }
-
-      PCL_MAKE_ALIGNED_OPERATOR_NEW
+  enum OUTPUT_TYPE {
+    OUTPUT_Y,
+    OUTPUT_X,
+    OUTPUT_X_Y,
+    OUTPUT_MAGNITUDE,
+    OUTPUT_DIRECTION,
+    OUTPUT_MAGNITUDE_DIRECTION,
+    OUTPUT_ALL
   };
-}
+
+  enum DETECTOR_KERNEL_TYPE {
+    CANNY,
+    SOBEL,
+    PREWITT,
+    ROBERTS,
+    LOG,
+    DERIVATIVE_CENTRAL,
+    DERIVATIVE_FORWARD,
+    DERIVATIVE_BACKWARD
+  };
+
+private:
+  OUTPUT_TYPE output_type_;
+  DETECTOR_KERNEL_TYPE detector_kernel_type_;
+  bool non_maximal_suppression_;
+  bool hysteresis_thresholding_;
+
+  float hysteresis_threshold_low_;
+  float hysteresis_threshold_high_;
+  float non_max_suppression_radius_x_;
+  float non_max_suppression_radius_y_;
+
+public:
+  Edge()
+  : output_type_(OUTPUT_X)
+  , detector_kernel_type_(SOBEL)
+  , non_maximal_suppression_(false)
+  , hysteresis_thresholding_(false)
+  , hysteresis_threshold_low_(20)
+  , hysteresis_threshold_high_(80)
+  , non_max_suppression_radius_x_(3)
+  , non_max_suppression_radius_y_(3)
+  {}
+
+  /** \brief Set the output type.
+   * \param[in] output_type the output type
+   */
+  void
+  setOutputType(OUTPUT_TYPE output_type)
+  {
+    output_type_ = output_type;
+  }
+
+  void
+  setHysteresisThresholdLow(float threshold)
+  {
+    hysteresis_threshold_low_ = threshold;
+  }
+
+  void
+  setHysteresisThresholdHigh(float threshold)
+  {
+    hysteresis_threshold_high_ = threshold;
+  }
+
+  /**
+   * \param[in] input_x
+   * \param[in] input_y
+   * \param[out] output
+   */
+  void
+  sobelMagnitudeDirection(const pcl::PointCloud<PointInT>& input_x,
+                          const pcl::PointCloud<PointInT>& input_y,
+                          pcl::PointCloud<PointOutT>& output);
+
+  /** Perform Canny edge detection with two separated input images for horizontal and
+   * vertical derivatives.
+   *
+   * All edges of magnitude above t_high are always classified as edges. All edges
+   * below t_low are discarded. Edge values between t_low and t_high are classified
+   * as edges only if they are connected to edges having magnitude > t_high and are
+   * located in a direction perpendicular to that strong edge.
+   *
+   * \param[in] input_x Input point cloud passed by reference for the first derivative
+   *                    in the horizontal direction
+   * \param[in] input_y Input point cloud passed by reference for the first derivative
+   *                    in the vertical direction
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  canny(const pcl::PointCloud<PointInT>& input_x,
+        const pcl::PointCloud<PointInT>& input_y,
+        pcl::PointCloud<PointOutT>& output);
+
+  /** \brief This is a convenience function which performs edge detection based on
+   * the variable detector_kernel_type_
+   * \param[out] output
+   */
+  void
+  detectEdge(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief All edges of magnitude above t_high are always classified as edges.
+   * All edges below t_low are discarded.
+   * Edge values between t_low and t_high are classified as edges only if they are
+   * connected to edges having magnitude > t_high and are located in a direction
+   * perpendicular to that strong edge.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  detectEdgeCanny(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Uses the Sobel kernel for edge detection.
+   * This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  detectEdgeSobel(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Uses the Prewitt kernel for edge detection.
+   * This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  detectEdgePrewitt(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Uses the Roberts kernel for edge detection.
+   * This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  detectEdgeRoberts(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Uses the LoG kernel for edge detection.
+   * Zero crossings of the Laplacian operator applied on an image indicate edges.
+   * Gaussian kernel is used to smoothen the image prior to the Laplacian.
+   * This is because Laplacian uses the second order derivative of the image and hence,
+   * is very sensitive to noise. The implementation is not two-step but rather applies
+   * the LoG kernel directly.
+   *
+   * \param[in] kernel_sigma variance of the LoG kernel used.
+   * \param[in] kernel_size a LoG kernel of dimensions kernel_size x kernel_size is
+   *                        used.
+   * \param[out] output Output point cloud passed by reference.
+   */
+  void
+  detectEdgeLoG(const float kernel_sigma,
+                const float kernel_size,
+                pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Computes the image derivatives in X direction using the kernel
+   * kernel::derivativeYCentralKernel. This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  computeDerivativeXCentral(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Computes the image derivatives in Y direction using the kernel
+   * kernel::derivativeYCentralKernel. This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  computeDerivativeYCentral(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Computes the image derivatives in X direction using the kernel
+   * kernel::derivativeYForwardKernel. This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  computeDerivativeXForward(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Computes the image derivatives in Y direction using the kernel
+   * kernel::derivativeYForwardKernel. This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  computeDerivativeYForward(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Computes the image derivatives in X direction using the kernel
+   * kernel::derivativeXBackwardKernel. This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param output Output point cloud passed by reference
+   */
+  void
+  computeDerivativeXBackward(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Computes the image derivatives in Y direction using the kernel
+   * kernel::derivativeYBackwardKernel. This function does NOT include a smoothing step.
+   * The image should be smoothed before using this function to reduce noise.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  computeDerivativeYBackward(pcl::PointCloud<PointOutT>& output);
+
+  /** \brief Override function to implement the pcl::Filter interface */
+  void
+  applyFilter(pcl::PointCloud<PointOutT>& /*output*/)
+  {}
+
+  /** \brief Set the input point cloud pointer
+   * \param[in] input pointer to input point cloud
+   */
+  void
+  setInputCloud(PointCloudInPtr input)
+  {
+    input_ = input;
+  }
+
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+} // namespace pcl
+
 #include <pcl/2d/impl/edge.hpp>

--- a/2d/include/pcl/2d/impl/convolution.hpp
+++ b/2d/include/pcl/2d/impl/convolution.hpp
@@ -39,114 +39,99 @@
 #define PCL_2D_CONVOLUTION_IMPL_HPP
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Convolution<PointT>::filter (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Convolution<PointT>::filter(pcl::PointCloud<PointT>& output)
 {
   int input_row = 0;
   int input_col = 0;
   // default boundary option : zero padding
   output = *input_;
 
-  int iw = static_cast<int> (input_->width),
-      ih = static_cast<int> (input_->height),
-      kw = static_cast<int> (kernel_.width),
-      kh = static_cast<int> (kernel_.height);
-  switch (boundary_options_)
-  {
-    default:
-    case BOUNDARY_OPTION_CLAMP:
-    {
-      for (int i = 0; i < ih; i++)
-      {
-        for (int j = 0; j < iw; j++)
-        {
-          float intensity = 0;
-          for (int k = 0; k < kh; k++)
-          {
-            for (int l = 0; l < kw; l++)
-            {
-              int ikkh = i + k - kh / 2, jlkw = j + l - kw / 2;
-              if (ikkh < 0)
-                input_row = 0;
-              else if (ikkh >= ih)
-                input_row = ih - 1;
-              else
-                input_row = ikkh;
+  int iw = static_cast<int>(input_->width), ih = static_cast<int>(input_->height),
+      kw = static_cast<int>(kernel_.width), kh = static_cast<int>(kernel_.height);
+  switch (boundary_options_) {
+  default:
+  case BOUNDARY_OPTION_CLAMP: {
+    for (int i = 0; i < ih; i++) {
+      for (int j = 0; j < iw; j++) {
+        float intensity = 0;
+        for (int k = 0; k < kh; k++) {
+          for (int l = 0; l < kw; l++) {
+            int ikkh = i + k - kh / 2, jlkw = j + l - kw / 2;
+            if (ikkh < 0)
+              input_row = 0;
+            else if (ikkh >= ih)
+              input_row = ih - 1;
+            else
+              input_row = ikkh;
 
-              if (jlkw < 0)
-                input_col = 0;
-              else if (jlkw >= iw)
-                input_col = iw - 1;
-              else
-                input_col = jlkw;
+            if (jlkw < 0)
+              input_col = 0;
+            else if (jlkw >= iw)
+              input_col = iw - 1;
+            else
+              input_col = jlkw;
 
-              intensity += kernel_ (l, k).intensity * (*input_)(input_col, input_row).intensity;
-            }
+            intensity +=
+                kernel_(l, k).intensity * (*input_)(input_col, input_row).intensity;
           }
-          output (j, i).intensity = intensity;
         }
+        output(j, i).intensity = intensity;
       }
-      break;
     }
+    break;
+  }
 
-    case BOUNDARY_OPTION_MIRROR:
-    {
-      for (int i = 0; i < ih; i++)
-      {
-        for (int j = 0; j < iw; j++)
-        {
-          float intensity = 0;
-          for (int k = 0; k < kh; k++)
-          {
-            for (int l = 0; l < kw; l++)
-            {
-              int ikkh = i + k - kh / 2, jlkw = j + l - kw / 2;
-              if (ikkh < 0)
-                input_row = -ikkh - 1;
-              else if (ikkh >= ih)
-                input_row = 2 * ih - 1 - ikkh;
-              else
-                input_row = ikkh;
+  case BOUNDARY_OPTION_MIRROR: {
+    for (int i = 0; i < ih; i++) {
+      for (int j = 0; j < iw; j++) {
+        float intensity = 0;
+        for (int k = 0; k < kh; k++) {
+          for (int l = 0; l < kw; l++) {
+            int ikkh = i + k - kh / 2, jlkw = j + l - kw / 2;
+            if (ikkh < 0)
+              input_row = -ikkh - 1;
+            else if (ikkh >= ih)
+              input_row = 2 * ih - 1 - ikkh;
+            else
+              input_row = ikkh;
 
-              if (jlkw < 0)
-                input_col = -jlkw - 1;
-              else if (jlkw >= iw)
-                input_col = 2 * iw - 1 - jlkw;
-              else
-                input_col = jlkw;
+            if (jlkw < 0)
+              input_col = -jlkw - 1;
+            else if (jlkw >= iw)
+              input_col = 2 * iw - 1 - jlkw;
+            else
+              input_col = jlkw;
 
-              intensity += kernel_ (l, k).intensity * ((*input_)(input_col, input_row).intensity);
-            }
+            intensity +=
+                kernel_(l, k).intensity * ((*input_)(input_col, input_row).intensity);
           }
-          output (j, i).intensity = intensity;
         }
+        output(j, i).intensity = intensity;
       }
-      break;
     }
-    
-    case BOUNDARY_OPTION_ZERO_PADDING:
-    {
-      for (int i = 0; i < ih; i++)
-      {
-        for (int j = 0; j < iw; j++)
-        {
-          float intensity = 0;
-          for (int k = 0; k < kh; k++)
-          {
-            for (int l = 0; l < kw; l++)
-            {
-              int ikkh = i + k - kh / 2, jlkw = j + l - kw / 2;
-              if (ikkh < 0 || ikkh >= ih || jlkw < 0 || jlkw >= iw)
-                continue;
-              intensity += kernel_ (l, k).intensity * ((*input_)(jlkw, ikkh).intensity);
-            }
+    break;
+  }
+
+  case BOUNDARY_OPTION_ZERO_PADDING: {
+    for (int i = 0; i < ih; i++) {
+      for (int j = 0; j < iw; j++) {
+        float intensity = 0;
+        for (int k = 0; k < kh; k++) {
+          for (int l = 0; l < kw; l++) {
+            int ikkh = i + k - kh / 2, jlkw = j + l - kw / 2;
+            if (ikkh < 0 || ikkh >= ih || jlkw < 0 || jlkw >= iw)
+              continue;
+            intensity += kernel_(l, k).intensity * ((*input_)(jlkw, ikkh).intensity);
           }
-          output (j, i).intensity = intensity;
         }
+        output(j, i).intensity = intensity;
       }
-      break;
     }
-  }  // switch
+    break;
+  }
+  } // switch
 }
 
 #endif

--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -427,14 +427,17 @@ pcl::Edge<PointInT, PointOutT>::canny(const pcl::PointCloud<PointInT>& input_x,
         continue;
 
       (*maxima)(j, i).intensity = std::numeric_limits<float>::max();
-      cannyTraceEdge(1, 0, i, j, *maxima);
-      cannyTraceEdge(-1, 0, i, j, *maxima);
-      cannyTraceEdge(1, 1, i, j, *maxima);
+
+      // clang-format off
+      cannyTraceEdge( 1,  0, i, j, *maxima);
+      cannyTraceEdge(-1,  0, i, j, *maxima);
+      cannyTraceEdge( 1,  1, i, j, *maxima);
       cannyTraceEdge(-1, -1, i, j, *maxima);
-      cannyTraceEdge(0, -1, i, j, *maxima);
-      cannyTraceEdge(0, 1, i, j, *maxima);
-      cannyTraceEdge(-1, 1, i, j, *maxima);
-      cannyTraceEdge(1, -1, i, j, *maxima);
+      cannyTraceEdge( 0, -1, i, j, *maxima);
+      cannyTraceEdge( 0,  1, i, j, *maxima);
+      cannyTraceEdge(-1,  1, i, j, *maxima);
+      cannyTraceEdge( 1, -1, i, j, *maxima);
+      // clang-format on
     }
   }
 

--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -42,342 +42,335 @@
 #include <pcl/common/common_headers.h> // rad2deg()
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::detectEdgeSobel (
-    pcl::PointCloud<PointOutT> &output)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::detectEdgeSobel(pcl::PointCloud<PointOutT>& output)
 {
-  convolution_.setInputCloud (input_);
-  pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_X);
-  kernel_.fetchKernel (*kernel_x);
-  convolution_.setKernel (*kernel_x);
-  convolution_.filter (*magnitude_x);
+  convolution_.setInputCloud(input_);
+  pcl::PointCloud<PointXYZI>::Ptr kernel_x(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_x(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::SOBEL_X);
+  kernel_.fetchKernel(*kernel_x);
+  convolution_.setKernel(*kernel_x);
+  convolution_.filter(*magnitude_x);
 
-  pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_Y);
-  kernel_.fetchKernel (*kernel_y);
-  convolution_.setKernel (*kernel_y);
-  convolution_.filter (*magnitude_y);
+  pcl::PointCloud<PointXYZI>::Ptr kernel_y(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_y(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::SOBEL_Y);
+  kernel_.fetchKernel(*kernel_y);
+  convolution_.setKernel(*kernel_y);
+  convolution_.filter(*magnitude_y);
 
   const int height = input_->height;
   const int width = input_->width;
 
-  output.resize (height * width);
+  output.resize(height * width);
   output.height = height;
   output.width = width;
 
-  for (size_t i = 0; i < output.size (); ++i)
-  {
+  for (size_t i = 0; i < output.size(); ++i) {
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
-    output[i].magnitude = 
-      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
-    output[i].direction = 
-      std::atan2 ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
+    output[i].magnitude =
+        std::sqrt((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity +
+                  (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+    output[i].direction =
+        std::atan2((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::sobelMagnitudeDirection (
-    const pcl::PointCloud<PointInT> &input_x, 
-    const pcl::PointCloud<PointInT> &input_y,
-    pcl::PointCloud<PointOutT> &output)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::sobelMagnitudeDirection(
+    const pcl::PointCloud<PointInT>& input_x,
+    const pcl::PointCloud<PointInT>& input_y,
+    pcl::PointCloud<PointOutT>& output)
 {
-  convolution_.setInputCloud (input_x.makeShared());
-  pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_X);
-  kernel_.fetchKernel (*kernel_x);
-  convolution_.setKernel (*kernel_x);
-  convolution_.filter (*magnitude_x);
+  convolution_.setInputCloud(input_x.makeShared());
+  pcl::PointCloud<PointXYZI>::Ptr kernel_x(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_x(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::SOBEL_X);
+  kernel_.fetchKernel(*kernel_x);
+  convolution_.setKernel(*kernel_x);
+  convolution_.filter(*magnitude_x);
 
-  convolution_.setInputCloud (input_y.makeShared());
-  pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::SOBEL_Y);
-  kernel_.fetchKernel (*kernel_y);
-  convolution_.setKernel (*kernel_y);
-  convolution_.filter (*magnitude_y);
+  convolution_.setInputCloud(input_y.makeShared());
+  pcl::PointCloud<PointXYZI>::Ptr kernel_y(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_y(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::SOBEL_Y);
+  kernel_.fetchKernel(*kernel_y);
+  convolution_.setKernel(*kernel_y);
+  convolution_.filter(*magnitude_y);
 
   const int height = input_x.height;
   const int width = input_x.width;
 
-  output.resize (height * width);
+  output.resize(height * width);
   output.height = height;
   output.width = width;
 
-  for (size_t i = 0; i < output.size (); ++i)
-  {
+  for (size_t i = 0; i < output.size(); ++i) {
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
-    output[i].magnitude = 
-      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
-    output[i].direction = 
-      std::atan2 ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
+    output[i].magnitude =
+        std::sqrt((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity +
+                  (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+    output[i].direction =
+        std::atan2((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::detectEdgePrewitt (pcl::PointCloud<PointOutT> &output)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::detectEdgePrewitt(pcl::PointCloud<PointOutT>& output)
 {
-  convolution_.setInputCloud (input_);
+  convolution_.setInputCloud(input_);
 
-  pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::PREWITT_X);
-  kernel_.fetchKernel (*kernel_x);
-  convolution_.setKernel (*kernel_x);
-  convolution_.filter (*magnitude_x);
+  pcl::PointCloud<PointXYZI>::Ptr kernel_x(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_x(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::PREWITT_X);
+  kernel_.fetchKernel(*kernel_x);
+  convolution_.setKernel(*kernel_x);
+  convolution_.filter(*magnitude_x);
 
-  pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::PREWITT_Y);
-  kernel_.fetchKernel (*kernel_y);
-  convolution_.setKernel (*kernel_y);
-  convolution_.filter (*magnitude_y);
+  pcl::PointCloud<PointXYZI>::Ptr kernel_y(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_y(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::PREWITT_Y);
+  kernel_.fetchKernel(*kernel_y);
+  convolution_.setKernel(*kernel_y);
+  convolution_.filter(*magnitude_y);
 
   const int height = input_->height;
   const int width = input_->width;
 
-  output.resize (height * width);
+  output.resize(height * width);
   output.height = height;
   output.width = width;
 
-  for (size_t i = 0; i < output.size (); ++i)
-  {
+  for (size_t i = 0; i < output.size(); ++i) {
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
-    output[i].magnitude = 
-      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
-    output[i].direction = 
-      std::atan2 ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
+    output[i].magnitude =
+        std::sqrt((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity +
+                  (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+    output[i].direction =
+        std::atan2((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::detectEdgeRoberts (pcl::PointCloud<PointOutT> &output)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::detectEdgeRoberts(pcl::PointCloud<PointOutT>& output)
 {
-  convolution_.setInputCloud (input_);
+  convolution_.setInputCloud(input_);
 
-  pcl::PointCloud<PointXYZI>::Ptr kernel_x (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_x (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::ROBERTS_X);
-  kernel_.fetchKernel (*kernel_x);
-  convolution_.setKernel (*kernel_x);
-  convolution_.filter (*magnitude_x);
+  pcl::PointCloud<PointXYZI>::Ptr kernel_x(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_x(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::ROBERTS_X);
+  kernel_.fetchKernel(*kernel_x);
+  convolution_.setKernel(*kernel_x);
+  convolution_.filter(*magnitude_x);
 
-  pcl::PointCloud<PointXYZI>::Ptr kernel_y (new pcl::PointCloud<PointXYZI>);
-  pcl::PointCloud<PointXYZI>::Ptr magnitude_y (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::ROBERTS_Y);
-  kernel_.fetchKernel (*kernel_y);
-  convolution_.setKernel (*kernel_y);
-  convolution_.filter (*magnitude_y);
+  pcl::PointCloud<PointXYZI>::Ptr kernel_y(new pcl::PointCloud<PointXYZI>);
+  pcl::PointCloud<PointXYZI>::Ptr magnitude_y(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::ROBERTS_Y);
+  kernel_.fetchKernel(*kernel_y);
+  convolution_.setKernel(*kernel_y);
+  convolution_.filter(*magnitude_y);
 
   const int height = input_->height;
   const int width = input_->width;
 
-  output.resize (height * width);
+  output.resize(height * width);
   output.height = height;
   output.width = width;
 
-  for (size_t i = 0; i < output.size (); ++i)
-  {
+  for (size_t i = 0; i < output.size(); ++i) {
     output[i].magnitude_x = (*magnitude_x)[i].intensity;
     output[i].magnitude_y = (*magnitude_y)[i].intensity;
-    output[i].magnitude = 
-      std::sqrt ((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity + 
-                 (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
-    output[i].direction = 
-      std::atan2 ((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
+    output[i].magnitude =
+        std::sqrt((*magnitude_x)[i].intensity * (*magnitude_x)[i].intensity +
+                  (*magnitude_y)[i].intensity * (*magnitude_y)[i].intensity);
+    output[i].direction =
+        std::atan2((*magnitude_y)[i].intensity, (*magnitude_x)[i].intensity);
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template<typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::cannyTraceEdge (
-    int rowOffset, int colOffset, int row, int col, 
-    pcl::PointCloud<PointXYZI> &maxima)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::cannyTraceEdge(
+    int rowOffset, int colOffset, int row, int col, pcl::PointCloud<PointXYZI>& maxima)
 {
   int newRow = row + rowOffset;
   int newCol = col + colOffset;
-  PointXYZI &pt = maxima (newCol, newRow);
+  PointXYZI& pt = maxima(newCol, newRow);
 
-  if (newRow > 0 && newRow < static_cast<int> (maxima.height) && newCol > 0 && newCol < static_cast<int> (maxima.width))
-  {
-    if (pt.intensity == 0.0f || pt.intensity == std::numeric_limits<float>::max ())
+  if (newRow > 0 && newRow < static_cast<int>(maxima.height) && newCol > 0 &&
+      newCol < static_cast<int>(maxima.width)) {
+    if (pt.intensity == 0.0f || pt.intensity == std::numeric_limits<float>::max())
       return;
 
-    pt.intensity = std::numeric_limits<float>::max ();
-    cannyTraceEdge ( 1, 0, newRow, newCol, maxima);
-    cannyTraceEdge (-1, 0, newRow, newCol, maxima);
-    cannyTraceEdge ( 1, 1, newRow, newCol, maxima);
-    cannyTraceEdge (-1, -1, newRow, newCol, maxima);
-    cannyTraceEdge ( 0, -1, newRow, newCol, maxima);
-    cannyTraceEdge ( 0, 1, newRow, newCol, maxima);
-    cannyTraceEdge (-1, 1, newRow, newCol, maxima);
-    cannyTraceEdge ( 1, -1, newRow, newCol, maxima);
+    pt.intensity = std::numeric_limits<float>::max();
+    cannyTraceEdge(1, 0, newRow, newCol, maxima);
+    cannyTraceEdge(-1, 0, newRow, newCol, maxima);
+    cannyTraceEdge(1, 1, newRow, newCol, maxima);
+    cannyTraceEdge(-1, -1, newRow, newCol, maxima);
+    cannyTraceEdge(0, -1, newRow, newCol, maxima);
+    cannyTraceEdge(0, 1, newRow, newCol, maxima);
+    cannyTraceEdge(-1, 1, newRow, newCol, maxima);
+    cannyTraceEdge(1, -1, newRow, newCol, maxima);
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::discretizeAngles (pcl::PointCloud<PointOutT> &thet)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::discretizeAngles(pcl::PointCloud<PointOutT>& thet)
 {
   const int height = thet.height;
   const int width = thet.width;
   float angle;
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
-      angle = pcl::rad2deg (thet (j, i).direction);
-      if (((angle <= 22.5) && (angle >= -22.5)) || (angle >= 157.5) || (angle <= -157.5))
-        thet (j, i).direction = 0;
-      else
-        if (((angle > 22.5) && (angle < 67.5)) || ((angle < -112.5) && (angle > -157.5)))
-          thet (j, i).direction = 45;
-        else
-          if (((angle >= 67.5) && (angle <= 112.5)) || ((angle <= -67.5) && (angle >= -112.5)))
-            thet (j, i).direction = 90;
-          else
-            if (((angle > 112.5) && (angle < 157.5)) || ((angle < -22.5) && (angle > -67.5)))
-              thet (j, i).direction = 135;
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
+      angle = pcl::rad2deg(thet(j, i).direction);
+      if (((angle <= 22.5) && (angle >= -22.5)) || (angle >= 157.5) ||
+          (angle <= -157.5))
+        thet(j, i).direction = 0;
+      else if (((angle > 22.5) && (angle < 67.5)) ||
+               ((angle < -112.5) && (angle > -157.5)))
+        thet(j, i).direction = 45;
+      else if (((angle >= 67.5) && (angle <= 112.5)) ||
+               ((angle <= -67.5) && (angle >= -112.5)))
+        thet(j, i).direction = 90;
+      else if (((angle > 112.5) && (angle < 157.5)) ||
+               ((angle < -22.5) && (angle > -67.5)))
+        thet(j, i).direction = 135;
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::suppressNonMaxima (
-    const pcl::PointCloud<PointXYZIEdge> &edges, 
-    pcl::PointCloud<PointXYZI> &maxima, float tLow)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::suppressNonMaxima(
+    const pcl::PointCloud<PointXYZIEdge>& edges,
+    pcl::PointCloud<PointXYZI>& maxima,
+    float tLow)
 {
   const int height = edges.height;
   const int width = edges.width;
 
   maxima.height = height;
   maxima.width = width;
-  maxima.resize (height * width);
+  maxima.resize(height * width);
 
-  for (auto &point : maxima)
+  for (auto& point : maxima)
     point.intensity = 0.0f;
 
   // tHigh and non-maximal supression
-  for (int i = 1; i < height - 1; i++)
-  {
-    for (int j = 1; j < width - 1; j++)
-    {
-      const PointXYZIEdge &ptedge = edges (j, i);
-      PointXYZI &ptmax = maxima (j, i);
+  for (int i = 1; i < height - 1; i++) {
+    for (int j = 1; j < width - 1; j++) {
+      const PointXYZIEdge& ptedge = edges(j, i);
+      PointXYZI& ptmax = maxima(j, i);
 
       if (ptedge.magnitude < tLow)
         continue;
 
-      //maxima (j, i).intensity = 0;
-      
-      switch (int (ptedge.direction))
-      {
-        case 0:
-        {
-          if (ptedge.magnitude >= edges (j - 1, i).magnitude && 
-              ptedge.magnitude >= edges (j + 1, i).magnitude)
-            ptmax.intensity = ptedge.magnitude;
-          break;
-        }
-        case 45:
-        {
-          if (ptedge.magnitude >= edges (j - 1, i - 1).magnitude && 
-              ptedge.magnitude >= edges (j + 1, i + 1).magnitude)
-            ptmax.intensity = ptedge.magnitude;
-          break;
-        }
-        case 90:
-        {
-          if (ptedge.magnitude >= edges (j, i - 1).magnitude && 
-              ptedge.magnitude >= edges (j, i + 1).magnitude)
-            ptmax.intensity = ptedge.magnitude;
-          break;
-        }
-        case 135:
-        {
-          if (ptedge.magnitude >= edges (j + 1, i - 1).magnitude && 
-              ptedge.magnitude >= edges (j - 1, i + 1).magnitude)
-            ptmax.intensity = ptedge.magnitude;
-          break;
-        }
+      // maxima (j, i).intensity = 0;
+
+      switch (int(ptedge.direction)) {
+      case 0: {
+        if (ptedge.magnitude >= edges(j - 1, i).magnitude &&
+            ptedge.magnitude >= edges(j + 1, i).magnitude)
+          ptmax.intensity = ptedge.magnitude;
+        break;
+      }
+      case 45: {
+        if (ptedge.magnitude >= edges(j - 1, i - 1).magnitude &&
+            ptedge.magnitude >= edges(j + 1, i + 1).magnitude)
+          ptmax.intensity = ptedge.magnitude;
+        break;
+      }
+      case 90: {
+        if (ptedge.magnitude >= edges(j, i - 1).magnitude &&
+            ptedge.magnitude >= edges(j, i + 1).magnitude)
+          ptmax.intensity = ptedge.magnitude;
+        break;
+      }
+      case 135: {
+        if (ptedge.magnitude >= edges(j + 1, i - 1).magnitude &&
+            ptedge.magnitude >= edges(j - 1, i + 1).magnitude)
+          ptmax.intensity = ptedge.magnitude;
+        break;
+      }
       }
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template<typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::detectEdgeCanny (pcl::PointCloud<PointOutT> &output)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::detectEdgeCanny(pcl::PointCloud<PointOutT>& output)
 {
   float tHigh = hysteresis_threshold_high_;
   float tLow = hysteresis_threshold_low_;
   const int height = input_->height;
   const int width = input_->width;
 
-  output.resize (height * width);
+  output.resize(height * width);
   output.height = height;
   output.width = width;
 
   // Noise reduction using gaussian blurring
-  pcl::PointCloud<PointXYZI>::Ptr gaussian_kernel (new pcl::PointCloud<PointXYZI>);
-  PointCloudInPtr smoothed_cloud (new PointCloudIn);
-  kernel_.setKernelSize (3);
-  kernel_.setKernelSigma (1.0);
-  kernel_.setKernelType (kernel<PointXYZI>::GAUSSIAN);
-  kernel_.fetchKernel (*gaussian_kernel);
-  convolution_.setKernel (*gaussian_kernel);
-  convolution_.setInputCloud (input_);
-  convolution_.filter (*smoothed_cloud);
-  
+  pcl::PointCloud<PointXYZI>::Ptr gaussian_kernel(new pcl::PointCloud<PointXYZI>);
+  PointCloudInPtr smoothed_cloud(new PointCloudIn);
+  kernel_.setKernelSize(3);
+  kernel_.setKernelSigma(1.0);
+  kernel_.setKernelType(kernel<PointXYZI>::GAUSSIAN);
+  kernel_.fetchKernel(*gaussian_kernel);
+  convolution_.setKernel(*gaussian_kernel);
+  convolution_.setInputCloud(input_);
+  convolution_.filter(*smoothed_cloud);
+
   // Edge detection using Sobel
-  pcl::PointCloud<PointXYZIEdge>::Ptr edges (new pcl::PointCloud<PointXYZIEdge>);
-  setInputCloud (smoothed_cloud);
-  detectEdgeSobel (*edges);
-  
+  pcl::PointCloud<PointXYZIEdge>::Ptr edges(new pcl::PointCloud<PointXYZIEdge>);
+  setInputCloud(smoothed_cloud);
+  detectEdgeSobel(*edges);
+
   // Edge discretization
-  discretizeAngles (*edges);
+  discretizeAngles(*edges);
 
   // tHigh and non-maximal supression
-  pcl::PointCloud<PointXYZI>::Ptr maxima (new pcl::PointCloud<PointXYZI>);
-  suppressNonMaxima (*edges, *maxima, tLow);
+  pcl::PointCloud<PointXYZI>::Ptr maxima(new pcl::PointCloud<PointXYZI>);
+  suppressNonMaxima(*edges, *maxima, tLow);
 
   // Edge tracing
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
-      if ((*maxima)(j, i).intensity < tHigh || (*maxima)(j, i).intensity == std::numeric_limits<float>::max ())
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
+      if ((*maxima)(j, i).intensity < tHigh ||
+          (*maxima)(j, i).intensity == std::numeric_limits<float>::max())
         continue;
 
-      (*maxima)(j, i).intensity = std::numeric_limits<float>::max ();
-      cannyTraceEdge ( 1, 0, i, j, *maxima);
-      cannyTraceEdge (-1, 0, i, j, *maxima);
-      cannyTraceEdge ( 1, 1, i, j, *maxima);
-      cannyTraceEdge (-1, -1, i, j, *maxima);
-      cannyTraceEdge ( 0, -1, i, j, *maxima);
-      cannyTraceEdge ( 0, 1, i, j, *maxima);
-      cannyTraceEdge (-1, 1, i, j, *maxima);
-      cannyTraceEdge ( 1, -1, i, j, *maxima);
+      (*maxima)(j, i).intensity = std::numeric_limits<float>::max();
+      cannyTraceEdge(1, 0, i, j, *maxima);
+      cannyTraceEdge(-1, 0, i, j, *maxima);
+      cannyTraceEdge(1, 1, i, j, *maxima);
+      cannyTraceEdge(-1, -1, i, j, *maxima);
+      cannyTraceEdge(0, -1, i, j, *maxima);
+      cannyTraceEdge(0, 1, i, j, *maxima);
+      cannyTraceEdge(-1, 1, i, j, *maxima);
+      cannyTraceEdge(1, -1, i, j, *maxima);
     }
   }
 
   // Final thresholding
-  for (size_t i = 0; i < input_->size (); ++i)
-  {
-    if ((*maxima)[i].intensity == std::numeric_limits<float>::max ())
+  for (size_t i = 0; i < input_->size(); ++i) {
+    if ((*maxima)[i].intensity == std::numeric_limits<float>::max())
       output[i].magnitude = 255;
     else
       output[i].magnitude = 0;
@@ -385,96 +378,93 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeCanny (pcl::PointCloud<PointOutT> &out
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::canny (
-    const pcl::PointCloud<PointInT> &input_x, 
-    const pcl::PointCloud<PointInT> &input_y,
-    pcl::PointCloud<PointOutT> &output)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::canny(const pcl::PointCloud<PointInT>& input_x,
+                                      const pcl::PointCloud<PointInT>& input_y,
+                                      pcl::PointCloud<PointOutT>& output)
 {
   float tHigh = hysteresis_threshold_high_;
   float tLow = hysteresis_threshold_low_;
   const int height = input_x.height;
   const int width = input_x.width;
 
-  output.resize (height * width);
+  output.resize(height * width);
   output.height = height;
   output.width = width;
 
   // Noise reduction using gaussian blurring
-  pcl::PointCloud<PointXYZI>::Ptr gaussian_kernel (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelSize (3);
-  kernel_.setKernelSigma (1.0);
-  kernel_.setKernelType (kernel<PointXYZI>::GAUSSIAN);
-  kernel_.fetchKernel (*gaussian_kernel);
-  convolution_.setKernel (*gaussian_kernel);
+  pcl::PointCloud<PointXYZI>::Ptr gaussian_kernel(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelSize(3);
+  kernel_.setKernelSigma(1.0);
+  kernel_.setKernelType(kernel<PointXYZI>::GAUSSIAN);
+  kernel_.fetchKernel(*gaussian_kernel);
+  convolution_.setKernel(*gaussian_kernel);
 
   PointCloudIn smoothed_cloud_x;
-  convolution_.setInputCloud (input_x.makeShared());
-  convolution_.filter (smoothed_cloud_x);
+  convolution_.setInputCloud(input_x.makeShared());
+  convolution_.filter(smoothed_cloud_x);
 
   PointCloudIn smoothed_cloud_y;
-  convolution_.setInputCloud (input_y.makeShared());
-  convolution_.filter (smoothed_cloud_y);
-
+  convolution_.setInputCloud(input_y.makeShared());
+  convolution_.filter(smoothed_cloud_y);
 
   // Edge detection using Sobel
-  pcl::PointCloud<PointXYZIEdge>::Ptr edges (new pcl::PointCloud<PointXYZIEdge>);
-  sobelMagnitudeDirection (smoothed_cloud_x, smoothed_cloud_y, *edges.get ());
+  pcl::PointCloud<PointXYZIEdge>::Ptr edges(new pcl::PointCloud<PointXYZIEdge>);
+  sobelMagnitudeDirection(smoothed_cloud_x, smoothed_cloud_y, *edges.get());
 
   // Edge discretization
-  discretizeAngles (*edges);
+  discretizeAngles(*edges);
 
-  pcl::PointCloud<PointXYZI>::Ptr maxima (new pcl::PointCloud<PointXYZI>);
-  suppressNonMaxima (*edges, *maxima, tLow);
+  pcl::PointCloud<PointXYZI>::Ptr maxima(new pcl::PointCloud<PointXYZI>);
+  suppressNonMaxima(*edges, *maxima, tLow);
 
   // Edge tracing
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
-      if ((*maxima)(j, i).intensity < tHigh || (*maxima)(j, i).intensity == std::numeric_limits<float>::max ())
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
+      if ((*maxima)(j, i).intensity < tHigh ||
+          (*maxima)(j, i).intensity == std::numeric_limits<float>::max())
         continue;
 
-      (*maxima)(j, i).intensity = std::numeric_limits<float>::max ();
-      cannyTraceEdge ( 1, 0, i, j, *maxima);
-      cannyTraceEdge (-1, 0, i, j, *maxima);
-      cannyTraceEdge ( 1, 1, i, j, *maxima);
-      cannyTraceEdge (-1, -1, i, j, *maxima);
-      cannyTraceEdge ( 0, -1, i, j, *maxima);
-      cannyTraceEdge ( 0, 1, i, j, *maxima);
-      cannyTraceEdge (-1, 1, i, j, *maxima);
-      cannyTraceEdge ( 1, -1, i, j, *maxima);
+      (*maxima)(j, i).intensity = std::numeric_limits<float>::max();
+      cannyTraceEdge(1, 0, i, j, *maxima);
+      cannyTraceEdge(-1, 0, i, j, *maxima);
+      cannyTraceEdge(1, 1, i, j, *maxima);
+      cannyTraceEdge(-1, -1, i, j, *maxima);
+      cannyTraceEdge(0, -1, i, j, *maxima);
+      cannyTraceEdge(0, 1, i, j, *maxima);
+      cannyTraceEdge(-1, 1, i, j, *maxima);
+      cannyTraceEdge(1, -1, i, j, *maxima);
     }
   }
 
   // Final thresholding
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
-      if ((*maxima)(j, i).intensity == std::numeric_limits<float>::max ())
-        output (j, i).magnitude = 255;
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
+      if ((*maxima)(j, i).intensity == std::numeric_limits<float>::max())
+        output(j, i).magnitude = 255;
       else
-        output (j, i).magnitude = 0;
+        output(j, i).magnitude = 0;
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template<typename PointInT, typename PointOutT> void
-pcl::Edge<PointInT, PointOutT>::detectEdgeLoG (
-    const float kernel_sigma, const float kernel_size,
-    pcl::PointCloud<PointOutT> &output)
+template <typename PointInT, typename PointOutT>
+void
+pcl::Edge<PointInT, PointOutT>::detectEdgeLoG(const float kernel_sigma,
+                                              const float kernel_size,
+                                              pcl::PointCloud<PointOutT>& output)
 {
-  convolution_.setInputCloud (input_);
+  convolution_.setInputCloud(input_);
 
-  pcl::PointCloud<PointXYZI>::Ptr log_kernel (new pcl::PointCloud<PointXYZI>);
-  kernel_.setKernelType (kernel<PointXYZI>::LOG);
-  kernel_.setKernelSigma (kernel_sigma);
-  kernel_.setKernelSize (kernel_size);
-  kernel_.fetchKernel (*log_kernel);
-  convolution_.setKernel (*log_kernel);
-  convolution_.filter (output);
+  pcl::PointCloud<PointXYZI>::Ptr log_kernel(new pcl::PointCloud<PointXYZI>);
+  kernel_.setKernelType(kernel<PointXYZI>::LOG);
+  kernel_.setKernelSigma(kernel_sigma);
+  kernel_.setKernelSize(kernel_size);
+  kernel_.fetchKernel(*log_kernel);
+  convolution_.setKernel(*log_kernel);
+  convolution_.filter(output);
 }
 
 #endif

--- a/2d/include/pcl/2d/impl/kernel.hpp
+++ b/2d/include/pcl/2d/impl/kernel.hpp
@@ -39,290 +39,329 @@
 #define PCL_2D_KERNEL_IMPL_HPP
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::fetchKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::fetchKernel(pcl::PointCloud<PointT>& kernel)
 {
-  switch (kernel_type_)
-  {
-    case SOBEL_X:
-    {
-      sobelKernelX (kernel);
-      break;
-    }
-    case SOBEL_Y:
-    {
-      sobelKernelY (kernel);
-      break;
-    }
-    case PREWITT_X:
-    {
-      prewittKernelX (kernel);
-      break;
-    }
-    case PREWITT_Y:
-    {
-      prewittKernelY (kernel);
-      break;
-    }
-    case ROBERTS_X:
-    {
-      robertsKernelX (kernel);
-      break;
-    }
-    case ROBERTS_Y:
-    {
-      robertsKernelY (kernel);
-      break;
-    }
-    case LOG:
-    {
-      loGKernel (kernel);
-      break;
-    }
-    case DERIVATIVE_CENTRAL_X:
-    {
-      derivativeXCentralKernel (kernel);
-      break;
-    }
-    case DERIVATIVE_FORWARD_X:
-    {
-      derivativeXForwardKernel (kernel);
-      break;
-    }
-    case DERIVATIVE_BACKWARD_X:
-    {
-      derivativeXBackwardKernel (kernel);
-      break;
-    }
-    case DERIVATIVE_CENTRAL_Y:
-    {
-      derivativeYCentralKernel (kernel);
-      break;
-    }
-    case DERIVATIVE_FORWARD_Y:
-    {
-      derivativeYForwardKernel (kernel);
-      break;
-    }
-    case DERIVATIVE_BACKWARD_Y:
-    {
-      derivativeYBackwardKernel (kernel);
-      break;
-    }
-    case GAUSSIAN:
-    {
-      gaussianKernel (kernel);
-      break;
-    }
+  switch (kernel_type_) {
+  case SOBEL_X: {
+    sobelKernelX(kernel);
+    break;
+  }
+  case SOBEL_Y: {
+    sobelKernelY(kernel);
+    break;
+  }
+  case PREWITT_X: {
+    prewittKernelX(kernel);
+    break;
+  }
+  case PREWITT_Y: {
+    prewittKernelY(kernel);
+    break;
+  }
+  case ROBERTS_X: {
+    robertsKernelX(kernel);
+    break;
+  }
+  case ROBERTS_Y: {
+    robertsKernelY(kernel);
+    break;
+  }
+  case LOG: {
+    loGKernel(kernel);
+    break;
+  }
+  case DERIVATIVE_CENTRAL_X: {
+    derivativeXCentralKernel(kernel);
+    break;
+  }
+  case DERIVATIVE_FORWARD_X: {
+    derivativeXForwardKernel(kernel);
+    break;
+  }
+  case DERIVATIVE_BACKWARD_X: {
+    derivativeXBackwardKernel(kernel);
+    break;
+  }
+  case DERIVATIVE_CENTRAL_Y: {
+    derivativeYCentralKernel(kernel);
+    break;
+  }
+  case DERIVATIVE_FORWARD_Y: {
+    derivativeYForwardKernel(kernel);
+    break;
+  }
+  case DERIVATIVE_BACKWARD_Y: {
+    derivativeYBackwardKernel(kernel);
+    break;
+  }
+  case GAUSSIAN: {
+    gaussianKernel(kernel);
+    break;
+  }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::gaussianKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::gaussianKernel(pcl::PointCloud<PointT>& kernel)
 {
   float sum = 0;
-  kernel.resize (kernel_size_ * kernel_size_);
+  kernel.resize(kernel_size_ * kernel_size_);
   kernel.height = kernel_size_;
   kernel.width = kernel_size_;
 
   double sigma_sqr = 2 * sigma_ * sigma_;
 
-  for (int i = 0; i < kernel_size_; i++)
-  {
-    for (int j = 0; j < kernel_size_; j++)
-    {
+  for (int i = 0; i < kernel_size_; i++) {
+    for (int j = 0; j < kernel_size_; j++) {
       int iks = (i - kernel_size_ / 2);
       int jks = (j - kernel_size_ / 2);
-      kernel (j, i).intensity = std::exp (float (- double (iks * iks + jks * jks) / sigma_sqr));
-      sum += float (kernel (j, i).intensity);
+      kernel(j, i).intensity =
+          std::exp(float(-double(iks * iks + jks * jks) / sigma_sqr));
+      sum += float(kernel(j, i).intensity);
     }
   }
 
   // Normalizing the kernel
-  for (size_t i = 0; i < kernel.size (); ++i)
+  for (size_t i = 0; i < kernel.size(); ++i)
     kernel[i].intensity /= sum;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
-pcl::kernel<PointT>::loGKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::loGKernel(pcl::PointCloud<PointT>& kernel)
 {
   float sum = 0;
   float temp = 0;
-  kernel.resize (kernel_size_ * kernel_size_);
+  kernel.resize(kernel_size_ * kernel_size_);
   kernel.height = kernel_size_;
   kernel.width = kernel_size_;
 
   double sigma_sqr = 2 * sigma_ * sigma_;
-  
-  for (int i = 0; i < kernel_size_; i++)
-  {
-    for (int j = 0; j < kernel_size_; j++)
-    {
-      int iks = (i - kernel_size_ / 2); 
-      int jks = (j - kernel_size_ / 2); 
-      temp = float (double (iks * iks  + jks * jks) / sigma_sqr);
-      kernel (j, i).intensity = (1.0f - temp) * std::exp (-temp);
-      sum += kernel (j, i).intensity;
+
+  for (int i = 0; i < kernel_size_; i++) {
+    for (int j = 0; j < kernel_size_; j++) {
+      int iks = (i - kernel_size_ / 2);
+      int jks = (j - kernel_size_ / 2);
+      temp = float(double(iks * iks + jks * jks) / sigma_sqr);
+      kernel(j, i).intensity = (1.0f - temp) * std::exp(-temp);
+      sum += kernel(j, i).intensity;
     }
   }
 
   // Normalizing the kernel
-  for (size_t i = 0; i < kernel.size (); ++i)
+  for (size_t i = 0; i < kernel.size(); ++i)
     kernel[i].intensity /= sum;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::sobelKernelX (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::sobelKernelX(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (9);
+  kernel.resize(9);
   kernel.height = 3;
   kernel.width = 3;
-  kernel (0, 0).intensity = -1; kernel (1, 0).intensity = 0; kernel (2, 0).intensity = 1;
-  kernel (0, 1).intensity = -2; kernel (1, 1).intensity = 0; kernel (2, 1).intensity = 2;
-  kernel (0, 2).intensity = -1; kernel (1, 2).intensity = 0; kernel (2, 2).intensity = 1;
+  kernel(0, 0).intensity = -1;
+  kernel(1, 0).intensity = 0;
+  kernel(2, 0).intensity = 1;
+  kernel(0, 1).intensity = -2;
+  kernel(1, 1).intensity = 0;
+  kernel(2, 1).intensity = 2;
+  kernel(0, 2).intensity = -1;
+  kernel(1, 2).intensity = 0;
+  kernel(2, 2).intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::prewittKernelX (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::prewittKernelX(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (9);
+  kernel.resize(9);
   kernel.height = 3;
   kernel.width = 3;
-  kernel (0, 0).intensity = -1; kernel (1, 0).intensity = 0; kernel (2, 0).intensity = 1;
-  kernel (0, 1).intensity = -1; kernel (1, 1).intensity = 0; kernel (2, 1).intensity = 1;
-  kernel (0, 2).intensity = -1; kernel (1, 2).intensity = 0; kernel (2, 2).intensity = 1;
+  kernel(0, 0).intensity = -1;
+  kernel(1, 0).intensity = 0;
+  kernel(2, 0).intensity = 1;
+  kernel(0, 1).intensity = -1;
+  kernel(1, 1).intensity = 0;
+  kernel(2, 1).intensity = 1;
+  kernel(0, 2).intensity = -1;
+  kernel(1, 2).intensity = 0;
+  kernel(2, 2).intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::robertsKernelX (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::robertsKernelX(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (4);
+  kernel.resize(4);
   kernel.height = 2;
   kernel.width = 2;
-  kernel (0, 0).intensity = 1; kernel (1, 0).intensity = 0;
-  kernel (0, 1).intensity = 0; kernel (1, 1).intensity = -1;
+  kernel(0, 0).intensity = 1;
+  kernel(1, 0).intensity = 0;
+  kernel(0, 1).intensity = 0;
+  kernel(1, 1).intensity = -1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::sobelKernelY (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::sobelKernelY(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (9);
+  kernel.resize(9);
   kernel.height = 3;
   kernel.width = 3;
-  kernel (0, 0).intensity = -1; kernel (1, 0).intensity = -2; kernel (2, 0).intensity = -1;
-  kernel (0, 1).intensity = 0; kernel (1, 1).intensity = 0; kernel (2, 1).intensity = 0;
-  kernel (0, 2).intensity = 1; kernel (1, 2).intensity = 2; kernel (2, 2).intensity = 1;
+  kernel(0, 0).intensity = -1;
+  kernel(1, 0).intensity = -2;
+  kernel(2, 0).intensity = -1;
+  kernel(0, 1).intensity = 0;
+  kernel(1, 1).intensity = 0;
+  kernel(2, 1).intensity = 0;
+  kernel(0, 2).intensity = 1;
+  kernel(1, 2).intensity = 2;
+  kernel(2, 2).intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::prewittKernelY (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::prewittKernelY(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (9);
+  kernel.resize(9);
   kernel.height = 3;
   kernel.width = 3;
-  kernel (0, 0).intensity = 1; kernel (1, 0).intensity = 1; kernel (2, 0).intensity = 1;
-  kernel (0, 1).intensity = 0; kernel (1, 1).intensity = 0; kernel (2, 1).intensity = 0;
-  kernel (0, 2).intensity = -1; kernel (1, 2).intensity = -1; kernel (2, 2).intensity = -1;
+  kernel(0, 0).intensity = 1;
+  kernel(1, 0).intensity = 1;
+  kernel(2, 0).intensity = 1;
+  kernel(0, 1).intensity = 0;
+  kernel(1, 1).intensity = 0;
+  kernel(2, 1).intensity = 0;
+  kernel(0, 2).intensity = -1;
+  kernel(1, 2).intensity = -1;
+  kernel(2, 2).intensity = -1;
 }
 
-template <typename PointT> void
-pcl::kernel<PointT>::robertsKernelY (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::robertsKernelY(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (4);
+  kernel.resize(4);
   kernel.height = 2;
   kernel.width = 2;
-  kernel (0, 0).intensity = 0; kernel (1, 0).intensity = 1;
-  kernel (0, 1).intensity = -1; kernel (1, 1).intensity = 0;
+  kernel(0, 0).intensity = 0;
+  kernel(1, 0).intensity = 1;
+  kernel(0, 1).intensity = -1;
+  kernel(1, 1).intensity = 0;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::derivativeXCentralKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::derivativeXCentralKernel(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (3);
+  kernel.resize(3);
   kernel.height = 1;
   kernel.width = 3;
-  kernel (0, 0).intensity = -1; kernel (1, 0).intensity = 0; kernel (2, 0).intensity = 1;
+  kernel(0, 0).intensity = -1;
+  kernel(1, 0).intensity = 0;
+  kernel(2, 0).intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::derivativeXForwardKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::derivativeXForwardKernel(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (3);
+  kernel.resize(3);
   kernel.height = 1;
   kernel.width = 3;
-  kernel (0, 0).intensity = 0; kernel (1, 0).intensity = -1; kernel (2, 0).intensity = 1;
+  kernel(0, 0).intensity = 0;
+  kernel(1, 0).intensity = -1;
+  kernel(2, 0).intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::derivativeXBackwardKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::derivativeXBackwardKernel(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (3);
+  kernel.resize(3);
   kernel.height = 1;
   kernel.width = 3;
-  kernel (0, 0).intensity = -1; kernel (1, 0).intensity = 1; kernel (2, 0).intensity = 0;
+  kernel(0, 0).intensity = -1;
+  kernel(1, 0).intensity = 1;
+  kernel(2, 0).intensity = 0;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::derivativeYCentralKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::derivativeYCentralKernel(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (3);
+  kernel.resize(3);
   kernel.height = 3;
   kernel.width = 1;
-  kernel (0, 0).intensity = -1; kernel (0, 1).intensity = 0; kernel (0, 2).intensity = 1;
+  kernel(0, 0).intensity = -1;
+  kernel(0, 1).intensity = 0;
+  kernel(0, 2).intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::derivativeYForwardKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::derivativeYForwardKernel(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (3);
+  kernel.resize(3);
   kernel.height = 3;
   kernel.width = 1;
-  kernel (0, 0).intensity = 0; kernel (0, 1).intensity = -1; kernel (0, 2).intensity = 1;
+  kernel(0, 0).intensity = 0;
+  kernel(0, 1).intensity = -1;
+  kernel(0, 2).intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::derivativeYBackwardKernel (pcl::PointCloud<PointT> &kernel)
+template <typename PointT>
+void
+pcl::kernel<PointT>::derivativeYBackwardKernel(pcl::PointCloud<PointT>& kernel)
 {
-  kernel.resize (3);
+  kernel.resize(3);
   kernel.height = 3;
   kernel.width = 1;
-  kernel (0, 0).intensity = -1; kernel (0, 1).intensity = 1; kernel (0, 2).intensity = 0;
+  kernel(0, 0).intensity = -1;
+  kernel(0, 1).intensity = 1;
+  kernel(0, 2).intensity = 0;
 }
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::setKernelType (KERNEL_ENUM kernel_type)
+template <typename PointT>
+void
+pcl::kernel<PointT>::setKernelType(KERNEL_ENUM kernel_type)
 {
   kernel_type_ = kernel_type;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::setKernelSize (int kernel_size)
+template <typename PointT>
+void
+pcl::kernel<PointT>::setKernelSize(int kernel_size)
 {
   kernel_size_ = kernel_size;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::kernel<PointT>::setKernelSigma (float kernel_sigma)
+template <typename PointT>
+void
+pcl::kernel<PointT>::setKernelSigma(float kernel_sigma)
 {
   sigma_ = kernel_sigma;
 }
-
 
 #endif

--- a/2d/include/pcl/2d/impl/kernel.hpp
+++ b/2d/include/pcl/2d/impl/kernel.hpp
@@ -44,62 +44,48 @@ void
 pcl::kernel<PointT>::fetchKernel(pcl::PointCloud<PointT>& kernel)
 {
   switch (kernel_type_) {
-  case SOBEL_X: {
+  case SOBEL_X:
     sobelKernelX(kernel);
     break;
-  }
-  case SOBEL_Y: {
+  case SOBEL_Y:
     sobelKernelY(kernel);
     break;
-  }
-  case PREWITT_X: {
+  case PREWITT_X:
     prewittKernelX(kernel);
     break;
-  }
-  case PREWITT_Y: {
+  case PREWITT_Y:
     prewittKernelY(kernel);
     break;
-  }
-  case ROBERTS_X: {
+  case ROBERTS_X:
     robertsKernelX(kernel);
     break;
-  }
-  case ROBERTS_Y: {
+  case ROBERTS_Y:
     robertsKernelY(kernel);
     break;
-  }
-  case LOG: {
+  case LOG:
     loGKernel(kernel);
     break;
-  }
-  case DERIVATIVE_CENTRAL_X: {
+  case DERIVATIVE_CENTRAL_X:
     derivativeXCentralKernel(kernel);
     break;
-  }
-  case DERIVATIVE_FORWARD_X: {
+  case DERIVATIVE_FORWARD_X:
     derivativeXForwardKernel(kernel);
     break;
-  }
-  case DERIVATIVE_BACKWARD_X: {
+  case DERIVATIVE_BACKWARD_X:
     derivativeXBackwardKernel(kernel);
     break;
-  }
-  case DERIVATIVE_CENTRAL_Y: {
+  case DERIVATIVE_CENTRAL_Y:
     derivativeYCentralKernel(kernel);
     break;
-  }
-  case DERIVATIVE_FORWARD_Y: {
+  case DERIVATIVE_FORWARD_Y:
     derivativeYForwardKernel(kernel);
     break;
-  }
-  case DERIVATIVE_BACKWARD_Y: {
+  case DERIVATIVE_BACKWARD_Y:
     derivativeYBackwardKernel(kernel);
     break;
-  }
-  case GAUSSIAN: {
+  case GAUSSIAN:
     gaussianKernel(kernel);
     break;
-  }
   }
 }
 

--- a/2d/include/pcl/2d/impl/keypoint.hpp
+++ b/2d/include/pcl/2d/impl/keypoint.hpp
@@ -42,53 +42,57 @@
 #ifndef PCL_2D_KEYPOINT_HPP_
 #define PCL_2D_KEYPOINT_HPP_
 
-#include <pcl/2d/edge.h>
-#include <pcl/2d/convolution.h>
 #include <limits>
+#include <pcl/2d/convolution.h>
+#include <pcl/2d/edge.h>
 
 //////////////////////////////////////////////////////////////////////////////
 void
-pcl::keypoint::harrisCorner (ImageType &output, ImageType &input, const float sigma_d, const float sigma_i, const float alpha, const float thresh){
+pcl::keypoint::harrisCorner(ImageType& output,
+                            ImageType& input,
+                            const float sigma_d,
+                            const float sigma_i,
+                            const float alpha,
+                            const float thresh)
+{
 
   /*creating the gaussian kernels*/
   ImageType kernel_d;
   ImageType kernel_i;
-  conv_2d.gaussianKernel  (5, sigma_d, kernel_d);
-  conv_2d.gaussianKernel  (5, sigma_i, kernel_i);
+  conv_2d.gaussianKernel(5, sigma_d, kernel_d);
+  conv_2d.gaussianKernel(5, sigma_i, kernel_i);
 
   /*scaling the image with differentiation scale*/
   ImageType smoothed_image;
-  conv_2d.convolve  (smoothed_image, kernel_d, input);
+  conv_2d.convolve(smoothed_image, kernel_d, input);
 
   /*image derivatives*/
   ImageType I_x, I_y;
-  edge_detection.ComputeDerivativeXCentral  (I_x, smoothed_image);
-  edge_detection.ComputeDerivativeYCentral  (I_y, smoothed_image);
+  edge_detection.ComputeDerivativeXCentral(I_x, smoothed_image);
+  edge_detection.ComputeDerivativeYCentral(I_y, smoothed_image);
 
   /*second moment matrix*/
   ImageType I_x2, I_y2, I_xI_y;
-  imageElementMultiply  (I_x2, I_x, I_x);
-  imageElementMultiply  (I_y2, I_y, I_y);
-  imageElementMultiply  (I_xI_y, I_x, I_y);
+  imageElementMultiply(I_x2, I_x, I_x);
+  imageElementMultiply(I_y2, I_y, I_y);
+  imageElementMultiply(I_xI_y, I_x, I_y);
 
   /*scaling second moment matrix with integration scale*/
   ImageType M00, M10, M11;
-  conv_2d.convolve  (M00, kernel_i, I_x2);
-  conv_2d.convolve  (M10, kernel_i, I_xI_y);
-  conv_2d.convolve  (M11, kernel_i, I_y2);
+  conv_2d.convolve(M00, kernel_i, I_x2);
+  conv_2d.convolve(M10, kernel_i, I_xI_y);
+  conv_2d.convolve(M11, kernel_i, I_y2);
 
   /*harris function*/
-  const size_t height = input.size ();
-  const size_t width = input[0].size ();
-  output.resize (height);
-  for (size_t i = 0; i < height; i++)
-  {
-    output[i].resize (width);
-    for (size_t j = 0; j < width; j++)
-    {
-      output[i][j] = M00[i][j] * M11[i][j] - (M10[i][j] * M10[i][j]) - alpha * ((M00[i][j] + M11[i][j]) * (M00[i][j] + M11[i][j]));
-      if (thresh != 0)
-      {
+  const size_t height = input.size();
+  const size_t width = input[0].size();
+  output.resize(height);
+  for (size_t i = 0; i < height; i++) {
+    output[i].resize(width);
+    for (size_t j = 0; j < width; j++) {
+      output[i][j] = M00[i][j] * M11[i][j] - (M10[i][j] * M10[i][j]) -
+                     alpha * ((M00[i][j] + M11[i][j]) * (M00[i][j] + M11[i][j]));
+      if (thresh != 0) {
         if (output[i][j] < thresh)
           output[i][j] = 0;
         else
@@ -98,13 +102,12 @@ pcl::keypoint::harrisCorner (ImageType &output, ImageType &input, const float si
   }
 
   /*local maxima*/
-  for (size_t i = 1; i < height - 1; i++)
-  {
-    for (size_t j = 1; j < width - 1; j++)
-    {
-      if (output[i][j] > output[i - 1][j - 1] && output[i][j] > output[i - 1][j] && output[i][j] > output[i - 1][j + 1] &&
-          output[i][j] > output[i][j - 1] && output[i][j] > output[i][j + 1] &&
-          output[i][j] > output[i + 1][j - 1] && output[i][j] > output[i + 1][j] && output[i][j] > output[i + 1][j + 1])
+  for (size_t i = 1; i < height - 1; i++) {
+    for (size_t j = 1; j < width - 1; j++) {
+      if (output[i][j] > output[i - 1][j - 1] && output[i][j] > output[i - 1][j] &&
+          output[i][j] > output[i - 1][j + 1] && output[i][j] > output[i][j - 1] &&
+          output[i][j] > output[i][j + 1] && output[i][j] > output[i + 1][j - 1] &&
+          output[i][j] > output[i + 1][j] && output[i][j] > output[i + 1][j + 1])
         ;
       else
         output[i][j] = 0;
@@ -114,56 +117,57 @@ pcl::keypoint::harrisCorner (ImageType &output, ImageType &input, const float si
 
 //////////////////////////////////////////////////////////////////////////////
 void
-pcl::keypoint::hessianBlob (ImageType &output, ImageType &input, const float sigma, bool SCALED){
+pcl::keypoint::hessianBlob(ImageType& output,
+                           ImageType& input,
+                           const float sigma,
+                           bool SCALED)
+{
   /*creating the gaussian kernels*/
   ImageType kernel, cornerness;
-  conv_2d.gaussianKernel  (5, sigma, kernel);
+  conv_2d.gaussianKernel(5, sigma, kernel);
 
   /*scaling the image with differentiation scale*/
   ImageType smoothed_image;
-  conv_2d.convolve  (smoothed_image, kernel, input);
+  conv_2d.convolve(smoothed_image, kernel, input);
 
   /*image derivatives*/
   ImageType I_x, I_y;
-  edge_detection.ComputeDerivativeXCentral  (I_x, smoothed_image);
-  edge_detection.ComputeDerivativeYCentral  (I_y, smoothed_image);
+  edge_detection.ComputeDerivativeXCentral(I_x, smoothed_image);
+  edge_detection.ComputeDerivativeYCentral(I_y, smoothed_image);
 
   /*second moment matrix*/
   ImageType I_xx, I_yy, I_xy;
-  edge_detection.ComputeDerivativeXCentral  (I_xx, I_x);
-  edge_detection.ComputeDerivativeYCentral  (I_xy, I_x);
-  edge_detection.ComputeDerivativeYCentral  (I_yy, I_y);
+  edge_detection.ComputeDerivativeXCentral(I_xx, I_x);
+  edge_detection.ComputeDerivativeYCentral(I_xy, I_x);
+  edge_detection.ComputeDerivativeYCentral(I_yy, I_y);
   /*Determinant of Hessian*/
-  const size_t height = input.size ();
-  const size_t width = input[0].size ();
+  const size_t height = input.size();
+  const size_t width = input[0].size();
   float min = std::numeric_limits<float>::max();
   float max = std::numeric_limits<float>::min();
-  cornerness.resize (height);
-  for (size_t i = 0; i < height; i++)
-  {
-    cornerness[i].resize (width);
-    for (size_t j = 0; j < width; j++)
-    {
-      cornerness[i][j] = sigma*sigma*(I_xx[i][j]+I_yy[i][j]-I_xy[i][j]*I_xy[i][j]);
-      if(SCALED){
-        if(cornerness[i][j]  < min)
+  cornerness.resize(height);
+  for (size_t i = 0; i < height; i++) {
+    cornerness[i].resize(width);
+    for (size_t j = 0; j < width; j++) {
+      cornerness[i][j] =
+          sigma * sigma * (I_xx[i][j] + I_yy[i][j] - I_xy[i][j] * I_xy[i][j]);
+      if (SCALED) {
+        if (cornerness[i][j] < min)
           min = cornerness[i][j];
-        if(cornerness[i][j] > max)
+        if (cornerness[i][j] > max)
           max = cornerness[i][j];
       }
     }
 
     /*local maxima*/
-    output.resize (height);
-    output[0].resize (width);
-    output[height-1].resize (width);
-    for (size_t i = 1; i < height - 1; i++)
-    {
-      output[i].resize (width);
-      for (size_t j = 1; j < width - 1; j++)
-      {
-        if(SCALED)
-          output[i][j] = ((cornerness[i][j]-min)/(max-min));
+    output.resize(height);
+    output[0].resize(width);
+    output[height - 1].resize(width);
+    for (size_t i = 1; i < height - 1; i++) {
+      output[i].resize(width);
+      for (size_t j = 1; j < width - 1; j++) {
+        if (SCALED)
+          output[i][j] = ((cornerness[i][j] - min) / (max - min));
         else
           output[i][j] = cornerness[i][j];
       }
@@ -173,54 +177,61 @@ pcl::keypoint::hessianBlob (ImageType &output, ImageType &input, const float sig
 
 //////////////////////////////////////////////////////////////////////////////
 void
-pcl::keypoint::hessianBlob (ImageType &output, ImageType &input, const float start_scale, const float scaling_factor, const int num_scales){
+pcl::keypoint::hessianBlob(ImageType& output,
+                           ImageType& input,
+                           const float start_scale,
+                           const float scaling_factor,
+                           const int num_scales)
+{
   const size_t height = input.size();
   const size_t width = input[0].size();
   const int local_search_radius = 1;
   float scale = start_scale;
   std::vector<ImageType> cornerness;
   cornerness.resize(num_scales);
-  for(int i = 0;i < num_scales;i++){
+  for (int i = 0; i < num_scales; i++) {
     hessianBlob(cornerness[i], input, scale, false);
     scale *= scaling_factor;
   }
   bool non_max_flag = false;
   float scale_max, local_max;
-  for(size_t i = 0;i < height;i++){
-    for(size_t j = 0;j < width;j++){
+  for (size_t i = 0; i < height; i++) {
+    for (size_t j = 0; j < width; j++) {
       scale_max = std::numeric_limits<float>::min();
       /*default output in case of no blob at the current point is 0*/
       output[i][j] = 0;
-      for(int k = 0;k < num_scales;k++){
+      for (int k = 0; k < num_scales; k++) {
         /*check if the current point (k,i,j) is a maximum in the defined search radius*/
         non_max_flag = false;
         local_max = cornerness[k][i][j];
-        for(int n = -local_search_radius; n <= local_search_radius;n++){
-          if(n+k < 0 || n+k >= num_scales)
+        for (int n = -local_search_radius; n <= local_search_radius; n++) {
+          if (n + k < 0 || n + k >= num_scales)
             continue;
-          for(int l = -local_search_radius;l <= local_search_radius;l++){
-            if(l+i < 0 || l+i >= height)
+          for (int l = -local_search_radius; l <= local_search_radius; l++) {
+            if (l + i < 0 || l + i >= height)
               continue;
-            for(int m = -local_search_radius; m <= local_search_radius;m++){
-              if(m+j < 0 || m+j >= width)
+            for (int m = -local_search_radius; m <= local_search_radius; m++) {
+              if (m + j < 0 || m + j >= width)
                 continue;
-              if(cornerness[n+k][l+i][m+j] > local_max){
+              if (cornerness[n + k][l + i][m + j] > local_max) {
                 non_max_flag = true;
                 break;
               }
             }
-            if(non_max_flag)
+            if (non_max_flag)
               break;
           }
-          if(non_max_flag)
+          if (non_max_flag)
             break;
         }
-        /*if the current point is a point of local maximum, check if it is a maximum point across scales*/
-        if(!non_max_flag){
-          if(cornerness[k][i][j] > scale_max){
+        /*if the current point is a point of local maximum, check if it is a maximum
+         * point across scales*/
+        if (!non_max_flag) {
+          if (cornerness[k][i][j] > scale_max) {
             scale_max = cornerness[k][i][j];
-            /*output indicates the scale at which the blob is found at the current location in the image*/
-            output[i][i] = start_scale*pow(scaling_factor, k);
+            /*output indicates the scale at which the blob is found at the current
+             * location in the image*/
+            output[i][i] = start_scale * pow(scaling_factor, k);
           }
         }
       }
@@ -230,18 +241,19 @@ pcl::keypoint::hessianBlob (ImageType &output, ImageType &input, const float sta
 
 //////////////////////////////////////////////////////////////////////////////
 void
-pcl::keypoint::imageElementMultiply (ImageType &output, ImageType &input1, ImageType &input2){
-  const size_t height = input1.size ();
-  const size_t width = input1[0].size ();
-  output.resize (height);
-  for (size_t i = 0; i < height; i++)
-  {
-    output[i].resize (width);
-    for (size_t j = 0; j < width; j++)
-    {
+pcl::keypoint::imageElementMultiply(ImageType& output,
+                                    ImageType& input1,
+                                    ImageType& input2)
+{
+  const size_t height = input1.size();
+  const size_t width = input1[0].size();
+  output.resize(height);
+  for (size_t i = 0; i < height; i++) {
+    output[i].resize(width);
+    for (size_t j = 0; j < width; j++) {
       output[i][j] = input1[i][j] * input2[i][j];
     }
   }
 }
 
-#endif  // PCL_2D_KEYPOINT_HPP_
+#endif // PCL_2D_KEYPOINT_HPP_

--- a/2d/include/pcl/2d/impl/morphology.hpp
+++ b/2d/include/pcl/2d/impl/morphology.hpp
@@ -40,8 +40,9 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Assumes input, kernel and output images have 0's and 1's only
-template<typename PointT> void
-pcl::Morphology<PointT>::erosionBinary (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::erosionBinary(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
@@ -51,52 +52,49 @@ pcl::Morphology<PointT>::erosionBinary (pcl::PointCloud<PointT> &output)
 
   output.width = width;
   output.height = height;
-  output.resize (width * height);
+  output.resize(width * height);
 
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
       // Operation done only at 1's
-      if ((*input_)(j, i).intensity == 0)
-      {
-        output (j, i).intensity = 0;
+      if ((*input_)(j, i).intensity == 0) {
+        output(j, i).intensity = 0;
         continue;
       }
       mismatch_flag = false;
-      for (int k = 0; k < kernel_height; k++)
-      {
+      for (int k = 0; k < kernel_height; k++) {
         if (mismatch_flag)
           break;
-        for (int l = 0; l < kernel_width; l++)
-        {
+        for (int l = 0; l < kernel_width; l++) {
           // We only check for 1's in the kernel
           if ((*structuring_element_)(l, k).intensity == 0)
             continue;
-          if ((i + k - kernel_height / 2) < 0 || (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 || (j + l - kernel_width / 2) >= width)
-          {
+          if ((i + k - kernel_height / 2) < 0 ||
+              (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 ||
+              (j + l - kernel_width / 2) >= width) {
             continue;
           }
-          // If one of the elements of the kernel and image don't match, 
+          // If one of the elements of the kernel and image don't match,
           // the output image is 0. So, move to the next point.
-          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity != 1)
-          {
-            output (j, i).intensity = 0;
+          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2)
+                  .intensity != 1) {
+            output(j, i).intensity = 0;
             mismatch_flag = true;
             break;
           }
         }
       }
       // Assign value according to mismatch flag
-      output (j, i).intensity = (mismatch_flag) ? 0 : 1;
+      output(j, i).intensity = (mismatch_flag) ? 0 : 1;
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
 // Assumes input, kernel and output images have 0's and 1's only
-template <typename PointT> void
-pcl::Morphology<PointT>::dilationBinary (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::dilationBinary(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
@@ -106,109 +104,109 @@ pcl::Morphology<PointT>::dilationBinary (pcl::PointCloud<PointT> &output)
 
   output.width = width;
   output.height = height;
-  output.resize (width * height);
+  output.resize(width * height);
 
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
       match_flag = false;
-      for (int k = 0; k < kernel_height; k++)
-      {
+      for (int k = 0; k < kernel_height; k++) {
         if (match_flag)
           break;
-        for (int l = 0; l < kernel_width; l++)
-        {
+        for (int l = 0; l < kernel_width; l++) {
           // We only check for 1's in the kernel
           if ((*structuring_element_)(l, k).intensity == 0)
             continue;
-          if ((i + k - kernel_height / 2) < 0 || (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 || (j + l - kernel_width / 2) >= height)
-          {
+          if ((i + k - kernel_height / 2) < 0 ||
+              (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 ||
+              (j + l - kernel_width / 2) >= height) {
             continue;
           }
-          // If any position where kernel is 1 and image is also one is detected, 
+          // If any position where kernel is 1 and image is also one is detected,
           // matching occurs
-          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity == 1)
-          {
+          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2)
+                  .intensity == 1) {
             match_flag = true;
             break;
           }
         }
       }
       // Assign value according to match flag
-      output (j, i).intensity = (match_flag) ? 1 : 0;
+      output(j, i).intensity = (match_flag) ? 1 : 0;
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
 // Assumes input, kernel and output images have 0's and 1's only
-template <typename PointT> void
-pcl::Morphology<PointT>::openingBinary (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::openingBinary(pcl::PointCloud<PointT>& output)
 {
-  PointCloudInPtr intermediate_output (new PointCloudIn);
-  erosionBinary (*intermediate_output);
-  this->setInputCloud (intermediate_output);
-  dilationBinary (output);
+  PointCloudInPtr intermediate_output(new PointCloudIn);
+  erosionBinary(*intermediate_output);
+  this->setInputCloud(intermediate_output);
+  dilationBinary(output);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 // Assumes input, kernel and output images have 0's and 1's only
-template <typename PointT> void
-pcl::Morphology<PointT>::closingBinary (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::closingBinary(pcl::PointCloud<PointT>& output)
 {
-  PointCloudInPtr intermediate_output (new PointCloudIn);
-  dilationBinary (*intermediate_output);
-  this->setInputCloud (intermediate_output);
-  erosionBinary (output);
+  PointCloudInPtr intermediate_output(new PointCloudIn);
+  dilationBinary(*intermediate_output);
+  this->setInputCloud(intermediate_output);
+  erosionBinary(output);
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::erosionGray (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::erosionGray(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
   const int kernel_height = structuring_element_->height;
   const int kernel_width = structuring_element_->width;
   float min;
-  output.resize (width * height);
+  output.resize(width * height);
   output.width = width;
   output.height = height;
 
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
       min = -1;
-      for (int k = 0; k < kernel_height; k++)
-      {
-        for (int l = 0; l < kernel_width; l++)
-        {
+      for (int k = 0; k < kernel_height; k++) {
+        for (int l = 0; l < kernel_width; l++) {
           // We only check for 1's in the kernel
           if ((*structuring_element_)(l, k).intensity == 0)
             continue;
-          if ((i + k - kernel_height / 2) < 0 || (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 || (j + l - kernel_width / 2) >= width)
-          {
+          if ((i + k - kernel_height / 2) < 0 ||
+              (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 ||
+              (j + l - kernel_width / 2) >= width) {
             continue;
           }
-          // If one of the elements of the kernel and image don't match, 
+          // If one of the elements of the kernel and image don't match,
           // the output image is 0. So, move to the next point.
-          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity < min || min == -1)
-          {
-            min = (*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity;
+          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity <
+                  min ||
+              min == -1) {
+            min = (*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2)
+                      .intensity;
           }
         }
       }
       // Assign value according to mismatch flag
-      output (j, i).intensity = min;
+      output(j, i).intensity = min;
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::dilationGray (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::dilationGray(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
@@ -216,75 +214,75 @@ pcl::Morphology<PointT>::dilationGray (pcl::PointCloud<PointT> &output)
   const int kernel_width = structuring_element_->width;
   float max;
 
-  output.resize (width * height);
+  output.resize(width * height);
   output.width = width;
   output.height = height;
 
-  for (int i = 0; i < height; i++)
-  {
-    for (int j = 0; j < width; j++)
-    {
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
       max = -1;
-      for (int k = 0; k < kernel_height; k++)
-      {
-        for (int l = 0; l < kernel_width; l++)
-        {
+      for (int k = 0; k < kernel_height; k++) {
+        for (int l = 0; l < kernel_width; l++) {
           // We only check for 1's in the kernel
           if ((*structuring_element_)(l, k).intensity == 0)
             continue;
-          if ((i + k - kernel_height / 2) < 0 || (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 || (j + l - kernel_width / 2) >= width)
-          {
+          if ((i + k - kernel_height / 2) < 0 ||
+              (i + k - kernel_height / 2) >= height || (j + l - kernel_width / 2) < 0 ||
+              (j + l - kernel_width / 2) >= width) {
             continue;
           }
-          // If one of the elements of the kernel and image don't match, 
+          // If one of the elements of the kernel and image don't match,
           // the output image is 0. So, move to the next point.
-          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity > max || max == -1)
-          {
-            max = (*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity;
+          if ((*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2).intensity >
+                  max ||
+              max == -1) {
+            max = (*input_)(j + l - kernel_width / 2, i + k - kernel_height / 2)
+                      .intensity;
           }
         }
       }
       // Assign value according to mismatch flag
-      output (j, i).intensity = max;
+      output(j, i).intensity = max;
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::openingGray (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::openingGray(pcl::PointCloud<PointT>& output)
 {
-  PointCloudInPtr intermediate_output (new PointCloudIn);
-  erosionGray (*intermediate_output);
-  this->setInputCloud (intermediate_output);
-  dilationGray (output);
+  PointCloudInPtr intermediate_output(new PointCloudIn);
+  erosionGray(*intermediate_output);
+  this->setInputCloud(intermediate_output);
+  dilationGray(output);
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::closingGray (pcl::PointCloud<PointT> &output)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::closingGray(pcl::PointCloud<PointT>& output)
 {
-  PointCloudInPtr intermediate_output (new PointCloudIn);
-  dilationGray (*intermediate_output);
-  this->setInputCloud (intermediate_output);
-  erosionGray (output);
+  PointCloudInPtr intermediate_output(new PointCloudIn);
+  dilationGray(*intermediate_output);
+  this->setInputCloud(intermediate_output);
+  erosionGray(output);
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::subtractionBinary (
-    pcl::PointCloud<PointT> &output, 
-    const pcl::PointCloud<PointT> &input1, 
-    const pcl::PointCloud<PointT> &input2)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::subtractionBinary(pcl::PointCloud<PointT>& output,
+                                           const pcl::PointCloud<PointT>& input1,
+                                           const pcl::PointCloud<PointT>& input2)
 {
   const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
   output.width = width;
   output.height = height;
-  output.resize (height * width);
+  output.resize(height * width);
 
-  for (size_t i = 0; i < output.size (); ++i)
-  {
+  for (size_t i = 0; i < output.size(); ++i) {
     if (input1[i].intensity == 1 && input2[i].intensity == 0)
       output[i].intensity = 1;
     else
@@ -293,20 +291,19 @@ pcl::Morphology<PointT>::subtractionBinary (
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::unionBinary (
-    pcl::PointCloud<PointT> &output, 
-    const pcl::PointCloud<PointT> &input1, 
-    const pcl::PointCloud<PointT> &input2)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::unionBinary(pcl::PointCloud<PointT>& output,
+                                     const pcl::PointCloud<PointT>& input1,
+                                     const pcl::PointCloud<PointT>& input2)
 {
   const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
   output.width = width;
   output.height = height;
-  output.resize (height * width);
+  output.resize(height * width);
 
-  for (size_t i = 0; i < output.size (); ++i)
-  {
+  for (size_t i = 0; i < output.size(); ++i) {
     if (input1[i].intensity == 1 || input2[i].intensity == 1)
       output[i].intensity = 1;
     else
@@ -315,20 +312,19 @@ pcl::Morphology<PointT>::unionBinary (
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::intersectionBinary (
-    pcl::PointCloud<PointT> &output, 
-    const pcl::PointCloud<PointT> &input1, 
-    const pcl::PointCloud<PointT> &input2)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::intersectionBinary(pcl::PointCloud<PointT>& output,
+                                            const pcl::PointCloud<PointT>& input1,
+                                            const pcl::PointCloud<PointT>& input2)
 {
   const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
   output.width = width;
   output.height = height;
-  output.resize (height * width);
+  output.resize(height * width);
 
-  for (size_t i = 0; i < output.size (); ++i)
-  {
+  for (size_t i = 0; i < output.size(); ++i) {
     if (input1[i].intensity == 1 && input2[i].intensity == 1)
       output[i].intensity = 1;
     else
@@ -337,44 +333,47 @@ pcl::Morphology<PointT>::intersectionBinary (
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::structuringElementCircular (
-    pcl::PointCloud<PointT> &kernel, const int radius)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::structuringElementCircular(pcl::PointCloud<PointT>& kernel,
+                                                    const int radius)
 {
   const int dim = 2 * radius;
   kernel.height = dim;
   kernel.width = dim;
-  kernel.resize (dim * dim);
+  kernel.resize(dim * dim);
 
-  for (int i = 0; i < dim; i++)
-  {
-    for (int j = 0; j < dim; j++)
-    {
+  for (int i = 0; i < dim; i++) {
+    for (int j = 0; j < dim; j++) {
       if (((i - radius) * (i - radius) + (j - radius) * (j - radius)) < radius * radius)
-        kernel (j, i).intensity = 1;
+        kernel(j, i).intensity = 1;
       else
-        kernel (j, i).intensity = 0;
+        kernel(j, i).intensity = 0;
     }
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::structuringElementRectangle (
-    pcl::PointCloud<PointT> &kernel, const int height, const int width)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::structuringElementRectangle(pcl::PointCloud<PointT>& kernel,
+                                                     const int height,
+                                                     const int width)
 {
   kernel.height = height;
   kernel.width = width;
-  kernel.resize (height * width);
-  for (size_t i = 0; i < kernel.size (); ++i)
+  kernel.resize(height * width);
+  for (size_t i = 0; i < kernel.size(); ++i)
     kernel[i].intensity = 1;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Morphology<PointT>::setStructuringElement (const PointCloudInPtr &structuring_element)
+template <typename PointT>
+void
+pcl::Morphology<PointT>::setStructuringElement(
+    const PointCloudInPtr& structuring_element)
 {
   structuring_element_ = structuring_element;
 }
 
-#endif    // PCL_2D_MORPHOLOGY_HPP_
+#endif // PCL_2D_MORPHOLOGY_HPP_

--- a/2d/include/pcl/2d/kernel.h
+++ b/2d/include/pcl/2d/kernel.h
@@ -40,204 +40,200 @@
 #include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 
-namespace pcl
-{
-  template<typename PointT>
-  class kernel
-  {
-    public:
+namespace pcl {
 
-      /**
-       * enumerates the different types of kernels available.
-       */
-      enum KERNEL_ENUM
-      {
-        SOBEL_X,              //!< SOBEL_X
-        SOBEL_Y,              //!< SOBEL_Y
-        PREWITT_X,            //!< PREWITT_X
-        PREWITT_Y,            //!< PREWITT_Y
-        ROBERTS_X,            //!< ROBERTS_X
-        ROBERTS_Y,            //!< ROBERTS_Y
-        LOG,                  //!< LOG
-        DERIVATIVE_CENTRAL_X, //!< DERIVATIVE_CENTRAL_X
-        DERIVATIVE_FORWARD_X, //!< DERIVATIVE_FORWARD_X
-        DERIVATIVE_BACKWARD_X,//!< DERIVATIVE_BACKWARD_X
-        DERIVATIVE_CENTRAL_Y, //!< DERIVATIVE_CENTRAL_Y
-        DERIVATIVE_FORWARD_Y, //!< DERIVATIVE_FORWARD_Y
-        DERIVATIVE_BACKWARD_Y,//!< DERIVATIVE_BACKWARD_Y
-        GAUSSIAN              //!< GAUSSIAN
-      };
-
-      int kernel_size_;
-      float sigma_;
-      KERNEL_ENUM kernel_type_;
-
-      kernel () :
-        kernel_size_ (3),
-        sigma_ (1.0),
-        kernel_type_ (GAUSSIAN)
-      {
-
-      }
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * Helper function which returns the kernel selected by the kernel_type_ enum
-       */
-      void fetchKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * Gaussian kernel with size (kernel_size_ x kernel_size_) and variance sigma_
-       */
-
-      void gaussianKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * Laplacian of Gaussian kernel with size (kernel_size_ x kernel_size_) and variance sigma_
-       */
-
-      void loGKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * 3x3 Sobel kernel in the X direction
-       */
-
-      void sobelKernelX (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * 3x3 Prewitt kernel in the X direction
-       */
-
-      void prewittKernelX (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * 2x2 Roberts kernel in the X direction
-       */
-
-      void robertsKernelX (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * 3x3 Sobel kernel in the Y direction
-       */
-
-      void sobelKernelY (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * 3x3 Prewitt kernel in the Y direction
-       */
-
-      void prewittKernelY (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * 2x2 Roberts kernel in the Y direction
-       */
-
-      void robertsKernelY (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * kernel [-1 0 1]
-       */
-
-      void derivativeXCentralKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * kernel [-1 0 1]'
-       */
-
-      void derivativeYCentralKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * kernel [0 -1 1]
-       */
-
-      void derivativeXForwardKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * kernel [0 -1 1]'
-       */
-
-      void derivativeYForwardKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * kernel [-1 1 0]
-       */
-
-      void derivativeXBackwardKernel (pcl::PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel Kernel point cloud passed by reference
-       *
-       * kernel [-1 1 0]'
-       */
-
-      void derivativeYBackwardKernel (PointCloud<PointT> &kernel);
-
-      /**
-       *
-       * @param kernel_type enum indicating the kernel type wanted
-       *
-       * select the kernel type.
-       */
-      void setKernelType (KERNEL_ENUM kernel_type);
-
-      /**
-       *
-       * @param kernel_size kernel of size kernel_size x kernel_size is created(LoG and Gaussian only)
-       *
-       * Setter function for kernel_size_
-       */
-      void setKernelSize (int kernel_size);
-
-      /**
-       *
-       * @param kernel_sigma variance of the Gaussian or LoG kernels.
-       *
-       * Setter function for kernel_sigma_
-       */
-      void setKernelSigma (float kernel_sigma);
+template <typename PointT>
+class kernel {
+public:
+  /// Different types of kernels available.
+  enum KERNEL_ENUM {
+    SOBEL_X,               //!< SOBEL_X
+    SOBEL_Y,               //!< SOBEL_Y
+    PREWITT_X,             //!< PREWITT_X
+    PREWITT_Y,             //!< PREWITT_Y
+    ROBERTS_X,             //!< ROBERTS_X
+    ROBERTS_Y,             //!< ROBERTS_Y
+    LOG,                   //!< LOG
+    DERIVATIVE_CENTRAL_X,  //!< DERIVATIVE_CENTRAL_X
+    DERIVATIVE_FORWARD_X,  //!< DERIVATIVE_FORWARD_X
+    DERIVATIVE_BACKWARD_X, //!< DERIVATIVE_BACKWARD_X
+    DERIVATIVE_CENTRAL_Y,  //!< DERIVATIVE_CENTRAL_Y
+    DERIVATIVE_FORWARD_Y,  //!< DERIVATIVE_FORWARD_Y
+    DERIVATIVE_BACKWARD_Y, //!< DERIVATIVE_BACKWARD_Y
+    GAUSSIAN               //!< GAUSSIAN
   };
-}
+
+  int kernel_size_;
+  float sigma_;
+  KERNEL_ENUM kernel_type_;
+
+  kernel() : kernel_size_(3), sigma_(1.0), kernel_type_(GAUSSIAN) {}
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * Helper function which returns the kernel selected by the kernel_type_ enum
+   */
+  void
+  fetchKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * Gaussian kernel with size (kernel_size_ x kernel_size_) and variance sigma_
+   */
+  void
+  gaussianKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * Laplacian of Gaussian kernel with size (kernel_size_ x kernel_size_) and variance
+   * sigma_
+   */
+  void
+  loGKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * 3x3 Sobel kernel in the X direction
+   */
+  void
+  sobelKernelX(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * 3x3 Prewitt kernel in the X direction
+   */
+  void
+  prewittKernelX(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * 2x2 Roberts kernel in the X direction
+   */
+  void
+  robertsKernelX(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * 3x3 Sobel kernel in the Y direction
+   */
+  void
+  sobelKernelY(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * 3x3 Prewitt kernel in the Y direction
+   */
+  void
+  prewittKernelY(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * 2x2 Roberts kernel in the Y direction
+   */
+  void
+  robertsKernelY(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * kernel [-1 0 1]
+   */
+  void
+  derivativeXCentralKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * kernel [-1 0 1]'
+   */
+  void
+  derivativeYCentralKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * kernel [0 -1 1]
+   */
+  void
+  derivativeXForwardKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * kernel [0 -1 1]'
+   */
+  void
+  derivativeYForwardKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * kernel [-1 1 0]
+   */
+  void
+  derivativeXBackwardKernel(pcl::PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel Kernel point cloud passed by reference
+   *
+   * kernel [-1 1 0]'
+   */
+  void
+  derivativeYBackwardKernel(PointCloud<PointT>& kernel);
+
+  /**
+   *
+   * @param kernel_type enum indicating the kernel type wanted
+   *
+   * select the kernel type.
+   */
+  void
+  setKernelType(KERNEL_ENUM kernel_type);
+
+  /**
+   *
+   * @param kernel_size kernel of size kernel_size x kernel_size is created(LoG and
+   * Gaussian only)
+   *
+   * Setter function for kernel_size_
+   */
+  void
+  setKernelSize(int kernel_size);
+
+  /**
+   *
+   * @param kernel_sigma variance of the Gaussian or LoG kernels.
+   *
+   * Setter function for kernel_sigma_
+   */
+  void
+  setKernelSigma(float kernel_sigma);
+};
+
+} // namespace pcl
 
 #include <pcl/2d/impl/kernel.hpp>

--- a/2d/include/pcl/2d/keypoint.h
+++ b/2d/include/pcl/2d/keypoint.h
@@ -43,30 +43,38 @@
 
 #include <pcl/2d/edge.h>
 
-namespace pcl
-{
-  class Keypoint
-  {
-    private:
-      Edge edge_detection;
-      Convolution conv_2d;
-    public:
-      Keypoint  ()
-      {
-      }
-      
-      void 
-      harrisCorner  (ImageType &output, ImageType &input, const float sigma_d, const float sigma_i, const float alpha, const float thresh);
-      
-      void 
-      hessianBlob  (ImageType &output, ImageType &input, const float sigma, bool SCALE);
-      
-      void 
-      hessianBlob  (ImageType &output, ImageType &input, const float start_scale, const float scaling_factor, const int num_scales);
+namespace pcl {
 
-      void 
-      imageElementMultiply  (ImageType &output, ImageType &input1, ImageType &input2);
-  };
-}
+class Keypoint {
+private:
+  Edge edge_detection;
+  Convolution conv_2d;
+
+public:
+  Keypoint() {}
+
+  void
+  harrisCorner(ImageType& output,
+               ImageType& input,
+               const float sigma_d,
+               const float sigma_i,
+               const float alpha,
+               const float thresh);
+
+  void
+  hessianBlob(ImageType& output, ImageType& input, const float sigma, bool SCALE);
+
+  void
+  hessianBlob(ImageType& output,
+              ImageType& input,
+              const float start_scale,
+              const float scaling_factor,
+              const int num_scales);
+
+  void
+  imageElementMultiply(ImageType& output, ImageType& input1, ImageType& input2);
+};
+
+} // namespace pcl
 
 #include <pcl/2d/impl/keypoint.hpp>

--- a/2d/include/pcl/2d/morphology.h
+++ b/2d/include/pcl/2d/morphology.h
@@ -39,159 +39,168 @@
 
 #include <pcl/pcl_base.h>
 
-namespace pcl
-{
-  template <typename PointT>
-  class Morphology : public PCLBase<PointT>
-  {
-    private:
-      using PointCloudIn = pcl::PointCloud<PointT>;
-      using PointCloudInPtr = typename PointCloudIn::Ptr;
+namespace pcl {
 
-      PointCloudInPtr structuring_element_;
+template <typename PointT>
+class Morphology : public PCLBase<PointT> {
+private:
+  using PointCloudIn = pcl::PointCloud<PointT>;
+  using PointCloudInPtr = typename PointCloudIn::Ptr;
 
-    public:
-      using PCLBase<PointT>::input_;
+  PointCloudInPtr structuring_element_;
 
-      Morphology () {}
+public:
+  using PCLBase<PointT>::input_;
 
-      /** \brief This function performs erosion followed by dilation. 
-        * It is useful for removing noise in the form of small blobs and patches.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      openingBinary (pcl::PointCloud<PointT> &output);
+  Morphology() {}
 
-      /** \brief This function performs dilation followed by erosion. 
-        * It is useful for filling up (holes/cracks/small discontinuities) in a binary 
-        * segmented region
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      closingBinary (pcl::PointCloud<PointT> &output);
+  /** \brief This function performs erosion followed by dilation.
+   * It is useful for removing noise in the form of small blobs and patches.
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  openingBinary(pcl::PointCloud<PointT>& output);
 
-      /** \brief Binary dilation is similar to a logical disjunction of sets. 
-        * At each pixel having value 1, if for all pixels in the structuring element  having value 1, the corresponding
-        * pixels in the input image are also 1, the center pixel is set to 1. Otherwise, it is set to 0.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      erosionBinary (pcl::PointCloud<PointT> &output);
+  /** \brief This function performs dilation followed by erosion.
+   * It is useful for filling up (holes/cracks/small discontinuities) in a binary
+   * segmented region
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  closingBinary(pcl::PointCloud<PointT>& output);
 
-      /** \brief Binary erosion is similar to a logical addition of sets. 
-        * At each pixel having value 1, if at least one pixel in the structuring  element is 1 and the corresponding point
-        * in the input image is 1, the center pixel is set to 1. Otherwise, it is set to 0.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      dilationBinary  (pcl::PointCloud<PointT> &output);
+  /** \brief Binary dilation is similar to a logical disjunction of sets.
+   * At each pixel having value 1, if for all pixels in the structuring element  having
+   * value 1, the corresponding pixels in the input image are also 1, the center pixel
+   * is set to 1. Otherwise, it is set to 0.
+   *
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  erosionBinary(pcl::PointCloud<PointT>& output);
 
-      /** \brief Grayscale erosion followed by dilation.
-        * This is used to remove small bright artifacts from the image. Large bright objects are relatively undisturbed.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      openingGray (pcl::PointCloud<PointT> &output);
+  /** \brief Binary erosion is similar to a logical addition of sets.
+   * At each pixel having value 1, if at least one pixel in the structuring  element is
+   * 1 and the corresponding point in the input image is 1, the center pixel is set
+   * to 1. Otherwise, it is set to 0.
+   *
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  dilationBinary(pcl::PointCloud<PointT>& output);
 
-      /** \brief Grayscale dilation followed by erosion.
-        * This is used to remove small dark artifacts from the image. Bright features or large dark features are relatively undisturbed.
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      closingGray (pcl::PointCloud<PointT> &output);
+  /** \brief Grayscale erosion followed by dilation.
+   * This is used to remove small bright artifacts from the image. Large bright objects
+   * are relatively undisturbed.
+   *
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  openingGray(pcl::PointCloud<PointT>& output);
 
-      /** \brief Takes the min of the pixels where kernel is 1
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      erosionGray (pcl::PointCloud<PointT> &output);
+  /** \brief Grayscale dilation followed by erosion.
+   * This is used to remove small dark artifacts from the image. Bright features or
+   * large dark features are relatively undisturbed.
+   *
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  closingGray(pcl::PointCloud<PointT>& output);
 
-      /** \brief Takes the max of the pixels where kernel is 1
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      dilationGray (pcl::PointCloud<PointT> &output);
+  /** \brief Takes the min of the pixels where kernel is 1
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  erosionGray(pcl::PointCloud<PointT>& output);
 
-      /** \brief Set operation
-        * output = input1 - input2
-        * \param[out] output Output point cloud passed by reference
-        * \param[in] input1
-        * \param[in] input2
-        */
-      void 
-      subtractionBinary (pcl::PointCloud<PointT> &output, 
-                         const pcl::PointCloud<PointT> &input1, 
-                         const pcl::PointCloud<PointT> &input2);
+  /** \brief Takes the max of the pixels where kernel is 1
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  dilationGray(pcl::PointCloud<PointT>& output);
 
-      /** \brief Set operation
-        * \f$output = input1 \cup input2\f$
-        * \param[out] output Output point cloud passed by reference
-        * \param[in] input1
-        * \param[in] input2
-        */
-      void 
-      unionBinary (pcl::PointCloud<PointT> &output, 
-                   const pcl::PointCloud<PointT> &input1, 
-                   const pcl::PointCloud<PointT> &input2);
+  /** \brief Set operation
+   * output = input1 - input2
+   * \param[out] output Output point cloud passed by reference
+   * \param[in] input1
+   * \param[in] input2
+   */
+  void
+  subtractionBinary(pcl::PointCloud<PointT>& output,
+                    const pcl::PointCloud<PointT>& input1,
+                    const pcl::PointCloud<PointT>& input2);
 
-      /** \brief Set operation \f$ output = input1 \cap input2 \f$
-        * \param[out] output Output point cloud passed by reference
-        * \param[in] input1
-        * \param[in] input2
-       */
-      void 
-      intersectionBinary (pcl::PointCloud<PointT> &output, 
-                          const pcl::PointCloud<PointT> &input1, 
-                          const pcl::PointCloud<PointT> &input2);
+  /** \brief Set operation
+   * \f$output = input1 \cup input2\f$
+   * \param[out] output Output point cloud passed by reference
+   * \param[in] input1
+   * \param[in] input2
+   */
+  void
+  unionBinary(pcl::PointCloud<PointT>& output,
+              const pcl::PointCloud<PointT>& input1,
+              const pcl::PointCloud<PointT>& input2);
 
-      /** \brief Creates a circular structing element. The size of the kernel created is 2*radius x 2*radius.
-        * Center of the structuring element is the center of the circle.
-        * All values lying on the circle are 1 and the others are 0.
-        *
-        * \param[out] kernel structuring element kernel passed by reference
-        * \param[in] radius Radius of the circular structuring element.
-        */
-      void 
-      structuringElementCircular (pcl::PointCloud<PointT> &kernel, const int radius);
+  /** \brief Set operation \f$ output = input1 \cap input2 \f$
+   * \param[out] output Output point cloud passed by reference
+   * \param[in] input1
+   * \param[in] input2
+   */
+  void
+  intersectionBinary(pcl::PointCloud<PointT>& output,
+                     const pcl::PointCloud<PointT>& input1,
+                     const pcl::PointCloud<PointT>& input2);
 
-      /** \brief Creates a rectangular structing element of size height x width.         *
-        * All values are 1.
-        *
-        * \param[out] kernel structuring element kernel passed by reference
-        * \param[in] height height number of rows in the structuring element
-        * \param[in] width number of columns in the structuring element
-        *
-        */
-      void 
-      structuringElementRectangle (pcl::PointCloud<PointT> &kernel, 
-                                   const int height, const int width);
+  /** \brief Creates a circular structing element. The size of the kernel created is
+   * 2*radius x 2*radius. Center of the structuring element is the center of the circle.
+   * All values lying on the circle are 1 and the others are 0.
+   *
+   * \param[out] kernel structuring element kernel passed by reference
+   * \param[in] radius Radius of the circular structuring element.
+   */
+  void
+  structuringElementCircular(pcl::PointCloud<PointT>& kernel, const int radius);
 
-      enum MORPHOLOGICAL_OPERATOR_TYPE
-      {
-        EROSION_GRAY,
-        DILATION_GRAY,
-        OPENING_GRAY,
-        CLOSING_GRAY,
-        EROSION_BINARY,
-        DILATION_BINARY,
-        OPENING_BINARY,
-        CLOSING_BINARY
-      };
+  /** \brief Creates a rectangular structing element of size height x width.         *
+   * All values are 1.
+   *
+   * \param[out] kernel structuring element kernel passed by reference
+   * \param[in] height height number of rows in the structuring element
+   * \param[in] width number of columns in the structuring element
+   *
+   */
+  void
+  structuringElementRectangle(pcl::PointCloud<PointT>& kernel,
+                              const int height,
+                              const int width);
 
-      MORPHOLOGICAL_OPERATOR_TYPE operator_type;
-
-      /**
-        * \param[out] output Output point cloud passed by reference
-        */
-      void 
-      applyMorphologicalOperation (pcl::PointCloud<PointT> &output);
-      
-      /**
-        * \param[in] structuring_element The structuring element to be used for the morphological operation
-        */
-      void 
-      setStructuringElement (const PointCloudInPtr &structuring_element);
+  enum MORPHOLOGICAL_OPERATOR_TYPE {
+    EROSION_GRAY,
+    DILATION_GRAY,
+    OPENING_GRAY,
+    CLOSING_GRAY,
+    EROSION_BINARY,
+    DILATION_BINARY,
+    OPENING_BINARY,
+    CLOSING_BINARY
   };
-}
+
+  MORPHOLOGICAL_OPERATOR_TYPE operator_type;
+
+  /**
+   * \param[out] output Output point cloud passed by reference
+   */
+  void
+  applyMorphologicalOperation(pcl::PointCloud<PointT>& output);
+
+  /**
+   * \param[in] structuring_element The structuring element to be used for the
+   *                                 morphological operation
+   */
+  void
+  setStructuringElement(const PointCloudInPtr& structuring_element);
+};
+
+} // namespace pcl
 
 #include <pcl/2d/impl/morphology.hpp>

--- a/2d/src/examples.cpp
+++ b/2d/src/examples.cpp
@@ -46,24 +46,27 @@
 
 using namespace pcl;
 
-void example_edge ()
+void
+example_edge()
 {
   Edge<pcl::PointXYZRGB> edge;
 
   /*dummy clouds*/
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
 
   /*example 1*/
   edge.output_type_ = Edge<pcl::PointXYZRGB>::OUTPUT_X_Y;
-  edge.detectEdgeRoberts (*output_cloud, *input_cloud);
+  edge.detectEdgeRoberts(*output_cloud, *input_cloud);
 
   /*example 2*/
   edge.hysteresis_threshold_low_ = 20;
   edge.hysteresis_threshold_high_ = 80;
   edge.non_max_suppression_radius_x_ = 3;
   edge.non_max_suppression_radius_y_ = 3;
-  edge.detectEdgeCanny (*output_cloud, *input_cloud);
+  edge.detectEdgeCanny(*output_cloud, *input_cloud);
 
   /*example 3*/
   edge.detector_kernel_type_ = Edge<pcl::PointXYZRGB>::PREWITT;
@@ -74,61 +77,69 @@ void example_edge ()
   edge.non_max_suppression_radius_x_ = 1;
   edge.non_max_suppression_radius_y_ = 1;
   edge.output_type_ = Edge<pcl::PointXYZRGB>::OUTPUT_X_Y;
-  edge.detectEdge (*output_cloud, *input_cloud);
+  edge.detectEdge(*output_cloud, *input_cloud);
 }
 
-void example_convolution ()
+void
+example_convolution()
 {
   Kernel<pcl::PointXYZRGB> kernel;
   Convolution<pcl::PointXYZRGB> convolution;
 
   /*dummy clouds*/
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr kernel_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr kernel_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
 
   /*example 1 : Gaussian Smoothing*/
   kernel.sigma_ = 2.0;
   kernel.kernel_size_ = 3;
-  kernel.gaussianKernel (*kernel_cloud);
+  kernel.gaussianKernel(*kernel_cloud);
   convolution.kernel_ = *kernel_cloud;
-  convolution.convolve (*output_cloud, *input_cloud);
+  convolution.convolve(*output_cloud, *input_cloud);
 
   /*example 2 : forward derivative in X direction*/
   kernel.kernel_type_ = Kernel<pcl::PointXYZRGB>::DERIVATIVE_FORWARD_X;
-  kernel.fetchKernel (*kernel_cloud);
+  kernel.fetchKernel(*kernel_cloud);
   convolution.kernel_ = *kernel_cloud;
-  convolution.convolve (*output_cloud, *input_cloud);
+  convolution.convolve(*output_cloud, *input_cloud);
 
   /*example 3*/
   kernel.kernel_type_ = Kernel<pcl::PointXYZRGB>::DERIVATIVE_FORWARD_X;
-  kernel.fetchKernel (convolution.kernel_);
-  convolution.convolve (*output_cloud, *input_cloud);
+  kernel.fetchKernel(convolution.kernel_);
+  convolution.convolve(*output_cloud, *input_cloud);
 }
 
-void example_morphology ()
+void
+example_morphology()
 {
   Morphology<pcl::PointXYZRGB> morphology;
 
   /*dummy clouds*/
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr structuring_element_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr structuring_element_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud(
+      new pcl::PointCloud<pcl::PointXYZRGB>);
 
   /*example 1 : Gaussian Smoothing*/
-  morphology.structuringElementCircular (*structuring_element_cloud, 3);
+  morphology.structuringElementCircular(*structuring_element_cloud, 3);
   morphology.structuring_element_ = *structuring_element_cloud;
   morphology.operator_type_ = Morphology<pcl::PointXYZRGB>::EROSION_GRAY;
-  morphology.applyMorphologicalOperation (*output_cloud, *input_cloud);
+  morphology.applyMorphologicalOperation(*output_cloud, *input_cloud);
 
   /*example 2 : forward derivative in X direction*/
-  morphology.structuringElementCircular (morphology.structuring_element_, 3);
+  morphology.structuringElementCircular(morphology.structuring_element_, 3);
   morphology.operator_type_ = Morphology<pcl::PointXYZRGB>::EROSION_GRAY;
-  morphology.applyMorphologicalOperation (*output_cloud, *input_cloud);
-
+  morphology.applyMorphologicalOperation(*output_cloud, *input_cloud);
 }
 
-int main(char *args, int argv)
+int
+main(char* args, int argv)
 {
   return 0;
 }


### PR DESCRIPTION
After the first pass of clang-format some of the docstrings were screwed up (different `\param` lines joined). Therefore, I needed to apply some manual docstring formatting here and there and then run clang-format again to reach equilibrium.