### PR TITLE
Use size_t instead of a signed 32 bit integer to compute addres…

### DIFF
--- a/filters/src/crop_box.cpp
+++ b/filters/src/crop_box.cpp
@@ -75,11 +75,11 @@ pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
   bool translation_is_zero = (translation_ != Eigen::Vector3f::Zero ());
   bool inverse_transform_matrix_is_identity = inverse_transform.matrix ().isIdentity ();
 
-  for (size_t index = 0; index < indices_->size (); ++index)
+  for (std::size_t index = 0; index < indices_->size (); ++index)
   {
     // Get local point
-    size_t point_offset = static_cast<size_t>((*indices_)[index]) * input_->point_step;
-    size_t offset = point_offset + input_->fields[x_idx_].offset;
+    std::size_t point_offset = static_cast<std::size_t>((*indices_)[index]) * input_->point_step;
+    std::size_t offset = point_offset + input_->fields[x_idx_].offset;
     memcpy (local_pt.data (), &input_->data[offset], sizeof (float)*3);
 
     // Check if the point is invalid
@@ -165,11 +165,11 @@ pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (std::vector<int> &indices)
   bool translation_is_zero = (translation_ != Eigen::Vector3f::Zero ());
   bool inverse_transform_matrix_is_identity = inverse_transform.matrix ().isIdentity ();
 
-  for (size_t index = 0; index < indices_->size (); index++)
+  for (std::size_t index = 0; index < indices_->size (); index++)
   {
     // Get local point
-    size_t point_offset = static_cast<size_t>((*indices_)[index]) * input_->point_step;
-    size_t offset = point_offset + input_->fields[x_idx_].offset;
+    std::size_t point_offset = static_cast<std::size_t>((*indices_)[index]) * input_->point_step;
+    std::size_t offset = point_offset + input_->fields[x_idx_].offset;
     memcpy (local_pt.data (), &input_->data[offset], sizeof (float)*3);
 
     // Transform point to world space

--- a/filters/src/crop_box.cpp
+++ b/filters/src/crop_box.cpp
@@ -78,8 +78,8 @@ pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
   for (size_t index = 0; index < indices_->size (); ++index)
   {
     // Get local point
-    int point_offset = ((*indices_)[index] * input_->point_step);
-    int offset = point_offset + input_->fields[x_idx_].offset;
+    size_t point_offset = static_cast<size_t>((*indices_)[index]) * input_->point_step;
+    size_t offset = point_offset + input_->fields[x_idx_].offset;
     memcpy (local_pt.data (), &input_->data[offset], sizeof (float)*3);
 
     // Check if the point is invalid
@@ -168,8 +168,8 @@ pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (std::vector<int> &indices)
   for (size_t index = 0; index < indices_->size (); index++)
   {
     // Get local point
-    int point_offset = ((*indices_)[index] * input_->point_step);
-    int offset = point_offset + input_->fields[x_idx_].offset;
+    size_t point_offset = static_cast<size_t>((*indices_)[index]) * input_->point_step;
+    size_t offset = point_offset + input_->fields[x_idx_].offset;
     memcpy (local_pt.data (), &input_->data[offset], sizeof (float)*3);
 
     // Transform point to world space


### PR DESCRIPTION
Fixes a crash due to an integer overflow when point clouds have more than ca. 44 M points.

Fixes #3417