### PR TITLE
loadplyfile may parse the header error

### DIFF
--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -529,7 +529,8 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
             error_callback_ (line_number_, "parse error");
           return false;
         }
-        istream.ignore (char_ignore_count);
+        if(element_index!= element.count-1)
+          istream.ignore (char_ignore_count);
         ++line_number_;
         std::istringstream stringstream (line);
         stringstream.unsetf (std::ios_base::skipws);

--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -529,9 +529,11 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
             error_callback_ (line_number_, "parse error");
           return false;
         }
-        if(element_index!= element.count-1)
-          istream.ignore (char_ignore_count);
+        istream.ignore (char_ignore_count);
         ++line_number_;
+        if(istream.eof()) 
+          return true;
+        
         std::istringstream stringstream (line);
         stringstream.unsetf (std::ios_base::skipws);
         stringstream >> std::ws;


### PR DESCRIPTION
the iostream may be fail state with the last ingore in the end of the file in linux.