### PR TITLE
Fix mingw-w64 issues with math defines

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,28 +1,52 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
-# Number of days of inactivity before a stale Issue or Pull Request is closed
-# False means never close
-daysUntilClose: false
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  - "needs: author reply"
+  - "needs: more work"
+
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels:
-  - "status: needs review"
-  - "status: needs testing"
-  - "status: needs decision"
-  - "status: ready to merge"
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
 # Label to use when marking as stale
 staleLabel: "status: stale"
-# Comment to post when marking as stale. Set to `false` to disable
-markComment: |
-  This pull request has been automatically marked as stale because it hasn't had
-  any activity in the past 60 days. Commenting or adding a new commit to the
-  pull request will revert this.
 
-  Come back whenever you have time. We look forward to your contribution.
-# Comment to post when removing the stale label. Set to `false` to disable
-unmarkComment: false
-# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
-closeComment: false
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had any activity in the past month. It will be closed if no further activity occurs.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
 # Limit to only `issues` or `pulls`
-only: pulls
+# only: issues
+
+# Configuration settings that are specific to just 'pulls':
+pulls:
+  daysUntilClose: false
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had any activity in the past month. Commenting or adding a new commit to the pull request will revert this.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,8 @@ elseif(__COMPILER_PATHSCALE)
   set(CMAKE_COMPILER_IS_PATHSCALE 1)
 elseif(MSVC)
   set(CMAKE_COMPILER_IS_MSVC 1)
+elseif(MINGW)
+  set(CMAKE_COMPILER_IS_MINGW 1)
 endif()
 
 # Create a variable with expected default CXX flags
@@ -213,6 +215,10 @@ if(CMAKE_COMPILER_IS_CLANG)
     endif()
   endif()
   set(CLANG_LIBRARIES "stdc++")
+endif()
+
+if(CMAKE_COMPILER_IS_MINGW)
+  add_definitions(-DPCL_ONLY_CORE_POINT_TYPES)
 endif()
 
 include("${PCL_SOURCE_DIR}/cmake/pcl_utils.cmake")

--- a/apps/cloud_composer/src/cloud_composer.cpp
+++ b/apps/cloud_composer/src/cloud_composer.cpp
@@ -210,13 +210,13 @@ pcl::cloud_composer::ComposerMainWindow::initializePlugins ()
 {
   QDir plugin_dir = QCoreApplication::applicationDirPath ();
   qDebug() << plugin_dir.path ()<< "   "<<QDir::cleanPath ("../lib/cloud_composer_plugins");
-#if _WIN32
+#ifdef _WIN32
   if (!plugin_dir.cd (QDir::cleanPath ("cloud_composer_plugins")))
 #else
   if (!plugin_dir.cd (QDir::cleanPath ("../lib/cloud_composer_plugins")))
 #endif
   {
-    #if _WIN32
+    #ifdef _WIN32
       if (!plugin_dir.cd (QDir::cleanPath ("cloud_composer_plugins")))
     #else
       if (!plugin_dir.cd (QDir::cleanPath ("../lib")))
@@ -226,7 +226,7 @@ pcl::cloud_composer::ComposerMainWindow::initializePlugins ()
       }
   }
   QStringList plugin_filter;
-#if _WIN32
+#ifdef _WIN32
   plugin_filter << "pcl_cc_tool_*.dll";
 #else
   plugin_filter << "libpcl_cc_tool_*.so";

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloud.h
@@ -48,7 +48,7 @@
 # include <OpenGL/gl.h>
 # include <OpenGL/glu.h>
 #else
-#if _WIN32
+#ifdef _WIN32
 // Need this to pull in APIENTRY, etc.
 #include "windows.h"
 #endif

--- a/cmake/Modules/FindRSSDK2.cmake
+++ b/cmake/Modules/FindRSSDK2.cmake
@@ -9,7 +9,7 @@
 #  RSSDK2_INCLUDE_DIRS          The location(s) of RealSense SDK 2.0 headers
 #  RSSDK2_LIBRARIES             Libraries needed to use RealSense SDK 2.0
 
-find_package(realsense2)
+find_package(realsense2 QUIET)
 
 set(RSSDK2_FOUND ${realsense2_FOUND})
 set(RSSDK2_INCLUDE_DIRS ${realsense2_INCLUDE_DIR})
@@ -17,4 +17,6 @@ set(RSSDK2_LIBRARIES ${realsense2_LIBRARY})
 
 if(RSSDK2_FOUND)
   message(STATUS "RealSense SDK 2 found (include: ${RSSDK2_INCLUDE_DIRS}, lib: ${RSSDK2_LIBRARIES}, version: ${realsense2_VERSION})")
+else ()
+  message(STATUS "Could NOT find RSSDK2")
 endif()

--- a/common/include/pcl/common/file_io.h
+++ b/common/include/pcl/common/file_io.h
@@ -39,12 +39,10 @@
 #pragma once
 
 #include <iostream>
-#ifndef _WIN32
-  #include <boost/filesystem.hpp>
-  #include <boost/range/iterator_range.hpp>
-#endif
 #include <vector>
 #include <algorithm>
