### PR TITLE
Adding space for -Wliteral-suffix

### DIFF
--- a/outofcore/src/visualization/viewport.cpp
+++ b/outofcore/src/visualization/viewport.cpp
@@ -182,7 +182,7 @@ Viewport::viewportHudUpdate ()
 
   char points_loaded_str[50];
   snprintf (points_loaded_str, sizeof(points_loaded_str),
-            "%"PRIu64" points/%"PRIu64" mb", points_loaded, data_loaded/1024);
+            "%" PRIu64 " points/%" PRIu64 " mb", points_loaded, data_loaded/1024);
   points_hud_actor_->SetInput (points_loaded_str);
 }
 


### PR DESCRIPTION
https://github.com/PointCloudLibrary/pcl/pull/3388#issuecomment-541052178

No more warnings on Arch or MacOS for outofcore/tools