### PR TITLE
Adding configurable `pcl::index_t`

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -57,6 +57,7 @@ set(incs
   include/pcl/pcl_base.h
   include/pcl/pcl_exports.h
   include/pcl/pcl_macros.h
+  include/pcl/types.h
   include/pcl/point_cloud.h
   include/pcl/point_traits.h
   include/pcl/point_types_conversion.h

--- a/common/include/pcl/PCLHeader.h
+++ b/common/include/pcl/PCLHeader.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <pcl/memory.h>  // for shared_ptr
+
 #include <string>   // for string
 #include <ostream>  // for ostream
-
-#include <pcl/memory.h>  // for shared_ptr
 
 namespace pcl
 {
@@ -41,3 +41,4 @@ namespace pcl
   }
 
 } // namespace pcl
+

--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <pcl/memory.h>  // for shared_ptr
+
 #include <string>   // for string
 #include <ostream>  // for ostream
-
-#include <pcl/memory.h>  // for shared_ptr
 
 namespace pcl
 {
@@ -45,3 +45,4 @@ namespace pcl
     return (s);
   }
 } // namespace pcl
+

--- a/common/include/pcl/make_shared.h
+++ b/common/include/pcl/make_shared.h
@@ -39,3 +39,4 @@
 #warning "Do not use this header, its contents have been moved to pcl/memory.h"
 
 #include <pcl/memory.h>
+

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -65,8 +65,6 @@
 #include <cstdint>
 #include <iostream>
 
-#include <boost/cstdint.hpp>
-
 #include <pcl/pcl_config.h>
 
 // It seems that __has_cpp_attribute doesn't work correctly
@@ -87,30 +85,7 @@
   #define PCL_DEPRECATED(message)
 #endif
 
-namespace pcl
-{
-  /// \deprecated use std::uint8_t instead of pcl::uint8_t
-  using uint8_t PCL_DEPRECATED("use std::uint8_t instead of pcl::uint8_t") = std::uint8_t;
-  /// \deprecated use std::int8_t instead of pcl::int8_t
-  using int8_t PCL_DEPRECATED("use std::int8_t instead of pcl::int8_t") = std::int8_t;
-  /// \deprecated use std::uint16_t instead of pcl::uint16_t
-  using uint16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::uint16_t") = std::uint16_t;
-  /// \deprecated use std::uint16_t instead of pcl::int16_t
-  using int16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::int16_t") = std::int16_t;
-  /// \deprecated use std::uint32_t instead of pcl::uint32_t
-  using uint32_t PCL_DEPRECATED("use std::uint32_t instead of pcl::uint32_t") = std::uint32_t;
-  /// \deprecated use std::int32_t instead of pcl::int32_t
-  using int32_t PCL_DEPRECATED("use std::int32_t instead of pcl::int32_t") = std::int32_t;
-  /// \deprecated use std::uint64_t instead of pcl::uint64_t
-  using uint64_t PCL_DEPRECATED("use std::uint64_t instead of pcl::uint64_t") = std::uint64_t;
-  /// \deprecated use std::int64_t instead of pcl::int64_t
-  using int64_t PCL_DEPRECATED("use std::int64_t instead of pcl::int64_t") = std::int64_t;
-  /// \deprecated use std::int_fast16_t instead of pcl::int_fast16_t
-  using int_fast16_t PCL_DEPRECATED("use std::int_fast16_t instead of pcl::int_fast16_t") = std::int_fast16_t;
-}
-
 #if defined _WIN32
-
 // Define math constants, without including math.h, to prevent polluting global namespace with old math methods
 // Copied from math.h
 // Check for M_2_SQRTPI since the cmath header on mingw-w64 doesn't seem to define
@@ -395,3 +370,4 @@ aligned_free (void* ptr)
 #else
   #define PCL_NODISCARD
 #endif
+

