### PR TITLE
Refactor grabber to use `unique_ptr`

### DIFF
--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -85,7 +85,11 @@ namespace pcl
       Grabber& operator=(Grabber&&) = default;
 
       /** \brief virtual destructor. */
-      virtual inline ~Grabber () noexcept;
+      #if defined(_MSC_VER)
+        virtual inline ~Grabber () noexcept {}
+      #else
+        virtual inline ~Grabber () noexcept = default;
+      #endif
 
       /** \brief registers a callback function/method to a signal with the corresponding signature
         * \param[in] callback: the callback function/method

--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -31,16 +31,18 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #pragma once
 
 #include <pcl/pcl_config.h>
 
 // needed for the grabber interface / observers
 #include <map>
+#include <memory>
 #include <iostream>
 #include <string>
 #include <typeinfo>
+#include <tuple>
 #include <vector>
 #include <sstream>
 #include <pcl/pcl_macros.h>
@@ -57,6 +59,31 @@ namespace pcl
   class PCL_EXPORTS Grabber
   {
     public:
+      /**
+       * \brief Default ctor
+       */
+      Grabber() = default;
+
+      /**
+       * \brief No copy ctor since Grabber can't be copied
+       */
+      Grabber(const Grabber&) = delete;
+
+      /**
+       * \brief No copy assign operator since Grabber can't be copied
+       */
+      Grabber& operator=(const Grabber&) = delete;
+
+      /**
+       * \brief Move ctor
+       */
+      Grabber(Grabber&&) = default;
+
+      /**
+       * \brief Move assign operator
+       */
+      Grabber& operator=(Grabber&&) = default;
+
       /** \brief virtual destructor. */
       virtual inline ~Grabber () noexcept;
 
@@ -82,19 +109,19 @@ namespace pcl
       /** \brief indicates whether a signal with given parameter-type exists or not
         * \return true if signal exists, false otherwise
         */
-      template<typename T> bool 
-      providesCallback () const;
+      template<typename T> bool
+      providesCallback () const noexcept;
 
       /** \brief For devices that are streaming, the streams are started by calling this method.
         *        Trigger-based devices, just trigger the device once for each call of start.
         */
-      virtual void 
+      virtual void
       start () = 0;
 
       /** \brief For devices that are streaming, the streams are stopped.
         *        This method has no effect for triggered devices.
         */
-      virtual void 
+      virtual void
       stop () = 0;
 
       /** \brief For devices that are streaming, stopped streams are started and running stream are stopped.
@@ -107,17 +134,17 @@ namespace pcl
       /** \brief returns the name of the concrete subclass.
         * \return the name of the concrete driver.
         */
-      virtual std::string 
+      virtual std::string
       getName () const = 0;
 
       /** \brief Indicates whether the grabber is streaming or not. This value is not defined for triggered devices.
         * \return true if grabber is running / streaming. False otherwise.
         */
-      virtual bool 
+      virtual bool
       isRunning () const = 0;
 
       /** \brief returns fps. 0 if trigger based. */
-      virtual float 
+      virtual float
       getFramesPerSecond () const = 0;
 
     protected:
@@ -125,40 +152,34 @@ namespace pcl
       virtual void
       signalsChanged () { }
 
-      template<typename T> boost::signals2::signal<T>* 
-      find_signal () const;
+      template<typename T> boost::signals2::signal<T>*
+      find_signal () const noexcept;
 
-      template<typename T> int 
-      num_slots () const;
+      template<typename T> int
+      num_slots () const noexcept;
 
-      template<typename T> void 
+      template<typename T> void
       disconnect_all_slots ();
 
-      template<typename T> void 
+      template<typename T> void
       block_signal ();
-      
-      template<typename T> void 
+
+      template<typename T> void
       unblock_signal ();
-      
-      inline void 
+
+      inline void
       block_signals ();
-      
-      inline void 
+
+      inline void
       unblock_signals ();
 
