### PR TITLE
Suppress Nurbs warnings

### DIFF
--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_archive.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_archive.h
@@ -2485,6 +2485,7 @@ protected:
   bool Flush() = 0;
 
   /*
+  Applications (like Rhino) override this function to load plug-ins
   Description:
     When ON_BinaryArchive::ReadObject() encounters userdata and
     the user data class id is not present,  LoadUserDataApplication
@@ -2495,9 +2496,12 @@ protected:
     2 - the application was already loaded
   */
   virtual
-  int LoadUserDataApplication( 
-    ON_UUID application_id 
-    );
+  int LoadUserDataApplication(
+    ON_UUID /*application_id*/
+    )
+  {
+    return 0;
+  }
 
   bool SetArchive3dmVersion(int);
 

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_archive.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_archive.h
@@ -890,11 +890,11 @@ public:
   bool ReadBool( bool* );
 
 	bool ReadChar(    // Read an array of 8 bit chars
-			size_t,       // number of chars to read
+			std::size_t,       // number of chars to read
 			char*    
 			);  
 	bool ReadChar(    // Read an array of 8 bit unsigned chars
-			size_t,       // number of unsigned chars to read
+			std::size_t,       // number of unsigned chars to read
 			unsigned char*    
 			);  
 	bool ReadChar(    // Read a single 8 bit char
@@ -905,11 +905,11 @@ public:
 			);  
 
 	bool ReadShort(   // Read an array of 16 bit shorts
-			size_t,       // number of shorts to read
+			std::size_t,       // number of shorts to read
 			short*    
 			);  
 	bool ReadShort(   // Read an array of 16 bit unsigned shorts
-			size_t,       // number of shorts to read
+			std::size_t,       // number of shorts to read
 			unsigned short*    
 			);  
 	bool ReadShort(   // Read a single 16 bit short
@@ -920,11 +920,11 @@ public:
 			);  
 
 	bool ReadInt( // Read an array of 32 bit integers
-			size_t,	      // number of ints to read
+			std::size_t,	      // number of ints to read
 			int*      
 			); 
 	bool ReadInt( // Read an array of 32 bit integers
-			size_t,	      // number of ints to read
+			std::size_t,	      // number of ints to read
 			unsigned int*      
 			); 
 	bool ReadInt( // Read a single 32 bit integer
@@ -935,11 +935,11 @@ public:
 			); 
 
 	bool ReadBigInt( // Read an array of 64 bit integers
-			size_t,	      // number of ints to read
+			std::size_t,	      // number of ints to read
 			ON__INT64*      
 			); 
 	bool ReadBigInt( // Read an array of 64 bit integers
-			size_t,	      // number of ints to read
+			std::size_t,	      // number of ints to read
 			ON__UINT64*      
 			); 
 	bool ReadBigInt( // Read a single 64 bit integer
@@ -950,11 +950,11 @@ public:
 			); 
 
 	bool ReadLong( // Read an array of 32 bit integers
-			size_t,	      // number of ints to read
+			std::size_t,	      // number of ints to read
 			long*      
 			); 
 	bool ReadLong( // Read an array of 32 bit integers
-			size_t,	      // number of ints to read
+			std::size_t,	      // number of ints to read
 			unsigned long*      
 			); 
 	bool ReadLong( // Read a single 32 bit integer
@@ -964,7 +964,7 @@ public:
 			unsigned long*      
 			); 
 	bool ReadSize( // Read a single std::size_t
-			size_t*
+			std::size_t*
 			); 
 
   bool ReadBigSize( std::size_t* ); // 64 bits
@@ -973,14 +973,14 @@ public:
 
 
 	bool ReadFloat(   // Read an array of floats
-			size_t,       // number of floats
+			std::size_t,       // number of floats
 			float*
 			);
 	bool ReadFloat(   // Read a single float
 			float*
 			);
 	bool ReadDouble(  // Read an array of IEEE doubles
-			size_t,       // number of doubles
+			std::size_t,       // number of doubles
 			double*
 			);
 	bool ReadDouble(  // Read a single double
@@ -1173,11 +1173,11 @@ public:
   bool WriteBool( bool );
 
   bool WriteChar(    // Write an array of 8 bit chars
-			size_t,       // number of chars to write
+			std::size_t,       // number of chars to write
 			const char*    
 			);  
 	bool WriteChar(    // Write an array of 8 bit unsigned chars
-			size_t,       // number of unsigned chars to write
+			std::size_t,       // number of unsigned chars to write
 			const unsigned char*    
 			);  
 	bool WriteChar(    // Write a single 8 bit char
@@ -1188,11 +1188,11 @@ public:
 			);  
 
 	bool WriteShort(   // Write an array of 16 bit shorts
-			size_t,       // number of shorts to write
+			std::size_t,       // number of shorts to write
 			const short*    
 			);  
 	bool WriteShort(   // Write an array of 16 bit unsigned shorts
-			size_t,       // number of shorts to write
+			std::size_t,       // number of shorts to write
 			const unsigned short*    
 			);  
 	bool WriteShort(   // Write a single 16 bit short
@@ -1203,11 +1203,11 @@ public:
 			);  
 
 	bool WriteInt( // Write an array of 32 bit integers
-			size_t,	      // number of ints to write
+			std::size_t,	      // number of ints to write
 			const int*      
 			); 
 	bool WriteInt( // Write an array of 32 bit integers
-			size_t,	      // number of ints to write
+			std::size_t,	      // number of ints to write
 			const unsigned int*      
 			); 
 	bool WriteInt( // Write a single 32 bit integer
@@ -1218,11 +1218,11 @@ public:
 			); 
 
 	bool WriteBigInt( // Write an array of 64 bit integers
-			size_t,	      // number of ints to write
+			std::size_t,	      // number of ints to write
 			const ON__INT64*      
 			); 
 	bool WriteBigInt( // Write an array of 64 bit integers
-			size_t,	      // number of ints to write
+			std::size_t,	      // number of ints to write
 			const ON__UINT64*      
 			); 
 	bool WriteBigInt( // Write a single 64 bit integer
@@ -1233,11 +1233,11 @@ public:
 			); 
 
 	bool WriteLong( // Write an array of 32 bit integers
-			size_t,	      // number of ints to write
+			std::size_t,	      // number of ints to write
 			const long*      
 			); 
 	bool WriteLong( // Write an array of 32 bit integers
-			size_t,	      // number of ints to write
+			std::size_t,	      // number of ints to write
 			const unsigned long*      
 			); 
 	bool WriteLong( // Write a single 32 bit integer
@@ -1247,7 +1247,7 @@ public:
 			unsigned long
 			); 
 	bool WriteSize( // Write a single std::size_t
-			size_t
+			std::size_t
 			); 
 
   bool WriteBigSize( std::size_t ); // 64 bits 
@@ -1255,7 +1255,7 @@ public:
   bool WriteBigTime( time_t ); // UCT seconds since 1 January 1970 (64 bits)
 
 	bool WriteFloat(   // Write a number of IEEE floats
-			size_t,       // number of doubles
+			std::size_t,       // number of doubles
 			const float*
 			);
 	bool WriteFloat(   // Write a single float

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_base64.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_base64.h
@@ -266,7 +266,7 @@ public:
 
   // Returns true if an error occured during decoding because
   // invalid input was passed to Decode().
-  const bool Error() const;
+  bool Error() const;
 
 private:
   int m_status; // 1: error - decoding stopped

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_fsp_defs.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_fsp_defs.h
@@ -38,7 +38,7 @@ bool ON_SimpleFixedSizePool<T>::Create(
 }
 
 template <class T>
-size_t ON_SimpleFixedSizePool<T>::SizeofElement() const
+std::size_t ON_SimpleFixedSizePool<T>::SizeofElement() const
 {
   return ON_FixedSizePool::SizeofElement();
 }
@@ -68,13 +68,13 @@ void ON_SimpleFixedSizePool<T>::Destroy()
 }
 
 template <class T>
-size_t ON_SimpleFixedSizePool<T>::ActiveElementCount() const
+std::size_t ON_SimpleFixedSizePool<T>::ActiveElementCount() const
 {
   return ON_FixedSizePool::ActiveElementCount();
 }
 
 template <class T>
-size_t ON_SimpleFixedSizePool<T>::TotalElementCount() const
+std::size_t ON_SimpleFixedSizePool<T>::TotalElementCount() const
 {
   return ON_FixedSizePool::TotalElementCount();
 }

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_light.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_light.h
@@ -113,11 +113,11 @@ public:
   void SetStyle(ON::light_style);
   ON::light_style Style() const;
 
-  const ON_BOOL32 IsPointLight() const;
-  const ON_BOOL32 IsDirectionalLight() const;
-  const ON_BOOL32 IsSpotLight() const;
-  const ON_BOOL32 IsLinearLight() const;
-  const ON_BOOL32 IsRectangularLight() const;
+  ON_BOOL32 IsPointLight() const;
+  ON_BOOL32 IsDirectionalLight() const;
+  ON_BOOL32 IsSpotLight() const;
+  ON_BOOL32 IsLinearLight() const;
+  ON_BOOL32 IsRectangularLight() const;
 
   ON::coordinate_system CoordinateSystem() const; // determined by style
 

--- a/surface/include/pcl/surface/on_nurbs/fitting_surface_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_surface_pdm.h
@@ -106,6 +106,9 @@ namespace pcl
        */
       FittingSurface (int order, NurbsDataSurface *data, Eigen::Vector3d z = Eigen::Vector3d (0.0, 0.0, 1.0));
 
+      /** \brief Default virtual destructor */
+      virtual ~FittingSurface() = default;
+
       /** \brief Refines surface by inserting a knot in the middle of each element.
        * \param[in] dim dimension of refinement (0,1)
        */

--- a/surface/src/3rdparty/opennurbs/opennurbs_3dm_settings.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_3dm_settings.cpp
@@ -724,7 +724,7 @@ ON_3dmAnnotationSettings& ON_3dmAnnotationSettings::operator=(const ON_3dmAnnota
   return *this;
 }
 
-void ON_3dmAnnotationSettings::Dump( ON_TextLog& text_log ) const
+void ON_3dmAnnotationSettings::Dump( ON_TextLog& ) const
 {
   // TODO
 }
@@ -966,7 +966,7 @@ ON_3dmConstructionPlane& ON_3dmConstructionPlane::operator=(const ON_3dmConstruc
 }
 */
 
-void ON_3dmConstructionPlane::Dump( ON_TextLog& text_log ) const
+void ON_3dmConstructionPlane::Dump( ON_TextLog& ) const
 {
   // TODO
 }
@@ -1056,7 +1056,7 @@ ON_3dmConstructionPlaneGridDefaults& ON_3dmConstructionPlaneGridDefaults::operat
   return *this;
 }
 
-void ON_3dmConstructionPlaneGridDefaults::Dump(ON_TextLog& text_log) const
+void ON_3dmConstructionPlaneGridDefaults::Dump(ON_TextLog&) const
 {
   // TODO
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_annotation.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_annotation.cpp
@@ -81,7 +81,7 @@ ON_Annotation::ON_Annotation()
   Create();
 }
 
-ON_Annotation::ON_Annotation(const ON_Annotation& src)
+ON_Annotation::ON_Annotation(const ON_Annotation& src) : ON_Geometry(src)
 {
   Create();
   *this = src;

--- a/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
@@ -75,7 +75,7 @@ void ON_TextExtra::SetDefaults()
   m_border_offset = 0.1;
 }
 
-void ON_TextExtra::Dump( ON_TextLog& text_log ) const
+void ON_TextExtra::Dump( ON_TextLog& ) const
 {
   // do nothing
 }
@@ -278,7 +278,7 @@ void ON_DimensionExtra::SetDefaults()
   m_modelspace_basepoint = ON_origin;
 }
 
-void ON_DimensionExtra::Dump( ON_TextLog& text_log ) const
+void ON_DimensionExtra::Dump( ON_TextLog& ) const
 {
   // do nothing
 }
@@ -3081,7 +3081,7 @@ ON_AngularDimension2Extra::~ON_AngularDimension2Extra()
 {
 }
 
-void ON_AngularDimension2Extra::Dump( ON_TextLog& text_log ) const
+void ON_AngularDimension2Extra::Dump( ON_TextLog& ) const
 {
   // do nothing
 }
