### PR TITLE
fix: typo in walkthrough doc

### DIFF
--- a/doc/tutorials/content/walkthrough.rst
+++ b/doc/tutorials/content/walkthrough.rst
@@ -208,7 +208,7 @@ Registration
 
 	Combining several datasets into a global consistent model is usually performed using a technique called registration. The key idea is to identify corresponding points between the data sets and find a transformation that minimizes the distance (alignment error) between corresponding points. This process is repeated, since correspondence search is affected by the relative position and orientation of the data sets. Once the alignment errors fall below a given threshold, the registration is said to be complete.
 
-	The *registration* library implements a plethora of point cloud registration algorithms for both organized an unorganized (general purpose) datasets. For instance, PCL contains a set of powerful algorithms that allow the estimation of multiple sets of correspondences, as well as methods for rejecting bad correspondences, and estimating transformations in a robust manner.
+	The *registration* library implements a plethora of point cloud registration algorithms for both organized and unorganized (general purpose) datasets. For instance, PCL contains a set of powerful algorithms that allow the estimation of multiple sets of correspondences, as well as methods for rejecting bad correspondences, and estimating transformations in a robust manner.
 
 	.. image:: images/registration/scans.jpg
 	


### PR DESCRIPTION
- Fix a typo under `Registration` section