### PR TITLE
Clean up `Filter` and `FilterIndices`, move `indices_`/`input_` from public to protected section

### DIFF
--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -84,11 +84,7 @@ namespace pcl
       PCLBase (const PCLBase& base);
 
       /** \brief Destructor. */
-      virtual ~PCLBase ()
-      {
-        input_.reset ();
-        indices_.reset ();
-      }
+      virtual ~PCLBase () = default;
 
       /** \brief Provide a pointer to the input dataset
         * \param[in] cloud the const boost shared pointer to a PointCloud message
@@ -197,11 +193,7 @@ namespace pcl
       PCLBase ();
 
       /** \brief destructor. */
-      virtual ~PCLBase()
-      {
-        input_.reset ();
-        indices_.reset ();
-      }
+      virtual ~PCLBase () = default;
 
       /** \brief Provide a pointer to the input dataset
         * \param cloud the const boost shared pointer to a PointCloud message

--- a/filters/include/pcl/filters/filter.h
+++ b/filters/include/pcl/filters/filter.h
@@ -83,9 +83,6 @@ namespace pcl
   class Filter : public PCLBase<PointT>
   {
     public:
-      using PCLBase<PointT>::indices_;
-      using PCLBase<PointT>::input_;
-
       using Ptr = shared_ptr<Filter<PointT> >;
       using ConstPtr = shared_ptr<const Filter<PointT> >;
 
@@ -103,9 +100,6 @@ namespace pcl
         extract_removed_indices_ (extract_removed_indices)
       {
       }
-
-      /** \brief Empty destructor */
-      ~Filter () {}
 
       /** \brief Get the point indices being removed */
       inline IndicesConstPtr const
@@ -153,6 +147,9 @@ namespace pcl
       }
 
     protected:
+
+      using PCLBase<PointT>::indices_;
+      using PCLBase<PointT>::input_;
 
       using PCLBase<PointT>::initCompute;
       using PCLBase<PointT>::deinitCompute;
@@ -208,9 +205,6 @@ namespace pcl
         extract_removed_indices_ (extract_removed_indices)
       {
       }
-
-      /** \brief Empty destructor */
-      ~Filter () {}
 
       /** \brief Get the point indices being removed */
       inline IndicesConstPtr const

--- a/filters/include/pcl/filters/filter_indices.h
+++ b/filters/include/pcl/filters/filter_indices.h
@@ -85,29 +85,19 @@ namespace pcl
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).
         */
       FilterIndices (bool extract_removed_indices = false) :
-          negative_ (false), 
-          keep_organized_ (false), 
+          Filter<PointT> (extract_removed_indices),
+          negative_ (false),
+          keep_organized_ (false),
           user_filter_value_ (std::numeric_limits<float>::quiet_NaN ())
       {
-        extract_removed_indices_ = extract_removed_indices;
       }
 
-      /** \brief Empty virtual destructor. */
-      
-      ~FilterIndices ()
-      {
-      }
-
-      inline void
-      filter (PointCloud &output)
-      {
-        pcl::Filter<PointT>::filter (output);
-      }
+      using Filter<PointT>::filter;
 
       /** \brief Calls the filtering method and returns the filtered point cloud indices.
         * \param[out] indices the resultant filtered point cloud indices
         */
-      inline void
+      void
       filter (std::vector<int> &indices)
       {
         if (!initCompute ())
@@ -212,24 +202,14 @@ namespace pcl
         * \param[in] extract_removed_indices Set to true if you want to extract the indices of points being removed (default = false).
         */
       FilterIndices (bool extract_removed_indices = false) :
+          Filter<PCLPointCloud2> (extract_removed_indices),
           negative_ (false), 
           keep_organized_ (false), 
           user_filter_value_ (std::numeric_limits<float>::quiet_NaN ())
       {
-        extract_removed_indices_ = extract_removed_indices;
       }
 
-      /** \brief Empty virtual destructor. */
-      
-      ~FilterIndices ()
-      {
-      }
-
-      virtual void
-      filter (PCLPointCloud2 &output)
-      {
-        pcl::Filter<PCLPointCloud2>::filter (output);
-      }
+      using Filter<PCLPointCloud2>::filter;
 
       /** \brief Calls the filtering method and returns the filtered point cloud indices.
         * \param[out] indices the resultant filtered point cloud indices


### PR DESCRIPTION
Just did some class cleanup while prototyping the new SamplingFilter class.