### PR TITLE
Generic detection idiom for `isFinite` with more usage specific…

### DIFF
--- a/common/include/pcl/common/point_tests.h
+++ b/common/include/pcl/common/point_tests.h
@@ -39,6 +39,8 @@
 
 #pragma once
 
+#include <pcl/point_types.h>
+
 #ifdef _MSC_VER
 #include <Eigen/src/StlSupport/details.h>
 #endif
@@ -100,5 +102,43 @@ namespace pcl
   isFinite<pcl::Normal> (const pcl::Normal &n)
   {
     return (std::isfinite (n.normal_x) && std::isfinite (n.normal_y) && std::isfinite (n.normal_z));
+  }
+
+  // generic fallback cases
+  template <typename PointT, traits::HasNoXY<PointT> = true> constexpr inline bool
+  isXYFinite (const PointT&) noexcept
+  {
+    return true;
+  }
+
+  template <typename PointT, traits::HasNoXYZ<PointT> = true> constexpr inline bool
+  isXYZFinite (const PointT&) noexcept
+  {
+    return true;
+  }
+
+  template <typename PointT, traits::HasNoNormal<PointT> = true> constexpr inline bool
+  isNormalFinite (const PointT&) noexcept
+  {
+    return true;
+  }
+
+  // special cases for checks
+  template <typename PointT, traits::HasXY<PointT> = true> inline bool
+  isXYFinite (const PointT& pt) noexcept
+  {
+    return std::isfinite(pt.x) && std::isfinite(pt.y);
+  }
+
+  template <typename PointT, traits::HasXYZ<PointT> = true> inline bool
+  isXYZFinite (const PointT& pt) noexcept
+  {
+    return std::isfinite(pt.x) && std::isfinite(pt.y) && std::isfinite(pt.z);
+  }
+
+  template <typename PointT, traits::HasNormal<PointT> = true> inline bool
+  isNormalFinite (const PointT& pt) noexcept
+  {
+    return std::isfinite(pt.normal_x) && std::isfinite(pt.normal_y) && std::isfinite(pt.normal_z);
   }
 }

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -1700,7 +1700,4 @@ namespace pcl
   }
 } // End namespace
 
-// Preserve API for PCL users < 1.4
-#include <pcl/common/point_tests.h>
-
 #endif

--- a/common/include/pcl/point_types.h
+++ b/common/include/pcl/point_types.h
@@ -790,12 +790,43 @@ namespace pcl
                                                             has_field<PointT, boost::mpl::_2> > >::type
     { };
 
+    /** \brief Traits defined for ease of use with fields already registered before
+     *
+     * has_<fields to be detected>: struct with `value` datamember defined at compiletime
+     * has_<fields to be detected>_v: constexpr boolean
+     * Has<Fields to be detected>: concept modelling name alias for `enable_if`
+     */
+
+    /** Metafunction to check if a given point type has x and y fields. */
+    template <typename PointT>
+    struct has_xy : has_all_fields<PointT, boost::mpl::vector<pcl::fields::x,
+                                                              pcl::fields::y> >
+    { };
+
+    template <typename PointT>
+    constexpr auto has_xy_v = has_xy<PointT>::value;
+
+    template <typename PointT>
+    using HasXY = std::enable_if_t<has_xy_v<PointT>, bool>;
+
+    template <typename PointT>
+    using HasNoXY = std::enable_if_t<!has_xy_v<PointT>, bool>;
+
     /** Metafunction to check if a given point type has x, y, and z fields. */
     template <typename PointT>
     struct has_xyz : has_all_fields<PointT, boost::mpl::vector<pcl::fields::x,
                                                                pcl::fields::y,
                                                                pcl::fields::z> >
     { };
+
+    template <typename PointT>
+    constexpr auto has_xyz_v = has_xyz<PointT>::value;
+
+    template <typename PointT>
+    using HasXYZ = std::enable_if_t<has_xyz_v<PointT>, bool>;
+
+    template <typename PointT>
+    using HasNoXYZ = std::enable_if_t<!has_xyz_v<PointT>, bool>;
 
     /** Metafunction to check if a given point type has normal_x, normal_y, and
       * normal_z fields. */
@@ -805,15 +836,42 @@ namespace pcl
                                                                   pcl::fields::normal_z> >
     { };
 
+    template <typename PointT>
+    constexpr auto has_normal_v = has_normal<PointT>::value;
+
+    template <typename PointT>
+    using HasNormal = std::enable_if_t<has_normal_v<PointT>, bool>;
+
+    template <typename PointT>
+    using HasNoNormal = std::enable_if_t<!has_normal_v<PointT>, bool>;
+
     /** Metafunction to check if a given point type has curvature field. */
     template <typename PointT>
     struct has_curvature : has_field<PointT, pcl::fields::curvature>
     { };
 
