### PR TITLE
Fix compilation of CUDA code on Windows

### DIFF
--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -47,6 +47,7 @@
 #include <pcl/PointIndices.h>
 #include <pcl/conversions.h>
 #include <pcl/exceptions.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/PolygonMesh.h>
 #include <locale>
 
@@ -75,7 +76,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFieldIndex<PointT> (field_name, fields) instead")]]
+  PCL_DEPRECATED("use getFieldIndex<PointT> (field_name, fields) instead")
   inline int
   getFieldIndex (const pcl::PointCloud<PointT> &cloud, const std::string &field_name, 
                  std::vector<pcl::PCLPointField> &fields);
@@ -105,7 +106,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFields<PointT> () with return value instead")]]
+  PCL_DEPRECATED("use getFields<PointT> () with return value instead")
   inline void
   getFields (const pcl::PointCloud<PointT> &cloud, std::vector<pcl::PCLPointField> &fields);
 
@@ -115,7 +116,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFields<PointT> () with return value instead")]]
+  PCL_DEPRECATED("use getFields<PointT> () with return value instead")
   inline void 
   getFields (std::vector<pcl::PCLPointField> &fields);
 
@@ -327,7 +328,7 @@ namespace pcl
     * \return true if successful, false otherwise (e.g., name/number of fields differs)
     * \ingroup common
     */
-  [[deprecated("use pcl::concatenate() instead, but beware of subtle difference in behavior (see documentation)")]]
+  PCL_DEPRECATED("use pcl::concatenate() instead, but beware of subtle difference in behavior (see documentation)")
   PCL_EXPORTS bool 
   concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
                          const pcl::PCLPointCloud2 &cloud2,

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -1155,11 +1155,11 @@ namespace pcl
 
     inline PointWithViewpoint (): PointWithViewpoint (0.f, 0.f, 0.f) {}
 
-    [[deprecated("Use ctor accepting all position (x, y, z) data")]]
+    PCL_DEPRECATED("Use ctor accepting all position (x, y, z) data")
     inline PointWithViewpoint (float _x, float _y = 0.f):
       PointWithViewpoint (_x, _y, 0.f) {}
 
-    [[deprecated("Use ctor accepting all viewpoint (vp_x, vp_y, vp_z) data")]]
+    PCL_DEPRECATED("Use ctor accepting all viewpoint (vp_x, vp_y, vp_z) data")
     inline PointWithViewpoint (float _x, float _y, float _z, float _vp_x, float _vp_y = 0.f):
       PointWithViewpoint (_x, _y, _z, _vp_x, _vp_y, 0.f) {}
     

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -76,6 +76,24 @@
 
 #include <pcl/pcl_config.h>
 
