### PR TITLE
Use sqrt only when needed in SAC Models

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -192,10 +192,10 @@ pcl::SampleConsensusModelCircle2D<PointT>::countWithinDistance (
 
   const auto inlier_check = [&](const auto& idx) {
     const double squared_distance =
-        ( input_->points[idx].x - model_coefficients[0] ) *
-        ( input_->points[idx].x - model_coefficients[0] ) +
-        ( input_->points[idx].y - model_coefficients[1] ) *
-        ( input_->points[idx].y - model_coefficients[1] );
+        ( this->input_->points[idx].x - model_coefficients[0] ) *
+        ( this->input_->points[idx].x - model_coefficients[0] ) +
+        ( this->input_->points[idx].y - model_coefficients[1] ) *
+        ( this->input_->points[idx].y - model_coefficients[1] );
 
     return squared_distance < squared_threshold;
   };
@@ -323,10 +323,10 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
 
   const auto outlier_check = [&](const auto& idx) {
     const double squared_distance =
-        ( input_->points[idx].x - model_coefficients[0] ) *
-        ( input_->points[idx].x - model_coefficients[0] ) +
-        ( input_->points[idx].y - model_coefficients[1] ) *
-        ( input_->points[idx].y - model_coefficients[1] );
+        ( this->input_->points[idx].x - model_coefficients[0] ) *
+        ( this->input_->points[idx].x - model_coefficients[0] ) +
+        ( this->input_->points[idx].y - model_coefficients[1] ) *
+        ( this->input_->points[idx].y - model_coefficients[1] );
 
     return !(squared_distance < squared_threshold);
   };

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -169,21 +169,21 @@ pcl::SampleConsensusModelCircle3D<PointT>::selectWithinDistance (
     inliers.clear ();
     return;
   }
-  int nr_p = 0;
-  inliers.resize (indices_->size ());
+  inliers.reserve (indices_->size ());
+  const auto squared_threshold = threshold * threshold;
 
   // Iterate through the 3d points and calculate the distances from them to the sphere
-  for (std::size_t i = 0; i < indices_->size (); ++i)
+  for (const auto& idx: *indices_)
   {
     // what i have:
     // P : Sample Point
-    Eigen::Vector3d P (input_->points[(*indices_)[i]].x, input_->points[(*indices_)[i]].y, input_->points[(*indices_)[i]].z);
+    const Eigen::Vector3d P = input_->points[idx].getVector3fMap ().template cast<double> ();
     // C : Circle Center
-    Eigen::Vector3d C (model_coefficients[0], model_coefficients[1], model_coefficients[2]);
+    const Eigen::Vector3d C (model_coefficients[0], model_coefficients[1], model_coefficients[2]);
     // N : Circle (Plane) Normal
-    Eigen::Vector3d N (model_coefficients[4], model_coefficients[5], model_coefficients[6]);
+    const Eigen::Vector3d N (model_coefficients[4], model_coefficients[5], model_coefficients[6]);
     // r : Radius
-    double r = model_coefficients[3];
+    const double r = model_coefficients[3];
 
     Eigen::Vector3d helper_vectorPC = P - C;
     // 1.1. get line parameter
@@ -196,14 +196,12 @@ pcl::SampleConsensusModelCircle3D<PointT>::selectWithinDistance (
     Eigen::Vector3d K = C + r * helper_vectorP_projC.normalized ();
     Eigen::Vector3d distanceVector =  P - K;
 
-    if (distanceVector.norm () < threshold)
+    if (distanceVector.squaredNorm () < squared_threshold)
     {
       // Returns the indices of the points whose distances are smaller than the threshold
-      inliers[nr_p] = (*indices_)[i];
-      nr_p++;
+      inliers.push_back (idx);
     }
   }
-  inliers.resize (nr_p);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
@@ -198,6 +198,14 @@ pcl::SampleConsensusModelSphere<PointT>::selectWithinDistance (
       // @TODO: should abs be used here? The negative sign shows the direction of error
       // this should ideally be squared_distance + radius**2 + 2*radius*distance
       error_sqr_dists_.push_back (std::sqrt (squared_distance) - radius);
+      // @TODO: remove, only to test behavior change
+      if (std::abs (error_sqr_dists_.back ()) >= threshold)
+      {
+          std::cout << "sqr_dist:" << squared_distance << "\t"
+                    << "sqr_thresh: " << squared_threshold << "\t"
+                    << "error: " << error_sqr_dists_.back () << "\t"
+                    << "threshold: " << threshold << "\n";
+      }
     }
   }
 }

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
@@ -193,6 +193,16 @@ pcl::SampleConsensusModelSphere<PointT>::selectWithinDistance (
         ( input_->points[idx].z - model_coefficients[2] ) *
         ( input_->points[idx].z - model_coefficients[2] );
 
+    // @TODO: remove, only to test behavior change
+    if ((std::abs (std::sqrt(squared_distance) - radius) - threshold) !=
+        (std::abs (squared_distance - distance_offset) - squared_threshold))
+    {
+        std::cout << "sqr_dist:" << squared_distance << "\t"
+                  << "sqr_thresh: " << squared_threshold << "\t"
+                  << "error: " << (std::sqrt(squared_distance) - radius) << "\t"
+                  << "threshold: " << threshold << "\t";
+                  << "distance_offset: " << distance_offset << "\n";
+    }
     if (std::abs (squared_distance - distance_offset) < squared_threshold)
     {
       // Store the indices of the points whose distances are smaller than the threshold
@@ -200,14 +210,6 @@ pcl::SampleConsensusModelSphere<PointT>::selectWithinDistance (
       // @TODO: should abs be used here? The negative sign shows the direction of error
       // this should ideally be squared_distance + radius**2 + 2*radius*distance
       error_sqr_dists_.push_back (std::sqrt (squared_distance) - radius);
-      // @TODO: remove, only to test behavior change
-      if (std::abs (error_sqr_dists_.back ()) >= threshold)
-      {
-          std::cout << "sqr_dist:" << squared_distance << "\t"
-                    << "sqr_thresh: " << squared_threshold << "\t"
-                    << "error: " << error_sqr_dists_.back () << "\t"
-                    << "threshold: " << threshold << "\n";
-      }
     }
   }
 }


### PR DESCRIPTION
Reminded by the reduced usage of sqrt in the SSE PR