### PR TITLE
Fix warning: 'toList' is deprecated: Use values() instead.

### DIFF
--- a/apps/cloud_composer/src/toolbox_model.cpp
+++ b/apps/cloud_composer/src/toolbox_model.cpp
@@ -163,7 +163,7 @@ pcl::cloud_composer::ToolBoxModel::updateEnabledTools (const QItemSelection& cur
     }
   }
   enableAllTools ();
-  QList <QStandardItem*> enabled_tools = tool_items.toList (); 
+  QList <QStandardItem*> enabled_tools = tool_items.values (); 
   QMap <QStandardItem*,QString> disabled_tools;
   QMutableListIterator<QStandardItem*> enabled_itr(enabled_tools);
   //Go through tools, removing from enabled list if they fail to pass tests


### PR DESCRIPTION
`QSet::toList` will not [exists anymore](https://github.com/qt/qtbase/commit/92f984273262531f909ede17a324f546fe502b5c) with Qt6.