### PR TITLE
Remove policy push/pop from PCLConfig.cmake file.

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -12,6 +12,10 @@
 #                                   www.pointclouds.org
 #------------------------------------------------------------------------------------
 
+# Set default policy behavior similar to minimum requirement version
+cmake_policy(VERSION 3.5)
+
+# explicitly set policies we already support in newer cmake versions
 if(POLICY CMP0074)
   # TODO: update *_ROOT variables to be PCL_*_ROOT or equivalent.
   # CMP0074 directly affects how Find* modules work and *_ROOT variables.  Since

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -17,7 +17,6 @@ if(POLICY CMP0074)
   # CMP0074 directly affects how Find* modules work and *_ROOT variables.  Since
   # this is a config file that will be consumed by parent projects with (likely)
   # NEW behavior, we need to push a policy stack.
-  cmake_policy(PUSH)
   cmake_policy(SET CMP0074 NEW)
 endif()
 
@@ -35,9 +34,6 @@ macro(pcl_report_not_found _reason)
     message(FATAL_ERROR ${_reason})
   elseif(NOT PCL_FIND_QUIETLY)
     message(WARNING ${_reason})
-  endif()
-  if(POLICY CMP0074)
-    cmake_policy(POP)
   endif()
   return()
 endmacro()
@@ -471,9 +467,6 @@ set(PCL_TO_FIND_COMPONENTS ${_PCL_TO_FIND_COMPONENTS})
 unset(_PCL_TO_FIND_COMPONENTS)
 
 if(NOT PCL_TO_FIND_COMPONENTS)
-  if(POLICY CMP0074)
-    cmake_policy(POP)
-  endif()
   return()
 endif()
 
@@ -667,7 +660,3 @@ endif()
 
 find_package_handle_standard_args(PCL DEFAULT_MSG PCL_LIBRARIES PCL_INCLUDE_DIRS)
 mark_as_advanced(PCL_LIBRARIES PCL_INCLUDE_DIRS PCL_LIBRARY_DIRS)
-
-if(POLICY CMP0074)
-  cmake_policy(POP)
-endif()


### PR DESCRIPTION
These are not required because cmake automatically creates a new stack entry when find_package() is invoked.

Closes #2726, fixes #3062.