### PR TITLE
Fixed ordering of statements to resolve debug message

### DIFF
--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -450,9 +450,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransfor
     if (nr_iterations_ >= max_iterations_ || delta < 1)
     {
       converged_ = true;
-      previous_transformation_ = transformation_;
       PCL_DEBUG ("[pcl::%s::computeTransformation] Convergence reached. Number of iterations: %d out of %d. Transformation difference: %f\n",
                  getClassName ().c_str (), nr_iterations_, max_iterations_, (transformation_ - previous_transformation_).array ().abs ().sum ());
+      previous_transformation_ = transformation_;
     }
     else
       PCL_DEBUG ("[pcl::%s::computeTransformation] Convergence failed\n", getClassName ().c_str ());


### PR DESCRIPTION
The original ordering set `previous_transformation_=transformation_` before the print out. Therefore, during the print out statement, the resulting subtraction will always result to 0. Putting the debug statement before the subtraction resolves this issue. 