### PR TITLE
Convert `boost::shared_ptr` to `pcl::shared_ptr`

### DIFF
--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -88,8 +88,8 @@ private:
                     float tLow);
 
 public:
-  using Ptr = boost::shared_ptr<Edge<PointInT, PointOutT>>;
-  using ConstPtr = boost::shared_ptr<const Edge<PointInT, PointOutT>>;
+  using Ptr = shared_ptr<Edge<PointInT, PointOutT>>;
+  using ConstPtr = shared_ptr<const Edge<PointInT, PointOutT>>;
 
   enum OUTPUT_TYPE {
     OUTPUT_Y,

--- a/common/include/pcl/ModelCoefficients.h
+++ b/common/include/pcl/ModelCoefficients.h
@@ -20,8 +20,8 @@ namespace pcl
     std::vector<float> values;
 
   public:
-    using Ptr = boost::shared_ptr< ::pcl::ModelCoefficients>;
-    using ConstPtr = boost::shared_ptr<const ::pcl::ModelCoefficients>;
+    using Ptr = shared_ptr< ::pcl::ModelCoefficients>;
+    using ConstPtr = shared_ptr<const ::pcl::ModelCoefficients>;
   }; // struct ModelCoefficients
 
   using ModelCoefficientsPtr = ModelCoefficients::Ptr;

--- a/common/include/pcl/PCLHeader.h
+++ b/common/include/pcl/PCLHeader.h
@@ -24,8 +24,8 @@ namespace pcl
     /** \brief Coordinate frame ID */
     std::string frame_id;
 
-    using Ptr = boost::shared_ptr<PCLHeader>;
-    using ConstPtr = boost::shared_ptr<const PCLHeader>;
+    using Ptr = shared_ptr<PCLHeader>;
+    using ConstPtr = shared_ptr<const PCLHeader>;
   }; // struct PCLHeader
 
   using HeaderPtr = PCLHeader::Ptr;

--- a/common/include/pcl/PCLImage.h
+++ b/common/include/pcl/PCLImage.h
@@ -26,8 +26,8 @@ namespace pcl
 
     std::vector<std::uint8_t> data;
 
-    using Ptr = boost::shared_ptr< ::pcl::PCLImage>;
-    using ConstPtr = boost::shared_ptr<const ::pcl::PCLImage>;
+    using Ptr = shared_ptr< ::pcl::PCLImage>;
+    using ConstPtr = shared_ptr<const ::pcl::PCLImage>;
   }; // struct PCLImage
 
   using PCLImagePtr = PCLImage::Ptr;

--- a/common/include/pcl/PCLPointCloud2.h
+++ b/common/include/pcl/PCLPointCloud2.h
@@ -35,8 +35,8 @@ namespace pcl
     std::uint8_t is_dense = 0;
 
   public:
-    using Ptr = boost::shared_ptr< ::pcl::PCLPointCloud2>;
-    using ConstPtr = boost::shared_ptr<const ::pcl::PCLPointCloud2>;
+    using Ptr = shared_ptr< ::pcl::PCLPointCloud2>;
+    using ConstPtr = shared_ptr<const ::pcl::PCLPointCloud2>;
 
     //////////////////////////////////////////////////////////////////////////
     /** \brief Inplace concatenate two pcl::PCLPointCloud2

--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 #include <ostream>
-#include <boost/shared_ptr.hpp>
 #include <pcl/pcl_macros.h>
 
 namespace pcl
@@ -30,8 +29,8 @@ namespace pcl
                            FLOAT64 = 8 };
 
   public:
-    using Ptr = boost::shared_ptr< ::pcl::PCLPointField>;
-    using ConstPtr = boost::shared_ptr<const ::pcl::PCLPointField>;
+    using Ptr = shared_ptr< ::pcl::PCLPointField>;
+    using ConstPtr = shared_ptr<const ::pcl::PCLPointField>;
   }; // struct PCLPointField
 
   using PCLPointFieldPtr = PCLPointField::Ptr;

--- a/common/include/pcl/PointIndices.h
+++ b/common/include/pcl/PointIndices.h
@@ -19,8 +19,8 @@ namespace pcl
     std::vector<int> indices;
 
     public:
-      using Ptr = boost::shared_ptr< ::pcl::PointIndices>;
-      using ConstPtr = boost::shared_ptr<const ::pcl::PointIndices>;
+      using Ptr = shared_ptr< ::pcl::PointIndices>;
+      using ConstPtr = shared_ptr<const ::pcl::PointIndices>;
   }; // struct PointIndices
 
   using PointIndicesPtr = PointIndices::Ptr;

--- a/common/include/pcl/PolygonMesh.h
+++ b/common/include/pcl/PolygonMesh.h
@@ -94,8 +94,8 @@ namespace pcl
     }
 
   public:
-    using Ptr = boost::shared_ptr< ::pcl::PolygonMesh>;
-    using ConstPtr = boost::shared_ptr<const ::pcl::PolygonMesh>;
+    using Ptr = shared_ptr< ::pcl::PolygonMesh>;
+    using ConstPtr = shared_ptr<const ::pcl::PolygonMesh>;
   }; // struct PolygonMesh
 
   using PolygonMeshPtr = PolygonMesh::Ptr;

--- a/common/include/pcl/TextureMesh.h
+++ b/common/include/pcl/TextureMesh.h
@@ -96,8 +96,8 @@ namespace pcl
     std::vector<pcl::TexMaterial>               tex_materials;    // define texture material
 
     public:
-      using Ptr = boost::shared_ptr<pcl::TextureMesh>;
-      using ConstPtr = boost::shared_ptr<const pcl::TextureMesh>;
+      using Ptr = shared_ptr<pcl::TextureMesh>;
+      using ConstPtr = shared_ptr<const pcl::TextureMesh>;
    }; // struct TextureMesh
 
    using TextureMeshPtr = TextureMesh::Ptr;

--- a/common/include/pcl/Vertices.h
+++ b/common/include/pcl/Vertices.h
@@ -19,8 +19,8 @@ namespace pcl
     std::vector<std::uint32_t> vertices;
 
   public:
-    using Ptr = boost::shared_ptr<Vertices>;
-    using ConstPtr = boost::shared_ptr<const Vertices>;
+    using Ptr = shared_ptr<Vertices>;
+    using ConstPtr = shared_ptr<const Vertices>;
   }; // struct Vertices
 
 

--- a/common/include/pcl/correspondence.h
+++ b/common/include/pcl/correspondence.h
@@ -42,7 +42,7 @@
 #pragma GCC system_header 
 #endif
 
-#include <boost/shared_ptr.hpp>
+#include <pcl/make_shared.h>
 #include <Eigen/StdVector>
 #include <Eigen/Geometry>
 #include <pcl/pcl_exports.h>
@@ -86,8 +86,8 @@ namespace pcl
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const Correspondence& c);
 
   using Correspondences = std::vector< pcl::Correspondence, Eigen::aligned_allocator<pcl::Correspondence> >;
-  using CorrespondencesPtr = boost::shared_ptr<Correspondences>;
-  using CorrespondencesConstPtr = boost::shared_ptr<const Correspondences >;
+  using CorrespondencesPtr = shared_ptr<Correspondences>;
+  using CorrespondencesConstPtr = shared_ptr<const Correspondences >;
 
   /**
     * \brief Get the query points of correspondences that are present in

--- a/common/include/pcl/make_shared.h
+++ b/common/include/pcl/make_shared.h
@@ -53,30 +53,30 @@ namespace pcl
 #ifdef DOXYGEN_ONLY
 
 /**
- * \brief Returns a boost::shared_ptr compliant with type T's allocation policy.
+ * \brief Returns a pcl::shared_ptr compliant with type T's allocation policy.
  *
  * boost::allocate_shared or boost::make_shared will be invoked in case T has or
  * doesn't have a custom allocator, respectively.
  *
  * \see pcl::has_custom_allocator, PCL_MAKE_ALIGNED_OPERATOR_NEW
- * \tparam T Type of the object to create a boost::shared_ptr of
+ * \tparam T Type of the object to create a pcl::shared_ptr of
  * \tparam Args Types for the arguments to pcl::make_shared
  * \param args List of arguments with which an instance of T will be constructed
- * \return boost::shared_ptr of an instance of type T
+ * \return pcl::shared_ptr of an instance of type T
  */
 template<typename T, typename ... Args>
-boost::shared_ptr<T> make_shared(Args&&... args);
+shared_ptr<T> make_shared(Args&&... args);
 
 #else
 
 template<typename T, typename ... Args>
-std::enable_if_t<has_custom_allocator<T>::value, boost::shared_ptr<T>> make_shared(Args&&... args)
+std::enable_if_t<has_custom_allocator<T>::value, shared_ptr<T>> make_shared(Args&&... args)
 {
   return boost::allocate_shared<T>(Eigen::aligned_allocator<T>(), std::forward<Args> (args)...);
 }
 
 template<typename T, typename ... Args>