+// It seems that __has_cpp_attribute doesn't work correctly
+// when compiling with some versions of nvcc so we
+// additionally check if nvcc is used before setting the
+// PCL_DEPRECATED macro to [[deprecated]].
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(deprecated) && !defined(__CUDACC__)
+  #define PCL_DEPRECATED(message) [[deprecated(message)]]
+#elif defined(__GNUC__) || defined(__clang__)
+  #define PCL_DEPRECATED(message) __attribute__((deprecated(message)))
+#elif defined(_MSC_VER)
+  // Until Visual Studio 2013 you had to use __declspec(deprecated).
+  // However, we decided to ignore the deprecation for these version because
+  // of simplicity reasons. See PR #3634 for the details.
+  #define PCL_DEPRECATED(message)
+#else
+  #warning "You need to implement PCL_DEPRECATED for this compiler"
+  #define PCL_DEPRECATED(message)
+#endif
+
 namespace pcl
 {
   /**
@@ -89,15 +107,15 @@ namespace pcl
   template <typename T>
   using shared_ptr = boost::shared_ptr<T>;
 
-  using uint8_t [[deprecated("use std::uint8_t instead of pcl::uint8_t")]] = std::uint8_t;
-  using int8_t [[deprecated("use std::int8_t instead of pcl::int8_t")]] = std::int8_t;
-  using uint16_t [[deprecated("use std::uint16_t instead of pcl::uint16_t")]] = std::uint16_t;
-  using int16_t [[deprecated("use std::uint16_t instead of pcl::int16_t")]] = std::int16_t;
-  using uint32_t [[deprecated("use std::uint32_t instead of pcl::uint32_t")]] = std::uint32_t;
-  using int32_t [[deprecated("use std::int32_t instead of pcl::int32_t")]] = std::int32_t;
-  using uint64_t [[deprecated("use std::uint64_t instead of pcl::uint64_t")]] = std::uint64_t;
-  using int64_t [[deprecated("use std::int64_t instead of pcl::int64_t")]] = std::int64_t;
-  using int_fast16_t [[deprecated("use std::int_fast16_t instead of pcl::int_fast16_t")]] = std::int_fast16_t;
+  using uint8_t PCL_DEPRECATED("use std::uint8_t instead of pcl::uint8_t") = std::uint8_t;
+  using int8_t PCL_DEPRECATED("use std::int8_t instead of pcl::int8_t") = std::int8_t;
+  using uint16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::uint16_t") = std::uint16_t;
+  using int16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::int16_t") = std::int16_t;
+  using uint32_t PCL_DEPRECATED("use std::uint32_t instead of pcl::uint32_t") = std::uint32_t;
+  using int32_t PCL_DEPRECATED("use std::int32_t instead of pcl::int32_t") = std::int32_t;
+  using uint64_t PCL_DEPRECATED("use std::uint64_t instead of pcl::uint64_t") = std::uint64_t;
+  using int64_t PCL_DEPRECATED("use std::int64_t instead of pcl::int64_t") = std::int64_t;
+  using int_fast16_t PCL_DEPRECATED("use std::int_fast16_t instead of pcl::int_fast16_t") = std::int_fast16_t;
 }
 
 #if defined _WIN32 && defined _MSC_VER
@@ -134,15 +152,15 @@ namespace pcl
 
 
 template<typename T>
-[[deprecated("use std::isnan instead of pcl_isnan")]]
+PCL_DEPRECATED("use std::isnan instead of pcl_isnan")
 bool pcl_isnan (T&& x) { return std::isnan (std::forward<T> (x)); }
 
 template<typename T>
-[[deprecated("use std::isfinite instead of pcl_isfinite")]]
+PCL_DEPRECATED("use std::isfinite instead of pcl_isfinite")
 bool pcl_isfinite (T&& x) { return std::isfinite (std::forward<T> (x)); }
 
 template<typename T>
-[[deprecated("use std::isinf instead of pcl_isinf")]]
+PCL_DEPRECATED("use std::isinf instead of pcl_isinf")
 bool pcl_isinf (T&& x) { return std::isinf (std::forward<T> (x)); }
 
 

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -138,7 +138,7 @@ namespace pcl
   namespace detail
   {
     template <typename PointT>
-    [[deprecated("use createMapping() instead")]]
+    PCL_DEPRECATED("use createMapping() instead")
     shared_ptr<pcl::MsgFieldMap>&
     getMapping (pcl::PointCloud<PointT>& p);
   } // namespace detail
@@ -606,7 +606,7 @@ namespace pcl
 
     protected:
       // This is motivated by ROS integration. Users should not need to access mapping_.
-      [[deprecated("rewrite your code to avoid using this protected field")]] shared_ptr<MsgFieldMap> mapping_;
+      PCL_DEPRECATED("rewrite your code to avoid using this protected field") shared_ptr<MsgFieldMap> mapping_;
 
       friend shared_ptr<MsgFieldMap>& detail::getMapping<PointT>(pcl::PointCloud<PointT> &p);
 

--- a/features/include/pcl/features/rsd.h
+++ b/features/include/pcl/features/rsd.h
@@ -89,7 +89,7 @@ namespace pcl
               int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
 
   template <typename PointInT, typename PointNT, typename PointOutT>
-  [[deprecated("use computeRSD() overload that takes input point clouds by const reference")]]
+  PCL_DEPRECATED("use computeRSD() overload that takes input point clouds by const reference")
   Eigen::MatrixXf
   computeRSD (typename pcl::PointCloud<PointInT>::ConstPtr &surface, typename pcl::PointCloud<PointNT>::ConstPtr &normals,
               const std::vector<int> &indices, double max_dist,
@@ -115,7 +115,7 @@ namespace pcl
               int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
 
   template <typename PointNT, typename PointOutT>
-  [[deprecated("use computeRSD() overload that takes input point cloud by const reference")]]
+  PCL_DEPRECATED("use computeRSD() overload that takes input point cloud by const reference")
   Eigen::MatrixXf
   computeRSD (typename pcl::PointCloud<PointNT>::ConstPtr &normals,
               const std::vector<int> &indices, const std::vector<float> &sqr_dists, double max_dist,

--- a/filters/include/pcl/filters/passthrough.h
+++ b/filters/include/pcl/filters/passthrough.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/filters/filter_indices.h>
 
 namespace pcl
@@ -286,7 +287,7 @@ namespace pcl
         * Default: false.
         * \param[in] limit_negative return data inside the interval (false) or outside (true)
         */
-      [[deprecated("use inherited FilterIndices::setNegative() instead")]]
+      PCL_DEPRECATED("use inherited FilterIndices::setNegative() instead")
       inline void
       setFilterLimitsNegative (const bool limit_negative)
       {
@@ -296,7 +297,7 @@ namespace pcl
       /** \brief Get whether the data outside the interval (min/max) is to be returned (true) or inside (false).
         * \param[out] limit_negative true if data \b outside the interval [min; max] is to be returned, false otherwise
         */
-      [[deprecated("use inherited FilterIndices::getNegative() instead")]]
+      PCL_DEPRECATED("use inherited FilterIndices::getNegative() instead")
       inline void
       getFilterLimitsNegative (bool &limit_negative) const
       {
@@ -306,7 +307,7 @@ namespace pcl
       /** \brief Get whether the data outside the interval (min/max) is to be returned (true) or inside (false).
         * \return true if data \b outside the interval [min; max] is to be returned, false otherwise
         */
-      [[deprecated("use inherited FilterIndices::getNegative() instead")]]
+      PCL_DEPRECATED("use inherited FilterIndices::getNegative() instead")
       inline bool
       getFilterLimitsNegative () const
       {

--- a/io/include/pcl/compression/entropy_range_coder.h
+++ b/io/include/pcl/compression/entropy_range_coder.h
@@ -49,6 +49,8 @@
 #include <cstdio>
 #include <cstdint>
 
+#include <pcl/pcl_macros.h>
+
 namespace pcl
 {
 
@@ -168,7 +170,7 @@ namespace pcl
        * \param n_arg: some value
        * \return binary logarithm (log2) of argument n_arg
        */
-      [[deprecated("use std::log2 instead")]]
+      PCL_DEPRECATED("use std::log2 instead")
       inline double
       Log2 (double n_arg)
       {

--- a/io/include/pcl/io/ascii_io.h
+++ b/io/include/pcl/io/ascii_io.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/io/file_io.h>
 #include <pcl/PCLPointField.h>
 #include <pcl/common/io.h>
@@ -116,7 +117,7 @@ namespace pcl
         * \param[in] p  a point type
         */
       template<typename PointT>
-      [[deprecated("use parameterless setInputFields<PointT>() instead")]]
+      PCL_DEPRECATED("use parameterless setInputFields<PointT>() instead")
       inline void setInputFields (const PointT p)
       {
         (void) p;

--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -72,7 +72,7 @@ namespace pcl
         * \return Connection object, that can be used to disconnect the callback method from the signal again.
         */
       template<typename T, template<typename> class FunctionT>
-      [[deprecated ("please assign the callback to a std::function.")]]
+      PCL_DEPRECATED ("please assign the callback to a std::function.")
       boost::signals2::connection
       registerCallback (const FunctionT<T>& callback)
       {

--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include "pcl/pcl_config.h"
+#include <pcl/pcl_macros.h>
 
 #include <pcl/io/grabber.h>
 #include <pcl/io/impl/synchronized_queue.hpp>
@@ -70,7 +71,7 @@ namespace pcl
        */
       using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba = void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr &, float, float);
 
-      using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb [[deprecated("use sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba instead")]]
+      using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb PCL_DEPRECATED("use sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba instead")
               = sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba;
 
       /** \brief Signal used for a single sector
@@ -96,7 +97,7 @@ namespace pcl
        */
       using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba = void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr &);
 
-      using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb [[deprecated("use sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba instead")]]
+      using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb PCL_DEPRECATED("use sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba instead")
               = sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba;
 
       /** \brief Constructor taking an optional path to an HDL corrections file.  The Grabber will listen on the default IP/port for data packets [192.168.3.255/2368]

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -44,6 +44,7 @@
 #include <pcl/octree/octree_iterator.h>
 #include <pcl/octree/octree_key.h>
 #include <pcl/octree/octree_nodes.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl {
 namespace octree {
@@ -236,14 +237,14 @@ public:
   using LeafNodeIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
   using ConstLeafNodeIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
-  [[deprecated("use leaf_depth_begin() instead")]] LeafNodeIterator
+  PCL_DEPRECATED("use leaf_depth_begin() instead")
+  LeafNodeIterator
   leaf_begin(unsigned int max_depth_arg = 0)
   {
     return LeafNodeIterator(this, max_depth_arg);
   };
 
-  [[deprecated("use leaf_depth_end() instead")]] const LeafNodeIterator
-  leaf_end()
+  PCL_DEPRECATED("use leaf_depth_end() instead") const LeafNodeIterator leaf_end()
   {
     return LeafNodeIterator();
   };
@@ -937,8 +938,7 @@ protected:
    * \param n_arg: some value
    * \return binary logarithm (log2) of argument n_arg
    */
-  [[deprecated("use std::log2 instead")]] inline double
-  Log2(double n_arg)
+  PCL_DEPRECATED("use std::log2 instead") inline double Log2(double n_arg)
   {
     return std::log2(n_arg);
   }

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -44,6 +44,7 @@
 #include <pcl/octree/octree_iterator.h>
 #include <pcl/octree/octree_key.h>
 #include <pcl/octree/octree_nodes.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl {
 namespace octree {
@@ -125,14 +126,14 @@ public:
   using LeafNodeIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
   using ConstLeafNodeIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
-  [[deprecated("use leaf_depth_begin() instead")]] LeafNodeIterator
+  PCL_DEPRECATED("use leaf_depth_begin() instead")
+  LeafNodeIterator
   leaf_begin(unsigned int max_depth_arg = 0u)
   {
     return LeafNodeIterator(this, max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
-  [[deprecated("use leaf_depth_end() instead")]] const LeafNodeIterator
-  leaf_end()
+  PCL_DEPRECATED("use leaf_depth_end() instead") const LeafNodeIterator leaf_end()
   {
     return LeafNodeIterator(this, 0, nullptr);
   };
@@ -685,8 +686,7 @@ protected:
    * \param n_arg: some value
    * \return binary logarithm (log2) of argument n_arg
    */
-  [[deprecated("use std::log2 instead")]] double
-  Log2(double n_arg)
+  PCL_DEPRECATED("use std::log2 instead") double Log2(double n_arg)
   {
     return std::log2(n_arg);
   }

--- a/recognition/include/pcl/recognition/mask_map.h
+++ b/recognition/include/pcl/recognition/mask_map.h
@@ -78,7 +78,7 @@ public:
     return (data_.data());
   }
 
-  [[deprecated("Use new version diff getDifferenceMask(mask0, mask1)")]]
+  PCL_DEPRECATED("Use new version diff getDifferenceMask(mask0, mask1)")
   static void
   getDifferenceMask(const MaskMap& mask0, const MaskMap& mask1, MaskMap& diff_mask);
 

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/segmentation/boost.h>
 #include <pcl/segmentation/comparator.h>
 #include <pcl/point_types.h>
@@ -210,7 +211,7 @@ namespace pcl
       using experimental::EuclideanClusterComparator<PointT, PointLT>::setExcludeLabels;
 
       /** \brief Default constructor for EuclideanClusterComparator. */
-      [[deprecated("remove PointNT from template parameters")]]
+      PCL_DEPRECATED("remove PointNT from template parameters")
       EuclideanClusterComparator ()
         : normals_ ()
         , angular_threshold_ (0.0f)
@@ -219,19 +220,19 @@ namespace pcl
       /** \brief Provide a pointer to the input normals.
        * \param[in] normals the input normal cloud
        */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline void
       setInputNormals (const PointCloudNConstPtr& normals) { normals_ = normals; }
 
       /** \brief Get the input normals. */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline PointCloudNConstPtr
       getInputNormals () const { return (normals_); }
 
       /** \brief Set the tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane.
         * \param[in] angular_threshold the tolerance in radians
         */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline void
       setAngularThreshold (float angular_threshold)
       {
@@ -239,14 +240,14 @@ namespace pcl
       }
 
       /** \brief Get the angular threshold in radians for difference in normal direction between neighboring points, to be considered part of the same plane. */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline float
       getAngularThreshold () const { return (std::acos (angular_threshold_) ); }
 
       /** \brief Set labels in the label cloud to exclude.
         * \param[in] exclude_labels a vector of bools corresponding to whether or not a given label should be considered
         */
-      [[deprecated("use setExcludeLabels(const ExcludeLabelSetConstPtr &) instead")]]
+      PCL_DEPRECATED("use setExcludeLabels(const ExcludeLabelSetConstPtr &) instead")
       void
       setExcludeLabels (const std::vector<bool>& exclude_labels)
       {

--- a/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
@@ -41,6 +41,7 @@
 
 #include <pcl/segmentation/planar_region.h>
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/common/angles.h>
 #include <pcl/PointIndices.h>
 #include <pcl/ModelCoefficients.h>
@@ -284,7 +285,7 @@ namespace pcl
         * \param [in] labels The labels produced by the initial segmentation
         * \param [in] label_indices The list of indices corresponding to each label
         */
-      [[deprecated("centroids and covariances parameters are not used; they are deprecated and will be removed in future releases")]]
+      PCL_DEPRECATED("centroids and covariances parameters are not used; they are deprecated and will be removed in future releases")
       void
       refine (std::vector<ModelCoefficients>& model_coefficients, 
               std::vector<PointIndices>& inlier_indices,

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/search/pcl_search.h>
 
 namespace pcl
@@ -59,7 +60,7 @@ namespace pcl
       pcl::PointCloud<PointT> &output);
 
   template <typename PointT>
-  [[deprecated("tgt parameter is not used; it is deprecated and will be removed in future releases")]]
+  PCL_DEPRECATED("tgt parameter is not used; it is deprecated and will be removed in future releases")
   inline void getPointCloudDifference (
       const pcl::PointCloud<PointT> &src,
       const pcl::PointCloud<PointT> & /* tgt */,

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -194,7 +194,7 @@ namespace pcl
        */
       SupervoxelClustering (float voxel_resolution, float seed_resolution);
 
-      [[deprecated("constructor with flag for using the single camera transform is deprecated. Default behavior is now to use the transform for organized clouds, and not use it for unorganized. Use setUseSingleCameraTransform() to override the defaults.")]]
+      PCL_DEPRECATED("constructor with flag for using the single camera transform is deprecated. Default behavior is now to use the transform for organized clouds, and not use it for unorganized. Use setUseSingleCameraTransform() to override the defaults.")
       SupervoxelClustering (float voxel_resolution, float seed_resolution, bool) : SupervoxelClustering (voxel_resolution, seed_resolution) { }
 
       /** \brief This destructor destroys the cloud, normals and search method used for
@@ -278,7 +278,7 @@ namespace pcl
         * color(it's random). Points that are unlabeled will be black
         * \note This will expand the label_colors_ vector so that it can accommodate all labels
         */
-      [[deprecated("use getLabeledCloud() instead. An example of how to display and save with colorized labels can be found in examples/segmentation/example_supervoxels.cpp")]]
+      PCL_DEPRECATED("use getLabeledCloud() instead. An example of how to display and save with colorized labels can be found in examples/segmentation/example_supervoxels.cpp")
       typename pcl::PointCloud<PointXYZRGBA>::Ptr
       getColoredCloud () const
       { 

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -356,7 +356,7 @@ namespace pcl
       /** \brief Sets whether the surface and normal are approximated using a polynomial, or only via tangent estimation.
         * \param[in] polynomial_fit set to true for polynomial fit
         */
-      [[deprecated("use setPolynomialOrder() instead")]]
+      PCL_DEPRECATED("use setPolynomialOrder() instead")
       inline void
       setPolynomialFit (bool polynomial_fit)
       {
@@ -374,7 +374,7 @@ namespace pcl
       }
 
       /** \brief Get the polynomial_fit value (true if the surface and normal are approximated using a polynomial). */
-      [[deprecated("use getPolynomialOrder() instead")]]
+      PCL_DEPRECATED("use getPolynomialOrder() instead")
       inline bool
       getPolynomialFit () const { return (order_ > 1); }
 
@@ -746,7 +746,7 @@ namespace pcl
   };
 
   template <typename PointInT, typename PointOutT>
-  using MovingLeastSquaresOMP [[deprecated("use MovingLeastSquares instead, it supports OpenMP now")]] = MovingLeastSquares<PointInT, PointOutT>;
+  using MovingLeastSquaresOMP PCL_DEPRECATED("use MovingLeastSquares instead, it supports OpenMP now") = MovingLeastSquares<PointInT, PointOutT>;
 }
 
 #ifdef PCL_NO_PRECOMPILE

--- a/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
@@ -16,6 +16,8 @@
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
 
+#include <pcl/pcl_macros.h>
+
 // This define is up here so anybody who want's to defeat the
 // bozo vaccine has to be doing it on purpose.
 #define BOZO_VACCINE_699FCC4262D4488c9109F1B7A37CE926
@@ -5820,7 +5822,7 @@ void ON_Annotation2Text::SetText(const wchar_t* s)
 
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
-[[deprecated("Use the version that takes a model transform argument")]]
+PCL_DEPRECATED("Use the version that takes a model transform argument")
 bool ON_Annotation2::GetTextXform( 
       ON_RECT /*gdi_text_rect*/,
       const ON_Font& /*font*/,
@@ -5860,7 +5862,7 @@ bool ON_Annotation2::GetTextXform(
 // New function added Oct 30, 07 - LW 
 // To use model xform to draw annotation in blocks correctly
 #if 0
-[[deprecated("Use the version that takes a dimstyle pointer")]]
+PCL_DEPRECATED("Use the version that takes a dimstyle pointer")
 bool ON_Annotation2::GetTextXform( 
       ON_RECT gdi_text_rect,
       const ON_Font& font,
@@ -5989,7 +5991,7 @@ static bool GetLeaderEndAndDirection( const ON_Annotation2* pAnn,
 
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
-[[deprecated("Use the version that takes a model transform argument")]]
+PCL_DEPRECATED("Use the version that takes a model transform argument")
 bool ON_Annotation2::GetTextXform( 
       ON_RECT /*gdi_text_rect*/,
       int /*gdi_height_of_I*/,

--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -42,6 +42,7 @@
 #endif
 
 // PCL includes
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/common/io.h>
 #include <pcl/visualization/common/common.h>
@@ -113,7 +114,7 @@ namespace pcl
           * This virtual method should not be overriden or used. The default implementation
           * is provided only for backwards compatibility with handlers that were written
           * before PCL 1.10.0 and will be removed in future. */
-        [[deprecated("use getColor() without parameters instead")]]
+        PCL_DEPRECATED("use getColor() without parameters instead")
         virtual bool
         getColor (vtkSmartPointer<vtkDataArray> &scalars) const {
           scalars = getColor ();
@@ -615,7 +616,7 @@ namespace pcl
           * This virtual method should not be overriden or used. The default implementation
           * is provided only for backwards compatibility with handlers that were written
           * before PCL 1.10.0 and will be removed in future. */
-        [[deprecated("use getColor() without parameters instead")]]
+        PCL_DEPRECATED("use getColor() without parameters instead")
         virtual bool
         getColor (vtkSmartPointer<vtkDataArray> &scalars) const {
           scalars = getColor ();


### PR DESCRIPTION
In pcl_macros.h the attribute [[deprecated]] is used. It seems that
nvcc doesn't support this attribute under Windows at the moment.
I tried it with CUDA Toolkit 10.1 with Windows 10. I also checked the
release notes of 10.2 but they didn't address it there.

To fix this I omit the attribute under Windows when nvcc is used using
preprocessor directives. This is the simplest way of avoiding the
issue. A more elegant solution would be if we added a macro similar to
how it is done at the bottom of pcl_macros.h with [[fallthrough]] and
[[nodiscard]].

Let me know if this is ok or if we should use a macro.