-      template<typename T> boost::signals2::signal<T>* 
+      template<typename T> boost::signals2::signal<T>*
       createSignal ();
 
-      std::map<std::string, boost::signals2::signal_base*> signals_;
+      std::map<std::string, std::unique_ptr<boost::signals2::signal_base>> signals_;
       std::map<std::string, std::vector<boost::signals2::connection> > connections_;
       std::map<std::string, std::vector<boost::signals2::shared_connection_block> > shared_connections_;
   } ;
-
-  Grabber::~Grabber () noexcept
-  {
-    for (auto &signal : signals_)
-      delete signal.second;
-  }
 
   bool
   Grabber::toggle ()
@@ -174,25 +195,24 @@ namespace pcl
   }
 
   template<typename T> boost::signals2::signal<T>*
-  Grabber::find_signal () const
+  Grabber::find_signal () const noexcept
   {
     using Signal = boost::signals2::signal<T>;
 
-    std::map<std::string, boost::signals2::signal_base*>::const_iterator signal_it = signals_.find (typeid (T).name ());
+    const auto signal_it = signals_.find (typeid (T).name ());
     if (signal_it != signals_.end ())
-      return (dynamic_cast<Signal*> (signal_it->second));
-
-    return (NULL);
+    {
+      return (static_cast<Signal*> (signal_it->second.get ()));
+    }
+    return nullptr;
   }
 
   template<typename T> void
   Grabber::disconnect_all_slots ()
   {
-    using Signal = boost::signals2::signal<T>;
-
-    if (signals_.find (typeid (T).name ()) != signals_.end ())
+    const auto signal = find_signal<T> ();
+    if (signal != nullptr)
     {
-      Signal* signal = dynamic_cast<Signal*> (signals_[typeid (T).name ()]);
       signal->disconnect_all_slots ();
     }
   }
@@ -230,39 +250,56 @@ namespace pcl
   }
 
   template<typename T> int
-  Grabber::num_slots () const
+  Grabber::num_slots () const noexcept
   {
-    using Signal = boost::signals2::signal<T>;
-
-    // see if we have a signal for this type
-    std::map<std::string, boost::signals2::signal_base*>::const_iterator signal_it = signals_.find (typeid (T).name ());
-    if (signal_it != signals_.end ())
+    const auto signal = find_signal<T> ();
+    if (signal != nullptr)
     {
-      Signal* signal = dynamic_cast<Signal*> (signal_it->second);
-      return (static_cast<int> (signal->num_slots ()));
+      return static_cast<int> (signal->num_slots ());
     }
-    return (0);
+    return 0;
   }
 
   template<typename T> boost::signals2::signal<T>*
   Grabber::createSignal ()
   {
     using Signal = boost::signals2::signal<T>;
+    using Base = boost::signals2::signal_base;
+    // DefferedPtr serves 2 purposes:
+    // * allows MSVC to copy it around, can't do that with unique_ptr<T>
+    // * performs dynamic allocation only when required. If the key is found, this
+    //   struct is a no-op, otherwise it allocates when implicit conversion operator
+    //   is called inside emplace/try_emplace
+    struct DefferedPtr {
+      operator std::unique_ptr<Base>() const { return std::make_unique<Signal>(); }
+    };
+    // TODO: remove later for C++17 features: structured bindings and try_emplace
+    #ifdef __cpp_structured_bindings
+      const auto [iterator, success] =
+    #else
+      typename decltype(signals_)::const_iterator iterator;
+      bool success;
+      std::tie (iterator, success) =
+    #endif
 
-    if (signals_.find (typeid (T).name ()) == signals_.end ())
+    #ifdef __cpp_lib_map_try_emplace
+      signals_.try_emplace (
+    #else
+      signals_.emplace (
+    #endif
+                         std::string (typeid (T).name ()), DefferedPtr ());
+    if (!success)
     {
-      Signal* signal = new Signal ();
-      signals_[typeid (T).name ()] = signal;
-      return (signal);
+      return nullptr;
     }
-    return (nullptr);
+    return static_cast<Signal*> (iterator->second.get ());
   }
 
   template<typename T> boost::signals2::connection
   Grabber::registerCallback (const std::function<T> & callback)
   {
-    using Signal = boost::signals2::signal<T>;
-    if (signals_.find (typeid (T).name ()) == signals_.end ())
+    const auto signal = find_signal<T> ();
+    if (signal == nullptr)
     {
       std::stringstream sstream;
 
@@ -271,7 +308,6 @@ namespace pcl
       PCL_THROW_EXCEPTION (pcl::IOException, "[" << getName () << "] " << sstream.str ());
       //return (boost::signals2::connection ());
     }
-    Signal* signal = dynamic_cast<Signal*> (signals_[typeid (T).name ()]);
     boost::signals2::connection ret = signal->connect (callback);
 
     connections_[typeid (T).name ()].push_back (ret);
@@ -281,11 +317,9 @@ namespace pcl
   }
 
   template<typename T> bool
-  Grabber::providesCallback () const
+  Grabber::providesCallback () const noexcept
   {
-    if (signals_.find (typeid (T).name ()) == signals_.end ())
-      return (false);
-    return (true);
+    return find_signal<T> ();
   }
 
 } // namespace

