### PR TITLE
[gpu] fix compilation bug in initRegistration for only OpenNi

### DIFF
--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -771,16 +771,15 @@ struct KinFuLSApp
   void
   initRegistration ()
   {
-    registration_ = 
-      #ifdef HAVE_OPENNI
-      capture_.providesCallback<pcl::ONIGrabber::sig_cb_openni_image_depth_image> ()
-      #endif
-      #if defined(HAVE_OPENNI) && defined(HAVE_OPENNI2)
-      ||
-      #endif
-      #ifdef HAVE_OPENNI2
-      capture_.providesCallback<pcl::io::OpenNI2Grabber::sig_cb_openni_image_depth_image> ();
-      #endif
+    registration_ =
+    #if defined(HAVE_OPENNI) && !defined(HAVE_OPENNI2)
+    capture_.providesCallback<pcl::ONIGrabber::sig_cb_openni_image_depth_image> ();
+    #elif !defined(HAVE_OPENNI) && defined(HAVE_OPENNI2)
+    capture_.providesCallback<pcl::io::OpenNI2Grabber::sig_cb_openni_image_depth_image> ();
+    #elif defined(HAVE_OPENNI) && defined(HAVE_OPENNI2)
+    capture_.providesCallback<pcl::ONIGrabber::sig_cb_openni_image_depth_image> () ||
+    capture_.providesCallback<pcl::io::OpenNI2Grabber::sig_cb_openni_image_depth_image> ();
+    #endif
     std::cout << "Registration mode: " << (registration_ ? "On" : "Off (not supported by source)") << std::endl;
   }
 


### PR DESCRIPTION
…infuLS_app.cpp

Fix compile error:
```
pcl-master/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp:784:5: error: expected ‘;’ before ‘std’
     std::cout << "Registration mode: " << (registration_ ? "On" : "Off (not supported by source)") << std::endl;
```