### PR TITLE
[gpu] Replace uint64_type by std::uint64_t

### DIFF
--- a/gpu/surface/src/convex_hull.cpp
+++ b/gpu/surface/src/convex_hull.cpp
@@ -74,8 +74,6 @@ struct pcl::gpu::PseudoConvexHull3D::Impl
 
 pcl::gpu::PseudoConvexHull3D::PseudoConvexHull3D(std::size_t bsize)
 {
-  pcl::gpu::Static<sizeof(pcl::device::std::uint64_type) == 8>::check();
-
   impl_.reset( new Impl(bsize) );
 }
 pcl::gpu::PseudoConvexHull3D::~PseudoConvexHull3D() {}

--- a/gpu/surface/src/cuda/convex_hull.cu
+++ b/gpu/surface/src/cuda/convex_hull.cu
@@ -66,8 +66,6 @@ namespace pcl
 {
   namespace device
   { 	  
-	  __global__ void size_check() { Static<sizeof(std::uint64_type) == 8>::check(); };
-	  
 	  template<bool use_max>
 	  struct IndOp
 	  {
@@ -262,7 +260,7 @@ namespace pcl
 	  }
 	  	  
 	  __device__ __forceinline__
-	  std::uint64_type 
+	  std::uint64_t 
 	  operator()(const PointType& p) const
 	  {                   
 		  float4 x = p;
@@ -314,13 +312,13 @@ namespace pcl
           //if (neg_count == 0)
           //  then internal point ==>> idx = INT_MAX
 
-		  std::uint64_type res = idx;
+		  std::uint64_t res = idx;
 		  res <<= 32;
 		  return res + *reinterpret_cast<unsigned int*>(&dist);
 	  }		
 	};		
 
-    __global__ void initalClassifyKernel(const InitalClassify ic, const PointType* points, int cloud_size, std::uint64_type* output) 
+    __global__ void initalClassifyKernel(const InitalClassify ic, const PointType* points, int cloud_size, std::uint64_t* output) 
     { 
         int index = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -334,7 +332,7 @@ void pcl::device::PointStream::initalClassify()
 {        
   //thrust::device_ptr<const PointType> beg(cloud.ptr());
   //thrust::device_ptr<const PointType> end = beg + cloud_size;
-  thrust::device_ptr<std::uint64_type> out(facets_dists.ptr());
+  thrust::device_ptr<std::uint64_t> out(facets_dists.ptr());
   
   InitalClassify ic(simplex.p1, simplex.p2, simplex.p3, simplex.p4, cloud_diag);
   //thrust::transform(beg, end, out, ic);
@@ -359,7 +357,7 @@ namespace pcl
     __device__ int new_cloud_size;    
 	struct SearchFacetHeads
 	{		
-	  std::uint64_type *facets_dists;
+	  std::uint64_t *facets_dists;
 	  int cloud_size;
 	  int facet_count;
 	  int *perm;
@@ -371,8 +369,8 @@ namespace pcl
 	  __device__ __forceinline__
 	  void operator()(int facet) const
 	  {			
-		const std::uint64_type* b = facets_dists;
-		const std::uint64_type* e = b + cloud_size;
+		const std::uint64_t* b = facets_dists;
+		const std::uint64_t* e = b + cloud_size;
 
         bool last_thread = facet == facet_count;
 
@@ -588,7 +586,7 @@ namespace pcl
   {
 	  struct Classify
 	  {
-		std::uint64_type* facets_dists;
+		std::uint64_t* facets_dists;
 		int* scan_buffer;
 
 		int* head_points;
@@ -613,7 +611,7 @@ namespace pcl
 
           if (hi == perm_index)
           {
-            std::uint64_type res = std::numeric_limits<int>::max();
+            std::uint64_t res = std::numeric_limits<int>::max();
 		    res <<= 32;		                      
             facets_dists[point_idx] = res;
           }
@@ -689,7 +687,7 @@ namespace pcl
             // if (neg_count == 0)
             // new_idx = INT_MAX ==>> internal point
                       	       	 	   
-            std::uint64_type res = new_idx;
+            std::uint64_t res = new_idx;
 		    res <<= 32;
 		    res += *reinterpret_cast<unsigned int*>(&dist);
 
@@ -731,8 +729,8 @@ void pcl::device::PointStream::classify(FacetStream& fs)
   cudaSafeCall( cudaGetLastError() );
   cudaSafeCall( cudaDeviceSynchronize() );
   
-  thrust::device_ptr<std::uint64_type> beg(facets_dists.ptr());
-  thrust::device_ptr<std::uint64_type> end = beg + cloud_size;
+  thrust::device_ptr<std::uint64_t> beg(facets_dists.ptr());
+  thrust::device_ptr<std::uint64_t> end = beg + cloud_size;
   
   thrust::device_ptr<int> pbeg(perm.ptr());
   thrust::sort_by_key(beg, end, pbeg);

--- a/gpu/surface/src/cuda/device.h
+++ b/gpu/surface/src/cuda/device.h
@@ -71,7 +71,7 @@ namespace pcl
     struct LessThanByFacet
     {
       __device__ __forceinline__
-      bool operator()(const std::uint64_type& e1, const int& e2) const
+      bool operator()(const std::uint64_t& e1, const int& e2) const
       {
         int i1 = (int)(e1 >> 32);
         return i1 < e2;

--- a/gpu/surface/src/internal.h
+++ b/gpu/surface/src/internal.h
@@ -37,19 +37,19 @@
 
 #pragma once
 
-#include <pcl/gpu/containers/device_array.h>
+#include <cstdint>
 #include <cuda_runtime.h>
+
+#include <pcl/gpu/containers/device_array.h>
 
 namespace pcl
 {
   namespace device
   {
-	  using std::uint64_type = unsigned long long;
-
 	  using PointType = float4;
 	  using Cloud = pcl::gpu::DeviceArray<PointType>;
 
-	  using FacetsDists = DeviceArray<std::uint64_type>;
+	  using FacetsDists = DeviceArray<std::uint64_t>;
 	  using Perm = DeviceArray<int>;
 
 	  struct InitalSimplex


### PR DESCRIPTION
Removed additionally checks for size of `uint64_type`, as result will be always true, as this type is [defined](https://en.cppreference.com/w/cpp/types/integer) as:

> unsigned integer type with width of exactly 8, 16, 32 and 64 bits respectively
(provided only if the implementation directly supports the type)

This fixes current compile issues due to bad PR with sed `s/uint64_t/std::uint64_t` for uint64_type before.