### PR TITLE
std::size_t modifications for module common

### DIFF
--- a/apps/src/openni_uniform_sampling.cpp
+++ b/apps/src/openni_uniform_sampling.cpp
@@ -91,8 +91,8 @@ class OpenNIUniformSampling
       pcl::PointCloud<pcl::PointXYZRGBA> sampled;
       pass_.filter (sampled);
       *cloud_  = *cloud;
-      
-      pcl::copyPointCloud<pcl::PointXYZRGBA, pcl::PointXYZ> (sampled, *keypoints_);
+
+      pcl::copyPointCloud (sampled, *keypoints_);
     }
 
     void

--- a/common/include/pcl/ModelCoefficients.h
+++ b/common/include/pcl/ModelCoefficients.h
@@ -32,7 +32,7 @@ namespace pcl
     s << "header: " << std::endl;
     s << v.header;
     s << "values[]" << std::endl;
-    for (size_t i = 0; i < v.values.size (); ++i)
+    for (std::size_t i = 0; i < v.values.size (); ++i)
     {
       s << "  values[" << i << "]: ";
       s << "  " << v.values[i] << std::endl;

--- a/common/include/pcl/PCLImage.h
+++ b/common/include/pcl/PCLImage.h
@@ -52,7 +52,7 @@ namespace pcl
     s << "step: ";
     s << "  " << v.step << std::endl;
     s << "data[]" << std::endl;
-    for (size_t i = 0; i < v.data.size (); ++i)
+    for (std::size_t i = 0; i < v.data.size (); ++i)
     {
       s << "  data[" << i << "]: ";
       s << "  " << v.data[i] << std::endl;

--- a/common/include/pcl/PCLPointCloud2.h
+++ b/common/include/pcl/PCLPointCloud2.h
@@ -114,7 +114,7 @@ namespace pcl
     s << "width: ";
     s << "  " << v.width << std::endl;
     s << "fields[]" << std::endl;
-    for (size_t i = 0; i < v.fields.size (); ++i)
+    for (std::size_t i = 0; i < v.fields.size (); ++i)
     {
       s << "  fields[" << i << "]: ";
       s << std::endl;
@@ -127,7 +127,7 @@ namespace pcl
     s << "row_step: ";
     s << "  " << v.row_step << std::endl;
     s << "data[]" << std::endl;
-    for (size_t i = 0; i < v.data.size (); ++i)
+    for (std::size_t i = 0; i < v.data.size (); ++i)
     {
       s << "  data[" << i << "]: ";
       s << "  " << v.data[i] << std::endl;

--- a/common/include/pcl/PointIndices.h
+++ b/common/include/pcl/PointIndices.h
@@ -31,7 +31,7 @@ namespace pcl
     s << "header: " << std::endl;
     s << "  " << v.header;
     s << "indices[]" << std::endl;
-    for (size_t i = 0; i < v.indices.size (); ++i)
+    for (std::size_t i = 0; i < v.indices.size (); ++i)
     {
       s << "  indices[" << i << "]: ";
       s << "  " << v.indices[i] << std::endl;

--- a/common/include/pcl/PolygonMesh.h
+++ b/common/include/pcl/PolygonMesh.h
@@ -108,7 +108,7 @@ namespace pcl
     s << "cloud: " << std::endl;
     s << v.cloud;
     s << "polygons[]" << std::endl;
-    for (size_t i = 0; i < v.polygons.size (); ++i)
+    for (std::size_t i = 0; i < v.polygons.size (); ++i)
     {
       s << "  polygons[" << i << "]: " << std::endl;
       s << v.polygons[i];

--- a/common/include/pcl/Vertices.h
+++ b/common/include/pcl/Vertices.h
@@ -30,7 +30,7 @@ namespace pcl
   inline std::ostream& operator<<(std::ostream& s, const  ::pcl::Vertices & v)
   {
     s << "vertices[]" << std::endl;
-    for (size_t i = 0; i < v.vertices.size (); ++i)
+    for (std::size_t i = 0; i < v.vertices.size (); ++i)
     {
       s << "  vertices[" << i << "]: ";
       s << "  " << v.vertices[i] << std::endl;

--- a/common/include/pcl/cloud_iterator.h
+++ b/common/include/pcl/cloud_iterator.h
@@ -74,7 +74,7 @@ namespace pcl
       unsigned getCurrentIndex () const;
 
       /** \brief Size of the range the iterator is going through. Depending on how the CloudIterator was constructed this is the size of the cloud or indices/correspondences. */
-      size_t size () const;
+      std::size_t size () const;
 
       void reset ();
 
@@ -104,7 +104,7 @@ namespace pcl
           virtual unsigned getCurrentIndex () const = 0;
 
           /** \brief Size of the range the iterator is going through. Depending on how the CloudIterator was constructed this is the size of the cloud or indices/correspondences. */
-          virtual size_t size () const = 0;
+          virtual std::size_t size () const = 0;
 
           virtual void reset () = 0;
 
@@ -143,7 +143,7 @@ namespace pcl
       unsigned getCurrentIndex () const;
 
       /** \brief Size of the range the iterator is going through. Depending on how the ConstCloudIterator was constructed this is the size of the cloud or indices/correspondences. */
-      size_t size () const;
+      std::size_t size () const;
 
       void reset ();
 
@@ -173,7 +173,7 @@ namespace pcl
           virtual unsigned getCurrentIndex () const = 0;
 
           /** \brief Size of the range the iterator is going through. Depending on how the ConstCloudIterator was constructed this is the size of the cloud or indices/correspondences. */
-          virtual size_t size () const = 0;
+          virtual std::size_t size () const = 0;
 
           virtual void reset () = 0;
 

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -1045,7 +1045,7 @@ namespace pcl
       get (PointOutT& point) const;
 
       /** Get the total number of points that were added. */
-      inline size_t
+      inline std::size_t
       getSize () const
       {
         return (num_points_);
@@ -1055,7 +1055,7 @@ namespace pcl
 
     private:
 
-      size_t num_points_ = 0;
+      std::size_t num_points_ = 0;
       typename pcl::detail::Accumulators<PointT>::type accumulators_;
 
   };
@@ -1076,7 +1076,7 @@ namespace pcl
     * not valid.
     *
     * \ingroup common */
-  template <typename PointInT, typename PointOutT> size_t
+  template <typename PointInT, typename PointOutT> std::size_t
   computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                    PointOutT& centroid);
 
@@ -1088,7 +1088,7 @@ namespace pcl
     * documentation for computeCentroid().
     *
     * \ingroup common */
-  template <typename PointInT, typename PointOutT> size_t
+  template <typename PointInT, typename PointOutT> std::size_t
   computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                    const std::vector<int>& indices,
                    PointOutT& centroid);

--- a/common/include/pcl/common/colors.h
+++ b/common/include/pcl/common/colors.h
@@ -67,13 +67,13 @@ namespace pcl
       /** Get a color from the lookup table with a given id.
         *
         * The id should be less than the size of the LUT (see size()). */
-      static RGB at (size_t color_id);
+      static RGB at (std::size_t color_id);
 
       /** Get the number of colors in the lookup table.
         *
         * Note: the number of colors is different from the number of elements
         * in the lookup table (each color is defined by three bytes). */
-      static size_t size ();
+      static std::size_t size ();
 
       /** Get a raw pointer to the lookup table. */
       static const unsigned char* data ();

--- a/common/include/pcl/common/distances.h
+++ b/common/include/pcl/common/distances.h
@@ -37,6 +37,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include <pcl/common/common.h>
 
 /**
@@ -101,7 +103,8 @@ namespace pcl
                  PointT &pmin, PointT &pmax)
   {
     double max_dist = std::numeric_limits<double>::min ();
-    int i_min = -1, i_max = -1;
+    const auto token = std::numeric_limits<std::size_t>::max();
+    std::size_t i_min = token, i_max = token;
 
     for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
@@ -119,7 +122,7 @@ namespace pcl
       }
     }
 
-    if (i_min == -1 || i_max == -1)
+    if (i_min == token || i_max == token)
       return (max_dist = std::numeric_limits<double>::min ());
 
     pmin = cloud.points[i_min];
@@ -140,7 +143,8 @@ namespace pcl
                  PointT &pmin, PointT &pmax)
   {
     double max_dist = std::numeric_limits<double>::min ();
-    int i_min = -1, i_max = -1;
+    const auto token = std::numeric_limits<std::size_t>::max();
+    std::size_t i_min = token, i_max = token;
 
     for (std::size_t i = 0; i < indices.size (); ++i)
     {
@@ -158,7 +162,7 @@ namespace pcl
       }
     }
 
-    if (i_min == -1 || i_max == -1)
+    if (i_min == token || i_max == token)
       return (max_dist = std::numeric_limits<double>::min ());
 
     pmin = cloud.points[indices[i_min]];

--- a/common/include/pcl/common/distances.h
+++ b/common/include/pcl/common/distances.h
@@ -103,9 +103,9 @@ namespace pcl
     double max_dist = std::numeric_limits<double>::min ();
     int i_min = -1, i_max = -1;
 
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
-      for (size_t j = i; j < cloud.points.size (); ++j)
+      for (std::size_t j = i; j < cloud.points.size (); ++j)
       {
         // Compute the distance 
         double dist = (cloud.points[i].getVector4fMap () - 
@@ -142,9 +142,9 @@ namespace pcl
     double max_dist = std::numeric_limits<double>::min ();
     int i_min = -1, i_max = -1;
 
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (std::size_t i = 0; i < indices.size (); ++i)
     {
-      for (size_t j = i; j < indices.size (); ++j)
+      for (std::size_t j = i; j < indices.size (); ++j)
       {
         // Compute the distance 
         double dist = (cloud.points[indices[i]].getVector4fMap () - 

--- a/common/include/pcl/common/feature_histogram.h
+++ b/common/include/pcl/common/feature_histogram.h
@@ -55,7 +55,7 @@ namespace pcl
         * \param[in] min lower threshold.
         * \param[in] max upper threshold.
         */
-      FeatureHistogram (const size_t number_of_bins, const float min,
+      FeatureHistogram (const std::size_t number_of_bins, const float min,
           const float max);
 
       /** \brief Public destructor. */
@@ -76,13 +76,13 @@ namespace pcl
       /** \brief Get the number of elements was added to the histogram.
         * \return number of elements in the histogram.
         */
-      size_t
+      std::size_t
       getNumberOfElements () const;
 
       /** \brief Get number of bins in the histogram.
         * \return number of bins in the histogram.
         */
-      size_t
+      std::size_t
       getNumberOfBins () const;
 
       /** \brief Increase a bin, that corresponds the value.
@@ -115,9 +115,9 @@ namespace pcl
       float step_;
 
       /** \brief Number of values was added to the histogram. */
-      size_t number_of_elements_;
+      std::size_t number_of_elements_;
 
       /** \brief Number of bins. */
-      size_t number_of_bins_;
+      std::size_t number_of_bins_;
   };
 }

--- a/common/include/pcl/common/fft/kiss_fft.h
+++ b/common/include/pcl/common/fft/kiss_fft.h
@@ -80,7 +80,7 @@ typedef struct kiss_fft_state* kiss_fft_cfg;
  * */
 
 kiss_fft_cfg PCL_EXPORTS 
-kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem); 
+kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem);
 
 /*
  * kiss_fft(cfg,in_out_buf)

--- a/common/include/pcl/common/impl/accumulators.hpp
+++ b/common/include/pcl/common/impl/accumulators.hpp
@@ -79,7 +79,7 @@ namespace pcl
       add (const PointT& t) { xyz += t.getVector3fMap (); }
 
       template <typename PointT> void
-      get (PointT& t, size_t n) const { t.getVector3fMap () = xyz / n; }
+      get (PointT& t, std::size_t n) const { t.getVector3fMap () = xyz / n; }
 
       PCL_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -102,7 +102,7 @@ namespace pcl
       add (const PointT& t) { normal += t.getNormalVector4fMap (); }
 
       template <typename PointT> void
-      get (PointT& t, size_t) const
+      get (PointT& t, std::size_t) const
       {
 #if EIGEN_VERSION_AT_LEAST (3, 3, 0)
         t.getNormalVector4fMap () = normal.normalized ();
@@ -133,7 +133,7 @@ namespace pcl
       add (const PointT& t) { curvature += t.curvature; }
 
       template <typename PointT> void
-      get (PointT& t, size_t n) const { t.curvature = curvature / n; }
+      get (PointT& t, std::size_t n) const { t.curvature = curvature / n; }
 
     };
 
@@ -158,7 +158,7 @@ namespace pcl
       }
 
       template <typename PointT> void
-      get (PointT& t, size_t n) const
+      get (PointT& t, std::size_t n) const
       {
         t.rgba = static_cast<uint32_t> (a / n) << 24 |
                  static_cast<uint32_t> (r / n) << 16 |
@@ -183,7 +183,7 @@ namespace pcl
       add (const PointT& t) { intensity += t.intensity; }
 
       template <typename PointT> void
-      get (PointT& t, size_t n) const { t.intensity = intensity / n; }
+      get (PointT& t, std::size_t n) const { t.intensity = intensity / n; }
 
     };
 
@@ -195,7 +195,7 @@ namespace pcl
 
       // Storage
       // A better performance may be achieved with a heap structure
-      std::map<uint32_t, size_t> labels;
+      std::map<uint32_t, std::size_t> labels;
 
       AccumulatorLabel () { }
 
@@ -210,9 +210,9 @@ namespace pcl
       }
 
       template <typename PointT> void
-      get (PointT& t, size_t) const
+      get (PointT& t, std::size_t) const
       {
-        size_t max = 0;
+        std::size_t max = 0;
         for (const auto &label : labels)
           if (label.second > max)
           {
@@ -281,9 +281,9 @@ namespace pcl
     {
 
       PointT& p;
-      size_t n;
+      std::size_t n;
 
-      GetPoint (PointT& point, size_t num) : p (point), n (num) { }
+      GetPoint (PointT& point, std::size_t num) : p (point), n (num) { }
 
       template <typename AccumulatorT> void
       operator () (AccumulatorT& accumulator) const

--- a/common/include/pcl/common/impl/bivariate_polynomial.hpp
+++ b/common/include/pcl/common/impl/bivariate_polynomial.hpp
@@ -39,6 +39,8 @@
 #ifndef BIVARIATE_POLYNOMIAL_HPP
 #define BIVARIATE_POLYNOMIAL_HPP
 
+#include <algorithm>
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename real>
 pcl::BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree) :
@@ -113,11 +115,8 @@ pcl::BivariatePolynomialT<real>::deepCopy (const pcl::BivariatePolynomialT<real>
     gradient_x = new pcl::BivariatePolynomialT<real> ();
     gradient_y = new pcl::BivariatePolynomialT<real> ();
   }
-  real* tmpParameters1 = parameters;
-  const real* tmpParameters2 = other.parameters;
-  unsigned int noOfParameters = getNoOfParameters ();
-  for (unsigned int i=0; i<noOfParameters; i++)
-    *tmpParameters1++ = *tmpParameters2++;
+
+  std::copy_n(other.parameters, getNoOfParameters (), parameters);
 
   if (other.gradient_x != NULL) 
   {

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -88,11 +88,11 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (std::size_t i = 0; i < cloud.size (); ++i)
+    for (const auto& point: cloud)
     {
-      centroid[0] += cloud[i].x;
-      centroid[1] += cloud[i].y;
-      centroid[2] += cloud[i].z;
+      centroid[0] += point.x;
+      centroid[1] += point.y;
+      centroid[2] += point.z;
     }
     centroid /= static_cast<Scalar> (cloud.size ());
     centroid[3] = 1;
@@ -101,15 +101,15 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   }
   // NaN or Inf values could exist => check for them
   unsigned cp = 0;
-  for (std::size_t i = 0; i < cloud.size (); ++i)
+  for (const auto& point: cloud)
   {
     // Check if the point is invalid
-    if (!isFinite (cloud [i]))
+    if (!isFinite (point))
       continue;
 
-    centroid[0] += cloud[i].x;
-    centroid[1] += cloud[i].y;
-    centroid[2] += cloud[i].z;
+    centroid[0] += point.x;
+    centroid[1] += point.y;
+    centroid[2] += point.z;
     ++cp;
   }
   centroid /= static_cast<Scalar> (cp);
@@ -132,7 +132,7 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (const int &index : indices)
+    for (const int& index : indices)
     {
       centroid[0] += cloud[index].x;
       centroid[1] += cloud[index].y;
@@ -144,7 +144,7 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   }
   // NaN or Inf values could exist => check for them
     unsigned cp = 0;
-  for (const int &index : indices)
+  for (const int& index : indices)
   {
     // Check if the point is invalid
     if (!isFinite (cloud [index]))
@@ -187,12 +187,12 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = static_cast<unsigned> (cloud.size ());
     // For each point in the cloud
-    for (std::size_t i = 0; i < point_count; ++i)
+    for (const auto& point: cloud)
     {
       Eigen::Matrix<Scalar, 4, 1> pt;
-      pt[0] = cloud[i].x - centroid[0];
-      pt[1] = cloud[i].y - centroid[1];
-      pt[2] = cloud[i].z - centroid[2];
+      pt[0] = point.x - centroid[0];
+      pt[1] = point.y - centroid[1];
+      pt[2] = point.z - centroid[2];
 
       covariance_matrix (1, 1) += pt.y () * pt.y ();
       covariance_matrix (1, 2) += pt.y () * pt.z ();
@@ -210,16 +210,16 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = 0;
     // For each point in the cloud
-    for (std::size_t i = 0; i < cloud.size (); ++i)
+    for (const auto& point: cloud)
     {
       // Check if the point is invalid
-      if (!isFinite (cloud [i]))
+      if (!isFinite (point))
         continue;
 
       Eigen::Matrix<Scalar, 4, 1> pt;
-      pt[0] = cloud[i].x - centroid[0];
-      pt[1] = cloud[i].y - centroid[1];
-      pt[2] = cloud[i].z - centroid[2];
+      pt[0] = point.x - centroid[0];
+      pt[1] = point.y - centroid[1];
+      pt[2] = point.z - centroid[2];
 
       covariance_matrix (1, 1) += pt.y () * pt.y ();
       covariance_matrix (1, 2) += pt.y () * pt.z ();
@@ -271,12 +271,12 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = indices.size ();
     // For each point in the cloud
-    for (std::size_t i = 0; i < point_count; ++i)
+    for (const auto& idx: indices)
     {
       Eigen::Matrix<Scalar, 4, 1> pt;
-      pt[0] = cloud[indices[i]].x - centroid[0];
-      pt[1] = cloud[indices[i]].y - centroid[1];
-      pt[2] = cloud[indices[i]].z - centroid[2];
+      pt[0] = cloud[idx].x - centroid[0];
+      pt[1] = cloud[idx].y - centroid[1];
+      pt[2] = cloud[idx].z - centroid[2];
 
       covariance_matrix (1, 1) += pt.y () * pt.y ();
       covariance_matrix (1, 2) += pt.y () * pt.z ();
@@ -374,30 +374,30 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = static_cast<unsigned int> (cloud.size ());
     // For each point in the cloud
-    for (std::size_t i = 0; i < point_count; ++i)
+    for (const auto& point: cloud)
     {
-      accu [0] += cloud[i].x * cloud[i].x;
-      accu [1] += cloud[i].x * cloud[i].y;
-      accu [2] += cloud[i].x * cloud[i].z;
-      accu [3] += cloud[i].y * cloud[i].y;
-      accu [4] += cloud[i].y * cloud[i].z;
-      accu [5] += cloud[i].z * cloud[i].z;
+      accu [0] += point.x * point.x;
+      accu [1] += point.x * point.y;
+      accu [2] += point.x * point.z;
+      accu [3] += point.y * point.y;
+      accu [4] += point.y * point.z;
+      accu [5] += point.z * point.z;
     }
   }
   else
   {
     point_count = 0;
-    for (std::size_t i = 0; i < cloud.size (); ++i)
+    for (const auto& point: cloud)
     {
-      if (!isFinite (cloud[i]))
+      if (!isFinite (point))
         continue;
 
-      accu [0] += cloud[i].x * cloud[i].x;
-      accu [1] += cloud[i].x * cloud[i].y;
-      accu [2] += cloud[i].x * cloud[i].z;
-      accu [3] += cloud[i].y * cloud[i].y;
-      accu [4] += cloud[i].y * cloud[i].z;
-      accu [5] += cloud[i].z * cloud[i].z;
+      accu [0] += point.x * point.x;
+      accu [1] += point.x * point.y;
+      accu [2] += point.x * point.z;
+      accu [3] += point.y * point.y;
+      accu [4] += point.y * point.z;
+      accu [5] += point.z * point.z;
       ++point_count;
     }
   }
@@ -491,36 +491,36 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = cloud.size ();
     // For each point in the cloud
-    for (std::size_t i = 0; i < point_count; ++i)
+    for (const auto& point: cloud)
     {
-      accu [0] += cloud[i].x * cloud[i].x;
-      accu [1] += cloud[i].x * cloud[i].y;
-      accu [2] += cloud[i].x * cloud[i].z;
-      accu [3] += cloud[i].y * cloud[i].y; // 4
-      accu [4] += cloud[i].y * cloud[i].z; // 5
-      accu [5] += cloud[i].z * cloud[i].z; // 8
-      accu [6] += cloud[i].x;
-      accu [7] += cloud[i].y;
-      accu [8] += cloud[i].z;
+      accu [0] += point.x * point.x;
+      accu [1] += point.x * point.y;
+      accu [2] += point.x * point.z;
+      accu [3] += point.y * point.y; // 4
+      accu [4] += point.y * point.z; // 5
+      accu [5] += point.z * point.z; // 8
+      accu [6] += point.x;
+      accu [7] += point.y;
+      accu [8] += point.z;
     }
   }
   else
   {
     point_count = 0;
-    for (std::size_t i = 0; i < cloud.size (); ++i)
+    for (const auto& point: cloud)
     {
-      if (!isFinite (cloud[i]))
+      if (!isFinite (point))
         continue;
 
-      accu [0] += cloud[i].x * cloud[i].x;
-      accu [1] += cloud[i].x * cloud[i].y;
-      accu [2] += cloud[i].x * cloud[i].z;
-      accu [3] += cloud[i].y * cloud[i].y;
-      accu [4] += cloud[i].y * cloud[i].z;
-      accu [5] += cloud[i].z * cloud[i].z;
-      accu [6] += cloud[i].x;
-      accu [7] += cloud[i].y;
-      accu [8] += cloud[i].z;
+      accu [0] += point.x * point.x;
+      accu [1] += point.x * point.y;
+      accu [2] += point.x * point.z;
+      accu [3] += point.y * point.y;
+      accu [4] += point.y * point.z;
+      accu [5] += point.z * point.z;
+      accu [6] += point.x;
+      accu [7] += point.y;
+      accu [8] += point.z;
       ++point_count;
     }
   }
@@ -662,11 +662,11 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out = cloud_in;
 
   // Subtract the centroid from cloud_in
-  for (std::size_t i = 0; i < cloud_in.points.size (); ++i)
+  for (auto& point: cloud_out)
   {
-    cloud_out[i].x -= static_cast<float> (centroid[0]);
-    cloud_out[i].y -= static_cast<float> (centroid[1]);
-    cloud_out[i].z -= static_cast<float> (centroid[2]);
+    point.x -= static_cast<float> (centroid[0]);
+    point.y -= static_cast<float> (centroid[1]);
+    point.z -= static_cast<float> (centroid[2]);
   }
 }
 
@@ -810,14 +810,14 @@ pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.empty ())
     return;
+
   // Iterate over each point
-  int size = static_cast<int> (cloud.size ());
-  for (int i = 0; i < size; ++i)
+  for (const auto& pt: cloud)
   {
     // Iterate over each dimension
-    pcl::for_each_type<FieldList> (NdCentroidFunctor<PointT, Scalar> (cloud[i], centroid));
+    pcl::for_each_type<FieldList> (NdCentroidFunctor<PointT, Scalar> (pt, centroid));
   }
-  centroid /= static_cast<Scalar> (size);
+  centroid /= static_cast<Scalar> (cloud.size ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -833,14 +833,14 @@ pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
 
   if (indices.empty ())
     return;
+
   // Iterate over each point
-  int nr_points = static_cast<int> (indices.size ());
-  for (int i = 0; i < nr_points; ++i)
+  for (const auto& index: indices)
   {
     // Iterate over each dimension
-    pcl::for_each_type <FieldList> (NdCentroidFunctor<PointT, Scalar> (cloud[indices[i]], centroid));
+    pcl::for_each_type<FieldList> (NdCentroidFunctor<PointT, Scalar> (cloud[index], centroid));
   }
-  centroid /= static_cast<Scalar> (nr_points);
+  centroid /= static_cast<Scalar> (indices.size ());
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -881,12 +881,12 @@ pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
   pcl::CentroidPoint<PointInT> cp;
 
   if (cloud.is_dense)
-    for (std::size_t i = 0; i < cloud.size (); ++i)
-      cp.add (cloud[i]);
+    for (const auto& point: cloud)
+      cp.add (point);
   else
-    for (std::size_t i = 0; i < cloud.size (); ++i)
-      if (pcl::isFinite (cloud[i]))
-        cp.add (cloud[i]);
+    for (const auto& point: cloud)
+      if (pcl::isFinite (point))
+        cp.add (point);
 
   cp.get (centroid);
   return (cp.getSize ());

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -88,7 +88,7 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < cloud.size (); ++i)
+    for (std::size_t i = 0; i < cloud.size (); ++i)
     {
       centroid[0] += cloud[i].x;
       centroid[1] += cloud[i].y;
@@ -101,7 +101,7 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   }
   // NaN or Inf values could exist => check for them
   unsigned cp = 0;
-  for (size_t i = 0; i < cloud.size (); ++i)
+  for (std::size_t i = 0; i < cloud.size (); ++i)
   {
     // Check if the point is invalid
     if (!isFinite (cloud [i]))
@@ -187,7 +187,7 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = static_cast<unsigned> (cloud.size ());
     // For each point in the cloud
-    for (size_t i = 0; i < point_count; ++i)
+    for (std::size_t i = 0; i < point_count; ++i)
     {
       Eigen::Matrix<Scalar, 4, 1> pt;
       pt[0] = cloud[i].x - centroid[0];
@@ -210,7 +210,7 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = 0;
     // For each point in the cloud
-    for (size_t i = 0; i < cloud.size (); ++i)
+    for (std::size_t i = 0; i < cloud.size (); ++i)
     {
       // Check if the point is invalid
       if (!isFinite (cloud [i]))
@@ -265,13 +265,13 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   // Initialize to 0
   covariance_matrix.setZero ();
 
-  size_t point_count;
+  std::size_t point_count;
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
     point_count = indices.size ();
     // For each point in the cloud
-    for (size_t i = 0; i < point_count; ++i)
+    for (std::size_t i = 0; i < point_count; ++i)
     {
       Eigen::Matrix<Scalar, 4, 1> pt;
       pt[0] = cloud[indices[i]].x - centroid[0];
@@ -374,7 +374,7 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   {
     point_count = static_cast<unsigned int> (cloud.size ());
     // For each point in the cloud
-    for (size_t i = 0; i < point_count; ++i)
+    for (std::size_t i = 0; i < point_count; ++i)
     {
       accu [0] += cloud[i].x * cloud[i].x;
       accu [1] += cloud[i].x * cloud[i].y;
@@ -387,7 +387,7 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   else
   {
     point_count = 0;
-    for (size_t i = 0; i < cloud.size (); ++i)
+    for (std::size_t i = 0; i < cloud.size (); ++i)
     {
       if (!isFinite (cloud[i]))
         continue;
@@ -486,12 +486,12 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
-  size_t point_count;
+  std::size_t point_count;
   if (cloud.is_dense)
   {
     point_count = cloud.size ();
     // For each point in the cloud
-    for (size_t i = 0; i < point_count; ++i)
+    for (std::size_t i = 0; i < point_count; ++i)
     {
       accu [0] += cloud[i].x * cloud[i].x;
       accu [1] += cloud[i].x * cloud[i].y;
@@ -507,7 +507,7 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   else
   {
     point_count = 0;
-    for (size_t i = 0; i < cloud.size (); ++i)
+    for (std::size_t i = 0; i < cloud.size (); ++i)
     {
       if (!isFinite (cloud[i]))
         continue;
@@ -552,7 +552,7 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
-  size_t point_count;
+  std::size_t point_count;
   if (cloud.is_dense)
   {
     point_count = indices.size ();
@@ -662,7 +662,7 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out = cloud_in;
 
   // Subtract the centroid from cloud_in
-  for (size_t i = 0; i < cloud_in.points.size (); ++i)
+  for (std::size_t i = 0; i < cloud_in.points.size (); ++i)
   {
     cloud_out[i].x -= static_cast<float> (centroid[0]);
     cloud_out[i].y -= static_cast<float> (centroid[1]);
@@ -692,7 +692,7 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out.resize (indices.size ());
 
   // Subtract the centroid from cloud_in
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.size (); ++i)
   {
     cloud_out[i].x = static_cast<float> (cloud_in[indices[i]].x - centroid[0]);
     cloud_out[i].y = static_cast<float> (cloud_in[indices[i]].y - centroid[1]);
@@ -747,11 +747,11 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
                        const Eigen::Matrix<Scalar, 4, 1> &centroid,
                        Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
 {
-  size_t npts = cloud_in.size ();
+  std::size_t npts = cloud_in.size ();
 
   cloud_out = Eigen::Matrix<Scalar, 4, Eigen::Dynamic>::Zero (4, npts);        // keep the data aligned
 
-  for (size_t i = 0; i < npts; ++i)
+  for (std::size_t i = 0; i < npts; ++i)
   {
     cloud_out (0, i) = cloud_in[i].x - centroid[0];
     cloud_out (1, i) = cloud_in[i].y - centroid[1];
@@ -771,11 +771,11 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
                        const Eigen::Matrix<Scalar, 4, 1> &centroid,
                        Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
 {
-  size_t npts = indices.size ();
+  std::size_t npts = indices.size ();
 
   cloud_out = Eigen::Matrix<Scalar, 4, Eigen::Dynamic>::Zero (4, npts);        // keep the data aligned
 
-  for (size_t i = 0; i < npts; ++i)
+  for (std::size_t i = 0; i < npts; ++i)
   {
     cloud_out (0, i) = cloud_in[indices[i]].x - centroid[0];
     cloud_out (1, i) = cloud_in[indices[i]].y - centroid[1];
@@ -874,17 +874,17 @@ pcl::CentroidPoint<PointT>::get (PointOutT& point) const
   }
 }
 
-template <typename PointInT, typename PointOutT> size_t
+template <typename PointInT, typename PointOutT> std::size_t
 pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                       PointOutT& centroid)
 {
   pcl::CentroidPoint<PointInT> cp;
 
   if (cloud.is_dense)
-    for (size_t i = 0; i < cloud.size (); ++i)
+    for (std::size_t i = 0; i < cloud.size (); ++i)
       cp.add (cloud[i]);
   else
-    for (size_t i = 0; i < cloud.size (); ++i)
+    for (std::size_t i = 0; i < cloud.size (); ++i)
       if (pcl::isFinite (cloud[i]))
         cp.add (cloud[i]);
 
@@ -892,7 +892,7 @@ pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
   return (cp.getSize ());
 }
 
-template <typename PointInT, typename PointOutT> size_t
+template <typename PointInT, typename PointOutT> std::size_t
 pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                       const std::vector<int>& indices,
                       PointOutT& centroid)

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -108,7 +108,7 @@ pcl::getPointsInBox (const pcl::PointCloud<PointT> &cloud,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       // Check if the point is inside bounds
       if (cloud.points[i].x < min_pt[0] || cloud.points[i].y < min_pt[1] || cloud.points[i].z < min_pt[2])
@@ -121,7 +121,7 @@ pcl::getPointsInBox (const pcl::PointCloud<PointT> &cloud,
   // NaN or Inf values could exist => check for them
   else
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       // Check if the point is invalid
       if (!std::isfinite (cloud.points[i].x) || 
@@ -151,7 +151,7 @@ pcl::getMaxDistance (const pcl::PointCloud<PointT> &cloud, const Eigen::Vector4f
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       pcl::Vector3fMapConst pt = cloud.points[i].getVector3fMap ();
       dist = (pivot_pt3 - pt).norm ();
@@ -165,7 +165,7 @@ pcl::getMaxDistance (const pcl::PointCloud<PointT> &cloud, const Eigen::Vector4f
   // NaN or Inf values could exist => check for them
   else
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       // Check if the point is invalid
       if (!std::isfinite (cloud.points[i].x) || !std::isfinite (cloud.points[i].y) || !std::isfinite (cloud.points[i].z))
@@ -199,7 +199,7 @@ pcl::getMaxDistance (const pcl::PointCloud<PointT> &cloud, const std::vector<int
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (std::size_t i = 0; i < indices.size (); ++i)
     {
       pcl::Vector3fMapConst pt = cloud.points[indices[i]].getVector3fMap ();
       dist = (pivot_pt3 - pt).norm ();
@@ -213,7 +213,7 @@ pcl::getMaxDistance (const pcl::PointCloud<PointT> &cloud, const std::vector<int
   // NaN or Inf values could exist => check for them
   else
   {
-    for (size_t i = 0; i < indices.size (); ++i)
+    for (std::size_t i = 0; i < indices.size (); ++i)
     {
       // Check if the point is invalid
       if (!std::isfinite (cloud.points[indices[i]].x) || !std::isfinite (cloud.points[indices[i]].y)
@@ -248,7 +248,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, PointT &min_pt, PointT &
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       pcl::Array4fMapConst pt = cloud.points[i].getArray4fMap ();
       min_p = min_p.min (pt);
@@ -258,7 +258,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, PointT &min_pt, PointT &
   // NaN or Inf values could exist => check for them
   else
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       // Check if the point is invalid
       if (!std::isfinite (cloud.points[i].x) || 
@@ -285,7 +285,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, Eigen::Vector4f &min_pt,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       pcl::Array4fMapConst pt = cloud.points[i].getArray4fMap ();
       min_p = min_p.min (pt);
@@ -295,7 +295,7 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, Eigen::Vector4f &min_pt,
   // NaN or Inf values could exist => check for them
   else
   {
-    for (size_t i = 0; i < cloud.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud.points.size (); ++i)
     {
       // Check if the point is invalid
       if (!std::isfinite (cloud.points[i].x) || 

--- a/common/include/pcl/common/impl/common.hpp
+++ b/common/include/pcl/common/impl/common.hpp
@@ -248,9 +248,9 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, PointT &min_pt, PointT &
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (std::size_t i = 0; i < cloud.points.size (); ++i)
+    for (const auto& point: cloud.points)
     {
-      pcl::Array4fMapConst pt = cloud.points[i].getArray4fMap ();
+      const auto pt = point.getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }
@@ -258,14 +258,14 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, PointT &min_pt, PointT &
   // NaN or Inf values could exist => check for them
   else
   {
-    for (std::size_t i = 0; i < cloud.points.size (); ++i)
+    for (const auto& point: cloud.points)
     {
       // Check if the point is invalid
-      if (!std::isfinite (cloud.points[i].x) || 
-          !std::isfinite (cloud.points[i].y) || 
-          !std::isfinite (cloud.points[i].z))
+      if (!std::isfinite (point.x) ||
+          !std::isfinite (point.y) ||
+          !std::isfinite (point.z))
         continue;
-      pcl::Array4fMapConst pt = cloud.points[i].getArray4fMap ();
+      const auto pt = point.getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }
@@ -285,9 +285,9 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, Eigen::Vector4f &min_pt,
   // If the data is dense, we don't need to check for NaN
   if (cloud.is_dense)
   {
-    for (std::size_t i = 0; i < cloud.points.size (); ++i)
+    for (const auto& point: cloud.points)
     {
-      pcl::Array4fMapConst pt = cloud.points[i].getArray4fMap ();
+      const auto pt = point.getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }
@@ -295,14 +295,14 @@ pcl::getMinMax3D (const pcl::PointCloud<PointT> &cloud, Eigen::Vector4f &min_pt,
   // NaN or Inf values could exist => check for them
   else
   {
-    for (std::size_t i = 0; i < cloud.points.size (); ++i)
+    for (const auto& point: cloud.points)
     {
       // Check if the point is invalid
-      if (!std::isfinite (cloud.points[i].x) || 
-          !std::isfinite (cloud.points[i].y) || 
-          !std::isfinite (cloud.points[i].z))
+      if (!std::isfinite (point.x) ||
+          !std::isfinite (point.y) ||
+          !std::isfinite (point.z))
         continue;
-      pcl::Array4fMapConst pt = cloud.points[i].getArray4fMap ();
+      const auto pt = point.getArray4fMap ();
       min_p = min_p.min (pt);
       max_p = max_p.max (pt);
     }

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -39,6 +39,8 @@
 #ifndef PCL_COMMON_EIGEN_IMPL_HPP_
 #define PCL_COMMON_EIGEN_IMPL_HPP_
 
+#include <algorithm>
+
 #include <pcl/console/print.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -859,8 +861,7 @@ pcl::transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
   Eigen::Matrix < Scalar, 4, 1 > v_plane_in (values.data ());
   pcl::transformPlane (v_plane_in, v_plane_in, transformation);
   plane_out->values.resize (4);
-  for (int i = 0; i < 4; i++)
-    plane_in->values[i] = v_plane_in[i];
+  std::copy_n(v_plane_in.data (), 4, plane_in->values.begin ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -52,7 +52,7 @@ pcl::computeRoots2 (const Scalar& b, const Scalar& c, Roots& roots)
   if (d < 0.0)  // no real roots ! THIS SHOULD NOT HAPPEN!
     d = 0.0;
 
-  Scalar sd = ::std::sqrt (d);
+  Scalar sd = std::sqrt (d);
 
   roots (2) = 0.5f * (b + sd);
   roots (1) = 0.5f * (b - sd);
@@ -155,7 +155,7 @@ pcl::eigen22 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& ei
   if (temp < 0)
     temp = 0;
 
-  eigenvalue = trace - ::std::sqrt (temp);
+  eigenvalue = trace - std::sqrt (temp);
 
   eigenvector[0] = -mat.coeff (1);
   eigenvector[1] = mat.coeff (0) - eigenvalue;
@@ -200,7 +200,7 @@ pcl::eigen22 (const Matrix& mat, Matrix& eigenvectors, Vector& eigenvalues)
   if (temp < 0)
     temp = 0;
   else
-    temp = ::std::sqrt (temp);
+    temp = std::sqrt (temp);
 
   eigenvalues.coeffRef (0) = trace - temp;
   eigenvalues.coeffRef (1) = trace + temp;
@@ -209,7 +209,7 @@ pcl::eigen22 (const Matrix& mat, Matrix& eigenvectors, Vector& eigenvalues)
   eigenvectors.coeffRef (0) = -mat.coeff (1);
   eigenvectors.coeffRef (2) = mat.coeff (0) - eigenvalues.coeff (0);
   typename Matrix::Scalar norm = static_cast<typename Matrix::Scalar> (1.0)
-      / static_cast<typename Matrix::Scalar> (::std::sqrt (eigenvectors.coeffRef (0) * eigenvectors.coeffRef (0) + eigenvectors.coeffRef (2) * eigenvectors.coeffRef (2)));
+      / static_cast<typename Matrix::Scalar> (std::sqrt (eigenvectors.coeffRef (0) * eigenvectors.coeffRef (0) + eigenvectors.coeffRef (2) * eigenvectors.coeffRef (2)));
   eigenvectors.coeffRef (0) *= norm;
   eigenvectors.coeffRef (2) *= norm;
   eigenvectors.coeffRef (1) = eigenvectors.coeffRef (2);

--- a/common/include/pcl/common/impl/file_io.hpp
+++ b/common/include/pcl/common/impl/file_io.hpp
@@ -68,19 +68,19 @@ namespace pcl
 
 std::string getFilenameWithoutPath(const std::string& input)
 {
-  size_t filename_start = input.find_last_of('/', static_cast<size_t>(-1)) + 1;
+  std::size_t filename_start = input.find_last_of('/', static_cast<std::size_t>(-1)) + 1;
   return input.substr(filename_start, input.size()-filename_start);
 }
 
 std::string getFilenameWithoutExtension(const std::string& input)
 {
-  size_t dot_position = input.find_last_of('.', input.size());
+  std::size_t dot_position = input.find_last_of('.', input.size());
   return input.substr(0, dot_position);
 }
 
 std::string getFileExtension(const std::string& input)
 {
-  size_t dot_position = input.find_last_of('.', input.size());
+  std::size_t dot_position = input.find_last_of('.', input.size());
   return input.substr(dot_position+1, input.size());
 }
 

--- a/common/include/pcl/common/impl/generate.hpp
+++ b/common/include/pcl/common/impl/generate.hpp
@@ -166,13 +166,11 @@ pcl::common::CloudGenerator<PointT, GeneratorT>::fill (int width, int height, pc
   cloud.height = height;
   cloud.resize (cloud.width * cloud.height);
   cloud.is_dense = true;
-  for (typename pcl::PointCloud<PointT>::iterator points_it = cloud.begin ();
-       points_it != cloud.end ();
-       ++points_it)
+  for (auto& point: cloud)
   {
-    points_it->x = x_generator_.run ();
-    points_it->y = y_generator_.run ();
-    points_it->z = z_generator_.run ();
+    point.x = x_generator_.run ();
+    point.y = y_generator_.run ();
+    point.z = z_generator_.run ();
   }
   return (0);
 }

--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -51,13 +51,7 @@ pcl::getFieldIndex (const pcl::PointCloud<PointT> &,
                     const std::string &field_name, 
                     std::vector<pcl::PCLPointField> &fields)
 {
-  fields.clear ();
-  // Get the fields list
-  pcl::for_each_type<typename pcl::traits::fieldList<PointT>::type>(pcl::detail::FieldAdder<PointT>(fields));
-  for (std::size_t d = 0; d < fields.size (); ++d)
-    if (fields[d].name == field_name)
-      return (static_cast<int>(d));
-  return (-1);
+  return getFieldIndex<PointT>(field_name, fields);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -130,9 +124,9 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
+template <typename PointT, typename IndicesVectorAllocator> void
 pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
-                     const std::vector<int> &indices,
+                     const std::vector<int, IndicesVectorAllocator> &indices,
                      pcl::PointCloud<PointT> &cloud_out)
 {
   // Do we want to copy everything?
@@ -157,62 +151,15 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
-                     const std::vector<int, Eigen::aligned_allocator<int> > &indices,
-                     pcl::PointCloud<PointT> &cloud_out)
-{
-  // Do we want to copy everything?
-  if (indices.size () == cloud_in.points.size ())
-  {
-    cloud_out = cloud_in;
-    return;
-  }
-
-  // Allocate enough space and copy the basics
-  cloud_out.points.resize (indices.size ());
-  cloud_out.header   = cloud_in.header;
-  cloud_out.width    = static_cast<uint32_t> (indices.size ());
-  cloud_out.height   = 1;
-  cloud_out.is_dense = cloud_in.is_dense;
-  cloud_out.sensor_orientation_ = cloud_in.sensor_orientation_;
-  cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
-
-  // Iterate over each point
-  for (std::size_t i = 0; i < indices.size (); ++i)
-    cloud_out.points[i] = cloud_in.points[indices[i]];
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
+template <typename PointInT, typename PointOutT, typename IndicesVectorAllocator> void
 pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
-                     const std::vector<int> &indices,
+                     const std::vector<int, IndicesVectorAllocator> &indices,
                      pcl::PointCloud<PointOutT> &cloud_out)
 {
   // Allocate enough space and copy the basics
   cloud_out.points.resize (indices.size ());
   cloud_out.header   = cloud_in.header;
   cloud_out.width    = uint32_t (indices.size ());
-  cloud_out.height   = 1;
-  cloud_out.is_dense = cloud_in.is_dense;
-  cloud_out.sensor_orientation_ = cloud_in.sensor_orientation_;
-  cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
-
-  // Iterate over each point
-  for (std::size_t i = 0; i < indices.size (); ++i)
-    copyPoint (cloud_in.points[indices[i]], cloud_out.points[i]);
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointOutT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
-                     const std::vector<int, Eigen::aligned_allocator<int> > &indices,
-                     pcl::PointCloud<PointOutT> &cloud_out)
-{
-  // Allocate enough space and copy the basics
-  cloud_out.points.resize (indices.size ());
-  cloud_out.header   = cloud_in.header;
-  cloud_out.width    = static_cast<uint32_t> (indices.size ());
   cloud_out.height   = 1;
   cloud_out.is_dense = cloud_in.is_dense;
   cloud_out.sensor_orientation_ = cloud_in.sensor_orientation_;
@@ -305,14 +252,13 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
                      const std::vector<pcl::PointIndices> &indices,
                      pcl::PointCloud<PointOutT> &cloud_out)
 {
-  int nr_p = 0;
-  for (const auto &index : indices)
-    nr_p += index.indices.size ();
+  const auto nr_p = std::accumulate(indices.begin (), indices.end (), 0,
+      [](const auto& acc, const auto& index) { return index.indices.size() + acc; });
 
   // Do we want to copy everything? Remember we assume UNIQUE indices
   if (nr_p == cloud_in.points.size ())
   {
-    copyPointCloud<PointInT, PointOutT> (cloud_in, cloud_out);
+    copyPointCloud (cloud_in, cloud_out);
     return;
   }
 
@@ -326,7 +272,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
   cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
 
   // Iterate over each cluster
-  int cp = 0;
+  std::size_t cp = 0;
   for (const auto &cluster_index : indices)
   {
     // Iterate over each idx

--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -54,7 +54,7 @@ pcl::getFieldIndex (const pcl::PointCloud<PointT> &,
   fields.clear ();
   // Get the fields list
   pcl::for_each_type<typename pcl::traits::fieldList<PointT>::type>(pcl::detail::FieldAdder<PointT>(fields));
-  for (size_t d = 0; d < fields.size (); ++d)
+  for (std::size_t d = 0; d < fields.size (); ++d)
     if (fields[d].name == field_name)
       return (static_cast<int>(d));
   return (-1);
@@ -97,7 +97,7 @@ pcl::getFieldsList (const pcl::PointCloud<PointT> &)
   std::vector<pcl::PCLPointField> fields;
   pcl::for_each_type<typename pcl::traits::fieldList<PointT>::type>(pcl::detail::FieldAdder<PointT>(fields));
   std::string result;
-  for (size_t i = 0; i < fields.size () - 1; ++i)
+  for (std::size_t i = 0; i < fields.size () - 1; ++i)
     result += fields[i].name + " ";
   result += fields[fields.size () - 1].name;
   return (result);
@@ -125,7 +125,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
     memcpy (&cloud_out.points[0], &cloud_in.points[0], cloud_in.points.size () * sizeof (PointInT));
   else
     // Iterate over each point
-    for (size_t i = 0; i < cloud_in.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud_in.points.size (); ++i)
       copyPoint (cloud_in.points[i], cloud_out.points[i]);
 }
 
@@ -152,7 +152,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
 
   // Iterate over each point
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.size (); ++i)
     cloud_out.points[i] = cloud_in.points[indices[i]];
 }
 
@@ -179,7 +179,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
 
   // Iterate over each point
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.size (); ++i)
     cloud_out.points[i] = cloud_in.points[indices[i]];
 }
 
@@ -199,7 +199,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
   cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
 
   // Iterate over each point
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.size (); ++i)
     copyPoint (cloud_in.points[indices[i]], cloud_out.points[i]);
 }
 
@@ -219,7 +219,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
   cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
 
   // Iterate over each point
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.size (); ++i)
     copyPoint (cloud_in.points[indices[i]], cloud_out.points[i]);
 }
 
@@ -246,7 +246,7 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
 
   // Iterate over each point
-  for (size_t i = 0; i < indices.indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.indices.size (); ++i)
     cloud_out.points[i] = cloud_in.points[indices.indices[i]];
 }
 
@@ -364,7 +364,7 @@ pcl::concatenateFields (const pcl::PointCloud<PointIn1T> &cloud1_in,
     cloud_out.is_dense = true;
 
   // Iterate over each point
-  for (size_t i = 0; i < cloud_out.points.size (); ++i)
+  for (std::size_t i = 0; i < cloud_out.points.size (); ++i)
   {
     // Iterate over each dimension
     pcl::for_each_type <FieldList1> (pcl::NdConcatenateFunctor <PointIn1T, PointOutT> (cloud1_in.points[i], cloud_out.points[i]));

--- a/common/include/pcl/common/impl/pca.hpp
+++ b/common/include/pcl/common/impl/pca.hpp
@@ -96,7 +96,7 @@ pcl::PCA<PointT>::update (const PointT& input_point, FLAG flag)
     PCL_THROW_EXCEPTION (InitFailedException, "[pcl::PCA::update] PCA initCompute failed");
 
   Eigen::Vector3f input (input_point.x, input_point.y, input_point.z);
-  const size_t n = eigenvectors_.cols ();// number of eigen vectors
+  const std::size_t n = eigenvectors_.cols ();// number of eigen vectors
   Eigen::VectorXf meanp = (float(n) * (mean_.head<3>() + input)) / float(n + 1);
   Eigen::VectorXf a = eigenvectors_.transpose() * (input - mean_.head<3>());
   Eigen::VectorXf y = (eigenvectors_ * a) + mean_.head<3>();
@@ -180,13 +180,13 @@ pcl::PCA<PointT>::project (const PointCloud& input, PointCloud& projection)
   if (input.is_dense)
   {
     projection.resize (input.size ());
-    for (size_t i = 0; i < input.size (); ++i)
+    for (std::size_t i = 0; i < input.size (); ++i)
       project (input[i], projection[i]);
   }
   else
   {
     PointT p;
-    for (size_t i = 0; i < input.size (); ++i)
+    for (std::size_t i = 0; i < input.size (); ++i)
     {
       if (!std::isfinite (input[i].x) || 
           !std::isfinite (input[i].y) ||
@@ -222,13 +222,13 @@ pcl::PCA<PointT>::reconstruct (const PointCloud& projection, PointCloud& input)
   if (input.is_dense)
   {
     input.resize (projection.size ());
-    for (size_t i = 0; i < projection.size (); ++i)
+    for (std::size_t i = 0; i < projection.size (); ++i)
       reconstruct (projection[i], input[i]);
   }
   else
   {
     PointT p;
-    for (size_t i = 0; i < input.size (); ++i)
+    for (std::size_t i = 0; i < input.size (); ++i)
     {
       if (!std::isfinite (input[i].x) || 
           !std::isfinite (input[i].y) ||

--- a/common/include/pcl/common/impl/pca.hpp
+++ b/common/include/pcl/common/impl/pca.hpp
@@ -186,13 +186,13 @@ pcl::PCA<PointT>::project (const PointCloud& input, PointCloud& projection)
   else
   {
     PointT p;
-    for (std::size_t i = 0; i < input.size (); ++i)
+    for (const auto& pt: input)
     {
-      if (!std::isfinite (input[i].x) || 
-          !std::isfinite (input[i].y) ||
-          !std::isfinite (input[i].z))
+      if (!std::isfinite (pt.x) ||
+          !std::isfinite (pt.y) ||
+          !std::isfinite (pt.z))
         continue;
-      project (input[i], p);
+      project (pt, p);
       projection.push_back (p);
     }
   }

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -116,9 +116,9 @@ inline void
     //std::cout << "Constant element is 0 => Adding root 0 and calling solveLinearEquation.\n";
     std::vector<real> tmpRoots;
     solveLinearEquation (a, b, tmpRoots);
-    for (unsigned int i=0; i<tmpRoots.size (); i++)
-      if (!isNearlyZero (tmpRoots[i]))
-        roots.push_back (tmpRoots[i]);
+    for (const auto& tmpRoot: tmpRoots)
+      if (!isNearlyZero (tmpRoot))
+        roots.push_back (tmpRoot);
     return;
   }
 
@@ -172,9 +172,9 @@ inline void
     //std::cout << "Constant element is 0 => Adding root 0 and calling solveQuadraticEquation.\n";
     std::vector<real> tmpRoots;
     solveQuadraticEquation (a, b, c, tmpRoots);
-    for (unsigned int i=0; i<tmpRoots.size (); i++)
-      if (!isNearlyZero (tmpRoots[i]))
-        roots.push_back (tmpRoots[i]);
+    for (const auto& tmpRoot: tmpRoots)
+      if (!isNearlyZero (tmpRoot))
+        roots.push_back (tmpRoot);
     return;
   }
 
@@ -275,9 +275,9 @@ inline void
     //std::cout << "Constant element is 0 => Adding root 0 and calling solveCubicEquation.\n";
     std::vector<real> tmpRoots;
     solveCubicEquation (a, b, c, d, tmpRoots);
-    for (unsigned int i=0; i<tmpRoots.size (); i++)
-      if (!isNearlyZero (tmpRoots[i]))
-        roots.push_back (tmpRoots[i]);
+    for (const auto& tmpRoot: tmpRoots)
+      if (!isNearlyZero (tmpRoot))
+        roots.push_back (tmpRoot);
     return;
   }
 
@@ -303,16 +303,15 @@ inline void
     //std::cout << "Using beta=0 condition\n";
     std::vector<real> tmpRoots;
     solveQuadraticEquation (1.0, alpha, gamma, tmpRoots);
-    for (unsigned int i=0; i<tmpRoots.size (); i++)
+    for (const auto& quadraticRoot: tmpRoots)
     {
-      double qudraticRoot = tmpRoots[i];
-      if (sqrtIsNearlyZero (qudraticRoot))
+      if (sqrtIsNearlyZero (quadraticRoot))
       {
         roots.push_back (-resubValue);
       }
-      else if (qudraticRoot > 0.0)
+      else if (quadraticRoot > 0.0)
       {
-        root1 = sqrt (qudraticRoot);
+        root1 = sqrt (quadraticRoot);
         roots.push_back (root1 - resubValue);
         roots.push_back (-root1 - resubValue);
       }
@@ -455,10 +454,9 @@ inline bool
   real tmpX, tmpY;
   real *tmpC = new real[parameters_size];
   real* tmpCEndPtr = &tmpC[parameters_size-1];
-  for (typename std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >::const_iterator it=samplePoints.begin ();
-       it!=samplePoints.end (); ++it)
+  for (const auto& point: samplePoints)
   {
-    currentX= (*it)[0]; currentY= (*it)[1]; currentZ= (*it)[2];
+    currentX= point[0]; currentY= point[1]; currentZ= point[2];
     //std::cout << "current point: "<<currentX<<","<<currentY<<" => "<<currentZ<<"\n";
     //unsigned int posInC = parameters_size-1;
     real* tmpCPtr = tmpCEndPtr;
@@ -548,8 +546,7 @@ inline bool
     return false;
   }
 
-  for (unsigned int i=0; i<parameters_size; i++)
-    ret.parameters[i] = parameters[i];
+  std::copy_n(parameters.data(), parameters_size, ret.parameters);
 
   //std::cout << "Resulting polynomial is "<<ret<<"\n";
 

--- a/common/include/pcl/common/impl/spring.hpp
+++ b/common/include/pcl/common/impl/spring.hpp
@@ -200,13 +200,10 @@ pcl::common::mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
   output.reserve (new_height * old_width);
   for(std::size_t i = 0; i < amount; i++)
   {
-    typename PointCloud<PointT>::iterator up;
-    if (output.height % 2 ==  0)
-      up = output.begin () + (2*i) * old_width;
-    else
-      up = output.begin () + (2*i+1) * old_width;
+    const auto extra_odd = output.height % 2;
+    auto up = output.begin () + (2*i + extra_odd) * old_width;
     output.insert (output.begin (), up, up + old_width);
-    typename PointCloud<PointT>::iterator bottom = output.end () - (2*i+1) * old_width;
+    auto bottom = output.end () - (2*i+1) * old_width;
     output.insert (output.end (), bottom, bottom + old_width);
   }
   output.width = old_width;

--- a/common/include/pcl/common/impl/spring.hpp
+++ b/common/include/pcl/common/impl/spring.hpp
@@ -42,7 +42,7 @@
 
 template <typename PointT> void 
 pcl::common::expandColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                            const PointT& val, const size_t& amount)
+                            const PointT& val, const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -74,7 +74,7 @@ pcl::common::expandColumns (const PointCloud<PointT>& input, PointCloud<PointT>&
 
 template <typename PointT> void 
 pcl::common::expandRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const PointT& val, const size_t& amount)
+                         const PointT& val, const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -95,7 +95,7 @@ pcl::common::expandRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
 
 template <typename PointT> void 
 pcl::common::duplicateColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                               const size_t& amount)
+                               const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -107,14 +107,14 @@ pcl::common::duplicateColumns (const PointCloud<PointT>& input, PointCloud<Point
                          "[pcl::common::duplicateColumns] error: " 
                          << "columns expansion requires organised point cloud");
 
-  size_t old_height = input.height;
-  size_t old_width = input.width;
-  size_t new_width = old_width + 2*amount;
+  std::size_t old_height = input.height;
+  std::size_t old_width = input.width;
+  std::size_t new_width = old_width + 2*amount;
   if (&input != &output)
     output = input;
   output.reserve (new_width * old_height);
-  for (size_t j = 0; j < old_height; ++j)
-    for(size_t i = 0; i < amount; ++i)
+  for (std::size_t j = 0; j < old_height; ++j)
+    for(std::size_t i = 0; i < amount; ++i)
     {
       typename PointCloud<PointT>::iterator start = output.begin () + (j * new_width);
       output.insert (start, *start);
@@ -128,7 +128,7 @@ pcl::common::duplicateColumns (const PointCloud<PointT>& input, PointCloud<Point
 
 template <typename PointT> void 
 pcl::common::duplicateRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                            const size_t& amount)
+                            const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.height/2))
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -141,7 +141,7 @@ pcl::common::duplicateRows (const PointCloud<PointT>& input, PointCloud<PointT>&
   if (&input != &output)
     output = input;
   output.reserve (new_height * old_width);
-  for(size_t i = 0; i < amount; ++i)
+  for(std::size_t i = 0; i < amount; ++i)
   {
     output.insert (output.begin (), output.begin (), output.begin () + old_width);
     output.insert (output.end (), output.end () - old_width, output.end ());
@@ -153,7 +153,7 @@ pcl::common::duplicateRows (const PointCloud<PointT>& input, PointCloud<PointT>&
 
 template <typename PointT> void 
 pcl::common::mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                                  const size_t& amount)
+                                  const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -165,14 +165,14 @@ pcl::common::mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>&
                          "[pcl::common::mirrorColumns] error: " 
                          << "columns expansion requires organised point cloud");
 
-  size_t old_height = input.height;
-  size_t old_width = input.width;
-  size_t new_width = old_width + 2*amount;
+  std::size_t old_height = input.height;
+  std::size_t old_width = input.width;
+  std::size_t new_width = old_width + 2*amount;
   if (&input != &output)
     output = input;
   output.reserve (new_width * old_height);
-  for (size_t j = 0; j < old_height; ++j)
-    for(size_t i = 0; i < amount; ++i)
+  for (std::size_t j = 0; j < old_height; ++j)
+    for(std::size_t i = 0; i < amount; ++i)
     {
       typename PointCloud<PointT>::iterator start = output.begin () + (j * new_width);
       output.insert (start, *(start + 2*i));
@@ -185,7 +185,7 @@ pcl::common::mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>&
 
 template <typename PointT> void 
 pcl::common::mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const size_t& amount)
+                         const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.height/2))
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -198,7 +198,7 @@ pcl::common::mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
   if (&input != &output)
     output = input;
   output.reserve (new_height * old_width);
-  for(size_t i = 0; i < amount; i++)
+  for(std::size_t i = 0; i < amount; i++)
   {
     typename PointCloud<PointT>::iterator up;
     if (output.height % 2 ==  0)
@@ -215,7 +215,7 @@ pcl::common::mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
 
 template <typename PointT> void 
 pcl::common::deleteRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const size_t& amount)
+                         const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.height/2))
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -232,7 +232,7 @@ pcl::common::deleteRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
 
 template <typename PointT> void 
 pcl::common::deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const size_t& amount)
+                         const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.width/2))
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -247,7 +247,7 @@ pcl::common::deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& ou
   uint32_t old_height = input.height;
   uint32_t old_width = input.width;
   uint32_t new_width = old_width - 2 * amount;
-  for(size_t j = 0; j < old_height; j++)
+  for(std::size_t j = 0; j < old_height; j++)
   {
     typename PointCloud<PointT>::iterator start = output.begin () + j * new_width;
     output.erase (start, start + amount);

--- a/common/include/pcl/common/impl/transforms.hpp
+++ b/common/include/pcl/common/impl/transforms.hpp
@@ -99,7 +99,7 @@ namespace pcl
 
       Transformer(const Eigen::Matrix4f& tf)
       {
-        for (size_t i = 0; i < 4; ++i)
+        for (std::size_t i = 0; i < 4; ++i)
           c[i] = _mm_load_ps (tf.col (i).data ());
       }
 
@@ -131,7 +131,7 @@ namespace pcl
 
       Transformer(const Eigen::Matrix4d& tf)
       {
-        for (size_t i = 0; i < 4; ++i)
+        for (std::size_t i = 0; i < 4; ++i)
         {
           c[i][0] = _mm_load_pd (tf.col (i).data () + 0);
           c[i][1] = _mm_load_pd (tf.col (i).data () + 2);
@@ -144,7 +144,7 @@ namespace pcl
         __m128d p0 = _mm_mul_pd (xx, c[0][0]);
         __m128d p1 = _mm_mul_pd (xx, c[0][1]);
 
-        for (size_t i = 1; i < 3; ++i)
+        for (std::size_t i = 1; i < 3; ++i)
         {
           __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
           p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
@@ -159,7 +159,7 @@ namespace pcl
         __m128d p0 = c[3][0];
         __m128d p1 = c[3][1];
 
-        for (size_t i = 0; i < 3; ++i)
+        for (std::size_t i = 0; i < 3; ++i)
         {
           __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
           p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
@@ -181,7 +181,7 @@ namespace pcl
 
     Transformer(const Eigen::Matrix4d& tf)
     {
-      for (size_t i = 0; i < 4; ++i)
+      for (std::size_t i = 0; i < 4; ++i)
         c[i] = _mm256_load_pd (tf.col (i).data ());
     }
 
@@ -236,14 +236,14 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   if (cloud_in.is_dense)
   {
     // If the dataset is dense, simply transform it!
-    for (size_t i = 0; i < cloud_out.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud_out.points.size (); ++i)
       tf.se3 (cloud_in[i].data, cloud_out[i].data);
   }
   else
   {
     // Dataset might contain NaNs and Infs, so check for them first,
     // otherwise we get errors during the multiplication (?)
-    for (size_t i = 0; i < cloud_out.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud_out.points.size (); ++i)
     {
       if (!std::isfinite (cloud_in.points[i].x) || 
           !std::isfinite (cloud_in.points[i].y) || 
@@ -262,7 +262,7 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
                           const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
                           bool copy_all_fields)
 {
-  size_t npts = indices.size ();
+  std::size_t npts = indices.size ();
   // In order to transform the data, we need to remove NaNs
   cloud_out.is_dense = cloud_in.is_dense;
   cloud_out.header   = cloud_in.header;
@@ -276,7 +276,7 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   if (cloud_in.is_dense)
   {
     // If the dataset is dense, simply transform it!
-    for (size_t i = 0; i < npts; ++i)
+    for (std::size_t i = 0; i < npts; ++i)
     {
       // Copy fields first, then transform xyz data
       if (copy_all_fields)
@@ -288,7 +288,7 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   {
     // Dataset might contain NaNs and Infs, so check for them first,
     // otherwise we get errors during the multiplication (?)
-    for (size_t i = 0; i < npts; ++i)
+    for (std::size_t i = 0; i < npts; ++i)
     {
       if (copy_all_fields)
         cloud_out.points[i] = cloud_in.points[indices[i]];
@@ -328,7 +328,7 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   // If the data is dense, we don't need to check for NaN
   if (cloud_in.is_dense)
   {
-    for (size_t i = 0; i < cloud_out.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud_out.points.size (); ++i)
     {
       tf.se3 (cloud_in[i].data, cloud_out[i].data);
       tf.so3 (cloud_in[i].data_n, cloud_out[i].data_n);
@@ -337,7 +337,7 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   // Dataset might contain NaNs and Infs, so check for them first.
   else
   {
-    for (size_t i = 0; i < cloud_out.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud_out.points.size (); ++i)
     {
       if (!std::isfinite (cloud_in.points[i].x) || 
           !std::isfinite (cloud_in.points[i].y) || 
@@ -357,7 +357,7 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
                                      const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
                                      bool copy_all_fields)
 {
-  size_t npts = indices.size ();
+  std::size_t npts = indices.size ();
   // In order to transform the data, we need to remove NaNs
   cloud_out.is_dense = cloud_in.is_dense;
   cloud_out.header   = cloud_in.header;
@@ -371,7 +371,7 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   // If the data is dense, we don't need to check for NaN
   if (cloud_in.is_dense)
   {
-    for (size_t i = 0; i < cloud_out.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud_out.points.size (); ++i)
     {
       // Copy fields first, then transform
       if (copy_all_fields)
@@ -383,7 +383,7 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   // Dataset might contain NaNs and Infs, so check for them first.
   else
   {
-    for (size_t i = 0; i < cloud_out.points.size (); ++i)
+    for (std::size_t i = 0; i < cloud_out.points.size (); ++i)
     {
       // Copy fields first, then transform
       if (copy_all_fields)

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -59,7 +59,7 @@ namespace pcl
   getFieldIndex (const pcl::PCLPointCloud2 &cloud, const std::string &field_name)
   {
     // Get the index we need
-    for (size_t d = 0; d < cloud.fields.size (); ++d)
+    for (std::size_t d = 0; d < cloud.fields.size (); ++d)
       if (cloud.fields[d].name == field_name)
         return (static_cast<int>(d));
     return (-1);
@@ -118,7 +118,7 @@ namespace pcl
   getFieldsList (const pcl::PCLPointCloud2 &cloud)
   {
     std::string result;
-    for (size_t i = 0; i < cloud.fields.size () - 1; ++i)
+    for (std::size_t i = 0; i < cloud.fields.size () - 1; ++i)
       result += cloud.fields[i].name + " ";
     result += cloud.fields[cloud.fields.size () - 1].name;
     return (result);

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -40,7 +40,9 @@
 
 #pragma once
 
+#include <numeric>
 #include <string>
+
 #include <pcl/pcl_base.h>
 #include <pcl/PointIndices.h>
 #include <pcl/conversions.h>
@@ -59,10 +61,11 @@ namespace pcl
   getFieldIndex (const pcl::PCLPointCloud2 &cloud, const std::string &field_name)
   {
     // Get the index we need
-    for (std::size_t d = 0; d < cloud.fields.size (); ++d)
-      if (cloud.fields[d].name == field_name)
-        return (static_cast<int>(d));
-    return (-1);
+    const auto result = std::find_if(cloud.fields.begin (), cloud.fields.end (),
+        [&field_name](const auto field) { return field.name == field_name; });
+    if (result == cloud.fields.end ())
+      return -1;
+    return std::distance(cloud.fields.begin (), result);
   }
 
   /** \brief Get the index of a specified field (i.e., dimension/channel)
@@ -117,11 +120,8 @@ namespace pcl
   inline std::string
   getFieldsList (const pcl::PCLPointCloud2 &cloud)
   {
-    std::string result;
-    for (std::size_t i = 0; i < cloud.fields.size () - 1; ++i)
-      result += cloud.fields[i].name + " ";
-    result += cloud.fields[cloud.fields.size () - 1].name;
-    return (result);
+    return std::accumulate(std::next (cloud.fields.begin ()), cloud.fields.end (), cloud.fields[0].name,
+        [](const auto& acc, const auto& field) { return acc + " " + field.name; });
   }
 
   /** \brief Obtains the size of a specific field data type in bytes
@@ -360,21 +360,9 @@ namespace pcl
     * \note Assumes unique indices.
     * \ingroup common
     */
-  template <typename PointT> void 
+  template <typename PointT, typename IndicesVectorAllocator = std::allocator<int>> void
   copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
-                  const std::vector<int> &indices, 
-                  pcl::PointCloud<PointT> &cloud_out);
- 
-  /** \brief Extract the indices of a given point cloud as a new point cloud
-    * \param[in] cloud_in the input point cloud dataset
-    * \param[in] indices the vector of indices representing the points to be copied from \a cloud_in
-    * \param[out] cloud_out the resultant output point cloud dataset
-    * \note Assumes unique indices.
-    * \ingroup common
-    */
-  template <typename PointT> void 
-  copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
-                  const std::vector<int, Eigen::aligned_allocator<int> > &indices, 
+                  const std::vector<int, IndicesVectorAllocator> &indices,
                   pcl::PointCloud<PointT> &cloud_out);
 
   /** \brief Extract the indices of a given point cloud as a new point cloud
@@ -417,21 +405,9 @@ namespace pcl
     * \note Assumes unique indices.
     * \ingroup common
     */
-  template <typename PointInT, typename PointOutT> void 
+  template <typename PointInT, typename PointOutT, typename IndicesVectorAllocator = std::allocator<int>> void
   copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in, 
-                  const std::vector<int> &indices, 
-                  pcl::PointCloud<PointOutT> &cloud_out);
-
-  /** \brief Extract the indices of a given point cloud as a new point cloud
-    * \param[in] cloud_in the input point cloud dataset
-    * \param[in] indices the vector of indices representing the points to be copied from \a cloud_in
-    * \param[out] cloud_out the resultant output point cloud dataset
-    * \note Assumes unique indices.
-    * \ingroup common
-    */
-  template <typename PointInT, typename PointOutT> void 
-  copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in, 
-                  const std::vector<int, Eigen::aligned_allocator<int> > &indices, 
+                  const std::vector<int, IndicesVectorAllocator> &indices,
                   pcl::PointCloud<PointOutT> &cloud_out);
 
   /** \brief Extract the indices of a given point cloud as a new point cloud

--- a/common/include/pcl/common/pca.h
+++ b/common/include/pcl/common/pca.h
@@ -166,7 +166,7 @@ namespace pcl
         * \param[in] nb_cols the number of columns to be considered col_start included
         */
       void