+#include <boost/filesystem.hpp>
+#include <boost/range/iterator_range.hpp>
 
 /** 
   * \file pcl/common/file_io.h

--- a/common/include/pcl/common/file_io.h
+++ b/common/include/pcl/common/file_io.h
@@ -40,7 +40,8 @@
 
 #include <iostream>
 #ifndef _WIN32
-  #include <dirent.h>
+  #include <boost/filesystem.hpp>
+  #include <boost/range/iterator_range.hpp>
 #endif
 #include <vector>
 #include <algorithm>

--- a/common/include/pcl/common/file_io.h
+++ b/common/include/pcl/common/file_io.h
@@ -41,8 +41,6 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
-#include <boost/filesystem.hpp>
-#include <boost/range/iterator_range.hpp>
 
 /** 
   * \file pcl/common/file_io.h

--- a/common/include/pcl/common/impl/file_io.hpp
+++ b/common/include/pcl/common/impl/file_io.hpp
@@ -39,6 +39,9 @@
 #ifndef PCL_COMMON_FILE_IO_IMPL_HPP_
 #define PCL_COMMON_FILE_IO_IMPL_HPP_
 
+#include <boost/filesystem.hpp>
+#include <boost/range/iterator_range.hpp>
+
 namespace pcl
 {
 
@@ -51,20 +54,17 @@ void getAllPcdFilesInDirectory(const std::string& directory, std::vector<std::st
     {
       if (boost::filesystem::is_regular_file(entry))
       {
-        std::string file_name = entry.path().filename().string();
-        if (entry.path().extension() == "pcd")
-          file_names.emplace_back(file_name);
+        if (entry.path().extension() == ".pcd")
+          file_names.emplace_back(entry.path().filename().string());
       }
     }
   }
   else
   {
-    std::cerr << "Could not open directory.\n";
+    std::cerr << "Given path is not a directory\n";
     return;
   }
   std::sort(file_names.begin(), file_names.end());
-  //for (unsigned int i=0; i<file_names.size(); ++i)
-  //std::cout << file_names[i]<<"\n";
 }
 
 std::string getFilenameWithoutPath(const std::string& input)

--- a/common/include/pcl/common/impl/file_io.hpp
+++ b/common/include/pcl/common/impl/file_io.hpp
@@ -42,21 +42,30 @@
 namespace pcl
 {
 
-  void getAllPcdFilesInDirectory(const std::string& directory, std::vector<std::string>& file_names)
+void getAllPcdFilesInDirectory(const std::string& directory, std::vector<std::string>& file_names)
+{
+  boost::filesystem::path p(directory);
+  if(boost::filesystem::is_directory(p))
   {
-    boost::filesystem::path p(directory);
-    if(boost::filesystem::is_directory(p)) {
-      for(auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(p), {}))
-        if (boost::filesystem::is_regular_file(entry)) {
-          std::string file_name = entry.path().filename().string();
-          if (file_name.size() >= 4 && file_name.substr(file_name.size()-4, 4)==".pcd")
-            file_names.emplace_back(file_name);
-        }
+    for(const auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(p), {}))
+    {
+      if (boost::filesystem::is_regular_file(entry))
+      {
+        std::string file_name = entry.path().filename().string();
+        if (entry.path().extension() == "pcd")
+          file_names.emplace_back(file_name);
+      }
     }
-    std::sort(file_names.begin(), file_names.end());
-    //for (unsigned int i=0; i<file_names.size(); ++i)
-      //std::cout << file_names[i]<<"\n";
   }
+  else
+  {
+    std::cerr << "Could not open directory.\n";
+    return;
+  }
+  std::sort(file_names.begin(), file_names.end());
+  //for (unsigned int i=0; i<file_names.size(); ++i)
+  //std::cout << file_names[i]<<"\n";
+}
 
 std::string getFilenameWithoutPath(const std::string& input)
 {

--- a/common/include/pcl/common/impl/file_io.hpp
+++ b/common/include/pcl/common/impl/file_io.hpp
@@ -45,21 +45,15 @@ namespace pcl
 #ifndef _WIN32
   void getAllPcdFilesInDirectory(const std::string& directory, std::vector<std::string>& file_names)
   {
-    DIR *dp;
-    struct dirent *dirp;
-    if((dp  = opendir(directory.c_str())) == nullptr) {
-      std::cerr << "Could not open directory.\n";
-      return;
+    boost::filesystem::path p(directory);
+    if(boost::filesystem::is_directory(p)) {
+      for(boost::filesystem::directory_entry& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(p), {}))
+        if (boost::filesystem::is_regular_file(entry)) {
+          std::string file_name = entry.path().filename().string();
+          if (file_name.size() >= 4 && file_name.substr(file_name.size()-4, 4)==".pcd")
+            file_names.emplace_back(file_name);
+        }
     }
-    while ((dirp = readdir(dp)) != nullptr) {
-      if (dirp->d_type == DT_REG)  // Only regular files
-      {
-        std::string file_name = dirp->d_name;
-        if (file_name.substr(file_name.size()-4, 4)==".pcd")
-          file_names.emplace_back(dirp->d_name);
-      }
-    }
-    closedir(dp);
     std::sort(file_names.begin(), file_names.end());
     //for (unsigned int i=0; i<file_names.size(); ++i)
       //std::cout << file_names[i]<<"\n";

--- a/common/include/pcl/common/impl/file_io.hpp
+++ b/common/include/pcl/common/impl/file_io.hpp
@@ -42,12 +42,11 @@
 namespace pcl
 {
 
-#ifndef _WIN32
   void getAllPcdFilesInDirectory(const std::string& directory, std::vector<std::string>& file_names)
   {
     boost::filesystem::path p(directory);
     if(boost::filesystem::is_directory(p)) {
-      for(boost::filesystem::directory_entry& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(p), {}))
+      for(auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(p), {}))
         if (boost::filesystem::is_regular_file(entry)) {
           std::string file_name = entry.path().filename().string();
           if (file_name.size() >= 4 && file_name.substr(file_name.size()-4, 4)==".pcd")
@@ -58,7 +57,6 @@ namespace pcl
     //for (unsigned int i=0; i<file_names.size(); ++i)
       //std::cout << file_names[i]<<"\n";
   }
-#endif
 
 std::string getFilenameWithoutPath(const std::string& input)
 {

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -47,6 +47,7 @@
 #include <pcl/PointIndices.h>
 #include <pcl/conversions.h>
 #include <pcl/exceptions.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/PolygonMesh.h>
 #include <locale>
 
@@ -75,7 +76,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFieldIndex<PointT> (field_name, fields) instead")]]
+  PCL_DEPRECATED("use getFieldIndex<PointT> (field_name, fields) instead")
   inline int
   getFieldIndex (const pcl::PointCloud<PointT> &cloud, const std::string &field_name, 
                  std::vector<pcl::PCLPointField> &fields);
@@ -105,7 +106,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFields<PointT> () with return value instead")]]
+  PCL_DEPRECATED("use getFields<PointT> () with return value instead")
   inline void
   getFields (const pcl::PointCloud<PointT> &cloud, std::vector<pcl::PCLPointField> &fields);
 
@@ -115,7 +116,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  [[deprecated("use getFields<PointT> () with return value instead")]]
+  PCL_DEPRECATED("use getFields<PointT> () with return value instead")
   inline void 
   getFields (std::vector<pcl::PCLPointField> &fields);
 
@@ -327,7 +328,7 @@ namespace pcl
     * \return true if successful, false otherwise (e.g., name/number of fields differs)
     * \ingroup common
     */
-  [[deprecated("use pcl::concatenate() instead, but beware of subtle difference in behavior (see documentation)")]]
+  PCL_DEPRECATED("use pcl::concatenate() instead, but beware of subtle difference in behavior (see documentation)")
   PCL_EXPORTS bool 
   concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
                          const pcl::PCLPointCloud2 &cloud2,

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -1155,11 +1155,11 @@ namespace pcl
 
     inline PointWithViewpoint (): PointWithViewpoint (0.f, 0.f, 0.f) {}
 
-    [[deprecated("Use ctor accepting all position (x, y, z) data")]]
+    PCL_DEPRECATED("Use ctor accepting all position (x, y, z) data")
     inline PointWithViewpoint (float _x, float _y = 0.f):
       PointWithViewpoint (_x, _y, 0.f) {}
 
-    [[deprecated("Use ctor accepting all viewpoint (vp_x, vp_y, vp_z) data")]]
+    PCL_DEPRECATED("Use ctor accepting all viewpoint (vp_x, vp_y, vp_z) data")
     inline PointWithViewpoint (float _x, float _y, float _z, float _vp_x, float _vp_y = 0.f):
       PointWithViewpoint (_x, _y, _z, _vp_x, _vp_y, 0.f) {}
     

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -76,6 +76,24 @@
 
 #include <pcl/pcl_config.h>
 
