### PR TITLE
Add Dockerfiles for images used on CI

### DIFF
--- a/.dev/docker/doc/Dockerfile
+++ b/.dev/docker/doc/Dockerfile
@@ -1,0 +1,13 @@
+FROM pointcloudlibrary/env:19.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y \
+      doxygen-latex \
+      dvipng \
+      git \
+      python3-pip \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install Jinja2==2.8.1 sphinx sphinxcontrib-doxylink

--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -1,0 +1,42 @@
+ARG UBUNTU_DISTRO=16.04
+FROM ubuntu:${UBUNTU_DISTRO}
+
+ARG VTK_VERSION=6
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y \
+      cmake \
+      g++ \
+      wget \
+      libboost-date-time-dev \
+      libboost-filesystem-dev \
+      libboost-iostreams-dev \
+      libeigen3-dev \
+      libflann-dev \
+      libglew-dev \
+      libgtest-dev \
+      libopenni-dev \
+      libopenni2-dev \
+      libproj-dev \
+      libqhull-dev \
+      libqt5opengl5-dev \
+      libusb-1.0-0-dev \
+      libvtk${VTK_VERSION}-dev \
+      libvtk${VTK_VERSION}-qt-dev \
+      qtbase5-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO- https://github.com/IntelRealSense/librealsense/archive/v2.23.0.tar.gz | tar xz \
+ && cd librealsense-2.23.0 \
+ && mkdir build \
+ && cd build \
+ && cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_GRAPHICAL_EXAMPLES=OFF \
+ && make -j2 \
+ && make install \
+ && cd ../.. \
+ && rm -rf librealsense-2.23.0
+
+RUN wget -qO ensenso.deb https://download.ensenso.com/s/ensensosdk/download?files=ensenso-sdk-2.2.160-x64.deb \
+ && dpkg -i ensenso.deb \
+ && rm ensenso.deb

--- a/.dev/docker/fmt/Dockerfile
+++ b/.dev/docker/fmt/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:19.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ARG CLANG_FORMAT_VERSION=8
+
+RUN apt-get update \
+ && apt-get install -y \
+      clang-format-${CLANG_FORMAT_VERSION} \
+      bash \
+      git \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR adds three Dockerfiles:
 * `env`: Ubuntu image with environment setup for PCL build. OS version is configurable, as well as VTK version. For CI we currently use the default parameters, i.e. Ubuntu 16.04 and VTK 6.
 * `doc`: image for documentation generation, based on the `env` image.
 * `fmt`: image for formatting check with `clang-format`.

Both `doc` and `fmt` are based on the latest Ubuntu release to make sure we get a reasonably up-to-date version of `doxygen` and `clang-format`.

Fixes #2973.