-std::enable_if_t<!has_custom_allocator<T>::value, boost::shared_ptr<T>> make_shared(Args&&... args)
+std::enable_if_t<!has_custom_allocator<T>::value, shared_ptr<T>> make_shared(Args&&... args)
 {
   return boost::make_shared<T>(std::forward<Args> (args)...);
 }

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -58,8 +58,8 @@ namespace pcl
 {
   // definitions used everywhere
   using Indices = std::vector<int>;
-  using IndicesPtr = boost::shared_ptr<Indices>;
-  using IndicesConstPtr = boost::shared_ptr<const Indices>;
+  using IndicesPtr = shared_ptr<Indices>;
+  using IndicesConstPtr = shared_ptr<const Indices>;
 
   /////////////////////////////////////////////////////////////////////////////////////////
   /** \brief PCL base class. Implements methods that are used by most PCL algorithms.

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -66,6 +66,7 @@
 #include <iostream>
 
 #include <boost/cstdint.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
 
 //Eigen has an enum that clashes with X11 Success define, which is ultimately included by pcl
 #ifdef Success
@@ -77,6 +78,17 @@
 
 namespace pcl
 {
+  /**
+   * \brief Alias for boost::shared_ptr
+   *
+   * For ease of switching from boost::shared_ptr to std::shared_ptr
+   *
+   * \see pcl::make_shared
+   * \tparam T Type of the object stored inside the shared_ptr
+   */
+  template <typename T>
+  using shared_ptr = boost::shared_ptr<T>;
+
   using uint8_t [[deprecated("use std::uint8_t instead of pcl::uint8_t")]] = std::uint8_t;
   using int8_t [[deprecated("use std::int8_t instead of pcl::int8_t")]] = std::int8_t;
   using uint16_t [[deprecated("use std::uint16_t instead of pcl::uint16_t")]] = std::uint16_t;

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -49,7 +49,7 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/point_traits.h>
 
-#include <boost/shared_ptr.hpp>
+#include <pcl/make_shared.h>
 
 #include <algorithm>
 #include <utility>
@@ -139,7 +139,7 @@ namespace pcl
   {
     template <typename PointT>
     [[deprecated("use createMapping() instead")]]
-    boost::shared_ptr<pcl::MsgFieldMap>&
+    shared_ptr<pcl::MsgFieldMap>&
     getMapping (pcl::PointCloud<PointT>& p);
   } // namespace detail
 
@@ -412,8 +412,8 @@ namespace pcl
       using PointType = PointT;  // Make the template class available from the outside
       using VectorType = std::vector<PointT, Eigen::aligned_allocator<PointT> >;
       using CloudVectorType = std::vector<PointCloud<PointT>, Eigen::aligned_allocator<PointCloud<PointT> > >;
-      using Ptr = boost::shared_ptr<PointCloud<PointT> >;
-      using ConstPtr = boost::shared_ptr<const PointCloud<PointT> >;
+      using Ptr = shared_ptr<PointCloud<PointT> >;
+      using ConstPtr = shared_ptr<const PointCloud<PointT> >;
 
       // std container compatibility typedefs according to
       // http://en.cppreference.com/w/cpp/concept/Container
@@ -606,9 +606,9 @@ namespace pcl
 
     protected:
       // This is motivated by ROS integration. Users should not need to access mapping_.
-      [[deprecated("rewrite your code to avoid using this protected field")]] boost::shared_ptr<MsgFieldMap> mapping_;
+      [[deprecated("rewrite your code to avoid using this protected field")]] shared_ptr<MsgFieldMap> mapping_;
 
-      friend boost::shared_ptr<MsgFieldMap>& detail::getMapping<PointT>(pcl::PointCloud<PointT> &p);
+      friend shared_ptr<MsgFieldMap>& detail::getMapping<PointT>(pcl::PointCloud<PointT> &p);
 
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW
@@ -616,7 +616,7 @@ namespace pcl
 
   namespace detail
   {
-    template <typename PointT> boost::shared_ptr<pcl::MsgFieldMap>&
+    template <typename PointT> shared_ptr<pcl::MsgFieldMap>&
     getMapping (pcl::PointCloud<PointT>& p)
     {
       return (p.mapping_);

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -73,8 +73,8 @@ namespace pcl
       bool trivial_ = false;
 
     public:
-      using Ptr = boost::shared_ptr<PointRepresentation<PointT> >;
-      using ConstPtr = boost::shared_ptr<const PointRepresentation<PointT> >;
+      using Ptr = shared_ptr<PointRepresentation<PointT> >;
+      using ConstPtr = shared_ptr<const PointRepresentation<PointT> >;
 
       /** \brief Empty destructor */
       virtual ~PointRepresentation () = default;
@@ -181,8 +181,8 @@ namespace pcl
 
     public:
       // Boost shared pointers
-      using Ptr = boost::shared_ptr<DefaultPointRepresentation<PointDefault> >;
-      using ConstPtr = boost::shared_ptr<const DefaultPointRepresentation<PointDefault> >;
+      using Ptr = shared_ptr<DefaultPointRepresentation<PointDefault> >;
+      using ConstPtr = shared_ptr<const DefaultPointRepresentation<PointDefault> >;
 
       DefaultPointRepresentation ()
       {
@@ -288,8 +288,8 @@ namespace pcl
 
     public:
       // Boost shared pointers
-      using Ptr = boost::shared_ptr<DefaultFeatureRepresentation<PointDefault>>;
-      using ConstPtr = boost::shared_ptr<const DefaultFeatureRepresentation<PointDefault>>;
+      using Ptr = shared_ptr<DefaultFeatureRepresentation<PointDefault>>;
+      using ConstPtr = shared_ptr<const DefaultFeatureRepresentation<PointDefault>>;
       using FieldList = typename pcl::traits::fieldList<PointDefault>::type;
 
       DefaultFeatureRepresentation ()
@@ -534,8 +534,8 @@ namespace pcl
 
     public:
       // Boost shared pointers
-      using Ptr = boost::shared_ptr<CustomPointRepresentation<PointDefault> >;
-      using ConstPtr = boost::shared_ptr<const CustomPointRepresentation<PointDefault> >;
+      using Ptr = shared_ptr<CustomPointRepresentation<PointDefault> >;
+      using ConstPtr = shared_ptr<const CustomPointRepresentation<PointDefault> >;
 
       /** \brief Constructor
         * \param[in] max_dim the maximum number of dimensions to use

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -57,8 +57,8 @@ namespace pcl
       // =====TYPEDEFS=====
       using BaseClass = pcl::PointCloud<PointWithRange>;
       using VectorOfEigenVector3f = std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f> >;
-      using Ptr = boost::shared_ptr<RangeImage>;
-      using ConstPtr = boost::shared_ptr<const RangeImage>;
+      using Ptr = shared_ptr<RangeImage>;
+      using ConstPtr = shared_ptr<const RangeImage>;
       
       enum CoordinateFrame
       {

--- a/common/include/pcl/range_image/range_image_planar.h
+++ b/common/include/pcl/range_image/range_image_planar.h
@@ -53,8 +53,8 @@ namespace pcl
     public:
       // =====TYPEDEFS=====
       using BaseClass = RangeImage;
-      using Ptr = boost::shared_ptr<RangeImagePlanar>;
-      using ConstPtr = boost::shared_ptr<const RangeImagePlanar>;
+      using Ptr = shared_ptr<RangeImagePlanar>;
+      using ConstPtr = shared_ptr<const RangeImagePlanar>;
       
       // =====CONSTRUCTOR & DESTRUCTOR=====
       /** Constructor */

--- a/common/include/pcl/range_image/range_image_spherical.h
+++ b/common/include/pcl/range_image/range_image_spherical.h
@@ -52,8 +52,8 @@ namespace pcl
     public:
       // =====TYPEDEFS=====
       using BaseClass = RangeImage;
-      using Ptr = boost::shared_ptr<RangeImageSpherical>;
-      using ConstPtr = boost::shared_ptr<const RangeImageSpherical>;
+      using Ptr = shared_ptr<RangeImageSpherical>;
+      using ConstPtr = shared_ptr<const RangeImageSpherical>;
 
       // =====CONSTRUCTOR & DESTRUCTOR=====
       /** Constructor */

--- a/cuda/apps/src/kinect_normals_cuda.cpp
+++ b/cuda/apps/src/kinect_normals_cuda.cpp
@@ -120,7 +120,7 @@ class NormalEstimation
 
       // we got a cloud in device..
 
-      boost::shared_ptr<typename Storage<float4>::type> normals;
+      shared_ptr<typename Storage<float4>::type> normals;
       {
         ScopeTimeCPU time ("Normal Estimation");
         float focallength = 580/2.0;
@@ -164,7 +164,7 @@ class NormalEstimation
       d2c.compute<Storage> (depth_image, image, constant, data, false, 1, smoothing_nr_iterations, smoothing_filter_size);
       //d2c.compute<Storage> (depth_image, image, constant, data, true, 2);
 
-      boost::shared_ptr<typename Storage<float4>::type> normals;      
+      shared_ptr<typename Storage<float4>::type> normals;      
       {
         ScopeTimeCPU time ("Normal Estimation");
         normals = computeFastPointNormals<Storage> (data);

--- a/cuda/apps/src/kinect_planes_cuda.cpp
+++ b/cuda/apps/src/kinect_planes_cuda.cpp
@@ -145,7 +145,7 @@ class MultiRansac
       d2c.compute<Storage> (depth_image, image, constant, data, true, 2, smoothing_nr_iterations, smoothing_filter_size);
 
       // Compute normals
-      boost::shared_ptr<typename Storage<float4>::type> normals;
+      shared_ptr<typename Storage<float4>::type> normals;
       {
         ScopeTimeCPU time ("Normal Estimation");
         //normals = computeFastPointNormals<Storage> (data);

--- a/cuda/apps/src/kinect_segmentation_cuda.cpp
+++ b/cuda/apps/src/kinect_segmentation_cuda.cpp
@@ -167,7 +167,7 @@ class Segmentation
 
       // we got a cloud in device..
 
-      boost::shared_ptr<typename Storage<float4>::type> normals;
+      shared_ptr<typename Storage<float4>::type> normals;
       {
         ScopeTimeCPU time ("Normal Estimation");
         constexpr float focallength = 580/2.0;
@@ -214,7 +214,7 @@ class Segmentation
         d2c.compute<Storage> (depth_image, image, constant, data, false, 1, smoothing_nr_iterations, smoothing_filter_size);
       }
 
-      boost::shared_ptr<typename Storage<float4>::type> normals;      
+      shared_ptr<typename Storage<float4>::type> normals;      
       {
         ScopeTimeCPU time ("Normal Estimation");
         if (normal_method == 1)

--- a/cuda/apps/src/kinect_segmentation_planes_cuda.cpp
+++ b/cuda/apps/src/kinect_segmentation_planes_cuda.cpp
@@ -141,7 +141,7 @@ class Segmentation
 
       // we got a cloud in device..
 
-      boost::shared_ptr<typename Storage<float4>::type> normals;      
+      shared_ptr<typename Storage<float4>::type> normals;      
       {
         ScopeTimeCPU time ("TIMING: Normal Estimation");
         constexpr float focallength = 580/2.0;
@@ -178,7 +178,7 @@ class Segmentation
       // Compute the PointCloud on the device
       d2c.compute<Storage> (depth_image, image, constant, data, true, 2);
 
-      boost::shared_ptr<typename Storage<float4>::type> normals;
+      shared_ptr<typename Storage<float4>::type> normals;
       {
         ScopeTimeCPU time ("TIMING: Normal Estimation");
         normals = computeFastPointNormals<Storage> (data);

--- a/cuda/common/include/pcl/cuda/point_cloud.h
+++ b/cuda/common/include/pcl/cuda/point_cloud.h
@@ -196,8 +196,8 @@ namespace pcl
         /** \brief True if no points are invalid (e.g., have NaN or Inf values). */
         bool is_dense;
   
-        using Ptr = boost::shared_ptr<PointCloudAOS<Storage> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudAOS<Storage> >;
+        using Ptr = shared_ptr<PointCloudAOS<Storage> >;
+        using ConstPtr = shared_ptr<const PointCloudAOS<Storage> >;
     };
   
     /** @b PointCloudSOA represents a SOA (Struct of Arrays) PointCloud
@@ -277,8 +277,8 @@ namespace pcl
         /** \brief True if no points are invalid (e.g., have NaN or Inf values). */
         bool is_dense;
   
-        using Ptr = boost::shared_ptr<PointCloudSOA<Storage> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudSOA<Storage> >;
+        using Ptr = shared_ptr<PointCloudSOA<Storage> >;
+        using ConstPtr = shared_ptr<const PointCloudSOA<Storage> >;
   
         //////////////////////////////////////////////////////////////////////////////////////
         // Extras. Testing ZIP iterators

--- a/cuda/features/include/pcl/cuda/features/normal_3d.h
+++ b/cuda/features/include/pcl/cuda/features/normal_3d.h
@@ -51,20 +51,20 @@ namespace pcl
       void computePointNormals (InputIteratorT begin, InputIteratorT end, OutputIteratorT output, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors);
   
     template <template <typename> class Storage, typename InputIteratorT>
-      boost::shared_ptr<typename Storage<float4>::type> computePointNormals (InputIteratorT begin, InputIteratorT end, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors);
+      shared_ptr<typename Storage<float4>::type> computePointNormals (InputIteratorT begin, InputIteratorT end, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors);
 
     // fast normal computations
     template <typename OutputIteratorT, template <typename> class Storage>
       void computeFastPointNormals (OutputIteratorT output, const typename PointCloudAOS<Storage>::ConstPtr &input);
   
     template <template <typename> class Storage>
-      boost::shared_ptr<typename Storage<float4>::type> computeFastPointNormals (const typename PointCloudAOS<Storage>::ConstPtr &input);
+      shared_ptr<typename Storage<float4>::type> computeFastPointNormals (const typename PointCloudAOS<Storage>::ConstPtr &input);
 
     // Weird normal estimation (normal deviations - more of an art project..)
     template <typename InputIteratorT, typename OutputIteratorT, template <typename> class Storage>
       void computeWeirdPointNormals (InputIteratorT begin, InputIteratorT end, OutputIteratorT output, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors);
   
     template <template <typename> class Storage, typename InputIteratorT>
-      boost::shared_ptr<typename Storage<float4>::type> computeWeirdPointNormals (InputIteratorT begin, InputIteratorT end, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors);
+      shared_ptr<typename Storage<float4>::type> computeWeirdPointNormals (InputIteratorT begin, InputIteratorT end, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors);
   } // namespace
 } // namespace

--- a/cuda/features/src/normal_3d.cu
+++ b/cuda/features/src/normal_3d.cu
@@ -50,10 +50,10 @@ namespace pcl
     }
   
     template <template <typename> class Storage, typename InputIteratorT>
-      boost::shared_ptr<typename Storage<float4>::type> computePointNormals (InputIteratorT begin, InputIteratorT end, 
-          float focallength, const boost::shared_ptr <const PointCloudAOS <Storage> > &input, float radius, int desired_number_neighbors)
+      shared_ptr<typename Storage<float4>::type> computePointNormals (InputIteratorT begin, InputIteratorT end, 
+          float focallength, const shared_ptr <const PointCloudAOS <Storage> > &input, float radius, int desired_number_neighbors)
     {
-      boost::shared_ptr<typename Storage<float4>::type> normals (new typename Storage<float4>::type);
+      shared_ptr<typename Storage<float4>::type> normals (new typename Storage<float4>::type);
       normals->resize (end - begin);
       computePointNormals<InputIteratorT, typename Storage<float4>::type::iterator, Storage> (begin, end, normals->begin(), focallength, input, radius, desired_number_neighbors);
       return normals;
@@ -67,9 +67,9 @@ namespace pcl
     }
 
     template <template <typename> class Storage>
-      boost::shared_ptr<typename Storage<float4>::type> computeFastPointNormals (const typename PointCloudAOS<Storage>::ConstPtr &input)
+      shared_ptr<typename Storage<float4>::type> computeFastPointNormals (const typename PointCloudAOS<Storage>::ConstPtr &input)
     {
-      boost::shared_ptr<typename Storage<float4>::type> normals (new typename Storage<float4>::type);
+      shared_ptr<typename Storage<float4>::type> normals (new typename Storage<float4>::type);
       normals->resize (input->points.size());
       computeFastPointNormals<typename Storage<float4>::type::iterator, Storage> (normals->begin(), input);
       return normals;
@@ -88,9 +88,9 @@ namespace pcl
     }
   
     template <template <typename> class Storage, typename InputIteratorT>
-      boost::shared_ptr<typename Storage<float4>::type> computeWeirdPointNormals (InputIteratorT begin, InputIteratorT end, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors)
+      shared_ptr<typename Storage<float4>::type> computeWeirdPointNormals (InputIteratorT begin, InputIteratorT end, float focallength, const typename PointCloudAOS<Storage>::ConstPtr &input, float radius, int desired_number_neighbors)
     {
-      boost::shared_ptr<typename Storage<float4>::type> normals (new typename Storage<float4>::type);
+      shared_ptr<typename Storage<float4>::type> normals (new typename Storage<float4>::type);
       normals->resize (end - begin);
       computeWeirdPointNormals<InputIteratorT, typename Storage<float4>::type::iterator, Storage> (begin, end, normals->begin(), focallength, input, radius, desired_number_neighbors);
       return normals;
@@ -116,7 +116,7 @@ namespace pcl
                    float radius,
                    int desired_number_neighbors);
     
-    template PCL_EXPORTS boost::shared_ptr<typename Device<float4>::type> computePointNormals<Device, typename PointIterator<Device,PointXYZRGB>::type >
+    template PCL_EXPORTS shared_ptr<typename Device<float4>::type> computePointNormals<Device, typename PointIterator<Device,PointXYZRGB>::type >
                   (PointIterator<Device,PointXYZRGB>::type begin,
                    PointIterator<Device,PointXYZRGB>::type end,
                    float focallength,
@@ -124,7 +124,7 @@ namespace pcl
                    float radius,
                    int desired_number_neighbors);
     
-    template PCL_EXPORTS boost::shared_ptr<typename Host<float4>::type> computePointNormals<Host, typename PointIterator<Host,PointXYZRGB>::type >
+    template PCL_EXPORTS shared_ptr<typename Host<float4>::type> computePointNormals<Host, typename PointIterator<Host,PointXYZRGB>::type >
                   (PointIterator<Host,PointXYZRGB>::type begin,
                    PointIterator<Host,PointXYZRGB>::type end,
                    float focallength,
@@ -141,10 +141,10 @@ namespace pcl
                   (Host<float4>::type::iterator output,
                    const PointCloudAOS<Host>::ConstPtr &input);
     
-    template PCL_EXPORTS boost::shared_ptr<typename Device<float4>::type> computeFastPointNormals<Device>
+    template PCL_EXPORTS shared_ptr<typename Device<float4>::type> computeFastPointNormals<Device>
                   (const PointCloudAOS<Device>::ConstPtr &input);
     
-    template PCL_EXPORTS boost::shared_ptr<typename Host<float4>::type> computeFastPointNormals<Host>
+    template PCL_EXPORTS shared_ptr<typename Host<float4>::type> computeFastPointNormals<Host>
                   (const PointCloudAOS<Host>::ConstPtr &input);
 
     // Aaaand, a couple of instantiations
@@ -166,7 +166,7 @@ namespace pcl
                    float radius,
                    int desired_number_neighbors);
     
-    template PCL_EXPORTS boost::shared_ptr<typename Device<float4>::type> computeWeirdPointNormals<Device, typename PointIterator<Device,PointXYZRGB>::type >
+    template PCL_EXPORTS shared_ptr<typename Device<float4>::type> computeWeirdPointNormals<Device, typename PointIterator<Device,PointXYZRGB>::type >
                   (PointIterator<Device,PointXYZRGB>::type begin,
                    PointIterator<Device,PointXYZRGB>::type end,
                    float focallength,
@@ -174,7 +174,7 @@ namespace pcl
                    float radius,
                    int desired_number_neighbors);
     
-    template PCL_EXPORTS boost::shared_ptr<typename Host<float4>::type> computeWeirdPointNormals<Host, typename PointIterator<Host,PointXYZRGB>::type >
+    template PCL_EXPORTS shared_ptr<typename Host<float4>::type> computeWeirdPointNormals<Host, typename PointIterator<Host,PointXYZRGB>::type >
                   (PointIterator<Host,PointXYZRGB>::type begin,
                    PointIterator<Host,PointXYZRGB>::type end,
                    float focallength,

--- a/cuda/io/include/pcl/cuda/io/extract_indices.h
+++ b/cuda/io/include/pcl/cuda/io/extract_indices.h
@@ -44,9 +44,9 @@ namespace pcl
 namespace cuda
 {
   template <template <typename> class Storage, class DataT, class MaskT>
-  void extractMask (const boost::shared_ptr<typename Storage<DataT>::type> &input,
+  void extractMask (const shared_ptr<typename Storage<DataT>::type> &input,
                           MaskT* mask, 
-                          boost::shared_ptr<typename Storage<DataT>::type> &output);
+                          shared_ptr<typename Storage<DataT>::type> &output);
   template <template <typename> class Storage, class T>
   void extractMask (const typename PointCloudAOS<Storage>::Ptr &input,
                           T* mask, 
@@ -73,7 +73,7 @@ namespace cuda
                        typename PointCloudAOS<Storage>::Ptr &output, const OpenNIRGB& color);
   template <template <typename> class Storage>
   void colorIndices  (typename PointCloudAOS<Storage>::Ptr &input,
-                       boost::shared_ptr<typename Storage<int>::type> indices, 
+                       shared_ptr<typename Storage<int>::type> indices, 
                        const OpenNIRGB& color);
   template <template <typename> class Storage>
   void colorCloud  (typename PointCloudAOS<Storage>::Ptr &input,

--- a/cuda/io/src/extract_indices.cu
+++ b/cuda/io/src/extract_indices.cu
@@ -69,9 +69,9 @@ void extractMask (const typename PointCloudAOS<Storage>::Ptr &input,
 }
 
 template <template <typename> class Storage, class DataT, class MaskT>
-void extractMask (const boost::shared_ptr<typename Storage<DataT>::type> &input,
+void extractMask (const shared_ptr<typename Storage<DataT>::type> &input,
                         MaskT* mask, 
-                        boost::shared_ptr<typename Storage<DataT>::type> &output)
+                        shared_ptr<typename Storage<DataT>::type> &output)
 {
   if (!output)
     output.reset (new typename Storage<DataT>::type);
@@ -142,7 +142,7 @@ void removeIndices  (const typename PointCloudAOS<Storage>::Ptr &input,
 
 template <template <typename> class Storage>
 void colorIndices  (typename PointCloudAOS<Storage>::Ptr &input,
-               boost::shared_ptr<typename Storage<int>::type> indices, 
+               shared_ptr<typename Storage<int>::type> indices, 
                const OpenNIRGB& color)
 {
   thrust::transform_if (input->points.begin (), input->points.end (), indices->begin (), input->points.begin (), ChangeColor (color), isInlier());
@@ -206,10 +206,10 @@ template PCL_EXPORTS void removeIndices<Device> (const PointCloudAOS<Device>::Pt
                                                           PointCloudAOS<Device>::Ptr &output, const OpenNIRGB& color);
 
 template PCL_EXPORTS void colorIndices<Host> (PointCloudAOS<Host>::Ptr &input,
-                                                       boost::shared_ptr<Host<int>::type> indices, 
+                                                       shared_ptr<Host<int>::type> indices, 
                                                        const OpenNIRGB& color);
 template PCL_EXPORTS void colorIndices<Device> (PointCloudAOS<Device>::Ptr &input,
-                                                          boost::shared_ptr<Device<int>::type> indices, 
+                                                          shared_ptr<Device<int>::type> indices, 
                                                           const OpenNIRGB& color);
 template PCL_EXPORTS void colorCloud<Host>  (PointCloudAOS<Host>::Ptr &input, Host<char4>::type &colors);
 template PCL_EXPORTS void colorCloud<Device>(PointCloudAOS<Device>::Ptr &input, Device<char4>::type &colors);
@@ -219,13 +219,13 @@ void extractMask<Device,unsigned char> (const PointCloudAOS<Device>::Ptr &input,
 template PCL_EXPORTS 
 void extractMask<Host,unsigned char> (const PointCloudAOS<Host>::Ptr &input, unsigned char* mask, PointCloudAOS<Host>::Ptr &output);
 template PCL_EXPORTS
-void extractMask<Device,float4,unsigned char> (const boost::shared_ptr<Device<float4>::type> &input,
+void extractMask<Device,float4,unsigned char> (const shared_ptr<Device<float4>::type> &input,
                         unsigned char* mask, 
-                        boost::shared_ptr<Device<float4>::type> &output);
+                        shared_ptr<Device<float4>::type> &output);
 template PCL_EXPORTS
-void extractMask<Host,float4,unsigned char> (const boost::shared_ptr<Host<float4>::type> &input,
+void extractMask<Host,float4,unsigned char> (const shared_ptr<Host<float4>::type> &input,
                         unsigned char* mask, 
-                        boost::shared_ptr<Host<float4>::type> &output);
+                        shared_ptr<Host<float4>::type> &output);
 
 } // namespace
 } // namespace

--- a/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac.h
+++ b/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac.h
@@ -62,11 +62,11 @@ namespace pcl
 
       public:
         using Coefficients = typename Storage<float>::type;
-        using CoefficientsPtr = boost::shared_ptr <Coefficients>;
-        using CoefficientsConstPtr = boost::shared_ptr <const Coefficients>;
+        using CoefficientsPtr = shared_ptr <Coefficients>;
+        using CoefficientsConstPtr = shared_ptr <const Coefficients>;
 
-        using Ptr = boost::shared_ptr<SampleConsensus>;
-        using ConstPtr = boost::shared_ptr<const SampleConsensus>;
+        using Ptr = shared_ptr<SampleConsensus>;
+        using ConstPtr = shared_ptr<const SampleConsensus>;
 
         /** \brief Constructor for base SAC.
           * \param model a Sample Consensus model

--- a/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model.h
+++ b/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model.h
@@ -91,16 +91,16 @@ namespace pcl
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<SampleConsensusModel>;
-        using ConstPtr = boost::shared_ptr<const SampleConsensusModel>;
+        using Ptr = shared_ptr<SampleConsensusModel>;
+        using ConstPtr = shared_ptr<const SampleConsensusModel>;
 
         using Indices = typename Storage<int>::type;
-        using IndicesPtr = boost::shared_ptr<typename Storage<int>::type>;
-        using IndicesConstPtr = boost::shared_ptr<const typename Storage<int>::type>;
+        using IndicesPtr = shared_ptr<typename Storage<int>::type>;
+        using IndicesConstPtr = shared_ptr<const typename Storage<int>::type>;
 
         using Coefficients = typename Storage<float>::type;
-        using CoefficientsPtr = boost::shared_ptr <Coefficients>;
-        using CoefficientsConstPtr = boost::shared_ptr <const Coefficients>;
+        using CoefficientsPtr = shared_ptr <Coefficients>;
+        using CoefficientsConstPtr = shared_ptr <const Coefficients>;
 
         using Hypotheses = typename Storage<float4>::type;
         //TODO: should be std::vector<int> instead of int. but currently, only 1point plane model supports this
@@ -331,11 +331,11 @@ namespace pcl
 
   //      friend class ProgressiveSampleConsensus<PointT>;
 
-        inline boost::shared_ptr<typename Storage<float4>::type>
+        inline shared_ptr<typename Storage<float4>::type>
         getNormals () { return (normals_); }
 
         inline
-          void setNormals (boost::shared_ptr<typename Storage<float4>::type> normals) { normals_ = normals; }
+          void setNormals (shared_ptr<typename Storage<float4>::type> normals) { normals_ = normals; }
 
 
       protected:
@@ -347,7 +347,7 @@ namespace pcl
 
         /** \brief A boost shared pointer to the point cloud data array. */
         PointCloudConstPtr input_;
-        boost::shared_ptr<typename Storage<float4>::type> normals_;
+        shared_ptr<typename Storage<float4>::type> normals_;
 
         /** \brief A pointer to the vector of point indices to use. */
         IndicesPtr indices_;
@@ -375,8 +375,8 @@ namespace pcl
   //      using PointCloudNConstPtr = typename pcl::PointCloud<PointNT>::ConstPtr;
   //      using PointCloudNPtr = typename pcl::PointCloud<PointNT>::Ptr;
   //
-  //      using Ptr = boost::shared_ptr<SampleConsensusModelFromNormals>;
-  //      using ConstPtr = boost::shared_ptr<const SampleConsensusModelFromNormals>;
+  //      using Ptr = shared_ptr<SampleConsensusModelFromNormals>;
+  //      using ConstPtr = shared_ptr<const SampleConsensusModelFromNormals>;
   //
   //      /* \brief Empty constructor for base SampleConsensusModelFromNormals. */
   //      SampleConsensusModelFromNormals () : normal_distance_weight_ (0.0) {};

--- a/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model_1point_plane.h
+++ b/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model_1point_plane.h
@@ -176,8 +176,8 @@ namespace pcl
         using Samples = typename SampleConsensusModel<Storage>::Samples;
 
 
-        using Ptr = boost::shared_ptr<SampleConsensusModel1PointPlane>;
-        using ConstPtr = boost::shared_ptr<const SampleConsensusModel1PointPlane>;
+        using Ptr = shared_ptr<SampleConsensusModel1PointPlane>;
+        using ConstPtr = shared_ptr<const SampleConsensusModel1PointPlane>;
 
         /** \brief Constructor for base SampleConsensusModel1PointPlane.
           * \param cloud the input point cloud dataset

--- a/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model_plane.h
+++ b/cuda/sample_consensus/include/pcl/cuda/sample_consensus/sac_model_plane.h
@@ -96,8 +96,8 @@ namespace pcl
         using Hypotheses = typename SampleConsensusModel<Storage>::Hypotheses;
         using Samples = typename SampleConsensusModel<Storage>::Samples;
 
-        using Ptr = boost::shared_ptr<SampleConsensusModelPlane>;
-        using ConstPtr = boost::shared_ptr<const SampleConsensusModelPlane>;
+        using Ptr = shared_ptr<SampleConsensusModelPlane>;
+        using ConstPtr = shared_ptr<const SampleConsensusModelPlane>;
 
         /** \brief Constructor for base SampleConsensusModelPlane.
           * \param cloud the input point cloud dataset

--- a/cuda/segmentation/include/pcl/cuda/segmentation/connected_components.h
+++ b/cuda/segmentation/include/pcl/cuda/segmentation/connected_components.h
@@ -51,7 +51,7 @@ namespace pcl
     void createNormalsImage (const OutT &dst, InT &normals);
 
     template <template <typename> class Storage>
-    void markInliers (const typename PointCloudAOS<Storage>::ConstPtr &input, typename Storage<int>::type &region_mask, std::vector<boost::shared_ptr<typename Storage<int>::type> > inlier_stencils);
+    void markInliers (const typename PointCloudAOS<Storage>::ConstPtr &input, typename Storage<int>::type &region_mask, std::vector<shared_ptr<typename Storage<int>::type> > inlier_stencils);
 
     template <template <typename> class Storage>
     std::vector<typename Storage<int>::type> createRegionStencils (typename Storage<int>::type &parent, typename Storage<int>::type &rank, typename Storage<int>::type &size, int min_size, float percentage);

--- a/cuda/segmentation/src/connected_components.cu
+++ b/cuda/segmentation/src/connected_components.cu
@@ -82,7 +82,7 @@ namespace pcl
 
 
     template <template <typename> class Storage>
-    void markInliers (const typename PointCloudAOS<Storage>::ConstPtr &input, typename Storage<int>::type &region_mask, std::vector<boost::shared_ptr<typename Storage<int>::type> > inlier_stencils)
+    void markInliers (const typename PointCloudAOS<Storage>::ConstPtr &input, typename Storage<int>::type &region_mask, std::vector<shared_ptr<typename Storage<int>::type> > inlier_stencils)
     {
       region_mask.resize (input->points.size());
       //int** stencils = new int*[inlier_stencils.size()];
@@ -175,8 +175,8 @@ namespace pcl
     }
 
 
-    template PCL_EXPORTS void markInliers<Device> (const typename PointCloudAOS<Device>::ConstPtr &input, Device<int>::type &region_mask, std::vector<boost::shared_ptr<Device<int>::type> > inlier_stencils);
-    template PCL_EXPORTS void markInliers<Host>   (const typename PointCloudAOS<Host>  ::ConstPtr &input, Host<int>::type &region_mask, std::vector<boost::shared_ptr<Host<int>::type> > inlier_stencils);
+    template PCL_EXPORTS void markInliers<Device> (const typename PointCloudAOS<Device>::ConstPtr &input, Device<int>::type &region_mask, std::vector<shared_ptr<Device<int>::type> > inlier_stencils);
+    template PCL_EXPORTS void markInliers<Host>   (const typename PointCloudAOS<Host>  ::ConstPtr &input, Host<int>::type &region_mask, std::vector<shared_ptr<Host<int>::type> > inlier_stencils);
 
 
     template PCL_EXPORTS void createIndicesImage<Device,

--- a/doc/tutorials/content/how_features_work.rst
+++ b/doc/tutorials/content/how_features_work.rst
@@ -54,13 +54,13 @@ the table below for a reference on each of the terms used.
 +=============+================================================+
 | Foo         | a class named `Foo`                            |
 +-------------+------------------------------------------------+
-| FooPtr      | a boost shared pointer to a class `Foo`,       |
+| FooPtr      | a shared pointer to a class `Foo`,       |
 |             |                                                | 
-|             | e.g., `boost::shared_ptr<Foo>`                 |
+|             | e.g., `shared_ptr<Foo>`                 |
 +-------------+------------------------------------------------+
-| FooConstPtr | a const boost shared pointer to a class `Foo`, |
+| FooConstPtr | a const shared pointer to a class `Foo`, |
 |             |                                                |
-|             | e.g., `const boost::shared_ptr<const Foo>`     |
+|             | e.g., `const shared_ptr<const Foo>`     |
 +-------------+------------------------------------------------+
 
 How to pass the input
@@ -168,7 +168,7 @@ The following code snippet will estimate a set of surface normals for a subset o
      ne.setInputCloud (cloud);
 
      // Pass the indices
-     boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
+     pcl::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
      ne.setIndices (indicesptr);
 
      // Create an empty kdtree representation, and pass it to the normal estimation object. 

--- a/doc/tutorials/content/mobile_streaming.rst
+++ b/doc/tutorials/content/mobile_streaming.rst
@@ -138,7 +138,7 @@ socket to the client:
 
     struct PointCloudBuffers
     {
-      typedef boost::shared_ptr<PointCloudBuffers> Ptr;
+      typedef pcl::shared_ptr<PointCloudBuffers> Ptr;
       std::vector<short> points;
       std::vector<unsigned char> rgb;
     };

--- a/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
+++ b/doc/tutorials/content/sources/ensenso_cameras/ensenso_cloud_images_viewer.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <pcl/common/common.h>
+#include <pcl/make_shared.h>
 #include <pcl/console/print.h>
 #include <pcl/io/ensenso_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
@@ -28,7 +29,7 @@ typedef pcl::PointCloud<PointT> PointCloudT;
 
 /** @brief Convenience typdef for the Ensenso grabber callback */
 typedef std::pair<pcl::PCLImage, pcl::PCLImage> PairOfImages;
-typedef boost::shared_ptr<PairOfImages> PairOfImagesPtr;
+typedef pcl::shared_ptr<PairOfImages> PairOfImagesPtr;
 
 /** @brief CloudViewer pointer */
 pcl::visualization::CloudViewer::Ptr viewer_ptr;

--- a/doc/tutorials/content/sources/stick_segmentation/stick_segmentation.cpp
+++ b/doc/tutorials/content/sources/stick_segmentation/stick_segmentation.cpp
@@ -2,6 +2,7 @@
 #include <pcl/console/parse.h>
 #include <pcl/console/time.h>
 #include <pcl/point_types.h>
+#include <pcl/make_shared.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/filters/passthrough.h>
 #include <pcl/filters/voxel_grid.h>
@@ -18,7 +19,7 @@ template <typename PointT>
 class ConditionThresholdHSV : public pcl::ConditionBase<PointT>
 {
   public:
-    typedef boost::shared_ptr<ConditionThresholdHSV<PointT> > Ptr;
+    typedef pcl::shared_ptr<ConditionThresholdHSV<PointT> > Ptr;
     
     ConditionThresholdHSV (float min_h, float max_h, float min_s, float max_s, float min_v, float max_v) :
       min_h_(min_h), max_h_(max_h), min_s_(min_s), max_s_(max_s), min_v_(min_v), max_v_(max_v)

--- a/features/include/pcl/features/3dsc.h
+++ b/features/include/pcl/features/3dsc.h
@@ -73,8 +73,8 @@ namespace pcl
   class ShapeContext3DEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<ShapeContext3DEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const ShapeContext3DEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<ShapeContext3DEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const ShapeContext3DEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;

--- a/features/include/pcl/features/board.h
+++ b/features/include/pcl/features/board.h
@@ -58,8 +58,8 @@ namespace pcl
   class BOARDLocalReferenceFrameEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const BOARDLocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
 
       /** \brief Constructor. */
       BOARDLocalReferenceFrameEstimation () :

--- a/features/include/pcl/features/boundary.h
+++ b/features/include/pcl/features/boundary.h
@@ -80,8 +80,8 @@ namespace pcl
   class BoundaryEstimation: public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<BoundaryEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const BoundaryEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<BoundaryEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const BoundaryEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;

--- a/features/include/pcl/features/brisk_2d.h
+++ b/features/include/pcl/features/brisk_2d.h
@@ -67,8 +67,8 @@ namespace pcl
   class BRISK2DEstimation// : public Feature<PointT, KeyPointT>
   {
     public:
-      using Ptr = boost::shared_ptr<BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> >;
-      using ConstPtr = boost::shared_ptr<const BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> >;
+      using Ptr = shared_ptr<BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> >;
+      using ConstPtr = shared_ptr<const BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT> >;
 
       using PointCloudInT = pcl::PointCloud<PointInT>;
       using PointCloudInTConstPtr = typename PointCloudInT::ConstPtr;

--- a/features/include/pcl/features/cppf.h
+++ b/features/include/pcl/features/cppf.h
@@ -87,8 +87,8 @@ namespace pcl
   class CPPFEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<CPPFEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const CPPFEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<CPPFEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const CPPFEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::feature_name_;

--- a/features/include/pcl/features/crh.h
+++ b/features/include/pcl/features/crh.h
@@ -60,8 +60,8 @@ namespace pcl
   class CRHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<CRHEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const CRHEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<CRHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const CRHEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;

--- a/features/include/pcl/features/cvfh.h
+++ b/features/include/pcl/features/cvfh.h
@@ -63,8 +63,8 @@ namespace pcl
   class CVFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<CVFHEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const CVFHEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<CVFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const CVFHEstimation<PointInT, PointNT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;

--- a/features/include/pcl/features/don.h
+++ b/features/include/pcl/features/don.h
@@ -75,8 +75,8 @@ namespace pcl
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
     public:
-      using Ptr = boost::shared_ptr<DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const DifferenceOfNormalsEstimation<PointInT, PointNT, PointOutT> >;
 
       /**
         * Creates a new Difference of Normals filter.

--- a/features/include/pcl/features/esf.h
+++ b/features/include/pcl/features/esf.h
@@ -59,8 +59,8 @@ namespace pcl
   class ESFEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<ESFEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const ESFEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<ESFEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const ESFEstimation<PointInT, PointOutT> >;
 
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;

--- a/features/include/pcl/features/feature.h
+++ b/features/include/pcl/features/feature.h
@@ -110,8 +110,8 @@ namespace pcl
 
       using BaseClass = PCLBase<PointInT>;
 
-      using Ptr = boost::shared_ptr< Feature<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr< const Feature<PointInT, PointOutT> >;
+      using Ptr = shared_ptr< Feature<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr< const Feature<PointInT, PointOutT> >;
 
       using KdTree = pcl::search::Search<PointInT>;
       using KdTreePtr = typename KdTree::Ptr;
@@ -319,8 +319,8 @@ namespace pcl
       using PointCloudNPtr = typename PointCloudN::Ptr;
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      using Ptr = boost::shared_ptr< FeatureFromNormals<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr< const FeatureFromNormals<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr< FeatureFromNormals<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr< const FeatureFromNormals<PointInT, PointNT, PointOutT> >;
 
       // Members derived from the base class
       using Feature<PointInT, PointOutT>::input_;
@@ -378,8 +378,8 @@ namespace pcl
     using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
 
     public:
-      using Ptr = boost::shared_ptr< FeatureFromLabels<PointInT, PointLT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr< const FeatureFromLabels<PointInT, PointLT, PointOutT> >;
+      using Ptr = shared_ptr< FeatureFromLabels<PointInT, PointLT, PointOutT> >;
+      using ConstPtr = shared_ptr< const FeatureFromLabels<PointInT, PointLT, PointOutT> >;
 
       // Members derived from the base class
       using Feature<PointInT, PointOutT>::input_;

--- a/features/include/pcl/features/flare.h
+++ b/features/include/pcl/features/flare.h
@@ -84,8 +84,8 @@ namespace pcl
       using PointCloudSignedDistance = pcl::PointCloud<SignedDistanceT>;
       using PointCloudSignedDistancePtr = typename PointCloudSignedDistance::Ptr;
 
-      using Ptr = boost::shared_ptr<FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const FLARELocalReferenceFrameEstimation<PointInT, PointNT, PointOutT> >;
 
     public:
       /** \brief Constructor. */

--- a/features/include/pcl/features/fpfh.h
+++ b/features/include/pcl/features/fpfh.h
@@ -79,8 +79,8 @@ namespace pcl
   class FPFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<FPFHEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const FPFHEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<FPFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const FPFHEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/fpfh_omp.h
+++ b/features/include/pcl/features/fpfh_omp.h
@@ -74,8 +74,8 @@ namespace pcl
   class FPFHEstimationOMP : public FPFHEstimation<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<FPFHEstimationOMP<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const FPFHEstimationOMP<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<FPFHEstimationOMP<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const FPFHEstimationOMP<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/gasd.h
+++ b/features/include/pcl/features/gasd.h
@@ -78,8 +78,8 @@ namespace pcl
     public:
       using typename Feature<PointInT, PointOutT>::PointCloudIn;
       using typename Feature<PointInT, PointOutT>::PointCloudOut;
-      using Ptr = boost::shared_ptr<GASDEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const GASDEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<GASDEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const GASDEstimation<PointInT, PointOutT> >;
 
       /** \brief Constructor.
        * \param[in] view_direction view direction
@@ -259,8 +259,8 @@ namespace pcl
   {
     public:
       using typename Feature<PointInT, PointOutT>::PointCloudOut;
-      using Ptr = boost::shared_ptr<GASDColorEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const GASDColorEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<GASDColorEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const GASDColorEstimation<PointInT, PointOutT> >;
 
       /** \brief Constructor.
        * \param[in] view_direction view direction

--- a/features/include/pcl/features/gfpfh.h
+++ b/features/include/pcl/features/gfpfh.h
@@ -64,8 +64,8 @@ namespace pcl
   class GFPFHEstimation : public FeatureFromLabels<PointInT, PointLT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<GFPFHEstimation<PointInT, PointLT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const GFPFHEstimation<PointInT, PointLT, PointOutT> >;
+      using Ptr = shared_ptr<GFPFHEstimation<PointInT, PointLT, PointOutT> >;
+      using ConstPtr = shared_ptr<const GFPFHEstimation<PointInT, PointLT, PointOutT> >;
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::feature_name_;
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::getClassName;
       using FeatureFromLabels<PointInT, PointLT, PointOutT>::indices_;

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -198,7 +198,7 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointFeature> void
 pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::determinePersistentFeatures (FeatureCloud &output_features,
-                                                                                           boost::shared_ptr<std::vector<int> > &output_indices)
+                                                                                           shared_ptr<std::vector<int> > &output_indices)
 {
   if (!initCompute ())
     return;

--- a/features/include/pcl/features/integral_image2D.h
+++ b/features/include/pcl/features/integral_image2D.h
@@ -108,8 +108,8 @@ namespace pcl
   class IntegralImage2D
   {
     public:
-      using Ptr = boost::shared_ptr<IntegralImage2D<DataType, Dimension>>;
-      using ConstPtr = boost::shared_ptr<const IntegralImage2D<DataType, Dimension>>;
+      using Ptr = shared_ptr<IntegralImage2D<DataType, Dimension>>;
+      using ConstPtr = shared_ptr<const IntegralImage2D<DataType, Dimension>>;
       static const unsigned second_order_size = (Dimension * (Dimension + 1)) >> 1;
       using ElementType = Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::IntegralType, Dimension, 1>;
       using SecondOrderType = Eigen::Matrix<typename IntegralImageTypeTraits<DataType>::IntegralType, second_order_size, 1>;
@@ -232,8 +232,8 @@ namespace pcl
   class IntegralImage2D <DataType, 1>
   {
     public:
-      using Ptr = boost::shared_ptr<IntegralImage2D<DataType, 1>>;
-      using ConstPtr = boost::shared_ptr<const IntegralImage2D<DataType, 1>>;
+      using Ptr = shared_ptr<IntegralImage2D<DataType, 1>>;
+      using ConstPtr = shared_ptr<const IntegralImage2D<DataType, 1>>;
 
       static const unsigned second_order_size = 1;
       using ElementType = typename IntegralImageTypeTraits<DataType>::IntegralType;

--- a/features/include/pcl/features/integral_image_normal.h
+++ b/features/include/pcl/features/integral_image_normal.h
@@ -71,8 +71,8 @@ namespace pcl
     using Feature<PointInT, PointOutT>::indices_;
 
     public:
-      using Ptr = boost::shared_ptr<IntegralImageNormalEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const IntegralImageNormalEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<IntegralImageNormalEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const IntegralImageNormalEstimation<PointInT, PointOutT> >;
 
       /** \brief Different types of border handling. */
         enum BorderPolicy

--- a/features/include/pcl/features/intensity_gradient.h
+++ b/features/include/pcl/features/intensity_gradient.h
@@ -56,8 +56,8 @@ namespace pcl
   class IntensityGradientEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> >;
-      using ConstPtr = boost::shared_ptr<const IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> >;
+      using Ptr = shared_ptr<IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> >;
+      using ConstPtr = shared_ptr<const IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelectorT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/intensity_spin.h
+++ b/features/include/pcl/features/intensity_spin.h
@@ -58,8 +58,8 @@ namespace pcl
   class IntensitySpinEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<IntensitySpinEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const IntensitySpinEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<IntensitySpinEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const IntensitySpinEstimation<PointInT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
 

--- a/features/include/pcl/features/linear_least_squares_normal.h
+++ b/features/include/pcl/features/linear_least_squares_normal.h
@@ -51,8 +51,8 @@ namespace pcl
   class LinearLeastSquaresNormalEstimation : public Feature<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<LinearLeastSquaresNormalEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const LinearLeastSquaresNormalEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<LinearLeastSquaresNormalEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const LinearLeastSquaresNormalEstimation<PointInT, PointOutT> >;
       using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
       using Feature<PointInT, PointOutT>::input_;

--- a/features/include/pcl/features/moment_invariants.h
+++ b/features/include/pcl/features/moment_invariants.h
@@ -55,8 +55,8 @@ namespace pcl
   class MomentInvariantsEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<MomentInvariantsEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const MomentInvariantsEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<MomentInvariantsEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const MomentInvariantsEstimation<PointInT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/multiscale_feature_persistence.h
+++ b/features/include/pcl/features/multiscale_feature_persistence.h
@@ -63,8 +63,8 @@ namespace pcl
   class MultiscaleFeaturePersistence : public PCLBase<PointSource>
   {
     public:
-      using Ptr = boost::shared_ptr<MultiscaleFeaturePersistence<PointSource, PointFeature> >;
-      using ConstPtr = boost::shared_ptr<const MultiscaleFeaturePersistence<PointSource, PointFeature> >;
+      using Ptr = shared_ptr<MultiscaleFeaturePersistence<PointSource, PointFeature> >;
+      using ConstPtr = shared_ptr<const MultiscaleFeaturePersistence<PointSource, PointFeature> >;
       using FeatureCloud = pcl::PointCloud<PointFeature>;
       using FeatureCloudPtr = typename pcl::PointCloud<PointFeature>::Ptr;
       using FeatureEstimatorPtr = typename pcl::Feature<PointSource, PointFeature>::Ptr;
@@ -89,7 +89,7 @@ namespace pcl
        */
       void
       determinePersistentFeatures (FeatureCloud &output_features,
-                                   boost::shared_ptr<std::vector<int> > &output_indices);
+                                   shared_ptr<std::vector<int> > &output_indices);
 
       /** \brief Method for setting the scale parameters for the algorithm
        * \param scale_values vector of scales to determine the characteristic of each scaling step

--- a/features/include/pcl/features/narf_descriptor.h
+++ b/features/include/pcl/features/narf_descriptor.h
@@ -55,8 +55,8 @@ namespace pcl
   class PCL_EXPORTS NarfDescriptor : public Feature<PointWithRange,Narf36>
   {
     public:
-      using Ptr = boost::shared_ptr<NarfDescriptor>;
-      using ConstPtr = boost::shared_ptr<const NarfDescriptor>;
+      using Ptr = shared_ptr<NarfDescriptor>;
+      using ConstPtr = shared_ptr<const NarfDescriptor>;
       // =====TYPEDEFS=====
       using BaseClass = Feature<PointWithRange,Narf36>;
       

--- a/features/include/pcl/features/normal_3d.h
+++ b/features/include/pcl/features/normal_3d.h
@@ -242,8 +242,8 @@ namespace pcl
   class NormalEstimation: public Feature<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<NormalEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const NormalEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<NormalEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const NormalEstimation<PointInT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/normal_3d_omp.h
+++ b/features/include/pcl/features/normal_3d_omp.h
@@ -53,8 +53,8 @@ namespace pcl
   class NormalEstimationOMP: public NormalEstimation<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<NormalEstimationOMP<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const NormalEstimationOMP<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<NormalEstimationOMP<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const NormalEstimationOMP<PointInT, PointOutT> >;
       using NormalEstimation<PointInT, PointOutT>::feature_name_;
       using NormalEstimation<PointInT, PointOutT>::getClassName;
       using NormalEstimation<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/normal_based_signature.h
+++ b/features/include/pcl/features/normal_based_signature.h
@@ -67,8 +67,8 @@ namespace pcl
       using FeatureFromNormals<PointT, PointNT, PointFeature>::normals_;
 
       using FeatureCloud = pcl::PointCloud<PointFeature>;
-      using Ptr = boost::shared_ptr<NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> >;
-      using ConstPtr = boost::shared_ptr<const NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> >;
+      using Ptr = shared_ptr<NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> >;
+      using ConstPtr = shared_ptr<const NormalBasedSignatureEstimation<PointT, PointNT, PointFeature> >;
 
 
 

--- a/features/include/pcl/features/organized_edge_detection.h
+++ b/features/include/pcl/features/organized_edge_detection.h
@@ -65,8 +65,8 @@ namespace pcl
     using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
     public:
-      using Ptr = boost::shared_ptr<OrganizedEdgeBase<PointT, PointLT> >;
-      using ConstPtr = boost::shared_ptr<const OrganizedEdgeBase<PointT, PointLT> >;
+      using Ptr = shared_ptr<OrganizedEdgeBase<PointT, PointLT> >;
+      using ConstPtr = shared_ptr<const OrganizedEdgeBase<PointT, PointLT> >;
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;
       using PCLBase<PointT>::initCompute;

--- a/features/include/pcl/features/our_cvfh.h
+++ b/features/include/pcl/features/our_cvfh.h
@@ -61,8 +61,8 @@ namespace pcl
   class OURCVFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<OURCVFHEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const OURCVFHEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<OURCVFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const OURCVFHEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/pfh.h
+++ b/features/include/pcl/features/pfh.h
@@ -81,8 +81,8 @@ namespace pcl
   class PFHEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<PFHEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const PFHEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<PFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const PFHEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/pfhrgb.h
+++ b/features/include/pcl/features/pfhrgb.h
@@ -48,8 +48,8 @@ namespace pcl
   class PFHRGBEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<PFHRGBEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const PFHRGBEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<PFHRGBEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const PFHRGBEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::surface_;

--- a/features/include/pcl/features/ppf.h
+++ b/features/include/pcl/features/ppf.h
@@ -76,8 +76,8 @@ namespace pcl
   class PPFEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<PPFEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const PPFEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<PPFEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const PPFEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::feature_name_;

--- a/features/include/pcl/features/ppfrgb.h
+++ b/features/include/pcl/features/ppfrgb.h
@@ -72,8 +72,8 @@ namespace pcl
   class PPFRGBRegionEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const PPFRGBRegionEstimation<PointInT, PointNT, PointOutT> >;
       using PCLBase<PointInT>::indices_;
       using Feature<PointInT, PointOutT>::input_;
       using Feature<PointInT, PointOutT>::feature_name_;

--- a/features/include/pcl/features/principal_curvatures.h
+++ b/features/include/pcl/features/principal_curvatures.h
@@ -60,8 +60,8 @@ namespace pcl
   class PrincipalCurvaturesEstimation : public FeatureFromNormals<PointInT, PointNT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/range_image_border_extractor.h
+++ b/features/include/pcl/features/range_image_border_extractor.h
@@ -55,8 +55,8 @@ namespace pcl
   class PCL_EXPORTS RangeImageBorderExtractor : public Feature<PointWithRange,BorderDescription>
   {
     public:
-      using Ptr = boost::shared_ptr<RangeImageBorderExtractor>;
-      using ConstPtr = boost::shared_ptr<const RangeImageBorderExtractor>;
+      using Ptr = shared_ptr<RangeImageBorderExtractor>;
+      using ConstPtr = shared_ptr<const RangeImageBorderExtractor>;
       // =====TYPEDEFS=====
       using BaseClass = Feature<PointWithRange,BorderDescription>;
       

--- a/features/include/pcl/features/rift.h
+++ b/features/include/pcl/features/rift.h
@@ -75,8 +75,8 @@ namespace pcl
       using PointCloudGradientPtr = typename PointCloudGradient::Ptr;
       using PointCloudGradientConstPtr = typename PointCloudGradient::ConstPtr;
 
-      using Ptr = boost::shared_ptr<RIFTEstimation<PointInT, GradientT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const RIFTEstimation<PointInT, GradientT, PointOutT> >;
+      using Ptr = shared_ptr<RIFTEstimation<PointInT, GradientT, PointOutT> >;
+      using ConstPtr = shared_ptr<const RIFTEstimation<PointInT, GradientT, PointOutT> >;
 
 
       /** \brief Empty constructor. */

--- a/features/include/pcl/features/rsd.h
+++ b/features/include/pcl/features/rsd.h
@@ -161,8 +161,8 @@ namespace pcl
       using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
       using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
 
-      using Ptr = boost::shared_ptr<RSDEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const RSDEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<RSDEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const RSDEstimation<PointInT, PointNT, PointOutT> >;
 
 
       /** \brief Empty constructor. */
@@ -220,7 +220,7 @@ namespace pcl
       /** \brief Returns a pointer to the list of full distance-angle histograms for all points.
         * \return the histogram being saved when computing RSD
 	*/
-      inline boost::shared_ptr<std::vector<Eigen::MatrixXf, Eigen::aligned_allocator<Eigen::MatrixXf> > >
+      inline shared_ptr<std::vector<Eigen::MatrixXf, Eigen::aligned_allocator<Eigen::MatrixXf> > >
       getHistograms () const { return (histograms_); }
 
     protected:
@@ -234,7 +234,7 @@ namespace pcl
       computeFeature (PointCloudOut &output) override;
 
       /** \brief The list of full distance-angle histograms for all points. */
-      boost::shared_ptr<std::vector<Eigen::MatrixXf, Eigen::aligned_allocator<Eigen::MatrixXf> > > histograms_;
+      shared_ptr<std::vector<Eigen::MatrixXf, Eigen::aligned_allocator<Eigen::MatrixXf> > > histograms_;
 
     private:
       /** \brief The number of subdivisions for the considered distance interval. */

--- a/features/include/pcl/features/shot.h
+++ b/features/include/pcl/features/shot.h
@@ -68,8 +68,8 @@ namespace pcl
                              public FeatureWithLocalReferenceFrames<PointInT, PointRFT>
   {
     public:
-      using Ptr = boost::shared_ptr<SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> >;
-      using ConstPtr = boost::shared_ptr<const SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> >;
+      using Ptr = shared_ptr<SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = shared_ptr<const SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::input_;
@@ -219,8 +219,8 @@ namespace pcl
   class SHOTEstimation : public SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      using Ptr = boost::shared_ptr<SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
-      using ConstPtr = boost::shared_ptr<const SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
+      using Ptr = shared_ptr<SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = shared_ptr<const SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::feature_name_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::getClassName;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::indices_;
@@ -297,8 +297,8 @@ namespace pcl
   class SHOTColorEstimation : public SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      using Ptr = boost::shared_ptr<SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
-      using ConstPtr = boost::shared_ptr<const SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
+      using Ptr = shared_ptr<SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = shared_ptr<const SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT> >;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::feature_name_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::getClassName;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::indices_;

--- a/features/include/pcl/features/shot_lrf.h
+++ b/features/include/pcl/features/shot_lrf.h
@@ -65,8 +65,8 @@ namespace pcl
   class SHOTLocalReferenceFrameEstimation : public Feature<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const SHOTLocalReferenceFrameEstimation<PointInT, PointOutT> >;
       /** \brief Constructor */
       SHOTLocalReferenceFrameEstimation ()
       {

--- a/features/include/pcl/features/shot_lrf_omp.h
+++ b/features/include/pcl/features/shot_lrf_omp.h
@@ -66,8 +66,8 @@ namespace pcl
   class SHOTLocalReferenceFrameEstimationOMP : public SHOTLocalReferenceFrameEstimation<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const SHOTLocalReferenceFrameEstimationOMP<PointInT, PointOutT> >;
       /** \brief Constructor */
     SHOTLocalReferenceFrameEstimationOMP ()
       {

--- a/features/include/pcl/features/shot_omp.h
+++ b/features/include/pcl/features/shot_omp.h
@@ -69,8 +69,8 @@ namespace pcl
   class SHOTEstimationOMP : public SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      using Ptr = boost::shared_ptr<SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
-      using ConstPtr = boost::shared_ptr<const SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
+      using Ptr = shared_ptr<SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = shared_ptr<const SHOTEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::input_;
@@ -148,8 +148,8 @@ namespace pcl
   class SHOTColorEstimationOMP : public SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>
   {
     public:
-      using Ptr = boost::shared_ptr<SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
-      using ConstPtr = boost::shared_ptr<const SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
+      using Ptr = shared_ptr<SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
+      using ConstPtr = shared_ptr<const SHOTColorEstimationOMP<PointInT, PointNT, PointOutT, PointRFT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::input_;

--- a/features/include/pcl/features/spin_image.h
+++ b/features/include/pcl/features/spin_image.h
@@ -87,8 +87,8 @@ namespace pcl
   class SpinImageEstimation : public Feature<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<SpinImageEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const SpinImageEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<SpinImageEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const SpinImageEstimation<PointInT, PointNT, PointOutT> >;
       using Feature<PointInT, PointOutT>::feature_name_;
       using Feature<PointInT, PointOutT>::getClassName;
       using Feature<PointInT, PointOutT>::indices_;

--- a/features/include/pcl/features/statistical_multiscale_interest_region_extraction.h
+++ b/features/include/pcl/features/statistical_multiscale_interest_region_extraction.h
@@ -64,9 +64,9 @@ namespace pcl
   class StatisticalMultiscaleInterestRegionExtraction : public PCLBase<PointT>
   {
     public:
-      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-      using Ptr = boost::shared_ptr<StatisticalMultiscaleInterestRegionExtraction<PointT> >;
-      using ConstPtr = boost::shared_ptr<const StatisticalMultiscaleInterestRegionExtraction<PointT> >;
+      using IndicesPtr = shared_ptr<std::vector<int> >;
+      using Ptr = shared_ptr<StatisticalMultiscaleInterestRegionExtraction<PointT> >;
+      using ConstPtr = shared_ptr<const StatisticalMultiscaleInterestRegionExtraction<PointT> >;
 
 
       /** \brief Empty constructor */

--- a/features/include/pcl/features/usc.h
+++ b/features/include/pcl/features/usc.h
@@ -77,8 +77,8 @@ namespace pcl
 
       using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
       using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
-      using Ptr = boost::shared_ptr<UniqueShapeContext<PointInT, PointOutT, PointRFT> >;
-      using ConstPtr = boost::shared_ptr<const UniqueShapeContext<PointInT, PointOutT, PointRFT> >;
+      using Ptr = shared_ptr<UniqueShapeContext<PointInT, PointOutT, PointRFT> >;
+      using ConstPtr = shared_ptr<const UniqueShapeContext<PointInT, PointOutT, PointRFT> >;
 
 
       /** \brief Constructor. */

--- a/features/include/pcl/features/vfh.h
+++ b/features/include/pcl/features/vfh.h
@@ -80,8 +80,8 @@ namespace pcl
       using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
 
       using PointCloudOut = typename Feature<PointInT, PointOutT>::PointCloudOut;
-      using Ptr = boost::shared_ptr<VFHEstimation<PointInT, PointNT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const VFHEstimation<PointInT, PointNT, PointOutT> >;
+      using Ptr = shared_ptr<VFHEstimation<PointInT, PointNT, PointOutT> >;
+      using ConstPtr = shared_ptr<const VFHEstimation<PointInT, PointNT, PointOutT> >;
 
 
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/approximate_voxel_grid.h
+++ b/filters/include/pcl/filters/approximate_voxel_grid.h
@@ -118,8 +118,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<ApproximateVoxelGrid<PointT> >;
-      using ConstPtr = boost::shared_ptr<const ApproximateVoxelGrid<PointT> >;
+      using Ptr = shared_ptr<ApproximateVoxelGrid<PointT> >;
+      using ConstPtr = shared_ptr<const ApproximateVoxelGrid<PointT> >;
 
 
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/bilateral.h
+++ b/filters/include/pcl/filters/bilateral.h
@@ -62,8 +62,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<BilateralFilter<PointT> >;
-      using ConstPtr = boost::shared_ptr<const BilateralFilter<PointT> >;
+      using Ptr = shared_ptr<BilateralFilter<PointT> >;
+      using ConstPtr = shared_ptr<const BilateralFilter<PointT> >;
  
 
       /** \brief Constructor. 

--- a/filters/include/pcl/filters/box_clipper3D.h
+++ b/filters/include/pcl/filters/box_clipper3D.h
@@ -53,8 +53,8 @@ namespace pcl
   {
     public:
 
-      using Ptr = boost::shared_ptr<BoxClipper3D<PointT> >;
-      using ConstPtr = boost::shared_ptr<const BoxClipper3D<PointT> >;
+      using Ptr = shared_ptr<BoxClipper3D<PointT> >;
+      using ConstPtr = shared_ptr<const BoxClipper3D<PointT> >;
 
 
       /**

--- a/filters/include/pcl/filters/clipper3D.h
+++ b/filters/include/pcl/filters/clipper3D.h
@@ -53,8 +53,8 @@ namespace pcl
   class Clipper3D
   {
     public:
-      using Ptr = boost::shared_ptr<Clipper3D<PointT> >;
-      using ConstPtr = boost::shared_ptr<const Clipper3D<PointT> >;
+      using Ptr = shared_ptr<Clipper3D<PointT> >;
+      using ConstPtr = shared_ptr<const Clipper3D<PointT> >;
  
       /**
         * \brief virtual destructor. Never throws an exception.

--- a/filters/include/pcl/filters/conditional_removal.h
+++ b/filters/include/pcl/filters/conditional_removal.h
@@ -89,8 +89,8 @@ namespace pcl
   class ComparisonBase
   {
     public:
-      using Ptr = boost::shared_ptr<ComparisonBase<PointT> >;
-      using ConstPtr = boost::shared_ptr<const ComparisonBase<PointT> >;
+      using Ptr = shared_ptr<ComparisonBase<PointT> >;
+      using ConstPtr = shared_ptr<const ComparisonBase<PointT> >;
 
       /** \brief Constructor. */
       ComparisonBase () : capable_ (false), offset_ (), op_ () {}
@@ -133,8 +133,8 @@ namespace pcl
     using ComparisonBase<PointT>::capable_;
 
     public:
-      using Ptr = boost::shared_ptr<FieldComparison<PointT> >;
-      using ConstPtr = boost::shared_ptr<const FieldComparison<PointT> >;
+      using Ptr = shared_ptr<FieldComparison<PointT> >;
+      using ConstPtr = shared_ptr<const FieldComparison<PointT> >;
 
 
       /** \brief Construct a FieldComparison
@@ -197,8 +197,8 @@ namespace pcl
     using ComparisonBase<PointT>::op_;
 
     public:
-      using Ptr = boost::shared_ptr<PackedRGBComparison<PointT> >;
-      using ConstPtr = boost::shared_ptr<const PackedRGBComparison<PointT> >;
+      using Ptr = shared_ptr<PackedRGBComparison<PointT> >;
+      using ConstPtr = shared_ptr<const PackedRGBComparison<PointT> >;
 
       /** \brief Construct a PackedRGBComparison
         * \param component_name either "r", "g" or "b"
@@ -244,8 +244,8 @@ namespace pcl
     using ComparisonBase<PointT>::op_;
 
     public:
-      using Ptr = boost::shared_ptr<PackedHSIComparison<PointT> >;
-      using ConstPtr = boost::shared_ptr<const PackedHSIComparison<PointT> >;
+      using Ptr = shared_ptr<PackedHSIComparison<PointT> >;
+      using ConstPtr = shared_ptr<const PackedHSIComparison<PointT> >;
  
       /** \brief Construct a PackedHSIComparison 
         * \param component_name either "h", "s" or "i"
@@ -312,8 +312,8 @@ namespace pcl
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW  // needed whenever there is a fixed size Eigen:: vector or matrix in a class
 
-      using Ptr = boost::shared_ptr<TfQuadraticXYZComparison<PointT> >;
-      using ConstPtr = boost::shared_ptr<const TfQuadraticXYZComparison<PointT> >;
+      using Ptr = shared_ptr<TfQuadraticXYZComparison<PointT> >;
+      using ConstPtr = shared_ptr<const TfQuadraticXYZComparison<PointT> >;
 
       /** \brief Constructor.
        */
@@ -450,8 +450,8 @@ namespace pcl
       using ComparisonBasePtr = typename ComparisonBase::Ptr;
       using ComparisonBaseConstPtr = typename ComparisonBase::ConstPtr;
 
-      using Ptr = boost::shared_ptr<ConditionBase<PointT> >;
-      using ConstPtr = boost::shared_ptr<const ConditionBase<PointT> >;
+      using Ptr = shared_ptr<ConditionBase<PointT> >;
+      using ConstPtr = shared_ptr<const ConditionBase<PointT> >;
 
       /** \brief Constructor. */
       ConditionBase () : capable_ (true), comparisons_ (), conditions_ ()
@@ -506,8 +506,8 @@ namespace pcl
     using ConditionBase<PointT>::comparisons_;
 
     public:
-      using Ptr = boost::shared_ptr<ConditionAnd<PointT> >;
-      using ConstPtr = boost::shared_ptr<const ConditionAnd<PointT> >;
+      using Ptr = shared_ptr<ConditionAnd<PointT> >;
+      using ConstPtr = shared_ptr<const ConditionAnd<PointT> >;
 
       /** \brief Constructor. */
       ConditionAnd () :
@@ -534,8 +534,8 @@ namespace pcl
     using ConditionBase<PointT>::comparisons_;
 
     public:
-      using Ptr = boost::shared_ptr<ConditionOr<PointT> >;
-      using ConstPtr = boost::shared_ptr<const ConditionOr<PointT> >;
+      using Ptr = shared_ptr<ConditionOr<PointT> >;
+      using ConstPtr = shared_ptr<const ConditionOr<PointT> >;
 
       /** \brief Constructor. */
       ConditionOr () :

--- a/filters/include/pcl/filters/convolution.h
+++ b/filters/include/pcl/filters/convolution.h
@@ -80,8 +80,8 @@ namespace pcl
         using PointCloudInPtr = typename PointCloudIn::Ptr;
         using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;
         using PointCloudOut = pcl::PointCloud<PointOut>;
-        using Ptr = boost::shared_ptr< Convolution<PointIn, PointOut> >;
-        using ConstPtr = boost::shared_ptr< const Convolution<PointIn, PointOut> >;
+        using Ptr = shared_ptr< Convolution<PointIn, PointOut> >;
+        using ConstPtr = shared_ptr< const Convolution<PointIn, PointOut> >;
 
 
         /// The borders policy available

--- a/filters/include/pcl/filters/convolution_3d.h
+++ b/filters/include/pcl/filters/convolution_3d.h
@@ -54,8 +54,8 @@ namespace pcl
     class ConvolvingKernel
     {
       public:
-        using Ptr = boost::shared_ptr<ConvolvingKernel<PointInT, PointOutT> >;
-        using ConstPtr = boost::shared_ptr<const ConvolvingKernel<PointInT, PointOutT> >;
+        using Ptr = shared_ptr<ConvolvingKernel<PointInT, PointOutT> >;
+        using ConstPtr = shared_ptr<const ConvolvingKernel<PointInT, PointOutT> >;
  
         using PointCloudInConstPtr = typename PointCloud<PointInT>::ConstPtr;
 
@@ -118,8 +118,8 @@ namespace pcl
         using ConvolvingKernel<PointInT, PointOutT>::input_;
         using ConvolvingKernel<PointInT, PointOutT>::operator ();
         using ConvolvingKernel<PointInT, PointOutT>::makeInfinite;
-        using Ptr = boost::shared_ptr<GaussianKernel<PointInT, PointOutT> >;
-        using ConstPtr = boost::shared_ptr<GaussianKernel<PointInT, PointOutT> >;
+        using Ptr = shared_ptr<GaussianKernel<PointInT, PointOutT> >;
+        using ConstPtr = shared_ptr<GaussianKernel<PointInT, PointOutT> >;
 
         /** Default constructor */
         GaussianKernel ()
@@ -176,8 +176,8 @@ namespace pcl
         using GaussianKernel<PointInT, PointOutT>::makeInfinite;
         using GaussianKernel<PointInT, PointOutT>::sigma_sqr_;
         using GaussianKernel<PointInT, PointOutT>::threshold_;
-        using Ptr = boost::shared_ptr<GaussianKernelRGB<PointInT, PointOutT> >;
-        using ConstPtr = boost::shared_ptr<GaussianKernelRGB<PointInT, PointOutT> >;
+        using Ptr = shared_ptr<GaussianKernelRGB<PointInT, PointOutT> >;
+        using ConstPtr = shared_ptr<GaussianKernelRGB<PointInT, PointOutT> >;
 
         /** Default constructor */
         GaussianKernelRGB ()
@@ -204,8 +204,8 @@ namespace pcl
         using KdTree = pcl::search::Search<PointIn>;
         using KdTreePtr = typename KdTree::Ptr;
         using PointCloudOut = pcl::PointCloud<PointOut>;
-        using Ptr = boost::shared_ptr<Convolution3D<PointIn, PointOut, KernelT> >;
-        using ConstPtr = boost::shared_ptr<Convolution3D<PointIn, PointOut, KernelT> >;
+        using Ptr = shared_ptr<Convolution3D<PointIn, PointOut, KernelT> >;
+        using ConstPtr = shared_ptr<Convolution3D<PointIn, PointOut, KernelT> >;
 
         using pcl::PCLBase<PointIn>::indices_;
         using pcl::PCLBase<PointIn>::input_;

--- a/filters/include/pcl/filters/covariance_sampling.h
+++ b/filters/include/pcl/filters/covariance_sampling.h
@@ -72,8 +72,8 @@ namespace pcl
       using NormalsConstPtr = typename pcl::PointCloud<PointNT>::ConstPtr;
 
     public:
-      using Ptr = boost::shared_ptr< CovarianceSampling<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr< const CovarianceSampling<PointT, PointNT> >;
+      using Ptr = shared_ptr< CovarianceSampling<PointT, PointNT> >;
+      using ConstPtr = shared_ptr< const CovarianceSampling<PointT, PointNT> >;
  
       /** \brief Empty constructor. */
       CovarianceSampling ()

--- a/filters/include/pcl/filters/crop_box.h
+++ b/filters/include/pcl/filters/crop_box.h
@@ -63,8 +63,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<CropBox<PointT> >;
-      using ConstPtr = boost::shared_ptr<const CropBox<PointT> >;
+      using Ptr = shared_ptr<CropBox<PointT> >;
+      using ConstPtr = shared_ptr<const CropBox<PointT> >;
 
       /** \brief Constructor.
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).

--- a/filters/include/pcl/filters/crop_hull.h
+++ b/filters/include/pcl/filters/crop_hull.h
@@ -61,8 +61,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<CropHull<PointT> >;
-      using ConstPtr = boost::shared_ptr<const CropHull<PointT> >;
+      using Ptr = shared_ptr<CropHull<PointT> >;
+      using ConstPtr = shared_ptr<const CropHull<PointT> >;
 
       /** \brief Empty Constructor. */
       CropHull () :

--- a/filters/include/pcl/filters/extract_indices.h
+++ b/filters/include/pcl/filters/extract_indices.h
@@ -76,8 +76,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<ExtractIndices<PointT> >;
-      using ConstPtr = boost::shared_ptr<const ExtractIndices<PointT> >;
+      using Ptr = shared_ptr<ExtractIndices<PointT> >;
+      using ConstPtr = shared_ptr<const ExtractIndices<PointT> >;
 
       /** \brief Constructor.
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).

--- a/filters/include/pcl/filters/fast_bilateral.h
+++ b/filters/include/pcl/filters/fast_bilateral.h
@@ -61,8 +61,8 @@ namespace pcl
 
     public:
     
-      using Ptr = boost::shared_ptr<FastBilateralFilter<PointT> >;
-      using ConstPtr = boost::shared_ptr<const FastBilateralFilter<PointT> >;
+      using Ptr = shared_ptr<FastBilateralFilter<PointT> >;
+      using ConstPtr = shared_ptr<const FastBilateralFilter<PointT> >;
 
       /** \brief Empty constructor. */
       FastBilateralFilter ()

--- a/filters/include/pcl/filters/fast_bilateral_omp.h
+++ b/filters/include/pcl/filters/fast_bilateral_omp.h
@@ -67,8 +67,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<FastBilateralFilterOMP<PointT> >;
-      using ConstPtr = boost::shared_ptr<const FastBilateralFilterOMP<PointT> >;
+      using Ptr = shared_ptr<FastBilateralFilterOMP<PointT> >;
+      using ConstPtr = shared_ptr<const FastBilateralFilterOMP<PointT> >;
 
       /** \brief Empty constructor. */
       FastBilateralFilterOMP (unsigned int nr_threads = 0)

--- a/filters/include/pcl/filters/filter.h
+++ b/filters/include/pcl/filters/filter.h
@@ -86,8 +86,8 @@ namespace pcl
       using PCLBase<PointT>::indices_;
       using PCLBase<PointT>::input_;
 
-      using Ptr = boost::shared_ptr<Filter<PointT> >;
-      using ConstPtr = boost::shared_ptr<const Filter<PointT> >;
+      using Ptr = shared_ptr<Filter<PointT> >;
+      using ConstPtr = shared_ptr<const Filter<PointT> >;
 
 
       using PointCloud = pcl::PointCloud<PointT>;
@@ -192,8 +192,8 @@ namespace pcl
   class PCL_EXPORTS Filter<pcl::PCLPointCloud2> : public PCLBase<pcl::PCLPointCloud2>
   {
     public:
-      using Ptr = boost::shared_ptr<Filter<pcl::PCLPointCloud2> >;
-      using ConstPtr = boost::shared_ptr<const Filter<pcl::PCLPointCloud2> >;
+      using Ptr = shared_ptr<Filter<pcl::PCLPointCloud2> >;
+      using ConstPtr = shared_ptr<const Filter<pcl::PCLPointCloud2> >;
 
       using PCLPointCloud2 = pcl::PCLPointCloud2;
       using PCLPointCloud2Ptr = PCLPointCloud2::Ptr;

--- a/filters/include/pcl/filters/filter_indices.h
+++ b/filters/include/pcl/filters/filter_indices.h
@@ -77,8 +77,8 @@ namespace pcl
       using Filter<PointT>::extract_removed_indices_;
       using PointCloud = pcl::PointCloud<PointT>;
 
-      using Ptr = boost::shared_ptr<FilterIndices<PointT> >;
-      using ConstPtr = boost::shared_ptr<const FilterIndices<PointT> >;
+      using Ptr = shared_ptr<FilterIndices<PointT> >;
+      using ConstPtr = shared_ptr<const FilterIndices<PointT> >;
 
 
       /** \brief Constructor.

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -82,8 +82,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<FrustumCulling<PointT> >;
-      using ConstPtr = boost::shared_ptr<const FrustumCulling<PointT> >;
+      using Ptr = shared_ptr<FrustumCulling<PointT> >;
+      using ConstPtr = shared_ptr<const FrustumCulling<PointT> >;
 
 
       using Filter<PointT>::getClassName;

--- a/filters/include/pcl/filters/normal_space.h
+++ b/filters/include/pcl/filters/normal_space.h
@@ -66,8 +66,8 @@ namespace pcl
 
     public:
       
-      using Ptr = boost::shared_ptr<NormalSpaceSampling<PointT, NormalT> >;
-      using ConstPtr = boost::shared_ptr<const NormalSpaceSampling<PointT, NormalT> >;
+      using Ptr = shared_ptr<NormalSpaceSampling<PointT, NormalT> >;
+      using ConstPtr = shared_ptr<const NormalSpaceSampling<PointT, NormalT> >;
 
       /** \brief Empty constructor. */
       NormalSpaceSampling ()

--- a/filters/include/pcl/filters/passthrough.h
+++ b/filters/include/pcl/filters/passthrough.h
@@ -86,8 +86,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<PassThrough<PointT> >;
-      using ConstPtr = boost::shared_ptr<const PassThrough<PointT> >;
+      using Ptr = shared_ptr<PassThrough<PointT> >;
+      using ConstPtr = shared_ptr<const PassThrough<PointT> >;
 
 
       /** \brief Constructor.

--- a/filters/include/pcl/filters/plane_clipper3D.h
+++ b/filters/include/pcl/filters/plane_clipper3D.h
@@ -51,8 +51,8 @@ namespace pcl
   {
     public:
 
-      using Ptr = boost::shared_ptr< PlaneClipper3D<PointT> >;
-      using ConstPtr = boost::shared_ptr< const PlaneClipper3D<PointT> >;
+      using Ptr = shared_ptr< PlaneClipper3D<PointT> >;
+      using ConstPtr = shared_ptr< const PlaneClipper3D<PointT> >;
 
       /**
        * @author Suat Gedikli <gedikli@willowgarage.com>

--- a/filters/include/pcl/filters/project_inliers.h
+++ b/filters/include/pcl/filters/project_inliers.h
@@ -79,8 +79,8 @@ namespace pcl
     using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
     public:
 
-      using Ptr = boost::shared_ptr<ProjectInliers<PointT> >;
-      using ConstPtr = boost::shared_ptr<const ProjectInliers<PointT> >;
+      using Ptr = shared_ptr<ProjectInliers<PointT> >;
+      using ConstPtr = shared_ptr<const ProjectInliers<PointT> >;
 
 
       /** \brief Empty constructor. */

--- a/filters/include/pcl/filters/pyramid.h
+++ b/filters/include/pcl/filters/pyramid.h
@@ -64,8 +64,8 @@ namespace pcl
       public:
         using PointCloudPtr = typename PointCloud<PointT>::Ptr;
         using PointCloudConstPtr = typename PointCloud<PointT>::ConstPtr;
-        using Ptr = boost::shared_ptr< Pyramid<PointT> >;
-        using ConstPtr = boost::shared_ptr< const Pyramid<PointT> >;
+        using Ptr = shared_ptr< Pyramid<PointT> >;
+        using ConstPtr = shared_ptr< const Pyramid<PointT> >;
  
         Pyramid (int levels = 4)
           : levels_ (levels)

--- a/filters/include/pcl/filters/radius_outlier_removal.h
+++ b/filters/include/pcl/filters/radius_outlier_removal.h
@@ -78,8 +78,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<RadiusOutlierRemoval<PointT> >;
-      using ConstPtr = boost::shared_ptr<const RadiusOutlierRemoval<PointT> >;
+      using Ptr = shared_ptr<RadiusOutlierRemoval<PointT> >;
+      using ConstPtr = shared_ptr<const RadiusOutlierRemoval<PointT> >;
 
 
       /** \brief Constructor.

--- a/filters/include/pcl/filters/random_sample.h
+++ b/filters/include/pcl/filters/random_sample.h
@@ -70,8 +70,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<RandomSample<PointT> >;
-      using ConstPtr = boost::shared_ptr<const RandomSample<PointT> >;
+      using Ptr = shared_ptr<RandomSample<PointT> >;
+      using ConstPtr = shared_ptr<const RandomSample<PointT> >;
 
       /** \brief Empty constructor. */
       RandomSample (bool extract_removed_indices = false) : 
@@ -162,8 +162,8 @@ namespace pcl
 
     public:
   
-      using Ptr = boost::shared_ptr<RandomSample<pcl::PCLPointCloud2> >;
-      using ConstPtr = boost::shared_ptr<const RandomSample<pcl::PCLPointCloud2> >;
+      using Ptr = shared_ptr<RandomSample<pcl::PCLPointCloud2> >;
+      using ConstPtr = shared_ptr<const RandomSample<pcl::PCLPointCloud2> >;
   
       /** \brief Empty constructor. */
       RandomSample () : sample_ (UINT_MAX), seed_ (static_cast<unsigned int> (time (nullptr)))

--- a/filters/include/pcl/filters/sampling_surface_normal.h
+++ b/filters/include/pcl/filters/sampling_surface_normal.h
@@ -66,8 +66,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<SamplingSurfaceNormal<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SamplingSurfaceNormal<PointT> >;
+      using Ptr = shared_ptr<SamplingSurfaceNormal<PointT> >;
+      using ConstPtr = shared_ptr<const SamplingSurfaceNormal<PointT> >;
 
       /** \brief Empty constructor. */
       SamplingSurfaceNormal () : 

--- a/filters/include/pcl/filters/shadowpoints.h
+++ b/filters/include/pcl/filters/shadowpoints.h
@@ -68,8 +68,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr< ShadowPoints<PointT, NormalT> >;
-      using ConstPtr = boost::shared_ptr< const ShadowPoints<PointT, NormalT> >;
+      using Ptr = shared_ptr< ShadowPoints<PointT, NormalT> >;
+      using ConstPtr = shared_ptr< const ShadowPoints<PointT, NormalT> >;
 
       /** \brief Empty constructor. */
       ShadowPoints (bool extract_removed_indices = false) : 

--- a/filters/include/pcl/filters/statistical_outlier_removal.h
+++ b/filters/include/pcl/filters/statistical_outlier_removal.h
@@ -87,8 +87,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<StatisticalOutlierRemoval<PointT> >;
-      using ConstPtr = boost::shared_ptr<const StatisticalOutlierRemoval<PointT> >;
+      using Ptr = shared_ptr<StatisticalOutlierRemoval<PointT> >;
+      using ConstPtr = shared_ptr<const StatisticalOutlierRemoval<PointT> >;
 
 
       /** \brief Constructor.

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -70,8 +70,8 @@ namespace pcl
     using Filter<PointT>::getClassName;
 
     public:
-      using Ptr = boost::shared_ptr<UniformSampling<PointT> >;
-      using ConstPtr = boost::shared_ptr<const UniformSampling<PointT> >;
+      using Ptr = shared_ptr<UniformSampling<PointT> >;
+      using ConstPtr = shared_ptr<const UniformSampling<PointT> >;
 
       /** \brief Empty constructor. */
       UniformSampling (bool extract_removed_indices = false) :

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -188,8 +188,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<VoxelGrid<PointT> >;
-      using ConstPtr = boost::shared_ptr<const VoxelGrid<PointT> >;
+      using Ptr = shared_ptr<VoxelGrid<PointT> >;
+      using ConstPtr = shared_ptr<const VoxelGrid<PointT> >;
 
       /** \brief Empty constructor. */
       VoxelGrid () :

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -83,8 +83,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<VoxelGrid<PointT> >;
-      using ConstPtr = boost::shared_ptr<const VoxelGrid<PointT> >;
+      using Ptr = shared_ptr<VoxelGrid<PointT> >;
+      using ConstPtr = shared_ptr<const VoxelGrid<PointT> >;
 
 
       /** \brief Simple structure to hold a centroid, covarince and the number of points in a leaf.

--- a/filters/include/pcl/filters/voxel_grid_label.h
+++ b/filters/include/pcl/filters/voxel_grid_label.h
@@ -51,8 +51,8 @@ namespace pcl
   {
     public:
 
-      using Ptr = boost::shared_ptr<VoxelGridLabel>;
-      using ConstPtr = boost::shared_ptr<const VoxelGridLabel>;
+      using Ptr = shared_ptr<VoxelGridLabel>;
+      using ConstPtr = shared_ptr<const VoxelGridLabel>;
 
 
       /** \brief Constructor.

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -101,8 +101,8 @@ namespace pcl
       public:
 
         using Self = MeshBase <DerivedT, MeshTraitsT, MeshTagT>;
-        using Ptr = boost::shared_ptr<Self>;
-        using ConstPtr = boost::shared_ptr<const Self>;
+        using Ptr = shared_ptr<Self>;
+        using ConstPtr = shared_ptr<const Self>;
 
         using Derived = DerivedT;
 

--- a/geometry/include/pcl/geometry/planar_polygon.h
+++ b/geometry/include/pcl/geometry/planar_polygon.h
@@ -53,8 +53,8 @@ namespace pcl
   class PlanarPolygon
   {
     public:
-      using Ptr = boost::shared_ptr<PlanarPolygon<PointT> >;
-      using ConstPtr = boost::shared_ptr<const PlanarPolygon<PointT> >;
+      using Ptr = shared_ptr<PlanarPolygon<PointT> >;
+      using ConstPtr = shared_ptr<const PlanarPolygon<PointT> >;
 
        /** \brief Empty constructor for PlanarPolygon */
       PlanarPolygon () : contour_ ()

--- a/geometry/include/pcl/geometry/polygon_mesh.h
+++ b/geometry/include/pcl/geometry/polygon_mesh.h
@@ -63,8 +63,8 @@ namespace pcl
         using Base = pcl::geometry::MeshBase <PolygonMesh <MeshTraitsT>, MeshTraitsT, PolygonMeshTag>;
 
         using Self = PolygonMesh<MeshTraitsT>;
-        using Ptr = boost::shared_ptr<Self>;
-        using ConstPtr = boost::shared_ptr<const Self>;
+        using Ptr = shared_ptr<Self>;
+        using ConstPtr = shared_ptr<const Self>;
 
         using VertexData = typename Base::VertexData;
         using HalfEdgeData = typename Base::HalfEdgeData;

--- a/geometry/include/pcl/geometry/quad_mesh.h
+++ b/geometry/include/pcl/geometry/quad_mesh.h
@@ -63,8 +63,8 @@ namespace pcl
         using Base = pcl::geometry::MeshBase <QuadMesh <MeshTraitsT>, MeshTraitsT, QuadMeshTag>;
 
         using Self = QuadMesh<MeshTraitsT>;
-        using Ptr = boost::shared_ptr<Self>;
-        using ConstPtr = boost::shared_ptr<const Self>;
+        using Ptr = shared_ptr<Self>;
+        using ConstPtr = shared_ptr<const Self>;
 
         using VertexData = typename Base::VertexData;
         using HalfEdgeData = typename Base::HalfEdgeData;

--- a/geometry/include/pcl/geometry/triangle_mesh.h
+++ b/geometry/include/pcl/geometry/triangle_mesh.h
@@ -65,8 +65,8 @@ namespace pcl
         using Base = pcl::geometry::MeshBase <TriangleMesh <MeshTraitsT>, MeshTraitsT, TriangleMeshTag>;
 
         using Self = TriangleMesh<MeshTraitsT>;
-        using Ptr = boost::shared_ptr<Self>;
-        using ConstPtr = boost::shared_ptr<const Self>;
+        using Ptr = shared_ptr<Self>;
+        using ConstPtr = shared_ptr<const Self>;
 
         using VertexData = typename Base::VertexData;
         using HalfEdgeData = typename Base::HalfEdgeData;

--- a/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/color_volume.h
@@ -56,8 +56,8 @@ namespace pcl
     {
     public:
       using PointType = PointXYZ;
-      using Ptr = boost::shared_ptr<ColorVolume>;
-      using ConstPtr = boost::shared_ptr<const ColorVolume>;
+      using Ptr = shared_ptr<ColorVolume>;
+      using ConstPtr = shared_ptr<const ColorVolume>;
 
       /** \brief Constructor
         * \param[in] tsdf tsdf volume to get parameters from

--- a/gpu/kinfu/include/pcl/gpu/kinfu/marching_cubes.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/marching_cubes.h
@@ -65,8 +65,8 @@ namespace pcl
       using PointType = pcl::PointXYZ;
       
       /** \brief Smart pointer. */
-      using Ptr = boost::shared_ptr<MarchingCubes>;
-      using ConstPtr = boost::shared_ptr<const MarchingCubes>;
+      using Ptr = shared_ptr<MarchingCubes>;
+      using ConstPtr = shared_ptr<const MarchingCubes>;
 
       /** \brief Default constructor */
       MarchingCubes();

--- a/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/raycaster.h
@@ -56,8 +56,8 @@ namespace pcl
     struct PCL_EXPORTS RayCaster
     {
     public:
-      using Ptr = boost::shared_ptr<RayCaster>;
-      using ConstPtr = boost::shared_ptr<const RayCaster>;
+      using Ptr = shared_ptr<RayCaster>;
+      using ConstPtr = shared_ptr<const RayCaster>;
       using MapArr = DeviceArray2D<float>;
       using View = DeviceArray2D<PixelRGB>;
       using Depth = DeviceArray2D<unsigned short>;     

--- a/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/tsdf_volume.h
@@ -54,8 +54,8 @@ namespace pcl
     class PCL_EXPORTS TsdfVolume
     {
     public:
-      using Ptr = boost::shared_ptr<TsdfVolume>;
-      using ConstPtr = boost::shared_ptr<const TsdfVolume>;
+      using Ptr = shared_ptr<TsdfVolume>;
+      using ConstPtr = shared_ptr<const TsdfVolume>;
 
       /** \brief Supported Point Types */
       using PointType = PointXYZ;

--- a/gpu/kinfu/tools/camera_pose.h
+++ b/gpu/kinfu/tools/camera_pose.h
@@ -52,8 +52,8 @@
 class CameraPoseProcessor
 {
   public:
-    using Ptr = boost::shared_ptr<CameraPoseProcessor>;
-    using ConstPtr = boost::shared_ptr<const CameraPoseProcessor>;
+    using Ptr = shared_ptr<CameraPoseProcessor>;
+    using ConstPtr = shared_ptr<const CameraPoseProcessor>;
 
     virtual ~CameraPoseProcessor () {}
 

--- a/gpu/kinfu/tools/evaluation.h
+++ b/gpu/kinfu/tools/evaluation.h
@@ -50,8 +50,8 @@
 class Evaluation
 {
 public:
-  using Ptr = boost::shared_ptr<Evaluation>; 
-  using ConstPtr = boost::shared_ptr<const Evaluation>;
+  using Ptr = shared_ptr<Evaluation>; 
+  using ConstPtr = shared_ptr<const Evaluation>;
   using RGB = pcl::gpu::KinfuTracker::PixelRGB;
 
   Evaluation(const std::string& folder);

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -116,8 +116,8 @@ namespace pcl
       using RgbCloudConstPtr = pcl::PointCloud<RGB>::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerRGBCloud<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRGBCloud<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerRGBCloud<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerRGBCloud<PointT> >;
         
         /** \brief Constructor. */
         PointCloudColorHandlerRGBCloud (const PointCloudConstPtr& cloud, const RgbCloudConstPtr& colors)
@@ -307,8 +307,8 @@ pcl::PolygonMesh::Ptr convertToMesh(const DeviceArray<PointXYZ>& triangles)
 
 struct CurrentFrameCloudView
 {
-  using Ptr = boost::shared_ptr<CurrentFrameCloudView>;
-  using ConstPtr = boost::shared_ptr<const CurrentFrameCloudView>;
+  using Ptr = shared_ptr<CurrentFrameCloudView>;
+  using ConstPtr = shared_ptr<const CurrentFrameCloudView>;
 
   CurrentFrameCloudView() : cloud_device_ (480, 640), cloud_viewer_ ("Frame Cloud Viewer")
   {

--- a/gpu/kinfu/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu/tools/kinfu_app_sim.cpp
@@ -574,8 +574,8 @@ pcl::PolygonMesh::Ptr convertToMesh(const DeviceArray<PointXYZ>& triangles)
 
 struct CurrentFrameCloudView
 {
-  using Ptr = boost::shared_ptr<CurrentFrameCloudView>;
-  using ConstPtr = boost::shared_ptr<const CurrentFrameCloudView>;
+  using Ptr = shared_ptr<CurrentFrameCloudView>;
+  using ConstPtr = shared_ptr<const CurrentFrameCloudView>;
 
   CurrentFrameCloudView() : cloud_device_ (480, 640), cloud_viewer_ ("Frame Cloud Viewer")
   {

--- a/gpu/kinfu/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu/tools/record_tsdfvolume.cpp
@@ -77,8 +77,8 @@ class DeviceVolume
 {
 public:
 
-  using Ptr = boost::shared_ptr<DeviceVolume>;
-  using ConstPtr = boost::shared_ptr<const DeviceVolume>;
+  using Ptr = shared_ptr<DeviceVolume>;
+  using ConstPtr = shared_ptr<const DeviceVolume>;
 
   /** \brief Constructor
    * param[in] volume_size size of the volume in mm

--- a/gpu/kinfu/tools/tsdf_volume.h
+++ b/gpu/kinfu/tools/tsdf_volume.h
@@ -58,8 +58,8 @@ namespace pcl
   {
   public:
 
-    using Ptr = boost::shared_ptr<TSDFVolume<VoxelT, WeightT> >;
-    using ConstPtr = boost::shared_ptr<const TSDFVolume<VoxelT, WeightT> >;
+    using Ptr = shared_ptr<TSDFVolume<VoxelT, WeightT> >;
+    using ConstPtr = shared_ptr<const TSDFVolume<VoxelT, WeightT> >;
 
     // using VoxelTVec = Eigen::Matrix<VoxelT, Eigen::Dynamic, 1>;
     using VoxelTVec = Eigen::VectorXf;
@@ -283,8 +283,8 @@ public:
   //  void
   //  integrateVolume (const Eigen::MatrixXf &depth_scaled, float tranc_dist, const Eigen::Matrix3f &R_inv, const Eigen::Vector3f &t, const Intr &intr);
 
-    using VolumePtr = boost::shared_ptr<std::vector<VoxelT> >;
-    using WeightsPtr = boost::shared_ptr<std::vector<WeightT> >;
+    using VolumePtr = shared_ptr<std::vector<VoxelT> >;
+    using WeightsPtr = shared_ptr<std::vector<WeightT> >;
 
     Header header_;
     VolumePtr volume_;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/color_volume.h
@@ -60,8 +60,8 @@ namespace pcl
       {
       public:
         using PointType = PointXYZ;
-        using Ptr = boost::shared_ptr<ColorVolume>;
-        using ConstPtr = boost::shared_ptr<const ColorVolume>;
+        using Ptr = shared_ptr<ColorVolume>;
+        using ConstPtr = shared_ptr<const ColorVolume>;
 
         /**
          * \brief Constructor

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/marching_cubes.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/marching_cubes.h
@@ -69,8 +69,8 @@ namespace pcl
         using PointType = pcl::PointXYZ;
         
         /** \brief Smart pointer. */
-        using Ptr = boost::shared_ptr<MarchingCubes>;
-        using ConstPtr = boost::shared_ptr<const MarchingCubes>;
+        using Ptr = shared_ptr<MarchingCubes>;
+        using ConstPtr = shared_ptr<const MarchingCubes>;
 
         /** \brief Default constructor */
         MarchingCubes();

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
@@ -61,8 +61,8 @@ namespace pcl
       struct PCL_EXPORTS RayCaster
       {
       public:
-        using Ptr = boost::shared_ptr<RayCaster>;
-        using ConstPtr = boost::shared_ptr<const RayCaster>;
+        using Ptr = shared_ptr<RayCaster>;
+        using ConstPtr = shared_ptr<const RayCaster>;
         using MapArr = pcl::gpu::DeviceArray2D<float>;
         using View = pcl::gpu::DeviceArray2D<PixelRGB>;
         using Depth = pcl::gpu::DeviceArray2D<unsigned short>;     

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/tsdf_volume.h
@@ -61,8 +61,8 @@ namespace pcl
       class PCL_EXPORTS TsdfVolume
       {
       public:
-        using Ptr = boost::shared_ptr<TsdfVolume>;
-        using ConstPtr = boost::shared_ptr<const TsdfVolume>;
+        using Ptr = shared_ptr<TsdfVolume>;
+        using ConstPtr = shared_ptr<const TsdfVolume>;
 
         /** \brief Supported Point Types */
         using PointType = PointXYZ;
@@ -277,8 +277,8 @@ namespace pcl
         float tranc_dist_;
 
         // The following member are resulting from the merge of TSDFVolume with TsdfVolume class.
-        using VolumePtr = boost::shared_ptr<std::vector<float> >;
-        using WeightsPtr = boost::shared_ptr<std::vector<short> >;
+        using VolumePtr = shared_ptr<std::vector<float> >;
+        using WeightsPtr = shared_ptr<std::vector<short> >;
 
         Header header_;
         VolumePtr volume_host_;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
@@ -64,8 +64,8 @@ namespace pcl
     {
       public:
 
-        using Ptr = boost::shared_ptr<WorldModel<PointT> >;
-        using ConstPtr = boost::shared_ptr<const WorldModel<PointT> >;
+        using Ptr = shared_ptr<WorldModel<PointT> >;
+        using ConstPtr = shared_ptr<const WorldModel<PointT> >;
 
         using PointCloud = pcl::PointCloud<PointT>;
         using PointCloudPtr = typename PointCloud::Ptr;

--- a/gpu/kinfu_large_scale/tools/color_handler.h
+++ b/gpu/kinfu_large_scale/tools/color_handler.h
@@ -54,8 +54,8 @@ namespace pcl
       using RgbCloudConstPtr = pcl::PointCloud<RGB>::ConstPtr;
 
     public:
-      using Ptr = boost::shared_ptr<PointCloudColorHandlerRGBHack<PointT> >;
-      using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRGBHack<PointT> >;
+      using Ptr = shared_ptr<PointCloudColorHandlerRGBHack<PointT> >;
+      using ConstPtr = shared_ptr<const PointCloudColorHandlerRGBHack<PointT> >;
       
       PointCloudColorHandlerRGBHack (const PointCloudConstPtr& cloud, const RgbCloudConstPtr& colors) : 
           PointCloudColorHandler<PointT> (cloud), rgb_ (colors)

--- a/gpu/kinfu_large_scale/tools/evaluation.h
+++ b/gpu/kinfu_large_scale/tools/evaluation.h
@@ -50,8 +50,8 @@
 class Evaluation
 {
 public:
-  using Ptr = boost::shared_ptr<Evaluation>; 
-  using ConstPtr = boost::shared_ptr<const Evaluation>;
+  using Ptr = shared_ptr<Evaluation>; 
+  using ConstPtr = shared_ptr<const Evaluation>;
   using RGB = pcl::gpu::kinfuLS::PixelRGB;
 
   Evaluation(const std::string& folder);

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -1010,8 +1010,8 @@ struct KinFuLSApp
     {
       #ifdef HAVE_OPENNI2
       using namespace pcl::io;
-      using DepthImagePtr = boost::shared_ptr<DepthImage>;
-      using ImagePtr = boost::shared_ptr<Image>;
+      using DepthImagePtr = shared_ptr<DepthImage>;
+      using ImagePtr = shared_ptr<Image>;
 
       std::function<void (const ImagePtr&, const DepthImagePtr&, float)> func1 =
           [this] (const ImagePtr& img, const DepthImagePtr& depth, float constant)
@@ -1041,8 +1041,8 @@ struct KinFuLSApp
     {
       #ifdef HAVE_OPENNI
       using namespace openni_wrapper;
-      using DepthImagePtr = boost::shared_ptr<DepthImage>;
-      using ImagePtr = boost::shared_ptr<Image>;
+      using DepthImagePtr = shared_ptr<DepthImage>;
+      using ImagePtr = shared_ptr<Image>;
 
       std::function<void (const ImagePtr&, const DepthImagePtr&, float)> func1 =
           [this] (const ImagePtr& img, const DepthImagePtr& depth, float constant)
@@ -1177,7 +1177,7 @@ struct KinFuLSApp
 
   SceneCloudView scene_cloud_view_;
   ImageView image_view_;
-  boost::shared_ptr<CurrentFrameCloudView> current_frame_cloud_view_;
+  shared_ptr<CurrentFrameCloudView> current_frame_cloud_view_;
 
   KinfuTracker::DepthMap depth_device_;
 
@@ -1332,7 +1332,7 @@ main (int argc, char* argv[])
   //  if (checkIfPreFermiGPU(device))
   //    return std::cout << std::endl << "Kinfu is supported only for Fermi and Kepler arhitectures. It is not even compiled for pre-Fermi by default. Exiting..." << std::endl, 1;
 
-  boost::shared_ptr<pcl::Grabber> capture;
+  shared_ptr<pcl::Grabber> capture;
   bool triggered_capture = false;
   bool pcd_input = false;
   bool oni2_interface = false;

--- a/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
+++ b/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
@@ -85,8 +85,8 @@ class MapsBuffer
     
     struct MapsRgb
     {
-      using Ptr = boost::shared_ptr<MapsRgb>;
-      using ConstPtr = boost::shared_ptr<const MapsRgb>;
+      using Ptr = shared_ptr<MapsRgb>;
+      using ConstPtr = shared_ptr<const MapsRgb>;
 
       pcl::gpu::PtrStepSz<const PixelRGB> rgb_;
       pcl::gpu::PtrStepSz<const unsigned short> depth_;      

--- a/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu_large_scale/tools/record_tsdfvolume.cpp
@@ -75,8 +75,8 @@ class DeviceVolume
 {
 public:
 
-  using Ptr = boost::shared_ptr<DeviceVolume>;
-  using ConstPtr = boost::shared_ptr<const DeviceVolume>;
+  using Ptr = shared_ptr<DeviceVolume>;
+  using ConstPtr = shared_ptr<const DeviceVolume>;
 
   /** \brief Constructor
    * param[in] volume_size size of the volume in mm

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -64,8 +64,8 @@ namespace pcl
             virtual ~Octree();
 
             /** \brief Types */
-            using Ptr = boost::shared_ptr<Octree>;
-            using ConstPtr = boost::shared_ptr<const Octree>;
+            using Ptr = shared_ptr<Octree>;
+            using ConstPtr = shared_ptr<const Octree>;
 
             /** \brief Point typwe supported */
             using PointType = pcl::PointXYZ;

--- a/gpu/people/include/pcl/gpu/people/bodyparts_detector.h
+++ b/gpu/people/include/pcl/gpu/people/bodyparts_detector.h
@@ -64,8 +64,8 @@ namespace pcl
       class PCL_EXPORTS RDFBodyPartsDetector
       {
         public:
-          using Ptr = boost::shared_ptr<RDFBodyPartsDetector>;          
-          using ConstPtr = boost::shared_ptr<const RDFBodyPartsDetector>;
+          using Ptr = shared_ptr<RDFBodyPartsDetector>;          
+          using ConstPtr = shared_ptr<const RDFBodyPartsDetector>;
           using BlobMatrix = std::vector<std::vector<Blob2, Eigen::aligned_allocator<Blob2> > >;
           
           using Labels = DeviceArray2D<unsigned char>;

--- a/gpu/people/include/pcl/gpu/people/face_detector.h
+++ b/gpu/people/include/pcl/gpu/people/face_detector.h
@@ -57,8 +57,8 @@ namespace pcl
       class FaceDetector
       {
         public:
-          using Ptr = boost::shared_ptr<FaceDetector>;
-          using ConstPtr = boost::shared_ptr<const FaceDetector>;
+          using Ptr = shared_ptr<FaceDetector>;
+          using ConstPtr = shared_ptr<const FaceDetector>;
           //using Labels = DeviceArray2D<unsigned char>;
           //using Depth = DeviceArray2D<unsigned short>;
           //using Image = DeviceArray2D<pcl::RGB>;

--- a/gpu/people/include/pcl/gpu/people/organized_plane_detector.h
+++ b/gpu/people/include/pcl/gpu/people/organized_plane_detector.h
@@ -58,8 +58,8 @@ namespace pcl
       class OrganizedPlaneDetector
       {
         public:
-          using Ptr = boost::shared_ptr<OrganizedPlaneDetector>;
-          using ConstPtr = boost::shared_ptr<const OrganizedPlaneDetector>;
+          using Ptr = shared_ptr<OrganizedPlaneDetector>;
+          using ConstPtr = shared_ptr<const OrganizedPlaneDetector>;
 
           using PointTC = pcl::PointXYZRGBA;
           using PointT = pcl::PointXYZ;

--- a/gpu/people/include/pcl/gpu/people/people_detector.h
+++ b/gpu/people/include/pcl/gpu/people/people_detector.h
@@ -62,8 +62,8 @@ namespace pcl
       class PCL_EXPORTS PeopleDetector
       {
         public:
-          using Ptr = boost::shared_ptr<PeopleDetector>;                              
-          using ConstPtr = boost::shared_ptr<const PeopleDetector>;
+          using Ptr = shared_ptr<PeopleDetector>;                              
+          using ConstPtr = shared_ptr<const PeopleDetector>;
 
           using PointTC = pcl::PointXYZRGBA;
           using PointT = pcl::PointXYZ;

--- a/gpu/people/include/pcl/gpu/people/person_attribs.h
+++ b/gpu/people/include/pcl/gpu/people/person_attribs.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include <iosfwd>
-#include <boost/shared_ptr.hpp>
+#include <pcl/make_shared.h>
 
 #include <pcl/pcl_exports.h>
 
@@ -16,8 +16,8 @@ namespace pcl
       class PCL_EXPORTS PersonAttribs
       {
         public:
-          using Ptr = boost::shared_ptr<PersonAttribs>;
-          using ConstPtr = boost::shared_ptr<const PersonAttribs>;
+          using Ptr = shared_ptr<PersonAttribs>;
+          using ConstPtr = shared_ptr<const PersonAttribs>;
 
           /** \brief Constructor creates generic values from **/
           PersonAttribs();

--- a/gpu/people/include/pcl/gpu/people/probability_processor.h
+++ b/gpu/people/include/pcl/gpu/people/probability_processor.h
@@ -60,8 +60,8 @@ namespace pcl
       class PCL_EXPORTS ProbabilityProcessor
       {        
         public:
-          using Ptr = boost::shared_ptr<ProbabilityProcessor>;
-          using ConstPtr = boost::shared_ptr<const ProbabilityProcessor>;
+          using Ptr = shared_ptr<ProbabilityProcessor>;
+          using ConstPtr = shared_ptr<const ProbabilityProcessor>;
           using Depth = DeviceArray2D<unsigned short>;
           using Labels = DeviceArray2D<unsigned char>;
 

--- a/gpu/people/tools/people_app.cpp
+++ b/gpu/people/tools/people_app.cpp
@@ -387,7 +387,7 @@ int main(int argc, char** argv)
   pc::parse_argument (argc, argv, "-w", write);
 
   // selecting data source
-  boost::shared_ptr<pcl::Grabber> capture;
+  shared_ptr<pcl::Grabber> capture;
   string openni_device, oni_file, pcd_file, pcd_folder;  
    
   try

--- a/io/include/pcl/compression/octree_pointcloud_compression.h
+++ b/io/include/pcl/compression/octree_pointcloud_compression.h
@@ -78,8 +78,8 @@ namespace pcl
         using PointCloudConstPtr = typename OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::PointCloudConstPtr;
 
         // Boost shared pointers
-        using Ptr = boost::shared_ptr<OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> >;
-        using ConstPtr = boost::shared_ptr<const OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> >;
+        using Ptr = shared_ptr<OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> >;
+        using ConstPtr = shared_ptr<const OctreePointCloudCompression<PointT, LeafT, BranchT, OctreeT> >;
 
         using LeafNode = typename OctreeT::LeafNode;
         using BranchNode = typename OctreeT::BranchNode;

--- a/io/include/pcl/io/davidsdk_grabber.h
+++ b/io/include/pcl/io/davidsdk_grabber.h
@@ -67,8 +67,8 @@ namespace pcl
   {
     public:
       /** @cond */
-      using Ptr = boost::shared_ptr<DavidSDKGrabber>;
-      using ConstPtr = boost::shared_ptr<const DavidSDKGrabber>;
+      using Ptr = shared_ptr<DavidSDKGrabber>;
+      using ConstPtr = shared_ptr<const DavidSDKGrabber>;
 
       // Define callback signature typedefs
       using sig_cb_davidsdk_point_cloud = void(const pcl::PointCloud<pcl::PointXYZ>::Ptr &);

--- a/io/include/pcl/io/depth_sense_grabber.h
+++ b/io/include/pcl/io/depth_sense_grabber.h
@@ -58,8 +58,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<DepthSenseGrabber>;
-      using ConstPtr = boost::shared_ptr<const DepthSenseGrabber>;
+      using Ptr = shared_ptr<DepthSenseGrabber>;
+      using ConstPtr = shared_ptr<const DepthSenseGrabber>;
 
       using sig_cb_depth_sense_point_cloud = void(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&);
       using sig_cb_depth_sense_point_cloud_rgba = void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&);

--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -71,15 +71,15 @@ namespace pcl
 
     public:
       /** @cond */
-      using Ptr = boost::shared_ptr<EnsensoGrabber>;
-      using ConstPtr = boost::shared_ptr<const EnsensoGrabber>;
+      using Ptr = shared_ptr<EnsensoGrabber>;
+      using ConstPtr = shared_ptr<const EnsensoGrabber>;
 
       // Define callback signature typedefs
       using sig_cb_ensenso_point_cloud = void(const pcl::PointCloud<pcl::PointXYZ>::Ptr&);
 
-      using sig_cb_ensenso_images = void(const boost::shared_ptr<PairOfImages>&);
+      using sig_cb_ensenso_images = void(const shared_ptr<PairOfImages>&);
 
-      using sig_cb_ensenso_point_cloud_images = void(const pcl::PointCloud<pcl::PointXYZ>::Ptr&,const boost::shared_ptr<PairOfImages>&);
+      using sig_cb_ensenso_point_cloud_images = void(const pcl::PointCloud<pcl::PointXYZ>::Ptr&,const shared_ptr<PairOfImages>&);
 
      /** @endcond */
 
@@ -425,7 +425,7 @@ namespace pcl
       /** @brief Reference to the NxLib tree root
        * @warning You must handle NxLib exceptions manually when playing with @ref root_ !
        * See ensensoExceptionHandling in ensenso_grabber.cpp */
-      boost::shared_ptr<const NxLibItem> root_;
+      shared_ptr<const NxLibItem> root_;
 
       /** @brief Reference to the camera tree
        *  @warning You must handle NxLib exceptions manually when playing with @ref camera_ ! */

--- a/io/include/pcl/io/image.h
+++ b/io/include/pcl/io/image.h
@@ -57,8 +57,8 @@ namespace pcl
     class PCL_EXPORTS Image
     {
       public:
-        using Ptr = boost::shared_ptr<Image>;
-        using ConstPtr = boost::shared_ptr<const Image>;
+        using Ptr = shared_ptr<Image>;
+        using ConstPtr = shared_ptr<const Image>;
 
         using Clock = std::chrono::high_resolution_clock;
         using Timestamp = std::chrono::high_resolution_clock::time_point;

--- a/io/include/pcl/io/image_depth.h
+++ b/io/include/pcl/io/image_depth.h
@@ -55,8 +55,8 @@ namespace pcl
     class PCL_EXPORTS DepthImage
     {
       public:
-        using Ptr = boost::shared_ptr<DepthImage>;
-        using ConstPtr = boost::shared_ptr<const DepthImage>;
+        using Ptr = shared_ptr<DepthImage>;
+        using ConstPtr = shared_ptr<const DepthImage>;
 
         using Clock = std::chrono::high_resolution_clock;
         using Timestamp = std::chrono::high_resolution_clock::time_point;

--- a/io/include/pcl/io/image_grabber.h
+++ b/io/include/pcl/io/image_grabber.h
@@ -217,8 +217,8 @@ namespace pcl
   template <typename PointT> class ImageGrabber : public ImageGrabberBase, public FileGrabber<PointT>
   {
     public:
-    using Ptr = boost::shared_ptr<ImageGrabber>;
-    using ConstPtr = boost::shared_ptr<const ImageGrabber>;
+    using Ptr = shared_ptr<ImageGrabber>;
+    using ConstPtr = shared_ptr<const ImageGrabber>;
 
     ImageGrabber (const std::string& dir, 
                   float frames_per_second = 0, 

--- a/io/include/pcl/io/image_ir.h
+++ b/io/include/pcl/io/image_ir.h
@@ -54,8 +54,8 @@ namespace pcl
     class PCL_EXPORTS IRImage
     {
       public:
-        using Ptr = boost::shared_ptr<IRImage>;
-        using ConstPtr = boost::shared_ptr<const IRImage>;
+        using Ptr = shared_ptr<IRImage>;
+        using ConstPtr = shared_ptr<const IRImage>;
 
         using Clock = std::chrono::high_resolution_clock;
         using Timestamp = std::chrono::high_resolution_clock::time_point;

--- a/io/include/pcl/io/image_metadata_wrapper.h
+++ b/io/include/pcl/io/image_metadata_wrapper.h
@@ -53,8 +53,8 @@ namespace pcl
     class FrameWrapper
     {
       public:
-        using Ptr = boost::shared_ptr<FrameWrapper>;
-        using ConstPtr = boost::shared_ptr<const FrameWrapper>;
+        using Ptr = shared_ptr<FrameWrapper>;
+        using ConstPtr = shared_ptr<const FrameWrapper>;
 
         virtual
         ~FrameWrapper() = default;

--- a/io/include/pcl/io/openni2/openni2_device.h
+++ b/io/include/pcl/io/openni2/openni2_device.h
@@ -73,8 +73,8 @@ namespace pcl
       class PCL_EXPORTS OpenNI2Device
       {
         public:
-          using Ptr = boost::shared_ptr<OpenNI2Device>;
-          using ConstPtr = boost::shared_ptr<const OpenNI2Device>;
+          using Ptr = shared_ptr<OpenNI2Device>;
+          using ConstPtr = shared_ptr<const OpenNI2Device>;
 
           using ImageCallbackFunction = std::function<void(Image::Ptr, void* cookie) >;
           using DepthImageCallbackFunction = std::function<void(DepthImage::Ptr, void* cookie) >;

--- a/io/include/pcl/io/openni2/openni2_device_manager.h
+++ b/io/include/pcl/io/openni2/openni2_device_manager.h
@@ -58,7 +58,7 @@ namespace pcl
 
         // This may not actually be a singleton yet. Need to work out cross-dll incerface.
         // Based on http://stackoverflow.com/a/13431981/1789618
-        static boost::shared_ptr<OpenNI2DeviceManager> getInstance ()
+        static shared_ptr<OpenNI2DeviceManager> getInstance ()
         {
           static auto instance = pcl::make_shared<OpenNI2DeviceManager>();
           return (instance);

--- a/io/include/pcl/io/openni2_grabber.h
+++ b/io/include/pcl/io/openni2_grabber.h
@@ -75,8 +75,8 @@ namespace pcl
     class PCL_EXPORTS OpenNI2Grabber : public Grabber
     {
       public:
-        using Ptr = boost::shared_ptr<OpenNI2Grabber>;
-        using ConstPtr = boost::shared_ptr<const OpenNI2Grabber>;
+        using Ptr = shared_ptr<OpenNI2Grabber>;
+        using ConstPtr = shared_ptr<const OpenNI2Grabber>;
 
         // Templated images
         using DepthImage = pcl::io::DepthImage;

--- a/io/include/pcl/io/openni_camera/openni_depth_image.h
+++ b/io/include/pcl/io/openni_camera/openni_depth_image.h
@@ -39,6 +39,7 @@
 #pragma once
  
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include "openni.h"
@@ -56,8 +57,8 @@ namespace openni_wrapper
   class PCL_EXPORTS DepthImage
   {
     public:
-      using Ptr = boost::shared_ptr<DepthImage>;
-      using ConstPtr = boost::shared_ptr<const DepthImage>;
+      using Ptr = pcl::shared_ptr<DepthImage>;
+      using ConstPtr = pcl::shared_ptr<const DepthImage>;
 
       /** \brief Constructor
         * \param[in] depth_meta_data the actual data from the OpenNI library
@@ -68,7 +69,7 @@ namespace openni_wrapper
         * \param[in] no_sample_value defines which values in the depth data are indicating that no depth (disparity) could be determined .
         * \attention The focal length may change, depending whether the depth stream is registered/mapped to the RGB stream or not.
         */
-      inline DepthImage (boost::shared_ptr<xn::DepthMetaData> depth_meta_data, float baseline, float focal_length, XnUInt64 shadow_value, XnUInt64 no_sample_value) throw ();
+      inline DepthImage (pcl::shared_ptr<xn::DepthMetaData> depth_meta_data, float baseline, float focal_length, XnUInt64 shadow_value, XnUInt64 no_sample_value) throw ();
 
       /** \brief Destructor. Never throws an exception. */
       inline virtual ~DepthImage () throw ();
@@ -155,14 +156,14 @@ namespace openni_wrapper
       getTimeStamp () const throw ();
 
     protected:
-      boost::shared_ptr<xn::DepthMetaData> depth_md_;
+      pcl::shared_ptr<xn::DepthMetaData> depth_md_;
       float baseline_;
       float focal_length_;
       XnUInt64 shadow_value_;
       XnUInt64 no_sample_value_;
   } ;
 
-  DepthImage::DepthImage (boost::shared_ptr<xn::DepthMetaData> depth_meta_data, float baseline, float focal_length, XnUInt64 shadow_value, XnUInt64 no_sample_value) throw ()
+  DepthImage::DepthImage (pcl::shared_ptr<xn::DepthMetaData> depth_meta_data, float baseline, float focal_length, XnUInt64 shadow_value, XnUInt64 no_sample_value) throw ()
   : depth_md_ (std::move(depth_meta_data))
   , baseline_ (baseline)
   , focal_length_ (focal_length)

--- a/io/include/pcl/io/openni_camera/openni_device.h
+++ b/io/include/pcl/io/openni_camera/openni_device.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include "openni_exception.h"
@@ -78,8 +79,8 @@ namespace openni_wrapper
         OpenNI_12_bit_depth = 1, // Default mode: regular 12-bit depth
       };
 
-      using Ptr = boost::shared_ptr<OpenNIDevice>;
-      using ConstPtr = boost::shared_ptr<const OpenNIDevice>;
+      using Ptr = pcl::shared_ptr<OpenNIDevice>;
+      using ConstPtr = pcl::shared_ptr<const OpenNIDevice>;
 
       using ImageCallbackFunction = std::function<void(Image::Ptr, void* cookie) >;
       using DepthImageCallbackFunction = std::function<void(DepthImage::Ptr, void* cookie) >;
@@ -476,7 +477,7 @@ namespace openni_wrapper
       setRegistration (bool on_off);
 
       virtual Image::Ptr
-      getCurrentImage (boost::shared_ptr<xn::ImageMetaData> image_data) const throw () = 0;
+      getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_data) const throw () = 0;
 
       void 
       Init ();

--- a/io/include/pcl/io/openni_camera/openni_device_kinect.h
+++ b/io/include/pcl/io/openni_camera/openni_device_kinect.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include "openni_device.h"
@@ -65,7 +66,7 @@ namespace openni_wrapper
     bool isSynchronizationSupported () const throw () override;
 
   protected:
-    Image::Ptr getCurrentImage (boost::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
+    Image::Ptr getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
     void enumAvailableModes () throw ();
     bool isImageResizeSupported (unsigned input_width, unsigned input_height, unsigned output_width, unsigned output_height) const throw () override;
     ImageBayerGRBG::DebayeringMethod debayering_method_;

--- a/io/include/pcl/io/openni_camera/openni_device_oni.h
+++ b/io/include/pcl/io/openni_camera/openni_device_oni.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include "openni_device.h"
@@ -61,8 +62,8 @@ namespace openni_wrapper
     friend class OpenNIDriver;
   public:
 
-    using Ptr = boost::shared_ptr<DeviceONI>;
-    using ConstPtr = boost::shared_ptr<const DeviceONI>;
+    using Ptr = pcl::shared_ptr<DeviceONI>;
+    using ConstPtr = pcl::shared_ptr<const DeviceONI>;
 
     DeviceONI (xn::Context& context, const std::string& file_name, bool repeat = false, bool streaming = true);
     ~DeviceONI () throw ();
@@ -98,7 +99,7 @@ namespace openni_wrapper
     }
 
   protected:
-    Image::Ptr getCurrentImage (boost::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
+    Image::Ptr getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
 
     void PlayerThreadFunction ();
     static void __stdcall NewONIDepthDataAvailable (xn::ProductionNode& node, void* cookie) throw ();

--- a/io/include/pcl/io/openni_camera/openni_device_primesense.h
+++ b/io/include/pcl/io/openni_camera/openni_device_primesense.h
@@ -37,6 +37,7 @@
 #pragma once
  
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include "openni_device.h"
@@ -62,7 +63,7 @@ public:
   //virtual void setImageOutputMode (const XnMapOutputMode& output_mode);
 
 protected:
-  Image::Ptr getCurrentImage (boost::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
+  Image::Ptr getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
   void enumAvailableModes () throw ();
   bool isImageResizeSupported (unsigned input_width, unsigned input_height, unsigned output_width, unsigned output_height) const throw () override;
 

--- a/io/include/pcl/io/openni_camera/openni_device_xtion.h
+++ b/io/include/pcl/io/openni_camera/openni_device_xtion.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include "openni_device.h"
@@ -64,7 +65,7 @@ namespace openni_wrapper
     //virtual void setImageOutputMode (const XnMapOutputMode& output_mode);
 
   protected:
-    Image::Ptr getCurrentImage (boost::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
+    Image::Ptr getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) const throw () override;
     void enumAvailableModes () throw ();
     bool isImageResizeSupported (unsigned input_width, unsigned input_height, unsigned output_width, unsigned output_height) const throw () override;
 

--- a/io/include/pcl/io/openni_camera/openni_image.h
+++ b/io/include/pcl/io/openni_camera/openni_image.h
@@ -37,6 +37,7 @@
 #pragma once
  
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include <pcl/pcl_exports.h>
@@ -58,8 +59,8 @@ namespace openni_wrapper
   class PCL_EXPORTS Image
   {
   public:
-    using Ptr = boost::shared_ptr<Image>;
-    using ConstPtr = boost::shared_ptr<const Image>;
+    using Ptr = pcl::shared_ptr<Image>;
+    using ConstPtr = pcl::shared_ptr<const Image>;
 
     enum Encoding
     {
@@ -73,7 +74,7 @@ namespace openni_wrapper
      * @brief Constructor
      * @param[in] image_meta_data the actual image data from the OpenNI driver
      */
-    inline Image (boost::shared_ptr<xn::ImageMetaData> image_meta_data) throw ();
+    inline Image (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) throw ();
 
     /**
      * @author Suat Gedikli
@@ -165,10 +166,10 @@ namespace openni_wrapper
     inline const xn::ImageMetaData& getMetaData () const throw ();
 
   protected:
-    boost::shared_ptr<xn::ImageMetaData> image_md_;
+    pcl::shared_ptr<xn::ImageMetaData> image_md_;
   } ;
 
-  Image::Image (boost::shared_ptr<xn::ImageMetaData> image_meta_data) throw ()
+  Image::Image (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) throw ()
   : image_md_ (std::move(image_meta_data))
   {
   }

--- a/io/include/pcl/io/openni_camera/openni_image_bayer_grbg.h
+++ b/io/include/pcl/io/openni_camera/openni_image_bayer_grbg.h
@@ -39,6 +39,7 @@
 #pragma once
  
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include <pcl/pcl_macros.h>
@@ -60,7 +61,7 @@ namespace openni_wrapper
         EdgeAwareWeighted
       };
 
-      ImageBayerGRBG (boost::shared_ptr<xn::ImageMetaData> image_meta_data, DebayeringMethod method) throw ();
+      ImageBayerGRBG (pcl::shared_ptr<xn::ImageMetaData> image_meta_data, DebayeringMethod method) throw ();
       ~ImageBayerGRBG () throw ();
 
       inline Encoding

--- a/io/include/pcl/io/openni_camera/openni_image_rgb24.h
+++ b/io/include/pcl/io/openni_camera/openni_image_rgb24.h
@@ -37,6 +37,7 @@
 #pragma once
  
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include "openni_image.h"
@@ -55,7 +56,7 @@ namespace openni_wrapper
   {
   public:
 
-    ImageRGB24 (boost::shared_ptr<xn::ImageMetaData> image_meta_data) throw ();
+    ImageRGB24 (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) throw ();
     ~ImageRGB24 () throw ();
 
     inline Encoding

--- a/io/include/pcl/io/openni_camera/openni_image_yuv_422.h
+++ b/io/include/pcl/io/openni_camera/openni_image_yuv_422.h
@@ -37,6 +37,7 @@
 #pragma once
  
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include <pcl/pcl_macros.h>
@@ -54,7 +55,7 @@ namespace openni_wrapper
   class PCL_EXPORTS ImageYUV422 : public Image
   {
   public:
-    ImageYUV422 (boost::shared_ptr<xn::ImageMetaData> image_meta_data) throw ();
+    ImageYUV422 (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) throw ();
     ~ImageYUV422 () throw ();
 
     inline Encoding

--- a/io/include/pcl/io/openni_camera/openni_ir_image.h
+++ b/io/include/pcl/io/openni_camera/openni_ir_image.h
@@ -37,6 +37,7 @@
 #define __OPENNI_IR_IMAGE__
 
 #include <pcl/pcl_macros.h>
+#include <pcl/make_shared.h>
 #include "openni.h"
 #include "openni_exception.h"
 #include <pcl/io/boost.h>
@@ -51,10 +52,10 @@ namespace openni_wrapper
 class PCL_EXPORTS IRImage
 {
 public:
-  using Ptr = boost::shared_ptr<IRImage>;
-  using ConstPtr = boost::shared_ptr<const IRImage>;
+  using Ptr = pcl::shared_ptr<IRImage>;
+  using ConstPtr = pcl::shared_ptr<const IRImage>;
 
-  inline IRImage (boost::shared_ptr<xn::IRMetaData> ir_meta_data) throw ();
+  inline IRImage (pcl::shared_ptr<xn::IRMetaData> ir_meta_data) throw ();
   inline virtual ~IRImage () throw ();
 
   void fillRaw (unsigned width, unsigned height, unsigned short* ir_buffer, unsigned line_step = 0) const;
@@ -66,10 +67,10 @@ public:
   inline const xn::IRMetaData& getMetaData () const throw ();
 
 protected:
-  boost::shared_ptr<xn::IRMetaData> ir_md_;
+  pcl::shared_ptr<xn::IRMetaData> ir_md_;
 };
 
-IRImage::IRImage (boost::shared_ptr<xn::IRMetaData> ir_meta_data) throw ()
+IRImage::IRImage (pcl::shared_ptr<xn::IRMetaData> ir_meta_data) throw ()
 : ir_md_ (std::move(ir_meta_data))
 {
 }

--- a/io/include/pcl/io/openni_grabber.h
+++ b/io/include/pcl/io/openni_grabber.h
@@ -70,8 +70,8 @@ namespace pcl
   class PCL_EXPORTS OpenNIGrabber : public Grabber
   {
     public:
-      using Ptr = boost::shared_ptr<OpenNIGrabber>;
-      using ConstPtr = boost::shared_ptr<const OpenNIGrabber>;
+      using Ptr = shared_ptr<OpenNIGrabber>;
+      using ConstPtr = shared_ptr<const OpenNIGrabber>;
 
       enum Mode
       {

--- a/io/include/pcl/io/pcd_grabber.h
+++ b/io/include/pcl/io/pcd_grabber.h
@@ -44,14 +44,13 @@
 #include <pcl/io/file_grabber.h>
 #include <pcl/common/time_trigger.h>
 #include <pcl/conversions.h>
+#include <pcl/make_shared.h>
 
 #ifdef HAVE_OPENNI
 #include <pcl/io/openni_camera/openni_image.h>
 #include <pcl/io/openni_camera/openni_image_rgb24.h>
 #include <pcl/io/openni_camera/openni_depth_image.h>
 #endif
-
-#include <boost/shared_ptr.hpp>
 
 #include <string>
 #include <vector>
@@ -158,8 +157,8 @@ namespace pcl
   template <typename PointT> class PCDGrabber : public PCDGrabberBase, public FileGrabber<PointT>
   {
     public:
-      using Ptr = boost::shared_ptr<PCDGrabber>;
-      using ConstPtr = boost::shared_ptr<const PCDGrabber>;
+      using Ptr = shared_ptr<PCDGrabber>;
+      using ConstPtr = shared_ptr<const PCDGrabber>;
 
       PCDGrabber (const std::string& pcd_path, float frames_per_second = 0, bool repeat = false);
       PCDGrabber (const std::vector<std::string>& pcd_files, float frames_per_second = 0, bool repeat = false);
@@ -260,7 +259,7 @@ namespace pcl
     if (!cloud->isOrganized ())
       return;
 
-    boost::shared_ptr<xn::DepthMetaData> depth_meta_data (new xn::DepthMetaData);
+    shared_ptr<xn::DepthMetaData> depth_meta_data (new xn::DepthMetaData);
     depth_meta_data->AllocateData (cloud->width, cloud->height);
     XnDepthPixel* depth_map = depth_meta_data->WritableData ();
     std::uint32_t k = 0;
@@ -284,7 +283,7 @@ namespace pcl
     {
       rgba_index = fields[rgba_index].offset;
 
-      boost::shared_ptr<xn::ImageMetaData> image_meta_data (new xn::ImageMetaData);
+      shared_ptr<xn::ImageMetaData> image_meta_data (new xn::ImageMetaData);
       image_meta_data->AllocateData (cloud->width, cloud->height, XN_PIXEL_FORMAT_RGB24);
       XnRGB24Pixel* image_map = image_meta_data->WritableRGB24Data ();
       k = 0;

--- a/io/include/pcl/io/point_cloud_image_extractors.h
+++ b/io/include/pcl/io/point_cloud_image_extractors.h
@@ -80,8 +80,8 @@ namespace pcl
       public:
         using PointCloud = pcl::PointCloud<PointT>;
 
-        using Ptr = boost::shared_ptr<PointCloudImageExtractor<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractor<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractor<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractor<PointT> >;
 
         /** \brief Constructor. */
         PointCloudImageExtractor ()
@@ -133,8 +133,8 @@ namespace pcl
       using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudImageExtractorWithScaling<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorWithScaling<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractorWithScaling<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractorWithScaling<PointT> >;
 
         /** \brief Different scaling methods.
           * <ul>
@@ -205,8 +205,8 @@ namespace pcl
       using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromNormalField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromNormalField<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractorFromNormalField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractorFromNormalField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudImageExtractorFromNormalField () {}
@@ -232,8 +232,8 @@ namespace pcl
       using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromRGBField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromRGBField<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractorFromRGBField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractorFromRGBField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudImageExtractorFromRGBField () {}
@@ -261,8 +261,8 @@ namespace pcl
       using PointCloud = typename PointCloudImageExtractor<PointT>::PointCloud;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromLabelField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromLabelField<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractorFromLabelField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractorFromLabelField<PointT> >;
 
         /** \brief Different modes for color mapping. */
         enum ColorMode
@@ -319,8 +319,8 @@ namespace pcl
       using ScalingMethod = typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromZField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromZField<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractorFromZField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractorFromZField<PointT> >;
 
         /** \brief Constructor.
           * \param[in] scaling_factor a scaling factor to apply to each depth value (default 10000)
@@ -361,8 +361,8 @@ namespace pcl
       using ScalingMethod = typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromCurvatureField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromCurvatureField<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractorFromCurvatureField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractorFromCurvatureField<PointT> >;
 
         /** \brief Constructor.
           * \param[in] scaling_method a scaling method to use (default SCALING_FULL_RANGE)
@@ -403,8 +403,8 @@ namespace pcl
       using ScalingMethod = typename PointCloudImageExtractorWithScaling<PointT>::ScalingMethod;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudImageExtractorFromIntensityField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudImageExtractorFromIntensityField<PointT> >;
+        using Ptr = shared_ptr<PointCloudImageExtractorFromIntensityField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudImageExtractorFromIntensityField<PointT> >;
 
         /** \brief Constructor.
           * \param[in] scaling_method a scaling method to use (default SCALING_NO)

--- a/io/include/pcl/io/real_sense_grabber.h
+++ b/io/include/pcl/io/real_sense_grabber.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/io/grabber.h>
+#include <pcl/make_shared.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/common/time.h>
@@ -65,8 +66,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr<RealSenseGrabber>;
-      using ConstPtr = boost::shared_ptr<const RealSenseGrabber>;
+      using Ptr = shared_ptr<RealSenseGrabber>;
+      using ConstPtr = shared_ptr<const RealSenseGrabber>;
 
       using sig_cb_real_sense_point_cloud = void(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr&);
       using sig_cb_real_sense_point_cloud_rgba = void(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr&);

--- a/io/include/pcl/io/robot_eye_grabber.h
+++ b/io/include/pcl/io/robot_eye_grabber.h
@@ -43,6 +43,7 @@
 #include <pcl/io/impl/synchronized_queue.hpp>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
+#include <pcl/make_shared.h>
 #include <boost/asio.hpp>
 
 #include <memory>

--- a/io/src/ensenso_grabber.cpp
+++ b/io/src/ensenso_grabber.cpp
@@ -963,7 +963,7 @@ pcl::EnsensoGrabber::processGrabbing ()
       if (num_slots<sig_cb_ensenso_point_cloud> () > 0 || num_slots<sig_cb_ensenso_images> () > 0 || num_slots<sig_cb_ensenso_point_cloud_images> () > 0)
       {
         pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
-        boost::shared_ptr<PairOfImages> images (new PairOfImages);
+        shared_ptr<PairOfImages> images (new PairOfImages);
 
         fps_mutex_.lock ();
         frequency_.event ();

--- a/io/src/openni_camera/openni_device.cpp
+++ b/io/src/openni_camera/openni_device.cpp
@@ -36,6 +36,7 @@
  *
  */
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #ifdef __GNUC__
@@ -835,7 +836,7 @@ openni_wrapper::OpenNIDevice::ImageDataThreadFunction ()
     image_generator_.WaitAndUpdateData ();
     xn::ImageMetaData image_md;
     image_generator_.GetMetaData (image_md);
-    boost::shared_ptr<xn::ImageMetaData> image_data (new xn::ImageMetaData);
+    pcl::shared_ptr<xn::ImageMetaData> image_data (new xn::ImageMetaData);
     image_data->CopyFrom (image_md);
     image_lock.unlock ();
     
@@ -864,7 +865,7 @@ openni_wrapper::OpenNIDevice::DepthDataThreadFunction ()
     depth_generator_.WaitAndUpdateData ();
     xn::DepthMetaData depth_md;
     depth_generator_.GetMetaData (depth_md);    
-    boost::shared_ptr<xn::DepthMetaData> depth_data (new xn::DepthMetaData);
+    pcl::shared_ptr<xn::DepthMetaData> depth_data (new xn::DepthMetaData);
     depth_data->CopyFrom (depth_md);
     depth_lock.unlock ();
 
@@ -894,7 +895,7 @@ openni_wrapper::OpenNIDevice::IRDataThreadFunction ()
     ir_generator_.WaitAndUpdateData ();
     xn::IRMetaData ir_md;
     ir_generator_.GetMetaData (ir_md);
-    boost::shared_ptr<xn::IRMetaData> ir_data (new xn::IRMetaData);
+    pcl::shared_ptr<xn::IRMetaData> ir_data (new xn::IRMetaData);
     ir_data->CopyFrom (ir_md);
     ir_lock.unlock ();
 

--- a/io/src/openni_camera/openni_device_kinect.cpp
+++ b/io/src/openni_camera/openni_device_kinect.cpp
@@ -36,6 +36,7 @@
  *
  */
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #ifdef __GNUC__
@@ -131,7 +132,7 @@ openni_wrapper::DeviceKinect::enumAvailableModes () throw ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 openni_wrapper::Image::Ptr 
-openni_wrapper::DeviceKinect::getCurrentImage (boost::shared_ptr<xn::ImageMetaData> image_data) const throw ()
+openni_wrapper::DeviceKinect::getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_data) const throw ()
 {
   return (Image::Ptr (new ImageBayerGRBG (image_data, debayering_method_)));
 }

--- a/io/src/openni_camera/openni_device_oni.cpp
+++ b/io/src/openni_camera/openni_device_oni.cpp
@@ -36,6 +36,7 @@
  *
  */
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #ifdef __GNUC__
@@ -247,7 +248,7 @@ openni_wrapper::DeviceONI::NewONIIRDataAvailable (xn::ProductionNode&, void* coo
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 openni_wrapper::Image::Ptr 
-openni_wrapper::DeviceONI::getCurrentImage(boost::shared_ptr<xn::ImageMetaData> image_meta_data) const throw ()
+openni_wrapper::DeviceONI::getCurrentImage(pcl::shared_ptr<xn::ImageMetaData> image_meta_data) const throw ()
 {
   return (openni_wrapper::Image::Ptr (new openni_wrapper::ImageRGB24 (image_meta_data)));
 }

--- a/io/src/openni_camera/openni_device_primesense.cpp
+++ b/io/src/openni_camera/openni_device_primesense.cpp
@@ -36,6 +36,7 @@
  *
  */
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #ifdef __GNUC__
@@ -170,7 +171,7 @@ openni_wrapper::DevicePrimesense::enumAvailableModes () throw ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 openni_wrapper::Image::Ptr 
-openni_wrapper::DevicePrimesense::getCurrentImage (boost::shared_ptr<xn::ImageMetaData> image_data) const throw ()
+openni_wrapper::DevicePrimesense::getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_data) const throw ()
 {
   return (openni_wrapper::Image::Ptr (new ImageYUV422 (image_data)));
 }

--- a/io/src/openni_camera/openni_device_xtion.cpp
+++ b/io/src/openni_camera/openni_device_xtion.cpp
@@ -36,6 +36,7 @@
  *
  */
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #ifdef __GNUC__
@@ -115,7 +116,7 @@ openni_wrapper::DeviceXtionPro::enumAvailableModes () throw ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 openni_wrapper::Image::Ptr 
-openni_wrapper::DeviceXtionPro::getCurrentImage (boost::shared_ptr<xn::ImageMetaData>) const throw ()
+openni_wrapper::DeviceXtionPro::getCurrentImage (pcl::shared_ptr<xn::ImageMetaData>) const throw ()
 {
   return (Image::Ptr (reinterpret_cast<Image*> (0)));
 }

--- a/io/src/openni_camera/openni_image_bayer_grbg.cpp
+++ b/io/src/openni_camera/openni_image_bayer_grbg.cpp
@@ -36,6 +36,7 @@
  *
  */
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include <pcl/io/openni_camera/openni_image_bayer_grbg.h>
@@ -50,7 +51,7 @@
 using namespace std;
 
 //////////////////////////////////////////////////////////////////////////////
-openni_wrapper::ImageBayerGRBG::ImageBayerGRBG (boost::shared_ptr<xn::ImageMetaData> image_meta_data, DebayeringMethod method) throw ()
+openni_wrapper::ImageBayerGRBG::ImageBayerGRBG (pcl::shared_ptr<xn::ImageMetaData> image_meta_data, DebayeringMethod method) throw ()
 : Image (std::move(image_meta_data))
 , debayering_method_ (method)
 {

--- a/io/src/openni_camera/openni_image_rgb24.cpp
+++ b/io/src/openni_camera/openni_image_rgb24.cpp
@@ -1,11 +1,12 @@
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include <pcl/io/openni_camera/openni_image_rgb24.h>
 
 namespace openni_wrapper
 {
-ImageRGB24::ImageRGB24 (boost::shared_ptr<xn::ImageMetaData> image_meta_data) throw ()
+ImageRGB24::ImageRGB24 (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) throw ()
 : Image (std::move(image_meta_data))
 {
 }

--- a/io/src/openni_camera/openni_image_yuv_422.cpp
+++ b/io/src/openni_camera/openni_image_yuv_422.cpp
@@ -35,6 +35,7 @@
  *
  */
 #include <pcl/pcl_config.h>
+#include <pcl/make_shared.h>
 #ifdef HAVE_OPENNI
 
 #include <pcl/io/openni_camera/openni_image_yuv_422.h>
@@ -47,7 +48,7 @@ using namespace std;
 namespace openni_wrapper
 {
 
-ImageYUV422::ImageYUV422 (boost::shared_ptr<xn::ImageMetaData> image_meta_data) throw ()
+ImageYUV422::ImageYUV422 (pcl::shared_ptr<xn::ImageMetaData> image_meta_data) throw ()
 : Image (std::move(image_meta_data))
 {
 }

--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -55,8 +55,8 @@ namespace pcl
   class KdTree
   {
     public:
-      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-      using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
+      using IndicesPtr = shared_ptr<std::vector<int> >;
+      using IndicesConstPtr = shared_ptr<const std::vector<int> >;
 
       using PointCloud = pcl::PointCloud<PointT>;
       using PointCloudPtr = typename PointCloud::Ptr;
@@ -66,8 +66,8 @@ namespace pcl
       using PointRepresentationConstPtr = typename PointRepresentation::ConstPtr;
 
       // Boost shared pointers
-      using Ptr = boost::shared_ptr<KdTree<PointT> >;
-      using ConstPtr = boost::shared_ptr<const KdTree<PointT> >;
+      using Ptr = shared_ptr<KdTree<PointT> >;
+      using ConstPtr = shared_ptr<const KdTree<PointT> >;
 
       /** \brief Empty constructor for KdTree. Sets some internal values to their defaults. 
         * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise. 

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -78,14 +78,14 @@ namespace pcl
       using PointCloud = typename KdTree<PointT>::PointCloud;
       using PointCloudConstPtr = typename KdTree<PointT>::PointCloudConstPtr;
 
-      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-      using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
+      using IndicesPtr = shared_ptr<std::vector<int> >;
+      using IndicesConstPtr = shared_ptr<const std::vector<int> >;
 
       using FLANNIndex = ::flann::Index<Dist>;
 
       // Boost shared pointers
-      using Ptr = boost::shared_ptr<KdTreeFLANN<PointT, Dist> >;
-      using ConstPtr = boost::shared_ptr<const KdTreeFLANN<PointT, Dist> >;
+      using Ptr = shared_ptr<KdTreeFLANN<PointT, Dist> >;
+      using ConstPtr = shared_ptr<const KdTreeFLANN<PointT, Dist> >;
 
       /** \brief Default Constructor for KdTreeFLANN.
         * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise. 

--- a/keypoints/include/pcl/keypoints/agast_2d.h
+++ b/keypoints/include/pcl/keypoints/agast_2d.h
@@ -63,8 +63,8 @@ namespace pcl
       class PCL_EXPORTS AbstractAgastDetector
       {
         public:
-          using Ptr = boost::shared_ptr<AbstractAgastDetector>;
-          using ConstPtr = boost::shared_ptr<const AbstractAgastDetector>;
+          using Ptr = shared_ptr<AbstractAgastDetector>;
+          using ConstPtr = shared_ptr<const AbstractAgastDetector>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process
@@ -265,8 +265,8 @@ namespace pcl
       class PCL_EXPORTS AgastDetector7_12s : public AbstractAgastDetector
       {
         public:
-          using Ptr = boost::shared_ptr<AgastDetector7_12s>;
-          using ConstPtr = boost::shared_ptr<const AgastDetector7_12s>;
+          using Ptr = shared_ptr<AgastDetector7_12s>;
+          using ConstPtr = shared_ptr<const AgastDetector7_12s>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process
@@ -336,8 +336,8 @@ namespace pcl
       class PCL_EXPORTS AgastDetector5_8 : public AbstractAgastDetector
       {
         public:
-          using Ptr = boost::shared_ptr<AgastDetector5_8>;
-          using ConstPtr = boost::shared_ptr<const AgastDetector5_8>;
+          using Ptr = shared_ptr<AgastDetector5_8>;
+          using ConstPtr = shared_ptr<const AgastDetector5_8>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process
@@ -407,8 +407,8 @@ namespace pcl
       class PCL_EXPORTS OastDetector9_16 : public AbstractAgastDetector
       {
         public:
-          using Ptr = boost::shared_ptr<OastDetector9_16>;
-          using ConstPtr = boost::shared_ptr<const OastDetector9_16>;
+          using Ptr = shared_ptr<OastDetector9_16>;
+          using ConstPtr = shared_ptr<const OastDetector9_16>;
 
           /** \brief Constructor. 
             * \param[in] width the width of the image to process

--- a/keypoints/include/pcl/keypoints/brisk_2d.h
+++ b/keypoints/include/pcl/keypoints/brisk_2d.h
@@ -71,8 +71,8 @@ namespace pcl
   class BriskKeypoint2D: public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<BriskKeypoint2D<PointInT, PointOutT, IntensityT> >;
-      using ConstPtr = boost::shared_ptr<const BriskKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using Ptr = shared_ptr<BriskKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using ConstPtr = shared_ptr<const BriskKeypoint2D<PointInT, PointOutT, IntensityT> >;
 
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;

--- a/keypoints/include/pcl/keypoints/harris_2d.h
+++ b/keypoints/include/pcl/keypoints/harris_2d.h
@@ -53,8 +53,8 @@ namespace pcl
   class HarrisKeypoint2D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<HarrisKeypoint2D<PointInT, PointOutT, IntensityT> >;
-      using ConstPtr = boost::shared_ptr<const HarrisKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using Ptr = shared_ptr<HarrisKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using ConstPtr = shared_ptr<const HarrisKeypoint2D<PointInT, PointOutT, IntensityT> >;
 
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;

--- a/keypoints/include/pcl/keypoints/harris_3d.h
+++ b/keypoints/include/pcl/keypoints/harris_3d.h
@@ -51,8 +51,8 @@ namespace pcl
   class HarrisKeypoint3D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<HarrisKeypoint3D<PointInT, PointOutT, NormalT> >;
-      using ConstPtr = boost::shared_ptr<const HarrisKeypoint3D<PointInT, PointOutT, NormalT> >;
+      using Ptr = shared_ptr<HarrisKeypoint3D<PointInT, PointOutT, NormalT> >;
+      using ConstPtr = shared_ptr<const HarrisKeypoint3D<PointInT, PointOutT, NormalT> >;
 
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;

--- a/keypoints/include/pcl/keypoints/harris_6d.h
+++ b/keypoints/include/pcl/keypoints/harris_6d.h
@@ -49,8 +49,8 @@ namespace pcl
   class HarrisKeypoint6D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<HarrisKeypoint6D<PointInT, PointOutT, NormalT> >;
-      using ConstPtr = boost::shared_ptr<const HarrisKeypoint6D<PointInT, PointOutT, NormalT> >;
+      using Ptr = shared_ptr<HarrisKeypoint6D<PointInT, PointOutT, NormalT> >;
+      using ConstPtr = shared_ptr<const HarrisKeypoint6D<PointInT, PointOutT, NormalT> >;
 
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;

--- a/keypoints/include/pcl/keypoints/iss_3d.h
+++ b/keypoints/include/pcl/keypoints/iss_3d.h
@@ -84,8 +84,8 @@ namespace pcl
   class ISSKeypoint3D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<ISSKeypoint3D<PointInT, PointOutT, NormalT> >;
-      using ConstPtr = boost::shared_ptr<const ISSKeypoint3D<PointInT, PointOutT, NormalT> >;
+      using Ptr = shared_ptr<ISSKeypoint3D<PointInT, PointOutT, NormalT> >;
+      using ConstPtr = shared_ptr<const ISSKeypoint3D<PointInT, PointOutT, NormalT> >;
 
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;

--- a/keypoints/include/pcl/keypoints/keypoint.h
+++ b/keypoints/include/pcl/keypoints/keypoint.h
@@ -54,8 +54,8 @@ namespace pcl
   class Keypoint : public PCLBase<PointInT>
   {
     public:
-      using Ptr = boost::shared_ptr<Keypoint<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const Keypoint<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<Keypoint<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const Keypoint<PointInT, PointOutT> >;
 
       using PCLBase<PointInT>::indices_;
       using PCLBase<PointInT>::input_;

--- a/keypoints/include/pcl/keypoints/narf_keypoint.h
+++ b/keypoints/include/pcl/keypoints/narf_keypoint.h
@@ -59,8 +59,8 @@ class RangeImageBorderExtractor;
 class PCL_EXPORTS NarfKeypoint : public Keypoint<PointWithRange, int>
 {
   public:
-    using Ptr = boost::shared_ptr<NarfKeypoint>;
-    using ConstPtr = boost::shared_ptr<const NarfKeypoint>;
+    using Ptr = shared_ptr<NarfKeypoint>;
+    using ConstPtr = shared_ptr<const NarfKeypoint>;
 
     // =====TYPEDEFS=====
     using BaseClass = Keypoint<PointWithRange, int>;

--- a/keypoints/include/pcl/keypoints/sift_keypoint.h
+++ b/keypoints/include/pcl/keypoints/sift_keypoint.h
@@ -93,8 +93,8 @@ namespace pcl
   class SIFTKeypoint : public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<SIFTKeypoint<PointInT, PointOutT> >;
-      using ConstPtr = boost::shared_ptr<const SIFTKeypoint<PointInT, PointOutT> >;
+      using Ptr = shared_ptr<SIFTKeypoint<PointInT, PointOutT> >;
+      using ConstPtr = shared_ptr<const SIFTKeypoint<PointInT, PointOutT> >;
 
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;

--- a/keypoints/include/pcl/keypoints/smoothed_surfaces_keypoint.h
+++ b/keypoints/include/pcl/keypoints/smoothed_surfaces_keypoint.h
@@ -54,8 +54,8 @@ namespace pcl
   class SmoothedSurfacesKeypoint : public Keypoint <PointT, PointT>
   {
     public:
-      using Ptr = boost::shared_ptr<SmoothedSurfacesKeypoint<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const SmoothedSurfacesKeypoint<PointT, PointNT> >;
+      using Ptr = shared_ptr<SmoothedSurfacesKeypoint<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const SmoothedSurfacesKeypoint<PointT, PointNT> >;
 
       using PCLBase<PointT>::input_;
       using Keypoint<PointT, PointT>::name_;

--- a/keypoints/include/pcl/keypoints/susan.h
+++ b/keypoints/include/pcl/keypoints/susan.h
@@ -56,8 +56,8 @@ namespace pcl
   class SUSANKeypoint : public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT> >;
-      using ConstPtr = boost::shared_ptr<const SUSANKeypoint<PointInT, PointOutT, NormalT, Intensity> >;
+      using Ptr = shared_ptr<SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT> >;
+      using ConstPtr = shared_ptr<const SUSANKeypoint<PointInT, PointOutT, NormalT, Intensity> >;
 
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;

--- a/keypoints/include/pcl/keypoints/trajkovic_2d.h
+++ b/keypoints/include/pcl/keypoints/trajkovic_2d.h
@@ -54,8 +54,8 @@ namespace pcl
   class TrajkovicKeypoint2D : public Keypoint<PointInT, PointOutT>
   {
     public:
-      using Ptr = boost::shared_ptr<TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> >;
-      using ConstPtr = boost::shared_ptr<const TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using Ptr = shared_ptr<TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> >;
+      using ConstPtr = shared_ptr<const TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT> >;
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
       using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;

--- a/keypoints/include/pcl/keypoints/trajkovic_3d.h
+++ b/keypoints/include/pcl/keypoints/trajkovic_3d.h
@@ -54,8 +54,8 @@ namespace pcl
   class TrajkovicKeypoint3D : public Keypoint<PointInT, PointOutT>
   {
     public:
-    using Ptr = boost::shared_ptr<TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> >;
-    using ConstPtr = boost::shared_ptr<const TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> >;
+    using Ptr = shared_ptr<TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> >;
+    using ConstPtr = shared_ptr<const TrajkovicKeypoint3D<PointInT, PointOutT, NormalT> >;
       using PointCloudIn = typename Keypoint<PointInT, PointOutT>::PointCloudIn;
       using PointCloudOut = typename Keypoint<PointInT, PointOutT>::PointCloudOut;
       using PointCloudInConstPtr = typename PointCloudIn::ConstPtr;

--- a/ml/include/pcl/ml/dt/decision_tree_data_provider.h
+++ b/ml/include/pcl/ml/dt/decision_tree_data_provider.h
@@ -55,16 +55,16 @@ class PCL_EXPORTS DecisionTreeTrainerDataProvider {
   std::vector<LabelType> label_data_;
 
 public:
-  using Ptr = boost::shared_ptr<DecisionTreeTrainerDataProvider<FeatureType,
-                                                                DataSet,
-                                                                LabelType,
-                                                                ExampleIndex,
-                                                                NodeType>>;
-  using ConstPtr = boost::shared_ptr<const DecisionTreeTrainerDataProvider<FeatureType,
-                                                                           DataSet,
-                                                                           LabelType,
-                                                                           ExampleIndex,
-                                                                           NodeType>>;
+  using Ptr = shared_ptr<DecisionTreeTrainerDataProvider<FeatureType,
+                                                         DataSet,
+                                                         LabelType,
+                                                         ExampleIndex,
+                                                         NodeType>>;
+  using ConstPtr = shared_ptr<const DecisionTreeTrainerDataProvider<FeatureType,
+                                                                    DataSet,
+                                                                    LabelType,
+                                                                    ExampleIndex,
+                                                                    NodeType>>;
 
   /** Constructor. */
   DecisionTreeTrainerDataProvider() {}

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -83,8 +83,8 @@ namespace pcl
         OctreePointCloud (const double resolution_arg);
 
         // public typedefs
-        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
+        using IndicesPtr = shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = shared_ptr<const std::vector<int> >;
 
         using PointCloud = pcl::PointCloud<PointT>;
         using PointCloudPtr = typename PointCloud::Ptr;
@@ -95,8 +95,8 @@ namespace pcl
        // using DoubleBuffer = OctreePointCloud<PointT, LeafContainerT, BranchContainerT, Octree2BufBase<LeafContainerT> >;
 
         // Boost shared pointers
-        using Ptr = boost::shared_ptr<OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> >;
-        using ConstPtr = boost::shared_ptr<const OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> >;
+        using Ptr = shared_ptr<OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> >;
+        using ConstPtr = shared_ptr<const OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT> >;
 
         // Eigen aligned allocator
         using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency.h
@@ -83,8 +83,8 @@ namespace pcl
         using OctreeBaseT = OctreeBase<LeafContainerT, BranchContainerT>;
 
         using OctreeAdjacencyT = OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>;
-        using Ptr = boost::shared_ptr<OctreeAdjacencyT>;
-        using ConstPtr = boost::shared_ptr<const OctreeAdjacencyT>;
+        using Ptr = shared_ptr<OctreeAdjacencyT>;
+        using ConstPtr = shared_ptr<const OctreeAdjacencyT>;
 
         using OctreePointCloudT = OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeBaseT>;
         using LeafNode = typename OctreePointCloudT::LeafNode;

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -69,8 +69,8 @@ namespace pcl
 
       public:
 
-        using Ptr = boost::shared_ptr<OctreePointCloudChangeDetector<PointT, LeafContainerT, BranchContainerT>>;
-        using ConstPtr = boost::shared_ptr<const OctreePointCloudChangeDetector<PointT, LeafContainerT, BranchContainerT>>;
+        using Ptr = shared_ptr<OctreePointCloudChangeDetector<PointT, LeafContainerT, BranchContainerT>>;
+        using ConstPtr = shared_ptr<const OctreePointCloudChangeDetector<PointT, LeafContainerT, BranchContainerT>>;
 
         /** \brief Constructor.
          *  \param resolution_arg:  octree resolution at lowest octree level

--- a/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
+++ b/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
@@ -141,8 +141,8 @@ namespace pcl
     class OctreePointCloudVoxelCentroid : public OctreePointCloud<PointT, LeafContainerT, BranchContainerT>
     {
       public:
-        using Ptr = boost::shared_ptr<OctreePointCloudVoxelCentroid<PointT, LeafContainerT> >;
-        using ConstPtr = boost::shared_ptr<const OctreePointCloudVoxelCentroid<PointT, LeafContainerT> >;
+        using Ptr = shared_ptr<OctreePointCloudVoxelCentroid<PointT, LeafContainerT> >;
+        using ConstPtr = shared_ptr<const OctreePointCloudVoxelCentroid<PointT, LeafContainerT> >;
 
         using OctreeT = OctreePointCloud<PointT, LeafContainerT, BranchContainerT>;
         using LeafNode = typename OctreeT::LeafNode;

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -57,16 +57,16 @@ namespace pcl
     {
       public:
         // public typedefs
-        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
+        using IndicesPtr = shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = shared_ptr<const std::vector<int> >;
 
         using PointCloud = pcl::PointCloud<PointT>;
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
         // Boost shared pointers
-        using Ptr = boost::shared_ptr<OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> >;
-        using ConstPtr = boost::shared_ptr<const OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> >;
+        using Ptr = shared_ptr<OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> >;
+        using ConstPtr = shared_ptr<const OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT> >;
 
         // Eigen aligned allocator
         using AlignedPointTVector = std::vector<PointT, Eigen::aligned_allocator<PointT> >;

--- a/outofcore/include/pcl/outofcore/octree_base.h
+++ b/outofcore/include/pcl/outofcore/octree_base.h
@@ -175,13 +175,13 @@ namespace pcl
         using DepthFirstIterator = OutofcoreDepthFirstIterator<PointT, ContainerT>;
         using DepthFirstConstIterator = const OutofcoreDepthFirstIterator<PointT, ContainerT>;
 
-        using Ptr = boost::shared_ptr<OutofcoreOctreeBase<ContainerT, PointT> >;
-        using ConstPtr = boost::shared_ptr<const OutofcoreOctreeBase<ContainerT, PointT> >;
+        using Ptr = shared_ptr<OutofcoreOctreeBase<ContainerT, PointT> >;
+        using ConstPtr = shared_ptr<const OutofcoreOctreeBase<ContainerT, PointT> >;
 
         using PointCloud = pcl::PointCloud<PointT>;
 
-        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
+        using IndicesPtr = shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = shared_ptr<const std::vector<int> >;
 
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;

--- a/outofcore/include/pcl/outofcore/outofcore_base_data.h
+++ b/outofcore/include/pcl/outofcore/outofcore_base_data.h
@@ -96,8 +96,8 @@ namespace pcl
     class PCL_EXPORTS OutofcoreOctreeBaseMetadata : public OutofcoreAbstractMetadata
     {
       public:
-        using Ptr = boost::shared_ptr<OutofcoreOctreeBaseMetadata>;
-        using ConstPtr = boost::shared_ptr<const OutofcoreOctreeBaseMetadata>;
+        using Ptr = shared_ptr<OutofcoreOctreeBaseMetadata>;
+        using ConstPtr = shared_ptr<const OutofcoreOctreeBaseMetadata>;
 
         /** \brief Empty constructor */
         OutofcoreOctreeBaseMetadata ();

--- a/outofcore/include/pcl/outofcore/outofcore_node_data.h
+++ b/outofcore/include/pcl/outofcore/outofcore_node_data.h
@@ -84,8 +84,8 @@ namespace pcl
 
       public:
         //public typedefs
-        using Ptr = boost::shared_ptr<OutofcoreOctreeNodeMetadata>;
-        using ConstPtr = boost::shared_ptr<const OutofcoreOctreeNodeMetadata>;
+        using Ptr = shared_ptr<OutofcoreOctreeNodeMetadata>;
+        using ConstPtr = shared_ptr<const OutofcoreOctreeNodeMetadata>;
   
         /** \brief Empty constructor */
         OutofcoreOctreeNodeMetadata ();

--- a/recognition/include/pcl/recognition/cg/hough_3d.h
+++ b/recognition/include/pcl/recognition/cg/hough_3d.h
@@ -60,8 +60,8 @@ namespace pcl
       public:
         PCL_MAKE_ALIGNED_OPERATOR_NEW
 
-        using Ptr = boost::shared_ptr<HoughSpace3D>;
-        using ConstPtr = boost::shared_ptr<const HoughSpace3D>;
+        using Ptr = shared_ptr<HoughSpace3D>;
+        using ConstPtr = shared_ptr<const HoughSpace3D>;
 
         /** \brief Constructor
           *

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -111,8 +111,8 @@ namespace pcl
 
       public:
 
-        using Ptr = boost::shared_ptr<FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>>;
-        using ConstPtr = boost::shared_ptr<const FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>>;
+        using Ptr = shared_ptr<FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>>;
+        using ConstPtr = shared_ptr<const FaceDetectorDataProvider<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>>;
 
         FaceDetectorDataProvider()
         {

--- a/recognition/include/pcl/recognition/implicit_shape_model.h
+++ b/recognition/include/pcl/recognition/implicit_shape_model.h
@@ -76,8 +76,8 @@ namespace pcl
     {
       public:
 
-        using Ptr = boost::shared_ptr<ISMVoteList<PointT> >;
-        using ConstPtr = boost::shared_ptr<const ISMVoteList<PointT>>;
+        using Ptr = shared_ptr<ISMVoteList<PointT> >;
+        using ConstPtr = shared_ptr<const ISMVoteList<PointT>>;
 
         /** \brief Empty constructor with member variables initialization. */
         ISMVoteList ();
@@ -159,8 +159,8 @@ namespace pcl
       */
     struct PCL_EXPORTS ISMModel
     {
-      using Ptr = boost::shared_ptr<ISMModel>;
-      using ConstPtr = boost::shared_ptr<const ISMModel>;
+      using Ptr = shared_ptr<ISMModel>;
+      using ConstPtr = shared_ptr<const ISMModel>;
 
       /** \brief Simple constructor that initializes the structure. */
       ISMModel ();

--- a/registration/include/pcl/registration/convergence_criteria.h
+++ b/registration/include/pcl/registration/convergence_criteria.h
@@ -63,8 +63,8 @@ namespace pcl
     class PCL_EXPORTS ConvergenceCriteria
     {
       public:
-        using Ptr = boost::shared_ptr<ConvergenceCriteria>;
-        using ConstPtr = boost::shared_ptr<const ConvergenceCriteria>;
+        using Ptr = shared_ptr<ConvergenceCriteria>;
+        using ConstPtr = shared_ptr<const ConvergenceCriteria>;
 
         /** \brief Empty constructor. */
         ConvergenceCriteria () {}

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -62,8 +62,8 @@ namespace pcl
     class CorrespondenceEstimationBase: public PCLBase<PointSource>
     {
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const CorrespondenceEstimationBase<PointSource, PointTarget, Scalar> >;
 
         // using PCLBase<PointSource>::initCompute;
         using PCLBase<PointSource>::deinitCompute;
@@ -361,8 +361,8 @@ namespace pcl
     class CorrespondenceEstimation : public CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceEstimation<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimation<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<CorrespondenceEstimation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const CorrespondenceEstimation<PointSource, PointTarget, Scalar> >;
 
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::point_representation_;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::input_transformed_;

--- a/registration/include/pcl/registration/correspondence_estimation_backprojection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_backprojection.h
@@ -55,8 +55,8 @@ namespace pcl
     class CorrespondenceEstimationBackProjection : public CorrespondenceEstimationBase <PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> >;
+        using Ptr = shared_ptr<CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> >;
+        using ConstPtr = shared_ptr<const CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar> >;
 
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;

--- a/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
+++ b/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
@@ -77,8 +77,8 @@ namespace pcl
     class CorrespondenceEstimationNormalShooting : public CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> >;
+        using Ptr = shared_ptr<CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> >;
+        using ConstPtr = shared_ptr<const CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar> >;
 
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute;
         using CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal;

--- a/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
@@ -77,8 +77,8 @@ namespace pcl
         using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
         using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
-        using Ptr = boost::shared_ptr< CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr< const CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr< CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr< const CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar> >;
 
 
 

--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -58,8 +58,8 @@ namespace pcl
     class CorrespondenceRejector
     {
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejector>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejector>;
+        using Ptr = shared_ptr<CorrespondenceRejector>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejector>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejector () 
@@ -199,8 +199,8 @@ namespace pcl
     class DataContainerInterface
     {
       public:
-        using Ptr = boost::shared_ptr<DataContainerInterface>;
-        using ConstPtr = boost::shared_ptr<const DataContainerInterface>;
+        using Ptr = shared_ptr<DataContainerInterface>;
+        using ConstPtr = shared_ptr<const DataContainerInterface>;
 
         virtual ~DataContainerInterface () = default;
         virtual double getCorrespondenceScore (int index) = 0;

--- a/registration/include/pcl/registration/correspondence_rejection_distance.h
+++ b/registration/include/pcl/registration/correspondence_rejection_distance.h
@@ -65,8 +65,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorDistance>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorDistance>;
+        using Ptr = shared_ptr<CorrespondenceRejectorDistance>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorDistance>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorDistance () : max_distance_(std::numeric_limits<float>::max ())

--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -66,8 +66,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorFeatures>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorFeatures>;
+        using Ptr = shared_ptr<CorrespondenceRejectorFeatures>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorFeatures>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorFeatures () : max_distance_ (std::numeric_limits<float>::max ())
@@ -162,7 +162,7 @@ namespace pcl
             virtual double getCorrespondenceScore (int index) = 0;
             virtual bool isCorrespondenceValid (int index) = 0;
 
-            using Ptr = boost::shared_ptr<FeatureContainerInterface>;
+            using Ptr = shared_ptr<FeatureContainerInterface>;
         };
 
         using FeaturesMap = std::unordered_map<std::string, FeatureContainerInterface::Ptr>;

--- a/registration/include/pcl/registration/correspondence_rejection_median_distance.h
+++ b/registration/include/pcl/registration/correspondence_rejection_median_distance.h
@@ -65,8 +65,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorMedianDistance>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorMedianDistance>;
+        using Ptr = shared_ptr<CorrespondenceRejectorMedianDistance>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorMedianDistance>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorMedianDistance () 

--- a/registration/include/pcl/registration/correspondence_rejection_one_to_one.h
+++ b/registration/include/pcl/registration/correspondence_rejection_one_to_one.h
@@ -62,8 +62,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorOneToOne>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorOneToOne>;
+        using Ptr = shared_ptr<CorrespondenceRejectorOneToOne>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorOneToOne>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorOneToOne ()

--- a/registration/include/pcl/registration/correspondence_rejection_poly.h
+++ b/registration/include/pcl/registration/correspondence_rejection_poly.h
@@ -68,8 +68,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorPoly<SourceT, TargetT> >;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorPoly<SourceT, TargetT> >;
+        using Ptr = shared_ptr<CorrespondenceRejectorPoly<SourceT, TargetT> >;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorPoly<SourceT, TargetT> >;
         
         using PointCloudSource = pcl::PointCloud<SourceT>;
         using PointCloudSourcePtr = typename PointCloudSource::Ptr;

--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
@@ -69,8 +69,8 @@ namespace pcl
         using CorrespondenceRejector::rejection_name_;
         using CorrespondenceRejector::getClassName;
 
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorSampleConsensus<PointT> >;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorSampleConsensus<PointT> >;
+        using Ptr = shared_ptr<CorrespondenceRejectorSampleConsensus<PointT> >;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorSampleConsensus<PointT> >;
 
         /** \brief Empty constructor. Sets the inlier threshold to 5cm (0.05m), 
           * and the maximum number of iterations to 1000. 

--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus_2d.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus_2d.h
@@ -69,8 +69,8 @@ namespace pcl
         using CorrespondenceRejectorSampleConsensus<PointT>::max_iterations_;
         using CorrespondenceRejectorSampleConsensus<PointT>::best_transformation_;
 
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorSampleConsensus2D<PointT> >;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorSampleConsensus2D<PointT> >;
+        using Ptr = shared_ptr<CorrespondenceRejectorSampleConsensus2D<PointT> >;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorSampleConsensus2D<PointT> >;
 
         /** \brief Empty constructor. Sets the inlier threshold to 5cm (0.05m), 
           * and the maximum number of iterations to 1000. 

--- a/registration/include/pcl/registration/correspondence_rejection_surface_normal.h
+++ b/registration/include/pcl/registration/correspondence_rejection_surface_normal.h
@@ -64,8 +64,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorSurfaceNormal>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorSurfaceNormal>;
+        using Ptr = shared_ptr<CorrespondenceRejectorSurfaceNormal>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorSurfaceNormal>;
 
         /** \brief Empty constructor. Sets the threshold to 1.0. */
         CorrespondenceRejectorSurfaceNormal () 

--- a/registration/include/pcl/registration/correspondence_rejection_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_trimmed.h
@@ -67,8 +67,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorTrimmed>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorTrimmed>;
+        using Ptr = shared_ptr<CorrespondenceRejectorTrimmed>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorTrimmed>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorTrimmed () : 

--- a/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
@@ -68,8 +68,8 @@ namespace pcl
       using CorrespondenceRejector::getClassName;
 
       public:
-        using Ptr = boost::shared_ptr<CorrespondenceRejectorVarTrimmed>;
-        using ConstPtr = boost::shared_ptr<const CorrespondenceRejectorVarTrimmed>;
+        using Ptr = shared_ptr<CorrespondenceRejectorVarTrimmed>;
+        using ConstPtr = shared_ptr<const CorrespondenceRejectorVarTrimmed>;
 
         /** \brief Empty constructor. */
         CorrespondenceRejectorVarTrimmed () : 

--- a/registration/include/pcl/registration/default_convergence_criteria.h
+++ b/registration/include/pcl/registration/default_convergence_criteria.h
@@ -65,8 +65,8 @@ namespace pcl
     class DefaultConvergenceCriteria : public ConvergenceCriteria
     {
       public:
-        using Ptr = boost::shared_ptr<DefaultConvergenceCriteria<Scalar> >;
-        using ConstPtr = boost::shared_ptr<const DefaultConvergenceCriteria<Scalar> >;
+        using Ptr = shared_ptr<DefaultConvergenceCriteria<Scalar> >;
+        using ConstPtr = shared_ptr<const DefaultConvergenceCriteria<Scalar> >;
 
         using Matrix4 = Eigen::Matrix<Scalar, 4, 4>;
 

--- a/registration/include/pcl/registration/elch.h
+++ b/registration/include/pcl/registration/elch.h
@@ -62,8 +62,8 @@ namespace pcl
     class ELCH : public PCLBase<PointT>
     {
       public:
-        using Ptr = boost::shared_ptr<ELCH<PointT> >;
-        using ConstPtr = boost::shared_ptr<const ELCH<PointT> >;
+        using Ptr = shared_ptr<ELCH<PointT> >;
+        using ConstPtr = shared_ptr<const ELCH<PointT> >;
 
         using PointCloud = pcl::PointCloud<PointT>;
         using PointCloudPtr = typename PointCloud::Ptr;
@@ -82,7 +82,7 @@ namespace pcl
           Vertex,
           boost::no_property>;
 
-        using LoopGraphPtr = boost::shared_ptr<LoopGraph>;
+        using LoopGraphPtr = shared_ptr<LoopGraph>;
 
         using Registration = pcl::Registration<PointT, PointT>;
         using RegistrationPtr = typename Registration::Ptr;

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -90,14 +90,14 @@ namespace pcl
       using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       using MatricesVector = std::vector< Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >;
-      using MatricesVectorPtr = boost::shared_ptr<MatricesVector>;
-      using MatricesVectorConstPtr = boost::shared_ptr<const MatricesVector>;
+      using MatricesVectorPtr = shared_ptr<MatricesVector>;
+      using MatricesVectorConstPtr = shared_ptr<const MatricesVector>;
       
       using InputKdTree = typename Registration<PointSource, PointTarget>::KdTree;
       using InputKdTreePtr = typename Registration<PointSource, PointTarget>::KdTreePtr;
 
-      using Ptr = boost::shared_ptr< GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
-      using ConstPtr = boost::shared_ptr< const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+      using Ptr = shared_ptr< GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+      using ConstPtr = shared_ptr< const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
 
 
       using Vector6d = Eigen::Matrix<double, 6, 1>;

--- a/registration/include/pcl/registration/gicp6d.h
+++ b/registration/include/pcl/registration/gicp6d.h
@@ -169,8 +169,8 @@ namespace pcl
           using PointRepresentation<PointXYZLAB>::trivial_;
 
         public:
-          using Ptr = boost::shared_ptr<MyPointRepresentation>;
-          using ConstPtr = boost::shared_ptr<const MyPointRepresentation>;
+          using Ptr = shared_ptr<MyPointRepresentation>;
+          using ConstPtr = shared_ptr<const MyPointRepresentation>;
 
           MyPointRepresentation ()
           {

--- a/registration/include/pcl/registration/graph_handler.h
+++ b/registration/include/pcl/registration/graph_handler.h
@@ -81,10 +81,10 @@ namespace pcl
     class GraphHandler
     {
       public:
-        using Ptr = boost::shared_ptr<GraphHandler<GraphT> >;
-        using ConstPtr = boost::shared_ptr<const GraphHandler<GraphT> >;
-        using GraphPtr = boost::shared_ptr<GraphT>;
-        using GraphConstPtr = boost::shared_ptr<const GraphT>;
+        using Ptr = shared_ptr<GraphHandler<GraphT> >;
+        using ConstPtr = shared_ptr<const GraphHandler<GraphT> >;
+        using GraphPtr = shared_ptr<GraphT>;
+        using GraphConstPtr = shared_ptr<const GraphT>;
 
         using Vertex = typename boost::graph_traits<GraphT>::vertex_descriptor;
         using Edge = typename boost::graph_traits<GraphT>::edge_descriptor;

--- a/registration/include/pcl/registration/ia_fpcs.h
+++ b/registration/include/pcl/registration/ia_fpcs.h
@@ -77,8 +77,8 @@ namespace pcl
     {
     public:
       /** \cond */
-      using Ptr = boost::shared_ptr <FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
-      using ConstPtr = boost::shared_ptr <const FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
+      using Ptr = shared_ptr <FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
+      using ConstPtr = shared_ptr <const FPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
 
       using KdTreeReciprocal = pcl::search::KdTree<PointSource>;
       using KdTreeReciprocalPtr = typename KdTreeReciprocal::Ptr;

--- a/registration/include/pcl/registration/ia_kfpcs.h
+++ b/registration/include/pcl/registration/ia_kfpcs.h
@@ -55,8 +55,8 @@ namespace pcl
     {
     public:
       /** \cond */
-      using Ptr = boost::shared_ptr <KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
-      using ConstPtr = boost::shared_ptr <const KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
+      using Ptr = shared_ptr <KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
+      using ConstPtr = shared_ptr <const KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar> >;
 
       using PointCloudSource = pcl::PointCloud<PointSource>;
       using PointCloudSourcePtr = typename PointCloudSource::Ptr;

--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -82,15 +82,15 @@ namespace pcl
       using FeatureCloudPtr = typename FeatureCloud::Ptr;
       using FeatureCloudConstPtr = typename FeatureCloud::ConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> >;
+      using Ptr = shared_ptr<SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT> >;
 
 
       class ErrorFunctor
       {
         public:
-          using Ptr = boost::shared_ptr<ErrorFunctor>;
-          using ConstPtr = boost::shared_ptr<const ErrorFunctor>;
+          using Ptr = shared_ptr<ErrorFunctor>;
+          using ConstPtr = shared_ptr<const ErrorFunctor>;
 
           virtual ~ErrorFunctor () = default;
           virtual float operator () (float d) const = 0;

--- a/registration/include/pcl/registration/icp.h
+++ b/registration/include/pcl/registration/icp.h
@@ -106,8 +106,8 @@ namespace pcl
       using PointIndicesPtr = PointIndices::Ptr;
       using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-      using Ptr = boost::shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
-      using ConstPtr = boost::shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using Ptr = shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
 
       using Registration<PointSource, PointTarget, Scalar>::reg_name_;
       using Registration<PointSource, PointTarget, Scalar>::getClassName;
@@ -318,8 +318,8 @@ namespace pcl
       using IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformation_estimation_;
       using IterativeClosestPoint<PointSource, PointTarget, Scalar>::correspondence_rejectors_;
 
-      using Ptr = boost::shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
-      using ConstPtr = boost::shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using Ptr = shared_ptr<IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = shared_ptr<const IterativeClosestPoint<PointSource, PointTarget, Scalar> >;
 
       /** \brief Empty constructor. */
       IterativeClosestPointWithNormals ()

--- a/registration/include/pcl/registration/icp_nl.h
+++ b/registration/include/pcl/registration/icp_nl.h
@@ -73,8 +73,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr< IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> >;
-      using ConstPtr = boost::shared_ptr< const IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> >;
+      using Ptr = shared_ptr< IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = shared_ptr< const IterativeClosestPointNonLinear<PointSource, PointTarget, Scalar> >;
 
       using Matrix4 = typename Registration<PointSource, PointTarget, Scalar>::Matrix4;
 

--- a/registration/include/pcl/registration/joint_icp.h
+++ b/registration/include/pcl/registration/joint_icp.h
@@ -72,8 +72,8 @@ namespace pcl
       using PointIndicesPtr = PointIndices::Ptr;
       using PointIndicesConstPtr = PointIndices::ConstPtr;
 
-      using Ptr = boost::shared_ptr<JointIterativeClosestPoint<PointSource, PointTarget, Scalar> >;
-      using ConstPtr = boost::shared_ptr<const JointIterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using Ptr = shared_ptr<JointIterativeClosestPoint<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = shared_ptr<const JointIterativeClosestPoint<PointSource, PointTarget, Scalar> >;
 
       using CorrespondenceEstimation = pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>;
       using CorrespondenceEstimationPtr = typename CorrespondenceEstimation::Ptr;

--- a/registration/include/pcl/registration/lum.h
+++ b/registration/include/pcl/registration/lum.h
@@ -110,8 +110,8 @@ namespace pcl
     class LUM
     {
       public:
-        using Ptr = boost::shared_ptr<LUM<PointT> >;
-        using ConstPtr = boost::shared_ptr<const LUM<PointT> >;
+        using Ptr = shared_ptr<LUM<PointT> >;
+        using ConstPtr = shared_ptr<const LUM<PointT> >;
 
         using PointCloud = pcl::PointCloud<PointT>;
         using PointCloudPtr = typename PointCloud::Ptr;
@@ -132,7 +132,7 @@ namespace pcl
         };
 
         using SLAMGraph = boost::adjacency_list<boost::eigen_vecS, boost::eigen_vecS, boost::bidirectionalS, VertexProperties, EdgeProperties, boost::no_property, boost::eigen_listS>;
-        using SLAMGraphPtr = boost::shared_ptr<SLAMGraph>;
+        using SLAMGraphPtr = shared_ptr<SLAMGraph>;
         using Vertex = typename SLAMGraph::vertex_descriptor;
         using Edge = typename SLAMGraph::edge_descriptor;
 

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -87,8 +87,8 @@ namespace pcl
 
     public:
 
-      using Ptr = boost::shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> >;
-      using ConstPtr = boost::shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> >;
+      using Ptr = shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> >;
+      using ConstPtr = shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> >;
 
 
       /** \brief Constructor.

--- a/registration/include/pcl/registration/ndt_2d.h
+++ b/registration/include/pcl/registration/ndt_2d.h
@@ -70,8 +70,8 @@ namespace pcl
 
     public:
 
-        using Ptr = boost::shared_ptr< NormalDistributionsTransform2D<PointSource, PointTarget> >;
-        using ConstPtr = boost::shared_ptr< const NormalDistributionsTransform2D<PointSource, PointTarget> >;
+        using Ptr = shared_ptr< NormalDistributionsTransform2D<PointSource, PointTarget> >;
+        using ConstPtr = shared_ptr< const NormalDistributionsTransform2D<PointSource, PointTarget> >;
 
       /** \brief Empty constructor. */
       NormalDistributionsTransform2D ()

--- a/registration/include/pcl/registration/ppf_registration.h
+++ b/registration/include/pcl/registration/ppf_registration.h
@@ -78,9 +78,9 @@ namespace pcl
         }
       };
       using FeatureHashMapType = std::unordered_multimap<HashKeyStruct, std::pair<std::size_t, std::size_t>, HashKeyStruct>;
-      using FeatureHashMapTypePtr = boost::shared_ptr<FeatureHashMapType>;
-      using Ptr = boost::shared_ptr<PPFHashMapSearch>;
-      using ConstPtr = boost::shared_ptr<const PPFHashMapSearch>;
+      using FeatureHashMapTypePtr = shared_ptr<FeatureHashMapType>;
+      using Ptr = shared_ptr<PPFHashMapSearch>;
+      using ConstPtr = shared_ptr<const PPFHashMapSearch>;
 
 
       /** \brief Constructor for the PPFHashMapSearch class which sets the two step parameters for the enclosed data structure
@@ -115,7 +115,7 @@ namespace pcl
       nearestNeighborSearch (float &f1, float &f2, float &f3, float &f4,
                              std::vector<std::pair<std::size_t, std::size_t> > &indices);
 
-      /** \brief Convenience method for returning a copy of the class instance as a boost::shared_ptr */
+      /** \brief Convenience method for returning a copy of the class instance as a shared_ptr */
       Ptr
       makeShared() { return Ptr (new PPFHashMapSearch (*this)); }
 

--- a/registration/include/pcl/registration/pyramid_feature_matching.h
+++ b/registration/include/pcl/registration/pyramid_feature_matching.h
@@ -69,10 +69,10 @@ namespace pcl
     public:
       using PCLBase<PointFeature>::input_;
 
-      using Ptr = boost::shared_ptr<PyramidFeatureHistogram<PointFeature> >;
-      using ConstPtr = boost::shared_ptr<const PyramidFeatureHistogram<PointFeature>>;
+      using Ptr = shared_ptr<PyramidFeatureHistogram<PointFeature> >;
+      using ConstPtr = shared_ptr<const PyramidFeatureHistogram<PointFeature>>;
       using PyramidFeatureHistogramPtr = Ptr;
-      using FeatureRepresentationConstPtr = boost::shared_ptr<const pcl::PointRepresentation<PointFeature> >;
+      using FeatureRepresentationConstPtr = shared_ptr<const pcl::PointRepresentation<PointFeature> >;
 
 
       /** \brief Empty constructor that instantiates the feature representation variable */

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -67,8 +67,8 @@ namespace pcl
       using PCLBase<PointSource>::input_;
       using PCLBase<PointSource>::indices_;
 
-      using Ptr = boost::shared_ptr< Registration<PointSource, PointTarget, Scalar> >;
-      using ConstPtr = boost::shared_ptr< const Registration<PointSource, PointTarget, Scalar> >;
+      using Ptr = shared_ptr< Registration<PointSource, PointTarget, Scalar> >;
+      using ConstPtr = shared_ptr< const Registration<PointSource, PointTarget, Scalar> >;
 
       using CorrespondenceRejectorPtr = pcl::registration::CorrespondenceRejector::Ptr;
       using KdTree = pcl::search::KdTree<PointTarget>;

--- a/registration/include/pcl/registration/sample_consensus_prerejective.h
+++ b/registration/include/pcl/registration/sample_consensus_prerejective.h
@@ -104,8 +104,8 @@ namespace pcl
       using FeatureCloudPtr = typename FeatureCloud::Ptr;
       using FeatureCloudConstPtr = typename FeatureCloud::ConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> >;
+      using Ptr = shared_ptr<SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusPrerejective<PointSource, PointTarget, FeatureT> >;
 
       using FeatureKdTreePtr = typename KdTreeFLANN<FeatureT>::Ptr;
       

--- a/registration/include/pcl/registration/transformation_estimation.h
+++ b/registration/include/pcl/registration/transformation_estimation.h
@@ -120,8 +120,8 @@ namespace pcl
             Matrix4 &transformation_matrix) const = 0;
 
 
-        using Ptr = boost::shared_ptr<TransformationEstimation<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimation<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimation<PointSource, PointTarget, Scalar> >;
     };
   }
 }

--- a/registration/include/pcl/registration/transformation_estimation_2D.h
+++ b/registration/include/pcl/registration/transformation_estimation_2D.h
@@ -59,8 +59,8 @@ namespace pcl
     class TransformationEstimation2D : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimation2D<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimation2D<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimation2D<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimation2D<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 

--- a/registration/include/pcl/registration/transformation_estimation_3point.h
+++ b/registration/include/pcl/registration/transformation_estimation_3point.h
@@ -60,8 +60,8 @@ namespace pcl
     {
       public:
         /** \cond */
-        using Ptr = boost::shared_ptr<TransformationEstimation3Point<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimation3Point<PointSource, PointTarget, Scalar> >;        
+        using Ptr = shared_ptr<TransformationEstimation3Point<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimation3Point<PointSource, PointTarget, Scalar> >;        
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
         /** \endcond */
 

--- a/registration/include/pcl/registration/transformation_estimation_dq.h
+++ b/registration/include/pcl/registration/transformation_estimation_dq.h
@@ -57,8 +57,8 @@ namespace pcl
     class TransformationEstimationDQ : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 

--- a/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
+++ b/registration/include/pcl/registration/transformation_estimation_dual_quaternion.h
@@ -57,8 +57,8 @@ namespace pcl
     class TransformationEstimationDualQuaternion : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 

--- a/registration/include/pcl/registration/transformation_estimation_lm.h
+++ b/registration/include/pcl/registration/transformation_estimation_lm.h
@@ -69,8 +69,8 @@ namespace pcl
       using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationLM<PointSource, PointTarget, MatScalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationLM<PointSource, PointTarget, MatScalar> >;
+        using Ptr = shared_ptr<TransformationEstimationLM<PointSource, PointTarget, MatScalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationLM<PointSource, PointTarget, MatScalar> >;
 
         using VectorX = Eigen::Matrix<MatScalar, Eigen::Dynamic, 1>;
         using Vector4 = Eigen::Matrix<MatScalar, 4, 1>;

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane.h
@@ -58,8 +58,8 @@ namespace pcl
     class TransformationEstimationPointToPlane : public TransformationEstimationLM<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationPointToPlane<PointSource, PointTarget, Scalar> >;
 
         using PointCloudSource = pcl::PointCloud<PointSource>;
         using PointCloudSourcePtr = typename PointCloudSource::Ptr;

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls.h
@@ -63,8 +63,8 @@ namespace pcl
     class TransformationEstimationPointToPlaneLLS : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
         

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
@@ -63,8 +63,8 @@ namespace pcl
     class TransformationEstimationPointToPlaneLLSWeighted : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
         

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -67,8 +67,8 @@ namespace pcl
       using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> >;
+        using Ptr = shared_ptr<TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar> >;
 
         using VectorX = Eigen::Matrix<MatScalar, Eigen::Dynamic, 1>;
         using Vector4 = Eigen::Matrix<MatScalar, 4, 1>;

--- a/registration/include/pcl/registration/transformation_estimation_svd.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd.h
@@ -58,8 +58,8 @@ namespace pcl
     class TransformationEstimationSVD : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationSVD<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationSVD<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationSVD<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationSVD<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 

--- a/registration/include/pcl/registration/transformation_estimation_svd_scale.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd_scale.h
@@ -58,8 +58,8 @@ namespace pcl
     class TransformationEstimationSVDScale : public TransformationEstimationSVD<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationSVDScale<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimationSVD<PointSource, PointTarget, Scalar>::Matrix4;
 

--- a/registration/include/pcl/registration/transformation_estimation_symmetric_point_to_plane_lls.h
+++ b/registration/include/pcl/registration/transformation_estimation_symmetric_point_to_plane_lls.h
@@ -61,8 +61,8 @@ namespace pcl
     class TransformationEstimationSymmetricPointToPlaneLLS : public TransformationEstimation<PointSource, PointTarget, Scalar>
     {
       public:
-        using Ptr = boost::shared_ptr<TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar> >;
 
         using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
         using Vector6 = Eigen::Matrix<Scalar, 6, 1>;

--- a/registration/include/pcl/registration/transformation_validation.h
+++ b/registration/include/pcl/registration/transformation_validation.h
@@ -69,8 +69,8 @@ namespace pcl
     {
       public:
         using Matrix4 = Eigen::Matrix<Scalar, 4, 4>;
-        using Ptr = boost::shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> >;
 
         using PointCloudSource = pcl::PointCloud<PointSource>;
         using PointCloudSourcePtr = typename PointCloudSource::Ptr;

--- a/registration/include/pcl/registration/transformation_validation_euclidean.h
+++ b/registration/include/pcl/registration/transformation_validation_euclidean.h
@@ -76,8 +76,8 @@ namespace pcl
       public:
         using Matrix4 = typename TransformationValidation<PointSource, PointTarget, Scalar>::Matrix4;
         
-        using Ptr = boost::shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> >;
+        using Ptr = shared_ptr<TransformationValidation<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationValidation<PointSource, PointTarget, Scalar> >;
 
         using KdTree = pcl::search::KdTree<PointTarget>;
         using KdTreePtr = typename KdTree::Ptr;
@@ -237,8 +237,8 @@ namespace pcl
           using pcl::PointRepresentation<PointTarget>::nr_dimensions_;
           using pcl::PointRepresentation<PointTarget>::trivial_;
           public:
-            using Ptr = boost::shared_ptr<MyPointRepresentation>;
-            using ConstPtr = boost::shared_ptr<const MyPointRepresentation>;
+            using Ptr = shared_ptr<MyPointRepresentation>;
+            using ConstPtr = shared_ptr<const MyPointRepresentation>;
             
             MyPointRepresentation ()
             {

--- a/registration/include/pcl/registration/warp_point_rigid.h
+++ b/registration/include/pcl/registration/warp_point_rigid.h
@@ -61,8 +61,8 @@ namespace pcl
         using VectorX = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
         using Vector4 = Eigen::Matrix<Scalar, 4, 1>;
 
-        using Ptr = boost::shared_ptr<WarpPointRigid<PointSourceT, PointTargetT, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const WarpPointRigid<PointSourceT, PointTargetT, Scalar> >;
+        using Ptr = shared_ptr<WarpPointRigid<PointSourceT, PointTargetT, Scalar> >;
+        using ConstPtr = shared_ptr<const WarpPointRigid<PointSourceT, PointTargetT, Scalar> >;
 
         /** \brief Constructor
           * \param[in] nr_dim the number of dimensions

--- a/registration/include/pcl/registration/warp_point_rigid_3d.h
+++ b/registration/include/pcl/registration/warp_point_rigid_3d.h
@@ -61,8 +61,8 @@ namespace pcl
         using Matrix4 = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::Matrix4;
         using VectorX = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::VectorX;
 
-        using Ptr = boost::shared_ptr<WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> >;
+        using Ptr = shared_ptr<WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> >;
+        using ConstPtr = shared_ptr<const WarpPointRigid3D<PointSourceT, PointTargetT, Scalar> >;
 
         /** \brief Constructor. */
         WarpPointRigid3D () : WarpPointRigid<PointSourceT, PointTargetT, Scalar> (3) {}

--- a/registration/include/pcl/registration/warp_point_rigid_6d.h
+++ b/registration/include/pcl/registration/warp_point_rigid_6d.h
@@ -62,8 +62,8 @@ namespace pcl
         using Matrix4 = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::Matrix4;
         using VectorX = typename WarpPointRigid<PointSourceT, PointTargetT, Scalar>::VectorX;
 
-        using Ptr = boost::shared_ptr<WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> >;
-        using ConstPtr = boost::shared_ptr<const WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> >;
+        using Ptr = shared_ptr<WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> >;
+        using ConstPtr = shared_ptr<const WarpPointRigid6D<PointSourceT, PointTargetT, Scalar> >;
 
         WarpPointRigid6D () : WarpPointRigid<PointSourceT, PointTargetT, Scalar> (6) {}
       

--- a/sample_consensus/include/pcl/sample_consensus/lmeds.h
+++ b/sample_consensus/include/pcl/sample_consensus/lmeds.h
@@ -58,8 +58,8 @@ namespace pcl
     using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      using Ptr = boost::shared_ptr<LeastMedianSquares<PointT> >;
-      using ConstPtr = boost::shared_ptr<const LeastMedianSquares<PointT> >;
+      using Ptr = shared_ptr<LeastMedianSquares<PointT> >;
+      using ConstPtr = shared_ptr<const LeastMedianSquares<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/mlesac.h
+++ b/sample_consensus/include/pcl/sample_consensus/mlesac.h
@@ -60,8 +60,8 @@ namespace pcl
     using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr; 
 
     public:
-      using Ptr = boost::shared_ptr<MaximumLikelihoodSampleConsensus<PointT> >;
-      using ConstPtr = boost::shared_ptr<const MaximumLikelihoodSampleConsensus<PointT> >;
+      using Ptr = shared_ptr<MaximumLikelihoodSampleConsensus<PointT> >;
+      using ConstPtr = shared_ptr<const MaximumLikelihoodSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/msac.h
+++ b/sample_consensus/include/pcl/sample_consensus/msac.h
@@ -58,8 +58,8 @@ namespace pcl
     using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      using Ptr = boost::shared_ptr<MEstimatorSampleConsensus<PointT> >;
-      using ConstPtr = boost::shared_ptr<const MEstimatorSampleConsensus<PointT> >;
+      using Ptr = shared_ptr<MEstimatorSampleConsensus<PointT> >;
+      using ConstPtr = shared_ptr<const MEstimatorSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/prosac.h
+++ b/sample_consensus/include/pcl/sample_consensus/prosac.h
@@ -57,8 +57,8 @@ namespace pcl
     using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      using Ptr = boost::shared_ptr<ProgressiveSampleConsensus>;
-      using ConstPtr = boost::shared_ptr<const ProgressiveSampleConsensus>;
+      using Ptr = shared_ptr<ProgressiveSampleConsensus>;
+      using ConstPtr = shared_ptr<const ProgressiveSampleConsensus>;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/ransac.h
+++ b/sample_consensus/include/pcl/sample_consensus/ransac.h
@@ -58,8 +58,8 @@ namespace pcl
     using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      using Ptr = boost::shared_ptr<RandomSampleConsensus<PointT> >;
-      using ConstPtr = boost::shared_ptr<const RandomSampleConsensus<PointT> >;
+      using Ptr = shared_ptr<RandomSampleConsensus<PointT> >;
+      using ConstPtr = shared_ptr<const RandomSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/rmsac.h
+++ b/sample_consensus/include/pcl/sample_consensus/rmsac.h
@@ -59,8 +59,8 @@ namespace pcl
     using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      using Ptr = boost::shared_ptr<RandomizedMEstimatorSampleConsensus<PointT> >;
-      using ConstPtr = boost::shared_ptr<const RandomizedMEstimatorSampleConsensus<PointT> >;
+      using Ptr = shared_ptr<RandomizedMEstimatorSampleConsensus<PointT> >;
+      using ConstPtr = shared_ptr<const RandomizedMEstimatorSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/rransac.h
+++ b/sample_consensus/include/pcl/sample_consensus/rransac.h
@@ -58,8 +58,8 @@ namespace pcl
     using SampleConsensusModelPtr = typename SampleConsensusModel<PointT>::Ptr;
 
     public:
-      using Ptr = boost::shared_ptr<RandomizedRandomSampleConsensus<PointT> >;
-      using ConstPtr = boost::shared_ptr<const RandomizedRandomSampleConsensus<PointT> >;
+      using Ptr = shared_ptr<RandomizedRandomSampleConsensus<PointT> >;
+      using ConstPtr = shared_ptr<const RandomizedRandomSampleConsensus<PointT> >;
 
       using SampleConsensus<PointT>::max_iterations_;
       using SampleConsensus<PointT>::threshold_;

--- a/sample_consensus/include/pcl/sample_consensus/sac.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac.h
@@ -64,8 +64,8 @@ namespace pcl
       SampleConsensus () {};
 
     public:
-      using Ptr = boost::shared_ptr<SampleConsensus<T> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensus<T> >;
+      using Ptr = shared_ptr<SampleConsensus<T> >;
+      using ConstPtr = shared_ptr<const SampleConsensus<T> >;
 
 
       /** \brief Constructor for base SAC.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -73,8 +73,8 @@ namespace pcl
       using PointCloudPtr = typename PointCloud::Ptr;
       using SearchPtr = typename pcl::search::Search<PointT>::Ptr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModel<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModel<PointT> >;
+      using Ptr = shared_ptr<SampleConsensusModel<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModel<PointT> >;
 
     protected:
       /** \brief Empty constructor for base SampleConsensusModel.
@@ -583,8 +583,8 @@ namespace pcl
       using PointCloudNConstPtr = typename pcl::PointCloud<PointNT>::ConstPtr;
       using PointCloudNPtr = typename pcl::PointCloud<PointNT>::Ptr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelFromNormals<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelFromNormals<PointT, PointNT> >;
+      using Ptr = shared_ptr<SampleConsensusModelFromNormals<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelFromNormals<PointT, PointNT> >;
 
       /** \brief Empty constructor for base SampleConsensusModelFromNormals. */
       SampleConsensusModelFromNormals () : normal_distance_weight_ (0.0), normals_ () {};

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -70,8 +70,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelCircle2D<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelCircle2D<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelCircle2D<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelCircle2D<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelCircle2D.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -70,8 +70,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelCircle3D<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelCircle3D<PointT> >;
+      using Ptr = shared_ptr<SampleConsensusModelCircle3D<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelCircle3D<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelCircle3D.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -77,8 +77,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelCone<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelCone<PointT, PointNT>>;
+      using Ptr = shared_ptr<SampleConsensusModelCone<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelCone<PointT, PointNT>>;
 
       /** \brief Constructor for base SampleConsensusModelCone.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -77,8 +77,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelCylinder<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelCylinder<PointT, PointNT>>;
+      using Ptr = shared_ptr<SampleConsensusModelCylinder<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelCylinder<PointT, PointNT>>;
 
       /** \brief Constructor for base SampleConsensusModelCylinder.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -72,8 +72,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelLine<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelLine<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelLine<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelLine<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelLine.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -99,8 +99,8 @@ namespace pcl
       using PointCloudNPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr;
       using PointCloudNConstPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelNormalParallelPlane<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelNormalParallelPlane<PointT, PointNT>>;
+      using Ptr = shared_ptr<SampleConsensusModelNormalParallelPlane<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelNormalParallelPlane<PointT, PointNT>>;
 
       /** \brief Constructor for base SampleConsensusModelNormalParallelPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -91,8 +91,8 @@ namespace pcl
       using PointCloudNPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr;
       using PointCloudNConstPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelNormalPlane<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelNormalPlane<PointT, PointNT>>;
+      using Ptr = shared_ptr<SampleConsensusModelNormalPlane<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelNormalPlane<PointT, PointNT>>;
 
       /** \brief Constructor for base SampleConsensusModelNormalPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -85,8 +85,8 @@ namespace pcl
       using PointCloudNPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNPtr;
       using PointCloudNConstPtr = typename SampleConsensusModelFromNormals<PointT, PointNT>::PointCloudNConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelNormalSphere<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelNormalSphere<PointT, PointNT>>;
+      using Ptr = shared_ptr<SampleConsensusModelNormalSphere<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelNormalSphere<PointT, PointNT>>;
 
       /** \brief Constructor for base SampleConsensusModelNormalSphere.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -71,8 +71,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModelLine<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModelLine<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelParallelLine<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelParallelLine<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelParallelLine<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelParallelLine<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelParallelLine.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -72,8 +72,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModelPlane<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelParallelPlane<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelParallelPlane<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelParallelPlane<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelParallelPlane<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelParallelPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -77,8 +77,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModelPlane<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModelPlane<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelPerpendicularPlane<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelPerpendicularPlane<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelPerpendicularPlane<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelPerpendicularPlane<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelPerpendicularPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -145,8 +145,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelPlane<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelPlane<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelPlane<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelPlane<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelPlane.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -69,8 +69,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelRegistration<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelRegistration<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelRegistration<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelRegistration<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelRegistration.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -66,8 +66,8 @@ namespace pcl
       using PointCloudPtr = typename pcl::SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename pcl::SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelRegistration2D<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelRegistration2D<PointT> >;
+      using Ptr = shared_ptr<SampleConsensusModelRegistration2D<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelRegistration2D<PointT> >;
 
       /** \brief Constructor for base SampleConsensusModelRegistration2D.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -70,8 +70,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelSphere<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelSphere<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelSphere<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelSphere<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelSphere.
         * \param[in] cloud the input point cloud dataset

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -76,8 +76,8 @@ namespace pcl
       using PointCloudPtr = typename SampleConsensusModel<PointT>::PointCloudPtr;
       using PointCloudConstPtr = typename SampleConsensusModel<PointT>::PointCloudConstPtr;
 
-      using Ptr = boost::shared_ptr<SampleConsensusModelStick<PointT> >;
-      using ConstPtr = boost::shared_ptr<const SampleConsensusModelStick<PointT>>;
+      using Ptr = shared_ptr<SampleConsensusModelStick<PointT> >;
+      using ConstPtr = shared_ptr<const SampleConsensusModelStick<PointT>>;
 
       /** \brief Constructor for base SampleConsensusModelStick.
         * \param[in] cloud the input point cloud dataset

--- a/search/include/pcl/search/brute_force.h
+++ b/search/include/pcl/search/brute_force.h
@@ -53,8 +53,8 @@ namespace pcl
       using PointCloud = typename Search<PointT>::PointCloud;
       using PointCloudConstPtr = typename Search<PointT>::PointCloudConstPtr;
 
-      using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-      using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
+      using IndicesPtr = shared_ptr<std::vector<int> >;
+      using IndicesConstPtr = shared_ptr<const std::vector<int> >;
 
       using pcl::search::Search<PointT>::input_;
       using pcl::search::Search<PointT>::indices_;

--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -104,8 +104,8 @@ namespace pcl
       using Search<PointT>::sorted_results_;
 
       public:
-        using Ptr = boost::shared_ptr<FlannSearch<PointT, FlannDistance> >;
-        using ConstPtr = boost::shared_ptr<const FlannSearch<PointT, FlannDistance> >;
+        using Ptr = shared_ptr<FlannSearch<PointT, FlannDistance> >;
+        using ConstPtr = shared_ptr<const FlannSearch<PointT, FlannDistance> >;
         
         using PointCloud = typename Search<PointT>::PointCloud;
         using PointCloudConstPtr = typename Search<PointT>::PointCloudConstPtr;
@@ -113,11 +113,11 @@ namespace pcl
         using typename Search<PointT>::IndicesPtr;
         using typename Search<PointT>::IndicesConstPtr;
 
-        using MatrixPtr = boost::shared_ptr<flann::Matrix<float> >;
-        using MatrixConstPtr = boost::shared_ptr<const flann::Matrix<float> >;
+        using MatrixPtr = shared_ptr<flann::Matrix<float> >;
+        using MatrixConstPtr = shared_ptr<const flann::Matrix<float> >;
 
         using Index = flann::NNIndex<FlannDistance>;
-        using IndexPtr = boost::shared_ptr<flann::NNIndex<FlannDistance> >;
+        using IndexPtr = shared_ptr<flann::NNIndex<FlannDistance> >;
 
         using PointRepresentation = pcl::PointRepresentation<PointT>;
         using PointRepresentationPtr = typename PointRepresentation::Ptr;
@@ -141,7 +141,7 @@ namespace pcl
             */
             virtual ~FlannIndexCreator () {}
         };
-        using FlannIndexCreatorPtr = boost::shared_ptr<FlannIndexCreator>;
+        using FlannIndexCreatorPtr = shared_ptr<FlannIndexCreator>;
 
         /** \brief Creates a FLANN KdTreeSingleIndex from the given input data.
           */

--- a/search/include/pcl/search/kdtree.h
+++ b/search/include/pcl/search/kdtree.h
@@ -75,8 +75,8 @@ namespace pcl
         using pcl::search::Search<PointT>::radiusSearch;
         using pcl::search::Search<PointT>::sorted_results_;
 
-        using Ptr = boost::shared_ptr<KdTree<PointT, Tree> >;
-        using ConstPtr = boost::shared_ptr<const KdTree<PointT, Tree> >;
+        using Ptr = shared_ptr<KdTree<PointT, Tree> >;
+        using ConstPtr = shared_ptr<const KdTree<PointT, Tree> >;
 
         using KdTreePtr = typename Tree::Ptr;
         using KdTreeConstPtr = typename Tree::ConstPtr;

--- a/search/include/pcl/search/octree.h
+++ b/search/include/pcl/search/octree.h
@@ -69,8 +69,8 @@ namespace pcl
     {
       public:
         // public typedefs
-        using Ptr = boost::shared_ptr<pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> >;
-        using ConstPtr = boost::shared_ptr<const pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> >;
+        using Ptr = shared_ptr<pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> >;
+        using ConstPtr = shared_ptr<const pcl::search::Octree<PointT,LeafTWrap,BranchTWrap,OctreeT> >;
 
         using typename Search<PointT>::IndicesPtr;
         using typename Search<PointT>::IndicesConstPtr;

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -70,8 +70,8 @@ namespace pcl
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
         using typename Search<PointT>::IndicesConstPtr;
 
-        using Ptr = boost::shared_ptr<pcl::search::OrganizedNeighbor<PointT> >;
-        using ConstPtr = boost::shared_ptr<const pcl::search::OrganizedNeighbor<PointT> >;
+        using Ptr = shared_ptr<pcl::search::OrganizedNeighbor<PointT> >;
+        using ConstPtr = shared_ptr<const pcl::search::OrganizedNeighbor<PointT> >;
 
         using pcl::search::Search<PointT>::indices_;
         using pcl::search::Search<PointT>::sorted_results_;

--- a/search/include/pcl/search/search.h
+++ b/search/include/pcl/search/search.h
@@ -77,11 +77,11 @@ namespace pcl
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<pcl::search::Search<PointT> >;
-        using ConstPtr = boost::shared_ptr<const pcl::search::Search<PointT> >;
+        using Ptr = shared_ptr<pcl::search::Search<PointT> >;
+        using ConstPtr = shared_ptr<const pcl::search::Search<PointT> >;
 
-        using IndicesPtr = boost::shared_ptr<std::vector<int> >;
-        using IndicesConstPtr = boost::shared_ptr<const std::vector<int> >;
+        using IndicesPtr = shared_ptr<std::vector<int> >;
+        using IndicesConstPtr = shared_ptr<const std::vector<int> >;
 
         /** Constructor. */
         Search (const std::string& name = "", bool sorted = false);

--- a/segmentation/include/pcl/segmentation/comparator.h
+++ b/segmentation/include/pcl/segmentation/comparator.h
@@ -57,8 +57,8 @@ namespace pcl
       using PointCloudPtr = typename PointCloud::Ptr;
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-      using Ptr = boost::shared_ptr<Comparator<PointT> >;
-      using ConstPtr = boost::shared_ptr<const Comparator<PointT> >;
+      using Ptr = shared_ptr<Comparator<PointT> >;
+      using ConstPtr = shared_ptr<const Comparator<PointT> >;
 
       /** \brief Empty constructor for comparator. */
       Comparator () : input_ ()

--- a/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
+++ b/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
@@ -46,7 +46,7 @@
 namespace pcl
 {
   using IndicesClusters = std::vector<pcl::PointIndices>;
-  using IndicesClustersPtr = boost::shared_ptr<std::vector<pcl::PointIndices> >;
+  using IndicesClustersPtr = shared_ptr<std::vector<pcl::PointIndices> >;
 
   /** \brief @b ConditionalEuclideanClustering performs segmentation based on Euclidean distance and a user-defined clustering condition.
     * \details The condition that need to hold is currently passed using a function pointer.

--- a/segmentation/include/pcl/segmentation/cpc_segmentation.h
+++ b/segmentation/include/pcl/segmentation/cpc_segmentation.h
@@ -177,8 +177,8 @@ namespace pcl
           using SampleConsensusModelPtr = SampleConsensusModel<WeightSACPointType>::Ptr;
 
         public:
-          using Ptr = boost::shared_ptr<WeightedRandomSampleConsensus>;
-          using ConstPtr = boost::shared_ptr<const WeightedRandomSampleConsensus>;
+          using Ptr = shared_ptr<WeightedRandomSampleConsensus>;
+          using ConstPtr = shared_ptr<const WeightedRandomSampleConsensus>;
 
           /** \brief WeightedRandomSampleConsensus (Weighted RAndom SAmple Consensus) main constructor
             * \param[in] model a Sample Consensus model

--- a/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
@@ -61,8 +61,8 @@ namespace pcl
       using PointCloudNPtr = typename PointCloudN::Ptr;
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      using Ptr = boost::shared_ptr<EdgeAwarePlaneComparator<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const EdgeAwarePlaneComparator<PointT, PointNT> >;
+      using Ptr = shared_ptr<EdgeAwarePlaneComparator<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const EdgeAwarePlaneComparator<PointT, PointNT> >;
 
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -62,12 +62,12 @@ namespace pcl
         using PointCloudLPtr = typename PointCloudL::Ptr;
         using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
-        using Ptr = boost::shared_ptr<EuclideanClusterComparator<PointT, PointLT> >;
-        using ConstPtr = boost::shared_ptr<const EuclideanClusterComparator<PointT, PointLT> >;
+        using Ptr = shared_ptr<EuclideanClusterComparator<PointT, PointLT> >;
+        using ConstPtr = shared_ptr<const EuclideanClusterComparator<PointT, PointLT> >;
 
         using ExcludeLabelSet = std::set<std::uint32_t>;
-        using ExcludeLabelSetPtr = boost::shared_ptr<ExcludeLabelSet>;
-        using ExcludeLabelSetConstPtr = boost::shared_ptr<const ExcludeLabelSet>;
+        using ExcludeLabelSetPtr = shared_ptr<ExcludeLabelSet>;
+        using ExcludeLabelSetConstPtr = shared_ptr<const ExcludeLabelSet>;
 
         /** \brief Default constructor for EuclideanClusterComparator. */
         EuclideanClusterComparator ()
@@ -204,8 +204,8 @@ namespace pcl
       using PointCloudNPtr = typename PointCloudN::Ptr;
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
 
-      using Ptr = boost::shared_ptr<EuclideanClusterComparator<PointT, PointNT, PointLT> >;
-      using ConstPtr = boost::shared_ptr<const EuclideanClusterComparator<PointT, PointNT, PointLT> >;
+      using Ptr = shared_ptr<EuclideanClusterComparator<PointT, PointNT, PointLT> >;
+      using ConstPtr = shared_ptr<const EuclideanClusterComparator<PointT, PointNT, PointLT> >;
 
       using experimental::EuclideanClusterComparator<PointT, PointLT>::setExcludeLabels;
 

--- a/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_plane_coefficient_comparator.h
@@ -60,8 +60,8 @@ namespace pcl
       using PointCloudNPtr = typename PointCloudN::Ptr;
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      using Ptr = boost::shared_ptr<EuclideanPlaneCoefficientComparator<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const EuclideanPlaneCoefficientComparator<PointT, PointNT> >;
+      using Ptr = shared_ptr<EuclideanPlaneCoefficientComparator<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const EuclideanPlaneCoefficientComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -62,8 +62,8 @@ namespace pcl
       using PointCloudNPtr = typename PointCloudN::Ptr;
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      using Ptr = boost::shared_ptr<GroundPlaneComparator<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const GroundPlaneComparator<PointT, PointNT> >;
+      using Ptr = shared_ptr<GroundPlaneComparator<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const GroundPlaneComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       
@@ -82,7 +82,7 @@ namespace pcl
       /** \brief Constructor for GroundPlaneComparator.
         * \param[in] plane_coeff_d a reference to a vector of d coefficients of plane equations.  Must be the same size as the input cloud and input normals.  a, b, and c coefficients are in the input normals.
         */
-      GroundPlaneComparator (boost::shared_ptr<std::vector<float> >& plane_coeff_d) 
+      GroundPlaneComparator (shared_ptr<std::vector<float> >& plane_coeff_d) 
         : normals_ ()
         , plane_coeff_d_ (plane_coeff_d)
         , angular_threshold_ (std::cos (pcl::deg2rad (3.0f)))
@@ -128,7 +128,7 @@ namespace pcl
         * \param[in] plane_coeff_d a pointer to the plane coefficients.
         */
       void
-      setPlaneCoeffD (boost::shared_ptr<std::vector<float> >& plane_coeff_d)
+      setPlaneCoeffD (shared_ptr<std::vector<float> >& plane_coeff_d)
       {
         plane_coeff_d_ = plane_coeff_d;
       }
@@ -233,7 +233,7 @@ namespace pcl
       
     protected:
       PointCloudNConstPtr normals_;
-      boost::shared_ptr<std::vector<float> > plane_coeff_d_;
+      shared_ptr<std::vector<float> > plane_coeff_d_;
       float angular_threshold_;
       float road_angular_threshold_;
       float distance_threshold_;

--- a/segmentation/include/pcl/segmentation/min_cut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/min_cut_segmentation.h
@@ -101,7 +101,7 @@ namespace pcl
 
       using InEdgeIterator = boost::graph_traits<mGraph>::in_edge_iterator;
 
-      using mGraphPtr = boost::shared_ptr<mGraph>;
+      using mGraphPtr = shared_ptr<mGraph>;
 
     public:
 

--- a/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
@@ -62,8 +62,8 @@ namespace pcl
       using PointCloudNPtr = typename PointCloudN::Ptr;
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      using Ptr = boost::shared_ptr<PlaneCoefficientComparator<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const PlaneCoefficientComparator<PointT, PointNT> >;
+      using Ptr = shared_ptr<PlaneCoefficientComparator<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const PlaneCoefficientComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       
@@ -80,7 +80,7 @@ namespace pcl
       /** \brief Constructor for PlaneCoefficientComparator.
         * \param[in] plane_coeff_d a reference to a vector of d coefficients of plane equations.  Must be the same size as the input cloud and input normals.  a, b, and c coefficients are in the input normals.
         */
-      PlaneCoefficientComparator (boost::shared_ptr<std::vector<float> >& plane_coeff_d) 
+      PlaneCoefficientComparator (shared_ptr<std::vector<float> >& plane_coeff_d) 
         : normals_ ()
         , plane_coeff_d_ (plane_coeff_d)
         , angular_threshold_ (pcl::deg2rad (2.0f))
@@ -122,7 +122,7 @@ namespace pcl
         * \param[in] plane_coeff_d a pointer to the plane coefficients.
         */
       void
-      setPlaneCoeffD (boost::shared_ptr<std::vector<float> >& plane_coeff_d)
+      setPlaneCoeffD (shared_ptr<std::vector<float> >& plane_coeff_d)
       {
         plane_coeff_d_ = plane_coeff_d;
       }
@@ -200,7 +200,7 @@ namespace pcl
       
     protected:
       PointCloudNConstPtr normals_;
-      boost::shared_ptr<std::vector<float> > plane_coeff_d_;
+      shared_ptr<std::vector<float> > plane_coeff_d_;
       float angular_threshold_;
       float distance_threshold_;
       bool depth_dependent_;

--- a/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_refinement_comparator.h
@@ -65,8 +65,8 @@ namespace pcl
       using PointCloudLPtr = typename PointCloudL::Ptr;
       using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
 
-      using Ptr = boost::shared_ptr<PlaneRefinementComparator<PointT, PointNT, PointLT> >;
-      using ConstPtr = boost::shared_ptr<const PlaneRefinementComparator<PointT, PointNT, PointLT> >;
+      using Ptr = shared_ptr<PlaneRefinementComparator<PointT, PointNT, PointLT> >;
+      using ConstPtr = shared_ptr<const PlaneRefinementComparator<PointT, PointNT, PointLT> >;
 
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;
@@ -85,8 +85,8 @@ namespace pcl
         * \param[in] models
         * \param[in] refine_labels
         */
-      PlaneRefinementComparator (boost::shared_ptr<std::vector<pcl::ModelCoefficients> >& models,
-                                 boost::shared_ptr<std::vector<bool> >& refine_labels)
+      PlaneRefinementComparator (shared_ptr<std::vector<pcl::ModelCoefficients> >& models,
+                                 shared_ptr<std::vector<bool> >& refine_labels)
         : models_ (models)
         , labels_ ()
         , refine_labels_ (refine_labels)
@@ -104,7 +104,7 @@ namespace pcl
         * \param[in] models a vector of model coefficients produced by the initial segmentation step.
         */
       void
-      setModelCoefficients (boost::shared_ptr<std::vector<pcl::ModelCoefficients> >& models)
+      setModelCoefficients (shared_ptr<std::vector<pcl::ModelCoefficients> >& models)
       {
         models_ = models;
       }
@@ -122,7 +122,7 @@ namespace pcl
         * \param[in] refine_labels A vector of bools 0-max_label, true if the label should be refined.
         */
       void
-      setRefineLabels (boost::shared_ptr<std::vector<bool> >& refine_labels)
+      setRefineLabels (shared_ptr<std::vector<bool> >& refine_labels)
       {
         refine_labels_ = refine_labels;
       }
@@ -140,7 +140,7 @@ namespace pcl
         * \param[in] label_to_model A vector of size max_label, with the index of each corresponding model in models
         */
       inline void
-      setLabelToModel (boost::shared_ptr<std::vector<int> >& label_to_model)
+      setLabelToModel (shared_ptr<std::vector<int> >& label_to_model)
       {
         label_to_model_ = label_to_model;
       }
@@ -155,7 +155,7 @@ namespace pcl
       }
 
       /** \brief Get the vector of model coefficients to which we will compare. */
-      inline boost::shared_ptr<std::vector<pcl::ModelCoefficients> >
+      inline shared_ptr<std::vector<pcl::ModelCoefficients> >
       getModelCoefficients () const
       {
         return (models_);
@@ -206,10 +206,10 @@ namespace pcl
       }
 
     protected:
-      boost::shared_ptr<std::vector<pcl::ModelCoefficients> > models_;
+      shared_ptr<std::vector<pcl::ModelCoefficients> > models_;
       PointCloudLPtr labels_;
-      boost::shared_ptr<std::vector<bool> > refine_labels_;
-      boost::shared_ptr<std::vector<int> > label_to_model_;
+      shared_ptr<std::vector<bool> > refine_labels_;
+      shared_ptr<std::vector<int> > label_to_model_;
       bool depth_dependent_;
       using PlaneCoefficientComparator<PointT, PointNT>::z_axis_;
   };

--- a/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/rgb_plane_coefficient_comparator.h
@@ -61,8 +61,8 @@ namespace pcl
       using PointCloudNPtr = typename PointCloudN::Ptr;
       using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
       
-      using Ptr = boost::shared_ptr<RGBPlaneCoefficientComparator<PointT, PointNT> >;
-      using ConstPtr = boost::shared_ptr<const RGBPlaneCoefficientComparator<PointT, PointNT> >;
+      using Ptr = shared_ptr<RGBPlaneCoefficientComparator<PointT, PointNT> >;
+      using ConstPtr = shared_ptr<const RGBPlaneCoefficientComparator<PointT, PointNT> >;
 
       using pcl::Comparator<PointT>::input_;
       using pcl::PlaneCoefficientComparator<PointT, PointNT>::normals_;
@@ -78,7 +78,7 @@ namespace pcl
       /** \brief Constructor for RGBPlaneCoefficientComparator.
         * \param[in] plane_coeff_d a reference to a vector of d coefficients of plane equations.  Must be the same size as the input cloud and input normals.  a, b, and c coefficients are in the input normals.
         */
-      RGBPlaneCoefficientComparator (boost::shared_ptr<std::vector<float> >& plane_coeff_d) 
+      RGBPlaneCoefficientComparator (shared_ptr<std::vector<float> >& plane_coeff_d) 
         : PlaneCoefficientComparator<PointT, PointNT> (plane_coeff_d), color_threshold_ (50.0f)
       {
       }

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -71,8 +71,8 @@ namespace pcl
         normals_ (new pcl::PointCloud<Normal> ())
         {  } 
 
-      using Ptr = boost::shared_ptr<Supervoxel<PointT> >;
-      using ConstPtr = boost::shared_ptr<const Supervoxel<PointT> >;
+      using Ptr = shared_ptr<Supervoxel<PointT> >;
+      using ConstPtr = shared_ptr<const Supervoxel<PointT> >;
 
       /** \brief Gets the centroid of the supervoxel
        *  \param[out] centroid_arg centroid of the supervoxel

--- a/simulation/include/pcl/simulation/camera.h
+++ b/simulation/include/pcl/simulation/camera.h
@@ -11,8 +11,8 @@ namespace simulation {
 
 class PCL_EXPORTS Camera {
 public:
-  using Ptr = boost::shared_ptr<Camera>;
-  using ConstPtr = boost::shared_ptr<const Camera>;
+  using Ptr = shared_ptr<Camera>;
+  using ConstPtr = shared_ptr<const Camera>;
 
   Camera() : x_(0), y_(0), z_(0), roll_(0), pitch_(0), yaw_(0)
   {

--- a/simulation/include/pcl/simulation/glsl_shader.h
+++ b/simulation/include/pcl/simulation/glsl_shader.h
@@ -11,7 +11,7 @@
 
 #include <Eigen/Core>
 #include <GL/glew.h>
-#include <boost/shared_ptr.hpp>
+#include <pcl/make_shared.h>
 
 namespace pcl {
 namespace simulation {
@@ -28,8 +28,8 @@ enum ShaderType {
 /** A GLSL shader program.  */
 class PCL_EXPORTS Program {
 public:
-  using Ptr = boost::shared_ptr<Program>;
-  using ConstPtr = boost::shared_ptr<const Program>;
+  using Ptr = shared_ptr<Program>;
+  using ConstPtr = shared_ptr<const Program>;
 
   /** Construct an empty shader program.  */
   Program();

--- a/simulation/include/pcl/simulation/model.h
+++ b/simulation/include/pcl/simulation/model.h
@@ -60,14 +60,14 @@ public:
   virtual void
   draw() = 0;
 
-  using Ptr = boost::shared_ptr<Model>;
-  using ConstPtr = boost::shared_ptr<const Model>;
+  using Ptr = shared_ptr<Model>;
+  using ConstPtr = shared_ptr<const Model>;
 };
 
 class PCL_EXPORTS TriangleMeshModel : public Model {
 public:
-  using Ptr = boost::shared_ptr<TriangleMeshModel>;
-  using ConstPtr = boost::shared_ptr<const TriangleMeshModel>;
+  using Ptr = shared_ptr<TriangleMeshModel>;
+  using ConstPtr = shared_ptr<const TriangleMeshModel>;
 
   TriangleMeshModel(pcl::PolygonMesh::Ptr plg);
 
@@ -91,8 +91,8 @@ public:
   void
   draw() override;
 
-  using Ptr = boost::shared_ptr<PolygonMeshModel>;
-  using ConstPtr = boost::shared_ptr<const PolygonMeshModel>;
+  using Ptr = shared_ptr<PolygonMeshModel>;
+  using ConstPtr = shared_ptr<const PolygonMeshModel>;
 
 private:
   std::vector<SinglePoly> polygons;
@@ -114,8 +114,8 @@ private:
 
 class PCL_EXPORTS PointCloudModel : public Model {
 public:
-  using Ptr = boost::shared_ptr<PointCloudModel>;
-  using ConstPtr = boost::shared_ptr<const PointCloudModel>;
+  using Ptr = shared_ptr<PointCloudModel>;
+  using ConstPtr = shared_ptr<const PointCloudModel>;
 
   PointCloudModel(GLenum mode, pcl::PointCloud<pcl::PointXYZRGB>::Ptr pc);
 
@@ -169,8 +169,8 @@ private:
 
 class PCL_EXPORTS TexturedQuad {
 public:
-  using Ptr = boost::shared_ptr<TexturedQuad>;
-  using ConstPtr = boost::shared_ptr<const TexturedQuad>;
+  using Ptr = shared_ptr<TexturedQuad>;
+  using ConstPtr = shared_ptr<const TexturedQuad>;
 
   TexturedQuad(int width, int height);
   ~TexturedQuad();

--- a/simulation/include/pcl/simulation/range_likelihood.h
+++ b/simulation/include/pcl/simulation/range_likelihood.h
@@ -27,8 +27,8 @@ namespace pcl {
 namespace simulation {
 class PCL_EXPORTS RangeLikelihood {
 public:
-  using Ptr = boost::shared_ptr<RangeLikelihood>;
-  using ConstPtr = boost::shared_ptr<const RangeLikelihood>;
+  using Ptr = shared_ptr<RangeLikelihood>;
+  using ConstPtr = shared_ptr<const RangeLikelihood>;
 
 public:
   /** Create a new object to compute range image likelihoods.

--- a/simulation/include/pcl/simulation/scene.h
+++ b/simulation/include/pcl/simulation/scene.h
@@ -20,8 +20,8 @@ namespace simulation {
 
 class PCL_EXPORTS Scene {
 public:
-  using Ptr = boost::shared_ptr<Scene>;
-  using ConstPtr = boost::shared_ptr<Scene>;
+  using Ptr = shared_ptr<Scene>;
+  using ConstPtr = shared_ptr<Scene>;
 
   void
   draw();

--- a/simulation/tools/simulation_io.hpp
+++ b/simulation/tools/simulation_io.hpp
@@ -33,8 +33,8 @@ namespace simulation {
 
 class PCL_EXPORTS SimExample {
 public:
-  using Ptr = boost::shared_ptr<SimExample>;
-  using ConstPtr = boost::shared_ptr<const SimExample>;
+  using Ptr = shared_ptr<SimExample>;
+  using ConstPtr = shared_ptr<const SimExample>;
 
   SimExample(int argc, char** argv, int height, int width);
   void

--- a/surface/include/pcl/surface/bilateral_upsampling.h
+++ b/surface/include/pcl/surface/bilateral_upsampling.h
@@ -62,8 +62,8 @@ namespace pcl
   class BilateralUpsampling: public CloudSurfaceProcessing<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<BilateralUpsampling<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const BilateralUpsampling<PointInT, PointOutT> > ConstPtr;
+      typedef shared_ptr<BilateralUpsampling<PointInT, PointOutT> > Ptr;
+      typedef shared_ptr<const BilateralUpsampling<PointInT, PointOutT> > ConstPtr;
 
       using PCLBase<PointInT>::input_;
       using PCLBase<PointInT>::indices_;

--- a/surface/include/pcl/surface/concave_hull.h
+++ b/surface/include/pcl/surface/concave_hull.h
@@ -55,8 +55,8 @@ namespace pcl
   class ConcaveHull : public MeshConstruction<PointInT>
   {
     protected:
-      using Ptr = boost::shared_ptr<ConcaveHull<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const ConcaveHull<PointInT> >;
+      using Ptr = shared_ptr<ConcaveHull<PointInT> >;
+      using ConstPtr = shared_ptr<const ConcaveHull<PointInT> >;
 
       using PCLBase<PointInT>::input_;
       using PCLBase<PointInT>::indices_;

--- a/surface/include/pcl/surface/convex_hull.h
+++ b/surface/include/pcl/surface/convex_hull.h
@@ -78,8 +78,8 @@ namespace pcl
       using PCLBase<PointInT>::deinitCompute;
 
     public:
-      using Ptr = boost::shared_ptr<ConvexHull<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const ConvexHull<PointInT> >;
+      using Ptr = shared_ptr<ConvexHull<PointInT> >;
+      using ConstPtr = shared_ptr<const ConvexHull<PointInT> >;
 
       using MeshConstruction<PointInT>::reconstruct;
 

--- a/surface/include/pcl/surface/ear_clipping.h
+++ b/surface/include/pcl/surface/ear_clipping.h
@@ -52,8 +52,8 @@ namespace pcl
   class PCL_EXPORTS EarClipping : public MeshProcessing
   {
     public:
-      using Ptr = boost::shared_ptr<EarClipping>;
-      using ConstPtr = boost::shared_ptr<const EarClipping>;
+      using Ptr = shared_ptr<EarClipping>;
+      using ConstPtr = shared_ptr<const EarClipping>;
 
       using MeshProcessing::input_mesh_;
       using MeshProcessing::initCompute;

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -132,8 +132,8 @@ namespace pcl
   class GreedyProjectionTriangulation : public MeshConstruction<PointInT>
   {
     public:
-      using Ptr = boost::shared_ptr<GreedyProjectionTriangulation<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const GreedyProjectionTriangulation<PointInT> >;
+      using Ptr = shared_ptr<GreedyProjectionTriangulation<PointInT> >;
+      using ConstPtr = shared_ptr<const GreedyProjectionTriangulation<PointInT> >;
 
       using MeshConstruction<PointInT>::tree_;
       using MeshConstruction<PointInT>::input_;

--- a/surface/include/pcl/surface/grid_projection.h
+++ b/surface/include/pcl/surface/grid_projection.h
@@ -74,8 +74,8 @@ namespace pcl
   class GridProjection : public SurfaceReconstruction<PointNT>
   {
     public:
-      using Ptr = boost::shared_ptr<GridProjection<PointNT> >;
-      using ConstPtr = boost::shared_ptr<const GridProjection<PointNT> >;
+      using Ptr = shared_ptr<GridProjection<PointNT> >;
+      using ConstPtr = shared_ptr<const GridProjection<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;

--- a/surface/include/pcl/surface/marching_cubes.h
+++ b/surface/include/pcl/surface/marching_cubes.h
@@ -363,8 +363,8 @@ namespace pcl
   class MarchingCubes : public SurfaceReconstruction<PointNT>
   {
     public:
-      using Ptr = boost::shared_ptr<MarchingCubes<PointNT> >;
-      using ConstPtr = boost::shared_ptr<const MarchingCubes<PointNT> >;
+      using Ptr = shared_ptr<MarchingCubes<PointNT> >;
+      using ConstPtr = shared_ptr<const MarchingCubes<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;

--- a/surface/include/pcl/surface/marching_cubes_hoppe.h
+++ b/surface/include/pcl/surface/marching_cubes_hoppe.h
@@ -52,8 +52,8 @@ namespace pcl
   class MarchingCubesHoppe : public MarchingCubes<PointNT>
   {
     public:
-      using Ptr = boost::shared_ptr<MarchingCubesHoppe<PointNT> >;
-      using ConstPtr = boost::shared_ptr<const MarchingCubesHoppe<PointNT> >;
+      using Ptr = shared_ptr<MarchingCubesHoppe<PointNT> >;
+      using ConstPtr = shared_ptr<const MarchingCubesHoppe<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;

--- a/surface/include/pcl/surface/marching_cubes_rbf.h
+++ b/surface/include/pcl/surface/marching_cubes_rbf.h
@@ -54,8 +54,8 @@ namespace pcl
   class MarchingCubesRBF : public MarchingCubes<PointNT>
   {
     public:
-      using Ptr = boost::shared_ptr<MarchingCubesRBF<PointNT> >;
-      using ConstPtr = boost::shared_ptr<const MarchingCubesRBF<PointNT> >;
+      using Ptr = shared_ptr<MarchingCubesRBF<PointNT> >;
+      using ConstPtr = shared_ptr<const MarchingCubesRBF<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -252,8 +252,8 @@ namespace pcl
   class MovingLeastSquares : public CloudSurfaceProcessing<PointInT, PointOutT>
   {
     public:
-      typedef boost::shared_ptr<MovingLeastSquares<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const MovingLeastSquares<PointInT, PointOutT> > ConstPtr;
+      typedef shared_ptr<MovingLeastSquares<PointInT, PointOutT> > Ptr;
+      typedef shared_ptr<const MovingLeastSquares<PointInT, PointOutT> > ConstPtr;
 
       using PCLBase<PointInT>::input_;
       using PCLBase<PointInT>::indices_;

--- a/surface/include/pcl/surface/organized_fast_mesh.h
+++ b/surface/include/pcl/surface/organized_fast_mesh.h
@@ -64,8 +64,8 @@ namespace pcl
   class OrganizedFastMesh : public MeshConstruction<PointInT>
   {
     public:
-      using Ptr = boost::shared_ptr<OrganizedFastMesh<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const OrganizedFastMesh<PointInT> >;
+      using Ptr = shared_ptr<OrganizedFastMesh<PointInT> >;
+      using ConstPtr = shared_ptr<const OrganizedFastMesh<PointInT> >;
 
       using MeshConstruction<PointInT>::input_;
       using MeshConstruction<PointInT>::check_tree_;

--- a/surface/include/pcl/surface/poisson.h
+++ b/surface/include/pcl/surface/poisson.h
@@ -60,8 +60,8 @@ namespace pcl
   class Poisson : public SurfaceReconstruction<PointNT>
   {
     public:
-      using Ptr = boost::shared_ptr<Poisson<PointNT> >;
-      using ConstPtr = boost::shared_ptr<const Poisson<PointNT> >;
+      using Ptr = shared_ptr<Poisson<PointNT> >;
+      using ConstPtr = shared_ptr<const Poisson<PointNT> >;
 
       using SurfaceReconstruction<PointNT>::input_;
       using SurfaceReconstruction<PointNT>::tree_;

--- a/surface/include/pcl/surface/processing.h
+++ b/surface/include/pcl/surface/processing.h
@@ -56,8 +56,8 @@ namespace pcl
   class CloudSurfaceProcessing : public PCLBase<PointInT>
   {
     public:
-      typedef boost::shared_ptr<CloudSurfaceProcessing<PointInT, PointOutT> > Ptr;
-      typedef boost::shared_ptr<const CloudSurfaceProcessing<PointInT, PointOutT> > ConstPtr;
+      typedef shared_ptr<CloudSurfaceProcessing<PointInT, PointOutT> > Ptr;
+      typedef shared_ptr<const CloudSurfaceProcessing<PointInT, PointOutT> > ConstPtr;
 
       using PCLBase<PointInT>::input_;
       using PCLBase<PointInT>::indices_;
@@ -93,8 +93,8 @@ namespace pcl
   class PCL_EXPORTS MeshProcessing
   {
     public:
-      using Ptr = boost::shared_ptr<MeshProcessing>;
-      using ConstPtr = boost::shared_ptr<const MeshProcessing>;
+      using Ptr = shared_ptr<MeshProcessing>;
+      using ConstPtr = shared_ptr<const MeshProcessing>;
 
       using PolygonMeshConstPtr = PolygonMesh::ConstPtr;
 

--- a/surface/include/pcl/surface/reconstruction.h
+++ b/surface/include/pcl/surface/reconstruction.h
@@ -60,8 +60,8 @@ namespace pcl
   class PCLSurfaceBase: public PCLBase<PointInT>
   {
     public:
-      using Ptr = boost::shared_ptr<PCLSurfaceBase<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const PCLSurfaceBase<PointInT> >;
+      using Ptr = shared_ptr<PCLSurfaceBase<PointInT> >;
+      using ConstPtr = shared_ptr<const PCLSurfaceBase<PointInT> >;
 
       using KdTree = pcl::search::Search<PointInT>;
       using KdTreePtr = typename KdTree::Ptr;
@@ -118,8 +118,8 @@ namespace pcl
   class SurfaceReconstruction: public PCLSurfaceBase<PointInT>
   {
     public:
-      using Ptr = boost::shared_ptr<SurfaceReconstruction<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const SurfaceReconstruction<PointInT> >;
+      using Ptr = shared_ptr<SurfaceReconstruction<PointInT> >;
+      using ConstPtr = shared_ptr<const SurfaceReconstruction<PointInT> >;
 
       using PCLSurfaceBase<PointInT>::input_;
       using PCLSurfaceBase<PointInT>::indices_;
@@ -187,8 +187,8 @@ namespace pcl
   class MeshConstruction: public PCLSurfaceBase<PointInT>
   {
     public:
-      using Ptr = boost::shared_ptr<MeshConstruction<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const MeshConstruction<PointInT> >;
+      using Ptr = shared_ptr<MeshConstruction<PointInT> >;
+      using ConstPtr = shared_ptr<const MeshConstruction<PointInT> >;
 
       using PCLSurfaceBase<PointInT>::input_;
       using PCLSurfaceBase<PointInT>::indices_;

--- a/surface/include/pcl/surface/simplification_remove_unused_vertices.h
+++ b/surface/include/pcl/surface/simplification_remove_unused_vertices.h
@@ -48,8 +48,8 @@ namespace pcl
     class PCL_EXPORTS SimplificationRemoveUnusedVertices
     {
       public:
-        using Ptr = boost::shared_ptr<SimplificationRemoveUnusedVertices>;
-        using ConstPtr = boost::shared_ptr<const SimplificationRemoveUnusedVertices>;
+        using Ptr = shared_ptr<SimplificationRemoveUnusedVertices>;
+        using ConstPtr = shared_ptr<const SimplificationRemoveUnusedVertices>;
 
         /** \brief Constructor. */
         SimplificationRemoveUnusedVertices () {};

--- a/surface/include/pcl/surface/surfel_smoothing.h
+++ b/surface/include/pcl/surface/surfel_smoothing.h
@@ -49,8 +49,8 @@ namespace pcl
     using PCLBase<PointT>::initCompute;
 
     public:
-      typedef boost::shared_ptr<SurfelSmoothing<PointT, PointNT> > Ptr;
-      typedef boost::shared_ptr<const SurfelSmoothing<PointT, PointNT> > ConstPtr;
+      typedef shared_ptr<SurfelSmoothing<PointT, PointNT> > Ptr;
+      typedef shared_ptr<const SurfelSmoothing<PointT, PointNT> > ConstPtr;
 
       using PointCloudIn = pcl::PointCloud<PointT>;
       using PointCloudInPtr = typename pcl::PointCloud<PointT>::Ptr;

--- a/surface/include/pcl/surface/texture_mapping.h
+++ b/surface/include/pcl/surface/texture_mapping.h
@@ -99,8 +99,8 @@ namespace pcl
   {
     public:
      
-      using Ptr = boost::shared_ptr<TextureMapping<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const TextureMapping<PointInT> >;
+      using Ptr = shared_ptr<TextureMapping<PointInT> >;
+      using ConstPtr = shared_ptr<const TextureMapping<PointInT> >;
 
       using PointCloud = pcl::PointCloud<PointInT>;
       using PointCloudPtr = typename PointCloud::Ptr;

--- a/tracking/include/pcl/tracking/coherence.h
+++ b/tracking/include/pcl/tracking/coherence.h
@@ -16,8 +16,8 @@ namespace pcl
     class PointCoherence
     {
     public:
-      using Ptr = boost::shared_ptr<PointCoherence<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const PointCoherence<PointInT> >;
+      using Ptr = shared_ptr<PointCoherence<PointInT> >;
+      using ConstPtr = shared_ptr<const PointCoherence<PointInT> >;
       
     public:
       /** \brief empty constructor */
@@ -59,8 +59,8 @@ namespace pcl
     class PointCloudCoherence
     {
     public:
-      using Ptr = boost::shared_ptr<PointCloudCoherence<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const PointCloudCoherence<PointInT> >;
+      using Ptr = shared_ptr<PointCloudCoherence<PointInT> >;
+      using ConstPtr = shared_ptr<const PointCloudCoherence<PointInT> >;
 
       using PointCloudIn = pcl::PointCloud<PointInT>;
       using PointCloudInPtr = typename PointCloudIn::Ptr;

--- a/tracking/include/pcl/tracking/distance_coherence.h
+++ b/tracking/include/pcl/tracking/distance_coherence.h
@@ -18,8 +18,8 @@ namespace pcl
     {
     public:
 
-      using Ptr = boost::shared_ptr<DistanceCoherence<PointInT> >;
-      using ConstPtr = boost::shared_ptr<const DistanceCoherence<PointInT>>;
+      using Ptr = shared_ptr<DistanceCoherence<PointInT> >;
+      using ConstPtr = shared_ptr<const DistanceCoherence<PointInT>>;
 
       /** \brief initialize the weight to 1.0. */
       DistanceCoherence ()

--- a/tracking/include/pcl/tracking/hsv_color_coherence.h
+++ b/tracking/include/pcl/tracking/hsv_color_coherence.h
@@ -16,8 +16,8 @@ namespace pcl
     class HSVColorCoherence: public PointCoherence<PointInT>
     {
       public:
-        using Ptr = boost::shared_ptr<HSVColorCoherence<PointInT> >;
-        using ConstPtr = boost::shared_ptr<const HSVColorCoherence<PointInT> >;
+        using Ptr = shared_ptr<HSVColorCoherence<PointInT> >;
+        using ConstPtr = shared_ptr<const HSVColorCoherence<PointInT> >;
 
         /** \brief initialize the weights of the computation.
             weight_, h_weight_, s_weight_ default to 1.0 and

--- a/tracking/include/pcl/tracking/kld_adaptive_particle_filter.h
+++ b/tracking/include/pcl/tracking/kld_adaptive_particle_filter.h
@@ -43,8 +43,8 @@ namespace pcl
 
       using BaseClass = Tracker<PointInT, StateT>;
 
-      using Ptr = boost::shared_ptr<KLDAdaptiveParticleFilterTracker<PointInT, StateT>>;
-      using ConstPtr = boost::shared_ptr<const KLDAdaptiveParticleFilterTracker<PointInT, StateT>>;
+      using Ptr = shared_ptr<KLDAdaptiveParticleFilterTracker<PointInT, StateT>>;
+      using ConstPtr = shared_ptr<const KLDAdaptiveParticleFilterTracker<PointInT, StateT>>;
 
       using PointCloudIn = typename Tracker<PointInT, StateT>::PointCloudIn;
       using PointCloudInPtr = typename PointCloudIn::Ptr;

--- a/tracking/include/pcl/tracking/kld_adaptive_particle_filter_omp.h
+++ b/tracking/include/pcl/tracking/kld_adaptive_particle_filter_omp.h
@@ -46,8 +46,8 @@ namespace pcl
 
       using BaseClass = Tracker<PointInT, StateT>;
 
-      using Ptr = boost::shared_ptr<KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>>;
-      using ConstPtr = boost::shared_ptr<const KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>>;
+      using Ptr = shared_ptr<KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>>;
+      using ConstPtr = shared_ptr<const KLDAdaptiveParticleFilterOMPTracker<PointInT, StateT>>;
 
       using PointCloudIn = typename Tracker<PointInT, StateT>::PointCloudIn;
       using PointCloudInPtr = typename PointCloudIn::Ptr;

--- a/tracking/include/pcl/tracking/nearest_pair_point_cloud_coherence.h
+++ b/tracking/include/pcl/tracking/nearest_pair_point_cloud_coherence.h
@@ -25,8 +25,8 @@ namespace pcl
         using PointCloudInConstPtr = typename PointCloudCoherence<PointInT>::PointCloudInConstPtr;
         using BaseClass = PointCloudCoherence<PointInT>;
         
-        using Ptr = boost::shared_ptr<NearestPairPointCloudCoherence<PointInT> >;
-        using ConstPtr = boost::shared_ptr<const NearestPairPointCloudCoherence<PointInT> >;
+        using Ptr = shared_ptr<NearestPairPointCloudCoherence<PointInT> >;
+        using ConstPtr = shared_ptr<const NearestPairPointCloudCoherence<PointInT> >;
         using SearchPtr = typename pcl::search::Search<PointInT>::Ptr;
         using SearchConstPtr = typename pcl::search::Search<PointInT>::ConstPtr;
 

--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -32,8 +32,8 @@ namespace pcl
         using Tracker<PointInT, StateT>::indices_;
         using Tracker<PointInT, StateT>::getClassName;
 
-        using Ptr = boost::shared_ptr<ParticleFilterTracker<PointInT, StateT>>;
-        using ConstPtr = boost::shared_ptr<const ParticleFilterTracker<PointInT, StateT>>;
+        using Ptr = shared_ptr<ParticleFilterTracker<PointInT, StateT>>;
+        using ConstPtr = shared_ptr<const ParticleFilterTracker<PointInT, StateT>>;
 
         using BaseClass = Tracker<PointInT, StateT>;
         

--- a/tracking/include/pcl/tracking/pyramidal_klt.h
+++ b/tracking/include/pcl/tracking/pyramidal_klt.h
@@ -70,8 +70,8 @@ namespace pcl
         using FloatImage = pcl::PointCloud<float>;
         using FloatImagePtr = FloatImage::Ptr;
         using FloatImageConstPtr = FloatImage::ConstPtr;
-        using Ptr = boost::shared_ptr<PyramidalKLTTracker<PointInT, IntensityT> >;
-        using ConstPtr = boost::shared_ptr<const PyramidalKLTTracker<PointInT, IntensityT> >;
+        using Ptr = shared_ptr<PyramidalKLTTracker<PointInT, IntensityT> >;
+        using ConstPtr = shared_ptr<const PyramidalKLTTracker<PointInT, IntensityT> >;
 
         using TrackerBase::tracker_name_;
         using TrackerBase::input_;

--- a/tracking/include/pcl/tracking/tracker.h
+++ b/tracking/include/pcl/tracking/tracker.h
@@ -63,8 +63,8 @@ namespace pcl
       using PCLBase<PointInT>::input_;
       
       using BaseClass = PCLBase<PointInT>;
-      using Ptr = boost::shared_ptr< Tracker<PointInT, StateT> >;
-      using ConstPtr = boost::shared_ptr< const Tracker<PointInT, StateT> >;
+      using Ptr = shared_ptr< Tracker<PointInT, StateT> >;
+      using ConstPtr = shared_ptr< const Tracker<PointInT, StateT> >;
 
       using SearchPtr = typename pcl::search::Search<PointInT>::Ptr;
       using SearchConstPtr = typename pcl::search::Search<PointInT>::ConstPtr;

--- a/visualization/include/pcl/visualization/cloud_viewer.h
+++ b/visualization/include/pcl/visualization/cloud_viewer.h
@@ -52,8 +52,8 @@ namespace pcl
     class PCL_EXPORTS CloudViewer : boost::noncopyable
     {
       public:
-        using Ptr = boost::shared_ptr<CloudViewer>;
-        using ConstPtr = boost::shared_ptr<const CloudViewer>;
+        using Ptr = shared_ptr<CloudViewer>;
+        using ConstPtr = shared_ptr<const CloudViewer>;
 
         using ColorACloud = pcl::PointCloud<pcl::PointXYZRGBA>;
         using ColorCloud = pcl::PointCloud<pcl::PointXYZRGB>;

--- a/visualization/include/pcl/visualization/common/actor_map.h
+++ b/visualization/include/pcl/visualization/common/actor_map.h
@@ -98,12 +98,12 @@ namespace pcl
     };
 
     using CloudActorMap = std::unordered_map<std::string, CloudActor>;
-    using CloudActorMapPtr = boost::shared_ptr<CloudActorMap>;
+    using CloudActorMapPtr = shared_ptr<CloudActorMap>;
 
     using ShapeActorMap = std::unordered_map<std::string, vtkSmartPointer<vtkProp> >;
-    using ShapeActorMapPtr = boost::shared_ptr<ShapeActorMap>;
+    using ShapeActorMapPtr = shared_ptr<ShapeActorMap>;
 
     using CoordinateActorMap = std::unordered_map<std::string, vtkSmartPointer<vtkProp> >;
-    using CoordinateActorMapPtr = boost::shared_ptr<CoordinateActorMap>;
+    using CoordinateActorMapPtr = shared_ptr<CoordinateActorMap>;
   }
 }

--- a/visualization/include/pcl/visualization/histogram_visualizer.h
+++ b/visualization/include/pcl/visualization/histogram_visualizer.h
@@ -56,8 +56,8 @@ namespace pcl
     class PCL_EXPORTS PCLHistogramVisualizer
     {
       public:
-        using Ptr = boost::shared_ptr<PCLHistogramVisualizer>;
-        using ConstPtr = boost::shared_ptr<const PCLHistogramVisualizer>;
+        using Ptr = shared_ptr<PCLHistogramVisualizer>;
+        using ConstPtr = shared_ptr<const PCLHistogramVisualizer>;
 
         /** \brief PCL histogram visualizer constructor. */
         PCLHistogramVisualizer ();

--- a/visualization/include/pcl/visualization/image_viewer.h
+++ b/visualization/include/pcl/visualization/image_viewer.h
@@ -117,8 +117,8 @@ namespace pcl
     class PCL_EXPORTS ImageViewer
     {
       public:
-        using Ptr = boost::shared_ptr<ImageViewer>;
-        using ConstPtr = boost::shared_ptr<const ImageViewer>;
+        using Ptr = shared_ptr<ImageViewer>;
+        using ConstPtr = shared_ptr<const ImageViewer>;
 
         /** \brief Constructor.
           * \param[in] window_title the title of the window

--- a/visualization/include/pcl/visualization/pcl_plotter.h
+++ b/visualization/include/pcl/visualization/pcl_plotter.h
@@ -76,8 +76,8 @@ namespace pcl
     class PCL_EXPORTS PCLPlotter
     {
       public:
-        using Ptr = boost::shared_ptr<PCLPlotter>;
-        using ConstPtr = boost::shared_ptr<const PCLPlotter>;
+        using Ptr = shared_ptr<PCLPlotter>;
+        using ConstPtr = shared_ptr<const PCLPlotter>;
 
         /**\brief A representation of polynomial function. i'th element of the vector denotes the coefficient of x^i of the polynomial in variable x. 
          */

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -86,8 +86,8 @@ namespace pcl
     class PCL_EXPORTS PCLVisualizer
     {
       public:
-        using Ptr = boost::shared_ptr<PCLVisualizer>;
-        using ConstPtr = boost::shared_ptr<const PCLVisualizer>;
+        using Ptr = shared_ptr<PCLVisualizer>;
+        using ConstPtr = shared_ptr<const PCLVisualizer>;
 
         using GeometryHandler = PointCloudGeometryHandler<pcl::PCLPointCloud2>;
         using GeometryHandlerPtr = GeometryHandler::Ptr;

--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -68,8 +68,8 @@ namespace pcl
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudColorHandler<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandler<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandler<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandler<PointT> >;
 
         /** \brief Constructor. */
         PointCloudColorHandler () :
@@ -158,8 +158,8 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerRandom<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRandom<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerRandom<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerRandom<PointT> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerRandom () :
@@ -208,8 +208,8 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerCustom<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerCustom<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerCustom<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerCustom<PointT> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerCustom (double r, double g, double b)
@@ -271,8 +271,8 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerRGBField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRGBField<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerRGBField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerRGBField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerRGBField ()
@@ -331,8 +331,8 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerHSVField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerHSVField<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerHSVField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerHSVField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerHSVField (const PointCloudConstPtr &cloud);
@@ -381,8 +381,8 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerGenericField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerGenericField<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerGenericField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerGenericField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerGenericField (const std::string &field_name)
@@ -447,8 +447,8 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerRGBAField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRGBAField<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerRGBAField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerRGBAField<PointT> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerRGBAField ()
@@ -508,8 +508,8 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerLabelField<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerLabelField<PointT> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerLabelField<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerLabelField<PointT> >;
 
         /** \brief Constructor.
           * \param[in] static_mapping Use a static colormapping from label_id to color (default true) */
@@ -575,8 +575,8 @@ namespace pcl
         using PointCloudPtr = PointCloud::Ptr;
         using PointCloudConstPtr = PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudColorHandler<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandler<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudColorHandler<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandler<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudColorHandler (const PointCloudConstPtr &cloud) :
@@ -657,8 +657,8 @@ namespace pcl
       using PointCloudConstPtr = PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerRandom<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRandom<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerRandom<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerRandom<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerRandom (const PointCloudConstPtr &cloud) :
@@ -742,8 +742,8 @@ namespace pcl
       using PointCloudConstPtr = PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerRGBField<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRGBField<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerRGBField<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerRGBField<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerRGBField (const PointCloudConstPtr &cloud);
@@ -779,8 +779,8 @@ namespace pcl
       using PointCloudConstPtr = PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerHSVField<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerHSVField<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerHSVField<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerHSVField<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerHSVField (const PointCloudConstPtr &cloud);
@@ -823,8 +823,8 @@ namespace pcl
       using PointCloudConstPtr = PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerGenericField<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerGenericField<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerGenericField<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerGenericField<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerGenericField (const PointCloudConstPtr &cloud,
@@ -866,8 +866,8 @@ namespace pcl
       using PointCloudConstPtr = PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerRGBAField<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerRGBAField<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerRGBAField<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerRGBAField<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudColorHandlerRGBAField (const PointCloudConstPtr &cloud);
@@ -904,8 +904,8 @@ namespace pcl
       using PointCloudConstPtr = PointCloud::ConstPtr;
 
       public:
-        using Ptr = boost::shared_ptr<PointCloudColorHandlerLabelField<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudColorHandlerLabelField<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudColorHandlerLabelField<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudColorHandlerLabelField<PointCloud> >;
 
         /** \brief Constructor.
           * \param[in] static_mapping Use a static colormapping from label_id to color (default true) */

--- a/visualization/include/pcl/visualization/point_cloud_geometry_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_geometry_handlers.h
@@ -65,8 +65,8 @@ namespace pcl
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudGeometryHandler<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudGeometryHandler<PointT> >;
+        using Ptr = shared_ptr<PointCloudGeometryHandler<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudGeometryHandler<PointT> >;
 
         /** \brief Constructor. */
         PointCloudGeometryHandler (const PointCloudConstPtr &cloud) :
@@ -143,8 +143,8 @@ namespace pcl
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudGeometryHandlerXYZ<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudGeometryHandlerXYZ<PointT> >;
+        using Ptr = shared_ptr<PointCloudGeometryHandlerXYZ<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudGeometryHandlerXYZ<PointT> >;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerXYZ (const PointCloudConstPtr &cloud);
@@ -191,8 +191,8 @@ namespace pcl
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudGeometryHandlerSurfaceNormal<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudGeometryHandlerSurfaceNormal<PointT> >;
+        using Ptr = shared_ptr<PointCloudGeometryHandlerSurfaceNormal<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudGeometryHandlerSurfaceNormal<PointT> >;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerSurfaceNormal (const PointCloudConstPtr &cloud);
@@ -236,8 +236,8 @@ namespace pcl
         using PointCloudPtr = typename PointCloud::Ptr;
         using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudGeometryHandlerCustom<PointT> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudGeometryHandlerCustom<PointT> >;
+        using Ptr = shared_ptr<PointCloudGeometryHandlerCustom<PointT> >;
+        using ConstPtr = shared_ptr<const PointCloudGeometryHandlerCustom<PointT> >;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerCustom (const PointCloudConstPtr &cloud,
@@ -327,8 +327,8 @@ namespace pcl
         using PointCloudPtr = PointCloud::Ptr;
         using PointCloudConstPtr = PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudGeometryHandler<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudGeometryHandler<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudGeometryHandler<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudGeometryHandler<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudGeometryHandler (const PointCloudConstPtr &cloud, const Eigen::Vector4f & = Eigen::Vector4f::Zero ())
@@ -407,8 +407,8 @@ namespace pcl
         using PointCloudPtr = PointCloud::Ptr;
         using PointCloudConstPtr = PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudGeometryHandlerXYZ<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudGeometryHandlerXYZ<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudGeometryHandlerXYZ<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudGeometryHandlerXYZ<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerXYZ (const PointCloudConstPtr &cloud);
@@ -440,8 +440,8 @@ namespace pcl
         using PointCloudPtr = PointCloud::Ptr;
         using PointCloudConstPtr = PointCloud::ConstPtr;
 
-        using Ptr = boost::shared_ptr<PointCloudGeometryHandlerSurfaceNormal<PointCloud> >;
-        using ConstPtr = boost::shared_ptr<const PointCloudGeometryHandlerSurfaceNormal<PointCloud> >;
+        using Ptr = shared_ptr<PointCloudGeometryHandlerSurfaceNormal<PointCloud> >;
+        using ConstPtr = shared_ptr<const PointCloudGeometryHandlerSurfaceNormal<PointCloud> >;
 
         /** \brief Constructor. */
         PointCloudGeometryHandlerSurfaceNormal (const PointCloudConstPtr &cloud);

--- a/visualization/src/cloud_viewer.cpp
+++ b/visualization/src/cloud_viewer.cpp
@@ -50,15 +50,15 @@ namespace pcl
     virtual ~cloud_show_base() = default;
     virtual void pop () = 0;
     virtual bool popped () const = 0;
-    using Ptr = boost::shared_ptr<cloud_show_base>;
-    using ConstPtr = boost::shared_ptr<const cloud_show_base>;
+    using Ptr = shared_ptr<cloud_show_base>;
+    using ConstPtr = shared_ptr<const cloud_show_base>;
   };
 
   template <typename CloudT> 
   struct cloud_show : cloud_show_base
   {
-    using Ptr = boost::shared_ptr<cloud_show>;
-    using ConstPtr = boost::shared_ptr<const cloud_show>;
+    using Ptr = shared_ptr<cloud_show>;
+    using ConstPtr = shared_ptr<const cloud_show>;
 
     cloud_show (const std::string &cloud_name, typename CloudT::ConstPtr cloud,
       pcl::visualization::PCLVisualizer::Ptr viewer) :


### PR DESCRIPTION
* Provides a `pcl::shared_ptr`
* Converts all references to `boost::shared_ptr` to `pcl::shared_ptr`
* Fixes headers for successful compilation

This PR will allow for 2 PCL releases: 1.10 (with boost::shared_ptr) and 1.11 (with std::shared_ptr) with just 1 commit in the changelog.

Results achieved by:
1. Provide the alias
2. Copy the file in backup location
3.
    ```
    for dir in `ls */ -d`; do
      grep 'boost::shared_ptr' $dir -lr | xargs sed 's/boost::shared_ptr/shared_ptr/' -i;
    done
    ```
4. Copy the file back
5. Fix compilation errors