### PR TITLE
Restructure and add functionality to PCLPointCloud2 filters Par…

### DIFF
--- a/filters/src/crop_box.cpp
+++ b/filters/src/crop_box.cpp
@@ -43,98 +43,55 @@
 void
 pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
 {
-  // Resize output cloud to sample size
-  output.data.resize (input_->data.size ());
-  removed_indices_->resize (input_->data.size ());
-
-  // Copy the common fields
-  output.fields = input_->fields;
-  output.is_bigendian = input_->is_bigendian;
-  output.row_step = input_->row_step;
-  output.point_step = input_->point_step;
-  output.height = 1;
-
-  int indices_count = 0;
-  int removed_indices_count = 0;
-
-  Eigen::Affine3f transform = Eigen::Affine3f::Identity();
-  Eigen::Affine3f inverse_transform = Eigen::Affine3f::Identity();
-
-  if (rotation_ != Eigen::Vector3f::Zero ())
+  std::vector<int> indices;
+  if (keep_organized_)
   {
-    pcl::getTransformation (0, 0, 0,
-                            rotation_ (0), rotation_ (1), rotation_ (2),
-                            transform);
-    inverse_transform = transform.inverse();
-  }
+    bool temp = extract_removed_indices_;
+    extract_removed_indices_ = true;
+    applyFilter (indices);
+    extract_removed_indices_ = temp;
+    PCL_DEBUG ("[pcl::%s<pcl::PCLPointCloud2>::applyFilter] Removing %lu points of %lu points.\n",
+               filter_name_.c_str (), removed_indices_->size(), input_->height * input_->width);
 
-  //PointXYZ local_pt;
-  Eigen::Vector3f local_pt (Eigen::Vector3f::Zero ());
+    output = *input_;
 
-  bool transform_matrix_is_identity = transform_.matrix ().isIdentity ();
-  bool translation_is_zero = (translation_ != Eigen::Vector3f::Zero ());
-  bool inverse_transform_matrix_is_identity = inverse_transform.matrix ().isIdentity ();
-
-  for (std::size_t index = 0; index < indices_->size (); ++index)
-  {
-    // Get local point
-    std::size_t point_offset = static_cast<std::size_t>((*indices_)[index]) * input_->point_step;
-    std::size_t offset = point_offset + input_->fields[x_idx_].offset;
-    memcpy (local_pt.data (), &input_->data[offset], sizeof (float)*3);
-
-    // Check if the point is invalid
-    if (!std::isfinite (local_pt.x ()) ||
-        !std::isfinite (local_pt.y ()) ||
-        !std::isfinite (local_pt.z ()))
-      continue;
-
-    // Transform point to world space
-    if (!transform_matrix_is_identity)
-      local_pt = transform_ * local_pt;
-
-    if (translation_is_zero)
+    // Get x, y, z fields. We should not just assume that they are the first fields of each point
+    std::vector<std::uint32_t> offsets;
+    for (const pcl::PCLPointField &field : input_->fields)
     {
-      local_pt.x () = local_pt.x () - translation_ (0);
-      local_pt.y () = local_pt.y () - translation_ (1);
-      local_pt.z () = local_pt.z () - translation_ (2);
+      if (field.name == "x" ||
+          field.name == "y" ||
+          field.name == "z")
+        offsets.push_back (field.offset);
     }
+    PCL_DEBUG ("[pcl::%s<pcl::PCLPointCloud2>::applyFilter] Found %lu fields called 'x', 'y', or 'z'.\n",
+               filter_name_.c_str (), offsets.size());
 
-    // Transform point to local space of crop box
-    if (!inverse_transform_matrix_is_identity)
-      local_pt = inverse_transform * local_pt;
-
-    // If outside the cropbox
-    if ( (local_pt.x () < min_pt_[0] || local_pt.y () < min_pt_[1] || local_pt.z () < min_pt_[2]) ||
-         (local_pt.x () > max_pt_[0] || local_pt.y () > max_pt_[1] || local_pt.z () > max_pt_[2]))
+    // For every "removed" point, set the x, y, z fields to user_filter_value_
+    const static float user_filter_value = user_filter_value_;
+    for (const auto ri : *removed_indices_) // ri = removed index
     {
-      if (negative_)
+      std::uint8_t* pt_data = reinterpret_cast<std::uint8_t*> (&output.data[ri * output.point_step]);
+      for (const auto &offset : offsets)
       {
-        memcpy (&output.data[indices_count++ * output.point_step],
-                &input_->data[index * output.point_step], output.point_step);
-      }
-      else if (extract_removed_indices_)
-      {
-        (*removed_indices_)[removed_indices_count++] = static_cast<int> ((*indices_)[index]);
+        memcpy (pt_data + offset, &user_filter_value, sizeof (float));
       }
     }
-    // If inside the cropbox
-    else
+    if (!std::isfinite (user_filter_value_))
     {
-      if (negative_ && extract_removed_indices_)
-      {
-        (*removed_indices_)[removed_indices_count++] = static_cast<int> ((*indices_)[index]);
-      }
-      else if (!negative_) {
-        memcpy (&output.data[indices_count++ * output.point_step],
-                &input_->data[index * output.point_step], output.point_step);
-      }
+      PCL_DEBUG ("[pcl::%s<pcl::PCLPointCloud2>::applyFilter] user_filter_value_ is %f, which is not finite, "
+                 "so the is_dense field of the output will be set to false.\n", filter_name_.c_str (), user_filter_value_);
+      output.is_dense = false;
     }
   }
-  output.width = indices_count;
-  output.row_step = output.point_step * output.width;
-  output.data.resize (output.width * output.height * output.point_step);
-
-  removed_indices_->resize (removed_indices_count);
+  else
+  {
+    // Here indices is used, not removed_indices_, so no need to change extract_removed_indices_.
+    applyFilter (indices);
+    PCL_DEBUG ("[pcl::%s<pcl::PCLPointCloud2>::applyFilter] Removing %lu points of %lu points.\n",
+               filter_name_.c_str (), (input_->height * input_->width) - indices.size(), input_->height * input_->width);
+    pcl::copyPointCloud (*input_, indices, output);
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/filters/src/random_sample.cpp
+++ b/filters/src/random_sample.cpp
@@ -100,45 +100,65 @@ pcl::RandomSample<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
 void
 pcl::RandomSample<pcl::PCLPointCloud2>::applyFilter (std::vector<int> &indices)
 {
-  unsigned N = input_->width * input_->height;
+  // Note: this function does not have to access input_ at all
+  std::size_t N = indices_->size ();
+  std::size_t sample_size = negative_ ? N - sample_ : sample_;
   // If sample size is 0 or if the sample size is greater then input cloud size
   //   then return all indices
-  if (sample_ >= N)
+  if (sample_size >= N)
   {
     indices = *indices_;
+    removed_indices_->clear ();
   }
   else
   {
     // Resize output indices to sample size
-    indices.resize (sample_);
+    indices.resize (sample_size);
+    if (extract_removed_indices_)
+      removed_indices_->resize (N - sample_size);
 
     // Set random seed so derived indices are the same each time the filter runs
     std::srand (seed_);
 
-    unsigned top = N - sample_;
-    unsigned i = 0;
-    unsigned index = 0;
-
-    // Algorithm A
-    for (std::size_t n = sample_; n >= 2; n--)
+    // Algorithm S
+    std::size_t i = 0;
+    std::size_t index = 0;
+    std::vector<bool> added;
+    if (extract_removed_indices_)
+      added.resize (indices_->size (), false);
+    std::size_t n = sample_size;
+    while (n > 0)
     {
-      float V = unifRand ();
-      unsigned S = 0;
-      float quot = float (top) / float (N);
-      while (quot > V)
+      // Step 1: [Generate U.] Generate a random variate U that is uniformly distributed between 0 and 1.
+      const float U = unifRand ();
+      // Step 2: [Test.] If N * U > n, go to Step 4.
+      if ((N * U) <= n)
       {
-        S++;
-        top--;
-        N--;
-        quot *= float (top) / float (N);
+        // Step 3: [Select.] Select the next record in the file for the sample, and set n : = n - 1.
+        if (extract_removed_indices_)
+          added[index] = true;
+        indices[i++] = (*indices_)[index];
+        --n;
       }
-      index += S;
-      indices[i++] = (*indices_)[index++];
-      N--;
+      // Step 4: [Don't select.] Skip over the next record (do not include it in the sample).
+      // Set N : = N - 1.
+      --N;
+      ++index;
+      // If n > 0, then return to Step 1; otherwise, the sample is complete and the algorithm terminates.
     }
 
-    index += N * static_cast<unsigned> (unifRand ());
-    indices[i++] = (*indices_)[index++];
+    // Now populate removed_indices_ appropriately
+    if (extract_removed_indices_)
+    {
+      std::size_t ri = 0;
+      for (std::size_t i = 0; i < added.size (); i++)
+      {
+        if (!added[i])
+        {
+          (*removed_indices_)[ri++] = (*indices_)[i];
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
- replace two applyFilter(indices) functions
- previously, the functions did not consider removed_indices_ and extract_removed_indices_
- applyFilter(indices) in RandomSample previously also did not consider negative_
- adapted code from the templated filters (hpp files) was used
- follow-up to pr #3483, see also issue #3471 