### PR TITLE
Fix compilation warnings when using VTK [version >= 8.2]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,25 +377,26 @@ endif()
 option(WITH_VTK "Build VTK-Visualizations" TRUE)
 if(WITH_VTK AND NOT ANDROID)
   set(PCL_VTK_COMPONENTS
-    vtkChartsCore
-    vtkCommonCore
-    vtkCommonDataModel
-    vtkCommonExecutionModel
-    vtkFiltersCore
-    vtkFiltersExtraction
-    vtkFiltersModeling
-    vtkImagingCore
-    vtkImagingSources
-    vtkInteractionStyle
-    vtkInteractionWidgets
-    vtkIOCore
-    vtkIOGeometry
-    vtkIOImage
-    vtkIOLegacy
-    vtkIOPLY
-    vtkRenderingAnnotation
-    vtkRenderingLOD
-    vtkViewsContext2D
+    ChartsCore
+    CommonCore
+    CommonDataModel
+    CommonExecutionModel
+    FiltersCore
+    FiltersExtraction
+    FiltersGeometry
+    FiltersModeling
+    ImagingCore
+    ImagingSources
+    InteractionStyle
+    InteractionWidgets
+    IOCore
+    IOGeometry
+    IOImage
+    IOLegacy
+    IOPLY
+    RenderingAnnotation
+    RenderingLOD
+    ViewsContext2D
   )
   find_package(VTK COMPONENTS ${PCL_VTK_COMPONENTS})
   if(VTK_FOUND AND ("${VTK_VERSION}" VERSION_LESS 6.2))
@@ -405,16 +406,14 @@ if(WITH_VTK AND NOT ANDROID)
 
   if(VTK_FOUND)
     if(NOT DEFINED VTK_RENDERING_BACKEND)
-      # On old VTK versions this variable does not exist. In this case it is
-      # safe to assume OpenGL backend
-      set(VTK_RENDERING_BACKEND "OpenGL")
+      # In this case it is safe to assume OpenGL backend
+      set(VTK_RENDERING_BACKEND "OpenGL2")
     endif()
-    list(APPEND PCL_VTK_COMPONENTS vtkRenderingContext${VTK_RENDERING_BACKEND})
-
+    list(APPEND PCL_VTK_COMPONENTS RenderingContext${VTK_RENDERING_BACKEND})
     if(WITH_QT)
-      if(";${VTK_MODULES_ENABLED};" MATCHES ";vtkGUISupportQt;" AND ";${VTK_MODULES_ENABLED};" MATCHES ";vtkRenderingQt;")
+      if(";${VTK_AVAILABLE_COMPONENTS};" MATCHES ";GUISupportQt;" AND ";${VTK_AVAILABLE_COMPONENTS};" MATCHES ";RenderingQt;")
         set(QVTK_FOUND ON)
-        list(APPEND PCL_VTK_COMPONENTS vtkRenderingQt vtkGUISupportQt)
+        list(APPEND PCL_VTK_COMPONENTS RenderingQt GUISupportQt)
       else()
         unset(QVTK_FOUND)
       endif()

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/cloud_view.h
@@ -70,7 +70,7 @@ namespace pcl
       ProjectModel* 
       getModel () const { return model_; }
       
-      QVTKWidget* 
+      QVTKOpenGLNativeWidget*
       getQVTK() const {return qvtk_; }
       
       pcl::visualization::PCLVisualizer::Ptr
@@ -141,7 +141,7 @@ namespace pcl
       
       pcl::visualization::PCLVisualizer::Ptr vis_;
       ProjectModel* model_;
-      QVTKWidget* qvtk_;
+      QVTKOpenGLNativeWidget* qvtk_;
       vtkSmartPointer<InteractorStyleSwitch> style_switch_;
       
       vtkSmartPointer<vtkOrientationMarkerWidget> axes_widget_;

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/items/fpfh_item.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/items/fpfh_item.h
@@ -43,7 +43,7 @@
 #include <pcl/apps/cloud_composer/items/cloud_composer_item.h>
 #include <pcl/visualization/pcl_plotter.h>
 
-class QVTKWidget;
+class QVTKOpenGLNativeWidget;
 
 namespace pcl
 {
@@ -74,7 +74,7 @@ namespace pcl
         pcl::PointCloud<pcl::FPFHSignature33>::Ptr fpfh_ptr_;
         double radius_;
         pcl::visualization::PCLPlotter::Ptr plot_;
-        QVTKWidget *qvtk_;
+        QVTKOpenGLNativeWidget *qvtk_;
         QWidget *hist_page_;
     };
 

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/point_selectors/interactor_style_switch.h
@@ -45,7 +45,7 @@
 #include <pcl/visualization/common/ren_win_interact_map.h>
 #include <pcl/visualization/pcl_visualizer.h>
 
