### PR TITLE
Ignore deprecated use for testing surface::MovingLeastSquares

### DIFF
--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -130,7 +130,7 @@ TEST (PCL, copyPointCloud)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-#pragma GCC diagnostic ignored "-Wdeprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic push
 TEST (PCL, concatenatePointCloud)
 {

--- a/test/surface/test_moving_least_squares.cpp
+++ b/test/surface/test_moving_least_squares.cpp
@@ -62,6 +62,8 @@ search::KdTree<PointXYZ>::Ptr tree3;
 search::KdTree<PointNormal>::Ptr tree4;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic push
 TEST (PCL, MovingLeastSquares)
 {
   // Init objects
@@ -172,6 +174,7 @@ TEST (PCL, MovingLeastSquares)
   EXPECT_NEAR (mls_normals->points[10].curvature, 0.107273, 1e-1);
   EXPECT_NEAR (double (mls_normals->size ()), 29394, 2);
 }
+#pragma GCC diagnostic pop
 
 /* ---[ */
 int


### PR DESCRIPTION
Also uses narrower deprecated-declaraion (doesn't cover "deprecated-copy")