### PR TITLE
Remove `SupervoxelClustering::getColoredVoxelCloud()`

### DIFF
--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/supervoxels.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/supervoxels.hpp
@@ -41,6 +41,7 @@
 #include <pcl/apps/cloud_composer/tools/supervoxels.h>
 #include <pcl/apps/cloud_composer/impl/cloud_item.hpp>
 #include <pcl/apps/cloud_composer/items/normals_item.h>
+#include <pcl/make_shared.h>
 #include <pcl/point_cloud.h>
 #include <pcl/segmentation/supervoxel_clustering.h>
 
@@ -95,11 +96,12 @@ pcl::cloud_composer::SupervoxelsTool::performTemplatedAction (const QList <const
     std::map <std::uint32_t, typename pcl::Supervoxel<PointT>::Ptr > refined_supervoxel_clusters;
     super.refineSupervoxels (3, refined_supervoxel_clusters);
   
-    typename pcl::PointCloud<PointXYZRGBA>::Ptr color_segments;
-    color_segments= super.getColoredVoxelCloud ();
-    
-    CloudItem*  cloud_item_out = CloudItem::createCloudItemFromTemplate<PointXYZRGBA>(input_item->text(),color_segments);
- 
+    auto label_segments = super.getLabeledVoxelCloud();
+    auto color_segments = pcl::make_shared<pcl::PointCloud<PointXYZRGBA>>();
+    pcl::copyPointCloud(*label_segments, *color_segments);
+    for (size_t i = 0; i < label_segments->size(); ++i)
+      color_segments->at(i).rgba = GlasbeyLUT::at(label_segments->at(i).label % GlasbeyLUT::size()).rgba;
+    CloudItem*  cloud_item_out = CloudItem::createCloudItemFromTemplate<PointXYZRGBA>(input_item->text(), color_segments);
     
     output.append (cloud_item_out);
     

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -296,20 +296,6 @@ namespace pcl
       typename pcl::PointCloud<PointXYZL>::Ptr
       getLabeledCloud () const;
 
-      /** \brief Returns an RGB colorized voxelized cloud showing superpixels
-       * Otherwise it returns an empty pointer.
-       * Points that belong to the same supervoxel have the same color.
-       * But this function doesn't guarantee that different segments will have different
-       * color(it's random). Points that are unlabeled will be black
-       * \note This will expand the label_colors_ vector so that it can accommodate all labels
-       */
-      [[deprecated("use getLabeledVoxelCloud() instead. An example of how to display and save with colorized labels can be found in examples/segmentation/example_supervoxels.cpp")]]
-      pcl::PointCloud<pcl::PointXYZRGBA>::Ptr
-      getColoredVoxelCloud () const
-      {
-        return pcl::PointCloud<PointXYZRGBA>::Ptr (new pcl::PointCloud<PointXYZRGBA>);
-      }
-
       /** \brief Returns labeled voxelized cloud
        * Points that belong to the same supervoxel have the same label.
        * Labels for segments start from 1, unlabled points have label 0


### PR DESCRIPTION
Get rid of the last remaining usage of deprecated `SupervoxelClustering::getColoredVoxelCloud()` function and completely remove it.

Fixes #1427.