### PR TITLE
Fix warning: 'qVariantFromValue<void *>' is deprecated: Use QVariant::fromValue() instead.

### DIFF
--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/cloud_composer_item.h
@@ -152,7 +152,7 @@ namespace pcl
 
         static QVariant asQVariant (T* ptr)
         {
-          return (qVariantFromValue (static_cast<void*>(ptr)));
+          return (QVariant::fromValue (static_cast<void*>(ptr)));
         }
     };
     


### PR DESCRIPTION
From [Qt documentation](https://doc.qt.io/qt-5/qvariant-obsolete.html#qVariantFromValue):
> This function was provided as a workaround for MSVC 6 which did not support member template functions.

Even though this method is deprecated for a long time, it was only [marked as deprecated](https://github.com/qt/qtbase/commit/c19d556863d931f5fd04d9e27ee7a47aafeaca2a) when Qt5.14  was released.