### PR TITLE
Add arguments to VS projects.

### DIFF
--- a/.ci/azure-pipelines/build-macos.yml
+++ b/.ci/azure-pipelines/build-macos.yml
@@ -51,7 +51,7 @@ jobs:
           cmake --build . -- test_filters test_registration test_registration_api
           cmake --build . -- -j2
         displayName: 'Build Library'
-      - script: cd $BUILD_DIR/test && ctest -V -T Test
+      - script: cd $BUILD_DIR && cmake --build . -- tests
         displayName: 'Run Unit Tests'
       - task: PublishTestResults@2
         inputs:

--- a/.ci/azure-pipelines/build-ubuntu-16-04.yaml
+++ b/.ci/azure-pipelines/build-ubuntu-16-04.yaml
@@ -41,8 +41,7 @@ jobs:
           cmake --build . -- -j2
         displayName: 'Build Library'
       - script: |
-          cd $BUILD_DIR/test
-          ctest -V -T Test
+          cd $BUILD_DIR && cmake --build . -- tests
         displayName: 'Run Unit Tests'
       - task: PublishTestResults@2
         inputs:

--- a/.ci/azure-pipelines/build-ubuntu-19-10.yaml
+++ b/.ci/azure-pipelines/build-ubuntu-19-10.yaml
@@ -42,8 +42,7 @@ jobs:
           cmake --build . -- -j2
         displayName: 'Build Library'
       - script: |
-          cd $BUILD_DIR/test
-          ctest -V -T Test
+          cd $BUILD_DIR && cmake --build . -- tests
         displayName: 'Run Unit Tests'
       - task: PublishTestResults@2
         inputs:

--- a/.ci/azure-pipelines/build-windows.yml
+++ b/.ci/azure-pipelines/build-windows.yml
@@ -37,7 +37,7 @@ jobs:
         displayName: 'CMake Configuration'
       - script: cd %BUILD_DIR% && cmake --build . --config %CONFIGURATION%
         displayName: 'Build Library'
-      - script: cd %BUILD_DIR%/test && ctest -C %CONFIGURATION% -V -T Test
+      - script: cd %BUILD_DIR% && cmake --build . --target tests --config %CONFIGURATION%
         displayName: 'Run Unit Tests'
       - task: PublishTestResults@2
         inputs:

--- a/cmake/pcl_targets.cmake
+++ b/cmake/pcl_targets.cmake
@@ -385,6 +385,21 @@ macro(PCL_ADD_TEST _name _exename)
   # must link explicitly against boost only on Windows
   target_link_libraries(${_exename} ${Boost_LIBRARIES})
 
+  #Only applies to MSVC
+  if(MSVC)    
+    #Requires CMAKE version 3.13.0
+    if(CMAKE_VERSION VERSION_LESS "3.13.0" AND (NOT ArgumentWarningShown))
+      message(WARNING "Arguments for unit test projects are not added - this requires at least CMake 3.13. Can be added manually in \"Project settings -> Debugging -> Command arguments\"")
+      SET (ArgumentWarningShown TRUE PARENT_SCOPE)
+    else()
+      #Only add if there are arguments to test
+      if(PCL_ADD_TEST_ARGUMENTS)
+        string (REPLACE ";" " " PCL_ADD_TEST_ARGUMENTS_STR "${PCL_ADD_TEST_ARGUMENTS}")
+        set_target_properties(${_exename} PROPERTIES VS_DEBUGGER_COMMAND_ARGUMENTS ${PCL_ADD_TEST_ARGUMENTS_STR})
+      endif()
+    endif()
+  endif()
+
   set_target_properties(${_exename} PROPERTIES FOLDER "Tests")
   add_test(NAME ${_name} COMMAND ${_exename} ${PCL_ADD_TEST_ARGUMENTS})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,14 @@ include_directories(SYSTEM ${GTEST_INCLUDE_DIRS} ${GTEST_SRC_DIR})
 add_library(pcl_gtest STATIC ${GTEST_SRC_DIR}/src/gtest-all.cc)
 
 enable_testing()
-add_custom_target(tests "${CMAKE_CTEST_COMMAND}" "-V" VERBATIM)
+
+if(MSVC)
+  # VS needs -C config to run correct
+  add_custom_target(tests "${CMAKE_CTEST_COMMAND}" -C $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release> -V -T Test VERBATIM)
+else()
+  add_custom_target(tests "${CMAKE_CTEST_COMMAND}" -V -T Test VERBATIM)
+endif()  
+
 set_target_properties(tests PROPERTIES FOLDER "Tests")
 
 add_subdirectory(2d)


### PR DESCRIPTION
Adds arguments to test projects in VS, so clouds etc. is properly found.



However I later found out that running the unit test from the unit test explorer in VS, still doesn't pick them up.

Also, if I run the Tests project, which seems to init ctest, some other arguments are passed and it complains about -C 'release/debug' argument is not present.