-      setIndices (size_t row_start, size_t col_start, size_t nb_rows, size_t nb_cols) override
+      setIndices (std::size_t row_start, std::size_t col_start, std::size_t nb_rows, std::size_t nb_cols) override
       {
         Base::setIndices (row_start, col_start, nb_rows, nb_cols);
         compute_done_ = false;

--- a/common/include/pcl/common/spring.h
+++ b/common/include/pcl/common/spring.h
@@ -55,7 +55,7 @@ namespace pcl
      */
     template <typename PointT> void
     expandRows (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                const PointT& val, const size_t& amount);
+                const PointT& val, const std::size_t& amount);
 
     /** expand point cloud inserting \a amount columns at 
       * the right and the left of a point cloud and filling them with 
@@ -67,7 +67,7 @@ namespace pcl
       */
     template <typename PointT> void
     expandColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                   const PointT& val, const size_t& amount);
+                   const PointT& val, const std::size_t& amount);
 
     /** expand point cloud duplicating the \a amount top and bottom rows times.
       * \param[in] input the input point cloud
@@ -76,7 +76,7 @@ namespace pcl
       */
     template <typename PointT> void
     duplicateRows (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                   const size_t& amount);
+                   const std::size_t& amount);
 
     /** expand point cloud duplicating the \a amount right and left columns
       * times.
@@ -86,7 +86,7 @@ namespace pcl
       */
     template <typename PointT> void
     duplicateColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                      const size_t& amount);
