### PR TITLE
Update stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,28 +1,52 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
-# Number of days of inactivity before a stale Issue or Pull Request is closed
-# False means never close
-daysUntilClose: false
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  - "needs: author reply"
+  - "needs: more work"
+
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels:
-  - "status: needs review"
-  - "status: needs testing"
-  - "status: needs decision"
-  - "status: ready to merge"
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
 # Label to use when marking as stale
 staleLabel: "status: stale"
-# Comment to post when marking as stale. Set to `false` to disable
-markComment: |
-  This pull request has been automatically marked as stale because it hasn't had
-  any activity in the past 60 days. Commenting or adding a new commit to the
-  pull request will revert this.
 
-  Come back whenever you have time. We look forward to your contribution.
-# Comment to post when removing the stale label. Set to `false` to disable
-unmarkComment: false
-# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
-closeComment: false
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had any activity in the past month. It will be closed if no further activity occurs.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
 # Limit to only `issues` or `pulls`
-only: pulls
+# only: issues
+
+# Configuration settings that are specific to just 'pulls':
+pulls:
+  daysUntilClose: false
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had any activity in the past month. Commenting or adding a new commit to the pull request will revert this.


### PR DESCRIPTION
This alternates the behavior of the stalebot in several ways:
  * Issues can now be stale. We want the bot to chase down unconfirmed issues abandoned by their authors. If the author has lost interest, why would we care?
  * Reduce timeout until issue/pr is considered stale to 1 month. One of the purposes of marking issues/prs as stale is to poke their authors to return and finish off work. The longer we wait, the less the chance they are still somewhat motivated.
  * Stale issues are automatically closed after 7 days. If the author did not reply to the poke, close the issue soon. It can be re-opened anyway if the author awakens.
  * Only "needs: author reply" and "needs: more work" labels can become stale. These indicate that action from the author is needed.

This change comes out of the discussion in #3602.