### PR TITLE
Treat compiler warnings as errors

### DIFF
--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -7,7 +7,7 @@ jobs:
     variables:
       BUILD_DIR: '$(Agent.WorkFolder)/build'
       GOOGLE_TEST_DIR: '$(Agent.WorkFolder)/googletest'
-      CMAKE_CXX_FLAGS: '-Wall -Wextra -Wabi -O2'
+      CMAKE_CXX_FLAGS: '-Wall -Wextra -Wabi -Werror -O2'
     steps:
       - script: |
           brew install pkg-config qt5 libpcap brewsci/science/openni

--- a/.ci/azure-pipelines/build-ubuntu-16-04.yaml
+++ b/.ci/azure-pipelines/build-ubuntu-16-04.yaml
@@ -12,7 +12,7 @@ jobs:
     container: env1604
     variables:
       BUILD_DIR: '$(Agent.BuildDirectory)/build'
-      CMAKE_CXX_FLAGS: '-Wall -Wextra -O2'
+      CMAKE_CXX_FLAGS: '-Wall -Wextra -Werror -O2'
     steps:
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR

--- a/.ci/azure-pipelines/build-ubuntu-19-10.yaml
+++ b/.ci/azure-pipelines/build-ubuntu-19-10.yaml
@@ -12,7 +12,7 @@ jobs:
     container: env1910
     variables:
       BUILD_DIR: '$(Agent.BuildDirectory)/build'
-      CMAKE_CXX_FLAGS: '-Wall -Wextra -O2'
+      CMAKE_CXX_FLAGS: '-Wall -Wextra -Werror -O2'
     steps:
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR


### PR DESCRIPTION
This ensures that commits with warnings do not get a pass through CI.

Some commits have been already merged. This will track other warnings based on issues/PR

Current status per CI:
* [x] Format
* [x] MacOS Mojave
* [x] MacOS Catalina
* [x] Ubuntu 16.04
* [ ] Ubuntu 19.10
* [ ] Windows 32-bit
* [ ] Windows 64-bit
* [ ] Documentation: WIP by @aPonza

Current status of modules:
* Issues
  * [ ] Features: #3368
  * [ ] Apps: #3370
* Pull requests
  * [x] Common: #3374
  * [x] Segmentation: #3375
  * [x] People: #3377
  * [x] Surface/Nurbs: #3345
  * [x] Recognition/Metslib: #3384
  * [x] Tests: #3385, #3382 fixes #3378, #3425 fixes #3405, #3677 fixes #3373
  * [x] Registration: #3389 fixes #3376
  * [x] Filters: #3429 fixes #3367
  * [x] Apps: #3406 fixes #3403, #3469 fixes #1427

Other related problems(?):
* AppleClang warnings: fixed by #3777 
  * [x] Closed: #3785
  * [x] `missing field 'fst_bytesalloc' initializer`: fixed by #3736
  * [x] `ld: warning: text-based stub file are out of sync. Falling back to library file for linking` [Possible solutions on SO](https://stackoverflow.com/questions/51314888) ~~#3330~~ fixed by #3736
* ~Mismatch in flags for different compilers on the same system (GCC vs Clang on Linux)~
* ~Mismatch in flags for different compilers on different systems (GCC vs AppleClang vs MSVC) <Might never be resolved>~

~PS: This should be draft or normal PR?~ [Draft](https://github.com/PointCloudLibrary/pcl/pull/3379#issuecomment-535837261)

/fixes #2746 