### PR TITLE
Rejuvinate MaskMap

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -363,3 +363,9 @@ aligned_free (void* ptr)
 #else
   #define PCL_FALLTHROUGH ;
 #endif
+
+#if __has_cpp_attribute(nodiscard)
+  #define PCL_NODISCARD [[nodiscard]]
+#else
+  #define PCL_NODISCARD
+#endif

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -606,8 +606,7 @@ extractFeatures (const MaskMap & mask, const size_t nr_features, const size_t mo
     MaskMap eroded_mask;
     erode (mask, eroded_mask);
 
-    MaskMap diff_mask;
-    MaskMap::getDifferenceMask (mask, eroded_mask, diff_mask);
+    auto diff_mask = MaskMap::getDifferenceMask (mask, eroded_mask);
 
     for (size_t row_index = 0; row_index < height; ++row_index)
     {

--- a/recognition/include/pcl/recognition/mask_map.h
+++ b/recognition/include/pcl/recognition/mask_map.h
@@ -4,7 +4,7 @@
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2010-2011, Willow Garage, Inc.
  *
- *  All rights reserved. 
+ *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -37,83 +37,98 @@
 
 #pragma once
 
-#include <vector>
 #include <pcl/pcl_macros.h>
+
 #include <cstring>
+#include <vector>
 
-namespace pcl
-{
-  class PCL_EXPORTS MaskMap
+namespace pcl {
+class PCL_EXPORTS MaskMap {
+public:
+  MaskMap() = default;
+
+  MaskMap(std::size_t width, std::size_t height);
+
+  virtual ~MaskMap() = default;
+
+  void
+  resize(std::size_t width, std::size_t height);
+
+  inline std::size_t
+  getWidth() const
   {
-    public:
-      MaskMap ();
-      MaskMap (size_t width, size_t height);
-      virtual ~MaskMap ();
+    return (width_);
+  }
 
-      void
-      resize (size_t width, size_t height);
+  inline std::size_t
+  getHeight() const
+  {
+    return (height_);
+  }
 
-      inline size_t 
-      getWidth () const { return (width_); }
-      
-      inline size_t
-      getHeight () const { return (height_); }
-      
-      inline unsigned char* 
-      getData () { return (&data_[0]); }
+  inline unsigned char*
+  getData()
+  {
+    return (data_.data());
+  }
 
-      inline const unsigned char* 
-      getData () const { return (&data_[0]); }
+  inline const unsigned char*
+  getData() const
+  {
+    return (data_.data());
+  }
 
-      static void
-      getDifferenceMask (const MaskMap & mask0,
-                         const MaskMap & mask1,
-                         MaskMap & diff_mask);
+  [[deprecated("Use new version diff getDifferenceMask(mask0, mask1)")]]
+  static void
+  getDifferenceMask(const MaskMap& mask0, const MaskMap& mask1, MaskMap& diff_mask);
 
-      inline void
-      set (const size_t x, const size_t y)
-      {
-        data_[y*width_+x] = 255;
-      }
+  PCL_NODISCARD
+  static MaskMap
+  getDifferenceMask(const MaskMap& mask0, const MaskMap& mask1);
 
-      inline void
-      unset (const size_t x, const size_t y)
-      {
-        data_[y*width_+x] = 0;
-      }
+  inline void
+  set(const std::size_t x, const std::size_t y)
+  {
+    data_[y * width_ + x] = 255;
+  }
 
-      inline bool
-      isSet (const size_t x, const size_t y) const
-      {
-        return (data_[y*width_+x] != 0);
-      }
+  inline void
+  unset(const std::size_t x, const std::size_t y)
+  {
+    data_[y * width_ + x] = 0;
+  }
 
-      inline void
-      reset ()
-      {
-        memset (&data_[0], 0, width_*height_);
-      }
+  inline bool
+  isSet(const std::size_t x, const std::size_t y) const
+  {
+    return (data_[y * width_ + x] != 0);
+  }
 
-      inline unsigned char & 
-      operator() (const size_t x, const size_t y) 
-      { 
-        return (data_[y*width_+x]); 
-      }
+  inline void
+  reset()
+  {
+    data_.assign(data_.size(), 0);
+  }
 
-      inline const unsigned char & 
-      operator() (const size_t x, const size_t y) const
-      { 
-        return (data_[y*width_+x]); 
-      }
+  inline unsigned char&
+  operator()(const std::size_t x, const std::size_t y)
+  {
+    return (data_[y * width_ + x]);
+  }
 
-      void
-      erode (MaskMap & eroded_mask) const;
+  inline const unsigned char&
+  operator()(const std::size_t x, const std::size_t y) const
+  {
+    return (data_[y * width_ + x]);
+  }
 
-    private:
-      //unsigned char * data_;
-      std::vector<unsigned char> data_;
-      size_t width_;
-      size_t height_;  
-  };
+  void
+  erode(MaskMap& eroded_mask) const;
 
-}
+private:
+  std::vector<unsigned char> data_;
+  std::size_t width_ = 0;
+  std::size_t height_ = 0;
+};
+
+} // namespace pcl

--- a/recognition/src/mask_map.cpp
+++ b/recognition/src/mask_map.cpp
@@ -4,7 +4,7 @@
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2010-2011, Willow Garage, Inc.
  *
- *  All rights reserved. 
+ *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -40,82 +40,63 @@
 #include <cassert>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-pcl::MaskMap::MaskMap ()
-  : data_ (0), width_ (0), height_ (0)
-{
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-pcl::MaskMap::MaskMap (const size_t width, const size_t height)
-  : width_ (width), height_ (height)
-{
-  data_.resize (width*height);
-}  
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-pcl::MaskMap::~MaskMap ()
-{
-}
+pcl::MaskMap::MaskMap(const std::size_t width, const std::size_t height)
+: data_(width * height), width_(width), height_(height)
+{}
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::MaskMap::resize (const size_t width, const size_t height)
+pcl::MaskMap::resize(const std::size_t width, const std::size_t height)
 {
-  data_.resize (width*height);
+  data_.resize(width * height);
   width_ = width;
   height_ = height;
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::MaskMap::getDifferenceMask (const MaskMap & mask0,
-                                 const MaskMap & mask1,
-                                 MaskMap & diff_mask)
+pcl::MaskMap::getDifferenceMask(const MaskMap& mask0,
+                                const MaskMap& mask1,
+                                MaskMap& diff_mask)
 {
-  const size_t width = mask0.getWidth ();
-  const size_t height = mask0.getHeight ();
-
-  assert (width == mask1.getWidth ());
-  assert (height == mask1.getHeight ());
-
-  diff_mask.resize (width, height);
-  diff_mask.reset ();
-
-  for (size_t row_index = 0; row_index < height; ++row_index)
-  {
-    for (size_t col_index = 0; col_index < width; ++col_index)
-    {
-      if (mask0 (col_index, row_index) != mask1 (col_index, row_index))
-      {
-        diff_mask (col_index, row_index) = 255;
-      }
-    }
-  }
+  diff_mask = getDifferenceMask(mask0, mask1);
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////////
+pcl::MaskMap
+pcl::MaskMap::getDifferenceMask(const MaskMap& mask0, const MaskMap& mask1)
+{
+  assert(mask0.getWidth() == mask1.getWidth());
+  assert(mask0.getHeight() == mask1.getHeight());
+
+  pcl::MaskMap diff_mask{mask0.getWidth(), mask0.getHeight()};
+
+  std::transform(std::cbegin(mask0.data_),
+                 std::cend(mask0.data_),
+                 std::cbegin(mask1.data_),
+                 std::begin(diff_mask.data_),
+                 [](const char& b0, const char& b1) { return b0 == b1 ? 0 : 255; });
+
+  return diff_mask;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::MaskMap::erode (MaskMap & eroded_mask) const
+pcl::MaskMap::erode(MaskMap& eroded_mask) const
 {
-  const MaskMap & mask_in = *this;
-  eroded_mask.resize (width_, height_);
+  const MaskMap& mask_in = *this;
+  eroded_mask.resize(width_, height_);
 
-  for (size_t row_index = 1; row_index < height_-1; ++row_index)
-  {
-    for (size_t col_index = 1; col_index < width_-1; ++col_index)
-    {
-      if (!mask_in.isSet (col_index, row_index-1) ||
-          !mask_in.isSet (col_index-1, row_index) ||
-          !mask_in.isSet (col_index+1, row_index) ||
-          !mask_in.isSet (col_index, row_index+1))
-      {
-        eroded_mask.unset (col_index, row_index);
+  for (std::size_t row_index = 1; row_index < height_ - 1; ++row_index) {
+    for (std::size_t col_index = 1; col_index < width_ - 1; ++col_index) {
+      if (!mask_in.isSet(col_index, row_index - 1) ||
+          !mask_in.isSet(col_index - 1, row_index) ||
+          !mask_in.isSet(col_index + 1, row_index) ||
+          !mask_in.isSet(col_index, row_index + 1)) {
+        eroded_mask.unset(col_index, row_index);
       }
-      else
-      {
-        eroded_mask.set (col_index, row_index);
+      else {
+        eroded_mask.set(col_index, row_index);
       }
     }
   }


### PR DESCRIPTION
Quick refactor to mask_map to make it more into C++14
- "default" to mark default constructor and destructor
- default values for member variables instead of default constructor
- avoid output parameters passed by reference, RVO will make the job for
us

This PR deprecates `void getDifferenceMask(const MaskMap&, const MaskMap&, MaskMap&)` in favor of a new overload with return value instead of output parameter.