-class QVTKWidget;
+class QVTKOpenGLNativeWidget;
 
 namespace pcl
 {
@@ -93,7 +93,7 @@ namespace pcl
         initializeInteractorStyles (pcl::visualization::PCLVisualizer::Ptr vis, ProjectModel* model);
         
         inline void 
-        setQVTKWidget (QVTKWidget* qvtk) { qvtk_ = qvtk; }
+        setQVTKWidget (QVTKOpenGLNativeWidget* qvtk) { qvtk_ = qvtk; }
                 
         void
         setCurrentInteractorStyle (interactor_styles::INTERACTOR_STYLES interactor_style);
@@ -134,7 +134,7 @@ namespace pcl
         vtkSmartPointer<vtkPointPicker> point_picker_;
         
         /** \brief Internal pointer to QVTKWidget that this Switch works with */
-        QVTKWidget* qvtk_;
+        QVTKOpenGLNativeWidget* qvtk_;
         /** \brief Internal pointer to PCLVisualizer that this Switch works with */
         pcl::visualization::PCLVisualizer::Ptr vis_;
       private:

--- a/apps/cloud_composer/src/cloud_view.cpp
+++ b/apps/cloud_composer/src/cloud_view.cpp
@@ -7,7 +7,7 @@
 
 #include <QDebug>
 
-#include <QVTKWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 
 pcl::cloud_composer::CloudView::CloudView (QWidget* parent)
   : QWidget (parent)
@@ -15,10 +15,10 @@ pcl::cloud_composer::CloudView::CloudView (QWidget* parent)
   vis_.reset (new pcl::visualization::PCLVisualizer ("", false));
   vis_->getInteractorStyle ()->setKeyboardModifier (pcl::visualization::INTERACTOR_KB_MOD_SHIFT);
   //Create the QVTKWidget
-  qvtk_ = new QVTKWidget (this);
-  qvtk_->SetRenderWindow (vis_->getRenderWindow ());
+  qvtk_ = new QVTKOpenGLNativeWidget (this);
+  qvtk_->setRenderWindow (vis_->getRenderWindow());
   initializeInteractorSwitch ();
-  vis_->setupInteractor (qvtk_->GetInteractor (), qvtk_->GetRenderWindow (), style_switch_);
+  vis_->setupInteractor (qvtk_->interactor (), qvtk_->renderWindow (), style_switch_);
   
   QGridLayout *mainLayout = new QGridLayout (this);
   mainLayout-> addWidget (qvtk_,0,0);
@@ -31,10 +31,10 @@ pcl::cloud_composer::CloudView::CloudView (ProjectModel* model, QWidget* parent)
   vis_.reset (new pcl::visualization::PCLVisualizer ("", false));
  // vis_->getInteractorStyle ()->setKeyboardModifier (pcl::visualization::INTERACTOR_KB_MOD_SHIFT);
   //Create the QVTKWidget
-  qvtk_ = new QVTKWidget (this);
-  qvtk_->SetRenderWindow (vis_->getRenderWindow ());
+  qvtk_ = new QVTKOpenGLNativeWidget (this);
+  qvtk_->setRenderWindow (vis_->getRenderWindow ());
   initializeInteractorSwitch ();
-  vis_->setupInteractor (qvtk_->GetInteractor (), qvtk_->GetRenderWindow (), style_switch_);
+  vis_->setupInteractor (qvtk_->interactor (), qvtk_->renderWindow (), style_switch_);
   setModel(model);
   
   QGridLayout *mainLayout = new QGridLayout (this);
@@ -59,7 +59,7 @@ pcl::cloud_composer::CloudView::setModel (ProjectModel* new_model)
   qvtk_->show();
   qvtk_->update ();
   
- // vis_->addOrientationMarkerWidgetAxes (qvtk_->GetInteractor ());
+ // vis_->addOrientationMarkerWidgetAxes (qvtk_->interactor ());
 }
 
 void
