### PR TITLE
Fix CMakeLists in VFH tutorial

### DIFF
--- a/doc/tutorials/content/sources/vfh_recognition/CMakeLists.txt
+++ b/doc/tutorials/content/sources/vfh_recognition/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(SYSTEM
 
 add_executable(build_tree build_tree.cpp)
 target_link_libraries(build_tree ${PCL_LIBRARIES} ${Boost_LIBRARIES}
-                                 FLANN::FLANN ${HDF5_hdf5_LIBRARY})
+                                 FLANN::FLANN ${HDF5_LIBRARIES})
 
 add_executable(nearest_neighbors nearest_neighbors.cpp)
-target_link_libraries(nearest_neighbors ${PCL_LIBRARIES} ${Boost_LIBRARIES} FLANN::FLANN ${HDF5_hdf5_LIBRARY})
+target_link_libraries(nearest_neighbors ${PCL_LIBRARIES} ${Boost_LIBRARIES} FLANN::FLANN ${HDF5_LIBRARIES})


### PR DESCRIPTION
`HDF5_hdf5_LIBRARY` variable is not populated by `find_package(HDF5)`, thus we are not linking to this library. Instead, this commit uses `HDF5_LIBRARIES` variable, which is what we want according to the CMake documentation.

This problem was reported in #3309.