### PR TITLE
Fix undefined behaviour in `OctNode`

### DIFF
--- a/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp
+++ b/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp
@@ -794,7 +794,8 @@ namespace pcl
     long long _InterleaveBits( int p[3] )
     {
       long long key = 0;
-      for( int i=0 ; i<32 ; i++ ) key |= ( ( p[0] & (1<<i) )<<(2*i) ) | ( ( p[1] & (1<<i) )<<(2*i+1) ) | ( ( p[2] & (1<<i) )<<(2*i+2) );
+      long long _p[3] = {p[0],p[1],p[2]};
+      for( int i=0 ; i<31 ; i++ ) key |= ( ( _p[0] & (1ull<<i) )<<(2*i) ) | ( ( _p[1] & (1ull<<i) )<<(2*i+1) ) | ( ( _p[2] & (1ull<<i) )<<(2*i+2) );
       return key;
     }
     template <class NodeData,class Real>


### PR DESCRIPTION
Fixes an undefined behaviour in pcl::poisson::OctNode due to bit shifting greater than the number of bits of the type.

To check the fix please compile the following code with `-fsanitize=undefined`. It should throw runtime errors for the first function but not the second.

Note: I had to decrease the loop from `i<32` to `i<31` since `i==31` would also cause an undefined behaviour for 64-bit variables.

```cpp
#include <iostream>
#include <stdio.h>

long long _InterleaveBits( int p[3] )
{
  long long key = 0;
  for( int i=0 ; i<32 ; i++ ) 
  {
    key |= ( ( p[0] & (1<<i) )<<(2*i) ) | ( ( p[1] & (1<<i) )<<(2*i+1) ) | ( ( p[2] & (1<<i) )<<(2*i+2) );
  }
  return key;
}

long long _FixedInterleaveBits( int _p[3] )
{
  long long key = 0;
  long long p[3] = {_p[0],_p[1],_p[2]};
  for( int i=0 ; i<31 ; i++ ) 
  {
    key |= ( ( p[0] & (1ull<<i) )<<(2*i) ) | ( ( p[1] & (1ull<<i) )<<(2*i+1) ) | ( ( p[2] & (1ull<<i) )<<(2*i+2) );
  }
  return key;
}

int main() {
  int p[3] = {0,255,128};
  std::cout << _InterleaveBits(p) << std::endl;
  std::cout << _FixedInterleaveBits(p) << std::endl;
}
```