--- a/io/include/pcl/io/image_grabber.h
+++ b/io/include/pcl/io/image_grabber.h
@@ -79,37 +79,37 @@ namespace pcl
     ~ImageGrabberBase () noexcept;
 
     /** \brief Starts playing the list of PCD files if frames_per_second is > 0. Otherwise it works as a trigger: publishes only the next PCD file in the list. */
-    void 
+    void
     start () override;
-      
+
     /** \brief Stops playing the list of PCD files if frames_per_second is > 0. Otherwise the method has no effect. */
-    void 
+    void
     stop () override;
-      
+
     /** \brief Triggers a callback with new data */
-    virtual void 
+    virtual void
     trigger ();
 
     /** \brief whether the grabber is started (publishing) or not.
      * \return true only if publishing.
      */
-    bool 
+    bool
     isRunning () const override;
-      
+
     /** \return The name of the grabber */
-    std::string 
+    std::string
     getName () const override;
-      
+
     /** \brief Rewinds to the first PCD file in the list.*/
-    virtual void 
+    virtual void
     rewind ();
 
     /** \brief Returns the frames_per_second. 0 if grabber is trigger-based */
-    float 
+    float
     getFramesPerSecond () const override;
 
     /** \brief Returns whether the repeat flag is on */
-    bool 
+    bool
     isRepeatOn () const;
 
     /** \brief Returns if the last frame is reached */
@@ -120,7 +120,7 @@ namespace pcl
     std::string
     getCurrentDepthFileName () const;
 
-    /** \brief Returns the filename of the previous indexed file 
+    /** \brief Returns the filename of the previous indexed file
      *  SDM: adding this back in, but is this useful, or confusing? */
     std::string
     getPrevDepthFileName () const;
@@ -139,18 +139,18 @@ namespace pcl
     void
     setRGBImageFiles (const std::vector<std::string>& rgb_image_files);
 
-    /** \brief Define custom focal length and center pixel. This will override ANY other setting of parameters for the duration of the grabber's life, whether by factory defaults or explicitly read from a frame_[timestamp].xml file. 
+    /** \brief Define custom focal length and center pixel. This will override ANY other setting of parameters for the duration of the grabber's life, whether by factory defaults or explicitly read from a frame_[timestamp].xml file.
      *  \param[in] focal_length_x Horizontal focal length (fx)
      *  \param[in] focal_length_y Vertical focal length (fy)
      *  \param[in] principal_point_x Horizontal coordinates of the principal point (cx)
      *  \param[in] principal_point_y Vertical coordinates of the principal point (cy)
      */
     virtual void