+                      const std::size_t& amount);
 
     /** expand point cloud mirroring \a amount top and bottom rows. 
       * \param[in] input the input point cloud
@@ -95,7 +95,7 @@ namespace pcl
       */
     template <typename PointT> void
     mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                const size_t& amount);
+                const std::size_t& amount);
 
     /** expand point cloud mirroring \a amount right and left columns.
       * \param[in] input the input point cloud
@@ -104,7 +104,7 @@ namespace pcl
       */
     template <typename PointT> void
     mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                   const size_t& amount);
+                   const std::size_t& amount);
 
     /** delete \a amount rows in top and bottom of point cloud 
       * \param[in] input the input point cloud
@@ -113,7 +113,7 @@ namespace pcl
       */
     template <typename PointT> void
     deleteRows (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                const size_t& amount);
+                const std::size_t& amount);
 
     /** delete \a amount columns in top and bottom of point cloud
       * \param[in] input the input point cloud
@@ -122,7 +122,7 @@ namespace pcl
       */
     template <typename PointT> void
     deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                const size_t& amount);
+                const std::size_t& amount);
   };
 }
 

--- a/common/include/pcl/common/synchronizer.h
+++ b/common/include/pcl/common/synchronizer.h
@@ -108,11 +108,11 @@ namespace pcl
       std::unique_lock<std::mutex> lock1 (mutex1_);
       std::unique_lock<std::mutex> lock2 (mutex2_);
 