@@ -5821,12 +5821,12 @@ void ON_Annotation2Text::SetText(const wchar_t* s)
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
 bool ON_Annotation2::GetTextXform( 
-      ON_RECT gdi_text_rect,
-      const ON_Font& font,
-      const ON_DimStyle& dimstyle,
-      double dimscale,
-      const ON_Viewport* vp,
-      ON_Xform& xform
+      ON_RECT /*gdi_text_rect*/,
+      const ON_Font& /*font*/,
+      const ON_DimStyle& /*dimstyle*/,
+      double /*dimscale*/,
+      const ON_Viewport* /*vp*/,
+      ON_Xform& /*xform*/
       ) const
 {
   ON_ERROR("This function should not be used. Use the version that takes a model transform argument.");
@@ -5988,15 +5988,15 @@ static bool GetLeaderEndAndDirection( const ON_Annotation2* pAnn,
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
 bool ON_Annotation2::GetTextXform( 
-      ON_RECT gdi_text_rect,
-      int gdi_height_of_I,
-      double dimstyle_textheight,
-      double dimstyle_textgap,
-      ON::eTextDisplayMode dimstyle_textalignment,
-      double dimscale,
-      ON_3dVector cameraX,
-      ON_3dVector cameraY,
-      ON_Xform& xform
+      ON_RECT /*gdi_text_rect*/,
+      int /*gdi_height_of_I*/,
+      double /*dimstyle_textheight*/,
+      double /*dimstyle_textgap*/,
+      ON::eTextDisplayMode /*dimstyle_textalignment*/,
+      double /*dimscale*/,
+      ON_3dVector /*cameraX*/,
+      ON_3dVector /*cameraY*/,
+      ON_Xform& /*xform*/
       ) const
 {
   ON_ERROR("This function should not be used. Use the version that takes a model transform argument.");

--- a/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
@@ -5820,6 +5820,7 @@ void ON_Annotation2Text::SetText(const wchar_t* s)
 
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
+[[deprecated("Use the version that takes a model transform argument")]]
 bool ON_Annotation2::GetTextXform( 
       ON_RECT /*gdi_text_rect*/,
       const ON_Font& /*font*/,
@@ -5859,6 +5860,7 @@ bool ON_Annotation2::GetTextXform(
 // New function added Oct 30, 07 - LW 
 // To use model xform to draw annotation in blocks correctly
 #if 0
+[[deprecated("Use the version that takes a dimstyle pointer")]]
 bool ON_Annotation2::GetTextXform( 
       ON_RECT gdi_text_rect,
       const ON_Font& font,
@@ -5987,6 +5989,7 @@ static bool GetLeaderEndAndDirection( const ON_Annotation2* pAnn,
 
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
+[[deprecated("Use the version that takes a model transform argument")]]
 bool ON_Annotation2::GetTextXform( 
       ON_RECT /*gdi_text_rect*/,
       int /*gdi_height_of_I*/,

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -592,7 +592,7 @@ ON_BinaryArchive::WriteMode() const
 
 bool
 ON_BinaryArchive::ReadChar(    // Read an array of 8 bit chars
-		size_t count,       // number of chars to read
+		std::size_t count,       // number of chars to read
 		char*  p  
 		)
 {
@@ -601,7 +601,7 @@ ON_BinaryArchive::ReadChar(    // Read an array of 8 bit chars
 
 bool
 ON_BinaryArchive::ReadChar(    // Read an array of 8 bit unsigned chars
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		unsigned char* p   
 		)
 {
@@ -626,7 +626,7 @@ ON_BinaryArchive::ReadChar(    // Read a single 8 bit unsigned char
 
 bool
 ON_BinaryArchive::ReadInt16( // Read an array of 16 bit integers
-		size_t count,            // number of unsigned integers to read
+		std::size_t count,            // number of unsigned integers to read
 		ON__INT16* p
 		)
 {
@@ -646,7 +646,7 @@ ON_BinaryArchive::ReadInt16( // Read an array of 16 bit integers
 
 bool
 ON_BinaryArchive::ReadShort(   // Read an array of 16 bit shorts
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		short* p
 		)
 {
@@ -683,7 +683,7 @@ ON_BinaryArchive::ReadShort(   // Read an array of 16 bit shorts
 
 bool
 ON_BinaryArchive::ReadShort(   // Read an array of 16 bit unsigned shorts
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		unsigned short* p
 		)
 {
@@ -708,7 +708,7 @@ ON_BinaryArchive::ReadShort(   // Read a single 16 bit unsigned short
 
 bool
 ON_BinaryArchive::ReadInt32( // Read an array of 32 bit integers
-		size_t count,            // number of 32 bit integers to read
+		std::size_t count,            // number of 32 bit integers to read
 		ON__INT32* p
 		)
 {
@@ -728,7 +728,7 @@ ON_BinaryArchive::ReadInt32( // Read an array of 32 bit integers
 
 bool
 ON_BinaryArchive::ReadInt( // Read an array of integers
-		size_t count,          // number of unsigned chars to read
+		std::size_t count,          // number of unsigned chars to read
 		int* p
 		)
 {
@@ -766,7 +766,7 @@ ON_BinaryArchive::ReadInt( // Read an array of integers
 
 bool
 ON_BinaryArchive::ReadInt( // Read an array of 32 bit integers
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		unsigned int* p
 		)
 {
@@ -790,7 +790,7 @@ ON_BinaryArchive::ReadInt( // Read a single 32 bit unsigned integer
 }
 
 bool ON_BinaryArchive::ReadBigInt( // Read an array of 64 bit integers
-		size_t,
+		std::size_t,
 		ON__INT64* p 
 		)
 {
@@ -798,7 +798,7 @@ bool ON_BinaryArchive::ReadBigInt( // Read an array of 64 bit integers
 }
 
 bool ON_BinaryArchive::ReadBigInt( // Read an array of 64 bit integers
-		size_t,
+		std::size_t,
 		ON__UINT64* p
 		)
 {
@@ -823,7 +823,7 @@ bool ON_BinaryArchive::ReadBigInt( // Read a single 64 bit unsigned integer
 
 bool
 ON_BinaryArchive::ReadLong( // Read an array of 32 bit integers
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		long* p
 		)
 {
@@ -861,7 +861,7 @@ ON_BinaryArchive::ReadLong( // Read an array of 32 bit integers
 
 bool
 ON_BinaryArchive::ReadLong( // Read an array of 32 bit integers
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		unsigned long* p
 		)
 {
@@ -886,7 +886,7 @@ ON_BinaryArchive::ReadLong( // Read a single 32 bit unsigned integer
 
 bool
 ON_BinaryArchive::ReadFloat(   // Read an array of floats
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		float* p
 		)
 {
@@ -904,7 +904,7 @@ ON_BinaryArchive::ReadFloat(   // Read a single float
 
 bool
 ON_BinaryArchive::ReadDouble(  // Read an array of IEEE 64 bit doubles
-		size_t count,       // number of unsigned chars to read
+		std::size_t count,       // number of unsigned chars to read
 		double* p
 		)
 {
@@ -2341,7 +2341,7 @@ bool ON_BinaryArchive::ReadBool( bool *b )
 
 bool
 ON_BinaryArchive::WriteChar(    // Write an array of 8 bit chars
-		size_t count,       // number of chars to write
+		std::size_t count,       // number of chars to write
 		const char* p   
 		)
 {
@@ -2350,7 +2350,7 @@ ON_BinaryArchive::WriteChar(    // Write an array of 8 bit chars
 
 bool
 ON_BinaryArchive::WriteChar(    // Write an array of 8 bit unsigned chars
-		size_t count,       // number of unsigned chars to write
+		std::size_t count,       // number of unsigned chars to write
 		const unsigned char* p
 		)
 {
@@ -2375,7 +2375,7 @@ ON_BinaryArchive::WriteChar(    // Write a single 8 bit unsigned char
 
 bool
 ON_BinaryArchive::WriteInt16(   // Write an array of 16 bit shorts
-		size_t count,               // number of shorts to write
+		std::size_t count,               // number of shorts to write
 		const ON__INT16* p
 		)
 {
@@ -2404,7 +2404,7 @@ ON_BinaryArchive::WriteInt16(   // Write an array of 16 bit shorts
 
 bool
 ON_BinaryArchive::WriteShort(   // Write an array of 16 bit shorts
-		size_t count,       // number of shorts to write
+		std::size_t count,       // number of shorts to write
 		const short* p
 		)
 {
@@ -2441,7 +2441,7 @@ ON_BinaryArchive::WriteShort(   // Write an array of 16 bit shorts
 
 bool
 ON_BinaryArchive::WriteShort(   // Write an array of 16 bit unsigned shorts
-		size_t count,       // number of shorts to write
+		std::size_t count,       // number of shorts to write
 		const unsigned short* p
 		)
 {
@@ -2466,7 +2466,7 @@ ON_BinaryArchive::WriteShort(   // Write a single 16 bit unsigned short
 
 bool
 ON_BinaryArchive::WriteInt32( // Write an array of 32 bit integers
-		size_t count,	            // number of ints to write
+		std::size_t count,	            // number of ints to write
 		const ON__INT32* p    
 		)
 {
@@ -2495,7 +2495,7 @@ ON_BinaryArchive::WriteInt32( // Write an array of 32 bit integers
 
 bool
 ON_BinaryArchive::ReadInt64( // Read an array of 64 bit integers
-		size_t count,            // number of 64 bit integers to read
+		std::size_t count,            // number of 64 bit integers to read
 		ON__INT64* p
 		)
 {
@@ -2517,7 +2517,7 @@ ON_BinaryArchive::ReadInt64( // Read an array of 64 bit integers
 
 bool
 ON_BinaryArchive::WriteInt64( // Write an array of 64 bit integers
-		size_t count,	            // number of ints to write
+		std::size_t count,	            // number of ints to write
 		const ON__INT64* p    
 		)
 {
@@ -2550,7 +2550,7 @@ ON_BinaryArchive::WriteInt64( // Write an array of 64 bit integers
 
 bool
 ON_BinaryArchive::WriteInt( // Write an array of integers
-		size_t count,	          // number of ints to write
+		std::size_t count,	          // number of ints to write
 		const int* p    
 		)
 {
@@ -2635,7 +2635,7 @@ bool ON_BinaryArchive::ReadBigTime( time_t* t )
 
 bool
 ON_BinaryArchive::WriteInt( // Write an array of 32 bit integers
-		size_t count,	      // number of ints to write
+		std::size_t count,	      // number of ints to write
 		const unsigned int* p
 		)
 {
@@ -2659,7 +2659,7 @@ ON_BinaryArchive::WriteInt( // Write a single 32 bit integer
 }
 
 bool ON_BinaryArchive::WriteBigInt( // Write an array of 64 bit integers
-		size_t count,
+		std::size_t count,
 		const ON__INT64* p      
 		)
 {
@@ -2667,7 +2667,7 @@ bool ON_BinaryArchive::WriteBigInt( // Write an array of 64 bit integers
 }
 
 bool ON_BinaryArchive::WriteBigInt( // Write an array of 64 bit integers
-		size_t count,
+		std::size_t count,
 		const ON__UINT64* p     
 		)
 {
@@ -2692,7 +2692,7 @@ bool ON_BinaryArchive::WriteBigInt( // Write a single 64 bit unsigned integer
 
 bool
 ON_BinaryArchive::WriteLong( // Write an array of longs
-		size_t count,	      // number of longs to write
+		std::size_t count,	      // number of longs to write
 		const long* p    
 		)
 {
@@ -2729,7 +2729,7 @@ ON_BinaryArchive::WriteLong( // Write an array of longs
 
 bool
 ON_BinaryArchive::WriteLong( // Write an array of longs
-		size_t count,	      // number of longs to write
+		std::size_t count,	      // number of longs to write
 		const unsigned long* p
 		)
 {
@@ -2755,7 +2755,7 @@ ON_BinaryArchive::WriteLong( // Write a single unsigned long
 
 bool
 ON_BinaryArchive::WriteFloat(   // Write a number of IEEE floats
-		size_t count,       // number of doubles
+		std::size_t count,       // number of doubles
 		const float* p
 		)
 {
@@ -2773,7 +2773,7 @@ ON_BinaryArchive::WriteFloat(   // Write a single float
 
 bool
 ON_BinaryArchive::WriteDouble(  // Write a single double
-		size_t count,       // number of doubles
+		std::size_t count,       // number of doubles
 		const double* p
 		)
 {
@@ -4520,7 +4520,7 @@ int ON_BinaryArchive::ArchiveOpenNURBSVersion() const
   return m_3dm_opennurbs_version;
 }
 
-size_t ON_BinaryArchive::ArchiveStartOffset() const
+std::size_t ON_BinaryArchive::ArchiveStartOffset() const
 {
   return m_3dm_start_section_offset;
 }
@@ -5658,7 +5658,7 @@ bool ON_BinaryArchive::ReadChunkValue( ON__UINT32 typecode, ON__INT64* value64 )
   return rc;
 }
 
-size_t ON_BinaryArchive::SizeofChunkLength() const
+std::size_t ON_BinaryArchive::SizeofChunkLength() const
 {
   // Version 1 - 4 and early version 5 files had
   // 4 byte chunk lengths.  In October of 2009,
@@ -13196,12 +13196,12 @@ ON_BinaryFile::EnableMemoryBuffer(
 }
 
 
-size_t ON_BinaryFile::Read( std::size_t count, void* p )
+std::size_t ON_BinaryFile::Read( std::size_t count, void* p )
 {
   return (m_fp) ? fread( p, 1, count, m_fp ) : 0;
 }
 
-size_t ON_BinaryFile::Write( std::size_t count, const void* p )
+std::size_t ON_BinaryFile::Write( std::size_t count, const void* p )
 {
   std::size_t rc = 0;
   if ( m_fp ) 
@@ -13257,7 +13257,7 @@ bool ON_BinaryFile::Flush()
   return rc;
 }
 
-size_t ON_BinaryFile::CurrentPosition() const
+std::size_t ON_BinaryFile::CurrentPosition() const
 {
   std::size_t offset = 0;
 
@@ -13304,7 +13304,7 @@ bool ON_BinaryFile::AtEnd() const
       else 
       {
         int buffer;
-        size_t res = fread( &buffer, 1, 1, m_fp );
+        std::size_t res = fread( &buffer, 1, 1, m_fp );
         (void) res;
         if ( feof( m_fp ) ) 
         {
@@ -14725,7 +14725,7 @@ ON_Read3dmBufferArchive::~ON_Read3dmBufferArchive()
 }
 
 // ON_BinaryArchive overrides
-size_t ON_Read3dmBufferArchive::CurrentPosition() const
+std::size_t ON_Read3dmBufferArchive::CurrentPosition() const
 {
   return m_buffer_position;
 }
@@ -14768,7 +14768,7 @@ bool ON_Read3dmBufferArchive::AtEnd() const
   return (m_buffer_position >= m_sizeof_buffer) ? true : false;
 }
 
-size_t ON_Read3dmBufferArchive::Read( std::size_t count, void* buffer )
+std::size_t ON_Read3dmBufferArchive::Read( std::size_t count, void* buffer )
 {
   if ( count <= 0 || 0 == buffer )
     return 0;
@@ -14788,7 +14788,7 @@ size_t ON_Read3dmBufferArchive::Read( std::size_t count, void* buffer )
   return count;
 }
 
-size_t ON_Read3dmBufferArchive::Write( std::size_t, const void* )
+std::size_t ON_Read3dmBufferArchive::Write( std::size_t, const void* )
 {
   // ON_Read3dmBufferArchive does not support Write() and Flush()
   return 0;
@@ -14801,7 +14801,7 @@ bool ON_Read3dmBufferArchive::Flush()
 }
 
 
-size_t ON_Read3dmBufferArchive::SizeOfBuffer() const
+std::size_t ON_Read3dmBufferArchive::SizeOfBuffer() const
 {
   return m_sizeof_buffer;
 }
@@ -14877,7 +14877,7 @@ void ON_Write3dmBufferArchive::AllocBuffer( std::size_t sz )
 }
 
 // ON_BinaryArchive overrides
-size_t ON_Write3dmBufferArchive::CurrentPosition() const
+std::size_t ON_Write3dmBufferArchive::CurrentPosition() const
 {
   return m_buffer_position;
 }
@@ -14920,7 +14920,7 @@ bool ON_Write3dmBufferArchive::AtEnd() const
   return (m_buffer_position >= m_sizeof_buffer) ? true : false;
 }
 
-size_t ON_Write3dmBufferArchive::Read( std::size_t count, void* buffer )
+std::size_t ON_Write3dmBufferArchive::Read( std::size_t count, void* buffer )
 {
   if ( count <= 0 || 0 == buffer )
     return 0;
@@ -14940,7 +14940,7 @@ size_t ON_Write3dmBufferArchive::Read( std::size_t count, void* buffer )
   return count;
 }
 
-size_t ON_Write3dmBufferArchive::Write( std::size_t sz, const void* buffer )
+std::size_t ON_Write3dmBufferArchive::Write( std::size_t sz, const void* buffer )
 {
   if ( sz <= 0 || 0 == buffer )
     return 0;
@@ -14968,7 +14968,7 @@ bool ON_Write3dmBufferArchive::Flush()
 }
 
 
-size_t ON_Write3dmBufferArchive::SizeOfBuffer() const
+std::size_t ON_Write3dmBufferArchive::SizeOfBuffer() const
 {
   return m_sizeof_buffer;
 }
@@ -14991,7 +14991,7 @@ void* ON_Write3dmBufferArchive::HarvestBuffer()
   return buffer;
 }
 
-size_t ON_Write3dmBufferArchive::SizeOfArchive() const
+std::size_t ON_Write3dmBufferArchive::SizeOfArchive() const
 {
   return m_sizeof_archive;
 }
@@ -15026,7 +15026,7 @@ ON_Buffer* ON_BinaryArchiveBuffer::Buffer() const
   return m_buffer;
 }
 
-size_t ON_BinaryArchiveBuffer::CurrentPosition() const
+std::size_t ON_BinaryArchiveBuffer::CurrentPosition() const
 {
   if ( 0 != m_buffer )
     return (std::size_t)m_buffer->CurrentPosition();
@@ -15066,7 +15066,7 @@ bool ON_BinaryArchiveBuffer::SeekFromEnd( ON__INT64 offset )
   return false;
 }
 
-size_t ON_BinaryArchiveBuffer::Read( std::size_t count, void* a )
+std::size_t ON_BinaryArchiveBuffer::Read( std::size_t count, void* a )
 {
   if ( 0 != m_buffer )
     return (std::size_t)m_buffer->Read(count,a);
@@ -15074,7 +15074,7 @@ size_t ON_BinaryArchiveBuffer::Read( std::size_t count, void* a )
   return 0;
 }
 
-size_t ON_BinaryArchiveBuffer::Write( std::size_t count, const void* a )
+std::size_t ON_BinaryArchiveBuffer::Write( std::size_t count, const void* a )
 {
   if ( 0 != m_buffer )
     return (std::size_t)m_buffer->Write(count,a);

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -790,7 +790,7 @@ ON_BinaryArchive::ReadInt( // Read a single 32 bit unsigned integer
 }
 
 bool ON_BinaryArchive::ReadBigInt( // Read an array of 64 bit integers
-		size_t count,
+		size_t,
 		ON__INT64* p 
 		)
 {
@@ -798,7 +798,7 @@ bool ON_BinaryArchive::ReadBigInt( // Read an array of 64 bit integers
 }
 
 bool ON_BinaryArchive::ReadBigInt( // Read an array of 64 bit integers
-		size_t count,
+		size_t,
 		ON__UINT64* p
 		)
 {
@@ -3866,7 +3866,7 @@ bool ON_BinaryArchive::WriteObjectUserData( const ON_Object& object )
 }
 
 int
-ON_BinaryArchive::LoadUserDataApplication( ON_UUID application_id )
+ON_BinaryArchive::LoadUserDataApplication( ON_UUID )
 {
   // This is a virtual function.
   // Rhino overrides this function to load plug-ins.

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -13312,7 +13312,8 @@ bool ON_BinaryFile::AtEnd() const
       else 
       {
         int buffer;
-        fread( &buffer, 1, 1, m_fp );
+        size_t res = fread( &buffer, 1, 1, m_fp );
+        (void) res;
         if ( feof( m_fp ) ) 
         {
           rc = true;

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -3865,14 +3865,6 @@ bool ON_BinaryArchive::WriteObjectUserData( const ON_Object& object )
   return rc;
 }
 
-int
-ON_BinaryArchive::LoadUserDataApplication( ON_UUID )
-{
-  // This is a virtual function.
-  // Rhino overrides this function to load plug-ins.
-  return 0;
-}
-
 int ON_BinaryArchive::ReadObject( ON_Object** ppObject )
 {
   if ( !ppObject ) 

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -13965,9 +13965,12 @@ char* ON_BinaryArchive::ON_TypecodeParse( unsigned int tcode, char* typecode_nam
   sub_name = ON_BinaryArchive::TypecodeName( tcode & TCODE_SHORT );
   if ( sub_name )
   {
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
-    if ( slen <= 0 ) return 0; *s++ = '|'; slen--;
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = '|'; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
     while ( *sub_name )
     {
       if ( slen <= 0 )
@@ -13980,9 +13983,12 @@ char* ON_BinaryArchive::ON_TypecodeParse( unsigned int tcode, char* typecode_nam
   sub_name = ON_BinaryArchive::TypecodeName( tcode & TCODE_CRC );
   if ( sub_name )
   {
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
-    if ( slen <= 0 ) return 0; *s++ = '|'; slen--;
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = '|'; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
     while ( *sub_name )
     {
       if ( slen <= 0 )
@@ -13995,9 +14001,12 @@ char* ON_BinaryArchive::ON_TypecodeParse( unsigned int tcode, char* typecode_nam
   sub_name = ON_BinaryArchive::TypecodeName( tcode & 0x7FFF );
   if ( sub_name )
   {
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
-    if ( slen <= 0 ) return 0; *s++ = '|'; slen--;
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = '|'; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
     while ( *sub_name )
     {
       if ( slen <= 0 )
@@ -14008,11 +14017,16 @@ char* ON_BinaryArchive::ON_TypecodeParse( unsigned int tcode, char* typecode_nam
   }
   else 
   {
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
-    if ( slen <= 0 ) return 0; *s++ = '|'; slen--;
-    if ( slen <= 0 ) return 0; *s++ = ' '; slen--;
-    if ( slen <= 0 ) return 0; *s++ = '0'; slen--;
-    if ( slen <= 0 ) return 0; *s++ = 'x'; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = '|'; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = ' '; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = '0'; slen--;
+    if ( slen <= 0 ) return 0;
+    *s++ = 'x'; slen--;
     c = h[((tcode & 0x7000) / 0x1000) & 0xF];
     if ( slen > 0 ) {*s++ = c; slen--;}
     c = h[((tcode & 0xF00) / 0x100) & 0xF];

--- a/surface/src/3rdparty/opennurbs/opennurbs_base64.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_base64.cpp
@@ -79,7 +79,7 @@ void ON_DecodeBase64::SetError()
   m_status = 1;
 }
 
-const bool ON_DecodeBase64::Error() const
+bool ON_DecodeBase64::Error() const
 {
   return (1 == m_status);
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_bezier.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_bezier.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
+#include <pcl/pcl_macros.h>
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -1374,7 +1375,7 @@ bool ON_BezierCurve::GetCV( int i, ON::point_style style, double* Point ) const
   switch(style) {
   case ON::euclidean_rational:
     Point[dim] = w;
-    // no break here
+    PCL_FALLTHROUGH
   case ON::not_rational:
     if ( w == 0.0 )
       return false;
@@ -2502,7 +2503,7 @@ bool ON_BezierSurface::GetCV( int i, int j, ON::point_style style, double* Point
   switch(style) {
   case ON::euclidean_rational:
     Point[dim] = w;
-    // no break here
+    PCL_FALLTHROUGH
   case ON::not_rational:
     if ( w == 0.0 )
       return false;

--- a/surface/src/3rdparty/opennurbs/opennurbs_bezier.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_bezier.cpp
@@ -305,11 +305,11 @@ void ON_PolynomialSurface::Destroy()
 }
 
 ON_BOOL32 ON_PolynomialSurface::Evaluate( // returns false if unable to evaluate
-       double s, 
-       double t,           // evaluation parameter
-       int der_count,      // number of derivatives (>=0)
-       int v_stride,       // array stride (>=Dimension())
-       double* v           // array of length stride*(ndir+1)*(ndir+2)/2
+       double,
+       double,           // evaluation parameter
+       int,              // number of derivatives (>=0)
+       int,       // array stride (>=Dimension())
+       double*       // array of length stride*(ndir+1)*(ndir+2)/2
        ) const
 {
   ON_ERROR("TODO: - finish ON_PolynomialSurface::Evaluate()\n");

--- a/surface/src/3rdparty/opennurbs/opennurbs_beziervolume.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_beziervolume.cpp
@@ -15,6 +15,8 @@
 */
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
+#include <pcl/pcl_macros.h>
+
 
 bool ON_BezierCage::Read(ON_BinaryArchive& archive)
 {
@@ -870,7 +872,7 @@ bool ON_BezierCage::GetCV( int i, int j, int k, ON::point_style style, double* P
   switch(style) {
   case ON::euclidean_rational:
     Point[dim] = w;
-    // no break here
+    PCL_FALLTHROUGH
   case ON::not_rational:
     if ( w == 0.0 )
       return false;

--- a/surface/src/3rdparty/opennurbs/opennurbs_beziervolume.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_beziervolume.cpp
@@ -549,7 +549,7 @@ ON_Interval ON_BezierCage::Domain(
 bool ON_BezierCage::Evaluate( // returns false if unable to evaluate
        double r, double s, double t,       // evaluation parameter
        int der_count,            // number of derivatives (>=0)
-       int v_stride,             // array stride (>=Dimension())
+       int,                      // array stride (>=Dimension())
        double* v                 // array of length stride*(ndir+1)*(ndir+2)/2
        ) const
 {  
@@ -1085,7 +1085,7 @@ bool ON_BezierCage::ReserveCVCapacity(
 
 
 bool ON_BezierCage::IsSingular(		 // true if surface side is collapsed to a point
-       int side														 // side of parameter space to test
+       int														 // side of parameter space to test
 																			// 0 = south, 1 = east, 2 = north, 3 = west, 4 = bottom, 5 =top
 				) const
 {

--- a/surface/src/3rdparty/opennurbs/opennurbs_bounding_box.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_bounding_box.cpp
@@ -1104,7 +1104,7 @@ int ON_BoundingBox::IsVisible(
   const ON_Xform& bbox2c
   ) const
 {
-  int i,j,k,n;
+  int i,j,k;
   unsigned int all_out, some_out, out;
   double bx,by,bz,x,w;
   const double* p;
@@ -1115,7 +1115,6 @@ int ON_BoundingBox::IsVisible(
   some_out = 0;    // will be != 0 if some portion of box is outside visible region
   all_out  = 0xFFFFFFFF; // will be == 0 if some portion of box is inside visible region
   p = &bbox2c.m_xform[0][0];
-  n = 0; 
   i = 2; bx = m_min.x;
   while(i--)
   {

--- a/surface/src/3rdparty/opennurbs/opennurbs_brep_region.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_brep_region.cpp
@@ -155,7 +155,7 @@ ON_BOOL32 ON_BrepRegionTopologyUserData::GetDescription( ON_wString& description
 
 ON_OBJECT_IMPLEMENT(ON_BrepFaceSide,ON_Object,"30930370-0D5B-4ee4-8083-BD635C7398A4");
 
-ON_BOOL32 ON_BrepFaceSide::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_BrepFaceSide::IsValid( ON_TextLog* ) const
 {
   return true;
 }
@@ -283,7 +283,7 @@ int ON_BrepFaceSide::SurfaceNormalDirection() const
 
 ON_OBJECT_IMPLEMENT(ON_BrepRegion,ON_Object,"CA7A0092-7EE6-4f99-B9D2-E1D6AA798AA1");
 
-ON_BOOL32 ON_BrepRegion::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_BrepRegion::IsValid( ON_TextLog* ) const
 {
   return true;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_brep_tools.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_brep_tools.cpp
@@ -397,22 +397,15 @@ void ON_Brep::SetTolerancesBoxesAndFlags(
 static
 bool CheckForMatchingVertexIndices( int i, int j, int corner_vi[4] )
 {
-  ON_BOOL32 rc = false;
   if ( corner_vi[i] >= 0 || corner_vi[j] >= 0 )
   {
     if ( corner_vi[i] == -1 )
     {
       corner_vi[i] = corner_vi[j];
-      rc = true;
     }
     else if ( corner_vi[j] == -1 )
     {
       corner_vi[j] = corner_vi[i];
-      rc = true;
-    }
-    else if ( corner_vi[i] == corner_vi[j] )
-    {
-      rc = true;
     }
   }
   return true;
@@ -2119,7 +2112,6 @@ bool ON_Brep::CloseTrimGap( ON_BrepTrim& trim0, ON_BrepTrim& trim1 )
     p.y = p0.y;
 
   int coord0_lock = -1;
-  int coord1_lock = -1;
   switch(trim0.m_iso)
   {
   case ON_Surface::x_iso:
@@ -2144,7 +2136,6 @@ bool ON_Brep::CloseTrimGap( ON_BrepTrim& trim0, ON_BrepTrim& trim1 )
   case ON_Surface::W_iso:
   case ON_Surface::E_iso:
     // vertical iso curve - lock x coordinate
-    coord1_lock = 0;
     switch(coord0_lock)
     {
     case 0:
@@ -2174,7 +2165,6 @@ bool ON_Brep::CloseTrimGap( ON_BrepTrim& trim0, ON_BrepTrim& trim1 )
   case ON_Surface::S_iso:
   case ON_Surface::N_iso:
     // horizontal iso curve - lock y coordinate
-    coord1_lock = 1;
     switch(coord0_lock)
     {
     case 0:

--- a/surface/src/3rdparty/opennurbs/opennurbs_brep_tools.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_brep_tools.cpp
@@ -2015,12 +2015,12 @@ bool ON_Brep::ChangeVertex( int old_vi, int new_vi, bool bClearTolerances )
   return true;
 }
 
-ON_BOOL32 ON_BrepEdge::SetStartPoint(ON_3dPoint start_point)
+ON_BOOL32 ON_BrepEdge::SetStartPoint(ON_3dPoint)
 {
   return false;
 }
 
-ON_BOOL32 ON_BrepEdge::SetEndPoint(ON_3dPoint end_point)
+ON_BOOL32 ON_BrepEdge::SetEndPoint(ON_3dPoint)
 {
   return false;
 }
@@ -2065,7 +2065,7 @@ ON_BOOL32 ON_BrepTrim::SetStartPoint(ON_3dPoint point)
   return false;
 }
 
-ON_BOOL32 ON_BrepTrim::SetEndPoint(ON_3dPoint end_point)
+ON_BOOL32 ON_BrepTrim::SetEndPoint(ON_3dPoint)
 {
   return false;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_cone.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_cone.cpp
@@ -108,7 +108,7 @@ ON_3dPoint ON_Cone::PointAt( double radial_parameter, double height_parameter ) 
   return plane.PointAt(r*cos(radial_parameter),r*sin(radial_parameter)) + height_parameter*plane.zaxis;
 }
 
-ON_3dVector ON_Cone::NormalAt( double radial_parameter, double height_parameter ) const
+ON_3dVector ON_Cone::NormalAt( double radial_parameter, double ) const
 {
   double s = sin(radial_parameter);
   double c = cos(radial_parameter);

--- a/surface/src/3rdparty/opennurbs/opennurbs_curve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_curve.cpp
@@ -158,7 +158,7 @@ ON_BOOL32 ON_Curve::SetDomain( double, double )
   return false;
 }
 
-ON_BOOL32 ON_Curve::ChangeClosedCurveSeam( double t )
+ON_BOOL32 ON_Curve::ChangeClosedCurveSeam( double )
 {
   // this virtual function is overridden by curves that can be closed
   return false;
@@ -216,8 +216,8 @@ ON_BOOL32 ON_Curve::GetParameterTolerance( // returns tminus < tplus: parameters
 }
 
 int ON_Curve::IsPolyline(
-      ON_SimpleArray<ON_3dPoint>* pline_points, // default = NULL
-      ON_SimpleArray<double>* pline_t // default = NULL
+      ON_SimpleArray<ON_3dPoint>*, // default = NULL
+      ON_SimpleArray<double>* // default = NULL
       ) const
 {
   // virtual function that is overridden
@@ -572,7 +572,7 @@ bool ON_Curve::GetNextDiscontinuity(
                 double t0,
                 double t1,
                 double* t,
-                int* hint,
+                int*,
                 int* dtype,
                 double cos_angle_tolerance,
                 double curvature_tolerance
@@ -905,12 +905,12 @@ ON_3dPoint ON_Curve::PointAtEnd() const
 }
 
 
-ON_BOOL32 ON_Curve::SetStartPoint(ON_3dPoint start_point)
+ON_BOOL32 ON_Curve::SetStartPoint(ON_3dPoint)
 {
   return false;
 }
 
-ON_BOOL32 ON_Curve::SetEndPoint(ON_3dPoint end_point)
+ON_BOOL32 ON_Curve::SetEndPoint(ON_3dPoint)
 {
   return false;
 }
@@ -1101,19 +1101,19 @@ ON_BOOL32 ON_Curve::EvPoint( // returns false if unable to evaluate
   return rc;
 }
 
-bool ON_Brep::EvaluatePoint( const class ON_ObjRef& objref, ON_3dPoint& P ) const
+bool ON_Brep::EvaluatePoint( const class ON_ObjRef&, ON_3dPoint& ) const
 {
   // TODO
   return false;
 }
 
-bool ON_Surface::EvaluatePoint( const class ON_ObjRef& objref, ON_3dPoint& P ) const
+bool ON_Surface::EvaluatePoint( const class ON_ObjRef&, ON_3dPoint& ) const
 {
   // TODO
   return false;
 }
 
-bool ON_PolyCurve::EvaluatePoint( const class ON_ObjRef& objref, ON_3dPoint& P ) const
+bool ON_PolyCurve::EvaluatePoint( const class ON_ObjRef&, ON_3dPoint& ) const
 {
   // TODO
   return false;
@@ -2040,7 +2040,7 @@ bool ON_NurbsCurve::SpanIsLinear(
   return false;
 }
 
-ON_BOOL32 ON_Curve::Trim( const ON_Interval& in )
+ON_BOOL32 ON_Curve::Trim( const ON_Interval& )
 {
   // TODO - make this pure virtual
   return false;
@@ -2048,7 +2048,7 @@ ON_BOOL32 ON_Curve::Trim( const ON_Interval& in )
 
 
 bool ON_Curve::Extend(
-  const ON_Interval& domain
+  const ON_Interval&
   )
 
 {
@@ -2152,9 +2152,9 @@ ON_BOOL32 ON_Curve::Split(
 
 // virtual
 int ON_Curve::GetNurbForm(
-      ON_NurbsCurve& nurbs_curve,
-      double tolerance,
-      const ON_Interval* subdomain
+      ON_NurbsCurve&,
+      double,
+      const ON_Interval*
       ) const
 {
   return 0;

--- a/surface/src/3rdparty/opennurbs/opennurbs_curve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_curve.cpp
@@ -1406,7 +1406,6 @@ bool ON_MatchCurveEnds( ON_Curve* curve0,
     if ( !rc )
     {
       // try to close the gap
-      ON_Curve* seg[2] = {0,0};
       int fix[2] = {0,0};
       ON_3dPoint fixPoint[2];
       fixPoint[0] = ON_UNSET_POINT;
@@ -1432,7 +1431,6 @@ bool ON_MatchCurveEnds( ON_Curve* curve0,
             return false;
           ct = ON_CurveType(c);
         }
-        seg[i] = c;
         switch(ct)
         {
         case ON::ctArc: // arc
@@ -2670,7 +2668,6 @@ ON_JoinCurves(const ON_SimpleArray<const ON_Curve*>& InCurves,
       }
       if (SArray[j].bRev) C->Reverse();
       if (PC->Count()){
-        bool bSet = true;
         if (!ON_ForceMatchCurveEnds(*PC, 1, *C, 0)) {
           ON_3dPoint P = PC->PointAtEnd();
           ON_3dPoint Q = C->PointAtStart();
@@ -2682,7 +2679,6 @@ ON_JoinCurves(const ON_SimpleArray<const ON_Curve*>& InCurves,
               C = NC;
             }
             else {
-              bSet = false;
               delete NC;
               if (PC->Count()) {
                 pc_added = true;

--- a/surface/src/3rdparty/opennurbs/opennurbs_curveonsurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_curveonsurface.cpp
@@ -25,7 +25,7 @@ ON_CurveOnSurface::ON_CurveOnSurface( ON_Curve* c2, ON_Curve* c3, ON_Surface* s 
                  : m_c2(c2), m_c3(c3), m_s(s)
 {}
 
-ON_CurveOnSurface::ON_CurveOnSurface( const ON_CurveOnSurface& src ) : m_c2(0), m_c3(0), m_s(0)
+ON_CurveOnSurface::ON_CurveOnSurface( const ON_CurveOnSurface& src ) : ON_Curve(src), m_c2(0), m_c3(0), m_s(0)
 {
   *this = src;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_curveonsurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_curveonsurface.cpp
@@ -89,7 +89,7 @@ ON_CurveOnSurface::~ON_CurveOnSurface()
 }
 
 ON_BOOL32
-ON_CurveOnSurface::IsValid( ON_TextLog* text_log ) const
+ON_CurveOnSurface::IsValid( ON_TextLog* ) const
 {
   if ( !m_c2 )
     return false;
@@ -280,9 +280,9 @@ ON_CurveOnSurface::IsArc( // true if curve locus in an arc or circle
 
 ON_BOOL32
 ON_CurveOnSurface::IsPlanar(
-      ON_Plane* plane, // if not NULL and true is returned, then plane parameters
+      ON_Plane*, // plane if not NULL and true is returned, then plane parameters
                          // are filled in
-      double tolerance // tolerance to use when checking linearity
+      double // tolerance to use when checking linearity
       ) const
 {
   return ( ON_PlaneSurface::Cast(m_s) ) ? true : false;
@@ -290,8 +290,8 @@ ON_CurveOnSurface::IsPlanar(
 
 ON_BOOL32
 ON_CurveOnSurface::IsInPlane(
-      const ON_Plane& plane, // plane to test
-      double tolerance // tolerance to use when checking linearity
+      const ON_Plane&, // plane to test
+      double // tolerance to use when checking linearity
       ) const
 {
   return false;
@@ -428,9 +428,9 @@ ON_CurveOnSurface::GetNurbForm( // returns 0: unable to create NURBS representat
                  //            curve's parameterization and the NURBS
                  //            parameterization may not match to the 
                  //            desired accuracy.
-      ON_NurbsCurve& nurbs,
-      double tolerance,  // (>=0)
-      const ON_Interval* subdomain  // OPTIONAL subdomain of 2d curve
+      ON_NurbsCurve&,  // nurbs
+      double,  // tolerance (>=0)
+      const ON_Interval*  // OPTIONAL subdomain of 2d curve
       ) const
 {
   ON_ERROR("TODO - finish ON_CurveOnSurface::GetNurbForm().");

--- a/surface/src/3rdparty/opennurbs/opennurbs_cylinder.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_cylinder.cpp
@@ -116,7 +116,7 @@ ON_3dPoint ON_Cylinder::PointAt( double s, double t ) const
   return ( circle.PointAt(s) + t*circle.plane.zaxis );
 }
 
-ON_3dPoint ON_Cylinder::NormalAt( double s, double t ) const
+ON_3dPoint ON_Cylinder::NormalAt( double s, double ) const
 {
   ON_3dVector N = ON_CrossProduct( circle.TangentAt(s), circle.plane.zaxis );
   N.Unitize();

--- a/surface/src/3rdparty/opennurbs/opennurbs_dimstyle.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_dimstyle.cpp
@@ -327,7 +327,7 @@ bool ON_DimStyleExtra::IsDefault() const
   return true;
 }
 
-void ON_DimStyleExtra::Dump( ON_TextLog& text_log ) const
+void ON_DimStyleExtra::Dump( ON_TextLog& ) const
 {
   // do nothing
 }
@@ -723,7 +723,7 @@ ON_DimStyle& ON_DimStyle::operator=( const ON_3dmAnnotationSettings& src)
 //
 // ON_Object overrides
 
-ON_BOOL32 ON_DimStyle::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_DimStyle::IsValid( ON_TextLog* ) const
 {
   return ( m_dimstyle_name.Length() > 0 && m_dimstyle_index >= 0);
 }
@@ -1255,7 +1255,7 @@ void ON_DimStyle::SetSuppressExtension2( bool suppress)
 }
 
 // This function deprecated 5/01/07 LW
-void ON_DimStyle::Composite( const ON_DimStyle& OverRide)
+void ON_DimStyle::Composite( const ON_DimStyle& /*OverRide*/)
 {
 /*
   InvalidateAllFields();

--- a/surface/src/3rdparty/opennurbs/opennurbs_embedded_file.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_embedded_file.cpp
@@ -448,7 +448,7 @@ static bool ON_Buffer_IsNotValid()
   return false;
 }
 
-bool ON_Buffer::IsValid( const ON_TextLog* text_log ) const
+bool ON_Buffer::IsValid( const ON_TextLog* ) const
 {
   // This function is primarily used to discover bugs
   // in the ON_Buffer member function code.

--- a/surface/src/3rdparty/opennurbs/opennurbs_error_message.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_error_message.cpp
@@ -18,7 +18,7 @@
 
 
 void ON_ErrorMessage(
-        int message_type, // 0=warning - serious problem that code is designed to handle
+        int,              // 0=warning - serious problem that code is designed to handle
                           // 1=error - serious problem code will attempt to handle
                           //           The thing causing the error is a bug that must
                           //           be fixed.

--- a/surface/src/3rdparty/opennurbs/opennurbs_extensions.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_extensions.cpp
@@ -3034,7 +3034,7 @@ bool ONX_Model::Write(
 bool ONX_Model::Write( 
        ON_BinaryArchive& archive,
        int version,
-       const char* sStartSectionComment,
+       const char*,
        ON_TextLog* error_log
        )
 {
@@ -5139,10 +5139,10 @@ static int AuditObjectTableHelper(
 }
 
 static int AuditHistoryRecordTableHelper( 
-      ONX_Model& model,
-      bool bAttemptRepair,
-      int* repair_count,
-      ON_TextLog* text_log 
+      ONX_Model&,
+      bool,
+      int*,
+      ON_TextLog*
       )
 {
   // TODO - make sure object id's exist

--- a/surface/src/3rdparty/opennurbs/opennurbs_font.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_font.cpp
@@ -82,7 +82,7 @@ void ON_Font::Defaults()
 //
 // ON_Object overrides
 
-ON_BOOL32 ON_Font::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_Font::IsValid( ON_TextLog* ) const
 {
   return ( m_font_name.Length() > 0 
            && m_font_index >= 0 
@@ -277,7 +277,7 @@ int CALLBACK ON__IsSymbolFontFaceNameHelper( ENUMLOGFONTEX*, NEWTEXTMETRICEX*, D
 bool ON_Font::IsSymbolFontFaceName( const wchar_t* s)
 {
   bool rc = false;
-
+  (void) s; // no op to supress warning
 #if defined(ON_OS_WINDOWS_GDI)
   if( s && s[0])
   {

--- a/surface/src/3rdparty/opennurbs/opennurbs_fsp.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_fsp.cpp
@@ -10,7 +10,7 @@ ON_FixedSizePool::~ON_FixedSizePool()
   Destroy();
 }
 
-size_t ON_FixedSizePool::SizeofElement() const
+std::size_t ON_FixedSizePool::SizeofElement() const
 {
   return m_sizeof_element;
 }
@@ -130,12 +130,12 @@ ON_MEMORY_POOL* ON_FixedSizePool::Heap()
   return m_heap;
 }
 
-size_t ON_FixedSizePool::ActiveElementCount() const
+std::size_t ON_FixedSizePool::ActiveElementCount() const
 {
   return m_active_element_count;
 }
 
-size_t ON_FixedSizePool::TotalElementCount() const
+std::size_t ON_FixedSizePool::TotalElementCount() const
 {
   return m_total_element_count;
 }
@@ -404,7 +404,7 @@ void* ON_FixedSizePoolIterator::FirstElement(std::size_t element_index)
   return m_it_element;
 }
 
-size_t ON_FixedSizePool::BlockElementCapacity( const void* block ) const
+std::size_t ON_FixedSizePool::BlockElementCapacity( const void* block ) const
 {
   // returns number of items that can be allocated from block
   if ( 0 == block || m_sizeof_element <= 0 )
@@ -413,7 +413,7 @@ size_t ON_FixedSizePool::BlockElementCapacity( const void* block ) const
   return (block_end - ((char*)block))/m_sizeof_element;
 }
 
-size_t ON_FixedSizePool::BlockElementCount( const void* block ) const
+std::size_t ON_FixedSizePool::BlockElementCount( const void* block ) const
 {
   // returns number of items allocated from block
   if ( 0 == block || m_sizeof_element <= 0 )

--- a/surface/src/3rdparty/opennurbs/opennurbs_geometry.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_geometry.cpp
@@ -230,7 +230,7 @@ ON_BOOL32 ON_Geometry::HasBrepForm() const
   return false;
 }
 
-ON_Brep* ON_Geometry::BrepForm( ON_Brep* brep ) const
+ON_Brep* ON_Geometry::BrepForm( ON_Brep* ) const
 {
   // override if specific geoemtry has brep form
   return NULL;
@@ -245,7 +245,7 @@ ON_COMPONENT_INDEX ON_Geometry::ComponentIndex() const
   return ci;  
 }
 
-bool ON_Geometry::EvaluatePoint( const class ON_ObjRef& objref, ON_3dPoint& P ) const
+bool ON_Geometry::EvaluatePoint( const class ON_ObjRef&, ON_3dPoint& P ) const
 {
   // virtual function default
   P = ON_UNSET_POINT;

--- a/surface/src/3rdparty/opennurbs/opennurbs_group.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_group.cpp
@@ -31,7 +31,7 @@ ON_Group::~ON_Group()
 //
 // ON_Object overrides
 
-ON_BOOL32 ON_Group::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_Group::IsValid( ON_TextLog* ) const
 {
   return ( m_group_name.Length() > 0 && m_group_index >= 0 );
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_hatch.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_hatch.cpp
@@ -109,7 +109,7 @@ void ON_HatchExtra::SetDefaults()
   m_basepoint.Set(0.0,0.0);
 }
 
-void ON_HatchExtra::Dump(ON_TextLog& text_log) const
+void ON_HatchExtra::Dump(ON_TextLog&) const
 {
 }
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_instance.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_instance.cpp
@@ -563,7 +563,7 @@ int ON_InstanceDefinition::Dimension() const
 ON_BOOL32 ON_InstanceDefinition::GetBBox(
        double* boxmin,
        double* boxmax,
-       ON_BOOL32 bGrowBox
+       ON_BOOL32
        ) const
 {
   if ( boxmin )
@@ -582,7 +582,7 @@ ON_BOOL32 ON_InstanceDefinition::GetBBox(
 }
 
 ON_BOOL32 ON_InstanceDefinition::Transform( 
-       const ON_Xform& xform
+       const ON_Xform&
        )
 {
   // instance DEFs cannot be transformed
@@ -1050,7 +1050,7 @@ ON__IDefLayerSettingsUserData& ON__IDefLayerSettingsUserData::operator=(const ON
 }
 
 // virtual ON_Object override
-ON_BOOL32 ON__IDefLayerSettingsUserData::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON__IDefLayerSettingsUserData::IsValid( ON_TextLog* ) const
 {
   return true;
 }
@@ -1568,7 +1568,7 @@ ON__IDefAlternativePathUserData& ON__IDefAlternativePathUserData::operator=(cons
 }
 
 // virtual ON_Object override
-ON_BOOL32 ON__IDefAlternativePathUserData::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON__IDefAlternativePathUserData::IsValid( ON_TextLog* ) const
 {
   return !m_alternate_path.IsEmpty();
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_knot.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_knot.cpp
@@ -67,7 +67,7 @@ double ON_KnotTolerance( int order, int cv_count, const double* knot,
 // Computes tolerance associated with span of a knot vector
 //
 
-double ON_SpanTolerance( int order, int cv_count, const double* knot, int span_index )
+double ON_SpanTolerance( int order, int, const double* knot, int span_index )
 {
   const int i0 = span_index+order-2;
   return ON_DomainTolerance( knot[i0], knot[i0+1] );

--- a/surface/src/3rdparty/opennurbs/opennurbs_layer.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_layer.cpp
@@ -2366,36 +2366,30 @@ bool ON_Layer::GetSavedSettings( ON_Layer& layer, unsigned int& ) const
   const ON__LayerSettingsUserData* ud = ON__LayerSettingsUserData::LayerSettings(*this,false);
   if ( 0 == ud )
     return false;
-  bool rc = false;
 
   if ( ud->HaveColor() )
   {
     layer.m_color = ud->m_color;
-    rc = true;
   }
 
   if ( ud->HavePlotColor() )
   {
     layer.m_plot_color = ud->m_plot_color;
-    rc = true;
   }
 
   if ( ud->HaveVisible() )
   {
     layer.m_bVisible = ud->m_bVisible;
-    rc = true;
   }
 
   if ( ud->HaveLocked() )
   {
     layer.m_bLocked = ud->m_bLocked;
-    rc = true;
   }
 
   if ( ud->HavePlotWeight() )
   {
     layer.m_plot_weight_mm = ud->m_plot_weight_mm;
-    rc = true;
   }
 
   return true;

--- a/surface/src/3rdparty/opennurbs/opennurbs_layer.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_layer.cpp
@@ -875,7 +875,7 @@ void ON__LayerPerViewSettings::SetDefaultValues()
   m_plot_weight_mm = ON_UNSET_VALUE;
 }
 
-bool ON__LayerPerViewSettings::Write(const ON_Layer& layer, ON_BinaryArchive& binary_archive) const
+bool ON__LayerPerViewSettings::Write(const ON_Layer&, ON_BinaryArchive& binary_archive) const
 {
   if ( !binary_archive.BeginWrite3dmChunk(TCODE_ANONYMOUS_CHUNK,1,2) )
     return false;
@@ -1147,7 +1147,7 @@ ON__LayerExtensions::~ON__LayerExtensions()
 }
 
 // virtual ON_Object override
-ON_BOOL32 ON__LayerExtensions::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON__LayerExtensions::IsValid( ON_TextLog* ) const
 {
   return true;
 }
@@ -1161,7 +1161,7 @@ unsigned int ON__LayerExtensions::SizeOf() const
 }
 
 // virtual ON_Object override
-ON__UINT32 ON__LayerExtensions::DataCRC(ON__UINT32 current_remainder) const
+ON__UINT32 ON__LayerExtensions::DataCRC(ON__UINT32) const
 {
   ON__UINT32 crc = 0;
   crc = m_vp_settings.DataCRC(crc);
@@ -2201,7 +2201,7 @@ ON__LayerSettingsUserData::~ON__LayerSettingsUserData()
 }
 
 // virtual ON_Object override
-ON_BOOL32 ON__LayerSettingsUserData::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON__LayerSettingsUserData::IsValid( ON_TextLog* ) const
 {
   return true;
 }
@@ -2361,7 +2361,7 @@ unsigned int ON_Layer::SavedSettings() const
   return ( 0 != ud ? ud->m_settings : 0 );
 }
 
-bool ON_Layer::GetSavedSettings( ON_Layer& layer, unsigned int& settings ) const
+bool ON_Layer::GetSavedSettings( ON_Layer& layer, unsigned int& ) const
 {
   const ON__LayerSettingsUserData* ud = ON__LayerSettingsUserData::LayerSettings(*this,false);
   if ( 0 == ud )

--- a/surface/src/3rdparty/opennurbs/opennurbs_light.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_light.cpp
@@ -366,7 +366,7 @@ ON::light_style ON_Light::Style() const
   return m_style;
 }
 
-const ON_BOOL32 ON_Light::IsPointLight() const
+ON_BOOL32 ON_Light::IsPointLight() const
 {
   ON_BOOL32 rc;
   switch(m_style)
@@ -383,7 +383,7 @@ const ON_BOOL32 ON_Light::IsPointLight() const
   return rc;
 }
 
-const ON_BOOL32 ON_Light::IsDirectionalLight() const
+ON_BOOL32 ON_Light::IsDirectionalLight() const
 {
   ON_BOOL32 rc;
   switch(m_style)
@@ -400,7 +400,7 @@ const ON_BOOL32 ON_Light::IsDirectionalLight() const
   return rc;
 }
 
-const ON_BOOL32 ON_Light::IsSpotLight() const
+ON_BOOL32 ON_Light::IsSpotLight() const
 {
   ON_BOOL32 rc;
   switch(m_style)
@@ -417,7 +417,7 @@ const ON_BOOL32 ON_Light::IsSpotLight() const
   return rc;
 }
 
-const ON_BOOL32 ON_Light::IsLinearLight() const
+ON_BOOL32 ON_Light::IsLinearLight() const
 {
   ON_BOOL32 rc;
   switch(m_style)
@@ -434,7 +434,7 @@ const ON_BOOL32 ON_Light::IsLinearLight() const
   return rc;
 }
 
-const ON_BOOL32 ON_Light::IsRectangularLight() const
+ON_BOOL32 ON_Light::IsRectangularLight() const
 {
   ON_BOOL32 rc;
   switch(m_style)

--- a/surface/src/3rdparty/opennurbs/opennurbs_light.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_light.cpp
@@ -49,7 +49,7 @@ ON_Light::~ON_Light()
 {
 }
 
-ON_BOOL32 ON_Light::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_Light::IsValid( ON_TextLog* ) const
 {
   int s = Style();
   if ( s <= ON::unknown_light_style || s >= ON::light_style_count ) {

--- a/surface/src/3rdparty/opennurbs/opennurbs_light.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_light.cpp
@@ -126,11 +126,14 @@ void ON_Light::Dump( ON_TextLog& dump ) const
 
   dump.Print("location = "); dump.Print(Location()); dump.Print("\n");
   if ( bDumpDir )
-    dump.Print("direction = "); dump.Print(Direction()); dump.Print("\n");
+    dump.Print("direction = ");
+  dump.Print(Direction()); dump.Print("\n");
   if ( bDumpLength )
-    dump.Print("length = "); dump.Print(Length()); dump.Print("\n");
+    dump.Print("length = ");
+  dump.Print(Length()); dump.Print("\n");
   if ( bDumpWidth )
-    dump.Print("width = "); dump.Print(Width()); dump.Print("\n");
+    dump.Print("width = ");
+  dump.Print(Width()); dump.Print("\n");
 
   dump.Print("intensity = %g%%\n",Intensity()*100.0);
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_linecurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_linecurve.cpp
@@ -155,7 +155,7 @@ ON_LineCurve::SwapCoordinates( int i, int j )
   return rc;
 }
 
-ON_BOOL32 ON_LineCurve::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_LineCurve::IsValid( ON_TextLog* ) const
 {
   return ( m_t[0] < m_t[1] && m_line.Length() > 0.0 ) ? true : false;
 }
@@ -275,7 +275,7 @@ int ON_LineCurve::Degree() const
 
 ON_BOOL32
 ON_LineCurve::IsLinear(  // true if curve locus is a line segment
-      double tolerance   // tolerance to use when checking linearity
+      double   // tolerance to use when checking linearity
       ) const
 {
   return IsValid();
@@ -313,10 +313,10 @@ int ON_LineCurve::IsPolyline(
 
 ON_BOOL32
 ON_LineCurve::IsArc( // true if curve locus in an arc or circle
-      const ON_Plane* plane, // if not NULL, test is performed in this plane
-      ON_Arc* arc,         // if not NULL and true is returned, then arc
+      const ON_Plane*, // if not NULL, test is performed in this plane
+      ON_Arc*,         // if not NULL and true is returned, then arc
                               // arc parameters are filled in
-      double tolerance // tolerance to use when checking linearity
+      double // tolerance to use when checking linearity
       ) const
 {
   return false;
@@ -384,11 +384,11 @@ ON_BOOL32 ON_LineCurve::Evaluate( // returns false if unable to evaluate
        int der_count,  // number of derivatives (>=0)
        int v_stride,   // v[] array stride (>=Dimension())
        double* v,      // v[] array of length stride*(ndir+1)
-       int side,       // optional - determines which side to evaluate from
+       int,            // optional - determines which side to evaluate from
                        //         0 = default
                        //      <  0 to evaluate from below, 
                        //      >  0 to evaluate from above
-       int* hint       // optional - evaluation hint (int) used to speed
+       int*            // optional - evaluation hint (int) used to speed
                        //            repeated evaluations
        ) const
 {
@@ -439,7 +439,7 @@ ON_BOOL32 ON_LineCurve::SetEndPoint(ON_3dPoint end_point)
 
 int ON_LineCurve::GetNurbForm(
       ON_NurbsCurve& c,
-      double tolerance,
+      double,
       const ON_Interval* subdomain
       ) const
 {

--- a/surface/src/3rdparty/opennurbs/opennurbs_linecurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_linecurve.cpp
@@ -56,7 +56,7 @@ ON_LineCurve::ON_LineCurve( const ON_Line& L, double t0, double t1 ) : m_line(L)
 {
 }
 
-ON_LineCurve::ON_LineCurve( const ON_LineCurve& src )
+ON_LineCurve::ON_LineCurve( const ON_LineCurve& src ) : ON_Curve(src)
 {
   *this = src;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
@@ -1441,8 +1441,8 @@ void ON_SerialNumberMap::GarbageCollectHelper()
         while ( k < m_sn_block0.m_count && m_sn_block0.m_sn[k].m_sn < sn1 )
           snarray[snarray_count++] = m_sn_block0.m_sn[k++];
       }
-      n = (snarray_count > SN_BLOCK_CAPACITY) 
-        ? SN_BLOCK_CAPACITY 
+      n = (snarray_count > static_cast<size_t>(SN_BLOCK_CAPACITY))
+        ? static_cast<size_t>(SN_BLOCK_CAPACITY)
         : snarray_count;
       if ( k < m_sn_block0.m_count )
       {

--- a/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
@@ -656,12 +656,12 @@ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::FindElementHelper(uns
   return 0;
 }
 
-size_t ON_SerialNumberMap::ActiveSerialNumberCount() const
+std::size_t ON_SerialNumberMap::ActiveSerialNumberCount() const
 {
   return m_sn_count - m_sn_purged;
 }
 
-size_t ON_SerialNumberMap::ActiveIdCount() const
+std::size_t ON_SerialNumberMap::ActiveIdCount() const
 {
   return m_active_id_count;
 }
@@ -800,7 +800,7 @@ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::FindId(ON_UUID id) co
 }
 
 
-size_t ON_SerialNumberMap::GetElements(
+std::size_t ON_SerialNumberMap::GetElements(
         unsigned int sn0,
         unsigned int sn1, 
         std::size_t max_count,
@@ -1143,7 +1143,7 @@ int ON_SerialNumberMap::SN_BLOCK::CompareMaxSN(const void* a, const void* b)
   return 0;
 }
 
-size_t ON_SerialNumberMap::SN_BLOCK::ActiveElementEstimate(unsigned int sn0, unsigned int sn1) const
+std::size_t ON_SerialNumberMap::SN_BLOCK::ActiveElementEstimate(unsigned int sn0, unsigned int sn1) const
 {
   std::size_t c = m_count-m_purged;
   if ( c > 0 )
@@ -1261,7 +1261,7 @@ bool ON_SerialNumberMap::IsValid(ON_TextLog* textlog) const
   return true;
 }
 
-size_t ON_SerialNumberMap::GarbageCollectMoveHelper(ON_SerialNumberMap::SN_BLOCK* dst,ON_SerialNumberMap::SN_BLOCK* src)
+std::size_t ON_SerialNumberMap::GarbageCollectMoveHelper(ON_SerialNumberMap::SN_BLOCK* dst,ON_SerialNumberMap::SN_BLOCK* src)
 {
   // This helper is used by GarbageCollectHelper and moves
   // as many entries as possible from src to dst.  
@@ -1441,8 +1441,8 @@ void ON_SerialNumberMap::GarbageCollectHelper()
         while ( k < m_sn_block0.m_count && m_sn_block0.m_sn[k].m_sn < sn1 )
           snarray[snarray_count++] = m_sn_block0.m_sn[k++];
       }
-      n = (snarray_count > static_cast<size_t>(SN_BLOCK_CAPACITY))
-        ? static_cast<size_t>(SN_BLOCK_CAPACITY)
+      n = (snarray_count > static_cast<std::size_t>(SN_BLOCK_CAPACITY))
+        ? static_cast<std::size_t>(SN_BLOCK_CAPACITY)
         : snarray_count;
       if ( k < m_sn_block0.m_count )
       {
@@ -1633,7 +1633,7 @@ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::AddSerialNumberAndId(
   return e;
 }
 
-size_t ON_SerialNumberMap::HashIndex(const ON_UUID* id) const
+std::size_t ON_SerialNumberMap::HashIndex(const ON_UUID* id) const
 {
   // this is a private member function and the caller
   // insures the id pointer is not null.

--- a/surface/src/3rdparty/opennurbs/opennurbs_material.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_material.cpp
@@ -82,7 +82,7 @@ ON_Material::~ON_Material()
 {}
 
 ON_BOOL32
-ON_Material::IsValid( ON_TextLog* text_log ) const
+ON_Material::IsValid( ON_TextLog* ) const
 {
   return true;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_matrix.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_matrix.cpp
@@ -1044,7 +1044,7 @@ bool ON_Matrix::IsColOrthoNormal() const
 bool ON_Matrix::Invert( double zero_tolerance )
 {
   ON_Workspace ws;
-  int i, j, k, ix, jx, rank;
+  int i, j, k, ix, jx;
   double x;
   const int n = MinCount();
   if ( n < 1 )
@@ -1055,7 +1055,6 @@ bool ON_Matrix::Invert( double zero_tolerance )
   int* col = ws.GetIntMemory(n);
 
   I.SetDiagonal(1.0);
-  rank = 0;
 
   double** this_m = ThisM();
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
@@ -1011,7 +1011,7 @@ bool ON_Mesh::WriteFaceArray( int vcount, int fcount, ON_BinaryArchive& file ) c
   return rc;
 }
 
-bool ON_Mesh::ReadFaceArray( int vcount, int fcount, ON_BinaryArchive& file )
+bool ON_Mesh::ReadFaceArray( int, int fcount, ON_BinaryArchive& file )
 {
   unsigned char  cvi[4];
   unsigned short svi[4];
@@ -3302,7 +3302,7 @@ bool ON_Mesh::GetCurvatureStats( // returns true if successful
   return rc;
 }
 
-int ON_MeshTopology::WaitUntilReady(int sleep_value) const
+int ON_MeshTopology::WaitUntilReady(int) const
 {
   return m_b32IsValid;
 }
@@ -3556,8 +3556,8 @@ ON_Mesh::ComputeFaceNormals()
 //}
 
 bool ON_Mesh::CombineCoincidentVertices( 
-        const ON_3fVector tolerance,
-        double cos_normal_angle // = -1.0  // cosine(break angle) -1.0 will merge all coincident vertices
+        const ON_3fVector /*tolerance*/,
+        double //cos_normal_angle // = -1.0  // cosine(break angle) -1.0 will merge all coincident vertices
         )
 {
   // TODO - If you need this function, please ask Dale Lear to finish it.
@@ -4905,7 +4905,7 @@ bool ON_MeshCurvatureStats::Read( ON_BinaryArchive& file )
 bool ON_MeshCurvatureStats::Set( ON::curvature_style kappa_style,
                                  int Kcount,
                                  const ON_SurfaceCurvature* K,
-                                 const ON_3fVector* N, // needed for normal sectional curvatures
+                                 const ON_3fVector* /*N*/, // needed for normal sectional curvatures
                                  double infinity
                                  )
 {
@@ -8135,7 +8135,7 @@ ON_BOOL32 ON_MeshVertexRef::GetBBox(
 }
 
 ON_BOOL32 ON_MeshVertexRef::Transform( 
-       const ON_Xform& xform
+       const ON_Xform&
        )
 {
   return false;
@@ -8271,7 +8271,7 @@ ON_BOOL32 ON_MeshEdgeRef::GetBBox(
 }
 
 ON_BOOL32 ON_MeshEdgeRef::Transform( 
-       const ON_Xform& xform
+       const ON_Xform&
        )
 {
   return false;
@@ -8417,7 +8417,7 @@ ON_BOOL32 ON_MeshFaceRef::GetBBox(
 }
 
 ON_BOOL32 ON_MeshFaceRef::Transform( 
-       const ON_Xform& xform
+       const ON_Xform&
        )
 {
   return false;
@@ -9698,7 +9698,7 @@ ON_PerObjectMeshParameters::~ON_PerObjectMeshParameters()
 }
 
 // virtual ON_Object override
-ON_BOOL32 ON_PerObjectMeshParameters::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_PerObjectMeshParameters::IsValid( ON_TextLog* ) const
 {
   return true;
 }
@@ -9846,7 +9846,7 @@ bool ON_3dmObjectAttributes::EnableCustomRenderMeshParameters(bool bEnable)
   return (!bEnable || 0 != ud);
 }
 
-void ON_Mesh::DestroyTree( bool bDeleteTree )
+void ON_Mesh::DestroyTree( bool )
 {
 }
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
@@ -414,8 +414,9 @@ ON_Mesh::ON_Mesh(
   m_hidden_count = 0;
 }
 
-ON_Mesh::ON_Mesh( const ON_Mesh& src ) 
-: m_packed_tex_rotate(0)
+ON_Mesh::ON_Mesh( const ON_Mesh& src )
+: ON_Geometry(src)
+, m_packed_tex_rotate(0)
 , m_parent(0) 
 , m_mesh_parameters(0) 
 , m_invalid_count(0) 

--- a/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_mesh.cpp
@@ -7136,7 +7136,6 @@ bool ON_MeshTopology::Create()
     const int topv_count = m_topv.Count();
     if ( topv_count >= 2 ) 
     {
-      bool rc = false;
       int ei, ecnt, fi, vi0, vi1, efi, topfvi[4];
       ON_MeshFace f;
 
@@ -7149,7 +7148,6 @@ bool ON_MeshTopology::Create()
         
         if ( ecnt > 0 ) 
         {
-          rc = true;
           ON_SortMeshFaceSidesByVertexIndex( ecnt, e );
 
           // count number of topological edges and allocate storage
@@ -7522,10 +7520,8 @@ const ON_MeshPartition* ON_Mesh::CreatePartition(
               )
 {
   ON_Workspace ws;
-  bool bNeedFaceSort = true;
   if ( m_partition ) 
   {
-    bNeedFaceSort = false;
     if (   m_partition->m_partition_max_triangle_count > partition_max_triangle_count
         || m_partition->m_partition_max_vertex_count > partition_max_vertex_count )
         DestroyPartition();
@@ -7692,13 +7688,12 @@ const ON_MeshPartition* ON_Mesh::CreatePartition(
 
       // fill in m_part.vi[]
       int m, pi, partition_count = m_partition->m_part.Count();
-      int vi0, vi1, vi2, vi3;
+      int vi0, vi2, vi3;
       for (vi2 = 0; vi2 < vertex_count && pmark[vi2]<2; vi2++)
       {/*empty for body*/}
       vi3=vi2;
       for ( pi = 0; pi < partition_count; pi++ ) {
         vi0 = vi2;
-        vi1 = vi3;
         m = 2*pi + 4;
         for ( vi2 = vi3; vi2 < vertex_count && pmark[vi2] <  m; vi2++) 
         {/*empty for body*/}

--- a/surface/src/3rdparty/opennurbs/opennurbs_mesh_ngon.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_mesh_ngon.cpp
@@ -236,7 +236,7 @@ ON_MeshNgonUserData& ON_MeshNgonUserData::operator=(const ON_MeshNgonUserData& s
   return *this;
 }
 
-ON_BOOL32 ON_MeshNgonUserData::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_MeshNgonUserData::IsValid( ON_TextLog* ) const
 {
   return true;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_morph.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_morph.cpp
@@ -449,7 +449,7 @@ void ON_SpaceMorph::SetQuickPreview( bool bQuickPreview )
   m_bQuickPreview = bQuickPreview ? true : false;
 }
 
-bool ON_SpaceMorph::IsIdentity( const ON_BoundingBox& bbox ) const
+bool ON_SpaceMorph::IsIdentity( const ON_BoundingBox& ) const
 {
   return false;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbscurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbscurve.cpp
@@ -54,7 +54,7 @@ ON_NurbsCurve::ON_NurbsCurve()
   Initialize();
 }
 
-ON_NurbsCurve::ON_NurbsCurve( const ON_NurbsCurve& src )
+ON_NurbsCurve::ON_NurbsCurve( const ON_NurbsCurve& src ) : ON_Curve(src)
 {
   ON__SET__THIS__PTR(m_s_ON_NurbsCurve_ptr);
   Initialize();

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbscurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbscurve.cpp
@@ -1453,7 +1453,7 @@ bool ON_IsG2CurvatureContinuous(
 bool ON_IsGsmoothCurvatureContinuous(
   const ON_3dVector Km, 
   const ON_3dVector Kp,
-  double cos_angle_tolerance,
+  double,
   double curvature_tolerance
   )
 {
@@ -3270,7 +3270,7 @@ ON_BOOL32 ON_NurbsCurve::Split(
 
 
 int ON_NurbsCurve::GetNurbForm( ON_NurbsCurve& curve, 
-                                double tolerance,
+                                double,
                                 const ON_Interval* subdomain  // OPTIONAL subdomain of ON::ProxyCurve::Domain()
                                 ) const
 {
@@ -3493,8 +3493,8 @@ bool ON_NurbsSurface::IsDuplicate(
 
 
 bool ON_Brep::IsDuplicate( 
-        const ON_Brep& other, 
-        double tolerance 
+        const ON_Brep&,
+        double
         ) const
 {
   // OBSOLETE FUNCTION - REMOVE

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbscurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbscurve.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
+#include <pcl/pcl_macros.h>
 
 ON_OBJECT_IMPLEMENT(ON_NurbsCurve,ON_Curve,"4ED7D4DD-E947-11d3-BFE5-0010830122F0");
 
@@ -2131,7 +2132,7 @@ ON_NurbsCurve::GetCV( int i, ON::point_style style, double* Point ) const
   switch(style) {
   case ON::euclidean_rational:
     Point[dim] = w;
-    // no break here
+    PCL_FALLTHROUGH
   case ON::not_rational:
     if ( w == 0.0 )
       return false;

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
@@ -2597,12 +2597,11 @@ bool ON_MakeDegreesCompatible(
        ON_NurbsCurve& nurbs_curveB
        )
 {
-  bool rc = false;
   if ( nurbs_curveA.m_order > nurbs_curveB.m_order )
-    rc = nurbs_curveB.IncreaseDegree( nurbs_curveA.Degree() )?true:false;
+    nurbs_curveB.IncreaseDegree( nurbs_curveA.Degree() );
   else
-    rc = nurbs_curveA.IncreaseDegree( nurbs_curveB.Degree() )?true:false;
-  return (nurbs_curveA.m_order == nurbs_curveA.m_order);
+    nurbs_curveA.IncreaseDegree( nurbs_curveB.Degree() );
+  return true;
 }
 
 static

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
@@ -1198,9 +1198,9 @@ ON_NurbsSurface::GetNurbForm( // returns 0: unable to create NURBS representatio
 }
 
 ON_Surface* ON_NurbsSurface::Offset(
-      double offset_distance, 
-      double tolerance, 
-      double* max_deviation
+      double,
+      double,
+      double*
       ) const
 {
   // 3rd party developers who want to enhance openNURBS

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
@@ -15,6 +15,8 @@
 */
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
+#include <pcl/pcl_macros.h>
+
 
 ON_OBJECT_IMPLEMENT(ON_NurbsSurface,ON_Surface,"4ED7D4DE-E947-11d3-BFE5-0010830122F0");
 
@@ -1853,7 +1855,7 @@ ON_NurbsSurface::GetCV( int i, int j, ON::point_style style, double* Point ) con
   switch(style) {
   case ON::euclidean_rational:
     Point[dim] = w;
-    // no break here
+    PCL_FALLTHROUGH
   case ON::not_rational:
     if ( w == 0.0 )
       return false;

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbssurface.cpp
@@ -60,7 +60,7 @@ ON_NurbsSurface::ON_NurbsSurface()
   Initialize();
 }
 
-ON_NurbsSurface::ON_NurbsSurface( const ON_NurbsSurface& src )
+ON_NurbsSurface::ON_NurbsSurface( const ON_NurbsSurface& src ) : ON_Surface(src)
 {
   ON__SET__THIS__PTR(m_s_ON_NurbsSurface_ptr);
   Initialize();

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbsvolume.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbsvolume.cpp
@@ -2231,7 +2231,7 @@ ON_BOOL32 ON_MorphControl::GetBBox(
 bool ON_MorphControl::GetTightBoundingBox( 
 		ON_BoundingBox& tight_bbox, 
     int bGrowBox,
-		const ON_Xform* xform
+		const ON_Xform*
     ) const
 {
   bool rc = false;

--- a/surface/src/3rdparty/opennurbs/opennurbs_nurbsvolume.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_nurbsvolume.cpp
@@ -15,6 +15,8 @@
 */
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
+#include <pcl/pcl_macros.h>
+
 
 ON_OBJECT_IMPLEMENT(ON_NurbsCage,ON_Geometry,"06936AFB-3D3C-41ac-BF70-C9319FA480A1");
 
@@ -1682,7 +1684,7 @@ bool ON_NurbsCage::GetCV( int i, int j, int k, ON::point_style style, double* Po
   switch(style) {
   case ON::euclidean_rational:
     Point[dim] = w;
-    // no break here
+    PCL_FALLTHROUGH
   case ON::not_rational:
     if ( w == 0.0 )
       return false;

--- a/surface/src/3rdparty/opennurbs/opennurbs_object.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_object.cpp
@@ -1702,11 +1702,11 @@ ON_BOOL32 ON_Object::Read(
 
 }
 
-void ON_Object::DestroyRuntimeCache( bool bDelete )
+void ON_Object::DestroyRuntimeCache( bool )
 {
 }
 
-void ON_Curve::DestroyRuntimeCache( bool bDelete )
+void ON_Curve::DestroyRuntimeCache( bool )
 {
 }
 
@@ -1722,7 +1722,7 @@ void ON_CurveProxy::DestroyRuntimeCache( bool bDelete )
   }
 }
 
-void ON_Surface::DestroyRuntimeCache( bool bDelete )
+void ON_Surface::DestroyRuntimeCache( bool )
 {
 }
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_object_history.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_object_history.cpp
@@ -1522,7 +1522,7 @@ ON_HistoryRecord& ON_HistoryRecord::operator=(const ON_HistoryRecord& src)
   return *this;
 }
 
-ON_BOOL32 ON_HistoryRecord::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_HistoryRecord::IsValid( ON_TextLog* ) const
 {
   return true;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_offsetsurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_offsetsurface.cpp
@@ -125,7 +125,7 @@ const ON_Surface* ON_OffsetSurface::BaseSurface() const
 ON_BOOL32 ON_OffsetSurface::GetBBox(
        double* bbox_min,
        double* bbox_max,
-       ON_BOOL32 bGrowBox
+       ON_BOOL32
        ) const
 {
   ON_BOOL32 rc = ON_SurfaceProxy::GetBBox(bbox_min,bbox_max);

--- a/surface/src/3rdparty/opennurbs/opennurbs_planesurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_planesurface.cpp
@@ -22,7 +22,7 @@ ON_OBJECT_IMPLEMENT(ON_ClippingPlaneSurface,ON_PlaneSurface,"DBC5A584-CE3F-4170-
 ON_PlaneSurface::ON_PlaneSurface()
 {}
 
-ON_PlaneSurface::ON_PlaneSurface( const ON_PlaneSurface& src )
+ON_PlaneSurface::ON_PlaneSurface( const ON_PlaneSurface& src ) : ON_Surface(src)
 {
   *this = src;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_planesurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_planesurface.cpp
@@ -76,7 +76,7 @@ ON_PlaneSurface::~ON_PlaneSurface()
 {}
 
 ON_BOOL32
-ON_PlaneSurface::IsValid( ON_TextLog* text_log ) const
+ON_PlaneSurface::IsValid( ON_TextLog* ) const
 {
   return (   m_plane.IsValid() 
            && m_domain[0].IsIncreasing() && m_domain[1].IsIncreasing() 
@@ -198,7 +198,7 @@ ON_Interval ON_PlaneSurface::Domain( int dir ) const
   return dir ? m_domain[1] : m_domain[0];
 }
 
-int ON_PlaneSurface::SpanCount( int dir ) const
+int ON_PlaneSurface::SpanCount( int ) const
 {
   return 1;
 }
@@ -224,7 +224,7 @@ ON_BOOL32 ON_PlaneSurface::GetSpanVector( int dir, double* s ) const
   return d.IsIncreasing();
 }
 
-int ON_PlaneSurface::Degree( int dir ) const
+int ON_PlaneSurface::Degree( int ) const
 {
   return 1;
 }
@@ -241,7 +241,7 @@ ON_PlaneSurface::GetParameterTolerance(
   return ON_GetParameterTolerance( m_domain[dir][0], m_domain[dir][1], t, tminus, tplus );
 }
 
-ON_BOOL32 ON_PlaneSurface::IsPlanar( ON_Plane* plane, double tolerance ) const
+ON_BOOL32 ON_PlaneSurface::IsPlanar( ON_Plane* plane, double ) const
 {
   if ( plane )
     *plane = this->m_plane;
@@ -249,19 +249,19 @@ ON_BOOL32 ON_PlaneSurface::IsPlanar( ON_Plane* plane, double tolerance ) const
 }
 
 ON_BOOL32 
-ON_PlaneSurface::IsClosed( int dir ) const
+ON_PlaneSurface::IsClosed( int ) const
 {
   return false;
 }
 
 ON_BOOL32 
-ON_PlaneSurface::IsPeriodic( int dir ) const
+ON_PlaneSurface::IsPeriodic( int ) const
 {
   return false;
 }
 
 ON_BOOL32 
-ON_PlaneSurface::IsSingular( int side ) const
+ON_PlaneSurface::IsSingular( int ) const
 {
   return false;
 }
@@ -298,15 +298,15 @@ ON_PlaneSurface::Reverse( int dir )
 }
 
 bool ON_PlaneSurface::IsContinuous(
-    ON::continuity desired_continuity,
-    double s, 
-    double t, 
-    int* hint, // default = NULL,
-    double point_tolerance, // default=ON_ZERO_TOLERANCE
-    double d1_tolerance, // default==ON_ZERO_TOLERANCE
-    double d2_tolerance, // default==ON_ZERO_TOLERANCE
-    double cos_angle_tolerance, // default==ON_DEFAULT_ANGLE_TOLERANCE_COSINE
-    double curvature_tolerance  // default==ON_SQRT_EPSILON
+    ON::continuity,
+    double,
+    double,
+    int*,   // default = NULL,
+    double, // default=ON_ZERO_TOLERANCE
+    double, // default==ON_ZERO_TOLERANCE
+    double, // default==ON_ZERO_TOLERANCE
+    double, // default==ON_DEFAULT_ANGLE_TOLERANCE_COSINE
+    double  // default==ON_SQRT_EPSILON
     ) const
 {
   return true;
@@ -335,11 +335,11 @@ ON_PlaneSurface::Evaluate( // returns false if unable to evaluate
        int der_count,  // number of derivatives (>=0)
        int v_stride,   // v[] array stride (>=Dimension())
        double* v,      // v[] array of length stride*(ndir+1)
-       int side,       // optional - determines which side to evaluate from
+       int     ,       // optional - determines which side to evaluate from
                        //         0 = default
                        //      <  0 to evaluate from below, 
                        //      >  0 to evaluate from above
-       int* hint       // optional - evaluation hint (int) used to speed
+       int*            // optional - evaluation hint (int) used to speed
                        //            repeated evaluations
        ) const
 {
@@ -583,7 +583,7 @@ bool ON_PlaneSurface::GetClosestPoint( const ON_3dPoint& test_point,
 // true if returned if the search is successful.  false is returned if
 // the search fails.
 ON_BOOL32 ON_PlaneSurface::GetLocalClosestPoint( const ON_3dPoint& test_point, // test_point
-        double s0, double t0,     // seed_parameters
+        double, double,     // seed_parameters
         double* s,double* t,   // parameters of local closest point returned here
         const ON_Interval* sdomain, // first parameter sub_domain
         const ON_Interval* tdomain  // second parameter sub_domain
@@ -596,7 +596,7 @@ ON_BOOL32 ON_PlaneSurface::GetLocalClosestPoint( const ON_3dPoint& test_point, /
 
 ON_Surface* ON_PlaneSurface::Offset(
       double offset_distance, 
-      double tolerance, 
+      double,
       double* max_deviation
       ) const
 {
@@ -626,7 +626,7 @@ ON_PlaneSurface::GetNurbForm( // returns 0: unable to create NURBS representatio
                    //            parameterization may not match to the 
                    //            desired accuracy.
         ON_NurbsSurface& nurbs,
-        double tolerance
+        double
         ) const
 {
   ON_BOOL32 rc = IsValid();

--- a/surface/src/3rdparty/opennurbs/opennurbs_point.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_point.cpp
@@ -2602,7 +2602,8 @@ int ON_4fPoint::MaximumCoordinateIndex() const
 {
   const float* a = &x;
   int i = ( fabs(y) > fabs(x) ) ? 1 : 0;
-  if (fabs(z) > fabs(a[i])) i = 2; if (fabs(w) > fabs(a[i])) i = 3;
+  if (fabs(z) > fabs(a[i])) i = 2;
+  if (fabs(w) > fabs(a[i])) i = 3;
   return i;
 }
 
@@ -4898,7 +4899,8 @@ int ON_4dPoint::MaximumCoordinateIndex() const
 {
   const double* a = &x;
   int i = ( fabs(y) > fabs(x) ) ? 1 : 0;
-  if (fabs(z) > fabs(a[i])) i = 2; if (fabs(w) > fabs(a[i])) i = 3;
+  if (fabs(z) > fabs(a[i])) i = 2;
+  if (fabs(w) > fabs(a[i])) i = 3;
   return i;
 }
 
@@ -4912,7 +4914,8 @@ int ON_4dPoint::MinimumCoordinateIndex() const
 {
   const double* a = &x;
   int i = ( fabs(y) < fabs(x) ) ? 1 : 0;
-  if (fabs(z) < fabs(a[i])) i = 2; if (fabs(w) < fabs(a[i])) i = 3;
+  if (fabs(z) < fabs(a[i])) i = 2;
+  if (fabs(w) < fabs(a[i])) i = 3;
   return i;
 }
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_pointcloud.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_pointcloud.cpp
@@ -46,7 +46,7 @@ ON_PointCloud::ON_PointCloud( int capacity ) : m_P(capacity), m_flags(0)
   m_hidden_count=0;
 }
 
-ON_PointCloud::ON_PointCloud( const ON_PointCloud& src )
+ON_PointCloud::ON_PointCloud( const ON_PointCloud& src ) : ON_Geometry(src)
 {
   *this = src;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_pointcloud.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_pointcloud.cpp
@@ -96,7 +96,7 @@ void ON_PointCloud::EmergencyDestroy()
   m_bbox.Destroy();
 }
 
-ON_BOOL32 ON_PointCloud::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_PointCloud::IsValid( ON_TextLog* ) const
 {
   return ( m_P.Count() > 0 ) ? true : false;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_pointgrid.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_pointgrid.cpp
@@ -31,7 +31,7 @@ ON_PointGrid::ON_PointGrid( int c0, int c1 )
   Create(c0,c1);
 }
 
-ON_PointGrid::ON_PointGrid( const ON_PointGrid& src )
+ON_PointGrid::ON_PointGrid( const ON_PointGrid& src ) : ON_Geometry(src)
 {
   *this = src;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_pointgrid.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_pointgrid.cpp
@@ -201,7 +201,7 @@ void ON_PointGrid::Dump( ON_TextLog& dump ) const
   }
 }
 
-ON_BOOL32 ON_PointGrid::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_PointGrid::IsValid( ON_TextLog* ) const
 {
   ON_BOOL32 rc = false;
   if ( ON_IsValidPointGrid( 3, false, 

--- a/surface/src/3rdparty/opennurbs/opennurbs_polycurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_polycurve.cpp
@@ -29,7 +29,7 @@ ON_PolyCurve::ON_PolyCurve( int capacity )
 }
 
 ON_PolyCurve::ON_PolyCurve( const ON_PolyCurve& src )
-              : m_segment(src.Count()), m_t(src.Count()+1)
+              : ON_Curve(src), m_segment(src.Count()), m_t(src.Count()+1)
 {
   *this = src;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_polycurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_polycurve.cpp
@@ -1111,7 +1111,7 @@ static ON_NurbsCurve* ChangeArcEnd( const ON_ArcCurve* arc, ON_3dPoint P, ON_3dP
   return nc;
 }
 
-bool ON_PolyCurve::CloseGap( int gap_index, int ends_to_modify )
+bool ON_PolyCurve::CloseGap( int gap_index, int )
 {
   const int count = m_segment.Count();
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_polyedgecurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_polyedgecurve.cpp
@@ -231,12 +231,12 @@ ON_PolyEdgeCurve::~ON_PolyEdgeCurve()
 {
 }
 
-ON_BOOL32 ON_PolyEdgeCurve::SetStartPoint( ON_3dPoint start_point )
+ON_BOOL32 ON_PolyEdgeCurve::SetStartPoint( ON_3dPoint )
 {
   return false; // cannot change edges
 }
 
-ON_BOOL32 ON_PolyEdgeCurve::SetEndPoint( ON_3dPoint end_point )
+ON_BOOL32 ON_PolyEdgeCurve::SetEndPoint( ON_3dPoint )
 {
   return false; // cannot change edges
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_polylinecurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_polylinecurve.cpp
@@ -420,10 +420,10 @@ int ON_PolylineCurve::IsPolyline(
 
 ON_BOOL32
 ON_PolylineCurve::IsArc( // true if curve locus in an arc or circle
-      const ON_Plane* plane, // if not NULL, test is performed in this plane
-      ON_Arc* arc,         // if not NULL and true is returned, then arc
+      const ON_Plane*, // if not NULL, test is performed in this plane
+      ON_Arc*,         // if not NULL and true is returned, then arc
                               // arc parameters are filled in
-      double tolerance // tolerance to use when checking linearity
+      double // tolerance to use when checking linearity
       ) const
 {
   return false;
@@ -1218,7 +1218,7 @@ ON_BOOL32 ON_PolylineCurve::Split(
 
 int ON_PolylineCurve::GetNurbForm( 
                                   ON_NurbsCurve& nurb, 
-                                  double tol,
+                                  double,
                                   const ON_Interval* subdomain  // OPTIONAL subdomain of ON::ProxyCurve::Domain()
                                   ) const
 {

--- a/surface/src/3rdparty/opennurbs/opennurbs_polylinecurve.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_polylinecurve.cpp
@@ -23,7 +23,7 @@ ON_PolylineCurve::ON_PolylineCurve()
   m_dim = 3;
 }
 
-ON_PolylineCurve::ON_PolylineCurve( const ON_PolylineCurve& L )
+ON_PolylineCurve::ON_PolylineCurve( const ON_PolylineCurve& L ) : ON_Curve(L)
 {
   *this = L;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_rtree.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_rtree.cpp
@@ -78,7 +78,7 @@ static bool SearchHelper(const ON_RTreeNode* a_node, struct ON_RTreeCapsule* a_c
 // ON_RTreeMemPool
 //
 
-size_t ON_MemoryPageSize()
+std::size_t ON_MemoryPageSize()
 {
 #if defined(ON_COMPILER_MSC)
   static std::size_t pagesize = 0;
@@ -290,12 +290,12 @@ void ON_RTreeMemPool::FreeListNode(struct ON_RTreeListNode* list_node)
   }
 }
 
-size_t ON_RTreeMemPool::SizeOf() const
+std::size_t ON_RTreeMemPool::SizeOf() const
 {
   return m_sizeof_heap;
 }
 
-size_t ON_RTreeMemPool::SizeOfUnusedBuffer() const
+std::size_t ON_RTreeMemPool::SizeOfUnusedBuffer() const
 {
   const struct Blk* blk;
   std::size_t sz = m_buffer_capacity;
@@ -1466,7 +1466,7 @@ static void CountRec(ON_RTreeNode* a_node, int& a_count)
   }
 }
 
-size_t ON_RTree::SizeOf() const
+std::size_t ON_RTree::SizeOf() const
 {
   return m_mem_pool.SizeOf();
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_sort.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_sort.cpp
@@ -43,6 +43,8 @@ ON__QSORT_FASTER_THAN_HSORT.
 void 
 ON_qsort( void *base, std::size_t nel, std::size_t width, int (*compar)(void*,const void *, const void *),void* context)
 {
+  // no-op to suppress warning on all compilers
+  (void) base; (void) nel; (void) width; (void) compar; (void) context;
 #if defined(ON__HAVE_RELIABLE_SYSTEM_CONTEXT_QSORT)
   // The call here must be a thread safe system qsort
   // that is faster than the alternative code in this function.

--- a/surface/src/3rdparty/opennurbs/opennurbs_string.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_string.cpp
@@ -86,7 +86,7 @@ void ON_String::EmergencyDestroy()
 	Create();
 }
 
-void ON_String::EnableReferenceCounting( bool bEnable )
+void ON_String::EnableReferenceCounting( bool )
 {
   // TODO fill this in;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_sumsurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_sumsurface.cpp
@@ -73,7 +73,7 @@ void ON_SumSurface::EmergencyDestroy()
   m_curve[1] = 0;
 }
 
-ON_SumSurface::ON_SumSurface( const ON_SumSurface& src )
+ON_SumSurface::ON_SumSurface( const ON_SumSurface& src ) : ON_Surface(src)
 {
   ON__SET__THIS__PTR(m_s_ON_SumSurface_ptr);
   m_curve[0] = 0;

--- a/surface/src/3rdparty/opennurbs/opennurbs_sumsurface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_sumsurface.cpp
@@ -621,7 +621,7 @@ ON_BOOL32 ON_SumSurface::IsPeriodic( int dir ) const
   return rc;
 }
 
-ON_BOOL32 ON_SumSurface::IsSingular( int side ) const
+ON_BOOL32 ON_SumSurface::IsSingular( int ) const
 {
   return false;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_surface.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_surface.cpp
@@ -309,7 +309,7 @@ ON_Surface::IsIsoparametric( const ON_BoundingBox& bbox ) const
 }
 
 
-ON_BOOL32 ON_Surface::IsPlanar( ON_Plane* plane, double tolerance ) const
+ON_BOOL32 ON_Surface::IsPlanar( ON_Plane*, double ) const
 {
   return false;
 }
@@ -369,7 +369,7 @@ ON_Surface::IsClosed(int dir) const
   return false;
 }
 
-ON_BOOL32 ON_Surface::IsPeriodic(int dir) const
+ON_BOOL32 ON_Surface::IsPeriodic(int) const
 {
   return false;
 }
@@ -380,7 +380,7 @@ bool ON_Surface::GetNextDiscontinuity(
                 double t0,
                 double t1,
                 double* t,
-                int* hint,
+                int*,
                 int* dtype,
                 double cos_angle_tolerance,
                 double curvature_tolerance
@@ -795,7 +795,7 @@ bool ON_Surface::IsContinuous(
 }
 
 ON_BOOL32 
-ON_Surface::IsSingular(int side) const
+ON_Surface::IsSingular(int) const
 {
   return false;
 }
@@ -1241,11 +1241,11 @@ ON_Surface::EvNormal( // returns false if unable to evaluate
 
 //virtual
 ON_Curve* ON_Surface::IsoCurve(
-       int dir,    // 0 first parameter varies and second parameter is constant
+       int    ,    // 0 first parameter varies and second parameter is constant
                    //   e.g., point on IsoCurve(0,c) at t is srf(t,c) - Horizontal
                    // 1 first parameter is constant and second parameter varies
                    //   e.g., point on IsoCurve(1,c) at t is srf(c,t) - Vertical
-       double c    // value of constant parameter 
+       double      // value of constant parameter
        ) const
 {
   return NULL;
@@ -1253,8 +1253,8 @@ ON_Curve* ON_Surface::IsoCurve(
 
 //virtual
 ON_BOOL32 ON_Surface::Trim(
-       int dir,
-       const ON_Interval& domain
+       int,
+       const ON_Interval&
        )
 {
   return false;
@@ -1262,8 +1262,8 @@ ON_BOOL32 ON_Surface::Trim(
 
 //virtual
 bool ON_Surface::Extend(
-      int dir,
-      const ON_Interval& domain
+      int,
+      const ON_Interval&
       )
 {
   return false;
@@ -1271,10 +1271,10 @@ bool ON_Surface::Extend(
 
 //virtual
 ON_BOOL32 ON_Surface::Split(
-       int dir,
-       double c,
-       ON_Surface*& west_or_south_side,
-       ON_Surface*& east_or_north_side
+       int,
+       double,
+       ON_Surface*&,
+       ON_Surface*&
        ) const
 {
   return false;
@@ -1282,8 +1282,8 @@ ON_BOOL32 ON_Surface::Split(
 
 // virtual
 int ON_Surface::GetNurbForm(
-      ON_NurbsSurface& nurbs_surface,
-      double tolerance
+      ON_NurbsSurface&,
+      double
       ) const
 {
   return 0;
@@ -1321,8 +1321,8 @@ bool ON_Surface::GetNurbFormParameterFromSurfaceParameter(
 ON_NurbsSurface* ON_Surface::NurbsSurface(
       ON_NurbsSurface* pNurbsSurface,
       double tolerance,
-      const ON_Interval* s_subdomain,
-      const ON_Interval* t_subdomain
+      const ON_Interval*,
+      const ON_Interval*
       ) const
 {
   ON_NurbsSurface* nurbs_surface = pNurbsSurface;

--- a/surface/src/3rdparty/opennurbs/opennurbs_userdata.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_userdata.cpp
@@ -406,7 +406,7 @@ ON_UnknownUserDataArchive::~ON_UnknownUserDataArchive()
 {
 }
 
-size_t ON_UnknownUserDataArchive::CurrentPosition() const
+std::size_t ON_UnknownUserDataArchive::CurrentPosition() const
 {
   return m_buffer_position;
 }
@@ -445,7 +445,7 @@ bool ON_UnknownUserDataArchive::AtEnd() const
   return (m_buffer_position >= m_sizeof_buffer) ? true : false;
 }
 
-size_t ON_UnknownUserDataArchive::Read( std::size_t count, void* buffer )
+std::size_t ON_UnknownUserDataArchive::Read( std::size_t count, void* buffer )
 {
   std::size_t maxcount = 0;
 
@@ -468,7 +468,7 @@ size_t ON_UnknownUserDataArchive::Read( std::size_t count, void* buffer )
   return count;
 }
 
-size_t ON_UnknownUserDataArchive::Write( std::size_t, const void* )
+std::size_t ON_UnknownUserDataArchive::Write( std::size_t, const void* )
 {
   // ON_UnknownUserDataArchive does not support Write() and Flush()
   return 0;

--- a/surface/src/3rdparty/opennurbs/opennurbs_userdata.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_userdata.cpp
@@ -200,7 +200,7 @@ ON_BOOL32 ON_UserData::IsUnknownUserData() const
   return (ClassId() == &ON_UnknownUserData::m_ON_UnknownUserData_class_id)?true:false;
 }
 
-ON_BOOL32 ON_UserData::GetDescription( ON_wString& description )
+ON_BOOL32 ON_UserData::GetDescription( ON_wString& )
 {
   return true;
 }
@@ -529,7 +529,7 @@ bool ON_UserDataHolder::MoveUserDataTo(  const ON_Object& source_object, bool bA
   return (0 != source_object.FirstUserData());
 }
 
-ON_BOOL32 ON_UserDataHolder::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_UserDataHolder::IsValid( ON_TextLog* ) const
 {
   return true;
 }
@@ -1104,7 +1104,7 @@ ON_DocumentUserStringList::~ON_DocumentUserStringList()
 {
 }
 
-ON_BOOL32 ON_DocumentUserStringList::IsValid( ON_TextLog* text_log ) const
+ON_BOOL32 ON_DocumentUserStringList::IsValid( ON_TextLog* ) const
 {
   return true;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_wstring.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_wstring.cpp
@@ -239,7 +239,7 @@ void ON_wString::EmergencyDestroy()
 	Create();
 }
 
-void ON_wString::EnableReferenceCounting( bool bEnable )
+void ON_wString::EnableReferenceCounting( bool )
 {
   // TODO fill this in;
 }

--- a/surface/src/3rdparty/opennurbs/opennurbs_zlib.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_zlib.cpp
@@ -191,7 +191,7 @@ bool ON_BinaryArchive::ReadCompressedBuffer( // read and uncompress
   return rc;
 }
 
-size_t ON_BinaryArchive::WriteDeflate( // returns number of bytes written
+std::size_t ON_BinaryArchive::WriteDeflate( // returns number of bytes written
         std::size_t sizeof___inbuffer,  // sizeof uncompressed input data ( > 0 )
         const void* in___buffer     // uncompressed input data ( != NULL )
         )
@@ -820,7 +820,7 @@ bool ON_CompressedBuffer::Compress(
 {
   Destroy();
 
-  //size_t compressed_size = 0;
+  //std::size_t compressed_size = 0;
   bool rc = false;
 
   if ( sizeof__inbuffer > 0 && 0 == inbuffer )
@@ -1047,7 +1047,7 @@ bool ON_CompressedBuffer::WriteChar(
 }
 
 
-size_t ON_CompressedBuffer::DeflateHelper( // returns number of bytes written
+std::size_t ON_CompressedBuffer::DeflateHelper( // returns number of bytes written
         ON_CompressedBufferHelper* helper,
         std::size_t sizeof___inbuffer,  // sizeof uncompressed input data ( > 0 )
         const void* in___buffer     // uncompressed input data ( != NULL )

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -698,8 +698,8 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
 
   if (d_shortest_hint < d_shortest_elem)
     return hint;
-  
-    return param;
+
+  return param;
 }
 
 double

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -676,7 +676,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
+    for (std::size_t j = 0; j < static_cast<std::size_t>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 
@@ -719,7 +719,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
+    for (std::size_t j = 0; j < static_cast<std::size_t>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -246,7 +246,7 @@ ON_NurbsCurve
 FittingCurve2d::initNurbsCPS (int order, const vector_vec2d &cps)
 {
   ON_NurbsCurve nurbs;
-  if (cps.size () < order)
+  if (cps.size () < static_cast<size_t>(order))
   {
     printf ("[FittingCurve2d::initCPsNurbsCurve2D] Warning, number of control points too low.\n");
     return nurbs;
@@ -567,7 +567,7 @@ FittingCurve2d::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::Vecto
   if (is_corner >= 0)
   {
     double param1, param2;
-    if (is_corner == 0 || is_corner == elements.size () - 1)
+    if (is_corner == 0 || is_corner == static_cast<int>(elements.size ()) - 1)
     {
       double x0a = elements[0];
       double x0b = elements[elements.size () - 1];
@@ -676,7 +676,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < nurbs.Order (); j++)
+    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 
@@ -719,7 +719,7 @@ FittingCurve2d::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const Ei
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < nurbs.Order (); j++)
+    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 

--- a/surface/src/on_nurbs/fitting_curve_2d.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d.cpp
@@ -246,7 +246,7 @@ ON_NurbsCurve
 FittingCurve2d::initNurbsCPS (int order, const vector_vec2d &cps)
 {
   ON_NurbsCurve nurbs;
-  if (cps.size () < static_cast<size_t>(order))
+  if (cps.size () < static_cast<std::size_t>(order))
   {
     printf ("[FittingCurve2d::initCPsNurbsCurve2D] Warning, number of control points too low.\n");
     return nurbs;

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -1068,8 +1068,8 @@ FittingCurve2dAPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, cons
 
   if (d_shortest_hint < d_shortest_elem)
     return hint;
-  
-    return param;
+
+  return param;
 }
 
 double

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -1046,7 +1046,7 @@ FittingCurve2dAPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, cons
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
+    for (std::size_t j = 0; j < static_cast<std::size_t>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 

--- a/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_apdm.cpp
@@ -120,9 +120,9 @@ FittingCurve2dAPDM::fitting (FitParameter &param)
   bool stop (false);
   for (unsigned j = 0; j < param.iterations && !stop; j++)
   {
-    if (2 * m_nurbs.CVCount () < m_data->interior.size ())
+    if (2 * m_nurbs.CVCount () < static_cast<int>(m_data->interior.size ()))
       if (!(j % param.addCPsIteration))
-        if (m_nurbs.CVCount () < param.maxCPs)
+        if (m_nurbs.CVCount () < static_cast<int>(param.maxCPs))
           addCPsOnClosestPointViolation (param.addCPsAccuracy);
 
     assemble (param.param);
@@ -504,7 +504,7 @@ FittingCurve2dAPDM::initCPsNurbsCurve2D (int order, const vector_vec2d &cps)
 {
   int cp_red = order - 2;
   ON_NurbsCurve nurbs;
-  if (cps.size () < 3 || cps.size () < (2 * cp_red + 1))
+  if (cps.size () < 3 || cps.size () < (2 * static_cast<std::size_t>(cp_red) + 1))
   {
     printf ("[FittingCurve2dAPDM::initCPsNurbsCurve2D] Warning, number of control points too low.\n");
     return nurbs;
@@ -937,7 +937,7 @@ FittingCurve2dAPDM::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::V
   if (is_corner >= 0)
   {
     double param1, param2;
-    if (is_corner == 0 || is_corner == elements.size () - 1)
+    if (is_corner == 0 || is_corner == static_cast<int>(elements.size ()) - 1)
     {
       double x0a = elements[0];
       double x0b = elements[elements.size () - 1];
@@ -1046,7 +1046,7 @@ FittingCurve2dAPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, cons
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < nurbs.Order (); j++)
+    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 
@@ -1089,7 +1089,7 @@ FittingCurve2dAPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, cons
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (std::size_t j = 0; j < nurbs.Order (); j++)
+    for (std::size_t j = 0; j < static_cast<std::size_t>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 

--- a/surface/src/on_nurbs/fitting_curve_2d_asdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_asdm.cpp
@@ -289,7 +289,7 @@ FittingCurve2dASDM::assembleInterior (double wInt, double sigma2, double rScale,
     double param;
     Eigen::Vector2d pt, t, n;
     double error;
-    if (p < int (m_data->interior_param.size ()))
+    if (p < static_cast<unsigned int>(m_data->interior_param.size ()))
     {
       param = findClosestElementMidPoint (m_nurbs, pcp, m_data->interior_param[p]);
       param = inverseMapping (m_nurbs, pcp, param, error, pt, t, rScale, in_max_steps, in_accuracy, m_quiet);

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -805,7 +805,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
+    for (std::size_t j = 0; j < static_cast<std::size_t>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 
@@ -847,7 +847,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
+    for (std::size_t j = 0; j < static_cast<std::size_t>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -365,7 +365,7 @@ FittingCurve2dPDM::initCPsNurbsCurve2D (int order, const vector_vec2d &cps)
 {
   int cp_red = order - 2;
   ON_NurbsCurve nurbs;
-  if (cps.size () < 3 || cps.size () < (2 * static_cast<size_t>(cp_red) + 1))
+  if (cps.size () < 3 || cps.size () < (2 * static_cast<std::size_t>(cp_red) + 1))
   {
     printf ("[FittingCurve2dPDM::initCPsNurbsCurve2D] Warning, number of control points too low.\n");
     return nurbs;

--- a/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_pdm.cpp
@@ -365,7 +365,7 @@ FittingCurve2dPDM::initCPsNurbsCurve2D (int order, const vector_vec2d &cps)
 {
   int cp_red = order - 2;
   ON_NurbsCurve nurbs;
-  if (cps.size () < 3 || cps.size () < (2 * cp_red + 1))
+  if (cps.size () < 3 || cps.size () < (2 * static_cast<size_t>(cp_red) + 1))
   {
     printf ("[FittingCurve2dPDM::initCPsNurbsCurve2D] Warning, number of control points too low.\n");
     return nurbs;
@@ -696,7 +696,7 @@ FittingCurve2dPDM::inverseMappingO2 (const ON_NurbsCurve &nurbs, const Eigen::Ve
   if (is_corner >= 0)
   {
     double param1, param2;
-    if (is_corner == 0 || is_corner == elements.size () - 1)
+    if (is_corner == 0 || is_corner == static_cast<int>(elements.size ()) - 1)
     {
       double x0a = elements[0];
       double x0b = elements[elements.size () - 1];
@@ -805,7 +805,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < nurbs.Order (); j++)
+    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 
@@ -847,7 +847,7 @@ FittingCurve2dPDM::findClosestElementMidPoint (const ON_NurbsCurve &nurbs, const
     double &xi1 = elements[i + 1];
     double dxi = xi1 - xi0;
 
-    for (unsigned j = 0; j < nurbs.Order (); j++)
+    for (unsigned j = 0; j < static_cast<unsigned int>(nurbs.Order ()); j++)
     {
       double xi = xi0 + (seg * j) * dxi;
 

--- a/surface/src/on_nurbs/fitting_curve_2d_sdm.cpp
+++ b/surface/src/on_nurbs/fitting_curve_2d_sdm.cpp
@@ -237,7 +237,7 @@ FittingCurve2dSDM::assembleInterior (double wInt, double rScale, unsigned &row)
     double param;
     Eigen::Vector2d pt, t, n;
     double error;
-    if (p < int (m_data->interior_param.size ()))
+    if (p < static_cast<unsigned int>(m_data->interior_param.size ()))
     {
       param = findClosestElementMidPoint (m_nurbs, pcp, m_data->interior_param[p]);
       param = inverseMapping (m_nurbs, pcp, param, error, pt, t, rScale, in_max_steps, in_accuracy, m_quiet);

--- a/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
@@ -116,7 +116,7 @@ FittingCylinder::refine (int dim, unsigned span_index)
 {
   std::vector<double> elements = getElementVector (m_nurbs, dim);
 
-  if (span_index > int (elements.size ()) - 2)
+  if (span_index + 2 > elements.size ())
   {
     printf ("[NurbsTools::refine(int, unsigned)] Warning span index out of bounds\n");
     return;

--- a/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_cylinder_pdm.cpp
@@ -507,6 +507,7 @@ FittingCylinder::addCageBoundaryRegularisation (double weight, int side, unsigne
   {
     case EAST:
       i = m_nurbs.m_cv_count[0] - 1;
+      PCL_FALLTHROUGH
     case WEST:
       for (j = 1; j < (m_nurbs.m_cv_count[1] - 2 * cp_red) + 1; j++)
       {

--- a/surface/src/on_nurbs/fitting_sphere_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_sphere_pdm.cpp
@@ -409,6 +409,7 @@ FittingSphere::addCageBoundaryRegularisation (double weight, int side, unsigned 
   {
     case EAST:
       i = m_nurbs.m_cv_count[0] - 1;
+      PCL_FALLTHROUGH
     case WEST:
       for (j = 1; j < (m_nurbs.m_cv_count[1] - 2 * cp_red) + 1; j++)
       {

--- a/surface/src/on_nurbs/fitting_surface_im.cpp
+++ b/surface/src/on_nurbs/fitting_surface_im.cpp
@@ -36,6 +36,8 @@
  */
 
 #include <pcl/surface/on_nurbs/fitting_surface_im.h>
+#include <pcl/pcl_macros.h>
+
 #include <stdexcept>
 
 using namespace pcl;
@@ -391,6 +393,7 @@ FittingSurfaceIM::addCageBoundaryRegularisation (double weight, int side, unsign
   {
     case SOUTH:
       j = m_nurbs.m_cv_count[1] - 1;
+      PCL_FALLTHROUGH
     case NORTH:
       for (i = 1; i < (m_nurbs.m_cv_count[0] - 1); i++)
       {
@@ -407,6 +410,7 @@ FittingSurfaceIM::addCageBoundaryRegularisation (double weight, int side, unsign
 
     case EAST:
       i = m_nurbs.m_cv_count[0] - 1;
+      PCL_FALLTHROUGH
     case WEST:
       for (j = 1; j < (m_nurbs.m_cv_count[1] - 1); j++)
       {

--- a/surface/src/on_nurbs/fitting_surface_pdm.cpp
+++ b/surface/src/on_nurbs/fitting_surface_pdm.cpp
@@ -35,8 +35,10 @@
  *
  */
 
-#include <stdexcept>
 #include <pcl/surface/on_nurbs/fitting_surface_pdm.h>
+#include <pcl/pcl_macros.h>
+
+#include <stdexcept>
 
 using namespace pcl;
 using namespace on_nurbs;
@@ -638,6 +640,7 @@ FittingSurface::addCageBoundaryRegularisation (double weight, int side, unsigned
   {
     case SOUTH:
       j = m_nurbs.m_cv_count[1] - 1;
+      PCL_FALLTHROUGH
     case NORTH:
       for (i = 1; i < (m_nurbs.m_cv_count[0] - 1); i++)
       {
@@ -656,6 +659,7 @@ FittingSurface::addCageBoundaryRegularisation (double weight, int side, unsigned
 
     case EAST:
       i = m_nurbs.m_cv_count[0] - 1;
+      PCL_FALLTHROUGH
     case WEST:
       for (j = 1; j < (m_nurbs.m_cv_count[1] - 1); j++)
       {

--- a/surface/src/on_nurbs/fitting_surface_tdm.cpp
+++ b/surface/src/on_nurbs/fitting_surface_tdm.cpp
@@ -35,8 +35,10 @@
  *
  */
 
-#include <stdexcept>
 #include <pcl/surface/on_nurbs/fitting_surface_tdm.h>
+#include <pcl/pcl_macros.h>
+
+#include <stdexcept>
 
 using namespace pcl;
 using namespace on_nurbs;
@@ -308,6 +310,7 @@ FittingSurfaceTDM::addCageBoundaryRegularisation (double weight, int side, unsig
   {
     case SOUTH:
       j = m_nurbs.CVCount (1) - 1;
+      PCL_FALLTHROUGH
     case NORTH:
       for (i = 1; i < (m_nurbs.CVCount (0) - 1); i++)
       {
@@ -334,6 +337,7 @@ FittingSurfaceTDM::addCageBoundaryRegularisation (double weight, int side, unsig
 
     case EAST:
       i = m_nurbs.CVCount (0) - 1;
+      PCL_FALLTHROUGH
     case WEST:
       for (j = 1; j < (m_nurbs.CVCount (1) - 1); j++)
       {

--- a/surface/src/on_nurbs/global_optimization_pdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_pdm.cpp
@@ -37,6 +37,8 @@
 
 #include <pcl/surface/on_nurbs/global_optimization_pdm.h>
 #include <pcl/surface/on_nurbs/closing_boundary.h>
+#include <pcl/pcl_macros.h>
+
 #include <stdexcept>
 
 #undef DEBUG
@@ -611,6 +613,7 @@ GlobalOptimization::addCageBoundaryRegularisation (unsigned id, int ncps, double
   {
     case SOUTH:
       j = nurbs->CVCount (1) - 1;
+      PCL_FALLTHROUGH
     case NORTH:
       for (i = 1; i < (nurbs->CVCount (0) - 1); i++)
       {
@@ -629,6 +632,7 @@ GlobalOptimization::addCageBoundaryRegularisation (unsigned id, int ncps, double
 
     case EAST:
       i = nurbs->CVCount (0) - 1;
+      PCL_FALLTHROUGH
     case WEST:
       for (j = 1; j < (nurbs->CVCount (1) - 1); j++)
       {

--- a/surface/src/on_nurbs/global_optimization_pdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_pdm.cpp
@@ -242,7 +242,7 @@ GlobalOptimization::assembleCommonBoundaries (unsigned id1, double weight, unsig
     Eigen::Vector3d p0 = data1->common_boundary_point[i];
     Eigen::Vector2i id (id1, data1->common_boundary_idx[i]);
 
-    if (id (1) < 0 || id (1) >= m_nurbs.size ())
+    if (id (1) < 0 || id (1) >= static_cast<int>(m_nurbs.size ()))
       throw std::runtime_error (
                                 "[GlobalOptimization::assembleCommonBoundaries] Error, common boundary index out of bounds.\n");
 

--- a/surface/src/on_nurbs/global_optimization_tdm.cpp
+++ b/surface/src/on_nurbs/global_optimization_tdm.cpp
@@ -37,6 +37,8 @@
 
 #include <pcl/surface/on_nurbs/global_optimization_tdm.h>
 #include <pcl/surface/on_nurbs/closing_boundary.h>
+#include <pcl/pcl_macros.h>
+
 #include <stdexcept>
 
 using namespace pcl;
@@ -888,6 +890,7 @@ GlobalOptimizationTDM::addCageBoundaryRegularisation (unsigned id, int ncps, dou
   {
     case SOUTH:
       j = nurbs->CVCount (1) - 1;
+      PCL_FALLTHROUGH
     case NORTH:
       for (i = 1; i < (nurbs->CVCount (0) - 1); i++)
       {
@@ -914,6 +917,7 @@ GlobalOptimizationTDM::addCageBoundaryRegularisation (unsigned id, int ncps, dou
 
     case EAST:
       i = nurbs->CVCount (0) - 1;
+      PCL_FALLTHROUGH
     case WEST:
       for (j = 1; j < (nurbs->CVCount (1) - 1); j++)
       {


### PR DESCRIPTION
While preparing to work on the release items, I noticed nurbs was spewing out an impressive number of warnings. I decided to finally clean it up. There's only a deprecation warning missing.

Situations in which I commented variables instead of simply deleting them are usually a sign that there is commented code in the function's body which originally intended to use them. 

Most if not all, ctor base class initializations that I added to suppress the compiler warnings are actually no-ops. Probably the reason they were not being invoked in the first place.