### PR TITLE
Fix pragma declaration for CI gcc, use "-Wdeprecated-declaratio…

### DIFF
--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -130,7 +130,7 @@ TEST (PCL, copyPointCloud)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-#pragma GCC diagnostic ignored "-Wdeprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic push
 TEST (PCL, concatenatePointCloud)
 {


### PR DESCRIPTION
CI doesn't like the wider warning flag (or it might be new)