### PR TITLE
Removes warnings about multi-line macro and not covered by if

### DIFF
--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -184,13 +184,15 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
     if( !soft_bin || bin_size==1 ) {
       // interpolate w.r.t. orientation only, not spatial bin_size
       H1=H+(x/bin_size)*hb;
-      #define GH H1[O0[y]]+=M0[y]; H1[O1[y]]+=M1[y]; y++;
-      if( bin_size==1 )      for(y=0; y<h0;) { GH; H1++; }
-      else if( bin_size==2 ) for(y=0; y<h0;) { GH; GH; H1++; }
-      else if( bin_size==3 ) for(y=0; y<h0;) { GH; GH; GH; H1++; }
-      else if( bin_size==4 ) for(y=0; y<h0;) { GH; GH; GH; GH; H1++; }
-      else for( y=0; y<h0;) { for( int y1=0; y1<bin_size; y1++ ) { GH; } H1++; }
-      #undef GH
+      const auto GH = [&H1, &O0, &O1, &y, &M0, &M1]()
+      {
+          H1[O0[y]]+=M0[y]; H1[O1[y]]+=M1[y]; y++;
+      };
+      if( bin_size==1 )      for(y=0; y<h0;) { GH(); H1++; }
+      else if( bin_size==2 ) for(y=0; y<h0;) { GH(); GH(); H1++; }
+      else if( bin_size==3 ) for(y=0; y<h0;) { GH(); GH(); GH(); H1++; }
+      else if( bin_size==4 ) for(y=0; y<h0;) { GH(); GH(); GH(); GH(); H1++; }
+      else for( y=0; y<h0;) { for( int y1=0; y1<bin_size; y1++ ) { GH(); } H1++; }
 
     } else {
       // interpolate using trilinear interpolation
@@ -200,19 +202,34 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
       if( x==0 ) { init=(0+.5f)*sInv-0.5f; xb=init; }
       hasLf = xb>=0; xb0 = hasLf?(int)xb:-1; hasRt = xb0 < wb-1;
       xd=xb-xb0; xb+=sInv; yb=init; y=0;
-      // macros for code conciseness
-      #define GHinit yd=yb-yb0; yb+=sInv; H0=H+xb0*hb+yb0; xyd=xd*yd; \
-      ms[0]=1-xd-yd+xyd; ms[1]=yd-xyd; ms[2]=xd-xyd; ms[3]=xyd;
-      #define GH(H,ma,mb) H1=H; pcl::sse_stru(*H1,pcl::sse_add(pcl::sse_ldu(*H1),pcl::sse_mul(ma,mb)));
+      // lambda for code conciseness
+      // @TODO: remove the very generic closure for specific variable one
+      const auto GHinit = [&]()
+      {
+          yd=yb-yb0;
+          yb+=sInv;
+          H0=H+xb0*hb+yb0;
+          xyd=xd*yd;
+
+          ms[0]=1-xd-yd+xyd;
+          ms[1]=yd-xyd;
+          ms[2]=xd-xyd;
+          ms[3]=xyd;
+      };
+      const auto GH = [&H1](const auto&H, const auto&ma, const auto&mb)
+      {
+          H1=H;
+          pcl::sse_stru(*H1, pcl::sse_add(pcl::sse_ldu(*H1), pcl::sse_mul(ma,mb)));
+      };
       // leading rows, no top bin_size
       for( ; y<bin_size/2; y++ ) {
-        yb0=-1; GHinit;
+        yb0=-1; GHinit();
         if(hasLf) { H0[O0[y]+1]+=ms[1]*M0[y]; H0[O1[y]+1]+=ms[1]*M1[y]; }
         if(hasRt) { H0[O0[y]+hb+1]+=ms[3]*M0[y]; H0[O1[y]+hb+1]+=ms[3]*M1[y]; }
       }
       // main rows, has top and bottom bins, use SSE for minor speedup
       for( ; ; y++ ) {
-        yb0 = (int) yb; if(yb0>=hb-1) break; GHinit;
+        yb0 = (int) yb; if(yb0>=hb-1) break; GHinit();
         _m0=pcl::sse_set(M0[y]); _m1=pcl::sse_set(M1[y]);
         if(hasLf) { _m=pcl::sse_set(0,0,ms[1],ms[0]);
         GH(H0+O0[y],_m,_m0); GH(H0+O1[y],_m,_m1); }
@@ -221,24 +238,32 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
       }      
       // final rows, no bottom bin_size
       for( ; y<h0; y++ ) {
-        yb0 = (int) yb; GHinit;
+        yb0 = (int) yb; GHinit();
         if(hasLf) { H0[O0[y]]+=ms[0]*M0[y]; H0[O1[y]]+=ms[0]*M1[y]; }
         if(hasRt) { H0[O0[y]+hb]+=ms[2]*M0[y]; H0[O1[y]+hb]+=ms[2]*M1[y]; }
       }       
-      #undef GHinit
-      #undef GH
 #else
       float ms[4], xyd, yb, xd, yd;  
       bool hasLf, hasRt; int xb0, yb0;
       if( x==0 ) { init=(0+.5f)*sInv-0.5f; xb=init; }
       hasLf = xb>=0; xb0 = hasLf?(int)xb:-1; hasRt = xb0 < wb-1;
       xd=xb-xb0; xb+=sInv; yb=init; y=0;
-      // macros for code conciseness
-      #define GHinit yd=yb-yb0; yb+=sInv; H0=H+xb0*hb+yb0; xyd=xd*yd; \
-      ms[0]=1-xd-yd+xyd; ms[1]=yd-xyd; ms[2]=xd-xyd; ms[3]=xyd;
+      // lambda for code conciseness
+      const auto GHinit = [&]()
+      {
+          yd=yb-yb0;
+          yb+=sInv;
+          H0=H+xb0*hb+yb0;
+          xyd=xd*yd;
+
+          ms[0]=1-xd-yd+xyd;
+          ms[1]=yd-xyd;
+          ms[2]=xd-xyd;
+          ms[3]=xyd;
+      };
       // leading rows, no top bin_size
       for( ; y<bin_size/2; y++ ) {
-        yb0=-1; GHinit;
+        yb0=-1; GHinit();
         if(hasLf) { H0[O0[y]+1]+=ms[1]*M0[y]; H0[O1[y]+1]+=ms[1]*M1[y]; }
         if(hasRt) { H0[O0[y]+hb+1]+=ms[3]*M0[y]; H0[O1[y]+hb+1]+=ms[3]*M1[y]; }
       }
@@ -247,7 +272,7 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
         yb0 = (int) yb;
         if(yb0>=hb-1) 
           break; 
-        GHinit;
+        GHinit();
   
         if(hasLf) 
         {
@@ -266,11 +291,10 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
       }      
       // final rows, no bottom bin_size
       for( ; y<h0; y++ ) {
-        yb0 = (int) yb; GHinit;
+        yb0 = (int) yb; GHinit();
         if(hasLf) { H0[O0[y]]+=ms[0]*M0[y]; H0[O1[y]]+=ms[0]*M1[y]; }
         if(hasRt) { H0[O0[y]+hb]+=ms[2]*M0[y]; H0[O1[y]+hb]+=ms[2]*M1[y]; }
       }       
-      #undef GHinit
 #endif     
     }
   }
