### PR TITLE
Fixed if/ifdef WIN32 issues

### DIFF
--- a/apps/cloud_composer/src/cloud_composer.cpp
+++ b/apps/cloud_composer/src/cloud_composer.cpp
@@ -210,13 +210,13 @@ pcl::cloud_composer::ComposerMainWindow::initializePlugins ()
 {
   QDir plugin_dir = QCoreApplication::applicationDirPath ();
   qDebug() << plugin_dir.path ()<< "   "<<QDir::cleanPath ("../lib/cloud_composer_plugins");
-#if _WIN32
+#ifdef _WIN32
   if (!plugin_dir.cd (QDir::cleanPath ("cloud_composer_plugins")))
 #else
   if (!plugin_dir.cd (QDir::cleanPath ("../lib/cloud_composer_plugins")))
 #endif
   {
-    #if _WIN32
+    #ifdef _WIN32
       if (!plugin_dir.cd (QDir::cleanPath ("cloud_composer_plugins")))
     #else
       if (!plugin_dir.cd (QDir::cleanPath ("../lib")))
@@ -226,7 +226,7 @@ pcl::cloud_composer::ComposerMainWindow::initializePlugins ()
       }
   }
   QStringList plugin_filter;
-#if _WIN32
+#ifdef _WIN32
   plugin_filter << "pcl_cc_tool_*.dll";
 #else
   plugin_filter << "libpcl_cc_tool_*.so";

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
@@ -48,7 +48,7 @@
 # include <OpenGL/gl.h>
 # include <OpenGL/glu.h>
 #else
-#if _WIN32
+#ifdef _WIN32
 // Need this to pull in APIENTRY, etc.
 #include "windows.h"
 #endif

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -121,7 +121,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   oss.flush ();
   data_idx = static_cast<int> (oss.tellp ());
 
-#if _WIN32
+#ifdef _WIN32
   HANDLE h_native_file = CreateFileA (file_name.c_str (), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h_native_file == INVALID_HANDLE_VALUE)
   {
@@ -161,7 +161,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   data_size = cloud.points.size () * fsize;
 
   // Prepare the map
-#if _WIN32
+#ifdef _WIN32
   HANDLE fm = CreateFileMappingA (h_native_file, NULL, PAGE_READWRITE, 0, (DWORD) (data_idx + data_size), NULL);
   if (fm == NULL)
   {
@@ -209,13 +209,13 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   }
 
   // If the user set the synchronization flag on, call msync
-#if !_WIN32
+#ifndef _WIN32
   if (map_synchronization_)
     msync (map, data_idx + data_size, MS_SYNC);
 #endif
 
   // Unmap the pages of memory
-#if _WIN32
+#ifdef _WIN32
     UnmapViewOfFile (map);
 #else
   if (::munmap (map, (data_idx + data_size)) == -1)
@@ -227,7 +227,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   }
 #endif
   // Close file
-#if _WIN32
+#ifdef _WIN32
   CloseHandle (h_native_file);
 #else
   io::raw_close (fd);
@@ -252,7 +252,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   oss.flush ();
   data_idx = static_cast<int> (oss.tellp ());
 
-#if _WIN32
+#ifdef _WIN32
   HANDLE h_native_file = CreateFileA (file_name.c_str (), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h_native_file == INVALID_HANDLE_VALUE)
   {
@@ -355,7 +355,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   }
   else
   {
-#if !_WIN32
+#ifndef _WIN32
     io::raw_close (fd);
 #endif
     resetLockingPermissions (file_name, file_lock);
@@ -364,7 +364,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   }
 
   // Prepare the map
-#if _WIN32
+#ifdef _WIN32
   HANDLE fm = CreateFileMapping (h_native_file, NULL, PAGE_READWRITE, 0, compressed_final_size, NULL);
   char *map = static_cast<char*>(MapViewOfFile (fm, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, compressed_final_size));
   CloseHandle (fm);
@@ -396,14 +396,14 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   // Copy the compressed data
   memcpy (&map[data_idx], temp_buf, data_size);
 
-#if !_WIN32
+#ifndef _WIN32
   // If the user set the synchronization flag on, call msync
   if (map_synchronization_)
     msync (map, compressed_final_size, MS_SYNC);
 #endif
 
   // Unmap the pages of memory
