### PR TITLE
Skip module "surface" on MacOS because of OpenGL error

### DIFF
--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -25,7 +25,7 @@ jobs:
             -DQt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5 \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
             -DBUILD_simulation=ON \
-            -DBUILD_surface_on_nurbs=ON \
+            -DBUILD_surface=OFF \
             -DBUILD_global_tests=ON \
             -DBUILD_examples=ON \
             -DBUILD_tools=ON \


### PR DESCRIPTION
This allows CI result to show build status of non-opengl related modules at a glance. Hopefully other modules are free of the issue