-      for (typename std::map<int, CallbackFunction>::iterator cb = cb_.begin (); cb != cb_.end (); ++cb)
+      for (const auto& cb: cb_)
       {
-        if (cb->second)
+        if (cb.second)
         {
-          cb->second.operator()(queueT1.front ().second, queueT2.front ().second, queueT1.front ().first, queueT2.front ().first);
+          cb.second.operator()(queueT1.front ().second, queueT2.front ().second, queueT1.front ().first, queueT2.front ().first);
         }
       }
 

--- a/common/include/pcl/common/time.h
+++ b/common/include/pcl/common/time.h
@@ -143,7 +143,7 @@ namespace pcl
         *
         * \param[in] window_size number of most recent events that are
         * considered in frequency estimation (default: 30) */
-      EventFrequency (size_t window_size = 30)
+      EventFrequency (std::size_t window_size = 30)
       : window_size_ (window_size)
       {
         stop_watch_.reset ();
@@ -178,7 +178,7 @@ namespace pcl
 
       pcl::StopWatch stop_watch_;
       std::queue<double> event_time_queue_;
-      const size_t window_size_;
+      const std::size_t window_size_;
 
   };
 

--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -254,7 +254,7 @@ namespace pcl
     }
 
     // Fill point cloud binary data (padding and all)
