### PR TITLE
Set compile features on imported PCL targets

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -648,6 +648,7 @@ foreach(component ${PCL_TO_FIND_COMPONENTS})
         PROPERTIES
           INTERFACE_COMPILE_DEFINITIONS "${definitions}"
           INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${PCL_COMPILE_OPTIONS}>"
+          INTERFACE_COMPILE_FEATURES "@PCL_CXX_COMPILE_FEATURES@"
           INTERFACE_INCLUDE_DIRECTORIES "${PCL_${COMPONENT}_INCLUDE_DIRS};${PCL_CONF_INCLUDE_DIR}"
       )
       # If possible, we use target_link_libraries to avoid problems with link-type keywords,

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -619,7 +619,7 @@ foreach(component ${PCL_TO_FIND_COMPONENTS})
     else() # header-only
       add_library(${pcl_component} INTERFACE IMPORTED)
     endif()
-    
+
     foreach(def ${PCL_DEFINITIONS})
       string(REPLACE " " ";" def2 ${def})
       string(REGEX REPLACE "^-D" "" def3 "${def2}")


### PR DESCRIPTION
The compile features (e.g. required C++ standard) were not set in the CMake >= 3.11 branch.

Fixes #3562, supersedes #3565.

