### PR TITLE
Remove redundant calls to std::string::c_str()

### DIFF
--- a/apps/include/pcl/apps/nn_classification.h
+++ b/apps/include/pcl/apps/nn_classification.h
@@ -137,7 +137,7 @@ namespace pcl
       loadTrainingFeatures(const std::string& file_name, const std::string& labels_file_name)
       {
         typename pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
-        if (pcl::io::loadPCDFile (file_name.c_str (), *cloud) != 0)
+        if (pcl::io::loadPCDFile (file_name, *cloud) != 0)
           return (false);
         std::vector<std::string> labels;
         std::ifstream f (labels_file_name.c_str ());

--- a/apps/include/pcl/apps/vfh_nn_classifier.h
+++ b/apps/include/pcl/apps/vfh_nn_classifier.h
@@ -150,7 +150,7 @@ namespace pcl
       {
         if (labels_.size () == training_features_->points.size ())
         {
-          if (pcl::io::savePCDFile (file_name.c_str (), *training_features_) != 0)
+          if (pcl::io::savePCDFile (file_name, *training_features_) != 0)
             return false;
           std::ofstream f (labels_file_name.c_str ());
           for (const auto& s : labels_)
@@ -194,7 +194,7 @@ namespace pcl
       bool loadTrainingFeatures(const std::string& file_name, const std::string& labels_file_name)
       {
         FeatureCloudPtr cloud (new FeatureCloud);
-        if (pcl::io::loadPCDFile (file_name.c_str (), *cloud) != 0)
+        if (pcl::io::loadPCDFile (file_name, *cloud) != 0)
           return false;
         std::vector<std::string> labels;
         std::ifstream f (labels_file_name.c_str ());
@@ -215,7 +215,7 @@ namespace pcl
       bool loadTrainingData (const std::string& file_name, std::string label)
       {
         pcl::PCLPointCloud2 cloud_blob;
-        if (pcl::io::loadPCDFile (file_name.c_str (), cloud_blob) != 0)
+        if (pcl::io::loadPCDFile (file_name, cloud_blob) != 0)
           return false;
         return addTrainingData (cloud_blob, label);
       }

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -66,7 +66,7 @@ int main (int argc, char *argv[])
 
   // Load cloud in blob format
   pcl::PCLPointCloud2 blob;
-  pcl::io::loadPCDFile (infile.c_str(), blob);
+  pcl::io::loadPCDFile (infile, blob);
 
   pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
         std::cout << "Loading point cloud...";
@@ -172,7 +172,7 @@ int main (int argc, char *argv[])
         pcl::PCDWriter writer;
 
         // Save DoN features
-        writer.write<PointOutT> (outfile.c_str (), *doncloud, false);
+        writer.write<PointOutT> (outfile, *doncloud, false);
 
   //Filter by magnitude
   std::cout << "Filtering out DoN mag <= "<< threshold <<  "..." << std::endl;

--- a/examples/features/example_shape_contexts.cpp
+++ b/examples/features/example_shape_contexts.cpp
@@ -53,7 +53,7 @@ main (int, char** argv)
   std::cout << "Reading " << filename << std::endl;
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
 
-  if (pcl::io::loadPCDFile <pcl::PointXYZ> (filename.c_str (), *cloud) == -1)
+  if (pcl::io::loadPCDFile <pcl::PointXYZ> (filename, *cloud) == -1)
   // load the file
   {
     PCL_ERROR ("Couldn't read file");

--- a/examples/features/example_spin_images.cpp
+++ b/examples/features/example_spin_images.cpp
@@ -54,7 +54,7 @@ main (int, char** argv)
   std::cout << "Reading " << filename << std::endl;
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
 
-  if (pcl::io::loadPCDFile <pcl::PointXYZ> (filename.c_str (), *cloud) == -1)
+  if (pcl::io::loadPCDFile <pcl::PointXYZ> (filename, *cloud) == -1)
   // load the file
   {
     PCL_ERROR ("Couldn't read file");

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -634,7 +634,7 @@ namespace pcl
       {
         pcl::PCDReader reader;
         // Open it
-        int res = reader.read (disk_storage_filename_.c_str (), *tmp_cloud);
+        int res = reader.read (disk_storage_filename_, *tmp_cloud);
         (void)res; 
         assert (res == 0);
       }

--- a/simulation/src/glsl_shader.cpp
+++ b/simulation/src/glsl_shader.cpp
@@ -44,7 +44,7 @@ void
 pcl::simulation::gllib::Program::setUniform(const std::string& name,
                                             const Eigen::Vector2f& v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniform2f(loc, v(0), v(1));
 }
 
@@ -52,7 +52,7 @@ void
 pcl::simulation::gllib::Program::setUniform(const std::string& name,
                                             const Eigen::Vector3f& v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniform3f(loc, v(0), v(1), v(2));
 }
 
@@ -60,7 +60,7 @@ void
 pcl::simulation::gllib::Program::setUniform(const std::string& name,
                                             const Eigen::Vector4f& v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniform4f(loc, v(0), v(1), v(2), v(4));
 }
 
@@ -68,7 +68,7 @@ void
 pcl::simulation::gllib::Program::setUniform(const std::string& name,
                                             const Eigen::Matrix3f& v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniformMatrix3fv(loc, 1, false, v.data());
 }
 
@@ -76,28 +76,28 @@ void
 pcl::simulation::gllib::Program::setUniform(const std::string& name,
                                             const Eigen::Matrix4f& v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniformMatrix4fv(loc, 1, false, v.data());
 }
 
 void
 pcl::simulation::gllib::Program::setUniform(const std::string& name, float v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniform1f(loc, v);
 }
 
 void
 pcl::simulation::gllib::Program::setUniform(const std::string& name, int v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniform1i(loc, v);
 }
 
 void
 pcl::simulation::gllib::Program::setUniform(const std::string& name, bool v)
 {
-  GLuint loc = getUniformLocation(name.c_str());
+  GLuint loc = getUniformLocation(name);
   glUniform1i(loc, (v ? 1 : 0));
 }
 

--- a/tools/elch.cpp
+++ b/tools/elch.cpp
@@ -150,7 +150,7 @@ main (int argc, char **argv)
   {
     std::string result_filename (cloud.first);
     result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-    pcl::io::savePCDFileBinary (result_filename.c_str (), *(cloud.second));
+    pcl::io::savePCDFileBinary (result_filename, *(cloud.second));
     std::cout << "saving result to " << result_filename << std::endl;
   }
 

--- a/tools/icp.cpp
+++ b/tools/icp.cpp
@@ -113,7 +113,7 @@ main (int argc, char **argv)
 
     std::string result_filename (argv[pcd_index]);
     result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-    pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
+    pcl::io::savePCDFileBinary (result_filename, *tmp);
     std::cout << "saving result to " << result_filename << std::endl;
   }
 

--- a/tools/icp2d.cpp
+++ b/tools/icp2d.cpp
@@ -80,7 +80,7 @@ main (int argc, char **argv)
 
   std::string result_filename (argv[pcd_indices[0]]);
   result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-  pcl::io::savePCDFile (result_filename.c_str (), *model);
+  pcl::io::savePCDFile (result_filename, *model);
   std::cout << "saving first model to " << result_filename << std::endl;
 
   Eigen::Matrix4f t (Eigen::Matrix4f::Identity ());
@@ -128,7 +128,7 @@ main (int argc, char **argv)
 
     std::string result_filename (argv[pcd_indices[i]]);
     result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-    pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
+    pcl::io::savePCDFileBinary (result_filename, *tmp);
     std::cout << "saving result to " << result_filename << std::endl;
   }
 

--- a/tools/lum.cpp
+++ b/tools/lum.cpp
@@ -130,7 +130,7 @@ main (int argc, char **argv)
   {
     std::string result_filename (clouds[i].first);
     result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-    pcl::io::savePCDFileBinary (result_filename.c_str (), *(clouds[i].second));
+    pcl::io::savePCDFileBinary (result_filename, *(clouds[i].second));
     //std::cout << "saving result to " << result_filename << std::endl;
   }
 

--- a/tools/ndt2d.cpp
+++ b/tools/ndt2d.cpp
@@ -118,7 +118,7 @@ main (int argc, char **argv)
   result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
   try
   {
-    pcl::io::savePCDFile (result_filename.c_str (), *model);
+    pcl::io::savePCDFile (result_filename, *model);
     std::cout << "saving first model to " << result_filename << std::endl;
   }
   catch(pcl::IOException& e)
@@ -167,7 +167,7 @@ main (int argc, char **argv)
     {
       std::string result_filename (argv[pcd_indices[i]]);
       result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-      pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
+      pcl::io::savePCDFileBinary (result_filename, *tmp);
       std::cout << "saving result to " << result_filename << std::endl;
     }
     catch(pcl::IOException& e)

--- a/tools/ndt3d.cpp
+++ b/tools/ndt3d.cpp
@@ -100,7 +100,7 @@ main (int argc, char **argv)
 
   std::string result_filename (argv[pcd_indices[0]]);
   result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-  pcl::io::savePCDFile (result_filename.c_str (), *model);
+  pcl::io::savePCDFile (result_filename, *model);
   std::cout << "saving first model to " << result_filename << std::endl;
 
   Eigen::Matrix4f t (Eigen::Matrix4f::Identity ());
@@ -146,7 +146,7 @@ main (int argc, char **argv)
 
     std::string result_filename (argv[pcd_indices[i]]);
     result_filename = result_filename.substr (result_filename.rfind ('/') + 1);
-    pcl::io::savePCDFileBinary (result_filename.c_str (), *tmp);
+    pcl::io::savePCDFileBinary (result_filename, *tmp);
     std::cout << "saving result to " << result_filename << std::endl;
   }
 

--- a/tools/unary_classifier_segment.cpp
+++ b/tools/unary_classifier_segment.cpp
@@ -90,7 +90,7 @@ loadTrainedFeatures (std::vector<FeatureT::Ptr> &out,
       print_highlight ("Loading %s \n", ss.str ().c_str ());
       
       FeatureT::Ptr features (new FeatureT);
-      if (loadPCDFile (ss.str ().c_str (), *features) < 0)
+      if (loadPCDFile (ss.str (), *features) < 0)
         return false;
 
       out.push_back (features);

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -431,7 +431,7 @@ main (int argc, char** argv)
 
     pcl::PCDWriter writer;
     PCL_INFO ("Wrote %lu points (%d x %d) to %s\n", cloud.points.size (), cloud.width, cloud.height, fname.c_str ());
-    writer.writeBinaryCompressed (fname.c_str (), cloud);
+    writer.writeBinaryCompressed (fname, cloud);
   } // sphere
   return (0);
 }


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-redundant-string-cstr' -fix`