@@ -206,7 +206,8 @@ pcl::cloud_composer::CloudView::setAxisVisibility (bool visible)
   if (visible)
   {
     qDebug () << "Adding coordinate system!";
-    vis_->addOrientationMarkerWidgetAxes ( qvtk_->GetInteractor() );
+    vis_->addOrientationMarkerWidgetAxes ( qvtk_->interactor() );
+
   }
   else
   {
@@ -226,7 +227,7 @@ pcl::cloud_composer::CloudView::addOrientationMarkerWidgetAxes ()
     axes_widget_ = vtkSmartPointer<vtkOrientationMarkerWidget>::New ();
     axes_widget_->SetOutlineColor ( 0.9300, 0.5700, 0.1300 );
     axes_widget_->SetOrientationMarker( axes );
-    axes_widget_->SetInteractor( qvtk_->GetInteractor () );
+    axes_widget_->SetInteractor( qvtk_->interactor () );
     axes_widget_->SetViewport( 0.0, 0.0, 0.4, 0.4 );
     axes_widget_->SetEnabled( 1 );
     axes_widget_->InteractiveOn();
@@ -257,7 +258,7 @@ pcl::cloud_composer::CloudView::initializeInteractorSwitch ()
 {
   style_switch_ = vtkSmartPointer<InteractorStyleSwitch>::New();
   style_switch_->initializeInteractorStyles (vis_, model_);
-  style_switch_->SetInteractor (qvtk_->GetInteractor ());
+  style_switch_->SetInteractor (qvtk_->interactor ());
   style_switch_->setCurrentInteractorStyle (interactor_styles::PCL_VISUALIZER);
   
   //Connect the events!

--- a/apps/cloud_composer/src/items/fpfh_item.cpp
+++ b/apps/cloud_composer/src/items/fpfh_item.cpp
@@ -3,7 +3,7 @@
 
 #include <QGridLayout>
 
-#include <QVTKWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 
 pcl::cloud_composer::FPFHItem::FPFHItem (QString name, const pcl::PointCloud<pcl::FPFHSignature33>::Ptr& fpfh_ptr, double radius)
   : CloudComposerItem (std::move(name))
@@ -40,7 +40,7 @@ pcl::cloud_composer::FPFHItem::getInspectorTabs ()
   if (!plot_)
   {
     plot_.reset (new pcl::visualization::PCLPlotter);
-    qvtk_ = new QVTKWidget ();
+    qvtk_ = new QVTKOpenGLNativeWidget ();
     hist_page_ = new QWidget ();
     QGridLayout *mainLayout = new QGridLayout (hist_page_);
     mainLayout-> addWidget (qvtk_,0,0);
@@ -49,8 +49,8 @@ pcl::cloud_composer::FPFHItem::getInspectorTabs ()
   //Plot the histogram
   plot_->addFeatureHistogram (*fpfh_ptr_, fpfh_ptr_->width, data(ItemDataRole::ITEM_ID).toString().toStdString ());
   //Set the render window of the QVTK widget, update
-  plot_->setViewInteractor (vtkSmartPointer<vtkRenderWindowInteractor> (qvtk_->GetInteractor ()));
-  qvtk_->SetRenderWindow (plot_->getRenderWindow ());
+  plot_->setViewInteractor (vtkSmartPointer<vtkRenderWindowInteractor> (qvtk_->interactor ()));
+  qvtk_->setRenderWindow (plot_->getRenderWindow ());
   qvtk_->show ();
   qvtk_->update ();
   

--- a/apps/include/pcl/apps/render_views_tesselated_sphere.h
+++ b/apps/include/pcl/apps/render_views_tesselated_sphere.h
@@ -11,6 +11,7 @@
 
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
+#include <vtkIdTypeArray.h>
 
 #include <functional>
 

--- a/apps/modeler/include/pcl/apps/modeler/render_window.h
+++ b/apps/modeler/include/pcl/apps/modeler/render_window.h
@@ -38,7 +38,7 @@
 
 #include <vtkSmartPointer.h>
 
-#include <QVTKWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 
 class vtkCubeAxesActor;
 
@@ -48,7 +48,7 @@ namespace pcl
   {
     class RenderWindowItem;
 
-    class RenderWindow : public QVTKWidget
+    class RenderWindow : public QVTKOpenGLNativeWidget
     {
       public:
         RenderWindow(RenderWindowItem* render_window_item, QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr);

--- a/apps/modeler/src/cloud_mesh_item.cpp
+++ b/apps/modeler/src/cloud_mesh_item.cpp
@@ -155,9 +155,9 @@ void
 pcl::modeler::CloudMeshItem::createChannels()
 {
   RenderWindowItem* render_window_item = dynamic_cast<RenderWindowItem*>(parent());
-  addChild(new PointsActorItem(this, cloud_mesh_, render_window_item->getRenderWindow()->GetRenderWindow()));
-  addChild(new NormalsActorItem(this, cloud_mesh_, render_window_item->getRenderWindow()->GetRenderWindow()));
-  addChild(new SurfaceActorItem(this, cloud_mesh_, render_window_item->getRenderWindow()->GetRenderWindow()));
+  addChild(new PointsActorItem(this, cloud_mesh_, render_window_item->getRenderWindow()->renderWindow()));
+  addChild(new NormalsActorItem(this, cloud_mesh_, render_window_item->getRenderWindow()->renderWindow()));
+  addChild(new SurfaceActorItem(this, cloud_mesh_, render_window_item->getRenderWindow()->renderWindow()));
   for (int i = 0, i_end = childCount(); i < i_end; ++ i)
   {
     ChannelActorItem* child_item = dynamic_cast<ChannelActorItem*>(child(i));
@@ -241,7 +241,7 @@ pcl::modeler::CloudMeshItem::updateRenderWindow()
   for (int i = 0, i_end = childCount(); i < i_end; ++ i)
   {
     ChannelActorItem* child_item = dynamic_cast<ChannelActorItem*>(child(i));
-    child_item->switchRenderWindow(render_window_item->getRenderWindow()->GetRenderWindow());
+    child_item->switchRenderWindow(render_window_item->getRenderWindow()->renderWindow());
   }
 
   render_window_item->getRenderWindow()->updateAxes();

--- a/apps/modeler/src/render_window.cpp
+++ b/apps/modeler/src/render_window.cpp
@@ -50,7 +50,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 pcl::modeler::RenderWindow::RenderWindow(RenderWindowItem* render_window_item, QWidget *parent, Qt::WindowFlags flags)
-  : QVTKWidget(parent, flags),
+  : QVTKOpenGLNativeWidget(parent, flags),
   axes_(vtkSmartPointer<vtkCubeAxesActor>::New()),
   render_window_item_(render_window_item)
 {
@@ -77,7 +77,7 @@ pcl::modeler::RenderWindow::~RenderWindow()
 void
 pcl::modeler::RenderWindow::initRenderer()
 {
-  vtkSmartPointer<vtkRenderWindow> win = GetRenderWindow();
+  vtkSmartPointer<vtkRenderWindow> win = renderWindow();
   vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
   win->AddRenderer(renderer);
 
@@ -107,7 +107,7 @@ pcl::modeler::RenderWindow::focusInEvent(QFocusEvent * event)
 {
   dynamic_cast<SceneTree*>(render_window_item_->treeWidget())->selectRenderWindowItem(render_window_item_);
 
-  QVTKWidget::focusInEvent(event);
+  QVTKOpenGLNativeWidget::focusInEvent(event);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -136,7 +136,7 @@ pcl::modeler::RenderWindow::setTitle(const QString& title)
 void
 pcl::modeler::RenderWindow::render()
 {
-  GetRenderWindow()->Render();
+  renderWindow()->Render();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -144,8 +144,8 @@ void
 pcl::modeler::RenderWindow::resetCamera()
 {
   double bounds[6];
-  GetRenderWindow()->GetRenderers()->GetFirstRenderer()->ComputeVisiblePropBounds(bounds);
-  GetRenderWindow()->GetRenderers()->GetFirstRenderer()->ResetCamera(bounds);
+  renderWindow()->GetRenderers()->GetFirstRenderer()->ComputeVisiblePropBounds(bounds);
+  renderWindow()->GetRenderers()->GetFirstRenderer()->ResetCamera(bounds);
   render();
 }
 
@@ -153,14 +153,14 @@ pcl::modeler::RenderWindow::resetCamera()
 void
 pcl::modeler::RenderWindow::getBackground(double& r, double& g, double& b)
 {
-  GetRenderWindow()->GetRenderers()->GetFirstRenderer()->GetBackground(r, g, b);
+  renderWindow()->GetRenderers()->GetFirstRenderer()->GetBackground(r, g, b);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
 pcl::modeler::RenderWindow::setBackground(double r, double g, double b)
 {
-  GetRenderWindow()->GetRenderers()->GetFirstRenderer()->SetBackground(r, g, b);
+  renderWindow()->GetRenderers()->GetFirstRenderer()->SetBackground(r, g, b);
 }
 
 
@@ -170,7 +170,7 @@ pcl::modeler::RenderWindow::updateAxes()
 {
   vtkBoundingBox bb;
 
-  vtkActorCollection* actors = GetRenderWindow()->GetRenderers()->GetFirstRenderer()->GetActors();
+  vtkActorCollection* actors = renderWindow()->GetRenderers()->GetFirstRenderer()->GetActors();
 
   actors->InitTraversal();
   for (int i = 0, i_end = actors->GetNumberOfItems(); i < i_end; ++ i)
@@ -187,7 +187,7 @@ pcl::modeler::RenderWindow::updateAxes()
   double bounds[6];
   bb.GetBounds(bounds);
   axes_->SetBounds(bounds);
-  axes_->SetCamera(GetRenderWindow()->GetRenderers()->GetFirstRenderer()->GetActiveCamera());
+  axes_->SetCamera(renderWindow()->GetRenderers()->GetFirstRenderer()->GetActiveCamera());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -195,9 +195,9 @@ void
 pcl::modeler::RenderWindow::setShowAxes(bool flag)
 {
   if (flag)
-    GetRenderWindow()->GetRenderers()->GetFirstRenderer()->AddActor(axes_);
+    renderWindow()->GetRenderers()->GetFirstRenderer()->AddActor(axes_);
   else
-    GetRenderWindow()->GetRenderers()->GetFirstRenderer()->RemoveActor(axes_);
+    renderWindow()->GetRenderers()->GetFirstRenderer()->RemoveActor(axes_);
 
   return;
 }

--- a/apps/src/manual_registration/manual_registration.cpp
+++ b/apps/src/manual_registration/manual_registration.cpp
@@ -70,8 +70,8 @@ ManualRegistration::ManualRegistration ()
 
   // Set up the source window
   vis_src_.reset (new pcl::visualization::PCLVisualizer ("", false));
-  ui_->qvtk_widget_src->SetRenderWindow (vis_src_->getRenderWindow ());
-  vis_src_->setupInteractor (ui_->qvtk_widget_src->GetInteractor (), ui_->qvtk_widget_src->GetRenderWindow ());
+  ui_->qvtk_widget_src->setRenderWindow (vis_src_->getRenderWindow());
+  vis_src_->setupInteractor (ui_->qvtk_widget_src->interactor (), ui_->qvtk_widget_src->renderWindow ());
   vis_src_->getInteractorStyle ()->setKeyboardModifier (pcl::visualization::INTERACTOR_KB_MOD_SHIFT);
   ui_->qvtk_widget_src->update ();
 
@@ -79,8 +79,8 @@ ManualRegistration::ManualRegistration ()
 
   // Set up the destination window
   vis_dst_.reset (new pcl::visualization::PCLVisualizer ("", false));
-  ui_->qvtk_widget_dst->SetRenderWindow (vis_dst_->getRenderWindow ());
-  vis_dst_->setupInteractor (ui_->qvtk_widget_dst->GetInteractor (), ui_->qvtk_widget_dst->GetRenderWindow ());
+  ui_->qvtk_widget_dst->setRenderWindow (vis_dst_->getRenderWindow());
+  vis_dst_->setupInteractor (ui_->qvtk_widget_dst->interactor (), ui_->qvtk_widget_dst->renderWindow ());
   vis_dst_->getInteractorStyle ()->setKeyboardModifier (pcl::visualization::INTERACTOR_KB_MOD_SHIFT);
   ui_->qvtk_widget_dst->update ();
 

--- a/apps/src/manual_registration/manual_registration.ui
+++ b/apps/src/manual_registration/manual_registration.ui
@@ -37,7 +37,7 @@
    </property>
    <layout class="QGridLayout" name="gridLayout">
     <item row="0" column="3">
-     <widget class="QVTKWidget" name="qvtk_widget_src">
+     <widget class="QVTKOpenGLNativeWidget" name="qvtk_widget_src">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>255</horstretch>
@@ -133,7 +133,7 @@
      </layout>
     </item>
     <item row="0" column="7">
-     <widget class="QVTKWidget" name="qvtk_widget_dst">
+     <widget class="QVTKOpenGLNativeWidget" name="qvtk_widget_dst">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>255</horstretch>
@@ -161,9 +161,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QVTKWidget</class>
+   <class>QVTKOpenGLNativeWidget</class>
    <extends>QWidget</extends>
-   <header>QVTKWidget.h</header>
+   <header>QVTKOpenGLNativeWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -93,8 +93,8 @@ PCDVideoPlayer::PCDVideoPlayer ()
 
   // Set up the qvtk window
   vis_.reset (new pcl::visualization::PCLVisualizer ("", false));
-  ui_->qvtkWidget->SetRenderWindow (vis_->getRenderWindow ());
-  vis_->setupInteractor (ui_->qvtkWidget->GetInteractor (), ui_->qvtkWidget->GetRenderWindow ());
+  ui_->qvtkWidget->setRenderWindow (vis_->getRenderWindow ());
+  vis_->setupInteractor (ui_->qvtkWidget->interactor (), ui_->qvtkWidget->renderWindow ());
   vis_->getInteractorStyle ()->setKeyboardModifier (pcl::visualization::INTERACTOR_KB_MOD_SHIFT);
   ui_->qvtkWidget->update ();
 

--- a/apps/src/pcd_video_player/pcd_video_player.ui
+++ b/apps/src/pcd_video_player/pcd_video_player.ui
@@ -25,7 +25,7 @@
     </property>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QVTKWidget" name="qvtkWidget"/>
+      <widget class="QVTKOpenGLNativeWidget" name="qvtkWidget"/>
      </item>
      <item>
       <widget class="QSlider" name="indexSlider">
@@ -145,9 +145,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QVTKWidget</class>
+   <class>QVTKOpenGLNativeWidget</class>
    <extends>QWidget</extends>
-   <header>QVTKWidget.h</header>
+   <header>QVTKOpenGLNativeWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/apps/src/render_views_tesselated_sphere.cpp
+++ b/apps/src/render_views_tesselated_sphere.cpp
@@ -31,7 +31,8 @@ void
 pcl::apps::RenderViewsTesselatedSphere::generateViews() {
   //center object
   double CoM[3];
-  vtkIdType npts_com = 0, *ptIds_com = nullptr;
+  vtkIdType npts_com = 0;
+  const vtkIdType *ptIds_com = nullptr;
   vtkSmartPointer<vtkCellArray> cells_com = polydata_->GetPolys ();
 
   double center[3], p1_com[3], p2_com[3], p3_com[3], totalArea_com = 0;
@@ -90,7 +91,8 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
   // * Compute area of the mesh
   //////////////////////////////
   vtkSmartPointer<vtkCellArray> cells = mapper->GetInput ()->GetPolys ();
-  vtkIdType npts = 0, *ptIds = nullptr;
+  vtkIdType npts = 0;
+  const vtkIdType *ptIds = nullptr;
 
   double p1[3], p2[3], p3[3], totalArea = 0;
   for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)
@@ -359,7 +361,8 @@ pcl::apps::RenderViewsTesselatedSphere::generateViews() {
       polydata->BuildCells ();
 
       vtkSmartPointer<vtkCellArray> cells = polydata->GetPolys ();
-      vtkIdType npts = 0, *ptIds = nullptr;
+      vtkIdType npts = 0;
+      const vtkIdType *ptIds = nullptr;
 
       double p1[3], p2[3], p3[3], area, totalArea = 0;
       for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -343,7 +343,7 @@ pcl::io::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::PolygonMe
 
   // Now handle the polygons
   mesh.polygons.resize (nr_polygons);
-  vtkIdType* cell_points;
+  const vtkIdType *cell_points;
   vtkIdType nr_cell_points;
   vtkCellArray * mesh_polygons = poly_data->GetPolys ();
   mesh_polygons->InitTraversal ();

--- a/surface/include/pcl/surface/vtk_smoothing/vtk.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk.h
@@ -45,3 +45,4 @@
 
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
+#include <vtkUnsignedCharArray.h>

--- a/surface/src/vtk_smoothing/vtk_utils.cpp
+++ b/surface/src/vtk_smoothing/vtk_utils.cpp
@@ -154,7 +154,7 @@ pcl::VTKUtils::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::Pol
   }
 
   mesh.polygons.resize (nr_polygons);
-  vtkIdType* cell_points;
+  const vtkIdType *cell_points;
   vtkIdType nr_cell_points;
   vtkCellArray * mesh_polygons = poly_data->GetPolys ();
   mesh_polygons->InitTraversal ();

--- a/tools/mesh_sampling.cpp
+++ b/tools/mesh_sampling.cpp
@@ -87,7 +87,7 @@ randPSurface (vtkPolyData * polydata, std::vector<double> * cumulativeAreas, dou
 
   double A[3], B[3], C[3];
   vtkIdType npts = 0;
-  vtkIdType *ptIds = nullptr;
+  const vtkIdType *ptIds = nullptr;
   polydata->GetCellPoints (el, npts, ptIds);
   polydata->GetPoint (ptIds[0], A);
   polydata->GetPoint (ptIds[1], B);
@@ -138,7 +138,8 @@ uniform_sampling (vtkSmartPointer<vtkPolyData> polydata, std::size_t n_samples, 
 
   double p1[3], p2[3], p3[3], totalArea = 0;
   std::vector<double> cumulativeAreas (cells->GetNumberOfCells (), 0);
-  vtkIdType npts = 0, *ptIds = nullptr;
+  vtkIdType npts = 0;
+  const vtkIdType *ptIds = nullptr;
   std::size_t cellId = 0;
   for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds); cellId++)
   {

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -39,7 +39,6 @@
 #define PCL_PCL_VISUALIZER_IMPL_H_
 
 #include <vtkVersion.h>
-#include <vtkSmartPointer.h>
 #include <vtkCellArray.h>
 #include <vtkLeaderActor2D.h>
 #include <vtkVectorText.h>
@@ -1696,18 +1695,15 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (
   {
     // Create polys from polyMesh.polygons
     vtkSmartPointer<vtkCellArray> cell_array = vtkSmartPointer<vtkCellArray>::New ();
-    vtkIdType *cell = cell_array->WritePointer (vertices.size (), vertices.size () * (max_size_of_polygon + 1));
     int idx = 0;
     if (!lookup.empty ())
     {
       for (std::size_t i = 0; i < vertices.size (); ++i, ++idx)
       {
         std::size_t n_points = vertices[i].vertices.size ();
-        *cell++ = n_points;
-        //cell_array->InsertNextCell (n_points);
+        cell_array->InsertNextCell (n_points);
         for (std::size_t j = 0; j < n_points; j++, ++idx)
-          *cell++ = lookup[vertices[i].vertices[j]];
-          //cell_array->InsertCellPoint (lookup[vertices[i].vertices[j]]);
+          cell_array->InsertCellPoint (lookup[vertices[i].vertices[j]]);
       }
     }
     else
@@ -1715,11 +1711,9 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (
       for (std::size_t i = 0; i < vertices.size (); ++i, ++idx)
       {
         std::size_t n_points = vertices[i].vertices.size ();
-        *cell++ = n_points;
-        //cell_array->InsertNextCell (n_points);
+        cell_array->InsertNextCell (n_points);
         for (std::size_t j = 0; j < n_points; j++, ++idx)
-          *cell++ = vertices[i].vertices[j];
-          //cell_array->InsertCellPoint (vertices[i].vertices[j]);
+          cell_array->InsertCellPoint (vertices[i].vertices[j]);
       }
     }
     vtkSmartPointer<vtkPolyData> polydata;
@@ -1873,16 +1867,16 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
 
   // Update the cells
   cells = vtkSmartPointer<vtkCellArray>::New ();
-  vtkIdType *cell = cells->WritePointer (verts.size (), verts.size () * (max_size_of_polygon + 1));
+  cells->AllocateEstimate(verts.size (), verts.size () * (max_size_of_polygon + 1));
   int idx = 0;
   if (!lookup.empty ())
   {
     for (std::size_t i = 0; i < verts.size (); ++i, ++idx)
     {
       std::size_t n_points = verts[i].vertices.size ();
-      *cell++ = n_points;
-      for (std::size_t j = 0; j < n_points; j++, cell++, ++idx)
-        *cell = lookup[verts[i].vertices[j]];
+      cells->InsertNextCell(n_points);
+      for (std::size_t j = 0; j < n_points; j++, ++idx)
+        cells->InsertCellPoint(lookup[verts[i].vertices[j]]);
     }
   }
   else
@@ -1890,9 +1884,9 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
     for (std::size_t i = 0; i < verts.size (); ++i, ++idx)
     {
       std::size_t n_points = verts[i].vertices.size ();
-      *cell++ = n_points;
-      for (std::size_t j = 0; j < n_points; j++, cell++, ++idx)
-        *cell = verts[i].vertices[j];
+      cells->InsertNextCell(n_points);
+      for (std::size_t j = 0; j < n_points; j++, ++idx)
+        cells->InsertCellPoint(verts[i].vertices[j]);
     }
   }
   cells->GetData ()->SetNumberOfValues (idx);

--- a/visualization/include/pcl/visualization/interactor_style.h
+++ b/visualization/include/pcl/visualization/interactor_style.h
@@ -51,8 +51,8 @@
 #include <boost/signals2/signal.hpp>
 #endif
 #include <vtkInteractorStyleRubberBandPick.h>
+#include <vtkRendererCollection.h>
 
-class vtkRendererCollection;
 class vtkLegendScaleActor;
 class vtkScalarBarActor;
 class vtkPNGWriter;

--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -50,6 +50,7 @@
 #include <vtkDataArray.h>
 #include <vtkFloatArray.h>
 #include <vtkUnsignedCharArray.h>
+#include <vtkRenderWindow.h>
 
 namespace pcl
 {

--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
@@ -25,13 +25,13 @@
 
 #include "vtkMapper.h"
 #include "vtkSmartPointer.h"
+#include "vtkShaderProgram.h"
 
 class vtkOpenGLRenderWindow;
 class vtkPolyData;
 class vtkRenderer;
 class vtkRenderWindow;
 class vtkShader2;
-class vtkShaderProgram2;
 class vtkVertexBufferObject;
 
 class PCL_EXPORTS vtkVertexBufferObjectMapper : public vtkMapper
@@ -56,7 +56,7 @@ public:
   void SetInput(vtkDataSet *input);
   vtkPolyData *GetInput();
   
-  void SetProgram(vtkSmartPointer<vtkShaderProgram2> program)
+  void SetProgram(vtkSmartPointer<vtkShaderProgram> program)
   {
     this->program = program;
   }
@@ -118,7 +118,7 @@ protected:
   vtkVertexBufferObject *normalVbo;
 //  vtkVertexBufferObject *normalIndiceVbo;
 
-  vtkSmartPointer<vtkShaderProgram2> program;
+  vtkSmartPointer<vtkShaderProgram> program;
 
   int FillInputPortInformation(int, vtkInformation*) override;
 

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -52,7 +52,6 @@
 #include <vtkScalarBarActor.h>
 #include <vtkPNGWriter.h>
 #include <vtkWindowToImageFilter.h>
-#include <vtkRendererCollection.h>
 #include <vtkActorCollection.h>
 #include <vtkLegendScaleActor.h>
 #include <vtkRenderer.h>
@@ -137,7 +136,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::saveCameraParameters (const st
 {
   FindPokedRenderer (Interactor->GetEventPosition ()[0], Interactor->GetEventPosition ()[1]);
 
-  ofstream ofs_cam (file.c_str ());
+  std::ofstream ofs_cam (file.c_str ());
   if (!ofs_cam.is_open ())
   {
     return (false);

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3159,16 +3159,16 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
 
   // Update the cells
   cells = vtkSmartPointer<vtkCellArray>::New ();
-  vtkIdType *cell = cells->WritePointer (verts.size (), verts.size () * (max_size_of_polygon + 1));
+  cells->AllocateEstimate(verts.size (), verts.size () * (max_size_of_polygon + 1));
   int idx = 0;
   if (!lookup.empty ())
   {
     for (std::size_t i = 0; i < verts.size (); ++i, ++idx)
     {
       std::size_t n_points = verts[i].vertices.size ();
-      *cell++ = n_points;
-      for (std::size_t j = 0; j < n_points; j++, cell++, ++idx)
-        *cell = lookup[verts[i].vertices[j]];
+      cells->InsertNextCell (n_points);
+      for (std::size_t j = 0; j < n_points; j++, ++idx)
+        cells->InsertCellPoint (lookup[verts[i].vertices[j]]);
     }
   }
   else
@@ -3176,9 +3176,9 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
     for (std::size_t i = 0; i < verts.size (); ++i, ++idx)
     {
       std::size_t n_points = verts[i].vertices.size ();
-      *cell++ = n_points;
-      for (std::size_t j = 0; j < n_points; j++, cell++, ++idx)
-        *cell = verts[i].vertices[j];
+      cells->InsertNextCell(n_points);
+      for (std::size_t j = 0; j < n_points; j++, ++idx)
+        cells->InsertCellPoint(verts[i].vertices[j]);
     }
   }
   cells->GetData ()->SetNumberOfValues (idx);
@@ -3551,7 +3551,8 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
 
   //center object
   double CoM[3];
-  vtkIdType npts_com = 0, *ptIds_com = nullptr;
+  vtkIdType npts_com = 0;
+  const vtkIdType *ptIds_com = nullptr;
   vtkSmartPointer<vtkCellArray> cells_com = polydata->GetPolys ();
 
   double center[3], p1_com[3], p2_com[3], p3_com[3], totalArea_com = 0;
@@ -3610,7 +3611,8 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
   // * Compute area of the mesh
   //////////////////////////////
   vtkSmartPointer<vtkCellArray> cells = mapper->GetInput ()->GetPolys ();
-  vtkIdType npts = 0, *ptIds = nullptr;
+  vtkIdType npts = 0;
+  const vtkIdType *ptIds = nullptr;
 
   double p1[3], p2[3], p3[3], totalArea = 0;
   for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)
@@ -3829,7 +3831,8 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
     polydata->BuildCells ();
 
     vtkSmartPointer<vtkCellArray> cells = polydata->GetPolys ();
-    vtkIdType npts = 0, *ptIds = nullptr;
+    vtkIdType npts = 0;
+    const vtkIdType *ptIds = nullptr;
 
     double p1[3], p2[3], p3[3], area, totalArea = 0;
     for (cells->InitTraversal (); cells->GetNextCell (npts, ptIds);)

--- a/visualization/src/vtk/vtkVertexBufferObjectMapper.cxx
+++ b/visualization/src/vtk/vtkVertexBufferObjectMapper.cxx
@@ -33,7 +33,6 @@
 #include "vtkProperty.h"
 #include "vtkRenderer.h"
 #include "vtkRenderWindow.h"
-#include "vtkShaderProgram2.h"
 #include "vtkShader2.h"
 #include "vtkShader2Collection.h"
 #include "vtkUniformVariables.h"


### PR DESCRIPTION
Fixes #3370 by

- Replacing deprecated [QVTKWidget](https://github.com/Kitware/VTK/blob/master/GUISupport/Qt/QVTKWidget.h) with `QVTKOpenGLNativeWidget`.
- Fixing warning that VTK CMake components no longer start with 'vtk'.
- Adding FiltersGeometry to fix unresolved symbol when linking to `vtkDataSetSurfaceFilter::New()` which is in `libvtkFiltersGeometry-8.90.so`.
- Fixing undefined reference to `std::ofstream` missing namespace.
- Fixing compilation issue: current versions of VTK have [vtkShaderProgram](https://vtk.org/doc/nightly/html/classvtkShaderProgram.html) but [vtkShaderProgram2](https://vtk.org/doc/release/6.3/html/classvtkShaderProgram2.html) seems to be only in older versions. 
- Numerous other minor related changes to build successfully.