### PR TITLE
Single check for USE_ROS macro

### DIFF
--- a/common/include/pcl/PCLHeader.h
+++ b/common/include/pcl/PCLHeader.h
@@ -4,7 +4,6 @@
 #include <ostream>  // for ostream
 
 #include <pcl/make_shared.h>  // for shared_ptr
-#include <pcl/pcl_config.h>   // for compatibility
 
 namespace pcl
 {

--- a/common/include/pcl/PCLHeader.h
+++ b/common/include/pcl/PCLHeader.h
@@ -1,14 +1,10 @@
 #pragma once
 
-#ifdef USE_ROS
-   #error USE_ROS setup requires PCL to compile against ROS message headers, which is now deprecated
-#endif 
+#include <string>   // for string
+#include <ostream>  // for ostream
 
-#include <string>
-#include <vector>
-#include <boost/shared_ptr.hpp>
-#include <pcl/pcl_macros.h>
-#include <ostream>
+#include <pcl/make_shared.h>  // for shared_ptr
+#include <pcl/pcl_config.h>   // for compatibility
 
 namespace pcl
 {

--- a/common/include/pcl/PCLImage.h
+++ b/common/include/pcl/PCLImage.h
@@ -1,15 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
-#include <ostream>
-
-#ifdef USE_ROS
-   #error USE_ROS setup requires PCL to compile against ROS message headers, which is now deprecated
-#endif   
+#include <string>   // for string
+#include <vector>   // for vector
+#include <ostream>  // for ostream
 
 // Include the correct Header path here
-#include <pcl/PCLHeader.h>
+#include <pcl/PCLHeader.h>   // for PCLHeader
 
 namespace pcl
 {

--- a/common/include/pcl/PCLImage.h
+++ b/common/include/pcl/PCLImage.h
@@ -4,7 +4,6 @@
 #include <vector>   // for vector
 #include <ostream>  // for ostream
 
-// Include the correct Header path here
 #include <pcl/PCLHeader.h>   // for PCLHeader
 
 namespace pcl

--- a/common/include/pcl/PCLPointCloud2.h
+++ b/common/include/pcl/PCLPointCloud2.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#ifdef USE_ROS
-   #error USE_ROS setup requires PCL to compile against ROS message headers, which is now deprecated
-#endif
-
 #include <ostream>
 #include <vector>
 
@@ -122,7 +118,7 @@ namespace pcl
     }
     s << "is_dense: ";
     s << "  " << v.is_dense << std::endl;
-    
+
     return (s);
   }
 

--- a/common/include/pcl/PCLPointCloud2.h
+++ b/common/include/pcl/PCLPointCloud2.h
@@ -5,7 +5,6 @@
 
 #include <boost/predef/other/endian.h>
 
-// Include the correct Header path here
 #include <pcl/PCLHeader.h>
 #include <pcl/PCLPointField.h>
 

--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -4,7 +4,6 @@
 #include <ostream>  // for ostream
 
 #include <pcl/make_shared.h>  // for shared_ptr
-#include <pcl/pcl_config.h>   // for compatibility
 
 namespace pcl
 {

--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -3,7 +3,7 @@
 #include <string>   // for string
 #include <ostream>  // for ostream
 
-#include <pcl/make_shared.h>  // for shared_ptr
+#include <pcl/pcl_macros.h>  // for shared_ptr
 
 namespace pcl
 {

--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -1,13 +1,10 @@
 #pragma once
 
-#ifdef USE_ROS
-   #error USE_ROS setup requires PCL to compile against ROS message headers, which is now deprecated
-#endif 
+#include <string>   // for string
+#include <ostream>  // for ostream
 
-#include <string>
-#include <vector>
-#include <ostream>
-#include <pcl/pcl_macros.h>
+#include <pcl/make_shared.h>  // for shared_ptr
+#include <pcl/pcl_config.h>   // for compatibility
 
 namespace pcl
 {

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <algorithm>
+#include <vector>
 
 #include <pcl/point_types.h>
 #include <pcl/pcl_macros.h>

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -7,11 +7,6 @@
   #error PCL requires C++14 or above
 #endif
 
-// PCL was a ROS package earlier but no longer depends on ROS
-#ifdef USE_ROS
-   #error USE_ROS setup requires PCL to compile against ROS message headers, which is now deprecated
-#endif
-
 #define BUILD_@CMAKE_BUILD_TYPE@
 /* PCL version information */
 #define PCL_MAJOR_VERSION ${PCL_VERSION_MAJOR}

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -7,6 +7,11 @@
   #error PCL requires C++14 or above
 #endif
 
+// PCL was a ROS package earlier but no longer depends on ROS
+#ifdef USE_ROS
+   #error USE_ROS setup requires PCL to compile against ROS message headers, which is now deprecated
+#endif
+
 #define BUILD_@CMAKE_BUILD_TYPE@
 /* PCL version information */
 #define PCL_MAJOR_VERSION ${PCL_VERSION_MAJOR}


### PR DESCRIPTION
USE_ROS was checked in multiple places, now it's checked in one place.

Easier to remove after deprecation period.