### PR TITLE
Removed 'throw' specifier deprecated in C++11 for metslib

### DIFF
--- a/recognition/include/pcl/recognition/3rdparty/metslib/abstract-search.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/abstract-search.hh
@@ -133,8 +133,7 @@ namespace mets {
     /// An exception mets::no_moves_error can be risen when no move is
     /// possible.
     virtual void
-    search() 
-      throw(no_moves_error) = 0;
+    search() = 0;
 
     /// @brief The solution recorder instance.
     const solution_recorder&

--- a/recognition/include/pcl/recognition/3rdparty/metslib/local-search.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/local-search.hh
@@ -79,8 +79,7 @@ namespace mets {
     /// moves.
     ///
     virtual void
-    search()
-      throw(no_moves_error);
+    search();
 
   protected:
     bool short_circuit_m;
@@ -107,7 +106,6 @@ mets::local_search<move_manager_t>::local_search(evaluable_solution& working,
 template<typename move_manager_t>
 void
 mets::local_search<move_manager_t>::search()
-  throw(no_moves_error)
 {
   using base_t = abstract_search<move_manager_t>;
   typename move_manager_t::iterator best_movit;

--- a/recognition/include/pcl/recognition/3rdparty/metslib/simulated-annealing.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/simulated-annealing.hh
@@ -121,8 +121,7 @@ namespace mets {
     /// Remember that this is a minimization process.
     ///
     virtual void
-    search()
-      throw(no_moves_error);
+    search();
 
     void setApplyAndEvaluate(bool b) {
       apply_and_evaluate = b;
@@ -221,7 +220,6 @@ simulated_annealing(evaluable_solution& working,
 template<typename move_manager_t>
 void
 mets::simulated_annealing<move_manager_t>::search()
-  throw(no_moves_error)
 {
   using base_t = abstract_search<move_manager_t>;
 

--- a/recognition/include/pcl/recognition/3rdparty/metslib/tabu-search.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/tabu-search.hh
@@ -241,8 +241,7 @@ namespace mets {
     /// An exception mets::no_moves_error is risen when no move
     /// is possible.
     void 
-    search() 
-      throw(no_moves_error);
+    search();
     
     enum {
       ASPIRATION_CRITERIA_MET = abstract_search<move_manager_type>::LAST,
@@ -401,7 +400,6 @@ tabu_search (feasible_solution& starting_solution,
 
 template<typename move_manager_t>
 void mets::tabu_search<move_manager_t>::search()
-  throw(no_moves_error)
 {
   using base_t = abstract_search<move_manager_t>;
   while(!termination_criteria_m(base_t::working_solution_m))


### PR DESCRIPTION
I thought of removing warnings using a pragma but this was easier.