@@ -289,9 +313,12 @@ pcl::people::HOG::normalization (float *H, int h, int w, int bin_size, int n_ori
   for( x=0; x<wb-1; x++ ) for( y=0; y<hb-1; y++ ) {
     N1=N+x*hb+y; *N1=1/float(std::sqrt( N1[0] + N1[1] + N1[hb] + N1[hb+1] +eps )); }
   // perform 4 normalizations per spatial block (handling boundary regions)
-  #define U(a,b) Gs[a][y]=H1[y]*N1[y-(b)]; if(Gs[a][y]>clip) Gs[a][y]=clip;
   for( o=0; o<n_orients; o++ ) for( x=0; x<wb; x++ ) {
     H1=H+o*nb+x*hb; N1=N+x*hb; float *Gs[4]; Gs[0]=G+o*nb+x*hb;
+    const auto U = [&Gs, &H1, &N1, &y, &clip](const auto&a, const auto&b)
+    {
+        Gs[a][y] = std::min(clip, H1[y] * N1[y - b]);
+    };
     for( y=1; y<4; y++ ) Gs[y]=Gs[y-1]+nb*n_orients;
     bool lf, md, rt; lf=(x==0); rt=(x==wb-1); md=(!lf && !rt);
     y=0; if(!rt) U(0,0); if(!lf) U(2,hb);
@@ -300,7 +327,6 @@ pcl::people::HOG::normalization (float *H, int h, int w, int bin_size, int n_ori
     if(rt) for( y=1; y<hb-1; y++ ) { U(2,hb); U(3,hb+1); }
     y=hb-1; if(!rt) U(1,1); if(!lf) U(3,hb+1);
   } free(N);
-  #undef U
 }
       
 void
@@ -385,7 +411,10 @@ pcl::people::HOG::grad1 (float *I, float *Gx, float *Gy, int h, int w, int x) co
       *_G++ = pcl::sse_mul(pcl::sse_sub(*_In++,*_Ip++), _r);
   }
   // compute column of Gy
-  #define GRADY(r) *Gy++ = (*In++-*Ip++)*r;
+  const auto GRADY = [&Gy, &In, &Ip](const auto& r)
+  {
+      *Gy++ = (*In++ - *Ip++) * r;
+  };
   Ip = I;
   In = Ip + 1;
   // GRADY(1); Ip--; for(y = 1; y < h-1; y++) GRADY(.5f); In--; GRADY(1);
