### PR TITLE
Added test for ICP example code

### DIFF
--- a/doc/tutorials/content/sources/iterative_closest_point/iterative_closest_point.cpp
+++ b/doc/tutorials/content/sources/iterative_closest_point/iterative_closest_point.cpp
@@ -6,39 +6,40 @@
 int
  main (int argc, char** argv)
 {
-  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_in (new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_in (new pcl::PointCloud<pcl::PointXYZ>(5,1));
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_out (new pcl::PointCloud<pcl::PointXYZ>);
 
   // Fill in the CloudIn data
-  cloud_in->width    = 5;
-  cloud_in->height   = 1;
-  cloud_in->is_dense = false;
-  cloud_in->points.resize (cloud_in->width * cloud_in->height);
-  for (std::size_t i = 0; i < cloud_in->points.size (); ++i)
+  for (auto& point : *cloud_in)
   {
-    cloud_in->points[i].x = 1024 * rand () / (RAND_MAX + 1.0f);
-    cloud_in->points[i].y = 1024 * rand () / (RAND_MAX + 1.0f);
-    cloud_in->points[i].z = 1024 * rand () / (RAND_MAX + 1.0f);
+    point.x = 1024 * rand() / (RAND_MAX + 1.0f);
+    point.y = 1024 * rand() / (RAND_MAX + 1.0f);
+    point.z = 1024 * rand() / (RAND_MAX + 1.0f);
   }
-  std::cout << "Saved " << cloud_in->points.size () << " data points to input:"
-      << std::endl;
-  for (std::size_t i = 0; i < cloud_in->points.size (); ++i) std::cout << "    " <<
-      cloud_in->points[i].x << " " << cloud_in->points[i].y << " " <<
-      cloud_in->points[i].z << std::endl;
+  
+  std::cout << "Saved " << cloud_in->points.size () << " data points to input:" << std::endl;
+      
+  for (auto& point : *cloud_in)
+    std::cout << point << std::endl;
+      
   *cloud_out = *cloud_in;
+  
   std::cout << "size:" << cloud_out->points.size() << std::endl;
-  for (std::size_t i = 0; i < cloud_in->points.size (); ++i)
-    cloud_out->points[i].x = cloud_in->points[i].x + 0.7f;
-  std::cout << "Transformed " << cloud_in->points.size () << " data points:"
-      << std::endl;
-  for (std::size_t i = 0; i < cloud_out->points.size (); ++i)
-    std::cout << "    " << cloud_out->points[i].x << " " <<
-      cloud_out->points[i].y << " " << cloud_out->points[i].z << std::endl;
+  for (auto& point : *cloud_out)
+    point.x += 0.7f;
+
+  std::cout << "Transformed " << cloud_in->points.size () << " data points:" << std::endl;
+      
+  for (auto& point : *cloud_out)
+    std::cout << point << std::endl;
+
   pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ> icp;
   icp.setInputSource(cloud_in);
   icp.setInputTarget(cloud_out);
+  
   pcl::PointCloud<pcl::PointXYZ> Final;
   icp.align(Final);
+
   std::cout << "has converged:" << icp.hasConverged() << " score: " <<
   icp.getFitnessScore() << std::endl;
   std::cout << icp.getFinalTransformation() << std::endl;

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -211,26 +211,26 @@ TEST (PCL, IterativeClosestPoint)
   reg.align (cloud_reg);
   EXPECT_EQ (int (cloud_reg.points.size ()), int (cloud_source.points.size ()));
 
-  //Eigen::Matrix4f transformation = reg.getFinalTransformation ();
-//  EXPECT_NEAR (transformation (0, 0), 0.8806,  1e-3);
-//  EXPECT_NEAR (transformation (0, 1), 0.036481287330389023, 1e-2);
-//  EXPECT_NEAR (transformation (0, 2), -0.4724, 1e-3);
-//  EXPECT_NEAR (transformation (0, 3), 0.03453, 1e-3);
-//
-//  EXPECT_NEAR (transformation (1, 0), -0.02354,  1e-3);
-//  EXPECT_NEAR (transformation (1, 1),  0.9992,   1e-3);
-//  EXPECT_NEAR (transformation (1, 2),  0.03326,  1e-3);
-//  EXPECT_NEAR (transformation (1, 3), -0.001519, 1e-3);
-//
-//  EXPECT_NEAR (transformation (2, 0),  0.4732,  1e-3);
-//  EXPECT_NEAR (transformation (2, 1), -0.01817, 1e-3);
-//  EXPECT_NEAR (transformation (2, 2),  0.8808,  1e-3);
-//  EXPECT_NEAR (transformation (2, 3),  0.04116, 1e-3);
-//
-//  EXPECT_EQ (transformation (3, 0), 0);
-//  EXPECT_EQ (transformation (3, 1), 0);
-//  EXPECT_EQ (transformation (3, 2), 0);
-//  EXPECT_EQ (transformation (3, 3), 1);
+  Eigen::Matrix4f transformation = reg.getFinalTransformation ();
+  EXPECT_NEAR (transformation (0, 0), 0.8806,  1e-3);
+  EXPECT_NEAR (transformation (0, 1), 0.036481287330389023, 1e-2);
+  EXPECT_NEAR (transformation (0, 2), -0.4724, 1e-3);
+  EXPECT_NEAR (transformation (0, 3), 0.03453, 1e-3);
+
+  EXPECT_NEAR (transformation (1, 0), -0.02354,  1e-3);
+  EXPECT_NEAR (transformation (1, 1),  0.9992,   1e-3);
+  EXPECT_NEAR (transformation (1, 2),  0.03326,  1e-3);
+  EXPECT_NEAR (transformation (1, 3), -0.001519, 1e-3);
+
+  EXPECT_NEAR (transformation (2, 0),  0.4732,  1e-3);
+  EXPECT_NEAR (transformation (2, 1), -0.01817, 1e-3);
+  EXPECT_NEAR (transformation (2, 2),  0.8808,  1e-3);
+  EXPECT_NEAR (transformation (2, 3),  0.04116, 1e-3);
+
+  EXPECT_EQ (transformation (3, 0), 0);
+  EXPECT_EQ (transformation (3, 1), 0);
+  EXPECT_EQ (transformation (3, 2), 0);
+  EXPECT_EQ (transformation (3, 3), 1);
 }
 
 TEST (PCL, IterativeClosestPointWithNormals)


### PR DESCRIPTION
As in an attempt to help with #3624, I have added a test for ICP - more or less copy of the [tutorial](https://github.com/PointCloudLibrary/pcl/blob/cc7fe363c6463a0abc617b1e17e94ab4bd4169ef/doc/tutorials/content/sources/iterative_closest_point/iterative_closest_point.cpp).

However, when I tried to check out pcl 1.8 I had (unrelated)linker errors and discontinued to investigate the error.

But maybe its of interest to have the ICP test?