### PR TITLE
Use default(none) for OpenMP definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,11 +274,17 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
 endif()
 
 ### ---[ Find universal dependencies
-find_package(OpenMP)
-if(OPENMP_FOUND)
+find_package(OpenMP COMPONENTS C CXX)
+if(OpenMP_FOUND)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-  message(STATUS "Found OpenMP")
+  if(${CMAKE_VERSION} VERSION_LESS "3.7")
+    message(STATUS "Found OpenMP")
+  else()
+    # We could use OpenMP_CXX_VERSION starting from CMake 3.9, but this value is only available on first run of CMake (see https://gitlab.kitware.com/cmake/cmake/issues/19150),
+    # so we use always OpenMP_CXX_SPEC_DATE, which is available since CMake 3.7.
+    message(STATUS "Found OpenMP, spec date ${OpenMP_CXX_SPEC_DATE}")
+  endif()
   if(MSVC)
     if(MSVC_VERSION EQUAL 1900)
       set(OPENMP_DLL VCOMP140)

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
@@ -320,7 +320,10 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
         voxel_grid_icp.filter (*cloud_voxelized_icp);
         source_->voxelizeAllModels (VOXEL_SIZE_ICP_);
 
-#pragma omp parallel for num_threads(omp_get_num_procs())
+#pragma omp parallel for \
+  default(none) \
+  shared(VOXEL_SIZE_ICP_, cloud_voxelized_icp) \
+  num_threads(omp_get_num_procs())
         for (int i = 0; i < static_cast<int> (models_->size ()); i++)
         {
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
@@ -506,7 +506,10 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
           source_->voxelizeAllModels (VOXEL_SIZE_ICP_);
         }
 