+    template <typename PointT>
+    constexpr auto has_curvature_v = has_curvature<PointT>::value;
+
+    template <typename PointT>
+    using HasCurvature = std::enable_if_t<has_curvature_v<PointT>, bool>;
+
+    template <typename PointT>
+    using HasNoCurvature = std::enable_if_t<!has_curvature_v<PointT>, bool>;
+
     /** Metafunction to check if a given point type has intensity field. */
     template <typename PointT>
     struct has_intensity : has_field<PointT, pcl::fields::intensity>
     { };
+
+    template <typename PointT>
+    constexpr auto has_intensity_v = has_intensity<PointT>::value;
+
+    template <typename PointT>
+    using HasIntensity = std::enable_if_t<has_intensity_v<PointT>, bool>;
+
+    template <typename PointT>
+    using HasNoIntensity = std::enable_if_t<!has_intensity_v<PointT>, bool>;
 
     /** Metafunction to check if a given point type has either rgb or rgba field. */
     template <typename PointT>
@@ -821,14 +879,34 @@ namespace pcl
                                                                 pcl::fields::rgba> >
     { };
 
+    template <typename PointT>
+    constexpr auto has_color_v = has_color<PointT>::value;
+
+    template <typename PointT>
+    using HasColor = std::enable_if_t<has_color_v<PointT>, bool>;
+
+    template <typename PointT>
+    using HasNoColor = std::enable_if_t<!has_color_v<PointT>, bool>;
+
     /** Metafunction to check if a given point type has label field. */
     template <typename PointT>
     struct has_label : has_field<PointT, pcl::fields::label>
     { };
 
+    template <typename PointT>
+    constexpr auto has_label_v = has_label<PointT>::value;
+
+    template <typename PointT>
+    using HasLabel = std::enable_if_t<has_label_v<PointT>, bool>;
+
+    template <typename PointT>
+    using HasNoLabel = std::enable_if_t<!has_label_v<PointT>, bool>;
   }
 
 } // namespace pcl
+
+// Not strictly required, merely to preserve API for PCL users < 1.4
+#include <pcl/common/point_tests.h>
 
 #if defined _MSC_VER
   #pragma warning(default: 4201)

--- a/test/common/test_type_traits.cpp
+++ b/test/common/test_type_traits.cpp
@@ -38,26 +38,129 @@
 
 #include <pcl/pcl_macros.h>
 #include <pcl/point_traits.h>
+#include <pcl/point_types.h>
 
 #include <gtest/gtest.h>
 
-
-struct Foo
-{
-public:
-  PCL_MAKE_ALIGNED_OPERATOR_NEW
-};
-
-struct Bar
-{
-};
-
 TEST (TypeTraits, HasCustomAllocatorTrait)
 {
+  struct Foo
+  {
+  public:
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
+  };
+
+  struct Bar
+  {
+  };
+
   EXPECT_TRUE(pcl::has_custom_allocator<Foo>::value);
   EXPECT_FALSE(pcl::has_custom_allocator<Bar>::value);
 }
 
