### PR TITLE
Better PointType ctor and reduced warnings in `register_point_struct.h`

### DIFF
--- a/common/include/pcl/common/point_tests.h
+++ b/common/include/pcl/common/point_tests.h
@@ -67,7 +67,7 @@ namespace pcl
 
   template<> inline bool isFinite<pcl::Axis>(const pcl::Axis&) { return (true); }
   template<> inline bool isFinite<pcl::BRISKSignature512>(const pcl::BRISKSignature512&) { return (true); }
-  template<> inline bool isFinite<pcl::BorderDescription>(const pcl::BorderDescription &p) { return true; }
+  template<> inline bool isFinite<pcl::BorderDescription>(const pcl::BorderDescription &) { return true; }
   template<> inline bool isFinite<pcl::Boundary>(const pcl::Boundary&) { return (true); }
   template<> inline bool isFinite<pcl::ESFSignature640>(const pcl::ESFSignature640&) { return (true); }
   template<> inline bool isFinite<pcl::FPFHSignature33>(const pcl::FPFHSignature33&) { return (true); }

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -958,7 +958,8 @@ namespace pcl
       rgba = p.rgba;
     }
 
-    inline PointXYZRGBNormal (float _curvature = 0.f): PointXYZRGBNormal (0.f, 0.f, 0.f) {}
+    inline PointXYZRGBNormal (float _curvature = 0.f):
+        PointXYZRGBNormal (0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, _curvature) {}
 
     inline PointXYZRGBNormal (float _x, float _y, float _z):
       PointXYZRGBNormal (_x, _y, _z, 0, 0, 0) {}
@@ -1014,10 +1015,10 @@ namespace pcl
       intensity = p.intensity;
     }
     
-    inline PointXYZINormal (float _intensity = 0.f): PointXYZINormal (0.f, 0.f, 0.f, 0.f) {}
+    inline PointXYZINormal (float _intensity = 0.f): PointXYZINormal (0.f, 0.f, 0.f, _intensity) {}
     
     inline PointXYZINormal (float _x, float _y, float _z, float _intensity = 0.f):
-      PointXYZINormal (_x, _y, _z, 0.f, 0.f, 0.f, 0.f) {}
+      PointXYZINormal (_x, _y, _z, _intensity, 0.f, 0.f, 0.f) {}
 
     inline PointXYZINormal (float _x, float _y, float _z, float _intensity,
                             float n_x, float n_y, float n_z, float _curvature = 0.f)
@@ -1064,10 +1065,10 @@ namespace pcl
       label = p.label;
     }
 
-    inline PointXYZLNormal (std::uint32_t _label = 0): PointXYZLNormal (0.f, 0.f, 0.f, 0) {}
+    inline PointXYZLNormal (std::uint32_t _label = 0): PointXYZLNormal (0.f, 0.f, 0.f, _label) {}
     
     inline PointXYZLNormal (float _x, float _y, float _z, std::uint32_t _label = 0.f):
-      PointXYZLNormal (_x, _y, _z, 0, 0.f, 0.f, 0.f) {}
+      PointXYZLNormal (_x, _y, _z, _label, 0.f, 0.f, 0.f) {}
 
     inline PointXYZLNormal (float _x, float _y, float _z, std::uint32_t _label,
                             float n_x, float n_y, float n_z, float _curvature = 0.f)
@@ -1334,7 +1335,7 @@ namespace pcl
     inline PPFRGBSignature (float _alpha = 0.f): PPFRGBSignature (0.f, 0.f, 0.f, 0.f, _alpha) {}
 
     inline PPFRGBSignature (float _f1, float _f2, float _f3, float _f4, float _alpha = 0.f):
-      PPFRGBSignature (0.f, 0.f, 0.f, 0.f, _alpha, 0.f, 0.f, 0.f) {}
+      PPFRGBSignature (_f1, _f2, _f3, _f4, _alpha, 0.f, 0.f, 0.f) {}
 
     inline PPFRGBSignature (float _f1, float _f2, float _f3, float _f4, float _alpha, float _r, float _g, float _b):
       f1 (_f1), f2 (_f2), f3 (_f3), f4 (_f4), r_ratio (_r), g_ratio (_g), b_ratio (_b), alpha_m (_alpha) {}

