### PR TITLE
Apply clang-format to ml module (part 1)

### DIFF
--- a/ml/include/pcl/ml/branch_estimator.h
+++ b/ml/include/pcl/ml/branch_estimator.h
@@ -34,7 +34,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
-  
+
 #pragma once
 
 #include <pcl/common/common.h>
@@ -43,104 +43,100 @@
 #include <istream>
 #include <ostream>
 
-namespace pcl
-{
+namespace pcl {
 
-  /** \brief Interface for branch estimators. */
-  class PCL_EXPORTS BranchEstimator
+/** Interface for branch estimators. */
+class PCL_EXPORTS BranchEstimator {
+public:
+  /** Destructor. */
+  virtual ~BranchEstimator() {}
+
+  /** Returns the number of branches the corresponding tree has. */
+  virtual size_t
+  getNumOfBranches() const = 0;
+
+  /** Computes the branch index for the specified result.
+   *
+   * \param[in] result the result the branch index will be computed for
+   * \param[in] flag the flag corresponding to the specified result
+   * \param[in] threshold the threshold used to compute the branch index
+   * \param[out] branch_index the destination for the computed branch index
+   */
+  virtual void
+  computeBranchIndex(const float result,
+                     const unsigned char flag,
+                     const float threshold,
+                     unsigned char& branch_index) const = 0;
+};
+
+/** Branch estimator for binary trees where the branch is computed only from the
+ *  threshold. */
+class PCL_EXPORTS BinaryTreeThresholdBasedBranchEstimator : public BranchEstimator {
+public:
+  /** Constructor. */
+  inline BinaryTreeThresholdBasedBranchEstimator() {}
+  /** Destructor. */
+  inline ~BinaryTreeThresholdBasedBranchEstimator() {}
+
+  /** Returns the number of branches the corresponding tree has. */
+  inline size_t
+  getNumOfBranches() const override
   {
-    public:
-      /** \brief Destructor. */
-      virtual ~BranchEstimator () {}
+    return 2;
+  }
 
-      /** \brief Returns the number of branches the corresponding tree has. */
-      virtual size_t 
-      getNumOfBranches () const = 0;
-
-      /** \brief Computes the branch index for the specified result.
-        * \param[in] result The result the branch index will be computed for.
-        * \param[in] flag The flag corresponding to the specified result.
-        * \param[in] threshold The threshold used to compute the branch index.
-        * \param[out] branch_index The destination for the computed branch index.
-        */
-      virtual void 
-      computeBranchIndex(
-        const float result,
-        const unsigned char flag,
-        const float threshold,
-        unsigned char & branch_index) const = 0;
-  };
-
-  /** \brief Branch estimator for binary trees where the branch is computed only from the threshold. */
-  class PCL_EXPORTS BinaryTreeThresholdBasedBranchEstimator
-    : public BranchEstimator
+  /** Computes the branch index for the specified result.
+   *
+   * \param[in] result the result the branch index will be computed for
+   * \param[in] flag the flag corresponding to the specified result
+   * \param[in] threshold the threshold used to compute the branch index
+   * \param[out] branch_index the destination for the computed branch index
+   */
+  inline void
+  computeBranchIndex(const float result,
+                     const unsigned char flag,
+                     const float threshold,
+                     unsigned char& branch_index) const override
   {
-    public:
-      /** \brief Constructor. */
-      inline BinaryTreeThresholdBasedBranchEstimator () {}
-      /** \brief Destructor. */
-      inline ~BinaryTreeThresholdBasedBranchEstimator () {}
+    (void)flag;
+    branch_index = (result > threshold) ? 1 : 0;
+  }
+};
 
-      /** \brief Returns the number of branches the corresponding tree has. */
-      inline size_t 
-      getNumOfBranches () const override
-      { 
-        return 2; 
-      }
-      
-      /** \brief Computes the branch index for the specified result.
-        * \param[in] result The result the branch index will be computed for.
-        * \param[in] flag The flag corresponding to the specified result.
-        * \param[in] threshold The threshold used to compute the branch index.
-        * \param[out] branch_index The destination for the computed branch index.
-        */
-      inline void 
-      computeBranchIndex(
-        const float result,
-        const unsigned char flag,
-        const float threshold,
-        unsigned char & branch_index) const override
-      {
-        (void)flag;
-        branch_index = (result > threshold) ? 1 : 0;
-      }
-  };
+/** Branch estimator for ternary trees where one branch is used for missing data
+ *  (indicated by flag != 0). */
+class PCL_EXPORTS TernaryTreeMissingDataBranchEstimator : public BranchEstimator {
+public:
+  /** Constructor. */
+  inline TernaryTreeMissingDataBranchEstimator() {}
+  /** Destructor. */
+  inline ~TernaryTreeMissingDataBranchEstimator() {}
 
-  /** \brief Branch estimator for ternary trees where one branch is used for missing data (indicated by flag != 0). */
-  class PCL_EXPORTS TernaryTreeMissingDataBranchEstimator
-    : public BranchEstimator
+  /** \brief Returns the number of branches the corresponding tree has. */
+  inline size_t
+  getNumOfBranches() const override
   {
-    public:
-      /** \brief Constructor. */
-      inline TernaryTreeMissingDataBranchEstimator () {}
-      /** \brief Destructor. */
-      inline ~TernaryTreeMissingDataBranchEstimator () {}
+    return 3;
+  }
 
-      /** \brief Returns the number of branches the corresponding tree has. */
-      inline size_t 
-      getNumOfBranches () const override
-      { 
-        return 3; 
-      }
-      
-      /** \brief Computes the branch index for the specified result.
-        * \param[in] result The result the branch index will be computed for.
-        * \param[in] flag The flag corresponding to the specified result.
-        * \param[in] threshold The threshold used to compute the branch index.
-        * \param[out] branch_index The destination for the computed branch index.
-        */
-      inline void 
-      computeBranchIndex(
-        const float result,
-        const unsigned char flag,
-        const float threshold,
-        unsigned char & branch_index) const override
-      {
-        if (flag == 0)
-          branch_index = (result > threshold) ? 1 : 0;
-        else
-          branch_index = 2;
-      }
-  };
+  /** Computes the branch index for the specified result.
+   *
+   * \param[in] result the result the branch index will be computed for
+   * \param[in] flag the flag corresponding to the specified result
+   * \param[in] threshold the threshold used to compute the branch index
+   * \param[out] branch_index the destination for the computed branch index
+   */
+  inline void
+  computeBranchIndex(const float result,
+                     const unsigned char flag,
+                     const float threshold,
+                     unsigned char& branch_index) const override
+  {
+    if (flag == 0)
+      branch_index = (result > threshold) ? 1 : 0;
+    else
+      branch_index = 2;
+  }
+};
 
-}
+} // namespace pcl

--- a/ml/include/pcl/ml/densecrf.h
+++ b/ml/include/pcl/ml/densecrf.h
@@ -45,120 +45,122 @@
 
 #include <pcl/ml/pairwise_potential.h>
 
-namespace pcl
-{
-  /** \brief
-   * 
+namespace pcl {
+
+class PCL_EXPORTS DenseCrf {
+public:
+  /** Constructor for DenseCrf class. */
+  DenseCrf(int N, int m);
+
+  /** Deconstructor for DenseCrf class. */
+  ~DenseCrf();
+
+  /** Set the input data vector.
+   *
+   *  The input data vector holds the measurements coordinates as ijk of the voxel grid.
    */
-  class PCL_EXPORTS DenseCrf
-  {
-    public:
+  void
+  setDataVector(const std::vector<Eigen::Vector3i,
+                                  Eigen::aligned_allocator<Eigen::Vector3i>> data);
 
-      /** \brief Constructor for DenseCrf class */
-      DenseCrf (int N, int m);
+  /** The associated color of the data. */
+  void
+  setColorVector(const std::vector<Eigen::Vector3i,
+                                   Eigen::aligned_allocator<Eigen::Vector3i>> color);
 
-      /** \brief Deconstructor for DenseCrf class */
-      ~DenseCrf ();
-      
-      /** \brief set the input data vector.
-       * The input data vector holds the measurements
-       * coordinates as ijk of the voxel grid
-       */
-      void
-      setDataVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data);
+  void
+  setUnaryEnergy(const std::vector<float> unary);
 
-      /** \brief The associated color of the data
-       */
-      void
-      setColorVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color);
+  void
+  addPairwiseEnergy(const std::vector<float>& feature,
+                    const int feature_dimension,
+                    const float w);
 
-      void
-      setUnaryEnergy (const std::vector<float> unary);
- 
-      /** \brief      */
-      void
-      addPairwiseEnergy (const std::vector<float> &feature, const int feature_dimension, const float w);
-      
-      
-      /** \brief Add a pairwise gaussian kernel
-       * 
-       */
-      void
-      addPairwiseGaussian (float sx, float sy, float sz, float w);
-      
-      /** \brief Add a bilateral gaussian kernel
-       * 
-       */
-      void
-      addPairwiseBilateral (float sx, float sy, float sz, 
-                            float sr, float sg, float sb,
-                            float w);
+  /** Add a pairwise gaussian kernel. */
+  void
+  addPairwiseGaussian(float sx, float sy, float sz, float w);
 
+  /** Add a bilateral gaussian kernel. */
+  void
+  addPairwiseBilateral(
+      float sx, float sy, float sz, float sr, float sg, float sb, float w);
 
-      void
-      addPairwiseNormals (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > &coord,
-                          std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &normals,
-                          float sx, float sy, float sz, 
-                          float snx, float sny, float snz,
-                          float w);
-      
+  void
+  addPairwiseNormals(
+      std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>>& coord,
+      std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>>& normals,
+      float sx,
+      float sy,
+      float sz,
+      float snx,
+      float sny,
+      float snz,
+      float w);
 
-      void
-      inference (int n_iterations, std::vector<float> &result, float relax = 1.0f);
- 
-      void
-      mapInference (int n_iterations, std::vector<int> &result, float relax = 1.0f);
-      
-      void
-      expAndNormalize (std::vector<float> &out, const std::vector<float> &in,
-                       float scale, float relax = 1.0f);
- 
-      void
-      expAndNormalizeORI ( float* out, const float* in, float scale=1.0f, float relax=1.0f );
-      void map ( int n_iterations, std::vector<int> result, float relax=1.0f );
-      std::vector<float> runInference( int n_iterations, float relax );
-      void startInference();
-      void stepInference( float relax );
-      
+  void
+  inference(int n_iterations, std::vector<float>& result, float relax = 1.0f);
 
-      void
-      runInference (float relax);
+  void
+  mapInference(int n_iterations, std::vector<int>& result, float relax = 1.0f);
 
+  void
+  expAndNormalize(std::vector<float>& out,
+                  const std::vector<float>& in,
+                  float scale,
+                  float relax = 1.0f);
 
-      void
-      getBarycentric (int idx, std::vector<float> &bary);
+  void
+  expAndNormalizeORI(float* out,
+                     const float* in,
+                     float scale = 1.0f,
+                     float relax = 1.0f);
+  void
+  map(int n_iterations, std::vector<int> result, float relax = 1.0f);
 
-      void
-      getFeatures (int idx, std::vector<float> &features);
-      
+  std::vector<float>
+  runInference(int n_iterations, float relax);
 
+  void
+  startInference();
 
-    protected:
+  void
+  stepInference(float relax);
 
-      /** \brief Number of variables and labels */
-      int N_, M_;
+  void
+  runInference(float relax);
 
-      /** \brief Data vector */
-      std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data_;
+  void
+  getBarycentric(int idx, std::vector<float>& bary);
 
-      /** \brief Color vector */
-      std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color_;
+  void
+  getFeatures(int idx, std::vector<float>& features);
 
-      /** TODO: double might use to much memory */
-      /** \brief CRF unary potentials */
-      std::vector<float> unary_;
+protected:
+  /** Number of variables and labels */
+  int N_, M_;
 
-      std::vector<float> current_;
-      std::vector<float> next_;
-      std::vector<float> tmp_;
+  /** Data vector */
+  std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> data_;
 
-      /** \brief pairwise potentials */
-      std::vector<PairwisePotential*> pairwise_potential_;
-          
-      /** \brief input types */
-      bool xyz_, rgb_, normal_;
+  /** Color vector */
+  std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> color_;
 
-    public:
-      PCL_MAKE_ALIGNED_OPERATOR_NEW
-  };
-}
+  /** CRF unary potentials */
+  /** TODO: double might use to much memory */
+  std::vector<float> unary_;
+
+  std::vector<float> current_;
+  std::vector<float> next_;
+  std::vector<float> tmp_;
+
+  /** Pairwise potentials */
+  std::vector<PairwisePotential*> pairwise_potential_;
+
+  /** Input types */
+  bool xyz_, rgb_, normal_;
+
+public:
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+} // namespace pcl

--- a/ml/include/pcl/ml/feature_handler.h
+++ b/ml/include/pcl/ml/feature_handler.h
@@ -34,73 +34,74 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
-  
+
 #pragma once
 
 #include <pcl/common/common.h>
 
-#include <vector>
 #include <ostream>
+#include <vector>
 
-namespace pcl
-{
+namespace pcl {
 
-  /** \brief Utility class interface which is used for creating and evaluating features. */
-  template <
-    class FeatureType,
-    class DataSet,
-    class ExampleIndex >
-  class PCL_EXPORTS FeatureHandler
-  {
-    public:
+/** Utility class interface which is used for creating and evaluating features. */
+template <class FeatureType, class DataSet, class ExampleIndex>
+class PCL_EXPORTS FeatureHandler {
+public:
+  /** Destructor. */
+  virtual ~FeatureHandler(){};
 
-      /** \brief Destructor. */
-      virtual 
-      ~FeatureHandler () {};
+  /** Creates random features.
+   *
+   * \param[in] num_of_features the number of random features to create
+   * \param[out] features the destination for the created features
+   */
+  virtual void
+  createRandomFeatures(const size_t num_of_features,
+                       std::vector<FeatureType>& features) = 0;
 
-      /** \brief Creates random features.
-        * \param[in] num_of_features The number of random features to create.
-        * \param[out] features The destination for the created features.
-        */
-      virtual void 
-      createRandomFeatures (const size_t num_of_features, std::vector<FeatureType> & features) = 0;
+  /** Evaluates a feature on the specified data.
+   *
+   * \param[in] feature the features to evaluate
+   * \param[in] data_set the data set on which the feature is evaluated
+   * \param[in] examples the examples which specify on which parts of the data set the
+   *            feature is evaluated
+   * \param[out] results the destination for the results of the feature evaluation
+   * \param[out] flags flags that are supplied together with the
+   *             results
+   */
+  virtual void
+  evaluateFeature(const FeatureType& feature,
+                  DataSet& data_set,
+                  std::vector<ExampleIndex>& examples,
+                  std::vector<float>& results,
+                  std::vector<unsigned char>& flags) const = 0;
 
-      /** \brief Evaluates a feature on the specified data. 
-        * \param[in] feature The features to evaluate.
-        * \param[in] data_set The data set on which the feature is evaluated.
-        * \param[in] examples The examples which specify on which parts of the data set the feature is evaluated.
-        * \param[out] results The destination for the results of the feature evaluation.
-        * \param[out] flags Flags that are supplied together with the results.
-        */
-      virtual void 
-      evaluateFeature (const FeatureType & feature,
-                       DataSet & data_set,
-                       std::vector<ExampleIndex> & examples,
-                       std::vector<float> & results,
-                       std::vector<unsigned char> & flags) const = 0;
+  /** Evaluates a feature on the specified data.
+   *
+   * \param[in] feature the features to evaluate
+   * \param[in] data_set the data set on which the feature is evaluated
+   * \param[in] example the examples which specify on which parts of the data set the
+   *            feature is evaluated
+   * \param[out] result the destination for the results of the feature evaluation
+   * \param[out] flag flags that are supplied together with the results
+   */
+  virtual void
+  evaluateFeature(const FeatureType& feature,
+                  DataSet& data_set,
+                  const ExampleIndex& example,
+                  float& result,
+                  unsigned char& flag) const = 0;
 
-      /** \brief Evaluates a feature on the specified data. 
-        * \param[in] feature The features to evaluate.
-        * \param[in] data_set The data set on which the feature is evaluated.
-        * \param[in] example The examples which specify on which parts of the data set the feature is evaluated.
-        * \param[out] result The destination for the results of the feature evaluation.
-        * \param[out] flag Flags that are supplied together with the results.
-        */
-      virtual void 
-      evaluateFeature (const FeatureType & feature,
-                       DataSet & data_set,
-                       const ExampleIndex & example,
-                       float & result,
-                       unsigned char & flag) const = 0;
+  /** Generates evaluation code for the specified feature and writes it to the specified
+   *  stream
+   *
+   * \param[in] feature the feature for which code is generated
+   * \param[out] stream the destination for the code
+   */
+  virtual void
+  generateCodeForEvaluation(const FeatureType& feature,
+                            ::std::ostream& stream) const = 0;
+};
 
-      /** \brief Generates evaluation code for the specified feature and writes it to the specified stream.
-        * \param[in] feature The feature for which code is generated.
-        * \param[out] stream The destination for the code.
-        */
-      virtual void 
-      generateCodeForEvaluation (const FeatureType & feature,
-                                 ::std::ostream & stream) const = 0;
-
-  };
-
-}
+} // namespace pcl

--- a/ml/include/pcl/ml/impl/svm/svm_wrapper.hpp
+++ b/ml/include/pcl/ml/impl/svm/svm_wrapper.hpp
@@ -1,44 +1,41 @@
-  /*
-  * Software License Agreement (BSD License)
-  *
-  *  Point Cloud Library (PCL) - www.pointclouds.org
-  *  Copyright (c) 2010-2012, Willow Garage, Inc.
-  *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
-  *
-  *  All rights reserved.
-  *
-  *  Redistribution and use in source and binary forms, with or without
-  *  modification, are permitted provided that the following conditions
-  *  are met:
-  *
-  *   * Redistributions of source code must retain the above copyright
-  *     notice, this list of conditions and the following disclaimer.
-  *   * Redistributions in binary form must reproduce the above
-  *     copyright notice, this list of conditions and the following
-  *     disclaimer in the documentation and/or other materials provided
-  *     with the distribution.
-  *   * Neither the name of copyright holders nor the names of its
-  *     contributors may be used to endorse or promote products derived
-  *     from this software without specific prior written permission.
-  *
-  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-  *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-  *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  *  POSSIBILITY OF SUCH DAMAGE.
-  *
-  */
- 
- #ifndef PCL_SVM_WRAPPER_IMPL_H_
- #define PCL_SVM_WRAPPER_IMPL_H_
- 
- #include <pcl/ml/svm_wrapper.h>
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
- #endif // PCL_SVM_WRAPPER_H_
+#pragma once
+
+#include <pcl/ml/svm_wrapper.h>

--- a/ml/include/pcl/ml/pairwise_potential.h
+++ b/ml/include/pcl/ml/pairwise_potential.h
@@ -43,43 +43,41 @@
 
 #include <pcl/ml/permutohedral.h>
 
-namespace pcl
-{
-  /** \brief
-   * 
-   */
-  class PairwisePotential
-  {
-    public:
+namespace pcl {
 
-      /** \brief Constructor for DenseCrf class */
-      PairwisePotential (const std::vector<float> &feature, const int D, const int N, const float w);
+class PairwisePotential {
+public:
+  /** Constructor for PairwisePotential class. */
+  PairwisePotential(const std::vector<float>& feature,
+                    const int D,
+                    const int N,
+                    const float w);
 
-      /** \brief Deconstructor for DenseCrf class */
-      ~PairwisePotential () {};
+  /** Deconstructor for PairwisePotential class. */
+  ~PairwisePotential(){};
 
-      /** \brief  */
-      void
-      compute (std::vector<float> &out, const std::vector<float> &in,
-               std::vector<float> &tmp, int value_size) const;
+  void
+  compute(std::vector<float>& out,
+          const std::vector<float>& in,
+          std::vector<float>& tmp,
+          int value_size) const;
 
-    protected:
-      /** \brief Permutohedral lattice */
-      Permutohedral lattice_;
+protected:
+  /// Permutohedral lattice
+  Permutohedral lattice_;
 
-      /** \brief Number of variables */
-      int N_;
+  /// Number of variables
+  int N_;
 
-      /** \brief weight */
-      float w_;
+  /// Weight
+  float w_;
 
-      /** \brief norm */
-      std::vector<float> norm_;
+  /// Norm
+  std::vector<float> norm_;
 
-      //DBUG
-    public:
-      std::vector<float> bary_;
-      std::vector<float> features_;
+public:
+  std::vector<float> bary_;
+  std::vector<float> features_;
+};
 
-  };
-}
+} // namespace pcl

--- a/ml/include/pcl/ml/permutohedral.h
+++ b/ml/include/pcl/ml/permutohedral.h
@@ -38,235 +38,267 @@
 #pragma once
 
 #ifdef __GNUC__
-#pragma GCC system_header 
+#pragma GCC system_header
 #endif
 
-#include <vector>
+#include <boost/intrusive/hashtable.hpp>
 #include <map>
 #include <pcl/common/eigen.h>
-#include <boost/intrusive/hashtable.hpp>
+#include <vector>
 
 // TODO: SWAP with Boost intrusive hash table
+#include <cassert>
+#include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cassert>
-#include <cstdio>
-#include <cmath>
 
 #include <pcl/pcl_macros.h>
 
-namespace pcl
+namespace pcl {
+/** Implementation of a high-dimensional gaussian filtering using the permutohedral
+ *  lattice.
+ *
+ * \author Christian Potthast (potthast@usc.edu)
+ *
+ * Adams_fasthigh-dimensional
+ *   author = {Andrew Adams and Jongmin Baek and Myers Abraham Davis},
+ *   title = {Fast high-dimensional filtering using the permutohedral lattice},
+ *   booktitle = {Computer Graphics Forum (EG 2010 Proceedings},
+ *   year = {},
+ *   pages = {2010}
+ * }
+ */
+
+class Permutohedral {
+protected:
+  struct Neighbors {
+    int n1, n2;
+    Neighbors(int n1 = 0, int n2 = 0) : n1(n1), n2(n2) {}
+  };
+
+public:
+  /** Constructor for Permutohedral class. */
+  Permutohedral();
+
+  /** Deconstructor for Permutohedral class. */
+  ~Permutohedral(){};
+
+  /** Initialization. */
+  void
+  init(const std::vector<float>& feature, const int feature_dimension, const int N);
+
+  void
+  compute(std::vector<float>& out,
+          const std::vector<float>& in,
+          int value_size,
+          int in_offset = 0,
+          int out_offset = 0,
+          int in_size = -1,
+          int out_size = -1) const;
+
+  void
+  initOLD(const std::vector<float>& feature, const int feature_dimension, const int N);
+
+  void
+  computeOLD(std::vector<float>& out,
+             const std::vector<float>& in,
+             int value_size,
+             int in_offset = 0,
+             int out_offset = 0,
+             int in_size = -1,
+             int out_size = -1) const;
+
+  void
+  debug();
+
+  /** Pseudo radnom generator. */
+  inline size_t
+  generateHashKey(const std::vector<short>& k)
+  {
+    size_t r = 0;
+    for (int i = 0; i < d_; i++) {
+      r += k[i];
+      r *= 1664525;
+      // r *= 5;
+    }
+    return r; // % (2* N_ * (d_+1));
+  }
+
+public:
+  /// Number of variables
+  int N_;
+
+  std::vector<Neighbors> blur_neighbors_;
+
+  /// Size of sparse discretized space
+  int M_;
+
+  /// Dimension of feature
+  int d_;
+
+  std::vector<float> offset_;
+  std::vector<float> offsetTMP_;
+  std::vector<float> barycentric_;
+
+  Neighbors* blur_neighborsOLD_;
+  int* offsetOLD_;
+  float* barycentricOLD_;
+  std::vector<float> baryOLD_;
+
+public:
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+class HashTableOLD {
+  // Don't copy!
+  HashTableOLD(const HashTableOLD& o)
+  : key_size_(o.key_size_), filled_(0), capacity_(o.capacity_)
+  {
+    table_ = new int[capacity_];
+    keys_ = new short[(capacity_ / 2 + 10) * key_size_];
+    memset(table_, -1, capacity_ * sizeof(int));
+  }
+
+protected:
+  size_t key_size_, filled_, capacity_;
+  short* keys_;
+  int* table_;
+
+  void
+  grow()
+  {
+    std::cout << "GROW" << std::endl;
+
+    // Swap out the old memory
+    short* old_keys = keys_;
+    int* old_table = table_;
+    int old_capacity = static_cast<int>(capacity_);
+    capacity_ *= 2;
+    // Allocate the new memory
+    keys_ = new short[(old_capacity + 10) * key_size_];
+    table_ = new int[capacity_];
+    memset(table_, -1, capacity_ * sizeof(int));
+    memcpy(keys_, old_keys, filled_ * key_size_ * sizeof(short));
+
+    // Reinsert each element
+    for (int i = 0; i < old_capacity; i++)
+      if (old_table[i] >= 0) {
+        int e = old_table[i];
+        size_t h = hash(old_keys + (getKey(e) - keys_)) % capacity_;
+        for (; table_[h] >= 0; h = h < capacity_ - 1 ? h + 1 : 0) {
+        };
+        table_[h] = e;
+      }
+
+    delete[] old_keys;
+    delete[] old_table;
+  }
+
+  size_t
+  hash(const short* k)
+  {
+    size_t r = 0;
+    for (size_t i = 0; i < key_size_; i++) {
+      r += k[i];
+      r *= 1664525;
+    }
+    return r;
+  }
+
+public:
+  explicit HashTableOLD(int key_size, int n_elements)
+  : key_size_(key_size), filled_(0), capacity_(2 * n_elements)
+  {
+    table_ = new int[capacity_];
+    keys_ = new short[(capacity_ / 2 + 10) * key_size_];
+    memset(table_, -1, capacity_ * sizeof(int));
+  }
+
+  ~HashTableOLD()
+  {
+    delete[] keys_;
+    delete[] table_;
+  }
+
+  int
+  size() const
+  {
+    return static_cast<int>(filled_);
+  }
+
+  void
+  reset()
+  {
+    filled_ = 0;
+    memset(table_, -1, capacity_ * sizeof(int));
+  }
+
+  int
+  find(const short* k, bool create = false)
+  {
+    if (2 * filled_ >= capacity_)
+      grow();
+    // Get the hash value
+    size_t h = hash(k) % capacity_;
+    // Find the element with he right key, using linear probing
+    while (1) {
+      int e = table_[h];
+      if (e == -1) {
+        if (create) {
+          // Insert a new key and return the new id
+          for (size_t i = 0; i < key_size_; i++)
+            keys_[filled_ * key_size_ + i] = k[i];
+          return table_[h] = static_cast<int>(filled_++);
+        }
+        else
+          return -1;
+      }
+      // Check if the current key is The One
+      bool good = true;
+      for (size_t i = 0; i < key_size_ && good; i++)
+        if (keys_[e * key_size_ + i] != k[i])
+          good = false;
+      if (good)
+        return e;
+      // Continue searching
+      h++;
+      if (h == capacity_)
+        h = 0;
+    }
+  }
+
+  const short*
+  getKey(int i) const
+  {
+    return keys_ + i * key_size_;
+  }
+};
+
+/*
+class HashTable
 {
-  /** \brief Implementation of a high-dimensional gaussian filtering using the permutohedral lattice
-    * \author Christian Potthast (potthast@usc.edu)
-    *
-    * Adams_fasthigh-dimensional
-    *   author = {Andrew Adams and Jongmin Baek and Myers Abraham Davis},
-    *   title = {Fast high-dimensional filtering using the permutohedral lattice},
-    *   booktitle = {Computer Graphics Forum (EG 2010 Proceedings},
-    *   year = {},
-    *   pages = {2010}
-    * }
-    */
-  class Permutohedral
-  {
-    protected:
-      struct Neighbors
-      {
-        int n1, n2;
-        Neighbors (int n1 = 0, int n2 = 0) : n1 (n1), n2 (n2) {}
-      };
-
-    public:
-
-      /** \brief Constructor for Permutohedral class */
-      Permutohedral ();
-
-      /** \brief Deconstructor for Permutohedral class */
-      ~Permutohedral () {};
-
-      /** \brief initialization */
-      void
-      init (const std::vector<float> &feature, const int feature_dimension, const int N);
-
-      void 
-      compute (std::vector<float> &out, const std::vector<float> &in, 
-               int value_size, 
-               int in_offset=0, int out_offset=0, 
-               int in_size = -1, int out_size = -1) const;
-      void
-      initOLD (const std::vector<float> &feature, const int feature_dimension, const int N);
-
-      void 
-      computeOLD (std::vector<float> &out, const std::vector<float> &in, 
-                  int value_size, 
-                  int in_offset=0, int out_offset=0, 
-                  int in_size = -1, int out_size = -1) const;
-
-      void
-      debug ();
-
-      // Pseudo radnom generator
-      inline
-      size_t generateHashKey (const std::vector<short> &k) 
-      {
-        size_t r = 0;
-        for (int i = 0; i < d_; i++)
-        {
-          r += k[i];
-          r *= 1664525;
-          //r *= 5;
-        }
-        return r;// % (2* N_ * (d_+1));
-      }
-
-    public:
-
-      /** \brief Number of variables */
-      int N_;
-
-      std::vector<Neighbors> blur_neighbors_;
-
-      /** \brief size of sparse discretized space */
-      int M_;
-
-      /** \brief dimension of feature */
-      int d_;
-
-      std::vector<float> offset_;
-      std::vector<float> offsetTMP_;
-      std::vector<float> barycentric_;
-
-      Neighbors * blur_neighborsOLD_;
-      int * offsetOLD_;
-      float * barycentricOLD_;
-      std::vector<float> baryOLD_;
-
-    public:
-      PCL_MAKE_ALIGNED_OPERATOR_NEW
-
-  };
-
-  class HashTableOLD
-  {
-    // Don't copy!
-    HashTableOLD( const HashTableOLD & o ): key_size_ ( o.key_size_ ), filled_(0), capacity_(o.capacity_) {
-      table_ = new int[ capacity_ ];
-      keys_ = new short[ (capacity_/2+10)*key_size_ ];
-      memset( table_, -1, capacity_*sizeof(int) );
-    }
-  protected:
-    size_t key_size_, filled_, capacity_;
-    short * keys_;
-    int * table_;
-    void grow(){
-      std::cout << "GROW" << std::endl;
-      
-      // Swap out the old memory
-      short * old_keys = keys_;
-      int * old_table = table_;
-      int old_capacity = static_cast<int> (capacity_);
-      capacity_ *= 2;
-      // Allocate the new memory
-      keys_ = new short[ (old_capacity+10)*key_size_ ];
-      table_ = new int[ capacity_ ];
-      memset( table_, -1, capacity_*sizeof(int) );
-      memcpy( keys_, old_keys, filled_*key_size_*sizeof(short) );
-      
-      // Reinsert each element
-      for( int i=0; i<old_capacity; i++ )
-        if (old_table[i] >= 0){
-          int e = old_table[i];
-          size_t h = hash( old_keys+(getKey(e)-keys_) ) % capacity_;
-          for (; table_[h] >= 0; h = h<capacity_-1 ? h+1 : 0) { };
-          table_[h] = e;
-        }
-      
-      delete [] old_keys;
-      delete [] old_table;
-    }
-    size_t hash( const short * k ) {
-      size_t r = 0;
-      for( size_t i=0; i<key_size_; i++ ){
-        r += k[i];
-        r *= 1664525;
-      }
-      return r;
-    }
   public:
-    explicit HashTableOLD( int key_size, int n_elements ) : key_size_ ( key_size ), filled_(0), capacity_(2*n_elements) {
-      table_ = new int[ capacity_ ];
-      keys_ = new short[ (capacity_/2+10)*key_size_ ];
-      memset( table_, -1, capacity_*sizeof(int) );
-    }
-    ~HashTableOLD() {
-      delete [] keys_;
-      delete [] table_;
-    }
-    int size() const {
-      return static_cast<int> (filled_);
-    }
-    void reset() {
-      filled_ = 0;
-      memset( table_, -1, capacity_*sizeof(int) );
-    }
-    int find( const short * k, bool create = false ){
-      if (2*filled_ >= capacity_) grow();
-      // Get the hash value
-      size_t h = hash( k ) % capacity_;
-      // Find the element with he right key, using linear probing
-      while(1){
-        int e = table_[h];
-        if (e==-1){
-          if (create){
-            // Insert a new key and return the new id
-            for( size_t i=0; i<key_size_; i++ )
-              keys_[ filled_*key_size_+i ] = k[i];
-            return table_[h] = static_cast<int> (filled_++);
-          }
-          else
-            return -1;
-        }
-        // Check if the current key is The One
-        bool good = true;
-        for( size_t i=0; i<key_size_ && good; i++ )
-          if (keys_[ e*key_size_+i ] != k[i])
-            good = false;
-        if (good)
-          return e;
-        // Continue searching
-        h++;
-        if (h==capacity_) h = 0;
-      }
-    }
-    const short * getKey( int i ) const{
-      return keys_+i*key_size_;
-    }
-  };
-  /*
-  class HashTable
-  {
-    public:
-      HashTable ( int N ) : N_ (2 * N) {};
+    HashTable ( int N ) : N_ (2 * N) {};
 
-      find (const std::vector<short> &k, bool create = false;)
-      {
-        
-        
+    find (const std::vector<short> &k, bool create = false;)
+    {
 
 
 
-      }
-      
 
-      
-    protected:
-      std::multimap<size_t, int> table_;
-      
-      std::vector<std::vector<short> > keys;
-      //keys.reserve ( (d_+1) * N_ );
-      // number of elements
-      int N_;
-  };*/
 
-}
+    }
+
+
+
+  protected:
+    std::multimap<size_t, int> table_;
+
+    std::vector<std::vector<short> > keys;
+    //keys.reserve ( (d_+1) * N_ );
+    // number of elements
+    int N_;
+};*/
+
+} // namespace pcl

--- a/ml/include/pcl/ml/regression_variance_stats_estimator.h
+++ b/ml/include/pcl/ml/regression_variance_stats_estimator.h
@@ -34,293 +34,295 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
-  
+
 #pragma once
 
 #include <pcl/common/common.h>
-#include <pcl/ml/stats_estimator.h>
 #include <pcl/ml/branch_estimator.h>
+#include <pcl/ml/stats_estimator.h>
 
 #include <istream>
 #include <ostream>
 
-namespace pcl
-{
+namespace pcl {
 
-  /** \brief Node for a regression trees which optimizes variance. */
-  template <class FeatureType, class LabelType>
-  class PCL_EXPORTS RegressionVarianceNode 
+/** Node for a regression trees which optimizes variance. */
+template <class FeatureType, class LabelType>
+class PCL_EXPORTS RegressionVarianceNode {
+public:
+  /** Constructor. */
+  RegressionVarianceNode() : value(0), variance(0), threshold(0), sub_nodes() {}
+
+  /** Destructor. */
+  virtual ~RegressionVarianceNode() {}
+
+  /** Serializes the node to the specified stream.
+   *
+   * \param[out] stream the destination for the serialization
+   */
+  inline void
+  serialize(std::ostream& stream) const
   {
-    public:
-      /** \brief Constructor. */
-      RegressionVarianceNode () : value(0), variance(0), threshold(0), sub_nodes() {}
-      /** \brief Destructor. */
-      virtual ~RegressionVarianceNode () {}
+    feature.serialize(stream);
 
-      /** \brief Serializes the node to the specified stream.
-        * \param[out] stream The destination for the serialization.
-        */
-      inline void 
-      serialize (std::ostream & stream) const
-      {
-        feature.serialize (stream);
+    stream.write(reinterpret_cast<const char*>(&threshold), sizeof(threshold));
 
-        stream.write (reinterpret_cast<const char*> (&threshold), sizeof (threshold));
+    stream.write(reinterpret_cast<const char*>(&value), sizeof(value));
+    stream.write(reinterpret_cast<const char*>(&variance), sizeof(variance));
 
-        stream.write (reinterpret_cast<const char*> (&value), sizeof (value));
-        stream.write (reinterpret_cast<const char*> (&variance), sizeof (variance));
+    const int num_of_sub_nodes = static_cast<int>(sub_nodes.size());
+    stream.write(reinterpret_cast<const char*>(&num_of_sub_nodes),
+                 sizeof(num_of_sub_nodes));
+    for (int sub_node_index = 0; sub_node_index < num_of_sub_nodes; ++sub_node_index) {
+      sub_nodes[sub_node_index].serialize(stream);
+    }
+  }
 
-        const int num_of_sub_nodes = static_cast<int> (sub_nodes.size ());
-        stream.write (reinterpret_cast<const char*> (&num_of_sub_nodes), sizeof (num_of_sub_nodes));
-        for (int sub_node_index = 0; sub_node_index < num_of_sub_nodes; ++sub_node_index)
-        {
-          sub_nodes[sub_node_index].serialize (stream);        
-        }
-      }
-
-      /** \brief Deserializes a node from the specified stream.
-        * \param[in] stream The source for the deserialization.
-        */
-      inline void 
-      deserialize (std::istream & stream)
-      {
-        feature.deserialize (stream);
-
-        stream.read (reinterpret_cast<char*> (&threshold), sizeof (threshold));
-
-        stream.read (reinterpret_cast<char*> (&value), sizeof (value));
-        stream.read (reinterpret_cast<char*> (&variance), sizeof (variance));
-
-        int num_of_sub_nodes;
-        stream.read (reinterpret_cast<char*> (&num_of_sub_nodes), sizeof (num_of_sub_nodes));
-        sub_nodes.resize (num_of_sub_nodes);
-
-        if (num_of_sub_nodes > 0)
-        {
-          for (int sub_node_index = 0; sub_node_index < num_of_sub_nodes; ++sub_node_index)
-          {
-            sub_nodes[sub_node_index].deserialize (stream);
-          }
-        }
-      }
-
-    public:
-      /** \brief The feature associated with the node. */
-      FeatureType feature;
-      /** \brief The threshold applied on the feature response. */
-      float threshold;
-
-      /** \brief The label value of this node. */
-      LabelType value;
-      /** \brief The variance of the labels that ended up at this node during training. */
-      LabelType variance;
-
-      /** \brief The child nodes. */
-      std::vector<RegressionVarianceNode> sub_nodes;
-  };
-
-  /** \brief Statistics estimator for regression trees which optimizes variance. */
-  template <class LabelDataType, class NodeType, class DataSet, class ExampleIndex>
-  class PCL_EXPORTS RegressionVarianceStatsEstimator
-    : public pcl::StatsEstimator<LabelDataType, NodeType, DataSet, ExampleIndex>
+  /** Deserializes a node from the specified stream.
+   *
+   * \param[in] stream the source for the deserialization
+   */
+  inline void
+  deserialize(std::istream& stream)
   {
-  
-    public:
-      /** \brief Constructor. */
-      RegressionVarianceStatsEstimator (BranchEstimator * branch_estimator) 
-        : branch_estimator_ (branch_estimator)
-      {}
-      /** \brief Destructor. */
-      virtual ~RegressionVarianceStatsEstimator () {}
-  
-      /** \brief Returns the number of branches the corresponding tree has. */
-      inline size_t 
-      getNumOfBranches () const 
-      { 
-        //return 2; 
-        return branch_estimator_->getNumOfBranches ();
+    feature.deserialize(stream);
+
+    stream.read(reinterpret_cast<char*>(&threshold), sizeof(threshold));
+
+    stream.read(reinterpret_cast<char*>(&value), sizeof(value));
+    stream.read(reinterpret_cast<char*>(&variance), sizeof(variance));
+
+    int num_of_sub_nodes;
+    stream.read(reinterpret_cast<char*>(&num_of_sub_nodes), sizeof(num_of_sub_nodes));
+    sub_nodes.resize(num_of_sub_nodes);
+
+    if (num_of_sub_nodes > 0) {
+      for (int sub_node_index = 0; sub_node_index < num_of_sub_nodes;
+           ++sub_node_index) {
+        sub_nodes[sub_node_index].deserialize(stream);
       }
+    }
+  }
 
-      /** \brief Returns the label of the specified node. 
-        * \param[in] node The node which label is returned.
-        */
-      inline LabelDataType 
-      getLabelOfNode (
-        NodeType & node) const
-      {
-        return node.value;
-      }
+public:
+  /** The feature associated with the node. */
+  FeatureType feature;
 
-      /** \brief Computes the information gain obtained by the specified threshold.
-        * \param[in] data_set The data set corresponding to the supplied result data.
-        * \param[in] examples The examples used for extracting the supplied result data.
-        * \param[in] label_data The label data corresponding to the specified examples.
-        * \param[in] results The results computed using the specified examples.
-        * \param[in] flags The flags corresponding to the results.
-        * \param[in] threshold The threshold for which the information gain is computed.
-        */
-      float 
-      computeInformationGain (
-        DataSet & data_set,
-        std::vector<ExampleIndex> & examples,
-        std::vector<LabelDataType> & label_data,
-        std::vector<float> & results,
-        std::vector<unsigned char> & flags,
-        const float threshold) const
-      {
-        const size_t num_of_examples = examples.size ();
-        const size_t num_of_branches = getNumOfBranches();
+  /** The threshold applied on the feature response. */
+  float threshold;
 
-        // compute variance
-        std::vector<LabelDataType> sums (num_of_branches+1, 0);
-        std::vector<LabelDataType> sqr_sums (num_of_branches+1, 0);
-        std::vector<size_t> branch_element_count (num_of_branches+1, 0);
+  /** The label value of this node. */
+  LabelType value;
 
-        for (size_t branch_index = 0; branch_index < num_of_branches; ++branch_index)
-        {
-          branch_element_count[branch_index] = 1;
-          ++branch_element_count[num_of_branches];
-        }
+  /** The variance of the labels that ended up at this node during training. */
+  LabelType variance;
 
-        for (size_t example_index = 0; example_index < num_of_examples; ++example_index)
-        {
-          unsigned char branch_index;
-          computeBranchIndex (results[example_index], flags[example_index], threshold, branch_index);
+  /** The child nodes. */
+  std::vector<RegressionVarianceNode> sub_nodes;
+};
 
-          LabelDataType label = label_data[example_index];
+/** Statistics estimator for regression trees which optimizes variance. */
+template <class LabelDataType, class NodeType, class DataSet, class ExampleIndex>
+class PCL_EXPORTS RegressionVarianceStatsEstimator
+: public pcl::StatsEstimator<LabelDataType, NodeType, DataSet, ExampleIndex> {
+public:
+  /** Constructor. */
+  RegressionVarianceStatsEstimator(BranchEstimator* branch_estimator)
+  : branch_estimator_(branch_estimator)
+  {}
 
-          sums[branch_index] += label;
-          sums[num_of_branches] += label;
+  /** Destructor. */
+  virtual ~RegressionVarianceStatsEstimator() {}
 
-          sqr_sums[branch_index] += label*label;
-          sqr_sums[num_of_branches] += label*label;
+  /** Returns the number of branches the corresponding tree has. */
+  inline size_t
+  getNumOfBranches() const
+  {
+    // return 2;
+    return branch_estimator_->getNumOfBranches();
+  }
 
-          ++branch_element_count[branch_index];
-          ++branch_element_count[num_of_branches];
-        }
+  /** Returns the label of the specified node.
+   *
+   * \param[in] node the node which label is returned
+   */
+  inline LabelDataType
+  getLabelOfNode(NodeType& node) const
+  {
+    return node.value;
+  }
 
-        std::vector<float> variances (num_of_branches+1, 0);
-        for (size_t branch_index = 0; branch_index < num_of_branches+1; ++branch_index)
-        {
-          const float mean_sum = static_cast<float>(sums[branch_index]) / branch_element_count[branch_index];
-          const float mean_sqr_sum = static_cast<float>(sqr_sums[branch_index]) / branch_element_count[branch_index];
-          variances[branch_index] = mean_sqr_sum - mean_sum*mean_sum;
-        }
+  /** Computes the information gain obtained by the specified threshold.
+   *
+   * \param[in] data_set the data set corresponding to the supplied result data
+   * \param[in] examples the examples used for extracting the supplied result data
+   * \param[in] label_data the label data corresponding to the specified examples
+   * \param[in] results the results computed using the specified examples
+   * \param[in] flags the flags corresponding to the results
+   * \param[in] threshold the threshold for which the information gain is computed
+   */
+  float
+  computeInformationGain(DataSet& data_set,
+                         std::vector<ExampleIndex>& examples,
+                         std::vector<LabelDataType>& label_data,
+                         std::vector<float>& results,
+                         std::vector<unsigned char>& flags,
+                         const float threshold) const
+  {
+    const size_t num_of_examples = examples.size();
+    const size_t num_of_branches = getNumOfBranches();
 
-        float information_gain = variances[num_of_branches];
-        for (size_t branch_index = 0; branch_index < num_of_branches; ++branch_index)
-        {
-          //const float weight = static_cast<float>(sums[branchIndex]) / sums[numOfBranches];
-          const float weight = static_cast<float>(branch_element_count[branch_index]) / static_cast<float>(branch_element_count[num_of_branches]);
-          information_gain -= weight*variances[branch_index];
-        }
+    // compute variance
+    std::vector<LabelDataType> sums(num_of_branches + 1, 0);
+    std::vector<LabelDataType> sqr_sums(num_of_branches + 1, 0);
+    std::vector<size_t> branch_element_count(num_of_branches + 1, 0);
 
-        return information_gain;
-      }
+    for (size_t branch_index = 0; branch_index < num_of_branches; ++branch_index) {
+      branch_element_count[branch_index] = 1;
+      ++branch_element_count[num_of_branches];
+    }
 
-      /** \brief Computes the branch indices for all supplied results.
-        * \param[in] results The results the branch indices will be computed for.
-        * \param[in] flags The flags corresponding to the specified results.
-        * \param[in] threshold The threshold used to compute the branch indices.
-        * \param[out] branch_indices The destination for the computed branch indices.
-        */
-      void 
-      computeBranchIndices (
-        std::vector<float> & results,
-        std::vector<unsigned char> & flags,
-        const float threshold,
-        std::vector<unsigned char> & branch_indices) const
-      {
-        const size_t num_of_results = results.size ();
-        const size_t num_of_branches = getNumOfBranches();
-
-        branch_indices.resize (num_of_results);
-        for (size_t result_index = 0; result_index < num_of_results; ++result_index)
-        {
-          unsigned char branch_index;
-          computeBranchIndex (results[result_index], flags[result_index], threshold, branch_index);
-          branch_indices[result_index] = branch_index;
-        }
-      }
-
-      /** \brief Computes the branch index for the specified result.
-        * \param[in] result The result the branch index will be computed for.
-        * \param[in] flag The flag corresponding to the specified result.
-        * \param[in] threshold The threshold used to compute the branch index.
-        * \param[out] branch_index The destination for the computed branch index.
-        */
-      inline void 
+    for (size_t example_index = 0; example_index < num_of_examples; ++example_index) {
+      unsigned char branch_index;
       computeBranchIndex(
-        const float result,
-        const unsigned char flag,
-        const float threshold,
-        unsigned char & branch_index) const
-      {
-        branch_estimator_->computeBranchIndex (result, flag, threshold, branch_index);
-        //branch_index = (result > threshold) ? 1 : 0;
-      }
+          results[example_index], flags[example_index], threshold, branch_index);
 
-      /** \brief Computes and sets the statistics for a node.
-        * \param[in] data_set The data set which is evaluated.
-        * \param[in] examples The examples which define which parts of the data set are used for evaluation.
-        * \param[in] label_data The label_data corresponding to the examples.
-        * \param[out] node The destination node for the statistics.
-        */
-      void 
-      computeAndSetNodeStats (
-        DataSet & data_set,
-        std::vector<ExampleIndex> & examples,
-        std::vector<LabelDataType> & label_data,
-        NodeType & node) const
-      {
-        const size_t num_of_examples = examples.size ();
+      LabelDataType label = label_data[example_index];
 
-        LabelDataType sum = 0.0f;
-        LabelDataType sqr_sum = 0.0f;
-        for (size_t example_index = 0; example_index < num_of_examples; ++example_index)
-        {
-          const LabelDataType label = label_data[example_index];
+      sums[branch_index] += label;
+      sums[num_of_branches] += label;
 
-          sum += label;
-          sqr_sum += label*label;
-        }
+      sqr_sums[branch_index] += label * label;
+      sqr_sums[num_of_branches] += label * label;
 
-        sum /= num_of_examples;
-        sqr_sum /= num_of_examples;
+      ++branch_element_count[branch_index];
+      ++branch_element_count[num_of_branches];
+    }
 
-        const float variance = sqr_sum - sum*sum;
+    std::vector<float> variances(num_of_branches + 1, 0);
+    for (size_t branch_index = 0; branch_index < num_of_branches + 1; ++branch_index) {
+      const float mean_sum =
+          static_cast<float>(sums[branch_index]) / branch_element_count[branch_index];
+      const float mean_sqr_sum = static_cast<float>(sqr_sums[branch_index]) /
+                                 branch_element_count[branch_index];
+      variances[branch_index] = mean_sqr_sum - mean_sum * mean_sum;
+    }
 
-        node.value = sum;
-        node.variance = variance;
-      }
+    float information_gain = variances[num_of_branches];
+    for (size_t branch_index = 0; branch_index < num_of_branches; ++branch_index) {
+      // const float weight = static_cast<float>(sums[branchIndex]) /
+      // sums[numOfBranches];
+      const float weight = static_cast<float>(branch_element_count[branch_index]) /
+                           static_cast<float>(branch_element_count[num_of_branches]);
+      information_gain -= weight * variances[branch_index];
+    }
 
-      /** \brief Generates code for branch index computation.
-        * \param[in] node The node for which code is generated.
-        * \param[out] stream The destination for the generated code.
-        */
-      void 
-      generateCodeForBranchIndexComputation (
-        NodeType & node,
-        std::ostream & stream) const
-      {
-        stream << "ERROR: RegressionVarianceStatsEstimator does not implement generateCodeForBranchIndex(...)";
-      }
+    return information_gain;
+  }
 
-      /** \brief Generates code for label output.
-        * \param[in] node The node for which code is generated.
-        * \param[out] stream The destination for the generated code.
-        */
-      void 
-      generateCodeForOutput (
-        NodeType & node,
-        std::ostream & stream) const
-      {
-        stream << "ERROR: RegressionVarianceStatsEstimator does not implement generateCodeForBranchIndex(...)";
-      }
+  /** Computes the branch indices for all supplied results.
+   *
+   * \param[in] results the results the branch indices will be computed for
+   * \param[in] flags the flags corresponding to the specified results
+   * \param[in] threshold the threshold used to compute the branch indices
+   * \param[out] branch_indices the destination for the computed branch indices
+   */
+  void
+  computeBranchIndices(std::vector<float>& results,
+                       std::vector<unsigned char>& flags,
+                       const float threshold,
+                       std::vector<unsigned char>& branch_indices) const
+  {
+    const size_t num_of_results = results.size();
+    const size_t num_of_branches = getNumOfBranches();
 
-    private:
-      /** \brief The branch estimator. */
-      pcl::BranchEstimator * branch_estimator_;
-  };
+    branch_indices.resize(num_of_results);
+    for (size_t result_index = 0; result_index < num_of_results; ++result_index) {
+      unsigned char branch_index;
+      computeBranchIndex(
+          results[result_index], flags[result_index], threshold, branch_index);
+      branch_indices[result_index] = branch_index;
+    }
+  }
 
-}
+  /** Computes the branch index for the specified result.
+   *
+   * \param[in] result the result the branch index will be computed for
+   * \param[in] flag the flag corresponding to the specified result
+   * \param[in] threshold the threshold used to compute the branch index
+   * \param[out] branch_index the destination for the computed branch index
+   */
+  inline void
+  computeBranchIndex(const float result,
+                     const unsigned char flag,
+                     const float threshold,
+                     unsigned char& branch_index) const
+  {
+    branch_estimator_->computeBranchIndex(result, flag, threshold, branch_index);
+    // branch_index = (result > threshold) ? 1 : 0;
+  }
+
+  /** Computes and sets the statistics for a node.
+   *
+   * \param[in] data_set the data set which is evaluated
+   * \param[in] examples the examples which define which parts of the data set are use
+   *            for evaluation
+   * \param[in] label_data the label_data corresponding to the examples
+   * \param[out] node the destination node for the statistics
+   */
+  void
+  computeAndSetNodeStats(DataSet& data_set,
+                         std::vector<ExampleIndex>& examples,
+                         std::vector<LabelDataType>& label_data,
+                         NodeType& node) const
+  {
+    const size_t num_of_examples = examples.size();
+
+    LabelDataType sum = 0.0f;
+    LabelDataType sqr_sum = 0.0f;
+    for (size_t example_index = 0; example_index < num_of_examples; ++example_index) {
+      const LabelDataType label = label_data[example_index];
+
+      sum += label;
+      sqr_sum += label * label;
+    }
+
+    sum /= num_of_examples;
+    sqr_sum /= num_of_examples;
+
+    const float variance = sqr_sum - sum * sum;
+
+    node.value = sum;
+    node.variance = variance;
+  }
+
+  /** Generates code for branch index computation.
+   *
+   * \param[in] node the node for which code is generated
+   * \param[out] stream the destination for the generated code
+   */
+  void
+  generateCodeForBranchIndexComputation(NodeType& node, std::ostream& stream) const
+  {
+    stream << "ERROR: RegressionVarianceStatsEstimator does not implement "
+              "generateCodeForBranchIndex(...)";
+  }
+
+  /** Generates code for label output.
+   *
+   * \param[in] node the node for which code is generated
+   * \param[out] stream the destination for the generated code
+   */
+  void
+  generateCodeForOutput(NodeType& node, std::ostream& stream) const
+  {
+    stream << "ERROR: RegressionVarianceStatsEstimator does not implement "
+              "generateCodeForBranchIndex(...)";
+  }
+
+private:
+  /// The branch estimator
+  pcl::BranchEstimator* branch_estimator_;
+};
+
+} // namespace pcl

--- a/ml/include/pcl/ml/stats_estimator.h
+++ b/ml/include/pcl/ml/stats_estimator.h
@@ -34,7 +34,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
-  
+
 #pragma once
 
 #include <pcl/common/common.h>
@@ -42,101 +42,104 @@
 #include <ostream>
 #include <vector>
 
-namespace pcl
-{
+namespace pcl {
 
-  /** \brief Class interface for gathering statistics for decision tree learning. */
-  template <
-    class LabelDataType, 
-    class NodeType, 
-    class DataSet,
-    class ExampleIndex >
-  class PCL_EXPORTS StatsEstimator
-  {
-  
-    public:
+/** Class interface for gathering statistics for decision tree learning. */
+template <class LabelDataType, class NodeType, class DataSet, class ExampleIndex>
+class PCL_EXPORTS StatsEstimator {
 
-      /** \brief Destructor. */
-      virtual 
-      ~StatsEstimator () {};
+public:
+  /** Destructor. */
+  virtual ~StatsEstimator(){};
 
-      /** \brief Returns the number of brances a node can have (e.g. a binary tree has 2). */
-      virtual size_t 
-      getNumOfBranches () const = 0;
+  /** Returns the number of brances a node can have (e.g. a binary tree has 2). */
+  virtual size_t
+  getNumOfBranches() const = 0;
 
-      /** \brief Computes and sets the statistics for a node. 
-        * \param[in] data_set The data set used for training.
-        * \param[in] examples The examples used for computing the statistics for the specified node.
-        * \param[in] label_data The labels corresponding to the examples.
-        * \param[out] node The destination node for the statistics.
-        */
-      virtual void 
-      computeAndSetNodeStats (DataSet & data_set,
-                              std::vector<ExampleIndex> & examples,
-                              std::vector<LabelDataType> & label_data,
-                              NodeType & node ) const = 0;
+  /** Computes and sets the statistics for a node.
+   *
+   * \param[in] data_set the data set used for training
+   * \param[in] examples the examples used for computing the statistics for the
+   *            specified node
+   * \param[in] label_data the labels corresponding to the examples
+   * \param[out] node The destination node for the statistics
+   */
+  virtual void
+  computeAndSetNodeStats(DataSet& data_set,
+                         std::vector<ExampleIndex>& examples,
+                         std::vector<LabelDataType>& label_data,
+                         NodeType& node) const = 0;
 
-      /** \brief Returns the label of the specified node. 
-        * \param[in] node The node from which the label is extracted. */
-      virtual LabelDataType 
-      getLabelOfNode (NodeType & node) const = 0;
+  /** Returns the label of the specified node.
+   *
+   * \param[in] node The node from which the label is extracted
+   */
+  virtual LabelDataType
+  getLabelOfNode(NodeType& node) const = 0;
 
-      /** \brief Computes the information gain obtained by the specified threshold on the supplied feature evaluation results.
-        * \param[in] data_set The data set used for extracting the supplied result values.
-        * \param[in] examples The examples used to extract the supplied result values.
-        * \param[in] label_data The labels corresponding to the examples.
-        * \param[in] results The results obtained from the feature evaluation.
-        * \param[in] flags The flags obtained together with the results.
-        * \param[in] threshold The threshold which is used to compute the information gain.
-        */
-      virtual float 
-      computeInformationGain (DataSet & data_set,
-                              std::vector<ExampleIndex> & examples,
-                              std::vector<LabelDataType> & label_data,
-                              std::vector<float> & results,
-                              std::vector<unsigned char> & flags,
-                              const float threshold) const = 0;
+  /** Computes the information gain obtained by the specified threshold on the supplied
+   *  feature evaluation results.
+   *
+   * \param[in] data_set the data set used for extracting the supplied result values.
+   * \param[in] examples the examples used to extract the supplied result values
+   * \param[in] label_data the labels corresponding to the examples
+   * \param[in] results the results obtained from the feature evaluation
+   * \param[in] flags the flags obtained together with the results
+   * \param[in] threshold the threshold which is used to compute the information gain
+   */
+  virtual float
+  computeInformationGain(DataSet& data_set,
+                         std::vector<ExampleIndex>& examples,
+                         std::vector<LabelDataType>& label_data,
+                         std::vector<float>& results,
+                         std::vector<unsigned char>& flags,
+                         const float threshold) const = 0;
 
-      /** \brief Computes the branch indices obtained by the specified threshold on the supplied feature evaluation results.
-        * \param[in] results The results obtained from the feature evaluation.
-        * \param[in] flags The flags obtained together with the results.
-        * \param[in] threshold The threshold which is used to compute the branch indices.
-        * \param[out] branch_indices The destination for the computed branch indices.
-        */
-      virtual void 
-      computeBranchIndices (std::vector<float> & results,
-                            std::vector<unsigned char> & flags,
-                            const float threshold,
-                            std::vector<unsigned char> & branch_indices) const = 0;
+  /** Computes the branch indices obtained by the specified threshold on the supplied
+   *  feature evaluation results.
+   *
+   * \param[in] results the results obtained from the feature evaluation
+   * \param[in] flags the flags obtained together with the results.
+   * \param[in] threshold the threshold which is used to compute the branch indices
+   * \param[out] branch_indices the destination for the computed branch indices.
+   */
+  virtual void
+  computeBranchIndices(std::vector<float>& results,
+                       std::vector<unsigned char>& flags,
+                       const float threshold,
+                       std::vector<unsigned char>& branch_indices) const = 0;
 
-      /** \brief Computes the branch indices obtained by the specified threshold on the supplied feature evaluation results.
-        * \param[in] result The result obtained from the feature evaluation.
-        * \param[in] flag The flag obtained together with the result.
-        * \param[in] threshold The threshold which is used to compute the branch index.
-        * \param[out] branch_index The destination for the computed branch index.
-        */
-      virtual void 
-      computeBranchIndex (const float result,
-                          const unsigned char flag,
-                          const float threshold,
-                          unsigned char & branch_index) const = 0;
+  /** Computes the branch indices obtained by the specified threshold on the supplied
+   *  feature evaluation results.
+   *
+   * \param[in] result the result obtained from the feature evaluation
+   * \param[in] flag the flag obtained together with the result
+   * \param[in] threshold the threshold which is used to compute the branch index
+   * \param[out] branch_index the destination for the computed branch index
+   */
+  virtual void
+  computeBranchIndex(const float result,
+                     const unsigned char flag,
+                     const float threshold,
+                     unsigned char& branch_index) const = 0;
 
-      /** \brief Generates code for computing the branch indices for the specified node and writes it to the specified stream.
-        * \param[in] node The node for which the branch index estimation code is generated.
-        * \param[out] stream The destination for the code.
-        */
-      virtual void 
-      generateCodeForBranchIndexComputation (NodeType & node,
-                                             std::ostream & stream) const = 0;
+  /** Generates code for computing the branch indices for the specified node and writes
+   *  it to the specified stream.
+   *
+   * \param[in] node the node for which the branch index estimation code is generated
+   * \param[out] stream the destination for the code
+   */
+  virtual void
+  generateCodeForBranchIndexComputation(NodeType& node, std::ostream& stream) const = 0;
 
-      /** \brief Generates code for computing the output for the specified node and writes it to the specified stream.
-        * \param[in] node The node for which the output estimation code is generated.
-        * \param[out] stream The destination for the code.
-        */
-      virtual void 
-      generateCodeForOutput (NodeType & node,
-                             std::ostream & stream ) const = 0;
+  /** Generates code for computing the output for the specified node and writes it to
+   *  the specified stream.
+   *
+   * \param[in] node the node for which the output estimation code is generated
+   * \param[out] stream the destination for the code
+   */
+  virtual void
+  generateCodeForOutput(NodeType& node, std::ostream& stream) const = 0;
+};
 
-  };
-
-}
+} // namespace pcl

--- a/ml/include/pcl/ml/svm.h
+++ b/ml/include/pcl/ml/svm.h
@@ -1,159 +1,182 @@
- /*
-  * Software License Agreement (BSD License)
-  *
-  *  Point Cloud Library (PCL) - www.pointclouds.org
-  *  Copyright (c) 2010-2012, Willow Garage, Inc.
-  *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
-  *
-  *  All rights reserved.
-  *
-  *  Redistribution and use in source and binary forms, with or without
-  *  modification, are permitted provided that the following conditions
-  *  are met:
-  *
-  *   * Redistributions of source code must retain the above copyright
-  *     notice, this list of conditions and the following disclaimer.
-  *   * Redistributions in binary form must reproduce the above
-  *     copyright notice, this list of conditions and the following
-  *     disclaimer in the documentation and/or other materials provided
-  *     with the distribution.
-  *   * Neither the name of copyright holders nor the names of its
-  *     contributors may be used to endorse or promote products derived
-  *     from this software without specific prior written permission.
-  *
-  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-  *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-  *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  *  POSSIBILITY OF SUCH DAMAGE.
-  *
-  */
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 #pragma once
 
 #define LIBSVM_VERSION 311
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-  extern int libsvm_version;
+extern int libsvm_version;
 
-  struct svm_node
-  {
-    int index;
-    double value;
-  };
+struct svm_node {
+  int index;
+  double value;
+};
 
-  struct svm_problem
-  {
-    int l;
-    double *y;
+struct svm_problem {
+  int l;
+  double* y;
 
-    struct svm_node **x;
-  };
+  struct svm_node** x;
+};
 
-  struct svm_scaling
-  {
-    // index = 1 if usable, index = 0 if not
+struct svm_scaling {
+  // index = 1 if usable, index = 0 if not
 
-    struct svm_node *obj;
+  struct svm_node* obj;
 
-    // max features scaled
-    int max;
-    
-    svm_scaling() : max(0)
-    {
-    }
-  };
+  // max features scaled
+  int max;
 
-  enum { C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR }; /* svm_type */
-  enum { LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED }; /* kernel_type */
+  svm_scaling() : max(0) {}
+};
 
-  struct svm_parameter
-  {
-    int svm_type;
-    int kernel_type;
-    int degree; /* for poly */
-    double gamma; /* for poly/rbf/sigmoid */
-    double coef0; /* for poly/sigmoid */
+enum { C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR }; /* svm_type */
+enum { LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED };       /* kernel_type */
 
-    /* these are for training only */
-    double cache_size; /* in MB */
-    double eps; /* stopping criteria */
-    double C; /* for C_SVC, EPSILON_SVR and NU_SVR */
-    int nr_weight;  /* for C_SVC */
-    int *weight_label; /* for C_SVC */
-    double* weight;  /* for C_SVC */
-    double nu; /* for NU_SVC, ONE_CLASS, and NU_SVR */
-    double p; /* for EPSILON_SVR */
-    int shrinking; /* use the shrinking heuristics */
-    int probability; /* do probability estimates */
-  };
+struct svm_parameter {
+  int svm_type;
+  int kernel_type;
+  int degree;   /* for poly */
+  double gamma; /* for poly/rbf/sigmoid */
+  double coef0; /* for poly/sigmoid */
+
+  /* these are for training only */
+  double cache_size; /* in MB */
+  double eps;        /* stopping criteria */
+  double C;          /* for C_SVC, EPSILON_SVR and NU_SVR */
+  int nr_weight;     /* for C_SVC */
+  int* weight_label; /* for C_SVC */
+  double* weight;    /* for C_SVC */
+  double nu;         /* for NU_SVC, ONE_CLASS, and NU_SVR */
+  double p;          /* for EPSILON_SVR */
+  int shrinking;     /* use the shrinking heuristics */
+  int probability;   /* do probability estimates */
+};
 
 //
 // svm_model
 //
 
-  struct svm_model
-  {
+struct svm_model {
 
-    struct svm_parameter param; /* parameter */
-    int nr_class;  /* number of classes, = 2 in regression/one class svm */
-    int l;   /* total #SV */
+  struct svm_parameter param; /* parameter */
+  int nr_class;               /* number of classes, = 2 in regression/one class svm */
+  int l;                      /* total #SV */
 
-    struct svm_node **SV;  /* SVs (SV[l]) */
-    double **sv_coef; /* coefficients for SVs in decision functions (sv_coef[k-1][l]) */
-    double *rho;  /* constants in decision functions (rho[k*(k-1)/2]) */
-    double *probA;  /* pariwise probability information */
-    double *probB;
+  struct svm_node** SV; /* SVs (SV[l]) */
+  double** sv_coef; /* coefficients for SVs in decision functions (sv_coef[k-1][l]) */
+  double* rho;      /* constants in decision functions (rho[k*(k-1)/2]) */
+  double* probA;    /* pariwise probability information */
+  double* probB;
 
-    /* for classification only */
+  /* for classification only */
 
-    int *label;  /* label of each class (label[k]) */
-    int *nSV;  /* number of SVs for each class (nSV[k]) */
-    /* nSV[0] + nSV[1] + ... + nSV[k-1] = l */
-    /* XXX */
-    int free_sv;  /* 1 if svm_model is created by svm_load_model*/
-    /* 0 if svm_model is created by svm_train */
+  int* label; /* label of each class (label[k]) */
+  int* nSV;   /* number of SVs for each class (nSV[k]) */
+  /* nSV[0] + nSV[1] + ... + nSV[k-1] = l */
+  /* XXX */
+  int free_sv; /* 1 if svm_model is created by svm_load_model*/
+  /* 0 if svm_model is created by svm_train */
 
-    /* for scaling */
+  /* for scaling */
 
-    struct svm_node *scaling;
-  };
+  struct svm_node* scaling;
+};
 
-  struct svm_model *svm_train (const struct svm_problem *prob, const struct svm_parameter *param);
-  void svm_cross_validation (const struct svm_problem *prob, const struct svm_parameter *param, int nr_fold, double *target);
+struct svm_model*
+svm_train(const struct svm_problem* prob, const struct svm_parameter* param);
+void
+svm_cross_validation(const struct svm_problem* prob,
+                     const struct svm_parameter* param,
+                     int nr_fold,
+                     double* target);
 
-  int svm_save_model (const char *model_file_name, const struct svm_model *model);
+int
+svm_save_model(const char* model_file_name, const struct svm_model* model);
 
-  struct svm_model *svm_load_model (const char *model_file_name);
+struct svm_model*
+svm_load_model(const char* model_file_name);
 
-  int svm_get_svm_type (const struct svm_model *model);
-  int svm_get_nr_class (const struct svm_model *model);
-  void svm_get_labels (const struct svm_model *model, int *label);
-  double svm_get_svr_probability (const struct svm_model *model);
+int
+svm_get_svm_type(const struct svm_model* model);
 
-  double svm_predict_values (const struct svm_model *model, const struct svm_node *x, double* dec_values);
-  double svm_predict (const struct svm_model *model, const struct svm_node *x);
-  double svm_predict_probability (const struct svm_model *model, const struct svm_node *x, double* prob_estimates);
+int
+svm_get_nr_class(const struct svm_model* model);
 
-  void svm_free_model_content (struct svm_model *model_ptr);
-  void svm_free_and_destroy_model (struct svm_model **model_ptr_ptr);
-  void svm_destroy_param (struct svm_parameter *param);
+void
+svm_get_labels(const struct svm_model* model, int* label);
 
-  const char *svm_check_parameter (const struct svm_problem *prob, const struct svm_parameter *param);
-  int svm_check_probability_model (const struct svm_model *model);
+double
+svm_get_svr_probability(const struct svm_model* model);
 
-  void svm_set_print_string_function (void (*print_func) (const char *));
+double
+svm_predict_values(const struct svm_model* model,
+                   const struct svm_node* x,
+                   double* dec_values);
+double
+svm_predict(const struct svm_model* model, const struct svm_node* x);
+
+double
+svm_predict_probability(const struct svm_model* model,
+                        const struct svm_node* x,
+                        double* prob_estimates);
+
+void
+svm_free_model_content(struct svm_model* model_ptr);
+
+void
+svm_free_and_destroy_model(struct svm_model** model_ptr_ptr);
+
+void
+svm_destroy_param(struct svm_parameter* param);
+
+const char*
+svm_check_parameter(const struct svm_problem* prob, const struct svm_parameter* param);
+
+int
+svm_check_probability_model(const struct svm_model* model);
+
+void
+svm_set_print_string_function(void (*print_func)(const char*));
 
 #ifdef __cplusplus
 }

--- a/ml/include/pcl/ml/svm_wrapper.h
+++ b/ml/include/pcl/ml/svm_wrapper.h
@@ -1,531 +1,568 @@
- /*
-  * Software License Agreement (BSD License)
-  *
-  *  Point Cloud Library (PCL) - www.pointclouds.org
-  *  Copyright (c) 2010-2012, Willow Garage, Inc.
-  *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
-  *
-  *  All rights reserved.
-  *
-  *  Redistribution and use in source and binary forms, with or without
-  *  modification, are permitted provided that the following conditions
-  *  are met:
-  *
-  *   * Redistributions of source code must retain the above copyright
-  *     notice, this list of conditions and the following disclaimer.
-  *   * Redistributions in binary form must reproduce the above
-  *     copyright notice, this list of conditions and the following
-  *     disclaimer in the documentation and/or other materials provided
-  *     with the distribution.
-  *   * Neither the name of copyright holders nor the names of its
-  *     contributors may be used to endorse or promote products derived
-  *     from this software without specific prior written permission.
-  *
-  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-  *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-  *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  *  POSSIBILITY OF SUCH DAMAGE.
-  *
-  */
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 #pragma once
 
+#include <cctype>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cctype>
-#include <cerrno>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <pcl/common/eigen.h>
 #include <vector>
 
 #include <pcl/ml/svm.h>
-#define Malloc(type,n) static_cast<type *> (malloc((n)*sizeof(type)))
+#define Malloc(type, n) static_cast<type*>(malloc((n) * sizeof(type)))
 
-namespace pcl
-{
+namespace pcl {
 
-  /** \brief The structure stores the parameters for the classificationa nd
-   * must be initialized and passed to the training method pcl::SVMTrain.
-   *  \param svm_type {C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR}
-   *  \param kernel_type {LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED}
-   *  \param probability sets the probability estimates
-   */
-  struct SVMParam: svm_parameter
+/** The structure stores the parameters for the classificationa nd must be initialized
+ *  and passed to the training method pcl::SVMTrain.
+ *
+ * \param svm_type {C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR}
+ * \param kernel_type {LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED}
+ * \param probability sets the probability estimates
+ */
+struct SVMParam : svm_parameter {
+  SVMParam()
   {
-    SVMParam ()
-    {
-      svm_type = C_SVC; // C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR
-      kernel_type = RBF; // LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED
-      degree = 3; // for poly
-      gamma = 0; // 1/num_features {for poly/rbf/sigmoid}
-      coef0 = 0; //  for poly/sigmoid
+    svm_type = C_SVC;  // C_SVC, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR
+    kernel_type = RBF; // LINEAR, POLY, RBF, SIGMOID, PRECOMPUTED
+    degree = 3;        // for poly
+    gamma = 0;         // 1/num_features {for poly/rbf/sigmoid}
+    coef0 = 0;         //  for poly/sigmoid
 
-      nu = 0.5; // for NU_SVC, ONE_CLASS, and NU_SVR
-      cache_size = 100; // in MB
-      C = 1; // for C_SVC, EPSILON_SVR and NU_SVR
-      eps = 1e-3; // stopping criteria
-      p = 0.1; // for EPSILON_SVR
-      shrinking = 0; // use the shrinking heuristics
-      probability = 0; // do probability estimates
+    nu = 0.5;         // for NU_SVC, ONE_CLASS, and NU_SVR
+    cache_size = 100; // in MB
+    C = 1;            // for C_SVC, EPSILON_SVR and NU_SVR
+    eps = 1e-3;       // stopping criteria
+    p = 0.1;          // for EPSILON_SVR
+    shrinking = 0;    // use the shrinking heuristics
+    probability = 0;  // do probability estimates
 
-      nr_weight = 0; // for C_SVC
-      weight_label = nullptr; // for C_SVC
-      weight = nullptr; // for C_SVC
+    nr_weight = 0;          // for C_SVC
+    weight_label = nullptr; // for C_SVC
+    weight = nullptr;       // for C_SVC
+  }
+};
+
+/** The structure initialize a model created by the SVM (Support Vector Machines)
+ *  classifier (pcl::SVMTrain).
+ */
+struct SVMModel : svm_model {
+  SVMModel()
+  {
+    l = 0;
+    probA = nullptr;
+    probB = nullptr;
+  }
+};
+
+/** The structure initialize a single feature value for the classification using
+ *  SVM (Support Vector Machines).
+ */
+struct SVMDataPoint {
+  /// It's the feature index. It has to be an integer number greater or equal to zero
+  int idx;
+  /// The value assigned to the correspondent feature.
+  float value;
+
+  SVMDataPoint() : idx(-1), value(0) {}
+};
+
+/** The structure stores the features and the label of a single sample which has to be
+ *  used for the training or the classification of the SVM (Support Vector Machines).
+ */
+struct SVMData {
+  /// Pointer to the label value. It is a mandatory to train the classifier
+  double label;
+  /// Vector of features for the specific sample.
+  std::vector<pcl::SVMDataPoint> SV;
+
+  SVMData() : label(std::numeric_limits<double>::signaling_NaN()) {}
+};
+
+/** Base class for SVM SVM (Support Vector Machines). */
+class SVM {
+protected:
+  std::vector<SVMData> training_set_; // Basic training set
+  svm_problem prob_;    // contains the problem (vector of samples with their features)
+  SVMModel model_;      // model of the classifier
+  svm_scaling scaling_; // for the best model training, the input dataset is scaled and
+                        // the scaling factors are stored here
+  SVMParam param_;      // it stores the training parameters
+  std::string class_name_; // The SVM class name.
+
+  char* line_;                 // buffer for line reading
+  int max_line_len_;           // max line length in the input file
+  bool labelled_training_set_; // it stores whether the input set of samples is labelled
+
+  /** Set for output printings during classification. */
+  static void
+  printNull(const char*){};
+
+  /** To read a line from the input file. Stored in "line_". */
+  char*
+  readline(FILE* input);
+
+  /** Outputs an error in file reading. */
+  void
+  exitInputError(int line_num)
+  {
+    fprintf(stderr, "Wrong input format at line %d\n", line_num);
+    exit(1);
+  }
+
+  /** Get a string representation of the name of this class. */
+  inline const std::string&
+  getClassName() const
+  {
+    return (class_name_);
+  }
+
+  /** Convert the input format (vector of SVMData) into a readable format for libSVM. */
+  void
+  adaptInputToLibSVM(std::vector<SVMData> training_set, svm_problem& prob);
+
+  /** Convert the libSVM format (svm_problem) into a easier output format. */
+  void
+  adaptLibSVMToInput(std::vector<SVMData>& training_set, svm_problem prob);
+
+  /** Load a problem from an extern file. */
+  bool
+  loadProblem(const char* filename, svm_problem& prob);
+
+  /** Save the raw problem in an extern file.*/
+  bool
+  saveProblem(const char* filename, bool labelled);
+
+  /** Save the problem (with normalized values) in an extern file.*/
+  bool
+  saveProblemNorm(const char* filename, svm_problem prob_, bool labelled);
+
+public:
+  /**  Constructor. */
+  SVM() : prob_(), line_(nullptr), max_line_len_(10000), labelled_training_set_(true) {}
+
+  /** Destructor. */
+  ~SVM()
+  {
+    svm_destroy_param(&param_); // delete parameters
+
+    if (scaling_.max > 0)
+      free(scaling_.obj); // delete scaling factors
+
+    // delete the problem
+    if (prob_.l > 0) {
+      free(prob_.x);
+      free(prob_.y);
+    }
+  }
+
+  /** Return the labels order from the classifier model. */
+  void
+  getLabel(std::vector<int>& labels)
+  {
+    int nr_class = svm_get_nr_class(&model_);
+    int* labels_ = static_cast<int*>(malloc(nr_class * sizeof(int)));
+    svm_get_labels(&model_, labels_);
+
+    for (int j = 0; j < nr_class; j++)
+      labels.push_back(labels_[j]);
+
+    free(labels_);
+  };
+
+  /** Save the classifier model in an extern file (in svmlight format). */
+  void
+  saveClassifierModel(const char* filename)
+  {
+    // exit if model has no data
+    if (model_.l == 0)
+      return;
+
+    if (svm_save_model(filename, &model_)) {
+      fprintf(stderr, "can't save model to file %s\n", filename);
+      exit(1);
     }
   };
+};
 
-  /** \brief The structure initialize a model created by the SVM (Support Vector Machines) classifier (pcl::SVMTrain)
-   */
-  struct SVMModel: svm_model
+/** SVM (Support Vector Machines) training class for the SVM machine learning.
+ *
+ *  It creates a model for the classifier from a labelled input dataset.
+ *
+ *  OPTIONAL: pcl::SVMParam has to be given as input to vary the default training method
+ *  and parameters.
+ */
+class SVMTrain : public SVM {
+protected:
+  using SVM::class_name_;
+  using SVM::labelled_training_set_;
+  using SVM::line_;
+  using SVM::max_line_len_;
+  using SVM::model_;
+  using SVM::param_;
+  using SVM::prob_;
+  using SVM::scaling_;
+  using SVM::training_set_;
+
+  /// Set to 1 to see the training output
+  bool debug_;
+  /// Set too 1 for cross validating the classifier
+  int cross_validation_;
+  /// Number of folds to be used during cross validation. It indicates in how many parts
+  /// is split the input training set.
+  int nr_fold_;
+
+  /** To cross validate the classifier. It is automatic for probability estimate. */
+  void
+  doCrossValidation();
+
+  /** It extracts scaling factors from the input training_set.
+   *
+   *  The scaling of the training_set is a mandatory for a good training of the
+   *  classifier. */
+  void
+  scaleFactors(std::vector<SVMData> training_set, svm_scaling& scaling);
+
+public:
+  /** Constructor. */
+  SVMTrain() : debug_(false), cross_validation_(0), nr_fold_(0)
   {
-    SVMModel ()
-    {
-      l = 0;
-      probA = nullptr;
-      probB = nullptr;
+    class_name_ = "SVMTrain";
+    svm_set_print_string_function(
+        &printNull); // Default to NULL to not print debugging info
+  }
+
+  /** Destructor. */
+  ~SVMTrain()
+  {
+    if (model_.l > 0)
+      svm_free_model_content(&model_);
+  }
+
+  /** Change default training parameters (pcl::SVMParam). */
+  void
+  setParameters(SVMParam param)
+  {
+    param_ = param;
+  }
+
+  /** Return the current training parameters. */
+  SVMParam
+  getParameters()
+  {
+    return param_;
+  }
+
+  /** Return the result of the training. */
+  SVMModel
+  getClassifierModel()
+  {
+    return model_;
+  }
+
+  /** It adds/store the training set with labelled data. */
+  void
+  setInputTrainingSet(std::vector<SVMData> training_set)
+  {
+    training_set_.insert(training_set_.end(), training_set.begin(), training_set.end());
+  }
+
+  /** Return the current training set. */
+  std::vector<SVMData>
+  getInputTrainingSet()
+  {
+    return training_set_;
+  }
+
+  /** Reset the training set. */
+  void
+  resetTrainingSet()
+  {
+    training_set_.clear();
+  }
+
+  /** Start the training of the SVM classifier.
+   *
+   * \return false if fails
+   */
+  bool
+  trainClassifier();
+
+  /** Read in a problem (in svmlight format).
+   *
+   * \return false if fails
+   */
+  bool
+  loadProblem(const char* filename)
+  {
+    return SVM::loadProblem(filename, prob_);
+  };
+
+  /** Set to 1 for debugging info. */
+  void
+  setDebugMode(bool in)
+  {
+    debug_ = in;
+
+    if (in)
+      svm_set_print_string_function(nullptr);
+    else
+      svm_set_print_string_function(&printNull);
+  };
+
+  /** Save the raw training set in a file (in svmlight format).
+   *
+   * \return false if fails
+   */
+  bool
+  saveTrainingSet(const char* filename)
+  {
+    return SVM::saveProblem(filename, true);
+  };
+
+  /** Save the normalized training set in a file (in svmlight format).
+   *
+   * \return false if fails
+   */
+  bool
+  saveNormTrainingSet(const char* filename)
+  {
+    return SVM::saveProblemNorm(filename, prob_, true);
+  };
+};
+
+/** SVM (Support Vector Machines) classification of a dataset.
+ *
+ *  It can be used both for testing a classifier model and for classify of new data.
+ */
+class SVMClassify : public SVM {
+protected:
+  using SVM::class_name_;
+  using SVM::labelled_training_set_;
+  using SVM::line_;
+  using SVM::max_line_len_;
+  using SVM::model_;
+  using SVM::param_;
+  using SVM::prob_;
+  using SVM::scaling_;
+  using SVM::training_set_;
+
+  bool model_extern_copied_; // Set to 0 if the model is loaded from an extern file.
+  bool predict_probability_; // Set to 1 to predict probabilities.
+  std::vector<std::vector<double>> prediction_; // It stores the resulting prediction.
+
+  /** It scales the input dataset using the model information. */
+  void
+  scaleProblem(svm_problem& input, svm_scaling scaling);
+
+public:
+  /** Constructor. */
+  SVMClassify() : model_extern_copied_(false), predict_probability_(false)
+  {
+    class_name_ = "SvmClassify";
+  }
+
+  /** Destructor. */
+  ~SVMClassify()
+  {
+    if (!model_extern_copied_ && model_.l > 0)
+      svm_free_model_content(&model_);
+  }
+
+  /** It adds/store the training set with labelled data. */
+  void
+  setInputTrainingSet(std::vector<SVMData> training_set)
+  {
+    assert(training_set.size() > 0);
+
+    if (scaling_.max == 0) {
+      // to be sure to have loaded the scaling
+      PCL_ERROR("[pcl::%s::setInputTrainingSet] Classifier model not loaded!\n",
+                getClassName().c_str());
+      return;
     }
-  };
 
-  /** \brief The structure initialize a single feature value for the classification using SVM (Support Vector Machines).
-   */
-  struct SVMDataPoint
+    training_set_.insert(training_set_.end(), training_set.begin(), training_set.end());
+    SVM::adaptInputToLibSVM(training_set_, prob_);
+  }
+
+  /** Return the current training set. */
+  std::vector<SVMData>
+  getInputTrainingSet()
   {
-    int idx; // It's the feature index. It has to be an integer number greater or equal to zero.
-    float value; // The value assigned to the correspondent feature.
+    return training_set_;
+  }
 
-    SVMDataPoint () : idx (-1), value (0)
-    {
+  /** Reset the training set. */
+  void
+  resetTrainingSet()
+  {
+    training_set_.clear();
+  }
+
+  /** Read in a classifier model (in svmlight format).
+   *
+   * \return false if fails
+   */
+  bool
+  loadClassifierModel(const char* filename);
+
+  /** Get the result of the classification. */
+  void
+  getClassificationResult(std::vector<std::vector<double>>& out)
+  {
+    out.clear();
+    out.insert(out.begin(), prediction_.begin(), prediction_.end());
+  }
+
+  /** Save the classification result in an extern file. */
+  void
+  saveClassificationResult(const char* filename);
+
+  /** Set the classifier model. */
+  void
+  setClassifierModel(SVMModel model)
+  {
+    // model (inner pointers are references)
+    model_ = model;
+    int i = 0;
+
+    while (model_.scaling[i].index != -1)
+      i++;
+
+    scaling_.max = i;
+    scaling_.obj = Malloc(struct svm_node, i + 1);
+    scaling_.obj[i].index = -1;
+
+    // Performing full scaling copy
+    for (int j = 0; j < i; j++) {
+      scaling_.obj[j] = model_.scaling[j];
     }
+
+    model_extern_copied_ = true;
   };
 
-  /** \brief The structure stores the features and the label of a single sample which has to be used
-   * for the training or the classification of the SVM (Support Vector Machines).
+  /** Read in a raw classification problem (in svmlight format).
+   *
+   *  The values are normalized using the classifier model information.
+   *
+   * \return false if fails
    */
-  struct SVMData
+  bool
+  loadClassProblem(const char* filename)
   {
-    double label; // Pointer to the label value. It is a mandatory to train the classifier.
-    std::vector<pcl::SVMDataPoint> SV; // Vector of features for the specific sample.
+    assert(model_.l != 0);
 
-    SVMData () : label (std::numeric_limits<double>::signaling_NaN())
-    {
-    }
+    bool out = SVM::loadProblem(filename, prob_);
+    SVM::adaptLibSVMToInput(training_set_, prob_);
+    scaleProblem(prob_, scaling_);
+    return out;
   };
 
-  /** \brief Base class for SVM SVM (Support Vector Machines).
+  /** Read in a normalized classification problem (in svmlight format).
+   *
+   *  The data are kept whitout normalizing.
+   *
+   * \return false if fails
    */
-  class SVM
+  bool
+  loadNormClassProblem(const char* filename)
   {
-    protected:
-      std::vector<SVMData> training_set_; // Basic training set
-      svm_problem prob_; // contains the problem (vector of samples with their features)
-      SVMModel model_; // model of the classifier
-      svm_scaling scaling_; // for the best model training, the input dataset is scaled and the scaling factors are stored here
-      SVMParam param_; // it stores the training parameters
-      std::string class_name_; // The SVM class name.
-
-      char *line_; // buffer for line reading
-      int max_line_len_; // max line length in the input file
-      bool labelled_training_set_; // it stores whether the input set of samples is labelled
-      /** \brief Set for output printings during classification. */
-      static void 
-      printNull (const char *) {}; 
-      
-      /** \brief To read a line from the input file. Stored in "line_". */
-      char* 
-      readline (FILE *input); 
-
-      /** \brief Outputs an error in file reading. */
-      void exitInputError (int line_num)
-      {
-        fprintf (stderr, "Wrong input format at line %d\n", line_num);
-        exit (1);
-      }
-      
-      /** \brief Get a string representation of the name of this class. */
-      inline const std::string&
-      getClassName () const
-      {
-        return (class_name_);
-      }
-      
-      /** \brief Convert the input format (vector of SVMData) into a readable format for libSVM. */
-      void adaptInputToLibSVM (std::vector<SVMData> training_set, svm_problem &prob);
-
-      /** \brief Convert the libSVM format (svm_problem) into a easier output format. */
-      void adaptLibSVMToInput (std::vector<SVMData> &training_set, svm_problem prob);
-
-      /** \brief Load a problem from an extern file. */
-      bool loadProblem (const char *filename, svm_problem &prob);
-
-      /** \brief Save the raw problem in an extern file.*/
-      bool saveProblem (const char *filename, bool labelled);
-
-      /** \brief Save the problem (with normalized values) in an extern file.*/
-      bool saveProblemNorm (const char *filename, svm_problem prob_, bool labelled);
-
-    public:
-      /** \brief  Constructor. */
-      SVM () : 
-        prob_ (), line_ (nullptr), max_line_len_ (10000), labelled_training_set_ (true)
-      {
-      }
-
-      /** \brief Destructor. */
-      ~SVM ()
-      {
-        svm_destroy_param (&param_); // delete parameters
-
-        if (scaling_.max > 0)
-          free (scaling_.obj); // delete scaling factors
-
-        // delete the problem
-        if (prob_.l > 0)
-        {
-          free (prob_.x);
-          free (prob_.y);
-        }
-      }
-
-      /** \brief Return the labels order from the classifier model. */
-      void
-      getLabel (std::vector<int> &labels)
-      {
-        int nr_class = svm_get_nr_class (&model_);
-        int *labels_ = static_cast<int *> (malloc (nr_class * sizeof (int)));
-        svm_get_labels (&model_, labels_);
-
-        for (int j = 0 ; j < nr_class; j++)
-          labels.push_back (labels_[j]);
-
-        free (labels_);
-      };
-
-      /** \brief Save the classifier model in an extern file (in svmlight format). */
-      void saveClassifierModel (const char *filename)
-      {
-        // exit if model has no data
-        if (model_.l == 0)
-          return;
-
-        if (svm_save_model (filename, &model_))
-        {
-          fprintf (stderr, "can't save model to file %s\n", filename);
-          exit (1);
-        }
-      };
+    bool out = SVM::loadProblem(filename, prob_);
+    SVM::adaptLibSVMToInput(training_set_, prob_);
+    return out;
   };
 
-  /** \brief SVM (Support Vector Machines) training class for the SVM machine learning. 
-   * It creates a model for the classifier from a labelled input dataset. 
-   * OPTIONAL: pcl::SVMParam has to be given as input to vary the default training method and parameters.
+  /** Set whether the classification has to be done with the probability estimate. (The
+   *  classifier model has to support it). */
+  void
+  setProbabilityEstimates(bool set)
+  {
+    predict_probability_ = set;
+  };
+
+  /** Start the classification on labelled input dataset.
+   *
+   *  It returns the accuracy percentage. To get the classification result, use
+   *  getClassificationResult().
+   *
+   * \return false if fails
    */
-  class SVMTrain : public SVM
-  {
-    protected:
-      using SVM::labelled_training_set_;
-      using SVM::model_;
-      using SVM::line_;
-      using SVM::max_line_len_;
-      using SVM::training_set_;
-      using SVM::prob_;
-      using SVM::scaling_;
-      using SVM::param_;
-      using SVM::class_name_;
+  bool
+  classificationTest();
 
-      bool debug_; // Set to 1 to see the training output
-      int cross_validation_; // Set too 1 for cross validating the classifier
-      int nr_fold_; // Number of folds to be used during cross validation. It indicates in how many parts is split the input training set.
-
-      /** \brief To cross validate the classifier. It is automatic for probability estimate. */
-      void 
-      doCrossValidation();
-      
-      /** \brief It extracts scaling factors from the input training_set. 
-       *  The scaling of the training_set is a mandatory for a good training of the classifier. */
-      void 
-      scaleFactors (std::vector<SVMData> training_set, svm_scaling &scaling);
-      
-    public:
-      /** \brief Constructor. */
-      SVMTrain() : debug_ (false), cross_validation_ (0), nr_fold_ (0)
-      {
-        class_name_ = "SVMTrain";
-        svm_set_print_string_function (&printNull); // Default to NULL to not print debugging info
-      }
-
-      /** \brief Destructor. */
-      ~SVMTrain ()
-      {
-        if (model_.l > 0)
-          svm_free_model_content (&model_);
-      }
-
-      /** \brief Change default training parameters (pcl::SVMParam). */
-      void
-      setParameters (SVMParam param)
-      {
-        param_ = param;
-      }
-
-      /** \brief Return the current training parameters. */
-      SVMParam
-      getParameters ()
-      {
-        return param_;
-      }
-
-      /** \brief Return the result of the training. */
-      SVMModel
-      getClassifierModel ()
-      {
-        return model_;
-      }
-
-      /** \brief It adds/store the training set with labelled data. */
-      void
-      setInputTrainingSet (std::vector<SVMData> training_set)
-      {
-        training_set_.insert (training_set_.end(), training_set.begin(), training_set.end());
-      }
-
-      /** \brief Return the current training set. */
-      std::vector<SVMData>
-      getInputTrainingSet ()
-      {
-        return training_set_;
-      }
-
-      /** \brief Reset the training set. */
-      void
-      resetTrainingSet ()
-      {
-        training_set_.clear();
-      }
-
-      /** \brief Start the training of the SVM classifier.
-          \return false if fails. */
-      bool
-      trainClassifier ();
-
-      /** \brief Read in a problem (in svmlight format). 
-       * \return false if fails. */
-      bool
-      loadProblem (const char *filename)
-      {
-        return SVM::loadProblem (filename, prob_);
-      };
-
-      /** \brief Set to 1 for debugging info. */
-      void
-      setDebugMode (bool in)
-      {
-        debug_ = in;
-
-        if (in)
-          svm_set_print_string_function (nullptr);
-        else
-          svm_set_print_string_function (&printNull);
-      };
-
-      /** \brief Save the raw training set in a file (in svmlight format). 
-       * \return false if fails. */
-      bool
-      saveTrainingSet (const char *filename)
-      {
-        return SVM::saveProblem (filename, true);
-      };
-
-      /** \brief Save the normalized training set in a file (in svmlight format). 
-       * \return false if fails. */
-      bool
-      saveNormTrainingSet (const char *filename)
-      {
-        return SVM::saveProblemNorm (filename, prob_, true);
-      };
-  };
-
-  /** \brief SVM (Support Vector Machines) classification of a dataset. 
-   * It can be used both for testing a classifier model and for classify of new data.
+  /** Start the classification on un-labelled input dataset.
+   *
+   *  To get the classification result, use getClassificationResult().
+   *
+   * \return false if fails
    */
-  class SVMClassify : public SVM
+  bool
+  classification();
+
+  /** Start the classification on a single set. */
+  std::vector<double>
+  classification(SVMData in);
+
+  /** Save the raw classification problem in a file (in svmlight format).
+   *
+   * \return false if fails
+   */
+  bool
+  saveClassProblem(const char* filename)
   {
-    protected:
-      using SVM::labelled_training_set_;
-      using SVM::model_;
-      using SVM::line_;
-      using SVM::max_line_len_;
-      using SVM::training_set_;
-      using SVM::prob_;
-      using SVM::scaling_;
-      using SVM::param_;
-      using SVM::class_name_;
-
-      bool model_extern_copied_; // Set to 0 if the model is loaded from an extern file.
-      bool predict_probability_; // Set to 1 to predict probabilities.
-      std::vector< std::vector<double> > prediction_; // It stores the resulting prediction.
-      
-      /** \brief It scales the input dataset using the model information. */
-      void scaleProblem (svm_problem &input, svm_scaling scaling);
-      
-    public:
-      /** \brief Constructor. */
-      SVMClassify () : model_extern_copied_ (false), predict_probability_ (false)
-      {
-        class_name_ = "SvmClassify";
-      }
-
-      /** \brief Destructor. */
-      ~SVMClassify ()
-      {
-        if (!model_extern_copied_ && model_.l > 0)
-          svm_free_model_content (&model_);
-      }
-
-      /** \brief It adds/store the training set with labelled data. */
-      void
-      setInputTrainingSet (std::vector<SVMData> training_set)
-      {
-        assert (training_set.size() > 0);
-
-        if (scaling_.max == 0)
-        {
-          // to be sure to have loaded the scaling
-          PCL_ERROR ("[pcl::%s::setInputTrainingSet] Classifier model not loaded!\n", getClassName ().c_str ());
-          return;
-        }
-        
-        training_set_.insert (training_set_.end(), training_set.begin(), training_set.end());
-        SVM::adaptInputToLibSVM (training_set_, prob_);
-      }
-
-      /** \brief Return the current training set. */
-      std::vector<SVMData>
-      getInputTrainingSet ()
-      {
-        return training_set_;
-      }
-
-      /** \brief Reset the training set. */
-      void
-      resetTrainingSet()
-      {
-        training_set_.clear();
-      }
-
-      /** \brief Read in a classifier model (in svmlight format). 
-       * \return false if fails. */
-      bool
-      loadClassifierModel (const char *filename);
-
-      /** \brief Get the result of the classification. */
-      void
-      getClassificationResult (std::vector< std::vector<double> > &out)
-      {
-        out.clear ();
-        out.insert (out.begin(), prediction_.begin(), prediction_.end());
-      }
-
-      /** \brief Save the classification result in an extern file. */
-      void
-      saveClassificationResult (const char *filename);
-
-      /** \brief Set the classifier model. */
-      void
-      setClassifierModel (SVMModel model)
-      {
-        // model (inner pointers are references)
-        model_ = model;
-        int i = 0;
-
-        while (model_.scaling[i].index != -1)
-          i++;
-
-        scaling_.max = i;
-        scaling_.obj = Malloc (struct svm_node, i + 1);
-        scaling_.obj[i].index = -1;
-
-        // Performing full scaling copy
-        for (int j = 0; j < i; j++)
-        {
-          scaling_.obj[j] = model_.scaling[j];
-        }
-
-        model_extern_copied_ = true;
-      };
-
-      /** \brief Read in a raw classification problem (in svmlight format).
-       *  The values are normalized using the classifier model information. 
-       * \return false if fails. */
-      bool
-      loadClassProblem (const char *filename)
-      {
-        assert (model_.l != 0);
-
-        bool out = SVM::loadProblem (filename, prob_);
-        SVM::adaptLibSVMToInput (training_set_, prob_);
-        scaleProblem (prob_, scaling_);
-        return out;
-      };
-
-      /** \brief Read in a normalized classification problem (in svmlight format).
-       * The data are kept whitout normalizing. 
-       * \return false if fails. */
-      bool
-      loadNormClassProblem (const char *filename)
-      {
-        bool out = SVM::loadProblem (filename, prob_);
-        SVM::adaptLibSVMToInput (training_set_, prob_);
-        return out;
-      };
-
-      /** \brief Set whether the classification has to be done with the probability estimate.
-       * (the classifier model has to support it). */
-      void
-      setProbabilityEstimates (bool set)
-      {
-        predict_probability_ = set;
-      };
-
-      /** \brief Start the classification on labelled input dataset. It returns the accuracy percentage.
-       * To get the classification result, use getClassificationResult.
-       * \return false if fails. */
-      bool
-      classificationTest ();
-
-      /** \brief Start the classification on un-labelled input dataset.
-       * To get the classification result, use getClassificationResult.
-       * \return false if fails. */
-      bool
-      classification ();
-
-      /** \brief Start the classification on a single set. */
-      std::vector<double>
-      classification (SVMData in);
-
-      /** \brief Save the raw classification problem in a file (in svmlight format). 
-       * \return false if fails. */
-      bool
-      saveClassProblem (const char *filename)
-      {
-        return SVM::saveProblem (filename, false);
-      };
-
-      /** \brief Save the normalized classification problem in a file (in svmlight format). 
-       * \return false if fails. */
-      bool
-      saveNormClassProblem (const char *filename)
-      {
-        return SVM::saveProblemNorm (filename, prob_, false);
-      };
+    return SVM::saveProblem(filename, false);
   };
-}
+
+  /** Save the normalized classification problem in a file (in svmlight format).
+   *
+   * \return false if fails
+   */
+  bool
+  saveNormClassProblem(const char* filename)
+  {
+    return SVM::saveProblemNorm(filename, prob_, false);
+  };
+};
+
+} // namespace pcl

--- a/ml/src/densecrf.cpp
+++ b/ml/src/densecrf.cpp
@@ -39,276 +39,253 @@
 
 #include <pcl/ml/densecrf.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-pcl::DenseCrf::DenseCrf (int N, int m) :
-  N_ (N), M_ (m),
-  xyz_ (false), rgb_ (false), normal_ (false)
+pcl::DenseCrf::DenseCrf(int N, int m)
+: N_(N), M_(m), xyz_(false), rgb_(false), normal_(false)
 {
-  current_.resize (N_ * M_, 0.0f);
-  next_.resize (N_ * M_, 0.0f);
-  tmp_.resize (2 * N_ * M_, 0.0f);
+  current_.resize(N_ * M_, 0.0f);
+  next_.resize(N_ * M_, 0.0f);
+  tmp_.resize(2 * N_ * M_, 0.0f);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-pcl::DenseCrf::~DenseCrf ()
+pcl::DenseCrf::~DenseCrf()
 {
-  for(auto &p : pairwise_potential_)
+  for (auto& p : pairwise_potential_)
     delete p;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::setDataVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > data)
+pcl::DenseCrf::setDataVector(
+    const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> data)
 {
   xyz_ = true;
   data_ = data;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::setColorVector (const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > color)
+pcl::DenseCrf::setColorVector(
+    const std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>> color)
 {
   rgb_ = true;
   color_ = color;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::setUnaryEnergy (const std::vector<float> unary)
+pcl::DenseCrf::setUnaryEnergy(const std::vector<float> unary)
 {
   unary_ = unary;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::addPairwiseEnergy (const std::vector<float> &feature, const int feature_dimension, const float w)
+pcl::DenseCrf::addPairwiseEnergy(const std::vector<float>& feature,
+                                 const int feature_dimension,
+                                 const float w)
 {
-  pairwise_potential_.push_back ( new PairwisePotential (feature, feature_dimension, N_, w) );
+  pairwise_potential_.push_back(
+      new PairwisePotential(feature, feature_dimension, N_, w));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::addPairwiseGaussian (float sx, float sy, float sz, float w)
+pcl::DenseCrf::addPairwiseGaussian(float sx, float sy, float sz, float w)
 {
   // create feature vector
   std::vector<float> feature;
   // reserve space for the three-dimensional Gaussian kernel
-  feature.resize (N_ * 3);
-  
+  feature.resize(N_ * 3);
+
   // fill the feature vector
-  for (size_t i = 0; i < data_.size (); i++)
-  {
-    feature[i * 3    ] = static_cast<float> (data_[i].x ()) / sx;
-    feature[i * 3 + 1] = static_cast<float> (data_[i].y ()) / sy;
-    feature[i * 3 + 2] = static_cast<float> (data_[i].z ()) / sz;
+  for (size_t i = 0; i < data_.size(); i++) {
+    feature[i * 3] = static_cast<float>(data_[i].x()) / sx;
+    feature[i * 3 + 1] = static_cast<float>(data_[i].y()) / sy;
+    feature[i * 3 + 2] = static_cast<float>(data_[i].z()) / sz;
   }
   // add kernel
-  addPairwiseEnergy (feature, 3, w);
+  addPairwiseEnergy(feature, 3, w);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::addPairwiseBilateral (float sx, float sy, float sz, 
-                                     float sr, float sg, float sb,
-                                     float w)
+pcl::DenseCrf::addPairwiseBilateral(
+    float sx, float sy, float sz, float sr, float sg, float sb, float w)
 {
   // create feature vector
   std::vector<float> feature;
   // reserve space for the six-dimensional Gaussian kernel
-  feature.resize (N_ * 6);
+  feature.resize(N_ * 6);
 
   // fill the feature vector
-  for (size_t i = 0; i < color_.size (); i++)
-  {
-    feature[i * 6    ] = static_cast<float> (data_[i].x ()) / sx;
-    feature[i * 6 + 1] = static_cast<float> (data_[i].y ()) / sy;
-    feature[i * 6 + 2] = static_cast<float> (data_[i].z ()) / sz;
-    feature[i * 6 + 3] = static_cast<float> (color_[i].x ()) / sr;
-    feature[i * 6 + 4] = static_cast<float> (color_[i].y ()) / sg;
-    feature[i * 6 + 5] = static_cast<float> (color_[i].z ()) / sb;
+  for (size_t i = 0; i < color_.size(); i++) {
+    feature[i * 6] = static_cast<float>(data_[i].x()) / sx;
+    feature[i * 6 + 1] = static_cast<float>(data_[i].y()) / sy;
+    feature[i * 6 + 2] = static_cast<float>(data_[i].z()) / sz;
+    feature[i * 6 + 3] = static_cast<float>(color_[i].x()) / sr;
+    feature[i * 6 + 4] = static_cast<float>(color_[i].y()) / sg;
+    feature[i * 6 + 5] = static_cast<float>(color_[i].z()) / sb;
   }
   // add kernel
-  addPairwiseEnergy (feature, 6, w);
+  addPairwiseEnergy(feature, 6, w);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::addPairwiseNormals (std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i> > &coord,
-                                   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> > &normals,
-                                   float sx, float sy, float sz, 
-                                   float snx, float sny, float snz,
-                                   float w)
+pcl::DenseCrf::addPairwiseNormals(
+    std::vector<Eigen::Vector3i, Eigen::aligned_allocator<Eigen::Vector3i>>& coord,
+    std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>>& normals,
+    float sx,
+    float sy,
+    float sz,
+    float snx,
+    float sny,
+    float snz,
+    float w)
 {
-  std::cout << coord.size () << std::endl;
-  std::cout << normals.size () << std::endl;
+  std::cout << coord.size() << std::endl;
+  std::cout << normals.size() << std::endl;
 
   // create feature vector
   std::vector<float> feature;
   // reserve space for the six-dimensional Gaussian kernel
-  feature.resize (N_ * 6);
+  feature.resize(N_ * 6);
 
   // fill the feature vector
-  for (size_t i = 0; i < coord.size (); i++)
-  {
-    if (std::isnan (normals[i].x ()))
-    {
-      if (i > 0)
-      {
-        normals[i].x () = normals[i-1].x ();
-        normals[i].y () = normals[i-1].y ();
-        normals[i].z () = normals[i-1].z ();
+  for (size_t i = 0; i < coord.size(); i++) {
+    if (std::isnan(normals[i].x())) {
+      if (i > 0) {
+        normals[i].x() = normals[i - 1].x();
+        normals[i].y() = normals[i - 1].y();
+        normals[i].z() = normals[i - 1].z();
       }
 
-      //std::cout << "NaN" << std::endl;
-      
+      // std::cout << "NaN" << std::endl;
     }
 
-    feature[i * 6    ] = static_cast<float> (coord[i].x ()) / sx;
-    feature[i * 6 + 1] = static_cast<float> (coord[i].y ()) / sy;
-    feature[i * 6 + 2] = static_cast<float> (coord[i].z ()) / sz;
-    feature[i * 6 + 3] = static_cast<float> (normals[i].x ()) / snx;
-    feature[i * 6 + 4] = static_cast<float> (normals[i].y ()) / sny;
-    feature[i * 6 + 5] = static_cast<float> (normals[i].z ()) / snz;
+    feature[i * 6] = static_cast<float>(coord[i].x()) / sx;
+    feature[i * 6 + 1] = static_cast<float>(coord[i].y()) / sy;
+    feature[i * 6 + 2] = static_cast<float>(coord[i].z()) / sz;
+    feature[i * 6 + 3] = static_cast<float>(normals[i].x()) / snx;
+    feature[i * 6 + 4] = static_cast<float>(normals[i].y()) / sny;
+    feature[i * 6 + 5] = static_cast<float>(normals[i].z()) / snz;
   }
   // add kernel
-  
+
   std::cout << "TEEEEST" << std::endl;
 
-  addPairwiseEnergy (feature, 6, w);
+  addPairwiseEnergy(feature, 6, w);
 
   std::cout << "TEEEEST2" << std::endl;
-
 }
 
-
-
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::inference (int n_iterations, std::vector<float> &result, float relax)
+pcl::DenseCrf::inference(int n_iterations, std::vector<float>& result, float relax)
 {
   // Start inference
   // Initialize using the unary energies
-  expAndNormalize (current_, unary_, -1);
+  expAndNormalize(current_, unary_, -1);
 
-  for (int i = 0; i < n_iterations; i++)
-  {
-    runInference (relax);
-    std::cout << "iteration: " << i+1 << " - DONE" << std::endl;
+  for (int i = 0; i < n_iterations; i++) {
+    runInference(relax);
+    std::cout << "iteration: " << i + 1 << " - DONE" << std::endl;
   }
-  
+
   // Copy the data into the result vector
   result = current_;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::mapInference (int n_iterations, std::vector<int> &result, float relax)
+pcl::DenseCrf::mapInference(int n_iterations, std::vector<int>& result, float relax)
 {
   // Start inference
   // Initialize using the unary energies
-  expAndNormalize (current_, unary_, -1);
+  expAndNormalize(current_, unary_, -1);
 
-  for (int i = 0; i < n_iterations; i++)
-  {
-    runInference (relax);
-    std::cout << "iteration: " << i+1 << " - DONE" << std::endl;
+  for (int i = 0; i < n_iterations; i++) {
+    runInference(relax);
+    std::cout << "iteration: " << i + 1 << " - DONE" << std::endl;
   }
 
   // Find the map
-  for (int i = 0; i < N_; i++)
-  {
+  for (int i = 0; i < N_; i++) {
     const int prob_idx = i * M_;
     // Find the max
     float p_label = current_[prob_idx];
     int idx = 0;
-    for (int j = 1; j < M_; j++) 
-    { 
-      if (p_label < current_[prob_idx + j])
-      {
+    for (int j = 1; j < M_; j++) {
+      if (p_label < current_[prob_idx + j]) {
         p_label = current_[prob_idx + j];
         idx = j;
       }
     }
     result[i] = idx;
   }
-  
 
-
-/*
-	for( int i = 0; i < N_; i++ ){
-		const float * p = prob + i*M_;
-		// Find the max and subtract it so that the std::exp doesn't explode
-		float mx = p[0];
-		int imx = 0;
-		for( int j=1; j<M_; j++ )
-			if( mx < p[j] ){
-				mx = p[j];
-				imx = j;
-			}
+  /*
+  for (int i = 0; i < N_; i++) {
+    const float* p = prob + i * M_;
+    // Find the max and subtract it so that the std::exp doesn't explode
+    float mx = p[0];
+    int imx = 0;
+    for (int j = 1; j < M_; j++)
+      if (mx < p[j]) {
+        mx = p[j];
+        imx = j;
+      }
     result[i] = imx
   }
-*/
-
+  */
 }
 
-
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::expAndNormalize (std::vector<float> &out, const std::vector<float> &in,
-                                float scale, float relax)
+pcl::DenseCrf::expAndNormalize(std::vector<float>& out,
+                               const std::vector<float>& in,
+                               float scale,
+                               float relax)
 {
-  std::vector<float> V (N_ + 10);
-	for( int i = 0; i < N_; i++ ){
-    int b_idx = i*M_;
-		// Find the max and subtract it so that the std::exp doesn't explode
-		float mx = scale * in[b_idx];
-		for( int j = 1; j < M_; j++ )
-			if( mx < scale * in[b_idx + j] )
-				mx = scale * in[b_idx + j];
-		float tt = 0;
-		for( int  j = 0; j < M_; j++ ){
-			V[j] = std::exp( scale * in[b_idx + j] - mx );
-			tt += V[j];
-		}
-		// Make it a probability
-		for( int j = 0; j < M_; j++ )
-			V[j] /= tt;
-		
-    int a_idx = i*M_;
-		for( int j = 0; j < M_; j++ )
-			if (relax == 1)
-				out[a_idx + j] = V[j];
-			else
-				out[a_idx + j] = (1-relax) * out[a_idx + j] + relax * V[j];
-	}
+  std::vector<float> V(N_ + 10);
+  for (int i = 0; i < N_; i++) {
+    int b_idx = i * M_;
+    // Find the max and subtract it so that the std::exp doesn't explode
+    float mx = scale * in[b_idx];
+    for (int j = 1; j < M_; j++)
+      if (mx < scale * in[b_idx + j])
+        mx = scale * in[b_idx + j];
+    float tt = 0;
+    for (int j = 0; j < M_; j++) {
+      V[j] = std::exp(scale * in[b_idx + j] - mx);
+      tt += V[j];
+    }
+    // Make it a probability
+    for (int j = 0; j < M_; j++)
+      V[j] /= tt;
+
+    int a_idx = i * M_;
+    for (int j = 0; j < M_; j++)
+      if (relax == 1)
+        out[a_idx + j] = V[j];
+      else
+        out[a_idx + j] = (1 - relax) * out[a_idx + j] + relax * V[j];
+  }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::DenseCrf::runInference (float relax)
+pcl::DenseCrf::runInference(float relax)
 {
   // set the unary potentials
-  for (size_t i = 0; i < unary_.size (); i++)
+  for (size_t i = 0; i < unary_.size(); i++)
     next_[i] = -unary_[i];
 
   // Add up all pairwise potentials
-  for(auto &p : pairwise_potential_)
-    p->compute( next_, current_, tmp_, M_ );
+  for (auto& p : pairwise_potential_)
+    p->compute(next_, current_, tmp_, M_);
 
   // Exponentiate and normalize
-  expAndNormalize( current_, next_, 1.0, relax );
+  expAndNormalize(current_, next_, 1.0, relax);
 }
 
 void
-pcl::DenseCrf::getBarycentric (int idx, std::vector<float> &bary)
+pcl::DenseCrf::getBarycentric(int idx, std::vector<float>& bary)
 {
   bary = pairwise_potential_[idx]->bary_;
 }
 
 void
-pcl::DenseCrf::getFeatures (int idx, std::vector<float> &features)
+pcl::DenseCrf::getFeatures(int idx, std::vector<float>& features)
 {
   features = pairwise_potential_[idx]->features_;
 }

--- a/ml/src/pairwise_potential.cpp
+++ b/ml/src/pairwise_potential.cpp
@@ -39,27 +39,27 @@
 
 #include <pcl/ml/pairwise_potential.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-pcl::PairwisePotential::PairwisePotential (const std::vector<float> &feature, 
-                                           const int feature_dimension, 
-                                           const int N, const float w) :
-  N_ (N), w_ (w)
-{  
-  //lattice_.init (feature, feature_dimension, N);
+pcl::PairwisePotential::PairwisePotential(const std::vector<float>& feature,
+                                          const int feature_dimension,
+                                          const int N,
+                                          const float w)
+: N_(N), w_(w)
+{
+  // lattice_.init (feature, feature_dimension, N);
   std::cout << "0---------" << std::endl;
-  lattice_.init (feature, feature_dimension, N);
-  
+  lattice_.init(feature, feature_dimension, N);
+
   std::cout << "1---------" << std::endl;
 
-  //lattice_.debug ();
+  // lattice_.debug ();
 
-  norm_.resize (N);
+  norm_.resize(N);
   for (int i = 0; i < N; i++)
     norm_[i] = 1;
 
   // Compute the normalization factor
 
-  //lattice_.compute (norm_, norm_, 1);
+  // lattice_.compute (norm_, norm_, 1);
 
   /*
   std::vector<float> normOLD;
@@ -70,30 +70,28 @@ pcl::PairwisePotential::PairwisePotential (const std::vector<float> &feature,
 
   std::cout << "2---------" << std::endl;
 
-  lattice_.compute (norm_, norm_, 1);
-
+  lattice_.compute(norm_, norm_, 1);
 
   std::cout << "3---------" << std::endl;
 
-/*
-  ///////////
-  // DEBUG //
-  bool same = true;
-  for (size_t i = 0; i < normOLD.size (); i++)
-  {
-    if (norm_[i] != normOLD[i])
-      same = false;
-  }
-  if (same)
-    std::cout << "DEBUG norm -  OK" << std::endl;
-  else
-    std::cout << "DEBUG norm - ERROR" << std::endl;
-*/
-  
+  /*
+    ///////////
+    // DEBUG //
+    bool same = true;
+    for (size_t i = 0; i < normOLD.size (); i++)
+    {
+      if (norm_[i] != normOLD[i])
+        same = false;
+    }
+    if (same)
+      std::cout << "DEBUG norm -  OK" << std::endl;
+    else
+      std::cout << "DEBUG norm - ERROR" << std::endl;
+  */
 
   // per pixel normalization
   for (int i = 0; i < N; i++)
-    norm_[i] = 1.0f / (norm_[i] + 1e-20f); 
+    norm_[i] = 1.0f / (norm_[i] + 1e-20f);
 
   std::cout << "4---------" << std::endl;
 
@@ -102,26 +100,23 @@ pcl::PairwisePotential::PairwisePotential (const std::vector<float> &feature,
   std::cout << "5---------" << std::endl;
 
   features_ = feature;
-  
+
   std::cout << "6---------" << std::endl;
 
-
-/*  
-  std::cout << "bary size: " << bary_.size () << std::endl;
-  for (int g = 0; g < 25; g++)
-    std::cout << bary_[g] << std::endl;
-*/
-
-
-
+  /*
+    std::cout << "bary size: " << bary_.size () << std::endl;
+    for (int g = 0; g < 25; g++)
+      std::cout << bary_[g] << std::endl;
+  */
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::PairwisePotential::compute (std::vector<float> &out, const std::vector<float> &in,
-                                 std::vector<float> &tmp, int value_size) const
+pcl::PairwisePotential::compute(std::vector<float>& out,
+                                const std::vector<float>& in,
+                                std::vector<float>& tmp,
+                                int value_size) const
 {
-  lattice_.compute (tmp, in, value_size);
+  lattice_.compute(tmp, in, value_size);
   for (int i = 0, k = 0; i < N_; i++)
     for (int j = 0; j < value_size; j++, k++)
       out[k] += w_ * norm_[i] * tmp[k];

--- a/ml/src/pairwise_potential.cpp
+++ b/ml/src/pairwise_potential.cpp
@@ -46,10 +46,10 @@ pcl::PairwisePotential::PairwisePotential(const std::vector<float>& feature,
 : N_(N), w_(w)
 {
   // lattice_.init (feature, feature_dimension, N);
-  std::cout << "0---------" << std::endl;
+  // std::cout << "0---------" << std::endl;
   lattice_.init(feature, feature_dimension, N);
 
-  std::cout << "1---------" << std::endl;
+  // std::cout << "1---------" << std::endl;
 
   // lattice_.debug ();
 
@@ -68,11 +68,11 @@ pcl::PairwisePotential::PairwisePotential(const std::vector<float>& feature,
     normOLD[i] = 1;
   */
 
-  std::cout << "2---------" << std::endl;
+  // std::cout << "2---------" << std::endl;
 
   lattice_.compute(norm_, norm_, 1);
 
-  std::cout << "3---------" << std::endl;
+  // std::cout << "3---------" << std::endl;
 
   /*
     ///////////
@@ -93,15 +93,15 @@ pcl::PairwisePotential::PairwisePotential(const std::vector<float>& feature,
   for (int i = 0; i < N; i++)
     norm_[i] = 1.0f / (norm_[i] + 1e-20f);
 
-  std::cout << "4---------" << std::endl;
+  // std::cout << "4---------" << std::endl;
 
   bary_ = lattice_.barycentric_;
 
-  std::cout << "5---------" << std::endl;
+  // std::cout << "5---------" << std::endl;
 
   features_ = feature;
 
-  std::cout << "6---------" << std::endl;
+  // std::cout << "6---------" << std::endl;
 
   /*
     std::cout << "bary size: " << bary_.size () << std::endl;

--- a/ml/src/permutohedral.cpp
+++ b/ml/src/permutohedral.cpp
@@ -37,362 +37,360 @@
 
 #include <pcl/ml/permutohedral.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
-pcl::Permutohedral::Permutohedral () :
-  N_ (0), M_ (0), d_ (0),
-  blur_neighborsOLD_(nullptr), offsetOLD_ (nullptr), barycentricOLD_ (nullptr) 
+pcl::Permutohedral::Permutohedral()
+: N_(0)
+, M_(0)
+, d_(0)
+, blur_neighborsOLD_(nullptr)
+, offsetOLD_(nullptr)
+, barycentricOLD_(nullptr)
 {}
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::Permutohedral::init (const std::vector<float> &feature, const int feature_dimension, const int N)
+pcl::Permutohedral::init(const std::vector<float>& feature,
+                         const int feature_dimension,
+                         const int N)
 {
   N_ = N;
   d_ = feature_dimension;
-  
+
   // Create hash table
-  std::vector<std::vector<short> > keys;
-  keys.reserve ((d_+1) * N_);
+  std::vector<std::vector<short>> keys;
+  keys.reserve((d_ + 1) * N_);
   std::multimap<size_t, int> hash_table;
 
   // reserve class memory
-  if (!offset_.empty ()) 
-    offset_.clear ();
-  offset_.resize ((d_ + 1) * N_);
+  if (!offset_.empty())
+    offset_.clear();
+  offset_.resize((d_ + 1) * N_);
 
-  if (!barycentric_.empty ()) 
-    barycentric_.clear ();
-  barycentric_.resize ((d_ + 1) * N_);
+  if (!barycentric_.empty())
+    barycentric_.clear();
+  barycentric_.resize((d_ + 1) * N_);
 
   // create vectors and matrices
-  Eigen::VectorXf scale_factor = Eigen::VectorXf::Zero (d_);
-  Eigen::VectorXf elevated = Eigen::VectorXf::Zero (d_ + 1);
-  Eigen::VectorXf rem0 = Eigen::VectorXf::Zero (d_+1);
-  Eigen::VectorXf barycentric = Eigen::VectorXf::Zero (d_+2);
-  Eigen::VectorXi rank = Eigen::VectorXi::Zero (d_+1);
+  Eigen::VectorXf scale_factor = Eigen::VectorXf::Zero(d_);
+  Eigen::VectorXf elevated = Eigen::VectorXf::Zero(d_ + 1);
+  Eigen::VectorXf rem0 = Eigen::VectorXf::Zero(d_ + 1);
+  Eigen::VectorXf barycentric = Eigen::VectorXf::Zero(d_ + 2);
+  Eigen::VectorXi rank = Eigen::VectorXi::Zero(d_ + 1);
   Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> canonical;
-  canonical = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>::Zero (d_+1, d_+1);
-  //short * key = new short[d_+1];
-  std::vector<short> key (d_+1);
+  canonical = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>::Zero(d_ + 1, d_ + 1);
+  // short * key = new short[d_+1];
+  std::vector<short> key(d_ + 1);
 
   // Compute the canonical simple
-  for (int i = 0; i <= d_; i++)
-  {
+  for (int i = 0; i <= d_; i++) {
     for (int j = 0; j <= (d_ - i); j++)
-      canonical (j, i) = i;
+      canonical(j, i) = i;
     for (int j = (d_ - i + 1); j <= d_; j++)
-      canonical (j, i) = i - (d_ + 1);
+      canonical(j, i) = i - (d_ + 1);
   }
 
   // Expected standard deviation of our filter (p.6 in [Adams etal 2010])
-  float inv_std_dev = std::sqrt (2.0f / 3.0f) * static_cast<float> (d_ + 1);
-  
+  float inv_std_dev = std::sqrt(2.0f / 3.0f) * static_cast<float>(d_ + 1);
+
   // Compute the diagonal part of E (p.5 in [Adams etal 2010])
   for (int i = 0; i < d_; i++)
-    scale_factor (i) = 1.0f / std::sqrt (static_cast<float> (i + 2) * static_cast<float> (i + 1)) * inv_std_dev;
+    scale_factor(i) = 1.0f /
+                      std::sqrt(static_cast<float>(i + 2) * static_cast<float>(i + 1)) *
+                      inv_std_dev;
 
   // Compute the simplex each feature lies in
   for (int k = 0; k < N_; k++)
-    //for (int k = 0; k < 5; k++)
+  // for (int k = 0; k < 5; k++)
   {
 
     // Elevate the feature  (y = Ep, see p.5 in [Adams etal 2010])
     int index = k * feature_dimension;
     // sm contains the sum of 1..n of our faeture vector
     float sm = 0;
-    for (int j = d_; j > 0; j--)
-    {
-      float cf = feature[index + j-1] * scale_factor (j-1);      
-      elevated (j) = sm - static_cast<float> (j) * cf;
+    for (int j = d_; j > 0; j--) {
+      float cf = feature[index + j - 1] * scale_factor(j - 1);
+      elevated(j) = sm - static_cast<float>(j) * cf;
       sm += cf;
     }
-    elevated (0) = sm;
+    elevated(0) = sm;
 
     // Find the closest 0-colored simplex through rounding
-    float down_factor = 1.0f / static_cast<float>(d_+1);
-    float up_factor = static_cast<float>(d_+1);
+    float down_factor = 1.0f / static_cast<float>(d_ + 1);
+    float up_factor = static_cast<float>(d_ + 1);
     int sum = 0;
-    for (int j = 0; j <= d_; j++){
-      float rd = std::floor (0.5f + (down_factor * elevated (j))) ;
-      rem0 (j) = rd * up_factor;
-      sum += static_cast<int> (rd);
+    for (int j = 0; j <= d_; j++) {
+      float rd = std::floor(0.5f + (down_factor * elevated(j)));
+      rem0(j) = rd * up_factor;
+      sum += static_cast<int>(rd);
     }
-    
-    // rank differential to find the permutation between this simplex and the canonical one.         
-    // (See pg. 3-4 in paper.)    
-    rank.setZero ();
+
+    // rank differential to find the permutation between this simplex and the canonical
+    // one. (See pg. 3-4 in paper.)
+    rank.setZero();
     Eigen::VectorXf tmp = elevated - rem0;
-    for (int i = 0; i < d_; i++){
-      for (int j = i+1; j <= d_; j++)
-        if (tmp (i) < tmp (j))
-          rank (i)++;
+    for (int i = 0; i < d_; i++) {
+      for (int j = i + 1; j <= d_; j++)
+        if (tmp(i) < tmp(j))
+          rank(i)++;
         else
-          rank (j)++;
+          rank(j)++;
     }
 
     // If the point doesn't lie on the plane (sum != 0) bring it back
-    for (int j = 0; j <= d_; j++){
-      rank (j) += sum;
-      if (rank (j) < 0){
-        rank (j) += d_+1;
-        rem0 (j) += static_cast<float> (d_ + 1);
+    for (int j = 0; j <= d_; j++) {
+      rank(j) += sum;
+      if (rank(j) < 0) {
+        rank(j) += d_ + 1;
+        rem0(j) += static_cast<float>(d_ + 1);
       }
-      else if (rank (j) > d_){
-        rank (j) -= d_+1;
-        rem0 (j) -= static_cast<float> (d_ + 1);
+      else if (rank(j) > d_) {
+        rank(j) -= d_ + 1;
+        rem0(j) -= static_cast<float>(d_ + 1);
       }
     }
 
     // Compute the barycentric coordinates (p.10 in [Adams etal 2010])
-    barycentric.setZero ();
+    barycentric.setZero();
     Eigen::VectorXf v = (elevated - rem0) * down_factor;
-    for (int j = 0; j <= d_; j++){
-      barycentric (d_ - rank (j)    ) += v (j);
-      barycentric (d_ + 1 - rank (j)) -= v (j);
+    for (int j = 0; j <= d_; j++) {
+      barycentric(d_ - rank(j)) += v(j);
+      barycentric(d_ + 1 - rank(j)) -= v(j);
     }
     // Wrap around
-    barycentric (0) += 1.0f + barycentric (d_+1);
+    barycentric(0) += 1.0f + barycentric(d_ + 1);
 
     // Compute all vertices and their offset
-    for (int remainder = 0; remainder <= d_; remainder++)
-    {
+    for (int remainder = 0; remainder <= d_; remainder++) {
       for (int j = 0; j < d_; j++)
-        key[j] = static_cast<short> (rem0 (j) + static_cast<float> (canonical ( rank (j), remainder)));
+        key[j] = static_cast<short>(rem0(j) +
+                                    static_cast<float>(canonical(rank(j), remainder)));
 
-      // insert key in hash table      
-      size_t hash_key = generateHashKey (key);
-      auto it = hash_table.find (hash_key);
+      // insert key in hash table
+      size_t hash_key = generateHashKey(key);
+      auto it = hash_table.find(hash_key);
       int key_index = -1;
-      if (it != hash_table.end ())
-      {
+      if (it != hash_table.end()) {
         // check if key is the right one
         int tmp_key_index = -1;
-        //for (int ii = key_index; ii < keys.size (); ii++)
-        for (; it != hash_table.end (); ++it)
-        {
+        // for (int ii = key_index; ii < keys.size (); ii++)
+        for (; it != hash_table.end(); ++it) {
           int ii = it->second;
           bool same = true;
           std::vector<short> k = keys[ii];
-          for (size_t i_k = 0; i_k < k.size (); i_k++)
-          {
-            if (key[i_k] != k[i_k])
-            {
+          for (size_t i_k = 0; i_k < k.size(); i_k++) {
+            if (key[i_k] != k[i_k]) {
               same = false;
               break;
             }
           }
 
-          if (same)
-          {
+          if (same) {
             tmp_key_index = ii;
             break;
           }
         }
-      
-        if (tmp_key_index == -1)
-        {
-          key_index = static_cast<int> (keys.size ());
-          keys.push_back (key);
-          hash_table.insert (std::pair<size_t, int> (hash_key, key_index));
+
+        if (tmp_key_index == -1) {
+          key_index = static_cast<int>(keys.size());
+          keys.push_back(key);
+          hash_table.insert(std::pair<size_t, int>(hash_key, key_index));
         }
         else
           key_index = tmp_key_index;
       }
-      
-      else
-      {  
-        key_index = static_cast<int> (keys.size ());
-        keys.push_back (key);
-        hash_table.insert (std::pair<size_t, int> (hash_key, key_index));
+
+      else {
+        key_index = static_cast<int>(keys.size());
+        keys.push_back(key);
+        hash_table.insert(std::pair<size_t, int>(hash_key, key_index));
       }
-      offset_[ k * (d_ + 1) + remainder ] = static_cast<float> (key_index);
-      
-      barycentric_[ k * (d_ + 1) + remainder ] = barycentric (remainder);
+      offset_[k * (d_ + 1) + remainder] = static_cast<float>(key_index);
+
+      barycentric_[k * (d_ + 1) + remainder] = barycentric(remainder);
     }
   }
 
   // Find the Neighbors of each lattice point
-		
-  // Get the number of vertices in the lattice
-  M_ = static_cast<int> (hash_table.size());
-		
-  // Create the neighborhood structure
-  if (!blur_neighbors_.empty ()) 
-    blur_neighbors_.clear ();
-  blur_neighbors_.resize ((d_+1)*M_);
 
-  std::vector<short> n1 (d_+1);
-  std::vector<short> n2 (d_+1);
+  // Get the number of vertices in the lattice
+  M_ = static_cast<int>(hash_table.size());
+
+  // Create the neighborhood structure
+  if (!blur_neighbors_.empty())
+    blur_neighbors_.clear();
+  blur_neighbors_.resize((d_ + 1) * M_);
+
+  std::vector<short> n1(d_ + 1);
+  std::vector<short> n2(d_ + 1);
 
   // For each of d+1 axes,
-  for (int j = 0; j <= d_; j++)
-  {
-    for (int i = 0; i < M_; i++)
-    {
+  for (int j = 0; j <= d_; j++) {
+    for (int i = 0; i < M_; i++) {
       std::vector<short> key = keys[i];
 
-      for (int k=0; k<d_; k++){
-        n1[k] = static_cast<short> (key[k] - 1);
-        n2[k] = static_cast<short> (key[k] + 1);
+      for (int k = 0; k < d_; k++) {
+        n1[k] = static_cast<short>(key[k] - 1);
+        n2[k] = static_cast<short>(key[k] + 1);
       }
-      n1[j] = static_cast<short> (key[j] + d_);
-      n2[j] = static_cast<short> (key[j] - d_);
+      n1[j] = static_cast<short>(key[j] + d_);
+      n2[j] = static_cast<short>(key[j] - d_);
 
-      std::multimap<size_t ,int>::iterator it;
+      std::multimap<size_t, int>::iterator it;
       size_t hash_key;
-      int key_index = -1;      
-      hash_key = generateHashKey (n1);
-      it = hash_table.find (hash_key);
-      if (it != hash_table.end ())
+      int key_index = -1;
+      hash_key = generateHashKey(n1);
+      it = hash_table.find(hash_key);
+      if (it != hash_table.end())
         key_index = it->second;
-      blur_neighbors_[j*M_+i].n1 = key_index;
+      blur_neighbors_[j * M_ + i].n1 = key_index;
 
       key_index = -1;
-      hash_key = generateHashKey (n2);
-      it = hash_table.find (hash_key);
-      if (it != hash_table.end ())
+      hash_key = generateHashKey(n2);
+      it = hash_table.find(hash_key);
+      if (it != hash_table.end())
         key_index = it->second;
-      blur_neighbors_[j*M_+i].n2 = key_index;
+      blur_neighbors_[j * M_ + i].n2 = key_index;
     }
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void 
-pcl::Permutohedral::compute (std::vector<float> &out, const std::vector<float> &in, 
-                             int value_size,
-                             int in_offset, int out_offset,
-                             int in_size, int out_size) const
+void
+pcl::Permutohedral::compute(std::vector<float>& out,
+                            const std::vector<float>& in,
+                            int value_size,
+                            int in_offset,
+                            int out_offset,
+                            int in_size,
+                            int out_size) const
 {
-  if (in_size == -1)  in_size = N_ -  in_offset;
-  if (out_size == -1) out_size = N_ - out_offset;
-		
+  if (in_size == -1)
+    in_size = N_ - in_offset;
+  if (out_size == -1)
+    out_size = N_ - out_offset;
+
   // Shift all values by 1 such that -1 -> 0 (used for blurring)
-  std::vector<float> values ((M_+2)*value_size, 0.0f);
-  std::vector<float> new_values ((M_+2)*value_size, 0.0f);
-	
+  std::vector<float> values((M_ + 2) * value_size, 0.0f);
+  std::vector<float> new_values((M_ + 2) * value_size, 0.0f);
+
   // Splatting
-  for (int i = 0;  i < in_size; i++)
-  {
-    for (int j = 0; j <= d_; j++)
-    {
-      int o = static_cast<int> (offset_[(in_offset + i) * (d_ + 1) + j]) + 1;
+  for (int i = 0; i < in_size; i++) {
+    for (int j = 0; j <= d_; j++) {
+      int o = static_cast<int>(offset_[(in_offset + i) * (d_ + 1) + j]) + 1;
       float w = barycentric_[(in_offset + i) * (d_ + 1) + j];
       for (int k = 0; k < value_size; k++)
-        values[ o * value_size + k ] += w * in[ i * value_size + k ];
+        values[o * value_size + k] += w * in[i * value_size + k];
     }
   }
-		
-  for (int j = 0; j <= d_; j++)
-  {
-    for (int i = 0; i < M_; i++)
-    {
-      int old_val_idx = (i+1) * value_size;
-      int new_val_idx = (i+1) * value_size;
-				
-      int n1 = blur_neighbors_[j*M_+i].n1+1;
-      int n2 = blur_neighbors_[j*M_+i].n2+1;
+
+  for (int j = 0; j <= d_; j++) {
+    for (int i = 0; i < M_; i++) {
+      int old_val_idx = (i + 1) * value_size;
+      int new_val_idx = (i + 1) * value_size;
+
+      int n1 = blur_neighbors_[j * M_ + i].n1 + 1;
+      int n2 = blur_neighbors_[j * M_ + i].n2 + 1;
       int n1_val_idx = n1 * value_size;
       int n2_val_idx = n2 * value_size;
-      
+
       for (int k = 0; k < value_size; k++)
-        new_values[new_val_idx + k] = values[old_val_idx + k] + 
-        0.5f * (values[n1_val_idx + k] + values[n2_val_idx + k]);        
+        new_values[new_val_idx + k] =
+            values[old_val_idx + k] +
+            0.5f * (values[n1_val_idx + k] + values[n2_val_idx + k]);
     }
-    values.swap (new_values);
+    values.swap(new_values);
   }
 
-  // Alpha is a magic scaling constant (write Andrew if you really wanna understand this)
-  float alpha = 1.0f / (1.0f + static_cast<float> (pow(2.0f, -d_)));
-		
+  // Alpha is a magic scaling constant (write Andrew if you really wanna understand
+  // this)
+  float alpha = 1.0f / (1.0f + static_cast<float>(pow(2.0f, -d_)));
+
   // Slicing
-  for (int i = 0; i < out_size; i++){
+  for (int i = 0; i < out_size; i++) {
     for (int k = 0; k < value_size; k++)
       out[i * value_size + k] = 0;
-    for (int j = 0; j <= d_; j++){
-      int o = static_cast<int> (offset_[(out_offset + i) * (d_ + 1) + j]) + 1;
+    for (int j = 0; j <= d_; j++) {
+      int o = static_cast<int>(offset_[(out_offset + i) * (d_ + 1) + j]) + 1;
       float w = barycentric_[(out_offset + i) * (d_ + 1) + j];
-      for (int k = 0; k <value_size; k++)
-        out[ i* value_size + k ] += w * values[ o * value_size + k ] * alpha;
+      for (int k = 0; k < value_size; k++)
+        out[i * value_size + k] += w * values[o * value_size + k] * alpha;
     }
-  }		
+  }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::Permutohedral::initOLD (const std::vector<float> &feature, const int feature_dimension, const int N)
+pcl::Permutohedral::initOLD(const std::vector<float>& feature,
+                            const int feature_dimension,
+                            const int N)
 {
-  // Compute the lattice coordinates for each feature [there is going to be a lot of magic here
+  // Compute the lattice coordinates for each feature [there is going to be a lot of
+  // magic here
   N_ = N;
   d_ = feature_dimension;
-  HashTableOLD hash_table(d_, N_*(d_+1));
+  HashTableOLD hash_table(d_, N_ * (d_ + 1));
 
   // Allocate the class memory
-  delete [] offsetOLD_;
-  offsetOLD_ = new int[ (d_+1)*N_ ];
-  delete [] barycentricOLD_;
-  barycentricOLD_ = new float[ (d_+1)*N_ ];
-		
-  // Allocate the local memory
-  float * scale_factor = new float[d_];
-  float * elevated = new float[d_+1];
-  float * rem0 = new float[d_+1];
-  float * barycentric = new float[d_+2];
-  int * rank = new int[d_+1];
-  short * canonical = new short[(d_+1)*(d_+1)];
-  short * key = new short[d_+1];
-		
-  // Compute the canonical simplex
-  for (int i=0; i<=d_; i++){
-    for (int j=0; j<=d_-i; j++)
-      canonical[i*(d_+1)+j] = static_cast<short> (i);
-    for (int j=d_-i+1; j<=d_; j++)
-      canonical[i*(d_+1)+j] = static_cast<short> (i - (d_+1));
-  }
-		
-  // Expected standard deviation of our filter (p.6 in [Adams etal 2010])
-  float inv_std_dev = std::sqrt (2.0f / 3.0f)* static_cast<float>(d_+1);
-  // Compute the diagonal part of E (p.5 in [Adams etal 2010])
-  for (int i=0; i<d_; i++)
-    scale_factor[i] = 1.0f / std::sqrt (static_cast<float>(i+2)*static_cast<float>(i+1)) * inv_std_dev;
-		
-  // Compute the simplex each feature lies in
-  for (int k=0; k<N_; k++)
-  {
-  //for (int k = 0; k < 500; k++){
-    // Elevate the feature (y = Ep, see p.5 in [Adams etal 2010])
-    //const float * f = feature + k*feature_size;
-    int index = k * feature_dimension;
+  delete[] offsetOLD_;
+  offsetOLD_ = new int[(d_ + 1) * N_];
+  delete[] barycentricOLD_;
+  barycentricOLD_ = new float[(d_ + 1) * N_];
 
+  // Allocate the local memory
+  float* scale_factor = new float[d_];
+  float* elevated = new float[d_ + 1];
+  float* rem0 = new float[d_ + 1];
+  float* barycentric = new float[d_ + 2];
+  int* rank = new int[d_ + 1];
+  short* canonical = new short[(d_ + 1) * (d_ + 1)];
+  short* key = new short[d_ + 1];
+
+  // Compute the canonical simplex
+  for (int i = 0; i <= d_; i++) {
+    for (int j = 0; j <= d_ - i; j++)
+      canonical[i * (d_ + 1) + j] = static_cast<short>(i);
+    for (int j = d_ - i + 1; j <= d_; j++)
+      canonical[i * (d_ + 1) + j] = static_cast<short>(i - (d_ + 1));
+  }
+
+  // Expected standard deviation of our filter (p.6 in [Adams etal 2010])
+  float inv_std_dev = std::sqrt(2.0f / 3.0f) * static_cast<float>(d_ + 1);
+  // Compute the diagonal part of E (p.5 in [Adams etal 2010])
+  for (int i = 0; i < d_; i++)
+    scale_factor[i] = 1.0f /
+                      std::sqrt(static_cast<float>(i + 2) * static_cast<float>(i + 1)) *
+                      inv_std_dev;
+
+  // Compute the simplex each feature lies in
+  for (int k = 0; k < N_; k++) {
+    // for (int k = 0; k < 500; k++){
+    // Elevate the feature (y = Ep, see p.5 in [Adams etal 2010])
+    // const float * f = feature + k*feature_size;
+    int index = k * feature_dimension;
 
     // sm contains the sum of 1..n of our faeture vector
     float sm = 0;
-    for (int j = d_; j > 0; j--)
-    {
-      //float cf = f[j-1]*scale_factor[j-1];
-      float cf = feature[index + j-1] * scale_factor[j-1];
-      elevated[j] = sm - static_cast<float>(j)*cf;
+    for (int j = d_; j > 0; j--) {
+      // float cf = f[j-1]*scale_factor[j-1];
+      float cf = feature[index + j - 1] * scale_factor[j - 1];
+      elevated[j] = sm - static_cast<float>(j) * cf;
       sm += cf;
     }
     elevated[0] = sm;
 
     // Find the closest 0-colored simplex through rounding
-    float down_factor = 1.0f / static_cast<float>(d_+1);
-    float up_factor = static_cast<float>(d_+1);
+    float down_factor = 1.0f / static_cast<float>(d_ + 1);
+    float up_factor = static_cast<float>(d_ + 1);
     int sum = 0;
-    for (int i=0; i<=d_; i++){
-      int rd = static_cast<int> (pcl_round (down_factor * elevated[i]));
-      rem0[i] = static_cast<float >(rd) * up_factor;
+    for (int i = 0; i <= d_; i++) {
+      int rd = static_cast<int>(pcl_round(down_factor * elevated[i]));
+      rem0[i] = static_cast<float>(rd) * up_factor;
       sum += rd;
     }
-			
-    // Find the simplex we are in and store it in rank (where rank describes what position coorinate i has in the sorted order of the features values)
-    for (int i=0; i<=d_; i++)
+
+    // Find the simplex we are in and store it in rank (where rank describes what
+    // position coorinate i has in the sorted order of the features values)
+    for (int i = 0; i <= d_; i++)
       rank[i] = 0;
-    for (int i=0; i<d_; i++)
-    {
+    for (int i = 0; i < d_; i++) {
       double di = elevated[i] - rem0[i];
-      for (int j=i+1; j<=d_; j++)
+      for (int j = i + 1; j <= d_; j++)
         if (di < elevated[j] - rem0[j])
           rank[i]++;
         else
@@ -400,184 +398,174 @@ pcl::Permutohedral::initOLD (const std::vector<float> &feature, const int featur
     }
 
     // If the point doesn't lie on the plane (sum != 0) bring it back
-    for (int i=0; i<=d_; i++){
+    for (int i = 0; i <= d_; i++) {
       rank[i] += sum;
-      if (rank[i] < 0){
-        rank[i] += d_+1;
-        rem0[i] += static_cast<float> (d_+1);
+      if (rank[i] < 0) {
+        rank[i] += d_ + 1;
+        rem0[i] += static_cast<float>(d_ + 1);
       }
-      else if (rank[i] > d_){
-        rank[i] -= d_+1;
-        rem0[i] -= static_cast<float> (d_+1);
+      else if (rank[i] > d_) {
+        rank[i] -= d_ + 1;
+        rem0[i] -= static_cast<float>(d_ + 1);
       }
     }
 
     // Compute the barycentric coordinates (p.10 in [Adams etal 2010])
-    for (int i=0; i<=d_+1; i++)
+    for (int i = 0; i <= d_ + 1; i++)
       barycentric[i] = 0;
-    for (int i=0; i<=d_; i++){
-      float v = (elevated[i] - rem0[i])*down_factor;
-      barycentric[d_-rank[i]  ] += v;
-      barycentric[d_-rank[i]+1] -= v;
+    for (int i = 0; i <= d_; i++) {
+      float v = (elevated[i] - rem0[i]) * down_factor;
+      barycentric[d_ - rank[i]] += v;
+      barycentric[d_ - rank[i] + 1] -= v;
     }
     // Wrap around
-    barycentric[0] += 1.0f + barycentric[d_+1];
-			
+    barycentric[0] += 1.0f + barycentric[d_ + 1];
+
     // Compute all vertices and their offset
-    for (int remainder = 0; remainder <= d_; remainder++)
-    {
+    for (int remainder = 0; remainder <= d_; remainder++) {
       for (int i = 0; i < d_; i++)
-        key[i] = static_cast<short int> (rem0[i] + canonical[remainder * (d_ + 1) + rank[i]]);
-      offsetOLD_[k*(d_+1)+remainder] = hash_table.find (key, true);
-      barycentricOLD_[k*(d_+1)+remainder] = barycentric[remainder];
-      baryOLD_.push_back (barycentric[remainder]);
+        key[i] =
+            static_cast<short int>(rem0[i] + canonical[remainder * (d_ + 1) + rank[i]]);
+      offsetOLD_[k * (d_ + 1) + remainder] = hash_table.find(key, true);
+      barycentricOLD_[k * (d_ + 1) + remainder] = barycentric[remainder];
+      baryOLD_.push_back(barycentric[remainder]);
     }
   }
 
-
-  
-
-  delete [] scale_factor;
-  delete [] elevated;
-  delete [] rem0;
-  delete [] barycentric;
-  delete [] rank;
-  delete [] canonical;
-  delete [] key;
+  delete[] scale_factor;
+  delete[] elevated;
+  delete[] rem0;
+  delete[] barycentric;
+  delete[] rank;
+  delete[] canonical;
+  delete[] key;
 
   // Find the Neighbors of each lattice point
-		
+
   // Get the number of vertices in the lattice
   M_ = hash_table.size();
-		
+
   // Create the neighborhood structure
   delete[] blur_neighborsOLD_;
-  blur_neighborsOLD_ = new Neighbors[ (d_+1)*M_ ];
-		
-  short * n1 = new short[d_+1];
-  short * n2 = new short[d_+1];
-		
+  blur_neighborsOLD_ = new Neighbors[(d_ + 1) * M_];
+
+  short* n1 = new short[d_ + 1];
+  short* n2 = new short[d_ + 1];
+
   // For each of d+1 axes,
-  for (int j = 0; j <= d_; j++){
-    for (int i=0; i<M_; i++){
-      const short * key = hash_table.getKey(i);
-      //std::cout << *key << std::endl;
-      for (int k=0; k<d_; k++){
-        n1[k] = static_cast<short int> (key[k] - 1);
-        n2[k] = static_cast<short int> (key[k] + 1);
+  for (int j = 0; j <= d_; j++) {
+    for (int i = 0; i < M_; i++) {
+      const short* key = hash_table.getKey(i);
+      // std::cout << *key << std::endl;
+      for (int k = 0; k < d_; k++) {
+        n1[k] = static_cast<short int>(key[k] - 1);
+        n2[k] = static_cast<short int>(key[k] + 1);
       }
-      n1[j] = static_cast<short int> (key[j] + d_);
-      n2[j] = static_cast<short int> (key[j] - d_);
+      n1[j] = static_cast<short int>(key[j] + d_);
+      n2[j] = static_cast<short int>(key[j] - d_);
 
-      //std::cout << *n1 << "  |  " << *n2 << std::endl;
-				
-      blur_neighborsOLD_[j*M_+i].n1 = hash_table.find(n1);
-      blur_neighborsOLD_[j*M_+i].n2 = hash_table.find(n2);
-/*
-      std::cout << hash_table.find(n1) << "  |  " <<
-      hash_table.find(n2) << std::endl;
-*/    
+      // std::cout << *n1 << "  |  " << *n2 << std::endl;
 
+      blur_neighborsOLD_[j * M_ + i].n1 = hash_table.find(n1);
+      blur_neighborsOLD_[j * M_ + i].n2 = hash_table.find(n2);
+      /*
+            std::cout << hash_table.find(n1) << "  |  " <<
+            hash_table.find(n2) << std::endl;
+      */
     }
   }
   delete[] n1;
   delete[] n2;
-
-
-
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void 
-pcl::Permutohedral::computeOLD (std::vector<float> &out, const std::vector<float> &in, 
-                                int value_size,
-                                int in_offset, int out_offset,
-                                int in_size, int out_size) const
+void
+pcl::Permutohedral::computeOLD(std::vector<float>& out,
+                               const std::vector<float>& in,
+                               int value_size,
+                               int in_offset,
+                               int out_offset,
+                               int in_size,
+                               int out_size) const
 {
-  if (in_size == -1)  in_size = N_ -  in_offset;
-  if (out_size == -1) out_size = N_ - out_offset;
-		
+  if (in_size == -1)
+    in_size = N_ - in_offset;
+  if (out_size == -1)
+    out_size = N_ - out_offset;
+
   // Shift all values by 1 such that -1 -> 0 (used for blurring)
-  float * values = new float[ (M_+2)*value_size ];
-  float * new_values = new float[ (M_+2)*value_size ];
-		
-  for (int i=0; i<(M_+2)*value_size; i++)
+  float* values = new float[(M_ + 2) * value_size];
+  float* new_values = new float[(M_ + 2) * value_size];
+
+  for (int i = 0; i < (M_ + 2) * value_size; i++)
     values[i] = new_values[i] = 0;
-		
+
   // Splatting
-  for (int i=0;  i<in_size; i++){
-    for (int j=0; j<=d_; j++){
-      int o = static_cast<int> (offsetOLD_[(in_offset+i)*(d_+1)+j]) + 1;
-      float w = barycentricOLD_[(in_offset+i)*(d_+1)+j];
-      for (int k=0; k<value_size; k++)
-        values[ o*value_size+k ] += w * in[ i*value_size+k ];
+  for (int i = 0; i < in_size; i++) {
+    for (int j = 0; j <= d_; j++) {
+      int o = static_cast<int>(offsetOLD_[(in_offset + i) * (d_ + 1) + j]) + 1;
+      float w = barycentricOLD_[(in_offset + i) * (d_ + 1) + j];
+      for (int k = 0; k < value_size; k++)
+        values[o * value_size + k] += w * in[i * value_size + k];
     }
   }
-		
-  for (int j=0; j<=d_; j++){
-    for (int i=0; i<M_; i++){
-      float * old_val = values + (i+1)*value_size;
-      float * new_val = new_values + (i+1)*value_size;
-				
-      int n1 = blur_neighborsOLD_[j*M_+i].n1+1;
-      int n2 = blur_neighborsOLD_[j*M_+i].n2+1;
-      float * n1_val = values + n1*value_size;
-      float * n2_val = values + n2*value_size;
-      for (int k=0; k<value_size; k++)
-        new_val[k] = old_val[k]+0.5f * (n1_val[k] + n2_val[k]);
+
+  for (int j = 0; j <= d_; j++) {
+    for (int i = 0; i < M_; i++) {
+      float* old_val = values + (i + 1) * value_size;
+      float* new_val = new_values + (i + 1) * value_size;
+
+      int n1 = blur_neighborsOLD_[j * M_ + i].n1 + 1;
+      int n2 = blur_neighborsOLD_[j * M_ + i].n2 + 1;
+      float* n1_val = values + n1 * value_size;
+      float* n2_val = values + n2 * value_size;
+      for (int k = 0; k < value_size; k++)
+        new_val[k] = old_val[k] + 0.5f * (n1_val[k] + n2_val[k]);
     }
-    float * tmp = values;
+    float* tmp = values;
     values = new_values;
     new_values = tmp;
   }
-  // Alpha is a magic scaling constant (write Andrew if you really wanna understand this)
-  float alpha = 1.0f / (1.0f + powf (2.0f, - float (d_)));
-		
+  // Alpha is a magic scaling constant (write Andrew if you really wanna understand
+  // this)
+  float alpha = 1.0f / (1.0f + powf(2.0f, -float(d_)));
+
   // Slicing
-  for (int i=0; i<out_size; i++)
-  {
-    for (int k=0; k<value_size; k++)
-      out[i*value_size+k] = 0;
-    for (int j=0; j<=d_; j++){
-      int o = static_cast<int> (offsetOLD_[(out_offset+i)*(d_+1)+j]) + 1;
-      float w = barycentricOLD_[(out_offset+i)*(d_+1)+j];
-      for (int k=0; k<value_size; k++)
-        out[ i*value_size+k ] += w * values[ o*value_size+k ] * alpha;
+  for (int i = 0; i < out_size; i++) {
+    for (int k = 0; k < value_size; k++)
+      out[i * value_size + k] = 0;
+    for (int j = 0; j <= d_; j++) {
+      int o = static_cast<int>(offsetOLD_[(out_offset + i) * (d_ + 1) + j]) + 1;
+      float w = barycentricOLD_[(out_offset + i) * (d_ + 1) + j];
+      for (int k = 0; k < value_size; k++)
+        out[i * value_size + k] += w * values[o * value_size + k] * alpha;
     }
   }
-		
-		
+
   delete[] values;
   delete[] new_values;
 }
 
-
-////////////////
+///////////////
 // DEBUG //////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////
 void
-pcl::Permutohedral::debug ()
+pcl::Permutohedral::debug()
 {
   bool same = true;
-  for (size_t i = 0; i < barycentric_.size (); i++)
-  {
+  for (size_t i = 0; i < barycentric_.size(); i++) {
     if (barycentric_[i] != barycentricOLD_[i])
       same = false;
-    if (offset_[i] != offsetOLD_[i])
-    {
+    if (offset_[i] != offsetOLD_[i]) {
       same = false;
     }
-    
   }
 
-  for (size_t i = 0; i < blur_neighbors_.size (); i++)
-  {
+  for (size_t i = 0; i < blur_neighbors_.size(); i++) {
     if (blur_neighbors_[i].n1 != blur_neighborsOLD_[i].n1)
       same = false;
     if (blur_neighbors_[i].n2 != blur_neighborsOLD_[i].n2)
       same = false;
   }
-
 
   if (same)
     std::cout << "DEBUG - OK" << std::endl;
@@ -589,6 +577,6 @@ pcl::Permutohedral::debug ()
 std::vector<float>
 pcl::Permuohedral::getBarycentric ()
 {
-  return 
+  return
 }
 */

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -1,91 +1,99 @@
- /*
-  * Software License Agreement (BSD License)
-  *
-  *  Point Cloud Library (PCL) - www.pointclouds.org
-  *  Copyright (c) 2010-2012, Willow Garage, Inc.
-  *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
-  *
-  *  All rights reserved.
-  *
-  *  Redistribution and use in source and binary forms, with or without
-  *  modification, are permitted provided that the following conditions
-  *  are met:
-  *
-  *   * Redistributions of source code must retain the above copyright
-  *     notice, this list of conditions and the following disclaimer.
-  *   * Redistributions in binary form must reproduce the above
-  *     copyright notice, this list of conditions and the following
-  *     disclaimer in the documentation and/or other materials provided
-  *     with the distribution.
-  *   * Neither the name of copyright holders nor the names of its
-  *     contributors may be used to endorse or promote products derived
-  *     from this software without specific prior written permission.
-  *
-  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-  *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-  *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  *  POSSIBILITY OF SUCH DAMAGE.
-  *
-  */
- 
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
 #ifndef _LIBSVM_HPP_
 #define _LIBSVM_HPP_
 
-#include <cmath>
-#include <cstdio>
-#include <cstdlib>
 #include <cctype>
 #include <cfloat>
-#include <cstring>
-#include <cstdarg>
 #include <climits>
-#include <pcl/ml/svm.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
+#include <pcl/ml/svm.h>
 int libsvm_version = LIBSVM_VERSION;
 using Qfloat = float;
 using schar = signed char;
 #ifndef min
-template <class T> static inline T min (T x, T y)
+template <class T>
+static inline T
+min(T x, T y)
 {
   return (x < y) ? x : y;
 }
 
 #endif
 #ifndef max
-template <class T> static inline T max (T x, T y)
+template <class T>
+static inline T
+max(T x, T y)
 {
   return (x > y) ? x : y;
 }
 
 #endif
-template <class T> static inline void swap (T& x, T& y)
+template <class T>
+static inline void
+swap(T& x, T& y)
 {
   T t = x;
   x = y;
   y = t;
 }
 
-template <class S, class T> static inline void 
-clone (T*& dst, S* src, int n)
+template <class S, class T>
+static inline void
+clone(T*& dst, S* src, int n)
 {
   dst = new T[n];
-  memcpy (reinterpret_cast<void*> (dst), reinterpret_cast<const void*> (src), sizeof (T) *n);
+  memcpy(
+      reinterpret_cast<void*>(dst), reinterpret_cast<const void*>(src), sizeof(T) * n);
 }
 
-static inline double powi (double base, int times)
+static inline double
+powi(double base, int times)
 {
   double tmp = base, ret = 1.0;
 
-  for (int t = times; t > 0; t /= 2)
-  {
+  for (int t = times; t > 0; t /= 2) {
     if (t % 2 == 1)
       ret *= tmp;
 
@@ -97,29 +105,33 @@ static inline double powi (double base, int times)
 
 #define INF HUGE_VAL
 #define TAU 1e-12
-#define Malloc(type,n) static_cast<type *> (malloc((n)*sizeof(type)))
-#define Realloc(var,type,n) static_cast<type *> (realloc(var,(n)*sizeof(type)))
+#define Malloc(type, n) static_cast<type*>(malloc((n) * sizeof(type)))
+#define Realloc(var, type, n) static_cast<type*>(realloc(var, (n) * sizeof(type)))
 
-static void print_string_stdout (const char *s)
+static void
+print_string_stdout(const char* s)
 {
-  fputs (s, stdout);
-  fflush (stdout);
+  fputs(s, stdout);
+  fflush(stdout);
 }
 
-static void (*svm_print_string) (const char *) = &print_string_stdout;
+static void (*svm_print_string)(const char*) = &print_string_stdout;
 #if 1
-static void info (const char *fmt, ...)
+static void
+info(const char* fmt, ...)
 {
   char buf[BUFSIZ];
   va_list ap;
-  va_start (ap, fmt);
-  vsprintf (buf, fmt, ap);
-  va_end (ap);
-  (*svm_print_string) (buf);
+  va_start(ap, fmt);
+  vsprintf(buf, fmt, ap);
+  va_end(ap);
+  (*svm_print_string)(buf);
 }
 
 #else
-static void info (const char *fmt, ...) {}
+static void
+info(const char* fmt, ...)
+{}
 
 #endif
 
@@ -130,61 +142,66 @@ static void info (const char *fmt, ...) {}
 // size is the cache size limit in bytes
 //
 
-class Cache
-{
+class Cache {
 
-  public:
-    Cache (int l, long int size);
-    ~Cache();
+public:
+  Cache(int l, long int size);
+  ~Cache();
 
-    // request data [0,len)
-    // return some position p where [p,len) need to be filled
-    // (p >= len if nothing needs to be filled)
-    int get_data (const int index, Qfloat **data, int len);
-    void swap_index (int i, int j);
+  // request data [0,len)
+  // return some position p where [p,len) need to be filled
+  // (p >= len if nothing needs to be filled)
+  int
+  get_data(const int index, Qfloat** data, int len);
+  void
+  swap_index(int i, int j);
 
-  private:
-    int l;
-    long int size;
+private:
+  int l;
+  long int size;
 
-    struct head_t
-    {
-      head_t *prev, *next; // a circular list
-      Qfloat *data;
-      int len;  // data[0,len) is cached in this entry
-    };
+  struct head_t {
+    head_t *prev, *next; // a circular list
+    Qfloat* data;
+    int len; // data[0,len) is cached in this entry
+  };
 
-    head_t *head;
-    head_t lru_head;
-    void lru_delete (head_t *h);
-    void lru_insert (head_t *h);
+  head_t* head;
+  head_t lru_head;
+  void
+  lru_delete(head_t* h);
+  void
+  lru_insert(head_t* h);
 };
 
-Cache::Cache (int l_, long int size_) : l (l_), size (size_)
+Cache::Cache(int l_, long int size_) : l(l_), size(size_)
 {
-  head = static_cast<head_t *> (calloc (l, sizeof (head_t))); // initialized to 0
-  size /= sizeof (Qfloat);
-  size -= l * sizeof (head_t) / sizeof (Qfloat);
-  size = max (size, 2 * static_cast<long int> (l)); // cache must be large enough for two columns
+  head = static_cast<head_t*>(calloc(l, sizeof(head_t))); // initialized to 0
+  size /= sizeof(Qfloat);
+  size -= l * sizeof(head_t) / sizeof(Qfloat);
+  size = max(
+      size, 2 * static_cast<long int>(l)); // cache must be large enough for two columns
   lru_head.next = lru_head.prev = &lru_head;
 }
 
 Cache::~Cache()
 {
-  for (head_t *h = lru_head.next; h != &lru_head; h = h->next)
-    free (h->data);
+  for (head_t* h = lru_head.next; h != &lru_head; h = h->next)
+    free(h->data);
 
-  free (head);
+  free(head);
 }
 
-void Cache::lru_delete (head_t *h)
+void
+Cache::lru_delete(head_t* h)
 {
   // delete from current location
   h->prev->next = h->next;
   h->next->prev = h->prev;
 }
 
-void Cache::lru_insert (head_t *h)
+void
+Cache::lru_insert(head_t* h)
 {
   // insert to last position
   h->next = &lru_head;
@@ -193,77 +210,74 @@ void Cache::lru_insert (head_t *h)
   h->next->prev = h;
 }
 
-int Cache::get_data (const int index, Qfloat **data, int len)
+int
+Cache::get_data(const int index, Qfloat** data, int len)
 {
-  head_t *h = &head[index];
+  head_t* h = &head[index];
 
   if (h->len)
-    lru_delete (h);
+    lru_delete(h);
 
   int more = len - h->len;
 
-  if (more > 0)
-  {
+  if (more > 0) {
     // free old space
-    while (size < more)
-    {
-      head_t *old = lru_head.next;
-      lru_delete (old);
-      free (old->data);
+    while (size < more) {
+      head_t* old = lru_head.next;
+      lru_delete(old);
+      free(old->data);
       size += old->len;
       old->data = nullptr;
       old->len = 0;
     }
 
     // allocate new space
-    h->data = static_cast<Qfloat *> (realloc (h->data, sizeof (Qfloat) * len));
+    h->data = static_cast<Qfloat*>(realloc(h->data, sizeof(Qfloat) * len));
 
     size -= more;
 
-    swap (h->len, len);
+    swap(h->len, len);
   }
 
-  lru_insert (h);
+  lru_insert(h);
 
   *data = h->data;
   return len;
 }
 
-void Cache::swap_index (int i, int j)
+void
+Cache::swap_index(int i, int j)
 {
   if (i == j)
     return;
 
   if (head[i].len)
-    lru_delete (&head[i]);
+    lru_delete(&head[i]);
 
   if (head[j].len)
-    lru_delete (&head[j]);
+    lru_delete(&head[j]);
 
-  swap (head[i].data, head[j].data);
+  swap(head[i].data, head[j].data);
 
-  swap (head[i].len, head[j].len);
+  swap(head[i].len, head[j].len);
 
   if (head[i].len)
-    lru_insert (&head[i]);
+    lru_insert(&head[i]);
 
   if (head[j].len)
-    lru_insert (&head[j]);
+    lru_insert(&head[j]);
 
   if (i > j)
-    swap (i, j);
+    swap(i, j);
 
-  for (head_t *h = lru_head.next; h != &lru_head; h = h->next)
-  {
-    if (h->len > i)
-    {
+  for (head_t* h = lru_head.next; h != &lru_head; h = h->next) {
+    if (h->len > i) {
       if (h->len > j)
-        swap (h->data[i], h->data[j]);
-      else
-      {
+        swap(h->data[i], h->data[j]);
+      else {
         // give up
-        lru_delete (h);
-        free (h->data);
+        lru_delete(h);
+        free(h->data);
         size += h->len;
         h->data = nullptr;
         h->len = 0;
@@ -280,112 +294,121 @@ void Cache::swap_index (int i, int j)
 // the member function get_Q is for getting one column from the Q Matrix
 //
 
-class QMatrix
-{
+class QMatrix {
 
-  public:
-    virtual Qfloat *get_Q (int column, int len) const = 0;
-    virtual double *get_QD() const = 0;
-    virtual void swap_index (int i, int j) const = 0;
-    virtual ~QMatrix() {}
+public:
+  virtual Qfloat*
+  get_Q(int column, int len) const = 0;
+  virtual double*
+  get_QD() const = 0;
+  virtual void
+  swap_index(int i, int j) const = 0;
+  virtual ~QMatrix() {}
 };
 
-class Kernel: public QMatrix
-{
+class Kernel : public QMatrix {
 
-  public:
-    Kernel (int l, svm_node * const * x, const svm_parameter& param);
-    ~Kernel();
+public:
+  Kernel(int l, svm_node* const* x, const svm_parameter& param);
+  ~Kernel();
 
-    static double k_function (const svm_node *x, const svm_node *y,
-                              const svm_parameter& param);
-    Qfloat *get_Q (int column, int len) const override = 0;
-    double *get_QD() const override = 0;
-    void swap_index (int i, int j) const override // no so const...
-    {
-      swap (x[i], x[j]);
-
-      if (x_square)
-        swap (x_square[i], x_square[j]);
-    }
-
-  protected:
-
-    double (Kernel::*kernel_function) (int i, int j) const;
-
-  private:
-    const svm_node **x;
-    double *x_square;
-
-    // svm_parameter
-    const int kernel_type;
-    const int degree;
-    const double gamma;
-    const double coef0;
-
-    static double dot (const svm_node *px, const svm_node *py);
-    double kernel_linear (int i, int j) const
-    {
-      return dot (x[i], x[j]);
-    }
-
-    double kernel_poly (int i, int j) const
-    {
-      return powi (gamma*dot (x[i], x[j]) + coef0, degree);
-    }
-
-    double kernel_rbf (int i, int j) const
-    {
-      return std::exp (-gamma* (x_square[i] + x_square[j] - 2*dot (x[i], x[j])));
-    }
-
-    double kernel_sigmoid (int i, int j) const
-    {
-      return std::tanh (gamma*dot (x[i], x[j]) + coef0);
-    }
-
-    double kernel_precomputed (int i, int j) const
-    {
-      return x[i][ int (x[j][0].value) ].value;
-    }
-};
-
-Kernel::Kernel (int l, svm_node * const * x_, const svm_parameter& param)
-    : kernel_type (param.kernel_type), degree (param.degree),
-    gamma (param.gamma), coef0 (param.coef0)
-{
-  switch (kernel_type)
+  static double
+  k_function(const svm_node* x, const svm_node* y, const svm_parameter& param);
+  Qfloat*
+  get_Q(int column, int len) const override = 0;
+  double*
+  get_QD() const override = 0;
+  void
+  swap_index(int i, int j) const override // no so const...
   {
+    swap(x[i], x[j]);
 
-    case LINEAR:
-      kernel_function = &Kernel::kernel_linear;
-      break;
-
-    case POLY:
-      kernel_function = &Kernel::kernel_poly;
-      break;
-
-    case RBF:
-      kernel_function = &Kernel::kernel_rbf;
-      break;
-
-    case SIGMOID:
-      kernel_function = &Kernel::kernel_sigmoid;
-      break;
-
-    case PRECOMPUTED:
-      kernel_function = &Kernel::kernel_precomputed;
-      break;
+    if (x_square)
+      swap(x_square[i], x_square[j]);
   }
 
-  clone (x, x_, l);
+protected:
+  double (Kernel::*kernel_function)(int i, int j) const;
 
-  if (kernel_type == RBF)
+private:
+  const svm_node** x;
+  double* x_square;
+
+  // svm_parameter
+  const int kernel_type;
+  const int degree;
+  const double gamma;
+  const double coef0;
+
+  static double
+  dot(const svm_node* px, const svm_node* py);
+  double
+  kernel_linear(int i, int j) const
   {
+    return dot(x[i], x[j]);
+  }
+
+  double
+  kernel_poly(int i, int j) const
+  {
+    return powi(gamma * dot(x[i], x[j]) + coef0, degree);
+  }
+
+  double
+  kernel_rbf(int i, int j) const
+  {
+    return std::exp(-gamma * (x_square[i] + x_square[j] - 2 * dot(x[i], x[j])));
+  }
+
+  double
+  kernel_sigmoid(int i, int j) const
+  {
+    return std::tanh(gamma * dot(x[i], x[j]) + coef0);
+  }
+
+  double
+  kernel_precomputed(int i, int j) const
+  {
+    return x[i][int(x[j][0].value)].value;
+  }
+};
+
+Kernel::Kernel(int l, svm_node* const* x_, const svm_parameter& param)
+: kernel_type(param.kernel_type)
+, degree(param.degree)
+, gamma(param.gamma)
+, coef0(param.coef0)
+{
+  switch (kernel_type) {
+
+  case LINEAR:
+    kernel_function = &Kernel::kernel_linear;
+    break;
+
+  case POLY:
+    kernel_function = &Kernel::kernel_poly;
+    break;
+
+  case RBF:
+    kernel_function = &Kernel::kernel_rbf;
+    break;
+
+  case SIGMOID:
+    kernel_function = &Kernel::kernel_sigmoid;
+    break;
+
+  case PRECOMPUTED:
+    kernel_function = &Kernel::kernel_precomputed;
+    break;
+  }
+
+  clone(x, x_, l);
+
+  if (kernel_type == RBF) {
     x_square = new double[l];
 
-    for (int i = 0;i < l;i++)
-      x_square[i] = dot (x[i], x[i]);
+    for (int i = 0; i < l; i++)
+      x_square[i] = dot(x[i], x[i]);
   }
   else
     x_square = nullptr;
@@ -397,20 +420,18 @@ Kernel::~Kernel()
   delete[] x_square;
 }
 
-double Kernel::dot (const svm_node *px, const svm_node *py)
+double
+Kernel::dot(const svm_node* px, const svm_node* py)
 {
   double sum = 0;
 
-  while (px->index != -1 && py->index != -1)
-  {
-    if (px->index == py->index)
-    {
+  while (px->index != -1 && py->index != -1) {
+    if (px->index == py->index) {
       sum += px->value * py->value;
       ++px;
       ++py;
     }
-    else
-    {
+    else {
       if (px->index > py->index)
         ++py;
       else
@@ -421,69 +442,60 @@ double Kernel::dot (const svm_node *px, const svm_node *py)
   return sum;
 }
 
-double Kernel::k_function (const svm_node *x, const svm_node *y,
-                           const svm_parameter& param)
+double
+Kernel::k_function(const svm_node* x, const svm_node* y, const svm_parameter& param)
 {
-  switch (param.kernel_type)
-  {
+  switch (param.kernel_type) {
 
-    case LINEAR:
-      return dot (x, y);
+  case LINEAR:
+    return dot(x, y);
 
-    case POLY:
-      return powi (param.gamma*dot (x, y) + param.coef0, param.degree);
+  case POLY:
+    return powi(param.gamma * dot(x, y) + param.coef0, param.degree);
 
-    case RBF:
-    {
-      double sum = 0;
+  case RBF: {
+    double sum = 0;
 
-      while (x->index != -1 && y->index != -1)
-      {
-        if (x->index == y->index)
-        {
-          double d = x->value - y->value;
-          sum += d * d;
-          ++x;
-          ++y;
-        }
-        else
-        {
-          if (x->index > y->index)
-          {
-            sum += y->value * y->value;
-            ++y;
-          }
-          else
-          {
-            sum += x->value * x->value;
-            ++x;
-          }
-        }
-      }
-
-      while (x->index != -1)
-      {
-        sum += x->value * x->value;
+    while (x->index != -1 && y->index != -1) {
+      if (x->index == y->index) {
+        double d = x->value - y->value;
+        sum += d * d;
         ++x;
-      }
-
-      while (y->index != -1)
-      {
-        sum += y->value * y->value;
         ++y;
       }
-
-      return std::exp (-param.gamma*sum);
+      else {
+        if (x->index > y->index) {
+          sum += y->value * y->value;
+          ++y;
+        }
+        else {
+          sum += x->value * x->value;
+          ++x;
+        }
+      }
     }
 
-    case SIGMOID:
-      return std::tanh (param.gamma*dot (x, y) + param.coef0);
+    while (x->index != -1) {
+      sum += x->value * x->value;
+      ++x;
+    }
 
-    case PRECOMPUTED:  //x: test (validation), y: SV
-      return x[ int (y->value) ].value;
+    while (y->index != -1) {
+      sum += y->value * y->value;
+      ++y;
+    }
 
-    default:
-      return 0;  // Unreachable
+    return std::exp(-param.gamma * sum);
+  }
+
+  case SIGMOID:
+    return std::tanh(param.gamma * dot(x, y) + param.coef0);
+
+  case PRECOMPUTED: // x: test (validation), y: SV
+    return x[int(y->value)].value;
+
+  default:
+    return 0; // Unreachable
   }
 }
 
@@ -506,98 +518,116 @@ double Kernel::k_function (const svm_node *x, const svm_node *y,
 // solution will be put in \alpha, objective value will be put in obj
 //
 
-class Solver
-{
+class Solver {
 
-  public:
-    Solver() {};
+public:
+  Solver(){};
 
-    virtual ~Solver() {};
+  virtual ~Solver(){};
 
-    struct SolutionInfo
-    {
-      double obj;
-      double rho;
-      double upper_bound_p;
-      double upper_bound_n;
-      double r; // for Solver_NU
-    };
+  struct SolutionInfo {
+    double obj;
+    double rho;
+    double upper_bound_p;
+    double upper_bound_n;
+    double r; // for Solver_NU
+  };
 
-    void Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
-                double *alpha_, double Cp, double Cn, double eps,
-                SolutionInfo* si, int shrinking);
+  void
+  Solve(int l,
+        const QMatrix& Q,
+        const double* p_,
+        const schar* y_,
+        double* alpha_,
+        double Cp,
+        double Cn,
+        double eps,
+        SolutionInfo* si,
+        int shrinking);
 
-  protected:
-    int active_size;
-    schar *y;
-    double *G;  // gradient of objective function
-    enum { LOWER_BOUND, UPPER_BOUND, FREE };
-    char *alpha_status; // LOWER_BOUND, UPPER_BOUND, FREE
-    double *alpha;
-    const QMatrix *Q;
-    const double *QD;
-    double eps;
-    double Cp, Cn;
-    double *p;
-    int *active_set;
-    double *G_bar;  // gradient, if we treat free variables as 0
-    int l;
-    bool unshrink; // XXX
+protected:
+  int active_size;
+  schar* y;
+  double* G; // gradient of objective function
+  enum { LOWER_BOUND, UPPER_BOUND, FREE };
+  char* alpha_status; // LOWER_BOUND, UPPER_BOUND, FREE
+  double* alpha;
+  const QMatrix* Q;
+  const double* QD;
+  double eps;
+  double Cp, Cn;
+  double* p;
+  int* active_set;
+  double* G_bar; // gradient, if we treat free variables as 0
+  int l;
+  bool unshrink; // XXX
 
-    double get_C (int i)
-    {
-      return (y[i] > 0) ? Cp : Cn;
-    }
+  double
+  get_C(int i)
+  {
+    return (y[i] > 0) ? Cp : Cn;
+  }
 
-    void update_alpha_status (int i)
-    {
-      if (alpha[i] >= get_C (i))
-        alpha_status[i] = UPPER_BOUND;
-      else
-        if (alpha[i] <= 0)
-          alpha_status[i] = LOWER_BOUND;
-        else
-          alpha_status[i] = FREE;
-    }
+  void
+  update_alpha_status(int i)
+  {
+    if (alpha[i] >= get_C(i))
+      alpha_status[i] = UPPER_BOUND;
+    else if (alpha[i] <= 0)
+      alpha_status[i] = LOWER_BOUND;
+    else
+      alpha_status[i] = FREE;
+  }
 
-    bool is_upper_bound (int i)
-    {
-      return alpha_status[i] == UPPER_BOUND;
-    }
+  bool
+  is_upper_bound(int i)
+  {
+    return alpha_status[i] == UPPER_BOUND;
+  }
 
-    bool is_lower_bound (int i)
-    {
-      return alpha_status[i] == LOWER_BOUND;
-    }
+  bool
+  is_lower_bound(int i)
+  {
+    return alpha_status[i] == LOWER_BOUND;
+  }
 
-    bool is_free (int i)
-    {
-      return alpha_status[i] == FREE;
-    }
+  bool
+  is_free(int i)
+  {
+    return alpha_status[i] == FREE;
+  }
 
-    void swap_index (int i, int j);
-    void reconstruct_gradient();
-    virtual int select_working_set (int &i, int &j);
-    virtual double calculate_rho();
-    virtual void do_shrinking();
+  void
+  swap_index(int i, int j);
+  void
+  reconstruct_gradient();
+  virtual int
+  select_working_set(int& i, int& j);
+  virtual double
+  calculate_rho();
+  virtual void
+  do_shrinking();
 
-  private:
-    bool be_shrunk (int i, double Gmax1, double Gmax2);
+private:
+  bool
+  be_shrunk(int i, double Gmax1, double Gmax2);
 };
 
-void Solver::swap_index (int i, int j)
+void
+Solver::swap_index(int i, int j)
 {
-  Q->swap_index (i, j);
-  swap (y[i], y[j]);
-  swap (G[i], G[j]);
-  swap (alpha_status[i], alpha_status[j]);
-  swap (alpha[i], alpha[j]);
-  swap (p[i], p[j]);
-  swap (active_set[i], active_set[j]);
-  swap (G_bar[i], G_bar[j]);
+  Q->swap_index(i, j);
+  swap(y[i], y[j]);
+  swap(G[i], G[j]);
+  swap(alpha_status[i], alpha_status[j]);
+  swap(alpha[i], alpha[j]);
+  swap(p[i], p[j]);
+  swap(active_set[i], active_set[j]);
+  swap(G_bar[i], G_bar[j]);
 }
 
-void Solver::reconstruct_gradient()
+void
+Solver::reconstruct_gradient()
 {
   // reconstruct inactive elements of G from G_bar and free variables
 
@@ -606,51 +636,55 @@ void Solver::reconstruct_gradient()
 
   int nr_free = 0;
 
-  for (int j = active_size;j < l;j++)
+  for (int j = active_size; j < l; j++)
     G[j] = G_bar[j] + p[j];
 
-  for (int j = 0;j < active_size;j++)
-    if (is_free (j))
+  for (int j = 0; j < active_size; j++)
+    if (is_free(j))
       nr_free++;
 
-  if (2*nr_free < active_size)
-    info ("\nWARNING: using -h 0 may be faster\n");
+  if (2 * nr_free < active_size)
+    info("\nWARNING: using -h 0 may be faster\n");
 
-  if (nr_free*l > 2*active_size* (l - active_size))
-  {
-    for (int i = active_size; i < l; i++)
-    {
-      const Qfloat *Q_i = Q->get_Q (i, active_size);
+  if (nr_free * l > 2 * active_size * (l - active_size)) {
+    for (int i = active_size; i < l; i++) {
+      const Qfloat* Q_i = Q->get_Q(i, active_size);
 
-      for (int j = 0;j < active_size;j++)
-        if (is_free (j))
+      for (int j = 0; j < active_size; j++)
+        if (is_free(j))
           G[i] += alpha[j] * Q_i[j];
     }
   }
-  else
-  {
+  else {
     for (int i = 0; i < active_size; i++)
-      if (is_free (i))
-      {
-        const Qfloat *Q_i = Q->get_Q (i, l);
+      if (is_free(i)) {
+        const Qfloat* Q_i = Q->get_Q(i, l);
         double alpha_i = alpha[i];
 
-        for (int j = active_size;j < l; j++)
+        for (int j = active_size; j < l; j++)
           G[j] += alpha_i * Q_i[j];
       }
   }
 }
 
-void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
-                    double *alpha_, double Cp, double Cn, double eps,
-                    SolutionInfo* si, int shrinking)
+void
+Solver::Solve(int l,
+              const QMatrix& Q,
+              const double* p_,
+              const schar* y_,
+              double* alpha_,
+              double Cp,
+              double Cn,
+              double eps,
+              SolutionInfo* si,
+              int shrinking)
 {
   this->l = l;
   this->Q = &Q;
   QD = Q.get_QD();
-  clone (p, p_, l);
-  clone (y, y_, l);
-  clone (alpha, alpha_, l);
+  clone(p, p_, l);
+  clone(y, y_, l);
+  clone(alpha, alpha_, l);
   this->Cp = Cp;
   this->Cn = Cn;
   this->eps = eps;
@@ -660,15 +694,15 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
   {
     alpha_status = new char[l];
 
-    for (int i = 0;i < l;i++)
-      update_alpha_status (i);
+    for (int i = 0; i < l; i++)
+      update_alpha_status(i);
   }
 
   // initialize active set (for shrinking)
   {
     active_set = new int[l];
 
-    for (int i = 0;i < l;i++)
+    for (int i = 0; i < l; i++)
       active_set[i] = i;
 
     active_size = l;
@@ -679,58 +713,53 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
     G = new double[l];
     G_bar = new double[l];
 
-    for (int i = 0; i < l; i++)
-    {
+    for (int i = 0; i < l; i++) {
       G[i] = p[i];
       G_bar[i] = 0;
     }
 
     for (int i = 0; i < l; i++)
-      if (!is_lower_bound (i))
-      {
-        const Qfloat *Q_i = Q.get_Q (i, l);
+      if (!is_lower_bound(i)) {
+        const Qfloat* Q_i = Q.get_Q(i, l);
         double alpha_i = alpha[i];
 
         for (int j = 0; j < l; j++)
           G[j] += alpha_i * Q_i[j];
 
-        if (is_upper_bound (i))
+        if (is_upper_bound(i))
           for (int j = 0; j < l; j++)
-            G_bar[j] += get_C (i) * Q_i[j];
+            G_bar[j] += get_C(i) * Q_i[j];
       }
   }
 
   // optimization step
 
   int iter = 0;
-  int max_iter = max (10000000, l > INT_MAX / 100 ? INT_MAX : 100 * l);
-  int counter = min (l, 1000) + 1;
+  int max_iter = max(10000000, l > INT_MAX / 100 ? INT_MAX : 100 * l);
+  int counter = min(l, 1000) + 1;
 
-  while (iter < max_iter)
-  {
+  while (iter < max_iter) {
     // show progress and do shrinking
 
-    if (--counter == 0)
-    {
-      counter = min (l, 1000);
+    if (--counter == 0) {
+      counter = min(l, 1000);
 
       if (shrinking)
         do_shrinking();
 
-      info (".");
+      info(".");
     }
 
     int i, j;
 
-    if (select_working_set (i, j) != 0)
-    {
+    if (select_working_set(i, j) != 0) {
       // reconstruct the whole gradient
       reconstruct_gradient();
       // reset active set size and check
       active_size = l;
-      info ("*");
+      info("*");
 
-      if (select_working_set (i, j) != 0)
+      if (select_working_set(i, j) != 0)
         break;
       counter = 1; // do shrinking next iteration
     }
@@ -739,17 +768,16 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 
     // update alpha[i] and alpha[j], handle bounds carefully
 
-    const Qfloat *Q_i = Q.get_Q (i, active_size);
-    const Qfloat *Q_j = Q.get_Q (j, active_size);
+    const Qfloat* Q_i = Q.get_Q(i, active_size);
+    const Qfloat* Q_j = Q.get_Q(j, active_size);
 
-    double C_i = get_C (i);
-    double C_j = get_C (j);
+    double C_i = get_C(i);
+    double C_j = get_C(j);
 
     double old_alpha_i = alpha[i];
     double old_alpha_j = alpha[j];
 
-    if (y[i] != y[j])
-    {
+    if (y[i] != y[j]) {
       double quad_coef = QD[i] + QD[j] + 2 * Q_i[j];
 
       if (quad_coef <= 0)
@@ -763,42 +791,33 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 
       alpha[j] += delta;
 
-      if (diff > 0)
-      {
-        if (alpha[j] < 0)
-        {
+      if (diff > 0) {
+        if (alpha[j] < 0) {
           alpha[j] = 0;
           alpha[i] = diff;
         }
       }
-      else
-      {
-        if (alpha[i] < 0)
-        {
+      else {
+        if (alpha[i] < 0) {
           alpha[i] = 0;
           alpha[j] = -diff;
         }
       }
 
-      if (diff > C_i - C_j)
-      {
-        if (alpha[i] > C_i)
-        {
+      if (diff > C_i - C_j) {
+        if (alpha[i] > C_i) {
           alpha[i] = C_i;
           alpha[j] = C_i - diff;
         }
       }
-      else
-      {
-        if (alpha[j] > C_j)
-        {
+      else {
+        if (alpha[j] > C_j) {
           alpha[j] = C_j;
           alpha[i] = C_j + diff;
         }
       }
     }
-    else
-    {
+    else {
       double quad_coef = QD[i] + QD[j] - 2 * Q_i[j];
 
       if (quad_coef <= 0)
@@ -812,35 +831,27 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 
       alpha[j] += delta;
 
-      if (sum > C_i)
-      {
-        if (alpha[i] > C_i)
-        {
+      if (sum > C_i) {
+        if (alpha[i] > C_i) {
           alpha[i] = C_i;
           alpha[j] = sum - C_i;
         }
       }
-      else
-      {
-        if (alpha[j] < 0)
-        {
+      else {
+        if (alpha[j] < 0) {
           alpha[j] = 0;
           alpha[i] = sum;
         }
       }
 
-      if (sum > C_j)
-      {
-        if (alpha[j] > C_j)
-        {
+      if (sum > C_j) {
+        if (alpha[j] > C_j) {
           alpha[j] = C_j;
           alpha[i] = sum - C_j;
         }
       }
-      else
-      {
-        if (alpha[i] < 0)
-        {
+      else {
+        if (alpha[i] < 0) {
           alpha[i] = 0;
           alpha[j] = sum;
         }
@@ -853,22 +864,20 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 
     double delta_alpha_j = alpha[j] - old_alpha_j;
 
-    for (int k = 0;k < active_size;k++)
-    {
+    for (int k = 0; k < active_size; k++) {
       G[k] += Q_i[k] * delta_alpha_i + Q_j[k] * delta_alpha_j;
     }
 
     // update alpha_status and G_bar
 
     {
-      bool ui = is_upper_bound (i);
-      bool uj = is_upper_bound (j);
-      update_alpha_status (i);
-      update_alpha_status (j);
+      bool ui = is_upper_bound(i);
+      bool uj = is_upper_bound(j);
+      update_alpha_status(i);
+      update_alpha_status(j);
 
-      if (ui != is_upper_bound (i))
-      {
-        Q_i = Q.get_Q (i, l);
+      if (ui != is_upper_bound(i)) {
+        Q_i = Q.get_Q(i, l);
 
         if (ui)
           for (int k = 0; k < l; k++)
@@ -878,9 +887,8 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
             G_bar[k] += C_i * Q_i[k];
       }
 
-      if (uj != is_upper_bound (j))
-      {
-        Q_j = Q.get_Q (j, l);
+      if (uj != is_upper_bound(j)) {
+        Q_j = Q.get_Q(j, l);
 
         if (uj)
           for (int k = 0; k < l; k++)
@@ -892,17 +900,15 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
     }
   }
 
-  if (iter >= max_iter)
-  {
-    if (active_size < l)
-    {
+  if (iter >= max_iter) {
+    if (active_size < l) {
       // reconstruct the whole gradient to calculate objective value
       reconstruct_gradient();
       active_size = l;
-      info ("*");
+      info("*");
     }
 
-    info ("\nWARNING: reaching max number of iterations");
+    info("\nWARNING: reaching max number of iterations");
   }
 
   // calculate rho
@@ -921,7 +927,7 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 
   // put back the solution
   {
-    for (int i = 0;i < l;i++)
+    for (int i = 0; i < l; i++)
       alpha_[active_set[i]] = alpha[i];
   }
 
@@ -937,7 +943,7 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 
   si->upper_bound_n = Cn;
 
-  info ("\noptimization finished, #iter = %d\n", iter);
+  info("\noptimization finished, #iter = %d\n", iter);
 
   delete[] p;
 
@@ -955,7 +961,8 @@ void Solver::Solve (int l, const QMatrix& Q, const double *p_, const schar *y_,
 }
 
 // return 1 if already optimal, return 0 otherwise
-int Solver::select_working_set (int &out_i, int &out_j)
+int
+Solver::select_working_set(int& out_i, int& out_j)
 {
   // return i,j such that
   // i: maximizes -y_i * grad(f)_i, i in I_up(\alpha)
@@ -969,21 +976,17 @@ int Solver::select_working_set (int &out_i, int &out_j)
   int Gmin_idx = -1;
   double obj_diff_min = INF;
 
-  for (int t = 0;t < active_size;t++)
-    if (y[t] == + 1)
-    {
-      if (!is_upper_bound (t))
-        if (-G[t] >= Gmax)
-        {
+  for (int t = 0; t < active_size; t++)
+    if (y[t] == +1) {
+      if (!is_upper_bound(t))
+        if (-G[t] >= Gmax) {
           Gmax = -G[t];
           Gmax_idx = t;
         }
     }
-    else
-    {
-      if (!is_lower_bound (t))
-        if (G[t] >= Gmax)
-        {
+    else {
+      if (!is_lower_bound(t))
+        if (G[t] >= Gmax) {
           Gmax = G[t];
           Gmax_idx = t;
         }
@@ -991,61 +994,52 @@ int Solver::select_working_set (int &out_i, int &out_j)
 
   int i = Gmax_idx;
 
-  const Qfloat *Q_i = nullptr;
+  const Qfloat* Q_i = nullptr;
 
   if (i != -1) // NULL Q_i not accessed: Gmax=-INF if i=-1
-    Q_i = Q->get_Q (i, active_size);
+    Q_i = Q->get_Q(i, active_size);
 
-  for (int j = 0;j < active_size;j++)
-  {
-    if (y[j] == + 1)
-    {
-      if (!is_lower_bound (j))
-      {
+  for (int j = 0; j < active_size; j++) {
+    if (y[j] == +1) {
+      if (!is_lower_bound(j)) {
         double grad_diff = Gmax + G[j];
 
         if (G[j] >= Gmax2)
           Gmax2 = G[j];
 
-        if (grad_diff > 0)
-        {
+        if (grad_diff > 0) {
           double obj_diff;
           double quad_coef = QD[i] + QD[j] - 2.0 * y[i] * Q_i[j];
 
           if (quad_coef > 0)
-            obj_diff = - (grad_diff * grad_diff) / quad_coef;
+            obj_diff = -(grad_diff * grad_diff) / quad_coef;
           else
-            obj_diff = - (grad_diff * grad_diff) / TAU;
+            obj_diff = -(grad_diff * grad_diff) / TAU;
 
-          if (obj_diff <= obj_diff_min)
-          {
+          if (obj_diff <= obj_diff_min) {
             Gmin_idx = j;
             obj_diff_min = obj_diff;
           }
         }
       }
     }
-    else
-    {
-      if (!is_upper_bound (j))
-      {
+    else {
+      if (!is_upper_bound(j)) {
         double grad_diff = Gmax - G[j];
 
         if (-G[j] >= Gmax2)
           Gmax2 = -G[j];
 
-        if (grad_diff > 0)
-        {
+        if (grad_diff > 0) {
           double obj_diff;
           double quad_coef = QD[i] + QD[j] + 2.0 * y[i] * Q_i[j];
 
           if (quad_coef > 0)
-            obj_diff = - (grad_diff * grad_diff) / quad_coef;
+            obj_diff = -(grad_diff * grad_diff) / quad_coef;
           else
-            obj_diff = - (grad_diff * grad_diff) / TAU;
+            obj_diff = -(grad_diff * grad_diff) / TAU;
 
-          if (obj_diff <= obj_diff_min)
-          {
+          if (obj_diff <= obj_diff_min) {
             Gmin_idx = j;
             obj_diff_min = obj_diff;
           }
@@ -1064,80 +1058,69 @@ int Solver::select_working_set (int &out_i, int &out_j)
   return 0;
 }
 
-bool Solver::be_shrunk (int i, double Gmax1, double Gmax2)
+bool
+Solver::be_shrunk(int i, double Gmax1, double Gmax2)
 {
-  if (is_upper_bound (i))
-  {
-    if (y[i] == + 1)
+  if (is_upper_bound(i)) {
+    if (y[i] == +1)
       return (-G[i] > Gmax1);
     return (-G[i] > Gmax2);
   }
-  if (is_lower_bound (i))
-  {
-    if (y[i] == + 1)
+  if (is_lower_bound(i)) {
+    if (y[i] == +1)
       return (G[i] > Gmax2);
     return (G[i] > Gmax1);
   }
   return (false);
 }
 
-void Solver::do_shrinking()
+void
+Solver::do_shrinking()
 {
-  double Gmax1 = -INF;  // max { -y_i * grad(f)_i | i in I_up(\alpha) }
-  double Gmax2 = -INF;  // max { y_i * grad(f)_i | i in I_low(\alpha) }
+  double Gmax1 = -INF; // max { -y_i * grad(f)_i | i in I_up(\alpha) }
+  double Gmax2 = -INF; // max { y_i * grad(f)_i | i in I_low(\alpha) }
 
   // find maximal violating pair first
 
-  for (int i = 0; i < active_size; i++)
-  {
-    if (y[i] == + 1)
-    {
-      if (!is_upper_bound (i))
-      {
+  for (int i = 0; i < active_size; i++) {
+    if (y[i] == +1) {
+      if (!is_upper_bound(i)) {
         if (-G[i] >= Gmax1)
           Gmax1 = -G[i];
       }
 
-      if (!is_lower_bound (i))
-      {
+      if (!is_lower_bound(i)) {
         if (G[i] >= Gmax2)
           Gmax2 = G[i];
       }
     }
-    else
-    {
-      if (!is_upper_bound (i))
-      {
+    else {
+      if (!is_upper_bound(i)) {
         if (-G[i] >= Gmax2)
           Gmax2 = -G[i];
       }
 
-      if (!is_lower_bound (i))
-      {
+      if (!is_lower_bound(i)) {
         if (G[i] >= Gmax1)
           Gmax1 = G[i];
       }
     }
   }
 
-  if (!unshrink && Gmax1 + Gmax2 <= eps*10)
-  {
+  if (!unshrink && Gmax1 + Gmax2 <= eps * 10) {
     unshrink = true;
     reconstruct_gradient();
     active_size = l;
-    info ("*");
+    info("*");
   }
 
   for (int i = 0; i < active_size; i++)
-    if (be_shrunk (i, Gmax1, Gmax2))
-    {
+    if (be_shrunk(i, Gmax1, Gmax2)) {
       active_size--;
 
-      while (active_size > i)
-      {
-        if (!be_shrunk (active_size, Gmax1, Gmax2))
-        {
-          swap_index (i, active_size);
+      while (active_size > i) {
+        if (!be_shrunk(active_size, Gmax1, Gmax2)) {
+          swap_index(i, active_size);
           break;
         }
 
@@ -1146,36 +1129,32 @@ void Solver::do_shrinking()
     }
 }
 
-double Solver::calculate_rho()
+double
+Solver::calculate_rho()
 {
   double r;
   int nr_free = 0;
   double ub = INF, lb = -INF, sum_free = 0;
 
-  for (int i = 0;i < active_size;i++)
-  {
+  for (int i = 0; i < active_size; i++) {
     double yG = y[i] * G[i];
 
-    if (is_upper_bound (i))
-    {
+    if (is_upper_bound(i)) {
       if (y[i] == -1)
-        ub = min (ub, yG);
+        ub = min(ub, yG);
       else
-        lb = max (lb, yG);
+        lb = max(lb, yG);
     }
-    else
-      if (is_lower_bound (i))
-      {
-        if (y[i] == + 1)
-          ub = min (ub, yG);
-        else
-          lb = max (lb, yG);
-      }
+    else if (is_lower_bound(i)) {
+      if (y[i] == +1)
+        ub = min(ub, yG);
       else
-      {
-        ++nr_free;
-        sum_free += yG;
-      }
+        lb = max(lb, yG);
+    }
+    else {
+      ++nr_free;
+      sum_free += yG;
+    }
   }
 
   if (nr_free > 0)
@@ -1192,30 +1171,42 @@ double Solver::calculate_rho()
 // additional constraint: e^T \alpha = constant
 //
 
-class Solver_NU : public Solver
-{
+class Solver_NU : public Solver {
 
-  public:
-    Solver_NU() {}
+public:
+  Solver_NU() {}
 
-    void Solve (int l, const QMatrix& Q, const double *p, const schar *y,
-                double *alpha, double Cp, double Cn, double eps,
-                SolutionInfo* si, int shrinking)
-    {
-      this->si = si;
-      Solver::Solve (l, Q, p, y, alpha, Cp, Cn, eps, si, shrinking);
-    }
+  void
+  Solve(int l,
+        const QMatrix& Q,
+        const double* p,
+        const schar* y,
+        double* alpha,
+        double Cp,
+        double Cn,
+        double eps,
+        SolutionInfo* si,
+        int shrinking)
+  {
+    this->si = si;
+    Solver::Solve(l, Q, p, y, alpha, Cp, Cn, eps, si, shrinking);
+  }
 
-  private:
-    SolutionInfo *si;
-    int select_working_set (int &i, int &j) override;
-    double calculate_rho() override;
-    bool be_shrunk (int i, double Gmax1, double Gmax2, double Gmax3, double Gmax4);
-    void do_shrinking() override;
+private:
+  SolutionInfo* si;
+  int
+  select_working_set(int& i, int& j) override;
+  double
+  calculate_rho() override;
+  bool
+  be_shrunk(int i, double Gmax1, double Gmax2, double Gmax3, double Gmax4);
+  void
+  do_shrinking() override;
 };
 
 // return 1 if already optimal, return 0 otherwise
-int Solver_NU::select_working_set (int &out_i, int &out_j)
+int
+Solver_NU::select_working_set(int& out_i, int& out_j)
 {
   // return i,j such that y_i = y_j and
   // i: maximizes -y_i * grad(f)_i, i in I_up(\alpha)
@@ -1234,21 +1225,17 @@ int Solver_NU::select_working_set (int &out_i, int &out_j)
   int Gmin_idx = -1;
   double obj_diff_min = INF;
 
-  for (int t = 0;t < active_size;t++)
-    if (y[t] == + 1)
-    {
-      if (!is_upper_bound (t))
-        if (-G[t] >= Gmaxp)
-        {
+  for (int t = 0; t < active_size; t++)
+    if (y[t] == +1) {
+      if (!is_upper_bound(t))
+        if (-G[t] >= Gmaxp) {
           Gmaxp = -G[t];
           Gmaxp_idx = t;
         }
     }
-    else
-    {
-      if (!is_lower_bound (t))
-        if (G[t] >= Gmaxn)
-        {
+    else {
+      if (!is_lower_bound(t))
+        if (G[t] >= Gmaxn) {
           Gmaxn = G[t];
           Gmaxn_idx = t;
         }
@@ -1257,65 +1244,56 @@ int Solver_NU::select_working_set (int &out_i, int &out_j)
   int ip = Gmaxp_idx;
 
   int in = Gmaxn_idx;
-  const Qfloat *Q_ip = nullptr;
-  const Qfloat *Q_in = nullptr;
+  const Qfloat* Q_ip = nullptr;
+  const Qfloat* Q_in = nullptr;
 
   if (ip != -1) // NULL Q_ip not accessed: Gmaxp=-INF if ip=-1
-    Q_ip = Q->get_Q (ip, active_size);
+    Q_ip = Q->get_Q(ip, active_size);
 
   if (in != -1)
-    Q_in = Q->get_Q (in, active_size);
+    Q_in = Q->get_Q(in, active_size);
 
-  for (int j = 0;j < active_size;j++)
-  {
-    if (y[j] == + 1)
-    {
-      if (!is_lower_bound (j))
-      {
+  for (int j = 0; j < active_size; j++) {
+    if (y[j] == +1) {
+      if (!is_lower_bound(j)) {
         double grad_diff = Gmaxp + G[j];
 
         if (G[j] >= Gmaxp2)
           Gmaxp2 = G[j];
 
-        if (grad_diff > 0)
-        {
+        if (grad_diff > 0) {
           double obj_diff;
           double quad_coef = QD[ip] + QD[j] - 2 * Q_ip[j];
 
           if (quad_coef > 0)
-            obj_diff = - (grad_diff * grad_diff) / quad_coef;
+            obj_diff = -(grad_diff * grad_diff) / quad_coef;
           else
-            obj_diff = - (grad_diff * grad_diff) / TAU;
+            obj_diff = -(grad_diff * grad_diff) / TAU;
 
-          if (obj_diff <= obj_diff_min)
-          {
+          if (obj_diff <= obj_diff_min) {
             Gmin_idx = j;
             obj_diff_min = obj_diff;
           }
         }
       }
     }
-    else
-    {
-      if (!is_upper_bound (j))
-      {
+    else {
+      if (!is_upper_bound(j)) {
         double grad_diff = Gmaxn - G[j];
 
         if (-G[j] >= Gmaxn2)
           Gmaxn2 = -G[j];
 
-        if (grad_diff > 0)
-        {
+        if (grad_diff > 0) {
           double obj_diff;
           double quad_coef = QD[in] + QD[j] - 2 * Q_in[j];
 
           if (quad_coef > 0)
-            obj_diff = - (grad_diff * grad_diff) / quad_coef;
+            obj_diff = -(grad_diff * grad_diff) / quad_coef;
           else
-            obj_diff = - (grad_diff * grad_diff) / TAU;
+            obj_diff = -(grad_diff * grad_diff) / TAU;
 
-          if (obj_diff <= obj_diff_min)
-          {
+          if (obj_diff <= obj_diff_min) {
             Gmin_idx = j;
             obj_diff_min = obj_diff;
           }
@@ -1324,10 +1302,10 @@ int Solver_NU::select_working_set (int &out_i, int &out_j)
     }
   }
 
-  if (max (Gmaxp + Gmaxp2, Gmaxn + Gmaxn2) < eps)
+  if (max(Gmaxp + Gmaxp2, Gmaxn + Gmaxn2) < eps)
     return 1;
 
-  if (y[Gmin_idx] == + 1)
+  if (y[Gmin_idx] == +1)
     out_i = Gmaxp_idx;
   else
     out_i = Gmaxn_idx;
@@ -1337,17 +1315,16 @@ int Solver_NU::select_working_set (int &out_i, int &out_j)
   return 0;
 }
 
-bool Solver_NU::be_shrunk (int i, double Gmax1, double Gmax2, double Gmax3, double Gmax4)
+bool
+Solver_NU::be_shrunk(int i, double Gmax1, double Gmax2, double Gmax3, double Gmax4)
 {
-  if (is_upper_bound (i))
-  {
-    if (y[i] == + 1)
+  if (is_upper_bound(i)) {
+    if (y[i] == +1)
       return (-G[i] > Gmax1);
     return (-G[i] > Gmax4);
   }
-  if (is_lower_bound (i))
-  {
-    if (y[i] == + 1)
+  if (is_lower_bound(i)) {
+    if (y[i] == +1)
       return (G[i] > Gmax2);
 
     return (G[i] > Gmax3);
@@ -1355,7 +1332,8 @@ bool Solver_NU::be_shrunk (int i, double Gmax1, double Gmax2, double Gmax3, doub
   return (false);
 }
 
-void Solver_NU::do_shrinking()
+void
+Solver_NU::do_shrinking()
 {
   double Gmax1 = -INF; // max { -y_i * grad(f)_i | y_i = +1, i in I_up(\alpha) }
   double Gmax2 = -INF; // max { y_i * grad(f)_i | y_i = +1, i in I_low(\alpha) }
@@ -1364,50 +1342,39 @@ void Solver_NU::do_shrinking()
 
   // find maximal violating pair first
 
-  for (int i = 0; i < active_size; i++)
-  {
-    if (!is_upper_bound (i))
-    {
-      if (y[i] == + 1)
-      {
+  for (int i = 0; i < active_size; i++) {
+    if (!is_upper_bound(i)) {
+      if (y[i] == +1) {
         if (-G[i] > Gmax1)
           Gmax1 = -G[i];
       }
-      else
-        if (-G[i] > Gmax4)
-          Gmax4 = -G[i];
+      else if (-G[i] > Gmax4)
+        Gmax4 = -G[i];
     }
 
-    if (!is_lower_bound (i))
-    {
-      if (y[i] == + 1)
-      {
+    if (!is_lower_bound(i)) {
+      if (y[i] == +1) {
         if (G[i] > Gmax2)
           Gmax2 = G[i];
       }
-      else
-        if (G[i] > Gmax3)
-          Gmax3 = G[i];
+      else if (G[i] > Gmax3)
+        Gmax3 = G[i];
     }
   }
 
-  if (!unshrink && max (Gmax1 + Gmax2, Gmax3 + Gmax4) <= eps*10)
-  {
+  if (!unshrink && max(Gmax1 + Gmax2, Gmax3 + Gmax4) <= eps * 10) {
     unshrink = true;
     reconstruct_gradient();
     active_size = l;
   }
 
   for (int i = 0; i < active_size; i++)
-    if (be_shrunk (i, Gmax1, Gmax2, Gmax3, Gmax4))
-    {
+    if (be_shrunk(i, Gmax1, Gmax2, Gmax3, Gmax4)) {
       active_size--;
 
-      while (active_size > i)
-      {
-        if (!be_shrunk (active_size, Gmax1, Gmax2, Gmax3, Gmax4))
-        {
-          swap_index (i, active_size);
+      while (active_size > i) {
+        if (!be_shrunk(active_size, Gmax1, Gmax2, Gmax3, Gmax4)) {
+          swap_index(i, active_size);
           break;
         }
 
@@ -1416,40 +1383,34 @@ void Solver_NU::do_shrinking()
     }
 }
 
-double Solver_NU::calculate_rho()
+double
+Solver_NU::calculate_rho()
 {
   int nr_free1 = 0, nr_free2 = 0;
   double ub1 = INF, ub2 = INF;
   double lb1 = -INF, lb2 = -INF;
   double sum_free1 = 0, sum_free2 = 0;
 
-  for (int i = 0;i < active_size;i++)
-  {
-    if (y[i] == + 1)
-    {
-      if (is_upper_bound (i))
-        lb1 = max (lb1, G[i]);
-      else
-        if (is_lower_bound (i))
-          ub1 = min (ub1, G[i]);
-        else
-        {
-          ++nr_free1;
-          sum_free1 += G[i];
-        }
+  for (int i = 0; i < active_size; i++) {
+    if (y[i] == +1) {
+      if (is_upper_bound(i))
+        lb1 = max(lb1, G[i]);
+      else if (is_lower_bound(i))
+        ub1 = min(ub1, G[i]);
+      else {
+        ++nr_free1;
+        sum_free1 += G[i];
+      }
     }
-    else
-    {
-      if (is_upper_bound (i))
-        lb2 = max (lb2, G[i]);
-      else
-        if (is_lower_bound (i))
-          ub2 = min (ub2, G[i]);
-        else
-        {
-          ++nr_free2;
-          sum_free2 += G[i];
-        }
+    else {
+      if (is_upper_bound(i))
+        lb2 = max(lb2, G[i]);
+      else if (is_lower_bound(i))
+        ub2 = min(ub2, G[i]);
+      else {
+        ++nr_free2;
+        sum_free2 += G[i];
+      }
     }
   }
 
@@ -1467,230 +1428,243 @@ double Solver_NU::calculate_rho()
 
   si->r = (r1 + r2) / 2;
 
-  return (r1 -r2) / 2;
+  return (r1 - r2) / 2;
 }
 
 //
 // Q matrices for various formulations
 //
 
-class SVC_Q: public Kernel
-{
+class SVC_Q : public Kernel {
 
-  public:
-    SVC_Q (const svm_problem& prob, const svm_parameter& param, const schar *y_)
-        : Kernel (prob.l, prob.x, param)
-    {
-      clone (y, y_, prob.l);
-      cache = new Cache (prob.l, static_cast<long int> (param.cache_size* (1 << 20)));
-      QD = new double[prob.l];
+public:
+  SVC_Q(const svm_problem& prob, const svm_parameter& param, const schar* y_)
+  : Kernel(prob.l, prob.x, param)
+  {
+    clone(y, y_, prob.l);
+    cache = new Cache(prob.l, static_cast<long int>(param.cache_size * (1 << 20)));
+    QD = new double[prob.l];
 
-      for (int i = 0;i < prob.l;i++)
-        QD[i] = (this->*kernel_function) (i, i);
+    for (int i = 0; i < prob.l; i++)
+      QD[i] = (this->*kernel_function)(i, i);
+  }
+
+  Qfloat*
+  get_Q(int i, int len) const override
+  {
+    Qfloat* data;
+    int start;
+
+    if ((start = cache->get_data(i, &data, len)) < len) {
+      for (int j = start; j < len; j++)
+        data[j] = Qfloat(y[i] * y[j] * (this->*kernel_function)(i, j));
     }
 
-    Qfloat *get_Q (int i, int len) const override
-    {
-      Qfloat *data;
-      int start;
+    return data;
+  }
 
-      if ( (start = cache->get_data (i, &data, len)) < len)
-      {
-        for (int j = start;j < len;j++)
-          data[j] = Qfloat (y[i] * y[j] * (this->*kernel_function) (i, j));
-      }
+  double*
+  get_QD() const override
+  {
+    return QD;
+  }
 
-      return data;
-    }
+  void
+  swap_index(int i, int j) const override
+  {
+    cache->swap_index(i, j);
+    Kernel::swap_index(i, j);
+    swap(y[i], y[j]);
+    swap(QD[i], QD[j]);
+  }
 
-    double *get_QD() const override
-    {
-      return QD;
-    }
+  ~SVC_Q()
+  {
+    delete[] y;
+    delete cache;
+    delete[] QD;
+  }
 
-    void swap_index (int i, int j) const override
-    {
-      cache->swap_index (i, j);
-      Kernel::swap_index (i, j);
-      swap (y[i], y[j]);
-      swap (QD[i], QD[j]);
-    }
-
-    ~SVC_Q()
-    {
-      delete[] y;
-      delete cache;
-      delete[] QD;
-    }
-
-  private:
-    schar *y;
-    Cache *cache;
-    double *QD;
+private:
+  schar* y;
+  Cache* cache;
+  double* QD;
 };
 
-class ONE_CLASS_Q: public Kernel
-{
+class ONE_CLASS_Q : public Kernel {
 
-  public:
-    ONE_CLASS_Q (const svm_problem& prob, const svm_parameter& param)
-        : Kernel (prob.l, prob.x, param)
-    {
-      cache = new Cache (prob.l, static_cast<long int> (param.cache_size* (1 << 20)));
-      QD = new double[prob.l];
+public:
+  ONE_CLASS_Q(const svm_problem& prob, const svm_parameter& param)
+  : Kernel(prob.l, prob.x, param)
+  {
+    cache = new Cache(prob.l, static_cast<long int>(param.cache_size * (1 << 20)));
+    QD = new double[prob.l];
 
-      for (int i = 0;i < prob.l;i++)
-        QD[i] = (this->*kernel_function) (i, i);
+    for (int i = 0; i < prob.l; i++)
+      QD[i] = (this->*kernel_function)(i, i);
+  }
+
+  Qfloat*
+  get_Q(int i, int len) const override
+  {
+    Qfloat* data;
+    int start;
+
+    if ((start = cache->get_data(i, &data, len)) < len) {
+      for (int j = start; j < len; j++)
+        data[j] = Qfloat((this->*kernel_function)(i, j));
     }
 
-    Qfloat *get_Q (int i, int len) const override
-    {
-      Qfloat *data;
-      int start;
+    return data;
+  }
 
-      if ( (start = cache->get_data (i, &data, len)) < len)
-      {
-        for (int j = start;j < len;j++)
-          data[j] = Qfloat ((this->*kernel_function) (i, j));
-      }
+  double*
+  get_QD() const override
+  {
+    return QD;
+  }
 
-      return data;
-    }
+  void
+  swap_index(int i, int j) const override
+  {
+    cache->swap_index(i, j);
+    Kernel::swap_index(i, j);
+    swap(QD[i], QD[j]);
+  }
 
-    double *get_QD() const override
-    {
-      return QD;
-    }
+  ~ONE_CLASS_Q()
+  {
+    delete cache;
+    delete[] QD;
+  }
 
-    void swap_index (int i, int j) const override
-    {
-      cache->swap_index (i, j);
-      Kernel::swap_index (i, j);
-      swap (QD[i], QD[j]);
-    }
-
-    ~ONE_CLASS_Q()
-    {
-      delete cache;
-      delete[] QD;
-    }
-
-  private:
-    Cache *cache;
-    double *QD;
+private:
+  Cache* cache;
+  double* QD;
 };
 
-class SVR_Q: public Kernel
-{
+class SVR_Q : public Kernel {
 
-  public:
-    SVR_Q (const svm_problem& prob, const svm_parameter& param)
-        : Kernel (prob.l, prob.x, param)
-    {
-      l = prob.l;
-      cache = new Cache (l, static_cast<long int> (param.cache_size* (1 << 20)));
-      QD = new double[2*l];
-      sign = new schar[2*l];
-      index = new int[2*l];
+public:
+  SVR_Q(const svm_problem& prob, const svm_parameter& param)
+  : Kernel(prob.l, prob.x, param)
+  {
+    l = prob.l;
+    cache = new Cache(l, static_cast<long int>(param.cache_size * (1 << 20)));
+    QD = new double[2 * l];
+    sign = new schar[2 * l];
+    index = new int[2 * l];
 
-      for (int k = 0;k < l;k++)
-      {
-        sign[k] = 1;
-        sign[k+l] = -1;
-        index[k] = k;
-        index[k+l] = k;
-        QD[k] = (this->*kernel_function) (k, k);
-        QD[k+l] = QD[k];
-      }
-
-      buffer[0] = new Qfloat[2*l];
-
-      buffer[1] = new Qfloat[2*l];
-      next_buffer = 0;
+    for (int k = 0; k < l; k++) {
+      sign[k] = 1;
+      sign[k + l] = -1;
+      index[k] = k;
+      index[k + l] = k;
+      QD[k] = (this->*kernel_function)(k, k);
+      QD[k + l] = QD[k];
     }
 
-    void swap_index (int i, int j) const override
-    {
-      swap (sign[i], sign[j]);
-      swap (index[i], index[j]);
-      swap (QD[i], QD[j]);
+    buffer[0] = new Qfloat[2 * l];
+
+    buffer[1] = new Qfloat[2 * l];
+    next_buffer = 0;
+  }
+
+  void
+  swap_index(int i, int j) const override
+  {
+    swap(sign[i], sign[j]);
+    swap(index[i], index[j]);
+    swap(QD[i], QD[j]);
+  }
+
+  Qfloat*
+  get_Q(int i, int len) const override
+  {
+    Qfloat* data;
+    int j, real_i = index[i];
+
+    if (cache->get_data(real_i, &data, l) < l) {
+      for (j = 0; j < l; j++)
+        data[j] = Qfloat((this->*kernel_function)(real_i, j));
     }
 
-    Qfloat *get_Q (int i, int len) const override
-    {
-      Qfloat *data;
-      int j, real_i = index[i];
+    // reorder and copy
+    Qfloat* buf = buffer[next_buffer];
 
-      if (cache->get_data (real_i, &data, l) < l)
-      {
-        for (j = 0;j < l;j++)
-          data[j] = Qfloat ((this->*kernel_function) (real_i, j));
-      }
+    next_buffer = 1 - next_buffer;
 
-      // reorder and copy
-      Qfloat *buf = buffer[next_buffer];
+    schar si = sign[i];
 
-      next_buffer = 1 - next_buffer;
+    for (j = 0; j < len; j++)
+      buf[j] = Qfloat(si) * Qfloat(sign[j]) * data[index[j]];
 
-      schar si = sign[i];
+    return buf;
+  }
 
-      for (j = 0;j < len;j++)
-        buf[j] = Qfloat (si) * Qfloat (sign[j]) * data[index[j]];
+  double*
+  get_QD() const override
+  {
+    return QD;
+  }
 
-      return buf;
-    }
+  ~SVR_Q()
+  {
+    delete cache;
+    delete[] sign;
+    delete[] index;
+    delete[] buffer[0];
+    delete[] buffer[1];
+    delete[] QD;
+  }
 
-    double *get_QD() const override
-    {
-      return QD;
-    }
-
-    ~SVR_Q()
-    {
-      delete cache;
-      delete[] sign;
-      delete[] index;
-      delete[] buffer[0];
-      delete[] buffer[1];
-      delete[] QD;
-    }
-
-  private:
-    int l;
-    Cache *cache;
-    schar *sign;
-    int *index;
-    mutable int next_buffer;
-    Qfloat *buffer[2];
-    double *QD;
+private:
+  int l;
+  Cache* cache;
+  schar* sign;
+  int* index;
+  mutable int next_buffer;
+  Qfloat* buffer[2];
+  double* QD;
 };
 
 //
 // construct and solve various formulations
 //
-static void solve_c_svc (
-  const svm_problem *prob, const svm_parameter* param,
-  double *alpha, Solver::SolutionInfo* si, double Cp, double Cn)
+static void
+solve_c_svc(const svm_problem* prob,
+            const svm_parameter* param,
+            double* alpha,
+            Solver::SolutionInfo* si,
+            double Cp,
+            double Cn)
 {
   int l = prob->l;
-  double *minus_ones = new double[l];
-  schar *y = new schar[l];
+  double* minus_ones = new double[l];
+  schar* y = new schar[l];
 
-  for (int i = 0; i < l; i++)
-  {
+  for (int i = 0; i < l; i++) {
     alpha[i] = 0;
     minus_ones[i] = -1;
 
     if (prob->y[i] > 0)
-      y[i] = + 1;
+      y[i] = +1;
     else
       y[i] = -1;
   }
 
   Solver s;
 
-  s.Solve (l, SVC_Q (*prob, *param, y), minus_ones, y,
-           alpha, Cp, Cn, param->eps, si, param->shrinking);
+  s.Solve(l,
+          SVC_Q(*prob, *param, y),
+          minus_ones,
+          y,
+          alpha,
+          Cp,
+          Cn,
+          param->eps,
+          si,
+          param->shrinking);
 
   double sum_alpha = 0;
 
@@ -1698,7 +1672,7 @@ static void solve_c_svc (
     sum_alpha += alpha[i];
 
   if (Cp == Cn)
-    info ("nu = %f\n", sum_alpha / (Cp*prob->l));
+    info("nu = %f\n", sum_alpha / (Cp * prob->l));
 
   for (int i = 0; i < l; i++)
     alpha[i] *= y[i];
@@ -1708,18 +1682,20 @@ static void solve_c_svc (
   delete[] y;
 }
 
-static void solve_nu_svc (
-  const svm_problem *prob, const svm_parameter *param,
-  double *alpha, Solver::SolutionInfo* si)
+static void
+solve_nu_svc(const svm_problem* prob,
+             const svm_parameter* param,
+             double* alpha,
+             Solver::SolutionInfo* si)
 {
   int l = prob->l;
   double nu = param->nu;
 
-  schar *y = new schar[l];
+  schar* y = new schar[l];
 
   for (int i = 0; i < l; i++)
     if (prob->y[i] > 0)
-      y[i] = + 1;
+      y[i] = +1;
     else
       y[i] = -1;
 
@@ -1728,30 +1704,36 @@ static void solve_nu_svc (
   double sum_neg = nu * l / 2;
 
   for (int i = 0; i < l; i++)
-    if (y[i] == + 1)
-    {
-      alpha[i] = min (1.0, sum_pos);
+    if (y[i] == +1) {
+      alpha[i] = min(1.0, sum_pos);
       sum_pos -= alpha[i];
     }
-    else
-    {
-      alpha[i] = min (1.0, sum_neg);
+    else {
+      alpha[i] = min(1.0, sum_neg);
       sum_neg -= alpha[i];
     }
 
-  double *zeros = new double[l];
+  double* zeros = new double[l];
 
   for (int i = 0; i < l; i++)
     zeros[i] = 0;
 
   Solver_NU s;
 
-  s.Solve (l, SVC_Q (*prob, *param, y), zeros, y,
-           alpha, 1.0, 1.0, param->eps, si,  param->shrinking);
+  s.Solve(l,
+          SVC_Q(*prob, *param, y),
+          zeros,
+          y,
+          alpha,
+          1.0,
+          1.0,
+          param->eps,
+          si,
+          param->shrinking);
 
   double r = si->r;
 
-  info ("C = %f\n", 1 / r);
+  info("C = %f\n", 1 / r);
 
   for (int i = 0; i < l; i++)
     alpha[i] *= y[i] / r;
@@ -1769,15 +1751,17 @@ static void solve_nu_svc (
   delete[] zeros;
 }
 
-static void solve_one_class (
-  const svm_problem *prob, const svm_parameter *param,
-  double *alpha, Solver::SolutionInfo* si)
+static void
+solve_one_class(const svm_problem* prob,
+                const svm_parameter* param,
+                double* alpha,
+                Solver::SolutionInfo* si)
 {
   int l = prob->l;
-  double *zeros = new double[l];
-  schar *ones = new schar[l];
+  double* zeros = new double[l];
+  schar* ones = new schar[l];
 
-  int n = int (param->nu * prob->l); // # of alpha's at upper bound
+  int n = int(param->nu * prob->l); // # of alpha's at upper bound
 
   for (int i = 0; i < n; i++)
     alpha[i] = 1;
@@ -1788,94 +1772,118 @@ static void solve_one_class (
   for (int i = n + 1; i < l; i++)
     alpha[i] = 0;
 
-  for (int i = 0; i < l; i++)
-  {
+  for (int i = 0; i < l; i++) {
     zeros[i] = 0;
     ones[i] = 1;
   }
 
   Solver s;
 
-  s.Solve (l, ONE_CLASS_Q (*prob, *param), zeros, ones,
-           alpha, 1.0, 1.0, param->eps, si, param->shrinking);
+  s.Solve(l,
+          ONE_CLASS_Q(*prob, *param),
+          zeros,
+          ones,
+          alpha,
+          1.0,
+          1.0,
+          param->eps,
+          si,
+          param->shrinking);
 
   delete[] zeros;
   delete[] ones;
 }
 
-static void solve_epsilon_svr (
-  const svm_problem *prob, const svm_parameter *param,
-  double *alpha, Solver::SolutionInfo* si)
+static void
+solve_epsilon_svr(const svm_problem* prob,
+                  const svm_parameter* param,
+                  double* alpha,
+                  Solver::SolutionInfo* si)
 {
   int l = prob->l;
-  double *alpha2 = new double[2*l];
-  double *linear_term = new double[2*l];
-  schar *y = new schar[2*l];
+  double* alpha2 = new double[2 * l];
+  double* linear_term = new double[2 * l];
+  schar* y = new schar[2 * l];
 
-  for (int i = 0; i < l; i++)
-  {
+  for (int i = 0; i < l; i++) {
     alpha2[i] = 0;
     linear_term[i] = param->p - prob->y[i];
     y[i] = 1;
 
-    alpha2[i+l] = 0;
-    linear_term[i+l] = param->p + prob->y[i];
-    y[i+l] = -1;
+    alpha2[i + l] = 0;
+    linear_term[i + l] = param->p + prob->y[i];
+    y[i + l] = -1;
   }
 
   Solver s;
 
-  s.Solve (2*l, SVR_Q (*prob, *param), linear_term, y,
-           alpha2, param->C, param->C, param->eps, si, param->shrinking);
+  s.Solve(2 * l,
+          SVR_Q(*prob, *param),
+          linear_term,
+          y,
+          alpha2,
+          param->C,
+          param->C,
+          param->eps,
+          si,
+          param->shrinking);
 
   double sum_alpha = 0;
 
-  for (int i = 0; i < l; i++)
-  {
-    alpha[i] = alpha2[i] - alpha2[i+l];
-    sum_alpha += std::abs (alpha[i]);
+  for (int i = 0; i < l; i++) {
+    alpha[i] = alpha2[i] - alpha2[i + l];
+    sum_alpha += std::abs(alpha[i]);
   }
 
-  info ("nu = %f\n", sum_alpha / (param->C*l));
+  info("nu = %f\n", sum_alpha / (param->C * l));
 
   delete[] alpha2;
   delete[] linear_term;
   delete[] y;
 }
 
-static void solve_nu_svr (
-  const svm_problem *prob, const svm_parameter *param,
-  double *alpha, Solver::SolutionInfo* si)
+static void
+solve_nu_svr(const svm_problem* prob,
+             const svm_parameter* param,
+             double* alpha,
+             Solver::SolutionInfo* si)
 {
   int l = prob->l;
   double C = param->C;
-  double *alpha2 = new double[2*l];
-  double *linear_term = new double[2*l];
-  schar *y = new schar[2*l];
+  double* alpha2 = new double[2 * l];
+  double* linear_term = new double[2 * l];
+  schar* y = new schar[2 * l];
 
   double sum = C * param->nu * l / 2;
 
-  for (int i = 0; i < l; i++)
-  {
-    alpha2[i] = alpha2[i+l] = min (sum, C);
+  for (int i = 0; i < l; i++) {
+    alpha2[i] = alpha2[i + l] = min(sum, C);
     sum -= alpha2[i];
 
-    linear_term[i] = - prob->y[i];
+    linear_term[i] = -prob->y[i];
     y[i] = 1;
 
-    linear_term[i+l] = prob->y[i];
-    y[i+l] = -1;
+    linear_term[i + l] = prob->y[i];
+    y[i + l] = -1;
   }
 
   Solver_NU s;
 
-  s.Solve (2*l, SVR_Q (*prob, *param), linear_term, y,
-           alpha2, C, C, param->eps, si, param->shrinking);
+  s.Solve(2 * l,
+          SVR_Q(*prob, *param),
+          linear_term,
+          y,
+          alpha2,
+          C,
+          C,
+          param->eps,
+          si,
+          param->shrinking);
 
-  info ("epsilon = %f\n", -si->r);
+  info("epsilon = %f\n", -si->r);
 
   for (int i = 0; i < l; i++)
-    alpha[i] = alpha2[i] - alpha2[i+l];
+    alpha[i] = alpha2[i] - alpha2[i + l];
 
   delete[] alpha2;
 
@@ -1888,70 +1896,63 @@ static void solve_nu_svr (
 // decision_function
 //
 
-struct decision_function
-{
-  double *alpha;
+struct decision_function {
+  double* alpha;
   double rho;
 };
 
-static decision_function svm_train_one (
-  const svm_problem *prob, const svm_parameter *param,
-  double Cp, double Cn)
+static decision_function
+svm_train_one(const svm_problem* prob, const svm_parameter* param, double Cp, double Cn)
 {
-  double *alpha = Malloc (double, prob->l);
+  double* alpha = Malloc(double, prob->l);
   Solver::SolutionInfo si;
 
-  switch (param->svm_type)
-  {
+  switch (param->svm_type) {
 
-    case C_SVC:
-      solve_c_svc (prob, param, alpha, &si, Cp, Cn);
-      break;
+  case C_SVC:
+    solve_c_svc(prob, param, alpha, &si, Cp, Cn);
+    break;
 
-    case NU_SVC:
-      solve_nu_svc (prob, param, alpha, &si);
-      break;
+  case NU_SVC:
+    solve_nu_svc(prob, param, alpha, &si);
+    break;
 
-    case ONE_CLASS:
-      solve_one_class (prob, param, alpha, &si);
-      break;
+  case ONE_CLASS:
+    solve_one_class(prob, param, alpha, &si);
+    break;
 
-    case EPSILON_SVR:
-      solve_epsilon_svr (prob, param, alpha, &si);
-      break;
+  case EPSILON_SVR:
+    solve_epsilon_svr(prob, param, alpha, &si);
+    break;
 
-    case NU_SVR:
-      solve_nu_svr (prob, param, alpha, &si);
-      break;
+  case NU_SVR:
+    solve_nu_svr(prob, param, alpha, &si);
+    break;
   }
 
-  info ("obj = %f, rho = %f\n", si.obj, si.rho);
+  info("obj = %f, rho = %f\n", si.obj, si.rho);
 
   // output SVs
 
   int nSV = 0;
   int nBSV = 0;
 
-  for (int i = 0;i < prob->l;i++)
-  {
-    if (std::abs (alpha[i]) > 0)
-    {
+  for (int i = 0; i < prob->l; i++) {
+    if (std::abs(alpha[i]) > 0) {
       ++nSV;
 
-      if (prob->y[i] > 0)
-      {
-        if (std::abs (alpha[i]) >= si.upper_bound_p)
+      if (prob->y[i] > 0) {
+        if (std::abs(alpha[i]) >= si.upper_bound_p)
           ++nBSV;
       }
-      else
-      {
-        if (std::abs (alpha[i]) >= si.upper_bound_n)
+      else {
+        if (std::abs(alpha[i]) >= si.upper_bound_n)
           ++nBSV;
       }
     }
   }
 
-  info ("nSV = %d, nBSV = %d\n", nSV, nBSV);
+  info("nSV = %d, nBSV = %d\n", nSV, nBSV);
 
   decision_function f;
   f.alpha = alpha;
@@ -1960,9 +1961,9 @@ static decision_function svm_train_one (
 }
 
 // Platt's binary SVM Probabilistic Output: an improvement from Lin et al.
-static void sigmoid_train (
-  int l, const double *dec_values, const double *labels,
-  double& A, double& B)
+static void
+sigmoid_train(
+    int l, const double* dec_values, const double* labels, double& A, double& B)
 {
   double prior1 = 0, prior0 = 0;
 
@@ -1984,17 +1985,16 @@ static void sigmoid_train (
 
   const double loTarget = 1 / (prior0 + 2.0);
 
-  double *t = Malloc (double, l);
+  double* t = Malloc(double, l);
 
   // Initial Point and Initial Fun Value
   A = 0.0;
 
-  B = std::log ( (prior0 + 1.0) / (prior1 + 1.0));
+  B = std::log((prior0 + 1.0) / (prior1 + 1.0));
 
   double fval = 0.0;
 
-  for (int i = 0; i < l; i++)
-  {
+  for (int i = 0; i < l; i++) {
     if (labels[i] > 0)
       t[i] = hiTarget;
     else
@@ -2003,14 +2003,13 @@ static void sigmoid_train (
     double fApB = dec_values[i] * A + B;
 
     if (fApB >= 0)
-      fval += t[i] * fApB + std::log (1 + std::exp (-fApB));
+      fval += t[i] * fApB + std::log(1 + std::exp(-fApB));
     else
-      fval += (t[i] - 1) * fApB + std::log (1 + std::exp (fApB));
+      fval += (t[i] - 1) * fApB + std::log(1 + std::exp(fApB));
   }
 
   int iter = 0;
-  for (; iter < max_iter; iter++)
-  {
+  for (; iter < max_iter; iter++) {
     // Update Gradient and Hessian (use H' = H + sigma I)
     double h11 = sigma; // numerically ensures strict PD
     double h22 = sigma;
@@ -2018,20 +2017,17 @@ static void sigmoid_train (
     double g1 = 0.0;
     double g2 = 0.0;
 
-    for (int i = 0; i < l; i++)
-    {
+    for (int i = 0; i < l; i++) {
       double fApB = dec_values[i] * A + B;
       double p, q;
 
-      if (fApB >= 0)
-      {
-        p = std::exp (-fApB) / (1.0 + std::exp (-fApB));
-        q = 1.0 / (1.0 + std::exp (-fApB));
+      if (fApB >= 0) {
+        p = std::exp(-fApB) / (1.0 + std::exp(-fApB));
+        q = 1.0 / (1.0 + std::exp(-fApB));
       }
-      else
-      {
-        p = 1.0 / (1.0 + std::exp (fApB));
-        q = std::exp (fApB) / (1.0 + std::exp (fApB));
+      else {
+        p = 1.0 / (1.0 + std::exp(fApB));
+        q = std::exp(fApB) / (1.0 + std::exp(fApB));
       }
 
       double d2 = p * q;
@@ -2045,42 +2041,38 @@ static void sigmoid_train (
     }
 
     // Stopping Criteria
-    if (std::abs (g1) < eps && std::abs (g2) < eps)
+    if (std::abs(g1) < eps && std::abs(g2) < eps)
       break;
 
     // Finding Newton direction: -inv(H') * g
     double det = h11 * h22 - h21 * h21;
 
-    double dA = - (h22 * g1 - h21 * g2) / det;
+    double dA = -(h22 * g1 - h21 * g2) / det;
 
-    double dB = - (-h21 * g1 + h11 * g2) / det;
+    double dB = -(-h21 * g1 + h11 * g2) / det;
 
     double gd = g1 * dA + g2 * dB;
 
+    double stepsize = 1; // Line Search
 
-    double stepsize = 1;  // Line Search
-
-    while (stepsize >= min_step)
-    {
+    while (stepsize >= min_step) {
       double newA = A + stepsize * dA;
       double newB = B + stepsize * dB;
 
       // New function value
       double newf = 0.0;
 
-      for (int i = 0; i < l; i++)
-      {
+      for (int i = 0; i < l; i++) {
         double fApB = dec_values[i] * newA + newB;
 
         if (fApB >= 0)
-          newf += t[i] * fApB + std::log (1 + std::exp (-fApB));
+          newf += t[i] * fApB + std::log(1 + std::exp(-fApB));
         else
-          newf += (t[i] - 1) * fApB + std::log (1 + std::exp (fApB));
+          newf += (t[i] - 1) * fApB + std::log(1 + std::exp(fApB));
       }
 
       // Check sufficient decrease
-      if (newf < fval + 0.0001*stepsize*gd)
-      {
+      if (newf < fval + 0.0001 * stepsize * gd) {
         A = newA;
         B = newB;
         fval = newf;
@@ -2089,67 +2081,63 @@ static void sigmoid_train (
       stepsize /= 2.0;
     }
 
-    if (stepsize < min_step)
-    {
-      info ("Line search fails in two-class probability estimates\n");
+    if (stepsize < min_step) {
+      info("Line search fails in two-class probability estimates\n");
       break;
     }
   }
 
   if (iter == max_iter)
-    info ("Reaching maximal iterations in two-class probability estimates\n");
+    info("Reaching maximal iterations in two-class probability estimates\n");
 
-  free (t);
+  free(t);
 }
 
-static double sigmoid_predict (double decision_value, double A, double B)
+static double
+sigmoid_predict(double decision_value, double A, double B)
 {
   double fApB = decision_value * A + B;
   // 1-p used later; avoid catastrophic cancellation
 
   if (fApB >= 0)
-    return std::exp (-fApB) / (1.0 + std::exp (-fApB));
-  return 1.0 / (1 + std::exp (fApB)) ;
+    return std::exp(-fApB) / (1.0 + std::exp(-fApB));
+  return 1.0 / (1 + std::exp(fApB));
 }
 
 // Method 2 from the multiclass_prob paper by Wu, Lin, and Weng
-static void multiclass_probability (int k, double **r, double *p)
+static void
+multiclass_probability(int k, double** r, double* p)
 {
-  const int max_iter = max (100, k);
-  double **Q = Malloc (double *, k);
-  double *Qp = Malloc (double, k);
+  const int max_iter = max(100, k);
+  double** Q = Malloc(double*, k);
+  double* Qp = Malloc(double, k);
   const double eps = 0.005 / k;
 
-  for (int t = 0;t < k;t++)
-  {
-    p[t] = 1.0 / k;  // Valid if k = 1
-    Q[t] = Malloc (double, k);
+  for (int t = 0; t < k; t++) {
+    p[t] = 1.0 / k; // Valid if k = 1
+    Q[t] = Malloc(double, k);
     Q[t][t] = 0;
 
-    for (int j = 0;j < t;j++)
-    {
+    for (int j = 0; j < t; j++) {
       Q[t][t] += r[j][t] * r[j][t];
       Q[t][j] = Q[j][t];
     }
 
-    for (int j = t + 1;j < k;j++)
-    {
+    for (int j = t + 1; j < k; j++) {
       Q[t][t] += r[j][t] * r[j][t];
       Q[t][j] = -r[j][t] * r[t][j];
     }
   }
 
   int iter = 0;
-  for (; iter < max_iter; iter++)
-  {
+  for (; iter < max_iter; iter++) {
     // stopping condition, recalculate QP,pQP for numerical accuracy
     double pQp = 0;
 
-    for (int t = 0;t < k;t++)
-    {
+    for (int t = 0; t < k; t++) {
       Qp[t] = 0;
 
-      for (int j = 0;j < k;j++)
+      for (int j = 0; j < k; j++)
         Qp[t] += Q[t][j] * p[j];
 
       pQp += p[t] * Qp[t];
@@ -2157,9 +2145,8 @@ static void multiclass_probability (int k, double **r, double *p)
 
     double max_error = 0;
 
-    for (int t = 0;t < k;t++)
-    {
-      double error = std::abs (Qp[t] - pQp);
+    for (int t = 0; t < k; t++) {
+      double error = std::abs(Qp[t] - pQp);
 
       if (error > max_error)
         max_error = error;
@@ -2168,14 +2155,12 @@ static void multiclass_probability (int k, double **r, double *p)
     if (max_error < eps)
       break;
 
-    for (int t = 0;t < k;t++)
-    {
+    for (int t = 0; t < k; t++) {
       double diff = (-Qp[t] + pQp) / Q[t][t];
       p[t] += diff;
       pQp = (pQp + diff * (diff * Q[t][t] + 2 * Qp[t])) / (1 + diff) / (1 + diff);
 
-      for (int j = 0;j < k;j++)
-      {
+      for (int j = 0; j < k; j++) {
         Qp[j] = (Qp[j] + diff * Q[t][j]) / (1 + diff);
         p[j] /= (1 + diff);
       }
@@ -2183,58 +2168,58 @@ static void multiclass_probability (int k, double **r, double *p)
   }
 
   if (iter == max_iter)
-    info ("Exceeds max_iter in multiclass_prob\n");
+    info("Exceeds max_iter in multiclass_prob\n");
 
-  for (int t = 0;t < k;t++)
-    free (Q[t]);
+  for (int t = 0; t < k; t++)
+    free(Q[t]);
 
-  free (Q);
+  free(Q);
 
-  free (Qp);
+  free(Qp);
 }
 
 // Cross-validation decision values for probability estimates
-static void svm_binary_svc_probability (
-  const svm_problem *prob, const svm_parameter *param,
-  double Cp, double Cn, double& probA, double& probB)
+static void
+svm_binary_svc_probability(const svm_problem* prob,
+                           const svm_parameter* param,
+                           double Cp,
+                           double Cn,
+                           double& probA,
+                           double& probB)
 {
   int nr_fold = 5;
-  int *perm = Malloc (int, prob->l);
-  double *dec_values = Malloc (double, prob->l);
+  int* perm = Malloc(int, prob->l);
+  double* dec_values = Malloc(double, prob->l);
 
   // random shuffle
 
   for (int i = 0; i < prob->l; i++)
     perm[i] = i;
 
-  for (int i = 0; i < prob->l; i++)
-  {
+  for (int i = 0; i < prob->l; i++) {
     int j = i + rand() % (prob->l - i);
-    swap (perm[i], perm[j]);
+    swap(perm[i], perm[j]);
   }
 
-  for (int i = 0; i < nr_fold; i++)
-  {
+  for (int i = 0; i < nr_fold; i++) {
     int begin = i * prob->l / nr_fold;
     int end = (i + 1) * prob->l / nr_fold;
 
     struct svm_problem subprob;
 
     subprob.l = prob->l - (end - begin);
-    subprob.x = Malloc (struct svm_node*, subprob.l);
-    subprob.y = Malloc (double, subprob.l);
+    subprob.x = Malloc(struct svm_node*, subprob.l);
+    subprob.y = Malloc(double, subprob.l);
 
     int k = 0;
 
-    for (int j = 0;j < begin;j++)
-    {
+    for (int j = 0; j < begin; j++) {
       subprob.x[k] = prob->x[perm[j]];
       subprob.y[k] = prob->y[perm[j]];
       ++k;
     }
 
-    for (int j = end;j < prob->l;j++)
-    {
+    for (int j = end; j < prob->l; j++) {
       subprob.x[k] = prob->x[perm[j]];
       subprob.y[k] = prob->y[perm[j]];
       ++k;
@@ -2242,121 +2227,120 @@ static void svm_binary_svc_probability (
 
     int p_count = 0, n_count = 0;
 
-    for (int j = 0;j < k;j++)
+    for (int j = 0; j < k; j++)
       if (subprob.y[j] > 0)
         p_count++;
       else
         n_count++;
 
     if (p_count == 0 && n_count == 0)
-      for (int j = begin;j < end;j++)
+      for (int j = begin; j < end; j++)
         dec_values[perm[j]] = 0;
-    else
-      if (p_count > 0 && n_count == 0)
-        for (int j = begin;j < end;j++)
-          dec_values[perm[j]] = 1;
-      else
-        if (p_count == 0 && n_count > 0)
-          for (int j = begin;j < end;j++)
-            dec_values[perm[j]] = -1;
-        else
-        {
-          svm_parameter subparam = *param;
-          subparam.probability = 0;
-          subparam.C = 1.0;
-          subparam.nr_weight = 2;
-          subparam.weight_label = Malloc (int, 2);
-          subparam.weight = Malloc (double, 2);
-          subparam.weight_label[0] = + 1;
-          subparam.weight_label[1] = -1;
-          subparam.weight[0] = Cp;
-          subparam.weight[1] = Cn;
+    else if (p_count > 0 && n_count == 0)
+      for (int j = begin; j < end; j++)
+        dec_values[perm[j]] = 1;
+    else if (p_count == 0 && n_count > 0)
+      for (int j = begin; j < end; j++)
+        dec_values[perm[j]] = -1;
+    else {
+      svm_parameter subparam = *param;
+      subparam.probability = 0;
+      subparam.C = 1.0;
+      subparam.nr_weight = 2;
+      subparam.weight_label = Malloc(int, 2);
+      subparam.weight = Malloc(double, 2);
+      subparam.weight_label[0] = +1;
+      subparam.weight_label[1] = -1;
+      subparam.weight[0] = Cp;
+      subparam.weight[1] = Cn;
 
-          struct svm_model *submodel = svm_train (&subprob, &subparam);
+      struct svm_model* submodel = svm_train(&subprob, &subparam);
 
-          for (int j = begin;j < end;j++)
-          {
-            svm_predict_values (submodel, prob->x[perm[j]], & (dec_values[perm[j]]));
-            // ensure +1 -1 order; reason not using CV subroutine
-            dec_values[perm[j]] *= submodel->label[0];
-          }
+      for (int j = begin; j < end; j++) {
+        svm_predict_values(submodel, prob->x[perm[j]], &(dec_values[perm[j]]));
+        // ensure +1 -1 order; reason not using CV subroutine
+        dec_values[perm[j]] *= submodel->label[0];
+      }
 
-          svm_free_and_destroy_model (&submodel);
+      svm_free_and_destroy_model(&submodel);
 
-          svm_destroy_param (&subparam);
-        }
+      svm_destroy_param(&subparam);
+    }
 
-    free (subprob.x);
+    free(subprob.x);
 
-    free (subprob.y);
+    free(subprob.y);
   }
 
-  sigmoid_train (prob->l, dec_values, prob->y, probA, probB);
+  sigmoid_train(prob->l, dec_values, prob->y, probA, probB);
 
-  free (dec_values);
-  free (perm);
+  free(dec_values);
+  free(perm);
 }
 
 // Return parameter of a Laplace distribution
-static double svm_svr_probability (
-  const svm_problem *prob, const svm_parameter *param)
+static double
+svm_svr_probability(const svm_problem* prob, const svm_parameter* param)
 {
   int nr_fold = 5;
-  double *ymv = Malloc (double, prob->l);
+  double* ymv = Malloc(double, prob->l);
   double mae = 0;
 
   svm_parameter newparam = *param;
   newparam.probability = 0;
-  svm_cross_validation (prob, &newparam, nr_fold, ymv);
+  svm_cross_validation(prob, &newparam, nr_fold, ymv);
 
-  for (int i = 0; i < prob->l; i++)
-  {
+  for (int i = 0; i < prob->l; i++) {
     ymv[i] = prob->y[i] - ymv[i];
-    mae += std::abs (ymv[i]);
+    mae += std::abs(ymv[i]);
   }
 
   mae /= prob->l;
 
-  double std = sqrt (2 * mae * mae);
+  double std = sqrt(2 * mae * mae);
   int count = 0;
   mae = 0;
 
   for (int i = 0; i < prob->l; i++)
-    if (std::abs (ymv[i]) > 5*std)
+    if (std::abs(ymv[i]) > 5 * std)
       count += 1;
     else
-      mae += std::abs (ymv[i]);
+      mae += std::abs(ymv[i]);
 
   mae /= (prob->l - count);
 
-  info ("Prob. model for test data: target value = predicted value + z,\nz: Laplace distribution e^(-|z|/sigma)/(2sigma),sigma= %g\n", mae);
+  info("Prob. model for test data: target value = predicted value + z,\nz: Laplace "
+       "distribution e^(-|z|/sigma)/(2sigma),sigma= %g\n",
+       mae);
 
-  free (ymv);
+  free(ymv);
 
   return mae;
 }
 
-
-// label: label name, start: begin of each class, count: #data of classes, perm: indices to the original data
-// perm, length l, must be allocated before calling this subroutine
-static void svm_group_classes (const svm_problem *prob, int *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
+// label: label name, start: begin of each class, count: #data of classes, perm: indices
+// to the original data perm, length l, must be allocated before calling this subroutine
+static void
+svm_group_classes(const svm_problem* prob,
+                  int* nr_class_ret,
+                  int** label_ret,
+                  int** start_ret,
+                  int** count_ret,
+                  int* perm)
 {
   int l = prob->l;
   int max_nr_class = 16;
   int nr_class = 0;
-  int *label = Malloc (int, max_nr_class);
-  int *count = Malloc (int, max_nr_class);
-  int *data_label = Malloc (int, l);
+  int* label = Malloc(int, max_nr_class);
+  int* count = Malloc(int, max_nr_class);
+  int* data_label = Malloc(int, l);
 
-  for (int i = 0; i < l; i++)
-  {
-    int this_label = int (prob->y[i]);
+  for (int i = 0; i < l; i++) {
+    int this_label = int(prob->y[i]);
     int j;
 
-    for (j = 0;j < nr_class;j++)
-    {
-      if (this_label == label[j])
-      {
+    for (j = 0; j < nr_class; j++) {
+      if (this_label == label[j]) {
         ++count[j];
         break;
       }
@@ -2364,13 +2348,11 @@ static void svm_group_classes (const svm_problem *prob, int *nr_class_ret, int *
 
     data_label[i] = j;
 
-    if (j == nr_class)
-    {
-      if (nr_class == max_nr_class)
-      {
+    if (j == nr_class) {
+      if (nr_class == max_nr_class) {
         max_nr_class *= 2;
-        label = static_cast<int *> (realloc (label, max_nr_class * sizeof (int)));
-        count = static_cast<int *> (realloc (count, max_nr_class * sizeof (int)));
+        label = static_cast<int*>(realloc(label, max_nr_class * sizeof(int)));
+        count = static_cast<int*>(realloc(count, max_nr_class * sizeof(int)));
       }
 
       label[nr_class] = this_label;
@@ -2380,15 +2362,14 @@ static void svm_group_classes (const svm_problem *prob, int *nr_class_ret, int *
     }
   }
 
-  int *start = Malloc (int, nr_class);
+  int* start = Malloc(int, nr_class);
 
   start[0] = 0;
 
   for (int i = 1; i < nr_class; i++)
-    start[i] = start[i-1] + count[i-1];
+    start[i] = start[i - 1] + count[i - 1];
 
-  for (int i = 0; i < l; i++)
-  {
+  for (int i = 0; i < l; i++) {
     perm[start[data_label[i]]] = i;
     ++start[data_label[i]];
   }
@@ -2396,7 +2377,7 @@ static void svm_group_classes (const svm_problem *prob, int *nr_class_ret, int *
   start[0] = 0;
 
   for (int i = 1; i < nr_class; i++)
-    start[i] = start[i-1] + count[i-1];
+    start[i] = start[i - 1] + count[i - 1];
 
   *nr_class_ret = nr_class;
 
@@ -2406,168 +2387,161 @@ static void svm_group_classes (const svm_problem *prob, int *nr_class_ret, int *
 
   *count_ret = count;
 
-  free (data_label);
+  free(data_label);
 }
 
 //
 // Interface functions
 //
-svm_model *svm_train (const svm_problem *prob, const svm_parameter *param)
+svm_model*
+svm_train(const svm_problem* prob, const svm_parameter* param)
 {
-  svm_model *model = Malloc (svm_model, 1);
+  svm_model* model = Malloc(svm_model, 1);
   model->param = *param;
   model->free_sv = 0; // XXX
   model->probA = nullptr;
   model->probB = nullptr;
 
-  if (param->svm_type == ONE_CLASS ||
-      param->svm_type == EPSILON_SVR ||
-      param->svm_type == NU_SVR)
-  {
+  if (param->svm_type == ONE_CLASS || param->svm_type == EPSILON_SVR ||
+      param->svm_type == NU_SVR) {
     // regression or one-class-svm
     model->nr_class = 2;
     model->label = nullptr;
     model->nSV = nullptr;
     model->probA = nullptr;
     model->probB = nullptr;
-    model->sv_coef = Malloc (double *, 1);
+    model->sv_coef = Malloc(double*, 1);
 
     if (param->probability &&
-        (param->svm_type == EPSILON_SVR ||
-         param->svm_type == NU_SVR))
-    {
-      model->probA = Malloc (double, 1);
-      model->probA[0] = svm_svr_probability (prob, param);
+        (param->svm_type == EPSILON_SVR || param->svm_type == NU_SVR)) {
+      model->probA = Malloc(double, 1);
+      model->probA[0] = svm_svr_probability(prob, param);
     }
 
-    decision_function f = svm_train_one (prob, param, 0, 0);
+    decision_function f = svm_train_one(prob, param, 0, 0);
 
-    model->rho = Malloc (double, 1);
+    model->rho = Malloc(double, 1);
     model->rho[0] = f.rho;
 
     int nSV = 0;
 
     for (int i = 0; i < prob->l; i++)
-      if (std::abs (f.alpha[i]) > 0)
+      if (std::abs(f.alpha[i]) > 0)
         ++nSV;
 
     model->l = nSV;
 
-    model->SV = Malloc (svm_node *, nSV);
+    model->SV = Malloc(svm_node*, nSV);
 
-    model->sv_coef[0] = Malloc (double, nSV);
+    model->sv_coef[0] = Malloc(double, nSV);
 
     int j = 0;
 
     for (int i = 0; i < prob->l; i++)
-      if (std::abs (f.alpha[i]) > 0)
-      {
+      if (std::abs(f.alpha[i]) > 0) {
         model->SV[j] = prob->x[i];
         model->sv_coef[0][j] = f.alpha[i];
         ++j;
       }
 
-    free (f.alpha);
+    free(f.alpha);
   }
-  else
-  {
+  else {
     // classification
     int l = prob->l;
     int nr_class;
-    int *label = nullptr;
-    int *start = nullptr;
-    int *count = nullptr;
-    int *perm = Malloc (int, l);
+    int* label = nullptr;
+    int* start = nullptr;
+    int* count = nullptr;
+    int* perm = Malloc(int, l);
 
     // group training data of the same class
-    svm_group_classes (prob, &nr_class, &label, &start, &count, perm);
+    svm_group_classes(prob, &nr_class, &label, &start, &count, perm);
 
     if (nr_class == 1)
-      info ("WARNING: training data in only one class. See README for details.\n");
+      info("WARNING: training data in only one class. See README for details.\n");
 
-    svm_node **x = Malloc (svm_node *, l);
+    svm_node** x = Malloc(svm_node*, l);
 
     for (int i = 0; i < l; i++)
       x[i] = prob->x[perm[i]];
 
     // calculate weighted C
 
-    double *weighted_C = Malloc (double, nr_class);
+    double* weighted_C = Malloc(double, nr_class);
 
     for (int i = 0; i < nr_class; i++)
       weighted_C[i] = param->C;
 
-    for (int i = 0; i < param->nr_weight; i++)
-    {
+    for (int i = 0; i < param->nr_weight; i++) {
       int j;
 
-      for (j = 0;j < nr_class;j++)
+      for (j = 0; j < nr_class; j++)
         if (param->weight_label[i] == label[j])
           break;
 
       if (j == nr_class)
-        fprintf (stderr, "WARNING: class label %d specified in weight is not found\n", param->weight_label[i]);
+        fprintf(stderr,
+                "WARNING: class label %d specified in weight is not found\n",
+                param->weight_label[i]);
       else
         weighted_C[j] *= param->weight[i];
     }
 
     // train k*(k-1)/2 models
 
-    bool *nonzero = Malloc (bool, l);
+    bool* nonzero = Malloc(bool, l);
 
     for (int i = 0; i < l; i++)
       nonzero[i] = false;
 
-    decision_function *f = Malloc (decision_function, nr_class * (nr_class - 1) / 2);
+    decision_function* f = Malloc(decision_function, nr_class * (nr_class - 1) / 2);
 
     double *probA = nullptr, *probB = nullptr;
 
-    if (param->probability)
-    {
-      probA = Malloc (double, nr_class * (nr_class - 1) / 2);
-      probB = Malloc (double, nr_class * (nr_class - 1) / 2);
+    if (param->probability) {
+      probA = Malloc(double, nr_class*(nr_class - 1) / 2);
+      probB = Malloc(double, nr_class*(nr_class - 1) / 2);
     }
 
     int p = 0;
 
     for (int i = 0; i < nr_class; i++)
-      for (int j = i + 1;j < nr_class;j++)
-      {
+      for (int j = i + 1; j < nr_class; j++) {
         svm_problem sub_prob;
         int si = start[i], sj = start[j];
         int ci = count[i], cj = count[j];
         sub_prob.l = ci + cj;
-        sub_prob.x = Malloc (svm_node *, sub_prob.l);
-        sub_prob.y = Malloc (double, sub_prob.l);
+        sub_prob.x = Malloc(svm_node*, sub_prob.l);
+        sub_prob.y = Malloc(double, sub_prob.l);
 
-        for (int k = 0; k < ci; k++)
-        {
-          sub_prob.x[k] = x[si+k];
-          sub_prob.y[k] = + 1;
+        for (int k = 0; k < ci; k++) {
+          sub_prob.x[k] = x[si + k];
+          sub_prob.y[k] = +1;
         }
 
-        for (int k = 0; k < cj; k++)
-        {
-          sub_prob.x[ci+k] = x[sj+k];
-          sub_prob.y[ci+k] = -1;
+        for (int k = 0; k < cj; k++) {
+          sub_prob.x[ci + k] = x[sj + k];
+          sub_prob.y[ci + k] = -1;
         }
 
         if (param->probability)
-          svm_binary_svc_probability (&sub_prob, param, weighted_C[i], weighted_C[j], probA[p], probB[p]);
+          svm_binary_svc_probability(
+              &sub_prob, param, weighted_C[i], weighted_C[j], probA[p], probB[p]);
 
-        f[p] = svm_train_one (&sub_prob, param, weighted_C[i], weighted_C[j]);
+        f[p] = svm_train_one(&sub_prob, param, weighted_C[i], weighted_C[j]);
 
         for (int k = 0; k < ci; k++)
-          if (!nonzero[si+k] && std::abs (f[p].alpha[k]) > 0)
-            nonzero[si+k] = true;
+          if (!nonzero[si + k] && std::abs(f[p].alpha[k]) > 0)
+            nonzero[si + k] = true;
 
         for (int k = 0; k < cj; k++)
-          if (!nonzero[sj+k] && std::abs (f[p].alpha[ci+k]) > 0)
-            nonzero[sj+k] = true;
+          if (!nonzero[sj + k] && std::abs(f[p].alpha[ci + k]) > 0)
+            nonzero[sj + k] = true;
 
-        free (sub_prob.x);
+        free(sub_prob.x);
 
-        free (sub_prob.y);
+        free(sub_prob.y);
 
         ++p;
       }
@@ -2576,45 +2550,40 @@ svm_model *svm_train (const svm_problem *prob, const svm_parameter *param)
 
     model->nr_class = nr_class;
 
-    model->label = Malloc (int, nr_class);
+    model->label = Malloc(int, nr_class);
 
     for (int i = 0; i < nr_class; i++)
       model->label[i] = label[i];
 
-    model->rho = Malloc (double, nr_class * (nr_class - 1) / 2);
+    model->rho = Malloc(double, nr_class*(nr_class - 1) / 2);
 
-    for (int i = 0; i < nr_class* (nr_class - 1) / 2; i++)
+    for (int i = 0; i < nr_class * (nr_class - 1) / 2; i++)
       model->rho[i] = f[i].rho;
 
-    if (param->probability)
-    {
-      model->probA = Malloc (double, nr_class * (nr_class - 1) / 2);
-      model->probB = Malloc (double, nr_class * (nr_class - 1) / 2);
+    if (param->probability) {
+      model->probA = Malloc(double, nr_class*(nr_class - 1) / 2);
+      model->probB = Malloc(double, nr_class*(nr_class - 1) / 2);
 
-      for (int i = 0; i < nr_class* (nr_class - 1) / 2; i++)
-      {
+      for (int i = 0; i < nr_class * (nr_class - 1) / 2; i++) {
         model->probA[i] = probA[i];
         model->probB[i] = probB[i];
       }
     }
-    else
-    {
+    else {
       model->probA = nullptr;
       model->probB = nullptr;
     }
 
     int total_sv = 0;
 
-    int *nz_count = Malloc (int, nr_class);
-    model->nSV = Malloc (int, nr_class);
+    int* nz_count = Malloc(int, nr_class);
+    model->nSV = Malloc(int, nr_class);
 
-    for (int i = 0; i < nr_class; i++)
-    {
+    for (int i = 0; i < nr_class; i++) {
       int nSV = 0;
 
-      for (int j = 0;j < count[i];j++)
-        if (nonzero[start[i] + j])
-        {
+      for (int j = 0; j < count[i]; j++)
+        if (nonzero[start[i] + j]) {
           ++nSV;
           ++total_sv;
         }
@@ -2624,33 +2593,32 @@ svm_model *svm_train (const svm_problem *prob, const svm_parameter *param)
       nz_count[i] = nSV;
     }
 
-    info ("Total nSV = %d\n", total_sv);
+    info("Total nSV = %d\n", total_sv);
 
     model->l = total_sv;
-    model->SV = Malloc (svm_node *, total_sv);
+    model->SV = Malloc(svm_node*, total_sv);
     p = 0;
 
     for (int i = 0; i < l; i++)
       if (nonzero[i])
         model->SV[p++] = x[i];
 
-    int *nz_start = Malloc (int, nr_class);
+    int* nz_start = Malloc(int, nr_class);
 
     nz_start[0] = 0;
 
     for (int i = 1; i < nr_class; i++)
-      nz_start[i] = nz_start[i-1] + nz_count[i-1];
+      nz_start[i] = nz_start[i - 1] + nz_count[i - 1];
 
-    model->sv_coef = Malloc (double *, nr_class - 1);
+    model->sv_coef = Malloc(double*, nr_class - 1);
 
     for (int i = 0; i < nr_class - 1; i++)
-      model->sv_coef[i] = Malloc (double, total_sv);
+      model->sv_coef[i] = Malloc(double, total_sv);
 
     p = 0;
 
     for (int i = 0; i < nr_class; i++)
-      for (int j = i + 1;j < nr_class;j++)
-      {
+      for (int j = i + 1; j < nr_class; j++) {
         // classifier (i,j): coefficients with
         // i are in sv_coef[j-1][nz_start[i]...],
         // j are in sv_coef[i][nz_start[j]...]
@@ -2663,77 +2631,77 @@ svm_model *svm_train (const svm_problem *prob, const svm_parameter *param)
         int q = nz_start[i];
 
         for (int k = 0; k < ci; k++)
-          if (nonzero[si+k])
-            model->sv_coef[j-1][q++] = f[p].alpha[k];
+          if (nonzero[si + k])
+            model->sv_coef[j - 1][q++] = f[p].alpha[k];
 
         q = nz_start[j];
 
         for (int k = 0; k < cj; k++)
-          if (nonzero[sj+k])
-            model->sv_coef[i][q++] = f[p].alpha[ci+k];
+          if (nonzero[sj + k])
+            model->sv_coef[i][q++] = f[p].alpha[ci + k];
 
         ++p;
       }
 
-    free (label);
+    free(label);
 
-    free (probA);
-    free (probB);
-    free (count);
-    free (perm);
-    free (start);
-    free (x);
-    free (weighted_C);
-    free (nonzero);
+    free(probA);
+    free(probB);
+    free(count);
+    free(perm);
+    free(start);
+    free(x);
+    free(weighted_C);
+    free(nonzero);
 
-    for (int i = 0; i < nr_class* (nr_class - 1) / 2; i++)
-      free (f[i].alpha);
+    for (int i = 0; i < nr_class * (nr_class - 1) / 2; i++)
+      free(f[i].alpha);
 
-    free (f);
+    free(f);
 
-    free (nz_count);
+    free(nz_count);
 
-    free (nz_start);
+    free(nz_start);
   }
 
   return model;
 }
 
 // Stratified cross validation
-void svm_cross_validation (const svm_problem *prob, const svm_parameter *param, int nr_fold, double *target)
+void
+svm_cross_validation(const svm_problem* prob,
+                     const svm_parameter* param,
+                     int nr_fold,
+                     double* target)
 {
-  int *fold_start = Malloc (int, nr_fold + 1);
+  int* fold_start = Malloc(int, nr_fold + 1);
   int l = prob->l;
-  int *perm = Malloc (int, l);
+  int* perm = Malloc(int, l);
   int nr_class;
 
   // stratified cv may not give leave-one-out rate
   // Each class to l folds -> some folds may have zero elements
 
-  if ( (param->svm_type == C_SVC ||
-        param->svm_type == NU_SVC) && nr_fold < l)
-  {
-    int *start = nullptr;
-    int *label = nullptr;
-    int *count = nullptr;
-    svm_group_classes (prob, &nr_class, &label, &start, &count, perm);
+  if ((param->svm_type == C_SVC || param->svm_type == NU_SVC) && nr_fold < l) {
+    int* start = nullptr;
+    int* label = nullptr;
+    int* count = nullptr;
+    svm_group_classes(prob, &nr_class, &label, &start, &count, perm);
 
     // random shuffle and then data grouped by fold using the array perm
-    int *fold_count = Malloc (int, nr_fold);
-    int *index = Malloc (int, l);
+    int* fold_count = Malloc(int, nr_fold);
+    int* index = Malloc(int, l);
 
     for (int i = 0; i < l; i++)
       index[i] = perm[i];
 
     for (int c = 0; c < nr_class; c++)
-      for (int i = 0; i < count[c]; i++)
-      {
+      for (int i = 0; i < count[c]; i++) {
         int j = i + rand() % (count[c] - i);
-        swap (index[start[c] + j], index[start[c] + i]);
+        swap(index[start[c] + j], index[start[c] + i]);
       }
 
-    for (int i = 0; i < nr_fold; i++)
-    {
+    for (int i = 0; i < nr_fold; i++) {
       fold_count[i] = 0;
 
       for (int c = 0; c < nr_class; c++)
@@ -2743,16 +2711,14 @@ void svm_cross_validation (const svm_problem *prob, const svm_parameter *param, 
     fold_start[0] = 0;
 
     for (int i = 1; i <= nr_fold; i++)
-      fold_start[i] = fold_start[i-1] + fold_count[i-1];
+      fold_start[i] = fold_start[i - 1] + fold_count[i - 1];
 
     for (int c = 0; c < nr_class; c++)
-      for (int i = 0; i < nr_fold; i++)
-      {
+      for (int i = 0; i < nr_fold; i++) {
         int begin = start[c] + i * count[c] / nr_fold;
         int end = start[c] + (i + 1) * count[c] / nr_fold;
 
-        for (int j = begin;j < end;j++)
-        {
+        for (int j = begin; j < end; j++) {
           perm[fold_start[i]] = index[j];
           fold_start[i]++;
         }
@@ -2761,126 +2727,122 @@ void svm_cross_validation (const svm_problem *prob, const svm_parameter *param, 
     fold_start[0] = 0;
 
     for (int i = 1; i <= nr_fold; i++)
-      fold_start[i] = fold_start[i-1] + fold_count[i-1];
+      fold_start[i] = fold_start[i - 1] + fold_count[i - 1];
 
-    free (start);
+    free(start);
 
-    free (label);
+    free(label);
 
-    free (count);
+    free(count);
 
-    free (index);
+    free(index);
 
-    free (fold_count);
+    free(fold_count);
   }
-  else
-  {
+  else {
     for (int i = 0; i < l; i++)
       perm[i] = i;
 
-    for (int i = 0; i < l; i++)
-    {
+    for (int i = 0; i < l; i++) {
       int j = i + rand() % (l - i);
-      swap (perm[i], perm[j]);
+      swap(perm[i], perm[j]);
     }
 
     for (int i = 0; i <= nr_fold; i++)
       fold_start[i] = i * l / nr_fold;
   }
 
-  for (int i = 0; i < nr_fold; i++)
-  {
+  for (int i = 0; i < nr_fold; i++) {
     int begin = fold_start[i];
-    int end = fold_start[i+1];
+    int end = fold_start[i + 1];
 
     struct svm_problem subprob;
 
     subprob.l = l - (end - begin);
-    subprob.x = Malloc (struct svm_node*, subprob.l);
-    subprob.y = Malloc (double, subprob.l);
+    subprob.x = Malloc(struct svm_node*, subprob.l);
+    subprob.y = Malloc(double, subprob.l);
 
     int k = 0;
 
-    for (int j = 0; j < begin; j++)
-    {
+    for (int j = 0; j < begin; j++) {
       subprob.x[k] = prob->x[perm[j]];
       subprob.y[k] = prob->y[perm[j]];
       ++k;
     }
 
-    for (int j = end; j < l; j++)
-    {
+    for (int j = end; j < l; j++) {
       subprob.x[k] = prob->x[perm[j]];
       subprob.y[k] = prob->y[perm[j]];
       ++k;
     }
 
-    struct svm_model *submodel = svm_train (&subprob, param);
+    struct svm_model* submodel = svm_train(&subprob, param);
 
-    if (param->probability &&
-        (param->svm_type == C_SVC || param->svm_type == NU_SVC))
-    {
-      double *prob_estimates = Malloc (double, svm_get_nr_class (submodel));
+    if (param->probability && (param->svm_type == C_SVC || param->svm_type == NU_SVC)) {
+      double* prob_estimates = Malloc(double, svm_get_nr_class(submodel));
 
       for (int j = begin; j < end; j++)
-        target[perm[j]] = svm_predict_probability (submodel, prob->x[perm[j]], prob_estimates);
+        target[perm[j]] =
+            svm_predict_probability(submodel, prob->x[perm[j]], prob_estimates);
 
-      free (prob_estimates);
+      free(prob_estimates);
     }
     else
       for (int j = begin; j < end; j++)
-        target[perm[j]] = svm_predict (submodel, prob->x[perm[j]]);
+        target[perm[j]] = svm_predict(submodel, prob->x[perm[j]]);
 
-    svm_free_and_destroy_model (&submodel);
+    svm_free_and_destroy_model(&submodel);
 
-    free (subprob.x);
+    free(subprob.x);
 
-    free (subprob.y);
+    free(subprob.y);
   }
 
-  free (fold_start);
+  free(fold_start);
 
-  free (perm);
+  free(perm);
 }
 
-
-int svm_get_svm_type (const svm_model *model)
+int
+svm_get_svm_type(const svm_model* model)
 {
   return model->param.svm_type;
 }
 
-int svm_get_nr_class (const svm_model *model)
+int
+svm_get_nr_class(const svm_model* model)
 {
   return model->nr_class;
 }
 
-void svm_get_labels (const svm_model *model, int* label)
+void
+svm_get_labels(const svm_model* model, int* label)
 {
   if (model->label != nullptr)
-    for (int i = 0;i < model->nr_class;i++)
+    for (int i = 0; i < model->nr_class; i++)
       label[i] = model->label[i];
 }
 
-double svm_get_svr_probability (const svm_model *model)
+double
+svm_get_svr_probability(const svm_model* model)
 {
-  if ( (model->param.svm_type == EPSILON_SVR || model->param.svm_type == NU_SVR) &&
-       model->probA != nullptr)
+  if ((model->param.svm_type == EPSILON_SVR || model->param.svm_type == NU_SVR) &&
+      model->probA != nullptr)
     return model->probA[0];
-  fprintf (stderr, "Model doesn't contain information for SVR probability inference\n");
+  fprintf(stderr, "Model doesn't contain information for SVR probability inference\n");
   return 0;
 }
 
-double svm_predict_values (const svm_model *model, const svm_node *x, double* dec_values)
+double
+svm_predict_values(const svm_model* model, const svm_node* x, double* dec_values)
 {
-  if (model->param.svm_type == ONE_CLASS ||
-      model->param.svm_type == EPSILON_SVR ||
-      model->param.svm_type == NU_SVR)
-  {
-    double *sv_coef = model->sv_coef[0];
+  if (model->param.svm_type == ONE_CLASS || model->param.svm_type == EPSILON_SVR ||
+      model->param.svm_type == NU_SVR) {
+    double* sv_coef = model->sv_coef[0];
     double sum = 0;
 
     for (int i = 0; i < model->l; i++)
-      sum += sv_coef[i] * Kernel::k_function (x, model->SV[i], model->param);
+      sum += sv_coef[i] * Kernel::k_function(x, model->SV[i], model->param);
 
     sum -= model->rho[0];
 
@@ -2894,19 +2856,19 @@ double svm_predict_values (const svm_model *model, const svm_node *x, double* de
   int nr_class = model->nr_class;
   int l = model->l;
 
-  double *kvalue = Malloc (double, l);
+  double* kvalue = Malloc(double, l);
 
   for (int i = 0; i < l; i++)
-    kvalue[i] = Kernel::k_function (x, model->SV[i], model->param);
+    kvalue[i] = Kernel::k_function(x, model->SV[i], model->param);
 
-  int *start = Malloc (int, nr_class);
+  int* start = Malloc(int, nr_class);
 
   start[0] = 0;
 
   for (int i = 1; i < nr_class; i++)
-    start[i] = start[i-1] + model->nSV[i-1];
+    start[i] = start[i - 1] + model->nSV[i - 1];
 
-  int *vote = Malloc (int, nr_class);
+  int* vote = Malloc(int, nr_class);
 
   for (int i = 0; i < nr_class; i++)
     vote[i] = 0;
@@ -2914,22 +2876,21 @@ double svm_predict_values (const svm_model *model, const svm_node *x, double* de
   int p = 0;
 
   for (int i = 0; i < nr_class; i++)
-    for (int j = i + 1;j < nr_class;j++)
-    {
+    for (int j = i + 1; j < nr_class; j++) {
       double sum = 0;
       int si = start[i];
       int sj = start[j];
       int ci = model->nSV[i];
       int cj = model->nSV[j];
 
-      double *coef1 = model->sv_coef[j-1];
-      double *coef2 = model->sv_coef[i];
+      double* coef1 = model->sv_coef[j - 1];
+      double* coef2 = model->sv_coef[i];
 
       for (int k = 0; k < ci; k++)
-        sum += coef1[si+k] * kvalue[si+k];
+        sum += coef1[si + k] * kvalue[si + k];
 
-      for (int k = 0 ;k < cj; k++)
-        sum += coef2[sj+k] * kvalue[sj+k];
+      for (int k = 0; k < cj; k++)
+        sum += coef2[sj + k] * kvalue[sj + k];
 
       sum -= model->rho[p];
 
@@ -2949,59 +2910,62 @@ double svm_predict_values (const svm_model *model, const svm_node *x, double* de
     if (vote[i] > vote[vote_max_idx])
       vote_max_idx = i;
 
-  free (kvalue);
-  free (start);
-  free (vote);
+  free(kvalue);
+  free(start);
+  free(vote);
 
   return model->label[vote_max_idx];
 }
 
-double svm_predict (const svm_model *model, const svm_node *x)
+double
+svm_predict(const svm_model* model, const svm_node* x)
 {
   int nr_class = model->nr_class;
-  double *dec_values;
+  double* dec_values;
 
-  if (model->param.svm_type == ONE_CLASS ||
-      model->param.svm_type == EPSILON_SVR ||
+  if (model->param.svm_type == ONE_CLASS || model->param.svm_type == EPSILON_SVR ||
       model->param.svm_type == NU_SVR)
-    dec_values = Malloc (double, 1);
+    dec_values = Malloc(double, 1);
   else
-    dec_values = Malloc (double, nr_class * (nr_class - 1) / 2);
+    dec_values = Malloc(double, nr_class*(nr_class - 1) / 2);
 
-  double pred_result = svm_predict_values (model, x, dec_values);
+  double pred_result = svm_predict_values(model, x, dec_values);
 
-  free (dec_values);
+  free(dec_values);
 
   return pred_result;
 }
 
-double svm_predict_probability (
-  const svm_model *model, const svm_node *x, double *prob_estimates)
+double
+svm_predict_probability(const svm_model* model,
+                        const svm_node* x,
+                        double* prob_estimates)
 {
-  if ( (model->param.svm_type == C_SVC || model->param.svm_type == NU_SVC) &&
-       model->probA != nullptr && model->probB != nullptr)
-  {
+  if ((model->param.svm_type == C_SVC || model->param.svm_type == NU_SVC) &&
+      model->probA != nullptr && model->probB != nullptr) {
     int nr_class = model->nr_class;
-    double *dec_values = Malloc (double, nr_class * (nr_class - 1) / 2);
-    svm_predict_values (model, x, dec_values);
+    double* dec_values = Malloc(double, nr_class*(nr_class - 1) / 2);
+    svm_predict_values(model, x, dec_values);
 
     double min_prob = 1e-7;
-    double **pairwise_prob = Malloc (double *, nr_class);
+    double** pairwise_prob = Malloc(double*, nr_class);
 
     for (int i = 0; i < nr_class; i++)
-      pairwise_prob[i] = Malloc (double, nr_class);
+      pairwise_prob[i] = Malloc(double, nr_class);
 
     int k = 0;
 
     for (int i = 0; i < nr_class; i++)
-      for (int j = i + 1;j < nr_class;j++)
-      {
-        pairwise_prob[i][j] = min (max (sigmoid_predict (dec_values[k], model->probA[k], model->probB[k]), min_prob), 1 - min_prob);
+      for (int j = i + 1; j < nr_class; j++) {
+        pairwise_prob[i][j] =
+            min(max(sigmoid_predict(dec_values[k], model->probA[k], model->probB[k]),
+                    min_prob),
+                1 - min_prob);
         pairwise_prob[j][i] = 1 - pairwise_prob[i][j];
         k++;
       }
 
-    multiclass_probability (nr_class, pairwise_prob, prob_estimates);
+    multiclass_probability(nr_class, pairwise_prob, prob_estimates);
 
     int prob_max_idx = 0;
 
@@ -3010,180 +2974,172 @@ double svm_predict_probability (
         prob_max_idx = i;
 
     for (int i = 0; i < nr_class; i++)
-      free (pairwise_prob[i]);
+      free(pairwise_prob[i]);
 
-    free (dec_values);
+    free(dec_values);
 
-    free (pairwise_prob);
+    free(pairwise_prob);
 
     return model->label[prob_max_idx];
   }
-  return svm_predict (model, x);
+  return svm_predict(model, x);
 }
 
-static const char *svm_type_table[] =
-{
-  "c_svc", "nu_svc", "one_class", "epsilon_svr", "nu_svr", nullptr
-};
+static const char* svm_type_table[] = {
+    "c_svc", "nu_svc", "one_class", "epsilon_svr", "nu_svr", nullptr};
 
-static const char *kernel_type_table[] =
-{
-  "linear", "polynomial", "rbf", "sigmoid", "precomputed", nullptr
-};
+static const char* kernel_type_table[] = {
+    "linear", "polynomial", "rbf", "sigmoid", "precomputed", nullptr};
 
-int svm_save_model (const char *model_file_name, const svm_model *model)
+int
+svm_save_model(const char* model_file_name, const svm_model* model)
 {
-  FILE *fp = fopen (model_file_name, "we");
+  FILE* fp = fopen(model_file_name, "we");
 
   if (fp == nullptr)
     return -1;
 
   const svm_parameter& param = model->param;
 
-  fprintf (fp, "svm_type %s\n", svm_type_table[param.svm_type]);
+  fprintf(fp, "svm_type %s\n", svm_type_table[param.svm_type]);
 
-  fprintf (fp, "kernel_type %s\n", kernel_type_table[param.kernel_type]);
+  fprintf(fp, "kernel_type %s\n", kernel_type_table[param.kernel_type]);
 
   if (param.kernel_type == POLY)
-    fprintf (fp, "degree %d\n", param.degree);
+    fprintf(fp, "degree %d\n", param.degree);
 
-  if (param.kernel_type == POLY || param.kernel_type == RBF || param.kernel_type == SIGMOID)
-    fprintf (fp, "gamma %g\n", param.gamma);
+  if (param.kernel_type == POLY || param.kernel_type == RBF ||
+      param.kernel_type == SIGMOID)
+    fprintf(fp, "gamma %g\n", param.gamma);
 
   if (param.kernel_type == POLY || param.kernel_type == SIGMOID)
-    fprintf (fp, "coef0 %g\n", param.coef0);
+    fprintf(fp, "coef0 %g\n", param.coef0);
 
   int nr_class = model->nr_class;
 
   int l = model->l;
 
-  fprintf (fp, "nr_class %d\n", nr_class);
+  fprintf(fp, "nr_class %d\n", nr_class);
 
-  fprintf (fp, "total_sv %d\n", l);
+  fprintf(fp, "total_sv %d\n", l);
 
   {
-    fprintf (fp, "rho");
+    fprintf(fp, "rho");
 
-    for (int i = 0;i < nr_class* (nr_class - 1) / 2;i++)
-      fprintf (fp, " %g", model->rho[i]);
+    for (int i = 0; i < nr_class * (nr_class - 1) / 2; i++)
+      fprintf(fp, " %g", model->rho[i]);
 
-    fprintf (fp, "\n");
+    fprintf(fp, "\n");
   }
 
-  if (model->label)
-  {
-    fprintf (fp, "label");
+  if (model->label) {
+    fprintf(fp, "label");
 
-    for (int i = 0;i < nr_class;i++)
-      fprintf (fp, " %d", model->label[i]);
+    for (int i = 0; i < nr_class; i++)
+      fprintf(fp, " %d", model->label[i]);
 
-    fprintf (fp, "\n");
+    fprintf(fp, "\n");
   }
 
   if (model->probA) // regression has probA only
   {
-    fprintf (fp, "probA");
+    fprintf(fp, "probA");
 
-    for (int i = 0;i < nr_class* (nr_class - 1) / 2;i++)
-      fprintf (fp, " %g", model->probA[i]);
+    for (int i = 0; i < nr_class * (nr_class - 1) / 2; i++)
+      fprintf(fp, " %g", model->probA[i]);
 
-    fprintf (fp, "\n");
+    fprintf(fp, "\n");
   }
 
-  if (model->probB)
-  {
-    fprintf (fp, "probB");
+  if (model->probB) {
+    fprintf(fp, "probB");
 
-    for (int i = 0;i < nr_class* (nr_class - 1) / 2;i++)
-      fprintf (fp, " %g", model->probB[i]);
+    for (int i = 0; i < nr_class * (nr_class - 1) / 2; i++)
+      fprintf(fp, " %g", model->probB[i]);
 
-    fprintf (fp, "\n");
+    fprintf(fp, "\n");
   }
 
-  if (model->nSV)
-  {
-    fprintf (fp, "nr_sv");
+  if (model->nSV) {
+    fprintf(fp, "nr_sv");
 
-    for (int i = 0;i < nr_class;i++)
-      fprintf (fp, " %d", model->nSV[i]);
+    for (int i = 0; i < nr_class; i++)
+      fprintf(fp, " %d", model->nSV[i]);
 
-    fprintf (fp, "\n");
+    fprintf(fp, "\n");
   }
 
-  fprintf (fp, "scaling ");
+  fprintf(fp, "scaling ");
 
   int ii = 0;
 
-  while (model->scaling[ii].index != -1)
-  {
+  while (model->scaling[ii].index != -1) {
     if (model->scaling[ii].index)
-      fprintf (fp, "%d:%.8g ", ii, model->scaling[ii].value);
+      fprintf(fp, "%d:%.8g ", ii, model->scaling[ii].value);
 
     ii++;
   }
 
-  fprintf (fp, "\n");
+  fprintf(fp, "\n");
 
+  fprintf(fp, "SV\n");
+  const double* const* sv_coef = model->sv_coef;
+  const svm_node* const* SV = model->SV;
 
-  fprintf (fp, "SV\n");
-  const double * const *sv_coef = model->sv_coef;
-  const svm_node * const *SV = model->SV;
+  for (int i = 0; i < l; i++) {
+    for (int j = 0; j < nr_class - 1; j++)
+      fprintf(fp, "%.16g ", sv_coef[j][i]);
 
-  for (int i = 0;i < l;i++)
-  {
-    for (int j = 0;j < nr_class - 1;j++)
-      fprintf (fp, "%.16g ", sv_coef[j][i]);
-
-    const svm_node *p = SV[i];
+    const svm_node* p = SV[i];
 
     if (param.kernel_type == PRECOMPUTED)
-      fprintf (fp, "0:%d ", int (p->value));
+      fprintf(fp, "0:%d ", int(p->value));
     else
-      while (p->index != -1)
-      {
-        fprintf (fp, "%d:%.8g ", p->index, p->value);
+      while (p->index != -1) {
+        fprintf(fp, "%d:%.8g ", p->index, p->value);
         p++;
       }
 
-    fprintf (fp, "\n");
+    fprintf(fp, "\n");
   }
 
-  if (ferror (fp) != 0 || fclose (fp) != 0)
+  if (ferror(fp) != 0 || fclose(fp) != 0)
     return -1;
   return 0;
 }
 
-static char *line = nullptr;
+static char* line = nullptr;
 static int max_line_len;
 
-static char* readline (FILE *input)
+static char*
+readline(FILE* input)
 {
-  if (fgets (line, max_line_len, input) == nullptr)
+  if (fgets(line, max_line_len, input) == nullptr)
     return nullptr;
 
-  while (strrchr (line, '\n') == nullptr)
-  {
+  while (strrchr(line, '\n') == nullptr) {
     max_line_len *= 2;
-    line = static_cast<char *> (realloc (line, max_line_len));
-    int len = int (strlen (line));
+    line = static_cast<char*>(realloc(line, max_line_len));
+    int len = int(strlen(line));
 
-    if (fgets (line + len, max_line_len - len, input) == nullptr)
+    if (fgets(line + len, max_line_len - len, input) == nullptr)
       break;
   }
 
   return line;
 }
 
-svm_model *svm_load_model (const char *model_file_name)
+svm_model*
+svm_load_model(const char* model_file_name)
 {
-  FILE *fp = fopen (model_file_name, "rbe");
+  FILE* fp = fopen(model_file_name, "rbe");
 
   if (fp == nullptr)
     return nullptr;
 
   // read parameters
 
-  svm_model *model = Malloc (svm_model, 1);
+  svm_model* model = Malloc(svm_model, 1);
 
   svm_parameter& param = model->param;
 
@@ -3197,206 +3153,171 @@ svm_model *svm_load_model (const char *model_file_name)
 
   model->nSV = nullptr;
 
-  model->scaling = Malloc (struct svm_node, 1);
+  model->scaling = Malloc(struct svm_node, 1);
 
   model->scaling[0].index = -1;
 
   char cmd[81];
 
-  while (true)
-  {
-    int res = fscanf (fp, "%80s", cmd);
+  while (true) {
+    int res = fscanf(fp, "%80s", cmd);
 
-    if (res > 0 && strcmp (cmd, "svm_type") == 0)
-    {
-      res = fscanf (fp, "%80s", cmd);
+    if (res > 0 && strcmp(cmd, "svm_type") == 0) {
+      res = fscanf(fp, "%80s", cmd);
 
       int i = 0;
-      for (i = 0; svm_type_table[i]; i++)
-      {
-        if (res > 0 && strcmp (svm_type_table[i], cmd) == 0)
-        {
+      for (i = 0; svm_type_table[i]; i++) {
+        if (res > 0 && strcmp(svm_type_table[i], cmd) == 0) {
           param.svm_type = i;
           break;
         }
       }
 
-      if (svm_type_table[i] == nullptr)
-      {
-        fprintf (stderr, "unknown svm type.\n");
-        free (model->rho);
-        free (model->label);
-        free (model->nSV);
-        free (model);
+      if (svm_type_table[i] == nullptr) {
+        fprintf(stderr, "unknown svm type.\n");
+        free(model->rho);
+        free(model->label);
+        free(model->nSV);
+        free(model);
         return nullptr;
       }
     }
-    else
-      if (res > 0 && strcmp (cmd, "kernel_type") == 0)
-      {
-        res = fscanf (fp, "%80s", cmd);
+    else if (res > 0 && strcmp(cmd, "kernel_type") == 0) {
+      res = fscanf(fp, "%80s", cmd);
 
-        int i = 0;
-        for (i = 0; kernel_type_table[i]; i++)
-        {
-          if (res > 0 && strcmp (kernel_type_table[i], cmd) == 0)
-          {
-            param.kernel_type = i;
-            break;
-          }
-        }
-
-        if (kernel_type_table[i] == nullptr)
-        {
-          fprintf (stderr, "unknown kernel function.\n");
-          free (model->rho);
-          free (model->label);
-          free (model->nSV);
-          free (model);
-          return nullptr;
+      int i = 0;
+      for (i = 0; kernel_type_table[i]; i++) {
+        if (res > 0 && strcmp(kernel_type_table[i], cmd) == 0) {
+          param.kernel_type = i;
+          break;
         }
       }
-      else
-        if (res > 0 && strcmp (cmd, "degree") == 0)
-          res = fscanf (fp, "%d", &param.degree);
-        else
-          if (res > 0 && strcmp (cmd, "gamma") == 0)
-            res = fscanf (fp, "%lf", &param.gamma);
-          else
-            if (res > 0 && strcmp (cmd, "coef0") == 0)
-              res = fscanf (fp, "%lf", &param.coef0);
-            else
-              if (res > 0 && strcmp (cmd, "nr_class") == 0)
-                res = fscanf (fp, "%d", &model->nr_class);
-              else
-                if (res > 0 && strcmp (cmd, "total_sv") == 0)
-                  res = fscanf (fp, "%d", &model->l);
-                else
-                  if (res > 0 && strcmp (cmd, "rho") == 0)
-                  {
-                    int n = model->nr_class * (model->nr_class - 1) / 2;
-                    model->rho = Malloc (double, n);
 
-                    for (int i = 0;(i < n) && (res > 0);i++)
-                      res = fscanf (fp, "%lf", &model->rho[i]);
-                  }
-                  else
-                    if (res > 0 && strcmp (cmd, "label") == 0)
-                    {
-                      int n = model->nr_class;
-                      model->label = Malloc (int, n);
+      if (kernel_type_table[i] == nullptr) {
+        fprintf(stderr, "unknown kernel function.\n");
+        free(model->rho);
+        free(model->label);
+        free(model->nSV);
+        free(model);
+        return nullptr;
+      }
+    }
+    else if (res > 0 && strcmp(cmd, "degree") == 0)
+      res = fscanf(fp, "%d", &param.degree);
+    else if (res > 0 && strcmp(cmd, "gamma") == 0)
+      res = fscanf(fp, "%lf", &param.gamma);
+    else if (res > 0 && strcmp(cmd, "coef0") == 0)
+      res = fscanf(fp, "%lf", &param.coef0);
+    else if (res > 0 && strcmp(cmd, "nr_class") == 0)
+      res = fscanf(fp, "%d", &model->nr_class);
+    else if (res > 0 && strcmp(cmd, "total_sv") == 0)
+      res = fscanf(fp, "%d", &model->l);
+    else if (res > 0 && strcmp(cmd, "rho") == 0) {
+      int n = model->nr_class * (model->nr_class - 1) / 2;
+      model->rho = Malloc(double, n);
 
-                      for (int i = 0;(i < n) && (res > 0);i++)
-                        res = fscanf (fp, "%d", &model->label[i]);
-                    }
-                    else
-                      if (res > 0 && strcmp (cmd, "probA") == 0)
-                      {
-                        int n = model->nr_class * (model->nr_class - 1) / 2;
-                        model->probA = Malloc (double, n);
+      for (int i = 0; (i < n) && (res > 0); i++)
+        res = fscanf(fp, "%lf", &model->rho[i]);
+    }
+    else if (res > 0 && strcmp(cmd, "label") == 0) {
+      int n = model->nr_class;
+      model->label = Malloc(int, n);
 
-                        for (int i = 0;(i < n) && (res > 0);i++)
-                          res = fscanf (fp, "%lf", &model->probA[i]);
-                      }
-                      else
-                        if (res > 0 && strcmp (cmd, "probB") == 0)
-                        {
-                          int n = model->nr_class * (model->nr_class - 1) / 2;
-                          model->probB = Malloc (double, n);
+      for (int i = 0; (i < n) && (res > 0); i++)
+        res = fscanf(fp, "%d", &model->label[i]);
+    }
+    else if (res > 0 && strcmp(cmd, "probA") == 0) {
+      int n = model->nr_class * (model->nr_class - 1) / 2;
+      model->probA = Malloc(double, n);
 
-                          for (int i = 0;(i < n) && (res > 0);i++)
-                            res = fscanf (fp, "%lf", &model->probB[i]);
-                        }
-                        else
-                          if (res > 0 && strcmp (cmd, "nr_sv") == 0)
-                          {
-                            int n = model->nr_class;
-                            model->nSV = Malloc (int, n);
+      for (int i = 0; (i < n) && (res > 0); i++)
+        res = fscanf(fp, "%lf", &model->probA[i]);
+    }
+    else if (res > 0 && strcmp(cmd, "probB") == 0) {
+      int n = model->nr_class * (model->nr_class - 1) / 2;
+      model->probB = Malloc(double, n);
 
-                            for (int i = 0;(i < n) && (res > 0);i++)
-                              res = fscanf (fp, "%d", &model->nSV[i]);
-                          }
-                          else
-                            if (res > 0 && strcmp (cmd, "scaling") == 0)
-                            {
-                              char *idx, buff[10000];
-                              int ii = 0;
-                              //char delims[]="\t: ";
-                              model->scaling = Malloc (struct svm_node, 1);
-                              res = fscanf (fp, "%10000[^\n]", buff);
-                              if (res <= 0)
-                                continue;
-                              idx = strtok (buff, ":");
+      for (int i = 0; (i < n) && (res > 0); i++)
+        res = fscanf(fp, "%lf", &model->probB[i]);
+    }
+    else if (res > 0 && strcmp(cmd, "nr_sv") == 0) {
+      int n = model->nr_class;
+      model->nSV = Malloc(int, n);
 
-                              while (idx != nullptr)
-                              {
-                                char *val = strtok (nullptr, " \t");
-                                int pre_ii = ii;
-                                ii = atoi (idx);
+      for (int i = 0; (i < n) && (res > 0); i++)
+        res = fscanf(fp, "%d", &model->nSV[i]);
+    }
+    else if (res > 0 && strcmp(cmd, "scaling") == 0) {
+      char *idx, buff[10000];
+      int ii = 0;
+      // char delims[]="\t: ";
+      model->scaling = Malloc(struct svm_node, 1);
+      res = fscanf(fp, "%10000[^\n]", buff);
+      if (res <= 0)
+        continue;
+      idx = strtok(buff, ":");
 
-                                model->scaling = Realloc (model->scaling, struct svm_node, ii + 2);
+      while (idx != nullptr) {
+        char* val = strtok(nullptr, " \t");
+        int pre_ii = ii;
+        ii = atoi(idx);
 
-                                //setting to zero the non defined scaling factors
+        model->scaling = Realloc(model->scaling, struct svm_node, ii + 2);
 
-                                for (int j = pre_ii + 1; j < ii; j++)
-                                {
-                                  model->scaling[j].index = 0;
-                                  model->scaling[j].value = 0;
-                                }
+        // setting to zero the non defined scaling factors
 
-                                model->scaling[ii].index = 1;
+        for (int j = pre_ii + 1; j < ii; j++) {
+          model->scaling[j].index = 0;
+          model->scaling[j].value = 0;
+        }
 
-                                model->scaling[ii].value = atof (val);
-                                ++ii;
-                                idx = strtok (nullptr, ":");
-                                //printf("%d e %f\n",model->scaling[ii-1].index,model->scaling[ii-1].value);
-                              }
+        model->scaling[ii].index = 1;
 
-                              model->scaling[ii].index = -1;
-                            }
-                            else
-                              if (res > 0 && strcmp (cmd, "SV") == 0)
-                              {
-                                //std::cout << cmd << std::endl;
-                                while (true)
-                                {
-                                  int c = getc (fp);
+        model->scaling[ii].value = atof(val);
+        ++ii;
+        idx = strtok(nullptr, ":");
+        // printf("%d e %f\n",model->scaling[ii-1].index,model->scaling[ii-1].value);
+      }
 
-                                  if (c == EOF || c == '\n')
-                                    break;
-                                }
+      model->scaling[ii].index = -1;
+    }
+    else if (res > 0 && strcmp(cmd, "SV") == 0) {
+      // std::cout << cmd << std::endl;
+      while (true) {
+        int c = getc(fp);
 
-                                break;
-                              }
-                              else
-                              {
-                                fprintf (stderr, "unknown text in model file: [%s]\n", cmd);
-                                free (model->rho);
-                                free (model->label);
-                                free (model->nSV);
-                                free (model);
-                                return nullptr;
-                              }
-    (void)res;  // to inform clang-tidy to ignore the dead-stores
+        if (c == EOF || c == '\n')
+          break;
+      }
+
+      break;
+    }
+    else {
+      fprintf(stderr, "unknown text in model file: [%s]\n", cmd);
+      free(model->rho);
+      free(model->label);
+      free(model->nSV);
+      free(model);
+      return nullptr;
+    }
+    (void)res; // to inform clang-tidy to ignore the dead-stores
   }
 
   // read sv_coef and SV
 
   int elements = 0;
 
-  long pos = ftell (fp);
+  long pos = ftell(fp);
 
   max_line_len = 10000;
 
-  line = Malloc (char, max_line_len);
+  line = Malloc(char, max_line_len);
 
-  while (readline (fp) != nullptr)
-  {
-    strtok (line, ":");
+  while (readline(fp) != nullptr) {
+    strtok(line, ":");
 
-    while (true)
-    {
-      char *p = strtok (nullptr, ":");
+    while (true) {
+      char* p = strtok(nullptr, ":");
 
       if (p == nullptr)
         break;
@@ -3407,54 +3328,51 @@ svm_model *svm_load_model (const char *model_file_name)
 
   elements += model->l;
 
-  fseek (fp, pos, SEEK_SET);
+  fseek(fp, pos, SEEK_SET);
 
   int m = model->nr_class - 1;
   int l = model->l;
-  model->sv_coef = Malloc (double *, m);
+  model->sv_coef = Malloc(double*, m);
 
   for (int i = 0; i < m; i++)
-    model->sv_coef[i] = Malloc (double, l);
+    model->sv_coef[i] = Malloc(double, l);
 
-  model->SV = Malloc (svm_node*, l);
+  model->SV = Malloc(svm_node*, l);
 
-  svm_node *x_space = nullptr;
+  svm_node* x_space = nullptr;
 
   if (l > 0)
-    x_space = Malloc (svm_node, elements);
+    x_space = Malloc(svm_node, elements);
 
   long int j = 0;
 
-  for (int i = 0; i < l; i++)
-  {
-    readline (fp);
+  for (int i = 0; i < l; i++) {
+    readline(fp);
     model->SV[i] = &x_space[j];
 
-    char *p = strtok (line, " \t");
-    model->sv_coef[0][i] = strtod (p, nullptr);
+    char* p = strtok(line, " \t");
+    model->sv_coef[0][i] = strtod(p, nullptr);
 
-    for (int k = 1;k < m;k++)
-    {
-      p = strtok (nullptr, " \t");
-      model->sv_coef[k][i] = strtod (p, nullptr);
+    for (int k = 1; k < m; k++) {
+      p = strtok(nullptr, " \t");
+      model->sv_coef[k][i] = strtod(p, nullptr);
     }
 
     int jj = 0;
 
-    while (true)
-    {
-      char *idx = strtok (nullptr, ":");
-      char *val = strtok (nullptr, " \t");
+    while (true) {
+      char* idx = strtok(nullptr, ":");
+      char* val = strtok(nullptr, " \t");
 
       if (val == nullptr)
         break;
 
-      x_space[j].index = int (strtol (idx, nullptr, 10));
+      x_space[j].index = int(strtol(idx, nullptr, 10));
 
-      x_space[j].value = strtod (val, nullptr);
+      x_space[j].value = strtod(val, nullptr);
 
-//             printf("i=%d, j=%d, %f ,%d e %f\n",i,j,model->sv_coef[0][i],
-//                    model->SV[i][jj].index, model->SV[i][jj].value);
+      //             printf("i=%d, j=%d, %f ,%d e %f\n",i,j,model->sv_coef[0][i],
+      //                    model->SV[i][jj].index, model->SV[i][jj].value);
       jj++;
 
       ++j;
@@ -3463,11 +3381,11 @@ svm_model *svm_load_model (const char *model_file_name)
     x_space[j++].index = -1;
   }
 
-  free (line);
+  free(line);
 
-  //printf("%d e %f\n",model->scaling[j-2].index,model->scaling[j-2].value);
+  // printf("%d e %f\n",model->scaling[j-2].index,model->scaling[j-2].value);
 
-  if (ferror (fp) != 0 || fclose (fp) != 0)
+  if (ferror(fp) != 0 || fclose(fp) != 0)
     return nullptr;
 
   model->free_sv = 1; // XXX
@@ -3475,78 +3393,74 @@ svm_model *svm_load_model (const char *model_file_name)
   return model;
 }
 
-void svm_free_model_content (svm_model* model_ptr)
+void
+svm_free_model_content(svm_model* model_ptr)
 {
   if (model_ptr->free_sv && model_ptr->l > 0 && model_ptr->SV != nullptr)
-    free (static_cast<void *> (model_ptr->SV[0]));
+    free(static_cast<void*>(model_ptr->SV[0]));
 
-  if (model_ptr->sv_coef)
-  {
-    for (int i = 0;i < model_ptr->nr_class - 1;i++)
-      free (model_ptr->sv_coef[i]);
+  if (model_ptr->sv_coef) {
+    for (int i = 0; i < model_ptr->nr_class - 1; i++)
+      free(model_ptr->sv_coef[i]);
   }
 
-  free (model_ptr->SV);
+  free(model_ptr->SV);
 
   model_ptr->SV = nullptr;
 
-  free (model_ptr->sv_coef);
+  free(model_ptr->sv_coef);
   model_ptr->sv_coef = nullptr;
 
-  free (model_ptr->rho);
+  free(model_ptr->rho);
   model_ptr->rho = nullptr;
 
-  free (model_ptr->label);
+  free(model_ptr->label);
   model_ptr->label = nullptr;
 
-  free (model_ptr->probA);
+  free(model_ptr->probA);
   model_ptr->probA = nullptr;
 
-  free (model_ptr->probB);
+  free(model_ptr->probB);
   model_ptr->probB = nullptr;
 
-  free (model_ptr->nSV);
+  free(model_ptr->nSV);
   model_ptr->nSV = nullptr;
 }
 
-void svm_free_and_destroy_model (svm_model** model_ptr_ptr)
+void
+svm_free_and_destroy_model(svm_model** model_ptr_ptr)
 {
-  if (model_ptr_ptr != nullptr && *model_ptr_ptr != nullptr)
-  {
-    svm_free_model_content (*model_ptr_ptr);
-    free (*model_ptr_ptr);
+  if (model_ptr_ptr != nullptr && *model_ptr_ptr != nullptr) {
+    svm_free_model_content(*model_ptr_ptr);
+    free(*model_ptr_ptr);
     *model_ptr_ptr = nullptr;
   }
 }
 
-void svm_destroy_param (svm_parameter* param)
+void
+svm_destroy_param(svm_parameter* param)
 {
-  free (param->weight_label);
-  free (param->weight);
+  free(param->weight_label);
+  free(param->weight);
 }
 
-const char *svm_check_parameter (const svm_problem *prob, const svm_parameter *param)
+const char*
+svm_check_parameter(const svm_problem* prob, const svm_parameter* param)
 {
   // svm_type
 
   int svm_type = param->svm_type;
 
-  if (svm_type != C_SVC &&
-      svm_type != NU_SVC &&
-      svm_type != ONE_CLASS &&
-      svm_type != EPSILON_SVR &&
-      svm_type != NU_SVR)
+  if (svm_type != C_SVC && svm_type != NU_SVC && svm_type != ONE_CLASS &&
+      svm_type != EPSILON_SVR && svm_type != NU_SVR)
     return "unknown svm type";
 
   // kernel_type, degree
 
   int kernel_type = param->kernel_type;
 
-  if (kernel_type != LINEAR &&
-      kernel_type != POLY &&
-      kernel_type != RBF &&
-      kernel_type != SIGMOID &&
-      kernel_type != PRECOMPUTED)
+  if (kernel_type != LINEAR && kernel_type != POLY && kernel_type != RBF &&
+      kernel_type != SIGMOID && kernel_type != PRECOMPUTED)
     return "unknown kernel type";
 
   if (param->gamma < 0)
@@ -3563,15 +3477,11 @@ const char *svm_check_parameter (const svm_problem *prob, const svm_parameter *p
   if (param->eps <= 0)
     return "eps <= 0";
 
-  if (svm_type == C_SVC ||
-      svm_type == EPSILON_SVR ||
-      svm_type == NU_SVR)
+  if (svm_type == C_SVC || svm_type == EPSILON_SVR || svm_type == NU_SVR)
     if (param->C <= 0)
       return "C <= 0";
 
-  if (svm_type == NU_SVC ||
-      svm_type == ONE_CLASS ||
-      svm_type == NU_SVR)
+  if (svm_type == NU_SVC || svm_type == ONE_CLASS || svm_type == NU_SVR)
     if (param->nu <= 0 || param->nu > 1)
       return "nu <= 0 or nu > 1";
 
@@ -3579,48 +3489,39 @@ const char *svm_check_parameter (const svm_problem *prob, const svm_parameter *p
     if (param->p < 0)
       return "p < 0";
 
-  if (param->shrinking != 0 &&
-      param->shrinking != 1)
+  if (param->shrinking != 0 && param->shrinking != 1)
     return "shrinking != 0 and shrinking != 1";
 
-  if (param->probability != 0 &&
-      param->probability != 1)
+  if (param->probability != 0 && param->probability != 1)
     return "probability != 0 and probability != 1";
 
-  if (param->probability == 1 &&
-      svm_type == ONE_CLASS)
+  if (param->probability == 1 && svm_type == ONE_CLASS)
     return "one-class SVM probability output not supported yet";
-
 
   // check whether nu-svc is feasible
 
-  if (svm_type == NU_SVC)
-  {
+  if (svm_type == NU_SVC) {
     int l = prob->l;
     int max_nr_class = 16;
     int nr_class = 0;
-    int *label = Malloc (int, max_nr_class);
-    int *count = Malloc (int, max_nr_class);
+    int* label = Malloc(int, max_nr_class);
+    int* count = Malloc(int, max_nr_class);
 
-    for (int i = 0; i < l; i++)
-    {
-      int this_label = int (prob->y[i]);
+    for (int i = 0; i < l; i++) {
+      int this_label = int(prob->y[i]);
       int j;
 
       for (j = 0; j < nr_class; j++)
-        if (this_label == label[j])
-        {
+        if (this_label == label[j]) {
           ++count[j];
           break;
         }
 
-      if (j == nr_class)
-      {
-        if (nr_class == max_nr_class)
-        {
+      if (j == nr_class) {
+        if (nr_class == max_nr_class) {
           max_nr_class *= 2;
-          label = static_cast<int *> (realloc (label, max_nr_class * sizeof (int)));
-          count = static_cast<int *> (realloc (count, max_nr_class * sizeof (int)));
+          label = static_cast<int*>(realloc(label, max_nr_class * sizeof(int)));
+          count = static_cast<int*>(realloc(count, max_nr_class * sizeof(int)));
         }
 
         label[nr_class] = this_label;
@@ -3630,40 +3531,39 @@ const char *svm_check_parameter (const svm_problem *prob, const svm_parameter *p
       }
     }
 
-    for (int i = 0; i < nr_class; i++)
-    {
+    for (int i = 0; i < nr_class; i++) {
       int n1 = count[i];
 
-      for (int j = i + 1;j < nr_class;j++)
-      {
+      for (int j = i + 1; j < nr_class; j++) {
         int n2 = count[j];
 
-        if (param->nu* (n1 + n2) / 2 > min (n1, n2))
-        {
-          free (label);
-          free (count);
+        if (param->nu * (n1 + n2) / 2 > min(n1, n2)) {
+          free(label);
+          free(count);
           return "specified nu is infeasible";
         }
       }
     }
 
-    free (label);
+    free(label);
 
-    free (count);
+    free(count);
   }
 
   return nullptr;
 }
 
-int svm_check_probability_model (const svm_model *model)
+int
+svm_check_probability_model(const svm_model* model)
 {
-  return ( (model->param.svm_type == C_SVC || model->param.svm_type == NU_SVC) &&
-           model->probA != nullptr && model->probB != nullptr) ||
-         ( (model->param.svm_type == EPSILON_SVR || model->param.svm_type == NU_SVR) &&
-           model->probA != nullptr);
+  return ((model->param.svm_type == C_SVC || model->param.svm_type == NU_SVC) &&
+          model->probA != nullptr && model->probB != nullptr) ||
+         ((model->param.svm_type == EPSILON_SVR || model->param.svm_type == NU_SVR) &&
+          model->probA != nullptr);
 }
 
-void svm_set_print_string_function (void (*print_func) (const char *))
+void
+svm_set_print_string_function(void (*print_func)(const char*))
 {
   if (print_func == nullptr)
     svm_print_string = &print_string_stdout;

--- a/ml/src/svm_wrapper.cpp
+++ b/ml/src/svm_wrapper.cpp
@@ -1,64 +1,62 @@
- /*
-  * Software License Agreement (BSD License)
-  *
-  *  Point Cloud Library (PCL) - www.pointclouds.org
-  *  Copyright (c) 2010-2012, Willow Garage, Inc.
-  *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
-  *
-  *  All rights reserved.
-  *
-  *  Redistribution and use in source and binary forms, with or without
-  *  modification, are permitted provided that the following conditions
-  *  are met:
-  *
-  *   * Redistributions of source code must retain the above copyright
-  *     notice, this list of conditions and the following disclaimer.
-  *   * Redistributions in binary form must reproduce the above
-  *     copyright notice, this list of conditions and the following
-  *     disclaimer in the documentation and/or other materials provided
-  *     with the distribution.
-  *   * Neither the name of copyright holders nor the names of its
-  *     contributors may be used to endorse or promote products derived
-  *     from this software without specific prior written permission.
-  *
-  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-  *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-  *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  *  POSSIBILITY OF SUCH DAMAGE.
-  *
-  */
-
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2000-2012 Chih-Chung Chang and Chih-Jen Lin
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 #ifndef PCL_SVM_WRAPPER_HPP_
 #define PCL_SVM_WRAPPER_HPP_
 
-#include <pcl/ml/svm_wrapper.h>
 #include <cassert>
 #include <fstream>
+#include <pcl/ml/svm_wrapper.h>
 
 char*
-pcl::SVM::readline (FILE *input)
+pcl::SVM::readline(FILE* input)
 {
-  if (fgets (line_, max_line_len_, input) == nullptr)
+  if (fgets(line_, max_line_len_, input) == nullptr)
     return nullptr;
 
   // Find the endline. If not found extend the max_line_len_
-  while (strrchr (line_ , '\n') == nullptr)
-  {
+  while (strrchr(line_, '\n') == nullptr) {
     max_line_len_ *= 2;
-    line_ = static_cast<char *> (realloc (line_, max_line_len_));
-    int len = int (strlen (line_));
+    line_ = static_cast<char*>(realloc(line_, max_line_len_));
+    int len = int(strlen(line_));
 
     // if the new read part of the string is unavailable, break the while
-    if (fgets (line_ + len, max_line_len_ - len, input) == nullptr)
+    if (fgets(line_ + len, max_line_len_ - len, input) == nullptr)
       break;
   }
 
@@ -66,27 +64,24 @@ pcl::SVM::readline (FILE *input)
 }
 
 void
-pcl::SVMTrain::doCrossValidation ()
+pcl::SVMTrain::doCrossValidation()
 {
   int total_correct = 0;
   double sumv = 0, sumy = 0, sumvv = 0, sumyy = 0, sumvy = 0;
-  double *target = Malloc (double, prob_.l);
+  double* target = Malloc(double, prob_.l);
 
-  // number of fold for the cross validation (n of folds = number of splitting of the input dataset)
-  if (nr_fold_ < 2)
-  {
-    fprintf (stderr, "n-fold cross validation: n must >= 2\n");
+  // number of fold for the cross validation (n of folds = number of splitting of the
+  // input dataset)
+  if (nr_fold_ < 2) {
+    fprintf(stderr, "n-fold cross validation: n must >= 2\n");
     return;
   }
 
-  svm_cross_validation (&prob_, &param_, nr_fold_, target); // perform cross validation
+  svm_cross_validation(&prob_, &param_, nr_fold_, target); // perform cross validation
 
-  if (param_.svm_type == EPSILON_SVR ||
-      param_.svm_type == NU_SVR)
-  {
+  if (param_.svm_type == EPSILON_SVR || param_.svm_type == NU_SVR) {
     double total_error = 0;
-    for (int i = 0; i < prob_.l; i++)
-    {
+    for (int i = 0; i < prob_.l; i++) {
       double y = prob_.y[i];
       double v = target[i];
       total_error += (v - y) * (v - y);
@@ -97,41 +92,40 @@ pcl::SVMTrain::doCrossValidation ()
       sumvy += v * y;
     }
 
-    pcl::console::print_info (" - Cross Validation Mean squared error = ");
-    pcl::console::print_value ("%g\n", total_error / prob_.l);
+    pcl::console::print_info(" - Cross Validation Mean squared error = ");
+    pcl::console::print_value("%g\n", total_error / prob_.l);
 
-    pcl::console::print_info (" - Cross Validation Squared correlation coefficient = ");
-    pcl::console::print_value ("%g\n",
-                               ( (prob_.l*sumvy - sumv*sumy) * (prob_.l*sumvy - sumv*sumy)) /
-                               ( (prob_.l*sumvv - sumv*sumv) * (prob_.l*sumyy - sumy*sumy))
-                              );
+    pcl::console::print_info(" - Cross Validation Squared correlation coefficient = ");
+    pcl::console::print_value(
+        "%g\n",
+        ((prob_.l * sumvy - sumv * sumy) * (prob_.l * sumvy - sumv * sumy)) /
+            ((prob_.l * sumvv - sumv * sumv) * (prob_.l * sumyy - sumy * sumy)));
   }
-  else
-  {
+  else {
     for (int i = 0; i < prob_.l; i++)
       if (target[i] == prob_.y[i])
         ++total_correct;
 
-    pcl::console::print_info (" - Cross Validation Accuracy = ");
-    pcl::console::print_value ("%g%%\n", 100.0*total_correct / prob_.l);
+    pcl::console::print_info(" - Cross Validation Accuracy = ");
+    pcl::console::print_value("%g%%\n", 100.0 * total_correct / prob_.l);
   }
 
-  free (target);
+  free(target);
 }
 
 void
-pcl::SVMTrain::scaleFactors (std::vector<SVMData> training_set, svm_scaling &scaling)
+pcl::SVMTrain::scaleFactors(std::vector<SVMData> training_set, svm_scaling& scaling)
 {
   int max = 0;
 
-  for (const auto &svm_data : training_set)
-    for (const auto &sample : svm_data.SV)
+  for (const auto& svm_data : training_set)
+    for (const auto& sample : svm_data.SV)
       if (sample.idx > max)
         max = sample.idx; // max number of features
 
   max += 1;
 
-  scaling.obj = Malloc (struct svm_node, max + 1);
+  scaling.obj = Malloc(struct svm_node, max + 1);
   scaling.max = max;
   scaling.obj[max].index = -1; // last index is -1
 
@@ -141,23 +135,21 @@ pcl::SVMTrain::scaleFactors (std::vector<SVMData> training_set, svm_scaling &sca
     scaling.obj[i].value = 0;
   }
 
-  for (const auto &svm_data : training_set)
-    for (const auto &sample : svm_data.SV)
+  for (const auto& svm_data : training_set)
+    for (const auto& sample : svm_data.SV)
       // save scaling factor finding the maximum value
-      if (std::abs (sample.value) > scaling.obj[sample.idx].value)
-      {
+      if (std::abs(sample.value) > scaling.obj[sample.idx].value) {
         scaling.obj[sample.idx].index = 1;
-        scaling.obj[sample.idx].value = std::abs (sample.value);
+        scaling.obj[sample.idx].value = std::abs(sample.value);
       }
 };
 
 void
-pcl::SVM::adaptLibSVMToInput (std::vector<SVMData> &training_set, svm_problem prob)
+pcl::SVM::adaptLibSVMToInput(std::vector<SVMData>& training_set, svm_problem prob)
 {
-  training_set.clear (); // Reset input
+  training_set.clear(); // Reset input
 
-  for (int i = 0; i < prob.l; i++)
-  {
+  for (int i = 0; i < prob.l; i++) {
     SVMData parent; // buffer data container
     int j = 0;
 
@@ -168,147 +160,141 @@ pcl::SVM::adaptLibSVMToInput (std::vector<SVMData> &training_set, svm_problem pr
     {
       SVMDataPoint seed; // single feature seed
 
-      if (std::isfinite (prob.x[i][j].value))
-      {
+      if (std::isfinite(prob.x[i][j].value)) {
         seed.idx = prob.x[i][j].index;
-        seed.value = float (prob.x[i][j].value);
-        parent.SV.push_back (seed);
+        seed.value = float(prob.x[i][j].value);
+        parent.SV.push_back(seed);
       }
 
       j++;
     }
 
-    training_set.push_back (parent);
+    training_set.push_back(parent);
   }
 };
 
 void
-pcl::SVM::adaptInputToLibSVM (std::vector<SVMData> training_set, svm_problem &prob)
+pcl::SVM::adaptInputToLibSVM(std::vector<SVMData> training_set, svm_problem& prob)
 {
-  assert (training_set.size() > 0);
-  assert (scaling_.max != 0);
+  assert(training_set.size() > 0);
+  assert(scaling_.max != 0);
 
-  if (scaling_.max == 0)
-  {
+  if (scaling_.max == 0) {
     // to be sure to have loaded the scaling
-    PCL_ERROR ("[pcl::%s::adaptInputToLibSVM] Classifier model not loaded!\n", getClassName ().c_str ());
+    PCL_ERROR("[pcl::%s::adaptInputToLibSVM] Classifier model not loaded!\n",
+              getClassName().c_str());
     return;
   }
 
-  prob.l = int (training_set.size ()); // n of elements/points
-  prob.y = Malloc (double, prob.l);
-  prob.x = Malloc (struct svm_node *, prob.l);
+  prob.l = int(training_set.size()); // n of elements/points
+  prob.y = Malloc(double, prob.l);
+  prob.x = Malloc(struct svm_node*, prob.l);
 
-  for (int i = 0; i < prob.l; i++)
-  {
-    if (std::isfinite (training_set[i].label) && labelled_training_set_)
-    {
+  for (int i = 0; i < prob.l; i++) {
+    if (std::isfinite(training_set[i].label) && labelled_training_set_) {
       prob.y[i] = training_set[i].label;
       labelled_training_set_ = true;
     }
     else
       labelled_training_set_ = false;
 
-    prob.x[i] = Malloc (struct svm_node, training_set[i].SV.size() + 1);
+    prob.x[i] = Malloc(struct svm_node, training_set[i].SV.size() + 1);
 
     int k = 0;
-    
+
     for (size_t j = 0; j < training_set[i].SV.size(); j++)
-      if (training_set[i].SV[j].idx != -1 && std::isfinite (training_set[i].SV[j].value))
-      {
+      if (training_set[i].SV[j].idx != -1 &&
+          std::isfinite(training_set[i].SV[j].value)) {
         prob.x[i][k].index = training_set[i].SV[j].idx;
-        if (training_set[i].SV[j].idx < scaling_.max && scaling_.obj[ training_set[i].SV[j].idx ].index == 1)
-          prob.x[i][k].value = training_set[i].SV[j].value / scaling_.obj[ training_set[i].SV[j].idx ].value;
+        if (training_set[i].SV[j].idx < scaling_.max &&
+            scaling_.obj[training_set[i].SV[j].idx].index == 1)
+          prob.x[i][k].value = training_set[i].SV[j].value /
+                               scaling_.obj[training_set[i].SV[j].idx].value;
         else
           prob.x[i][k].value = training_set[i].SV[j].value;
         k++;
       }
-      
+
     prob.x[i][k].index = -1;
   }
 };
 
 bool
-pcl::SVMTrain::trainClassifier ()
+pcl::SVMTrain::trainClassifier()
 {
-  if (training_set_.empty ())
-  {
+  if (training_set_.empty()) {
     // to be sure to have loaded the training set
-    PCL_ERROR ("[pcl::%s::trainClassifier] Training data not set!\n", getClassName ().c_str ());
+    PCL_ERROR("[pcl::%s::trainClassifier] Training data not set!\n",
+              getClassName().c_str());
     return false;
   }
-  
-  scaleFactors (training_set_, scaling_);
-  adaptInputToLibSVM (training_set_, prob_);
 
-  const char *error_msg;
-  error_msg = svm_check_parameter (&prob_, &param_);
+  scaleFactors(training_set_, scaling_);
+  adaptInputToLibSVM(training_set_, prob_);
+
+  const char* error_msg;
+  error_msg = svm_check_parameter(&prob_, &param_);
 
   // initialize gamma parameter
 
   if (param_.gamma == 0 && scaling_.max > 0)
     param_.gamma = 1.0 / scaling_.max;
 
-  if (error_msg)
-  {
-    PCL_ERROR ("[pcl::%s::trainClassifier] %s\n", getClassName ().c_str (), error_msg);
-    //fprintf (stderr, "ERROR: %s\n", error_msg);
-    exit (1);
+  if (error_msg) {
+    PCL_ERROR("[pcl::%s::trainClassifier] %s\n", getClassName().c_str(), error_msg);
+    // fprintf (stderr, "ERROR: %s\n", error_msg);
+    exit(1);
   }
 
-  if (cross_validation_)
-  {
-    doCrossValidation ();
+  if (cross_validation_) {
+    doCrossValidation();
   }
-  else
-  {
+  else {
     SVMModel* out;
-    out = static_cast<SVMModel*> (svm_train (&prob_, &param_));
-    if (out == nullptr)
-    {
-      PCL_ERROR ("[pcl::%s::trainClassifier] Error taining the classifier model.\n", getClassName ().c_str ());
+    out = static_cast<SVMModel*>(svm_train(&prob_, &param_));
+    if (out == nullptr) {
+      PCL_ERROR("[pcl::%s::trainClassifier] Error taining the classifier model.\n",
+                getClassName().c_str());
       return false;
     }
     model_ = *out;
     model_.scaling = scaling_.obj;
-    free (out);
+    free(out);
   }
 
   return true;
 }
 
 bool
-pcl::SVM::loadProblem (const char *filename, svm_problem &prob)
+pcl::SVM::loadProblem(const char* filename, svm_problem& prob)
 {
-  FILE *fp = fopen (filename, "re");
-  svm_node *x_space_;
-  char *endptr;
+  FILE* fp = fopen(filename, "re");
+  svm_node* x_space_;
+  char* endptr;
   char *idx, *val, *label;
 
-  if (fp == nullptr)
-  {
-    PCL_ERROR ("[pcl::%s] Can't open input file %s.\n", getClassName ().c_str (), filename);
+  if (fp == nullptr) {
+    PCL_ERROR(
+        "[pcl::%s] Can't open input file %s.\n", getClassName().c_str(), filename);
     return false;
   }
 
   int elements = 0;
   prob.l = 0;
 
-  line_ = Malloc (char, max_line_len_);
-  
+  line_ = Malloc(char, max_line_len_);
+
   // readline function writes one line in var. "line_"
-  while (readline (fp) != nullptr)
-  {
+  while (readline(fp) != nullptr) {
     // "\t" cuts the tab or space.
     // strtok splits the string into tokens
-    strtok (line_, " \t"); // label
+    strtok(line_, " \t"); // label
     ++elements;
     // features
 
-    while (true)
-    {
+    while (true) {
       // split the next element
-      char *p = strtok (nullptr, " \t");
+      char* p = strtok(nullptr, " \t");
 
       if (p == nullptr || *p == '\n') // check '\n' as ' ' may be after the last feature
         break;
@@ -316,153 +302,143 @@ pcl::SVM::loadProblem (const char *filename, svm_problem &prob)
       ++elements;
     }
     ++elements; // contains the number of elements in the string
-    ++prob.l; // number op
+    ++prob.l;   // number op
   }
 
-  rewind (fp); // returns to the top pos of fp
+  rewind(fp); // returns to the top pos of fp
 
-  prob.y = Malloc (double, prob.l);
-  prob.x = Malloc (struct svm_node *, prob.l);
-  x_space_ = Malloc (struct svm_node, elements);
+  prob.y = Malloc(double, prob.l);
+  prob.x = Malloc(struct svm_node*, prob.l);
+  x_space_ = Malloc(struct svm_node, elements);
 
   int max_index = 0;
   int j = 0;
   bool isUnlabelled = false;
 
-  for (int i = 0;i < prob.l;i++)
-  {
-    int inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed kernel has <index> start from 0
+  for (int i = 0; i < prob.l; i++) {
+    int inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed kernel
+                             // has <index> start from 0
     // read one line in the file
-    readline (fp);
+    readline(fp);
     prob.x[i] = &x_space_[j];
 
-    if (!isUnlabelled)
-    {
-      label = strtok (line_, " \t\n"); //save first element as label
-      char * pch;
-      pch = strpbrk (label, ":");
+    if (!isUnlabelled) {
+      label = strtok(line_, " \t\n"); // save first element as label
+      char* pch;
+      pch = strpbrk(label, ":");
       // std::cout << label << std::endl;
 
       // check if the first element is really a label
 
-      if (pch == nullptr)
-      {
+      if (pch == nullptr) {
         if (label == nullptr) // empty line
-          exitInputError (i + 1);
+          exitInputError(i + 1);
 
         labelled_training_set_ = true;
 
-        prob.y[i] = strtod (label, &endptr);
+        prob.y[i] = strtod(label, &endptr);
 
         if (endptr == label || *endptr != '\0')
-          exitInputError (i + 1);
+          exitInputError(i + 1);
 
-        //idx = strtok(NULL,":"); // indice
+        // idx = strtok(NULL,":"); // indice
       }
-      else
-      {
+      else {
         isUnlabelled = true;
         labelled_training_set_ = false;
         i = -1;
-        rewind (fp);
+        rewind(fp);
         continue;
       }
-    } //else
+    } // else
 
-//    idx=strtok(line,": \t\n");
+    //    idx=strtok(line,": \t\n");
     int k = 0;
 
-    while (true)
-    {
+    while (true) {
       if (k++ == 0 && isUnlabelled)
-        idx = strtok (line_, ": \t\n");
+        idx = strtok(line_, ": \t\n");
       else
-        idx = strtok (nullptr, ":"); // indice
+        idx = strtok(nullptr, ":"); // indice
 
-      val = strtok (nullptr, " \t"); // valore
+      val = strtok(nullptr, " \t"); // valore
 
       if (val == nullptr)
         break; // exit with the last element
 
-      //std::cout << idx << ":" << val<< " ";
+      // std::cout << idx << ":" << val<< " ";
       errno = 0;
 
-      x_space_[j].index = int (strtol (idx, &endptr, 10));
+      x_space_[j].index = int(strtol(idx, &endptr, 10));
 
-      if (endptr == idx || errno != 0 || *endptr != '\0' || x_space_[j].index <= inst_max_index)
-        exitInputError (i + 1);
+      if (endptr == idx || errno != 0 || *endptr != '\0' ||
+          x_space_[j].index <= inst_max_index)
+        exitInputError(i + 1);
       else
         inst_max_index = x_space_[j].index;
 
       errno = 0;
 
-      x_space_[j].value = strtod (val, &endptr);
+      x_space_[j].value = strtod(val, &endptr);
 
-      if (endptr == val || errno != 0 || (*endptr != '\0' && !isspace (*endptr)))
-        exitInputError (i + 1);
+      if (endptr == val || errno != 0 || (*endptr != '\0' && !isspace(*endptr)))
+        exitInputError(i + 1);
 
       ++j;
-
     }
 
-    //std::cout <<"\n";
+    // std::cout <<"\n";
     if (inst_max_index > max_index)
       max_index = inst_max_index;
 
     x_space_[j++].index = -1;
   }
 
-
-
   if (param_.gamma == 0 && max_index > 0)
     param_.gamma = 1.0 / max_index;
 
   if (param_.kernel_type == PRECOMPUTED)
-    for (int i = 0;i < prob.l;i++)
-    {
-      if (prob.x[i][0].index != 0)
-      {
-	PCL_ERROR ("[pcl::%s] Wrong input format: first column must be 0:sample_serial_number.\n", getClassName ().c_str () );
+    for (int i = 0; i < prob.l; i++) {
+      if (prob.x[i][0].index != 0) {
+        PCL_ERROR("[pcl::%s] Wrong input format: first column must be "
+                  "0:sample_serial_number.\n",
+                  getClassName().c_str());
         return false;
       }
 
-      if (int (prob.x[i][0].value) <= 0 || int (prob.x[i][0].value) > max_index)
-      {
-	PCL_ERROR ("[pcl::%s] Wrong input format: sample_serial_number out of range.\n", getClassName ().c_str () );
+      if (int(prob.x[i][0].value) <= 0 || int(prob.x[i][0].value) > max_index) {
+        PCL_ERROR("[pcl::%s] Wrong input format: sample_serial_number out of range.\n",
+                  getClassName().c_str());
         return false;
       }
     }
-  fclose (fp);
+  fclose(fp);
 
   return true;
 }
 
-
 bool
-pcl::SVM::saveProblem (const char *filename, bool labelled = false)
+pcl::SVM::saveProblem(const char* filename, bool labelled = false)
 {
-  assert (training_set_.size() > 0);
+  assert(training_set_.size() > 0);
   std::ofstream myfile;
-  myfile.open (filename);
+  myfile.open(filename);
 
-  if (!myfile.is_open())
-  {
-    PCL_ERROR ("[pcl::%s] Can't open/create file %s.\n", getClassName ().c_str (), filename);
+  if (!myfile.is_open()) {
+    PCL_ERROR(
+        "[pcl::%s] Can't open/create file %s.\n", getClassName().c_str(), filename);
     return false;
   }
-    
 
-  for (const auto &svm_data : training_set_)
-  {
+  for (const auto& svm_data : training_set_) {
 
-    if (labelled)
-    {
-      assert (std::isfinite (svm_data.label));
+    if (labelled) {
+      assert(std::isfinite(svm_data.label));
       myfile << svm_data.label << " ";
     }
 
-    for (const auto &sample : svm_data.SV)
-      if (std::isfinite (sample.value))
+    for (const auto& sample : svm_data.SV)
+      if (std::isfinite(sample.value))
         myfile << sample.idx << ":" << sample.value << " ";
 
     myfile << "\n";
@@ -470,39 +446,40 @@ pcl::SVM::saveProblem (const char *filename, bool labelled = false)
 
   myfile.close();
 
-  //std::cout << " * " << filename << " saved" << std::endl;
+  // std::cout << " * " << filename << " saved" << std::endl;
   return true;
 }
 
 bool
-pcl::SVM::saveProblemNorm (const char *filename, svm_problem prob_, bool labelled = false)
+pcl::SVM::saveProblemNorm(const char* filename,
+                          svm_problem prob_,
+                          bool labelled = false)
 {
-  if (prob_.l == 0)
-  {
-    PCL_ERROR ("[pcl::%s] Can't save file %s. Input data not set.\n", getClassName ().c_str (), filename);
+  if (prob_.l == 0) {
+    PCL_ERROR("[pcl::%s] Can't save file %s. Input data not set.\n",
+              getClassName().c_str(),
+              filename);
     return false;
   }
 
   std::ofstream myfile;
 
-  myfile.open (filename);
+  myfile.open(filename);
 
-  if (!myfile.is_open())
-  {
-    PCL_ERROR ("[pcl::%s] Can't open/create file %s.\n", getClassName ().c_str (), filename);
+  if (!myfile.is_open()) {
+    PCL_ERROR(
+        "[pcl::%s] Can't open/create file %s.\n", getClassName().c_str(), filename);
     return false;
   }
 
-  for (int j = 0; j < prob_.l ; j++)
-  {
+  for (int j = 0; j < prob_.l; j++) {
     if (labelled)
       myfile << prob_.y[j] << " ";
 
     // for (int i=0; i < nFeatures+2; i++)
     int i = 0;
 
-    while (prob_.x[j][i].index != -1)
-    {
+    while (prob_.x[j][i].index != -1) {
       myfile << prob_.x[j][i].index << ":" << prob_.x[j][i].value << " ";
       i++;
     }
@@ -512,27 +489,29 @@ pcl::SVM::saveProblemNorm (const char *filename, svm_problem prob_, bool labelle
 
   myfile.close();
 
-  //std::cout << " * " << filename << " saved" << std::endl;
+  // std::cout << " * " << filename << " saved" << std::endl;
   return true;
 }
 
 bool
-pcl::SVMClassify::loadClassifierModel (const char *filename)
+pcl::SVMClassify::loadClassifierModel(const char* filename)
 {
-  SVMModel *out;
-  out = static_cast<SVMModel*> (svm_load_model (filename));
-  if (out == nullptr)
-  {
-    PCL_ERROR ("[pcl::%s::loadClassifierModel] Can't open classifier model %s.\n", getClassName ().c_str (), filename);
+  SVMModel* out;
+  out = static_cast<SVMModel*>(svm_load_model(filename));
+  if (out == nullptr) {
+    PCL_ERROR("[pcl::%s::loadClassifierModel] Can't open classifier model %s.\n",
+              getClassName().c_str(),
+              filename);
     return false;
   }
-  
-  model_ = *out;
-  free (out);
 
-  if (model_.l == 0)
-  {
-    PCL_ERROR ("[pcl::%s::loadClassifierModel] Can't open classifier model %s.\n", getClassName ().c_str (), filename);
+  model_ = *out;
+  free(out);
+
+  if (model_.l == 0) {
+    PCL_ERROR("[pcl::%s::loadClassifierModel] Can't open classifier model %s.\n",
+              getClassName().c_str(),
+              filename);
     return false;
   }
 
@@ -549,38 +528,39 @@ pcl::SVMClassify::loadClassifierModel (const char *filename)
 }
 
 bool
-pcl::SVMClassify::classificationTest ()
+pcl::SVMClassify::classificationTest()
 {
-  if (model_.l == 0)
-  {
-    PCL_ERROR ("[pcl::%s::classificationTest] Classifier model has no data.\n", getClassName ().c_str ());
+  if (model_.l == 0) {
+    PCL_ERROR("[pcl::%s::classificationTest] Classifier model has no data.\n",
+              getClassName().c_str());
     return false;
   }
-  
-  if (prob_.l == 0)
-  {
-    PCL_ERROR ("[pcl::%s::classificationTest] Input dataset has no data.\n", getClassName ().c_str ());
-    return false;
-  }
-  
-  if (!labelled_training_set_)
-  {
-    PCL_ERROR ("[pcl::%s::classificationTest] Input dataset is not labelled.\n", getClassName ().c_str ());
-    return false;
-  }  
 
-  if (predict_probability_)
-  {
-    if (svm_check_probability_model (&model_) == 0)
-    {
-      PCL_WARN ("[pcl::%s::classificationTest] Classifier model does not support probabiliy estimates. Automatically disabled.\n", getClassName ().c_str ());
+  if (prob_.l == 0) {
+    PCL_ERROR("[pcl::%s::classificationTest] Input dataset has no data.\n",
+              getClassName().c_str());
+    return false;
+  }
+
+  if (!labelled_training_set_) {
+    PCL_ERROR("[pcl::%s::classificationTest] Input dataset is not labelled.\n",
+              getClassName().c_str());
+    return false;
+  }
+
+  if (predict_probability_) {
+    if (svm_check_probability_model(&model_) == 0) {
+      PCL_WARN("[pcl::%s::classificationTest] Classifier model does not support "
+               "probabiliy estimates. Automatically disabled.\n",
+               getClassName().c_str());
       predict_probability_ = false;
     }
   }
-  else
-  {
-    if (svm_check_probability_model (&model_) != 0)
-      PCL_WARN("[pcl::%s::classificationTest] Classifier model supports probability estimates, but disabled in prediction.\n", getClassName ().c_str ());
+  else {
+    if (svm_check_probability_model(&model_) != 0)
+      PCL_WARN("[pcl::%s::classificationTest] Classifier model supports probability "
+               "estimates, but disabled in prediction.\n",
+               getClassName().c_str());
   }
 
   int correct = 0;
@@ -589,58 +569,56 @@ pcl::SVMClassify::classificationTest ()
   double error = 0;
   double sump = 0, sumt = 0, sumpp = 0, sumtt = 0, sumpt = 0;
 
-  int svm_type = svm_get_svm_type (&model_);
-  int nr_class = svm_get_nr_class (&model_);
-  double *prob_estimates = nullptr;
+  int svm_type = svm_get_svm_type(&model_);
+  int nr_class = svm_get_nr_class(&model_);
+  double* prob_estimates = nullptr;
 
-  prediction_.clear ();
+  prediction_.clear();
 
-  if (predict_probability_)
-  {
+  if (predict_probability_) {
     if (svm_type == NU_SVR || svm_type == EPSILON_SVR)
-      PCL_WARN ("[pcl::%s::classificationTest] Prob. model for test data: target value = predicted value + z,\nz: Laplace distribution e^(-|z|/sigma)/(2sigma),sigma=%g\n", getClassName ().c_str (),svm_get_svr_probability (&model_));
-    else
-    {
-      prob_estimates = static_cast<double *> (malloc (nr_class * sizeof (double)));
+      PCL_WARN("[pcl::%s::classificationTest] Prob. model for test data: target value "
+               "= predicted value + z,\nz: Laplace distribution "
+               "e^(-|z|/sigma)/(2sigma),sigma=%g\n",
+               getClassName().c_str(),
+               svm_get_svr_probability(&model_));
+    else {
+      prob_estimates = static_cast<double*>(malloc(nr_class * sizeof(double)));
     }
   }
 
   int ii = 0;
 
-  prediction_.resize (prob_.l);
+  prediction_.resize(prob_.l);
 
-  while (ii < prob_.l)
-  {
-    //int i = 0;
+  while (ii < prob_.l) {
+    // int i = 0;
     double target_label, predict_label;
-    //char *idx, *val, *endptr;
-    //int inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed kernel has <index> start from 0
+    // char *idx, *val, *endptr;
+    // int inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed
+    // kernel has <index> start from 0
 
-    target_label = prob_.y[ii]; //takes the first label
+    target_label = prob_.y[ii]; // takes the first label
 
-    if (predict_probability_ && (svm_type == C_SVC || svm_type == NU_SVC))
-    {
-      predict_label = svm_predict_probability (&model_, prob_.x[ii], prob_estimates);
-      prediction_[ii].push_back (predict_label);
+    if (predict_probability_ && (svm_type == C_SVC || svm_type == NU_SVC)) {
+      predict_label = svm_predict_probability(&model_, prob_.x[ii], prob_estimates);
+      prediction_[ii].push_back(predict_label);
 
-      for (int j = 0; j < nr_class; j++)
-      {
-        prediction_[ii].push_back (prob_estimates[j]);
+      for (int j = 0; j < nr_class; j++) {
+        prediction_[ii].push_back(prob_estimates[j]);
       }
     }
-    else
-    {
-      predict_label = svm_predict (&model_, prob_.x[ii]);
-      prediction_[ii].push_back (predict_label);
+    else {
+      predict_label = svm_predict(&model_, prob_.x[ii]);
+      prediction_[ii].push_back(predict_label);
     }
-
 
     if (predict_label == target_label)
       ++correct;
 
     error += (predict_label - target_label) * (predict_label - target_label);
-    sump  += predict_label;
-    sumt  += target_label;
+    sump += predict_label;
+    sumt += target_label;
     sumpp += predict_label * predict_label;
     sumtt += target_label * target_label;
     sumpt += predict_label * target_label;
@@ -649,103 +627,100 @@ pcl::SVMClassify::classificationTest ()
     ii++;
   }
 
-  if (svm_type == NU_SVR || svm_type == EPSILON_SVR)
-  {
-    pcl::console::print_info (" - Mean squared error (regression) = ");
-    pcl::console::print_value ("%g\n", error / total);
+  if (svm_type == NU_SVR || svm_type == EPSILON_SVR) {
+    pcl::console::print_info(" - Mean squared error (regression) = ");
+    pcl::console::print_value("%g\n", error / total);
 
-    pcl::console::print_info (" - Squared correlation coefficient (regression) = ");
-    pcl::console::print_value ("%g\n",
-                               ( (total*sumpt - sump*sumt) * (total*sumpt - sump*sumt)) /
-                               ( (total*sumpp - sump*sump) * (total*sumtt - sumt*sumt))
-                              );
+    pcl::console::print_info(" - Squared correlation coefficient (regression) = ");
+    pcl::console::print_value(
+        "%g\n",
+        ((total * sumpt - sump * sumt) * (total * sumpt - sump * sumt)) /
+            ((total * sumpp - sump * sump) * (total * sumtt - sumt * sumt)));
   }
-  else
-  {
-    pcl::console::print_info (" - Accuracy (classification) = ");
-    pcl::console::print_value ("%g%% (%d/%d)\n",
-            double (correct) / total*100, correct, total);
+  else {
+    pcl::console::print_info(" - Accuracy (classification) = ");
+    pcl::console::print_value(
+        "%g%% (%d/%d)\n", double(correct) / total * 100, correct, total);
   }
 
   if (predict_probability_)
-    free (prob_estimates);
+    free(prob_estimates);
 
   return true;
 }
 
 bool
-pcl::SVMClassify::classification ()
+pcl::SVMClassify::classification()
 {
-  if (model_.l == 0)
-  {
-    PCL_ERROR ("[pcl::%s::classification] Classifier model has no data.\n", getClassName ().c_str ());
+  if (model_.l == 0) {
+    PCL_ERROR("[pcl::%s::classification] Classifier model has no data.\n",
+              getClassName().c_str());
     return false;
   }
-  
-  if (prob_.l == 0)
-  {
-    PCL_ERROR ("[pcl::%s::classification] Input dataset has no data.\n", getClassName ().c_str ());
-    return false;
-  }
-  
 
-  if (predict_probability_)
-  {
-    if (svm_check_probability_model (&model_) == 0)
-    {
-      PCL_WARN ("[pcl::%s::classification] Classifier model does not support probabiliy estimates. Automatically disabled.\n", getClassName ().c_str ());
+  if (prob_.l == 0) {
+    PCL_ERROR("[pcl::%s::classification] Input dataset has no data.\n",
+              getClassName().c_str());
+    return false;
+  }
+
+  if (predict_probability_) {
+    if (svm_check_probability_model(&model_) == 0) {
+      PCL_WARN("[pcl::%s::classification] Classifier model does not support probabiliy "
+               "estimates. Automatically disabled.\n",
+               getClassName().c_str());
       predict_probability_ = false;
     }
   }
-  else
-  {
-    if (svm_check_probability_model (&model_) != 0)
-      PCL_WARN("[pcl::%s::classification] Classifier model supports probability estimates, but disabled in prediction.\n", getClassName ().c_str ());
+  else {
+    if (svm_check_probability_model(&model_) != 0)
+      PCL_WARN("[pcl::%s::classification] Classifier model supports probability "
+               "estimates, but disabled in prediction.\n",
+               getClassName().c_str());
   }
 
-  //int correct = 0;
+  // int correct = 0;
   int total = 0;
-  int svm_type = svm_get_svm_type (&model_);
-  int nr_class = svm_get_nr_class (&model_);
+  int svm_type = svm_get_svm_type(&model_);
+  int nr_class = svm_get_nr_class(&model_);
 
-  double *prob_estimates = nullptr;
+  double* prob_estimates = nullptr;
 
   prediction_.clear();
 
-  if (predict_probability_)
-  {
+  if (predict_probability_) {
     if (svm_type == NU_SVR || svm_type == EPSILON_SVR)
-      PCL_WARN ("[pcl::%s::classificationTest] Prob. model for test data: target value = predicted value + z,\nz: Laplace distribution e^(-|z|/sigma)/(2sigma),sigma=%g\n", getClassName ().c_str (),svm_get_svr_probability (&model_));
-    else
-    {
-      prob_estimates = static_cast<double *> (malloc (nr_class * sizeof (double)));
+      PCL_WARN("[pcl::%s::classificationTest] Prob. model for test data: target value "
+               "= predicted value + z,\nz: Laplace distribution "
+               "e^(-|z|/sigma)/(2sigma),sigma=%g\n",
+               getClassName().c_str(),
+               svm_get_svr_probability(&model_));
+    else {
+      prob_estimates = static_cast<double*>(malloc(nr_class * sizeof(double)));
     }
   }
 
   int ii = 0;
 
-  prediction_.resize (prob_.l);
+  prediction_.resize(prob_.l);
 
-  while (ii < prob_.l)
-  {
+  while (ii < prob_.l) {
     double predict_label;
-    //char *idx, *val, *endptr;
-    //int inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed kernel has <index> start from 0
+    // char *idx, *val, *endptr;
+    // int inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed
+    // kernel has <index> start from 0
 
-    if (predict_probability_ && (svm_type == C_SVC || svm_type == NU_SVC))
-    {
-      predict_label = svm_predict_probability (&model_, prob_.x[ii], prob_estimates);
-      prediction_[ii].push_back (predict_label);
+    if (predict_probability_ && (svm_type == C_SVC || svm_type == NU_SVC)) {
+      predict_label = svm_predict_probability(&model_, prob_.x[ii], prob_estimates);
+      prediction_[ii].push_back(predict_label);
 
-      for (int j = 0;j < nr_class;j++)
-      {
-        prediction_[ii].push_back (prob_estimates[j]);
+      for (int j = 0; j < nr_class; j++) {
+        prediction_[ii].push_back(prob_estimates[j]);
       }
     }
-    else
-    {
-      predict_label = svm_predict (&model_, prob_.x[ii]);
-      prediction_[ii].push_back (predict_label);
+    else {
+      predict_label = svm_predict(&model_, prob_.x[ii]);
+      prediction_[ii].push_back(predict_label);
     }
 
     ++total;
@@ -754,112 +729,110 @@ pcl::SVMClassify::classification ()
   }
 
   if (predict_probability_)
-    free (prob_estimates);
+    free(prob_estimates);
 
   return (true);
 }
 
 std::vector<double>
-pcl::SVMClassify::classification (pcl::SVMData in)
+pcl::SVMClassify::classification(pcl::SVMData in)
 {
-  assert (model_.l != 0);
+  assert(model_.l != 0);
 
-  if (model_.l == 0)
-  {
-    PCL_ERROR ("[pcl::%s::classification] Classifier model has no data.\n", getClassName ().c_str ());
+  if (model_.l == 0) {
+    PCL_ERROR("[pcl::%s::classification] Classifier model has no data.\n",
+              getClassName().c_str());
     exit(0);
   }
-  
-  if (predict_probability_)
-  {
-    if (svm_check_probability_model (&model_) == 0)
-    {
-      PCL_WARN ("[pcl::%s::classification] Classifier model does not support probabiliy estimates. Automatically disabled.\n", getClassName ().c_str ());
+
+  if (predict_probability_) {
+    if (svm_check_probability_model(&model_) == 0) {
+      PCL_WARN("[pcl::%s::classification] Classifier model does not support probabiliy "
+               "estimates. Automatically disabled.\n",
+               getClassName().c_str());
       predict_probability_ = false;
     }
   }
-  else
-  {
-    if (svm_check_probability_model (&model_) != 0)
-      PCL_WARN("[pcl::%s::classification] Classifier model supports probability estimates, but disabled in prediction.\n", getClassName ().c_str ());
+  else {
+    if (svm_check_probability_model(&model_) != 0)
+      PCL_WARN("[pcl::%s::classification] Classifier model supports probability "
+               "estimates, but disabled in prediction.\n",
+               getClassName().c_str());
   }
 
-  int svm_type = svm_get_svm_type (&model_);
-  int nr_class = svm_get_nr_class (&model_);
-  double *prob_estimates = nullptr;
+  int svm_type = svm_get_svm_type(&model_);
+  int nr_class = svm_get_nr_class(&model_);
+  double* prob_estimates = nullptr;
 
-  svm_node *buff;
-  buff = Malloc (struct svm_node, in.SV.size() + 10);
+  svm_node* buff;
+  buff = Malloc(struct svm_node, in.SV.size() + 10);
 
-  for (size_t i = 0; i < in.SV.size (); i++)
-  {
+  for (size_t i = 0; i < in.SV.size(); i++) {
     buff[i].index = in.SV[i].idx;
 
-    if (in.SV[i].idx < scaling_.max  && scaling_.obj[in.SV[i].idx].index == 1)
+    if (in.SV[i].idx < scaling_.max && scaling_.obj[in.SV[i].idx].index == 1)
       buff[i].value = in.SV[i].value / scaling_.obj[in.SV[i].idx].value;
     else
       buff[i].value = in.SV[i].value;
   }
 
-  buff[in.SV.size ()].index = -1;
+  buff[in.SV.size()].index = -1;
 
   // clean the prediction vector
-  prediction_.clear ();
+  prediction_.clear();
 
-  if (predict_probability_)
-  {
+  if (predict_probability_) {
     if (svm_type == NU_SVR || svm_type == EPSILON_SVR)
-     PCL_WARN ("[pcl::%s::classification] Prob. model for test data: target value = predicted value + z,\nz: Laplace distribution e^(-|z|/sigma)/(2sigma),sigma=%g\n", getClassName ().c_str (),svm_get_svr_probability (&model_));
-    else
-    {
-      prob_estimates = static_cast<double *> (malloc (nr_class * sizeof (double)));
+      PCL_WARN("[pcl::%s::classification] Prob. model for test data: target value = "
+               "predicted value + z,\nz: Laplace distribution "
+               "e^(-|z|/sigma)/(2sigma),sigma=%g\n",
+               getClassName().c_str(),
+               svm_get_svr_probability(&model_));
+    else {
+      prob_estimates = static_cast<double*>(malloc(nr_class * sizeof(double)));
     }
   }
 
-  prediction_.resize (1);
+  prediction_.resize(1);
 
   double predict_label;
 
-  if (predict_probability_ && (svm_type == C_SVC || svm_type == NU_SVC))
-  {
-    predict_label = svm_predict_probability (&model_, buff, prob_estimates);
-    prediction_[0].push_back (predict_label);
+  if (predict_probability_ && (svm_type == C_SVC || svm_type == NU_SVC)) {
+    predict_label = svm_predict_probability(&model_, buff, prob_estimates);
+    prediction_[0].push_back(predict_label);
 
-    for (int j = 0;j < nr_class;j++)
-    {
-      prediction_[0].push_back (prob_estimates[j]);
+    for (int j = 0; j < nr_class; j++) {
+      prediction_[0].push_back(prob_estimates[j]);
     }
   }
-  else
-  {
-    predict_label = svm_predict (&model_, buff);
-    prediction_[0].push_back (predict_label);
+  else {
+    predict_label = svm_predict(&model_, buff);
+    prediction_[0].push_back(predict_label);
   }
 
   if (predict_probability_)
-    free (prob_estimates);
+    free(prob_estimates);
 
-  free (buff);
+  free(buff);
 
   return prediction_[0];
 };
 
 void
-pcl::SVMClassify::scaleProblem (svm_problem &input, svm_scaling scaling)
+pcl::SVMClassify::scaleProblem(svm_problem& input, svm_scaling scaling)
 {
-  assert (scaling.max != 0);
+  assert(scaling.max != 0);
 
-  for (int i = 0;i < input.l;i++)
-  {
+  for (int i = 0; i < input.l; i++) {
     int j = 0;
 
-    while (true)
-    {
+    while (true) {
       if (input.x[i][j].index == -1)
         break;
 
-      if (input.x[i][j].index < scaling.max && scaling.obj[ input.x[i][j].index ].index == 1)
-        input.x[i][j].value /= scaling.obj[ input.x[i][j].index ].value;
+      if (input.x[i][j].index < scaling.max &&
+          scaling.obj[input.x[i][j].index].index == 1)
+        input.x[i][j].value /= scaling.obj[input.x[i][j].index].value;
 
       j++;
     }
@@ -867,31 +840,29 @@ pcl::SVMClassify::scaleProblem (svm_problem &input, svm_scaling scaling)
 }
 
 void
-pcl::SVMClassify::saveClassificationResult (const char *filename)
+pcl::SVMClassify::saveClassificationResult(const char* filename)
 {
-  assert (prediction_.size() > 0);
-  assert (model_.l > 0);
+  assert(prediction_.size() > 0);
+  assert(model_.l > 0);
 
   std::ofstream output;
-  output.open (filename);
+  output.open(filename);
 
-  int nr_class = svm_get_nr_class (&model_);
-  int *labels = static_cast<int *> (malloc (nr_class * sizeof (int)));
-  svm_get_labels (&model_, labels);
+  int nr_class = svm_get_nr_class(&model_);
+  int* labels = static_cast<int*>(malloc(nr_class * sizeof(int)));
+  svm_get_labels(&model_, labels);
 
-  if (predict_probability_)
-  {
+  if (predict_probability_) {
     output << "labels ";
 
-    for (int j = 0 ; j < nr_class; j++)
+    for (int j = 0; j < nr_class; j++)
       output << labels[j] << " ";
 
     output << "\n";
   }
 
-  for (const auto &prediction : prediction_)
-  {
-    for (const double &value : prediction)
+  for (const auto& prediction : prediction_) {
+    for (const double& value : prediction)
       output << value << " ";
 
     output << "\n";
@@ -899,11 +870,11 @@ pcl::SVMClassify::saveClassificationResult (const char *filename)
 
   output.close();
 
-  free (labels);
+  free(labels);
 }
 
 #define PCL_INSTANTIATE_SVM(T) template class PCL_EXPORTS pcl::SVM<T>;
 #define PCL_INSTANTIATE_SVMTrain(T) template class PCL_EXPORTS pcl::SVMTrain<T>;
 #define PCL_INSTANTIATE_SVMClassify(T) template class PCL_EXPORTS pcl::SVMClassify<T>;
 
-#endif //PCL_SVM_WRAPPER_HPP_
+#endif // PCL_SVM_WRAPPER_HPP_


### PR DESCRIPTION
To keep this PR limited in the number of lines touched, it formats approximately half of the `ml` module files.

@kunaltyagi please don't waste too much time reading this code. It's in bad shape and I suspect most of it is not used. If you are wondering how this ended up in the library... in the ancient SVN times, there were no code reviews. Instead, a gang of core devs, Willow Garage interns, and GSoC students alike pushed code directly to master.