### PR TITLE
Add a flag to disable window autoresizing in `ImageViewer`

### DIFF
--- a/visualization/include/pcl/visualization/image_viewer.h
+++ b/visualization/include/pcl/visualization/image_viewer.h
@@ -260,10 +260,12 @@ namespace pcl
           * \param[in] height the height of the image
           * \param[in] layer_id the name of the layer (default: "image")
           * \param[in] opacity the opacity of the layer (default: 1.0)
+          * \param[in] autoresize flag to enable window to adapt to image size (default true)
           */
         void 
         addRGBImage (const unsigned char* data, unsigned width, unsigned height, 
-                     const std::string &layer_id = "rgb_image", double opacity = 1.0);
+                     const std::string &layer_id = "rgb_image", double opacity = 1.0,
+                     bool autoresize = true);
 
         /** \brief Show a 2D image on screen, obtained from the RGB channel of a point cloud.
           * \param[in] cloud the input data representing the RGB point cloud 

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -127,10 +127,11 @@ pcl::visualization::ImageViewer::~ImageViewer ()
 void
 pcl::visualization::ImageViewer::addRGBImage (
     const unsigned char* rgb_data, unsigned width, unsigned height,
-    const std::string &layer_id, double opacity)
+    const std::string &layer_id, double opacity, bool autoresize)
 {
-  if (unsigned (getSize ()[0]) != width ||
-      unsigned (getSize ()[1]) != height)
+  if (autoresize &&
+      (unsigned (getSize ()[0]) != width ||
+      unsigned (getSize ()[1]) != height))
     setSize (width, height);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)


### PR DESCRIPTION
a small update to disable window autoscaling

resizing automatically on each addRGB() call is a big pain when using a constrained window manager (like i3) and also when the image is simply bigger than the screen...
in such case, the frame rate slow down to 1fps due to a loop in vtk SetSize() function here :

https://github.com/Kitware/VTK/blob/v8.2.0/Rendering/OpenGL2/vtkXOpenGLRenderWindow.cxx#L1035-L1039

