### PR TITLE
Use for-ranged loop for boost::filesystem::directory_iterator

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
@@ -106,17 +106,16 @@ namespace pcl
             //load views, poses and self-occlusions
             std::vector < std::string > view_filenames;
             int number_of_views = 0;
-            bf::directory_iterator end_itr;
-            for (bf::directory_iterator itr (trained_dir); itr != end_itr; ++itr)
+            for (const auto& dir_entry : bf::directory_iterator(trained_dir))
             {
               //check if its a directory, then get models in it
-              if (!(bf::is_directory (*itr)))
+              if (!(bf::is_directory (dir_entry)))
               {
                 //check that it is a ply file and then add, otherwise ignore..
                 std::vector < std::string > strs;
                 std::vector < std::string > strs_;
 
-                std::string file = (itr->path ().filename ()).string();
+                std::string file = (dir_entry.path ().filename ()).string();
 
                 boost::split (strs, file, boost::is_any_of ("."));
                 boost::split (strs_, file, boost::is_any_of ("_"));
@@ -125,7 +124,7 @@ namespace pcl
 
                 if (extension == "pcd" && strs_[0] == "view")
                 {
-                  view_filenames.push_back ((itr->path ().filename ()).string());
+                  view_filenames.push_back ((dir_entry.path ().filename ()).string());
 
                   number_of_views++;
                 }

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/registered_views_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/registered_views_source.h
@@ -65,15 +65,14 @@ namespace pcl
         getViewsFilenames (bf::path & path_with_views, std::vector<std::string> & view_filenames)
         {
           int number_of_views = 0;
-          bf::directory_iterator end_itr;
-          for (bf::directory_iterator itr (path_with_views); itr != end_itr; ++itr)
+          for (const auto& dir_entry : bf::directory_iterator(path_with_views))
           {
-            if (!(bf::is_directory (*itr)))
+            if (!(bf::is_directory (dir_entry)))
             {
               std::vector < std::string > strs;
               std::vector < std::string > strs_;
 
-              std::string file = (itr->path ().filename ()).string();
+              std::string file = (dir_entry.path ().filename ()).string();
 
               boost::split (strs, file, boost::is_any_of ("."));
               boost::split (strs_, file, boost::is_any_of ("_"));
@@ -82,7 +81,7 @@ namespace pcl
 
               if (extension == "pcd" && (strs_[0].compare (view_prefix_) == 0))
               {
-                view_filenames.push_back ((itr->path ().filename ()).string());
+                view_filenames.push_back ((dir_entry.path ().filename ()).string());
 
                 number_of_views++;
               }
@@ -116,8 +115,7 @@ namespace pcl
             //load views and poses
             std::vector < std::string > view_filenames;
             int number_of_views = 0;
-            bf::directory_iterator end_itr;
-            for (bf::directory_iterator itr (trained_dir); itr != end_itr; ++itr)
+            for (const auto& dir_entry : bf::directory_iterator(trained_dir))
             {
               //check if its a directory, then get models in it
               if (!(bf::is_directory (*itr)))
@@ -126,7 +124,7 @@ namespace pcl
                 std::vector < std::string > strs;
                 std::vector < std::string > strs_;
 
-                std::string file = (itr->path ().filename ()).string();
+                std::string file = (dir_entry.path ().filename ()).string();
 
                 boost::split (strs, file, boost::is_any_of ("."));
                 boost::split (strs_, file, boost::is_any_of ("_"));
@@ -135,7 +133,7 @@ namespace pcl
 
                 if (extension == "pcd" && strs_[0] == "view")
                 {
-                  view_filenames.push_back ((itr->path ().filename ()).string());
+                  view_filenames.push_back ((dir_entry.path ().filename ()).string());
                   number_of_views++;
                 }
               }
@@ -256,11 +254,10 @@ namespace pcl
         bool
         isleafDirectory (bf::path & path)
         {
-          bf::directory_iterator end_itr;
           bool no_dirs_inside = true;
-          for (bf::directory_iterator itr (path); itr != end_itr; ++itr)
+          for (const auto& dir_entry : bf::directory_iterator(path))
           {
-            if (bf::is_directory (*itr))
+            if (bf::is_directory (dir_entry))
             {
               no_dirs_inside = false;
             }
@@ -272,18 +269,17 @@ namespace pcl
         void
         getModelsInDirectory (bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths)
         {
-          bf::directory_iterator end_itr;
-          for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+          for (const auto& dir_entry : bf::directory_iterator(dir))
           {
             //check if its a directory, then get models in it
-            if (bf::is_directory (*itr))
+            if (bf::is_directory (dir_entry))
             {
-              std::string so_far = rel_path_so_far + (itr->path ().filename ()).string() + "/";
-              bf::path curr_path = itr->path ();
+              std::string so_far = rel_path_so_far + (dir_entry.path ().filename ()).string() + "/";
+              bf::path curr_path = dir_entry.path ();
 
               if (isleafDirectory (curr_path))
               {
-                std::string path = rel_path_so_far + (itr->path ().filename ()).string();
+                std::string path = rel_path_so_far + (dir_entry.path ().filename ()).string();
                 relative_paths.push_back (path);
               }
               else

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/source.h
@@ -168,29 +168,28 @@ namespace pcl
       void
       getModelsInDirectory (bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths, std::string & ext)
       {
-        bf::directory_iterator end_itr;
-        for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+        for (const auto& dir_entry : bf::directory_iterator(dir))
         {
           //check if its a directory, then get models in it
-          if (bf::is_directory (*itr))
+          if (bf::is_directory (dir_entry))
           {
-            std::string so_far = rel_path_so_far + (itr->path ().filename ()).string() + "/";
+            std::string so_far = rel_path_so_far + (dir_entry.path ().filename ()).string() + "/";
 
-            bf::path curr_path = itr->path ();
+            bf::path curr_path = dir_entry.path ();
             getModelsInDirectory (curr_path, so_far, relative_paths, ext);
           }
           else
           {
             //check that it is a ply file and then add, otherwise ignore..
             std::vector < std::string > strs;
-            std::string file = (itr->path ().filename ()).string();
+            std::string file = (dir_entry.path ().filename ()).string();
 
             boost::split (strs, file, boost::is_any_of ("."));
             std::string extension = strs[strs.size () - 1];
 
             if (extension == ext)
             {
-              std::string path = rel_path_so_far + (itr->path ().filename ()).string();
+              std::string path = rel_path_so_far + (dir_entry.path ().filename ()).string();
 
               relative_paths.push_back (path);
             }

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_classifier.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_classifier.hpp
@@ -15,19 +15,17 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     for (size_t i = 0; i < models->size (); i++)
     {
       std::string path = source_->getModelDescriptorDir (models->at (i), training_dir_, descr_name_);
-      bf::path inside = path;
-      bf::directory_iterator end_itr;
 
-      for (bf::directory_iterator itr_in (inside); itr_in != end_itr; ++itr_in)
+      for (const auto& dir_entry : bf::directory_iterator(path))
       {
-        std::string file_name = (itr_in->path ().filename ()).string();
+        std::string file_name = (dir_entry.path ().filename ()).string();
 
         std::vector < std::string > strs;
         boost::split (strs, file_name, boost::is_any_of ("_"));
 
         if (strs[0] == "descriptor")
         {
-          std::string full_file_name = itr_in->path ().string ();
+          std::string full_file_name = dir_entry.path ().string ();
           std::vector < std::string > strs;
           boost::split (strs, full_file_name, boost::is_any_of ("/"));
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
@@ -87,12 +87,10 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     for (size_t i = 0; i < models->size (); i++)
     {
       std::string path = source_->getModelDescriptorDir (models->at (i), training_dir_, descr_name_);
-      bf::path inside = path;
-      bf::directory_iterator end_itr;
 
-      for (bf::directory_iterator itr_in (inside); itr_in != end_itr; ++itr_in)
+      for (const auto& dir_entry : bf::directory_iterator(path))
       {
-        std::string file_name = (itr_in->path ().filename ()).string();
+        std::string file_name = (dir_entry.path ().filename ()).string();
 
         std::vector < std::string > strs;
         boost::split (strs, file_name, boost::is_any_of ("_"));
@@ -105,7 +103,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
           boost::split (strs1, strs[2], boost::is_any_of ("."));
           int descriptor_id = atoi (strs1[0].c_str ());
 
-          std::string full_file_name = itr_in->path ().string ();
+          std::string full_file_name = dir_entry.path ().string ();
           typename pcl::PointCloud<FeatureT>::Ptr signature (new pcl::PointCloud<FeatureT>);
           pcl::io::loadPCDFile (full_file_name, *signature);
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
@@ -110,12 +110,10 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     for (size_t i = 0; i < models->size (); i++)
     {
       std::string path = source_->getModelDescriptorDir (models->at (i), training_dir_, descr_name_);
-      bf::path inside = path;
-      bf::directory_iterator end_itr;
 
-      for (bf::directory_iterator itr_in (inside); itr_in != end_itr; ++itr_in)
+      for (const auto& dir_entry : bf::directory_iterator(path))
       {
-        std::string file_name = (itr_in->path ().filename ()).string();
+        std::string file_name = (dir_entry.path ().filename ()).string();
 
         std::vector < std::string > strs;
         boost::split (strs, file_name, boost::is_any_of ("_"));
@@ -128,7 +126,7 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
           boost::split (strs1, strs[2], boost::is_any_of ("."));
           int descriptor_id = atoi (strs1[0].c_str ());
 
-          std::string full_file_name = itr_in->path ().string ();
+          std::string full_file_name = dir_entry.path ().string ();
           typename pcl::PointCloud<FeatureT>::Ptr signature (new pcl::PointCloud<FeatureT>);
           pcl::io::loadPCDFile (full_file_name, *signature);
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -18,19 +18,17 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
     for (size_t i = 0; i < models->size (); i++)
     {
       std::string path = source_->getModelDescriptorDir (models->at (i), training_dir_, descr_name_);
-      bf::path inside = path;
-      bf::directory_iterator end_itr;
 
-      for (bf::directory_iterator itr_in (inside); itr_in != end_itr; ++itr_in)
+      for (const auto& dir_entry : bf::directory_iterator(path))
       {
-        std::string file_name = (itr_in->path ().filename ()).string();
+        std::string file_name = (dir_entry.path ().filename ()).string();
 
         std::vector < std::string > strs;
         boost::split (strs, file_name, boost::is_any_of ("_"));
 
         if (strs[0] == "descriptor")
         {
-          std::string full_file_name = itr_in->path ().string ();
+          std::string full_file_name = dir_entry.path ().string ();
           std::string name = file_name.substr (0, file_name.length () - 4);
           std::vector < std::string > strs;
           boost::split (strs, name, boost::is_any_of ("_"));

--- a/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
+++ b/apps/3d_rec_framework/src/tools/local_recognition_mian_dataset.cpp
@@ -27,28 +27,27 @@ void
 getScenesInDirectory (bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths)
 {
   //list models in MODEL_FILES_DIR_ and return list
-  bf::directory_iterator end_itr;
-  for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+  for (const auto& dir_entry : bf::directory_iterator(dir))
   {
     //check if its a directory, then get models in it
-    if (bf::is_directory (*itr))
+    if (bf::is_directory (dir_entry))
     {
-      std::string so_far = rel_path_so_far + (itr->path ().filename ()).string() + "/";
-      bf::path curr_path = itr->path ();
+      std::string so_far = rel_path_so_far + (dir_entry.path ().filename ()).string() + "/";
+      bf::path curr_path = dir_entry.path ();
       getScenesInDirectory (curr_path, so_far, relative_paths);
     }
     else
     {
       //check that it is a ply file and then add, otherwise ignore..
       std::vector < std::string > strs;
-      std::string file = (itr->path ().filename ()).string();
+      std::string file = (dir_entry.path ().filename ()).string();
 
       boost::split (strs, file, boost::is_any_of ("."));
       std::string extension = strs[strs.size () - 1];
 
       if (extension == "pcd")
       {
-        std::string path = rel_path_so_far + (itr->path ().filename ()).string();
+        std::string path = rel_path_so_far + (dir_entry.path ().filename ()).string();
         relative_paths.push_back (path);
       }
     }
@@ -243,29 +242,28 @@ template<template<class > class DistT, typename PointT, typename FeatureT>
 void
 getModelsInDirectory (bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths, std::string & ext)
 {
-  bf::directory_iterator end_itr;
-  for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+  for (const auto& dir_entry : bf::directory_iterator(dir))
   {
     //check if its a directory, then get models in it
-    if (bf::is_directory (*itr))
+    if (bf::is_directory (dir_entry))
     {
-      std::string so_far = rel_path_so_far + (itr->path ().filename ()).string() + "/";
+      std::string so_far = rel_path_so_far + (dir_entry.path ().filename ()).string() + "/";
 
-      bf::path curr_path = itr->path ();
+      bf::path curr_path = dir_entry.path ();
       getModelsInDirectory (curr_path, so_far, relative_paths, ext);
     }
     else
     {
       //check that it is a ply file and then add, otherwise ignore..
       std::vector < std::string > strs;
-      std::string file = (itr->path ().filename ()).string();
+      std::string file = (dir_entry.path ().filename ()).string();
 
       boost::split (strs, file, boost::is_any_of ("."));
       std::string extension = strs[strs.size () - 1];
 
       if (extension == ext)
       {
-        std::string path = rel_path_so_far + (itr->path ().filename ()).string();
+        std::string path = rel_path_so_far + (dir_entry.path ().filename ()).string();
 
         relative_paths.push_back (path);
       }

--- a/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
+++ b/apps/include/pcl/apps/face_detection/face_detection_apps_utils.h
@@ -67,31 +67,26 @@ namespace face_detection_apps_utils
   inline
   void getFilesInDirectory(bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths, std::string & ext)
   {
-    bf::directory_iterator end_itr;
-    for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+    for (const auto& dir_entry : bf::directory_iterator(dir))
     {
       //check if its a directory, then get models in it
-      if (bf::is_directory (*itr))
+      if (bf::is_directory (dir_entry))
       {
-#if BOOST_FILESYSTEM_VERSION == 3
-        std::string so_far = rel_path_so_far + (itr->path().filename()).string() + "/";
-#else
-        std::string so_far = rel_path_so_far + (itr->path ()).filename () + "/";
-#endif
+        std::string so_far = rel_path_so_far + (dir_entry.path().filename()).string() + "/";
 
-        bf::path curr_path = itr->path ();
+        bf::path curr_path = dir_entry.path ();
         getFilesInDirectory (curr_path, so_far, relative_paths, ext);
       } else
       {
         //check that it is a ply file and then add, otherwise ignore..
         std::vector < std::string > strs;
-        std::string file = (itr->path().filename()).string();
+        std::string file = (dir_entry.path().filename()).string();
         boost::split (strs, file, boost::is_any_of ("."));
         std::string extension = strs[strs.size () - 1];
 
         if (extension == ext)
         {
-          std::string path = rel_path_so_far + (itr->path().filename()).string();
+          std::string path = rel_path_so_far + (dir_entry.path().filename()).string();
           relative_paths.push_back (path);
         }
       }

--- a/doc/tutorials/content/sources/iccv2011/src/build_all_object_models.cpp
+++ b/doc/tutorials/content/sources/iccv2011/src/build_all_object_models.cpp
@@ -12,25 +12,24 @@ namespace bf = boost::filesystem;
 inline void
 getModelsInDirectory (bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths)
 {
-  bf::directory_iterator end_itr;
-  for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+  for (const auto& dir_entry : bf::directory_iterator(dir))
   {
     //check if its a directory, then get models in it
-    if (bf::is_directory (*itr))
+    if (bf::is_directory (dir_entry))
     {
-      std::string so_far = rel_path_so_far + itr->path ().filename ().string () + "/";
-      bf::path curr_path = itr->path ();
+      std::string so_far = rel_path_so_far + dir_entry.path ().filename ().string () + "/";
+      bf::path curr_path = dir_entry.path ();
       getModelsInDirectory (curr_path, so_far, relative_paths);
     }
     else
     {
       std::vector<std::string> strs;
-      std::string file = itr->path ().filename ().string ();
+      std::string file = dir_entry.path ().filename ().string ();
       boost::split (strs, file, boost::is_any_of ("."));
       std::string extension = strs[strs.size () - 1];
 
       if((file.compare (0, 3, "raw") == 0) && extension == "pcd") {
-        std::string path = rel_path_so_far + itr->path ().filename ().string ();
+        std::string path = rel_path_so_far + dir_entry.path ().filename ().string ();
         relative_paths.push_back (path);
       }
     }

--- a/doc/tutorials/content/sources/iros2011/src/build_all_object_models.cpp
+++ b/doc/tutorials/content/sources/iros2011/src/build_all_object_models.cpp
@@ -12,25 +12,24 @@ namespace bf = boost::filesystem;
 inline void
 getModelsInDirectory (bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths)
 {
-  bf::directory_iterator end_itr;
-  for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+  for (const auto& dir_entry : bf::directory_iterator(dir))
   {
     //check if its a directory, then get models in it
-    if (bf::is_directory (*itr))
+    if (bf::is_directory (dir_entry))
     {
-      std::string so_far = rel_path_so_far + itr->path ().filename ().string () + "/";
-      bf::path curr_path = itr->path ();
+      std::string so_far = rel_path_so_far + dir_entry.path ().filename ().string () + "/";
+      bf::path curr_path = dir_entry.path ();
       getModelsInDirectory (curr_path, so_far, relative_paths);
     }
     else
     {
       std::vector<std::string> strs;
-      std::string file = itr->path ().filename ().string ();
+      std::string file = dir_entry.path ().filename ().string ();
       boost::split (strs, file, boost::is_any_of ("."));
       std::string extension = strs[strs.size () - 1];
 
       if((file.compare (0, 3, "raw") == 0) && extension == "pcd") {
-        std::string path = rel_path_so_far + itr->path ().filename ().string ();
+        std::string path = rel_path_so_far + dir_entry.path ().filename ().string ();
         relative_paths.push_back (path);
       }
     }

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -38,26 +38,25 @@ namespace pcl
 
         void getFilesInDirectory(bf::path & dir, std::string & rel_path_so_far, std::vector<std::string> & relative_paths, std::string & ext)
         {
-          bf::directory_iterator end_itr;
-          for (bf::directory_iterator itr (dir); itr != end_itr; ++itr)
+          for (const auto& dir_entry : bf::directory_iterator(dir))
           {
             //check if its a directory, then get models in it
-            if (bf::is_directory (*itr))
+            if (bf::is_directory (dir_entry))
             {
-              std::string so_far = rel_path_so_far + (itr->path ().filename ()).string () + "/";
-              bf::path curr_path = itr->path ();
+              std::string so_far = rel_path_so_far + (dir_entry.path ().filename ()).string () + "/";
+              bf::path curr_path = dir_entry.path ();
               getFilesInDirectory (curr_path, so_far, relative_paths, ext);
             } else
             {
               //check that it is a ply file and then add, otherwise ignore..
               std::vector < std::string > strs;
-              std::string file = (itr->path ().filename ()).string ();
+              std::string file = (dir_entry.path ().filename ()).string ();
               boost::split (strs, file, boost::is_any_of ("."));
               std::string extension = strs[strs.size () - 1];
 
               if (extension == ext)
               {
-                std::string path = rel_path_so_far + (itr->path ().filename ()).string ();
+                std::string path = rel_path_so_far + (dir_entry.path ().filename ()).string ();
                 relative_paths.push_back (path);
               }
             }


### PR DESCRIPTION
Don't really know how bf::directory_iterator be an iterator and return at same time an object which has a `begin()` and `end()` method, but [documentation](https://www.boost.org/doc/libs/1_71_0/libs/filesystem/doc/tutorial.html#Directory-iteration) says for-ranged loops can be used there.

Just to mention: Didn't found matching `rst`-files for adjusted tutorials.