### PR TITLE
Adding missing size_t that escaped sed

### DIFF
--- a/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
@@ -213,7 +213,7 @@ inline int cutGetMaxGflopsGraphicsDeviceId()
 #  ifdef _DEBUG // Do this only in debug mode...
 	inline void VSPrintf(FILE *file, LPCSTR fmt, ...)
 	{
-		size_t fmt2_sz	= 2048;
+		std::size_t fmt2_sz	= 2048;
 		char *fmt2		= (char*)malloc(fmt2_sz);
 		va_list  vlist;
 		va_start(vlist, fmt);

--- a/outofcore/src/cJSON.cpp
+++ b/outofcore/src/cJSON.cpp
@@ -427,9 +427,9 @@ static const char *parse_object(cJSON *item,const char *value)
 static char *print_object(cJSON *item,int depth,int fmt)
 {
 	char *out=nullptr;
-	size_t len=7;
+	std::size_t len=7;
 	cJSON *child=item->child;
-	size_t numentries=0,fail=0;
+	std::size_t numentries=0,fail=0;
 	/* Count the number of entries. */
 	while (child) numentries++,child=child->next;
 	/* Allocate space for the names and the objects */


### PR DESCRIPTION
Found a few leftovers based on Sergio's comment that several files don't have `size_t` replaced by `std::size_t`.

Others are commented.