### PR TITLE
Add formatting job on CI

### DIFF
--- a/.ci/azure-pipelines/formatting.yml
+++ b/.ci/azure-pipelines/formatting.yml
@@ -1,0 +1,31 @@
+resources:
+  containers:
+    - container: fmt
+      image: pointcloudlibrary/fmt
+
+jobs:
+  - job: formatting
+    displayName: Check code formatting
+    pool:
+      vmImage: 'Ubuntu 16.04'
+    container: fmt
+    steps:
+      - script: ./.dev/format.sh $(which clang-format) .
+        displayName: 'Run clang-format'
+      - script: git diff > formatting.patch
+        displayName: 'Compute diff'
+      - script: cat formatting.patch
+        displayName: 'Show diff'
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)'
+          contents: 'formatting.patch'
+          targetFolder: '$(Build.ArtifactStagingDirectory)'
+        displayName: 'Copy diff to staging directory'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: formatting
+        displayName: 'Publish diff'
+      - script: "[ ! -s formatting.patch ]"
+        displayName: 'Set job exit status'

--- a/.ci/azure-pipelines/formatting.yml
+++ b/.ci/azure-pipelines/formatting.yml
@@ -10,7 +10,7 @@ jobs:
       vmImage: 'Ubuntu 16.04'
     container: fmt
     steps:
-      - script: ./.dev/format.sh $(which clang-format) .
+      - script: ./.dev/format.sh $(which clang-format-8) .
         displayName: 'Run clang-format'
       - script: git diff > formatting.patch
         displayName: 'Compute diff'

--- a/.dev/format.sh
+++ b/.dev/format.sh
@@ -8,7 +8,7 @@
 
 format() {
     # don't use a directory with whitespace
-    local whitelist="2d cuda gpu ml simulation stereo tracking"
+    local whitelist="2d ml simulation stereo"
 
     local PCL_DIR="${2}"
     local formatter="${1}"

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,4 +1,4 @@
-find_package(ClangFormat 6)
+find_package(ClangFormat 7)
 # search for version number in clang-format without version number
 if(ClangFormat_FOUND)
   message(STATUS "Adding target 'format'")


### PR DESCRIPTION
This adds a new Azure pipeline that checks code formatting.

Additionally, as proposed in #3325:
 * remove modules that are not yet formatted from the formatting whitelist;
 * lift clang-format required version to 7.

Note that this pipeline won't be run on Azure until it's configuration is updated through web interface. This, however, can be done only after this PR is merged and pipeline YAML file is present in the repository. For reference, here is the result of running this pipeline on my fork: https://dev.azure.com/u7p11/pcl/_build/results?buildId=702

Closes #3325.