--- a/common/include/pcl/point_traits.h
+++ b/common/include/pcl/point_traits.h
@@ -197,7 +197,7 @@ namespace pcl
       return (field.name == traits::name<PointT, Tag>::value &&
               field.datatype == traits::datatype<PointT, Tag>::value &&
               (field.count == traits::datatype<PointT, Tag>::size ||
-               field.count == 0 && traits::datatype<PointT, Tag>::size == 1 /* see bug #821 */));
+               ((field.count == 0) && (traits::datatype<PointT, Tag>::size == 1 /* see bug #821 */))));
     }
   };
 

--- a/common/include/pcl/register_point_struct.h
+++ b/common/include/pcl/register_point_struct.h
@@ -68,7 +68,7 @@
 // Must be used in global namespace with name fully qualified
 #define POINT_CLOUD_REGISTER_POINT_STRUCT(name, fseq)               \
   POINT_CLOUD_REGISTER_POINT_STRUCT_I(name,                         \
-    BOOST_PP_CAT(POINT_CLOUD_REGISTER_POINT_STRUCT_X fseq, 0))      \
+    BOOST_PP_CAT(POINT_CLOUD_REGISTER_POINT_STRUCT_X fseq, 0))
   /***/
 
 #define POINT_CLOUD_REGISTER_POINT_WRAPPER(wrapper, pod)    \
@@ -77,7 +77,7 @@
     namespace traits {                                      \
       template<> struct POD<wrapper> { using type = pod; }; \
     }                                                       \
-  }                                                         \
+  }
   /***/
 
 // These macros help transform the unusual data structure (type, name, tag)(type, name, tag)...
@@ -106,7 +106,7 @@ namespace pcl
     {
       using type = std::remove_all_extents_t<T>;
       static const std::uint32_t count = sizeof (T) / sizeof (type);
-      for (int i = 0; i < count; ++i)
+      for (std::uint32_t i = 0; i < count; ++i)
         l[i] += r[i];
     }
 
@@ -123,7 +123,7 @@ namespace pcl
     {
       using type = std::remove_all_extents_t<T1>;
       static const std::uint32_t count = sizeof (T1) / sizeof (type);
-      for (int i = 0; i < count; ++i)
+      for (std::uint32_t i = 0; i < count; ++i)
         p[i] += scalar;
     }
 
@@ -140,7 +140,7 @@ namespace pcl
     {
       using type = std::remove_all_extents_t<T>;
       static const std::uint32_t count = sizeof (T) / sizeof (type);
-      for (int i = 0; i < count; ++i)
+      for (std::uint32_t i = 0; i < count; ++i)
         l[i] -= r[i];
     }
 
@@ -157,7 +157,7 @@ namespace pcl
     {
       using type = std::remove_all_extents_t<T1>;
       static const std::uint32_t count = sizeof (T1) / sizeof (type);
-      for (int i = 0; i < count; ++i)
+      for (std::uint32_t i = 0; i < count; ++i)
         p[i] -= scalar;
     }
 
@@ -174,7 +174,7 @@ namespace pcl
     {
       using type = std::remove_all_extents_t<T1>;
       static const std::uint32_t count = sizeof (T1) / sizeof (type);
-      for (int i = 0; i < count; ++i)
+      for (std::uint32_t i = 0; i < count; ++i)
         p[i] *= scalar;
     }
 
@@ -191,7 +191,7 @@ namespace pcl
     {
       using type = std::remove_all_extents_t<T1>;
       static const std::uint32_t count = sizeof (T1) / sizeof (type);
-      for (int i = 0; i < count; ++i)
+      for (std::uint32_t i = 0; i < count; ++i)
         p[i] /= scalar;
     }
   }
@@ -200,34 +200,34 @@ namespace pcl
 // Point operators
 #define PCL_PLUSEQ_POINT_TAG(r, data, elem)                \
   pcl::traits::plus (lhs.BOOST_PP_TUPLE_ELEM(3, 1, elem),  \
-                     rhs.BOOST_PP_TUPLE_ELEM(3, 1, elem)); \
+                     rhs.BOOST_PP_TUPLE_ELEM(3, 1, elem));
   /***/
 
 #define PCL_PLUSEQSC_POINT_TAG(r, data, elem)                 \
   pcl::traits::plusscalar (p.BOOST_PP_TUPLE_ELEM(3, 1, elem), \
-                           scalar);                           \
+                           scalar);
   /***/
