### PR TITLE
Deprecate outparameter getFields() in favor of return value

### DIFF
--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -59,7 +59,16 @@ template <typename PointT> int
 pcl::getFieldIndex (const std::string &field_name, 
                     std::vector<pcl::PCLPointField> &fields)
 {
-  getFields<PointT> (fields);
+  fields = getFields<PointT> ();
+  const auto& ref = fields;
+  return pcl::getFieldIndex<PointT> (field_name, ref);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointT> int
+pcl::getFieldIndex (const std::string &field_name,
+                    const std::vector<pcl::PCLPointField> &fields)
+{
   const auto result = std::find_if(fields.begin (), fields.end (),
       [&field_name](const auto& field) { return field.name == field_name; });
   if (result == fields.end ())
@@ -71,16 +80,24 @@ pcl::getFieldIndex (const std::string &field_name,
 template <typename PointT> void
 pcl::getFields (const pcl::PointCloud<PointT> &, std::vector<pcl::PCLPointField> &fields)
 {
-  getFields<PointT> (fields);
+  fields = getFields<PointT> ();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::getFields (std::vector<pcl::PCLPointField> &fields)
 {
-  fields.clear ();
+  fields = getFields<PointT> ();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointT> std::vector<pcl::PCLPointField>
+pcl::getFields ()
+{
+  std::vector<pcl::PCLPointField> fields;
   // Get the fields list
   pcl::for_each_type<typename pcl::traits::fieldList<PointT>::type>(pcl::detail::FieldAdder<PointT>(fields));
+  return fields;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -88,8 +105,7 @@ template <typename PointT> std::string
 pcl::getFieldsList (const pcl::PointCloud<PointT> &)
 {
   // Get the fields list
-  std::vector<pcl::PCLPointField> fields;
-  pcl::for_each_type<typename pcl::traits::fieldList<PointT>::type>(pcl::detail::FieldAdder<PointT>(fields));
+  const auto fields = getFields<PointT>();
   std::string result;
   for (std::size_t i = 0; i < fields.size () - 1; ++i)
     result += fields[i].name + " ";

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -88,6 +88,14 @@ namespace pcl
   template <typename PointT> inline int 
   getFieldIndex (const std::string &field_name, 
                  std::vector<pcl::PCLPointField> &fields);
+  /** \brief Get the index of a specified field (i.e., dimension/channel)
+    * \param[in] field_name the string defining the field name
+    * \param[in] fields a vector to the original \a PCLPointField vector that the raw PointCloud message contains
+    * \ingroup common
+    */
+  template <typename PointT> inline int
+  getFieldIndex (const std::string &field_name,
+                 const std::vector<pcl::PCLPointField> &fields);
 
   /** \brief Get the list of available fields (i.e., dimension/channel)
     * \param[in] cloud the point cloud message
@@ -103,8 +111,16 @@ namespace pcl
     * \param[out] fields a vector to the original \a PCLPointField vector that the raw PointCloud message contains
     * \ingroup common
     */
-  template <typename PointT> inline void 
+  template <typename PointT>
+  [[deprecated("use getFields<typename decltype(cloud)::PointType> () instead")]]
+  inline void 
   getFields (std::vector<pcl::PCLPointField> &fields);
+
+  /** \brief Get the list of available fields (i.e., dimension/channel)
+    * \ingroup common
+    */
+  template <typename PointT> inline std::vector<pcl::PCLPointField>
+  getFields ();
 
   /** \brief Get the list of all fields available in a given cloud
     * \param[in] cloud the point cloud message

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -75,12 +75,13 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFieldIndex<typename decltype(cloud)::PointType> () instead")]]
+  [[deprecated("use getFieldIndex<PointT> (field_name, fields) instead")]]
   inline int
   getFieldIndex (const pcl::PointCloud<PointT> &cloud, const std::string &field_name, 
                  std::vector<pcl::PCLPointField> &fields);
 
   /** \brief Get the index of a specified field (i.e., dimension/channel)
+    * \tparam PointT datatype for which fields is being queries
     * \param[in] field_name the string defining the field name
     * \param[out] fields a vector to the original \a PCLPointField vector that the raw PointCloud message contains
     * \ingroup common
@@ -89,6 +90,7 @@ namespace pcl
   getFieldIndex (const std::string &field_name, 
                  std::vector<pcl::PCLPointField> &fields);
   /** \brief Get the index of a specified field (i.e., dimension/channel)
+    * \tparam PointT datatype for which fields is being queries
     * \param[in] field_name the string defining the field name
     * \param[in] fields a vector to the original \a PCLPointField vector that the raw PointCloud message contains
     * \ingroup common
@@ -103,20 +105,22 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFields<typename decltype(cloud)::PointType> () instead")]]
+  [[deprecated("use getFields<PointT> () with return value instead")]]
   inline void
   getFields (const pcl::PointCloud<PointT> &cloud, std::vector<pcl::PCLPointField> &fields);
 
   /** \brief Get the list of available fields (i.e., dimension/channel)
+    * \tparam PointT datatype whose details are requested
     * \param[out] fields a vector to the original \a PCLPointField vector that the raw PointCloud message contains
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFields<typename decltype(cloud)::PointType> () instead")]]
+  [[deprecated("use getFields<PointT> () with return value instead")]]
   inline void 
   getFields (std::vector<pcl::PCLPointField> &fields);
 
   /** \brief Get the list of available fields (i.e., dimension/channel)
+    * \tparam PointT datatype whose details are requested
     * \ingroup common
     */
   template <typename PointT> inline std::vector<pcl::PCLPointField>

--- a/filters/include/pcl/filters/impl/conditional_removal.hpp
+++ b/filters/include/pcl/filters/impl/conditional_removal.hpp
@@ -55,8 +55,7 @@ pcl::FieldComparison<PointT>::FieldComparison (
   op_ = op;
 
   // Get all fields
-  std::vector<pcl::PCLPointField> point_fields;
-  pcl::getFields<PointT> (point_fields);
+  const auto point_fields = pcl::getFields<PointT> ();
 
   // Find field_name
   if (point_fields.empty ())
@@ -140,8 +139,7 @@ pcl::PackedRGBComparison<PointT>::PackedRGBComparison (
   component_name_ (component_name), component_offset_ (), compare_val_ (compare_val)
 {
   // get all the fields
-  std::vector<pcl::PCLPointField> point_fields;
-  pcl::getFields<PointT> (point_fields);
+  const auto point_fields = pcl::getFields<PointT> ();
 
   // Locate the "rgb" field
   size_t d;
@@ -230,8 +228,7 @@ pcl::PackedHSIComparison<PointT>::PackedHSIComparison (
   component_name_ (component_name), component_id_ (), compare_val_ (compare_val), rgb_offset_ ()
 {
   // Get all the fields
-  std::vector<pcl::PCLPointField> point_fields;
-  pcl::getFields<PointT> (point_fields);
+  const auto point_fields = pcl::getFields<PointT> ();
 
   // Locate the "rgb" field
   size_t d;
@@ -377,8 +374,7 @@ pcl::TfQuadraticXYZComparison<PointT>::TfQuadraticXYZComparison () :
   comp_scalar_ (0.0)
 {
   // get all the fields
-  std::vector<pcl::PCLPointField> point_fields;
-  pcl::getFields<PointT> (point_fields);
+  const auto point_fields = pcl::getFields<PointT> ();
 
   // Locate the "x" field
   size_t dX;
@@ -440,8 +436,7 @@ pcl::TfQuadraticXYZComparison<PointT>::TfQuadraticXYZComparison (const pcl::Comp
   comp_scalar_ (comparison_scalar)
 {
   // get all the fields
-  std::vector<pcl::PCLPointField> point_fields;
-  pcl::getFields<PointT> (point_fields);
+  const auto point_fields = pcl::getFields<PointT> ();
 
   // Locate the "x" field
   size_t dX;

--- a/filters/include/pcl/filters/impl/random_sample.hpp
+++ b/filters/include/pcl/filters/impl/random_sample.hpp
@@ -56,8 +56,7 @@ pcl::RandomSample<PointT>::applyFilter (PointCloud &output)
     extract_removed_indices_ = temp;
     copyPointCloud (*input_, output);
     // Get X, Y, Z fields
-    std::vector<pcl::PCLPointField> fields;
-    pcl::getFields<PointT> (fields);
+    const auto fields = pcl::getFields<PointT> ();
     std::vector<size_t> offsets;
     for (const auto &field : fields)
     {

--- a/io/include/pcl/io/impl/ascii_io.hpp
+++ b/io/include/pcl/io/impl/ascii_io.hpp
@@ -41,7 +41,7 @@
 template<typename PointT> void
 pcl::ASCIIReader::setInputFields ()
 {
-  pcl::getFields<PointT> (fields_);
+  fields_ = pcl::getFields<PointT> ();
 
   // Remove empty fields and adjust offset
   int offset =0;

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -62,8 +62,7 @@ pcl::PCDWriter::generateHeader (const pcl::PointCloud<PointT> &cloud, const int 
          "\nVERSION 0.7"
          "\nFIELDS";
 
-  std::vector<pcl::PCLPointField> fields;
-  pcl::getFields<PointT> (fields);
+  const auto fields = pcl::getFields<PointT> ();
  
   std::stringstream field_names, field_types, field_sizes, field_counts;
   for (const auto &field : fields)
@@ -141,12 +140,11 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   boost::interprocess::file_lock file_lock;
   setLockingPermissions (file_name, file_lock);
 
-  std::vector<pcl::PCLPointField> fields;
+  auto fields = pcl::getFields<PointT> ();
   std::vector<int> fields_sizes;
   size_t fsize = 0;
   size_t data_size = 0;
   size_t nri = 0;
-  pcl::getFields<PointT> (fields);
   // Compute the total size of the fields
   for (const auto &field : fields)
   {
@@ -274,11 +272,10 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   boost::interprocess::file_lock file_lock;
   setLockingPermissions (file_name, file_lock);
 
-  std::vector<pcl::PCLPointField> fields;
+  auto fields = pcl::getFields<PointT> ();
   size_t fsize = 0;
   size_t data_size = 0;
   size_t nri = 0;
-  pcl::getFields<PointT> (fields);
   std::vector<int> fields_sizes (fields.size ());
   // Compute the total size of the fields
   for (const auto &field : fields)
@@ -464,8 +461,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name, const pcl::PointCloud<
   fs.precision (precision);
   fs.imbue (std::locale::classic ());
 
-  std::vector<pcl::PCLPointField> fields;
-  pcl::getFields<PointT> (fields);
+  const auto fields = pcl::getFields<PointT> ();
 
   // Write the header information
   fs << generateHeader<PointT> (cloud) << "DATA ascii\n";
@@ -621,12 +617,11 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   boost::interprocess::file_lock file_lock;
   setLockingPermissions (file_name, file_lock);
 
-  std::vector<pcl::PCLPointField> fields;
+  auto fields = pcl::getFields<PointT> ();
   std::vector<int> fields_sizes;
   size_t fsize = 0;
   size_t data_size = 0;
   size_t nri = 0;
-  pcl::getFields<PointT> (fields);
   // Compute the total size of the fields
   for (const auto &field : fields)
   {
@@ -748,8 +743,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
   fs.precision (precision);
   fs.imbue (std::locale::classic ());
 
-  std::vector<pcl::PCLPointField> fields;
-  pcl::getFields<PointT> (fields);
+  const auto fields = pcl::getFields<PointT> ();
 
   // Write the header information
   fs << generateHeader<PointT> (cloud, static_cast<int> (indices.size ())) << "DATA ascii\n";

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -115,7 +115,7 @@ namespace pcl
         {
           source_cloud_updated_ = true;
           PCLBase<PointSource>::setInputCloud (cloud);
-          pcl::getFields<PointSource> (input_fields_);
+          input_fields_ = pcl::getFields<PointSource> ();
         }
 
         /** \brief Get a pointer to the input point cloud dataset target. */

--- a/registration/include/pcl/registration/icp.h
+++ b/registration/include/pcl/registration/icp.h
@@ -178,8 +178,7 @@ namespace pcl
       setInputSource (const PointCloudSourceConstPtr &cloud) override
       {
         Registration<PointSource, PointTarget, Scalar>::setInputSource (cloud);
-        std::vector<pcl::PCLPointField> fields;
-        pcl::getFields<PointSource> (fields);
+        const auto fields = pcl::getFields<PointSource> ();
         source_has_normals_ = false;
         for (const auto &field : fields)
         {
@@ -213,8 +212,7 @@ namespace pcl
       setInputTarget (const PointCloudTargetConstPtr &cloud) override
       {
         Registration<PointSource, PointTarget, Scalar>::setInputTarget (cloud);
-        std::vector<pcl::PCLPointField> fields;
-        pcl::getFields<PointSource> (fields);
+        const auto fields = pcl::getFields<PointSource> ();
         target_has_normals_ = false;
         for (const auto &field : fields)
         {

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -388,8 +388,7 @@ TEST (PCL, IO)
   EXPECT_FLOAT_EQ (last.intensity, static_cast<float> (nr_p - 1));
 
   // Test getFieldIndex
-  std::vector<pcl::PCLPointField> fields;
-  pcl::getFields<PointXYZI> (fields);
+  const auto fields = pcl::getFields<PointXYZI> ();
   EXPECT_EQ (fields.size (), size_t (4));
   int x_idx = pcl::getFieldIndex<PointXYZI> ("x", fields);
   EXPECT_EQ (x_idx, 0);


### PR DESCRIPTION
For `pcl::getFields<PointT>`:
* Adds a return value style function
* Deprecates the outparameter version
* Converts usage to the new version

/fixes #3380