### PR TITLE
Warn user of unorganized PCD for pcl_train_linemod_template

### DIFF
--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -261,14 +261,24 @@ main (int argc, char** argv)
   float max_height = std::numeric_limits<float>::max ();
   parse_argument (argc, argv, "-max_height", max_height);
 
+  uint32_t unorganized_pcd_cnt = 0;
   // Segment and create templates for each input file
   for (const int &p_file_index : p_file_indices)
   {
     // Load input file
     const std::string input_filename = argv[p_file_index];
     PointCloudXYZRGBA::Ptr cloud (new PointCloudXYZRGBA);
+  
     if (!loadCloud (input_filename, *cloud)) 
       return (-1);
+
+    if (!cloud->isOrganized())
+    {
+      std::string warn_msg = "Loaded point cloud is not organized. Skipping " + input_filename + ".\n";
+      print_warn(warn_msg.c_str());
+      ++unorganized_pcd_cnt;
+      continue;
+    }
 
     // Construct output filenames
     std::string sqmmt_filename = input_filename;
@@ -282,6 +292,11 @@ main (int argc, char** argv)
 
     // Train the LINE-MOD template and output it to the specified file
     compute (cloud, min_depth, max_depth, max_height, pcd_filename, sqmmt_filename);
+  }
+
+  if (unorganized_pcd_cnt == p_file_indices.size())
+  {
+    print_error("All input pcd files are unorganied.\n");
   }
 
 }

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -274,7 +274,7 @@ main (int argc, char** argv)
 
     if (!cloud->isOrganized())
     {
-      std::string warn_msg = "Loaded point cloud is not organized. Skipping " + input_filename + ".\n";
+      std::string warn_msg = "Unorganized point cloud detected. Skipping file " + input_filename + "\n";
       print_warn(warn_msg.c_str());
       ++unorganized_pcd_cnt;
       continue;

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -296,8 +296,7 @@ main (int argc, char** argv)
 
   if (unorganized_pcd_cnt == p_file_indices.size())
   {
-    print_error("All input pcd files are unorganied.\n");
+    print_error("All input pcd files are unorganized.\n");
   }
 
 }
-

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -261,7 +261,7 @@ main (int argc, char** argv)
   float max_height = std::numeric_limits<float>::max ();
   parse_argument (argc, argv, "-max_height", max_height);
 
-  std::size_t unorganized_pcd_cnt = 0;
+  bool processed_at_least_one_pcd = false;
   // Segment and create templates for each input file
   for (const int &p_file_index : p_file_indices)
   {
@@ -276,8 +276,11 @@ main (int argc, char** argv)
     {
       std::string warn_msg = "Unorganized point cloud detected. Skipping file " + input_filename + "\n";
       print_warn(warn_msg.c_str());
-      ++unorganized_pcd_cnt;
       continue;
+    }
+    else
+    {
+      processed_at_least_one_pcd = true;
     }
 
     // Construct output filenames
@@ -294,7 +297,7 @@ main (int argc, char** argv)
     compute (cloud, min_depth, max_depth, max_height, pcd_filename, sqmmt_filename);
   }
 
-  if (unorganized_pcd_cnt == p_file_indices.size())
+  if (!processed_at_least_one_pcd)
   {
     print_error("All input pcd files are unorganized.\n");
   }

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -261,7 +261,7 @@ main (int argc, char** argv)
   float max_height = std::numeric_limits<float>::max ();
   parse_argument (argc, argv, "-max_height", max_height);
 
-  uint32_t unorganized_pcd_cnt = 0;
+  std::size_t unorganized_pcd_cnt = 0;
   // Segment and create templates for each input file
   for (const int &p_file_index : p_file_indices)
   {


### PR DESCRIPTION
Added a check to warn user whether input PCD files are unorganized. If check fails, skip to next input file. Added counter to output error if all input files fail.

Fixes #3633 