-#pragma omp parallel for num_threads(omp_get_num_procs())
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud_voxelized_icp, VOXEL_SIZE_ICP_) \
+  num_threads(omp_get_num_procs())
         for (int i = 0; i < static_cast<int> (models_->size ()); i++)
         {
 

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -366,7 +366,11 @@ template<template<class > class Distance, typename PointInT, typename FeatureT>
       voxel_grid_icp.filter (*cloud_voxelized_icp);
       source_->voxelizeAllModels (VOXEL_SIZE_ICP_);
 
-#pragma omp parallel for schedule(dynamic,1) num_threads(omp_get_num_procs())
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud_voxelized_icp) \
+  schedule(dynamic,1) \
+  num_threads(omp_get_num_procs())
       for (int i = 0; i < static_cast<int>(models_->size ()); i++)
       {
 

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -65,6 +65,15 @@
 #include <cstdint>
 #include <iostream>
 
+// We need to check for GCC version, because GCC releases before 9 were implementing an
+// OpenMP 3.1 data sharing rule, even OpenMP 4 is supported, so a plain OpenMP version 4 check
+// isn't enough (see https://www.gnu.org/software/gcc/gcc-9/porting_to.html#ompdatasharing)
+#if defined _OPENMP && (_OPENMP <= 201307) || (__GNUC__ < 9)
+  #define OPENMP_LEGACY_CONST_DATA_SHARING_RULE 1
+#else
+  #define OPENMP_LEGACY_CONST_DATA_SHARING_RULE 0
+#endif
+
 #include <pcl/pcl_config.h>
 
 // It seems that __has_cpp_attribute doesn't work correctly

--- a/common/src/fft/kiss_fft.c
+++ b/common/src/fft/kiss_fft.c
@@ -255,7 +255,17 @@ void kf_work(
         int k;
 
         // execute the p different work units in different threads
-#       pragma omp parallel for
+// We cannot use OPENMP_LEGACY_CONST_DATA_SHARING_RULE here, because we cannot include
+// pcl_macros.h in this file as this is a C file.
+#if defined _OPENMP && (_OPENMP <= 201307) || (__GNUC__ < 9)
+#pragma omp parallel for \
+  default(none) \
+  shared(f, factors, Fout, in_stride)
+#else
+#pragma omp parallel for \
+  default(none) \
+  shared(f, factors, Fout, fstride, in_stride, m, p, st)
+#endif
         for (k=0;k<p;++k) 
             kf_work( Fout +k*m, f+ fstride*in_stride*k,fstride*p,in_stride,factors,st);
         // all threads have joined by this point

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -868,8 +868,13 @@ RangeImage::getOverlap (const RangeImage& other_range_image, const Eigen::Affine
   
   float max_distance_squared = max_distance*max_distance;
   
-  # pragma omp parallel for num_threads (max_no_of_threads) default (shared) schedule (dynamic, 1) \
-                        reduction (+ : valid_points_counter) reduction (+ : hits_counter)
+#pragma omp parallel for \
+  default(none) \
+  shared(max_distance_squared, other_range_image, pixel_step, relative_transformation, search_radius) \
+  schedule(dynamic, 1) \
+  reduction(+ : valid_points_counter) \
+  reduction(+ : hits_counter) \
+  num_threads(max_no_of_threads)
   for (int other_y=0; other_y<int (other_range_image.height); other_y+=pixel_step)
   {
     for (int other_x=0; other_x<int (other_range_image.width); other_x+=pixel_step)

--- a/features/include/pcl/features/impl/fpfh_omp.hpp
+++ b/features/include/pcl/features/impl/fpfh_omp.hpp
@@ -106,9 +106,11 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
 
   // Compute SPFH signatures for every point that needs them
 
-#ifdef _OPENMP
-#pragma omp parallel for shared (spfh_hist_lookup) private (nn_indices, nn_dists) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(spfh_hist_lookup, spfh_indices_vec) \
+  private(nn_indices, nn_dists) \
+  num_threads(threads_)
   for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t> (spfh_indices_vec.size ()); ++i)
   {
     // Get the next point index
@@ -133,9 +135,11 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
   nn_dists.clear();
 
   // Iterate over the entire index vector
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) private (nn_indices, nn_dists) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(nr_bins, output, spfh_hist_lookup) \
+  private(nn_dists, nn_indices) \
+  num_threads(threads_)
   for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
   {
     // Find the indices of point idx's neighbors...

--- a/features/include/pcl/features/impl/intensity_gradient.hpp
+++ b/features/include/pcl/features/impl/intensity_gradient.hpp
@@ -149,9 +149,11 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
   // If the data is dense, we don't need to check for NaN
   if (surface_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) private (nn_indices, nn_dists) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  private(nn_indices, nn_dists) \
+  num_threads(threads_)
     // Iterating over the entire index vector
     for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
     {
@@ -187,9 +189,11 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) private (nn_indices, nn_dists) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  private(nn_indices, nn_dists) \
+  num_threads(threads_)
     // Iterating over the entire index vector
     for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
     {

--- a/features/include/pcl/features/impl/normal_3d_omp.hpp
+++ b/features/include/pcl/features/impl/normal_3d_omp.hpp
@@ -70,9 +70,11 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
   // Save a few cycles by not checking every point for NaN/Inf values if the cloud is set to dense
   if (input_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) firstprivate (nn_indices, nn_dists) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  firstprivate(nn_indices, nn_dists) \
+  num_threads(threads_)
     // Iterating over the entire index vector
     for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
     {
@@ -97,9 +99,11 @@ pcl::NormalEstimationOMP<PointInT, PointOutT>::computeFeature (PointCloudOut &ou
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) firstprivate (nn_indices, nn_dists) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  firstprivate(nn_indices, nn_dists) \
+  num_threads(threads_)
     // Iterating over the entire index vector
     for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
     {

--- a/features/include/pcl/features/impl/shot_lrf_omp.hpp
+++ b/features/include/pcl/features/impl/shot_lrf_omp.hpp
@@ -72,9 +72,10 @@ pcl::SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT>::computeFeature (
   }
   tree_->setSortedResults (true);
 
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  num_threads(threads_)
   for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t> (indices_->size ()); ++i)
   {
     // point result

--- a/features/include/pcl/features/impl/shot_omp.hpp
+++ b/features/include/pcl/features/impl/shot_omp.hpp
@@ -148,9 +148,10 @@ pcl::SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::computeFeature (
 
   output.is_dense = true;
   // Iterating over the entire index vector
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  num_threads(threads_)
   for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
   {
 
@@ -234,9 +235,10 @@ pcl::SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT>::computeFeat
 
   output.is_dense = true;
   // Iterating over the entire index vector
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  num_threads(threads_)
   for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
   {
     Eigen::VectorXf shot;

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -371,7 +371,11 @@ void
 Narf::extractForInterestPoints (const RangeImage& range_image, const PointCloud<InterestPoint>& interest_points,
                                 int descriptor_size, float support_size, bool rotation_invariant, std::vector<Narf*>& feature_list)
 {
-  # pragma omp parallel for num_threads(max_no_of_threads) default(shared) schedule(dynamic, 10)
+#pragma omp parallel for \
+  default(none) \
+  shared(descriptor_size, feature_list, interest_points, range_image, rotation_invariant, support_size) \
+  schedule(dynamic, 10) \
+  num_threads(max_no_of_threads)
   //!!! nizar 20110408 : for OpenMP sake on MSVC this must be kept signed
   for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t>(interest_points.points.size ()); ++idx)
   {

--- a/filters/include/pcl/filters/impl/convolution.hpp
+++ b/filters/include/pcl/filters/impl/convolution.hpp
@@ -410,9 +410,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows (PointCloudOut& outp
   int last = input_->width - half_width_;
   if (input_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, width) \
+  num_threads(threads_)
     for(int j = 0; j < height; ++j)
     {
       for (int i = 0; i < half_width_; ++i)
@@ -427,9 +428,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows (PointCloudOut& outp
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, width) \
+  num_threads(threads_)
     for(int j = 0; j < height; ++j)
     {
       for (int i = 0; i < half_width_; ++i)
@@ -455,9 +457,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_duplicate (PointClou
   int w = last - 1;
   if (input_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, w, width) \
+  num_threads(threads_)
     for(int j = 0; j < height; ++j)
     {
       for (int i = half_width_; i < last; ++i)
@@ -472,9 +475,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_duplicate (PointClou
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, w, width) \
+  num_threads(threads_)
     for(int j = 0; j < height; ++j)
     {
       for (int i = half_width_; i < last; ++i)
@@ -500,9 +504,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_mirror (PointCloudOu
   int w = last - 1;
   if (input_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, w, width) \
+  num_threads(threads_)
     for(int j = 0; j < height; ++j)
     {
       for (int i = half_width_; i < last; ++i)
@@ -517,9 +522,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_mirror (PointCloudOu
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, w, width) \
+  num_threads(threads_)
     for(int j = 0; j < height; ++j)
     {
       for (int i = half_width_; i < last; ++i)
@@ -544,9 +550,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols (PointCloudOut& outp
   int last = input_->height - half_width_;
   if (input_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, width) \
+  num_threads(threads_)
     for(int i = 0; i < width; ++i)
     {
       for (int j = 0; j < half_width_; ++j)
@@ -561,9 +568,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols (PointCloudOut& outp
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(height, last, output, width) \
+  num_threads(threads_)
     for(int i = 0; i < width; ++i)
     {
       for (int j = 0; j < half_width_; ++j)
@@ -589,9 +597,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_duplicate (PointClou
   int h = last -1;
   if (input_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(h, height, last, output, width) \
+  num_threads(threads_)
     for(int i = 0; i < width; ++i)
     {
       for (int j = half_width_; j < last; ++j)
@@ -606,9 +615,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_duplicate (PointClou
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(h, height, last, output, width) \
+  num_threads(threads_)
     for(int i = 0; i < width; ++i)
     {
       for (int j = half_width_; j < last; ++j)
@@ -634,9 +644,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_mirror (PointCloudOu
   int h = last -1;
   if (input_->is_dense)
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(h, height, last, output, width) \
+  num_threads(threads_)
     for(int i = 0; i < width; ++i)
     {
       for (int j = half_width_; j < last; ++j)
@@ -651,9 +662,10 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_mirror (PointCloudOu
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(h, height, last, output, width) \
+  num_threads(threads_)
     for(int i = 0; i < width; ++i)
     {
       for (int j = half_width_; j < last; ++j)

--- a/filters/include/pcl/filters/impl/convolution_3d.hpp
+++ b/filters/include/pcl/filters/impl/convolution_3d.hpp
@@ -242,9 +242,11 @@ pcl::filters::Convolution3D<PointInT, PointOutT, KernelT>::convolve (PointCloudO
   std::vector<int> nn_indices;
   std::vector<float> nn_distances;
 
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) private (nn_indices, nn_distances) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  private(nn_indices, nn_distances) \
+  num_threads(threads_)
   for (std::int64_t point_idx = 0; point_idx < static_cast<std::int64_t> (surface_->size ()); ++point_idx)
   {
     const PointInT& point_in = surface_->points [point_idx];

--- a/filters/include/pcl/filters/impl/pyramid.hpp
+++ b/filters/include/pcl/filters/impl/pyramid.hpp
@@ -112,9 +112,10 @@ pcl::filters::Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
       output[l].reset (new pcl::PointCloud<PointT> (output[l-1]->width/2, output[l-1]->height/2));
       const PointCloud<PointT> &previous = *output[l-1];
       PointCloud<PointT> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
       for(int i=0; i < next.height; ++i)
       {
         for(int j=0; j < next.width; ++j)
@@ -147,9 +148,10 @@ pcl::filters::Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
       output[l].reset (new pcl::PointCloud<PointT> (output[l-1]->width/2, output[l-1]->height/2));
       const PointCloud<PointT> &previous = *output[l-1];
       PointCloud<PointT> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
       for(int i=0; i < next.height; ++i)
       {
         for(int j=0; j < next.width; ++j)
@@ -219,9 +221,10 @@ namespace pcl
           output[l].reset (new pcl::PointCloud<pcl::PointXYZRGB> (output[l-1]->width/2, output[l-1]->height/2));
           const PointCloud<pcl::PointXYZRGB> &previous = *output[l-1];
           PointCloud<pcl::PointXYZRGB> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
           for(int i=0; i < next.height; ++i)              // rows
           {
             for(int j=0; j < next.width; ++j)          // columns
@@ -264,9 +267,10 @@ namespace pcl
           output[l].reset (new pcl::PointCloud<pcl::PointXYZRGB> (output[l-1]->width/2, output[l-1]->height/2));
           const PointCloud<pcl::PointXYZRGB> &previous = *output[l-1];
           PointCloud<pcl::PointXYZRGB> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
           for(int i=0; i < next.height; ++i)
           {
             for(int j=0; j < next.width; ++j)
@@ -342,9 +346,10 @@ namespace pcl
           output[l].reset (new pcl::PointCloud<pcl::PointXYZRGBA> (output[l-1]->width/2, output[l-1]->height/2));
           const PointCloud<pcl::PointXYZRGBA> &previous = *output[l-1];
           PointCloud<pcl::PointXYZRGBA> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
           for(int i=0; i < next.height; ++i)              // rows
           {
             for(int j=0; j < next.width; ++j)          // columns
@@ -389,9 +394,10 @@ namespace pcl
           output[l].reset (new pcl::PointCloud<pcl::PointXYZRGBA> (output[l-1]->width/2, output[l-1]->height/2));
           const PointCloud<pcl::PointXYZRGBA> &previous = *output[l-1];
           PointCloud<pcl::PointXYZRGBA> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
           for(int i=0; i < next.height; ++i)
           {
             for(int j=0; j < next.width; ++j)
@@ -475,9 +481,10 @@ namespace pcl
           output[l].reset (new pcl::PointCloud<pcl::RGB> (output[l-1]->width/2, output[l-1]->height/2));
           const PointCloud<pcl::RGB> &previous = *output[l-1];
           PointCloud<pcl::RGB> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
           for(int i=0; i < next.height; ++i)
           {
             for(int j=0; j < next.width; ++j)
@@ -514,9 +521,10 @@ namespace pcl
           output[l].reset (new pcl::PointCloud<pcl::RGB> (output[l-1]->width/2, output[l-1]->height/2));
           const PointCloud<pcl::RGB> &previous = *output[l-1];
           PointCloud<pcl::RGB> &next = *output[l];
-#ifdef _OPENMP
-#pragma omp parallel for shared (next) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(next) \
+  num_threads(threads_)
           for(int i=0; i < next.height; ++i)
           {
             for(int j=0; j < next.width; ++j)

--- a/gpu/kinfu/src/tsdf_volume.cpp
+++ b/gpu/kinfu/src/tsdf_volume.cpp
@@ -304,7 +304,9 @@ pcl::gpu::TsdfVolume::downloadTsdf (std::vector<float>& tsdf) const
   tsdf.resize (volume_.cols() * volume_.rows());
   volume_.download(&tsdf[0], volume_.cols() * sizeof(int));
 
-#pragma omp parallel for
+#pragma omp parallel for \
+  default(none) \
+  shared(tsdf)
   for(int i = 0; i < (int) tsdf.size(); ++i)
   {
     float tmp = reinterpret_cast<short2*>(&tsdf[i])->x;
@@ -322,7 +324,9 @@ pcl::gpu::TsdfVolume::downloadTsdfAndWeighs (std::vector<float>& tsdf, std::vect
   weights.resize (volumeSize);
   volume_.download(&tsdf[0], volume_.cols() * sizeof(int));
 
-#pragma omp parallel for
+#pragma omp parallel for \
+  default(none) \
+  shared(weights, tsdf)
   for(int i = 0; i < (int) tsdf.size(); ++i)
   {
     short2 elem = *reinterpret_cast<short2*>(&tsdf[i]);

--- a/gpu/kinfu/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu/tools/record_tsdfvolume.cpp
@@ -181,7 +181,9 @@ DeviceVolume::getVolume (pcl::TSDFVolume<VoxelT, WeightT>::Ptr &volume)
 
   device_volume_.download (&volume_vec[0], device_volume_.cols() * sizeof(int));
 
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none) \
+    shared(volume, volume_vec, weights_vec)
   for(int i = 0; i < (int) volume->size(); ++i)
   {
     short2 *elem = (short2*)&volume_vec[i];

--- a/gpu/kinfu/tools/tsdf_volume.hpp
+++ b/gpu/kinfu/tools/tsdf_volume.hpp
@@ -168,7 +168,6 @@ pcl::TSDFVolume<VoxelT, WeightT>::convertToTsdfCloud (pcl::PointCloud<pcl::Point
   cloud->reserve (std::min (cloud_size/10, 500000));
 
   int volume_idx = 0, cloud_idx = 0;
-//#pragma omp parallel for // if used, increment over idx not possible! use index calculation
   for (int z = 0; z < sz; z+=step)
     for (int y = 0; y < sy; y+=step)
       for (int x = 0; x < sx; x+=step, ++cloud_idx)
@@ -245,7 +244,8 @@ pcl::TSDFVolume<VoxelT, WeightT>::extractNeighborhood (const Eigen::Vector3i &vo
   const Eigen::RowVector3i offset_vector (1, neighborhood_size, neighborhood_size*neighborhood_size);
 
   // loop over all voxels in 3D neighborhood
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none)
   for (int z = min_index(2); z <= max_index(2); ++z)
   {
     for (int y = min_index(1); y <= max_index(1); ++y)
@@ -297,7 +297,8 @@ pcl::TSDFVolume<VoxelT, WeightT>::addNeighborhood (const Eigen::Vector3i &voxel_
 
   Eigen::Vector3i index = min_index;
   // loop over all voxels in 3D neighborhood
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none)
   for (int z = min_index(2); z <= max_index(2); ++z)
   {
     for (int y = min_index(1); y <= max_index(1); ++y)
@@ -329,7 +330,8 @@ pcl::TSDFVolume<VoxelT, WeightT>::addNeighborhood (const Eigen::Vector3i &voxel_
 template <typename VoxelT, typename WeightT> void
 pcl::TSDFVolume<VoxelT, WeightT>::averageValues ()
 {
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none)
   for (std::size_t i = 0; i < volume_->size(); ++i)
   {
     WeightT &w = weights_->at(i);

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/standalone_marching_cubes.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/standalone_marching_cubes.hpp
@@ -191,8 +191,9 @@ pcl::gpu::kinfuLS::StandaloneMarchingCubes<PointT>::convertTsdfVectors (const Po
 	constexpr int DIVISOR = std::numeric_limits<short>::max();
 
     ///For every point in the cloud
-#pragma omp parallel for
- 	
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud, output) 	
 	for(int i = 0; i < (int) cloud.points.size (); ++i)
 	{
 	  int x = cloud.points[i].x;

--- a/gpu/kinfu_large_scale/src/tsdf_volume.cpp
+++ b/gpu/kinfu_large_scale/src/tsdf_volume.cpp
@@ -367,7 +367,6 @@ pcl::gpu::kinfuLS::TsdfVolume::convertToTsdfCloud ( pcl::PointCloud<pcl::PointXY
   cloud->reserve (std::min (cloud_size/10, 500000));
 
   int volume_idx = 0, cloud_idx = 0;
-  // #pragma omp parallel for // if used, increment over idx not possible! use index calculation
   for (int z = 0; z < sz; z+=step)
     for (int y = 0; y < sy; y+=step)
       for (int x = 0; x < sx; x+=step, ++cloud_idx)
@@ -393,7 +392,9 @@ pcl::gpu::kinfuLS::TsdfVolume::downloadTsdf (std::vector<float>& tsdf) const
   tsdf.resize (volume_.cols() * volume_.rows());
   volume_.download(&tsdf[0], volume_.cols() * sizeof(int));
 
-#pragma omp parallel for
+#pragma omp parallel for \
+  default(none) \
+  shared(tsdf)
   for(int i = 0; i < (int) tsdf.size(); ++i)
   {
     float tmp = reinterpret_cast<short2*>(&tsdf[i])->x;
@@ -418,7 +419,9 @@ pcl::gpu::kinfuLS::TsdfVolume::downloadTsdfAndWeights (std::vector<float>& tsdf,
   weights.resize (volumeSize);
   volume_.download(&tsdf[0], volume_.cols() * sizeof(int));
   
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none) \
+    shared(tsdf, weights)
   for(int i = 0; i < (int) tsdf.size(); ++i)
   {
     short2 elem = *reinterpret_cast<short2*>(&tsdf[i]);

--- a/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
@@ -179,7 +179,9 @@ DeviceVolume::getVolume (pcl::TSDFVolume<VoxelT, WeightT>::Ptr &volume)
 
   device_volume_.download (&volume_vec[0], device_volume_.cols() * sizeof(int));
 
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none) \
+    shared(volume, volume_vec, weights_vec)
   for(int i = 0; i < (int) volume->size(); ++i)
   {
     short2 *elem = (short2*)&volume_vec[i];

--- a/gpu/people/src/cuda/shs.cu
+++ b/gpu/people/src/cuda/shs.cu
@@ -178,7 +178,6 @@ void optimized_shs5(const PointCloud<PointXYZRGB> &cloud, float tolerance, const
 
     //  omp_set_num_threads(1);
     // Process all points in the indices vector
-    //#pragma omp parallel for
     for (int k = 0; k < static_cast<int> (indices_in.indices.size ()); ++k)
     {
         int i = indices_in.indices[k];

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -486,9 +486,9 @@ pcl::gpu::people::PeopleDetector::shs5(const pcl::PointCloud<PointT> &cloud, con
 
   // Process all points in the indices vector
   int total = static_cast<int> (indices.size ());
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud, intr, hue, indices, mask, squared_radius, storage, total)
   for (int k = 0; k < total; ++k)
   {
     int i = indices[k];

--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -151,7 +151,10 @@ pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename,
   double constant_x = 1.0 / parameters_.focal_length_x,
          constant_y = 1.0 / parameters_.focal_length_y;
 #ifdef _OPENMP
-#pragma omp parallel for num_threads (num_threads)
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud, constant_x, constant_y, uncompressed_data) \
+  num_threads(num_threads)
 #else
   (void) num_threads; // suppress warning if OMP is not present
 #endif
@@ -168,9 +171,7 @@ pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename,
       pt.x = pt.y = pt.z = std::numeric_limits<float>::quiet_NaN ();
       if (cloud.is_dense)
       {
-#ifdef _OPENMP
 #pragma omp critical
-#endif
       {
       if (cloud.is_dense)
         cloud.is_dense = false;
@@ -282,7 +283,10 @@ pcl::io::LZFRGB24ImageReader::readOMP (
   unsigned char *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
 
 #ifdef _OPENMP
-#pragma omp parallel for num_threads (num_threads)
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud, color_b, color_g, color_r) \
+  num_threads(num_threads)
 #else
   (void) num_threads; // suppress warning if OMP is not present
 #endif//_OPENMP
@@ -394,7 +398,10 @@ pcl::io::LZFYUV422ImageReader::readOMP (
   unsigned char *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
   
 #ifdef _OPENMP
-#pragma omp parallel for num_threads (num_threads)
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud, color_u, color_v, color_y, wh2) \
+  num_threads(num_threads)
 #else
   (void) num_threads; //suppress warning if OMP is not present
 #endif//_OPENMP
@@ -507,7 +514,9 @@ pcl::io::LZFBayer8ImageReader::readOMP (
   cloud.height = getHeight ();
   cloud.resize (getWidth () * getHeight ());
 #ifdef _OPENMP
-#pragma omp parallel for num_threads (num_threads)
+#pragma omp parallel for \
+  default(none) \
+  num_threads(num_threads)
 #else
   (void) num_threads; //suppress warning if OMP is not present
 #endif//_OPENMP

--- a/io/src/real_sense_2_grabber.cpp
+++ b/io/src/real_sense_2_grabber.cpp
@@ -292,9 +292,9 @@ namespace pcl
     const auto cloud_vertices_ptr = points.get_vertices ();
     const auto cloud_texture_ptr = points.get_texture_coordinates ();
 
-#ifdef _OPENMP
-#pragma omp parallel for 
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud, cloud_vertices_ptr, mapColorFunc)
     for (int index = 0; index < cloud->points.size (); ++index)
     {
       const auto ptr = cloud_vertices_ptr + index;

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -276,9 +276,10 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
     output.points.clear ();
     output.points.reserve (response->points.size());
 
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads(threads_)   
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output, response) \
+  num_threads(threads_)
     for (int idx = 0; idx < static_cast<int> (response->points.size ()); ++idx)
     {
       if (!isFinite (response->points[idx]) ||
@@ -299,9 +300,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
         }
       }
       if (is_maxima)
-#ifdef _OPENMP
 #pragma omp critical
-#endif
       {
         output.points.push_back (response->points[idx]);
         keypoints_indices_->indices.push_back (idx);
@@ -323,9 +322,11 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseHarris (PointCloudO
 {
   PCL_ALIGN (16) float covar [8];
   output.resize (input_->size ());
-#ifdef _OPENMP
-  #pragma omp parallel for shared (output) private (covar) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  private(covar) \
+  num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
     const PointInT& pointIn = input_->points [pIdx];
@@ -362,9 +363,11 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseNoble (PointCloudOu
 {
   PCL_ALIGN (16) float covar [8];
   output.resize (input_->size ());
-#ifdef _OPENMP
-  #pragma omp parallel for shared (output) private (covar) num_threads(threads_)
-#endif
+#pragma omp parallel \
+  for default(none) \
+  shared(output) \
+  private(covar) \
+  num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
     const PointInT& pointIn = input_->points [pIdx];
@@ -400,9 +403,11 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseLowe (PointCloudOut
 {
   PCL_ALIGN (16) float covar [8];
   output.resize (input_->size ());
-#ifdef _OPENMP
-  #pragma omp parallel for shared (output) private (covar) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  private(covar) \
+  num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
     const PointInT& pointIn = input_->points [pIdx];
@@ -457,9 +462,11 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseTomasi (PointCloudO
   PCL_ALIGN (16) float covar [8];
   Eigen::Matrix3f covariance_matrix;
   output.resize (input_->size ());
-#ifdef _OPENMP
-  #pragma omp parallel for shared (output) private (covar, covariance_matrix) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output) \
+  private(covar, covariance_matrix) \
+  num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
     const PointInT& pointIn = input_->points [pIdx];
@@ -503,9 +510,11 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::refineCorners (PointCloudOu
   Eigen::Vector3f NNTp;
   float diff;
   const unsigned max_iterations = 10;
-#ifdef _OPENMP
-  #pragma omp parallel for shared (corners) private (nnT, NNT, NNTInv, NNTp, diff) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(corners) \
+  private(nnT, NNT, NNTInv, NNTp, diff) \
+  num_threads(threads_)
   for (int cIdx = 0; cIdx < static_cast<int> (corners.size ()); ++cIdx)
   {
     unsigned iterations = 0;

--- a/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
@@ -164,9 +164,9 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
 
   pcl::PointCloud<pcl::PointXYZI>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZI>);
   cloud->resize (surface_->size ());
-#ifdef _OPENMP
-  #pragma omp parallel for num_threads(threads_) default(shared)
-#endif  
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
   for (unsigned idx = 0; idx < surface_->size (); ++idx)
   {
     cloud->points [idx].x = surface_->points [idx].x;
@@ -184,9 +184,9 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
   grad_est.setRadiusSearch (search_radius_);
   grad_est.compute (*intensity_gradients_);
   
-#ifdef _OPENMP
-  #pragma omp parallel for num_threads(threads_) default (shared)
-#endif    
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
   for (std::size_t idx = 0; idx < intensity_gradients_->size (); ++idx)
   {
     float len = intensity_gradients_->points [idx].gradient_x * intensity_gradients_->points [idx].gradient_x +
@@ -227,9 +227,9 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
     output.points.clear ();
     output.points.reserve (response->points.size());
 
-#ifdef _OPENMP
-  #pragma omp parallel for num_threads(threads_) default(shared)
-#endif  
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
     for (std::size_t idx = 0; idx < response->points.size (); ++idx)
     {
       if (!isFinite (response->points[idx]) || response->points[idx].intensity < threshold_)
@@ -248,9 +248,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloud
         }
       }
       if (is_maxima)
-#ifdef _OPENMP
         #pragma omp critical
-#endif
       {
         output.points.push_back (response->points[idx]);
         keypoints_indices_->indices.push_back (idx);
@@ -275,9 +273,10 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::responseTomasi (PointCloudO
   Eigen::SelfAdjointEigenSolver <Eigen::Matrix<float, 6, 6> > solver;
   Eigen::Matrix<float, 6, 6> covariance;
 
-#ifdef _OPENMP
-  #pragma omp parallel for default (shared) private (pointOut, covar, covariance, solver) num_threads(threads_)
-#endif  
+#pragma omp parallel for \
+  default(none) \
+  private(pointOut, covar, covariance, solver) \
+  num_threads(threads_)
   for (unsigned pIdx = 0; pIdx < input_->size (); ++pIdx)
   {
     const PointInT& pointIn = input_->points [pIdx];
@@ -347,10 +346,8 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::responseTomasi (PointCloudO
     pointOut.x = pointIn.x;
     pointOut.y = pointIn.y;
     pointOut.z = pointIn.z;
-#ifdef _OPENMP
-    #pragma omp critical
-#endif
 
+    #pragma omp critical
     output.points.push_back(pointOut);
   }
   output.height = input_->height;

--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -112,9 +112,11 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::getBoundaryPoints (PointCloudI
   pcl::BoundaryEstimation<PointInT, NormalT, pcl::Boundary> boundary_estimator;
   boundary_estimator.setInputCloud (input_);
 
-#ifdef _OPENMP
-#pragma omp parallel for private(u, v) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(angle_threshold, boundary_estimator, border_radius, edge_points, input) \
+  private(u, v) \
+  num_threads(threads_)
   for (int index = 0; index < int (input.points.size ()); index++)
   {
     edge_points[index] = false;
@@ -299,9 +301,10 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
 
   bool* borders = new bool [input_->size()];
 
-#ifdef _OPENMP
-  #pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(borders) \
+  num_threads(threads_)
   for (int index = 0; index < int (input_->size ()); index++)
   {
     borders[index] = false;
@@ -342,9 +345,10 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
   for (std::size_t i = 0; i < input_->size (); i++)
     prg_mem[i] = prg_local_mem + 3 * i;
 
-#ifdef _OPENMP
-  #pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(borders, omp_mem, prg_mem) \
+  num_threads(threads_)
   for (int index = 0; index < static_cast<int> (input_->size ()); index++)
   {
 #ifdef _OPENMP
@@ -395,11 +399,11 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
   }
 
   bool* feat_max = new bool [input_->size()];
-  bool is_max;
 
-#ifdef _OPENMP
-  #pragma omp parallel for private(is_max) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(feat_max) \
+  num_threads(threads_)
   for (int index = 0; index < int (input_->size ()); index++)
   {
     feat_max [index] = false;
@@ -417,7 +421,7 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
 
       if (n_neighbors >= min_neighbors_)
       {
-        is_max = true;
+        bool is_max = true;
 
         for (int j = 0 ; j < n_neighbors; j++)
           if (third_eigen_value_[index] < third_eigen_value_[nn_indices[j]])
@@ -428,15 +432,14 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
     }
   }
 
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(feat_max, output) \
+  num_threads(threads_)
   for (int index = 0; index < int (input_->size ()); index++)
   {
     if (feat_max[index])
-#ifdef _OPENMP
 #pragma omp critical
-#endif
     {
       PointOutT p;
       p.getVector3fMap () = input_->points[index].getVector3fMap ();

--- a/keypoints/include/pcl/keypoints/impl/susan.hpp
+++ b/keypoints/include/pcl/keypoints/impl/susan.hpp
@@ -309,9 +309,6 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
   label_idx_ = pcl::getFieldIndex<PointOutT> ("label", out_fields_);
 
   const int input_size = static_cast<int> (input_->size ());
-//#ifdef _OPENMP
-//#pragma omp parallel for shared (response) num_threads(threads_)
-//#endif
   for (int point_index = 0; point_index < input_size; ++point_index)
   {
     const PointInT& point_in = input_->points [point_index];
@@ -362,9 +359,6 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
           memcpy (reinterpret_cast<char*> (&point_out) + out_fields_[label_idx_].offset,
                   &label, sizeof (std::uint32_t));
         }
-//#ifdef _OPENMP
-//#pragma omp critical
-//#endif
         response->push_back (point_out);
       }
       else
@@ -398,9 +392,6 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
               memcpy (reinterpret_cast<char*> (&point_out) + out_fields_[label_idx_].offset,
                       &label, sizeof (std::uint32_t));
             }
-//#ifdef _OPENMP
-//#pragma omp critical
-//#endif
             response->push_back (point_out);
           }
         }
@@ -424,9 +415,6 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
     output.points.clear ();
     output.points.reserve (response->points.size());
     
-//#ifdef _OPENMP
-//#pragma omp parallel for shared (output) num_threads(threads_)   
-//#endif
     for (int idx = 0; idx < static_cast<int> (response->points.size ()); ++idx)
     {
       const PointOutT& point_in = response->points [idx];
@@ -449,9 +437,6 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
         }
       }
       if (is_minima)
-//#ifdef _OPENMP
-//#pragma omp critical
-//#endif
       {
         output.points.push_back (response->points[idx]);
         keypoints_indices_->indices.push_back (idx);

--- a/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
@@ -102,8 +102,16 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
 
   if (method_ == FOUR_CORNERS)
   {
-#ifdef _OPENMP
-#pragma omp parallel for num_threads (threads_)
+#if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
+#pragma omp parallel for \
+  default(none) \
+  shared(input, normals, response) \
+  num_threads(threads_)
+#else
+#pragma omp parallel for \
+  default(none) \
+  shared(h, input, normals, response, w) \
+  num_threads(threads_)
 #endif
     for(int j = half_window_size_; j < h; ++j)
     {
@@ -144,8 +152,16 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
   }
   else
   {
-#ifdef _OPENMP
-#pragma omp parallel for num_threads (threads_)
+#if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
+#pragma omp parallel for \
+  default(none) \
+  shared(input, normals, response) \
+  num_threads(threads_)
+#else
+#pragma omp parallel for \
+  default(none) \
+  shared(h, input, normals, response, w) \
+  num_threads(threads_)
 #endif
     for(int j = half_window_size_; j < h; ++j)
     {
@@ -230,8 +246,16 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
   const int width (input_->width);
   const int height (input_->height);
 
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
+#if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
+#pragma omp parallel for \
+  default(none) \
+  shared(indices, occupency_map, output) \
+  num_threads(threads_)
+#else
+#pragma omp parallel for \
+  default(none) \
+  shared(height, indices, occupency_map, output, width) \
+  num_threads(threads_)
 #endif
   for (int i = 0; i < static_cast<int>(indices.size ()); ++i)
   {
@@ -243,9 +267,7 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
     p.getVector3fMap () = input_->points[idx].getVector3fMap ();
     p.intensity = response_->points [idx];
 
-#ifdef _OPENMP
 #pragma omp critical
-#endif
     {
       output.push_back (p);
       keypoints_indices_->indices.push_back (idx);

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -279,8 +279,13 @@ NarfKeypoint::calculateCompleteInterestImage ()
     was_touched.resize (array_size, false);
     std::vector<int> neighbors_to_check;
     
-#   pragma omp parallel for num_threads (parameters_.max_no_of_threads) default (shared) \
-                            firstprivate (was_touched, neighbors_to_check, angle_histogram) schedule (dynamic, 10)
+#pragma omp parallel for \
+  default(none) \
+  shared(array_size, border_descriptions, interest_image, range_image, radius_reciprocal, radius_squared, scale_idx, \
+         surface_change_directions, surface_change_scores, start_usage_range) \
+  firstprivate(was_touched, neighbors_to_check, angle_histogram) \
+  schedule(dynamic, 10) \
+  num_threads(parameters_.max_no_of_threads)
     for (int index=0; index<array_size; ++index)
     {
       float& interest_value = interest_image[index];
@@ -473,9 +478,13 @@ NarfKeypoint::calculateSparseInterestImage ()
                    neighbors_within_radius_overhead;
   
   //double interest_value_calculation_start_time = getTime ();
-# pragma omp parallel for default (shared) num_threads (parameters_.max_no_of_threads) schedule (guided, 10) \
-                          firstprivate (was_touched, neighbors_to_check, angle_histogram, neighbors_within_radius_overhead, \
-                                        angle_elements, relevant_point_still_valid) 
+#pragma omp parallel for \
+  default(none) \
+  shared(array_size, border_descriptions, increased_radius_squared, radius_reciprocal, radius_overhead_squared, range_image, search_radius, \
+         surface_change_directions, surface_change_scores) \
+  num_threads(parameters_.max_no_of_threads) \
+  schedule(guided, 10) \
+  firstprivate(was_touched, neighbors_to_check, angle_histogram, neighbors_within_radius_overhead, angle_elements, relevant_point_still_valid) 
   for (int index=0; index<array_size; ++index)
   {
     if (interest_image_[index] <= 1.0f)

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -360,7 +360,10 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::initialize()
 
   {
     pcl::ScopeTime tcues ("Computing clutter cues");
-#pragma omp parallel for schedule(dynamic, 4) num_threads(omp_get_num_procs())
+#pragma omp parallel for \
+  default(none) \
+  schedule(dynamic, 4) \
+  num_threads(omp_get_num_procs())
     for (int j = 0; j < static_cast<int> (recognition_models_.size ()); j++)
       computeClutterCue (recognition_models_[j]);
   }

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -59,13 +59,13 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
   std::vector <int> ids (2);
   std::vector <float> dists_sqr (2);
 
-#ifdef _OPENMP
 #pragma omp parallel for \
-  reduction (+:mean_dist, num) \
-  private (ids, dists_sqr) shared (tree, cloud) firstprivate (s, max_dist_sqr) \
-  default (none)num_threads (nr_threads)
-#endif
-
+  default(none) \
+  shared(tree, cloud) \
+  private(ids, dists_sqr) \
+  reduction(+:mean_dist, num) \
+  firstprivate(s, max_dist_sqr) \
+  num_threads(nr_threads)
   for (int i = 0; i < 1000; i++)
   {
     tree.nearestKSearch (cloud->points[rand () % s], 2, ids, dists_sqr);
@@ -96,13 +96,13 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
   std::vector <int> ids (2);
   std::vector <float> dists_sqr (2);
 
-#ifdef _OPENMP
 #pragma omp parallel for \
-  reduction (+:mean_dist, num) \
-  private (ids, dists_sqr) shared (tree, cloud, indices) firstprivate (s, max_dist_sqr) \
-  default (none)num_threads (nr_threads)
-#endif
-
+  default(none) \
+  shared(tree, cloud, indices) \
+  private(ids, dists_sqr) \
+  reduction(+:mean_dist, num) \
+  firstprivate(s, max_dist_sqr) \
+  num_threads(nr_threads)
   for (int i = 0; i < 1000; i++)
   {
     tree.nearestKSearch (cloud->points[indices[rand () % s]], 2, ids, dists_sqr);
@@ -162,20 +162,18 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
   std::vector <MatchingCandidates> all_candidates (max_iterations_);
   pcl::StopWatch timer;
 
-  #ifdef _OPENMP
-  #pragma omp parallel num_threads (nr_threads_)
-  #endif
+  #pragma omp parallel \
+    default(none) \
+    shared(abort, all_candidates, timer) \
+    num_threads(nr_threads_)
   {
     #ifdef _OPENMP
     std::srand (static_cast <unsigned int> (std::time (NULL)) ^ omp_get_thread_num ());    
-    #pragma omp for schedule (dynamic)
+    #pragma omp for schedule(dynamic)
     #endif
     for (int i = 0; i < max_iterations_; i++)
     {
-
-      #ifdef _OPENMP
       #pragma omp flush (abort)
-      #endif
 
       MatchingCandidates candidates (1);
       std::vector <int> base_indices (4);
@@ -209,9 +207,7 @@ pcl::registration::FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scal
         abort = (abort ? abort : timer.getTimeSeconds () > max_runtime_);
 
 
-        #ifdef _OPENMP
         #pragma omp flush (abort)
-        #endif
       }
     }
   }

--- a/segmentation/include/pcl/segmentation/impl/approximate_progressive_morphological_filter.hpp
+++ b/segmentation/include/pcl/segmentation/impl/approximate_progressive_morphological_filter.hpp
@@ -133,9 +133,10 @@ pcl::ApproximateProgressiveMorphologicalFilter<PointT>::extract (std::vector<int
   Eigen::MatrixXf Zf (rows, cols);
   Zf.setConstant (std::numeric_limits<float>::quiet_NaN ());
 
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(A, global_min) \
+  num_threads(threads_)
   for (int i = 0; i < (int)input_->points.size (); ++i)
   {
     // ...then test for lower points within the cell
@@ -164,9 +165,10 @@ pcl::ApproximateProgressiveMorphologicalFilter<PointT>::extract (std::vector<int
     pcl::copyPointCloud<PointT> (*input_, ground, *cloud);
 
     // Apply the morphological opening operation at the current window size.
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(A, cols, half_sizes, i, rows, Z) \
+  num_threads(threads_)
     for (int row = 0; row < rows; ++row)
     {
       int rs, re;
@@ -198,9 +200,10 @@ pcl::ApproximateProgressiveMorphologicalFilter<PointT>::extract (std::vector<int
       }
     }
 
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(cols, half_sizes, i, rows, Z, Zf) \
+  num_threads(threads_)
     for (int row = 0; row < rows; ++row)
     {
       int rs, re;

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -292,9 +292,11 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performProcessing (PointCloudOut &
 #endif
 
   // For all points
-#ifdef _OPENMP
-#pragma omp parallel for schedule (dynamic,1000) num_threads (threads)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(corresponding_input_indices, projected_points, projected_points_normals) \
+  schedule(dynamic,1000) \
+  num_threads(threads)
   for (int cp = 0; cp < static_cast<int> (indices_->size ()); ++cp)
   {
     // Allocate enough space to hold the results of nearest neighbor searches

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -299,7 +299,9 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector<se
   }
   
   // remove also Nans
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    shared(nan_mask, point_cloud) \
+    default(none)
   for (int pIdx = 0; pIdx < int (point_cloud->size ()); ++pIdx)
   {
     if (!isFinite (point_cloud->points [pIdx]))
@@ -310,7 +312,9 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector<se
   if (!input_indices.empty ())
     input_indices_.reset (new pcl::Indices (input_indices));
   
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    shared(input_indices, input_indices_, point_cloud, search_methods) \
+    default(none)
   for (int sIdx = 0; sIdx < int (search_methods.size ()); ++sIdx)
     search_methods [sIdx]->setInputCloud (point_cloud, input_indices_);
 
@@ -320,7 +324,9 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector<se
     // find nn for each point in the cloud
     for (const int &query_index : query_indices)
     {
-      #pragma omp parallel for
+      #pragma omp parallel for \
+        shared(indices, input_indices, indices_mask, distances, knn, nan_mask, passed, point_cloud, query_index, search_methods) \
+        default(none)
       for (int sIdx = 0; sIdx < int (search_methods.size ()); ++sIdx)
       {
         search_methods [sIdx]->nearestKSearch (point_cloud->points[query_index], knn, indices [sIdx], distances [sIdx]);
@@ -330,7 +336,9 @@ testKNNSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector<se
       }
       
       // compare results to each other
-      #pragma omp parallel for
+      #pragma omp parallel for \
+        shared(distances, indices, passed, search_methods) \
+        default(none)
       for (int sIdx = 1; sIdx < int (search_methods.size ()); ++sIdx)
       {
         passed [sIdx] = passed [sIdx] && compareResults (indices [0],    distances [0],    search_methods [0]->getName (),
@@ -369,7 +377,9 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector
   }
   
   // remove also Nans
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none) \
+    shared(nan_mask, point_cloud)
   for (int pIdx = 0; pIdx < int (point_cloud->size ()); ++pIdx)
   {
     if (!isFinite (point_cloud->points [pIdx]))
@@ -380,7 +390,9 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector
   if (!input_indices.empty ())
     input_indices_.reset (new pcl::Indices (input_indices));
   
-  #pragma omp parallel for
+  #pragma omp parallel for \
+    default(none) \
+    shared(input_indices_, point_cloud, search_methods)
   for (int sIdx = 0; sIdx < int (search_methods.size ()); ++sIdx)
     search_methods [sIdx]->setInputCloud (point_cloud, input_indices_);
 
@@ -391,7 +403,9 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector
     // find nn for each point in the cloud
     for (const int &query_index : query_indices)
     {
-      #pragma omp parallel for
+      #pragma omp parallel for \
+        default(none) \
+        shared(distances, indices, indices_mask, input_indices, nan_mask, passed, point_cloud, radius, query_index, search_methods)
       for (int sIdx = 0; sIdx < static_cast<int> (search_methods.size ()); ++sIdx)
       {
         search_methods [sIdx]->radiusSearch (point_cloud->points[query_index], radius, indices [sIdx], distances [sIdx], 0);
@@ -401,7 +415,9 @@ testRadiusSearch (typename PointCloud<PointT>::ConstPtr point_cloud, std::vector
       }
       
       // compare results to each other
-      #pragma omp parallel for
+      #pragma omp parallel for \
+        default(none) \
+        shared(distances, indices, passed, search_methods)
       for (int sIdx = 1; sIdx < static_cast<int> (search_methods.size ()); ++sIdx)
       {
         passed [sIdx] = passed [sIdx] && compareResults (indices [0],    distances [0],    search_methods [0]->getName (),

--- a/tools/fast_bilateral_filter.cpp
+++ b/tools/fast_bilateral_filter.cpp
@@ -112,9 +112,9 @@ saveCloud (const string &filename, const pcl::PCLPointCloud2 &output,
 int
 batchProcess (const std::vector<string> &pcd_files, string &output_dir, float sigma_s, float sigma_r)
 {
-#if _OPENMP
-#pragma omp parallel for
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(output_dir, pcd_files, sigma_r, sigma_s)
   for (int i = 0; i < int (pcd_files.size ()); ++i)
   {
     // Load the first file

--- a/tools/normal_estimation.cpp
+++ b/tools/normal_estimation.cpp
@@ -131,9 +131,9 @@ saveCloud (const string &filename, const pcl::PCLPointCloud2 &output,
 int
 batchProcess (const std::vector<string> &pcd_files, string &output_dir, int k, double radius)
 {
-#if _OPENMP
-#pragma omp parallel for
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(k, output_dir, pcd_files, radius)
   for (int i = 0; i < int (pcd_files.size ()); ++i)
   {
     // Load the first file

--- a/tracking/include/pcl/tracking/impl/kld_adaptive_particle_filter_omp.hpp
+++ b/tracking/include/pcl/tracking/impl/kld_adaptive_particle_filter_omp.hpp
@@ -23,9 +23,9 @@ pcl::tracking::KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>::weight ()
 {
   if (!use_normal_)
   {
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
     for (int i = 0; i < particle_num_; i++)
       this->computeTransformedPointCloudWithoutNormal (particles_->points[i], *transed_reference_vector_[i]);
     
@@ -40,9 +40,9 @@ pcl::tracking::KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>::weight ()
         change_counter_ = change_detector_interval_;
         coherence_->setTargetCloud (coherence_input);
         coherence_->initCompute ();
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
         for (int i = 0; i < particle_num_; i++)
         {
           IndicesPtr indices;
@@ -57,9 +57,9 @@ pcl::tracking::KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>::weight ()
       --change_counter_;
       coherence_->setTargetCloud (coherence_input);
       coherence_->initCompute ();
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
       for (int i = 0; i < particle_num_; i++)
       {
         IndicesPtr indices;
@@ -74,9 +74,10 @@ pcl::tracking::KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>::weight ()
     {
       indices_list[i] = IndicesPtr (new std::vector<int>);
     }
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(indices_list) \
+  num_threads(threads_)
     for (int i = 0; i < particle_num_; i++)
     {
       this->computeTransformedPointCloudWithNormal (particles_->points[i], *indices_list[i], *transed_reference_vector_[i]);
@@ -87,9 +88,10 @@ pcl::tracking::KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>::weight ()
     
     coherence_->setTargetCloud (coherence_input);
     coherence_->initCompute ();
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(indices_list) \
+  num_threads(threads_)
     for (int i = 0; i < particle_num_; i++)
     {
       coherence_->compute (transed_reference_vector_[i], indices_list[i], particles_->points[i].weight);

--- a/tracking/include/pcl/tracking/impl/particle_filter_omp.hpp
+++ b/tracking/include/pcl/tracking/impl/particle_filter_omp.hpp
@@ -23,9 +23,9 @@ pcl::tracking::ParticleFilterOMPTracker<PointInT, StateT>::weight ()
 {
   if (!use_normal_)
   {
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
     for (int i = 0; i < particle_num_; i++)
       this->computeTransformedPointCloudWithoutNormal (particles_->points[i], *transed_reference_vector_[i]);
     
@@ -40,9 +40,9 @@ pcl::tracking::ParticleFilterOMPTracker<PointInT, StateT>::weight ()
         change_counter_ = change_detector_interval_;
         coherence_->setTargetCloud (coherence_input);
         coherence_->initCompute ();
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
         for (int i = 0; i < particle_num_; i++)
         {
           IndicesPtr indices;   // dummy
@@ -57,9 +57,9 @@ pcl::tracking::ParticleFilterOMPTracker<PointInT, StateT>::weight ()
       --change_counter_;
       coherence_->setTargetCloud (coherence_input);
       coherence_->initCompute ();
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  num_threads(threads_)
       for (int i = 0; i < particle_num_; i++)
       {
         IndicesPtr indices;     // dummy
@@ -74,9 +74,10 @@ pcl::tracking::ParticleFilterOMPTracker<PointInT, StateT>::weight ()
     {
       indices_list[i] = IndicesPtr (new std::vector<int>);
     }
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(indices_list) \
+  num_threads(threads_)
     for (int i = 0; i < particle_num_; i++)
     {
       this->computeTransformedPointCloudWithNormal (particles_->points[i], *indices_list[i], *transed_reference_vector_[i]);
@@ -87,9 +88,10 @@ pcl::tracking::ParticleFilterOMPTracker<PointInT, StateT>::weight ()
     
     coherence_->setTargetCloud (coherence_input);
     coherence_->initCompute ();
-#ifdef _OPENMP
-#pragma omp parallel for num_threads(threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(indices_list) \
+  num_threads(threads_)
     for (int i = 0; i < particle_num_; i++)
     {
       coherence_->compute (transed_reference_vector_[i], indices_list[i], particles_->points[i].weight);

--- a/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
+++ b/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
@@ -229,9 +229,11 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::downsample (const Floa
     ii[i] = 2 * i;
 
   FloatImagePtr down (new FloatImage (width, height));
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) firstprivate (ii) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(down, height, output, smoothed, width) \
+  firstprivate(ii) \
+  num_threads(threads_)
   for (int j = 0; j < height; ++j)
   {
     int jj = 2*j;
@@ -275,9 +277,10 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::convolveRows (const Fl
   int last = input->width - kernel_size_2_;
   int w = last - 1;
 
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(input, height, last, output, w, width) \
+  num_threads(threads_)
   for (int j = 0; j < height; ++j)
   {
     for (int i = kernel_size_2_; i < last; ++i)
@@ -308,9 +311,10 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::convolveCols (const Fl
   int last = input->height - kernel_size_2_;
   int h = last -1;
 
-#ifdef _OPENMP
-#pragma omp parallel for shared (output) num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(input, h, height, last, output, width) \
+  num_threads(threads_)
   for (int i = 0; i < width; ++i)
   {
     for (int j = kernel_size_2_; j < last; ++j)
@@ -340,9 +344,10 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::computePyramids (const
 
   FloatImageConstPtr previous;
   FloatImagePtr tmp (new FloatImage (input->width, input->height));
-#ifdef _OPENMP
-#pragma omp parallel for num_threads (threads_)
-#endif
+#pragma omp parallel for \
+  default(none) \
+  shared(input, tmp) \
+  num_threads(threads_)
   for (int i = 0; i < static_cast<int> (input->size ()); ++i)
     tmp->points[i] = intensity_ (input->points[i]);
   previous = tmp;


### PR DESCRIPTION
Fix warnings reported by `run-clang-tidy -header-filter='.*' -checks='-*,openmp-use-default-none'`

Some notes, whch i didn't touched here:
- I believe there are currently some bugs in PCL if OpenMP is enabled, due to wrong expectation about usage of private (see [here](http://jakascorner.com/blog/2016/06/omp-data-sharing-attributes.html)). In general I don't see any good use case for `private` if values are always uninitialized.
- `#ifdef _OPENMP` is mostly unnecessary, as [Any pragma that is not recognized is ignored.](https://en.cppreference.com/w/cpp/preprocessor/impl)
- I don't see any reason, why tests are using OpenMP. Test cases should be small enough, that spawning new threads should be more expensive than without them.
- for-ranged loops are supported only since OpenMP 5.0, so we have to decide: Use OpenMP or for-ranged loops? (maybe drop OpenMP support in general as only really few parts of PCL are using it?)