-   //p.BOOST_PP_TUPLE_ELEM(3, 1, elem) += scalar;  \
+   //p.BOOST_PP_TUPLE_ELEM(3, 1, elem) += scalar;
 
 #define PCL_MINUSEQ_POINT_TAG(r, data, elem)                \
   pcl::traits::minus (lhs.BOOST_PP_TUPLE_ELEM(3, 1, elem),  \
-                      rhs.BOOST_PP_TUPLE_ELEM(3, 1, elem)); \
+                      rhs.BOOST_PP_TUPLE_ELEM(3, 1, elem));
   /***/
 
 #define PCL_MINUSEQSC_POINT_TAG(r, data, elem)                 \
   pcl::traits::minusscalar (p.BOOST_PP_TUPLE_ELEM(3, 1, elem), \
-                            scalar);                           \
+                            scalar);
   /***/
-   //p.BOOST_PP_TUPLE_ELEM(3, 1, elem) -= scalar;   \
+   //p.BOOST_PP_TUPLE_ELEM(3, 1, elem) -= scalar;
 
 #define PCL_MULEQSC_POINT_TAG(r, data, elem)                 \
   pcl::traits::mulscalar (p.BOOST_PP_TUPLE_ELEM(3, 1, elem), \
-                            scalar);                         \
+                            scalar);
   /***/
 
 #define PCL_DIVEQSC_POINT_TAG(r, data, elem)   \
   pcl::traits::divscalar (p.BOOST_PP_TUPLE_ELEM(3, 1, elem), \
-                            scalar);                         \
+                            scalar);
   /***/
 
 // Construct type traits given full sequence of (type, name, tag) triples
@@ -306,7 +306,7 @@ namespace pcl
       inline const name operator/ (const name& p, const float& scalar) \
       { name result = p; result /= scalar; return (result); }          \
     }                                                          \
-  }                                                            \
+  }
   /***/
 
 #define POINT_CLOUD_REGISTER_FIELD_TAG(r, name, elem)   \
@@ -324,14 +324,14 @@ namespace pcl
   const char name<point,                                                \
                   pcl::fields::BOOST_PP_TUPLE_ELEM(3, 2, elem),         \
                   dummy>::value[] =                                     \
-    BOOST_PP_STRINGIZE(BOOST_PP_TUPLE_ELEM(3, 2, elem));                \
+    BOOST_PP_STRINGIZE(BOOST_PP_TUPLE_ELEM(3, 2, elem));
   /***/
 
 #define POINT_CLOUD_REGISTER_FIELD_OFFSET(r, name, elem)                \
   template<> struct offset<name, pcl::fields::BOOST_PP_TUPLE_ELEM(3, 2, elem)> \
   {                                                                     \
     static const std::size_t value = offsetof(name, BOOST_PP_TUPLE_ELEM(3, 1, elem)); \
-  };                                                                    \
+  };
   /***/
 
 #define POINT_CLOUD_REGISTER_FIELD_DATATYPE(r, name, elem)              \
@@ -341,7 +341,7 @@ namespace pcl
     using decomposed = decomposeArray<type>;                            \
     static const std::uint8_t value = asEnum<decomposed::type>::value;       \
     static const std::uint32_t size = decomposed::value;                     \
-  };                                                                    \
+  };
   /***/
 
 #define POINT_CLOUD_TAG_OP(s, data, elem) pcl::fields::BOOST_PP_TUPLE_ELEM(3, 2, elem)
@@ -352,7 +352,7 @@ namespace pcl
   template<> struct fieldList<name>                             \
   {                                                             \
     using type = boost::mpl::vector<BOOST_PP_SEQ_ENUM(seq)>;    \
-  };                                                            \
+  };
   /***/
 
 #if defined _MSC_VER


### PR DESCRIPTION
Also removed unneeded line continuation in macros

Warnings fixed:
* unused variable
* multi-line comment
* sign mismatch