+TEST (TypeTraits, HasXY)
+{
+  static_assert(!pcl::traits::has_xy_v<pcl::Normal>,
+                "has_xy<> should detect lack of x and y fields");
+  static_assert(pcl::traits::has_xy_v<pcl::PointXYZ>,
+                "has_xy<> should detect x and y fields");
+}
+
+TEST (TypeTraits, HasXYZ)
+{
+  static_assert(!pcl::traits::has_xyz_v<pcl::Normal>,
+                "has_xyz<> should detect lack of x or y or z fields");
+  static_assert(pcl::traits::has_xyz_v<pcl::PointXYZ>,
+                "has_xyz<> should detect x, y and z fields");
+}
+
+TEST (TypeTraits, HasNormal)
+{
+  static_assert(!pcl::traits::has_normal_v<pcl::PointXYZ>,
+                "has_normal<> should detect lack of normal_{x or y or z} fields");
+  static_assert(pcl::traits::has_normal_v<pcl::Axis>,
+                "has_normal<> should detect normal_{x, y and z} fields");
+}
+
+TEST (TypeTraits, HasCurvature)
+{
+  static_assert(!pcl::traits::has_curvature_v<pcl::PointXYZ>,
+                "has_curvature<> should detect lack of curvature field");
+  static_assert(pcl::traits::has_curvature_v<pcl::Normal>,
+                "has_curvature<> should detect curvature field");
+}
+
+TEST (TypeTraits, HasIntensity)
+{
+  static_assert(!pcl::traits::has_intensity_v<pcl::InterestPoint>,
+                "has_intensity<> should detect lack of intensity field");
+  static_assert(pcl::traits::has_intensity_v<pcl::PointXYZI>,
+                "has_intensity<> should detect intensity field");
+}
+
+TEST (TypeTraits, HasColor)
+{
+  static_assert(!pcl::traits::has_color_v<pcl::PointXYZ>,
+                "has_color<> should detect lack of rgb field");
+  static_assert(pcl::traits::has_color_v<pcl::PointXYZRGB>,
+                "has_color<> should detect rgb field");
+  static_assert(pcl::traits::has_color_v<pcl::PointXYZRGBA>,
+                "has_color<> should detect rgb field");
+}
+
+TEST (TypeTraits, HasLabel)
+{
+  static_assert(!pcl::traits::has_label_v<pcl::PointXYZRGB>,
+                "has_label<> should detect lack of label field");
+  static_assert(pcl::traits::has_label_v<pcl::PointXYZRGBL>,
+                "has_label<> should detect label field");
+}
+
+TEST (TypeTests, IsXYFinite)
+{
+  EXPECT_TRUE(pcl::isXYFinite(pcl::RGB {}));
+  EXPECT_TRUE(pcl::isXYFinite(pcl::PointXYZ {2,3,4}));
+
+  EXPECT_TRUE(pcl::isXYFinite(pcl::PointXYZ {std::numeric_limits<float>::max(), 3, 4}));
+  EXPECT_TRUE(pcl::isXYFinite(pcl::PointXYZ {std::numeric_limits<float>::min(), 3, 4}));
+
+  EXPECT_FALSE(pcl::isXYFinite(pcl::PointXYZ {std::numeric_limits<float>::infinity(), 3, 4}));
+  EXPECT_FALSE(pcl::isXYFinite(pcl::PointXYZ {-std::numeric_limits<float>::infinity(), 3, 4}));
+
+  EXPECT_FALSE(pcl::isXYFinite(pcl::PointXYZ {std::numeric_limits<float>::quiet_NaN(), 3, 4}));
+  EXPECT_FALSE(pcl::isXYFinite(pcl::PointXYZ {-std::numeric_limits<float>::signaling_NaN(), 3, 4}));
+}
+
+
+TEST (TypeTests, IsXYZFinite)
+{
+  EXPECT_TRUE(pcl::isXYZFinite(pcl::RGB {}));
+  EXPECT_TRUE(pcl::isXYZFinite(pcl::PointXYZ {2,3,4}));
+
+  EXPECT_TRUE(pcl::isXYZFinite(pcl::PointXYZ {std::numeric_limits<float>::max(), 3, 4}));
+  EXPECT_TRUE(pcl::isXYZFinite(pcl::PointXYZ {std::numeric_limits<float>::min(), 3, 4}));
+
+  EXPECT_FALSE(pcl::isXYZFinite(pcl::PointXYZ {std::numeric_limits<float>::infinity(), 3, 4}));
+  EXPECT_FALSE(pcl::isXYZFinite(pcl::PointXYZ {-std::numeric_limits<float>::infinity(), 3, 4}));
+
+  EXPECT_FALSE(pcl::isXYZFinite(pcl::PointXYZ {std::numeric_limits<float>::quiet_NaN(), 3, 4}));
+  EXPECT_FALSE(pcl::isXYZFinite(pcl::PointXYZ {-std::numeric_limits<float>::signaling_NaN(), 3, 4}));
+}
+
+TEST (TypeTests, IsNormalFinite)
+{
+  EXPECT_TRUE(pcl::isNormalFinite(pcl::RGB {}));
+  EXPECT_TRUE(pcl::isNormalFinite(pcl::Normal {2,3,4}));
+
+  EXPECT_TRUE(pcl::isNormalFinite(pcl::Normal {std::numeric_limits<float>::max(), 3, 4}));
+  EXPECT_TRUE(pcl::isNormalFinite(pcl::Normal {std::numeric_limits<float>::min(), 3, 4}));
+
+  EXPECT_FALSE(pcl::isNormalFinite(pcl::Normal {std::numeric_limits<float>::infinity(), 3, 4}));
+  EXPECT_FALSE(pcl::isNormalFinite(pcl::Normal {-std::numeric_limits<float>::infinity(), 3, 4}));
+
+  EXPECT_FALSE(pcl::isNormalFinite(pcl::Normal {std::numeric_limits<float>::quiet_NaN(), 3, 4}));
+  EXPECT_FALSE(pcl::isNormalFinite(pcl::Normal {-std::numeric_limits<float>::signaling_NaN(), 3, 4}));
+}
 
 int
 main (int argc, char** argv)


### PR DESCRIPTION
Enhances PCL to have `isXYFinite`, `isXYZFinite`, `isNormalFinite` to handle specific cases in algorithm, not dependent on the actual type but still dependent on the contents.

Adds concepts like classes for future modernization for SFINAE.

\fixes #2664 (the concerns raised in it)