### PR TITLE
Treat compiler warnings as errors in Ubuntu 16.04 CI job

### DIFF
--- a/.ci/azure-pipelines/build-ubuntu-16-04.yaml
+++ b/.ci/azure-pipelines/build-ubuntu-16-04.yaml
@@ -12,13 +12,12 @@ jobs:
     container: env1604
     variables:
       BUILD_DIR: '$(Agent.BuildDirectory)/build'
-      CMAKE_CXX_FLAGS: '-Wall -Wextra -O2'
     steps:
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR
           cmake $(Build.SourcesDirectory) \
-            -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
+            -DPCL_WARNINGS_ARE_ERRORS=ON \
             -DBUILD_simulation=ON \
             -DBUILD_surface_on_nurbs=ON \
             -DBUILD_global_tests=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wabi")
     endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unknown-pragmas -fno-strict-aliasing -Wno-format-extra-args -Wno-sign-compare -Wno-invalid-offsetof -Wno-conversion ${SSE_FLAGS_STR}")
+    if(PCL_WARNINGS_ARE_ERRORS)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    endif()
   endif()
 
   if("${CMAKE_SHARED_LINKER_FLAGS}" STREQUAL "" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
@@ -153,6 +156,10 @@ if(CMAKE_COMPILER_IS_MSVC)
       set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG")
     endif()
     # /MANIFEST:NO") # please, don't disable manifest generation, otherwise crash at start for vs2008
+
+    if(PCL_WARNINGS_ARE_ERRORS)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
+    endif()
 
     include(ProcessorCount)
     ProcessorCount(CPUCores)

--- a/cmake/pcl_options.cmake
+++ b/cmake/pcl_options.cmake
@@ -46,6 +46,10 @@ mark_as_advanced(PCL_ENABLE_SSE)
 option(PCL_ENABLE_CCACHE "Enable using compiler cache for compilation" OFF)
 mark_as_advanced(PCL_ENABLE_CCACHE)
 
+# Treat compiler warnings as errors
+option(PCL_WARNINGS_ARE_ERRORS "Treat warnings as errors" OFF)
+mark_as_advanced(PCL_WARNINGS_ARE_ERRORS)
+
 # Display timing information for each compiler instance on screen
 option(CMAKE_TIMING_VERBOSE "Enable the display of timing information for each compiler instance." OFF)
 mark_as_advanced(CMAKE_TIMING_VERBOSE)

--- a/cmake/pcl_options.cmake
+++ b/cmake/pcl_options.cmake
@@ -42,7 +42,7 @@ mark_as_advanced(PCL_NO_PRECOMPILE)
 option(PCL_ENABLE_SSE "Enable or Disable SSE optimizations." ON)
 mark_as_advanced(PCL_ENABLE_SSE)
 
-# Allow the user to disable ccache if ccache is available
+# Allow the user to enable compiler cache
 option(PCL_ENABLE_CCACHE "Enable using compiler cache for compilation" OFF)
 mark_as_advanced(PCL_ENABLE_CCACHE)
 


### PR DESCRIPTION
This enables `-Wall` flag in Ubuntu 16.04 job, which is currently warning-free. The other pipelines still produce warnings; ticket #3379 will continue to track the progress towards having `-Wall` in all jobs.