+// It seems that __has_cpp_attribute doesn't work correctly
+// when compiling with some versions of nvcc so we
+// additionally check if nvcc is used before setting the
+// PCL_DEPRECATED macro to [[deprecated]].
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(deprecated) && !defined(__CUDACC__)
+  #define PCL_DEPRECATED(message) [[deprecated(message)]]
+#elif defined(__GNUC__) || defined(__clang__)
+  #define PCL_DEPRECATED(message) __attribute__((deprecated(message)))
+#elif defined(_MSC_VER)
+  // Until Visual Studio 2013 you had to use __declspec(deprecated).
+  // However, we decided to ignore the deprecation for these version because
+  // of simplicity reasons. See PR #3634 for the details.
+  #define PCL_DEPRECATED(message)
+#else
+  #warning "You need to implement PCL_DEPRECATED for this compiler"
+  #define PCL_DEPRECATED(message)
+#endif
+
 namespace pcl
 {
   /**
@@ -89,15 +107,15 @@ namespace pcl
   template <typename T>
   using shared_ptr = boost::shared_ptr<T>;
 
-  using uint8_t [[deprecated("use std::uint8_t instead of pcl::uint8_t")]] = std::uint8_t;
-  using int8_t [[deprecated("use std::int8_t instead of pcl::int8_t")]] = std::int8_t;
-  using uint16_t [[deprecated("use std::uint16_t instead of pcl::uint16_t")]] = std::uint16_t;
-  using int16_t [[deprecated("use std::uint16_t instead of pcl::int16_t")]] = std::int16_t;
-  using uint32_t [[deprecated("use std::uint32_t instead of pcl::uint32_t")]] = std::uint32_t;
-  using int32_t [[deprecated("use std::int32_t instead of pcl::int32_t")]] = std::int32_t;
-  using uint64_t [[deprecated("use std::uint64_t instead of pcl::uint64_t")]] = std::uint64_t;
-  using int64_t [[deprecated("use std::int64_t instead of pcl::int64_t")]] = std::int64_t;
-  using int_fast16_t [[deprecated("use std::int_fast16_t instead of pcl::int_fast16_t")]] = std::int_fast16_t;
+  using uint8_t PCL_DEPRECATED("use std::uint8_t instead of pcl::uint8_t") = std::uint8_t;
+  using int8_t PCL_DEPRECATED("use std::int8_t instead of pcl::int8_t") = std::int8_t;
+  using uint16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::uint16_t") = std::uint16_t;
+  using int16_t PCL_DEPRECATED("use std::uint16_t instead of pcl::int16_t") = std::int16_t;
+  using uint32_t PCL_DEPRECATED("use std::uint32_t instead of pcl::uint32_t") = std::uint32_t;
+  using int32_t PCL_DEPRECATED("use std::int32_t instead of pcl::int32_t") = std::int32_t;
+  using uint64_t PCL_DEPRECATED("use std::uint64_t instead of pcl::uint64_t") = std::uint64_t;
+  using int64_t PCL_DEPRECATED("use std::int64_t instead of pcl::int64_t") = std::int64_t;
+  using int_fast16_t PCL_DEPRECATED("use std::int_fast16_t instead of pcl::int_fast16_t") = std::int_fast16_t;
 }
 
 #if defined _WIN32 && defined _MSC_VER
@@ -134,15 +152,15 @@ namespace pcl
 
 
 template<typename T>
-[[deprecated("use std::isnan instead of pcl_isnan")]]
+PCL_DEPRECATED("use std::isnan instead of pcl_isnan")
 bool pcl_isnan (T&& x) { return std::isnan (std::forward<T> (x)); }
 
 template<typename T>
-[[deprecated("use std::isfinite instead of pcl_isfinite")]]
+PCL_DEPRECATED("use std::isfinite instead of pcl_isfinite")
 bool pcl_isfinite (T&& x) { return std::isfinite (std::forward<T> (x)); }
 
 template<typename T>
-[[deprecated("use std::isinf instead of pcl_isinf")]]
+PCL_DEPRECATED("use std::isinf instead of pcl_isinf")
 bool pcl_isinf (T&& x) { return std::isinf (std::forward<T> (x)); }
 
 

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -56,7 +56,7 @@
 #endif
 
 #ifndef _USE_MATH_DEFINES
-#define _USE_MATH_DEFINES
+  #define _USE_MATH_DEFINES
 #endif
 #include <cmath>
 #include <cstdarg>
@@ -118,11 +118,11 @@ namespace pcl
   using int_fast16_t PCL_DEPRECATED("use std::int_fast16_t instead of pcl::int_fast16_t") = std::int_fast16_t;
 }
 
-#if defined _WIN32 && defined _MSC_VER
+#if defined _WIN32
 
 // Define math constants, without including math.h, to prevent polluting global namespace with old math methods
 // Copied from math.h
-#ifndef _MATH_DEFINES_DEFINED
+#if !defined _MATH_DEFINES_DEFINED && !defined M_2_SQRTPI
   #define _MATH_DEFINES_DEFINED
 
   #define M_E        2.71828182845904523536   // e
@@ -140,15 +140,16 @@ namespace pcl
   #define M_SQRT1_2  0.707106781186547524401  // 1/sqrt(2)
 #endif
 
-// Stupid. This should be removed when all the PCL dependencies have min/max fixed.
-#ifndef NOMINMAX
-# define NOMINMAX
+#if defined _MSC_VER
+  // Stupid. This should be removed when all the PCL dependencies have min/max fixed.
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+
+  #define __PRETTY_FUNCTION__ __FUNCTION__
+  #define __func__ __FUNCTION__
 #endif
-
-# define __PRETTY_FUNCTION__ __FUNCTION__
-# define __func__ __FUNCTION__
-
-#endif //defined _WIN32 && defined _MSC_VER
+#endif // defined _WIN32
 
 
 template<typename T>

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -138,7 +138,7 @@ namespace pcl
   namespace detail
   {
     template <typename PointT>
-    [[deprecated("use createMapping() instead")]]
+    PCL_DEPRECATED("use createMapping() instead")
     shared_ptr<pcl::MsgFieldMap>&
     getMapping (pcl::PointCloud<PointT>& p);
   } // namespace detail
@@ -606,7 +606,7 @@ namespace pcl
 
     protected:
       // This is motivated by ROS integration. Users should not need to access mapping_.
-      [[deprecated("rewrite your code to avoid using this protected field")]] shared_ptr<MsgFieldMap> mapping_;
+      PCL_DEPRECATED("rewrite your code to avoid using this protected field") shared_ptr<MsgFieldMap> mapping_;
 
       friend shared_ptr<MsgFieldMap>& detail::getMapping<PointT>(pcl::PointCloud<PointT> &p);
 

--- a/cuda/nn/organized_neighbor_search.hpp
+++ b/cuda/nn/organized_neighbor_search.hpp
@@ -206,7 +206,7 @@ namespace pcl
         // select point from organized pointcloud
         x = x_pos + (*radiusSearchLookup_Iterator).x_diff_;
         y = y_pos + (*radiusSearchLookup_Iterator).y_diff_;
-        radiusSearchLookup_Iterator++;
+        ++radiusSearchLookup_Iterator;
         radiusSearchPointCount++;
 
         if ((x >= 0) && (y >= 0) && (x < (int)input_->width) && (y < (int)input_->height))

--- a/doc/tutorials/content/compression.rst
+++ b/doc/tutorials/content/compression.rst
@@ -210,13 +210,13 @@ Command line tool for PCL point cloud stream compression
 --------------------------------------------------------
 
 The pcl apps component contains a command line tool for point cloud compression
-and streaming: Simply execute "./openni_stream_compression -?" to see a full
+and streaming: Simply execute "./pcl_openni_octree_compression -?" to see a full
 list of options (note: the output on screen may differ)::
 
 
   PCL point cloud stream compression
 
-  usage: ./openni_stream_compression [mode] [profile] [parameters]
+  usage: ./pcl_openni_octree_compression [mode] [profile] [parameters]
 
   I/O: 
       -f file  : file name 
@@ -249,15 +249,15 @@ list of options (note: the output on screen may differ)::
       -e       : show input cloud during encoding
 
   example:
-      ./openni_stream_compression -x -p highC -t -f pc_compressed.pcc 
+      ./pcl_openni_octree_compression -x -p highC -t -f pc_compressed.pcc
 
 In order to stream compressed point cloud via TCP/IP, you can start the server with::
 
-  $ ./openni_stream_compression -s
+  $ ./pcl_openni_octree_compression -s
      
 It will listen on port 6666 for incoming connections. Now start the client with::     
 
-  $ ./openni_stream_compression -c SERVER_NAME
+  $ ./pcl_openni_octree_compression -c SERVER_NAME
   
 and remotely captured point clouds will be locally shown in the point cloud viewer.  
      

--- a/features/include/pcl/features/rsd.h
+++ b/features/include/pcl/features/rsd.h
@@ -89,7 +89,7 @@ namespace pcl
               int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
 
   template <typename PointInT, typename PointNT, typename PointOutT>
-  [[deprecated("use computeRSD() overload that takes input point clouds by const reference")]]
+  PCL_DEPRECATED("use computeRSD() overload that takes input point clouds by const reference")
   Eigen::MatrixXf
   computeRSD (typename pcl::PointCloud<PointInT>::ConstPtr &surface, typename pcl::PointCloud<PointNT>::ConstPtr &normals,
               const std::vector<int> &indices, double max_dist,
@@ -115,7 +115,7 @@ namespace pcl
               int nr_subdiv, double plane_radius, PointOutT &radii, bool compute_histogram = false);
 
   template <typename PointNT, typename PointOutT>
-  [[deprecated("use computeRSD() overload that takes input point cloud by const reference")]]
+  PCL_DEPRECATED("use computeRSD() overload that takes input point cloud by const reference")
   Eigen::MatrixXf
   computeRSD (typename pcl::PointCloud<PointNT>::ConstPtr &normals,
               const std::vector<int> &indices, const std::vector<float> &sqr_dists, double max_dist,

--- a/filters/include/pcl/filters/impl/filter.hpp
+++ b/filters/include/pcl/filters/impl/filter.hpp
@@ -112,12 +112,17 @@ pcl::removeNaNNormalsFromPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   index.resize (cloud_in.points.size ());
   std::size_t j = 0;
 
+  // Assume cloud is dense
+  cloud_out.is_dense = true;
+
   for (std::size_t i = 0; i < cloud_in.points.size (); ++i)
   {
     if (!std::isfinite (cloud_in.points[i].normal_x) ||
         !std::isfinite (cloud_in.points[i].normal_y) ||
         !std::isfinite (cloud_in.points[i].normal_z))
       continue;
+    if (cloud_out.is_dense && !pcl::isFinite(cloud_in.points[i]))
+      cloud_out.is_dense = false;
     cloud_out.points[j] = cloud_in.points[i];
     index[j] = static_cast<int>(i);
     j++;

--- a/filters/include/pcl/filters/passthrough.h
+++ b/filters/include/pcl/filters/passthrough.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/filters/filter_indices.h>
 
 namespace pcl
@@ -286,7 +287,7 @@ namespace pcl
         * Default: false.
         * \param[in] limit_negative return data inside the interval (false) or outside (true)
         */
-      [[deprecated("use inherited FilterIndices::setNegative() instead")]]
+      PCL_DEPRECATED("use inherited FilterIndices::setNegative() instead")
       inline void
       setFilterLimitsNegative (const bool limit_negative)
       {
@@ -296,7 +297,7 @@ namespace pcl
       /** \brief Get whether the data outside the interval (min/max) is to be returned (true) or inside (false).
         * \param[out] limit_negative true if data \b outside the interval [min; max] is to be returned, false otherwise
         */
-      [[deprecated("use inherited FilterIndices::getNegative() instead")]]
+      PCL_DEPRECATED("use inherited FilterIndices::getNegative() instead")
       inline void
       getFilterLimitsNegative (bool &limit_negative) const
       {
@@ -306,7 +307,7 @@ namespace pcl
       /** \brief Get whether the data outside the interval (min/max) is to be returned (true) or inside (false).
         * \return true if data \b outside the interval [min; max] is to be returned, false otherwise
         */
-      [[deprecated("use inherited FilterIndices::getNegative() instead")]]
+      PCL_DEPRECATED("use inherited FilterIndices::getNegative() instead")
       inline bool
       getFilterLimitsNegative () const
       {

--- a/io/include/pcl/compression/entropy_range_coder.h
+++ b/io/include/pcl/compression/entropy_range_coder.h
@@ -49,6 +49,8 @@
 #include <cstdio>
 #include <cstdint>
 
+#include <pcl/pcl_macros.h>
+
 namespace pcl
 {
 
@@ -168,7 +170,7 @@ namespace pcl
        * \param n_arg: some value
        * \return binary logarithm (log2) of argument n_arg
        */
-      [[deprecated("use std::log2 instead")]]
+      PCL_DEPRECATED("use std::log2 instead")
       inline double
       Log2 (double n_arg)
       {

--- a/io/include/pcl/io/ascii_io.h
+++ b/io/include/pcl/io/ascii_io.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/io/file_io.h>
 #include <pcl/PCLPointField.h>
 #include <pcl/common/io.h>
@@ -116,7 +117,7 @@ namespace pcl
         * \param[in] p  a point type
         */
       template<typename PointT>
-      [[deprecated("use parameterless setInputFields<PointT>() instead")]]
+      PCL_DEPRECATED("use parameterless setInputFields<PointT>() instead")
       inline void setInputFields (const PointT p)
       {
         (void) p;

--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -72,7 +72,7 @@ namespace pcl
         * \return Connection object, that can be used to disconnect the callback method from the signal again.
         */
       template<typename T, template<typename> class FunctionT>
-      [[deprecated ("please assign the callback to a std::function.")]]
+      PCL_DEPRECATED ("please assign the callback to a std::function.")
       boost::signals2::connection
       registerCallback (const FunctionT<T>& callback)
       {

--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include "pcl/pcl_config.h"
+#include <pcl/pcl_macros.h>
 
 #include <pcl/io/grabber.h>
 #include <pcl/io/impl/synchronized_queue.hpp>
@@ -70,7 +71,7 @@ namespace pcl
        */
       using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba = void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr &, float, float);
 
-      using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb [[deprecated("use sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba instead")]]
+      using sig_cb_velodyne_hdl_scan_point_cloud_xyzrgb PCL_DEPRECATED("use sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba instead")
               = sig_cb_velodyne_hdl_scan_point_cloud_xyzrgba;
 
       /** \brief Signal used for a single sector
@@ -96,7 +97,7 @@ namespace pcl
        */
       using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba = void (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr &);
 
-      using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb [[deprecated("use sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba instead")]]
+      using sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgb PCL_DEPRECATED("use sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba instead")
               = sig_cb_velodyne_hdl_sweep_point_cloud_xyzrgba;
 
       /** \brief Constructor taking an optional path to an HDL corrections file.  The Grabber will listen on the default IP/port for data packets [192.168.3.255/2368]

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -121,7 +121,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   oss.flush ();
   data_idx = static_cast<int> (oss.tellp ());
 
-#if _WIN32
+#ifdef _WIN32
   HANDLE h_native_file = CreateFileA (file_name.c_str (), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h_native_file == INVALID_HANDLE_VALUE)
   {
@@ -161,7 +161,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   data_size = cloud.points.size () * fsize;
 
   // Prepare the map
-#if _WIN32
+#ifdef _WIN32
   HANDLE fm = CreateFileMappingA (h_native_file, NULL, PAGE_READWRITE, 0, (DWORD) (data_idx + data_size), NULL);
   if (fm == NULL)
   {
@@ -209,13 +209,13 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   }
 
   // If the user set the synchronization flag on, call msync
-#if !_WIN32
+#ifndef _WIN32
   if (map_synchronization_)
     msync (map, data_idx + data_size, MS_SYNC);
 #endif
 
   // Unmap the pages of memory
-#if _WIN32
+#ifdef _WIN32
     UnmapViewOfFile (map);
 #else
   if (::munmap (map, (data_idx + data_size)) == -1)
@@ -227,7 +227,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   }
 #endif
   // Close file
-#if _WIN32
+#ifdef _WIN32
   CloseHandle (h_native_file);
 #else
   io::raw_close (fd);
@@ -252,7 +252,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   oss.flush ();
   data_idx = static_cast<int> (oss.tellp ());
 
-#if _WIN32
+#ifdef _WIN32
   HANDLE h_native_file = CreateFileA (file_name.c_str (), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h_native_file == INVALID_HANDLE_VALUE)
   {
@@ -355,7 +355,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   }
   else
   {
-#if !_WIN32
+#ifndef _WIN32
     io::raw_close (fd);
 #endif
     resetLockingPermissions (file_name, file_lock);
@@ -364,7 +364,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   }
 
   // Prepare the map
-#if _WIN32
+#ifdef _WIN32
   HANDLE fm = CreateFileMapping (h_native_file, NULL, PAGE_READWRITE, 0, compressed_final_size, NULL);
   char *map = static_cast<char*>(MapViewOfFile (fm, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, compressed_final_size));
   CloseHandle (fm);
@@ -396,14 +396,14 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   // Copy the compressed data
   memcpy (&map[data_idx], temp_buf, data_size);
 
-#if !_WIN32
+#ifndef _WIN32
   // If the user set the synchronization flag on, call msync
   if (map_synchronization_)
     msync (map, compressed_final_size, MS_SYNC);
 #endif
 
   // Unmap the pages of memory
-#if _WIN32
+#ifdef _WIN32
     UnmapViewOfFile (map);
 #else
   if (::munmap (map, (compressed_final_size)) == -1)
@@ -416,7 +416,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
 #endif
 
   // Close file
-#if _WIN32
+#ifdef _WIN32
   CloseHandle (h_native_file);
 #else
   io::raw_close (fd);
@@ -598,7 +598,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   oss.flush ();
   data_idx = static_cast<int> (oss.tellp ());
 
-#if _WIN32
+#ifdef _WIN32
   HANDLE h_native_file = CreateFileA (file_name.c_str (), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h_native_file == INVALID_HANDLE_VALUE)
   {
@@ -638,7 +638,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   data_size = indices.size () * fsize;
 
   // Prepare the map
-#if _WIN32
+#ifdef _WIN32
   HANDLE fm = CreateFileMapping (h_native_file, NULL, PAGE_READWRITE, 0, data_idx + data_size, NULL);
   char *map = static_cast<char*>(MapViewOfFile (fm, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, data_idx + data_size));
   CloseHandle (fm);
@@ -680,14 +680,14 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
     }
   }
 
-#if !_WIN32
+#ifndef _WIN32
   // If the user set the synchronization flag on, call msync
   if (map_synchronization_)
     msync (map, data_idx + data_size, MS_SYNC);
 #endif
 
   // Unmap the pages of memory
-#if _WIN32
+#ifdef _WIN32
     UnmapViewOfFile (map);
 #else
   if (::munmap (map, (data_idx + data_size)) == -1)
@@ -699,7 +699,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
   }
 #endif
   // Close file
-#if _WIN32
+#ifdef _WIN32
   CloseHandle(h_native_file);
 #else
   io::raw_close (fd);

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -192,7 +192,7 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
 
     getDeviceType(device.device_node.GetCreationInfo (), vendor_id, product_id );
 
-#if _WIN32
+#ifdef _WIN32
     if (vendor_id == 0x45e)
     {
       strcpy (const_cast<char*> (device_context_[device].device_node.GetDescription ().strVendor), "Microsoft");
@@ -428,7 +428,7 @@ openni_wrapper::OpenNIDriver::getSerialNumber (unsigned index) const throw ()
 void 
 openni_wrapper::OpenNIDriver::getDeviceType (const std::string& connectionString, unsigned short& vendorId, unsigned short& productId)
 {
-#if _WIN32
+#ifdef _WIN32
     // expected format: "\\?\usb#vid_[ID]&pid_[ID]#[SERIAL]#{GUID}"
     using tokenizer = boost::tokenizer<boost::char_separator<char> >;
     boost::char_separator<char> separators("#&_");

--- a/io/src/pcd_grabber.cpp
+++ b/io/src/pcd_grabber.cpp
@@ -204,7 +204,7 @@ bool
 pcl::PCDGrabberBase::PCDGrabberImpl::readTARHeader ()
 {
   // Read in the header
-#if WIN32
+#ifdef _WIN32
   int result = static_cast<int> (_read (tar_fd_, reinterpret_cast<char*> (&tar_header_), 512));
 #else
   int result = static_cast<int> (::read (tar_fd_, reinterpret_cast<char*> (&tar_header_), 512));
@@ -459,5 +459,4 @@ pcl::PCDGrabberBase::numFrames () const
 {
   return (impl_->numFrames ());
 }
-
 

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -44,6 +44,7 @@
 #include <pcl/octree/octree_iterator.h>
 #include <pcl/octree/octree_key.h>
 #include <pcl/octree/octree_nodes.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl {
 namespace octree {
@@ -236,14 +237,14 @@ public:
   using LeafNodeIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
   using ConstLeafNodeIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
-  [[deprecated("use leaf_depth_begin() instead")]] LeafNodeIterator
+  PCL_DEPRECATED("use leaf_depth_begin() instead")
+  LeafNodeIterator
   leaf_begin(unsigned int max_depth_arg = 0)
   {
     return LeafNodeIterator(this, max_depth_arg);
   };
 
-  [[deprecated("use leaf_depth_end() instead")]] const LeafNodeIterator
-  leaf_end()
+  PCL_DEPRECATED("use leaf_depth_end() instead") const LeafNodeIterator leaf_end()
   {
     return LeafNodeIterator();
   };
@@ -937,8 +938,7 @@ protected:
    * \param n_arg: some value
    * \return binary logarithm (log2) of argument n_arg
    */
-  [[deprecated("use std::log2 instead")]] inline double
-  Log2(double n_arg)
+  PCL_DEPRECATED("use std::log2 instead") inline double Log2(double n_arg)
   {
     return std::log2(n_arg);
   }

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -44,6 +44,7 @@
 #include <pcl/octree/octree_iterator.h>
 #include <pcl/octree/octree_key.h>
 #include <pcl/octree/octree_nodes.h>
+#include <pcl/pcl_macros.h>
 
 namespace pcl {
 namespace octree {
@@ -125,14 +126,14 @@ public:
   using LeafNodeIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
   using ConstLeafNodeIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
-  [[deprecated("use leaf_depth_begin() instead")]] LeafNodeIterator
+  PCL_DEPRECATED("use leaf_depth_begin() instead")
+  LeafNodeIterator
   leaf_begin(unsigned int max_depth_arg = 0u)
   {
     return LeafNodeIterator(this, max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
-  [[deprecated("use leaf_depth_end() instead")]] const LeafNodeIterator
-  leaf_end()
+  PCL_DEPRECATED("use leaf_depth_end() instead") const LeafNodeIterator leaf_end()
   {
     return LeafNodeIterator(this, 0, nullptr);
   };
@@ -685,8 +686,7 @@ protected:
    * \param n_arg: some value
    * \return binary logarithm (log2) of argument n_arg
    */
-  [[deprecated("use std::log2 instead")]] double
-  Log2(double n_arg)
+  PCL_DEPRECATED("use std::log2 instead") double Log2(double n_arg)
   {
     return std::log2(n_arg);
   }

--- a/people/include/pcl/people/impl/person_cluster.hpp
+++ b/people/include/pcl/people/impl/person_cluster.hpp
@@ -177,7 +177,7 @@ pcl::people::PersonCluster<PointT>::init (
     float min_z = c_z_;
     float max_x = c_x_;
     float max_z = c_z_;
-    for (std::vector<int>::const_iterator pit = points_indices_.indices.begin(); pit != points_indices_.indices.end(); pit++)
+    for (std::vector<int>::const_iterator pit = points_indices_.indices.begin(); pit != points_indices_.indices.end(); ++pit)
     {
       PointT* p = &input_cloud->points[*pit];
 

--- a/recognition/include/pcl/recognition/mask_map.h
+++ b/recognition/include/pcl/recognition/mask_map.h
@@ -78,7 +78,7 @@ public:
     return (data_.data());
   }
 
-  [[deprecated("Use new version diff getDifferenceMask(mask0, mask1)")]]
+  PCL_DEPRECATED("Use new version diff getDifferenceMask(mask0, mask1)")
   static void
   getDifferenceMask(const MaskMap& mask0, const MaskMap& mask1, MaskMap& diff_mask);
 

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -221,7 +221,7 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
   candidates.clear ();
 
   // loop over all candidates starting from the best one
-  for (MatchingCandidates::iterator it_candidate = candidates_.begin (), it_e = candidates_.end (); it_candidate != it_e; it_candidate++)
+  for (MatchingCandidates::iterator it_candidate = candidates_.begin (), it_e = candidates_.end (); it_candidate != it_e; ++it_candidate)
   {
     // stop if current candidate has no valid score
     if (it_candidate->fitness_score == FLT_MAX)
@@ -236,7 +236,7 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
       const float angle3d = Eigen::AngleAxisf (diff.block <3, 3> (0, 0)).angle ();
       const float translation3d = diff.block <3, 1> (0, 3).norm ();
       unique = angle3d > min_angle3d && translation3d > min_translation3d;
-      it++;
+      ++it;
     }
 
     // add candidate to best candidates

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -206,7 +206,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives 
     std::vector<float> distances;
     target_cells_.radiusSearch (x_trans_pt, resolution_, neighborhood, distances);
 
-    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin (); neighborhood_it != neighborhood.end (); neighborhood_it++)
+    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin (); neighborhood_it != neighborhood.end (); ++neighborhood_it)
     {
       cell = *neighborhood_it;
       x_pt = input_->points[idx];

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/segmentation/boost.h>
 #include <pcl/segmentation/comparator.h>
 #include <pcl/point_types.h>
@@ -210,7 +211,7 @@ namespace pcl
       using experimental::EuclideanClusterComparator<PointT, PointLT>::setExcludeLabels;
 
       /** \brief Default constructor for EuclideanClusterComparator. */
-      [[deprecated("remove PointNT from template parameters")]]
+      PCL_DEPRECATED("remove PointNT from template parameters")
       EuclideanClusterComparator ()
         : normals_ ()
         , angular_threshold_ (0.0f)
@@ -219,19 +220,19 @@ namespace pcl
       /** \brief Provide a pointer to the input normals.
        * \param[in] normals the input normal cloud
        */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline void
       setInputNormals (const PointCloudNConstPtr& normals) { normals_ = normals; }
 
       /** \brief Get the input normals. */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline PointCloudNConstPtr
       getInputNormals () const { return (normals_); }
 
       /** \brief Set the tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane.
         * \param[in] angular_threshold the tolerance in radians
         */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline void
       setAngularThreshold (float angular_threshold)
       {
@@ -239,14 +240,14 @@ namespace pcl
       }
 
       /** \brief Get the angular threshold in radians for difference in normal direction between neighboring points, to be considered part of the same plane. */
-      [[deprecated("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")]]
+      PCL_DEPRECATED("EuclideadClusterComparator never actually used normals and angular threshold, this function has no effect on the behavior of the comparator. It is deprecated and will be removed in future releases.")
       inline float
       getAngularThreshold () const { return (std::acos (angular_threshold_) ); }
 
       /** \brief Set labels in the label cloud to exclude.
         * \param[in] exclude_labels a vector of bools corresponding to whether or not a given label should be considered
         */
-      [[deprecated("use setExcludeLabels(const ExcludeLabelSetConstPtr &) instead")]]
+      PCL_DEPRECATED("use setExcludeLabels(const ExcludeLabelSetConstPtr &) instead")
       void
       setExcludeLabels (const std::vector<bool>& exclude_labels)
       {

--- a/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
@@ -41,6 +41,7 @@
 
 #include <pcl/segmentation/planar_region.h>
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/common/angles.h>
 #include <pcl/PointIndices.h>
 #include <pcl/ModelCoefficients.h>
@@ -284,7 +285,7 @@ namespace pcl
         * \param [in] labels The labels produced by the initial segmentation
         * \param [in] label_indices The list of indices corresponding to each label
         */
-      [[deprecated("centroids and covariances parameters are not used; they are deprecated and will be removed in future releases")]]
+      PCL_DEPRECATED("centroids and covariances parameters are not used; they are deprecated and will be removed in future releases")
       void
       refine (std::vector<ModelCoefficients>& model_coefficients, 
               std::vector<PointIndices>& inlier_indices,

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/search/pcl_search.h>
 
 namespace pcl
@@ -59,7 +60,7 @@ namespace pcl
       pcl::PointCloud<PointT> &output);
 
   template <typename PointT>
-  [[deprecated("tgt parameter is not used; it is deprecated and will be removed in future releases")]]
+  PCL_DEPRECATED("tgt parameter is not used; it is deprecated and will be removed in future releases")
   inline void getPointCloudDifference (
       const pcl::PointCloud<PointT> &src,
       const pcl::PointCloud<PointT> & /* tgt */,

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -194,7 +194,7 @@ namespace pcl
        */
       SupervoxelClustering (float voxel_resolution, float seed_resolution);
 
-      [[deprecated("constructor with flag for using the single camera transform is deprecated. Default behavior is now to use the transform for organized clouds, and not use it for unorganized. Use setUseSingleCameraTransform() to override the defaults.")]]
+      PCL_DEPRECATED("constructor with flag for using the single camera transform is deprecated. Default behavior is now to use the transform for organized clouds, and not use it for unorganized. Use setUseSingleCameraTransform() to override the defaults.")
       SupervoxelClustering (float voxel_resolution, float seed_resolution, bool) : SupervoxelClustering (voxel_resolution, seed_resolution) { }
 
       /** \brief This destructor destroys the cloud, normals and search method used for
@@ -278,7 +278,7 @@ namespace pcl
         * color(it's random). Points that are unlabeled will be black
         * \note This will expand the label_colors_ vector so that it can accommodate all labels
         */
-      [[deprecated("use getLabeledCloud() instead. An example of how to display and save with colorized labels can be found in examples/segmentation/example_supervoxels.cpp")]]
+      PCL_DEPRECATED("use getLabeledCloud() instead. An example of how to display and save with colorized labels can be found in examples/segmentation/example_supervoxels.cpp")
       typename pcl::PointCloud<PointXYZRGBA>::Ptr
       getColoredCloud () const
       { 

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -813,7 +813,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
         Eigen::Vector2f S1;
         Eigen::Vector2f S2;
         std::vector<int> to_erase;
-        for (std::vector<int>::iterator it = angleIdx.begin()+1; it != angleIdx.end()-1; it++)
+        for (std::vector<int>::iterator it = angleIdx.begin()+1; it != angleIdx.end()-1; ++it)
         {
           if (gaps[*(it-1)])
             angle_so_far = 0;

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -356,7 +356,7 @@ namespace pcl
       /** \brief Sets whether the surface and normal are approximated using a polynomial, or only via tangent estimation.
         * \param[in] polynomial_fit set to true for polynomial fit
         */
-      [[deprecated("use setPolynomialOrder() instead")]]
+      PCL_DEPRECATED("use setPolynomialOrder() instead")
       inline void
       setPolynomialFit (bool polynomial_fit)
       {
@@ -374,7 +374,7 @@ namespace pcl
       }
 
       /** \brief Get the polynomial_fit value (true if the surface and normal are approximated using a polynomial). */
-      [[deprecated("use getPolynomialOrder() instead")]]
+      PCL_DEPRECATED("use getPolynomialOrder() instead")
       inline bool
       getPolynomialFit () const { return (order_ > 1); }
 
@@ -746,7 +746,7 @@ namespace pcl
   };
 
   template <typename PointInT, typename PointOutT>
-  using MovingLeastSquaresOMP [[deprecated("use MovingLeastSquares instead, it supports OpenMP now")]] = MovingLeastSquares<PointInT, PointOutT>;
+  using MovingLeastSquaresOMP PCL_DEPRECATED("use MovingLeastSquares instead, it supports OpenMP now") = MovingLeastSquares<PointInT, PointOutT>;
 }
 
 #ifdef PCL_NO_PRECOMPILE

--- a/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_annotation2.cpp
@@ -16,6 +16,8 @@
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
 
+#include <pcl/pcl_macros.h>
+
 // This define is up here so anybody who want's to defeat the
 // bozo vaccine has to be doing it on purpose.
 #define BOZO_VACCINE_699FCC4262D4488c9109F1B7A37CE926
@@ -5820,7 +5822,7 @@ void ON_Annotation2Text::SetText(const wchar_t* s)
 
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
-[[deprecated("Use the version that takes a model transform argument")]]
+PCL_DEPRECATED("Use the version that takes a model transform argument")
 bool ON_Annotation2::GetTextXform( 
       ON_RECT /*gdi_text_rect*/,
       const ON_Font& /*font*/,
@@ -5860,7 +5862,7 @@ bool ON_Annotation2::GetTextXform(
 // New function added Oct 30, 07 - LW 
 // To use model xform to draw annotation in blocks correctly
 #if 0
-[[deprecated("Use the version that takes a dimstyle pointer")]]
+PCL_DEPRECATED("Use the version that takes a dimstyle pointer")
 bool ON_Annotation2::GetTextXform( 
       ON_RECT gdi_text_rect,
       const ON_Font& font,
@@ -5989,7 +5991,7 @@ static bool GetLeaderEndAndDirection( const ON_Annotation2* pAnn,
 
 // SDKBREAK Oct 30, 07 - LW
 // This function should not be used any longer
-[[deprecated("Use the version that takes a model transform argument")]]
+PCL_DEPRECATED("Use the version that takes a model transform argument")
 bool ON_Annotation2::GetTextXform( 
       ON_RECT /*gdi_text_rect*/,
       int /*gdi_height_of_I*/,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,8 @@ endif()
 
 set_target_properties(tests PROPERTIES FOLDER "Tests")
 
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+
 add_subdirectory(2d)
 add_subdirectory(common)
 add_subdirectory(features)

--- a/test/common/test_common.cpp
+++ b/test/common/test_common.cpp
@@ -48,6 +48,7 @@
 #include <pcl/point_cloud.h>
 
 #include <pcl/common/centroid.h>
+#include <pcl/test/gtest.h>
 
 using namespace pcl;
 
@@ -308,7 +309,7 @@ TEST (PCL, PointTypes)
 
 template <typename T> class XYZPointTypesTest : public ::testing::Test { };
 using XYZPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_XYZ_POINT_TYPES)>;
-TYPED_TEST_CASE(XYZPointTypesTest, XYZPointTypes);
+TYPED_TEST_SUITE(XYZPointTypesTest, XYZPointTypes);
 TYPED_TEST(XYZPointTypesTest, GetVectorXfMap)
 {
   TypeParam pt;
@@ -329,7 +330,7 @@ TYPED_TEST(XYZPointTypesTest, GetArrayXfMap)
 
 template <typename T> class NormalPointTypesTest : public ::testing::Test { };
 using NormalPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_NORMAL_POINT_TYPES)>;
-TYPED_TEST_CASE(NormalPointTypesTest, NormalPointTypes);
+TYPED_TEST_SUITE(NormalPointTypesTest, NormalPointTypes);
 TYPED_TEST(NormalPointTypesTest, GetNormalVectorXfMap)
 {
   TypeParam pt;
@@ -341,7 +342,7 @@ TYPED_TEST(NormalPointTypesTest, GetNormalVectorXfMap)
 
 template <typename T> class RGBPointTypesTest : public ::testing::Test { };
 using RGBPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_RGB_POINT_TYPES)>;
-TYPED_TEST_CASE(RGBPointTypesTest, RGBPointTypes);
+TYPED_TEST_SUITE(RGBPointTypesTest, RGBPointTypes);
 TYPED_TEST(RGBPointTypesTest, GetRGBVectorXi)
 {
   TypeParam pt; pt.r = 1; pt.g = 2; pt.b = 3; pt.a = 4;

--- a/test/common/test_transforms.cpp
+++ b/test/common/test_transforms.cpp
@@ -46,6 +46,7 @@
 #include <pcl/common/io.h>
 
 #include <pcl/pcl_tests.h>
+#include <pcl/test/gtest.h>
 
 using namespace pcl;
 
@@ -107,7 +108,7 @@ class Transforms : public ::testing::Test
   PCL_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
-TYPED_TEST_CASE (Transforms, TransformTypes);
+TYPED_TEST_SUITE (Transforms, TransformTypes);
 
 TYPED_TEST (Transforms, PointCloudXYZDense)
 {

--- a/test/common/test_type_traits.cpp
+++ b/test/common/test_type_traits.cpp
@@ -36,7 +36,6 @@
  */
 
 
-#include <pcl/pcl_macros.h>
 #include <pcl/point_traits.h>
 #include <pcl/point_types.h>
 

--- a/test/features/test_pfh_estimation.cpp
+++ b/test/features/test_pfh_estimation.cpp
@@ -50,6 +50,7 @@
 #include <pcl/features/vfh.h>
 #include <pcl/features/gfpfh.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/test/gtest.h>
 
 using PointT = pcl::PointNormal;
 using KdTreePtr = pcl::search::KdTree<PointT>::Ptr;
@@ -294,7 +295,7 @@ struct FPFHTest<FPFHEstimationOMP<PointT, PointT, FPFHSignature33> >
 using FPFHEstimatorTypes = ::testing::Types
         <FPFHEstimation<PointT, PointT, FPFHSignature33>,
          FPFHEstimationOMP<PointT, PointT, FPFHSignature33> >;
-TYPED_TEST_CASE (FPFHTest, FPFHEstimatorTypes);
+TYPED_TEST_SUITE (FPFHTest, FPFHEstimatorTypes);
 
 // This is a copy of the old FPFHEstimation test which will now
 // be applied to both FPFHEstimation and FPFHEstimationOMP

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -46,6 +46,7 @@
 #include "pcl/features/shot_lrf.h"
 #include <pcl/features/3dsc.h>
 #include <pcl/features/usc.h>
+#include <pcl/test/gtest.h>
 
 using namespace pcl;
 using namespace pcl::io;
@@ -371,7 +372,7 @@ struct SHOTShapeTest<SHOTEstimationOMP<PointXYZ, Normal, SHOT352> >
 using SHOTEstimatorTypes = ::testing::Types
         <SHOTEstimation<PointXYZ, Normal, SHOT352>,
          SHOTEstimationOMP<PointXYZ, Normal, SHOT352> >;
-TYPED_TEST_CASE (SHOTShapeTest, SHOTEstimatorTypes);
+TYPED_TEST_SUITE (SHOTShapeTest, SHOTEstimatorTypes);
 
 // This is a copy of the old SHOTShapeEstimation test which will now
 // be applied to both SHOTEstimation and SHOTEstimationOMP
@@ -560,7 +561,7 @@ struct SHOTShapeAndColorTest<SHOTColorEstimationOMP<PointXYZRGBA, Normal, SHOT13
 using SHOTColorEstimatorTypes= ::testing::Types
         <SHOTColorEstimation<PointXYZRGBA, Normal, SHOT1344>,
          SHOTColorEstimationOMP<PointXYZRGBA, Normal, SHOT1344> >;
-TYPED_TEST_CASE (SHOTShapeAndColorTest, SHOTColorEstimatorTypes);
+TYPED_TEST_SUITE (SHOTShapeAndColorTest, SHOTColorEstimatorTypes);
 
 // This is a copy of the old SHOTShapeAndColorEstimation test which will now
 // be applied to both SHOTColorEstimation and SHOTColorEstimationOMP

--- a/test/geometry/test_mesh_conversion.cpp
+++ b/test/geometry/test_mesh_conversion.cpp
@@ -47,6 +47,7 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
+#include <pcl/test/gtest.h>
 
 #include "test_mesh_common_functions.h"
 
@@ -152,7 +153,7 @@ using NonManifoldMeshTraits = MeshTraits<false>;
 
 using MeshTraitsTypes = testing::Types <ManifoldMeshTraits, NonManifoldMeshTraits>;
 
-TYPED_TEST_CASE (TestMeshConversion, MeshTraitsTypes);
+TYPED_TEST_SUITE (TestMeshConversion, MeshTraitsTypes);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_mesh_get_boundary.cpp
+++ b/test/geometry/test_mesh_get_boundary.cpp
@@ -42,6 +42,7 @@
 
 #include <pcl/geometry/polygon_mesh.h>
 #include <pcl/geometry/get_boundary.h>
+#include <pcl/test/gtest.h>
 #include "test_mesh_common_functions.h"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -68,7 +69,7 @@ class TestGetBoundary : public testing::Test
     using Mesh = MeshT;
 };
 
-TYPED_TEST_CASE (TestGetBoundary, MeshTypes);
+TYPED_TEST_SUITE (TestGetBoundary, MeshTypes);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_mesh_indices.cpp
+++ b/test/geometry/test_mesh_indices.cpp
@@ -44,6 +44,7 @@
 #include <gtest/gtest.h>
 
 #include <pcl/geometry/mesh_indices.h>
+#include <pcl/test/gtest.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -63,7 +64,7 @@ class TestMeshIndicesTyped : public testing::Test
 
 using MeshIndexTypes = testing::Types <VertexIndex, HalfEdgeIndex, EdgeIndex, FaceIndex>;
 
-TYPED_TEST_CASE (TestMeshIndicesTyped, MeshIndexTypes);
+TYPED_TEST_SUITE (TestMeshIndicesTyped, MeshIndexTypes);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_polygon_mesh.cpp
+++ b/test/geometry/test_polygon_mesh.cpp
@@ -44,6 +44,7 @@
 #include <gtest/gtest.h>
 
 #include <pcl/geometry/polygon_mesh.h>
+#include <pcl/test/gtest.h>
 
 #include "test_mesh_common_functions.h"
 
@@ -82,7 +83,7 @@ class TestPolygonMesh : public testing::Test
     using Mesh = MeshT;
 };
 
-TYPED_TEST_CASE (TestPolygonMesh, PolygonMeshTypes);
+TYPED_TEST_SUITE (TestPolygonMesh, PolygonMeshTypes);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_quad_mesh.cpp
+++ b/test/geometry/test_quad_mesh.cpp
@@ -44,6 +44,7 @@
 #include <gtest/gtest.h>
 
 #include <pcl/geometry/quad_mesh.h>
+#include <pcl/test/gtest.h>
 
 #include "test_mesh_common_functions.h"
 
@@ -80,7 +81,7 @@ class TestQuadMesh : public testing::Test
     using Mesh = MeshT;
 };
 
-TYPED_TEST_CASE (TestQuadMesh, QuadMeshTypes);
+TYPED_TEST_SUITE (TestQuadMesh, QuadMeshTypes);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_triangle_mesh.cpp
+++ b/test/geometry/test_triangle_mesh.cpp
@@ -44,6 +44,7 @@
 #include <gtest/gtest.h>
 
 #include <pcl/geometry/triangle_mesh.h>
+#include <pcl/test/gtest.h>
 
 #include "test_mesh_common_functions.h"
 
@@ -80,7 +81,7 @@ class TestTriangleMesh : public testing::Test
     using Mesh = MeshT;
 };
 
-TYPED_TEST_CASE (TestTriangleMesh, TriangleMeshTypes);
+TYPED_TEST_SUITE (TestTriangleMesh, TriangleMeshTypes);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/include/pcl/test/gtest.h
+++ b/test/include/pcl/test/gtest.h
@@ -2,7 +2,7 @@
  * Software License Agreement (BSD License)
  *
  *  Point Cloud Library (PCL) - www.pointclouds.org
- *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2019-, Open Perception, Inc.
  *
  *  All rights reserved.
  *
@@ -32,46 +32,34 @@
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- *
- * $Id$
- *
  */
 
+#pragma once
+
 #include <gtest/gtest.h>
-#include <pcl/common/geometry.h>
-#include <pcl/point_types.h>
-#include <pcl/test/gtest.h>
 
-using namespace pcl;
+/**
+ * \file pcl/test/gtest.h
+ *
+ * \brief Defines all the PCL test macros used
+ * \ingroup test
+ */
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename T> class XYZPointTypesTest : public ::testing::Test { };
-using XYZPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM(PCL_XYZ_POINT_TYPES)>;
-TYPED_TEST_SUITE(XYZPointTypesTest, XYZPointTypes);
+/**
+ * \brief Macro choose between TYPED_TEST_CASE and TYPED_TEST_SUITE depending on the GTest version
+ *
+ * \ingroup test
+ */
+#if !defined(TYPED_TEST_SUITE)
+  #define TYPED_TEST_SUITE TYPED_TEST_CASE
+#endif
 
-TYPED_TEST(XYZPointTypesTest, Distance)
-{
-  TypeParam p1, p2;
-  p1.x = 3; p1.y = 4; p1.z = 5;
-  p2.y = 1; p2.x = 1; p2.z = 1.5;
-  double distance = geometry::distance (p1, p2);
-  EXPECT_NEAR (distance, 5.024938, 1e-4);
-}
+/**
+ * \brief Macro choose between INSTANTIATE_TEST_CASE_P and INSTANTIATE_TEST_SUITE_P depending on the GTest version
+ *
+ * \ingroup test
+ */
+#if !defined(INSTANTIATE_TEST_SUITE_P)
+  #define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif
 
-TYPED_TEST(XYZPointTypesTest, SquaredDistance)
-{
-  TypeParam p1, p2;
-  p1.x = 3; p1.y = 4; p1.z = 5;
-  p2.y = 1; p2.x = 1; p2.z = 1.5;
-  double distance = geometry::squaredDistance (p1, p2);
-  EXPECT_NEAR (distance, 25.25, 1e-4);
-}
-
-/* ---[ */
-int
-main (int argc, char** argv)
-{
-  testing::InitGoogleTest (&argc, argv);
-  return (RUN_ALL_TESTS ());
-}
-/* ]--- */

--- a/test/io/test_buffers.cpp
+++ b/test/io/test_buffers.cpp
@@ -41,6 +41,7 @@
 #include <cstdint>
 
 #include <pcl/io/buffers.h>
+#include <pcl/test/gtest.h>
 
 using namespace pcl::io;
 
@@ -84,7 +85,7 @@ class BuffersTest : public ::testing::Test
 };
 
 using DataTypes = ::testing::Types<std::int8_t, std::int32_t, float>;
-TYPED_TEST_CASE (BuffersTest, DataTypes);
+TYPED_TEST_SUITE (BuffersTest, DataTypes);
 
 TYPED_TEST (BuffersTest, SingleBuffer)
 {

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -48,6 +48,7 @@
 #include <pcl/io/ply_io.h>
 #include <pcl/io/ascii_io.h>
 #include <pcl/io/obj_io.h>
+#include <pcl/test/gtest.h>
 #include <fstream>
 #include <locale>
 #include <stdexcept>
@@ -1319,7 +1320,7 @@ TEST (PCL, Locale)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T> class AutoIOTest : public testing::Test { };
 using PCLXyzNormalPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES PCL_NORMAL_POINT_TYPES)>;
-TYPED_TEST_CASE (AutoIOTest, PCLXyzNormalPointTypes);
+TYPED_TEST_SUITE (AutoIOTest, PCLXyzNormalPointTypes);
 TYPED_TEST (AutoIOTest, AutoLoadCloudFiles)
 {
   PointCloud<TypeParam> cloud;

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -41,6 +41,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <gtest/gtest.h>
+#include <pcl/test/gtest.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PLYReaderWriter)
@@ -288,7 +289,7 @@ TEST_F (PLYColorTest, LoadPLYFileColoredASCIIIntoPolygonMesh)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T> class PLYPointCloudTest : public PLYColorTest { };
 using RGBPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_RGB_POINT_TYPES)>;
-TYPED_TEST_CASE (PLYPointCloudTest, RGBPointTypes);
+TYPED_TEST_SUITE (PLYPointCloudTest, RGBPointTypes);
 TYPED_TEST (PLYPointCloudTest, LoadPLYFileColoredASCIIIntoPointCloud)
 {
   int res;
@@ -316,7 +317,7 @@ template<typename T>
 struct PLYCoordinatesIsDenseTest : public PLYTest {};
 
 using XYZPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_XYZ_POINT_TYPES)>;
-TYPED_TEST_CASE (PLYCoordinatesIsDenseTest, XYZPointTypes);
+TYPED_TEST_SUITE (PLYCoordinatesIsDenseTest, XYZPointTypes);
 
 TYPED_TEST (PLYCoordinatesIsDenseTest, NaNInCoordinates)
 {
@@ -410,7 +411,7 @@ template<typename T>
 struct PLYNormalsIsDenseTest : public PLYTest {};
 
 using NormalPointTypes = ::testing::Types<BOOST_PP_SEQ_ENUM (PCL_NORMAL_POINT_TYPES)>;
-TYPED_TEST_CASE (PLYNormalsIsDenseTest, NormalPointTypes);
+TYPED_TEST_SUITE (PLYNormalsIsDenseTest, NormalPointTypes);
 
 TYPED_TEST (PLYNormalsIsDenseTest, NaNInNormals)
 {

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -41,6 +41,7 @@
 #include <pcl/common/projection_matrix.h>
 #include <pcl/point_types.h>
 #include <gtest/gtest.h>
+#include <pcl/test/gtest.h>
 
 using pcl::octree::OctreeBase;
 using pcl::octree::OctreeIteratorBase;
@@ -154,7 +155,7 @@ using OctreeIteratorTypes = testing::Types
          OctreeLeafNodeDepthFirstIterator<OctreeBase<int> >,
          OctreeFixedDepthIterator<OctreeBase<int> >,
          OctreeLeafNodeBreadthFirstIterator<OctreeBase<int> > >;
-TYPED_TEST_CASE (OctreeIteratorTest, OctreeIteratorTypes);
+TYPED_TEST_SUITE (OctreeIteratorTest, OctreeIteratorTypes);
 
 TYPED_TEST (OctreeIteratorTest, CopyConstructor)
 {

--- a/test/sample_consensus/test_sample_consensus.cpp
+++ b/test/sample_consensus/test_sample_consensus.cpp
@@ -45,6 +45,7 @@
 #include <pcl/sample_consensus/ransac.h>
 #include <pcl/sample_consensus/rransac.h>
 #include <pcl/sample_consensus/sac_model_sphere.h>
+#include <pcl/test/gtest.h>
 
 #include <chrono>
 #include <condition_variable>
@@ -92,7 +93,7 @@ using sacTypes = ::testing::Types<
   RandomizedMEstimatorSampleConsensus<PointXYZ>,
   MaximumLikelihoodSampleConsensus<PointXYZ>
 >;
-TYPED_TEST_CASE(SacTest, sacTypes);
+TYPED_TEST_SUITE(SacTest, sacTypes);
 
 TYPED_TEST(SacTest, InfiniteLoop)
 {

--- a/test/segmentation/test_random_walker.cpp
+++ b/test/segmentation/test_random_walker.cpp
@@ -48,6 +48,7 @@
 #include <gtest/gtest.h>
 
 #include <pcl/segmentation/random_walker.h>
+#include <pcl/test/gtest.h>
 
 std::string TEST_DATA_DIR;
 
@@ -235,7 +236,7 @@ TEST_P (RandomWalkerTest, GetPotentials)
       }
 }
 
-INSTANTIATE_TEST_CASE_P (VariousGraphs,
+INSTANTIATE_TEST_SUITE_P (VariousGraphs,
                          RandomWalkerTest,
                          ::testing::Values ("graph0.info",
                                             "graph1.info",

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -223,10 +223,7 @@ compute (const PointCloudXYZRGBA::ConstPtr & input, float min_depth, float max_d
   trainTemplate (input, foreground_mask, linemod);
 
   // Save the LINEMOD template
-  std::ofstream file_stream;
-  file_stream.open (template_sqmmt_filename.c_str (), std::ofstream::out | std::ofstream::binary);
-  linemod.getTemplate (0).serialize (file_stream);
-  file_stream.close ();
+  linemod.saveTemplates (template_sqmmt_filename.c_str());
 }
 
 /* ---[ */

--- a/visualization/include/pcl/visualization/point_cloud_color_handlers.h
+++ b/visualization/include/pcl/visualization/point_cloud_color_handlers.h
@@ -42,6 +42,7 @@
 #endif
 
 // PCL includes
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/common/io.h>
 #include <pcl/visualization/common/common.h>
@@ -113,7 +114,7 @@ namespace pcl
           * This virtual method should not be overriden or used. The default implementation
           * is provided only for backwards compatibility with handlers that were written
           * before PCL 1.10.0 and will be removed in future. */
-        [[deprecated("use getColor() without parameters instead")]]
+        PCL_DEPRECATED("use getColor() without parameters instead")
         virtual bool
         getColor (vtkSmartPointer<vtkDataArray> &scalars) const {
           scalars = getColor ();
@@ -615,7 +616,7 @@ namespace pcl
           * This virtual method should not be overriden or used. The default implementation
           * is provided only for backwards compatibility with handlers that were written
           * before PCL 1.10.0 and will be removed in future. */
-        [[deprecated("use getColor() without parameters instead")]]
+        PCL_DEPRECATED("use getColor() without parameters instead")
         virtual bool
         getColor (vtkSmartPointer<vtkDataArray> &scalars) const {
           scalars = getColor ();


### PR DESCRIPTION
Fixes #3679

This is basically PR #3686, but rebased after #3694. I managed to bork the old PR when trying to rebase, so I just opened a new one instead.

Highlights:
 - There are issues with inclusion order of `cmath` on both MSVC and mingw-w64, so sometimes you get the math defines, sometimes not, depending on what other headers are included before, and if you have `_USE_MATH_DEFINES`
 - Compilation with mingw-w64 (from MSYS2) fails due to missing `M_PI`
 - The `math.h` and `cmath` headers on mingw does not use `_MATH_DEFINES_DEFINED` as far as I can see