### PR TITLE
Refactor attribute detection

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -365,22 +365,22 @@ aligned_free (void* ptr)
  *
  * \ingroup common
  */
-#if __has_cpp_attribute(fallthrough) && !(defined(__clang__) && __cplusplus < 201703L)
+#if (__cplusplus >= 201703L) || (defined(_MSC_VER) && (_MSC_VER >= 1910) && (_MSVC_LANG >= 201703L))
   #define PCL_FALLTHROUGH [[fallthrough]];
 #elif defined(__clang__)
   #define PCL_FALLTHROUGH [[clang::fallthrough]];
-#elif defined(__GNUC__)
-  #if __GNUC__ >= 7
-    #define PCL_FALLTHROUGH [[gnu::fallthrough]];
-  #else
-    #define PCL_FALLTHROUGH ;
-  #endif
+#elif defined(__GNUC__) && (__GNUC__ >= 7)
+  #define PCL_FALLTHROUGH [[gnu::fallthrough]];
 #else
-  #define PCL_FALLTHROUGH ;
+  #define PCL_FALLTHROUGH
 #endif
 
-#if __has_cpp_attribute(nodiscard)
+#if (__cplusplus >= 201703L) || (defined(_MSC_VER) && (_MSC_VER >= 1911) && (_MSVC_LANG >= 201703L))
   #define PCL_NODISCARD [[nodiscard]]
+#elif defined(__clang__) && ((__clang_major__ > 3) || ((__clang_major__ == 3) && (__clang_minor__ > 9)))
+  #define PCL_NODISCARD [[clang::warn_unused_result]]
+#elif defined(__GNUC__)
+  #define PCL_NODISCARD [[gnu::warn_unused_result]]
 #else
   #define PCL_NODISCARD
 #endif

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -377,7 +377,7 @@ aligned_free (void* ptr)
 
 #if (__cplusplus >= 201703L) || (defined(_MSC_VER) && (_MSC_VER >= 1911) && (_MSVC_LANG >= 201703L))
   #define PCL_NODISCARD [[nodiscard]]
-#elif defined(__clang__) && ((__clang_major__ > 3) || ((__clang_major__ == 3) && (__clang_minor__ > 9)))
+#elif defined(__clang__) && (PCL_LINEAR_VERSION(__clang_major__, __clang_minor__, 0) >= PCL_LINEAR_VERSION(3, 9, 0))
   #define PCL_NODISCARD [[clang::warn_unused_result]]
 #elif defined(__GNUC__)
   #define PCL_NODISCARD [[gnu::warn_unused_result]]

--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -63,9 +63,8 @@ pcl::PCLPointCloud2::concatenate (pcl::PCLPointCloud2 &cloud1, const pcl::PCLPoi
   {
     case 1:
       cloud1 = cloud2;
-      PCL_FALLTHROUGH;
+      PCL_FALLTHROUGH
     case 0:
-      PCL_FALLTHROUGH;
     case 2:
       cloud1.header.stamp = std::max (cloud1.header.stamp, cloud2.header.stamp);
       return (true);

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -76,14 +76,14 @@ pcl::PCLBase<pcl::PCLPointCloud2>::setInputCloud (const PCLPointCloud2ConstPtr &
   {
     switch (datatype)
     {
-      case pcl::PCLPointField::INT8: PCL_FALLTHROUGH;
+      case pcl::PCLPointField::INT8:
       case pcl::PCLPointField::UINT8: return 1;
 
-      case pcl::PCLPointField::INT16: PCL_FALLTHROUGH;
+      case pcl::PCLPointField::INT16:
       case pcl::PCLPointField::UINT16: return 2;
 
-      case pcl::PCLPointField::INT32: PCL_FALLTHROUGH;
-      case pcl::PCLPointField::UINT32: PCL_FALLTHROUGH;
+      case pcl::PCLPointField::INT32:
+      case pcl::PCLPointField::UINT32:
       case pcl::PCLPointField::FLOAT32: return 4;
 
       case pcl::PCLPointField::FLOAT64: return 8;


### PR DESCRIPTION
Currently the MSVC build is spammed with:
```
D:\a\1\s\common\include\pcl/pcl_macros.h(368): warning C4067: unexpected tokens following preprocessor directive - expected a newline (compiling source file D:\a\1\s\io\src\robot_eye_grabber.cpp) [D:\a\build\io\pcl_io.vcxproj]
D:\a\1\s\common\include\pcl/pcl_macros.h(382): warning C4067: unexpected tokens following preprocessor directive - expected a newline (compiling source file D:\a\1\s\io\src\robot_eye_grabber.cpp) [D:\a\build\io\pcl_io.vcxproj]
```

Reason is the usage of `__has_cpp_attribute`. This is a [C++20 macro](https://en.cppreference.com/w/cpp/feature_test). So as we currently compiling the code with C++14, this macro never exists. Because following Boost code is triggering here:
```
#ifndef __has_cpp_attribute
#define __has_cpp_attribute(x) 0
#endif
```
However: Aside this boost code causes a lot of warnings combined with MSVC, we can't even use it, as this requires at [least Boost 1.65](https://github.com/boostorg/config/commit/199577821118e1348a4ebe96ea8e77a135d41d61) during PCL [require only Boost 1.55](https://github.com/PointCloudLibrary/pcl/blob/3e04ea7f5e8dae81db2411f74ba18dc7da448c3d/cmake/pcl_find_boost.cmake#L33). So I removed usage of this macro.

Additionally I fixed some usage `PCL_FALLTHROUGH`:
- In case `[[fallthrough]]]` is not supported, we do not need to replace it by `;`. Replacing by nothing is enough.
-  `PCL_FALLTHROUGH` includes already semicolon, so it is not necessary to write `PCL_FALLTHROUGH;` as this will be replaced by `[[fallthrough]]];;`
- `[[fallthrough]]]` is not required in case of empty `case` cases (`PCLPointCloud2.cpp` is now a good example, when you have to use it and when not).

Another addition: `PCL_NODISCARD` is now working even for older compiler, as there is another GCC attribute for GCC >=4.8. See [here](https://gcc.gnu.org/projects/cxx-status.html). As C++14 requires at least GCC 4.9/5.0, it is not necessary to check for GCC version here.

Minimum required MSVC version I took from [here](https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B17_library_features).