### PR TITLE
Fix entropy range encoding in octree pointcloud compression

### DIFF
--- a/io/include/pcl/compression/impl/entropy_range_coder.hpp
+++ b/io/include/pcl/compression/impl/entropy_range_coder.hpp
@@ -294,7 +294,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
 
   // calculate amount of bytes per frequency table entry
   std::uint8_t frequencyTableByteSize = static_cast<std::uint8_t> (std::ceil (
-      std::log2 (static_cast<double> (cFreqTable_[static_cast<std::size_t> (frequencyTableSize - 1)])) / 8.0));
+      std::log2 (static_cast<double> (cFreqTable_[static_cast<std::size_t> (frequencyTableSize - 1)] + 1)) / 8.0));
 
   // write size of frequency table to output stream
   outputByteStream_arg.write (reinterpret_cast<const char*> (&frequencyTableSize), sizeof(frequencyTableSize));

--- a/test/io/test_range_coder.cpp
+++ b/test/io/test_range_coder.cpp
@@ -96,74 +96,74 @@ TEST (PCL, Adaptive_Range_Coder_Test)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, Static_Range_Coder_Test)
 {
-  std::stringstream sstream;
-  std::vector<char> inputCharData;
-  std::vector<char> outputCharData;
-
-  std::vector<unsigned int> inputIntData;
-  std::vector<unsigned int> outputIntData;
-
-  unsigned long writeByteLen;
-  unsigned long readByteLen;
-
-  // vector size
-  const unsigned int vectorSize = 10000;
-
-  inputCharData.resize(vectorSize);
-  outputCharData.resize(vectorSize);
-
-  inputIntData.resize(vectorSize);
-  outputIntData.resize(vectorSize);
-
-  // fill vectors with random data
-  for (std::size_t i=0; i<vectorSize; i++)
+  // Run test for different vector sizes
+  for (unsigned int vectorSize: { 253, 10000 })
   {
-    inputCharData[i] = static_cast<char> (rand () & 0xFF);
-    inputIntData[i] = static_cast<unsigned int> (rand () & 0xFFFF);
+    std::stringstream sstream;
+    std::vector<char> inputCharData;
+    std::vector<char> outputCharData;
+
+    std::vector<unsigned int> inputIntData;
+    std::vector<unsigned int> outputIntData;
+
+    unsigned long writeByteLen;
+    unsigned long readByteLen;
+
+    inputCharData.resize(vectorSize);
+    outputCharData.resize(vectorSize);
+
+    inputIntData.resize(vectorSize);
+    outputIntData.resize(vectorSize);
+
+    // fill vectors with random data
+    for (std::size_t i=0; i<vectorSize; i++)
+    {
+      inputCharData[i] = static_cast<char> (rand () & 0xFF);
+      inputIntData[i] = static_cast<unsigned int> (rand () & 0xFFFF);
+    }
+
+    // initialize static range coder
+    pcl::StaticRangeCoder rangeCoder;
+
+    // encode char vector to stringstream
+    writeByteLen = rangeCoder.encodeCharVectorToStream(inputCharData, sstream);
+
+    // decode stringstream to char vector
+    readByteLen = rangeCoder.decodeStreamToCharVector(sstream, outputCharData);
+
+    // compare amount of bytes that are read and written to/from stream
+    EXPECT_EQ (writeByteLen, readByteLen);
+    EXPECT_EQ (writeByteLen, sstream.str().length());
+
+    // compare input and output vector - should be identical
+    EXPECT_EQ (inputCharData.size(), outputCharData.size());
+    EXPECT_EQ (inputCharData.size(), vectorSize);
+
+    for (std::size_t i=0; i<vectorSize; i++)
+    {
+      EXPECT_EQ (inputCharData[i], outputCharData[i]);
+    }
+
+    sstream.clear();
+
+    // encode integer vector to stringstream
+    writeByteLen = rangeCoder.encodeIntVectorToStream(inputIntData, sstream);
+
+    // decode stringstream to integer vector
+    readByteLen = rangeCoder.decodeStreamToIntVector(sstream, outputIntData);
+
+    // compare amount of bytes that are read and written to/from stream
+    EXPECT_EQ (writeByteLen, readByteLen);
+
+    // compare input and output vector - should be identical
+    EXPECT_EQ (inputIntData.size(), outputIntData.size());
+    EXPECT_EQ (inputIntData.size(), vectorSize);
+
+    for (std::size_t i=0; i<vectorSize; i++)
+    {
+      EXPECT_EQ (inputIntData[i], outputIntData[i]);
+    }
   }
-
-  // initialize static range coder
-  pcl::StaticRangeCoder rangeCoder;
-
-  // encode char vector to stringstream
-  writeByteLen = rangeCoder.encodeCharVectorToStream(inputCharData, sstream);
-
-  // decode stringstream to char vector
-  readByteLen = rangeCoder.decodeStreamToCharVector(sstream, outputCharData);
-
-  // compare amount of bytes that are read and written to/from stream
-  EXPECT_EQ (writeByteLen, readByteLen);
-  EXPECT_EQ (writeByteLen, sstream.str().length());
-
-  // compare input and output vector - should be identical
-  EXPECT_EQ (inputCharData.size(), outputCharData.size());
-  EXPECT_EQ (inputCharData.size(), vectorSize);
-
-  for (std::size_t i=0; i<vectorSize; i++)
-  {
-    EXPECT_EQ (inputCharData[i], outputCharData[i]);
-  }
-
-  sstream.clear();
-
-  // encode integer vector to stringstream
-  writeByteLen = rangeCoder.encodeIntVectorToStream(inputIntData, sstream);
-
-  // decode stringstream to integer vector
-  readByteLen = rangeCoder.decodeStreamToIntVector(sstream, outputIntData);
-
-  // compare amount of bytes that are read and written to/from stream
-  EXPECT_EQ (writeByteLen, readByteLen);
-
-  // compare input and output vector - should be identical
-  EXPECT_EQ (inputIntData.size(), outputIntData.size());
-  EXPECT_EQ (inputIntData.size(), vectorSize);
-
-  for (std::size_t i=0; i<vectorSize; i++)
-  {
-    EXPECT_EQ (inputIntData[i], outputIntData[i]);
-  }
-
 }
 
 


### PR DESCRIPTION
## Error description

Octree Pointcloud compression encoding was faulty when pointcloud had 2^i - 3 points (problem was spotted with 253 points), leading to program crash when decoding the wrongly encoded compressed data.

## Error origin

The crash comes from a division by zero in `pcl::StaticRangeCoder::decodeStreamToIntVector()`, when frequency element value is read as 0 instead of 2^i. In fact, this frequency value is badly written in `pcl::StaticRangeCoder::encodeIntVectorToStream()` because bytes size of each frequency element is wrongly computed. 

For example, with n = 253 points, last frequency element is equal to 256. This value needs 2 bytes to be encoded. However, `frequencyTableByteSize` was set to 1 byte for this border case. As a result, only the 'null' byte was written to compressed data, missing the most significant one : this frequency element value is written as 0 instead of 256.

## Proposed correction

The frequencyTableByteSize is now corrected to consider this border case. No change occurs for other pointclouds sizes.