@@ -402,7 +431,6 @@ pcl::people::HOG::grad1 (float *I, float *Gx, float *Gy, int h, int w, int x) co
   for(; y < h-1; y++) GRADY(.5f);
   In--;
   GRADY(1);
-  #undef GRADY
 #else
   int y, y1;
   float *Ip, *In, r;
@@ -427,7 +455,10 @@ pcl::people::HOG::grad1 (float *I, float *Gx, float *Gy, int h, int w, int x) co
     *Gx++=(*In++ - *Ip++)*r;
   
   // compute column of Gy
-  #define GRADY(r) *Gy++=(*In++-*Ip++)*r;
+  const auto GRADY = [&Gy, &In, &Ip](const auto& r)
+  {
+      *Gy++ = (*In++ - *Ip++) * r;
+  };
   Ip=I; In=Ip+1;
   // GRADY(1); Ip--; for(y=1; y<h-1; y++) GRADY(.5f); In--; GRADY(1);
   y1=((~((size_t) Gy) + 1) & 15)/4; if(y1==0) y1=4; if(y1>h-1) y1=h-1;
@@ -436,7 +467,6 @@ pcl::people::HOG::grad1 (float *I, float *Gx, float *Gy, int h, int w, int x) co
   r = 0.5f;
   for(; y<h-1; y++)
     GRADY(.5f); In--; GRADY(1);
-  #undef GRADY
 #endif
 }
       


### PR DESCRIPTION
Needs review if the lines with warnings regarding if should be inside the lambda or outside it

Warning:
```c++
Building CXX object people/CMakeFiles/pcl_people.dir/src/hog.cpp.o
../people/src/hog.cpp: In member function ‘void pcl::people::HOG::normalization(float*, int, int, int, int, float, float*) const’:
../people/src/hog.cpp:292:18: warning: macro expands to multiple statements [-Wmultistatement-macros]
  292 |   #define U(a,b) Gs[a][y]=H1[y]*N1[y-(b)]; if(Gs[a][y]>clip) Gs[a][y]=clip;
      |                  ^~
../people/src/hog.cpp:297:18: note: in expansion of macro ‘U’
  297 |     y=0; if(!rt) U(0,0); if(!lf) U(2,hb);
      |                  ^
../people/src/hog.cpp:297:10: note: some parts of macro expansion are not guarded by this ‘if’ clause
  297 |     y=0; if(!rt) U(0,0); if(!lf) U(2,hb);
      |          ^~
../people/src/hog.cpp:292:18: warning: macro expands to multiple statements [-Wmultistatement-macros]
  292 |   #define U(a,b) Gs[a][y]=H1[y]*N1[y-(b)]; if(Gs[a][y]>clip) Gs[a][y]=clip;
      |                  ^~
../people/src/hog.cpp:297:34: note: in expansion of macro ‘U’
  297 |     y=0; if(!rt) U(0,0); if(!lf) U(2,hb);
      |                                  ^
../people/src/hog.cpp:297:26: note: some parts of macro expansion are not guarded by this ‘if’ clause
  297 |     y=0; if(!rt) U(0,0); if(!lf) U(2,hb);
      |                          ^~
../people/src/hog.cpp:292:18: warning: macro expands to multiple statements [-Wmultistatement-macros]
  292 |   #define U(a,b) Gs[a][y]=H1[y]*N1[y-(b)]; if(Gs[a][y]>clip) Gs[a][y]=clip;
      |                  ^~
../people/src/hog.cpp:301:21: note: in expansion of macro ‘U’
  301 |     y=hb-1; if(!rt) U(1,1); if(!lf) U(3,hb+1);
      |                     ^
../people/src/hog.cpp:301:13: note: some parts of macro expansion are not guarded by this ‘if’ clause
  301 |     y=hb-1; if(!rt) U(1,1); if(!lf) U(3,hb+1);
      |             ^~
../people/src/hog.cpp:292:18: warning: macro expands to multiple statements [-Wmultistatement-macros]
  292 |   #define U(a,b) Gs[a][y]=H1[y]*N1[y-(b)]; if(Gs[a][y]>clip) Gs[a][y]=clip;
      |                  ^~
../people/src/hog.cpp:301:37: note: in expansion of macro ‘U’
  301 |     y=hb-1; if(!rt) U(1,1); if(!lf) U(3,hb+1);
      |                                     ^
../people/src/hog.cpp:301:29: note: some parts of macro expansion are not guarded by this ‘if’ clause
  301 |     y=hb-1; if(!rt) U(1,1); if(!lf) U(3,hb+1);
      |                             ^~
```