-    size_t data_size = sizeof (PointT) * cloud.points.size ();
+    std::size_t data_size = sizeof (PointT) * cloud.points.size ();
     msg.data.resize (data_size);
     if (data_size)
     {
@@ -296,9 +296,9 @@ namespace pcl
     msg.encoding = "bgr8";
     msg.step = msg.width * sizeof (uint8_t) * 3;
     msg.data.resize (msg.step * msg.height);
-    for (size_t y = 0; y < cloud.height; y++)
+    for (std::size_t y = 0; y < cloud.height; y++)
     {
-      for (size_t x = 0; x < cloud.width; x++)
+      for (std::size_t x = 0; x < cloud.width; x++)
       {
         uint8_t * pixel = &(msg.data[y * msg.step + x * 3]);
         memcpy (pixel, &cloud (x, y).rgb, 3 * sizeof(uint8_t));
@@ -316,7 +316,7 @@ namespace pcl
   {
     int rgb_index = -1;
     // Get the index we need
-    for (size_t d = 0; d < cloud.fields.size (); ++d)
+    for (std::size_t d = 0; d < cloud.fields.size (); ++d)
       if (cloud.fields[d].name == "rgb")
       {
         rgb_index = static_cast<int>(d);
@@ -340,9 +340,9 @@ namespace pcl
     msg.step = static_cast<uint32_t>(msg.width * sizeof (uint8_t) * 3);
     msg.data.resize (msg.step * msg.height);
 
-    for (size_t y = 0; y < cloud.height; y++)
+    for (std::size_t y = 0; y < cloud.height; y++)
     {
-      for (size_t x = 0; x < cloud.width; x++, rgb_offset += point_step)
+      for (std::size_t x = 0; x < cloud.width; x++, rgb_offset += point_step)
       {
         uint8_t * pixel = &(msg.data[y * msg.step + x * 3]);
         memcpy (pixel, &(cloud.data[rgb_offset]), 3 * sizeof (uint8_t));

--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -314,17 +314,12 @@ namespace pcl
   inline void
   toPCLPointCloud2 (const pcl::PCLPointCloud2& cloud, pcl::PCLImage& msg)
   {
-    int rgb_index = -1;
-    // Get the index we need
-    for (std::size_t d = 0; d < cloud.fields.size (); ++d)
-      if (cloud.fields[d].name == "rgb")
-      {
-        rgb_index = static_cast<int>(d);
-        break;
-      }
-
-    if(rgb_index == -1)
+    const auto predicate = [](const auto& field) { return field.name == "rgb"; };
+    const auto result = std::find_if(cloud.fields.cbegin (), cloud.fields.cend (), predicate);
+    if (result == cloud.fields.end ())
       throw std::runtime_error ("No rgb field!!");
+
+    const auto rgb_index = std::distance(cloud.fields.begin (), result);
     if (cloud.width == 0 && cloud.height == 0)
       throw std::runtime_error ("Needs to be a dense like cloud!!");
     else

--- a/common/include/pcl/impl/cloud_iterator.hpp
+++ b/common/include/pcl/impl/cloud_iterator.hpp
@@ -90,7 +90,7 @@ namespace pcl
         return (iterator_ - cloud_.begin ());
       }
 
-      size_t size () const
+      std::size_t size () const
       {
         return cloud_.size ();
       }
@@ -162,7 +162,7 @@ namespace pcl
         return (iterator_ - indices_.begin ());
       }
 
-      size_t size () const
+      std::size_t size () const
       {
         return indices_.size ();
       }
@@ -230,7 +230,7 @@ namespace pcl
         return (unsigned (iterator_ - cloud_.begin ()));
       }
 
-      size_t size () const override
+      std::size_t size () const override
       {
         return cloud_.size ();
       }
@@ -304,7 +304,7 @@ namespace pcl
         return (unsigned (iterator_ - indices_.begin ()));
       }
 
-      size_t size () const override
+      std::size_t size () const override
       {
         return indices_.size ();
       }
@@ -419,7 +419,7 @@ pcl::CloudIterator<PointT>::getCurrentIndex () const
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <class PointT> size_t
+template <class PointT> std::size_t
 pcl::CloudIterator<PointT>::size () const
 {
   return (iterator_->size ());
@@ -533,7 +533,7 @@ pcl::ConstCloudIterator<PointT>::getCurrentIndex () const
 }
 
 //////////////////////////////////////////////////////////////////////////////
-template <class PointT> size_t
+template <class PointT> std::size_t
 pcl::ConstCloudIterator<PointT>::size () const
 {
   return (iterator_->size ());

--- a/common/include/pcl/impl/pcl_base.hpp
+++ b/common/include/pcl/impl/pcl_base.hpp
@@ -160,7 +160,7 @@ pcl::PCLBase<PointT>::initCompute ()
     {
       PCL_ERROR ("[initCompute] Failed to allocate %lu indices.\n", input_->points.size ());
     }
-    for (std::size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
+    for (auto i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
   }
 
   return (true);

--- a/common/include/pcl/impl/pcl_base.hpp
+++ b/common/include/pcl/impl/pcl_base.hpp
@@ -151,7 +151,7 @@ pcl::PCLBase<PointT>::initCompute ()
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
   if (fake_indices_ && indices_->size () != input_->points.size ())
   {
-    std::size_t indices_size = indices_->size ();
+    const auto indices_size = indices_->size ();
     try
     {
       indices_->resize (input_->points.size ());

--- a/common/include/pcl/impl/pcl_base.hpp
+++ b/common/include/pcl/impl/pcl_base.hpp
@@ -96,7 +96,7 @@ pcl::PCLBase<PointT>::setIndices (const PointIndicesConstPtr &indices)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::PCLBase<PointT>::setIndices (size_t row_start, size_t col_start, size_t nb_rows, size_t nb_cols)
+pcl::PCLBase<PointT>::setIndices (std::size_t row_start, std::size_t col_start, std::size_t nb_rows, std::size_t nb_cols)
 {
   if ((nb_rows > input_->height) || (row_start > input_->height))
   {
@@ -110,14 +110,14 @@ pcl::PCLBase<PointT>::setIndices (size_t row_start, size_t col_start, size_t nb_
     return;
   }
 
-  size_t row_end = row_start + nb_rows;
+  std::size_t row_end = row_start + nb_rows;
   if (row_end > input_->height)
   {
     PCL_ERROR ("[PCLBase::setIndices] %d is out of rows range %d", row_end, input_->height);
     return;
   }
 
-  size_t col_end = col_start + nb_cols;
+  std::size_t col_end = col_start + nb_cols;
   if (col_end > input_->width)
   {
     PCL_ERROR ("[PCLBase::setIndices] %d is out of columns range %d", col_end, input_->width);
@@ -126,8 +126,8 @@ pcl::PCLBase<PointT>::setIndices (size_t row_start, size_t col_start, size_t nb_
 
   indices_.reset (new std::vector<int>);
   indices_->reserve (nb_cols * nb_rows);
-  for(size_t i = row_start; i < row_end; i++)
-    for(size_t j = col_start; j < col_end; j++)
+  for(std::size_t i = row_start; i < row_end; i++)
+    for(std::size_t j = col_start; j < col_end; j++)
       indices_->push_back (static_cast<int> ((i * input_->width) + j));
   fake_indices_ = false;
   use_indices_  = true;
@@ -151,7 +151,7 @@ pcl::PCLBase<PointT>::initCompute ()
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
   if (fake_indices_ && indices_->size () != input_->points.size ())
   {
-    size_t indices_size = indices_->size ();
+    std::size_t indices_size = indices_->size ();
     try
     {
       indices_->resize (input_->points.size ());
@@ -160,7 +160,7 @@ pcl::PCLBase<PointT>::initCompute ()
     {
       PCL_ERROR ("[initCompute] Failed to allocate %lu indices.\n", input_->points.size ());
     }
-    for (size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
+    for (std::size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
   }
 
   return (true);

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -43,8 +43,11 @@
 #  pragma GCC system_header
 #endif
 
-#include <Eigen/Core>
+#include <algorithm>
 #include <ostream>
+
+#include <Eigen/Core>
+
 #include <pcl/pcl_macros.h>
 
 // Define all PCL point types
@@ -1346,14 +1349,14 @@ namespace pcl
   {
     inline ReferenceFrame (const _ReferenceFrame &p)
     {
-      for (int d = 0; d < 9; ++d)
-        rf[d] = p.rf[d];
+      std::copy_n(p.rf, 9, rf);
     }
 
     inline ReferenceFrame ()
     {
-      for (int d = 0; d < 3; ++d)
-        x_axis[d] = y_axis[d] = z_axis[d] = 0;
+      std::fill_n(x_axis, 3, 0);
+      std::fill_n(y_axis, 3, 0);
+      std::fill_n(z_axis, 3, 0);
     }
 
     friend std::ostream& operator << (std::ostream& os, const ReferenceFrame& p);
@@ -1685,8 +1688,14 @@ namespace pcl
   template <int N> std::ostream& 
   operator << (std::ostream& os, const Histogram<N>& p)
   {
-    for (int i = 0; i < N; ++i)
-    os << (i == 0 ? "(" : "") << p.histogram[i] << (i < N-1 ? ", " : ")");
+    // make constexpr
+    if (N > 0)
+    {
+        os << "(" << p.histogram[0];
+        std::for_each(p.histogram + 1, std::end(p.histogram),
+            [&os](const auto& hist) { os << ", " << hist; });
+        os << ")";
+    }
     return (os);
   }
 } // End namespace

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -126,7 +126,7 @@ namespace pcl
         * \param[in] nb_cols the number of columns to be considered col_start included
         */
       virtual void
-      setIndices (size_t row_start, size_t col_start, size_t nb_rows, size_t nb_cols);
+      setIndices (std::size_t row_start, std::size_t col_start, std::size_t nb_rows, std::size_t nb_cols);
 
       /** \brief Get a pointer to the vector of indices used. */
       inline IndicesPtr const
@@ -141,7 +141,7 @@ namespace pcl
         * or input_->points[(*indices_)[pos]]
         * \param[in] pos position in indices_ vector
         */
-      inline const PointT& operator[] (size_t pos) const
+      inline const PointT& operator[] (std::size_t pos) const
       {
         return ((*input_)[(*indices_)[pos]]);
       }

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -295,7 +295,7 @@ pcl_round (float number)
 #endif
 
 inline void*
-aligned_malloc (size_t size)
+aligned_malloc (std::size_t size)
 {
   void *ptr;
 #if   defined (MALLOC_ALIGNED)

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -205,7 +205,7 @@ pcl_round (float number)
 #endif
 
 #ifndef SET_ARRAY
-#define SET_ARRAY(var, value, size) { for (int i = 0; i < static_cast<int> (size); ++i) var[i]=value; }
+#define SET_ARRAY(var, value, size) { for (decltype(size) i = 0; i < size; ++i) var[i]=value; }
 #endif
 
 #ifndef PCL_EXTERN_C

--- a/common/include/pcl/pcl_tests.h
+++ b/common/include/pcl/pcl_tests.h
@@ -64,8 +64,8 @@ namespace pcl
     {
       SCOPED_TRACE("EXPECT_EQ_VECTORS failed");
       EXPECT_EQ (v1.size (), v2.size ());
-      size_t length = v1.size ();
-      for (size_t i = 0; i < length; ++i)
+      std::size_t length = v1.size ();
+      for (std::size_t i = 0; i < length; ++i)
         EXPECT_EQ (v1[i], v2[i]);
     }
 
@@ -74,8 +74,8 @@ namespace pcl
     {
       SCOPED_TRACE("EXPECT_NEAR_VECTORS failed");
       EXPECT_EQ (v1.size (), v2.size ());
-      size_t length = v1.size ();
-      for (size_t i = 0; i < length; ++i)
+      std::size_t length = v1.size ();
+      for (std::size_t i = 0; i < length; ++i)
         EXPECT_NEAR (v1[i], v2[i], epsilon);
     }
 

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -59,9 +59,9 @@ namespace pcl
   {
     struct FieldMapping
     {
-      size_t serialized_offset;
-      size_t struct_offset;
-      size_t size;
+      std::size_t serialized_offset;
+      std::size_t struct_offset;
+      std::size_t size;
     };
   } // namespace detail
 
@@ -220,7 +220,7 @@ namespace pcl
       {
         // Copy the obvious
         assert (indices.size () <= pc.size ());
-        for (size_t i = 0; i < indices.size (); i++)
+        for (std::size_t i = 0; i < indices.size (); i++)
           points[i] = pc.points[indices[i]];
       }
 
@@ -324,7 +324,7 @@ namespace pcl
         * \param[in] row the row coordinate
         */
       inline const PointT&
-      operator () (size_t column, size_t row) const
+      operator () (std::size_t column, std::size_t row) const
       {
         return (points[row * this->width + column]);
       }
@@ -335,7 +335,7 @@ namespace pcl
         * \param[in] row the row coordinate
         */
       inline PointT&
-      operator () (size_t column, size_t row)
+      operator () (std::size_t column, std::size_t row)
       {
         return (points[row * this->width + column]);
       }
@@ -461,14 +461,14 @@ namespace pcl
       inline const_iterator end () const  { return (points.end ()); }
 
       //capacity
-      inline size_t size () const { return (points.size ()); }
-      inline void reserve (size_t n) { points.reserve (n); }
+      inline std::size_t size () const { return (points.size ()); }
+      inline void reserve (std::size_t n) { points.reserve (n); }
       inline bool empty () const { return points.empty (); }
 
       /** \brief Resize the cloud
         * \param[in] n the new cloud size
         */
-      inline void resize (size_t n)
+      inline void resize (std::size_t n)
       {
         points.resize (n);
         if (width * height != n)
@@ -479,10 +479,10 @@ namespace pcl
       }
 
       //element access
-      inline const PointT& operator[] (size_t n) const { return (points[n]); }
-      inline PointT& operator[] (size_t n) { return (points[n]); }
-      inline const PointT& at (size_t n) const { return (points.at (n)); }
-      inline PointT& at (size_t n) { return (points.at (n)); }
+      inline const PointT& operator[] (std::size_t n) const { return (points[n]); }
+      inline PointT& operator[] (std::size_t n) { return (points[n]); }
+      inline const PointT& at (std::size_t n) const { return (points.at (n)); }
+      inline PointT& at (std::size_t n) { return (points.at (n)); }
       inline const PointT& front () const { return (points.front ()); }
       inline PointT& front () { return (points.front ()); }
       inline const PointT& back () const { return (points.back ()); }
@@ -536,7 +536,7 @@ namespace pcl
         * \param[in] pt the point to insert
         */
       inline void
-      insert (iterator position, size_t n, const PointT& pt)
+      insert (iterator position, std::size_t n, const PointT& pt)
       {
         points.insert (position, n, pt);
         width = static_cast<uint32_t> (points.size ());

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -39,6 +39,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <pcl/point_types.h>
 #include <pcl/pcl_macros.h>
 #include <pcl/for_each_type.h>
@@ -163,8 +165,7 @@ namespace pcl
       setRescaleValues (const float *rescale_array)
       {
         alpha_.resize (nr_dimensions_);
-        for (int i = 0; i < nr_dimensions_; ++i)
-          alpha_[i] = rescale_array[i];
+        std::copy_n(rescale_array, nr_dimensions_, alpha_.begin());
       }
 
       /** \brief Return the number of dimensions in the point's vector representation. */
@@ -208,8 +209,7 @@ namespace pcl
       {
         // If point type is unknown, treat it as a struct/array of floats
         const float* ptr = reinterpret_cast<const float*> (&p);
-        for (int i = 0; i < nr_dimensions_; ++i)
-          out[i] = ptr[i];
+        std::copy_n(ptr, nr_dimensions_, out);
       }
   };
 
@@ -568,8 +568,7 @@ namespace pcl
       {
         // If point type is unknown, treat it as a struct/array of floats
         const float *ptr = (reinterpret_cast<const float*> (&p)) + start_dim_;
-        for (int i = 0; i < nr_dimensions_; ++i)
-          out[i] = ptr[i];
+        std::copy_n(ptr, nr_dimensions_, out);
       }
 
     protected:

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -153,7 +153,7 @@ namespace pcl
     struct offset : offset<typename POD<PointT>::type, Tag>
     {
       // Contents of specialization:
-      // static const size_t value;
+      // static const std::size_t value;
 
       // Avoid infinite compile-time recursion
       BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
@@ -320,7 +320,7 @@ namespace pcl
     * \param[in] value the value to set
     */
   template <typename PointT, typename ValT> inline void
-  setFieldValue (PointT &pt, size_t field_offset, const ValT &value)
+  setFieldValue (PointT &pt, std::size_t field_offset, const ValT &value)
   {
     uint8_t* data_ptr = reinterpret_cast<uint8_t*>(&pt) + field_offset;
     *reinterpret_cast<ValT*>(data_ptr) = value;
@@ -332,7 +332,7 @@ namespace pcl
     * \param[out] value the value to retrieve
     */
   template <typename PointT, typename ValT> inline void
-  getFieldValue (const PointT &pt, size_t field_offset, ValT &value)
+  getFieldValue (const PointT &pt, std::size_t field_offset, ValT &value)
   {
     const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(&pt) + field_offset;
     value = *reinterpret_cast<const ValT*>(data_ptr);

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -361,13 +361,13 @@ namespace pcl
                                   PointCloud<PointXYZRGBA>&     out)
   {
     float bad_point = std::numeric_limits<float>::quiet_NaN();
-    size_t width_ = depth.width;
-    size_t height_ = depth.height;
+    std::size_t width_ = depth.width;
+    std::size_t height_ = depth.height;
     float constant_ = 1.0f / focal;
 
-    for (size_t v = 0; v < height_; v++)
+    for (std::size_t v = 0; v < height_; v++)
     {
-      for (size_t u = 0; u < width_; u++)
+      for (std::size_t u = 0; u < width_; u++)
       {
         PointXYZRGBA pt;
         float depth_ = depth.at (u, v).intensity;

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -240,11 +240,11 @@ RangeImage::doZBuffer (const PointCloudType& point_cloud, float noise_level, flo
   
   float x_real, y_real, range_of_current_point;
   int x, y;
-  for (typename pcl::PointCloud<PointType2>::VectorType::const_iterator it=points2.begin (); it!=points2.end (); ++it)
+  for (const auto& point: points2)
   {
-    if (!isFinite (*it))  // Check for NAN etc
+    if (!isFinite (point))  // Check for NAN etc
       continue;
-    Vector3fMapConst current_point = it->getVector3fMap ();
+    Vector3fMapConst current_point = point.getVector3fMap ();
     
     this->getImagePoint (current_point, x_real, y_real, range_of_current_point);
     this->real2DToInt2D (x_real, y_real, x, y);
@@ -1122,9 +1122,8 @@ RangeImage::getAverageViewPoint (const PointCloudTypeWithViewpoints& point_cloud
 {
   Eigen::Vector3f average_viewpoint (0,0,0);
   int point_counter = 0;
-  for (unsigned int point_idx=0; point_idx<point_cloud.points.size (); ++point_idx)
+  for (const auto& point: point_cloud.points)
   {
-    const typename PointCloudTypeWithViewpoints::PointType& point = point_cloud.points[point_idx];
     if (!std::isfinite (point.vp_x) || !std::isfinite (point.vp_y) || !std::isfinite (point.vp_z))
       continue;
     average_viewpoint[0] += point.vp_x;
@@ -1218,11 +1217,11 @@ template <typename PointCloudType> void
 RangeImage::integrateFarRanges (const PointCloudType& far_ranges)
 {
   float x_real, y_real, range_of_current_point;
-  for (typename PointCloudType::const_iterator it  = far_ranges.points.begin (); it != far_ranges.points.end (); ++it)
+  for (const auto& point: far_ranges.points)
   {
-    //if (!isFinite (*it))  // Check for NAN etc
+    //if (!isFinite (point))  // Check for NAN etc
       //continue;
-    Vector3fMapConst current_point = it->getVector3fMap ();
+    Vector3fMapConst current_point = point.getVector3fMap ();
     
     this->getImagePoint (current_point, x_real, y_real, range_of_current_point);
     

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -974,7 +974,8 @@ RangeImage::getSurfaceInformation (int x, int y, int radius, const Eigen::Vector
   if (eigen_values_all_neighbors!=nullptr)
     eigen_values_all_neighbors->setZero ();
   
-  int blocksize = static_cast<int> (pow (static_cast<double> ( (2.0 * radius + 1.0)), 2.0));
+  const auto sqrt_blocksize = 2 * radius + 1;
+  const auto blocksize = sqrt_blocksize * sqrt_blocksize;
   
   PointWithRange given_point;
   given_point.x=point[0];  given_point.y=point[1];  given_point.z=point[2];
@@ -1051,7 +1052,8 @@ RangeImage::getSquaredDistanceOfNthNeighbor (int x, int y, int radius, int n, in
   if (!std::isfinite (point.range))
     return -std::numeric_limits<float>::infinity ();
   
-  int blocksize = static_cast<int> (pow (static_cast<double> (2.0 * radius + 1.0), 2.0));
+  const auto sqrt_blocksize = 2 * radius + 1;
+  const auto blocksize = sqrt_blocksize * sqrt_blocksize;
   std::vector<float> neighbor_distances (blocksize);
   int neighbor_counter = 0;
   for (int y2=y-radius; y2<=y+radius; y2+=step_size)

--- a/common/include/pcl/register_point_struct.h
+++ b/common/include/pcl/register_point_struct.h
@@ -330,7 +330,7 @@ namespace pcl
 #define POINT_CLOUD_REGISTER_FIELD_OFFSET(r, name, elem)                \
   template<> struct offset<name, pcl::fields::BOOST_PP_TUPLE_ELEM(3, 2, elem)> \
   {                                                                     \
-    static const size_t value = offsetof(name, BOOST_PP_TUPLE_ELEM(3, 1, elem)); \
+    static const std::size_t value = offsetof(name, BOOST_PP_TUPLE_ELEM(3, 1, elem)); \
   };                                                                    \
   /***/
 

--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -153,7 +153,7 @@ pcl::PCLPointCloud2::concatenate (pcl::PCLPointCloud2 &cloud1, const pcl::PCLPoi
   cloud1.data.resize(data1_size + cloud2.data.size ());
   for (std::size_t cp = 0; cp < size2; ++cp)
   {
-    for (const auto field_data: valid_fields)
+    for (const auto& field_data: valid_fields)
     {
       const auto& i = field_data.idx1;
       const auto& j = field_data.idx2;

--- a/common/src/bearing_angle_image.cpp
+++ b/common/src/bearing_angle_image.cpp
@@ -104,9 +104,9 @@ BearingAngleImage::generateBAImage (PointCloud<PointXYZ>& point_cloud)
   uint8_t r, g, b, gray;
 
   // primary transformation process
-  for (int i = 0; i < static_cast<int> (height) - 1; ++i)
+  for (decltype(height) i = 0; i < height - 1; ++i)
   {
-    for (int j = 0; j < static_cast<int> (width) - 1; ++j)
+    for (decltype(width) j = 0; j < width - 1; ++j)
     {
       theta = getAngle (point_cloud.at (j, i + 1), point_cloud.at (j + 1, i));
 

--- a/common/src/colors.cpp
+++ b/common/src/colors.cpp
@@ -561,16 +561,16 @@ static const unsigned char VIRIDIS_LUT[] =
 };
 
 /// Number of colors in Glasbey lookup table
-static const size_t GLASBEY_LUT_SIZE = sizeof (GLASBEY_LUT) / (sizeof (GLASBEY_LUT[0]) * 3);
+static const std::size_t GLASBEY_LUT_SIZE = sizeof (GLASBEY_LUT) / (sizeof (GLASBEY_LUT[0]) * 3);
 
 /// Number of colors in Viridis lookup table
-static const size_t VIRIDIS_LUT_SIZE = sizeof (VIRIDIS_LUT) / (sizeof (VIRIDIS_LUT[0]) * 3);
+static const std::size_t VIRIDIS_LUT_SIZE = sizeof (VIRIDIS_LUT) / (sizeof (VIRIDIS_LUT[0]) * 3);
 
 static const unsigned char* LUTS[] = { GLASBEY_LUT, VIRIDIS_LUT };
-static const size_t LUT_SIZES[] = { GLASBEY_LUT_SIZE, VIRIDIS_LUT_SIZE };
+static const std::size_t LUT_SIZES[] = { GLASBEY_LUT_SIZE, VIRIDIS_LUT_SIZE };
 
 template<typename pcl::ColorLUTName T> pcl::RGB
-pcl::ColorLUT<T>::at (size_t color_id)
+pcl::ColorLUT<T>::at (std::size_t color_id)
 {
   assert (color_id < LUT_SIZES[T]);
   pcl::RGB color;
@@ -580,7 +580,7 @@ pcl::ColorLUT<T>::at (size_t color_id)
   return (color);
 }
 
-template<typename pcl::ColorLUTName T> size_t
+template<typename pcl::ColorLUTName T> std::size_t
 pcl::ColorLUT<T>::size ()
 {
   return LUT_SIZES[T];

--- a/common/src/common.cpp
+++ b/common/src/common.cpp
@@ -48,7 +48,7 @@ pcl::getMinMax (const pcl::PCLPointCloud2 &cloud, int,
   max_p = -FLT_MAX;
 
   int field_idx = -1;
-  for (size_t d = 0; d < cloud.fields.size (); ++d)
+  for (std::size_t d = 0; d < cloud.fields.size (); ++d)
     if (cloud.fields[d].name == field_name)
       field_idx = static_cast<int>(d);
 

--- a/common/src/common.cpp
+++ b/common/src/common.cpp
@@ -36,6 +36,9 @@
  * $Id: distances.cpp 527 2011-04-17 23:57:26Z rusu $
  *
  */
+
+#include <limits>
+
 #include <pcl/common/common.h>
 #include <pcl/console/print.h>
 
@@ -44,19 +47,17 @@ void
 pcl::getMinMax (const pcl::PCLPointCloud2 &cloud, int,
                 const std::string &field_name, float &min_p, float &max_p)
 {
-  min_p = FLT_MAX;
-  max_p = -FLT_MAX;
+  min_p = std::numeric_limits<float>::max();
+  max_p = -std::numeric_limits<float>::max();
 
-  int field_idx = -1;
-  for (std::size_t d = 0; d < cloud.fields.size (); ++d)
-    if (cloud.fields[d].name == field_name)
-      field_idx = static_cast<int>(d);
-
-  if (field_idx == -1)
+  const auto result = std::find_if(cloud.fields.begin (), cloud.fields.end (),
+      [&field_name](const auto& field) { return field.name == field_name; });
+  if (result == cloud.fields.end ())
   {
     PCL_ERROR ("[getMinMax] Invalid field (%s) given!\n", field_name.c_str ());
     return;
   }
+  const auto field_idx = std::distance(cloud.fields.begin (), result);
 
   for (unsigned int i = 0; i < cloud.fields[field_idx].count; ++i)
   {

--- a/common/src/correspondence.cpp
+++ b/common/src/correspondence.cpp
@@ -49,25 +49,25 @@ pcl::getRejectedQueryIndices (const pcl::Correspondences &correspondences_before
 {
   indices.clear();
 
-  const int nr_correspondences_before = static_cast<int> (correspondences_before.size ());
-  const int nr_correspondences_after = static_cast<int> (correspondences_after.size ());
+  const auto nr_correspondences_before = correspondences_before.size ();
+  const auto nr_correspondences_after = correspondences_after.size ();
 
   if (nr_correspondences_before == 0)
     return;
   if (nr_correspondences_after == 0)
   {
     indices.resize(nr_correspondences_before);
-    for (int i = 0; i < nr_correspondences_before; ++i)
+    for (std::size_t i = 0; i < nr_correspondences_before; ++i)
       indices[i] = correspondences_before[i].index_query;
     return;
   }
 
   std::vector<int> indices_before (nr_correspondences_before);
-  for (int i = 0; i < nr_correspondences_before; ++i)
+  for (std::size_t i = 0; i < nr_correspondences_before; ++i)
     indices_before[i] = correspondences_before[i].index_query;
 
   std::vector<int> indices_after (nr_correspondences_after);
-  for (int i = 0; i < nr_correspondences_after; ++i)
+  for (std::size_t i = 0; i < nr_correspondences_after; ++i)
     indices_after[i] = correspondences_after[i].index_query;
 
   if (presorting_required)

--- a/common/src/feature_histogram.cpp
+++ b/common/src/feature_histogram.cpp
@@ -40,7 +40,7 @@
 
 #include <pcl/console/print.h>
 
-pcl::FeatureHistogram::FeatureHistogram (size_t const number_of_bins,
+pcl::FeatureHistogram::FeatureHistogram (std::size_t const number_of_bins,
     const float min, const float max) : 
     histogram_ (number_of_bins, 0)
 {
@@ -83,13 +83,13 @@ pcl::FeatureHistogram::getThresholdMax () const
   return (threshold_max_);
 }
 
-size_t
+std::size_t
 pcl::FeatureHistogram::getNumberOfElements () const
 {
   return (number_of_elements_);
 }
 
-size_t
+std::size_t
 pcl::FeatureHistogram::getNumberOfBins () const
 {
   return (number_of_bins_);
@@ -105,7 +105,7 @@ pcl::FeatureHistogram::addValue (float value)
     ++number_of_elements_;
 
     // Increase the bin.
-    size_t bin_number = static_cast<size_t> ((value - threshold_min_) / step_);
+    std::size_t bin_number = static_cast<std::size_t> ((value - threshold_min_) / step_);
     ++histogram_[bin_number];
   }
 }
@@ -119,10 +119,10 @@ pcl::FeatureHistogram::getMeanValue ()
     return (0.0f);
   }
   // Smoothe the histogram and find a bin with a max smoothed value.
-  size_t max_idx = 0;
+  std::size_t max_idx = 0;
   float max = 0.50f * histogram_[0] + 
               0.25f * histogram_[1] * 2.0f;
-  for (size_t bin = 1; bin < histogram_.size () - 1; ++bin)
+  for (std::size_t bin = 1; bin < histogram_.size () - 1; ++bin)
   {
     float smothed_value = 0.25f * histogram_[bin - 1] + 
                           0.50f * histogram_[bin] + 
@@ -159,7 +159,7 @@ pcl::FeatureHistogram::getVariance (float mean)
   // Variable to accumulate the terms of variance.
   float variances_sum = 0;
 
-  for (size_t bin = 0; bin < number_of_bins_; ++bin)
+  for (std::size_t bin = 0; bin < number_of_bins_; ++bin)
   {
     if (histogram_[bin] > 0)
     {

--- a/common/src/gaussian.cpp
+++ b/common/src/gaussian.cpp
@@ -136,8 +136,8 @@ pcl::GaussianKernel::convolveRows (const pcl::PointCloud<float>& input,
                                    pcl::PointCloud<float>& output) const
 {
   assert (kernel.size () % 2 == 1);
-  size_t kernel_width = kernel.size () -1;
-  size_t radius = kernel.size () / 2;
+  std::size_t kernel_width = kernel.size () -1;
+  std::size_t radius = kernel.size () / 2;
   const pcl::PointCloud<float>* input_;
   if (&input != &output)
   {
@@ -152,8 +152,8 @@ pcl::GaussianKernel::convolveRows (const pcl::PointCloud<float>& input,
   else
     input_ = new pcl::PointCloud<float>(input);
   
-  size_t i;
-  for (size_t j = 0; j < input_->height; j++)
+  std::size_t i;
+  for (std::size_t j = 0; j < input_->height; j++)
   {
     for (i = 0 ; i < radius ; i++)
       output (i,j) = 0;
@@ -181,8 +181,8 @@ pcl::GaussianKernel::convolveCols (const pcl::PointCloud<float>& input,
                                    pcl::PointCloud<float>& output) const
 {
   assert (kernel.size () % 2 == 1);
-  size_t kernel_width = kernel.size () -1;
-  size_t radius = kernel.size () / 2;
+  std::size_t kernel_width = kernel.size () -1;
+  std::size_t radius = kernel.size () / 2;
   const pcl::PointCloud<float>* input_;
   if (&input != &output)
   {
@@ -197,8 +197,8 @@ pcl::GaussianKernel::convolveCols (const pcl::PointCloud<float>& input,
   else
     input_ = new pcl::PointCloud<float> (input);
 
-  size_t j;
-  for (size_t i = 0; i < input_->width; i++)
+  std::size_t j;
+  for (std::size_t i = 0; i < input_->width; i++)
   {
     for (j = 0 ; j < radius ; j++)
       output (i,j) = 0;

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -48,7 +48,7 @@ getFieldsSizes (const std::vector<pcl::PCLPointField> &fields,
 {
   int valid = 0;
   fields_sizes.resize (fields.size ());
-  for (size_t i = 0; i < fields.size (); ++i)
+  for (std::size_t i = 0; i < fields.size (); ++i)
   {
     if (fields[i].name == "_")
       continue;
@@ -95,7 +95,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
   cloud_out.is_bigendian = cloud2.is_bigendian;
 
   //We need to find how many fields overlap between the two clouds
-  size_t total_fields = cloud2.fields.size ();
+  std::size_t total_fields = cloud2.fields.size ();
 
   //for the non-matching fields in cloud1, we need to store the offset
   //from the beginning of the point
@@ -111,7 +111,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
 
   std::sort (cloud1_fields_sorted.begin (), cloud1_fields_sorted.end (), fieldComp);
 
-  for (size_t i = 0; i < cloud1_fields_sorted.size (); ++i)
+  for (std::size_t i = 0; i < cloud1_fields_sorted.size (); ++i)
   {
     bool match = false;
     for (const auto &field : cloud2.fields)
@@ -126,7 +126,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
       cloud1_unique_fields.push_back (cloud1_fields_sorted[i]);
 
       int size = 0;
-      size_t next_valid_field = i + 1;
+      std::size_t next_valid_field = i + 1;
 
       while (next_valid_field < cloud1_fields_sorted.size())
       {
@@ -150,7 +150,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
 
   //we need to compute the size of the additional data added from cloud 1
   uint32_t cloud1_unique_point_step = 0;
-  for (size_t i = 0; i < cloud1_unique_fields.size (); ++i)
+  for (std::size_t i = 0; i < cloud1_unique_fields.size (); ++i)
     cloud1_unique_point_step += field_sizes[i];
 
   //the total size of extra data should be the size of data per point
@@ -169,7 +169,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
   cloud_out.fields.resize (cloud2.fields.size () + cloud1_unique_fields.size ());
   int offset = cloud2.point_step;
 
-  for (size_t d = 0; d < cloud1_unique_fields.size (); ++d)
+  for (std::size_t d = 0; d < cloud1_unique_fields.size (); ++d)
   {
     const pcl::PCLPointField& f = *cloud1_unique_fields[d];
     cloud_out.fields[cloud2.fields.size () + d].name = f.name;
@@ -182,14 +182,14 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
  
   // Iterate over each point and perform the appropriate memcpys
   int point_offset = 0;
-  for (size_t cp = 0; cp < cloud_out.width * cloud_out.height; ++cp)
+  for (std::size_t cp = 0; cp < cloud_out.width * cloud_out.height; ++cp)
   {
     memcpy (&cloud_out.data[point_offset], &cloud2.data[cp * cloud2.point_step], cloud2.point_step);
     int field_offset = cloud2.point_step;
 
     // Copy each individual point, we have to do this on a per-field basis
     // since some fields are not unique
-    for (size_t i = 0; i < cloud1_unique_fields.size (); ++i)
+    for (std::size_t i = 0; i < cloud1_unique_fields.size (); ++i)
     {
       const pcl::PCLPointField& f = *cloud1_unique_fields[i];
       int local_data_size = f.count * pcl::getFieldSize (f.datatype);
@@ -249,7 +249,7 @@ pcl::concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
   
   // Copy cloud1 into cloud_out
   cloud_out = cloud1;
-  size_t nrpts = cloud_out.data.size ();
+  std::size_t nrpts = cloud_out.data.size ();
   // Height = 1 => no more organized
   cloud_out.width    = cloud1.width * cloud1.height + cloud2.width * cloud2.height;
   cloud_out.height   = 1;
@@ -277,10 +277,10 @@ pcl::concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
     cloud_out.data.resize (nrpts + (cloud2.width * cloud2.height) * cloud_out.point_step);
 
     // Copy the second cloud
-    for (size_t cp = 0; cp < cloud2.width * cloud2.height; ++cp)
+    for (std::size_t cp = 0; cp < cloud2.width * cloud2.height; ++cp)
     {
       int i = 0;
-      for (size_t j = 0; j < fields2.size (); ++j)
+      for (std::size_t j = 0; j < fields2.size (); ++j)
       {
         if (cloud1.fields[i].name == "_")
         {
@@ -303,7 +303,7 @@ pcl::concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
   }
   else
   {
-    for (size_t i = 0; i < cloud1.fields.size (); ++i)
+    for (std::size_t i = 0; i < cloud1.fields.size (); ++i)
     {
       // We're fine with the special RGB vs RGBA use case
       if ((cloud1.fields[i].name == "rgb" && cloud2.fields[i].name == "rgba") ||
@@ -346,13 +346,13 @@ pcl::getPointCloudAsEigen (const pcl::PCLPointCloud2 &in, Eigen::MatrixXf &out)
     return (false);
   }
 
-  size_t npts = in.width * in.height;
+  std::size_t npts = in.width * in.height;
   out = Eigen::MatrixXf::Ones (4, npts);
 
   Eigen::Array4i xyz_offset (in.fields[x_idx].offset, in.fields[y_idx].offset, in.fields[z_idx].offset, 0);
 
   // Copy the input dataset into Eigen format
-  for (size_t i = 0; i < npts; ++i)
+  for (std::size_t i = 0; i < npts; ++i)
   {
      // Unoptimized memcpys: assume fields x, y, z are in random order
      memcpy (&out (0, i), &in.data[xyz_offset[0]], sizeof (float));
@@ -394,12 +394,12 @@ pcl::getEigenAsPointCloud (Eigen::MatrixXf &in, pcl::PCLPointCloud2 &out)
     return (false);
   }
 
-  size_t npts = in.cols ();
+  std::size_t npts = in.cols ();
 
   Eigen::Array4i xyz_offset (out.fields[x_idx].offset, out.fields[y_idx].offset, out.fields[z_idx].offset, 0);
 
   // Copy the input dataset into Eigen format
-  for (size_t i = 0; i < npts; ++i)
+  for (std::size_t i = 0; i < npts; ++i)
   {
      // Unoptimized memcpys: assume fields x, y, z are in random order
      memcpy (&out.data[xyz_offset[0]], &in (0, i), sizeof (float));
@@ -431,7 +431,7 @@ pcl::copyPointCloud (
   cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);
 
   // Iterate over each point
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.size (); ++i)
     memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[indices[i] * cloud_in.point_step], cloud_in.point_step);
 }
 
@@ -454,7 +454,7 @@ pcl::copyPointCloud (
   cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);
 
   // Iterate over each point
-  for (size_t i = 0; i < indices.size (); ++i)
+  for (std::size_t i = 0; i < indices.size (); ++i)
     memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[indices[i] * cloud_in.point_step], cloud_in.point_step);
 }
 

--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -359,7 +359,7 @@ pcl::console::parse_x_arguments (int argc, const char * const * argv, const char
       boost::split (values, argv[i], boost::is_any_of (","), boost::token_compress_on);
 
       v.resize (values.size ());
-      for (size_t j = 0; j < v.size (); ++j)
+      for (std::size_t j = 0; j < v.size (); ++j)
         v[j] = atof (values.at (j).c_str ());
 
       return (i - 1);
@@ -382,7 +382,7 @@ pcl::console::parse_x_arguments (int argc, const char * const * argv, const char
       boost::split (values, argv[i], boost::is_any_of (","), boost::token_compress_on);
 
       v.resize (values.size ());
-      for (size_t j = 0; j < v.size (); ++j)
+      for (std::size_t j = 0; j < v.size (); ++j)
         v[j] = static_cast<float> (atof (values.at (j).c_str ()));
 
       return (i - 1);
@@ -405,7 +405,7 @@ pcl::console::parse_x_arguments (int argc, const char * const * argv, const char
       boost::split (values, argv[i], boost::is_any_of (","), boost::token_compress_on);
 
       v.resize (values.size ());
-      for (size_t j = 0; j < v.size (); ++j)
+      for (std::size_t j = 0; j < v.size (); ++j)
         v[j] = atoi (values.at (j).c_str ());
 
       return (i - 1);

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -70,7 +70,7 @@ pcl::PCLBase<pcl::PCLPointCloud2>::setInputCloud (const PCLPointCloud2ConstPtr &
 
   // Obtain the size of all fields. Restrict to sizeof FLOAT32 for now
   field_sizes_.resize (input_->fields.size ());
-  for (size_t d = 0; d < input_->fields.size (); ++d)
+  for (std::size_t d = 0; d < input_->fields.size (); ++d)
   {
     int fsize;
     switch (input_->fields[d].datatype)
@@ -139,7 +139,7 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
   if (fake_indices_ && indices_->size () != (input_->width * input_->height))
   {
-    size_t indices_size = indices_->size ();
+    std::size_t indices_size = indices_->size ();
     try
     {
       indices_->resize (input_->width * input_->height);
@@ -148,7 +148,7 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
     {
       PCL_ERROR ("[initCompute] Failed to allocate %lu indices.\n", (input_->width * input_->height));
     }
-    for (size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
+    for (std::size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
   }
 
   return (true);

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -36,6 +36,9 @@
  *
  */
 
+#include <algorithm>
+#include <numeric>
+
 #include <pcl/impl/pcl_base.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -68,50 +71,36 @@ pcl::PCLBase<pcl::PCLPointCloud2>::setInputCloud (const PCLPointCloud2ConstPtr &
       z_idx_ = d;
   }
 
-  // Obtain the size of all fields. Restrict to sizeof FLOAT32 for now
-  field_sizes_.resize (input_->fields.size ());
-  for (std::size_t d = 0; d < input_->fields.size (); ++d)
+  // Obtain the size of datatype
+  const auto sizeofDatatype = [](const auto& datatype) -> int
   {
-    int fsize;
-    switch (input_->fields[d].datatype)
+    switch (datatype)
     {
-      case pcl::PCLPointField::INT8:
-      case pcl::PCLPointField::UINT8:
-      {
-        fsize = 1;
-        break;
-      }
+      case pcl::PCLPointField::INT8: PCL_FALLTHROUGH;
+      case pcl::PCLPointField::UINT8: return 1;
 
-      case pcl::PCLPointField::INT16:
-      case pcl::PCLPointField::UINT16:
-      {
-        fsize = 2;
-        break;
-      }
+      case pcl::PCLPointField::INT16: PCL_FALLTHROUGH;
+      case pcl::PCLPointField::UINT16: return 2;
 
-      case pcl::PCLPointField::INT32:
-      case pcl::PCLPointField::UINT32:
-      case pcl::PCLPointField::FLOAT32:
-      {
-        fsize = 4;
-        break;
-      }
+      case pcl::PCLPointField::INT32: PCL_FALLTHROUGH;
+      case pcl::PCLPointField::UINT32: PCL_FALLTHROUGH;
+      case pcl::PCLPointField::FLOAT32: return 4;
 
-      case pcl::PCLPointField::FLOAT64:
-      {
-        fsize = 8;
-        break;
-      }
+      case pcl::PCLPointField::FLOAT64: return 8;
 
       default:
-      {
-        PCL_ERROR ("[PCLBase::setInputCloud] Invalid field type (%d)!\n", input_->fields[d].datatype);
-        fsize = 0;
-        break;
-      }
+        PCL_ERROR("[PCLBase::setInputCloud] Invalid field type (%d)!\n", datatype);
+        return 0;
     }
-    field_sizes_[d] = (std::min) (fsize, static_cast<int>(sizeof (float)));
-  }
+  };
+
+  // Restrict size of a field to be at-max sizeof(FLOAT32) for now
+  field_sizes_.resize(input_->fields.size());
+  std::transform(input_->fields.begin(), input_->fields.end(), field_sizes_.begin(),
+                 [&sizeofDatatype](const auto& field)
+                 {
+                   return std::min(sizeofDatatype(field.datatype), static_cast<int>(sizeof(float)));
+                 });
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -148,7 +137,8 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
     {
       PCL_ERROR ("[initCompute] Failed to allocate %lu indices.\n", (input_->width * input_->height));
     }
-    for (std::size_t i = indices_size; i < indices_->size (); ++i) { (*indices_)[i] = static_cast<int>(i); }
+    if (indices_size < indices_->size ())
+      std::iota(indices_->begin () + indices_size, indices_->end (), indices_size);
   }
 
   return (true);

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -128,7 +128,7 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
   if (fake_indices_ && indices_->size () != (input_->width * input_->height))
   {
-    std::size_t indices_size = indices_->size ();
+    const auto indices_size = indices_->size ();
     try
     {
       indices_->resize (input_->width * input_->height);

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -61,7 +61,7 @@ pcl::PCLBase<pcl::PCLPointCloud2>::setInputCloud (const PCLPointCloud2ConstPtr &
 {
   input_ = cloud;
 
-  for (int d = 0; d < static_cast<int>(cloud->fields.size ()); ++d)
+  for (std::size_t d = 0; d < cloud->fields.size (); ++d)
   {
     if (cloud->fields[d].name == x_field_name_)
       x_idx_ = d;

--- a/common/src/point_types.cpp
+++ b/common/src/point_types.cpp
@@ -304,7 +304,7 @@ namespace pcl
   {
     for (int i = 0; i < 9; ++i)
     os << (i == 0 ? "(" : "") << p.rf[i] << (i < 8 ? ", " : ")");
-    for (size_t i = 0; i < 1980; ++i)
+    for (std::size_t i = 0; i < 1980; ++i)
       os << (i == 0 ? "(" : "") << p.descriptor[i] << (i < 1979 ? ", " : ")");
     return (os);
   }
@@ -314,7 +314,7 @@ namespace pcl
   {
     for (int i = 0; i < 9; ++i)
     os << (i == 0 ? "(" : "") << p.rf[i] << (i < 8 ? ", " : ")");
-    for (size_t i = 0; i < 1960; ++i)
+    for (std::size_t i = 0; i < 1960; ++i)
       os << (i == 0 ? "(" : "") << p.descriptor[i] << (i < 1959 ? ", " : ")");
     return (os);
   }
@@ -324,7 +324,7 @@ namespace pcl
   {
     for (int i = 0; i < 9; ++i)
     os << (i == 0 ? "(" : "") << p.rf[i] << (i < 8 ? ", " : ")");
-    for (size_t i = 0; i < 352; ++i)
+    for (std::size_t i = 0; i < 352; ++i)
     os << (i == 0 ? "(" : "") << p.descriptor[i] << (i < 351 ? ", " : ")");
     return (os);
   }
@@ -334,7 +334,7 @@ namespace pcl
   {
     for (int i = 0; i < 9; ++i)
     os << (i == 0 ? "(" : "") << p.rf[i] << (i < 8 ? ", " : ")");
-    for (size_t i = 0; i < 1344; ++i)
+    for (std::size_t i = 0; i < 1344; ++i)
     os << (i == 0 ? "(" : "") << p.descriptor[i] << (i < 1343 ? ", " : ")");
     return (os);
   }

--- a/common/src/poses_from_matches.cpp
+++ b/common/src/poses_from_matches.cpp
@@ -84,7 +84,7 @@ pcl::PosesFromMatches::estimatePosesUsing2Correspondences (const pcl::PointCorre
                         y_direction (0.0f, 1.0f, 0.0f),
                         z_direction (0.0f, 0.0f, 1.0f);
   
-  int max_correspondence_idx = static_cast<int> (correspondences.size ());
+  const auto max_correspondence_idx = correspondences.size ();
   int counter_for_tested_combinations = 0,
       counter_for_added_pose_estimates = 0;
   float max_distance_quotient = 1.0f+parameters_.max_correspondence_distance_error,
@@ -98,10 +98,10 @@ pcl::PosesFromMatches::estimatePosesUsing2Correspondences (const pcl::PointCorre
   // testing the best correspondences pairs first, without being stuck too long with one specific
   // (possibly wrong) correspondence.
   bool done = false;
-  for (int correspondence2_idx = 0; correspondence2_idx < max_correspondence_idx && !done; ++correspondence2_idx)
+  for (std::size_t correspondence2_idx = 0; correspondence2_idx < max_correspondence_idx && !done; ++correspondence2_idx)
   {
     const pcl::PointCorrespondence6D& correspondence2 = correspondences[correspondence2_idx];
-    for (int correspondence1_idx = 0; correspondence1_idx < correspondence2_idx; ++correspondence1_idx)
+    for (std::size_t correspondence1_idx = 0; correspondence1_idx < correspondence2_idx; ++correspondence1_idx)
     {
       if (counter_for_tested_combinations >= max_no_of_tested_combinations)
       {
@@ -198,7 +198,7 @@ pcl::PosesFromMatches::estimatePosesUsing3Correspondences (const PointCorrespond
                         y_direction (0.0f, 1.0f, 0.0f),
                         z_direction (0.0f, 0.0f, 1.0f);
   
-  int max_correspondence_idx = static_cast<int> (correspondences.size ());
+  const auto max_correspondence_idx = correspondences.size ();
   int counter_for_tested_combinations = 0,
       counter_for_added_pose_estimates = 0;
   float max_distance_quotient = 1.0f+parameters_.max_correspondence_distance_error,
@@ -212,12 +212,12 @@ pcl::PosesFromMatches::estimatePosesUsing3Correspondences (const PointCorrespond
   // testing the best correspondences triples first, without being stuck too long with one specific
   // (possibly wrong) correspondence.
   bool done = false;
-  for (int correspondence3_idx = 0; correspondence3_idx < max_correspondence_idx && !done; ++correspondence3_idx)
+  for (std::size_t correspondence3_idx = 0; correspondence3_idx < max_correspondence_idx && !done; ++correspondence3_idx)
   {
     const pcl::PointCorrespondence6D& correspondence3 = correspondences[correspondence3_idx];
     const Eigen::Vector3f& point3 = correspondence3.point1,
                   & corr3  = correspondence3.point2;
-    for (int correspondence2_idx = 0; correspondence2_idx < correspondence3_idx && !done; ++correspondence2_idx)
+    for (std::size_t correspondence2_idx = 0; correspondence2_idx < correspondence3_idx && !done; ++correspondence2_idx)
     {
       const pcl::PointCorrespondence6D& correspondence2 = correspondences[correspondence2_idx];
       const Eigen::Vector3f& point2 = correspondence2.point1,
@@ -230,7 +230,7 @@ pcl::PosesFromMatches::estimatePosesUsing3Correspondences (const PointCorrespond
           || distance23_quotient_squared > max_distance_quotient_squared)
         continue;
       
-      for (int correspondence1_idx = 0; correspondence1_idx < correspondence2_idx; ++correspondence1_idx)
+      for (std::size_t correspondence1_idx = 0; correspondence1_idx < correspondence2_idx; ++correspondence1_idx)
       {
         if (counter_for_tested_combinations >= max_no_of_tested_combinations)
         {

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -252,12 +252,12 @@ RangeImage::cropImage (int borderSize, int top, int right, int bottom, int left)
   //std::cout << oldRangeImage.width<<"x"<<oldRangeImage.height<<" -> "<<width<<"x"<<height<<"\n";
   
   // Copy points
-  for (int y=0, oldY=top; y< static_cast<int> (height); ++y,++oldY) 
+  for (int y=0, oldY=top; y< static_cast<int> (height); ++y,++oldY)
   {
-    for (int x=0, oldX=left; x< static_cast<int> (width); ++x,++oldX) 
+    for (int x=0, oldX=left; x< static_cast<int> (width); ++x,++oldX)
     {
       PointWithRange& currentPoint = points[y*width + x];
-      if (oldX<0 || oldX>= static_cast<int> (oldRangeImage.width) || oldY<0 || oldY>= static_cast<int> (oldRangeImage.height)) 
+      if (oldX<0 || oldX>= static_cast<int> (oldRangeImage.width) || oldY<0 || oldY>= static_cast<int> (oldRangeImage.height))
       {
         currentPoint = unobserved_point;
         continue;
@@ -271,9 +271,9 @@ RangeImage::cropImage (int borderSize, int top, int right, int bottom, int left)
 void 
 RangeImage::recalculate3DPointPositions () 
 {
-  for (int y = 0; y < static_cast<int> (height); ++y) 
+  for (int y = 0; y < static_cast<int> (height); ++y)
   {
-    for (int x = 0; x < static_cast<int> (width); ++x) 
+    for (int x = 0; x < static_cast<int> (width); ++x)
     {
       PointWithRange& point = points[y*width + x];
       if (!std::isinf (point.range)) 

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -841,7 +841,7 @@ RangeImage::extractFarRanges (const pcl::PCLPointCloud2& point_cloud_data,
       vp_z_offset = point_cloud_data.fields[vp_z_idx].offset,
       distance_offset = point_cloud_data.fields[distance_idx].offset;
   
-  for (size_t point_idx = 0; point_idx < point_cloud_data.width*point_cloud_data.height; ++point_idx)
+  for (std::size_t point_idx = 0; point_idx < point_cloud_data.width*point_cloud_data.height; ++point_idx)
   {
     float x = *reinterpret_cast<const float*> (data+x_offset), 
           y = *reinterpret_cast<const float*> (data+y_offset), 

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -182,7 +182,7 @@ namespace pcl
     center_x_ = static_cast<float> (di_center_x) / static_cast<float> (skip);
     center_y_ = static_cast<float> (di_center_y) / static_cast<float> (skip);
     points.resize (width * height);
-    
+
     for (int y = 0; y < static_cast<int> (height); ++y)
     {
       for (int x = 0; x < static_cast<int> (width); ++x)

--- a/doc/tutorials/content/sources/don_segmentation/don_segmentation.cpp
+++ b/doc/tutorials/content/sources/don_segmentation/don_segmentation.cpp
@@ -103,7 +103,7 @@ main (int argc, char *argv[])
 
   // Create output cloud for DoN results
   PointCloud<PointNormal>::Ptr doncloud (new pcl::PointCloud<PointNormal>);
-  copyPointCloud<PointXYZRGB, PointNormal>(*cloud, *doncloud);
+  copyPointCloud (*cloud, *doncloud);
 
   std::cout << "Calculating DoN... " << std::endl;
   // Create DoN operator

--- a/doc/tutorials/content/sources/random_sample_consensus/random_sample_consensus.cpp
+++ b/doc/tutorials/content/sources/random_sample_consensus/random_sample_consensus.cpp
@@ -88,7 +88,7 @@ main(int argc, char** argv)
   }
 
   // copies all inliers of the model computed to another PointCloud
-  pcl::copyPointCloud<pcl::PointXYZ>(*cloud, inliers, *final);
+  pcl::copyPointCloud (*cloud, inliers, *final);
 
   // creates the visualization object and adds either our original cloud or all of the inliers
   // depending on the command line arguments specified.

--- a/doc/tutorials/content/sources/registration_api/example2.cpp
+++ b/doc/tutorials/content/sources/registration_api/example2.cpp
@@ -60,10 +60,10 @@ estimateNormals (const PointCloud<PointXYZ>::Ptr &src,
   // For debugging purposes only: uncomment the lines below and use pcl_viewer to view the results, i.e.:
   // pcl_viewer normals_src.pcd
   PointCloud<PointNormal> s, t;
-  copyPointCloud<PointXYZ, PointNormal> (*src, s);
-  copyPointCloud<Normal, PointNormal> (normals_src, s);
-  copyPointCloud<PointXYZ, PointNormal> (*tgt, t);
-  copyPointCloud<Normal, PointNormal> (normals_tgt, t);
+  copyPointCloud (*src, s);
+  copyPointCloud (normals_src, s);
+  copyPointCloud (*tgt, t);
+  copyPointCloud (normals_tgt, t);
   savePCDFileBinary ("normals_src.pcd", s);
   savePCDFileBinary ("normals_tgt.pcd", t);
 }
@@ -154,10 +154,10 @@ computeTransformation (const PointCloud<PointXYZ>::Ptr &src,
 
   // Copy the data and save it to disk
 /*  PointCloud<PointNormal> s, t;
-  copyPointCloud<PointXYZ, PointNormal> (*keypoints_src, s);
-  copyPointCloud<Normal, PointNormal> (normals_src, s);
-  copyPointCloud<PointXYZ, PointNormal> (*keypoints_tgt, t);
-  copyPointCloud<Normal, PointNormal> (normals_tgt, t);*/
+  copyPointCloud (*keypoints_src, s);
+  copyPointCloud (normals_src, s);
+  copyPointCloud (*keypoints_tgt, t);
+  copyPointCloud (normals_tgt, t);*/
 
   // Find correspondences between keypoints in FPFH space
   CorrespondencesPtr all_correspondences (new Correspondences), 

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -152,7 +152,7 @@ int main (int argc, char *argv[])
 
   // Create output cloud for DoN results
   PointCloud<PointOutT>::Ptr doncloud (new pcl::PointCloud<PointOutT>);
-  copyPointCloud<PointT, PointOutT>(*cloud, *doncloud);
+  copyPointCloud (*cloud, *doncloud);
 
   std::cout << "Calculating DoN... " << std::endl;
   // Create DoN operator

--- a/filters/include/pcl/filters/impl/morphological_filter.hpp
+++ b/filters/include/pcl/filters/impl/morphological_filter.hpp
@@ -61,7 +61,7 @@ pcl::applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPt
   if (cloud_in->empty ())
     return;
 
-  pcl::copyPointCloud<PointT, PointT> (*cloud_in, cloud_out);
+  pcl::copyPointCloud (*cloud_in, cloud_out);
 
   pcl::octree::OctreePointCloudSearch<PointT> tree (resolution);
 
@@ -116,7 +116,7 @@ pcl::applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPt
     {
       pcl::PointCloud<PointT> cloud_temp;
 
-      pcl::copyPointCloud<PointT, PointT> (*cloud_in, cloud_temp);
+      pcl::copyPointCloud (*cloud_in, cloud_temp);
 
       for (size_t p_idx = 0; p_idx < cloud_temp.points.size (); ++p_idx)
       {

--- a/keypoints/include/pcl/keypoints/agast_2d.h
+++ b/keypoints/include/pcl/keypoints/agast_2d.h
@@ -488,7 +488,7 @@ namespace pcl
         {
           pcl::PointCloud<pcl::PointUV> output_temp;
           detector->applyNonMaxSuppression (image_data, tmp_cloud, output_temp);
-          pcl::copyPointCloud<pcl::PointUV, Out> (output_temp, output);
+          pcl::copyPointCloud (output_temp, output);
         }
       };
 
@@ -516,7 +516,7 @@ namespace pcl
         {
           pcl::PointCloud<pcl::PointUV> output_temp;
           detector->detectKeypoints (image_data, output_temp);
-          pcl::copyPointCloud<pcl::PointUV, Out> (output_temp, output);
+          pcl::copyPointCloud (output_temp, output);
         }
       };
 

--- a/keypoints/include/pcl/keypoints/impl/brisk_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/brisk_2d.hpp
@@ -79,7 +79,7 @@ pcl::BriskKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointClo
   brisk_scale_space.constructPyramid (image_data, width, height);
   pcl::PointCloud<pcl::PointWithScale> output_temp;
   brisk_scale_space.getKeypoints (threshold_, output_temp.points);
-  pcl::copyPointCloud<pcl::PointWithScale, PointOutT> (output_temp, output);
+  pcl::copyPointCloud (output_temp, output);
 
   // we do not change the denseness
   output.width = int (output.points.size ());

--- a/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
@@ -79,7 +79,7 @@ pcl::GeometricConsistencyGrouping<PointModelT, PointSceneT>::clusterCorresponden
 
   //temp copy of scene cloud with the type cast to ModelT in order to use Ransac
   PointCloudPtr temp_scene_cloud_ptr (new PointCloud ());
-  pcl::copyPointCloud<PointSceneT, PointModelT> (*scene_, *temp_scene_cloud_ptr);
+  pcl::copyPointCloud (*scene_, *temp_scene_cloud_ptr);
 
   pcl::registration::CorrespondenceRejectorSampleConsensus<PointModelT> corr_rejector;
   corr_rejector.setMaximumIterations (10000);

--- a/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/hough_3d.hpp
@@ -274,7 +274,7 @@ pcl::Hough3DGrouping<PointModelT, PointSceneT, PointModelRfT, PointSceneRfT>::cl
   // Insert maximas into result vector, after Ransac correspondence rejection
   // Temp copy of scene cloud with the type cast to ModelT in order to use Ransac
   PointCloudPtr temp_scene_cloud_ptr (new PointCloud);
-  pcl::copyPointCloud<PointSceneT, PointModelT> (*scene_, *temp_scene_cloud_ptr);
+  pcl::copyPointCloud (*scene_, *temp_scene_cloud_ptr);
 
   pcl::registration::CorrespondenceRejectorSampleConsensus<PointModelT> corr_rejector;
   corr_rejector.setMaximumIterations (10000);
@@ -355,7 +355,7 @@ pcl::Hough3DGrouping<PointModelT, PointSceneT, PointModelRfT, PointSceneRfT>::re
 
   //// Temp copy of scene cloud with the type cast to ModelT in order to use Ransac
   //PointCloudPtr temp_scene_cloud_ptr (new PointCloud);
-  //pcl::copyPointCloud<PointSceneT, PointModelT> (*scene_, *temp_scene_cloud_ptr);
+  //pcl::copyPointCloud (*scene_, *temp_scene_cloud_ptr);
 
   //for (size_t i = 0; i < model_instances.size (); ++i)
   //{

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -1036,7 +1036,7 @@ TEST (PCL, CopyPointCloud)
     cloud_b.points[i].rgba = 255;
   }
 
-  pcl::copyPointCloud<pcl::PointXYZ, pcl::PointXYZRGBA> (cloud_a, cloud_b);
+  pcl::copyPointCloud (cloud_a, cloud_b);
 
   for (size_t i = 0; i < cloud_a.points.size (); ++i)
   {
@@ -1047,7 +1047,7 @@ TEST (PCL, CopyPointCloud)
     cloud_a.points[i].x = cloud_a.points[i].y = cloud_a.points[i].z = 0;
   }
 
-  pcl::copyPointCloud<pcl::PointXYZRGBA, pcl::PointXYZ> (cloud_b, cloud_a);
+  pcl::copyPointCloud (cloud_b, cloud_a);
 
   for (size_t i = 0; i < cloud_a.points.size (); ++i)
   {


### PR DESCRIPTION
* Replaced `size_t` with `std::size_t`
* Used modern for loops
* Used `std::size_t` for indices (in function internals) which don't affect class/struct layout
* Some changes to API to replace `int` with `std::size_t` for dimensions and indices
* Used `auto` to hide unimportant types

The aim is to to use `std::size_t` instead of `int` in all (most) modules and then convert the indices to PCL_INDEX_TYPE which can be set as `uint16_t` or `std::size_t` or even `int`. This is first in a series of such commits