--- a/common/include/pcl/types.h
+++ b/common/include/pcl/types.h
@@ -1,0 +1,135 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2020-, OpenPerception
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+/**
+ * \file pcl/types.h
+ *
+ * \brief Defines basic non-point types used by PCL
+ * \ingroup common
+ */
+
+#include <pcl/pcl_macros.h>
+
+#include <cstdint>
+
+namespace pcl
+{
+  using uint8_t PCL_DEPRECATED("use std::uint8_t instead of pcl::uint8_t") = std::uint8_t;
+  using int8_t PCL_DEPRECATED("use std::int8_t instead of pcl::int8_t") = std::int8_t;
+  using uint16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::uint16_t") = std::uint16_t;
+  using int16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::int16_t") = std::int16_t;
+  using uint32_t PCL_DEPRECATED("use std::uint32_t instead of pcl::uint32_t") = std::uint32_t;
+  using int32_t PCL_DEPRECATED("use std::int32_t instead of pcl::int32_t") = std::int32_t;
+  using uint64_t PCL_DEPRECATED("use std::uint64_t instead of pcl::uint64_t") = std::uint64_t;
+  using int64_t PCL_DEPRECATED("use std::int64_t instead of pcl::int64_t") = std::int64_t;
+  using int_fast16_t PCL_DEPRECATED("use std::int_fast16_t instead of pcl::int_fast16_t") = std::int_fast16_t;
+
+// temporary macros for customization. Only use for PCL < 1.12
+// Aim is to remove macros and instead allow multiple index types to coexist together
+#ifndef PCL_INDEX_SIZE
+#if PCL_MINOR_VERSION <= 11
+#define PCL_INDEX_SIZE sizeof(int)
+#else
+#define PCL_INDEX_SIZE 32
+#endif  // PCL_MINOR_VERSION
+#endif  // PCL_INDEX_SIZE
+
+#ifndef PCL_INDEX_SIGNED
+#define PCL_INDEX_SIGNED true
+#endif
+
+  namespace detail {
+    /**
+     * \brief int_type::type refers to an integral type that satisfies template parameters
+     * \tparam Bits number of bits in the integral type
+     * \tparam Signed signed or unsigned nature of the type
+     */
+    template <std::size_t Bits, bool Signed = true>
+    struct int_type { using type = void; };
+
+    /**
+     * \brief helper type to use for `int_type::type`
+     * \see int_type
+     */
+    template <std::size_t Bits, bool Signed = true>
+    using int_type_t = typename int_type<Bits, Signed>::type;
+
+    template <>
+    struct int_type<8, true> { using type = std::int8_t; };
+    template <>
+    struct int_type<8, false> { using type = std::uint8_t; };
+    template <>
+    struct int_type<16, true> { using type = std::int16_t; };
+    template <>
+    struct int_type<16, false> { using type = std::uint16_t; };
+    template <>
+    struct int_type<32, true> { using type = std::int32_t; };
+    template <>
+    struct int_type<32, false> { using type = std::uint32_t; };
+    template <>
+    struct int_type<64, true> { using type = std::int64_t; };
+    template <>
+    struct int_type<64, false> { using type = std::uint64_t; };
+
+    /**
+     * \brief number of bits in PCL's index type
+     *
+     * For PCL 1.11, please use PCL_INDEX_SIZE to choose a size best suited for your needs.
+     * PCL 1.12 will come with default 32, along with client code compile time choice
+     *
+     * PCL 1.11 has a default size = sizeof(int)
+     */
+    constexpr std::uint8_t index_type_size = PCL_INDEX_SIZE;
+
+    /**
+     * \brief signed/unsigned nature of PCL's index type
+     * For PCL 1.11, please use PCL_INDEX_SIGNED to choose a type best suited for your needs.
+     * PCL 1.12 will come with default signed, along with client code compile time choice
+     * Default: signed
+     */
+    constexpr bool index_type_signed = PCL_INDEX_SIGNED;
+}  // namespace detail
+
+  /**
+   * \brief Type used for indices in PCL
+   *
+   * Default index_t = int for PCL 1.11, std::int32_t for PCL >= 1.12
+   */
+  using index_t = detail::int_type_t<detail::index_type_size, detail::index_type_signed>;
+}  // namespace pcl
+

--- a/io/include/pcl/io/image.h
+++ b/io/include/pcl/io/image.h
@@ -33,21 +33,21 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 #pragma once
 
-#include <chrono>
-
-#include <pcl/pcl_config.h>
-#include <pcl/pcl_exports.h>
 #include <pcl/io/boost.h>
-
 #include <pcl/io/image_metadata_wrapper.h>
