### PR TITLE
Set default min and max angle for sac cone models

### DIFF
--- a/segmentation/include/pcl/segmentation/sac_segmentation.h
+++ b/segmentation/include/pcl/segmentation/sac_segmentation.h
@@ -341,8 +341,8 @@ namespace pcl
         , normals_ ()
         , distance_weight_ (0.1)
         , distance_from_origin_ (0)
-        , min_angle_ ()
-        , max_angle_ ()
+        , min_angle_ (0.0)
+        , max_angle_ (M_PI_2)
       {};
 
       /** \brief Provide a pointer to the input dataset that contains the point normals of 


### PR DESCRIPTION
Without this, a call to `setMinMaxOpeningAngle` is necessary, or else no model will be found. With default values, a possible source of error is eliminated.