-    setCameraIntrinsics (const double focal_length_x, 
-                         const double focal_length_y, 
-                         const double principal_point_x, 
+    setCameraIntrinsics (const double focal_length_x,
+                         const double focal_length_y,
+                         const double principal_point_x,
                          const double principal_point_y);
-    
+
     /** \brief Get the current focal length and center pixel. If the intrinsics have been manually set with setCameraIntrinsics, this will return those values. Else, if start () has been called and the grabber has found a frame_[timestamp].xml file, this will return the most recent values read. Else, returns factory defaults.
      *  \param[out] focal_length_x Horizontal focal length (fx)
      *  \param[out] focal_length_y Vertical focal length (fy)
@@ -158,16 +158,16 @@ namespace pcl
      *  \param[out] principal_point_y Vertical coordinates of the principal point (cy)
      */
     virtual void
-    getCameraIntrinsics (double &focal_length_x, 
-                         double &focal_length_y, 
-                         double &principal_point_x, 
+    getCameraIntrinsics (double &focal_length_x,
+                         double &focal_length_y,
+                         double &principal_point_x,
                          double &principal_point_y) const;
 
     /** \brief Define the units the depth data is stored in.
      *  Defaults to mm (0.001), meaning a brightness of 1000 corresponds to 1 m*/
     void
     setDepthImageUnits (float units);
-    
+
     /** \brief Set the number of threads, if we wish to use OpenMP for quicker cloud population.
      *  Note that for a standard (< 4 core) machine this is unlikely to yield a drastic speedup.*/
     void
@@ -178,14 +178,14 @@ namespace pcl
       */
     std::size_t
     numFrames () const;
-    
+
     /** \brief Gets the cloud in ROS form at location idx */
     bool
     getCloudAt (std::size_t idx, pcl::PCLPointCloud2 &blob, Eigen::Vector4f &origin, Eigen::Quaternionf &orientation) const;
 
 
     private:
-    virtual void 
+    virtual void
     publish (const pcl::PCLPointCloud2& blob, const Eigen::Vector4f& origin, const Eigen::Quaternionf& orientation) const = 0;
 
 
@@ -202,23 +202,23 @@ namespace pcl
     using Ptr = shared_ptr<ImageGrabber>;
     using ConstPtr = shared_ptr<const ImageGrabber>;
 
-    ImageGrabber (const std::string& dir, 
-                  float frames_per_second = 0, 
-                  bool repeat = false, 
+    ImageGrabber (const std::string& dir,
+                  float frames_per_second = 0,
+                  bool repeat = false,
                   bool pclzf_mode = false);
 
-    ImageGrabber (const std::string& depth_dir, 
-                  const std::string& rgb_dir, 
-                  float frames_per_second = 0, 
+    ImageGrabber (const std::string& depth_dir,
+                  const std::string& rgb_dir,
+                  float frames_per_second = 0,
                   bool repeat = false);
 
-    ImageGrabber (const std::vector<std::string>& depth_image_files, 
-                  float frames_per_second = 0, 
+    ImageGrabber (const std::vector<std::string>& depth_image_files,
+                  float frames_per_second = 0,
                   bool repeat = false);
-      
+
     /** \brief Empty destructor */
     ~ImageGrabber () noexcept {}
-    
+
     // Inherited from FileGrabber
     const typename pcl::PointCloud<PointT>::ConstPtr
     operator[] (std::size_t idx) const override;
@@ -228,29 +228,29 @@ namespace pcl
     size () const override;
 
     protected:
-    void 
+    void
     publish (const pcl::PCLPointCloud2& blob,
-             const Eigen::Vector4f& origin, 
+             const Eigen::Vector4f& origin,
              const Eigen::Quaternionf& orientation) const override;
     boost::signals2::signal<void (const typename pcl::PointCloud<PointT>::ConstPtr&)>* signal_;
   };
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   template<typename PointT>
-  ImageGrabber<PointT>::ImageGrabber (const std::string& dir, 
-                                      float frames_per_second, 
-                                      bool repeat, 
+  ImageGrabber<PointT>::ImageGrabber (const std::string& dir,
+                                      float frames_per_second,
+                                      bool repeat,
                                       bool pclzf_mode)
     : ImageGrabberBase (dir, frames_per_second, repeat, pclzf_mode)
   {
     signal_ = createSignal<void (const typename pcl::PointCloud<PointT>::ConstPtr&)>();
   }
-  
+
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   template<typename PointT>
-  ImageGrabber<PointT>::ImageGrabber (const std::string& depth_dir, 
-                                      const std::string& rgb_dir, 
-                                      float frames_per_second, 
+  ImageGrabber<PointT>::ImageGrabber (const std::string& depth_dir,
+                                      const std::string& rgb_dir,
+                                      float frames_per_second,
                                       bool repeat)
     : ImageGrabberBase (depth_dir, rgb_dir, frames_per_second, repeat)
   {
@@ -259,8 +259,8 @@ namespace pcl
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   template<typename PointT>
-  ImageGrabber<PointT>::ImageGrabber (const std::vector<std::string>& depth_image_files, 
-                                      float frames_per_second, 
+  ImageGrabber<PointT>::ImageGrabber (const std::vector<std::string>& depth_image_files,
+                                      float frames_per_second,
                                       bool repeat)
     : ImageGrabberBase (depth_image_files, frames_per_second, repeat), signal_ ()
   {

--- a/io/include/pcl/io/image_grabber.h
+++ b/io/include/pcl/io/image_grabber.h
@@ -75,24 +75,6 @@ namespace pcl
      */
     ImageGrabberBase (const std::vector<std::string>& depth_image_files, float frames_per_second, bool repeat);
 
-    /** \brief Copy constructor.
-     * \param[in] src the Image Grabber base object to copy into this
-     */
-    ImageGrabberBase (const ImageGrabberBase &src) : impl_ ()
-    {
-      *this = src;
-    }
-
-    /** \brief Copy operator.
-     * \param[in] src the Image Grabber base object to copy into this
-     */
-    ImageGrabberBase&
-    operator = (const ImageGrabberBase &src)
-    {
-      impl_ = src.impl_;
-      return (*this);
-    }
-
     /** \brief Virtual destructor. */
     ~ImageGrabberBase () noexcept;
 

--- a/io/include/pcl/io/pcd_grabber.h
+++ b/io/include/pcl/io/pcd_grabber.h
@@ -62,7 +62,7 @@ namespace pcl
     */
   class PCL_EXPORTS PCDGrabberBase : public Grabber
   {
-    public:   
+    public:
       /** \brief Constructor taking just one PCD file or one TAR file containing multiple PCD files.
         * \param[in] pcd_file path to the PCD file
         * \param[in] frames_per_second frames per second. If 0, start() functions like a trigger, publishing the next PCD in the list.
@@ -81,44 +81,44 @@ namespace pcl
       ~PCDGrabberBase () noexcept;
 
       /** \brief Starts playing the list of PCD files if frames_per_second is > 0. Otherwise it works as a trigger: publishes only the next PCD file in the list. */
-      void 
+      void
       start () override;
-      
+
       /** \brief Stops playing the list of PCD files if frames_per_second is > 0. Otherwise the method has no effect. */
-      void 
+      void
       stop () override;
-      
+
       /** \brief Triggers a callback with new data */
-      virtual void 
+      virtual void
       trigger ();
 
       /** \brief Indicates whether the grabber is streaming or not.
         * \return true if grabber is started and hasn't run out of PCD files.
         */
-      bool 
+      bool
       isRunning () const override;
-      
+
       /** \return The name of the grabber */
-      std::string 
+      std::string
       getName () const override;
-      
+
       /** \brief Rewinds to the first PCD file in the list.*/
-      virtual void 
+      virtual void
       rewind ();
 
       /** \brief Returns the frames_per_second. 0 if grabber is trigger-based */
-      float 
+      float
       getFramesPerSecond () const override;
 
       /** \brief Returns whether the repeat flag is on */
-      bool 
+      bool
       isRepeatOn () const;
-  
+
       /** \brief Get cloud (in ROS form) at a particular location */
       bool
-      getCloudAt (std::size_t idx, 
+      getCloudAt (std::size_t idx,
                   pcl::PCLPointCloud2 &blob,
-                  Eigen::Vector4f &origin, 
+                  Eigen::Vector4f &origin,
                   Eigen::Quaternionf &orientation) const;
 
       /** \brief Returns the size */
@@ -126,7 +126,7 @@ namespace pcl
       numFrames () const;
 
     private:
-      virtual void 
+      virtual void
       publish (const pcl::PCLPointCloud2& blob, const Eigen::Vector4f& origin, const Eigen::Quaternionf& orientation, const std::string& file_name) const = 0;
 
       // to separate and hide the implementation from interface: PIMPL
@@ -144,13 +144,13 @@ namespace pcl
 
       PCDGrabber (const std::string& pcd_path, float frames_per_second = 0, bool repeat = false);
       PCDGrabber (const std::vector<std::string>& pcd_files, float frames_per_second = 0, bool repeat = false);
-      
+
       /** \brief Virtual destructor. */
       ~PCDGrabber () noexcept
       {
         stop ();
       }
-    
+
       // Inherited from FileGrabber
       const typename pcl::PointCloud<PointT>::ConstPtr
       operator[] (std::size_t idx) const override;
@@ -160,9 +160,9 @@ namespace pcl
       size () const override;
     protected:
 
-      void 
+      void
       publish (const pcl::PCLPointCloud2& blob, const Eigen::Vector4f& origin, const Eigen::Quaternionf& orientation, const std::string& file_name) const override;
-      
+
       boost::signals2::signal<void (const typename pcl::PointCloud<PointT>::ConstPtr&)>* signal_;
       boost::signals2::signal<void (const std::string&)>* file_name_signal_;
 
@@ -224,7 +224,7 @@ namespace pcl
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  template<typename PointT> void 
+  template<typename PointT> void
   PCDGrabber<PointT>::publish (const pcl::PCLPointCloud2& blob, const Eigen::Vector4f& origin, const Eigen::Quaternionf& orientation, const std::string& file_name) const
   {
     typename pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT> ());
@@ -286,7 +286,7 @@ namespace pcl
       openni_wrapper::Image::Ptr image (new openni_wrapper::ImageRGB24 (image_meta_data));
       if (image_signal_->num_slots() > 0)
         image_signal_->operator()(image);
-      
+
       if (image_depth_image_signal_->num_slots() > 0)
         image_depth_image_signal_->operator()(image, depth_image, 1.0f / 525.0f);
     }

--- a/io/include/pcl/io/pcd_grabber.h
+++ b/io/include/pcl/io/pcd_grabber.h
@@ -77,24 +77,6 @@ namespace pcl
         */
       PCDGrabberBase (const std::vector<std::string>& pcd_files, float frames_per_second, bool repeat);
 
-      /** \brief Copy constructor.
-        * \param[in] src the PCD Grabber base object to copy into this
-        */
-      PCDGrabberBase (const PCDGrabberBase &src) : impl_ ()
-      {
-        *this = src;
-      }
-
-      /** \brief Copy operator.
-        * \param[in] src the PCD Grabber base object to copy into this
-        */
-      PCDGrabberBase&
-      operator = (const PCDGrabberBase &src)
-      {
-        impl_ = src.impl_;
-        return (*this);
-      }
-
       /** \brief Virtual destructor. */
       ~PCDGrabberBase () noexcept;
 

--- a/stereo/include/pcl/stereo/stereo_grabber.h
+++ b/stereo/include/pcl/stereo/stereo_grabber.h
@@ -72,21 +72,6 @@ public:
                     float frames_per_second,
                     bool repeat);
 
-  /** \brief Copy constructor.
-   * \param[in] src the Stereo Grabber base object to copy into this
-   */
-  StereoGrabberBase(const StereoGrabberBase& src) : impl_() { *this = src; }
-
-  /** \brief Copy operator.
-   * \param[in] src the Stereo Grabber base object to copy into this
-   */
-  StereoGrabberBase&
-  operator=(const StereoGrabberBase& src)
-  {
-    impl_ = src.impl_;
-    return (*this);
-  }
-
   /** \brief Virtual destructor. */
   ~StereoGrabberBase() noexcept;
 


### PR DESCRIPTION
Grabber should not be copyable based on the signal mechanism used.

* Fixes double free silent bug.
* Finishes the refactoring started in #3615

## Methodology
* Add noexcept
* Replace NULL with nullptr
* Use `const auto` for iterator return type
* Use other functions instead of duplicating code
* Replace normal pointers with unique_pointers and default dtor
* Add compiler specific code to deal with non-conformance wrt default dtor

This should have been the end of the saga, but no. MSVC has a non-conformance and surprisingly a check for shooting yourself in the foot that gcc doesn't have. This needed one more step:
* Bash head into keyboard till a correct patch was created. Time taken: 1 month

## Saga Continues
The issue of differing behavior between MSVC and GCC wasn't a single issue, despite the same error message, but was actually 2 different instances, with almost the same diagnostic. The blink-and-miss-it difference in diagnostic was the line number which triggered the error. Anyways, these are the 2 major difference  between MSVC and GCC
1. Non-conformance: MSVC tries to copy instead of in-place new in emplace
2. Extra Check: MSVC tries to create copy ctor and copy assignment operator despite nobody using them (technically)

### Non conformance
MSVC had an annoying bug which tries to copy despite the chance of a move since it has a throwing move assign operator. This non-conformance was surprisingly easier to handle since the compiler diagnostic pointed to the correct line. I was initially using `emplace` but then on reading the docs, I realized that I could prevent a dynamic allocation by using `try_emplace` **IFF** MSVC was providing the feature with C++14 flag due to it's non-conformance. To be clear, `try_emplace` is not a C++14 feature, but some compilers make it available (for some reasons), and so I added both methods in order to make the grabber a bit more efficient conditionally.

This needed a deferred allocation for `try_emplace` (else I went to all the macro magic trouble for no reasons) so that if the key is present, there's not even a peep about heap allocation. To eliminate the spurious dynamic memory allocation, I used an empty struct which could implicitly cast to the map's `value_type` and perform an allocation in that case. This had the added benefit that the struct was implicitly convertible to the desired type to both `emplace` and `try_emplace`. The empty struct is copyable, default constructible, no-throw movable and thus eliminates issues dealing with MSVC's non-conformance.

### The Check
This should have been the most straightforward fix, but I was already jaded from looking at the same error message due to non-conformance. I tried to create a MCVE but that didn't help since I didn't have MSVC and had to use Godbolt in order to compile (and let me tell you, MSVC on godbolt is nice, but can't compile much and timesout on including boost or even string). The issue was only on MSVC, not even clang which served as a red-herring to me, making me think it was something to do with MSVC's previous non-conformance.

The check in question is simply put, MSVC being conservative and instantiating the base-class functons when asked for by the Derived classes. In this case, the Derived class has a copy ctor and copy assignment op but the Base class does not. GCC should have thrown a similar error message that it's not possible to instantiate the class (because the copy functions are removed by default (since a member aka `std::map` with values of `std::unique_ptr` doesn't have them)). But it didn't. This is really a footgun waiting to shoot since the API claims that the derived class is copy-able, despite the base-class being move only.

I had a wild-goose chase running down conspiracy theories. In the end, I decided to explicitly delete the copy functions (coz MSVC might be stupid) and what-do-you-know, GCC, clang and MSVC all threw much better error messages. Then it was simply a matter of removing copy functions and adding move functions to derived classes. Finally the issue was resolved and I do have to say: good job MSVC. If only you could provide better error messages, this would not have taken almost a month.

## Lesson Learnt
Python is Zen 😆 , but yes, explicit is better than implicit.