### PR TITLE
Compilation errors related to symmetric ICP objective

### DIFF
--- a/registration/include/pcl/registration/icp.h
+++ b/registration/include/pcl/registration/icp.h
@@ -41,6 +41,7 @@
 #pragma once
 
 // PCL includes
+#include <pcl/make_shared.h>
 #include <pcl/sample_consensus/ransac.h>
 #include <pcl/sample_consensus/sac_model_registration.h>
 #include <pcl/registration/registration.h>
@@ -342,9 +343,9 @@ namespace pcl
         use_symmetric_objective_ = use_symmetric_objective;
         if (use_symmetric_objective_)
         {
-            auto symmetric_transformation_estimation = std::make_shared<pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar> > ();
+            auto symmetric_transformation_estimation = pcl::make_shared<pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar> > ();
             symmetric_transformation_estimation->setEnforceSameDirectionNormals (enforce_same_direction_normals_);
-            transformation_estimation_.reset (symmetric_transformation_estimation);
+            transformation_estimation_ = symmetric_transformation_estimation;
         }
         else
         {

--- a/registration/include/pcl/registration/impl/transformation_estimation_symmetric_point_to_plane_lls.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_symmetric_point_to_plane_lls.hpp
@@ -151,8 +151,8 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCl
   {
     const Vector3 p (source_it->x, source_it->y, source_it->z);
     const Vector3 q (target_it->x, target_it->y, target_it->z);
-    const Vector3 n1 (source_it->getNormalVector3fMap());
-    const Vector3 n2 (target_it->getNormalVector3fMap());
+    const Vector3 n1 (source_it->getNormalVector3fMap().template cast<Scalar>());
+    const Vector3 n2 (target_it->getNormalVector3fMap().template cast<Scalar>());
     Vector3 n;
     if (enforce_same_direction_normals_)
     {

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -191,6 +191,17 @@ TEST (PCL, IterativeClosestPoint)
 //  EXPECT_EQ (transformation (3, 3), 1);
 }
 
+TEST (PCL, IterativeClosestPointWithNormals)
+{
+  IterativeClosestPointWithNormals<PointNormal, PointNormal, float> reg_float;
+  reg_float.setUseSymmetricObjective(true);
+  EXPECT_TRUE(reg_float.getUseSymmetricObjective());
+
+  IterativeClosestPointWithNormals<PointNormal, PointNormal, double> reg_double;
+  reg_double.setUseSymmetricObjective(true);
+  EXPECT_TRUE(reg_double.getUseSymmetricObjective());
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
 sampleRandomTransform (Eigen::Affine3f &trans, float max_angle, float max_trans)


### PR DESCRIPTION
This PR fixes the compilation error reported in #3462 and a further (unreported) error that happens when the symmetric objective is instantiated with `double` precision.

Fixes #3462.