-#if _WIN32
+#ifdef _WIN32
     UnmapViewOfFile (map);
 #else
   if (::munmap (map, (compressed_final_size)) == -1)
@@ -416,7 +416,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
 #endif
 
   // Close file
-#if _WIN32
+#ifdef _WIN32
   CloseHandle (h_native_file);
 #else
   io::raw_close (fd);
@@ -598,7 +598,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   oss.flush ();
   data_idx = static_cast<int> (oss.tellp ());
 
-#if _WIN32
+#ifdef _WIN32
   HANDLE h_native_file = CreateFileA (file_name.c_str (), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h_native_file == INVALID_HANDLE_VALUE)
   {
@@ -638,7 +638,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   data_size = indices.size () * fsize;
 
   // Prepare the map
-#if _WIN32
+#ifdef _WIN32
   HANDLE fm = CreateFileMapping (h_native_file, NULL, PAGE_READWRITE, 0, data_idx + data_size, NULL);
   char *map = static_cast<char*>(MapViewOfFile (fm, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, data_idx + data_size));
   CloseHandle (fm);
@@ -680,14 +680,14 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
     }
   }
 
-#if !_WIN32
+#ifndef _WIN32
   // If the user set the synchronization flag on, call msync
   if (map_synchronization_)
     msync (map, data_idx + data_size, MS_SYNC);
 #endif
 
   // Unmap the pages of memory
-#if _WIN32
+#ifdef _WIN32
     UnmapViewOfFile (map);
 #else
   if (::munmap (map, (data_idx + data_size)) == -1)
@@ -699,7 +699,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   }
 #endif
   // Close file
-#if _WIN32
+#ifdef _WIN32
   CloseHandle(h_native_file);
 #else
   io::raw_close (fd);

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -192,7 +192,7 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
 
     getDeviceType(device.device_node.GetCreationInfo (), vendor_id, product_id );
 
-#if _WIN32
+#ifdef _WIN32
     if (vendor_id == 0x45e)
     {
       strcpy (const_cast<char*> (device_context_[device].device_node.GetDescription ().strVendor), "Microsoft");
@@ -428,7 +428,7 @@ openni_wrapper::OpenNIDriver::getSerialNumber (unsigned index) const throw ()
 void 
 openni_wrapper::OpenNIDriver::getDeviceType (const std::string& connectionString, unsigned short& vendorId, unsigned short& productId)
 {
-#if _WIN32
+#ifdef _WIN32
     // expected format: "\\?\usb#vid_[ID]&pid_[ID]#[SERIAL]#{GUID}"
     using tokenizer = boost::tokenizer<boost::char_separator<char> >;
     boost::char_separator<char> separators("#&_");

--- a/io/src/pcd_grabber.cpp
+++ b/io/src/pcd_grabber.cpp
@@ -204,7 +204,7 @@ bool
 pcl::PCDGrabberBase::PCDGrabberImpl::readTARHeader ()
 {
   // Read in the header
-#ifdef WIN32
+#ifdef _WIN32
   int result = static_cast<int> (_read (tar_fd_, reinterpret_cast<char*> (&tar_header_), 512));
 #else
   int result = static_cast<int> (::read (tar_fd_, reinterpret_cast<char*> (&tar_header_), 512));
@@ -459,5 +459,4 @@ pcl::PCDGrabberBase::numFrames () const
 {
   return (impl_->numFrames ());
 }
-
 

--- a/io/src/pcd_grabber.cpp
+++ b/io/src/pcd_grabber.cpp
@@ -204,7 +204,7 @@ bool
 pcl::PCDGrabberBase::PCDGrabberImpl::readTARHeader ()
 {
   // Read in the header
-#if WIN32
+#ifdef WIN32
   int result = static_cast<int> (_read (tar_fd_, reinterpret_cast<char*> (&tar_header_), 512));
 #else
   int result = static_cast<int> (::read (tar_fd_, reinterpret_cast<char*> (&tar_header_), 512));


### PR DESCRIPTION
Fixes #3667

Replaced all occurrences (a scary sentence) of `#if WIN32`, `#if _WIN32` and other variants with the proper `#ifdef` or `#ifndef`, in all `*.cpp`, `*.h` and `*.hpp` files, as discussed in #3667.

I'm not sure if I was supposed to touch `_WIN32` occurrences, but have done so anway.

Please do check my work.