### PR TITLE
close the correct file in pcl::io::savePLYFileBinary

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -1769,6 +1769,6 @@ pcl::io::savePLYFileBinary (const std::string &file_name, const pcl::PolygonMesh
   }
 
   // Close file
-  fs.close ();
+  fpout.close ();
   return (0);
 }


### PR DESCRIPTION
Fixes #3599

I kept the call to `close` despite it being redundant (the `fstream` destructor does this anaway) for the sake of consistency with other functions. AFAIK the only use case for manually closing `fstream` objects before going out of scope is to check the good flag which is not being done in `pcl::io::savePLYFileBinary`