### PR TITLE
Fix unnecessary const qualifiers ignored in casts

### DIFF
--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_weighted.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_weighted.hpp
@@ -224,7 +224,7 @@ pcl::registration::TransformationEstimationPointToPlaneWeighted<PointSource, Poi
     const pcl::Correspondences &correspondences,
     Matrix4 &transformation_matrix) const
 {
-  const int nr_correspondences = static_cast<const int> (correspondences.size ());
+  const int nr_correspondences = static_cast<int> (correspondences.size ());
   std::vector<int> indices_src (nr_correspondences);
   std::vector<int> indices_tgt (nr_correspondences);
   for (int i = 0; i < nr_correspondences; ++i)

--- a/surface/src/3rdparty/opennurbs/opennurbs_string.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_string.cpp
@@ -925,7 +925,7 @@ int ON_String::Replace( char token1, char token2 )
 
 int ON_String::Replace( unsigned char token1, unsigned char token2 )
 {
-  return Replace((const char)token1, (const char)token2);
+  return Replace((char)token1, (char)token2);
 }
 
 


### PR DESCRIPTION
Related #3379, removes warnings from 19.10 CI