+#include <pcl/memory.h>
+#include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
+
+#include <chrono>
 
 namespace pcl
 {
   namespace io
-  { 
+  {
 
     /**
     * @brief Image interface class providing an interface to fill a RGB or Grayscale image buffer.
@@ -212,3 +212,4 @@ namespace pcl
 
   } // namespace
 }
+

--- a/io/include/pcl/io/image_metadata_wrapper.h
+++ b/io/include/pcl/io/image_metadata_wrapper.h
@@ -1,17 +1,17 @@
 /*
  * Software License Agreement (BSD License)
- * 
+ *
  * Point Cloud Library (PCL) - www.pointclouds.org
  * Copyright (c) 2009-2012, Willow Garage, Inc.
  * Copyright (c) 2012-, Open Perception, Inc.
  * Copyright (c) 2014, respective authors.
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *  * Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  *  * Redistributions in binary form must reproduce the above
@@ -21,7 +21,7 @@
  *  * Neither the name of the copyright holder(s) nor the names of its
  *    contributors may be used to endorse or promote products derived
  *    from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -41,7 +41,6 @@
 
 #include <pcl/memory.h>
 #include <pcl/pcl_config.h>
-#include <pcl/pcl_macros.h>
 
 namespace pcl
 {
@@ -82,3 +81,4 @@ namespace pcl
 
   } // namespace
 }
+

--- a/io/src/lzf.cpp
+++ b/io/src/lzf.cpp
@@ -4,7 +4,7 @@
  * Point Cloud Library (PCL) - www.pointclouds.org
  * Copyright (c) 2000-2010 Marc Alexander Lehmann <schmorp@schmorp.de>
  * Copyright (c) 2010-2011, Willow Garage, Inc.
- * 
+ *
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -17,7 +17,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -35,11 +35,13 @@
  *
  */
 
-#include <pcl/io/lzf.h>
-#include <cstring>
-#include <climits>
 #include <pcl/console/print.h>
+#include <pcl/io/lzf.h>
+
 #include <cerrno>
+#include <climits>
+#include <cstddef>
+#include <cstring>
 
 /*
  * Size of hashtable is (1 << HLOG) * sizeof (char *)
@@ -114,7 +116,7 @@ pcl::lzfCompress (const void *const in_data, unsigned int in_len,
 
     hval = (hval << 8) | ip[2];
     hslot = htab + IDX (hval);
-    const unsigned char *ref = *hslot + (static_cast<const unsigned char*> (in_data)); 
+    const unsigned char *ref = *hslot + (static_cast<const unsigned char*> (in_data));
     *hslot = static_cast<unsigned int> (ip - (static_cast<const unsigned char*> (in_data)));
 
     // off requires a type wide enough to hold a general pointer difference.
@@ -125,14 +127,14 @@ pcl::lzfCompress (const void *const in_data, unsigned int in_len,
     // special workaround for it.
 #if defined (WIN32) && defined (_M_X64) && defined (_MSC_VER)
     // workaround for missing POSIX compliance
-    unsigned _int64 off; 
+    unsigned _int64 off;
 #else
     unsigned long off;
 #endif
 
     if (
         // The next test will actually take care of this, but this is faster if htab is initialized
-        ref < ip 
+        ref < ip
         && (off = ip - ref - 1) < (1 << 13)
         && ref > static_cast<const unsigned char *> (in_data)
         && ref[2] == ip[2]
@@ -145,7 +147,7 @@ pcl::lzfCompress (const void *const in_data, unsigned int in_len,
     {
       // Match found at *ref++
       unsigned int len = 2;
-      ptrdiff_t maxlen = in_end - ip - len;
+      std::ptrdiff_t maxlen = in_end - ip - len;
       maxlen = maxlen > ((1 << 8) + (1 << 3)) ? ((1 << 8) + (1 << 3)) : maxlen;
 
       // First a faster conservative test
@@ -248,7 +250,7 @@ pcl::lzfCompress (const void *const in_data, unsigned int in_len,
     }
   }
 
-  // At most 3 bytes can be missing here 
+  // At most 3 bytes can be missing here
   if (op + 3 > out_end)
     return (0);
 
@@ -274,7 +276,7 @@ pcl::lzfCompress (const void *const in_data, unsigned int in_len,
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-unsigned int 
+unsigned int
 pcl::lzfDecompress (const void *const in_data,  unsigned int in_len,
                     void             *out_data, unsigned int out_len)
 {

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -38,11 +38,10 @@
 
 #pragma once
 
-#include <cassert> // for assert
-#include <cstddef>
 #include <vector>
 
-#include <pcl/pcl_macros.h>
+#include <cassert>
+#include <cstddef>
 
 namespace pcl {
 namespace octree {

--- a/octree/include/pcl/octree/octree_key.h
+++ b/octree/include/pcl/octree/octree_key.h
@@ -60,7 +60,7 @@ public:
   {}
 
   /** \brief Copy constructor. */
-  OctreeKey(const OctreeKey& source) { memcpy(key_, source.key_, sizeof(key_)); }
+  OctreeKey(const OctreeKey& source) { std::memcpy(key_, source.key_, sizeof(key_)); }
 
   OctreeKey&
   operator=(const OctreeKey&) = default;

--- a/simulation/include/pcl/simulation/camera.h
+++ b/simulation/include/pcl/simulation/camera.h
@@ -2,7 +2,6 @@
 
 #include <Eigen/Dense>
 #include <Eigen/StdVector>
-#include <boost/shared_ptr.hpp>
 
 #include <pcl/memory.h>
 #include <pcl/pcl_macros.h>


### PR DESCRIPTION
* Separated types from macros
* Added `pcl::index_t` and related changes

TODO (need to discuss where):
* CMake integration for `PCL_INDEX_SIZE` and `PCL_INDEX_SIGNED`. Might make sense to have a separate PR for this and keep this strictly related to new type
* Use `pcl::index_t` in `Indices`