### PR TITLE
Reordered initializers in the correct order in `supervoxel_clus…

### DIFF
--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -139,8 +139,8 @@ namespace pcl
             rgb_ (0.0f, 0.0f, 0.0f),
             normal_ (0.0f, 0.0f, 0.0f, 0.0f),
             curvature_ (0.0f),
-            idx_(0),
             distance_(0),
+            idx_(0),
             owner_ (nullptr)
             {}
 


### PR DESCRIPTION
Resolves new reordering warnings caused by #3372 