### PR TITLE
Add precompiled computeApproximateCovariances; fix compilation error for the same

### DIFF
--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -130,6 +130,7 @@ set(srcs
   src/crh.cpp
   src/don.cpp
   src/fpfh.cpp
+  src/from_meshes.cpp
   src/gasd.cpp
   src/gfpfh.cpp
   src/integral_image_normal.cpp

--- a/features/include/pcl/features/from_meshes.h
+++ b/features/include/pcl/features/from_meshes.h
@@ -72,9 +72,9 @@ namespace pcl
       covariances.reserve (nr_points);
       for (const auto& point: normals.points)
       {
-        Eigen::Vector3d normal (normals.points[i].normal_x,
-                                normals.points[i].normal_y,
-                                normals.points[i].normal_z);
+        Eigen::Vector3d normal (point.normal_x,
+                                point.normal_y,
+                                point.normal_z);
 
         // compute rotation matrix
         Eigen::Matrix3d rot;

--- a/features/include/pcl/features/from_meshes.h
+++ b/features/include/pcl/features/from_meshes.h
@@ -52,7 +52,7 @@ namespace pcl
     }
 
 
-    /** \brief Compute GICP-style covariance matrices given a point cloud and 
+    /** \brief Compute GICP-style covariance matrices given a point cloud and
      * the corresponding surface normals.
      * \param[in] cloud Point cloud containing the XYZ coordinates,
      * \param[in] normals Point cloud containing the corresponding surface normals.
@@ -60,7 +60,7 @@ namespace pcl
      * \param[in] Optional: Epsilon for the expected noise along the surface normal (default: 0.001)
      */
     template <typename PointT, typename PointNT> inline void
-    computeApproximateCovariances(const pcl::PointCloud<PointT>& cloud, 
+    computeApproximateCovariances(const pcl::PointCloud<PointT>& cloud,
                                   const pcl::PointCloud<PointNT>& normals,
                                   std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >& covariances,
                                   double epsilon = 0.001)
@@ -97,3 +97,6 @@ namespace pcl
 
   }
 }
+
+#define PCL_INSTANTIATE_computeApproximateCovariances(T,NT) template PCL_EXPORTS void pcl::features::computeApproximateCovariances<T,NT> \
+    (const pcl::PointCloud<T>&, const pcl::PointCloud<NT>&, std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d>>&, double);

--- a/features/src/from_meshes.cpp
+++ b/features/src/from_meshes.cpp
@@ -1,0 +1,50 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/features/from_meshes.h>
+
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/point_types.h>
+#include <pcl/impl/instantiate.hpp>
+// Instantiations of specific point types
+#ifdef PCL_ONLY_CORE_POINT_TYPES
+  PCL_INSTANTIATE_PRODUCT(computeApproximateCovariances, ((pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA))((pcl::Normal)))
+#else
+  PCL_INSTANTIATE_PRODUCT(computeApproximateCovariances, (PCL_XYZ_POINT_TYPES)(PCL_NORMAL_POINT_TYPES))
+#endif
+#endif    // PCL_NO_PRECOMPILE


### PR DESCRIPTION
A colleague told me that `computeApproximateCovariances` failed to compile: it seems that the automatic change from old `for` loops to foreach loops introduced that bug.

This this an obvious albeit untested fix since I don't have a test case. I guess that it could ship in 1.10.2 considering how simple and breaking it is.