### PR TITLE
Use namespaces with their keyword

### DIFF
--- a/2d/include/pcl/2d/impl/convolution.hpp
+++ b/2d/include/pcl/2d/impl/convolution.hpp
@@ -38,10 +38,11 @@
 #ifndef PCL_2D_CONVOLUTION_IMPL_HPP
 #define PCL_2D_CONVOLUTION_IMPL_HPP
 
-//////////////////////////////////////////////////////////////////////////////
+namespace pcl {
+
 template <typename PointT>
 void
-pcl::Convolution<PointT>::filter(pcl::PointCloud<PointT>& output)
+Convolution<PointT>::filter(pcl::PointCloud<PointT>& output)
 {
   int input_row = 0;
   int input_col = 0;
@@ -133,5 +134,6 @@ pcl::Convolution<PointT>::filter(pcl::PointCloud<PointT>& output)
   }
   } // switch
 }
+} // namespace pcl
 
 #endif

--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -41,10 +41,11 @@
 #include <pcl/2d/convolution.h>
 #include <pcl/common/common_headers.h> // rad2deg()
 
-//////////////////////////////////////////////////////////////////////////////
+namespace pcl {
+
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::detectEdgeSobel(pcl::PointCloud<PointOutT>& output)
+Edge<PointInT, PointOutT>::detectEdgeSobel(pcl::PointCloud<PointOutT>& output)
 {
   convolution_.setInputCloud(input_);
   pcl::PointCloud<PointXYZI>::Ptr kernel_x(new pcl::PointCloud<PointXYZI>);
@@ -79,10 +80,9 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeSobel(pcl::PointCloud<PointOutT>& outp
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::sobelMagnitudeDirection(
+Edge<PointInT, PointOutT>::sobelMagnitudeDirection(
     const pcl::PointCloud<PointInT>& input_x,
     const pcl::PointCloud<PointInT>& input_y,
     pcl::PointCloud<PointOutT>& output)
@@ -121,10 +121,9 @@ pcl::Edge<PointInT, PointOutT>::sobelMagnitudeDirection(
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::detectEdgePrewitt(pcl::PointCloud<PointOutT>& output)
+Edge<PointInT, PointOutT>::detectEdgePrewitt(pcl::PointCloud<PointOutT>& output)
 {
   convolution_.setInputCloud(input_);
 
@@ -160,10 +159,9 @@ pcl::Edge<PointInT, PointOutT>::detectEdgePrewitt(pcl::PointCloud<PointOutT>& ou
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::detectEdgeRoberts(pcl::PointCloud<PointOutT>& output)
+Edge<PointInT, PointOutT>::detectEdgeRoberts(pcl::PointCloud<PointOutT>& output)
 {
   convolution_.setInputCloud(input_);
 
@@ -199,10 +197,9 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeRoberts(pcl::PointCloud<PointOutT>& ou
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::cannyTraceEdge(
+Edge<PointInT, PointOutT>::cannyTraceEdge(
     int rowOffset, int colOffset, int row, int col, pcl::PointCloud<PointXYZI>& maxima)
 {
   int newRow = row + rowOffset;
@@ -226,10 +223,9 @@ pcl::Edge<PointInT, PointOutT>::cannyTraceEdge(
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::discretizeAngles(pcl::PointCloud<PointOutT>& thet)
+Edge<PointInT, PointOutT>::discretizeAngles(pcl::PointCloud<PointOutT>& thet)
 {
   const int height = thet.height;
   const int width = thet.width;
@@ -253,10 +249,9 @@ pcl::Edge<PointInT, PointOutT>::discretizeAngles(pcl::PointCloud<PointOutT>& the
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::suppressNonMaxima(
+Edge<PointInT, PointOutT>::suppressNonMaxima(
     const pcl::PointCloud<PointXYZIEdge>& edges,
     pcl::PointCloud<PointXYZI>& maxima,
     float tLow)
@@ -312,10 +307,9 @@ pcl::Edge<PointInT, PointOutT>::suppressNonMaxima(
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::detectEdgeCanny(pcl::PointCloud<PointOutT>& output)
+Edge<PointInT, PointOutT>::detectEdgeCanny(pcl::PointCloud<PointOutT>& output)
 {
   float tHigh = hysteresis_threshold_high_;
   float tLow = hysteresis_threshold_low_;
@@ -377,12 +371,11 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeCanny(pcl::PointCloud<PointOutT>& outp
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::canny(const pcl::PointCloud<PointInT>& input_x,
-                                      const pcl::PointCloud<PointInT>& input_y,
-                                      pcl::PointCloud<PointOutT>& output)
+Edge<PointInT, PointOutT>::canny(const pcl::PointCloud<PointInT>& input_x,
+                                 const pcl::PointCloud<PointInT>& input_y,
+                                 pcl::PointCloud<PointOutT>& output)
 {
   float tHigh = hysteresis_threshold_high_;
   float tLow = hysteresis_threshold_low_;
@@ -452,12 +445,11 @@ pcl::Edge<PointInT, PointOutT>::canny(const pcl::PointCloud<PointInT>& input_x,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT>
 void
-pcl::Edge<PointInT, PointOutT>::detectEdgeLoG(const float kernel_sigma,
-                                              const float kernel_size,
-                                              pcl::PointCloud<PointOutT>& output)
+Edge<PointInT, PointOutT>::detectEdgeLoG(const float kernel_sigma,
+                                         const float kernel_size,
+                                         pcl::PointCloud<PointOutT>& output)
 {
   convolution_.setInputCloud(input_);
 
@@ -469,5 +461,7 @@ pcl::Edge<PointInT, PointOutT>::detectEdgeLoG(const float kernel_sigma,
   convolution_.setKernel(*log_kernel);
   convolution_.filter(output);
 }
+
+} // namespace pcl
 
 #endif

--- a/2d/include/pcl/2d/impl/kernel.hpp
+++ b/2d/include/pcl/2d/impl/kernel.hpp
@@ -38,10 +38,11 @@
 #ifndef PCL_2D_KERNEL_IMPL_HPP
 #define PCL_2D_KERNEL_IMPL_HPP
 
-//////////////////////////////////////////////////////////////////////////////
+namespace pcl {
+
 template <typename PointT>
 void
-pcl::kernel<PointT>::fetchKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::fetchKernel(pcl::PointCloud<PointT>& kernel)
 {
   switch (kernel_type_) {
   case SOBEL_X:
@@ -89,10 +90,9 @@ pcl::kernel<PointT>::fetchKernel(pcl::PointCloud<PointT>& kernel)
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::gaussianKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::gaussianKernel(pcl::PointCloud<PointT>& kernel)
 {
   float sum = 0;
   kernel.resize(kernel_size_ * kernel_size_);
@@ -116,10 +116,9 @@ pcl::kernel<PointT>::gaussianKernel(pcl::PointCloud<PointT>& kernel)
     kernel[i].intensity /= sum;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::loGKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::loGKernel(pcl::PointCloud<PointT>& kernel)
 {
   float sum = 0;
   float temp = 0;
@@ -144,10 +143,9 @@ pcl::kernel<PointT>::loGKernel(pcl::PointCloud<PointT>& kernel)
     kernel[i].intensity /= sum;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::sobelKernelX(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::sobelKernelX(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(9);
   kernel.height = 3;
@@ -163,10 +161,9 @@ pcl::kernel<PointT>::sobelKernelX(pcl::PointCloud<PointT>& kernel)
   kernel(2, 2).intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::prewittKernelX(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::prewittKernelX(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(9);
   kernel.height = 3;
@@ -182,10 +179,9 @@ pcl::kernel<PointT>::prewittKernelX(pcl::PointCloud<PointT>& kernel)
   kernel(2, 2).intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::robertsKernelX(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::robertsKernelX(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(4);
   kernel.height = 2;
@@ -196,10 +192,9 @@ pcl::kernel<PointT>::robertsKernelX(pcl::PointCloud<PointT>& kernel)
   kernel(1, 1).intensity = -1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::sobelKernelY(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::sobelKernelY(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(9);
   kernel.height = 3;
@@ -215,10 +210,9 @@ pcl::kernel<PointT>::sobelKernelY(pcl::PointCloud<PointT>& kernel)
   kernel(2, 2).intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::prewittKernelY(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::prewittKernelY(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(9);
   kernel.height = 3;
@@ -236,7 +230,7 @@ pcl::kernel<PointT>::prewittKernelY(pcl::PointCloud<PointT>& kernel)
 
 template <typename PointT>
 void
-pcl::kernel<PointT>::robertsKernelY(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::robertsKernelY(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(4);
   kernel.height = 2;
@@ -247,10 +241,9 @@ pcl::kernel<PointT>::robertsKernelY(pcl::PointCloud<PointT>& kernel)
   kernel(1, 1).intensity = 0;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::derivativeXCentralKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::derivativeXCentralKernel(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(3);
   kernel.height = 1;
@@ -260,10 +253,9 @@ pcl::kernel<PointT>::derivativeXCentralKernel(pcl::PointCloud<PointT>& kernel)
   kernel(2, 0).intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::derivativeXForwardKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::derivativeXForwardKernel(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(3);
   kernel.height = 1;
@@ -273,10 +265,9 @@ pcl::kernel<PointT>::derivativeXForwardKernel(pcl::PointCloud<PointT>& kernel)
   kernel(2, 0).intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::derivativeXBackwardKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::derivativeXBackwardKernel(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(3);
   kernel.height = 1;
@@ -286,10 +277,9 @@ pcl::kernel<PointT>::derivativeXBackwardKernel(pcl::PointCloud<PointT>& kernel)
   kernel(2, 0).intensity = 0;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::derivativeYCentralKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::derivativeYCentralKernel(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(3);
   kernel.height = 3;
@@ -299,10 +289,9 @@ pcl::kernel<PointT>::derivativeYCentralKernel(pcl::PointCloud<PointT>& kernel)
   kernel(0, 2).intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::derivativeYForwardKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::derivativeYForwardKernel(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(3);
   kernel.height = 3;
@@ -312,10 +301,9 @@ pcl::kernel<PointT>::derivativeYForwardKernel(pcl::PointCloud<PointT>& kernel)
   kernel(0, 2).intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::derivativeYBackwardKernel(pcl::PointCloud<PointT>& kernel)
+kernel<PointT>::derivativeYBackwardKernel(pcl::PointCloud<PointT>& kernel)
 {
   kernel.resize(3);
   kernel.height = 3;
@@ -325,29 +313,27 @@ pcl::kernel<PointT>::derivativeYBackwardKernel(pcl::PointCloud<PointT>& kernel)
   kernel(0, 2).intensity = 0;
 }
 
-//////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::setKernelType(KERNEL_ENUM kernel_type)
+kernel<PointT>::setKernelType(KERNEL_ENUM kernel_type)
 {
   kernel_type_ = kernel_type;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::setKernelSize(int kernel_size)
+kernel<PointT>::setKernelSize(int kernel_size)
 {
   kernel_size_ = kernel_size;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::kernel<PointT>::setKernelSigma(float kernel_sigma)
+kernel<PointT>::setKernelSigma(float kernel_sigma)
 {
   sigma_ = kernel_sigma;
 }
+
+} // namespace pcl
 
 #endif

--- a/2d/include/pcl/2d/impl/keypoint.hpp
+++ b/2d/include/pcl/2d/impl/keypoint.hpp
@@ -46,14 +46,16 @@
 #include <pcl/2d/convolution.h>
 #include <pcl/2d/edge.h>
 
-//////////////////////////////////////////////////////////////////////////////
+namespace pcl {
+namespace keypoint {
+
 void
-pcl::keypoint::harrisCorner(ImageType& output,
-                            ImageType& input,
-                            const float sigma_d,
-                            const float sigma_i,
-                            const float alpha,
-                            const float thresh)
+harrisCorner(ImageType& output,
+             ImageType& input,
+             const float sigma_d,
+             const float sigma_i,
+             const float alpha,
+             const float thresh)
 {
 
   /*creating the gaussian kernels*/
@@ -115,12 +117,8 @@ pcl::keypoint::harrisCorner(ImageType& output,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 void
-pcl::keypoint::hessianBlob(ImageType& output,
-                           ImageType& input,
-                           const float sigma,
-                           bool SCALED)
+hessianBlob(ImageType& output, ImageType& input, const float sigma, bool SCALED)
 {
   /*creating the gaussian kernels*/
   ImageType kernel, cornerness;
@@ -175,13 +173,12 @@ pcl::keypoint::hessianBlob(ImageType& output,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 void
-pcl::keypoint::hessianBlob(ImageType& output,
-                           ImageType& input,
-                           const float start_scale,
-                           const float scaling_factor,
-                           const int num_scales)
+hessianBlob(ImageType& output,
+            ImageType& input,
+            const float start_scale,
+            const float scaling_factor,
+            const int num_scales)
 {
   const std::size_t height = input.size();
   const std::size_t width = input[0].size();
@@ -239,11 +236,8 @@ pcl::keypoint::hessianBlob(ImageType& output,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 void
-pcl::keypoint::imageElementMultiply(ImageType& output,
-                                    ImageType& input1,
-                                    ImageType& input2)
+imageElementMultiply(ImageType& output, ImageType& input1, ImageType& input2)
 {
   const std::size_t height = input1.size();
   const std::size_t width = input1[0].size();
@@ -255,5 +249,7 @@ pcl::keypoint::imageElementMultiply(ImageType& output,
     }
   }
 }
+} // namespace keypoint
+} // namespace pcl
 
 #endif // PCL_2D_KEYPOINT_HPP_

--- a/2d/include/pcl/2d/impl/morphology.hpp
+++ b/2d/include/pcl/2d/impl/morphology.hpp
@@ -38,11 +38,12 @@
 #ifndef PCL_2D_MORPHOLOGY_HPP_
 #define PCL_2D_MORPHOLOGY_HPP_
 
-//////////////////////////////////////////////////////////////////////////////
+namespace pcl {
+
 // Assumes input, kernel and output images have 0's and 1's only
 template <typename PointT>
 void
-pcl::Morphology<PointT>::erosionBinary(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::erosionBinary(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
@@ -90,11 +91,10 @@ pcl::Morphology<PointT>::erosionBinary(pcl::PointCloud<PointT>& output)
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 // Assumes input, kernel and output images have 0's and 1's only
 template <typename PointT>
 void
-pcl::Morphology<PointT>::dilationBinary(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::dilationBinary(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
@@ -136,11 +136,10 @@ pcl::Morphology<PointT>::dilationBinary(pcl::PointCloud<PointT>& output)
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 // Assumes input, kernel and output images have 0's and 1's only
 template <typename PointT>
 void
-pcl::Morphology<PointT>::openingBinary(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::openingBinary(pcl::PointCloud<PointT>& output)
 {
   PointCloudInPtr intermediate_output(new PointCloudIn);
   erosionBinary(*intermediate_output);
@@ -148,11 +147,10 @@ pcl::Morphology<PointT>::openingBinary(pcl::PointCloud<PointT>& output)
   dilationBinary(output);
 }
 
-//////////////////////////////////////////////////////////////////////////////
 // Assumes input, kernel and output images have 0's and 1's only
 template <typename PointT>
 void
-pcl::Morphology<PointT>::closingBinary(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::closingBinary(pcl::PointCloud<PointT>& output)
 {
   PointCloudInPtr intermediate_output(new PointCloudIn);
   dilationBinary(*intermediate_output);
@@ -160,10 +158,9 @@ pcl::Morphology<PointT>::closingBinary(pcl::PointCloud<PointT>& output)
   erosionBinary(output);
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::erosionGray(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::erosionGray(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
@@ -203,10 +200,9 @@ pcl::Morphology<PointT>::erosionGray(pcl::PointCloud<PointT>& output)
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::dilationGray(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::dilationGray(pcl::PointCloud<PointT>& output)
 {
   const int height = input_->height;
   const int width = input_->width;
@@ -247,10 +243,9 @@ pcl::Morphology<PointT>::dilationGray(pcl::PointCloud<PointT>& output)
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::openingGray(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::openingGray(pcl::PointCloud<PointT>& output)
 {
   PointCloudInPtr intermediate_output(new PointCloudIn);
   erosionGray(*intermediate_output);
@@ -258,10 +253,9 @@ pcl::Morphology<PointT>::openingGray(pcl::PointCloud<PointT>& output)
   dilationGray(output);
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::closingGray(pcl::PointCloud<PointT>& output)
+Morphology<PointT>::closingGray(pcl::PointCloud<PointT>& output)
 {
   PointCloudInPtr intermediate_output(new PointCloudIn);
   dilationGray(*intermediate_output);
@@ -269,12 +263,11 @@ pcl::Morphology<PointT>::closingGray(pcl::PointCloud<PointT>& output)
   erosionGray(output);
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::subtractionBinary(pcl::PointCloud<PointT>& output,
-                                           const pcl::PointCloud<PointT>& input1,
-                                           const pcl::PointCloud<PointT>& input2)
+Morphology<PointT>::subtractionBinary(pcl::PointCloud<PointT>& output,
+                                      const pcl::PointCloud<PointT>& input1,
+                                      const pcl::PointCloud<PointT>& input2)
 {
   const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
@@ -290,12 +283,11 @@ pcl::Morphology<PointT>::subtractionBinary(pcl::PointCloud<PointT>& output,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::unionBinary(pcl::PointCloud<PointT>& output,
-                                     const pcl::PointCloud<PointT>& input1,
-                                     const pcl::PointCloud<PointT>& input2)
+Morphology<PointT>::unionBinary(pcl::PointCloud<PointT>& output,
+                                const pcl::PointCloud<PointT>& input1,
+                                const pcl::PointCloud<PointT>& input2)
 {
   const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
@@ -311,12 +303,11 @@ pcl::Morphology<PointT>::unionBinary(pcl::PointCloud<PointT>& output,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::intersectionBinary(pcl::PointCloud<PointT>& output,
-                                            const pcl::PointCloud<PointT>& input1,
-                                            const pcl::PointCloud<PointT>& input2)
+Morphology<PointT>::intersectionBinary(pcl::PointCloud<PointT>& output,
+                                       const pcl::PointCloud<PointT>& input1,
+                                       const pcl::PointCloud<PointT>& input2)
 {
   const int height = (input1.height < input2.height) ? input1.height : input2.height;
   const int width = (input1.width < input2.width) ? input1.width : input2.width;
@@ -332,11 +323,10 @@ pcl::Morphology<PointT>::intersectionBinary(pcl::PointCloud<PointT>& output,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::structuringElementCircular(pcl::PointCloud<PointT>& kernel,
-                                                    const int radius)
+Morphology<PointT>::structuringElementCircular(pcl::PointCloud<PointT>& kernel,
+                                               const int radius)
 {
   const int dim = 2 * radius;
   kernel.height = dim;
@@ -353,12 +343,11 @@ pcl::Morphology<PointT>::structuringElementCircular(pcl::PointCloud<PointT>& ker
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::structuringElementRectangle(pcl::PointCloud<PointT>& kernel,
-                                                     const int height,
-                                                     const int width)
+Morphology<PointT>::structuringElementRectangle(pcl::PointCloud<PointT>& kernel,
+                                                const int height,
+                                                const int width)
 {
   kernel.height = height;
   kernel.width = width;
@@ -367,13 +356,13 @@ pcl::Morphology<PointT>::structuringElementRectangle(pcl::PointCloud<PointT>& ke
     kernel[i].intensity = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 void
-pcl::Morphology<PointT>::setStructuringElement(
-    const PointCloudInPtr& structuring_element)
+Morphology<PointT>::setStructuringElement(const PointCloudInPtr& structuring_element)
 {
   structuring_element_ = structuring_element;
 }
+
+} // namespace pcl
 
 #endif // PCL_2D_MORPHOLOGY_HPP_

--- a/common/include/pcl/common/impl/bivariate_polynomial.hpp
+++ b/common/include/pcl/common/impl/bivariate_polynomial.hpp
@@ -36,6 +36,7 @@
  * $Id$
  *
  */
+
 #ifndef BIVARIATE_POLYNOMIAL_HPP
 #define BIVARIATE_POLYNOMIAL_HPP
 
@@ -45,32 +46,35 @@
 #include <iostream>
 #include <vector>
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template<typename real>
-pcl::BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree) :
+BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree) :
   degree(0), parameters(nullptr), gradient_x(nullptr), gradient_y(nullptr)
 {
   setDegree(new_degree);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real>
-pcl::BivariatePolynomialT<real>::BivariatePolynomialT (const BivariatePolynomialT& other) :
+BivariatePolynomialT<real>::BivariatePolynomialT (const BivariatePolynomialT& other) :
   degree(0), parameters(NULL), gradient_x(NULL), gradient_y(NULL)
 {
   deepCopy (other);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real>
-pcl::BivariatePolynomialT<real>::~BivariatePolynomialT ()
+BivariatePolynomialT<real>::~BivariatePolynomialT ()
 {
   memoryCleanUp ();
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::setDegree (int newDegree)
+BivariatePolynomialT<real>::setDegree (int newDegree)
 {
   if (newDegree <= 0)
   {
@@ -89,18 +93,18 @@ pcl::BivariatePolynomialT<real>::setDegree (int newDegree)
   delete gradient_y; gradient_y = nullptr;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::memoryCleanUp ()
+BivariatePolynomialT<real>::memoryCleanUp ()
 {
   delete[] parameters; parameters = nullptr;
   delete gradient_x; gradient_x = nullptr;
   delete gradient_y; gradient_y = nullptr;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::deepCopy (const pcl::BivariatePolynomialT<real>& other)
+BivariatePolynomialT<real>::deepCopy (const pcl::BivariatePolynomialT<real>& other)
 {
   if (this == &other) return;
   if (degree != other.degree)
@@ -129,9 +133,9 @@ pcl::BivariatePolynomialT<real>::deepCopy (const pcl::BivariatePolynomialT<real>
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::calculateGradient (bool forceRecalc)
+BivariatePolynomialT<real>::calculateGradient (bool forceRecalc)
 {
   if (gradient_x!=NULL && !forceRecalc) return;
 
@@ -160,9 +164,9 @@ pcl::BivariatePolynomialT<real>::calculateGradient (bool forceRecalc)
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> real
-pcl::BivariatePolynomialT<real>::getValue (real x, real y) const
+BivariatePolynomialT<real>::getValue (real x, real y) const
 {
   unsigned int parametersSize = getNoOfParameters ();
   real* tmpParameter = &parameters[parametersSize-1];
@@ -181,19 +185,19 @@ pcl::BivariatePolynomialT<real>::getValue (real x, real y) const
   return ret;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::getValueOfGradient (real x, real y, real& gradX, real& gradY)
+BivariatePolynomialT<real>::getValueOfGradient (real x, real y, real& gradX, real& gradY)
 {
   calculateGradient ();
   gradX = gradient_x->getValue (x, y);
   gradY = gradient_y->getValue (x, y);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::findCriticalPoints (std::vector<real>& x_values, std::vector<real>& y_values,
-                                                     std::vector<int>& types) const
+BivariatePolynomialT<real>::findCriticalPoints (std::vector<real>& x_values, std::vector<real>& y_values,
+                                                std::vector<int>& types) const
 {
   x_values.clear ();
   y_values.clear ();
@@ -228,9 +232,9 @@ pcl::BivariatePolynomialT<real>::findCriticalPoints (std::vector<real>& x_values
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> std::ostream&
-pcl::operator<< (std::ostream& os, const pcl::BivariatePolynomialT<real>& p)
+operator<< (std::ostream& os, const pcl::BivariatePolynomialT<real>& p)
 {
   real* tmpParameter = p.parameters;
   bool first = true;
@@ -266,26 +270,26 @@ pcl::operator<< (std::ostream& os, const pcl::BivariatePolynomialT<real>& p)
   return (os);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::writeBinary (std::ostream& os) const
+BivariatePolynomialT<real>::writeBinary (std::ostream& os) const
 {
   os.write (reinterpret_cast<const char*> (&degree), sizeof (int));
   unsigned int paramCnt = getNoOfParametersFromDegree (this->degree);
   os.write (reinterpret_cast<const char*> (this->parameters), paramCnt * sizeof (real));
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::writeBinary (const char* filename) const
+BivariatePolynomialT<real>::writeBinary (const char* filename) const
 {
   std::ofstream fout (filename);
   writeBinary (fout);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::readBinary (std::istream& os)
+BivariatePolynomialT<real>::readBinary (std::istream& os)
 {
   memoryCleanUp ();
   os.read (reinterpret_cast<char*> (&this->degree), sizeof (int));
@@ -294,12 +298,15 @@ pcl::BivariatePolynomialT<real>::readBinary (std::istream& os)
   os.read (reinterpret_cast<char*> (&(*this->parameters)), paramCnt * sizeof (real));
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename real> void
-pcl::BivariatePolynomialT<real>::readBinary (const char* filename)
+BivariatePolynomialT<real>::readBinary (const char* filename)
 {
   std::ifstream fin (filename);
   readBinary (fin);
 }
 
+} // namespace pcl
+
 #endif
+

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -45,14 +45,16 @@
 #include <pcl/conversions.h>
 #include <boost/mpl/size.hpp>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+namespace pcl
+{
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
-                        Eigen::Matrix<Scalar, 4, 1> &centroid)
+compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
+                   Eigen::Matrix<Scalar, 4, 1> &centroid)
 {
   // Initialize to 0
   centroid.setZero ();
-  
+
   unsigned cp = 0;
 
   // For each point in the cloud
@@ -74,10 +76,10 @@ pcl::compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
   return (cp);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud, 
-                        Eigen::Matrix<Scalar, 4, 1> &centroid)
+compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                   Eigen::Matrix<Scalar, 4, 1> &centroid)
 {
   if (cloud.empty ())
     return (0);
@@ -118,11 +120,11 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   return (cp);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud, 
-                        const std::vector<int> &indices,
-                        Eigen::Matrix<Scalar, 4, 1> &centroid)
+compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                   const std::vector<int> &indices,
+                   Eigen::Matrix<Scalar, 4, 1> &centroid)
 {
   if (indices.empty ())
     return (0);
@@ -160,20 +162,20 @@ pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
   return (cp);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
-                        const pcl::PointIndices &indices,
-                        Eigen::Matrix<Scalar, 4, 1> &centroid)
+compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                   const pcl::PointIndices &indices,
+                   Eigen::Matrix<Scalar, 4, 1> &centroid)
 {
   return (pcl::compute3DCentroid (cloud, indices.indices, centroid));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned
-pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                              const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                              Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                         const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                         Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   if (cloud.empty ())
     return (0);
@@ -240,11 +242,11 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   return (point_count);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                        const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                                        Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                   const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                   Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   unsigned point_count = pcl::computeCovarianceMatrix (cloud, centroid, covariance_matrix);
   if (point_count != 0)
@@ -252,12 +254,12 @@ pcl::computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
   return (point_count);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                              const std::vector<int> &indices,
-                              const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                              Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                         const std::vector<int> &indices,
+                         const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                         Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   if (indices.empty ())
     return (0);
@@ -323,22 +325,22 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   return (static_cast<unsigned int> (point_count));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                              const pcl::PointIndices &indices,
-                              const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                              Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                         const pcl::PointIndices &indices,
+                         const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                         Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   return (pcl::computeCovarianceMatrix (cloud, indices.indices, centroid, covariance_matrix));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                        const std::vector<int> &indices,
-                                        const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                                        Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                   const std::vector<int> &indices,
+                                   const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                   Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   unsigned point_count = pcl::computeCovarianceMatrix (cloud, indices, centroid, covariance_matrix);
   if (point_count != 0)
@@ -347,12 +349,12 @@ pcl::computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
   return (point_count);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                        const pcl::PointIndices &indices,
-                                        const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                                        Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                   const pcl::PointIndices &indices,
+                                   const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                   Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   unsigned int point_count = pcl::computeCovarianceMatrix (cloud, indices.indices, centroid, covariance_matrix);
   if (point_count != 0)
@@ -361,10 +363,10 @@ pcl::computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
   return point_count;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                              Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                         Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 6, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 6, Eigen::RowMajor>::Zero ();
@@ -415,11 +417,11 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   return (point_count);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                              const std::vector<int> &indices,
-                              Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                         const std::vector<int> &indices,
+                         Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 6, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 6, Eigen::RowMajor>::Zero ();
@@ -469,20 +471,20 @@ pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   return (point_count);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                              const pcl::PointIndices &indices,
-                              Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
+computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                         const pcl::PointIndices &indices,
+                         Eigen::Matrix<Scalar, 3, 3> &covariance_matrix)
 {
   return (computeCovarianceMatrix (cloud, indices.indices, covariance_matrix));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                     Eigen::Matrix<Scalar, 4, 1> &centroid)
+computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+                                Eigen::Matrix<Scalar, 4, 1> &centroid)
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
@@ -543,12 +545,12 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   return (static_cast<unsigned int> (point_count));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                     const std::vector<int> &indices,
-                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                     Eigen::Matrix<Scalar, 4, 1> &centroid)
+computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                const std::vector<int> &indices,
+                                Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+                                Eigen::Matrix<Scalar, 4, 1> &centroid)
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
@@ -610,22 +612,22 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   return (static_cast<unsigned int> (point_count));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline unsigned int
-pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                     const pcl::PointIndices &indices,
-                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                     Eigen::Matrix<Scalar, 4, 1> &centroid)
+computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                const pcl::PointIndices &indices,
+                                Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+                                Eigen::Matrix<Scalar, 4, 1> &centroid)
 {
   return (computeMeanAndCovarianceMatrix (cloud, indices.indices, covariance_matrix, centroid));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       pcl::PointCloud<PointT> &cloud_out,
-                       int npts)
+demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  pcl::PointCloud<PointT> &cloud_out,
+                  int npts)
 {
   // Calculate the number of points if not given
   if (npts == 0)
@@ -653,11 +655,11 @@ pcl::demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
   cloud_out.height = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       pcl::PointCloud<PointT> &cloud_out)
+demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  pcl::PointCloud<PointT> &cloud_out)
 {
   cloud_out = cloud_in;
 
@@ -670,12 +672,12 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                       const std::vector<int> &indices,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       pcl::PointCloud<PointT> &cloud_out)
+demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                  const std::vector<int> &indices,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  pcl::PointCloud<PointT> &cloud_out)
 {
   cloud_out.header = cloud_in.header;
   cloud_out.is_dense = cloud_in.is_dense;
@@ -700,22 +702,22 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                       const pcl::PointIndices& indices,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       pcl::PointCloud<PointT> &cloud_out)
+demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                  const pcl::PointIndices& indices,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  pcl::PointCloud<PointT> &cloud_out)
 {
   return (demeanPointCloud (cloud_in, indices.indices, centroid, cloud_out));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out,
-                       int npts)
+demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out,
+                  int npts)
 {
   // Calculate the number of points if not given
   if (npts == 0)
@@ -741,11 +743,11 @@ pcl::demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
+demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
 {
   std::size_t npts = cloud_in.size ();
 
@@ -764,12 +766,12 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   //cloud_out.block (3, 0, 1, npts).setZero ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                       const std::vector<int> &indices,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
+demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                  const std::vector<int> &indices,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
 {
   std::size_t npts = indices.size ();
 
@@ -788,20 +790,20 @@ pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   //cloud_out.block (3, 0, 1, npts).setZero ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                       const pcl::PointIndices &indices,
-                       const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                       Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
+demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                  const pcl::PointIndices &indices,
+                  const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                  Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out)
 {
   return (pcl::demeanPointCloud (cloud_in, indices.indices, centroid, cloud_out));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline void
-pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
+computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
 {
   using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
@@ -820,11 +822,11 @@ pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
   centroid /= static_cast<Scalar> (cloud.size ());
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline void
-pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                        const std::vector<int> &indices,
-                        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
+computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                   const std::vector<int> &indices,
+                   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
 {
   using FieldList = typename pcl::traits::fieldList<PointT>::type;
 
@@ -843,17 +845,17 @@ pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
   centroid /= static_cast<Scalar> (indices.size ());
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline void
-pcl::computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
-                        const pcl::PointIndices &indices, 
-                        Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
+computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                   const pcl::PointIndices &indices,
+                   Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
 {
   return (pcl::computeNDCentroid (cloud, indices.indices, centroid));
 }
 
 template <typename PointT> void
-pcl::CentroidPoint<PointT>::add (const PointT& point)
+CentroidPoint<PointT>::add (const PointT& point)
 {
   // Invoke add point on each accumulator
   boost::fusion::for_each (accumulators_, detail::AddPoint<PointT> (point));
@@ -862,7 +864,7 @@ pcl::CentroidPoint<PointT>::add (const PointT& point)
 
 template <typename PointT>
 template <typename PointOutT> void
-pcl::CentroidPoint<PointT>::get (PointOutT& point) const
+CentroidPoint<PointT>::get (PointOutT& point) const
 {
   if (num_points_ != 0)
   {
@@ -874,8 +876,9 @@ pcl::CentroidPoint<PointT>::get (PointOutT& point) const
   }
 }
 
+
 template <typename PointInT, typename PointOutT> std::size_t
-pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
+computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                       PointOutT& centroid)
 {
   pcl::CentroidPoint<PointInT> cp;
@@ -892,8 +895,9 @@ pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
   return (cp.getSize ());
 }
 
+
 template <typename PointInT, typename PointOutT> std::size_t
-pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
+computeCentroid (const pcl::PointCloud<PointInT>& cloud,
                       const std::vector<int>& indices,
                       PointOutT& centroid)
 {
@@ -910,6 +914,8 @@ pcl::computeCentroid (const pcl::PointCloud<PointInT>& cloud,
   cp.get (centroid);
   return (cp.getSize ());
 }
+
+} // namespace pcl
 
 #endif  //#ifndef PCL_COMMON_IMPL_CENTROID_H_
 

--- a/common/include/pcl/common/impl/copy_point.hpp
+++ b/common/include/pcl/common/impl/copy_point.hpp
@@ -46,100 +46,100 @@
 namespace pcl
 {
 
-  namespace detail
+namespace detail
+{
+
+/* CopyPointHelper and its specializations copy the contents of a source
+ * point to a target point. There are three cases:
+ *
+ *  - Points have the same type.
+ *    In this case a single `memcpy` is used.
+ *
+ *  - Points have different types and one of the following is true:
+ *      * both have RGB fields;
+ *      * both have RGBA fields;
+ *      * one or both have no RGB/RGBA fields.
+ *    In this case we find the list of common fields and copy their
+ *    contents one by one with `NdConcatenateFunctor`.
+ *
+ *  - Points have different types and one of these types has RGB field, and
+ *    the other has RGBA field.
+ *    In this case we also find the list of common fields and copy their
+ *    contents. In order to account for the fact that RGB and RGBA do not
+ *    match we have an additional `memcpy` to copy the contents of one into
+ *    another.
+ *
+ * An appropriate version of CopyPointHelper is instantiated during
+ * compilation time automatically, so there is absolutely no run-time
+ * overhead. */
+
+template <typename PointInT, typename PointOutT, typename Enable = void>
+struct CopyPointHelper { };
+
+template <typename PointInT, typename PointOutT>
+struct CopyPointHelper<PointInT, PointOutT, std::enable_if_t<std::is_same<PointInT, PointOutT>::value>>
+{
+  void operator () (const PointInT& point_in, PointOutT& point_out) const
   {
-
-    /* CopyPointHelper and its specializations copy the contents of a source
-     * point to a target point. There are three cases:
-     *
-     *  - Points have the same type.
-     *    In this case a single `memcpy` is used.
-     *
-     *  - Points have different types and one of the following is true:
-     *      * both have RGB fields;
-     *      * both have RGBA fields;
-     *      * one or both have no RGB/RGBA fields.
-     *    In this case we find the list of common fields and copy their
-     *    contents one by one with `NdConcatenateFunctor`.
-     *
-     *  - Points have different types and one of these types has RGB field, and
-     *    the other has RGBA field.
-     *    In this case we also find the list of common fields and copy their
-     *    contents. In order to account for the fact that RGB and RGBA do not
-     *    match we have an additional `memcpy` to copy the contents of one into
-     *    another.
-     *
-     * An appropriate version of CopyPointHelper is instantiated during
-     * compilation time automatically, so there is absolutely no run-time
-     * overhead. */
-
-    template <typename PointInT, typename PointOutT, typename Enable = void>
-    struct CopyPointHelper { };
-
-    template <typename PointInT, typename PointOutT>
-    struct CopyPointHelper<PointInT, PointOutT, std::enable_if_t<std::is_same<PointInT, PointOutT>::value>>
-    {
-      void operator () (const PointInT& point_in, PointOutT& point_out) const
-      {
-        memcpy (&point_out, &point_in, sizeof (PointInT));
-      }
-    };
-
-    template <typename PointInT, typename PointOutT>
-    struct CopyPointHelper<PointInT, PointOutT,
-                           std::enable_if_t<boost::mpl::and_<boost::mpl::not_<std::is_same<PointInT, PointOutT>>,
-                                                             boost::mpl::or_<boost::mpl::not_<pcl::traits::has_color<PointInT>>,
-                                                                             boost::mpl::not_<pcl::traits::has_color<PointOutT>>,
-                                                                             boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
-                                                                                              pcl::traits::has_field<PointOutT, pcl::fields::rgb>>,
-                                                                             boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
-                                                                                              pcl::traits::has_field<PointOutT, pcl::fields::rgba>>>>::value>>
-    {
-      void operator () (const PointInT& point_in, PointOutT& point_out) const
-      {
-        using FieldListInT = typename pcl::traits::fieldList<PointInT>::type;
-        using FieldListOutT = typename pcl::traits::fieldList<PointOutT>::type;
-        using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
-        pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointInT, PointOutT> (point_in, point_out));
-      }
-    };
-
-    template <typename PointInT, typename PointOutT>
-    struct CopyPointHelper<PointInT, PointOutT,
-                           std::enable_if_t<boost::mpl::and_<boost::mpl::not_<std::is_same<PointInT, PointOutT>>,
-                                            boost::mpl::or_<boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
-                                                                             pcl::traits::has_field<PointOutT, pcl::fields::rgba>>,
-                                                            boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
-                                                                             pcl::traits::has_field<PointOutT, pcl::fields::rgb>>>>::value>>
-    {
-      void operator () (const PointInT& point_in, PointOutT& point_out) const
-      {
-        using FieldListInT = typename pcl::traits::fieldList<PointInT>::type;
-        using FieldListOutT = typename pcl::traits::fieldList<PointOutT>::type;
-        using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
-        const std::uint32_t offset_in  = boost::mpl::if_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
-                                                    pcl::traits::offset<PointInT, pcl::fields::rgb>,
-                                                    pcl::traits::offset<PointInT, pcl::fields::rgba> >::type::value;
-        const std::uint32_t offset_out = boost::mpl::if_<pcl::traits::has_field<PointOutT, pcl::fields::rgb>,
-                                                    pcl::traits::offset<PointOutT, pcl::fields::rgb>,
-                                                    pcl::traits::offset<PointOutT, pcl::fields::rgba> >::type::value;
-        pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointInT, PointOutT> (point_in, point_out));
-        memcpy (reinterpret_cast<char*> (&point_out) + offset_out,
-                reinterpret_cast<const char*> (&point_in) + offset_in,
-                4);
-      }
-    };
-
+    memcpy (&point_out, &point_in, sizeof (PointInT));
   }
+};
 
-}
+template <typename PointInT, typename PointOutT>
+struct CopyPointHelper<PointInT, PointOutT,
+                       std::enable_if_t<boost::mpl::and_<boost::mpl::not_<std::is_same<PointInT, PointOutT>>,
+                                                         boost::mpl::or_<boost::mpl::not_<pcl::traits::has_color<PointInT>>,
+                                                                         boost::mpl::not_<pcl::traits::has_color<PointOutT>>,
+                                                                         boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
+                                                                                          pcl::traits::has_field<PointOutT, pcl::fields::rgb>>,
+                                                                         boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
+                                                                                          pcl::traits::has_field<PointOutT, pcl::fields::rgba>>>>::value>>
+{
+  void operator () (const PointInT& point_in, PointOutT& point_out) const
+  {
+    using FieldListInT = typename pcl::traits::fieldList<PointInT>::type;
+    using FieldListOutT = typename pcl::traits::fieldList<PointOutT>::type;
+    using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
+    pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointInT, PointOutT> (point_in, point_out));
+  }
+};
+
+template <typename PointInT, typename PointOutT>
+struct CopyPointHelper<PointInT, PointOutT,
+                       std::enable_if_t<boost::mpl::and_<boost::mpl::not_<std::is_same<PointInT, PointOutT>>,
+                                        boost::mpl::or_<boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
+                                                                         pcl::traits::has_field<PointOutT, pcl::fields::rgba>>,
+                                                        boost::mpl::and_<pcl::traits::has_field<PointInT, pcl::fields::rgba>,
+                                                                         pcl::traits::has_field<PointOutT, pcl::fields::rgb>>>>::value>>
+{
+  void operator () (const PointInT& point_in, PointOutT& point_out) const
+  {
+    using FieldListInT = typename pcl::traits::fieldList<PointInT>::type;
+    using FieldListOutT = typename pcl::traits::fieldList<PointOutT>::type;
+    using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
+    const std::uint32_t offset_in  = boost::mpl::if_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
+                                                pcl::traits::offset<PointInT, pcl::fields::rgb>,
+                                                pcl::traits::offset<PointInT, pcl::fields::rgba> >::type::value;
+    const std::uint32_t offset_out = boost::mpl::if_<pcl::traits::has_field<PointOutT, pcl::fields::rgb>,
+                                                pcl::traits::offset<PointOutT, pcl::fields::rgb>,
+                                                pcl::traits::offset<PointOutT, pcl::fields::rgba> >::type::value;
+    pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointInT, PointOutT> (point_in, point_out));
+    memcpy (reinterpret_cast<char*> (&point_out) + offset_out,
+            reinterpret_cast<const char*> (&point_in) + offset_in,
+            4);
+  }
+};
+
+} // namespace detail
 
 template <typename PointInT, typename PointOutT> void
-pcl::copyPoint (const PointInT& point_in, PointOutT& point_out)
+copyPoint (const PointInT& point_in, PointOutT& point_out)
 {
   detail::CopyPointHelper<PointInT, PointOutT> copy;
   copy (point_in, point_out);
 }
+
+} // namespace pcl
 
 #endif //PCL_COMMON_IMPL_COPY_POINT_HPP_
 

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -44,9 +44,11 @@
 #include <cmath>
 #include <pcl/console/print.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////
+namespace pcl
+{
+
 template <typename Scalar, typename Roots> inline void
-pcl::computeRoots2 (const Scalar& b, const Scalar& c, Roots& roots)
+computeRoots2 (const Scalar& b, const Scalar& c, Roots& roots)
 {
   roots (0) = Scalar (0);
   Scalar d = Scalar (b * b - 4.0 * c);
@@ -59,9 +61,9 @@ pcl::computeRoots2 (const Scalar& b, const Scalar& c, Roots& roots)
   roots (1) = 0.5f * (b - sd);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix, typename Roots> inline void
-pcl::computeRoots (const Matrix& m, Roots& roots)
+computeRoots (const Matrix& m, Roots& roots)
 {
   using Scalar = typename Matrix::Scalar;
 
@@ -124,9 +126,9 @@ pcl::computeRoots (const Matrix& m, Roots& roots)
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix, typename Vector> inline void
-pcl::eigen22 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
+eigen22 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
 {
   // if diagonal matrix, the eigenvalues are the diagonal elements
   // and the eigenvectors are not unique, thus set to Identity
@@ -163,9 +165,9 @@ pcl::eigen22 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& ei
   eigenvector.normalize ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix, typename Vector> inline void
-pcl::eigen22 (const Matrix& mat, Matrix& eigenvectors, Vector& eigenvalues)
+eigen22 (const Matrix& mat, Matrix& eigenvectors, Vector& eigenvalues)
 {
   // if diagonal matrix, the eigenvalues are the diagonal elements
   // and the eigenvectors are not unique, thus set to Identity
@@ -217,9 +219,9 @@ pcl::eigen22 (const Matrix& mat, Matrix& eigenvectors, Vector& eigenvalues)
   eigenvectors.coeffRef (3) = -eigenvectors.coeffRef (0);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix, typename Vector> inline void
-pcl::computeCorrespondingEigenVector (const Matrix& mat, const typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
+computeCorrespondingEigenVector (const Matrix& mat, const typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
 {
   using Scalar = typename Matrix::Scalar;
   // Scale the matrix so its entries are in [-1,1].  The scaling is applied
@@ -249,8 +251,9 @@ pcl::computeCorrespondingEigenVector (const Matrix& mat, const typename Matrix::
     eigenvector = vec3 / std::sqrt (len3);
 }
 
-namespace pcl {
-namespace detail{
+namespace detail
+{
+
 template <typename Vector, typename Scalar>
 struct EigenVector {
   Vector vector;
@@ -283,12 +286,12 @@ getLargest3x3Eigenvector (const Matrix scaledMatrix)
   return EigenVector<Vector, Scalar> {crossProduct.row (index) / length,
                                       length};
 }
-}  // namespace detail
-}  // namespace pcl
 
-//////////////////////////////////////////////////////////////////////////////////////////
+}  // namespace detail
+
+
 template <typename Matrix, typename Vector> inline void
-pcl::eigen33 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
+eigen33 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& eigenvector)
 {
   using Scalar = typename Matrix::Scalar;
   // Scale the matrix so its entries are in [-1,1].  The scaling is applied
@@ -310,9 +313,9 @@ pcl::eigen33 (const Matrix& mat, typename Matrix::Scalar& eigenvalue, Vector& ei
   eigenvector = detail::getLargest3x3Eigenvector<Vector> (scaledMat).vector;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix, typename Vector> inline void
-pcl::eigen33 (const Matrix& mat, Vector& evals)
+eigen33 (const Matrix& mat, Vector& evals)
 {
   using Scalar = typename Matrix::Scalar;
   Scalar scale = mat.cwiseAbs ().maxCoeff ();
@@ -324,9 +327,9 @@ pcl::eigen33 (const Matrix& mat, Vector& evals)
   evals *= scale;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix, typename Vector> inline void
-pcl::eigen33 (const Matrix& mat, Matrix& evecs, Vector& evals)
+eigen33 (const Matrix& mat, Matrix& evecs, Vector& evals)
 {
   using Scalar = typename Matrix::Scalar;
   // Scale the matrix so its entries are in [-1,1].  The scaling is applied
@@ -395,9 +398,9 @@ pcl::eigen33 (const Matrix& mat, Matrix& evecs, Vector& evals)
   evals *= scale;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix> inline typename Matrix::Scalar
-pcl::invert2x2 (const Matrix& matrix, Matrix& inverse)
+invert2x2 (const Matrix& matrix, Matrix& inverse)
 {
   using Scalar = typename Matrix::Scalar;
   Scalar det = matrix.coeff (0) * matrix.coeff (3) - matrix.coeff (1) * matrix.coeff (2);
@@ -414,9 +417,9 @@ pcl::invert2x2 (const Matrix& matrix, Matrix& inverse)
   return det;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix> inline typename Matrix::Scalar
-pcl::invert3x3SymMatrix (const Matrix& matrix, Matrix& inverse)
+invert3x3SymMatrix (const Matrix& matrix, Matrix& inverse)
 {
   using Scalar = typename Matrix::Scalar;
   // elements
@@ -449,9 +452,9 @@ pcl::invert3x3SymMatrix (const Matrix& matrix, Matrix& inverse)
   return det;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix> inline typename Matrix::Scalar
-pcl::invert3x3Matrix (const Matrix& matrix, Matrix& inverse)
+invert3x3Matrix (const Matrix& matrix, Matrix& inverse)
 {
   using Scalar = typename Matrix::Scalar;
 
@@ -482,9 +485,9 @@ pcl::invert3x3Matrix (const Matrix& matrix, Matrix& inverse)
   return det;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Matrix> inline typename Matrix::Scalar
-pcl::determinant3x3Matrix (const Matrix& matrix)
+determinant3x3Matrix (const Matrix& matrix)
 {
   // result is independent of Row/Col Major storage!
   return matrix.coeff (0) * (matrix.coeff (4) * matrix.coeff (8) - matrix.coeff (5) * matrix.coeff (7)) +
@@ -492,11 +495,11 @@ pcl::determinant3x3Matrix (const Matrix& matrix)
          matrix.coeff (2) * (matrix.coeff (3) * matrix.coeff (7) - matrix.coeff (4) * matrix.coeff (6)) ;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 void
-pcl::getTransFromUnitVectorsZY (const Eigen::Vector3f& z_axis,
-                                const Eigen::Vector3f& y_direction,
-                                Eigen::Affine3f& transformation)
+getTransFromUnitVectorsZY (const Eigen::Vector3f& z_axis,
+                           const Eigen::Vector3f& y_direction,
+                           Eigen::Affine3f& transformation)
 {
   Eigen::Vector3f tmp0 = (y_direction.cross(z_axis)).normalized();
   Eigen::Vector3f tmp1 = (z_axis.cross(tmp0)).normalized();
@@ -508,21 +511,21 @@ pcl::getTransFromUnitVectorsZY (const Eigen::Vector3f& z_axis,
   transformation(3,0)=0.0f;    transformation(3,1)=0.0f;    transformation(3,2)=0.0f;    transformation(3,3)=1.0f;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 Eigen::Affine3f
-pcl::getTransFromUnitVectorsZY (const Eigen::Vector3f& z_axis,
-                                const Eigen::Vector3f& y_direction)
+getTransFromUnitVectorsZY (const Eigen::Vector3f& z_axis,
+                           const Eigen::Vector3f& y_direction)
 {
   Eigen::Affine3f transformation;
   getTransFromUnitVectorsZY (z_axis, y_direction, transformation);
   return (transformation);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 void
-pcl::getTransFromUnitVectorsXY (const Eigen::Vector3f& x_axis,
-                                const Eigen::Vector3f& y_direction,
-                                Eigen::Affine3f& transformation)
+getTransFromUnitVectorsXY (const Eigen::Vector3f& x_axis,
+                           const Eigen::Vector3f& y_direction,
+                           Eigen::Affine3f& transformation)
 {
   Eigen::Vector3f tmp2 = (x_axis.cross(y_direction)).normalized();
   Eigen::Vector3f tmp1 = (tmp2.cross(x_axis)).normalized();
@@ -534,60 +537,61 @@ pcl::getTransFromUnitVectorsXY (const Eigen::Vector3f& x_axis,
   transformation(3,0)=0.0f;    transformation(3,1)=0.0f;    transformation(3,2)=0.0f;    transformation(3,3)=1.0f;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 Eigen::Affine3f
-pcl::getTransFromUnitVectorsXY (const Eigen::Vector3f& x_axis,
-                                const Eigen::Vector3f& y_direction)
+getTransFromUnitVectorsXY (const Eigen::Vector3f& x_axis,
+                           const Eigen::Vector3f& y_direction)
 {
   Eigen::Affine3f transformation;
   getTransFromUnitVectorsXY (x_axis, y_direction, transformation);
   return (transformation);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 void
-pcl::getTransformationFromTwoUnitVectors (const Eigen::Vector3f& y_direction,
-                                          const Eigen::Vector3f& z_axis,
-                                          Eigen::Affine3f& transformation)
+getTransformationFromTwoUnitVectors (const Eigen::Vector3f& y_direction,
+                                     const Eigen::Vector3f& z_axis,
+                                     Eigen::Affine3f& transformation)
 {
   getTransFromUnitVectorsZY (z_axis, y_direction, transformation);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 Eigen::Affine3f
-pcl::getTransformationFromTwoUnitVectors (const Eigen::Vector3f& y_direction,
-                                          const Eigen::Vector3f& z_axis)
+getTransformationFromTwoUnitVectors (const Eigen::Vector3f& y_direction,
+                                     const Eigen::Vector3f& z_axis)
 {
   Eigen::Affine3f transformation;
   getTransformationFromTwoUnitVectors (y_direction, z_axis, transformation);
   return (transformation);
 }
 
+
 void
-pcl::getTransformationFromTwoUnitVectorsAndOrigin (const Eigen::Vector3f& y_direction,
-                                                   const Eigen::Vector3f& z_axis,
-                                                   const Eigen::Vector3f& origin,
-                                                   Eigen::Affine3f& transformation)
+getTransformationFromTwoUnitVectorsAndOrigin (const Eigen::Vector3f& y_direction,
+                                              const Eigen::Vector3f& z_axis,
+                                              const Eigen::Vector3f& origin,
+                                              Eigen::Affine3f& transformation)
 {
   getTransformationFromTwoUnitVectors(y_direction, z_axis, transformation);
   Eigen::Vector3f translation = transformation*origin;
   transformation(0,3)=-translation[0];  transformation(1,3)=-translation[1];  transformation(2,3)=-translation[2];
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> void
-pcl::getEulerAngles (const Eigen::Transform<Scalar, 3, Eigen::Affine> &t, Scalar &roll, Scalar &pitch, Scalar &yaw)
+getEulerAngles (const Eigen::Transform<Scalar, 3, Eigen::Affine> &t, Scalar &roll, Scalar &pitch, Scalar &yaw)
 {
   roll = std::atan2 (t (2, 1), t (2, 2));
   pitch = asin (-t (2, 0));
   yaw = std::atan2 (t (1, 0), t (0, 0));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> void
-pcl::getTranslationAndEulerAngles (const Eigen::Transform<Scalar, 3, Eigen::Affine> &t,
-                                  Scalar &x, Scalar &y, Scalar &z,
-                                  Scalar &roll, Scalar &pitch, Scalar &yaw)
+getTranslationAndEulerAngles (const Eigen::Transform<Scalar, 3, Eigen::Affine> &t,
+                              Scalar &x, Scalar &y, Scalar &z,
+                              Scalar &roll, Scalar &pitch, Scalar &yaw)
 {
   x = t (0, 3);
   y = t (1, 3);
@@ -597,11 +601,11 @@ pcl::getTranslationAndEulerAngles (const Eigen::Transform<Scalar, 3, Eigen::Affi
   yaw = std::atan2 (t (1, 0), t (0, 0));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> void
-pcl::getTransformation (Scalar x, Scalar y, Scalar z,
-                        Scalar roll, Scalar pitch, Scalar yaw,
-                        Eigen::Transform<Scalar, 3, Eigen::Affine> &t)
+getTransformation (Scalar x, Scalar y, Scalar z,
+                   Scalar roll, Scalar pitch, Scalar yaw,
+                   Eigen::Transform<Scalar, 3, Eigen::Affine> &t)
 {
   Scalar A = std::cos (yaw),  B = sin (yaw),  C  = std::cos (pitch), D  = sin (pitch),
          E = std::cos (roll), F = sin (roll), DE = D*E,         DF = D*F;
@@ -612,9 +616,9 @@ pcl::getTransformation (Scalar x, Scalar y, Scalar z,
   t (3, 0) = 0;    t (3, 1) = 0;           t (3, 2) = 0;           t (3, 3) = 1;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Derived> void
-pcl::saveBinary (const Eigen::MatrixBase<Derived>& matrix, std::ostream& file)
+saveBinary (const Eigen::MatrixBase<Derived>& matrix, std::ostream& file)
 {
   std::uint32_t rows = static_cast<std::uint32_t> (matrix.rows ()), cols = static_cast<std::uint32_t> (matrix.cols ());
   file.write (reinterpret_cast<char*> (&rows), sizeof (rows));
@@ -627,9 +631,9 @@ pcl::saveBinary (const Eigen::MatrixBase<Derived>& matrix, std::ostream& file)
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Derived> void
-pcl::loadBinary (Eigen::MatrixBase<Derived> const & matrix_, std::istream& file)
+loadBinary (Eigen::MatrixBase<Derived> const & matrix_, std::istream& file)
 {
   Eigen::MatrixBase<Derived> &matrix = const_cast<Eigen::MatrixBase<Derived> &> (matrix_);
 
@@ -648,10 +652,10 @@ pcl::loadBinary (Eigen::MatrixBase<Derived> const & matrix_, std::istream& file)
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Derived, typename OtherDerived>
 typename Eigen::internal::umeyama_transform_matrix_type<Derived, OtherDerived>::type
-pcl::umeyama (const Eigen::MatrixBase<Derived>& src, const Eigen::MatrixBase<OtherDerived>& dst, bool with_scaling)
+umeyama (const Eigen::MatrixBase<Derived>& src, const Eigen::MatrixBase<OtherDerived>& dst, bool with_scaling)
 {
 #if EIGEN_VERSION_AT_LEAST (3, 3, 0)
   return Eigen::umeyama (src, dst, with_scaling);
@@ -725,11 +729,11 @@ pcl::umeyama (const Eigen::MatrixBase<Derived>& src, const Eigen::MatrixBase<Oth
 #endif
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> bool
-pcl::transformLine (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_in,
-                          Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_out,
-                    const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
+transformLine (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_in,
+                     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_out,
+               const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
 {
   if (line_in.innerSize () != 6 || line_out.innerSize () != 6)
   {
@@ -747,11 +751,11 @@ pcl::transformLine (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_in,
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> void
-pcl::transformPlane (const Eigen::Matrix<Scalar, 4, 1> &plane_in,
-                           Eigen::Matrix<Scalar, 4, 1> &plane_out,
-                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
+transformPlane (const Eigen::Matrix<Scalar, 4, 1> &plane_in,
+                      Eigen::Matrix<Scalar, 4, 1> &plane_out,
+                const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
 {
   Eigen::Hyperplane < Scalar, 3 > plane;
   plane.coeffs () << plane_in;
@@ -764,11 +768,11 @@ pcl::transformPlane (const Eigen::Matrix<Scalar, 4, 1> &plane_in,
   #endif
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> void
-pcl::transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
-                           pcl::ModelCoefficients::Ptr plane_out,
-                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
+transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
+                      pcl::ModelCoefficients::Ptr plane_out,
+                const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
 {
   std::vector<Scalar> values (plane_in->values.begin (), plane_in->values.end ());
   Eigen::Matrix < Scalar, 4, 1 > v_plane_in (values.data ());
@@ -777,12 +781,12 @@ pcl::transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
   std::copy_n(v_plane_in.data (), 4, plane_in->values.begin ());
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> bool
-pcl::checkCoordinateSystem (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_x,
-                            const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_y,
-                            const Scalar norm_limit,
-                            const Scalar dot_limit)
+checkCoordinateSystem (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_x,
+                       const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line_y,
+                       const Scalar norm_limit,
+                       const Scalar dot_limit)
 {
   if (line_x.innerSize () != 6 || line_y.innerSize () != 6)
   {
@@ -843,13 +847,13 @@ pcl::checkCoordinateSystem (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename Scalar> bool
-pcl::transformBetween2CoordinateSystems (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> from_line_x,
-                                         const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> from_line_y,
-                                         const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> to_line_x,
-                                         const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> to_line_y,
-                                         Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
+transformBetween2CoordinateSystems (const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> from_line_x,
+                                    const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> from_line_y,
+                                    const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> to_line_x,
+                                    const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> to_line_y,
+                                    Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
 {
   if (from_line_x.innerSize () != 6 || from_line_y.innerSize () != 6 || to_line_x.innerSize () != 6 || to_line_y.innerSize () != 6)
   {
@@ -901,4 +905,7 @@ pcl::transformBetween2CoordinateSystems (const Eigen::Matrix<Scalar, Eigen::Dyna
   return (true);
 }
 
+} // namespace pcl
+
 #endif  //PCL_COMMON_EIGEN_IMPL_HPP_
+

--- a/common/include/pcl/common/impl/gaussian.hpp
+++ b/common/include/pcl/common/impl/gaussian.hpp
@@ -4,7 +4,7 @@
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2010-2011, Willow Garage, Inc.
  *
- *  All rights reserved. 
+ *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -42,11 +42,14 @@
 
 #include <pcl/exceptions.h>
 
+namespace pcl
+{
+
 template <typename PointT> void
-pcl::GaussianKernel::convolveRows(const pcl::PointCloud<PointT> &input,
-                                  std::function <float (const PointT& p)> field_accessor,
-                                  const Eigen::VectorXf& kernel,
-                                  pcl::PointCloud<float> &output) const
+GaussianKernel::convolveRows(const pcl::PointCloud<PointT> &input,
+                             std::function <float (const PointT& p)> field_accessor,
+                             const Eigen::VectorXf& kernel,
+                             pcl::PointCloud<float> &output) const
 {
   assert(kernel.size () % 2 == 1);
   int kernel_width = kernel.size () -1;
@@ -76,10 +79,10 @@ pcl::GaussianKernel::convolveRows(const pcl::PointCloud<PointT> &input,
 }
 
 template <typename PointT> void
-pcl::GaussianKernel::convolveCols(const pcl::PointCloud<PointT> &input,
-                                  std::function <float (const PointT& p)> field_accessor,
-                                  const Eigen::VectorXf& kernel,
-                                  pcl::PointCloud<float> &output) const
+GaussianKernel::convolveCols(const pcl::PointCloud<PointT> &input,
+                             std::function <float (const PointT& p)> field_accessor,
+                             const Eigen::VectorXf& kernel,
+                             pcl::PointCloud<float> &output) const
 {
   assert(kernel.size () % 2 == 1);
   int kernel_width = kernel.size () -1;
@@ -110,4 +113,7 @@ pcl::GaussianKernel::convolveCols(const pcl::PointCloud<PointT> &input,
   }
 }
 
+} // namespace pcl
+
 #endif
+

--- a/common/include/pcl/common/impl/generate.hpp
+++ b/common/include/pcl/common/impl/generate.hpp
@@ -42,35 +42,40 @@
 
 #include <pcl/console/print.h>
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace common
+{
+
 template <typename PointT, typename GeneratorT>
-pcl::common::CloudGenerator<PointT, GeneratorT>::CloudGenerator ()
+CloudGenerator<PointT, GeneratorT>::CloudGenerator ()
   : x_generator_ ()
   , y_generator_ ()
   , z_generator_ ()
 {}
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT>
-pcl::common::CloudGenerator<PointT, GeneratorT>::CloudGenerator (const GeneratorParameters& params)
+CloudGenerator<PointT, GeneratorT>::CloudGenerator (const GeneratorParameters& params)
 {
   setParameters (params);
 }
 
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename GeneratorT>
-pcl::common::CloudGenerator<PointT, GeneratorT>::CloudGenerator (const GeneratorParameters& x_params,
-                                                                 const GeneratorParameters& y_params,
-                                                                 const GeneratorParameters& z_params)
+CloudGenerator<PointT, GeneratorT>::CloudGenerator (const GeneratorParameters& x_params,
+                                                    const GeneratorParameters& y_params,
+                                                    const GeneratorParameters& z_params)
   : x_generator_ (x_params)
   , y_generator_ (y_params)
   , z_generator_ (z_params)
 {}
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT> void
-pcl::common::CloudGenerator<PointT, GeneratorT>::setParameters (const GeneratorParameters& params)
+CloudGenerator<PointT, GeneratorT>::setParameters (const GeneratorParameters& params)
 {
   GeneratorParameters y_params = params;
   y_params.seed += 1;
@@ -78,54 +83,54 @@ pcl::common::CloudGenerator<PointT, GeneratorT>::setParameters (const GeneratorP
   z_params.seed += 1;
   x_generator_.setParameters (params);
   y_generator_.setParameters (y_params);
-  z_generator_.setParameters (z_params);  
+  z_generator_.setParameters (z_params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT> void
-pcl::common::CloudGenerator<PointT, GeneratorT>::setParametersForX (const GeneratorParameters& x_params)
+CloudGenerator<PointT, GeneratorT>::setParametersForX (const GeneratorParameters& x_params)
 {
   x_generator_.setParameters (x_params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT> void
-pcl::common::CloudGenerator<PointT, GeneratorT>::setParametersForY (const GeneratorParameters& y_params)
+CloudGenerator<PointT, GeneratorT>::setParametersForY (const GeneratorParameters& y_params)
 {
   y_generator_.setParameters (y_params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT> void
-pcl::common::CloudGenerator<PointT, GeneratorT>::setParametersForZ (const GeneratorParameters& z_params)
+CloudGenerator<PointT, GeneratorT>::setParametersForZ (const GeneratorParameters& z_params)
 {
   z_generator_.setParameters (z_params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename GeneratorT> const typename pcl::common::CloudGenerator<PointT, GeneratorT>::GeneratorParameters& 
-pcl::common::CloudGenerator<PointT, GeneratorT>::getParametersForX () const
+
+template <typename PointT, typename GeneratorT> const typename CloudGenerator<PointT, GeneratorT>::GeneratorParameters& 
+CloudGenerator<PointT, GeneratorT>::getParametersForX () const
 {
   x_generator_.getParameters ();
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename GeneratorT> const typename pcl::common::CloudGenerator<PointT, GeneratorT>::GeneratorParameters& 
-pcl::common::CloudGenerator<PointT, GeneratorT>::getParametersForY () const
+
+template <typename PointT, typename GeneratorT> const typename CloudGenerator<PointT, GeneratorT>::GeneratorParameters& 
+CloudGenerator<PointT, GeneratorT>::getParametersForY () const
 {
   y_generator_.getParameters ();
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename GeneratorT> const typename pcl::common::CloudGenerator<PointT, GeneratorT>::GeneratorParameters& 
-pcl::common::CloudGenerator<PointT, GeneratorT>::getParametersForZ () const
+
+template <typename PointT, typename GeneratorT> const typename CloudGenerator<PointT, GeneratorT>::GeneratorParameters& 
+CloudGenerator<PointT, GeneratorT>::getParametersForZ () const
 {
   z_generator_.getParameters ();
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT> PointT
-pcl::common::CloudGenerator<PointT, GeneratorT>::get ()
+CloudGenerator<PointT, GeneratorT>::get ()
 {
   PointT p;
   p.x = x_generator_.run ();
@@ -134,34 +139,34 @@ pcl::common::CloudGenerator<PointT, GeneratorT>::get ()
   return (p);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT> int
-pcl::common::CloudGenerator<PointT, GeneratorT>::fill (pcl::PointCloud<PointT>& cloud)
+CloudGenerator<PointT, GeneratorT>::fill (pcl::PointCloud<PointT>& cloud)
 {
   return (fill (cloud.width, cloud.height, cloud));
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename GeneratorT> int
-pcl::common::CloudGenerator<PointT, GeneratorT>::fill (int width, int height, pcl::PointCloud<PointT>& cloud)
+CloudGenerator<PointT, GeneratorT>::fill (int width, int height, pcl::PointCloud<PointT>& cloud)
 {
   if (width < 1)
   {
     PCL_ERROR ("[pcl::common::CloudGenerator] Cloud width must be >= 1!\n");
     return (-1);
   }
-  
+
   if (height < 1)
   {
     PCL_ERROR ("[pcl::common::CloudGenerator] Cloud height must be >= 1!\n");
     return (-1);
   }
-  
+
   if (!cloud.empty ())
   {
     PCL_WARN ("[pcl::common::CloudGenerator] Cloud data will be erased with new data!\n");
   }
-  
+
   cloud.width = width;
   cloud.height = height;
   cloud.resize (cloud.width * cloud.height);
@@ -175,31 +180,31 @@ pcl::common::CloudGenerator<PointT, GeneratorT>::fill (int width, int height, pc
   return (0);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT>
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::CloudGenerator ()
+CloudGenerator<pcl::PointXY, GeneratorT>::CloudGenerator ()
   : x_generator_ ()
   , y_generator_ ()
 {}
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT>
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::CloudGenerator (const GeneratorParameters& x_params,
-                                                                       const GeneratorParameters& y_params)
+CloudGenerator<pcl::PointXY, GeneratorT>::CloudGenerator (const GeneratorParameters& x_params,
+                                                          const GeneratorParameters& y_params)
   : x_generator_ (x_params)
   , y_generator_ (y_params)
 {}
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT>
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::CloudGenerator (const GeneratorParameters& params)
+CloudGenerator<pcl::PointXY, GeneratorT>::CloudGenerator (const GeneratorParameters& params)
 {
   setParameters (params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT> void
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::setParameters (const GeneratorParameters& params)
+CloudGenerator<pcl::PointXY, GeneratorT>::setParameters (const GeneratorParameters& params)
 {
   x_generator_.setParameters (params);
   GeneratorParameters y_params = params;
@@ -207,37 +212,37 @@ pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::setParameters (const Gene
   y_generator_.setParameters (y_params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT> void
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::setParametersForX (const GeneratorParameters& x_params)
+CloudGenerator<pcl::PointXY, GeneratorT>::setParametersForX (const GeneratorParameters& x_params)
 {
   x_generator_.setParameters (x_params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT> void
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::setParametersForY (const GeneratorParameters& y_params)
+CloudGenerator<pcl::PointXY, GeneratorT>::setParametersForY (const GeneratorParameters& y_params)
 {
   y_generator_.setParameters (y_params);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename GeneratorT> const typename pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::GeneratorParameters& 
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::getParametersForX () const
+
+template <typename GeneratorT> const typename CloudGenerator<pcl::PointXY, GeneratorT>::GeneratorParameters&
+CloudGenerator<pcl::PointXY, GeneratorT>::getParametersForX () const
 {
   x_generator_.getParameters ();
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename GeneratorT> const typename pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::GeneratorParameters& 
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::getParametersForY () const
+
+template <typename GeneratorT> const typename CloudGenerator<pcl::PointXY, GeneratorT>::GeneratorParameters&
+CloudGenerator<pcl::PointXY, GeneratorT>::getParametersForY () const
 {
   y_generator_.getParameters ();
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT> pcl::PointXY
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::get ()
+CloudGenerator<pcl::PointXY, GeneratorT>::get ()
 {
   pcl::PointXY p;
   p.x = x_generator_.run ();
@@ -245,29 +250,29 @@ pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::get ()
   return (p);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT> int
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::fill (pcl::PointCloud<pcl::PointXY>& cloud)
+CloudGenerator<pcl::PointXY, GeneratorT>::fill (pcl::PointCloud<pcl::PointXY>& cloud)
 {
   return (fill (cloud.width, cloud.height, cloud));
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename GeneratorT> int
-pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::fill (int width, int height, pcl::PointCloud<pcl::PointXY>& cloud)
+CloudGenerator<pcl::PointXY, GeneratorT>::fill (int width, int height, pcl::PointCloud<pcl::PointXY>& cloud)
 {
   if (width < 1)
   {
     PCL_ERROR ("[pcl::common::CloudGenerator] Cloud width must be >= 1\n!");
     return (-1);
   }
-  
+
   if (height < 1)
   {
     PCL_ERROR ("[pcl::common::CloudGenerator] Cloud height must be >= 1\n!");
     return (-1);
   }
-  
+
   if (!cloud.empty ())
     PCL_WARN ("[pcl::common::CloudGenerator] Cloud data will be erased with new data\n!");
 
@@ -284,4 +289,8 @@ pcl::common::CloudGenerator<pcl::PointXY, GeneratorT>::fill (int width, int heig
   return (0);
 }
 
+} // namespace common
+} // namespace pcl
+
 #endif
+

--- a/common/include/pcl/common/impl/intersections.hpp
+++ b/common/include/pcl/common/impl/intersections.hpp
@@ -41,12 +41,13 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/console/print.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////
+namespace pcl
+{
 
 bool
-pcl::lineWithLineIntersection (const Eigen::VectorXf &line_a, 
-                               const Eigen::VectorXf &line_b, 
-                               Eigen::Vector4f &point, double sqr_eps)
+lineWithLineIntersection (const Eigen::VectorXf &line_a,
+                          const Eigen::VectorXf &line_b,
+                          Eigen::Vector4f &point, double sqr_eps)
 {
   Eigen::Vector4f p1, p2;
   lineToLineSegment (line_a, line_b, p1, p2);
@@ -62,21 +63,22 @@ pcl::lineWithLineIntersection (const Eigen::VectorXf &line_a,
   return (false);
 }
 
+
 bool
-pcl::lineWithLineIntersection (const pcl::ModelCoefficients &line_a, 
-                               const pcl::ModelCoefficients &line_b, 
-                               Eigen::Vector4f &point, double sqr_eps)
+lineWithLineIntersection (const pcl::ModelCoefficients &line_a,
+                          const pcl::ModelCoefficients &line_b,
+                          Eigen::Vector4f &point, double sqr_eps)
 {
   Eigen::VectorXf coeff1 = Eigen::VectorXf::Map (&line_a.values[0], line_a.values.size ());
   Eigen::VectorXf coeff2 = Eigen::VectorXf::Map (&line_b.values[0], line_b.values.size ());
   return (lineWithLineIntersection (coeff1, coeff2, point, sqr_eps));
 }
 
-template <typename Scalar> bool 
-pcl::planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a, 
-                                 const Eigen::Matrix<Scalar, 4, 1> &plane_b,
-                                 Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line,
-                                 double angular_tolerance)
+template <typename Scalar> bool
+planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
+                            const Eigen::Matrix<Scalar, 4, 1> &plane_b,
+                            Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line,
+                            double angular_tolerance)
 {
   using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
   using Vector4 = Eigen::Matrix<Scalar, 4, 1>;
@@ -104,7 +106,7 @@ pcl::planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
 
   // Construct system of equations using lagrange multipliers with one objective function and two constraints
   Matrix5 langrange_coefs;
-  langrange_coefs << 2,0,0, plane_a[0], plane_b[0],  
+  langrange_coefs << 2,0,0, plane_a[0], plane_b[0],
                      0,2,0, plane_a[1], plane_b[1],
                      0,0,2, plane_a[2], plane_b[2],
                      plane_a[0], plane_a[1], plane_a[2], 0, 0,
@@ -121,11 +123,11 @@ pcl::planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
 }
 
 template <typename Scalar> bool
-pcl::threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a, 
-                              const Eigen::Matrix<Scalar, 4, 1> &plane_b,
-                              const Eigen::Matrix<Scalar, 4, 1> &plane_c,
-                              Eigen::Matrix<Scalar, 3, 1> &intersection_point,
-                              double determinant_tolerance)
+threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
+                         const Eigen::Matrix<Scalar, 4, 1> &plane_b,
+                         const Eigen::Matrix<Scalar, 4, 1> &plane_c,
+                         Eigen::Matrix<Scalar, 3, 1> &intersection_point,
+                         double determinant_tolerance)
 {
   using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
   using Matrix3 = Eigen::Matrix<Scalar, 3, 3>;
@@ -168,4 +170,7 @@ pcl::threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
   return (true);
 }
 
+} // namespace pcl
+
 #endif  //PCL_COMMON_INTERSECTIONS_IMPL_HPP
+

--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -45,29 +45,32 @@
 #include <pcl/common/copy_point.h>
 #include <pcl/point_types.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointT> int
-pcl::getFieldIndex (const pcl::PointCloud<PointT> &, 
-                    const std::string &field_name, 
-                    std::vector<pcl::PCLPointField> &fields)
+getFieldIndex (const pcl::PointCloud<PointT> &,
+               const std::string &field_name,
+               std::vector<pcl::PCLPointField> &fields)
 {
   return getFieldIndex<PointT>(field_name, fields);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> int
-pcl::getFieldIndex (const std::string &field_name, 
-                    std::vector<pcl::PCLPointField> &fields)
+getFieldIndex (const std::string &field_name,
+               std::vector<pcl::PCLPointField> &fields)
 {
   fields = getFields<PointT> ();
   const auto& ref = fields;
   return pcl::getFieldIndex<PointT> (field_name, ref);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> int
-pcl::getFieldIndex (const std::string &field_name,
-                    const std::vector<pcl::PCLPointField> &fields)
+getFieldIndex (const std::string &field_name,
+               const std::vector<pcl::PCLPointField> &fields)
 {
   const auto result = std::find_if(fields.begin (), fields.end (),
       [&field_name](const auto& field) { return field.name == field_name; });
@@ -76,23 +79,23 @@ pcl::getFieldIndex (const std::string &field_name,
   return std::distance(fields.begin (), result);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::getFields (const pcl::PointCloud<PointT> &, std::vector<pcl::PCLPointField> &fields)
+getFields (const pcl::PointCloud<PointT> &, std::vector<pcl::PCLPointField> &fields)
 {
   fields = getFields<PointT> ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::getFields (std::vector<pcl::PCLPointField> &fields)
+getFields (std::vector<pcl::PCLPointField> &fields)
 {
   fields = getFields<PointT> ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> std::vector<pcl::PCLPointField>
-pcl::getFields ()
+getFields ()
 {
   std::vector<pcl::PCLPointField> fields;
   // Get the fields list
@@ -100,9 +103,9 @@ pcl::getFields ()
   return fields;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> std::string
-pcl::getFieldsList (const pcl::PointCloud<PointT> &)
+getFieldsList (const pcl::PointCloud<PointT> &)
 {
   // Get the fields list
   const auto fields = getFields<PointT>();
@@ -113,10 +116,10 @@ pcl::getFieldsList (const pcl::PointCloud<PointT> &)
   return (result);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
-                     pcl::PointCloud<PointOutT> &cloud_out)
+copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
+                pcl::PointCloud<PointOutT> &cloud_out)
 {
   // Allocate enough space and copy the basics
   cloud_out.header   = cloud_in.header;
@@ -139,11 +142,11 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
       copyPoint (cloud_in.points[i], cloud_out.points[i]);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename IndicesVectorAllocator> void
-pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
-                     const std::vector<int, IndicesVectorAllocator> &indices,
-                     pcl::PointCloud<PointT> &cloud_out)
+copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                const std::vector<int, IndicesVectorAllocator> &indices,
+                pcl::PointCloud<PointT> &cloud_out)
 {
   // Do we want to copy everything?
   if (indices.size () == cloud_in.points.size ())
@@ -166,11 +169,11 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
     cloud_out.points[i] = cloud_in.points[indices[i]];
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IndicesVectorAllocator> void
-pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
-                     const std::vector<int, IndicesVectorAllocator> &indices,
-                     pcl::PointCloud<PointOutT> &cloud_out)
+copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
+                const std::vector<int, IndicesVectorAllocator> &indices,
+                pcl::PointCloud<PointOutT> &cloud_out)
 {
   // Allocate enough space and copy the basics
   cloud_out.points.resize (indices.size ());
@@ -186,10 +189,10 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
     copyPoint (cloud_in.points[indices[i]], cloud_out.points[i]);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
-                     const pcl::PointIndices &indices,
+copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                const pcl::PointIndices &indices,
                      pcl::PointCloud<PointT> &cloud_out)
 {
   // Do we want to copy everything?
@@ -213,20 +216,20 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
     cloud_out.points[i] = cloud_in.points[indices.indices[i]];
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
-                     const pcl::PointIndices &indices,
-                     pcl::PointCloud<PointOutT> &cloud_out)
+copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
+                const pcl::PointIndices &indices,
+                pcl::PointCloud<PointOutT> &cloud_out)
 {
   copyPointCloud (cloud_in, indices.indices, cloud_out);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, 
-                     const std::vector<pcl::PointIndices> &indices,
-                     pcl::PointCloud<PointT> &cloud_out)
+copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                const std::vector<pcl::PointIndices> &indices,
+                pcl::PointCloud<PointT> &cloud_out)
 {
   int nr_p = 0;
   for (const auto &index : indices)
@@ -262,11 +265,11 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in, 
-                     const std::vector<pcl::PointIndices> &indices,
-                     pcl::PointCloud<PointOutT> &cloud_out)
+copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
+                const std::vector<pcl::PointIndices> &indices,
+                pcl::PointCloud<PointOutT> &cloud_out)
 {
   const auto nr_p = std::accumulate(indices.begin (), indices.end (), 0,
       [](const auto& acc, const auto& index) { return index.indices.size() + acc; });
@@ -300,11 +303,11 @@ pcl::copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointIn1T, typename PointIn2T, typename PointOutT> void
-pcl::concatenateFields (const pcl::PointCloud<PointIn1T> &cloud1_in,
-                        const pcl::PointCloud<PointIn2T> &cloud2_in,
-                        pcl::PointCloud<PointOutT> &cloud_out)
+concatenateFields (const pcl::PointCloud<PointIn1T> &cloud1_in,
+                   const pcl::PointCloud<PointIn2T> &cloud2_in,
+                   pcl::PointCloud<PointOutT> &cloud_out)
 {
   using FieldList1 = typename pcl::traits::fieldList<PointIn1T>::type;
   using FieldList2 = typename pcl::traits::fieldList<PointIn2T>::type;
@@ -334,10 +337,10 @@ pcl::concatenateFields (const pcl::PointCloud<PointIn1T> &cloud1_in,
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, pcl::PointCloud<PointT> &cloud_out,
-                     int top, int bottom, int left, int right, pcl::InterpolationType border_type, const PointT& value)
+copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, pcl::PointCloud<PointT> &cloud_out,
+                int top, int bottom, int left, int right, pcl::InterpolationType border_type, const PointT& value)
 {
   if (top < 0 || left < 0 || bottom < 0 || right < 0)
   {
@@ -459,6 +462,8 @@ pcl::copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, pcl::PointCloud<Po
     }
   }
 }
+
+} // namespace pcl
 
 #endif // PCL_IO_IMPL_IO_H_
 

--- a/common/include/pcl/common/impl/pca.hpp
+++ b/common/include/pcl/common/impl/pca.hpp
@@ -45,9 +45,12 @@
 #include <pcl/common/transforms.h>
 #include <pcl/exceptions.h>
 
-/////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template<typename PointT> bool
-pcl::PCA<PointT>::initCompute () 
+PCA<PointT>::initCompute ()
 {
   if(!Base::initCompute ())
   {
@@ -57,10 +60,10 @@ pcl::PCA<PointT>::initCompute ()
   {
     PCL_THROW_EXCEPTION (InitFailedException, "[pcl::PCA::initCompute] number of points < 3");
   }
-  
+
   // Compute mean
   mean_ = Eigen::Vector4f::Zero ();
-  compute3DCentroid (*input_, *indices_, mean_);  
+  compute3DCentroid (*input_, *indices_, mean_);
   // Compute demeanished cloud
   Eigen::MatrixXf cloud_demean;
   demeanPointCloud (*input_, *indices_, mean_, cloud_demean);
@@ -68,7 +71,7 @@ pcl::PCA<PointT>::initCompute ()
   // Compute the product cloud_demean * cloud_demean^T
   const Eigen::Matrix3f alpha = (1.f / (float (indices_->size ()) - 1.f))
                                   * cloud_demean.topRows<3> () * cloud_demean.topRows<3> ().transpose ();
-  
+
   // Compute eigen vectors and values
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> evd (alpha);
   // Organize eigenvectors and eigenvalues in ascendent order
@@ -77,7 +80,7 @@ pcl::PCA<PointT>::initCompute ()
     eigenvalues_[i] = evd.eigenvalues () [2-i];
     eigenvectors_.col (i) = evd.eigenvectors ().col (2-i);
   }
-  // Enforce right hand rule 
+  // Enforce right hand rule
   eigenvectors_.col(2) = eigenvectors_.col(0).cross(eigenvectors_.col(1));
   // If not basis only then compute the coefficients
   if (!basis_only_)
@@ -86,9 +89,9 @@ pcl::PCA<PointT>::initCompute ()
   return (true);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> inline void 
-pcl::PCA<PointT>::update (const PointT& input_point, FLAG flag) 
+
+template<typename PointT> inline void
+PCA<PointT>::update (const PointT& input_point, FLAG flag)
 {
   if (!compute_done_)
     initCompute ();
@@ -101,7 +104,7 @@ pcl::PCA<PointT>::update (const PointT& input_point, FLAG flag)
   Eigen::VectorXf a = eigenvectors_.transpose() * (input - mean_.head<3>());
   Eigen::VectorXf y = (eigenvectors_ * a) + mean_.head<3>();
   Eigen::VectorXf h = y - input;
-  if (h.norm() > 0) 
+  if (h.norm() > 0)
     h.normalize ();
   else
     h.setZero ();
@@ -140,7 +143,7 @@ pcl::PCA<PointT>::update (const PointT& input_point, FLAG flag)
     coefficients_.col(coefficients_.cols()-1) = (R.transpose() * a) + etha;
   }
   mean_.head<3>() = meanp;
-  switch (flag) 
+  switch (flag)
   {
     case increase:
       if (eigenvectors_.rows() >= eigenvectors_.cols())
@@ -156,22 +159,22 @@ pcl::PCA<PointT>::update (const PointT& input_point, FLAG flag)
   }
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline void
-pcl::PCA<PointT>::project (const PointT& input, PointT& projection)
+PCA<PointT>::project (const PointT& input, PointT& projection)
 {
   if(!compute_done_)
     initCompute ();
   if (!compute_done_)
     PCL_THROW_EXCEPTION (InitFailedException, "[pcl::PCA::project] PCA initCompute failed");
-  
+
   Eigen::Vector3f demean_input = input.getVector3fMap () - mean_.head<3> ();
   projection.getVector3fMap () = eigenvectors_.transpose() * demean_input;
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline void
-pcl::PCA<PointT>::project (const PointCloud& input, PointCloud& projection)
+PCA<PointT>::project (const PointCloud& input, PointCloud& projection)
 {
   if(!compute_done_)
     initCompute ();
@@ -198,9 +201,9 @@ pcl::PCA<PointT>::project (const PointCloud& input, PointCloud& projection)
   }
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline void
-pcl::PCA<PointT>::reconstruct (const PointT& projection, PointT& input)
+PCA<PointT>::reconstruct (const PointT& projection, PointT& input)
 {
   if(!compute_done_)
     initCompute ();
@@ -211,9 +214,9 @@ pcl::PCA<PointT>::reconstruct (const PointT& projection, PointT& input)
   input.getVector3fMap ()+= mean_.head<3> ();
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline void
-pcl::PCA<PointT>::reconstruct (const PointCloud& projection, PointCloud& input)
+PCA<PointT>::reconstruct (const PointCloud& projection, PointCloud& input)
 {
   if(!compute_done_)
     initCompute ();
@@ -230,7 +233,7 @@ pcl::PCA<PointT>::reconstruct (const PointCloud& projection, PointCloud& input)
     PointT p;
     for (std::size_t i = 0; i < input.size (); ++i)
     {
-      if (!std::isfinite (input[i].x) || 
+      if (!std::isfinite (input[i].x) ||
           !std::isfinite (input[i].y) ||
           !std::isfinite (input[i].z))
         continue;
@@ -240,4 +243,7 @@ pcl::PCA<PointT>::reconstruct (const PointCloud& projection, PointCloud& input)
   }
 }
 
+} // namespace pcl
+
 #endif
+

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -35,24 +35,26 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
 #ifndef PCL_POLYNOMIAL_CALCULATIONS_HPP_
 #define PCL_POLYNOMIAL_CALCULATIONS_HPP_
 
-////////////////////////////////////
+
+namespace pcl
+{
 
 template <typename real>
 inline void
-  pcl::PolynomialCalculationsT<real>::Parameters::setZeroValue (real new_zero_value)
+PolynomialCalculationsT<real>::Parameters::setZeroValue (real new_zero_value)
 {
   zero_value = new_zero_value;
   sqr_zero_value = zero_value*zero_value;
 }
 
-////////////////////////////////////
 
 template <typename real>
 inline void
-  pcl::PolynomialCalculationsT<real>::solveLinearEquation (real a, real b, std::vector<real>& roots) const
+PolynomialCalculationsT<real>::solveLinearEquation (real a, real b, std::vector<real>& roots) const
 {
   //std::cout << "Trying to solve "<<a<<"x + "<<b<<" = 0\n";
 
@@ -81,11 +83,10 @@ inline void
 #endif
 }
 
-////////////////////////////////////
 
 template <typename real>
 inline void
-  pcl::PolynomialCalculationsT<real>::solveQuadraticEquation (real a, real b, real c, std::vector<real>& roots) const
+PolynomialCalculationsT<real>::solveQuadraticEquation (real a, real b, real c, std::vector<real>& roots) const
 {
   //std::cout << "Trying to solve "<<a<<"x^2 + "<<b<<"x + "<<c<<" = 0\n";
 
@@ -137,11 +138,10 @@ inline void
 #endif
 }
 
-////////////////////////////////////
 
 template<typename real>
 inline void
-  pcl::PolynomialCalculationsT<real>::solveCubicEquation (real a, real b, real c, real d, std::vector<real>& roots) const
+PolynomialCalculationsT<real>::solveCubicEquation (real a, real b, real c, real d, std::vector<real>& roots) const
 {
   //std::cout << "Trying to solve "<<a<<"x^3 + "<<b<<"x^2 + "<<c<<"x + "<<d<<" = 0\n";
 
@@ -239,12 +239,11 @@ inline void
 #endif
 }
 
-////////////////////////////////////
 
 template<typename real>
 inline void
-  pcl::PolynomialCalculationsT<real>::solveQuarticEquation (real a, real b, real c, real d, real e,
-                                                            std::vector<real>& roots) const
+PolynomialCalculationsT<real>::solveQuarticEquation (real a, real b, real c, real d, real e,
+                                                     std::vector<real>& roots) const
 {
   //std::cout << "Trying to solve "<<a<<"x^4 + "<<b<<"x^3 + "<<c<<"x^2 + "<<d<<"x + "<<e<<" = 0\n";
 
@@ -391,25 +390,23 @@ inline void
 #endif
 }
 
-////////////////////////////////////
 
 template<typename real>
 inline pcl::BivariatePolynomialT<real>
-  pcl::PolynomialCalculationsT<real>::bivariatePolynomialApproximation (
-      std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints, unsigned int polynomial_degree, bool& error) const
+PolynomialCalculationsT<real>::bivariatePolynomialApproximation (
+  std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints, unsigned int polynomial_degree, bool& error) const
 {
   pcl::BivariatePolynomialT<real> ret;
   error = bivariatePolynomialApproximation (samplePoints, polynomial_degree, ret);
   return ret;
 }
 
-////////////////////////////////////
 
 template<typename real>
 inline bool
-  pcl::PolynomialCalculationsT<real>::bivariatePolynomialApproximation (
-      std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints, unsigned int polynomial_degree,
-      pcl::BivariatePolynomialT<real>& ret) const
+PolynomialCalculationsT<real>::bivariatePolynomialApproximation (
+  std::vector<Eigen::Matrix<real, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<real, 3, 1> > >& samplePoints, unsigned int polynomial_degree,
+  pcl::BivariatePolynomialT<real>& ret) const
 {
   const auto parameters_size = BivariatePolynomialT<real>::getNoOfParametersFromDegree (polynomial_degree);
 
@@ -504,6 +501,8 @@ inline bool
 
   return true;
 }
+
+} // namespace pcl
 
 #endif      // PCL_POLYNOMIAL_CALCULATIONS_HPP_
 

--- a/common/include/pcl/common/impl/projection_matrix.hpp
+++ b/common/include/pcl/common/impl/projection_matrix.hpp
@@ -40,44 +40,47 @@
 
 #include <pcl/cloud_iterator.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 namespace pcl
 {
-  namespace common
+
+namespace common
+{
+
+namespace internal
+{
+
+template <typename MatrixT> void
+makeSymmetric (MatrixT& matrix, bool use_upper_triangular = true)
+{
+  if (use_upper_triangular && (MatrixT::Flags & Eigen::RowMajorBit))
   {
-    namespace internal
-    {
-      template <typename MatrixT> void
-      makeSymmetric (MatrixT& matrix, bool use_upper_triangular = true)
-      {
-        if (use_upper_triangular && (MatrixT::Flags & Eigen::RowMajorBit))
-        {
-          matrix.coeffRef (4) = matrix.coeff (1);
-          matrix.coeffRef (8) = matrix.coeff (2);
-          matrix.coeffRef (9) = matrix.coeff (6);
-          matrix.coeffRef (12) = matrix.coeff (3);
-          matrix.coeffRef (13) = matrix.coeff (7);
-          matrix.coeffRef (14) = matrix.coeff (11);
-        }
-        else
-        {
-          matrix.coeffRef (1) = matrix.coeff (4);
-          matrix.coeffRef (2) = matrix.coeff (8);
-          matrix.coeffRef (6) = matrix.coeff (9);
-          matrix.coeffRef (3) = matrix.coeff (12);
-          matrix.coeffRef (7) = matrix.coeff (13);
-          matrix.coeffRef (11) = matrix.coeff (14);
-        }
-      }
-    }
+    matrix.coeffRef (4) = matrix.coeff (1);
+    matrix.coeffRef (8) = matrix.coeff (2);
+    matrix.coeffRef (9) = matrix.coeff (6);
+    matrix.coeffRef (12) = matrix.coeff (3);
+    matrix.coeffRef (13) = matrix.coeff (7);
+    matrix.coeffRef (14) = matrix.coeff (11);
+  }
+  else
+  {
+    matrix.coeffRef (1) = matrix.coeff (4);
+    matrix.coeffRef (2) = matrix.coeff (8);
+    matrix.coeffRef (6) = matrix.coeff (9);
+    matrix.coeffRef (3) = matrix.coeff (12);
+    matrix.coeffRef (7) = matrix.coeff (13);
+    matrix.coeffRef (11) = matrix.coeff (14);
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////
-template <typename PointT> double 
-pcl::estimateProjectionMatrix (
-    typename pcl::PointCloud<PointT>::ConstPtr cloud, 
-    Eigen::Matrix<float, 3, 4, Eigen::RowMajor>& projection_matrix, 
+} // namespace internal
+} // namespace common
+
+
+template <typename PointT> double
+estimateProjectionMatrix (
+    typename pcl::PointCloud<PointT>::ConstPtr cloud,
+    Eigen::Matrix<float, 3, 4, Eigen::RowMajor>& projection_matrix,
     const std::vector<int>& indices)
 {
   // internally we calculate with double but store the result into float matrices.
@@ -88,19 +91,19 @@ pcl::estimateProjectionMatrix (
     PCL_ERROR ("[pcl::estimateProjectionMatrix] Input dataset is not organized!\n");
     return (-1.0);
   }
-  
+
   Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor> A = Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor>::Zero ();
   Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor> B = Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor>::Zero ();
   Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor> C = Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor>::Zero ();
   Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor> D = Eigen::Matrix<Scalar, 4, 4, Eigen::RowMajor>::Zero ();
 
   pcl::ConstCloudIterator <PointT> pointIt (*cloud, indices);
-  
+
   while (pointIt)
   {
     unsigned yIdx = pointIt.getCurrentPointIndex () / cloud->width;
     unsigned xIdx = pointIt.getCurrentPointIndex () % cloud->width;
-    
+
     const PointT& point = *pointIt;
     if (std::isfinite (point.x))
     {
@@ -167,14 +170,14 @@ pcl::estimateProjectionMatrix (
 
       D.coeffRef (15) += xx_yy;
     }
-    
+
     ++pointIt;
-  } // while  
-  
-  pcl::common::internal::makeSymmetric (A);
-  pcl::common::internal::makeSymmetric (B);
-  pcl::common::internal::makeSymmetric (C);
-  pcl::common::internal::makeSymmetric (D);
+  } // while
+
+  common::internal::makeSymmetric (A);
+  common::internal::makeSymmetric (B);
+  common::internal::makeSymmetric (C);
+  common::internal::makeSymmetric (D);
 
   Eigen::Matrix<Scalar, 12, 12, Eigen::RowMajor> X = Eigen::Matrix<Scalar, 12, 12, Eigen::RowMajor>::Zero ();
   X.topLeftCorner<4,4> ().matrix () = A;
@@ -190,7 +193,7 @@ pcl::estimateProjectionMatrix (
 
   // check whether the residual MSE is low. If its high, the cloud was not captured from a projective device.
   Eigen::Matrix<Scalar, 1, 1> residual_sqr = eigen_vectors.col (0).transpose () * X *  eigen_vectors.col (0);
-  
+
   double residual = residual_sqr.coeff (0);
 
   projection_matrix.coeffRef (0) = static_cast <float> (eigen_vectors.coeff (0));
@@ -212,4 +215,7 @@ pcl::estimateProjectionMatrix (
   return (residual);
 }
 
+} // namespace pcl
+
 #endif
+

--- a/common/include/pcl/common/impl/random.hpp
+++ b/common/include/pcl/common/impl/random.hpp
@@ -40,9 +40,16 @@
 #ifndef PCL_COMMON_RANDOM_HPP_
 #define PCL_COMMON_RANDOM_HPP_
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace common
+{
+
+
 template <typename T>
-pcl::common::UniformGenerator<T>::UniformGenerator(T min, T max, std::uint32_t seed)
+UniformGenerator<T>::UniformGenerator(T min, T max, std::uint32_t seed)
   : distribution_ (min, max)
 {
   parameters_ = Parameters (min, max, seed);
@@ -51,9 +58,8 @@ pcl::common::UniformGenerator<T>::UniformGenerator(T min, T max, std::uint32_t s
 }
 
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-pcl::common::UniformGenerator<T>::UniformGenerator(const Parameters& parameters)
+UniformGenerator<T>::UniformGenerator(const Parameters& parameters)
   : parameters_ (parameters)
   , distribution_ (parameters_.min, parameters_.max)
 {
@@ -61,9 +67,9 @@ pcl::common::UniformGenerator<T>::UniformGenerator(const Parameters& parameters)
     rng_.seed (parameters_.seed);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename T> void
-pcl::common::UniformGenerator<T>::setSeed (std::uint32_t seed)
+UniformGenerator<T>::setSeed (std::uint32_t seed)
 {
   if (seed != static_cast<std::uint32_t> (-1))
   {
@@ -72,9 +78,9 @@ pcl::common::UniformGenerator<T>::setSeed (std::uint32_t seed)
   }
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename T> void
-pcl::common::UniformGenerator<T>::setParameters (T min, T max, std::uint32_t seed)
+UniformGenerator<T>::setParameters (T min, T max, std::uint32_t seed)
 {
   parameters_.min = min;
   parameters_.max = max;
@@ -89,9 +95,9 @@ pcl::common::UniformGenerator<T>::setParameters (T min, T max, std::uint32_t see
   }
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename T> void
-pcl::common::UniformGenerator<T>::setParameters (const Parameters& parameters)
+UniformGenerator<T>::setParameters (const Parameters& parameters)
 {
   parameters_ = parameters;
   typename DistributionType::param_type params (parameters_.min, parameters_.max);
@@ -101,9 +107,9 @@ pcl::common::UniformGenerator<T>::setParameters (const Parameters& parameters)
     rng_.seed (parameters_.seed);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename T>
-pcl::common::NormalGenerator<T>::NormalGenerator(T mean, T sigma, std::uint32_t seed)
+NormalGenerator<T>::NormalGenerator(T mean, T sigma, std::uint32_t seed)
   : distribution_ (mean, sigma)
 {
   parameters_ = Parameters (mean, sigma, seed);
@@ -112,9 +118,8 @@ pcl::common::NormalGenerator<T>::NormalGenerator(T mean, T sigma, std::uint32_t 
 }
 
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-pcl::common::NormalGenerator<T>::NormalGenerator(const Parameters& parameters)
+NormalGenerator<T>::NormalGenerator(const Parameters& parameters)
   : parameters_ (parameters)
   , distribution_ (parameters_.mean, parameters_.sigma)
 {
@@ -122,9 +127,9 @@ pcl::common::NormalGenerator<T>::NormalGenerator(const Parameters& parameters)
     rng_.seed (parameters_.seed);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename T> void
-pcl::common::NormalGenerator<T>::setSeed (std::uint32_t seed)
+NormalGenerator<T>::setSeed (std::uint32_t seed)
 {
   if (seed != static_cast<std::uint32_t> (-1))
   {
@@ -133,9 +138,9 @@ pcl::common::NormalGenerator<T>::setSeed (std::uint32_t seed)
   }
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename T> void
-pcl::common::NormalGenerator<T>::setParameters (T mean, T sigma, std::uint32_t seed)
+NormalGenerator<T>::setParameters (T mean, T sigma, std::uint32_t seed)
 {
   parameters_.mean = mean;
   parameters_.sigma = sigma;
@@ -147,9 +152,9 @@ pcl::common::NormalGenerator<T>::setParameters (T mean, T sigma, std::uint32_t s
     rng_.seed (parameters_.seed);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename T> void
-pcl::common::NormalGenerator<T>::setParameters (const Parameters& parameters)
+NormalGenerator<T>::setParameters (const Parameters& parameters)
 {
   parameters_ = parameters;
   typename DistributionType::param_type params (parameters_.mean, parameters_.sigma);
@@ -158,5 +163,8 @@ pcl::common::NormalGenerator<T>::setParameters (const Parameters& parameters)
   if (parameters_.seed != static_cast<std::uint32_t> (-1))
     rng_.seed (parameters_.seed);
 }
+
+} // namespace common
+} // namespace pcl
 
 #endif

--- a/common/include/pcl/common/impl/spring.hpp
+++ b/common/include/pcl/common/impl/spring.hpp
@@ -40,9 +40,16 @@
 #ifndef PCL_POINT_CLOUD_SPRING_IMPL_HPP_
 #define PCL_POINT_CLOUD_SPRING_IMPL_HPP_
 
-template <typename PointT> void 
-pcl::common::expandColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output, 
-                            const PointT& val, const std::size_t& amount)
+
+namespace pcl
+{
+
+namespace common
+{
+
+template <typename PointT> void
+expandColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+               const PointT& val, const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -51,7 +58,7 @@ pcl::common::expandColumns (const PointCloud<PointT>& input, PointCloud<PointT>&
 
   if (!input.isOrganized () || amount > (input.width/2))
     PCL_THROW_EXCEPTION (InitFailedException,
-                         "[pcl::common::expandColumns] error: " 
+                         "[pcl::common::expandColumns] error: "
                          << "columns expansion requires organised point cloud");
 
   std::uint32_t old_height = input.height;
@@ -72,9 +79,9 @@ pcl::common::expandColumns (const PointCloud<PointT>& input, PointCloud<PointT>&
   output.height = old_height;
 }
 
-template <typename PointT> void 
-pcl::common::expandRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const PointT& val, const std::size_t& amount)
+template <typename PointT> void
+expandRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+            const PointT& val, const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -93,9 +100,9 @@ pcl::common::expandRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
   output.height = new_height;
 }
 
-template <typename PointT> void 
-pcl::common::duplicateColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                               const std::size_t& amount)
+template <typename PointT> void
+duplicateColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+                  const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -104,7 +111,7 @@ pcl::common::duplicateColumns (const PointCloud<PointT>& input, PointCloud<Point
 
   if (!input.isOrganized () || amount > (input.width/2))
     PCL_THROW_EXCEPTION (InitFailedException,
-                         "[pcl::common::duplicateColumns] error: " 
+                         "[pcl::common::duplicateColumns] error: "
                          << "columns expansion requires organised point cloud");
 
   std::size_t old_height = input.height;
@@ -126,13 +133,13 @@ pcl::common::duplicateColumns (const PointCloud<PointT>& input, PointCloud<Point
   output.height = old_height;
 }
 
-template <typename PointT> void 
-pcl::common::duplicateRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                            const std::size_t& amount)
+template <typename PointT> void
+duplicateRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+               const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.height/2))
     PCL_THROW_EXCEPTION (InitFailedException,
-                         "[pcl::common::duplicateRows] error: amount must be ]0.." 
+                         "[pcl::common::duplicateRows] error: amount must be ]0.."
                          << (input.height/2) << "] !");
 
   std::uint32_t old_height = input.height;
@@ -151,9 +158,9 @@ pcl::common::duplicateRows (const PointCloud<PointT>& input, PointCloud<PointT>&
   output.height = new_height;
 }
 
-template <typename PointT> void 
-pcl::common::mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                                  const std::size_t& amount)
+template <typename PointT> void
+mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+               const std::size_t& amount)
 {
   if (amount <= 0)
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -162,7 +169,7 @@ pcl::common::mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>&
 
   if (!input.isOrganized () || amount > (input.width/2))
     PCL_THROW_EXCEPTION (InitFailedException,
-                         "[pcl::common::mirrorColumns] error: " 
+                         "[pcl::common::mirrorColumns] error: "
                          << "columns expansion requires organised point cloud");
 
   std::size_t old_height = input.height;
@@ -183,13 +190,13 @@ pcl::common::mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>&
   output.height = old_height;
 }
 
-template <typename PointT> void 
-pcl::common::mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const std::size_t& amount)
+template <typename PointT> void
+mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+            const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.height/2))
     PCL_THROW_EXCEPTION (InitFailedException,
-                         "[pcl::common::mirrorRows] error: amount must be ]0.." 
+                         "[pcl::common::mirrorRows] error: amount must be ]0.."
                          << (input.height/2) << "] !");
 
   std::uint32_t old_height = input.height;
@@ -210,13 +217,13 @@ pcl::common::mirrorRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
   output.height = new_height;
 }
 
-template <typename PointT> void 
-pcl::common::deleteRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const std::size_t& amount)
+template <typename PointT> void
+deleteRows (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+            const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.height/2))
     PCL_THROW_EXCEPTION (InitFailedException,
-                         "[pcl::common::deleteRows] error: amount must be ]0.." 
+                         "[pcl::common::deleteRows] error: amount must be ]0.."
                          << (input.height/2) << "] !");
 
   std::uint32_t old_height = input.height;
@@ -227,9 +234,9 @@ pcl::common::deleteRows (const PointCloud<PointT>& input, PointCloud<PointT>& ou
   output.width = old_width;
 }
 
-template <typename PointT> void 
-pcl::common::deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& output,
-                         const std::size_t& amount)
+template <typename PointT> void
+deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& output,
+            const std::size_t& amount)
 {
   if (amount <= 0 || amount > (input.width/2))
     PCL_THROW_EXCEPTION (InitFailedException,
@@ -238,7 +245,7 @@ pcl::common::deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& ou
 
   if (!input.isOrganized ())
     PCL_THROW_EXCEPTION (InitFailedException,
-                         "[pcl::common::deleteCols] error: " 
+                         "[pcl::common::deleteCols] error: "
                          << "columns delete requires organised point cloud");
 
   std::uint32_t old_height = input.height;
@@ -249,10 +256,14 @@ pcl::common::deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& ou
     typename PointCloud<PointT>::iterator start = output.begin () + j * new_width;
     output.erase (start, start + amount);
     start = output.begin () + (j+1) * new_width;
-    output.erase (start, start + amount);    
+    output.erase (start, start + amount);
   }
   output.height = old_height;
   output.width = new_width;
 }
 
+} // namespace common
+} // namespace pcl
+
 #endif
+

--- a/common/include/pcl/common/impl/transformation_from_correspondences.hpp
+++ b/common/include/pcl/common/impl/transformation_from_correspondences.hpp
@@ -35,11 +35,16 @@
  *
  */
 
+#pragma once
+
 #include <pcl/common/eigen.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 inline void
-pcl::TransformationFromCorrespondences::reset ()
+TransformationFromCorrespondences::reset ()
 {
   no_of_samples_ = 0;
   accumulated_weight_ = 0.0;
@@ -48,28 +53,28 @@ pcl::TransformationFromCorrespondences::reset ()
   covariance_.fill(0);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 inline void
-pcl::TransformationFromCorrespondences::add (const Eigen::Vector3f& point, const Eigen::Vector3f& corresponding_point,
-                                             float weight)
+TransformationFromCorrespondences::add (const Eigen::Vector3f& point, const Eigen::Vector3f& corresponding_point,
+                                        float weight)
 {
   if (weight==0.0f)
     return;
-  
+
   ++no_of_samples_;
   accumulated_weight_ += weight;
   float alpha = weight/accumulated_weight_;
-  
+
   Eigen::Vector3f diff1 = point - mean1_, diff2 = corresponding_point - mean2_;
   covariance_ = (1.0f-alpha)*(covariance_ + alpha * (diff2 * diff1.transpose()));
-  
+
   mean1_ += alpha*(diff1);
   mean2_ += alpha*(diff2);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 inline Eigen::Affine3f
-pcl::TransformationFromCorrespondences::getTransformation ()
+TransformationFromCorrespondences::getTransformation ()
 {
   //Eigen::JacobiSVD<Eigen::Matrix<float, 3, 3> > svd (covariance_, Eigen::ComputeFullU | Eigen::ComputeFullV);
   Eigen::JacobiSVD<Eigen::Matrix<float, 3, 3> > svd (covariance_, Eigen::ComputeFullU | Eigen::ComputeFullV);
@@ -79,15 +84,18 @@ pcl::TransformationFromCorrespondences::getTransformation ()
   s.setIdentity();
   if (u.determinant()*v.determinant() < 0.0f)
     s(2,2) = -1.0f;
-  
+
   Eigen::Matrix<float, 3, 3> r = u * s * v.transpose();
   Eigen::Vector3f t = mean2_ - r*mean1_;
-  
+
   Eigen::Affine3f ret;
   ret(0,0)=r(0,0); ret(0,1)=r(0,1); ret(0,2)=r(0,2); ret(0,3)=t(0);
   ret(1,0)=r(1,0); ret(1,1)=r(1,1); ret(1,2)=r(1,2); ret(1,3)=t(1);
   ret(2,0)=r(2,0); ret(2,1)=r(2,1); ret(2,2)=r(2,2); ret(2,3)=t(2);
   ret(3,0)=0.0f;   ret(3,1)=0.0f;   ret(3,2)=0.0f;   ret(3,3)=1.0f;
-  
+
   return (ret);
 }
+
+} // namespace pcl
+

--- a/common/include/pcl/common/impl/transforms.hpp
+++ b/common/include/pcl/common/impl/transforms.hpp
@@ -53,174 +53,170 @@
 namespace pcl
 {
 
-  namespace detail
+namespace detail
+{
+
+/** A helper struct to apply an SO3 or SE3 transform to a 3D point.
+  * Supports single and double precision transform matrices. */
+template<typename Scalar>
+struct Transformer
+{
+  const Eigen::Matrix<Scalar, 4, 4>& tf;
+
+  /** Construct a transformer object.
+    * The transform matrix is captured by const reference. Make sure that it does not go out of scope before this
+    * object does. */
+  Transformer (const Eigen::Matrix<Scalar, 4, 4>& transform) : tf (transform) { };
+
+  /** Apply SO3 transform (top-left corner of the transform matrix).
+    * \param[in] src input 3D point (pointer to 3 floats)
+    * \param[out] tgt output 3D point (pointer to 4 floats), can be the same as input. The fourth element is set to 0. */
+  void so3 (const float* src, float* tgt) const
   {
+    const Scalar p[3] = { src[0], src[1], src[2] };  // need this when src == tgt
+    tgt[0] = static_cast<float> (tf (0, 0) * p[0] + tf (0, 1) * p[1] + tf (0, 2) * p[2]);
+    tgt[1] = static_cast<float> (tf (1, 0) * p[0] + tf (1, 1) * p[1] + tf (1, 2) * p[2]);
+    tgt[2] = static_cast<float> (tf (2, 0) * p[0] + tf (2, 1) * p[1] + tf (2, 2) * p[2]);
+    tgt[3] = 0;
+  }
 
-    /** A helper struct to apply an SO3 or SE3 transform to a 3D point.
-      * Supports single and double precision transform matrices. */
-    template<typename Scalar>
-    struct Transformer
-    {
-      const Eigen::Matrix<Scalar, 4, 4>& tf;
-
-      /** Construct a transformer object.
-        * The transform matrix is captured by const reference. Make sure that it does not go out of scope before this
-        * object does. */
-      Transformer (const Eigen::Matrix<Scalar, 4, 4>& transform) : tf (transform) { };
-
-      /** Apply SO3 transform (top-left corner of the transform matrix).
-        * \param[in] src input 3D point (pointer to 3 floats)
-        * \param[out] tgt output 3D point (pointer to 4 floats), can be the same as input. The fourth element is set to 0. */
-      void so3 (const float* src, float* tgt) const
-      {
-        const Scalar p[3] = { src[0], src[1], src[2] };  // need this when src == tgt
-        tgt[0] = static_cast<float> (tf (0, 0) * p[0] + tf (0, 1) * p[1] + tf (0, 2) * p[2]);
-        tgt[1] = static_cast<float> (tf (1, 0) * p[0] + tf (1, 1) * p[1] + tf (1, 2) * p[2]);
-        tgt[2] = static_cast<float> (tf (2, 0) * p[0] + tf (2, 1) * p[1] + tf (2, 2) * p[2]);
-        tgt[3] = 0;
-      }
-
-      /** Apply SE3 transform.
-        * \param[in] src input 3D point (pointer to 3 floats)
-        * \param[out] tgt output 3D point (pointer to 4 floats), can be the same as input. The fourth element is set to 1. */
-      void se3 (const float* src, float* tgt) const
-      {
-        const Scalar p[3] = { src[0], src[1], src[2] };  // need this when src == tgt
-        tgt[0] = static_cast<float> (tf (0, 0) * p[0] + tf (0, 1) * p[1] + tf (0, 2) * p[2] + tf (0, 3));
-        tgt[1] = static_cast<float> (tf (1, 0) * p[0] + tf (1, 1) * p[1] + tf (1, 2) * p[2] + tf (1, 3));
-        tgt[2] = static_cast<float> (tf (2, 0) * p[0] + tf (2, 1) * p[1] + tf (2, 2) * p[2] + tf (2, 3));
-        tgt[3] = 1;
-      }
-    };
+  /** Apply SE3 transform.
+    * \param[in] src input 3D point (pointer to 3 floats)
+    * \param[out] tgt output 3D point (pointer to 4 floats), can be the same as input. The fourth element is set to 1. */
+  void se3 (const float* src, float* tgt) const
+  {
+    const Scalar p[3] = { src[0], src[1], src[2] };  // need this when src == tgt
+    tgt[0] = static_cast<float> (tf (0, 0) * p[0] + tf (0, 1) * p[1] + tf (0, 2) * p[2] + tf (0, 3));
+    tgt[1] = static_cast<float> (tf (1, 0) * p[0] + tf (1, 1) * p[1] + tf (1, 2) * p[2] + tf (1, 3));
+    tgt[2] = static_cast<float> (tf (2, 0) * p[0] + tf (2, 1) * p[1] + tf (2, 2) * p[2] + tf (2, 3));
+    tgt[3] = 1;
+  }
+};
 
 #if defined(__SSE2__)
 
-    /** Optimized version for single-precision transforms using SSE2 intrinsics. */
-    template<>
-    struct Transformer<float>
-    {
-      /// Columns of the transform matrix stored in XMM registers.
-      __m128 c[4];
+/** Optimized version for single-precision transforms using SSE2 intrinsics. */
+template<>
+struct Transformer<float>
+{
+  /// Columns of the transform matrix stored in XMM registers.
+  __m128 c[4];
 
-      Transformer(const Eigen::Matrix4f& tf)
-      {
-        for (std::size_t i = 0; i < 4; ++i)
-          c[i] = _mm_load_ps (tf.col (i).data ());
-      }
+  Transformer(const Eigen::Matrix4f& tf)
+  {
+    for (std::size_t i = 0; i < 4; ++i)
+      c[i] = _mm_load_ps (tf.col (i).data ());
+  }
 
-      void so3 (const float* src, float* tgt) const
-      {
-        __m128 p0 = _mm_mul_ps (_mm_load_ps1 (&src[0]), c[0]);
-        __m128 p1 = _mm_mul_ps (_mm_load_ps1 (&src[1]), c[1]);
-        __m128 p2 = _mm_mul_ps (_mm_load_ps1 (&src[2]), c[2]);
-        _mm_store_ps (tgt, _mm_add_ps(p0, _mm_add_ps(p1, p2)));
-      }
+  void so3 (const float* src, float* tgt) const
+  {
+    __m128 p0 = _mm_mul_ps (_mm_load_ps1 (&src[0]), c[0]);
+    __m128 p1 = _mm_mul_ps (_mm_load_ps1 (&src[1]), c[1]);
+    __m128 p2 = _mm_mul_ps (_mm_load_ps1 (&src[2]), c[2]);
+    _mm_store_ps (tgt, _mm_add_ps(p0, _mm_add_ps(p1, p2)));
+  }
 
-      void se3 (const float* src, float* tgt) const
-      {
-        __m128 p0 = _mm_mul_ps (_mm_load_ps1 (&src[0]), c[0]);
-        __m128 p1 = _mm_mul_ps (_mm_load_ps1 (&src[1]), c[1]);
-        __m128 p2 = _mm_mul_ps (_mm_load_ps1 (&src[2]), c[2]);
-        _mm_store_ps (tgt, _mm_add_ps(p0, _mm_add_ps(p1, _mm_add_ps(p2, c[3]))));
-      }
-    };
+  void se3 (const float* src, float* tgt) const
+  {
+    __m128 p0 = _mm_mul_ps (_mm_load_ps1 (&src[0]), c[0]);
+    __m128 p1 = _mm_mul_ps (_mm_load_ps1 (&src[1]), c[1]);
+    __m128 p2 = _mm_mul_ps (_mm_load_ps1 (&src[2]), c[2]);
+    _mm_store_ps (tgt, _mm_add_ps(p0, _mm_add_ps(p1, _mm_add_ps(p2, c[3]))));
+  }
+};
 
 #if !defined(__AVX__)
 
-    /** Optimized version for double-precision transform using SSE2 intrinsics. */
-    template<>
-    struct Transformer<double>
+/** Optimized version for double-precision transform using SSE2 intrinsics. */
+template<>
+struct Transformer<double>
+{
+  /// Columns of the transform matrix stored in XMM registers.
+  __m128d c[4][2];
+
+  Transformer(const Eigen::Matrix4d& tf)
+  {
+    for (std::size_t i = 0; i < 4; ++i)
     {
-      /// Columns of the transform matrix stored in XMM registers.
-      __m128d c[4][2];
+      c[i][0] = _mm_load_pd (tf.col (i).data () + 0);
+      c[i][1] = _mm_load_pd (tf.col (i).data () + 2);
+    }
+  }
 
-      Transformer(const Eigen::Matrix4d& tf)
-      {
-        for (std::size_t i = 0; i < 4; ++i)
-        {
-          c[i][0] = _mm_load_pd (tf.col (i).data () + 0);
-          c[i][1] = _mm_load_pd (tf.col (i).data () + 2);
-        }
-      }
+  void so3 (const float* src, float* tgt) const
+  {
+    __m128d xx = _mm_cvtps_pd (_mm_load_ps1 (&src[0]));
+    __m128d p0 = _mm_mul_pd (xx, c[0][0]);
+    __m128d p1 = _mm_mul_pd (xx, c[0][1]);
 
-      void so3 (const float* src, float* tgt) const
-      {
-        __m128d xx = _mm_cvtps_pd (_mm_load_ps1 (&src[0]));
-        __m128d p0 = _mm_mul_pd (xx, c[0][0]);
-        __m128d p1 = _mm_mul_pd (xx, c[0][1]);
+    for (std::size_t i = 1; i < 3; ++i)
+    {
+      __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
+      p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
+      p1 = _mm_add_pd (_mm_mul_pd (vv, c[i][1]), p1);
+    }
 
-        for (std::size_t i = 1; i < 3; ++i)
-        {
-          __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
-          p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
-          p1 = _mm_add_pd (_mm_mul_pd (vv, c[i][1]), p1);
-        }
+    _mm_store_ps (tgt, _mm_movelh_ps (_mm_cvtpd_ps (p0), _mm_cvtpd_ps (p1)));
+  }
 
-        _mm_store_ps (tgt, _mm_movelh_ps (_mm_cvtpd_ps (p0), _mm_cvtpd_ps (p1)));
-      }
+  void se3 (const float* src, float* tgt) const
+  {
+    __m128d p0 = c[3][0];
+    __m128d p1 = c[3][1];
 
-      void se3 (const float* src, float* tgt) const
-      {
-        __m128d p0 = c[3][0];
-        __m128d p1 = c[3][1];
+    for (std::size_t i = 0; i < 3; ++i)
+    {
+      __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
+      p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
+      p1 = _mm_add_pd (_mm_mul_pd (vv, c[i][1]), p1);
+    }
 
-        for (std::size_t i = 0; i < 3; ++i)
-        {
-          __m128d vv = _mm_cvtps_pd (_mm_load_ps1 (&src[i]));
-          p0 = _mm_add_pd (_mm_mul_pd (vv, c[i][0]), p0);
-          p1 = _mm_add_pd (_mm_mul_pd (vv, c[i][1]), p1);
-        }
-
-        _mm_store_ps (tgt, _mm_movelh_ps (_mm_cvtpd_ps (p0), _mm_cvtpd_ps (p1)));
-      }
-
-    };
+    _mm_store_ps (tgt, _mm_movelh_ps (_mm_cvtpd_ps (p0), _mm_cvtpd_ps (p1)));
+  }
+};
 
 #else
 
-  /** Optimized version for double-precision transform using AVX intrinsics. */
-  template<>
-  struct Transformer<double>
+/** Optimized version for double-precision transform using AVX intrinsics. */
+template<>
+struct Transformer<double>
+{
+  __m256d c[4];
+
+  Transformer(const Eigen::Matrix4d& tf)
   {
-    __m256d c[4];
-
-    Transformer(const Eigen::Matrix4d& tf)
-    {
-      for (std::size_t i = 0; i < 4; ++i)
-        c[i] = _mm256_load_pd (tf.col (i).data ());
-    }
-
-    void so3 (const float* src, float* tgt) const
-    {
-      __m256d p0 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[0])), c[0]);
-      __m256d p1 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[1])), c[1]);
-      __m256d p2 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[2])), c[2]);
-      _mm_store_ps (tgt, _mm256_cvtpd_ps (_mm256_add_pd(p0, _mm256_add_pd(p1, p2))));
-    }
-
-    void se3 (const float* src, float* tgt) const
-    {
-      __m256d p0 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[0])), c[0]);
-      __m256d p1 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[1])), c[1]);
-      __m256d p2 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[2])), c[2]);
-      _mm_store_ps (tgt, _mm256_cvtpd_ps (_mm256_add_pd(p0, _mm256_add_pd(p1, _mm256_add_pd(p2, c[3])))));
-    }
-
-  };
-
-#endif
-#endif
-
+    for (std::size_t i = 0; i < 4; ++i)
+      c[i] = _mm256_load_pd (tf.col (i).data ());
   }
 
-}
+  void so3 (const float* src, float* tgt) const
+  {
+    __m256d p0 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[0])), c[0]);
+    __m256d p1 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[1])), c[1]);
+    __m256d p2 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[2])), c[2]);
+    _mm_store_ps (tgt, _mm256_cvtpd_ps (_mm256_add_pd(p0, _mm256_add_pd(p1, p2))));
+  }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+  void se3 (const float* src, float* tgt) const
+  {
+    __m256d p0 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[0])), c[0]);
+    __m256d p1 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[1])), c[1]);
+    __m256d p2 = _mm256_mul_pd (_mm256_cvtps_pd (_mm_load_ps1 (&src[2])), c[2]);
+    _mm_store_ps (tgt, _mm256_cvtpd_ps (_mm256_add_pd(p0, _mm256_add_pd(p1, _mm256_add_pd(p2, c[3])))));
+  }
+};
+
+#endif // !defined(__AVX__)
+#endif // defined(__SSE2__)
+
+} // namespace detail
+
+
 template <typename PointT, typename Scalar> void
-pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                          pcl::PointCloud<PointT> &cloud_out,
-                          const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
-                          bool copy_all_fields)
+transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                     pcl::PointCloud<PointT> &cloud_out,
+                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
+                     bool copy_all_fields)
 {
   if (&cloud_in != &cloud_out)
   {
@@ -259,13 +255,13 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                          const std::vector<int> &indices,
-                          pcl::PointCloud<PointT> &cloud_out,
-                          const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
-                          bool copy_all_fields)
+transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                     const std::vector<int> &indices,
+                     pcl::PointCloud<PointT> &cloud_out,
+                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
+                     bool copy_all_fields)
 {
   std::size_t npts = indices.size ();
   // In order to transform the data, we need to remove NaNs
@@ -306,12 +302,12 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
-                                     pcl::PointCloud<PointT> &cloud_out,
-                                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
-                                     bool copy_all_fields)
+transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
+                                pcl::PointCloud<PointT> &cloud_out,
+                                const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
+                                bool copy_all_fields)
 {
   if (&cloud_in != &cloud_out)
   {
@@ -354,13 +350,13 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> void
-pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
-                                     const std::vector<int> &indices,
-                                     pcl::PointCloud<PointT> &cloud_out,
-                                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
-                                     bool copy_all_fields)
+transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
+                                const std::vector<int> &indices,
+                                pcl::PointCloud<PointT> &cloud_out,
+                                const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform,
+                                bool copy_all_fields)
 {
   std::size_t npts = indices.size ();
   // In order to transform the data, we need to remove NaNs
@@ -405,13 +401,13 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline void
-pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                          pcl::PointCloud<PointT> &cloud_out,
-                          const Eigen::Matrix<Scalar, 3, 1> &offset,
-                          const Eigen::Quaternion<Scalar> &rotation,
-                          bool copy_all_fields)
+transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                     pcl::PointCloud<PointT> &cloud_out,
+                     const Eigen::Matrix<Scalar, 3, 1> &offset,
+                     const Eigen::Quaternion<Scalar> &rotation,
+                     bool copy_all_fields)
 {
   Eigen::Translation<Scalar, 3> translation (offset);
   // Assemble an Eigen Transform
@@ -419,13 +415,13 @@ pcl::transformPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   transformPointCloud (cloud_in, cloud_out, t, copy_all_fields);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline void
-pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
-                                     pcl::PointCloud<PointT> &cloud_out,
-                                     const Eigen::Matrix<Scalar, 3, 1> &offset,
-                                     const Eigen::Quaternion<Scalar> &rotation,
-                                     bool copy_all_fields)
+transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
+                                pcl::PointCloud<PointT> &cloud_out,
+                                const Eigen::Matrix<Scalar, 3, 1> &offset,
+                                const Eigen::Quaternion<Scalar> &rotation,
+                                bool copy_all_fields)
 {
   Eigen::Translation<Scalar, 3> translation (offset);
   // Assemble an Eigen Transform
@@ -433,10 +429,9 @@ pcl::transformPointCloudWithNormals (const pcl::PointCloud<PointT> &cloud_in,
   transformPointCloudWithNormals (cloud_in, cloud_out, t, copy_all_fields);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline PointT
-pcl::transformPoint (const PointT &point,
-                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
+transformPoint (const PointT &point, const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
 {
   PointT ret = point;
   pcl::detail::Transformer<Scalar> tf (transform.matrix ());
@@ -444,10 +439,9 @@ pcl::transformPoint (const PointT &point,
   return (ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> inline PointT
-pcl::transformPointWithNormal (const PointT &point,
-                     const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
+transformPointWithNormal (const PointT &point, const Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
 {
   PointT ret = point;
   pcl::detail::Transformer<Scalar> tf (transform.matrix ());
@@ -456,10 +450,10 @@ pcl::transformPointWithNormal (const PointT &point,
   return (ret);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT, typename Scalar> double
-pcl::getPrincipalTransformation (const pcl::PointCloud<PointT> &cloud,
-                                 Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
+getPrincipalTransformation (const pcl::PointCloud<PointT> &cloud,
+                            Eigen::Transform<Scalar, 3, Eigen::Affine> &transform)
 {
   EIGEN_ALIGN16 Eigen::Matrix<Scalar, 3, 3> covariance_matrix;
   Eigen::Matrix<Scalar, 4, 1> centroid;
@@ -478,4 +472,6 @@ pcl::getPrincipalTransformation (const pcl::PointCloud<PointT> &cloud,
 
   return (std::min (rel1, rel2));
 }
+
+} // namespace pcl
 

--- a/doc/advanced/content/pcl_style_guide.rst
+++ b/doc/advanced/content/pcl_style_guide.rst
@@ -167,27 +167,20 @@ variant of the GNU style formatting.
 2.1. Namespaces
 ^^^^^^^^^^^^^^^
 
-In a header file, the contets of a namespace should be indented, e.g.:
+In both header and implementation files, namespaces are to be explicitly
+declared, and their contents should not be indented, like clang-format
+enforces in the Formatting CI job, e.g.:
 
 .. code-block:: cpp
 
   namespace pcl
   {
-    class Foo
-    {
-      ...
-    };
-  }
 
-In an implementation file, the namespace must be added to each individual
-method or function definition, e.g.:
-
-.. code-block:: cpp
-
-  void
-  pcl::Foo::bar ()
+  class Foo
   {
     ...
+  };
+
   }
 
 
@@ -281,19 +274,6 @@ function/method, e.g.:
    int 
    exampleMethod (int example_arg);
 
-If multiple namespaces are declared within header files, always use **2
-spaces** to indent them, e.g.:
-
-.. code-block:: cpp
-
-   namespace foo
-   {
-     namespace bar
-     {
-        void
-        method (int my_var);
-      }
-   }
 
 Class and struct members are indented by **2 spaces**. Access qualifiers (public, private and protected) are put at the
 indentation level of the class body and members affected by these qualifiers are indented by one more level, i.e. 2 spaces. E.g.:
@@ -302,15 +282,16 @@ indentation level of the class body and members affected by these qualifiers are
 
    namespace foo
    {
-     class Bar
-     {
-       int i;
-       public:
-         int j;
-       protected:
-         void
-         baz ();
-     }
+
+   class Bar
+   {
+     int i;
+     public:
+       int j;
+     protected:
+       void
+       baz ();
+   };
    }
 
 

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -37,12 +37,16 @@
  *
  */
 
+
 #ifndef PCL_FEATURES_IMPL_BRISK_2D_HPP_
 #define PCL_FEATURES_IMPL_BRISK_2D_HPP_
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT, typename KeypointT, typename IntensityT>
-pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::BRISK2DEstimation ()
+BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::BRISK2DEstimation ()
   : rotation_invariance_enabled_ (true)
   , scale_invariance_enabled_ (true)
   , pattern_scale_ (1.0f)
@@ -81,9 +85,9 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::BRISK2DEstim
   generateKernel (r_list, n_list, 5.85f * pattern_scale_, 8.2f * pattern_scale_);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename KeypointT, typename IntensityT>
-pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::~BRISK2DEstimation ()
+BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::~BRISK2DEstimation ()
 {
    if (pattern_points_) delete [] pattern_points_;
   if (short_pairs_) delete [] short_pairs_;
@@ -92,10 +96,10 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::~BRISK2DEsti
   if (size_list_) delete [] size_list_;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename KeypointT, typename IntensityT> void
-pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
-    std::vector<float> &radius_list, 
+BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
+    std::vector<float> &radius_list,
     std::vector<int> &number_list, float d_max, float d_min,
     std::vector<int> index_change)
 {
@@ -138,9 +142,9 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKern
         {
           // the actual coordinates on the circle
           double alpha = double (num) * 2 * M_PI / double (number_list[ring]);
-          
+
           // feature rotation plus angle of the point
-          pattern_iterator->x = scale_list_[scale] * radius_list[ring] * static_cast<float> (std::cos (alpha + theta)); 
+          pattern_iterator->x = scale_list_[scale] * radius_list[ring] * static_cast<float> (std::cos (alpha + theta));
           pattern_iterator->y = scale_list_[scale] * radius_list[ring] * static_cast<float> (sin (alpha + theta));
           // and the gaussian kernel sigma
           if (ring == 0)
@@ -210,9 +214,9 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKern
   strings_ = int (std::ceil ((float (no_short_pairs_)) / 128.0)) * 4 * 4;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename KeypointT, typename IntensityT> inline int
-pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity (
+BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity (
     const std::vector<unsigned char> &image,
     int image_width, int,
     //const Stefan& integral,
@@ -243,26 +247,26 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedInte
     const int r_y   = static_cast<int> ((yf - float (y)) * 1024);
     const int r_x_1 = (1024 - r_x);
     const int r_y_1 = (1024 - r_y);
-    
+
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image.points[0].r) + x + y * imagecols;
     const unsigned char* ptr = static_cast<const unsigned char*>(&image[0]) + x + y * imagecols;
-    
+
     // just interpolate:
     ret_val = (r_x_1 * r_y_1 * int (*ptr));
-    
+
     //+ptr += sizeof (PointInT);
     ptr++;
 
     ret_val += (r_x * r_y_1 * int (*ptr));
-    
+
     //+ptr += (imagecols * sizeof (PointInT));
     ptr += imagecols;
-    
+
     ret_val += (r_x * r_y * int (*ptr));
-    
+
     //+ptr -= sizeof (PointInT);
     ptr--;
-    
+
     ret_val += (r_x_1 * r_y * int (*ptr));
     return (ret_val + 512) / 1024;
   }
@@ -306,32 +310,32 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedInte
   if (dx + dy > 2)
   {
     // now the calculation:
-    
+
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image.points[0].r) + x_left + imagecols * y_top;
     const unsigned char* ptr = static_cast<const unsigned char*>(&image[0]) + x_left + imagecols * y_top;
 
     // first the corners:
     ret_val = A * int (*ptr);
-  
+
     //+ptr += (dx + 1) * sizeof (PointInT);
     ptr += dx + 1;
-    
+
     ret_val += B * int (*ptr);
-    
+
     //+ptr += (dy * imagecols + 1) * sizeof (PointInT);
     ptr += dy * imagecols + 1;
-    
+
     ret_val += C * int (*ptr);
-    
+
     //+ptr -= (dx + 1) * sizeof (PointInT);
     ptr -= dx + 1;
-    
+
     ret_val += D * int (*ptr);
 
     // next the edges:
     //+int* ptr_integral;// = static_cast<int*> (integral.data) + x_left + integralcols * y_top + 1;
     const int* ptr_integral = static_cast<const int*> (&integral_image[0]) + x_left + integralcols * y_top + 1;
-    
+
     // find a simple path through the different surface corners
     const int tmp1 = (*ptr_integral);
     ptr_integral += dx;
@@ -368,16 +372,16 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedInte
   }
 
   // now the calculation:
-  
+
   //const unsigned char* ptr = static_cast<const unsigned char*> (&image.points[0].r) + x_left + imagecols * y_top;
   const unsigned char* ptr = static_cast<const unsigned char*>(&image[0]) + x_left + imagecols * y_top;
-  
+
   // first row:
   ret_val = A * int (*ptr);
-  
+
   //+ptr += sizeof (PointInT);
   ptr++;
-  
+
   //+const unsigned char* end1 = ptr + (dx * sizeof (PointInT));
   const unsigned char* end1 = ptr + dx;
 
@@ -385,25 +389,25 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedInte
   for (; ptr < end1; ptr++)
     ret_val += r_y_1_i * int (*ptr);
   ret_val += B * int (*ptr);
-  
+
   // middle ones:
   //+ptr += (imagecols - dx - 1) * sizeof (PointInT);
   ptr += imagecols - dx - 1;
-  
+
   //+const unsigned char* end_j = ptr + (dy * imagecols) * sizeof (PointInT);
   const unsigned char* end_j = ptr + dy * imagecols;
-  
+
   //+for (; ptr < end_j; ptr += (imagecols - dx - 1) * sizeof (PointInT))
   for (; ptr < end_j; ptr += imagecols - dx - 1)
   {
     ret_val += r_x_1_i * int (*ptr);
-    
+
     //+ptr += sizeof (PointInT);
     ptr++;
-    
+
     //+const unsigned char* end2 = ptr + (dx * sizeof (PointInT));
     const unsigned char* end2 = ptr + dx;
-    
+
     //+for (; ptr < end2; ptr += sizeof (PointInT))
     for (; ptr < end2; ptr++)
       ret_val += int (*ptr) * scaling;
@@ -412,10 +416,10 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedInte
   }
   // last row:
   ret_val += D * int (*ptr);
-  
+
   //+ptr += sizeof (PointInT);
   ptr++;
-  
+
   //+const unsigned char* end3 = ptr + (dx * sizeof (PointInT));
   const unsigned char* end3 = ptr + dx;
 
@@ -429,22 +433,21 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedInte
 }
 
 
-//////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT, typename KeypointT, typename IntensityT> bool
-pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::RoiPredicate (
+BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::RoiPredicate (
     const float min_x, const float min_y,
     const float max_x, const float max_y, const KeypointT& pt)
 {
   return ((pt.x < min_x) || (pt.x >= max_x) || (pt.y < min_y) || (pt.y >= max_y));
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename KeypointT, typename IntensityT> void
-pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
+BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
     PointCloudOutT &output)
 {
   if (!input_cloud_->isOrganized ())
-  {    
+  {
     PCL_ERROR ("[pcl::%s::initCompute] %s doesn't support non organized clouds!\n", name_.c_str ());
     return;
   }
@@ -463,13 +466,13 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   std::size_t ksize = keypoints_->points.size ();
   std::vector<int> kscales; // remember the scale per keypoint
   kscales.resize (ksize);
- 
+
   // initialize constants
   static const float lb_scalerange = std::log2 (scalerange_);
 
   typename std::vector<KeypointT, Eigen::aligned_allocator<KeypointT> >::iterator beginning = keypoints_->points.begin ();
   std::vector<int>::iterator beginningkscales = kscales.begin ();
-  
+
   static const float basic_size_06 = basic_size_ * 0.6f;
   unsigned int basicscale = 0;
 
@@ -635,12 +638,12 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
     // now iterate through all the pairings
     UINT32_ALIAS* ptr2 = reinterpret_cast<UINT32_ALIAS*> (ptr);
     const BriskShortPair* max = short_pairs_ + no_short_pairs_;
-    
+
     for (BriskShortPair* iter = short_pairs_; iter < max; ++iter)
     {
       t1 = *(values + iter->i);
       t2 = *(values + iter->j);
-      
+
       if (t1 > t2)
         *ptr2 |= ((1) << shifter);
 
@@ -656,7 +659,7 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
     }
 
     //ptr += strings_;
- 
+
     //// Account for the scale + orientation;
     //ptr += sizeof (output.points[0].scale);
     //ptr += sizeof (output.points[0].orientation);
@@ -671,6 +674,7 @@ pcl::BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   delete [] values;
 }
 
+} // namespace pcl
 
 #endif  //#ifndef PCL_FEATURES_IMPL_BRISK_2D_HPP_
 

--- a/features/include/pcl/features/impl/feature.hpp
+++ b/features/include/pcl/features/impl/feature.hpp
@@ -43,11 +43,14 @@
 
 #include <pcl/search/pcl_search.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 inline void
-pcl::solvePlaneParameters (const Eigen::Matrix3f &covariance_matrix,
-                           const Eigen::Vector4f &point,
-                           Eigen::Vector4f &plane_parameters, float &curvature)
+solvePlaneParameters (const Eigen::Matrix3f &covariance_matrix,
+                      const Eigen::Vector4f &point,
+                      Eigen::Vector4f &plane_parameters, float &curvature)
 {
   solvePlaneParameters (covariance_matrix, plane_parameters [0], plane_parameters [1], plane_parameters [2], curvature);
 
@@ -56,10 +59,10 @@ pcl::solvePlaneParameters (const Eigen::Matrix3f &covariance_matrix,
   plane_parameters[3] = -1 * plane_parameters.dot (point);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 inline void
-pcl::solvePlaneParameters (const Eigen::Matrix3f &covariance_matrix,
-                           float &nx, float &ny, float &nz, float &curvature)
+solvePlaneParameters (const Eigen::Matrix3f &covariance_matrix,
+                      float &nx, float &ny, float &nz, float &curvature)
 {
   // Avoid getting hung on Eigen's optimizers
 //  for (int i = 0; i < 9; ++i)
@@ -86,11 +89,9 @@ pcl::solvePlaneParameters (const Eigen::Matrix3f &covariance_matrix,
     curvature = 0;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> bool
-pcl::Feature<PointInT, PointOutT>::initCompute ()
+Feature<PointInT, PointOutT>::initCompute ()
 {
   if (!PCLBase<PointInT>::initCompute ())
   {
@@ -122,9 +123,9 @@ pcl::Feature<PointInT, PointOutT>::initCompute ()
     else
       tree_.reset (new pcl::search::KdTree<PointInT> (false));
   }
-  
+
   if (tree_->getInputCloud () != surface_) // Make sure the tree searches the surface
-    tree_->setInputCloud (surface_); 
+    tree_->setInputCloud (surface_);
 
 
   // Do a fast check to see if the search parameters are well defined
@@ -174,9 +175,9 @@ pcl::Feature<PointInT, PointOutT>::initCompute ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> bool
-pcl::Feature<PointInT, PointOutT>::deinitCompute ()
+Feature<PointInT, PointOutT>::deinitCompute ()
 {
   // Reset the surface
   if (fake_surface_)
@@ -187,9 +188,9 @@ pcl::Feature<PointInT, PointOutT>::deinitCompute ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> void
-pcl::Feature<PointInT, PointOutT>::compute (PointCloudOut &output)
+Feature<PointInT, PointOutT>::compute (PointCloudOut &output)
 {
   if (!initCompute ())
   {
@@ -225,11 +226,9 @@ pcl::Feature<PointInT, PointOutT>::compute (PointCloudOut &output)
   deinitCompute ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointNT, typename PointOutT> bool
-pcl::FeatureFromNormals<PointInT, PointNT, PointOutT>::initCompute ()
+FeatureFromNormals<PointInT, PointNT, PointOutT>::initCompute ()
 {
   if (!Feature<PointInT, PointOutT>::initCompute ())
   {
@@ -258,11 +257,9 @@ pcl::FeatureFromNormals<PointInT, PointNT, PointOutT>::initCompute ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointLT, typename PointOutT> bool
-pcl::FeatureFromLabels<PointInT, PointLT, PointOutT>::initCompute ()
+FeatureFromLabels<PointInT, PointLT, PointOutT>::initCompute ()
 {
   if (!Feature<PointInT, PointOutT>::initCompute ())
   {
@@ -289,12 +286,10 @@ pcl::FeatureFromLabels<PointInT, PointLT, PointOutT>::initCompute ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointRFT> bool
-pcl::FeatureWithLocalReferenceFrames<PointInT, PointRFT>::initLocalReferenceFrames (const std::size_t& indices_size,
-                                                                                    const LRFEstimationPtr& lrf_estimation)
+FeatureWithLocalReferenceFrames<PointInT, PointRFT>::initLocalReferenceFrames (const std::size_t& indices_size,
+                                                                               const LRFEstimationPtr& lrf_estimation)
 {
   if (frames_never_defined_)
     frames_.reset ();
@@ -333,6 +328,8 @@ pcl::FeatureWithLocalReferenceFrames<PointInT, PointRFT>::initLocalReferenceFram
 
   return (true);
 }
+
+} // namespace pcl
 
 #endif  //#ifndef PCL_FEATURES_IMPL_FEATURE_H_
 

--- a/features/include/pcl/features/impl/integral_image2D.hpp
+++ b/features/include/pcl/features/impl/integral_image2D.hpp
@@ -37,21 +37,25 @@
  * $Id: feature.h 2784 2011-10-15 22:05:38Z aichim $
  */
 
+
 #ifndef PCL_INTEGRAL_IMAGE2D_IMPL_H_
 #define PCL_INTEGRAL_IMAGE2D_IMPL_H_
 
 #include <cstddef>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename DataType, unsigned Dimension> void
-pcl::IntegralImage2D<DataType, Dimension>::setSecondOrderComputation (bool compute_second_order_integral_images)
+IntegralImage2D<DataType, Dimension>::setSecondOrderComputation (bool compute_second_order_integral_images)
 {
   compute_second_order_integral_images_ = compute_second_order_integral_images;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> void
-pcl::IntegralImage2D<DataType, Dimension>::setInput (const DataType * data, unsigned width,unsigned height, unsigned element_stride, unsigned row_stride)
+IntegralImage2D<DataType, Dimension>::setInput (const DataType * data, unsigned width,unsigned height, unsigned element_stride, unsigned row_stride)
 {
   if ((width + 1) * (height + 1) > first_order_integral_image_.size () )
   {
@@ -65,9 +69,9 @@ pcl::IntegralImage2D<DataType, Dimension>::setInput (const DataType * data, unsi
   computeIntegralImages (data, row_stride, element_stride);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> typename pcl::IntegralImage2D<DataType, Dimension>::ElementType
-pcl::IntegralImage2D<DataType, Dimension>::getFirstOrderSum (
+IntegralImage2D<DataType, Dimension>::getFirstOrderSum (
     unsigned start_x, unsigned start_y, unsigned width, unsigned height) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -79,9 +83,9 @@ pcl::IntegralImage2D<DataType, Dimension>::getFirstOrderSum (
           first_order_integral_image_[upper_right_idx] - first_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> typename pcl::IntegralImage2D<DataType, Dimension>::SecondOrderType
-pcl::IntegralImage2D<DataType, Dimension>::getSecondOrderSum (
+IntegralImage2D<DataType, Dimension>::getSecondOrderSum (
     unsigned start_x, unsigned start_y, unsigned width, unsigned height) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -93,9 +97,9 @@ pcl::IntegralImage2D<DataType, Dimension>::getSecondOrderSum (
           second_order_integral_image_[upper_right_idx] - second_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> unsigned
-pcl::IntegralImage2D<DataType, Dimension>::getFiniteElementsCount (
+IntegralImage2D<DataType, Dimension>::getFiniteElementsCount (
     unsigned start_x, unsigned start_y, unsigned width, unsigned height) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -107,9 +111,9 @@ pcl::IntegralImage2D<DataType, Dimension>::getFiniteElementsCount (
           finite_values_integral_image_[upper_right_idx] - finite_values_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> typename pcl::IntegralImage2D<DataType, Dimension>::ElementType
-pcl::IntegralImage2D<DataType, Dimension>::getFirstOrderSumSE (
+IntegralImage2D<DataType, Dimension>::getFirstOrderSumSE (
     unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -121,9 +125,9 @@ pcl::IntegralImage2D<DataType, Dimension>::getFirstOrderSumSE (
           first_order_integral_image_[upper_right_idx] - first_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> typename pcl::IntegralImage2D<DataType, Dimension>::SecondOrderType
-pcl::IntegralImage2D<DataType, Dimension>::getSecondOrderSumSE (
+IntegralImage2D<DataType, Dimension>::getSecondOrderSumSE (
     unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -135,9 +139,9 @@ pcl::IntegralImage2D<DataType, Dimension>::getSecondOrderSumSE (
           second_order_integral_image_[upper_right_idx] - second_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> unsigned
-pcl::IntegralImage2D<DataType, Dimension>::getFiniteElementsCountSE (
+IntegralImage2D<DataType, Dimension>::getFiniteElementsCountSE (
     unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -149,9 +153,9 @@ pcl::IntegralImage2D<DataType, Dimension>::getFiniteElementsCountSE (
           finite_values_integral_image_[upper_right_idx] - finite_values_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType, unsigned Dimension> void
-pcl::IntegralImage2D<DataType, Dimension>::computeIntegralImages (
+IntegralImage2D<DataType, Dimension>::computeIntegralImages (
     const DataType *data, unsigned row_stride, unsigned element_stride)
 {
   ElementType* previous_row = &first_order_integral_image_[0];
@@ -218,10 +222,9 @@ pcl::IntegralImage2D<DataType, Dimension>::computeIntegralImages (
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename DataType> void
-pcl::IntegralImage2D<DataType, 1>::setInput (const DataType * data, unsigned width,unsigned height, unsigned element_stride, unsigned row_stride)
+IntegralImage2D<DataType, 1>::setInput (const DataType * data, unsigned width,unsigned height, unsigned element_stride, unsigned row_stride)
 {
   if ((width + 1) * (height + 1) > first_order_integral_image_.size () )
   {
@@ -235,9 +238,9 @@ pcl::IntegralImage2D<DataType, 1>::setInput (const DataType * data, unsigned wid
   computeIntegralImages (data, row_stride, element_stride);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType> typename pcl::IntegralImage2D<DataType, 1>::ElementType
-pcl::IntegralImage2D<DataType, 1>::getFirstOrderSum (
+IntegralImage2D<DataType, 1>::getFirstOrderSum (
     unsigned start_x, unsigned start_y, unsigned width, unsigned height) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -249,9 +252,9 @@ pcl::IntegralImage2D<DataType, 1>::getFirstOrderSum (
           first_order_integral_image_[upper_right_idx] - first_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType> typename pcl::IntegralImage2D<DataType, 1>::SecondOrderType
-pcl::IntegralImage2D<DataType, 1>::getSecondOrderSum (
+IntegralImage2D<DataType, 1>::getSecondOrderSum (
     unsigned start_x, unsigned start_y, unsigned width, unsigned height) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -263,9 +266,9 @@ pcl::IntegralImage2D<DataType, 1>::getSecondOrderSum (
           second_order_integral_image_[upper_right_idx] - second_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType> unsigned
-pcl::IntegralImage2D<DataType, 1>::getFiniteElementsCount (
+IntegralImage2D<DataType, 1>::getFiniteElementsCount (
     unsigned start_x, unsigned start_y, unsigned width, unsigned height) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -277,9 +280,9 @@ pcl::IntegralImage2D<DataType, 1>::getFiniteElementsCount (
           finite_values_integral_image_[upper_right_idx] - finite_values_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType> typename pcl::IntegralImage2D<DataType, 1>::ElementType
-pcl::IntegralImage2D<DataType, 1>::getFirstOrderSumSE (
+IntegralImage2D<DataType, 1>::getFirstOrderSumSE (
     unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -291,9 +294,9 @@ pcl::IntegralImage2D<DataType, 1>::getFirstOrderSumSE (
           first_order_integral_image_[upper_right_idx] - first_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType> typename pcl::IntegralImage2D<DataType, 1>::SecondOrderType
-pcl::IntegralImage2D<DataType, 1>::getSecondOrderSumSE (
+IntegralImage2D<DataType, 1>::getSecondOrderSumSE (
     unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -305,9 +308,9 @@ pcl::IntegralImage2D<DataType, 1>::getSecondOrderSumSE (
           second_order_integral_image_[upper_right_idx] - second_order_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType> unsigned
-pcl::IntegralImage2D<DataType, 1>::getFiniteElementsCountSE (
+IntegralImage2D<DataType, 1>::getFiniteElementsCountSE (
     unsigned start_x, unsigned start_y, unsigned end_x, unsigned end_y) const
 {
   const unsigned upper_left_idx      = start_y * (width_ + 1) + start_x;
@@ -319,9 +322,9 @@ pcl::IntegralImage2D<DataType, 1>::getFiniteElementsCountSE (
           finite_values_integral_image_[upper_right_idx] - finite_values_integral_image_[lower_left_idx]  );
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename DataType> void
-pcl::IntegralImage2D<DataType, 1>::computeIntegralImages (
+IntegralImage2D<DataType, 1>::computeIntegralImages (
     const DataType *data, unsigned row_stride, unsigned element_stride)
 {
   ElementType* previous_row = &first_order_integral_image_[0];
@@ -381,5 +384,8 @@ pcl::IntegralImage2D<DataType, 1>::computeIntegralImages (
     }
   }
 }
+
+} // namespace pcl
+
 #endif    // PCL_INTEGRAL_IMAGE2D_IMPL_H_
 

--- a/filters/include/pcl/filters/impl/convolution.hpp
+++ b/filters/include/pcl/filters/impl/convolution.hpp
@@ -43,8 +43,14 @@
 #include <pcl/pcl_config.h>
 #include <pcl/common/distances.h>
 
+
+namespace pcl
+{
+namespace filters
+{
+
 template <typename PointIn, typename PointOut>
-pcl::filters::Convolution<PointIn, PointOut>::Convolution ()
+Convolution<PointIn, PointOut>::Convolution ()
   : borders_policy_ (BORDERS_POLICY_IGNORE)
   , distance_threshold_ (std::numeric_limits<float>::infinity ())
   , input_ ()
@@ -54,7 +60,7 @@ pcl::filters::Convolution<PointIn, PointOut>::Convolution ()
 {}
 
 template <typename PointIn, typename PointOut> void
-pcl::filters::Convolution<PointIn, PointOut>::initCompute (PointCloud<PointOut>& output)
+Convolution<PointIn, PointOut>::initCompute (PointCloud<PointOut>& output)
 {
   if (borders_policy_ != BORDERS_POLICY_IGNORE &&
       borders_policy_ != BORDERS_POLICY_MIRROR &&
@@ -85,7 +91,7 @@ pcl::filters::Convolution<PointIn, PointOut>::initCompute (PointCloud<PointOut>&
 }
 
 template <typename PointIn, typename PointOut> inline void
-pcl::filters::Convolution<PointIn, PointOut>::convolveRows (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolveRows (PointCloudOut& output)
 {
   try
   {
@@ -105,7 +111,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolveRows (PointCloudOut& outpu
 }
 
 template <typename PointIn, typename PointOut> inline void
-pcl::filters::Convolution<PointIn, PointOut>::convolveCols (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolveCols (PointCloudOut& output)
 {
   try
   {
@@ -125,9 +131,9 @@ pcl::filters::Convolution<PointIn, PointOut>::convolveCols (PointCloudOut& outpu
 }
 
 template <typename PointIn, typename PointOut> inline void
-pcl::filters::Convolution<PointIn, PointOut>::convolve (const Eigen::ArrayXf& h_kernel,
-                                                       const Eigen::ArrayXf& v_kernel,
-                                                       PointCloud<PointOut>& output)
+Convolution<PointIn, PointOut>::convolve (const Eigen::ArrayXf& h_kernel,
+                                          const Eigen::ArrayXf& v_kernel,
+                                          PointCloud<PointOut>& output)
 {
   try
   {
@@ -146,7 +152,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve (const Eigen::ArrayXf& h_
 }
 
 template <typename PointIn, typename PointOut> inline void
-pcl::filters::Convolution<PointIn, PointOut>::convolve (PointCloud<PointOut>& output)
+Convolution<PointIn, PointOut>::convolve (PointCloud<PointOut>& output)
 {
   try
   {
@@ -163,7 +169,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve (PointCloud<PointOut>& ou
 }
 
 template <typename PointIn, typename PointOut> inline PointOut
-pcl::filters::Convolution<PointIn, PointOut>::convolveOneRowDense (int i, int j)
+Convolution<PointIn, PointOut>::convolveOneRowDense (int i, int j)
 {
   using namespace pcl::common;
   PointOut result;
@@ -173,7 +179,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolveOneRowDense (int i, int j)
 }
 
 template <typename PointIn, typename PointOut> inline PointOut
-pcl::filters::Convolution<PointIn, PointOut>::convolveOneColDense (int i, int j)
+Convolution<PointIn, PointOut>::convolveOneColDense (int i, int j)
 {
   using namespace pcl::common;
   PointOut result;
@@ -183,7 +189,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolveOneColDense (int i, int j)
 }
 
 template <typename PointIn, typename PointOut> inline PointOut
-pcl::filters::Convolution<PointIn, PointOut>::convolveOneRowNonDense (int i, int j)
+Convolution<PointIn, PointOut>::convolveOneRowNonDense (int i, int j)
 {
   using namespace pcl::common;
   PointOut result;
@@ -209,7 +215,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolveOneRowNonDense (int i, int
 }
 
 template <typename PointIn, typename PointOut> inline PointOut
-pcl::filters::Convolution<PointIn, PointOut>::convolveOneColNonDense (int i, int j)
+Convolution<PointIn, PointOut>::convolveOneColNonDense (int i, int j)
 {
   using namespace pcl::common;
   PointOut result;
@@ -234,174 +240,167 @@ pcl::filters::Convolution<PointIn, PointOut>::convolveOneColNonDense (int i, int
   return (result);
 }
 
-namespace pcl
+template<> pcl::PointXYZRGB
+Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneRowDense (int i, int j)
 {
-  namespace filters
+  pcl::PointXYZRGB result;
+  float r = 0, g = 0, b = 0;
+  for (int k = kernel_width_, l = i - half_width_; k > -1; --k, ++l)
   {
-    template<> pcl::PointXYZRGB
-    Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneRowDense (int i, int j)
-    {
-      pcl::PointXYZRGB result;
-      float r = 0, g = 0, b = 0;
-      for (int k = kernel_width_, l = i - half_width_; k > -1; --k, ++l)
-      {
-        result.x += (*input_) (l,j).x * kernel_[k];
-        result.y += (*input_) (l,j).y * kernel_[k];
-        result.z += (*input_) (l,j).z * kernel_[k];
-        r += kernel_[k] * static_cast<float> ((*input_) (l,j).r);
-        g += kernel_[k] * static_cast<float> ((*input_) (l,j).g);
-        b += kernel_[k] * static_cast<float> ((*input_) (l,j).b);
-      }
-      result.r = static_cast<std::uint8_t> (r);
-      result.g = static_cast<std::uint8_t> (g);
-      result.b = static_cast<std::uint8_t> (b);
-      return (result);
-    }
-
-    template<> pcl::PointXYZRGB
-    Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneColDense (int i, int j)
-    {
-      pcl::PointXYZRGB result;
-      float r = 0, g = 0, b = 0;
-      for (int k = kernel_width_, l = j - half_width_; k > -1; --k, ++l)
-      {
-        result.x += (*input_) (i,l).x * kernel_[k];
-        result.y += (*input_) (i,l).y * kernel_[k];
-        result.z += (*input_) (i,l).z * kernel_[k];
-        r += kernel_[k] * static_cast<float> ((*input_) (i,l).r);
-        g += kernel_[k] * static_cast<float> ((*input_) (i,l).g);
-        b += kernel_[k] * static_cast<float> ((*input_) (i,l).b);
-      }
-      result.r = static_cast<std::uint8_t> (r);
-      result.g = static_cast<std::uint8_t> (g);
-      result.b = static_cast<std::uint8_t> (b);
-      return (result);
-    }
-
-    template<> pcl::PointXYZRGB
-    Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneRowNonDense (int i, int j)
-    {
-      pcl::PointXYZRGB result;
-      float weight = 0;
-      float r = 0, g = 0, b = 0;
-      for (int k = kernel_width_, l = i - half_width_; k > -1; --k, ++l)
-      {
-        if (!isFinite ((*input_) (l,j)))
-          continue;
-        if (pcl::squaredEuclideanDistance ((*input_) (i,j), (*input_) (l,j)) < distance_threshold_)
-        {
-          result.x += (*input_) (l,j).x * kernel_[k]; result.y += (*input_) (l,j).y * kernel_[k]; result.z += (*input_) (l,j).z * kernel_[k];
-          r+= kernel_[k] * static_cast<float> ((*input_) (l,j).r);
-          g+= kernel_[k] * static_cast<float> ((*input_) (l,j).g);
-          b+= kernel_[k] * static_cast<float> ((*input_) (l,j).b);
-          weight += kernel_[k];
-        }
-      }
-
-      if (weight == 0)
-        result.x = result.y = result.z = std::numeric_limits<float>::quiet_NaN ();
-      else
-      {
-        weight = 1.f/weight;
-        r*= weight; g*= weight; b*= weight;
-        result.x*= weight; result.y*= weight; result.z*= weight;
-        result.r = static_cast<std::uint8_t> (r);
-        result.g = static_cast<std::uint8_t> (g);
-        result.b = static_cast<std::uint8_t> (b);
-      }
-      return (result);
-    }
-
-    template<> pcl::PointXYZRGB
-    Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneColNonDense (int i, int j)
-    {
-      pcl::PointXYZRGB result;
-      float weight = 0;
-      float r = 0, g = 0, b = 0;
-      for (int k = kernel_width_, l = j - half_width_; k > -1; --k, ++l)
-      {
-        if (!isFinite ((*input_) (i,l)))
-          continue;
-        if (pcl::squaredEuclideanDistance ((*input_) (i,j), (*input_) (i,l)) < distance_threshold_)
-        {
-          result.x += (*input_) (i,l).x * kernel_[k]; result.y += (*input_) (i,l).y * kernel_[k]; result.z += (*input_) (i,l).z * kernel_[k];
-          r+= kernel_[k] * static_cast<float> ((*input_) (i,l).r);
-          g+= kernel_[k] * static_cast<float> ((*input_) (i,l).g);
-          b+= kernel_[k] * static_cast<float> ((*input_) (i,l).b);
-          weight+= kernel_[k];
-        }
-      }
-      if (weight == 0)
-        result.x = result.y = result.z = std::numeric_limits<float>::quiet_NaN ();
-      else
-      {
-        weight = 1.f/weight;
-        r*= weight; g*= weight; b*= weight;
-        result.x*= weight; result.y*= weight; result.z*= weight;
-        result.r = static_cast<std::uint8_t> (r);
-        result.g = static_cast<std::uint8_t> (g);
-        result.b = static_cast<std::uint8_t> (b);
-      }
-      return (result);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////////////////////
-    template<> pcl::RGB
-    Convolution<pcl::RGB, pcl::RGB>::convolveOneRowDense (int i, int j)
-    {
-      pcl::RGB result;
-      float r = 0, g = 0, b = 0;
-      for (int k = kernel_width_, l = i - half_width_; k > -1; --k, ++l)
-      {
-        r += kernel_[k] * static_cast<float> ((*input_) (l,j).r);
-        g += kernel_[k] * static_cast<float> ((*input_) (l,j).g);
-        b += kernel_[k] * static_cast<float> ((*input_) (l,j).b);
-      }
-      result.r = static_cast<std::uint8_t> (r);
-      result.g = static_cast<std::uint8_t> (g);
-      result.b = static_cast<std::uint8_t> (b);
-      return (result);
-    }
-
-    template<> pcl::RGB
-    Convolution<pcl::RGB, pcl::RGB>::convolveOneColDense (int i, int j)
-    {
-      pcl::RGB result;
-      float r = 0, g = 0, b = 0;
-      for (int k = kernel_width_, l = j - half_width_; k > -1; --k, ++l)
-      {
-        r += kernel_[k] * static_cast<float> ((*input_) (i,l).r);
-        g += kernel_[k] * static_cast<float> ((*input_) (i,l).g);
-        b += kernel_[k] * static_cast<float> ((*input_) (i,l).b);
-      }
-      result.r = static_cast<std::uint8_t> (r);
-      result.g = static_cast<std::uint8_t> (g);
-      result.b = static_cast<std::uint8_t> (b);
-      return (result);
-    }
-
-    template<> pcl::RGB
-    Convolution<pcl::RGB, pcl::RGB>::convolveOneRowNonDense (int i, int j)
-    {
-      return (convolveOneRowDense (i,j));
-    }
-
-    template<> pcl::RGB
-    Convolution<pcl::RGB, pcl::RGB>::convolveOneColNonDense (int i, int j)
-    {
-      return (convolveOneColDense (i,j));
-    }
-
-    template<> void
-    Convolution<pcl::RGB, pcl::RGB>::makeInfinite (pcl::RGB& p)
-    {
-      p.r = 0; p.g = 0; p.b = 0;
-    }    
+    result.x += (*input_) (l,j).x * kernel_[k];
+    result.y += (*input_) (l,j).y * kernel_[k];
+    result.z += (*input_) (l,j).z * kernel_[k];
+    r += kernel_[k] * static_cast<float> ((*input_) (l,j).r);
+    g += kernel_[k] * static_cast<float> ((*input_) (l,j).g);
+    b += kernel_[k] * static_cast<float> ((*input_) (l,j).b);
   }
+  result.r = static_cast<std::uint8_t> (r);
+  result.g = static_cast<std::uint8_t> (g);
+  result.b = static_cast<std::uint8_t> (b);
+  return (result);
+}
+
+template<> pcl::PointXYZRGB
+Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneColDense (int i, int j)
+{
+  pcl::PointXYZRGB result;
+  float r = 0, g = 0, b = 0;
+  for (int k = kernel_width_, l = j - half_width_; k > -1; --k, ++l)
+  {
+    result.x += (*input_) (i,l).x * kernel_[k];
+    result.y += (*input_) (i,l).y * kernel_[k];
+    result.z += (*input_) (i,l).z * kernel_[k];
+    r += kernel_[k] * static_cast<float> ((*input_) (i,l).r);
+    g += kernel_[k] * static_cast<float> ((*input_) (i,l).g);
+    b += kernel_[k] * static_cast<float> ((*input_) (i,l).b);
+  }
+  result.r = static_cast<std::uint8_t> (r);
+  result.g = static_cast<std::uint8_t> (g);
+  result.b = static_cast<std::uint8_t> (b);
+  return (result);
+}
+
+template<> pcl::PointXYZRGB
+Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneRowNonDense (int i, int j)
+{
+  pcl::PointXYZRGB result;
+  float weight = 0;
+  float r = 0, g = 0, b = 0;
+  for (int k = kernel_width_, l = i - half_width_; k > -1; --k, ++l)
+  {
+    if (!isFinite ((*input_) (l,j)))
+      continue;
+    if (pcl::squaredEuclideanDistance ((*input_) (i,j), (*input_) (l,j)) < distance_threshold_)
+    {
+      result.x += (*input_) (l,j).x * kernel_[k]; result.y += (*input_) (l,j).y * kernel_[k]; result.z += (*input_) (l,j).z * kernel_[k];
+      r+= kernel_[k] * static_cast<float> ((*input_) (l,j).r);
+      g+= kernel_[k] * static_cast<float> ((*input_) (l,j).g);
+      b+= kernel_[k] * static_cast<float> ((*input_) (l,j).b);
+      weight += kernel_[k];
+    }
+  }
+
+  if (weight == 0)
+    result.x = result.y = result.z = std::numeric_limits<float>::quiet_NaN ();
+  else
+  {
+    weight = 1.f/weight;
+    r*= weight; g*= weight; b*= weight;
+    result.x*= weight; result.y*= weight; result.z*= weight;
+    result.r = static_cast<std::uint8_t> (r);
+    result.g = static_cast<std::uint8_t> (g);
+    result.b = static_cast<std::uint8_t> (b);
+  }
+  return (result);
+}
+
+template<> pcl::PointXYZRGB
+Convolution<pcl::PointXYZRGB, pcl::PointXYZRGB>::convolveOneColNonDense (int i, int j)
+{
+  pcl::PointXYZRGB result;
+  float weight = 0;
+  float r = 0, g = 0, b = 0;
+  for (int k = kernel_width_, l = j - half_width_; k > -1; --k, ++l)
+  {
+    if (!isFinite ((*input_) (i,l)))
+      continue;
+    if (pcl::squaredEuclideanDistance ((*input_) (i,j), (*input_) (i,l)) < distance_threshold_)
+    {
+      result.x += (*input_) (i,l).x * kernel_[k]; result.y += (*input_) (i,l).y * kernel_[k]; result.z += (*input_) (i,l).z * kernel_[k];
+      r+= kernel_[k] * static_cast<float> ((*input_) (i,l).r);
+      g+= kernel_[k] * static_cast<float> ((*input_) (i,l).g);
+      b+= kernel_[k] * static_cast<float> ((*input_) (i,l).b);
+      weight+= kernel_[k];
+    }
+  }
+  if (weight == 0)
+    result.x = result.y = result.z = std::numeric_limits<float>::quiet_NaN ();
+  else
+  {
+    weight = 1.f/weight;
+    r*= weight; g*= weight; b*= weight;
+    result.x*= weight; result.y*= weight; result.z*= weight;
+    result.r = static_cast<std::uint8_t> (r);
+    result.g = static_cast<std::uint8_t> (g);
+    result.b = static_cast<std::uint8_t> (b);
+  }
+  return (result);
+}
+
+template<> pcl::RGB
+Convolution<pcl::RGB, pcl::RGB>::convolveOneRowDense (int i, int j)
+{
+  pcl::RGB result;
+  float r = 0, g = 0, b = 0;
+  for (int k = kernel_width_, l = i - half_width_; k > -1; --k, ++l)
+  {
+    r += kernel_[k] * static_cast<float> ((*input_) (l,j).r);
+    g += kernel_[k] * static_cast<float> ((*input_) (l,j).g);
+    b += kernel_[k] * static_cast<float> ((*input_) (l,j).b);
+  }
+  result.r = static_cast<std::uint8_t> (r);
+  result.g = static_cast<std::uint8_t> (g);
+  result.b = static_cast<std::uint8_t> (b);
+  return (result);
+}
+
+template<> pcl::RGB
+Convolution<pcl::RGB, pcl::RGB>::convolveOneColDense (int i, int j)
+{
+  pcl::RGB result;
+  float r = 0, g = 0, b = 0;
+  for (int k = kernel_width_, l = j - half_width_; k > -1; --k, ++l)
+  {
+    r += kernel_[k] * static_cast<float> ((*input_) (i,l).r);
+    g += kernel_[k] * static_cast<float> ((*input_) (i,l).g);
+    b += kernel_[k] * static_cast<float> ((*input_) (i,l).b);
+  }
+  result.r = static_cast<std::uint8_t> (r);
+  result.g = static_cast<std::uint8_t> (g);
+  result.b = static_cast<std::uint8_t> (b);
+  return (result);
+}
+
+template<> pcl::RGB
+Convolution<pcl::RGB, pcl::RGB>::convolveOneRowNonDense (int i, int j)
+{
+  return (convolveOneRowDense (i,j));
+}
+
+template<> pcl::RGB
+Convolution<pcl::RGB, pcl::RGB>::convolveOneColNonDense (int i, int j)
+{
+  return (convolveOneColDense (i,j));
+}
+
+template<> void
+Convolution<pcl::RGB, pcl::RGB>::makeInfinite (pcl::RGB& p)
+{
+  p.r = 0; p.g = 0; p.b = 0;
 }
 
 template <typename PointIn, typename PointOut> void
-pcl::filters::Convolution<PointIn, PointOut>::convolve_rows (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolve_rows (PointCloudOut& output)
 {
   using namespace pcl::common;
 
@@ -447,7 +446,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows (PointCloudOut& outp
 }
 
 template <typename PointIn, typename PointOut> void
-pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_duplicate (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolve_rows_duplicate (PointCloudOut& output)
 {
   using namespace pcl::common;
 
@@ -494,7 +493,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_duplicate (PointClou
 }
 
 template <typename PointIn, typename PointOut> void
-pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_mirror (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolve_rows_mirror (PointCloudOut& output)
 {
   using namespace pcl::common;
 
@@ -541,7 +540,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_rows_mirror (PointCloudOu
 }
 
 template <typename PointIn, typename PointOut> void
-pcl::filters::Convolution<PointIn, PointOut>::convolve_cols (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolve_cols (PointCloudOut& output)
 {
   using namespace pcl::common;
 
@@ -587,7 +586,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols (PointCloudOut& outp
 }
 
 template <typename PointIn, typename PointOut> void
-pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_duplicate (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolve_cols_duplicate (PointCloudOut& output)
 {
   using namespace pcl::common;
 
@@ -634,7 +633,7 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_duplicate (PointClou
 }
 
 template <typename PointIn, typename PointOut> void
-pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_mirror (PointCloudOut& output)
+Convolution<PointIn, PointOut>::convolve_cols_mirror (PointCloudOut& output)
 {
   using namespace pcl::common;
 
@@ -680,4 +679,8 @@ pcl::filters::Convolution<PointIn, PointOut>::convolve_cols_mirror (PointCloudOu
   }
 }
 
+} // namespace filters
+} // namespace pcl
+
 #endif //PCL_FILTERS_CONVOLUTION_IMPL_HPP
+

--- a/filters/include/pcl/filters/impl/fast_bilateral.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral.hpp
@@ -37,14 +37,18 @@
  * $Id$
  *
  */
+
 #ifndef PCL_FILTERS_IMPL_FAST_BILATERAL_HPP_
 #define PCL_FILTERS_IMPL_FAST_BILATERAL_HPP_
 
 #include <pcl/common/io.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointT> void
-pcl::FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
+FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
 {
   if (!input_->isOrganized ())
   {
@@ -164,12 +168,10 @@ pcl::FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
 }
 
 
-
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> std::size_t
-pcl::FastBilateralFilter<PointT>::Array3D::clamp (const std::size_t min_value,
-                                                  const std::size_t max_value,
-                                                  const std::size_t x)
+FastBilateralFilter<PointT>::Array3D::clamp (const std::size_t min_value,
+                                             const std::size_t max_value,
+                                             const std::size_t x)
 {
   if (x >= min_value && x <= max_value)
   {
@@ -182,11 +184,11 @@ pcl::FastBilateralFilter<PointT>::Array3D::clamp (const std::size_t min_value,
   return (max_value);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> Eigen::Vector2f
-pcl::FastBilateralFilter<PointT>::Array3D::trilinear_interpolation (const float x,
-                                                                    const float y,
-                                                                    const float z)
+FastBilateralFilter<PointT>::Array3D::trilinear_interpolation (const float x,
+                                                               const float y,
+                                                               const float z)
 {
   const std::size_t x_index  = clamp (0, x_dim_ - 1, static_cast<std::size_t> (x));
   const std::size_t xx_index = clamp (0, x_dim_ - 1, x_index + 1);
@@ -212,4 +214,7 @@ pcl::FastBilateralFilter<PointT>::Array3D::trilinear_interpolation (const float 
       x_alpha        * y_alpha        * z_alpha        * (*this)(xx_index, yy_index, zz_index);
 }
 
+} // namespace pcl
+
 #endif /* PCL_FILTERS_IMPL_FAST_BILATERAL_HPP_ */
+

--- a/filters/include/pcl/filters/impl/morphological_filter.hpp
+++ b/filters/include/pcl/filters/impl/morphological_filter.hpp
@@ -52,11 +52,12 @@
 #include <pcl/filters/morphological_filter.h>
 #include <pcl/octree/octree_search.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+namespace pcl
+{
 template <typename PointT> void
-pcl::applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPtr &cloud_in,
-                                 float resolution, const int morphological_operator,
-                                 pcl::PointCloud<PointT> &cloud_out)
+applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPtr &cloud_in,
+                            float resolution, const int morphological_operator,
+                            pcl::PointCloud<PointT> &cloud_out)
 {
   if (cloud_in->empty ())
     return;
@@ -202,7 +203,8 @@ pcl::applyMorphologicalOperator (const typename pcl::PointCloud<PointT>::ConstPt
   return;
 }
 
+} // namespace pcl
+
 #define PCL_INSTANTIATE_applyMorphologicalOperator(T) template PCL_EXPORTS void pcl::applyMorphologicalOperator<T> (const pcl::PointCloud<T>::ConstPtr &, float, const int, pcl::PointCloud<T> &);
 
 #endif  //#ifndef PCL_FILTERS_IMPL_MORPHOLOGICAL_FILTER_H_
-

--- a/filters/include/pcl/filters/impl/pyramid.hpp
+++ b/filters/include/pcl/filters/impl/pyramid.hpp
@@ -37,18 +37,26 @@
  *
  */
 
+
 #ifndef PCL_FILTERS_IMPL_PYRAMID_HPP
 #define PCL_FILTERS_IMPL_PYRAMID_HPP
 
+
+namespace pcl
+{
+
+namespace filters
+{
+
 template <typename PointT> bool
-pcl::filters::Pyramid<PointT>::initCompute ()
+Pyramid<PointT>::initCompute ()
 {
   if (!input_->isOrganized ())
   {
     PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should be at least 2!", getClassName ().c_str ());
     return (false);
   }
-  
+
   if (levels_ < 2)
   {
     PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should be at least 2!", getClassName ().c_str ());
@@ -58,13 +66,13 @@ pcl::filters::Pyramid<PointT>::initCompute ()
   // std::size_t ratio (std::pow (2, levels_));
   // std::size_t last_width = input_->width / ratio;
   // std::size_t last_height = input_->height / ratio;
-  
+
   if (levels_ > 4)
   {
     PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should not exceed 4!", getClassName ().c_str ());
     return (false);
   }
-  
+
   if (large_)
   {
     Eigen::VectorXf k (5);
@@ -82,12 +90,12 @@ pcl::filters::Pyramid<PointT>::initCompute ()
     if (threshold_ != std::numeric_limits<float>::infinity ())
       threshold_ *= threshold_;
   }
-  
+
   return (true);
 }
 
 template <typename PointT> void
-pcl::filters::Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
+Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
 {
   std::cout << "compute" << std::endl;
   if (!initCompute ())
@@ -113,8 +121,8 @@ pcl::filters::Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
       const PointCloud<PointT> &previous = *output[l-1];
       PointCloud<PointT> &next = *output[l];
 #pragma omp parallel for \
-  default(none) \
-  shared(next) \
+  default(none)          \
+  shared(next)           \
   num_threads(threads_)
       for(int i=0; i < next.height; ++i)
       {
@@ -122,14 +130,14 @@ pcl::filters::Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
         {
           for(int m=0; m < kernel_rows; ++m)
           {
-            int mm = kernel_rows - 1 - m;      
-            for(int n=0; n < kernel_cols; ++n) 
+            int mm = kernel_rows - 1 - m;
+            for(int n=0; n < kernel_cols; ++n)
             {
               int nn = kernel_cols - 1 - n;
 
               int ii = 2*i + (m - kernel_center_y);
               int jj = 2*j + (n - kernel_center_x);
-              
+
               if (ii < 0) ii = 0;
               if (ii >= previous.height) ii = previous.height - 1;
               if (jj < 0) jj = 0;
@@ -149,8 +157,8 @@ pcl::filters::Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
       const PointCloud<PointT> &previous = *output[l-1];
       PointCloud<PointT> &next = *output[l];
 #pragma omp parallel for \
-  default(none) \
-  shared(next) \
+  default(none)          \
+  shared(next)           \
   num_threads(threads_)
       for(int i=0; i < next.height; ++i)
       {
@@ -188,389 +196,387 @@ pcl::filters::Pyramid<PointT>::compute (std::vector<PointCloudPtr>& output)
         }
       }
     }
-  }    
-}
-
-namespace pcl
-{
-  namespace filters
-  {
-    template <> void 
-    Pyramid<pcl::PointXYZRGB>::compute (std::vector<Pyramid<pcl::PointXYZRGB>::PointCloudPtr> &output)
-    {
-      std::cout << "PointXYZRGB" << std::endl;
-      if (!initCompute ())
-      {
-        PCL_ERROR ("[pcl::%s::compute] initCompute failed!\n", getClassName ().c_str ());
-        return;
-      }
-      
-      int kernel_rows = static_cast<int> (kernel_.rows ());
-      int kernel_cols = static_cast<int> (kernel_.cols ());
-      int kernel_center_x = kernel_cols / 2;
-      int kernel_center_y = kernel_rows / 2;
-
-      output.resize (levels_ + 1);
-      output[0].reset (new pcl::PointCloud<pcl::PointXYZRGB>);
-      *(output[0]) = *input_;
-
-      if (input_->is_dense)
-      {
-        for (int l = 1; l <= levels_; ++l)
-        {
-          output[l].reset (new pcl::PointCloud<pcl::PointXYZRGB> (output[l-1]->width/2, output[l-1]->height/2));
-          const PointCloud<pcl::PointXYZRGB> &previous = *output[l-1];
-          PointCloud<pcl::PointXYZRGB> &next = *output[l];
-#pragma omp parallel for \
-  default(none) \
-  shared(next) \
-  num_threads(threads_)
-          for(int i=0; i < next.height; ++i)              // rows
-          {
-            for(int j=0; j < next.width; ++j)          // columns
-            {
-              float r = 0, g = 0, b = 0;
-              for(int m=0; m < kernel_rows; ++m)     // kernel rows
-              {
-                int mm = kernel_rows - 1 - m;      // row index of flipped kernel
-                for(int n=0; n < kernel_cols; ++n) // kernel columns
-                {
-                  int nn = kernel_cols - 1 - n;  // column index of flipped kernel
-                  // index of input signal, used for checking boundary
-                  int ii = 2*i + (m - kernel_center_y);
-                  int jj = 2*j + (n - kernel_center_x);
-                  
-                  // ignore input samples which are out of bound
-                  if (ii < 0) ii = 0;
-                  if (ii >= previous.height) ii = previous.height - 1;
-                  if (jj < 0) jj = 0;
-                  if (jj >= previous.width) jj = previous.width - 1;
-                  next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
-                  next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
-                  next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
-                  b += previous.at (jj,ii).b * kernel_ (mm,nn);
-                  g += previous.at (jj,ii).g * kernel_ (mm,nn);
-                  r += previous.at (jj,ii).r * kernel_ (mm,nn);
-                }
-              }
-              next.at (j,i).b = static_cast<std::uint8_t> (b);
-              next.at (j,i).g = static_cast<std::uint8_t> (g);
-              next.at (j,i).r = static_cast<std::uint8_t> (r);
-            }
-          }
-        }
-      }
-      else
-      {
-        for (int l = 1; l <= levels_; ++l)
-        {
-          output[l].reset (new pcl::PointCloud<pcl::PointXYZRGB> (output[l-1]->width/2, output[l-1]->height/2));
-          const PointCloud<pcl::PointXYZRGB> &previous = *output[l-1];
-          PointCloud<pcl::PointXYZRGB> &next = *output[l];
-#pragma omp parallel for \
-  default(none) \
-  shared(next) \
-  num_threads(threads_)
-          for(int i=0; i < next.height; ++i)
-          {
-            for(int j=0; j < next.width; ++j)
-            {
-              float weight = 0;
-              float r = 0, g = 0, b = 0;
-              for(int m=0; m < kernel_rows; ++m)
-              {
-                int mm = kernel_rows - 1 - m;
-                for(int n=0; n < kernel_cols; ++n)
-                {
-                  int nn = kernel_cols - 1 - n;
-                  int ii = 2*i + (m - kernel_center_y);
-                  int jj = 2*j + (n - kernel_center_x);
-                  if (ii < 0) ii = 0;
-                  if (ii >= previous.height) ii = previous.height - 1;
-                  if (jj < 0) jj = 0;
-                  if (jj >= previous.width) jj = previous.width - 1;
-                  if (!isFinite (previous.at (jj,ii)))
-                    continue;
-                  if (pcl::squaredEuclideanDistance (previous.at (2*j,2*i), previous.at (jj,ii)) < threshold_)
-                  {
-                    next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
-                    next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
-                    next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
-                    b += previous.at (jj,ii).b * kernel_ (mm,nn);
-                    g += previous.at (jj,ii).g * kernel_ (mm,nn);
-                    r += previous.at (jj,ii).r * kernel_ (mm,nn);
-                    weight+= kernel_ (mm,nn);
-                  }
-                }
-              }
-              if (weight == 0)
-                nullify (next.at (j,i));
-              else
-              {
-                weight = 1.f/weight;
-                r*= weight; g*= weight; b*= weight;
-                next.at (j,i).x*= weight; next.at (j,i).y*= weight; next.at (j,i).z*= weight;
-                next.at (j,i).b = static_cast<std::uint8_t> (b);
-                next.at (j,i).g = static_cast<std::uint8_t> (g);
-                next.at (j,i).r = static_cast<std::uint8_t> (r);
-              }
-            }
-          }
-        }
-      }    
-    }
-    
-    template <> void 
-    Pyramid<pcl::PointXYZRGBA>::compute (std::vector<Pyramid<pcl::PointXYZRGBA>::PointCloudPtr> &output)
-    {
-      std::cout << "PointXYZRGBA" << std::endl;
-      if (!initCompute ())
-      {
-        PCL_ERROR ("[pcl::%s::compute] initCompute failed!\n", getClassName ().c_str ());
-        return;
-      }
-      
-      int kernel_rows = static_cast<int> (kernel_.rows ());
-      int kernel_cols = static_cast<int> (kernel_.cols ());
-      int kernel_center_x = kernel_cols / 2;
-      int kernel_center_y = kernel_rows / 2;
-
-      output.resize (levels_ + 1);
-      output[0].reset (new pcl::PointCloud<pcl::PointXYZRGBA>);
-      *(output[0]) = *input_;
-
-      if (input_->is_dense)
-      {
-        for (int l = 1; l <= levels_; ++l)
-        {
-          output[l].reset (new pcl::PointCloud<pcl::PointXYZRGBA> (output[l-1]->width/2, output[l-1]->height/2));
-          const PointCloud<pcl::PointXYZRGBA> &previous = *output[l-1];
-          PointCloud<pcl::PointXYZRGBA> &next = *output[l];
-#pragma omp parallel for \
-  default(none) \
-  shared(next) \
-  num_threads(threads_)
-          for(int i=0; i < next.height; ++i)              // rows
-          {
-            for(int j=0; j < next.width; ++j)          // columns
-            {
-              float r = 0, g = 0, b = 0, a = 0;
-              for(int m=0; m < kernel_rows; ++m)     // kernel rows
-              {
-                int mm = kernel_rows - 1 - m;      // row index of flipped kernel
-                for(int n=0; n < kernel_cols; ++n) // kernel columns
-                {
-                  int nn = kernel_cols - 1 - n;  // column index of flipped kernel
-                  // index of input signal, used for checking boundary
-                  int ii = 2*i + (m - kernel_center_y);
-                  int jj = 2*j + (n - kernel_center_x);
-                  
-                  // ignore input samples which are out of bound
-                  if (ii < 0) ii = 0;
-                  if (ii >= previous.height) ii = previous.height - 1;
-                  if (jj < 0) jj = 0;
-                  if (jj >= previous.width) jj = previous.width - 1;
-                  next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
-                  next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
-                  next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
-                  b += previous.at (jj,ii).b * kernel_ (mm,nn);
-                  g += previous.at (jj,ii).g * kernel_ (mm,nn);
-                  r += previous.at (jj,ii).r * kernel_ (mm,nn);
-                  a += previous.at (jj,ii).a * kernel_ (mm,nn);
-                }
-              }
-              next.at (j,i).b = static_cast<std::uint8_t> (b);
-              next.at (j,i).g = static_cast<std::uint8_t> (g);
-              next.at (j,i).r = static_cast<std::uint8_t> (r);
-              next.at (j,i).a = static_cast<std::uint8_t> (a);
-            }
-          }
-        }
-      }
-      else
-      {
-        for (int l = 1; l <= levels_; ++l)
-        {
-          output[l].reset (new pcl::PointCloud<pcl::PointXYZRGBA> (output[l-1]->width/2, output[l-1]->height/2));
-          const PointCloud<pcl::PointXYZRGBA> &previous = *output[l-1];
-          PointCloud<pcl::PointXYZRGBA> &next = *output[l];
-#pragma omp parallel for \
-  default(none) \
-  shared(next) \
-  num_threads(threads_)
-          for(int i=0; i < next.height; ++i)
-          {
-            for(int j=0; j < next.width; ++j)
-            {
-              float weight = 0;
-              float r = 0, g = 0, b = 0, a = 0;
-              for(int m=0; m < kernel_rows; ++m)
-              {
-                int mm = kernel_rows - 1 - m;
-                for(int n=0; n < kernel_cols; ++n)
-                {
-                  int nn = kernel_cols - 1 - n;
-                  int ii = 2*i + (m - kernel_center_y);
-                  int jj = 2*j + (n - kernel_center_x);
-                  if (ii < 0) ii = 0;
-                  if (ii >= previous.height) ii = previous.height - 1;
-                  if (jj < 0) jj = 0;
-                  if (jj >= previous.width) jj = previous.width - 1;
-                  if (!isFinite (previous.at (jj,ii)))
-                    continue;
-                  if (pcl::squaredEuclideanDistance (previous.at (2*j,2*i), previous.at (jj,ii)) < threshold_)
-                  {
-                    next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
-                    next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
-                    next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
-                    b += previous.at (jj,ii).b * kernel_ (mm,nn);
-                    g += previous.at (jj,ii).g * kernel_ (mm,nn);
-                    r += previous.at (jj,ii).r * kernel_ (mm,nn);
-                    a += previous.at (jj,ii).a * kernel_ (mm,nn);
-                    weight+= kernel_ (mm,nn);
-                  }
-                }
-              }
-              if (weight == 0)
-                nullify (next.at (j,i));
-              else
-              {
-                weight = 1.f/weight;
-                r*= weight; g*= weight; b*= weight; a*= weight;
-                next.at (j,i).x*= weight; next.at (j,i).y*= weight; next.at (j,i).z*= weight;
-                next.at (j,i).b = static_cast<std::uint8_t> (b);
-                next.at (j,i).g = static_cast<std::uint8_t> (g);
-                next.at (j,i).r = static_cast<std::uint8_t> (r);
-                next.at (j,i).a = static_cast<std::uint8_t> (a);
-              }
-            }
-          }
-        }
-      }    
-    }
-
-    template<> void
-    Pyramid<pcl::RGB>::nullify (pcl::RGB& p)
-    {
-      p.r = 0; p.g = 0; p.b = 0;
-    }    
-
-    template <> void 
-    Pyramid<pcl::RGB>::compute (std::vector<Pyramid<pcl::RGB>::PointCloudPtr> &output)
-    {
-      std::cout << "RGB" << std::endl;
-      if (!initCompute ())
-      {
-        PCL_ERROR ("[pcl::%s::compute] initCompute failed!\n", getClassName ().c_str ());
-        return;
-      }
-      
-      int kernel_rows = static_cast<int> (kernel_.rows ());
-      int kernel_cols = static_cast<int> (kernel_.cols ());
-      int kernel_center_x = kernel_cols / 2;
-      int kernel_center_y = kernel_rows / 2;
-
-      output.resize (levels_ + 1);
-      output[0].reset (new pcl::PointCloud<pcl::RGB>);
-      *(output[0]) = *input_;
-
-      if (input_->is_dense)
-      {
-        for (int l = 1; l <= levels_; ++l)
-        {
-          output[l].reset (new pcl::PointCloud<pcl::RGB> (output[l-1]->width/2, output[l-1]->height/2));
-          const PointCloud<pcl::RGB> &previous = *output[l-1];
-          PointCloud<pcl::RGB> &next = *output[l];
-#pragma omp parallel for \
-  default(none) \
-  shared(next) \
-  num_threads(threads_)
-          for(int i=0; i < next.height; ++i)
-          {
-            for(int j=0; j < next.width; ++j)
-            {
-              float r = 0, g = 0, b = 0;
-              for(int m=0; m < kernel_rows; ++m)
-              {
-                int mm = kernel_rows - 1 - m;
-                for(int n=0; n < kernel_cols; ++n)
-                {
-                  int nn = kernel_cols - 1 - n;
-                  int ii = 2*i + (m - kernel_center_y);
-                  int jj = 2*j + (n - kernel_center_x);
-                  if (ii < 0) ii = 0;
-                  if (ii >= previous.height) ii = previous.height - 1;
-                  if (jj < 0) jj = 0;
-                  if (jj >= previous.width) jj = previous.width - 1;
-                  b += previous.at (jj,ii).b * kernel_ (mm,nn);
-                  g += previous.at (jj,ii).g * kernel_ (mm,nn);
-                  r += previous.at (jj,ii).r * kernel_ (mm,nn);
-                }
-              }
-              next.at (j,i).b = static_cast<std::uint8_t> (b);
-              next.at (j,i).g = static_cast<std::uint8_t> (g);
-              next.at (j,i).r = static_cast<std::uint8_t> (r);
-            }
-          }
-        }
-      }
-      else
-      {
-        for (int l = 1; l <= levels_; ++l)
-        {
-          output[l].reset (new pcl::PointCloud<pcl::RGB> (output[l-1]->width/2, output[l-1]->height/2));
-          const PointCloud<pcl::RGB> &previous = *output[l-1];
-          PointCloud<pcl::RGB> &next = *output[l];
-#pragma omp parallel for \
-  default(none) \
-  shared(next) \
-  num_threads(threads_)
-          for(int i=0; i < next.height; ++i)
-          {
-            for(int j=0; j < next.width; ++j)
-            {
-              float weight = 0;
-              float r = 0, g = 0, b = 0;
-              for(int m=0; m < kernel_rows; ++m)
-              {
-                int mm = kernel_rows - 1 - m;
-                for(int n=0; n < kernel_cols; ++n)
-                {
-                  int nn = kernel_cols - 1 - n;
-                  int ii = 2*i + (m - kernel_center_y);
-                  int jj = 2*j + (n - kernel_center_x);
-                  if (ii < 0) ii = 0;
-                  if (ii >= previous.height) ii = previous.height - 1;
-                  if (jj < 0) jj = 0;
-                  if (jj >= previous.width) jj = previous.width - 1;
-                  if (!isFinite (previous.at (jj,ii)))
-                    continue;
-                  if (pcl::squaredEuclideanDistance (previous.at (2*j,2*i), previous.at (jj,ii)) < threshold_)
-                  {
-                    b += previous.at (jj,ii).b * kernel_ (mm,nn);
-                    g += previous.at (jj,ii).g * kernel_ (mm,nn);
-                    r += previous.at (jj,ii).r * kernel_ (mm,nn);
-                    weight+= kernel_ (mm,nn);
-                  }
-                }
-              }
-              if (weight == 0)
-                nullify (next.at (j,i));
-              else
-              {
-                weight = 1.f/weight;
-                r*= weight; g*= weight; b*= weight;
-                next.at (j,i).b = static_cast<std::uint8_t> (b);
-                next.at (j,i).g = static_cast<std::uint8_t> (g);
-                next.at (j,i).r = static_cast<std::uint8_t> (r);
-              }
-            }
-          }
-        }
-      }    
-    }
-
   }
 }
 
+
+template <> void
+Pyramid<pcl::PointXYZRGB>::compute (std::vector<Pyramid<pcl::PointXYZRGB>::PointCloudPtr> &output)
+{
+  std::cout << "PointXYZRGB" << std::endl;
+  if (!initCompute ())
+  {
+    PCL_ERROR ("[pcl::%s::compute] initCompute failed!\n", getClassName ().c_str ());
+    return;
+  }
+
+  int kernel_rows = static_cast<int> (kernel_.rows ());
+  int kernel_cols = static_cast<int> (kernel_.cols ());
+  int kernel_center_x = kernel_cols / 2;
+  int kernel_center_y = kernel_rows / 2;
+
+  output.resize (levels_ + 1);
+  output[0].reset (new pcl::PointCloud<pcl::PointXYZRGB>);
+  *(output[0]) = *input_;
+
+  if (input_->is_dense)
+  {
+    for (int l = 1; l <= levels_; ++l)
+    {
+      output[l].reset (new pcl::PointCloud<pcl::PointXYZRGB> (output[l-1]->width/2, output[l-1]->height/2));
+      const PointCloud<pcl::PointXYZRGB> &previous = *output[l-1];
+      PointCloud<pcl::PointXYZRGB> &next = *output[l];
+#pragma omp parallel for \
+  default(none)          \
+  shared(next)           \
+  num_threads(threads_)
+      for(int i=0; i < next.height; ++i)              // rows
+      {
+        for(int j=0; j < next.width; ++j)          // columns
+        {
+          float r = 0, g = 0, b = 0;
+          for(int m=0; m < kernel_rows; ++m)     // kernel rows
+          {
+            int mm = kernel_rows - 1 - m;      // row index of flipped kernel
+            for(int n=0; n < kernel_cols; ++n) // kernel columns
+            {
+              int nn = kernel_cols - 1 - n;  // column index of flipped kernel
+              // index of input signal, used for checking boundary
+              int ii = 2*i + (m - kernel_center_y);
+              int jj = 2*j + (n - kernel_center_x);
+
+              // ignore input samples which are out of bound
+              if (ii < 0) ii = 0;
+              if (ii >= previous.height) ii = previous.height - 1;
+              if (jj < 0) jj = 0;
+              if (jj >= previous.width) jj = previous.width - 1;
+              next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
+              next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
+              next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
+              b += previous.at (jj,ii).b * kernel_ (mm,nn);
+              g += previous.at (jj,ii).g * kernel_ (mm,nn);
+              r += previous.at (jj,ii).r * kernel_ (mm,nn);
+            }
+          }
+          next.at (j,i).b = static_cast<std::uint8_t> (b);
+          next.at (j,i).g = static_cast<std::uint8_t> (g);
+          next.at (j,i).r = static_cast<std::uint8_t> (r);
+        }
+      }
+    }
+  }
+  else
+  {
+    for (int l = 1; l <= levels_; ++l)
+    {
+      output[l].reset (new pcl::PointCloud<pcl::PointXYZRGB> (output[l-1]->width/2, output[l-1]->height/2));
+      const PointCloud<pcl::PointXYZRGB> &previous = *output[l-1];
+      PointCloud<pcl::PointXYZRGB> &next = *output[l];
+#pragma omp parallel for \
+  default(none)          \
+  shared(next)           \
+  num_threads(threads_)
+      for(int i=0; i < next.height; ++i)
+      {
+        for(int j=0; j < next.width; ++j)
+        {
+          float weight = 0;
+          float r = 0, g = 0, b = 0;
+          for(int m=0; m < kernel_rows; ++m)
+          {
+            int mm = kernel_rows - 1 - m;
+            for(int n=0; n < kernel_cols; ++n)
+            {
+              int nn = kernel_cols - 1 - n;
+              int ii = 2*i + (m - kernel_center_y);
+              int jj = 2*j + (n - kernel_center_x);
+              if (ii < 0) ii = 0;
+              if (ii >= previous.height) ii = previous.height - 1;
+              if (jj < 0) jj = 0;
+              if (jj >= previous.width) jj = previous.width - 1;
+              if (!isFinite (previous.at (jj,ii)))
+                continue;
+              if (pcl::squaredEuclideanDistance (previous.at (2*j,2*i), previous.at (jj,ii)) < threshold_)
+              {
+                next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
+                next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
+                next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
+                b += previous.at (jj,ii).b * kernel_ (mm,nn);
+                g += previous.at (jj,ii).g * kernel_ (mm,nn);
+                r += previous.at (jj,ii).r * kernel_ (mm,nn);
+                weight+= kernel_ (mm,nn);
+              }
+            }
+          }
+          if (weight == 0)
+            nullify (next.at (j,i));
+          else
+          {
+            weight = 1.f/weight;
+            r*= weight; g*= weight; b*= weight;
+            next.at (j,i).x*= weight; next.at (j,i).y*= weight; next.at (j,i).z*= weight;
+            next.at (j,i).b = static_cast<std::uint8_t> (b);
+            next.at (j,i).g = static_cast<std::uint8_t> (g);
+            next.at (j,i).r = static_cast<std::uint8_t> (r);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <> void
+Pyramid<pcl::PointXYZRGBA>::compute (std::vector<Pyramid<pcl::PointXYZRGBA>::PointCloudPtr> &output)
+{
+  std::cout << "PointXYZRGBA" << std::endl;
+  if (!initCompute ())
+  {
+    PCL_ERROR ("[pcl::%s::compute] initCompute failed!\n", getClassName ().c_str ());
+    return;
+  }
+  
+  int kernel_rows = static_cast<int> (kernel_.rows ());
+  int kernel_cols = static_cast<int> (kernel_.cols ());
+  int kernel_center_x = kernel_cols / 2;
+  int kernel_center_y = kernel_rows / 2;
+
+  output.resize (levels_ + 1);
+  output[0].reset (new pcl::PointCloud<pcl::PointXYZRGBA>);
+  *(output[0]) = *input_;
+
+  if (input_->is_dense)
+  {
+    for (int l = 1; l <= levels_; ++l)
+    {
+      output[l].reset (new pcl::PointCloud<pcl::PointXYZRGBA> (output[l-1]->width/2, output[l-1]->height/2));
+      const PointCloud<pcl::PointXYZRGBA> &previous = *output[l-1];
+      PointCloud<pcl::PointXYZRGBA> &next = *output[l];
+#pragma omp parallel for \
+  default(none)          \
+  shared(next)           \
+  num_threads(threads_)
+      for(int i=0; i < next.height; ++i)              // rows
+      {
+        for(int j=0; j < next.width; ++j)          // columns
+        {
+          float r = 0, g = 0, b = 0, a = 0;
+          for(int m=0; m < kernel_rows; ++m)     // kernel rows
+          {
+            int mm = kernel_rows - 1 - m;      // row index of flipped kernel
+            for(int n=0; n < kernel_cols; ++n) // kernel columns
+            {
+              int nn = kernel_cols - 1 - n;  // column index of flipped kernel
+              // index of input signal, used for checking boundary
+              int ii = 2*i + (m - kernel_center_y);
+              int jj = 2*j + (n - kernel_center_x);
+
+              // ignore input samples which are out of bound
+              if (ii < 0) ii = 0;
+              if (ii >= previous.height) ii = previous.height - 1;
+              if (jj < 0) jj = 0;
+              if (jj >= previous.width) jj = previous.width - 1;
+              next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
+              next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
+              next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
+              b += previous.at (jj,ii).b * kernel_ (mm,nn);
+              g += previous.at (jj,ii).g * kernel_ (mm,nn);
+              r += previous.at (jj,ii).r * kernel_ (mm,nn);
+              a += previous.at (jj,ii).a * kernel_ (mm,nn);
+            }
+          }
+          next.at (j,i).b = static_cast<std::uint8_t> (b);
+          next.at (j,i).g = static_cast<std::uint8_t> (g);
+          next.at (j,i).r = static_cast<std::uint8_t> (r);
+          next.at (j,i).a = static_cast<std::uint8_t> (a);
+        }
+      }
+    }
+  }
+  else
+  {
+    for (int l = 1; l <= levels_; ++l)
+    {
+      output[l].reset (new pcl::PointCloud<pcl::PointXYZRGBA> (output[l-1]->width/2, output[l-1]->height/2));
+      const PointCloud<pcl::PointXYZRGBA> &previous = *output[l-1];
+      PointCloud<pcl::PointXYZRGBA> &next = *output[l];
+#pragma omp parallel for \
+  default(none)          \
+  shared(next)           \
+  num_threads(threads_)
+      for(int i=0; i < next.height; ++i)
+      {
+        for(int j=0; j < next.width; ++j)
+        {
+          float weight = 0;
+          float r = 0, g = 0, b = 0, a = 0;
+          for(int m=0; m < kernel_rows; ++m)
+          {
+            int mm = kernel_rows - 1 - m;
+            for(int n=0; n < kernel_cols; ++n)
+            {
+              int nn = kernel_cols - 1 - n;
+              int ii = 2*i + (m - kernel_center_y);
+              int jj = 2*j + (n - kernel_center_x);
+              if (ii < 0) ii = 0;
+              if (ii >= previous.height) ii = previous.height - 1;
+              if (jj < 0) jj = 0;
+              if (jj >= previous.width) jj = previous.width - 1;
+              if (!isFinite (previous.at (jj,ii)))
+                continue;
+              if (pcl::squaredEuclideanDistance (previous.at (2*j,2*i), previous.at (jj,ii)) < threshold_)
+              {
+                next.at (j,i).x += previous.at (jj,ii).x * kernel_ (mm,nn);
+                next.at (j,i).y += previous.at (jj,ii).y * kernel_ (mm,nn);
+                next.at (j,i).z += previous.at (jj,ii).z * kernel_ (mm,nn);
+                b += previous.at (jj,ii).b * kernel_ (mm,nn);
+                g += previous.at (jj,ii).g * kernel_ (mm,nn);
+                r += previous.at (jj,ii).r * kernel_ (mm,nn);
+                a += previous.at (jj,ii).a * kernel_ (mm,nn);
+                weight+= kernel_ (mm,nn);
+              }
+            }
+          }
+          if (weight == 0)
+            nullify (next.at (j,i));
+          else
+          {
+            weight = 1.f/weight;
+            r*= weight; g*= weight; b*= weight; a*= weight;
+            next.at (j,i).x*= weight; next.at (j,i).y*= weight; next.at (j,i).z*= weight;
+            next.at (j,i).b = static_cast<std::uint8_t> (b);
+            next.at (j,i).g = static_cast<std::uint8_t> (g);
+            next.at (j,i).r = static_cast<std::uint8_t> (r);
+            next.at (j,i).a = static_cast<std::uint8_t> (a);
+          }
+        }
+      }
+    }
+  }
+}
+
+template<> void
+Pyramid<pcl::RGB>::nullify (pcl::RGB& p)
+{
+  p.r = 0; p.g = 0; p.b = 0;
+}
+
+template <> void
+Pyramid<pcl::RGB>::compute (std::vector<Pyramid<pcl::RGB>::PointCloudPtr> &output)
+{
+  std::cout << "RGB" << std::endl;
+  if (!initCompute ())
+  {
+    PCL_ERROR ("[pcl::%s::compute] initCompute failed!\n", getClassName ().c_str ());
+    return;
+  }
+
+  int kernel_rows = static_cast<int> (kernel_.rows ());
+  int kernel_cols = static_cast<int> (kernel_.cols ());
+  int kernel_center_x = kernel_cols / 2;
+  int kernel_center_y = kernel_rows / 2;
+
+  output.resize (levels_ + 1);
+  output[0].reset (new pcl::PointCloud<pcl::RGB>);
+  *(output[0]) = *input_;
+
+  if (input_->is_dense)
+  {
+    for (int l = 1; l <= levels_; ++l)
+    {
+      output[l].reset (new pcl::PointCloud<pcl::RGB> (output[l-1]->width/2, output[l-1]->height/2));
+      const PointCloud<pcl::RGB> &previous = *output[l-1];
+      PointCloud<pcl::RGB> &next = *output[l];
+#pragma omp parallel for \
+  default(none)          \
+  shared(next)           \
+  num_threads(threads_)
+      for(int i=0; i < next.height; ++i)
+      {
+        for(int j=0; j < next.width; ++j)
+        {
+          float r = 0, g = 0, b = 0;
+          for(int m=0; m < kernel_rows; ++m)
+          {
+            int mm = kernel_rows - 1 - m;
+            for(int n=0; n < kernel_cols; ++n)
+            {
+              int nn = kernel_cols - 1 - n;
+              int ii = 2*i + (m - kernel_center_y);
+              int jj = 2*j + (n - kernel_center_x);
+              if (ii < 0) ii = 0;
+              if (ii >= previous.height) ii = previous.height - 1;
+              if (jj < 0) jj = 0;
+              if (jj >= previous.width) jj = previous.width - 1;
+              b += previous.at (jj,ii).b * kernel_ (mm,nn);
+              g += previous.at (jj,ii).g * kernel_ (mm,nn);
+              r += previous.at (jj,ii).r * kernel_ (mm,nn);
+            }
+          }
+          next.at (j,i).b = static_cast<std::uint8_t> (b);
+          next.at (j,i).g = static_cast<std::uint8_t> (g);
+          next.at (j,i).r = static_cast<std::uint8_t> (r);
+        }
+      }
+    }
+  }
+  else
+  {
+    for (int l = 1; l <= levels_; ++l)
+    {
+      output[l].reset (new pcl::PointCloud<pcl::RGB> (output[l-1]->width/2, output[l-1]->height/2));
+      const PointCloud<pcl::RGB> &previous = *output[l-1];
+      PointCloud<pcl::RGB> &next = *output[l];
+#pragma omp parallel for \
+  default(none)          \
+  shared(next)           \
+  num_threads(threads_)
+      for(int i=0; i < next.height; ++i)
+      {
+        for(int j=0; j < next.width; ++j)
+        {
+          float weight = 0;
+          float r = 0, g = 0, b = 0;
+          for(int m=0; m < kernel_rows; ++m)
+          {
+            int mm = kernel_rows - 1 - m;
+            for(int n=0; n < kernel_cols; ++n)
+            {
+              int nn = kernel_cols - 1 - n;
+              int ii = 2*i + (m - kernel_center_y);
+              int jj = 2*j + (n - kernel_center_x);
+              if (ii < 0) ii = 0;
+              if (ii >= previous.height) ii = previous.height - 1;
+              if (jj < 0) jj = 0;
+              if (jj >= previous.width) jj = previous.width - 1;
+              if (!isFinite (previous.at (jj,ii)))
+                continue;
+              if (pcl::squaredEuclideanDistance (previous.at (2*j,2*i), previous.at (jj,ii)) < threshold_)
+              {
+                b += previous.at (jj,ii).b * kernel_ (mm,nn);
+                g += previous.at (jj,ii).g * kernel_ (mm,nn);
+                r += previous.at (jj,ii).r * kernel_ (mm,nn);
+                weight+= kernel_ (mm,nn);
+              }
+            }
+          }
+          if (weight == 0)
+            nullify (next.at (j,i));
+          else
+          {
+            weight = 1.f/weight;
+            r*= weight; g*= weight; b*= weight;
+            next.at (j,i).b = static_cast<std::uint8_t> (b);
+            next.at (j,i).g = static_cast<std::uint8_t> (g);
+            next.at (j,i).r = static_cast<std::uint8_t> (r);
+          }
+        }
+      }
+    }
+  }
+}
+
+} // namespace filters
+} // namespace pcl
+
 #endif
+

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -34,82 +34,92 @@
  *  Author: Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
  */
 
+
 #ifndef PCL_GPU_CONTAINER_DEVICE_ARRAY_IMPL_HPP_
 #define PCL_GPU_CONTAINER_DEVICE_ARRAY_IMPL_HPP_
 
 
+namespace pcl
+{
+
+namespace gpu
+{
+
 /////////////////////  Inline implementations of DeviceArray ////////////////////////////////////////////
 
-template<class T> inline pcl::gpu::DeviceArray<T>::DeviceArray() {}
-template<class T> inline pcl::gpu::DeviceArray<T>::DeviceArray(std::size_t size) : DeviceMemory(size * elem_size) {}
-template<class T> inline pcl::gpu::DeviceArray<T>::DeviceArray(T *ptr, std::size_t size) : DeviceMemory(ptr, size * elem_size) {}
-template<class T> inline pcl::gpu::DeviceArray<T>::DeviceArray(const DeviceArray& other) : DeviceMemory(other) {}
-template<class T> inline pcl::gpu::DeviceArray<T>& pcl::gpu::DeviceArray<T>::operator=(const DeviceArray& other)
+template<class T> inline DeviceArray<T>::DeviceArray() {}
+template<class T> inline DeviceArray<T>::DeviceArray(std::size_t size) : DeviceMemory(size * elem_size) {}
+template<class T> inline DeviceArray<T>::DeviceArray(T *ptr, std::size_t size) : DeviceMemory(ptr, size * elem_size) {}
+template<class T> inline DeviceArray<T>::DeviceArray(const DeviceArray& other) : DeviceMemory(other) {}
+template<class T> inline DeviceArray<T>& DeviceArray<T>::operator=(const DeviceArray& other)
 { DeviceMemory::operator=(other); return *this; }
 
-template<class T> inline void pcl::gpu::DeviceArray<T>::create(std::size_t size) 
+template<class T> inline void DeviceArray<T>::create(std::size_t size)
 { DeviceMemory::create(size * elem_size); }
-template<class T> inline void pcl::gpu::DeviceArray<T>::release()  
+template<class T> inline void DeviceArray<T>::release()
 { DeviceMemory::release(); }
 
-template<class T> inline void pcl::gpu::DeviceArray<T>::copyTo(DeviceArray& other) const
+template<class T> inline void DeviceArray<T>::copyTo(DeviceArray& other) const
 { DeviceMemory::copyTo(other); }
-template<class T> inline void pcl::gpu::DeviceArray<T>::upload(const T *host_ptr, std::size_t size) 
+template<class T> inline void DeviceArray<T>::upload(const T *host_ptr, std::size_t size)
 { DeviceMemory::upload(host_ptr, size * elem_size); }
-template<class T> inline void pcl::gpu::DeviceArray<T>::download(T *host_ptr) const 
+template<class T> inline void DeviceArray<T>::download(T *host_ptr) const
 { DeviceMemory::download( host_ptr ); }
 
-template<class T> void pcl::gpu::DeviceArray<T>::swap(DeviceArray& other_arg) { DeviceMemory::swap(other_arg); }
+template<class T> void DeviceArray<T>::swap(DeviceArray& other_arg) { DeviceMemory::swap(other_arg); }
 
-template<class T> inline pcl::gpu::DeviceArray<T>::operator T*() { return ptr(); }
-template<class T> inline pcl::gpu::DeviceArray<T>::operator const T*() const { return ptr(); }
-template<class T> inline std::size_t pcl::gpu::DeviceArray<T>::size() const { return sizeBytes() / elem_size; }
+template<class T> inline DeviceArray<T>::operator T*() { return ptr(); }
+template<class T> inline DeviceArray<T>::operator const T*() const { return ptr(); }
+template<class T> inline std::size_t DeviceArray<T>::size() const { return sizeBytes() / elem_size; }
 
-template<class T> inline       T* pcl::gpu::DeviceArray<T>::ptr()       { return DeviceMemory::ptr<T>(); }
-template<class T> inline const T* pcl::gpu::DeviceArray<T>::ptr() const { return DeviceMemory::ptr<T>(); }
+template<class T> inline       T* DeviceArray<T>::ptr()       { return DeviceMemory::ptr<T>(); }
+template<class T> inline const T* DeviceArray<T>::ptr() const { return DeviceMemory::ptr<T>(); }
 
-template<class T> template<class A> inline void pcl::gpu::DeviceArray<T>::upload(const std::vector<T, A>& data) { upload(&data[0], data.size()); }
-template<class T> template<class A> inline void pcl::gpu::DeviceArray<T>::download(std::vector<T, A>& data) const { data.resize(size()); if (!data.empty()) download(&data[0]); }
+template<class T> template<class A> inline void DeviceArray<T>::upload(const std::vector<T, A>& data) { upload(&data[0], data.size()); }
+template<class T> template<class A> inline void DeviceArray<T>::download(std::vector<T, A>& data) const { data.resize(size()); if (!data.empty()) download(&data[0]); }
 
 /////////////////////  Inline implementations of DeviceArray2D ////////////////////////////////////////////
 
-template<class T> inline pcl::gpu::DeviceArray2D<T>::DeviceArray2D() {}
-template<class T> inline pcl::gpu::DeviceArray2D<T>::DeviceArray2D(int rows, int cols) : DeviceMemory2D(rows, cols * elem_size) {}
-template<class T> inline pcl::gpu::DeviceArray2D<T>::DeviceArray2D(int rows, int cols, void *data, std::size_t stepBytes) : DeviceMemory2D(rows, cols * elem_size, data, stepBytes) {}
-template<class T> inline pcl::gpu::DeviceArray2D<T>::DeviceArray2D(const DeviceArray2D& other) : DeviceMemory2D(other) {}
-template<class T> inline pcl::gpu::DeviceArray2D<T>& pcl::gpu::DeviceArray2D<T>::operator=(const DeviceArray2D& other)
+template<class T> inline DeviceArray2D<T>::DeviceArray2D() {}
+template<class T> inline DeviceArray2D<T>::DeviceArray2D(int rows, int cols) : DeviceMemory2D(rows, cols * elem_size) {}
+template<class T> inline DeviceArray2D<T>::DeviceArray2D(int rows, int cols, void *data, std::size_t stepBytes) : DeviceMemory2D(rows, cols * elem_size, data, stepBytes) {}
+template<class T> inline DeviceArray2D<T>::DeviceArray2D(const DeviceArray2D& other) : DeviceMemory2D(other) {}
+template<class T> inline DeviceArray2D<T>& DeviceArray2D<T>::operator=(const DeviceArray2D& other)
 { DeviceMemory2D::operator=(other); return *this; }
 
-template<class T> inline void pcl::gpu::DeviceArray2D<T>::create(int rows, int cols) 
+template<class T> inline void DeviceArray2D<T>::create(int rows, int cols)
 { DeviceMemory2D::create(rows, cols * elem_size); }
-template<class T> inline void pcl::gpu::DeviceArray2D<T>::release()  
+template<class T> inline void DeviceArray2D<T>::release()
 { DeviceMemory2D::release(); }
 
-template<class T> inline void pcl::gpu::DeviceArray2D<T>::copyTo(DeviceArray2D& other) const
+template<class T> inline void DeviceArray2D<T>::copyTo(DeviceArray2D& other) const
 { DeviceMemory2D::copyTo(other); }
-template<class T> inline void pcl::gpu::DeviceArray2D<T>::upload(const void *host_ptr, std::size_t host_step, int rows, int cols) 
+template<class T> inline void DeviceArray2D<T>::upload(const void *host_ptr, std::size_t host_step, int rows, int cols)
 { DeviceMemory2D::upload(host_ptr, host_step, rows, cols * elem_size); }
-template<class T> inline void pcl::gpu::DeviceArray2D<T>::download(void *host_ptr, std::size_t host_step) const 
+template<class T> inline void DeviceArray2D<T>::download(void *host_ptr, std::size_t host_step) const
 { DeviceMemory2D::download( host_ptr, host_step ); }
 
-template<class T> template<class A> inline void pcl::gpu::DeviceArray2D<T>::upload(const std::vector<T, A>& data, int cols) 
+template<class T> template<class A> inline void DeviceArray2D<T>::upload(const std::vector<T, A>& data, int cols)
 { upload(&data[0], cols * elem_size, data.size()/cols, cols); }
 
-template<class T> template<class A> inline void pcl::gpu::DeviceArray2D<T>::download(std::vector<T, A>& data, int& elem_step) const 
+template<class T> template<class A> inline void DeviceArray2D<T>::download(std::vector<T, A>& data, int& elem_step) const
 { elem_step = cols(); data.resize(cols() * rows()); if (!data.empty()) download(&data[0], colsBytes());  }
 
-template<class T> void  pcl::gpu::DeviceArray2D<T>::swap(DeviceArray2D& other_arg) { DeviceMemory2D::swap(other_arg); }
+template<class T> void  DeviceArray2D<T>::swap(DeviceArray2D& other_arg) { DeviceMemory2D::swap(other_arg); }
 
-template<class T> inline       T* pcl::gpu::DeviceArray2D<T>::ptr(int y)       { return DeviceMemory2D::ptr<T>(y); }
-template<class T> inline const T* pcl::gpu::DeviceArray2D<T>::ptr(int y) const { return DeviceMemory2D::ptr<T>(y); }
-            
-template<class T> inline pcl::gpu::DeviceArray2D<T>::operator T*() { return ptr(); }
-template<class T> inline pcl::gpu::DeviceArray2D<T>::operator const T*() const { return ptr(); }
+template<class T> inline       T* DeviceArray2D<T>::ptr(int y)       { return DeviceMemory2D::ptr<T>(y); }
+template<class T> inline const T* DeviceArray2D<T>::ptr(int y) const { return DeviceMemory2D::ptr<T>(y); }
 
-template<class T> inline int pcl::gpu::DeviceArray2D<T>::cols() const { return DeviceMemory2D::colsBytes()/elem_size; }
-template<class T> inline int pcl::gpu::DeviceArray2D<T>::rows() const { return DeviceMemory2D::rows(); }
+template<class T> inline DeviceArray2D<T>::operator T*() { return ptr(); }
+template<class T> inline DeviceArray2D<T>::operator const T*() const { return ptr(); }
 
-template<class T> inline std::size_t pcl::gpu::DeviceArray2D<T>::elem_step() const { return DeviceMemory2D::step()/elem_size; }
+template<class T> inline int DeviceArray2D<T>::cols() const { return DeviceMemory2D::colsBytes()/elem_size; }
+template<class T> inline int DeviceArray2D<T>::rows() const { return DeviceMemory2D::rows(); }
 
+template<class T> inline std::size_t DeviceArray2D<T>::elem_step() const { return DeviceMemory2D::step()/elem_size; }
 
-#endif /* PCL_GPU_CONTAINER_DEVICE_ARRAY_IMPL_HPP_ */ 
+} // namespace gpu
+} // namespace pcl
+
+#endif /* PCL_GPU_CONTAINER_DEVICE_ARRAY_IMPL_HPP_ */
+

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_memory.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_memory.hpp
@@ -37,25 +37,49 @@
 #ifndef PCL_GPU_CONTAINER_DEVICE_MEMORY_IMPL_HPP_
 #define PCL_GPU_CONTAINER_DEVICE_MEMORY_IMPL_HPP_
 
-/////////////////////  Inline implementations of DeviceMemory ////////////////////////////////////////////
+namespace pcl
+{
 
-template<class T> inline       T* pcl::gpu::DeviceMemory::ptr()       { return (      T*)data_; }
-template<class T> inline const T* pcl::gpu::DeviceMemory::ptr() const { return (const T*)data_; }
-                        
-template <class U> inline pcl::gpu::DeviceMemory::operator pcl::gpu::PtrSz<U>() const
+namespace gpu
+{
+
+/////////////////////  Inline implementations of DeviceMemory ////////////////////////////////////////////
+template<class T> inline T*
+DeviceMemory::ptr()
+{
+  return (T*)data_;
+}
+
+template<class T> inline const T*
+DeviceMemory::ptr() const
+{
+  return (const T*)data_;
+}
+
+template <class U> inline DeviceMemory::operator
+PtrSz<U>() const
 {
     PtrSz<U> result;
     result.data = (U*)ptr<U>();
     result.size = sizeBytes_/sizeof(U);
-    return result; 
+    return result;
 }
 
 /////////////////////  Inline implementations of DeviceMemory2D ////////////////////////////////////////////
-               
-template<class T>        T* pcl::gpu::DeviceMemory2D::ptr(int y_arg)       { return (      T*)((      char*)data_ + y_arg * step_); }
-template<class T>  const T* pcl::gpu::DeviceMemory2D::ptr(int y_arg) const { return (const T*)((const char*)data_ + y_arg * step_); }
-  
-template <class U> pcl::gpu::DeviceMemory2D::operator pcl::gpu::PtrStep<U>() const
+template<class T> T*
+DeviceMemory2D::ptr(int y_arg)
+{
+  return (T*)((char*)data_ + y_arg * step_);
+}
+
+template<class T> const T*
+DeviceMemory2D::ptr(int y_arg) const
+{
+  return (const T*)((const char*)data_ + y_arg * step_);
+}
+
+template <class U> DeviceMemory2D::operator
+PtrStep<U>() const
 {
     PtrStep<U> result;
     result.data = (U*)ptr<U>();
@@ -63,7 +87,8 @@ template <class U> pcl::gpu::DeviceMemory2D::operator pcl::gpu::PtrStep<U>() con
     return result;
 }
 
-template <class U> pcl::gpu::DeviceMemory2D::operator pcl::gpu::PtrStepSz<U>() const
+template <class U> DeviceMemory2D::operator
+PtrStepSz<U>() const
 {
     PtrStepSz<U> result;
     result.data = (U*)ptr<U>();
@@ -73,5 +98,7 @@ template <class U> pcl::gpu::DeviceMemory2D::operator pcl::gpu::PtrStepSz<U>() c
     return result;
 }
 
-#endif /* PCL_GPU_CONTAINER_DEVICE_MEMORY_IMPL_HPP_ */ 
+} // namespace gpu
+} // namespace pcl
 
+#endif /* PCL_GPU_CONTAINER_DEVICE_MEMORY_IMPL_HPP_ */

--- a/gpu/octree/test/data_source.hpp
+++ b/gpu/octree/test/data_source.hpp
@@ -34,6 +34,7 @@
  *  Author: Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
  */
 
+
 #ifndef _PCL_TEST_GPU_OCTREE_DATAGEN_
 #define _PCL_TEST_GPU_OCTREE_DATAGEN_
 
@@ -48,15 +49,22 @@
     EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(pcl::PointXYZ)
 #endif
 
+
+namespace pcl
+{
+
+namespace gpu
+{
+
 struct DataGenerator
 {
-    using PointType = pcl::gpu::Octree::PointType;
+    using PointType = Octree::PointType;
 
-    std::size_t data_size;            
+    std::size_t data_size;
     std::size_t tests_num;
 
     float cube_size;
-    float max_radius;     
+    float max_radius;
 
     float shared_radius;
 
@@ -74,43 +82,43 @@ struct DataGenerator
     }
 
     void operator()()
-    {             
+    {
         srand (0);
 
         points.resize(data_size);
         for(std::size_t i = 0; i < data_size; ++i)
-        {            
-            points[i].x = ((float)rand())/RAND_MAX * cube_size;  
-            points[i].y = ((float)rand())/RAND_MAX * cube_size;  
+        {
+            points[i].x = ((float)rand())/RAND_MAX * cube_size;
+            points[i].y = ((float)rand())/RAND_MAX * cube_size;
             points[i].z = ((float)rand())/RAND_MAX * cube_size;
         }
-        
+
 
         queries.resize(tests_num);
         radiuses.resize(tests_num);
         for (std::size_t i = 0; i < tests_num; ++i)
-        {            
-            queries[i].x = ((float)rand())/RAND_MAX * cube_size;  
-            queries[i].y = ((float)rand())/RAND_MAX * cube_size;  
-            queries[i].z = ((float)rand())/RAND_MAX * cube_size;  		
-            radiuses[i]  = ((float)rand())/RAND_MAX * max_radius;	
-        };        
+        {
+            queries[i].x = ((float)rand())/RAND_MAX * cube_size;
+            queries[i].y = ((float)rand())/RAND_MAX * cube_size;
+            queries[i].z = ((float)rand())/RAND_MAX * cube_size;
+            radiuses[i]  = ((float)rand())/RAND_MAX * max_radius;
+        };
 
         for(std::size_t i = 0; i < tests_num/2; ++i)
             indices.push_back(i*2);
     }
 
     void bruteForceSearch(bool log = false, float radius = -1.f)
-    {        
+    {
         if (log)
             std::cout << "BruteForceSearch";
 
         int value100 = std::min<int>(tests_num, 50);
-        int step = tests_num/value100;        
+        int step = tests_num/value100;
 
         bfresutls.resize(tests_num);
         for(std::size_t i = 0; i < tests_num; ++i)
-        {            
+        {
             if (log && i % step == 0)
             {
                 std::cout << ".";
@@ -119,7 +127,7 @@ struct DataGenerator
 
             std::vector<int>& curr_res = bfresutls[i];
             curr_res.clear();
-                        
+
             float query_radius = radius > 0 ? radius : radiuses[i];
             const PointType& query = queries[i];
 
@@ -141,8 +149,8 @@ struct DataGenerator
             std::cout << "Done" << std::endl;
     }
 
-    void printParams() const 
-    {        
+    void printParams() const
+    {
         std::cout << "Points number  = " << data_size << std::endl;
         std::cout << "Queries number = " << tests_num << std::endl;
         std::cout << "Cube size      = " << cube_size << std::endl;
@@ -152,8 +160,8 @@ struct DataGenerator
 
     template<typename Dst>
     struct ConvPoint
-    {    
-        Dst operator()(const PointType& src) const 
+    {
+        Dst operator()(const PointType& src) const
         {
             Dst dst;
             dst.x = src.x;
@@ -162,10 +170,10 @@ struct DataGenerator
             return dst;
         }
     };
-
 };
 
+} // namespace gpu
+} // namespace pcl
+
 #endif  /* _PCL_TEST_GPU_OCTREE_DATAGEN_ */
-
-
 

--- a/io/include/pcl/compression/color_coding.h
+++ b/io/include/pcl/compression/color_coding.h
@@ -45,357 +45,353 @@
 
 namespace pcl
 {
-  namespace octree
+
+namespace octree
+{
+
+using namespace std;
+
+/** \brief @b ColorCoding class
+ *  \note This class encodes 8-bit color information for octree-based point cloud compression.
+ *  \note
+ *  \note typename: PointT: type of point used in pointcloud
+ *  \author Julius Kammerl (julius@kammerl.de)
+ */
+template<typename PointT>
+class ColorCoding
+{
+  // public typedefs
+  using PointCloud = pcl::PointCloud<PointT>;
+  using PointCloudPtr = typename PointCloud::Ptr;
+  using PointCloudConstPtr = typename PointCloud::ConstPtr;
+
+public:
+  /** \brief Constructor.
+   *
+   * */
+  ColorCoding () :
+    output_ (), colorBitReduction_ (0)
   {
-    using namespace std;
+  }
 
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    /** \brief @b ColorCoding class
-     *  \note This class encodes 8-bit color information for octree-based point cloud compression.
-     *  \note
-     *  \note typename: PointT: type of point used in pointcloud
-     *  \author Julius Kammerl (julius@kammerl.de)
-     */
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    template<typename PointT>
-      class ColorCoding
+  /** \brief Empty class constructor. */
+  virtual
+  ~ColorCoding ()
+  {
+  }
+
+  /** \brief Define color bit depth of encoded color information.
+    * \param bitDepth_arg: amounts of bits for representing one color component
+    */
+  inline
+  void
+  setBitDepth (unsigned char bitDepth_arg)
+  {
+    colorBitReduction_ = static_cast<unsigned char> (8 - bitDepth_arg);
+  }
+
+  /** \brief Retrieve color bit depth of encoded color information.
+    * \return amounts of bits for representing one color component
+    */
+  inline unsigned char
+  getBitDepth ()
+  {
+    return (static_cast<unsigned char> (8 - colorBitReduction_));
+  }
+
+  /** \brief Set amount of voxels containing point color information and reserve memory
+    * \param voxelCount_arg: amounts of voxels
+    */
+  inline void
+  setVoxelCount (unsigned int voxelCount_arg)
+  {
+    pointAvgColorDataVector_.reserve (voxelCount_arg * 3);
+  }
+
+  /** \brief Set amount of points within point cloud to be encoded and reserve memory
+   *  \param pointCount_arg: amounts of points within point cloud
+   * */
+  inline
+  void
+  setPointCount (unsigned int pointCount_arg)
+  {
+    pointDiffColorDataVector_.reserve (pointCount_arg * 3);
+  }
+
+  /** \brief Initialize encoding of color information
+   * */
+  void
+  initializeEncoding ()
+  {
+    pointAvgColorDataVector_.clear ();
+
+    pointDiffColorDataVector_.clear ();
+  }
+
+  /** \brief Initialize decoding of color information
+   * */
+  void
+  initializeDecoding ()
+  {
+    pointAvgColorDataVector_Iterator_ = pointAvgColorDataVector_.begin ();
+
+    pointDiffColorDataVector_Iterator_ = pointDiffColorDataVector_.begin ();
+  }
+
+  /** \brief Get reference to vector containing averaged color data
+   * */
+  std::vector<char>&
+  getAverageDataVector ()
+  {
+    return pointAvgColorDataVector_;
+  }
+
+  /** \brief Get reference to vector containing differential color data
+   * */
+  std::vector<char>&
+  getDifferentialDataVector ()
+  {
+    return pointDiffColorDataVector_;
+  }
+
+  /** \brief Encode averaged color information for a subset of points from point cloud
+   * \param indexVector_arg indices defining a subset of points from points cloud
+   * \param rgba_offset_arg offset to color information
+   * \param inputCloud_arg input point cloud
+   * */
+  void
+  encodeAverageOfPoints (const typename std::vector<int>& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
+  {
+    unsigned int avgRed = 0;
+    unsigned int avgGreen = 0;
+    unsigned int avgBlue = 0;
+
+    // iterate over points
+    std::size_t len = indexVector_arg.size ();
+    for (std::size_t i = 0; i < len; i++)
+    {
+      // get color information from points
+      const int& idx = indexVector_arg[i];
+      const char* idxPointPtr = reinterpret_cast<const char*> (&inputCloud_arg->points[idx]);
+      const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
+
+      // add color information
+      avgRed += (colorInt >> 0) & 0xFF;
+      avgGreen += (colorInt >> 8) & 0xFF;
+      avgBlue += (colorInt >> 16) & 0xFF;
+
+    }
+
+    // calculated average color information
+    if (len > 1)
+    {
+      avgRed   /= static_cast<unsigned int> (len);
+      avgGreen /= static_cast<unsigned int> (len);
+      avgBlue  /= static_cast<unsigned int> (len);
+    }
+
+    // remove least significant bits
+    avgRed >>= colorBitReduction_;
+    avgGreen >>= colorBitReduction_;
+    avgBlue >>= colorBitReduction_;
+
+    // add to average color vector
+    pointAvgColorDataVector_.push_back (static_cast<char> (avgRed));
+    pointAvgColorDataVector_.push_back (static_cast<char> (avgGreen));
+    pointAvgColorDataVector_.push_back (static_cast<char> (avgBlue));
+  }
+
+  /** \brief Encode color information of a subset of points from point cloud
+   * \param indexVector_arg indices defining a subset of points from points cloud
+   * \param rgba_offset_arg offset to color information
+   * \param inputCloud_arg input point cloud
+   * */
+  void
+  encodePoints (const typename std::vector<int>& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
+  {
+    unsigned int avgRed;
+    unsigned int avgGreen;
+    unsigned int avgBlue;
+
+    // initialize
+    avgRed = avgGreen = avgBlue = 0;
+
+    // iterate over points
+    std::size_t len = indexVector_arg.size ();
+    for (std::size_t i = 0; i < len; i++)
+    {
+      // get color information from point
+      const int& idx = indexVector_arg[i];
+      const char* idxPointPtr = reinterpret_cast<const char*> (&inputCloud_arg->points[idx]);
+      const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
+
+      // add color information
+      avgRed += (colorInt >> 0) & 0xFF;
+      avgGreen += (colorInt >> 8) & 0xFF;
+      avgBlue += (colorInt >> 16) & 0xFF;
+
+    }
+
+    if (len > 1)
+    {
+      unsigned char diffRed;
+      unsigned char diffGreen;
+      unsigned char diffBlue;
+
+      // calculated average color information
+      avgRed   /= static_cast<unsigned int> (len);
+      avgGreen /= static_cast<unsigned int> (len);
+      avgBlue  /= static_cast<unsigned int> (len);
+
+      // iterate over points for differential encoding
+      for (std::size_t i = 0; i < len; i++)
       {
+        const int& idx = indexVector_arg[i];
+        const char* idxPointPtr = reinterpret_cast<const char*> (&inputCloud_arg->points[idx]);
+        const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
 
-      // public typedefs
-        using PointCloud = pcl::PointCloud<PointT>;
-        using PointCloudPtr = typename PointCloud::Ptr;
-        using PointCloudConstPtr = typename PointCloud::ConstPtr;
+        // extract color components and do XOR encoding with predicted average color
+        diffRed = (static_cast<unsigned char> (avgRed)) ^ static_cast<unsigned char> (((colorInt >> 0) & 0xFF));
+        diffGreen = (static_cast<unsigned char> (avgGreen)) ^ static_cast<unsigned char> (((colorInt >> 8) & 0xFF));
+        diffBlue = (static_cast<unsigned char> (avgBlue)) ^ static_cast<unsigned char> (((colorInt >> 16) & 0xFF));
 
-      public:
+        // remove least significant bits
+        diffRed = static_cast<unsigned char> (diffRed >> colorBitReduction_);
+        diffGreen = static_cast<unsigned char> (diffGreen >> colorBitReduction_);
+        diffBlue = static_cast<unsigned char> (diffBlue >> colorBitReduction_);
 
-        /** \brief Constructor.
-         *
-         * */
-        ColorCoding () :
-          output_ (), colorBitReduction_ (0)
-        {
-        }
+        // add to differential color vector
+        pointDiffColorDataVector_.push_back (static_cast<char> (diffRed));
+        pointDiffColorDataVector_.push_back (static_cast<char> (diffGreen));
+        pointDiffColorDataVector_.push_back (static_cast<char> (diffBlue));
+      }
+    }
 
-        /** \brief Empty class constructor. */
-        virtual
-        ~ColorCoding ()
-        {
-        }
+    // remove least significant bits from average color information
+    avgRed   >>= colorBitReduction_;
+    avgGreen >>= colorBitReduction_;
+    avgBlue  >>= colorBitReduction_;
 
-        /** \brief Define color bit depth of encoded color information.
-          * \param bitDepth_arg: amounts of bits for representing one color component
-          */
-        inline
-        void
-        setBitDepth (unsigned char bitDepth_arg)
-        {
-          colorBitReduction_ = static_cast<unsigned char> (8 - bitDepth_arg);
-        }
-
-        /** \brief Retrieve color bit depth of encoded color information.
-          * \return amounts of bits for representing one color component
-          */
-        inline unsigned char
-        getBitDepth ()
-        {
-          return (static_cast<unsigned char> (8 - colorBitReduction_));
-        }
-
-        /** \brief Set amount of voxels containing point color information and reserve memory
-          * \param voxelCount_arg: amounts of voxels
-          */
-        inline void
-        setVoxelCount (unsigned int voxelCount_arg)
-        {
-          pointAvgColorDataVector_.reserve (voxelCount_arg * 3);
-        }
-
-        /** \brief Set amount of points within point cloud to be encoded and reserve memory
-         *  \param pointCount_arg: amounts of points within point cloud
-         * */
-        inline
-        void
-        setPointCount (unsigned int pointCount_arg)
-        {
-          pointDiffColorDataVector_.reserve (pointCount_arg * 3);
-        }
-
-        /** \brief Initialize encoding of color information
-         * */
-        void
-        initializeEncoding ()
-        {
-          pointAvgColorDataVector_.clear ();
-
-          pointDiffColorDataVector_.clear ();
-        }
-
-        /** \brief Initialize decoding of color information
-         * */
-        void
-        initializeDecoding ()
-        {
-          pointAvgColorDataVector_Iterator_ = pointAvgColorDataVector_.begin ();
-
-          pointDiffColorDataVector_Iterator_ = pointDiffColorDataVector_.begin ();
-        }
-
-        /** \brief Get reference to vector containing averaged color data
-         * */
-        std::vector<char>&
-        getAverageDataVector ()
-        {
-          return pointAvgColorDataVector_;
-        }
-
-        /** \brief Get reference to vector containing differential color data
-         * */
-        std::vector<char>&
-        getDifferentialDataVector ()
-        {
-          return pointDiffColorDataVector_;
-        }
-
-        /** \brief Encode averaged color information for a subset of points from point cloud
-         * \param indexVector_arg indices defining a subset of points from points cloud
-         * \param rgba_offset_arg offset to color information
-         * \param inputCloud_arg input point cloud
-         * */
-        void
-        encodeAverageOfPoints (const typename std::vector<int>& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
-        {
-          unsigned int avgRed = 0;
-          unsigned int avgGreen = 0;
-          unsigned int avgBlue = 0;
-
-          // iterate over points
-          std::size_t len = indexVector_arg.size ();
-          for (std::size_t i = 0; i < len; i++)
-          {
-            // get color information from points
-            const int& idx = indexVector_arg[i];
-            const char* idxPointPtr = reinterpret_cast<const char*> (&inputCloud_arg->points[idx]);
-            const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
-
-            // add color information
-            avgRed += (colorInt >> 0) & 0xFF;
-            avgGreen += (colorInt >> 8) & 0xFF;
-            avgBlue += (colorInt >> 16) & 0xFF;
-
-          }
-
-          // calculated average color information
-          if (len > 1)
-          {
-            avgRed   /= static_cast<unsigned int> (len);
-            avgGreen /= static_cast<unsigned int> (len);
-            avgBlue  /= static_cast<unsigned int> (len);
-          }
-
-          // remove least significant bits
-          avgRed >>= colorBitReduction_;
-          avgGreen >>= colorBitReduction_;
-          avgBlue >>= colorBitReduction_;
-
-          // add to average color vector
-          pointAvgColorDataVector_.push_back (static_cast<char> (avgRed));
-          pointAvgColorDataVector_.push_back (static_cast<char> (avgGreen));
-          pointAvgColorDataVector_.push_back (static_cast<char> (avgBlue));
-        }
-
-        /** \brief Encode color information of a subset of points from point cloud
-         * \param indexVector_arg indices defining a subset of points from points cloud
-         * \param rgba_offset_arg offset to color information
-         * \param inputCloud_arg input point cloud
-         * */
-        void
-        encodePoints (const typename std::vector<int>& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
-        {
-          unsigned int avgRed;
-          unsigned int avgGreen;
-          unsigned int avgBlue;
-
-          // initialize
-          avgRed = avgGreen = avgBlue = 0;
-
-          // iterate over points
-          std::size_t len = indexVector_arg.size ();
-          for (std::size_t i = 0; i < len; i++)
-          {
-            // get color information from point
-            const int& idx = indexVector_arg[i];
-            const char* idxPointPtr = reinterpret_cast<const char*> (&inputCloud_arg->points[idx]);
-            const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
-
-            // add color information
-            avgRed += (colorInt >> 0) & 0xFF;
-            avgGreen += (colorInt >> 8) & 0xFF;
-            avgBlue += (colorInt >> 16) & 0xFF;
-
-          }
-
-          if (len > 1)
-          {
-            unsigned char diffRed;
-            unsigned char diffGreen;
-            unsigned char diffBlue;
-
-            // calculated average color information
-            avgRed   /= static_cast<unsigned int> (len);
-            avgGreen /= static_cast<unsigned int> (len);
-            avgBlue  /= static_cast<unsigned int> (len);
-
-            // iterate over points for differential encoding
-            for (std::size_t i = 0; i < len; i++)
-            {
-              const int& idx = indexVector_arg[i];
-              const char* idxPointPtr = reinterpret_cast<const char*> (&inputCloud_arg->points[idx]);
-              const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
-
-              // extract color components and do XOR encoding with predicted average color
-              diffRed = (static_cast<unsigned char> (avgRed)) ^ static_cast<unsigned char> (((colorInt >> 0) & 0xFF));
-              diffGreen = (static_cast<unsigned char> (avgGreen)) ^ static_cast<unsigned char> (((colorInt >> 8) & 0xFF));
-              diffBlue = (static_cast<unsigned char> (avgBlue)) ^ static_cast<unsigned char> (((colorInt >> 16) & 0xFF));
-
-              // remove least significant bits
-              diffRed = static_cast<unsigned char> (diffRed >> colorBitReduction_);
-              diffGreen = static_cast<unsigned char> (diffGreen >> colorBitReduction_);
-              diffBlue = static_cast<unsigned char> (diffBlue >> colorBitReduction_);
-
-              // add to differential color vector
-              pointDiffColorDataVector_.push_back (static_cast<char> (diffRed));
-              pointDiffColorDataVector_.push_back (static_cast<char> (diffGreen));
-              pointDiffColorDataVector_.push_back (static_cast<char> (diffBlue));
-            }
-          }
-
-          // remove least significant bits from average color information
-          avgRed   >>= colorBitReduction_;
-          avgGreen >>= colorBitReduction_;
-          avgBlue  >>= colorBitReduction_;
-
-          // add to differential color vector
-          pointAvgColorDataVector_.push_back (static_cast<char> (avgRed));
-          pointAvgColorDataVector_.push_back (static_cast<char> (avgGreen));
-          pointAvgColorDataVector_.push_back (static_cast<char> (avgBlue));
-
-        }
-
-        /** \brief Decode color information
-          * \param outputCloud_arg output point cloud
-          * \param beginIdx_arg index indicating first point to be assigned with color information
-          * \param endIdx_arg index indicating last point to be assigned with color information
-          * \param rgba_offset_arg offset to color information
-          */
-        void
-        decodePoints (PointCloudPtr outputCloud_arg, std::size_t beginIdx_arg, std::size_t endIdx_arg, unsigned char rgba_offset_arg)
-        {
-          assert (beginIdx_arg <= endIdx_arg);
-
-          // amount of points to be decoded
-          unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
-
-          // get averaged color information for current voxel
-          unsigned char avgRed = *(pointAvgColorDataVector_Iterator_++);
-          unsigned char avgGreen = *(pointAvgColorDataVector_Iterator_++);
-          unsigned char avgBlue = *(pointAvgColorDataVector_Iterator_++);
-
-          // invert bit shifts during encoding
-          avgRed = static_cast<unsigned char> (avgRed << colorBitReduction_);
-          avgGreen = static_cast<unsigned char> (avgGreen << colorBitReduction_);
-          avgBlue = static_cast<unsigned char> (avgBlue << colorBitReduction_);
-
-          // iterate over points
-          for (std::size_t i = 0; i < pointCount; i++)
-          {
-            unsigned int colorInt;
-            if (pointCount > 1)
-            {
-              // get differential color information from input vector
-              unsigned char diffRed   = static_cast<unsigned char> (*(pointDiffColorDataVector_Iterator_++));
-              unsigned char diffGreen = static_cast<unsigned char> (*(pointDiffColorDataVector_Iterator_++));
-              unsigned char diffBlue  = static_cast<unsigned char> (*(pointDiffColorDataVector_Iterator_++));
-
-              // invert bit shifts during encoding
-              diffRed = static_cast<unsigned char> (diffRed << colorBitReduction_);
-              diffGreen = static_cast<unsigned char> (diffGreen << colorBitReduction_);
-              diffBlue = static_cast<unsigned char> (diffBlue << colorBitReduction_);
-
-              // decode color information
-              colorInt = ((avgRed ^ diffRed) << 0) |
-                         ((avgGreen ^ diffGreen) << 8) |
-                         ((avgBlue ^ diffBlue) << 16);
-            }
-            else
-            {
-              // decode color information
-              colorInt = (avgRed << 0) | (avgGreen << 8) | (avgBlue << 16);
-            }
-
-            char* idxPointPtr = reinterpret_cast<char*> (&outputCloud_arg->points[beginIdx_arg + i]);
-            int& pointColor = *reinterpret_cast<int*> (idxPointPtr+rgba_offset_arg);
-            // assign color to point from point cloud
-            pointColor=colorInt;
-          }
-        }
-
-        /** \brief Set default color to points
-         * \param outputCloud_arg output point cloud
-         * \param beginIdx_arg index indicating first point to be assigned with color information
-         * \param endIdx_arg index indicating last point to be assigned with color information
-         * \param rgba_offset_arg offset to color information
-         * */
-        void
-        setDefaultColor (PointCloudPtr outputCloud_arg, std::size_t beginIdx_arg, std::size_t endIdx_arg, unsigned char rgba_offset_arg)
-        {
-          assert (beginIdx_arg <= endIdx_arg);
-
-          // amount of points to be decoded
-          unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
-
-          // iterate over points
-          for (std::size_t i = 0; i < pointCount; i++)
-          {
-            char* idxPointPtr = reinterpret_cast<char*> (&outputCloud_arg->points[beginIdx_arg + i]);
-            int& pointColor = *reinterpret_cast<int*> (idxPointPtr+rgba_offset_arg);
-            // assign color to point from point cloud
-            pointColor = defaultColor_;
-          }
-        }
-
-
-      protected:
-
-        /** \brief Pointer to output point cloud dataset. */
-        PointCloudPtr output_;
-
-        /** \brief Vector for storing average color information  */
-        std::vector<char> pointAvgColorDataVector_;
-
-        /** \brief Iterator on average color information vector */
-        std::vector<char>::const_iterator pointAvgColorDataVector_Iterator_;
-
-        /** \brief Vector for storing differential color information  */
-        std::vector<char> pointDiffColorDataVector_;
-
-        /** \brief Iterator on differential color information vector */
-        std::vector<char>::const_iterator pointDiffColorDataVector_Iterator_;
-
-        /** \brief Amount of bits to be removed from color components before encoding */
-        unsigned char colorBitReduction_;
-
-        // frame header identifier
-        static const int defaultColor_;
-
-      };
-
-    // define default color
-    template<typename PointT>
-    const int ColorCoding<PointT>::defaultColor_ = ((255) << 0) |
-                                                   ((255) << 8) |
-                                                   ((255) << 16);
+    // add to differential color vector
+    pointAvgColorDataVector_.push_back (static_cast<char> (avgRed));
+    pointAvgColorDataVector_.push_back (static_cast<char> (avgGreen));
+    pointAvgColorDataVector_.push_back (static_cast<char> (avgBlue));
 
   }
-}
+
+  /** \brief Decode color information
+    * \param outputCloud_arg output point cloud
+    * \param beginIdx_arg index indicating first point to be assigned with color information
+    * \param endIdx_arg index indicating last point to be assigned with color information
+    * \param rgba_offset_arg offset to color information
+    */
+  void
+  decodePoints (PointCloudPtr outputCloud_arg, std::size_t beginIdx_arg, std::size_t endIdx_arg, unsigned char rgba_offset_arg)
+  {
+    assert (beginIdx_arg <= endIdx_arg);
+
+    // amount of points to be decoded
+    unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
+
+    // get averaged color information for current voxel
+    unsigned char avgRed = *(pointAvgColorDataVector_Iterator_++);
+    unsigned char avgGreen = *(pointAvgColorDataVector_Iterator_++);
+    unsigned char avgBlue = *(pointAvgColorDataVector_Iterator_++);
+
+    // invert bit shifts during encoding
+    avgRed = static_cast<unsigned char> (avgRed << colorBitReduction_);
+    avgGreen = static_cast<unsigned char> (avgGreen << colorBitReduction_);
+    avgBlue = static_cast<unsigned char> (avgBlue << colorBitReduction_);
+
+    // iterate over points
+    for (std::size_t i = 0; i < pointCount; i++)
+    {
+      unsigned int colorInt;
+      if (pointCount > 1)
+      {
+        // get differential color information from input vector
+        unsigned char diffRed   = static_cast<unsigned char> (*(pointDiffColorDataVector_Iterator_++));
+        unsigned char diffGreen = static_cast<unsigned char> (*(pointDiffColorDataVector_Iterator_++));
+        unsigned char diffBlue  = static_cast<unsigned char> (*(pointDiffColorDataVector_Iterator_++));
+
+        // invert bit shifts during encoding
+        diffRed = static_cast<unsigned char> (diffRed << colorBitReduction_);
+        diffGreen = static_cast<unsigned char> (diffGreen << colorBitReduction_);
+        diffBlue = static_cast<unsigned char> (diffBlue << colorBitReduction_);
+
+        // decode color information
+        colorInt = ((avgRed ^ diffRed) << 0) |
+                   ((avgGreen ^ diffGreen) << 8) |
+                   ((avgBlue ^ diffBlue) << 16);
+      }
+      else
+      {
+        // decode color information
+        colorInt = (avgRed << 0) | (avgGreen << 8) | (avgBlue << 16);
+      }
+
+      char* idxPointPtr = reinterpret_cast<char*> (&outputCloud_arg->points[beginIdx_arg + i]);
+      int& pointColor = *reinterpret_cast<int*> (idxPointPtr+rgba_offset_arg);
+      // assign color to point from point cloud
+      pointColor=colorInt;
+    }
+  }
+
+  /** \brief Set default color to points
+   * \param outputCloud_arg output point cloud
+   * \param beginIdx_arg index indicating first point to be assigned with color information
+   * \param endIdx_arg index indicating last point to be assigned with color information
+   * \param rgba_offset_arg offset to color information
+   * */
+  void
+  setDefaultColor (PointCloudPtr outputCloud_arg, std::size_t beginIdx_arg, std::size_t endIdx_arg, unsigned char rgba_offset_arg)
+  {
+    assert (beginIdx_arg <= endIdx_arg);
+
+    // amount of points to be decoded
+    unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
+
+    // iterate over points
+    for (std::size_t i = 0; i < pointCount; i++)
+    {
+      char* idxPointPtr = reinterpret_cast<char*> (&outputCloud_arg->points[beginIdx_arg + i]);
+      int& pointColor = *reinterpret_cast<int*> (idxPointPtr+rgba_offset_arg);
+      // assign color to point from point cloud
+      pointColor = defaultColor_;
+    }
+  }
+
+protected:
+  /** \brief Pointer to output point cloud dataset. */
+  PointCloudPtr output_;
+
+  /** \brief Vector for storing average color information  */
+  std::vector<char> pointAvgColorDataVector_;
+
+  /** \brief Iterator on average color information vector */
+  std::vector<char>::const_iterator pointAvgColorDataVector_Iterator_;
+
+  /** \brief Vector for storing differential color information  */
+  std::vector<char> pointDiffColorDataVector_;
+
+  /** \brief Iterator on differential color information vector */
+  std::vector<char>::const_iterator pointDiffColorDataVector_Iterator_;
+
+  /** \brief Amount of bits to be removed from color components before encoding */
+  unsigned char colorBitReduction_;
+
+  // frame header identifier
+  static const int defaultColor_;
+};
+
+// define default color
+template<typename PointT>
+const int ColorCoding<PointT>::defaultColor_ = ((255) << 0) |
+                                               ((255) << 8) |
+                                               ((255) << 16);
+
+} // namespace octree
+} // namespace pcl
 
 #define PCL_INSTANTIATE_ColorCoding(T) template class PCL_EXPORTS pcl::octree::ColorCoding<T>;
+

--- a/io/include/pcl/compression/organized_pointcloud_conversion.h
+++ b/io/include/pcl/compression/organized_pointcloud_conversion.h
@@ -48,522 +48,510 @@
 
 namespace pcl
 {
-  namespace io
+namespace io
+{
+
+template<typename PointT> struct CompressionPointTraits
+{
+    static const bool hasColor = false;
+    static const unsigned int channels = 1;
+    static const std::size_t bytesPerPoint = 3 * sizeof(float);
+};
+
+template<>
+struct CompressionPointTraits<PointXYZRGB>
+{
+    static const bool hasColor = true;
+    static const unsigned int channels = 4;
+    static const std::size_t bytesPerPoint = 3 * sizeof(float) + 3 * sizeof(std::uint8_t);
+};
+
+template<>
+struct CompressionPointTraits<PointXYZRGBA>
+{
+    static const bool hasColor = true;
+    static const unsigned int channels = 4;
+    static const std::size_t bytesPerPoint = 3 * sizeof(float) + 3 * sizeof(std::uint8_t);
+};
+
+template <typename PointT, bool enableColor = CompressionPointTraits<PointT>::hasColor >
+struct OrganizedConversion;
+
+// Uncolored point cloud specialization
+template<typename PointT>
+struct OrganizedConversion<PointT, false>
+{
+  /** \brief Convert point cloud to disparity image
+    * \param[in] cloud_arg input point cloud
+    * \param[in] focalLength_arg focal length
+    * \param[in] disparityShift_arg disparity shift
+    * \param[in] disparityScale_arg disparity scaling
+    * \param[out] disparityData_arg output disparity image
+    * \ingroup io
+    */
+  static void convert(const pcl::PointCloud<PointT>& cloud_arg,
+                      float focalLength_arg,
+                      float disparityShift_arg,
+                      float disparityScale_arg,
+                      bool ,
+                      typename std::vector<std::uint16_t>& disparityData_arg,
+                      typename std::vector<std::uint8_t>&)
   {
+    std::size_t cloud_size = cloud_arg.points.size ();
 
-    template<typename PointT> struct CompressionPointTraits
+    // Clear image data
+    disparityData_arg.clear ();
+
+    disparityData_arg.reserve (cloud_size);
+
+    for (std::size_t i = 0; i < cloud_size; ++i)
     {
-        static const bool hasColor = false;
-        static const unsigned int channels = 1;
-        static const std::size_t bytesPerPoint = 3 * sizeof(float);
-    };
+      // Get point from cloud
+      const PointT& point = cloud_arg.points[i];
 
-    template<>
-    struct CompressionPointTraits<PointXYZRGB>
-    {
-        static const bool hasColor = true;
-        static const unsigned int channels = 4;
-        static const std::size_t bytesPerPoint = 3 * sizeof(float) + 3 * sizeof(std::uint8_t);
-    };
-
-    template<>
-    struct CompressionPointTraits<PointXYZRGBA>
-    {
-        static const bool hasColor = true;
-        static const unsigned int channels = 4;
-        static const std::size_t bytesPerPoint = 3 * sizeof(float) + 3 * sizeof(std::uint8_t);
-    };
-
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    template <typename PointT, bool enableColor = CompressionPointTraits<PointT>::hasColor >
-    struct OrganizedConversion;
-
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Uncolored point cloud specialization
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    template<typename PointT>
-    struct OrganizedConversion<PointT, false>
-    {
-      /** \brief Convert point cloud to disparity image
-        * \param[in] cloud_arg input point cloud
-        * \param[in] focalLength_arg focal length
-        * \param[in] disparityShift_arg disparity shift
-        * \param[in] disparityScale_arg disparity scaling
-        * \param[out] disparityData_arg output disparity image
-        * \ingroup io
-        */
-      static void convert(const pcl::PointCloud<PointT>& cloud_arg,
-                          float focalLength_arg,
-                          float disparityShift_arg,
-                          float disparityScale_arg,
-                          bool ,
-                          typename std::vector<std::uint16_t>& disparityData_arg,
-                          typename std::vector<std::uint8_t>&)
+      if (pcl::isFinite (point))
       {
-        std::size_t cloud_size = cloud_arg.points.size ();
+        // Inverse depth quantization
+        std::uint16_t disparity = static_cast<std::uint16_t> ( focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
+        disparityData_arg.push_back (disparity);
+      }
+      else
+      {
+        // Non-valid points are encoded with zeros
+        disparityData_arg.push_back (0);
+      }
+    }
+  }
 
-        // Clear image data
-        disparityData_arg.clear ();
+  /** \brief Convert disparity image to point cloud
+    * \param[in] disparityData_arg input depth image
+    * \param[in] width_arg width of disparity image
+    * \param[in] height_arg height of disparity image
+    * \param[in] focalLength_arg focal length
+    * \param[in] disparityShift_arg disparity shift
+    * \param[in] disparityScale_arg disparity scaling
+    * \param[out] cloud_arg output point cloud
+    * \ingroup io
+    */
+  static void convert(typename std::vector<std::uint16_t>& disparityData_arg,
+                      typename std::vector<std::uint8_t>&,
+                      bool,
+                      std::size_t width_arg,
+                      std::size_t height_arg,
+                      float focalLength_arg,
+                      float disparityShift_arg,
+                      float disparityScale_arg,
+                      pcl::PointCloud<PointT>& cloud_arg)
+  {
+    std::size_t cloud_size = width_arg * height_arg;
 
-        disparityData_arg.reserve (cloud_size);
+    assert(disparityData_arg.size()==cloud_size);
 
-        for (std::size_t i = 0; i < cloud_size; ++i)
+    // Reset point cloud
+    cloud_arg.points.clear ();
+    cloud_arg.points.reserve (cloud_size);
+
+    // Define point cloud parameters
+    cloud_arg.width = static_cast<std::uint32_t> (width_arg);
+    cloud_arg.height = static_cast<std::uint32_t> (height_arg);
+    cloud_arg.is_dense = false;
+
+    // Calculate center of disparity image
+    int centerX = static_cast<int> (width_arg / 2);
+    int centerY = static_cast<int> (height_arg / 2);
+
+    const float fl_const = 1.0f / focalLength_arg;
+    static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
+
+    std::size_t i = 0;
+    for (int y = -centerY; y < centerY; ++y )
+      for (int x = -centerX; x < centerX; ++x )
+      {
+        PointT newPoint;
+        const std::uint16_t& pixel_disparity = disparityData_arg[i];
+        ++i;
+
+        if (pixel_disparity)
         {
-          // Get point from cloud
-          const PointT& point = cloud_arg.points[i];
+          // Inverse depth decoding
+          float depth = focalLength_arg / (static_cast<float> (pixel_disparity) * disparityScale_arg + disparityShift_arg);
 
-          if (pcl::isFinite (point))
-          {
-            // Inverse depth quantization
-            std::uint16_t disparity = static_cast<std::uint16_t> ( focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
-            disparityData_arg.push_back (disparity);
-          }
-          else
-          {
-            // Non-valid points are encoded with zeros
-            disparityData_arg.push_back (0);
-          }
+          // Generate new points
+          newPoint.x = static_cast<float> (x) * depth * fl_const;
+          newPoint.y = static_cast<float> (y) * depth * fl_const;
+          newPoint.z = depth;
+
         }
-      }
+        else
+        {
+          // Generate bad point
+          newPoint.x = newPoint.y = newPoint.z = bad_point;
+        }
 
-      /** \brief Convert disparity image to point cloud
-        * \param[in] disparityData_arg input depth image
-        * \param[in] width_arg width of disparity image
-        * \param[in] height_arg height of disparity image
-        * \param[in] focalLength_arg focal length
-        * \param[in] disparityShift_arg disparity shift
-        * \param[in] disparityScale_arg disparity scaling
-        * \param[out] cloud_arg output point cloud
-        * \ingroup io
-        */
-      static void convert(typename std::vector<std::uint16_t>& disparityData_arg,
-                          typename std::vector<std::uint8_t>&,
-                          bool,
-                          std::size_t width_arg,
-                          std::size_t height_arg,
-                          float focalLength_arg,
-                          float disparityShift_arg,
-                          float disparityScale_arg,
-                          pcl::PointCloud<PointT>& cloud_arg)
+        cloud_arg.points.push_back (newPoint);
+      }
+  }
+
+  /** \brief Convert disparity image to point cloud
+    * \param[in] depthData_arg input depth image
+    * \param[in] width_arg width of disparity image
+    * \param[in] height_arg height of disparity image
+    * \param[in] focalLength_arg focal length
+    * \param[out] cloud_arg output point cloud
+    * \ingroup io
+    */
+  static void convert(typename std::vector<float>& depthData_arg,
+                      typename std::vector<std::uint8_t>&,
+                      bool,
+                      std::size_t width_arg,
+                      std::size_t height_arg,
+                      float focalLength_arg,
+                      pcl::PointCloud<PointT>& cloud_arg)
+  {
+    std::size_t cloud_size = width_arg * height_arg;
+
+    assert(depthData_arg.size()==cloud_size);
+
+    // Reset point cloud
+    cloud_arg.points.clear ();
+    cloud_arg.points.reserve (cloud_size);
+
+    // Define point cloud parameters
+    cloud_arg.width = static_cast<std::uint32_t> (width_arg);
+    cloud_arg.height = static_cast<std::uint32_t> (height_arg);
+    cloud_arg.is_dense = false;
+
+    // Calculate center of disparity image
+    int centerX = static_cast<int> (width_arg / 2);
+    int centerY = static_cast<int> (height_arg / 2);
+
+    const float fl_const = 1.0f / focalLength_arg;
+    static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
+
+    std::size_t i = 0;
+    for (int y = -centerY; y < centerY; ++y )
+      for (int x = -centerX; x < centerX; ++x )
       {
-        std::size_t cloud_size = width_arg * height_arg;
+        PointT newPoint;
+        const float& pixel_depth = depthData_arg[i];
+        ++i;
 
-        assert(disparityData_arg.size()==cloud_size);
+        if (pixel_depth)
+        {
+          // Inverse depth decoding
+          float depth = focalLength_arg / pixel_depth;
 
-        // Reset point cloud
-        cloud_arg.points.clear ();
-        cloud_arg.points.reserve (cloud_size);
+          // Generate new points
+          newPoint.x = static_cast<float> (x) * depth * fl_const;
+          newPoint.y = static_cast<float> (y) * depth * fl_const;
+          newPoint.z = depth;
 
-        // Define point cloud parameters
-        cloud_arg.width = static_cast<std::uint32_t> (width_arg);
-        cloud_arg.height = static_cast<std::uint32_t> (height_arg);
-        cloud_arg.is_dense = false;
+        }
+        else
+        {
+          // Generate bad point
+          newPoint.x = newPoint.y = newPoint.z = bad_point;
+        }
 
-        // Calculate center of disparity image
-        int centerX = static_cast<int> (width_arg / 2);
-        int centerY = static_cast<int> (height_arg / 2);
-
-        const float fl_const = 1.0f / focalLength_arg;
-        static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
-
-        std::size_t i = 0;
-        for (int y = -centerY; y < centerY; ++y )
-          for (int x = -centerX; x < centerX; ++x )
-          {
-            PointT newPoint;
-            const std::uint16_t& pixel_disparity = disparityData_arg[i];
-            ++i;
-
-            if (pixel_disparity)
-            {
-              // Inverse depth decoding
-              float depth = focalLength_arg / (static_cast<float> (pixel_disparity) * disparityScale_arg + disparityShift_arg);
-
-              // Generate new points
-              newPoint.x = static_cast<float> (x) * depth * fl_const;
-              newPoint.y = static_cast<float> (y) * depth * fl_const;
-              newPoint.z = depth;
-
-            }
-            else
-            {
-              // Generate bad point
-              newPoint.x = newPoint.y = newPoint.z = bad_point;
-            }
-
-            cloud_arg.points.push_back (newPoint);
-          }
-
+        cloud_arg.points.push_back (newPoint);
       }
+  }
+};
 
+// Colored point cloud specialization
+template <typename PointT>
+struct OrganizedConversion<PointT, true>
+{
+  /** \brief Convert point cloud to disparity image and rgb image
+    * \param[in] cloud_arg input point cloud
+    * \param[in] focalLength_arg focal length
+    * \param[in] disparityShift_arg disparity shift
+    * \param[in] disparityScale_arg disparity scaling
+    * \param[in] convertToMono convert color to mono/grayscale
+    * \param[out] disparityData_arg output disparity image
+    * \param[out] rgbData_arg output rgb image
+    * \ingroup io
+    */
+  static void convert(const pcl::PointCloud<PointT>& cloud_arg,
+                      float focalLength_arg,
+                      float disparityShift_arg,
+                      float disparityScale_arg,
+                      bool convertToMono,
+                      typename std::vector<std::uint16_t>& disparityData_arg,
+                      typename std::vector<std::uint8_t>& rgbData_arg)
+  {
+    std::size_t cloud_size = cloud_arg.points.size ();
 
-      /** \brief Convert disparity image to point cloud
-        * \param[in] depthData_arg input depth image
-        * \param[in] width_arg width of disparity image
-        * \param[in] height_arg height of disparity image
-        * \param[in] focalLength_arg focal length
-        * \param[out] cloud_arg output point cloud
-        * \ingroup io
-        */
-      static void convert(typename std::vector<float>& depthData_arg,
-                          typename std::vector<std::uint8_t>&,
-                          bool,
-                          std::size_t width_arg,
-                          std::size_t height_arg,
-                          float focalLength_arg,
-                          pcl::PointCloud<PointT>& cloud_arg)
-      {
-        std::size_t cloud_size = width_arg * height_arg;
+    // Reset output vectors
+    disparityData_arg.clear ();
+    rgbData_arg.clear ();
 
-        assert(depthData_arg.size()==cloud_size);
-
-        // Reset point cloud
-        cloud_arg.points.clear ();
-        cloud_arg.points.reserve (cloud_size);
-
-        // Define point cloud parameters
-        cloud_arg.width = static_cast<std::uint32_t> (width_arg);
-        cloud_arg.height = static_cast<std::uint32_t> (height_arg);
-        cloud_arg.is_dense = false;
-
-        // Calculate center of disparity image
-        int centerX = static_cast<int> (width_arg / 2);
-        int centerY = static_cast<int> (height_arg / 2);
-
-        const float fl_const = 1.0f / focalLength_arg;
-        static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
-
-        std::size_t i = 0;
-        for (int y = -centerY; y < centerY; ++y )
-          for (int x = -centerX; x < centerX; ++x )
-          {
-            PointT newPoint;
-            const float& pixel_depth = depthData_arg[i];
-            ++i;
-
-            if (pixel_depth)
-            {
-              // Inverse depth decoding
-              float depth = focalLength_arg / pixel_depth;
-
-              // Generate new points
-              newPoint.x = static_cast<float> (x) * depth * fl_const;
-              newPoint.y = static_cast<float> (y) * depth * fl_const;
-              newPoint.z = depth;
-
-            }
-            else
-            {
-              // Generate bad point
-              newPoint.x = newPoint.y = newPoint.z = bad_point;
-            }
-
-            cloud_arg.points.push_back (newPoint);
-          }
-
-      }
-
-    };
-
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Colored point cloud specialization
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    template <typename PointT>
-    struct OrganizedConversion<PointT, true>
+    // Allocate memory
+    disparityData_arg.reserve (cloud_size);
+    if (convertToMono)
     {
-      /** \brief Convert point cloud to disparity image and rgb image
-        * \param[in] cloud_arg input point cloud
-        * \param[in] focalLength_arg focal length
-        * \param[in] disparityShift_arg disparity shift
-        * \param[in] disparityScale_arg disparity scaling
-        * \param[in] convertToMono convert color to mono/grayscale
-        * \param[out] disparityData_arg output disparity image
-        * \param[out] rgbData_arg output rgb image
-        * \ingroup io
-        */
-      static void convert(const pcl::PointCloud<PointT>& cloud_arg,
-                          float focalLength_arg,
-                          float disparityShift_arg,
-                          float disparityScale_arg,
-                          bool convertToMono,
-                          typename std::vector<std::uint16_t>& disparityData_arg,
-                          typename std::vector<std::uint8_t>& rgbData_arg)
+      rgbData_arg.reserve (cloud_size);
+    } else
+    {
+      rgbData_arg.reserve (cloud_size * 3);
+    }
+
+    for (std::size_t i = 0; i < cloud_size; ++i)
+    {
+      const PointT& point = cloud_arg.points[i];
+
+      if (pcl::isFinite (point))
       {
-        std::size_t cloud_size = cloud_arg.points.size ();
-
-        // Reset output vectors
-        disparityData_arg.clear ();
-        rgbData_arg.clear ();
-
-        // Allocate memory
-        disparityData_arg.reserve (cloud_size);
         if (convertToMono)
         {
-          rgbData_arg.reserve (cloud_size);
+          // Encode point color
+          std::uint8_t grayvalue = static_cast<std::uint8_t>(0.2989 * point.r
+                                                    + 0.5870 * point.g
+                                                    + 0.1140 * point.b);
+
+          rgbData_arg.push_back (grayvalue);
         } else
         {
-          rgbData_arg.reserve (cloud_size * 3);
+          // Encode point color
+          rgbData_arg.push_back (point.r);
+          rgbData_arg.push_back (point.g);
+          rgbData_arg.push_back (point.b);
         }
 
+        // Inverse depth quantization
+        std::uint16_t disparity = static_cast<std::uint16_t> (focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
 
-        for (std::size_t i = 0; i < cloud_size; ++i)
-        {
-          const PointT& point = cloud_arg.points[i];
-
-          if (pcl::isFinite (point))
-          {
-            if (convertToMono)
-            {
-              // Encode point color
-              std::uint8_t grayvalue = static_cast<std::uint8_t>(0.2989 * point.r
-                                                        + 0.5870 * point.g
-                                                        + 0.1140 * point.b);
-
-              rgbData_arg.push_back (grayvalue);
-            } else
-            {
-              // Encode point color
-              rgbData_arg.push_back (point.r);
-              rgbData_arg.push_back (point.g);
-              rgbData_arg.push_back (point.b);
-            }
-
-
-            // Inverse depth quantization
-            std::uint16_t disparity = static_cast<std::uint16_t> (focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
-
-            // Encode disparity
-            disparityData_arg.push_back (disparity);
-          }
-          else
-          {
-
-            // Encode black point
-            if (convertToMono)
-            {
-              rgbData_arg.push_back (0);
-            } else
-            {
-              rgbData_arg.push_back (0);
-              rgbData_arg.push_back (0);
-              rgbData_arg.push_back (0);
-            }
-
-            // Encode bad point
-            disparityData_arg.push_back (0);
-          }
-        }
-
+        // Encode disparity
+        disparityData_arg.push_back (disparity);
       }
-
-      /** \brief Convert disparity image to point cloud
-        * \param[in] disparityData_arg output disparity image
-        * \param[in] rgbData_arg output rgb image
-        * \param[in] monoImage_arg input image is a single-channel mono image
-        * \param[in] width_arg width of disparity image
-        * \param[in] height_arg height of disparity image
-        * \param[in] focalLength_arg focal length
-        * \param[in] disparityShift_arg disparity shift
-        * \param[in] disparityScale_arg disparity scaling
-        * \param[out] cloud_arg output point cloud
-        * \ingroup io
-        */
-      static void convert(typename std::vector<std::uint16_t>& disparityData_arg,
-                          typename std::vector<std::uint8_t>& rgbData_arg,
-                          bool monoImage_arg,
-                          std::size_t width_arg,
-                          std::size_t height_arg,
-                          float focalLength_arg,
-                          float disparityShift_arg,
-                          float disparityScale_arg,
-                          pcl::PointCloud<PointT>& cloud_arg)
+      else
       {
-        std::size_t cloud_size = width_arg*height_arg;
-        bool hasColor = (!rgbData_arg.empty ());
-
-        // Check size of input data
-        assert (disparityData_arg.size()==cloud_size);
-        if (hasColor)
+        // Encode black point
+        if (convertToMono)
         {
-          if (monoImage_arg)
-          {
-            assert (rgbData_arg.size()==cloud_size);
-          } else
-          {
-            assert (rgbData_arg.size()==cloud_size*3);
-          }
-        }
-
-        // Reset point cloud
-        cloud_arg.points.clear();
-        cloud_arg.points.reserve(cloud_size);
-
-        // Define point cloud parameters
-        cloud_arg.width = static_cast<std::uint32_t>(width_arg);
-        cloud_arg.height = static_cast<std::uint32_t>(height_arg);
-        cloud_arg.is_dense = false;
-
-        // Calculate center of disparity image
-        int centerX = static_cast<int>(width_arg/2);
-        int centerY = static_cast<int>(height_arg/2);
-
-        const float fl_const = 1.0f/focalLength_arg;
-        static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
-
-        std::size_t i = 0;
-        for (int y = -centerY; y < centerY; ++y )
-          for (int x = -centerX; x < centerX; ++x )
-          {
-            PointT newPoint;
-
-            const std::uint16_t& pixel_disparity = disparityData_arg[i];
-
-            if (pixel_disparity && (pixel_disparity!=0x7FF))
-            {
-              float depth = focalLength_arg / (static_cast<float> (pixel_disparity) * disparityScale_arg + disparityShift_arg);
-
-              // Define point location
-              newPoint.z = depth;
-              newPoint.x = static_cast<float> (x) * depth * fl_const;
-              newPoint.y = static_cast<float> (y) * depth * fl_const;
-
-              if (hasColor)
-              {
-                if (monoImage_arg)
-                {
-                  // Define point color
-                  newPoint.r = rgbData_arg[i];
-                  newPoint.g = rgbData_arg[i];
-                  newPoint.b = rgbData_arg[i];
-                } else
-                {
-                  // Define point color
-                  newPoint.r = rgbData_arg[i*3+0];
-                  newPoint.g = rgbData_arg[i*3+1];
-                  newPoint.b = rgbData_arg[i*3+2];
-                }
-
-              } else
-              {
-                // Set white point color
-                newPoint.rgba = 0xffffffffu;
-              }
-            } else
-            {
-              // Define bad point
-              newPoint.x = newPoint.y = newPoint.z = bad_point;
-              newPoint.rgb = 0.0f;
-            }
-
-            // Add point to cloud
-            cloud_arg.points.push_back(newPoint);
-            // Increment point iterator
-            ++i;
-        }
-      }
-
-      /** \brief Convert disparity image to point cloud
-        * \param[in] depthData_arg output disparity image
-        * \param[in] rgbData_arg output rgb image
-        * \param[in] monoImage_arg input image is a single-channel mono image
-        * \param[in] width_arg width of disparity image
-        * \param[in] height_arg height of disparity image
-        * \param[in] focalLength_arg focal length
-        * \param[out] cloud_arg output point cloud
-        * \ingroup io
-        */
-      static void convert(typename std::vector<float>& depthData_arg,
-                          typename std::vector<std::uint8_t>& rgbData_arg,
-                          bool monoImage_arg,
-                          std::size_t width_arg,
-                          std::size_t height_arg,
-                          float focalLength_arg,
-                          pcl::PointCloud<PointT>& cloud_arg)
-      {
-        std::size_t cloud_size = width_arg*height_arg;
-        bool hasColor = (!rgbData_arg.empty ());
-
-        // Check size of input data
-        assert (depthData_arg.size()==cloud_size);
-        if (hasColor)
+          rgbData_arg.push_back (0);
+        } else
         {
-          if (monoImage_arg)
-          {
-            assert (rgbData_arg.size()==cloud_size);
-          } else
-          {
-            assert (rgbData_arg.size()==cloud_size*3);
-          }
+          rgbData_arg.push_back (0);
+          rgbData_arg.push_back (0);
+          rgbData_arg.push_back (0);
         }
 
-        // Reset point cloud
-        cloud_arg.points.clear();
-        cloud_arg.points.reserve(cloud_size);
-
-        // Define point cloud parameters
-        cloud_arg.width = static_cast<std::uint32_t>(width_arg);
-        cloud_arg.height = static_cast<std::uint32_t>(height_arg);
-        cloud_arg.is_dense = false;
-
-        // Calculate center of disparity image
-        int centerX = static_cast<int>(width_arg/2);
-        int centerY = static_cast<int>(height_arg/2);
-
-        const float fl_const = 1.0f/focalLength_arg;
-        static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
-
-        std::size_t i = 0;
-        for (int y = -centerY; y < centerY; ++y )
-          for (int x = -centerX; x < centerX; ++x )
-          {
-            PointT newPoint;
-
-            const float& pixel_depth = depthData_arg[i];
-
-            if (pixel_depth==pixel_depth)
-            {
-              float depth = focalLength_arg / pixel_depth;
-
-              // Define point location
-              newPoint.z = depth;
-              newPoint.x = static_cast<float> (x) * depth * fl_const;
-              newPoint.y = static_cast<float> (y) * depth * fl_const;
-
-              if (hasColor)
-              {
-                if (monoImage_arg)
-                {
-                  // Define point color
-                  newPoint.r = rgbData_arg[i];
-                  newPoint.g = rgbData_arg[i];
-                  newPoint.b = rgbData_arg[i];
-                } else
-                {
-                  // Define point color
-                  newPoint.r = rgbData_arg[i*3+0];
-                  newPoint.g = rgbData_arg[i*3+1];
-                  newPoint.b = rgbData_arg[i*3+2];
-                }
-
-              } else
-              {
-                // Set white point color
-                newPoint.rgba = 0xffffffffu;
-              }
-            } else
-            {
-              // Define bad point
-              newPoint.x = newPoint.y = newPoint.z = bad_point;
-              newPoint.rgb = 0.0f;
-            }
-
-            // Add point to cloud
-            cloud_arg.points.push_back(newPoint);
-            // Increment point iterator
-            ++i;
-        }
+        // Encode bad point
+        disparityData_arg.push_back (0);
       }
-    };
-
+    }
   }
-}
+
+  /** \brief Convert disparity image to point cloud
+    * \param[in] disparityData_arg output disparity image
+    * \param[in] rgbData_arg output rgb image
+    * \param[in] monoImage_arg input image is a single-channel mono image
+    * \param[in] width_arg width of disparity image
+    * \param[in] height_arg height of disparity image
+    * \param[in] focalLength_arg focal length
+    * \param[in] disparityShift_arg disparity shift
+    * \param[in] disparityScale_arg disparity scaling
+    * \param[out] cloud_arg output point cloud
+    * \ingroup io
+    */
+  static void convert(typename std::vector<std::uint16_t>& disparityData_arg,
+                      typename std::vector<std::uint8_t>& rgbData_arg,
+                      bool monoImage_arg,
+                      std::size_t width_arg,
+                      std::size_t height_arg,
+                      float focalLength_arg,
+                      float disparityShift_arg,
+                      float disparityScale_arg,
+                      pcl::PointCloud<PointT>& cloud_arg)
+  {
+    std::size_t cloud_size = width_arg*height_arg;
+    bool hasColor = (!rgbData_arg.empty ());
+
+    // Check size of input data
+    assert (disparityData_arg.size()==cloud_size);
+    if (hasColor)
+    {
+      if (monoImage_arg)
+      {
+        assert (rgbData_arg.size()==cloud_size);
+      } else
+      {
+        assert (rgbData_arg.size()==cloud_size*3);
+      }
+    }
+
+    // Reset point cloud
+    cloud_arg.points.clear();
+    cloud_arg.points.reserve(cloud_size);
+
+    // Define point cloud parameters
+    cloud_arg.width = static_cast<std::uint32_t>(width_arg);
+    cloud_arg.height = static_cast<std::uint32_t>(height_arg);
+    cloud_arg.is_dense = false;
+
+    // Calculate center of disparity image
+    int centerX = static_cast<int>(width_arg/2);
+    int centerY = static_cast<int>(height_arg/2);
+
+    const float fl_const = 1.0f/focalLength_arg;
+    static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
+
+    std::size_t i = 0;
+    for (int y = -centerY; y < centerY; ++y )
+      for (int x = -centerX; x < centerX; ++x )
+      {
+        PointT newPoint;
+
+        const std::uint16_t& pixel_disparity = disparityData_arg[i];
+
+        if (pixel_disparity && (pixel_disparity!=0x7FF))
+        {
+          float depth = focalLength_arg / (static_cast<float> (pixel_disparity) * disparityScale_arg + disparityShift_arg);
+
+          // Define point location
+          newPoint.z = depth;
+          newPoint.x = static_cast<float> (x) * depth * fl_const;
+          newPoint.y = static_cast<float> (y) * depth * fl_const;
+
+          if (hasColor)
+          {
+            if (monoImage_arg)
+            {
+              // Define point color
+              newPoint.r = rgbData_arg[i];
+              newPoint.g = rgbData_arg[i];
+              newPoint.b = rgbData_arg[i];
+            } else
+            {
+              // Define point color
+              newPoint.r = rgbData_arg[i*3+0];
+              newPoint.g = rgbData_arg[i*3+1];
+              newPoint.b = rgbData_arg[i*3+2];
+            }
+
+          } else
+          {
+            // Set white point color
+            newPoint.rgba = 0xffffffffu;
+          }
+        } else
+        {
+          // Define bad point
+          newPoint.x = newPoint.y = newPoint.z = bad_point;
+          newPoint.rgb = 0.0f;
+        }
+
+        // Add point to cloud
+        cloud_arg.points.push_back(newPoint);
+        // Increment point iterator
+        ++i;
+    }
+  }
+
+  /** \brief Convert disparity image to point cloud
+    * \param[in] depthData_arg output disparity image
+    * \param[in] rgbData_arg output rgb image
+    * \param[in] monoImage_arg input image is a single-channel mono image
+    * \param[in] width_arg width of disparity image
+    * \param[in] height_arg height of disparity image
+    * \param[in] focalLength_arg focal length
+    * \param[out] cloud_arg output point cloud
+    * \ingroup io
+    */
+  static void convert(typename std::vector<float>& depthData_arg,
+                      typename std::vector<std::uint8_t>& rgbData_arg,
+                      bool monoImage_arg,
+                      std::size_t width_arg,
+                      std::size_t height_arg,
+                      float focalLength_arg,
+                      pcl::PointCloud<PointT>& cloud_arg)
+  {
+    std::size_t cloud_size = width_arg*height_arg;
+    bool hasColor = (!rgbData_arg.empty ());
+
+    // Check size of input data
+    assert (depthData_arg.size()==cloud_size);
+    if (hasColor)
+    {
+      if (monoImage_arg)
+      {
+        assert (rgbData_arg.size()==cloud_size);
+      } else
+      {
+        assert (rgbData_arg.size()==cloud_size*3);
+      }
+    }
+
+    // Reset point cloud
+    cloud_arg.points.clear();
+    cloud_arg.points.reserve(cloud_size);
+
+    // Define point cloud parameters
+    cloud_arg.width = static_cast<std::uint32_t>(width_arg);
+    cloud_arg.height = static_cast<std::uint32_t>(height_arg);
+    cloud_arg.is_dense = false;
+
+    // Calculate center of disparity image
+    int centerX = static_cast<int>(width_arg/2);
+    int centerY = static_cast<int>(height_arg/2);
+
+    const float fl_const = 1.0f/focalLength_arg;
+    static const float bad_point = std::numeric_limits<float>::quiet_NaN ();
+
+    std::size_t i = 0;
+    for (int y = -centerY; y < centerY; ++y )
+      for (int x = -centerX; x < centerX; ++x )
+      {
+        PointT newPoint;
+
+        const float& pixel_depth = depthData_arg[i];
+
+        if (pixel_depth==pixel_depth)
+        {
+          float depth = focalLength_arg / pixel_depth;
+
+          // Define point location
+          newPoint.z = depth;
+          newPoint.x = static_cast<float> (x) * depth * fl_const;
+          newPoint.y = static_cast<float> (y) * depth * fl_const;
+
+          if (hasColor)
+          {
+            if (monoImage_arg)
+            {
+              // Define point color
+              newPoint.r = rgbData_arg[i];
+              newPoint.g = rgbData_arg[i];
+              newPoint.b = rgbData_arg[i];
+            } else
+            {
+              // Define point color
+              newPoint.r = rgbData_arg[i*3+0];
+              newPoint.g = rgbData_arg[i*3+1];
+              newPoint.b = rgbData_arg[i*3+2];
+            }
+
+          } else
+          {
+            // Set white point color
+            newPoint.rgba = 0xffffffffu;
+          }
+        } else
+        {
+          // Define bad point
+          newPoint.x = newPoint.y = newPoint.z = bad_point;
+          newPoint.rgb = 0.0f;
+        }
+
+        // Add point to cloud
+        cloud_arg.points.push_back(newPoint);
+        // Increment point iterator
+        ++i;
+    }
+  }
+};
+
+} // namespace io
+} // namespace pcl
+

--- a/io/include/pcl/compression/point_coding.h
+++ b/io/include/pcl/compression/point_coding.h
@@ -45,161 +45,163 @@
 
 namespace pcl
 {
-  namespace octree
-  {
-    /** \brief @b PointCoding class
-      * \note This class encodes 8-bit differential point information for octree-based point cloud compression.
-      * \note typename: PointT: type of point used in pointcloud
-      * \author Julius Kammerl (julius@kammerl.de)
-      */
-    template<typename PointT>
-    class PointCoding
+namespace octree
+{
+/** \brief @b PointCoding class
+  * \note This class encodes 8-bit differential point information for octree-based point cloud compression.
+  * \note typename: PointT: type of point used in pointcloud
+  * \author Julius Kammerl (julius@kammerl.de)
+  */
+template<typename PointT>
+class PointCoding
+{
+    // public typedefs
+    using PointCloud = pcl::PointCloud<PointT>;
+    using PointCloudPtr = typename PointCloud::Ptr;
+    using PointCloudConstPtr = typename PointCloud::ConstPtr;
+
+  public:
+    /** \brief Constructor. */
+    PointCoding () :
+      output_ (),
+      pointCompressionResolution_ (0.001f) // 1mm
     {
-        // public typedefs
-        using PointCloud = pcl::PointCloud<PointT>;
-        using PointCloudPtr = typename PointCloud::Ptr;
-        using PointCloudConstPtr = typename PointCloud::ConstPtr;
+    }
 
-      public:
-        /** \brief Constructor. */
-        PointCoding () :
-          output_ (),
-          pointCompressionResolution_ (0.001f) // 1mm
-        {
-        }
+    /** \brief Empty class constructor. */
+    virtual
+    ~PointCoding ()
+    {
+    }
 
-        /** \brief Empty class constructor. */
-        virtual
-        ~PointCoding ()
-        {
-        }
+    /** \brief Define precision of point information
+      * \param precision_arg: precision
+      */
+    inline void
+    setPrecision (float precision_arg)
+    {
+      pointCompressionResolution_ = precision_arg;
+    }
 
-        /** \brief Define precision of point information
-          * \param precision_arg: precision
-          */
-        inline void
-        setPrecision (float precision_arg)
-        {
-          pointCompressionResolution_ = precision_arg;
-        }
+    /** \brief Retrieve precision of point information
+      * \return precision
+      */
+    inline float
+    getPrecision ()
+    {
+      return (pointCompressionResolution_);
+    }
 
-        /** \brief Retrieve precision of point information
-          * \return precision
-          */
-        inline float
-        getPrecision ()
-        {
-          return (pointCompressionResolution_);
-        }
+    /** \brief Set amount of points within point cloud to be encoded and reserve memory
+      * \param pointCount_arg: amounts of points within point cloud
+      */
+    inline void
+    setPointCount (unsigned int pointCount_arg)
+    {
+      pointDiffDataVector_.reserve (pointCount_arg * 3);
+    }
 
-        /** \brief Set amount of points within point cloud to be encoded and reserve memory
-          * \param pointCount_arg: amounts of points within point cloud
-          */
-        inline void
-        setPointCount (unsigned int pointCount_arg)
-        {
-          pointDiffDataVector_.reserve (pointCount_arg * 3);
-        }
+    /** \brief Initialize encoding of differential point */
+    void
+    initializeEncoding ()
+    {
+      pointDiffDataVector_.clear ();
+    }
 
-        /** \brief Initialize encoding of differential point */
-        void
-        initializeEncoding ()
-        {
-          pointDiffDataVector_.clear ();
-        }
+    /** \brief Initialize decoding of differential point */
+    void
+    initializeDecoding ()
+    {
+      pointDiffDataVectorIterator_ = pointDiffDataVector_.begin ();
+    }
 
-        /** \brief Initialize decoding of differential point */
-        void
-        initializeDecoding ()
-        {
-          pointDiffDataVectorIterator_ = pointDiffDataVector_.begin ();
-        }
+    /** \brief Get reference to vector containing differential color data */
+    std::vector<char>&
+    getDifferentialDataVector ()
+    {
+      return (pointDiffDataVector_);
+    }
 
-        /** \brief Get reference to vector containing differential color data */
-        std::vector<char>&
-        getDifferentialDataVector ()
-        {
-          return (pointDiffDataVector_);
-        }
+    /** \brief Encode differential point information for a subset of points from point cloud
+      * \param indexVector_arg indices defining a subset of points from points cloud
+      * \param referencePoint_arg coordinates of reference point
+      * \param inputCloud_arg input point cloud
+      */
+    void
+    encodePoints (const typename std::vector<int>& indexVector_arg, const double* referencePoint_arg,
+                  PointCloudConstPtr inputCloud_arg)
+    {
+      std::size_t len = indexVector_arg.size ();
 
-        /** \brief Encode differential point information for a subset of points from point cloud
-          * \param indexVector_arg indices defining a subset of points from points cloud
-          * \param referencePoint_arg coordinates of reference point
-          * \param inputCloud_arg input point cloud
-          */
-        void
-        encodePoints (const typename std::vector<int>& indexVector_arg, const double* referencePoint_arg,
-                      PointCloudConstPtr inputCloud_arg)
-        {
-          std::size_t len = indexVector_arg.size ();
+      // iterate over points within current voxel
+      for (std::size_t i = 0; i < len; i++)
+      {
+        unsigned char diffX, diffY, diffZ;
 
-          // iterate over points within current voxel
-          for (std::size_t i = 0; i < len; i++)
-          {
-            unsigned char diffX, diffY, diffZ;
+        // retrieve point from cloud
+        const int& idx = indexVector_arg[i];
+        const PointT& idxPoint = inputCloud_arg->points[idx];
 
-            // retrieve point from cloud
-            const int& idx = indexVector_arg[i];
-            const PointT& idxPoint = inputCloud_arg->points[idx];
+        // differentially encode point coordinates and truncate overflow
+        diffX = static_cast<unsigned char> (max (-127, min<int>(127, static_cast<int> ((idxPoint.x - referencePoint_arg[0])  / pointCompressionResolution_))));
+        diffY = static_cast<unsigned char> (max (-127, min<int>(127, static_cast<int> ((idxPoint.y - referencePoint_arg[1])  / pointCompressionResolution_))));
+        diffZ = static_cast<unsigned char> (max (-127, min<int>(127, static_cast<int> ((idxPoint.z - referencePoint_arg[2])  / pointCompressionResolution_))));
 
-            // differentially encode point coordinates and truncate overflow
-            diffX = static_cast<unsigned char> (max (-127, min<int>(127, static_cast<int> ((idxPoint.x - referencePoint_arg[0])  / pointCompressionResolution_))));
-            diffY = static_cast<unsigned char> (max (-127, min<int>(127, static_cast<int> ((idxPoint.y - referencePoint_arg[1])  / pointCompressionResolution_))));
-            diffZ = static_cast<unsigned char> (max (-127, min<int>(127, static_cast<int> ((idxPoint.z - referencePoint_arg[2])  / pointCompressionResolution_))));
+        // store information in differential point vector
+        pointDiffDataVector_.push_back (diffX);
+        pointDiffDataVector_.push_back (diffY);
+        pointDiffDataVector_.push_back (diffZ);
+      }
+    }
 
-            // store information in differential point vector
-            pointDiffDataVector_.push_back (diffX);
-            pointDiffDataVector_.push_back (diffY);
-            pointDiffDataVector_.push_back (diffZ);
-          }
-        }
+    /** \brief Decode differential point information
+      * \param outputCloud_arg output point cloud
+      * \param referencePoint_arg coordinates of reference point
+      * \param beginIdx_arg index indicating first point to be assigned with color information
+      * \param endIdx_arg index indicating last point to be assigned with color information
+      */
+    void
+    decodePoints (PointCloudPtr outputCloud_arg, const double* referencePoint_arg, std::size_t beginIdx_arg,
+                  std::size_t endIdx_arg)
+    {
+      assert (beginIdx_arg <= endIdx_arg);
 
-        /** \brief Decode differential point information
-          * \param outputCloud_arg output point cloud
-          * \param referencePoint_arg coordinates of reference point
-          * \param beginIdx_arg index indicating first point to be assigned with color information
-          * \param endIdx_arg index indicating last point to be assigned with color information
-          */
-        void
-        decodePoints (PointCloudPtr outputCloud_arg, const double* referencePoint_arg, std::size_t beginIdx_arg,
-                      std::size_t endIdx_arg)
-        {
-          assert (beginIdx_arg <= endIdx_arg);
+      unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
 
-          unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
+      // iterate over points within current voxel
+      for (std::size_t i = 0; i < pointCount; i++)
+      {
+        // retrieve differential point information
+        const unsigned char& diffX = static_cast<unsigned char> (*(pointDiffDataVectorIterator_++));
+        const unsigned char& diffY = static_cast<unsigned char> (*(pointDiffDataVectorIterator_++));
+        const unsigned char& diffZ = static_cast<unsigned char> (*(pointDiffDataVectorIterator_++));
 
-          // iterate over points within current voxel
-          for (std::size_t i = 0; i < pointCount; i++)
-          {
-            // retrieve differential point information
-            const unsigned char& diffX = static_cast<unsigned char> (*(pointDiffDataVectorIterator_++));
-            const unsigned char& diffY = static_cast<unsigned char> (*(pointDiffDataVectorIterator_++));
-            const unsigned char& diffZ = static_cast<unsigned char> (*(pointDiffDataVectorIterator_++));
+        // retrieve point from point cloud
+        PointT& point = outputCloud_arg->points[beginIdx_arg + i];
 
-            // retrieve point from point cloud
-            PointT& point = outputCloud_arg->points[beginIdx_arg + i];
+        // decode point position
+        point.x = static_cast<float> (referencePoint_arg[0] + diffX * pointCompressionResolution_);
+        point.y = static_cast<float> (referencePoint_arg[1] + diffY * pointCompressionResolution_);
+        point.z = static_cast<float> (referencePoint_arg[2] + diffZ * pointCompressionResolution_);
+      }
+    }
 
-            // decode point position
-            point.x = static_cast<float> (referencePoint_arg[0] + diffX * pointCompressionResolution_);
-            point.y = static_cast<float> (referencePoint_arg[1] + diffY * pointCompressionResolution_);
-            point.z = static_cast<float> (referencePoint_arg[2] + diffZ * pointCompressionResolution_);
-          }
-        }
+  protected:
+    /** \brief Pointer to output point cloud dataset. */
+    PointCloudPtr output_;
 
-      protected:
-        /** \brief Pointer to output point cloud dataset. */
-        PointCloudPtr output_;
+    /** \brief Vector for storing differential point information  */
+    std::vector<char> pointDiffDataVector_;
 
-        /** \brief Vector for storing differential point information  */
-        std::vector<char> pointDiffDataVector_;
+    /** \brief Iterator on differential point information vector */
+    std::vector<char>::const_iterator pointDiffDataVectorIterator_;
 
-        /** \brief Iterator on differential point information vector */
-        std::vector<char>::const_iterator pointDiffDataVectorIterator_;
+    /** \brief Precision of point coding*/
+    float pointCompressionResolution_;
+};
 
-        /** \brief Precision of point coding*/
-        float pointCompressionResolution_;
-    };
-  }
-}
+} // namespace octree
+} // namespace pcl
 
 #define PCL_INSTANTIATE_ColorCoding(T) template class PCL_EXPORTS pcl::octree::ColorCoding<T>;
+

--- a/io/include/pcl/io/impl/ascii_io.hpp
+++ b/io/include/pcl/io/impl/ascii_io.hpp
@@ -35,11 +35,16 @@
  *
  */
 
+
 #ifndef PCL_IO_ASCII_IO_HPP_
 #define PCL_IO_ASCII_IO_HPP_
 
+
+namespace pcl
+{
+
 template<typename PointT> void
-pcl::ASCIIReader::setInputFields ()
+ASCIIReader::setInputFields ()
 {
   fields_ = pcl::getFields<PointT> ();
 
@@ -55,5 +60,6 @@ pcl::ASCIIReader::setInputFields ()
   }
 }
 
+} // namespace pcl
 
 #endif    //PCL_IO_ASCII_IO_HPP_

--- a/io/include/pcl/io/impl/buffers.hpp
+++ b/io/include/pcl/io/impl/buffers.hpp
@@ -43,6 +43,7 @@
 
 #include <pcl/pcl_macros.h>
 
+
 template <typename T>
 struct buffer_traits
 {
@@ -64,38 +65,45 @@ struct buffer_traits <double>
   static bool is_invalid (double value) { return std::isnan (value); };
 };
 
+
+namespace pcl
+{
+
+namespace io
+{
+
 template <typename T>
-pcl::io::Buffer<T>::Buffer (std::size_t size)
+Buffer<T>::Buffer (std::size_t size)
 : size_ (size)
 {
 }
 
 template <typename T>
-pcl::io::Buffer<T>::~Buffer ()
+Buffer<T>::~Buffer ()
 {
 }
 
 template <typename T>
-pcl::io::SingleBuffer<T>::SingleBuffer (std::size_t size)
+SingleBuffer<T>::SingleBuffer (std::size_t size)
 : Buffer<T> (size)
 , data_ (size, buffer_traits<T>::invalid ())
 {
 }
 
 template <typename T>
-pcl::io::SingleBuffer<T>::~SingleBuffer ()
+SingleBuffer<T>::~SingleBuffer ()
 {
 }
 
 template <typename T> T
-pcl::io::SingleBuffer<T>::operator[] (std::size_t idx) const
+SingleBuffer<T>::operator[] (std::size_t idx) const
 {
   assert (idx < size_);
   return (data_[idx]);
 }
 
 template <typename T> void
-pcl::io::SingleBuffer<T>::push (std::vector<T>& data)
+SingleBuffer<T>::push (std::vector<T>& data)
 {
   assert (data.size () == size_);
   std::lock_guard<std::mutex> lock (data_mutex_);
@@ -104,8 +112,8 @@ pcl::io::SingleBuffer<T>::push (std::vector<T>& data)
 }
 
 template <typename T>
-pcl::io::MedianBuffer<T>::MedianBuffer (std::size_t size,
-                                        unsigned char window_size)
+MedianBuffer<T>::MedianBuffer (std::size_t size,
+                               unsigned char window_size)
 : Buffer<T> (size)
 , window_size_ (window_size)
 , midpoint_ (window_size_ / 2)
@@ -130,12 +138,12 @@ pcl::io::MedianBuffer<T>::MedianBuffer (std::size_t size,
 }
 
 template <typename T>
-pcl::io::MedianBuffer<T>::~MedianBuffer ()
+MedianBuffer<T>::~MedianBuffer ()
 {
 }
 
 template <typename T> T
-pcl::io::MedianBuffer<T>::operator[] (std::size_t idx) const
+MedianBuffer<T>::operator[] (std::size_t idx) const
 {
   assert (idx < size_);
   int midpoint = (window_size_ - data_invalid_count_[idx]) / 2;
@@ -143,7 +151,7 @@ pcl::io::MedianBuffer<T>::operator[] (std::size_t idx) const
 }
 
 template <typename T> void
-pcl::io::MedianBuffer<T>::push (std::vector<T>& data)
+MedianBuffer<T>::push (std::vector<T>& data)
 {
   assert (data.size () == size_);
   std::lock_guard<std::mutex> lock (data_mutex_);
@@ -206,7 +214,7 @@ pcl::io::MedianBuffer<T>::push (std::vector<T>& data)
 }
 
 template <typename T> int
-pcl::io::MedianBuffer<T>::compare (T a, T b)
+MedianBuffer<T>::compare (T a, T b)
 {
   bool a_is_invalid = buffer_traits<T>::is_invalid (a);
   bool b_is_invalid = buffer_traits<T>::is_invalid (b);
@@ -222,8 +230,8 @@ pcl::io::MedianBuffer<T>::compare (T a, T b)
 }
 
 template <typename T>
-pcl::io::AverageBuffer<T>::AverageBuffer (std::size_t size,
-                                          unsigned char window_size)
+AverageBuffer<T>::AverageBuffer (std::size_t size,
+                                 unsigned char window_size)
 : Buffer<T> (size)
 , window_size_ (window_size)
 , data_current_idx_ (window_size_ - 1)
@@ -240,12 +248,12 @@ pcl::io::AverageBuffer<T>::AverageBuffer (std::size_t size,
 }
 
 template <typename T>
-pcl::io::AverageBuffer<T>::~AverageBuffer ()
+AverageBuffer<T>::~AverageBuffer ()
 {
 }
 
 template <typename T> T
-pcl::io::AverageBuffer<T>::operator[] (std::size_t idx) const
+AverageBuffer<T>::operator[] (std::size_t idx) const
 {
   assert (idx < size_);
   if (data_invalid_count_[idx] == window_size_)
@@ -254,7 +262,7 @@ pcl::io::AverageBuffer<T>::operator[] (std::size_t idx) const
 }
 
 template <typename T> void
-pcl::io::AverageBuffer<T>::push (std::vector<T>& data)
+AverageBuffer<T>::push (std::vector<T>& data)
 {
   assert (data.size () == size_);
   std::lock_guard<std::mutex> lock (data_mutex_);
@@ -287,6 +295,9 @@ pcl::io::AverageBuffer<T>::push (std::vector<T>& data)
   data_[data_current_idx_].swap (data);
   data.clear ();
 }
+
+} // namespace io
+} // namespace pcl
 
 #endif /* PCL_IO_IMPL_BUFFERS_HPP */
 

--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -49,9 +49,15 @@
 
 #define CLIP_CHAR(c) static_cast<unsigned char> ((c)>255?255:(c)<0?0:(c))
 
-//////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace io
+{
+
 template <typename PointT> bool
-pcl::io::LZFDepth16ImageReader::read (
+LZFDepth16ImageReader::read (
     const std::string &filename, pcl::PointCloud<PointT> &cloud)
 {
   std::uint32_t uncompressed_size;
@@ -100,9 +106,9 @@ pcl::io::LZFDepth16ImageReader::read (
       }
 
       pt.z = static_cast<float> (val * z_multiplication_factor_);
-      pt.x = (static_cast<float> (u) - static_cast<float> (parameters_.principal_point_x)) 
+      pt.x = (static_cast<float> (u) - static_cast<float> (parameters_.principal_point_x))
         * pt.z * static_cast<float> (constant_x);
-      pt.y = (static_cast<float> (v) - static_cast<float> (parameters_.principal_point_y)) 
+      pt.y = (static_cast<float> (v) - static_cast<float> (parameters_.principal_point_y))
         * pt.z * static_cast<float> (constant_y);
     }
   }
@@ -113,12 +119,12 @@ pcl::io::LZFDepth16ImageReader::read (
   cloud.sensor_orientation_.z () = 0.0f;
   return (true);
 }
-        
-///////////////////////////////////////////////////////////////////////////////
+
+
 template <typename PointT> bool
-pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename, 
-                                         pcl::PointCloud<PointT> &cloud, 
-                                         unsigned int num_threads)
+LZFDepth16ImageReader::readOMP (const std::string &filename,
+                                pcl::PointCloud<PointT> &cloud,
+                                unsigned int num_threads)
 {
   std::uint32_t uncompressed_size;
   std::vector<char> compressed_data;
@@ -151,8 +157,8 @@ pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename,
   double constant_x = 1.0 / parameters_.focal_length_x,
          constant_y = 1.0 / parameters_.focal_length_y;
 #ifdef _OPENMP
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for                                   \
+  default(none)                                            \
   shared(cloud, constant_x, constant_y, uncompressed_data) \
   num_threads(num_threads)
 #else
@@ -172,10 +178,10 @@ pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename,
       if (cloud.is_dense)
       {
 #pragma omp critical
-      {
-      if (cloud.is_dense)
-        cloud.is_dense = false;
-      }
+        {
+          if (cloud.is_dense)
+            cloud.is_dense = false;
+        }
       }
       continue;
     }
@@ -185,20 +191,19 @@ pcl::io::LZFDepth16ImageReader::readOMP (const std::string &filename,
       * pt.z * static_cast<float> (constant_x);
     pt.y = (static_cast<float> (v) - static_cast<float> (parameters_.principal_point_y)) 
       * pt.z * static_cast<float> (constant_y);
-    
   }
+
   cloud.sensor_origin_.setZero ();
   cloud.sensor_orientation_.w () = 1.0f;
   cloud.sensor_orientation_.x () = 0.0f;
   cloud.sensor_orientation_.y () = 0.0f;
   cloud.sensor_orientation_.z () = 0.0f;
   return (true);
-
 }
 
-//////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::io::LZFRGB24ImageReader::read (
+LZFRGB24ImageReader::read (
     const std::string &filename, pcl::PointCloud<PointT> &cloud)
 {
   std::uint32_t uncompressed_size;
@@ -245,9 +250,9 @@ pcl::io::LZFRGB24ImageReader::read (
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::io::LZFRGB24ImageReader::readOMP (
+LZFRGB24ImageReader::readOMP (
     const std::string &filename, pcl::PointCloud<PointT> &cloud, unsigned int num_threads)
 {
   std::uint32_t uncompressed_size;
@@ -283,8 +288,8 @@ pcl::io::LZFRGB24ImageReader::readOMP (
   unsigned char *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
 
 #ifdef _OPENMP
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for                   \
+  default(none)                            \
   shared(cloud, color_b, color_g, color_r) \
   num_threads(num_threads)
 #else
@@ -301,9 +306,9 @@ pcl::io::LZFRGB24ImageReader::readOMP (
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::io::LZFYUV422ImageReader::read (
+LZFYUV422ImageReader::read (
     const std::string &filename, pcl::PointCloud<PointT> &cloud)
 {
   std::uint32_t uncompressed_size;
@@ -338,7 +343,7 @@ pcl::io::LZFYUV422ImageReader::read (
   unsigned char *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
   unsigned char *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
   unsigned char *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
-  
+
   int y_idx = 0;
   for (int i = 0; i < wh2; ++i, y_idx += 2)
   {
@@ -359,9 +364,9 @@ pcl::io::LZFYUV422ImageReader::read (
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::io::LZFYUV422ImageReader::readOMP (
+LZFYUV422ImageReader::readOMP (
     const std::string &filename, pcl::PointCloud<PointT> &cloud, unsigned int num_threads)
 {
   std::uint32_t uncompressed_size;
@@ -396,10 +401,10 @@ pcl::io::LZFYUV422ImageReader::readOMP (
   unsigned char *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
   unsigned char *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
   unsigned char *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
-  
+
 #ifdef _OPENMP
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for                        \
+  default(none)                                 \
   shared(cloud, color_u, color_v, color_y, wh2) \
   num_threads(num_threads)
 #else
@@ -425,9 +430,9 @@ pcl::io::LZFYUV422ImageReader::readOMP (
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::io::LZFBayer8ImageReader::read (
+LZFBayer8ImageReader::read (
     const std::string &filename, pcl::PointCloud<PointT> &cloud)
 {
   std::uint32_t uncompressed_size;
@@ -455,9 +460,9 @@ pcl::io::LZFBayer8ImageReader::read (
 
   // Convert Bayer8 to RGB24
   std::vector<unsigned char> rgb_buffer (getWidth () * getHeight () * 3);
-  pcl::io::DeBayer i;
-  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (&uncompressed_data[0]), 
-                     static_cast<unsigned char*> (&rgb_buffer[0]), 
+  DeBayer i;
+  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (&uncompressed_data[0]),
+                     static_cast<unsigned char*> (&rgb_buffer[0]),
                      getWidth (), getHeight ());
   // Copy to PointT
   cloud.width  = getWidth ();
@@ -475,9 +480,9 @@ pcl::io::LZFBayer8ImageReader::read (
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::io::LZFBayer8ImageReader::readOMP (
+LZFBayer8ImageReader::readOMP (
     const std::string &filename, pcl::PointCloud<PointT> &cloud, unsigned int num_threads)
 {
   std::uint32_t uncompressed_size;
@@ -505,9 +510,9 @@ pcl::io::LZFBayer8ImageReader::readOMP (
 
   // Convert Bayer8 to RGB24
   std::vector<unsigned char> rgb_buffer (getWidth () * getHeight () * 3);
-  pcl::io::DeBayer i;
-  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (&uncompressed_data[0]), 
-                     static_cast<unsigned char*> (&rgb_buffer[0]), 
+  DeBayer i;
+  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (&uncompressed_data[0]),
+                     static_cast<unsigned char*> (&rgb_buffer[0]),
                      getWidth (), getHeight ());
   // Copy to PointT
   cloud.width  = getWidth ();
@@ -515,7 +520,7 @@ pcl::io::LZFBayer8ImageReader::readOMP (
   cloud.resize (getWidth () * getHeight ());
 #ifdef _OPENMP
 #pragma omp parallel for \
-  default(none) \
+  default(none)          \
   num_threads(num_threads)
 #else
   (void) num_threads; //suppress warning if OMP is not present
@@ -530,6 +535,9 @@ pcl::io::LZFBayer8ImageReader::readOMP (
   }
   return (true);
 }
+
+} // namespace io
+} // namespace pcl
 
 #endif  //#ifndef PCL_LZF_IMAGE_IO_HPP_
 

--- a/keypoints/include/pcl/keypoints/impl/agast_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/agast_2d.hpp
@@ -41,9 +41,12 @@
 
 #include <pcl/common/io.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT, typename IntensityT> bool
-pcl::AgastKeypoint2DBase<PointInT, PointOutT, IntensityT>::initCompute ()
+AgastKeypoint2DBase<PointInT, PointOutT, IntensityT>::initCompute ()
 {
   if (!pcl::Keypoint<PointInT, PointOutT>::initCompute ())
   {
@@ -52,7 +55,7 @@ pcl::AgastKeypoint2DBase<PointInT, PointOutT, IntensityT>::initCompute ()
   }
 
   if (!input_->isOrganized ())
-  {    
+  {
     PCL_ERROR ("[pcl::%s::initCompute] %s doesn't support non organized clouds!\n", name_.c_str ());
     return (false);
   }
@@ -60,9 +63,9 @@ pcl::AgastKeypoint2DBase<PointInT, PointOutT, IntensityT>::initCompute ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> void
-pcl::AgastKeypoint2D<PointInT, PointOutT>::detectKeypoints (PointCloudOut &output)
+AgastKeypoint2D<PointInT, PointOutT>::detectKeypoints (PointCloudOut &output)
 {
   // image size
   const std::size_t width = input_->width;
@@ -97,6 +100,9 @@ pcl::AgastKeypoint2D<PointInT, PointOutT>::detectKeypoints (PointCloudOut &outpu
   output.is_dense = true;
 }
 
+} // namespace pcl
 
 #define AgastKeypoint2D(T,I) template class PCL_EXPORTS pcl::AgastKeypoint2D<T,I>;
-#endif 
+
+#endif
+

--- a/keypoints/include/pcl/keypoints/impl/brisk_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/brisk_2d.hpp
@@ -42,9 +42,12 @@
 
 #include <pcl/common/io.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT, typename IntensityT> bool
-pcl::BriskKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
+BriskKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
 {
   if (!pcl::Keypoint<PointInT, PointOutT>::initCompute ())
   {
@@ -53,7 +56,7 @@ pcl::BriskKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
   }
 
   if (!input_->isOrganized ())
-  {    
+  {
     PCL_ERROR ("[pcl::%s::initCompute] %s doesn't support non organized clouds!\n", name_.c_str ());
     return (false);
   }
@@ -61,9 +64,9 @@ pcl::BriskKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::BriskKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCloudOut &output)
+BriskKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCloudOut &output)
 {
   // image size
   const int width = int (input_->width);
@@ -105,4 +108,7 @@ pcl::BriskKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointClo
   }
 }
 
-#endif 
+} // namespace pcl
+
+#endif
+

--- a/keypoints/include/pcl/keypoints/impl/harris_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_2d.hpp
@@ -37,72 +37,76 @@
  *
  */
 
+
 #ifndef PCL_HARRIS_KEYPOINT_2D_IMPL_H_
 #define PCL_HARRIS_KEYPOINT_2D_IMPL_H_
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setMethod (ResponseMethod method)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setMethod (ResponseMethod method)
 {
   method_ = method;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setThreshold (float threshold)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setThreshold (float threshold)
 {
   threshold_= threshold;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setRefine (bool do_refine)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setRefine (bool do_refine)
 {
   refine_ = do_refine;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setNonMaxSupression (bool nonmax)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setNonMaxSupression (bool nonmax)
 {
   nonmax_ = nonmax;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setWindowWidth (int window_width)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setWindowWidth (int window_width)
 {
   window_width_= window_width;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setWindowHeight (int window_height)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setWindowHeight (int window_height)
 {
   window_height_= window_height;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setSkippedPixels (int skipped_pixels)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setSkippedPixels (int skipped_pixels)
 {
   skipped_pixels_= skipped_pixels;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setMinimalDistance (int min_distance)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::setMinimalDistance (int min_distance)
 {
   min_distance_ = min_distance;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::computeSecondMomentMatrix (std::size_t index, float* coefficients) const
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::computeSecondMomentMatrix (std::size_t index, float* coefficients) const
 {
   static const int width = static_cast<int> (input_->width);
   static const int height = static_cast<int> (input_->height);
-  
+
   int x = static_cast<int> (index % input_->width);
   int y = static_cast<int> (index / input_->width);
   // indices        0   1   2
@@ -122,9 +126,9 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::computeSecondMomentMatri
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> bool
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
 {
   if (!pcl::Keypoint<PointInT, PointOutT>::initCompute ())
   {
@@ -133,17 +137,17 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
   }
 
   if (!input_->isOrganized ())
-  {    
+  {
     PCL_ERROR ("[pcl::%s::initCompute] %s doesn't support non organized clouds!\n", name_.c_str ());
     return (false);
   }
-  
+
   if (indices_->size () != input_->size ())
   {
     PCL_ERROR ("[pcl::%s::initCompute] %s doesn't support setting indices!\n", name_.c_str ());
     return (false);
   }
-  
+
   if ((window_height_%2) == 0)
   {
     PCL_ERROR ("[pcl::%s::initCompute] Window height must be odd!\n", name_.c_str ());
@@ -161,21 +165,21 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
     PCL_ERROR ("[pcl::%s::initCompute] Window size must be >= 3x3!\n", name_.c_str ());
     return (false);
   }
-  
+
   half_window_width_ = window_width_ / 2;
   half_window_height_ = window_height_ / 2;
 
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCloudOut &output)
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCloudOut &output)
 {
   derivatives_cols_.resize (input_->width, input_->height);
   derivatives_rows_.resize (input_->width, input_->height);
   //Compute cloud intensities first derivatives along columns and rows
-  //!!! nsallem 20120220 : we don't test here for density so if one term in nan the result is nan
+  //!!! nsallem 20120220 : we don't test here for density so if one term is nan the result is nan
   int w = static_cast<int> (input_->width) - 1;
   int h = static_cast<int> (input_->height) - 1;
   // j = 0 --> j-1 out of range ; use 0
@@ -212,9 +216,9 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCl
   derivatives_rows_(0,h) = (intensity_ ((*input_) (1,h)) - intensity_ ((*input_) (0,h))) * 0.5;
 
   for(int i = 1; i < w; ++i)
-	{
+  {
     derivatives_cols_(i,h) = (intensity_ ((*input_) (i,h)) - intensity_ ((*input_) (i,h-1))) * 0.5;
-	}
+  }
   derivatives_rows_(w,h) = (intensity_ ((*input_) (w,h)) - intensity_ ((*input_) (w-1,h))) * 0.5;
   derivatives_cols_(w,h) = (intensity_ ((*input_) (w,h)) - intensity_ ((*input_) (w,h-1))) * 0.5;
 
@@ -233,7 +237,7 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCl
       responseTomasi(*response_);
       break;
   }
-  
+
   if (!nonmax_)
   {
     output = *response_;
@@ -241,27 +245,27 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCl
       keypoints_indices_->indices.push_back (i);
   }
   else
-  {    
+  {
     std::sort (indices_->begin (), indices_->end (), [this] (int p1, int p2) { return greaterIntensityAtIndices (p1, p2); });
     const float threshold = threshold_ * response_->points[indices_->front ()].intensity;
     output.clear ();
     output.reserve (response_->size());
-    std::vector<bool> occupency_map (response_->size (), false);    
+    std::vector<bool> occupency_map (response_->size (), false);
     int width (response_->width);
     int height (response_->height);
     const int occupency_map_size (occupency_map.size ());
 
 #if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
-#pragma omp parallel for \
-  default(none) \
-  shared(occupency_map, output) \
-  firstprivate(width, height) \
+#pragma omp parallel for                                       \
+  default(none)                                                \
+  shared(occupency_map, output)                                \
+  firstprivate(width, height)                                  \
   num_threads(threads_)
 #else
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for                                       \
+  default(none)                                                \
   shared(occupency_map, occupency_map_size, output, threshold) \
-  firstprivate(width, height) \
+  firstprivate(width, height)                                  \
   num_threads(threads_)	
 #endif
     for (int i = 0; i < occupency_map_size; ++i)
@@ -270,15 +274,15 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCl
       const PointOutT& point_out = response_->points [idx];
       if (occupency_map[idx] || point_out.intensity < threshold || !isFinite (point_out))
         continue;
-        
+
 #pragma omp critical
       {
         output.push_back (point_out);
         keypoints_indices_->indices.push_back (idx);
       }
-      
-			int u_end = std::min (width, idx % width + min_distance_);
-			int v_end = std::min (height, idx / width + min_distance_);
+
+      int u_end = std::min (width, idx % width + min_distance_);
+      int v_end = std::min (height, idx / width + min_distance_);
       for(int u = std::max (0, idx % width - min_distance_); u < u_end; ++u)
         for(int v = std::max (0, idx / width - min_distance_); v < v_end; ++v)
           occupency_map[v*input_->width+u] = true;
@@ -295,9 +299,9 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCl
   output.is_dense = input_->is_dense;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseHarris (PointCloudOut &output) const
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseHarris (PointCloudOut &output) const
 {
   PCL_ALIGN (16) float covar [3];
   output.clear ();
@@ -305,16 +309,16 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseHarris (PointClo
   const int output_size (output.size ());
 
 #if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
-#pragma omp parallel for \
-  default(none) \
-  shared(output) \
-  private(covar) \
+#pragma omp parallel for      \
+  default(none)               \
+  shared(output)              \
+  private(covar)              \
   num_threads(threads_)
 #else
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for      \
+  default(none)               \
   shared(output, output_size) \
-  private(covar) \
+  private(covar)              \
   num_threads(threads_)
 #endif
   for (int index = 0; index < output_size; ++index)
@@ -341,9 +345,9 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseHarris (PointClo
   output.width = input_->width;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseNoble (PointCloudOut &output) const
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseNoble (PointCloudOut &output) const
 {
   PCL_ALIGN (16) float covar [3];
   output.clear ();
@@ -351,16 +355,16 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseNoble (PointClou
   const int output_size (output.size ());
 
 #if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
-#pragma omp parallel for \
-  default(none) \
-  shared(output) \
-  private(covar) \
+#pragma omp parallel for      \
+  default(none)               \
+  shared(output)              \
+  private(covar)              \
   num_threads(threads_)
 #else
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for      \
+  default(none)               \
   shared(output, output_size) \
-  private(covar) \
+  private(covar)              \
   num_threads(threads_)
 #endif
   for (int index = 0; index < output_size; ++index)
@@ -372,7 +376,7 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseNoble (PointClou
     out_point.z = in_point.z;
     out_point.intensity = 0;
     if (isFinite (in_point))
-    {    
+    {
       computeSecondMomentMatrix (index, covar);
       float trace = covar [0] + covar [2];
       if (trace != 0)
@@ -380,16 +384,16 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseNoble (PointClou
         float det = covar[0] * covar[2] - covar[1] * covar[1];
         out_point.intensity = det / trace;
       }
-    }    
+    }
   }
-  
+
   output.height = input_->height;
   output.width = input_->width;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseLowe (PointCloudOut &output) const
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseLowe (PointCloudOut &output) const
 {
   PCL_ALIGN (16) float covar [3];
   output.clear ();
@@ -397,19 +401,19 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseLowe (PointCloud
   const int output_size (output.size ());
 
 #if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
-#pragma omp parallel for \
-  default(none) \
-  shared(output) \
-  private(covar) \
+#pragma omp parallel for      \
+  default(none)               \
+  shared(output)              \
+  private(covar)              \
   num_threads(threads_)
 #else
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for      \
+  default(none)               \
   shared(output, output_size) \
-  private(covar) \
+  private(covar)              \
   num_threads(threads_)
 #endif
-  for (int index = 0; index < output_size; ++index)      
+  for (int index = 0; index < output_size; ++index)
   {
     PointOutT &out_point = output.points [index];
     const PointInT &in_point = input_->points [index];
@@ -418,7 +422,7 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseLowe (PointCloud
     out_point.z = in_point.z;
     out_point.intensity = 0;
     if (isFinite (in_point))
-    {    
+    {
       computeSecondMomentMatrix (index, covar);
       float trace = covar [0] + covar [2];
       if (trace != 0)
@@ -433,9 +437,9 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseLowe (PointCloud
   output.width = input_->width;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseTomasi (PointCloudOut &output) const
+HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseTomasi (PointCloudOut &output) const
 {
   PCL_ALIGN (16) float covar [3];
   output.clear ();
@@ -443,16 +447,16 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseTomasi (PointClo
   const int output_size (output.size ());
 
 #if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
-#pragma omp parallel for \
-  default(none) \
-  shared(output) \
-  private(covar) \
+#pragma omp parallel for      \
+  default(none)               \
+  shared(output)              \
+  private(covar)              \
   num_threads(threads_)
 #else
-#pragma omp parallel for \
-  default(none) \
+#pragma omp parallel for      \
+  default(none)               \
   shared(output, output_size) \
-  private(covar) \
+  private(covar)              \
   num_threads(threads_)
 #endif
   for (int index = 0; index < output_size; ++index)
@@ -464,16 +468,20 @@ pcl::HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseTomasi (PointClo
     out_point.z = in_point.z;
     out_point.intensity = 0;
     if (isFinite (in_point))
-    {      
+    {
       computeSecondMomentMatrix (index, covar);
       // min egenvalue
       out_point.intensity = ((covar[0] + covar[2] - sqrt((covar[0] - covar[2])*(covar[0] - covar[2]) + 4 * covar[1] * covar[1])) /2.0f);
-    }    
+    }
   }
-  
+
   output.height = input_->height;
   output.width = input_->width;
 }
 
+} // namespace pcl
+
 #define PCL_INSTANTIATE_HarrisKeypoint2D(T,U,I) template class PCL_EXPORTS pcl::HarrisKeypoint2D<T,U,I>;
+
 #endif // #ifndef PCL_HARRIS_KEYPOINT_2D_IMPL_H_
+

--- a/keypoints/include/pcl/keypoints/impl/keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/keypoint.hpp
@@ -35,12 +35,16 @@
  *
  */
 
+
 #ifndef PCL_KEYPOINT_IMPL_H_
 #define PCL_KEYPOINT_IMPL_H_
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT> bool
-pcl::Keypoint<PointInT, PointOutT>::initCompute ()
+Keypoint<PointInT, PointOutT>::initCompute ()
 {
   if (!PCLBase<PointInT>::initCompute ())
     return (false);
@@ -124,9 +128,9 @@ pcl::Keypoint<PointInT, PointOutT>::initCompute ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT> inline void
-pcl::Keypoint<PointInT, PointOutT>::compute (PointCloudOut &output)
+Keypoint<PointInT, PointOutT>::compute (PointCloudOut &output)
 {
   if (!initCompute ())
   {
@@ -143,6 +147,8 @@ pcl::Keypoint<PointInT, PointOutT>::compute (PointCloudOut &output)
   if (input_ == surface_)
     surface_.reset ();
 }
+
+} // namespace pcl
 
 #endif  //#ifndef PCL_KEYPOINT_IMPL_H_
 

--- a/keypoints/include/pcl/keypoints/impl/trajkovic_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_2d.hpp
@@ -35,11 +35,16 @@
  *
  */
 
+
 #ifndef PCL_TRAJKOVIC_KEYPOINT_2D_IMPL_H_
 #define PCL_TRAJKOVIC_KEYPOINT_2D_IMPL_H_
 
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT, typename IntensityT> bool
-pcl::TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
+TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
 {
   if (!PCLBase<PointInT>::initCompute ())
     return (false);
@@ -76,9 +81,9 @@ pcl::TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::initCompute ()
   return (true);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename IntensityT> void
-pcl::TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCloudOut &output)
+TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointCloudOut &output)
 {
   response_.reset (new pcl::PointCloud<float> (input_->width, input_->height));
   const int w = static_cast<int> (input_->width) - half_window_size_;
@@ -272,5 +277,9 @@ pcl::TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (Poin
   output.is_dense = input_->is_dense;
 }
 
+} // namespace pcl
+
 #define PCL_INSTANTIATE_TrajkovicKeypoint2D(T,U,I) template class PCL_EXPORTS pcl::TrajkovicKeypoint2D<T,U,I>;
+
 #endif
+

--- a/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_3d.hpp
@@ -40,8 +40,12 @@
 
 #include <pcl/features/integral_image_normal.h>
 
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT, typename NormalT> bool
-pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::initCompute ()
+TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::initCompute ()
 {
   if (!PCLBase<PointInT>::initCompute ())
     return (false);
@@ -89,9 +93,9 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::initCompute ()
   return (true);
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename PointOutT, typename NormalT> void
-pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut &output)
+TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut &output)
 {
   response_.reset (new pcl::PointCloud<float> (input_->width, input_->height));
   const Normals &normals = *normals_;
@@ -288,5 +292,9 @@ pcl::TrajkovicKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCl
   output.is_dense = true;
 }
 
+} // namespace pcl
+
 #define PCL_INSTANTIATE_TrajkovicKeypoint3D(T,U,N) template class PCL_EXPORTS pcl::TrajkovicKeypoint3D<T,U,N>;
+
 #endif
+

--- a/ml/include/pcl/ml/impl/dt/decision_forest_trainer.hpp
+++ b/ml/include/pcl/ml/impl/dt/decision_forest_trainer.hpp
@@ -37,12 +37,14 @@
 
 #pragma once
 
+namespace pcl {
+
 template <class FeatureType,
           class DataSet,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::DecisionForestTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionForestTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     DecisionForestTrainer()
 : num_of_trees_to_train_(1), decision_tree_trainer_()
 {}
@@ -52,7 +54,7 @@ template <class FeatureType,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::DecisionForestTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionForestTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     ~DecisionForestTrainer()
 {}
 
@@ -62,8 +64,8 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionForestTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
-    train(pcl::DecisionForest<NodeType>& forest)
+DecisionForestTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::train(
+    pcl::DecisionForest<NodeType>& forest)
 {
   for (std::size_t tree_index = 0; tree_index < num_of_trees_to_train_; ++tree_index) {
     pcl::DecisionTree<NodeType> tree;
@@ -72,3 +74,5 @@ pcl::DecisionForestTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeTy
     forest.push_back(tree);
   }
 }
+
+} // namespace pcl

--- a/ml/include/pcl/ml/impl/dt/decision_tree_evaluator.hpp
+++ b/ml/include/pcl/ml/impl/dt/decision_tree_evaluator.hpp
@@ -45,12 +45,14 @@
 
 #include <vector>
 
+namespace pcl {
+
 template <class FeatureType,
           class DataSet,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     DecisionTreeEvaluator()
 {}
 
@@ -59,7 +61,7 @@ template <class FeatureType,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     ~DecisionTreeEvaluator()
 {}
 
@@ -69,7 +71,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     evaluate(pcl::DecisionTree<NodeType>& tree,
              pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
              pcl::StatsEstimator<LabelType, NodeType, DataSet, ExampleIndex>&
@@ -106,7 +108,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     evaluateAndAdd(
         pcl::DecisionTree<NodeType>& tree,
         pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
@@ -143,7 +145,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     evaluate(pcl::DecisionTree<NodeType>& tree,
              pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
              pcl::StatsEstimator<LabelType, NodeType, DataSet, ExampleIndex>&
@@ -152,7 +154,6 @@ pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeTy
              ExampleIndex example,
              NodeType& leave)
 {
-
   NodeType* node = &(tree.getRoot());
 
   while (!node->sub_nodes.empty()) {
@@ -177,7 +178,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     getNodes(pcl::DecisionTree<NodeType>& tree,
              pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
              pcl::StatsEstimator<LabelType, NodeType, DataSet, ExampleIndex>&
@@ -206,3 +207,5 @@ pcl::DecisionTreeEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeTy
     nodes.push_back(node);
   }
 }
+
+} // namespace pcl

--- a/ml/include/pcl/ml/impl/dt/decision_tree_trainer.hpp
+++ b/ml/include/pcl/ml/impl/dt/decision_tree_trainer.hpp
@@ -37,12 +37,14 @@
 
 #pragma once
 
+namespace pcl {
+
 template <class FeatureType,
           class DataSet,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     DecisionTreeTrainer()
 : max_tree_depth_(15)
 , num_of_features_(1000)
@@ -61,7 +63,7 @@ template <class FeatureType,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     ~DecisionTreeTrainer()
 {}
 
@@ -71,8 +73,8 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
-    train(pcl::DecisionTree<NodeType>& tree)
+DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::train(
+    pcl::DecisionTree<NodeType>& tree)
 {
   // create random features
   std::vector<FeatureType> features;
@@ -107,7 +109,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     trainDecisionTreeNode(std::vector<FeatureType>& features,
                           std::vector<ExampleIndex>& examples,
                           std::vector<LabelType>& label_data,
@@ -272,7 +274,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     createThresholdsUniform(const std::size_t num_of_thresholds,
                             std::vector<float>& values,
                             std::vector<float>& thresholds)
@@ -303,3 +305,5 @@ pcl::DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType
         min_value + step * (static_cast<float>(threshold_index + 1));
   }
 }
+
+} // namespace pcl

--- a/ml/include/pcl/ml/impl/ferns/fern_evaluator.hpp
+++ b/ml/include/pcl/ml/impl/ferns/fern_evaluator.hpp
@@ -45,13 +45,14 @@
 
 #include <vector>
 
+namespace pcl {
+
 template <class FeatureType,
           class DataSet,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
-    FernEvaluator()
+FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::FernEvaluator()
 {}
 
 template <class FeatureType,
@@ -59,8 +60,7 @@ template <class FeatureType,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
-    ~FernEvaluator()
+FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::~FernEvaluator()
 {}
 
 template <class FeatureType,
@@ -69,7 +69,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::evaluate(
+FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::evaluate(
     pcl::Fern<FeatureType, NodeType>& fern,
     pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
     pcl::StatsEstimator<LabelType, NodeType, DataSet, ExampleIndex>& stats_estimator,
@@ -123,15 +123,13 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
-    evaluateAndAdd(
-        pcl::Fern<FeatureType, NodeType>& fern,
-        pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
-        pcl::StatsEstimator<LabelType, NodeType, DataSet, ExampleIndex>&
-            stats_estimator,
-        DataSet& data_set,
-        std::vector<ExampleIndex>& examples,
-        std::vector<LabelType>& label_data)
+FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::evaluateAndAdd(
+    pcl::Fern<FeatureType, NodeType>& fern,
+    pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
+    pcl::StatsEstimator<LabelType, NodeType, DataSet, ExampleIndex>& stats_estimator,
+    DataSet& data_set,
+    std::vector<ExampleIndex>& examples,
+    std::vector<LabelType>& label_data)
 {
   const std::size_t num_of_examples = examples.size();
   const std::size_t num_of_branches = stats_estimator.getNumOfBranches();
@@ -177,7 +175,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::getNodes(
+FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::getNodes(
     pcl::Fern<FeatureType, NodeType>& fern,
     pcl::FeatureHandler<FeatureType, DataSet, ExampleIndex>& feature_handler,
     pcl::StatsEstimator<LabelType, NodeType, DataSet, ExampleIndex>& stats_estimator,
@@ -224,3 +222,5 @@ pcl::FernEvaluator<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::get
     nodes.push_back(&(fern[node_index]));
   }
 }
+
+} // namespace pcl

--- a/ml/include/pcl/ml/impl/ferns/fern_trainer.hpp
+++ b/ml/include/pcl/ml/impl/ferns/fern_trainer.hpp
@@ -37,12 +37,14 @@
 
 #pragma once
 
+namespace pcl {
+
 template <class FeatureType,
           class DataSet,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::FernTrainer()
+FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::FernTrainer()
 : fern_depth_(10)
 , num_of_features_(1000)
 , num_of_thresholds_(10)
@@ -58,8 +60,7 @@ template <class FeatureType,
           class LabelType,
           class ExampleIndex,
           class NodeType>
-pcl::FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
-    ~FernTrainer()
+FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::~FernTrainer()
 {}
 
 template <class FeatureType,
@@ -68,7 +69,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::train(
+FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::train(
     pcl::Fern<FeatureType, NodeType>& fern)
 {
   const std::size_t num_of_branches = stats_estimator_->getNumOfBranches();
@@ -295,7 +296,7 @@ template <class FeatureType,
           class ExampleIndex,
           class NodeType>
 void
-pcl::FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
+FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     createThresholdsUniform(const std::size_t num_of_thresholds,
                             std::vector<float>& values,
                             std::vector<float>& thresholds)
@@ -325,3 +326,5 @@ pcl::FernTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
     thresholds[threshold_index] = min_value + step * (threshold_index + 1);
   }
 }
+
+} // namespace pcl

--- a/ml/include/pcl/ml/impl/kmeans.hpp
+++ b/ml/include/pcl/ml/impl/kmeans.hpp
@@ -47,17 +47,18 @@
 //#include <stdlib.h>
 //#include <time.h>
 
+namespace pcl {
 template <typename PointT>
-pcl::Kmeans<PointT>::Kmeans() : cluster_field_name_("")
+Kmeans<PointT>::Kmeans() : cluster_field_name_("")
 {}
 
 template <typename PointT>
-pcl::Kmeans<PointT>::~Kmeans()
+Kmeans<PointT>::~Kmeans()
 {}
 
 template <typename PointT>
 void
-pcl::Kmeans<PointT>::cluster(std::vector<PointIndices>& clusters)
+Kmeans<PointT>::cluster(std::vector<PointIndices>& clusters)
 {
   if (!initCompute() || (input_ != 0 && input_->points.empty()) ||
       (indices_ != 0 && indices_->empty())) {
@@ -157,5 +158,6 @@ pcl::Kmeans<PointT>::cluster(std::vector<PointIndices>& clusters)
 
   deinitCompute();
 }
+} // namespace pcl
 
 #define PCL_INSTANTIATE_Kmeans(T) template class PCL_EXPORTS pcl::Kmeans<T>;

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -41,11 +41,14 @@
 
 #include <cassert>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+namespace pcl {
+
+namespace octree {
+
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    voxelSearch(const PointT& point, std::vector<int>& point_idx_data)
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
+    const PointT& point, std::vector<int>& point_idx_data)
 {
   assert(isFinite(point) &&
          "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -65,24 +68,22 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return (b_success);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    voxelSearch(const int index, std::vector<int>& point_idx_data)
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
+    const int index, std::vector<int>& point_idx_data)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (this->voxelSearch(search_point, point_idx_data));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    nearestKSearch(const PointT& p_q,
-                   int k,
-                   std::vector<int>& k_indices,
-                   std::vector<float>& k_sqr_distances)
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
+    const PointT& p_q,
+    int k,
+    std::vector<int>& k_indices,
+    std::vector<float>& k_sqr_distances)
 {
   assert(this->leaf_count_ > 0);
   assert(isFinite(p_q) &&
@@ -119,24 +120,19 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return static_cast<int>(k_indices.size());
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    nearestKSearch(int index,
-                   int k,
-                   std::vector<int>& k_indices,
-                   std::vector<float>& k_sqr_distances)
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
+    int index, int k, std::vector<int>& k_indices, std::vector<float>& k_sqr_distances)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (nearestKSearch(search_point, k, k_indices, k_sqr_distances));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    approxNearestSearch(const PointT& p_q, int& result_index, float& sqr_distance)
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestSearch(
+    const PointT& p_q, int& result_index, float& sqr_distance)
 {
   assert(this->leaf_count_ > 0);
   assert(isFinite(p_q) &&
@@ -151,26 +147,24 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    approxNearestSearch(int query_index, int& result_index, float& sqr_distance)
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestSearch(
+    int query_index, int& result_index, float& sqr_distance)
 {
   const PointT search_point = this->getPointByIndex(query_index);
 
   return (approxNearestSearch(search_point, result_index, sqr_distance));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    radiusSearch(const PointT& p_q,
-                 const double radius,
-                 std::vector<int>& k_indices,
-                 std::vector<float>& k_sqr_distances,
-                 unsigned int max_nn) const
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
+    const PointT& p_q,
+    const double radius,
+    std::vector<int>& k_indices,
+    std::vector<float>& k_sqr_distances,
+    unsigned int max_nn) const
 {
   assert(isFinite(p_q) &&
          "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -192,28 +186,26 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return (static_cast<int>(k_indices.size()));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    radiusSearch(int index,
-                 const double radius,
-                 std::vector<int>& k_indices,
-                 std::vector<float>& k_sqr_distances,
-                 unsigned int max_nn) const
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
+    int index,
+    const double radius,
+    std::vector<int>& k_indices,
+    std::vector<float>& k_sqr_distances,
+    unsigned int max_nn) const
 {
   const PointT search_point = this->getPointByIndex(index);
 
   return (radiusSearch(search_point, radius, k_indices, k_sqr_distances, max_nn));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    boxSearch(const Eigen::Vector3f& min_pt,
-              const Eigen::Vector3f& max_pt,
-              std::vector<int>& k_indices) const
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearch(
+    const Eigen::Vector3f& min_pt,
+    const Eigen::Vector3f& max_pt,
+    std::vector<int>& k_indices) const
 {
 
   OctreeKey key;
@@ -226,10 +218,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return (static_cast<int>(k_indices.size()));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 double
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getKNearestNeighborRecursive(
         const PointT& point,
         unsigned int K,
@@ -339,10 +330,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return (smallest_squared_dist);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getNeighborsWithinRadiusRecursive(const PointT& point,
                                       const double radiusSquared,
                                       const BranchNode* node,
@@ -427,10 +417,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     approxNearestSearchRecursive(const PointT& point,
                                  const BranchNode* node,
                                  const OctreeKey& key,
@@ -517,25 +506,23 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 float
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    pointSquaredDist(const PointT& point_a, const PointT& point_b) const
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::pointSquaredDist(
+    const PointT& point_a, const PointT& point_b) const
 {
   return (point_a.getVector3fMap() - point_b.getVector3fMap()).squaredNorm();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
-    boxSearchRecursive(const Eigen::Vector3f& min_pt,
-                       const Eigen::Vector3f& max_pt,
-                       const BranchNode* node,
-                       const OctreeKey& key,
-                       unsigned int tree_depth,
-                       std::vector<int>& k_indices) const
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecursive(
+    const Eigen::Vector3f& min_pt,
+    const Eigen::Vector3f& max_pt,
+    const BranchNode* node,
+    const OctreeKey& key,
+    unsigned int tree_depth,
+    std::vector<int>& k_indices) const
 {
   // iterate over all children
   for (unsigned char child_idx = 0; child_idx < 8; child_idx++) {
@@ -602,10 +589,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelCenters(Eigen::Vector3f origin,
                                Eigen::Vector3f direction,
                                AlignedPointTVector& voxel_center_list,
@@ -639,10 +625,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return (0);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelIndices(Eigen::Vector3f origin,
                                Eigen::Vector3f direction,
                                std::vector<int>& k_indices,
@@ -674,10 +659,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return (0);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelCentersRecursive(double min_x,
                                         double min_y,
                                         double min_z,
@@ -871,10 +855,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   return (voxel_count);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
-pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
+OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelIndicesRecursive(double min_x,
                                         double min_y,
                                         double min_z,
@@ -1064,6 +1047,9 @@ pcl::octree::OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
 
   return (voxel_count);
 }
+
+} // namespace octree
+} // namespace pcl
 
 #define PCL_INSTANTIATE_OctreePointCloudSearch(T)                                      \
   template class PCL_EXPORTS pcl::octree::OctreePointCloudSearch<T>;

--- a/recognition/include/pcl/recognition/impl/cg/correspondence_grouping.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/correspondence_grouping.hpp
@@ -3,7 +3,7 @@
  *
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2010-2012, Willow Garage, Inc.
- *  
+ *
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -37,11 +37,16 @@
  *
  */
 
+
 #ifndef PCL_RECOGNITION_CORRESPONDENCE_GROUPING_IMPL_H_
 #define PCL_RECOGNITION_CORRESPONDENCE_GROUPING_IMPL_H_
 
+
+namespace pcl
+{
+
 template <typename PointModelT, typename PointSceneT> void
-pcl::CorrespondenceGrouping<PointModelT, PointSceneT>::cluster (std::vector<Correspondences> &clustered_corrs)
+CorrespondenceGrouping<PointModelT, PointSceneT>::cluster (std::vector<Correspondences> &clustered_corrs)
 {
   clustered_corrs.clear ();
   corr_group_scale_.clear ();
@@ -57,4 +62,7 @@ pcl::CorrespondenceGrouping<PointModelT, PointSceneT>::cluster (std::vector<Corr
   deinitCompute ();
 }
 
+} // namespace pcl
+
 #endif // PCL_RECOGNITION_CORRESPONDENCE_GROUPING_IMPL_H_
+

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -4,7 +4,7 @@
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2010-2012, Willow Garage, Inc.
  *
- *  All rights reserved. 
+ *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -44,17 +44,20 @@
 #include <pcl/point_cloud.h>
 #include <limits>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointXYZT, typename PointRGBT> bool
-pcl::LineRGBD<PointXYZT, PointRGBT>::readLTMHeader (int fd, pcl::io::TARHeader &header)
+LineRGBD<PointXYZT, PointRGBT>::readLTMHeader (int fd, pcl::io::TARHeader &header)
 {
   // Read in the header
   int result = static_cast<int> (::read (fd, reinterpret_cast<char*> (&header.file_name[0]), 512));
   if (result == -1)
     return (false);
 
-  // We only support regular files for now. 
-  // Additional file types in TAR include: hard links, symbolic links, device/special files, block devices, 
+  // We only support regular files for now.
+  // Additional file types in TAR include: hard links, symbolic links, device/special files, block devices,
   // directories, and named pipes.
   if (header.file_type[0] != '0' && header.file_type[0] != '\0')
     return (false);
@@ -69,15 +72,15 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::readLTMHeader (int fd, pcl::io::TARHeader &
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointXYZT, typename PointRGBT> bool
-pcl::LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name, const std::size_t object_id)
+LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name, const std::size_t object_id)
 {
   // Open the file
   int ltm_fd = io::raw_open(file_name.c_str (), O_RDONLY);
   if (ltm_fd == -1)
     return (false);
-  
+
   int ltm_offset = 0;
 
   pcl::io::TARHeader ltm_header;
@@ -215,9 +218,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointXYZT, typename PointRGBT> int
-pcl::LineRGBD<PointXYZT, PointRGBT>::createAndAddTemplate (
+LineRGBD<PointXYZT, PointRGBT>::createAndAddTemplate (
   pcl::PointCloud<pcl::PointXYZRGBA> & cloud,
   const std::size_t object_id,
   const MaskMap & mask_xyz,
@@ -311,9 +314,8 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::createAndAddTemplate (
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointXYZT, typename PointRGBT> bool
-pcl::LineRGBD<PointXYZT, PointRGBT>::addTemplate (const SparseQuantizedMultiModTemplate & sqmmt, pcl::PointCloud<pcl::PointXYZRGBA> & cloud, std::size_t object_id)
+LineRGBD<PointXYZT, PointRGBT>::addTemplate (const SparseQuantizedMultiModTemplate & sqmmt, pcl::PointCloud<pcl::PointXYZRGBA> & cloud, std::size_t object_id)
 {
   // add point cloud
   template_point_clouds_.resize (template_point_clouds_.size () + 1);
@@ -394,9 +396,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::addTemplate (const SparseQuantizedMultiModT
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointXYZT, typename PointRGBT> void 
-pcl::LineRGBD<PointXYZT, PointRGBT>::detect (
+
+template <typename PointXYZT, typename PointRGBT> void
+LineRGBD<PointXYZT, PointRGBT>::detect (
     std::vector<typename pcl::LineRGBD<PointXYZT, PointRGBT>::Detection> & detections)
 {
   std::vector<pcl::QuantizableModality*> modalities;
@@ -421,11 +423,11 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::detect (
     detection.response = linemod_detection.score;
 
     // compute bounding box:
-    // we assume that the bounding boxes of the templates are relative to the center of mass 
+    // we assume that the bounding boxes of the templates are relative to the center of mass
     // of the template points; so we also compute the center of mass of the points
-    // covered by the 
+    // covered by the
 
-    const pcl::SparseQuantizedMultiModTemplate & linemod_template = 
+    const pcl::SparseQuantizedMultiModTemplate & linemod_template =
       linemod_.getTemplate (linemod_detection.template_id);
 
     const std::size_t start_x = std::max (linemod_detection.x, 0);
@@ -492,9 +494,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::detect (
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointXYZT, typename PointRGBT> void 
-pcl::LineRGBD<PointXYZT, PointRGBT>::detectSemiScaleInvariant (
+
+template <typename PointXYZT, typename PointRGBT> void
+LineRGBD<PointXYZT, PointRGBT>::detectSemiScaleInvariant (
     std::vector<typename pcl::LineRGBD<PointXYZT, PointRGBT>::Detection> & detections,
     const float min_scale,
     const float max_scale,
@@ -522,11 +524,11 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::detectSemiScaleInvariant (
     detection.response = linemod_detection.score;
 
     // compute bounding box:
-    // we assume that the bounding boxes of the templates are relative to the center of mass 
+    // we assume that the bounding boxes of the templates are relative to the center of mass
     // of the template points; so we also compute the center of mass of the points
-    // covered by the 
+    // covered by the
 
-    const pcl::SparseQuantizedMultiModTemplate & linemod_template = 
+    const pcl::SparseQuantizedMultiModTemplate & linemod_template =
       linemod_.getTemplate (linemod_detection.template_id);
 
     const std::size_t start_x = std::max (linemod_detection.x, 0);
@@ -593,9 +595,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::detectSemiScaleInvariant (
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointXYZT, typename PointRGBT> void 
-pcl::LineRGBD<PointXYZT, PointRGBT>::computeTransformedTemplatePoints (
+
+template <typename PointXYZT, typename PointRGBT> void
+LineRGBD<PointXYZT, PointRGBT>::computeTransformedTemplatePoints (
     const std::size_t detection_id, pcl::PointCloud<pcl::PointXYZRGBA> &cloud)
 {
   if (detection_id >= detections_.size ())
@@ -607,11 +609,11 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::computeTransformedTemplatePoints (
   const pcl::BoundingBoxXYZ & template_bounding_box = bounding_boxes_[template_id];
   const pcl::BoundingBoxXYZ & detection_bounding_box = detections_[detection_id].bounding_box;
 
-  //std::cerr << "detection: " 
+  //std::cerr << "detection: "
   //  << detection_bounding_box.x << ", "
   //  << detection_bounding_box.y << ", "
   //  << detection_bounding_box.z << std::endl;
-  //std::cerr << "template: " 
+  //std::cerr << "template: "
   //  << template_bounding_box.x << ", "
   //  << template_bounding_box.y << ", "
   //  << template_bounding_box.z << std::endl;
@@ -619,7 +621,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::computeTransformedTemplatePoints (
   const float translation_y = detection_bounding_box.y - template_bounding_box.y;
   const float translation_z = detection_bounding_box.z - template_bounding_box.z;
 
-  //std::cerr << "translation: " 
+  //std::cerr << "translation: "
   //  << translation_x << ", "
   //  << translation_y << ", "
   //  << translation_z << std::endl;
@@ -640,9 +642,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::computeTransformedTemplatePoints (
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointXYZT, typename PointRGBT> void 
-pcl::LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
+
+template <typename PointXYZT, typename PointRGBT> void
+LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
 {
   const std::size_t nr_detections = detections_.size ();
   for (std::size_t detection_index = 0; detection_index < nr_detections; ++detection_index)
@@ -692,7 +694,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
     }
 
     std::vector<std::size_t> integral_depth_bins (nr_bins, 0);
-    
+
     integral_depth_bins[0] = depth_bins[0];
     for (std::size_t bin_index = 1; bin_index < nr_bins; ++bin_index)
     {
@@ -720,9 +722,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointXYZT, typename PointRGBT> void 
-pcl::LineRGBD<PointXYZT, PointRGBT>::applyProjectiveDepthICPOnDetections ()
+
+template <typename PointXYZT, typename PointRGBT> void
+LineRGBD<PointXYZT, PointRGBT>::applyProjectiveDepthICPOnDetections ()
 {
   const std::size_t nr_detections = detections_.size ();
   for (std::size_t detection_index = 0; detection_index < nr_detections; ++detection_index)
@@ -736,7 +738,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::applyProjectiveDepthICPOnDetections ()
     const std::size_t start_y = detection.region.y;
     const std::size_t pc_width = point_cloud.width;
     const std::size_t pc_height = point_cloud.height;
-    
+
     std::vector<std::pair<float, float> > depth_matches;
     for (std::size_t row_index = 0; row_index < pc_height; ++row_index)
     {
@@ -801,9 +803,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::applyProjectiveDepthICPOnDetections ()
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointXYZT, typename PointRGBT> void 
-pcl::LineRGBD<PointXYZT, PointRGBT>::removeOverlappingDetections ()
+
+template <typename PointXYZT, typename PointRGBT> void
+LineRGBD<PointXYZT, PointRGBT>::removeOverlappingDetections ()
 {
   // compute overlap between each detection
   const std::size_t nr_detections = detections_.size ();
@@ -820,7 +822,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::removeOverlappingDetections ()
         overlaps (detection_index_1, detection_index_2) = 0.0f;
       else
         overlaps (detection_index_1, detection_index_2) = computeBoundingBoxIntersectionVolume (
-          detections_[detection_index_1].bounding_box, 
+          detections_[detection_index_1].bounding_box,
           detections_[detection_index_2].bounding_box) / bounding_box_volume;
     }
   }
@@ -867,7 +869,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::removeOverlappingDetections ()
   for (std::size_t cluster_id = 0; cluster_id < nr_clusters; ++cluster_id)
   {
     std::vector<std::size_t> & cluster = clusters[cluster_id];
-    
+
     float average_center_x = 0.0f;
     float average_center_y = 0.0f;
     float average_center_z = 0.0f;
@@ -935,9 +937,9 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::removeOverlappingDetections ()
   detections_ = clustered_detections;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointXYZT, typename PointRGBT> float 
-pcl::LineRGBD<PointXYZT, PointRGBT>::computeBoundingBoxIntersectionVolume (
+
+template <typename PointXYZT, typename PointRGBT> float
+LineRGBD<PointXYZT, PointRGBT>::computeBoundingBoxIntersectionVolume (
   const BoundingBoxXYZ &box1, const BoundingBoxXYZ &box2)
 {
   const float x1_min = box1.x;
@@ -953,7 +955,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::computeBoundingBoxIntersectionVolume (
   const float x2_max = box2.x + box2.width;
   const float y2_max = box2.y + box2.height;
   const float z2_max = box2.z + box2.depth;
-  
+
   const float xi_min = std::max (x1_min, x2_min);
   const float yi_min = std::max (y1_min, y2_min);
   const float zi_min = std::max (z1_min, z2_min);
@@ -974,6 +976,7 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::computeBoundingBoxIntersectionVolume (
   return (intersection_volume);
 }
 
+} // namespace pcl
 
-#endif        // PCL_RECOGNITION_LINEMOD_LINE_RGBD_IMPL_HPP_ 
+#endif        // PCL_RECOGNITION_LINEMOD_LINE_RGBD_IMPL_HPP_
 

--- a/recognition/include/pcl/recognition/impl/ransac_based/simple_octree.hpp
+++ b/recognition/include/pcl/recognition/impl/ransac_based/simple_octree.hpp
@@ -11,38 +11,40 @@
 #include <algorithm>
 #include <cmath>
 
-//===============================================================================================================================
+
+namespace pcl
+{
+
+namespace recognition
+{
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::Node ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::Node ()
 : data_ (nullptr),
   parent_ (nullptr),
   children_(nullptr)
 {}
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::~Node ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::~Node ()
 {
   this->deleteChildren ();
   this->deleteData ();
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::setCenter (const Scalar *c)
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::setCenter (const Scalar *c)
 {
   center_[0] = c[0];
   center_[1] = c[1];
   center_[2] = c[2];
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::setBounds (const Scalar *b)
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::setBounds (const Scalar *b)
 {
   bounds_[0] = b[0];
   bounds_[1] = b[1];
@@ -52,10 +54,9 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::setBoun
   bounds_[5] = b[5];
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::computeRadius ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::computeRadius ()
 {
   Scalar v[3] = {static_cast<Scalar> (0.5)*(bounds_[1]-bounds_[0]),
                  static_cast<Scalar> (0.5)*(bounds_[3]-bounds_[2]),
@@ -64,10 +65,9 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::compute
   radius_ = static_cast<Scalar> (std::sqrt (v[0]*v[0] + v[1]*v[1] + v[2]*v[2]));
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline bool
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::createChildren ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::createChildren ()
 {
   if ( children_ )
     return (false);
@@ -152,10 +152,9 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::createC
   return (true);
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteChildren ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteChildren ()
 {
   if ( children_ )
   {
@@ -164,10 +163,9 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteC
   }
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteData ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteData ()
 {
   if ( data_ )
   {
@@ -176,10 +174,9 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::deleteD
   }
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::makeNeighbors (Node* node)
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::makeNeighbors (Node* node)
 {
   if ( !this->hasData () || !node->hasData () )
     return;
@@ -188,27 +185,24 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node::makeNei
   node->full_leaf_neighbors_.insert (this);
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::SimpleOctree ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::SimpleOctree ()
 : tree_levels_ (0),
   root_ (nullptr)
 {
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::~SimpleOctree ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::~SimpleOctree ()
 {
   this->clear ();
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::clear ()
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::clear ()
 {
   if ( root_ )
   {
@@ -219,10 +213,9 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::clear ()
   full_leaves_.clear();
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::build (const Scalar* bounds, Scalar voxel_size,
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::build (const Scalar* bounds, Scalar voxel_size,
     NodeDataCreator* node_data_creator)
 {
   if ( voxel_size <= 0 )
@@ -265,11 +258,10 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::build (const 
   root_->computeRadius ();
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
-typename pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node*
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::createLeaf (Scalar x, Scalar y, Scalar z)
+typename SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node*
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::createLeaf (Scalar x, Scalar y, Scalar z)
 {
   // Make sure that the input point is within the octree bounds
   if ( x < bounds_[0] || x > bounds_[1] ||
@@ -305,11 +297,10 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::createLeaf (S
   return (node);
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
-typename pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node*
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (int i, int j, int k)
+typename SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node*
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (int i, int j, int k)
 {
   Scalar offset = 0.5f*voxel_size_;
   Scalar p[3] = {bounds_[0] + offset + static_cast<Scalar> (i)*voxel_size_,
@@ -319,11 +310,10 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (
   return (this->getFullLeaf (p[0], p[1], p[2]));
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline
-typename pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node*
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (Scalar x, Scalar y, Scalar z)
+typename SimpleOctree<NodeData, NodeDataCreator, Scalar>::Node*
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (Scalar x, Scalar y, Scalar z)
 {
   // Make sure that the input point is within the octree bounds
   if ( x < bounds_[0] || x > bounds_[1] ||
@@ -357,10 +347,9 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::getFullLeaf (
   return (node);
 }
 
-//===============================================================================================================================
 
 template<typename NodeData, typename NodeDataCreator, typename Scalar> inline void
-pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::insertNeighbors (Node* node)
+SimpleOctree<NodeData, NodeDataCreator, Scalar>::insertNeighbors (Node* node)
 {
   const Scalar* c = node->getCenter ();
   Scalar s = static_cast<Scalar> (0.5)*voxel_size_;
@@ -397,6 +386,8 @@ pcl::recognition::SimpleOctree<NodeData, NodeDataCreator, Scalar>::insertNeighbo
   neigh = this->getFullLeaf (c[0]-s, c[1]-s, c[2]-s); if ( neigh ) node->makeNeighbors (neigh);
 }
 
-//===============================================================================================================================
+} // namespace recognition
+} // namespace pcl
 
 #endif /* SIMPLE_OCTREE_HPP_ */
+

--- a/recognition/include/pcl/recognition/impl/ransac_based/voxel_structure.hpp
+++ b/recognition/include/pcl/recognition/impl/ransac_based/voxel_structure.hpp
@@ -36,11 +36,19 @@
  *
  */
 
+
 #ifndef PCL_RECOGNITION_VOXEL_STRUCTURE_HPP_
 #define PCL_RECOGNITION_VOXEL_STRUCTURE_HPP_
 
+
+namespace pcl
+{
+
+namespace recognition
+{
+
 template<class T, typename REAL> inline void
-pcl::recognition::VoxelStructure<T,REAL>::build (const REAL bounds[6], int num_of_voxels[3])
+VoxelStructure<T,REAL>::build (const REAL bounds[6], int num_of_voxels[3])
 {
   this->clear();
 
@@ -72,10 +80,9 @@ pcl::recognition::VoxelStructure<T,REAL>::build (const REAL bounds[6], int num_o
   min_center_[2] = bounds_[4] + static_cast<REAL> (0.5)*spacing_[2];
 }
 
-//================================================================================================================================
 
 template<class T, typename REAL> inline T*
-pcl::recognition::VoxelStructure<T,REAL>::getVoxel (const REAL p[3])
+VoxelStructure<T,REAL>::getVoxel (const REAL p[3])
 {
   if ( p[0] < bounds_[0] || p[0] >= bounds_[1] || p[1] < bounds_[2] || p[1] >= bounds_[3] || p[2] < bounds_[4] || p[2] >= bounds_[5] )
     return nullptr;
@@ -87,10 +94,9 @@ pcl::recognition::VoxelStructure<T,REAL>::getVoxel (const REAL p[3])
   return &voxels_[z*num_of_voxels_xy_plane_ + y*num_of_voxels_[0] + x];
 }
 
-//================================================================================================================================
 
 template<class T, typename REAL> inline T*
-pcl::recognition::VoxelStructure<T,REAL>::getVoxel (int x, int y, int z) const
+VoxelStructure<T,REAL>::getVoxel (int x, int y, int z) const
 {
   if ( x < 0 || x >= num_of_voxels_[0] ) return nullptr;
   if ( y < 0 || y >= num_of_voxels_[1] ) return nullptr;
@@ -99,10 +105,9 @@ pcl::recognition::VoxelStructure<T,REAL>::getVoxel (int x, int y, int z) const
   return &voxels_[z*num_of_voxels_xy_plane_ + y*num_of_voxels_[0] + x];
 }
 
-//================================================================================================================================
 
 template<class T, typename REAL> inline int
-pcl::recognition::VoxelStructure<T,REAL>::getNeighbors (const REAL* p, T **neighs) const
+VoxelStructure<T,REAL>::getNeighbors (const REAL* p, T **neighs) const
 {
   if ( p[0] < bounds_[0] || p[0] >= bounds_[1] || p[1] < bounds_[2] || p[1] >= bounds_[3] || p[2] < bounds_[4] || p[2] >= bounds_[5] )
     return 0;
@@ -151,6 +156,8 @@ pcl::recognition::VoxelStructure<T,REAL>::getNeighbors (const REAL* p, T **neigh
   return num_neighs;
 }
 
-//================================================================================================================================
+} // namespace recognition
+} // namespace pcl
 
 #endif // PCL_RECOGNITION_VOXEL_STRUCTURE_HPP_
+

--- a/registration/include/pcl/registration/impl/correspondence_estimation.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation.hpp
@@ -37,15 +37,22 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_H_
 #define PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_H_
 
 #include <pcl/common/io.h>
 #include <pcl/common/copy_point.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::setInputTarget (
+CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::setInputTarget (
     const PointCloudTargetConstPtr &cloud)
 {
   if (cloud->points.empty ())
@@ -62,9 +69,9 @@ pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar
   target_cloud_updated_ = true;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> bool
-pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute ()
+CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute ()
 {
   if (!target_)
   {
@@ -87,9 +94,9 @@ pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar
   return (PCLBase<PointSource>::initCompute ());
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> bool
-pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal ()
+CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initComputeReciprocal ()
 {
   // Only update source kd-tree if a new target cloud was set
   if (source_cloud_updated_ && !force_no_recompute_reciprocal_)
@@ -108,9 +115,9 @@ pcl::registration::CorrespondenceEstimationBase<PointSource, PointTarget, Scalar
   return (true);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::determineCorrespondences (
+CorrespondenceEstimation<PointSource, PointTarget, Scalar>::determineCorrespondences (
     pcl::Correspondences &correspondences, double max_distance)
 {
   if (!initCompute ())
@@ -124,7 +131,7 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
   std::vector<float> distance (1);
   pcl::Correspondence corr;
   unsigned int nr_valid_correspondences = 0;
-  
+
   // Check if the template types are the same. If true, avoid a copy.
   // Both point types MUST be registered using the POINT_CLOUD_REGISTER_POINT_STRUCT macro!
   if (isSamePointType<PointSource, PointTarget> ())
@@ -145,7 +152,7 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
   else
   {
     PointTarget pt;
-    
+
     // Iterate over the input set of source indices
     for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
     {
@@ -166,9 +173,9 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
   deinitCompute ();
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::determineReciprocalCorrespondences (
+CorrespondenceEstimation<PointSource, PointTarget, Scalar>::determineReciprocalCorrespondences (
     pcl::Correspondences &correspondences, double max_distance)
 {
   if (!initCompute ())
@@ -216,7 +223,7 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
   {
     PointTarget pt_src;
     PointSource pt_tgt;
-   
+
     // Iterate over the input set of source indices
     for (std::vector<int>::const_iterator idx = indices_->begin (); idx != indices_->end (); ++idx)
     {
@@ -246,6 +253,10 @@ pcl::registration::CorrespondenceEstimation<PointSource, PointTarget, Scalar>::d
   deinitCompute ();
 }
 
+} // namespace registration
+} // namespace pcl
+
 //#define PCL_INSTANTIATE_CorrespondenceEstimation(T,U) template class PCL_EXPORTS pcl::registration::CorrespondenceEstimation<T,U>;
 
 #endif /* PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_H_ */
+

--- a/registration/include/pcl/registration/impl/correspondence_estimation_backprojection.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_backprojection.hpp
@@ -36,14 +36,21 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_BACK_PROJECTION_HPP_
 #define PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_BACK_PROJECTION_HPP_
 
 #include <pcl/common/copy_point.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> bool
-pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::initCompute ()
+CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::initCompute ()
 {
   if (!source_normals_ || !target_normals_)
   {
@@ -56,7 +63,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::determineCorrespondences (
+CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::determineCorrespondences (
     pcl::Correspondences &correspondences, double max_distance)
 {
   if (!initCompute ())
@@ -68,7 +75,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
   std::vector<float> nn_dists (k_);
 
   int min_index = 0;
-  
+
   pcl::Correspondence corr;
   unsigned int nr_valid_correspondences = 0;
 
@@ -84,7 +91,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
 
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       float min_dist = std::numeric_limits<float>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
@@ -92,7 +99,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
                           source_normals_->points[*idx_i].normal_y * target_normals_->points[nn_indices[j]].normal_y +
                           source_normals_->points[*idx_i].normal_z * target_normals_->points[nn_indices[j]].normal_z ;
         float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
-        
+
         if (dist < min_dist)
         {
           min_dist = dist;
@@ -111,15 +118,15 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
   else
   {
     PointTarget pt;
-    
+
     // Iterate over the input set of source indices
     for (std::vector<int>::const_iterator idx_i = indices_->begin (); idx_i != indices_->end (); ++idx_i)
     {
       tree_->nearestKSearch (input_->points[*idx_i], k_, nn_indices, nn_dists);
- 
+
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       float min_dist = std::numeric_limits<float>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
@@ -131,7 +138,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
                           source_normals_->points[*idx_i].normal_y * target_normals_->points[nn_indices[j]].normal_y +
                           source_normals_->points[*idx_i].normal_z * target_normals_->points[nn_indices[j]].normal_z ;
         float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
-        
+
         if (dist < min_dist)
         {
           min_dist = dist;
@@ -140,7 +147,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
       }
       if (min_dist > max_distance)
         continue;
-      
+
       corr.index_query = *idx_i;
       corr.index_match = nn_indices[min_index];
       corr.distance = nn_dists[min_index];//min_dist;
@@ -151,9 +158,9 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
   deinitCompute ();
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::determineReciprocalCorrespondences (
+CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::determineReciprocalCorrespondences (
     pcl::Correspondences &correspondences, double max_distance)
 {
   if (!initCompute ())
@@ -171,7 +178,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
   std::vector<float> distance_reciprocal (1);
 
   int min_index = 0;
-  
+
   pcl::Correspondence corr;
   unsigned int nr_valid_correspondences = 0;
   int target_idx = 0;
@@ -188,7 +195,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
 
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       float min_dist = std::numeric_limits<float>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
@@ -196,7 +203,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
                           source_normals_->points[*idx_i].normal_y * target_normals_->points[nn_indices[j]].normal_y +
                           source_normals_->points[*idx_i].normal_z * target_normals_->points[nn_indices[j]].normal_z ;
         float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
-        
+
         if (dist < min_dist)
         {
           min_dist = dist;
@@ -222,15 +229,15 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
   else
   {
     PointTarget pt;
-    
+
     // Iterate over the input set of source indices
     for (std::vector<int>::const_iterator idx_i = indices_->begin (); idx_i != indices_->end (); ++idx_i)
     {
       tree_->nearestKSearch (input_->points[*idx_i], k_, nn_indices, nn_dists);
- 
+
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       float min_dist = std::numeric_limits<float>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
@@ -242,7 +249,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
                           source_normals_->points[*idx_i].normal_y * target_normals_->points[nn_indices[j]].normal_y +
                           source_normals_->points[*idx_i].normal_z * target_normals_->points[nn_indices[j]].normal_z ;
         float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
-        
+
         if (dist < min_dist)
         {
           min_dist = dist;
@@ -251,7 +258,7 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
       }
       if (min_dist > max_distance)
         continue;
-      
+
       // Check if the correspondence is reciprocal
       target_idx = nn_indices[min_index];
       tree_reciprocal_->nearestKSearch (target_->points[target_idx], 1, index_reciprocal, distance_reciprocal);
@@ -268,5 +275,8 @@ pcl::registration::CorrespondenceEstimationBackProjection<PointSource, PointTarg
   correspondences.resize (nr_valid_correspondences);
   deinitCompute ();
 }
+
+} // namespace registration
+} // namespace pcl
 
 #endif    // PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_BACK_PROJECTION_HPP_

--- a/registration/include/pcl/registration/impl/correspondence_estimation_normal_shooting.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_normal_shooting.hpp
@@ -37,14 +37,21 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_NORMAL_SHOOTING_H_
 #define PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_NORMAL_SHOOTING_H_
 
 #include <pcl/common/copy_point.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> bool
-pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::initCompute ()
+CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::initCompute ()
 {
   if (!source_normals_)
   {
@@ -55,9 +62,9 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
   return (CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::initCompute ());
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::determineCorrespondences (
+CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::determineCorrespondences (
     pcl::Correspondences &correspondences, double max_distance)
 {
   if (!initCompute ())
@@ -69,7 +76,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
   std::vector<float> nn_dists (k_);
 
   int min_index = 0;
-  
+
   pcl::Correspondence corr;
   unsigned int nr_valid_correspondences = 0;
 
@@ -85,11 +92,11 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
 
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       double min_dist = std::numeric_limits<double>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
-        // computing the distance between a point and a line in 3d. 
+        // computing the distance between a point and a line in 3d.
         // Reference - http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
         pt.x = target_->points[nn_indices[j]].x - input_->points[*idx_i].x;
         pt.y = target_->points[nn_indices[j]].y - input_->points[*idx_i].y;
@@ -99,7 +106,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
         Eigen::Vector3d N (normal.normal_x, normal.normal_y, normal.normal_z);
         Eigen::Vector3d V (pt.x, pt.y, pt.z);
         Eigen::Vector3d C = N.cross (V);
-        
+
         // Check if we have a better correspondence
         double dist = C.dot (C);
         if (dist < min_dist)
@@ -120,15 +127,15 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
   else
   {
     PointTarget pt;
-    
+
     // Iterate over the input set of source indices
     for (std::vector<int>::const_iterator idx_i = indices_->begin (); idx_i != indices_->end (); ++idx_i)
     {
       tree_->nearestKSearch (input_->points[*idx_i], k_, nn_indices, nn_dists);
- 
+
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       double min_dist = std::numeric_limits<double>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
@@ -141,12 +148,12 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
         pt.x = target_->points[nn_indices[j]].x - pt_src.x;
         pt.y = target_->points[nn_indices[j]].y - pt_src.y;
         pt.z = target_->points[nn_indices[j]].z - pt_src.z;
-        
+
         const NormalT &normal = source_normals_->points[*idx_i];
         Eigen::Vector3d N (normal.normal_x, normal.normal_y, normal.normal_z);
         Eigen::Vector3d V (pt.x, pt.y, pt.z);
         Eigen::Vector3d C = N.cross (V);
-        
+
         // Check if we have a better correspondence
         double dist = C.dot (C);
         if (dist < min_dist)
@@ -157,7 +164,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
       }
       if (min_dist > max_distance)
         continue;
-      
+
       corr.index_query = *idx_i;
       corr.index_match = nn_indices[min_index];
       corr.distance = nn_dists[min_index];//min_dist;
@@ -168,9 +175,9 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
   deinitCompute ();
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::determineReciprocalCorrespondences (
+CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::determineReciprocalCorrespondences (
     pcl::Correspondences &correspondences, double max_distance)
 {
   if (!initCompute ())
@@ -189,7 +196,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
   std::vector<float> distance_reciprocal (1);
 
   int min_index = 0;
-  
+
   pcl::Correspondence corr;
   unsigned int nr_valid_correspondences = 0;
   int target_idx = 0;
@@ -206,11 +213,11 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
 
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       double min_dist = std::numeric_limits<double>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
-        // computing the distance between a point and a line in 3d. 
+        // computing the distance between a point and a line in 3d.
         // Reference - http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
         pt.x = target_->points[nn_indices[j]].x - input_->points[*idx_i].x;
         pt.y = target_->points[nn_indices[j]].y - input_->points[*idx_i].y;
@@ -220,7 +227,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
         Eigen::Vector3d N (normal.normal_x, normal.normal_y, normal.normal_z);
         Eigen::Vector3d V (pt.x, pt.y, pt.z);
         Eigen::Vector3d C = N.cross (V);
-        
+
         // Check if we have a better correspondence
         double dist = C.dot (C);
         if (dist < min_dist)
@@ -249,7 +256,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
   else
   {
     PointTarget pt;
-    
+
     // Iterate over the input set of source indices
     for (std::vector<int>::const_iterator idx_i = indices_->begin (); idx_i != indices_->end (); ++idx_i)
     {
@@ -257,7 +264,7 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
 
       // Among the K nearest neighbours find the one with minimum perpendicular distance to the normal
       double min_dist = std::numeric_limits<double>::max ();
-      
+
       // Find the best correspondence
       for (std::size_t j = 0; j < nn_indices.size (); j++)
       {
@@ -265,17 +272,17 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
         // Copy the source data to a target PointTarget format so we can search in the tree
         copyPoint (input_->points[*idx_i], pt_src);
 
-        // computing the distance between a point and a line in 3d. 
+        // computing the distance between a point and a line in 3d.
         // Reference - http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
         pt.x = target_->points[nn_indices[j]].x - pt_src.x;
         pt.y = target_->points[nn_indices[j]].y - pt_src.y;
         pt.z = target_->points[nn_indices[j]].z - pt_src.z;
-        
+
         const NormalT &normal = source_normals_->points[*idx_i];
         Eigen::Vector3d N (normal.normal_x, normal.normal_y, normal.normal_z);
         Eigen::Vector3d V (pt.x, pt.y, pt.z);
         Eigen::Vector3d C = N.cross (V);
-        
+
         // Check if we have a better correspondence
         double dist = C.dot (C);
         if (dist < min_dist)
@@ -304,5 +311,8 @@ pcl::registration::CorrespondenceEstimationNormalShooting<PointSource, PointTarg
   correspondences.resize (nr_valid_correspondences);
   deinitCompute ();
 }
+
+} // namespace registration
+} // namespace pcl
 
 #endif    // PCL_REGISTRATION_IMPL_CORRESPONDENCE_ESTIMATION_NORMAL_SHOOTING_H_

--- a/registration/include/pcl/registration/impl/correspondence_estimation_organized_projection.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_organized_projection.hpp
@@ -38,12 +38,19 @@
  *
  */
 
+
 #ifndef PCL_REGISTRATION_CORRESPONDENCE_ESTIMATION_ORGANIZED_PROJECTION_IMPL_HPP_
 #define PCL_REGISTRATION_CORRESPONDENCE_ESTIMATION_ORGANIZED_PROJECTION_IMPL_HPP_
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> bool
-pcl::registration::CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::initCompute ()
+CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::initCompute ()
 {
   // Set the target_cloud_updated_ variable to true, so that the kd-tree is not built - it is not needed for this class
   target_cloud_updated_ = false;
@@ -66,9 +73,9 @@ pcl::registration::CorrespondenceEstimationOrganizedProjection<PointSource, Poin
   return (true);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::determineCorrespondences (
+CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::determineCorrespondences (
     pcl::Correspondences &correspondences,
     double max_distance)
 {
@@ -113,15 +120,18 @@ pcl::registration::CorrespondenceEstimationOrganizedProjection<PointSource, Poin
   correspondences.resize (c_index);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::determineReciprocalCorrespondences (
+CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::determineReciprocalCorrespondences (
     pcl::Correspondences &correspondences,
     double max_distance)
 {
   // Call the normal determineCorrespondences (...), as doing it both ways will not improve the results
   determineCorrespondences (correspondences, max_distance);
 }
+
+} // namespace registration
+} // namespace pcl
 
 #endif    // PCL_REGISTRATION_CORRESPONDENCE_ESTIMATION_ORGANIZED_PROJECTION_IMPL_HPP_
 

--- a/registration/include/pcl/registration/impl/correspondence_rejection_features.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_features.hpp
@@ -37,12 +37,20 @@
  * $Id$
  *
  */
+
+
 #ifndef PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_FEATURES_HPP_
 #define PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_FEATURES_HPP_
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename FeatureT> inline void 
-pcl::registration::CorrespondenceRejectorFeatures::setSourceFeature (
+
+namespace pcl
+{
+
+namespace registration
+{
+
+template <typename FeatureT> inline void
+CorrespondenceRejectorFeatures::setSourceFeature (
     const typename pcl::PointCloud<FeatureT>::ConstPtr &source_feature, const std::string &key)
 {
   if (features_map_.count (key) == 0)
@@ -50,18 +58,18 @@ pcl::registration::CorrespondenceRejectorFeatures::setSourceFeature (
   boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->setSourceFeature (source_feature);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename FeatureT> inline typename pcl::PointCloud<FeatureT>::ConstPtr 
-pcl::registration::CorrespondenceRejectorFeatures::getSourceFeature (const std::string &key)
+
+template <typename FeatureT> inline typename pcl::PointCloud<FeatureT>::ConstPtr
+CorrespondenceRejectorFeatures::getSourceFeature (const std::string &key)
 {
   if (features_map_.count (key) == 0)
     return (nullptr);
   return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getSourceFeature ());
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename FeatureT> inline void 
-pcl::registration::CorrespondenceRejectorFeatures::setTargetFeature (
+
+template <typename FeatureT> inline void
+CorrespondenceRejectorFeatures::setTargetFeature (
     const typename pcl::PointCloud<FeatureT>::ConstPtr &target_feature, const std::string &key)
 {
   if (features_map_.count (key) == 0)
@@ -69,18 +77,18 @@ pcl::registration::CorrespondenceRejectorFeatures::setTargetFeature (
   boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->setTargetFeature (target_feature);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename FeatureT> inline typename pcl::PointCloud<FeatureT>::ConstPtr 
-pcl::registration::CorrespondenceRejectorFeatures::getTargetFeature (const std::string &key)
+
+template <typename FeatureT> inline typename pcl::PointCloud<FeatureT>::ConstPtr
+CorrespondenceRejectorFeatures::getTargetFeature (const std::string &key)
 {
   if (features_map_.count (key) == 0)
     return (nullptr);
   return (boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->getTargetFeature ());
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename FeatureT> inline void 
-pcl::registration::CorrespondenceRejectorFeatures::setDistanceThreshold (
+
+template <typename FeatureT> inline void
+CorrespondenceRejectorFeatures::setDistanceThreshold (
     double thresh, const std::string &key)
 {
   if (features_map_.count (key) == 0)
@@ -89,10 +97,8 @@ pcl::registration::CorrespondenceRejectorFeatures::setDistanceThreshold (
 }
 
 
-
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename FeatureT> inline void 
-pcl::registration::CorrespondenceRejectorFeatures::setFeatureRepresentation (
+template <typename FeatureT> inline void
+CorrespondenceRejectorFeatures::setFeatureRepresentation (
   const typename pcl::PointRepresentation<FeatureT>::ConstPtr &fr,
   const std::string &key)
 {
@@ -101,5 +107,8 @@ pcl::registration::CorrespondenceRejectorFeatures::setFeatureRepresentation (
   boost::static_pointer_cast<FeatureContainer<FeatureT> > (features_map_[key])->setFeatureRepresentation (fr);
 }
 
+} // namespace registration
+} // namespace pcl
 
 #endif /* PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_FEATURES_HPP_ */
+

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -37,15 +37,22 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_SAMPLE_CONSENSUS_HPP_
 #define PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_SAMPLE_CONSENSUS_HPP_
 
 #include <unordered_map>
 
-///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void 
-pcl::registration::CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCorrespondences (
-    const pcl::Correspondences& original_correspondences, 
+
+namespace pcl
+{
+
+namespace registration
+{
+
+template <typename PointT> void
+CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCorrespondences (
+    const pcl::Correspondences& original_correspondences,
     pcl::Correspondences& remaining_correspondences)
 {
   if (!input_)
@@ -133,4 +140,8 @@ pcl::registration::CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCo
    }
 }
 
+} // namespace registration
+} // namespace pcl
+
 #endif    // PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_SAMPLE_CONSENSUS_HPP_
+

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
@@ -35,6 +35,7 @@
  *
  *
  */
+
 #ifndef PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_SAMPLE_CONSENSUS_2D_HPP_
 #define PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_SAMPLE_CONSENSUS_2D_HPP_
 
@@ -43,10 +44,16 @@
 
 #include <unordered_map>
 
-///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void 
-pcl::registration::CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences (
-    const pcl::Correspondences& original_correspondences, 
+
+namespace pcl
+{
+
+namespace registration
+{
+
+template <typename PointT> void
+CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences (
+    const pcl::Correspondences& original_correspondences,
     pcl::Correspondences& remaining_correspondences)
 {
   if (!input_)
@@ -126,6 +133,9 @@ pcl::registration::CorrespondenceRejectorSampleConsensus2D<PointT>::getRemaining
   best_transformation_.row (2) = model_coefficients.segment<4>(8);
   best_transformation_.row (3) = model_coefficients.segment<4>(12);
 }
+
+} // namespace registration
+} // namespace pcl
 
 #endif    // PCL_REGISTRATION_IMPL_CORRESPONDENCE_REJECTION_SAMPLE_CONSENSUS_2D_HPP_
 

--- a/registration/include/pcl/registration/impl/correspondence_types.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_types.hpp
@@ -45,8 +45,15 @@
 #include <cstddef>
 #include <vector>
 
+
+namespace pcl
+{
+
+namespace registration
+{
+
 inline void
-pcl::registration::getCorDistMeanStd (const pcl::Correspondences &correspondences, double &mean, double &stddev)
+getCorDistMeanStd (const pcl::Correspondences &correspondences, double &mean, double &stddev)
 {
   if (correspondences.empty ())
     return;
@@ -64,7 +71,7 @@ pcl::registration::getCorDistMeanStd (const pcl::Correspondences &correspondence
 }
 
 inline void
-pcl::registration::getQueryIndices (const pcl::Correspondences& correspondences, std::vector<int>& indices)
+getQueryIndices (const pcl::Correspondences& correspondences, std::vector<int>& indices)
 {
   indices.resize (correspondences.size ());
   for (std::size_t i = 0; i < correspondences.size (); ++i)
@@ -73,9 +80,13 @@ pcl::registration::getQueryIndices (const pcl::Correspondences& correspondences,
 
 
 inline void
-pcl::registration::getMatchIndices (const pcl::Correspondences& correspondences, std::vector<int>& indices)
+getMatchIndices (const pcl::Correspondences& correspondences, std::vector<int>& indices)
 {
   indices.resize (correspondences.size ());
   for (std::size_t i = 0; i < correspondences.size (); ++i)
     indices[i] = correspondences[i].index_match;
 }
+
+} // namespace registration
+} // namespace pcl
+

--- a/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
+++ b/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
@@ -42,9 +42,15 @@
 
 #include <pcl/console/print.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename Scalar> bool
-pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
+DefaultConvergenceCriteria<Scalar>::hasConverged ()
 {
   if (convergence_state_ != CONVERGENCE_CRITERIA_NOT_CONVERGED)
   {
@@ -52,7 +58,7 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
     iterations_similar_transforms_ = 0;
     convergence_state_ = CONVERGENCE_CRITERIA_NOT_CONVERGED;
   }
-  
+
   bool is_similar = false;
 
   PCL_DEBUG ("[pcl::DefaultConvergenceCriteria::hasConverged] Iteration %d out of %d.\n", iterations_, max_iterations_);
@@ -98,7 +104,7 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
     }
     is_similar = true;
   }
-  
+
   // Relative
   if (std::abs (correspondences_cur_mse_ - correspondences_prev_mse_) / correspondences_prev_mse_ < mse_threshold_relative_)
   {
@@ -126,4 +132,8 @@ pcl::registration::DefaultConvergenceCriteria<Scalar>::hasConverged ()
   return (false);
 }
 
+} // namespace registration
+} // namespace pcl
+
 #endif    // PCL_REGISTRATION_DEFAULT_CONVERGENCE_CRITERIA_HPP_
+

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -37,18 +37,22 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_IMPL_GICP_HPP_
 #define PCL_REGISTRATION_IMPL_GICP_HPP_
 
 #include <pcl/registration/boost.h>
 #include <pcl/registration/exceptions.h>
 
-////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointSource, typename PointTarget>
 template<typename PointT> void
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud,
-                                                                                    const typename pcl::search::KdTree<PointT>::Ptr kdtree,
-                                                                                    MatricesVector& cloud_covariances)
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(typename pcl::PointCloud<PointT>::ConstPtr cloud,
+                                                                               const typename pcl::search::KdTree<PointT>::Ptr kdtree,
+                                                                               MatricesVector& cloud_covariances)
 {
   if (k_correspondences_ > int (cloud->size ()))
   {
@@ -121,9 +125,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovarian
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget> void
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(const Vector6d &x, const Eigen::Matrix3d &R, Vector6d& g) const
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(const Vector6d &x, const Eigen::Matrix3d &R, Vector6d& g) const
 {
   Eigen::Matrix3d dR_dPhi;
   Eigen::Matrix3d dR_dTheta;
@@ -176,13 +180,13 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivat
   g[5] = matricesInnerProd(dR_dPsi, R);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget> void
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigidTransformationBFGS (const PointCloudSource &cloud_src,
-                                                                                                  const std::vector<int> &indices_src,
-                                                                                                  const PointCloudTarget &cloud_tgt,
-                                                                                                  const std::vector<int> &indices_tgt,
-                                                                                                  Eigen::Matrix4f &transformation_matrix)
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigidTransformationBFGS (const PointCloudSource &cloud_src,
+                                                                                             const std::vector<int> &indices_src,
+                                                                                             const PointCloudTarget &cloud_tgt,
+                                                                                             const std::vector<int> &indices_tgt,
+                                                                                             Eigen::Matrix4f &transformation_matrix)
 {
   if (indices_src.size () < 4)     // need at least 4 samples
   {
@@ -241,9 +245,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigidTr
                         "[pcl::" << getClassName () << "::TransformationEstimationBFGS::estimateRigidTransformation] BFGS solver didn't converge!");
 }
 
-////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget> inline double
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::operator() (const Vector6d& x)
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::operator() (const Vector6d& x)
 {
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
@@ -266,9 +270,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
   return f/m;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget> inline void
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::df (const Vector6d& x, Vector6d& g)
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::df (const Vector6d& x, Vector6d& g)
 {
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
@@ -302,9 +306,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
   gicp_->computeRDerivative(x, R, g);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget> inline void
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::fdf (const Vector6d& x, double& f, Vector6d& g)
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFunctorWithIndices::fdf (const Vector6d& x, double& f, Vector6d& g)
 {
   Eigen::Matrix4f transformation_matrix = gicp_->base_transformation_;
   gicp_->applyState(transformation_matrix, x);
@@ -339,9 +343,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::OptimizationFun
   gicp_->computeRDerivative(x, R, g);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget> inline void
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f& guess)
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f& guess)
 {
   pcl::IterativeClosestPoint<PointSource, PointTarget>::initComputeReciprocal ();
   using namespace std;
@@ -354,7 +358,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransfor
   // Compute target cloud covariance matrices
   if ((!target_covariances_) || (target_covariances_->empty ()))
   {
-    target_covariances_.reset (new MatricesVector);  
+    target_covariances_.reset (new MatricesVector);
     computeCovariances<PointTarget> (target_, tree_, *target_covariances_);
   }
   // Compute input cloud covariance matrices
@@ -463,8 +467,9 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransfor
   pcl::transformPointCloud (*input_, output, final_transformation_);
 }
 
+
 template <typename PointSource, typename PointTarget> void
-pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::applyState(Eigen::Matrix4f &t, const Vector6d& x) const
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::applyState(Eigen::Matrix4f &t, const Vector6d& x) const
 {
   // !!! CAUTION Stanford GICP uses the Z Y X euler angles convention
   Eigen::Matrix3f R;
@@ -476,4 +481,7 @@ pcl::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::applyState(Eige
   t.col (3) += T;
 }
 
+} // namespace pcl
+
 #endif //PCL_REGISTRATION_IMPL_GICP_HPP_
+

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -37,11 +37,17 @@
 #ifndef PCL_REGISTRATION_IMPL_IA_KFPCS_H_
 #define PCL_REGISTRATION_IMPL_IA_KFPCS_H_
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar>
-pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::KFPCSInitialAlignment () :
+KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::KFPCSInitialAlignment () :
   lower_trl_boundary_ (-1.f),
-  upper_trl_boundary_ (-1.f),  
+  upper_trl_boundary_ (-1.f),
   lambda_ (0.5f),
   use_trl_score_ (false),
   indices_validation_ (new std::vector <int>)
@@ -50,9 +56,8 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
 }
 
 
-///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> bool
-pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::initCompute ()
+KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::initCompute ()
 {
   // due to sparse keypoint cloud, do not normalize delta with estimated point density
   if (normalize_delta_)
@@ -92,9 +97,8 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
 }
 
 
-///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::handleMatches (
+KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::handleMatches (
   const std::vector <int> &base_indices,
   std::vector <std::vector <int> > &matches,
   MatchingCandidates &candidates)
@@ -125,9 +129,8 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
 }
 
 
-///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> int
-pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::validateTransformation (
+KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::validateTransformation (
   Eigen::Matrix4f &transformation,
   float &fitness_score)
 {
@@ -137,7 +140,7 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
 
   const std::size_t nr_points = source_transformed.size ();
   float score_a = 0.f, score_b = 0.f;
-  
+
   // residual costs based on mse
   std::vector <int> ids;
   std::vector <float> dists_sqr;
@@ -172,9 +175,8 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
 }
 
 
-///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::finalCompute (
+KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::finalCompute (
   const std::vector <MatchingCandidates > &candidates)
 {
   // reorganize candidates into single vector
@@ -209,9 +211,9 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
   converged_ = fitness_score_ < score_threshold_;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::getNBestCandidates (
+KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::getNBestCandidates (
   int n,
   float min_angle3d,
   float min_translation3d,
@@ -248,9 +250,9 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar> void
-pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::getTBestCandidates (
+KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Scalar>::getTBestCandidates (
   float t,
   float min_angle3d,
   float min_translation3d,
@@ -283,6 +285,8 @@ pcl::registration::KFPCSInitialAlignment <PointSource, PointTarget, NormalT, Sca
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+} // namespace registration
+} // namespace pcl
 
 #endif // PCL_REGISTRATION_IMPL_IA_KFPCS_H_
+

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -43,9 +43,12 @@
 
 #include <pcl/common/distances.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename FeatureT> void 
-pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setSourceFeatures (const FeatureCloudConstPtr &features)
+
+namespace pcl
+{
+
+template <typename PointSource, typename PointTarget, typename FeatureT> void
+SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setSourceFeatures (const FeatureCloudConstPtr &features)
 {
   if (features == nullptr || features->empty ())
   {
@@ -55,9 +58,9 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setSou
   input_features_ = features;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename FeatureT> void 
-pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setTargetFeatures (const FeatureCloudConstPtr &features)
+
+template <typename PointSource, typename PointTarget, typename FeatureT> void
+SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setTargetFeatures (const FeatureCloudConstPtr &features)
 {
   if (features == nullptr || features->empty ())
   {
@@ -68,10 +71,10 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setTar
   feature_tree_->setInputCloud (target_features_);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename FeatureT> void 
-pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::selectSamples (
-    const PointCloudSource &cloud, int nr_samples, float min_sample_distance, 
+
+template <typename PointSource, typename PointTarget, typename FeatureT> void
+SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::selectSamples (
+    const PointCloudSource &cloud, int nr_samples, float min_sample_distance,
     std::vector<int> &sample_indices)
 {
   if (nr_samples > static_cast<int> (cloud.points.size ()))
@@ -127,10 +130,10 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::select
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename FeatureT> void 
-pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::findSimilarFeatures (
-    const FeatureCloud &input_features, const std::vector<int> &sample_indices, 
+
+template <typename PointSource, typename PointTarget, typename FeatureT> void
+SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::findSimilarFeatures (
+    const FeatureCloud &input_features, const std::vector<int> &sample_indices,
     std::vector<int> &corresponding_indices)
 {
   std::vector<int> nn_indices (k_correspondences_);
@@ -148,9 +151,9 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::findSi
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename FeatureT> float 
-pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::computeErrorMetric (
+
+template <typename PointSource, typename PointTarget, typename FeatureT> float
+SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::computeErrorMetric (
     const PointCloudSource &cloud, float)
 {
   std::vector<int> nn_index (1);
@@ -170,9 +173,9 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
   return (error);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename FeatureT> void 
-pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f& guess)
+
+template <typename PointSource, typename PointTarget, typename FeatureT> void
+SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f& guess)
 {
   // Some sanity checks first
   if (!input_features_)
@@ -216,7 +219,7 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
   final_transformation_ = guess;
   int i_iter = 0;
   converged_ = false;
-  if (!guess.isApprox (Eigen::Matrix4f::Identity (), 0.01f)) 
+  if (!guess.isApprox (Eigen::Matrix4f::Identity (), 0.01f))
   {
     // If guess is not the Identity matrix we check it.
     transformPointCloud (*input_, input_transformed, final_transformation_);
@@ -251,6 +254,8 @@ pcl::SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::comput
   // Apply the final transformation
   transformPointCloud (*input_, output, final_transformation_);
 }
+
+} // namespace pcl
 
 #endif  //#ifndef IA_RANSAC_HPP_
 

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -44,11 +44,14 @@
 #include <pcl/registration/boost.h>
 #include <pcl/correspondence.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud (
-    const PointCloudSource &input, 
-    PointCloudSource &output, 
+IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud (
+    const PointCloudSource &input,
+    PointCloudSource &output,
     const Matrix4 &transform)
 {
   Eigen::Vector4f pt (0.0f, 0.0f, 0.0f, 1.0f), pt_t;
@@ -111,12 +114,11 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud (
       memcpy (data_out + z_idx_offset_, &pt_t[2], sizeof (float));
     }
   }
-  
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation (
+IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation (
     PointCloudSource &output, const Matrix4 &guess)
 {
   // Point cloud containing the correspondences of each point in <input, indices>
@@ -137,7 +139,7 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
   }
   else
     *input_transformed = *input_;
- 
+
   transformation_ = Matrix4::Identity ();
 
   // Make blobs if necessary
@@ -224,7 +226,7 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
     // Transform the data
     transformCloud (*input_transformed, *input_transformed, transformation_);
 
-    // Obtain the final transformation    
+    // Obtain the final transformation
     final_transformation_ = transformation_ * final_transformation_;
 
     ++nr_iterations_;
@@ -250,8 +252,9 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
   transformCloud (*input_, output, final_transformation_);
 }
 
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::determineRequiredBlobData ()
+IterativeClosestPoint<PointSource, PointTarget, Scalar>::determineRequiredBlobData ()
 {
   need_source_blob_ = false;
   need_target_blob_ = false;
@@ -286,15 +289,17 @@ pcl::IterativeClosestPoint<PointSource, PointTarget, Scalar>::determineRequiredB
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::IterativeClosestPointWithNormals<PointSource, PointTarget, Scalar>::transformCloud (
-    const PointCloudSource &input, 
-    PointCloudSource &output, 
+IterativeClosestPointWithNormals<PointSource, PointTarget, Scalar>::transformCloud (
+    const PointCloudSource &input,
+    PointCloudSource &output,
     const Matrix4 &transform)
 {
   pcl::transformPointCloudWithNormals (input, output, transform);
 }
 
+} // namespace pcl
 
 #endif /* PCL_REGISTRATION_IMPL_ICP_HPP_ */
+

--- a/registration/include/pcl/registration/impl/incremental_registration.hpp
+++ b/registration/include/pcl/registration/impl/incremental_registration.hpp
@@ -38,14 +38,21 @@
 #ifndef PCL_REGISTRATION_IMPL_INCREMENTAL_REGISTRATION_HPP_
 #define PCL_REGISTRATION_IMPL_INCREMENTAL_REGISTRATION_HPP_
 
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointT, typename Scalar>
-pcl::registration::IncrementalRegistration<PointT, Scalar>::IncrementalRegistration () :
+IncrementalRegistration<PointT, Scalar>::IncrementalRegistration () :
   delta_transform_ (Matrix4::Identity ()),
   abs_transform_ (Matrix4::Identity ())
 {}
 
 template <typename PointT, typename Scalar> bool
-pcl::registration::IncrementalRegistration<PointT, Scalar>::registerCloud (const PointCloudConstPtr& cloud, const Matrix4& delta_estimate)
+IncrementalRegistration<PointT, Scalar>::registerCloud (const PointCloudConstPtr& cloud, const Matrix4& delta_estimate)
 {
   assert (registration_);
 
@@ -76,28 +83,32 @@ pcl::registration::IncrementalRegistration<PointT, Scalar>::registerCloud (const
 }
 
 template <typename PointT, typename Scalar> inline typename pcl::registration::IncrementalRegistration<PointT, Scalar>::Matrix4
-pcl::registration::IncrementalRegistration<PointT, Scalar>::getDeltaTransform () const
+IncrementalRegistration<PointT, Scalar>::getDeltaTransform () const
 {
   return (delta_transform_);
 }
 
 template <typename PointT, typename Scalar> inline typename pcl::registration::IncrementalRegistration<PointT, Scalar>::Matrix4
-pcl::registration::IncrementalRegistration<PointT, Scalar>::getAbsoluteTransform () const
+IncrementalRegistration<PointT, Scalar>::getAbsoluteTransform () const
 {
   return (abs_transform_);
 }
 
 template <typename PointT, typename Scalar> inline void
-pcl::registration::IncrementalRegistration<PointT, Scalar>::reset ()
+IncrementalRegistration<PointT, Scalar>::reset ()
 {
   last_cloud_.reset ();
   delta_transform_ = abs_transform_ = Matrix4::Identity ();
 }
 
 template <typename PointT, typename Scalar> inline void
-pcl::registration::IncrementalRegistration<PointT, Scalar>::setRegistration (RegistrationPtr registration)
+IncrementalRegistration<PointT, Scalar>::setRegistration (RegistrationPtr registration)
 {
   registration_ = registration;
 }
 
+} // namespace registration
+} // namespace pcl
+
 #endif /*PCL_REGISTRATION_IMPL_INCREMENTAL_REGISTRATION_HPP_*/
+

--- a/registration/include/pcl/registration/impl/joint_icp.hpp
+++ b/registration/include/pcl/registration/impl/joint_icp.hpp
@@ -1,16 +1,16 @@
 /*
  * Software License Agreement (BSD License)
- * 
+ *
  * Point Cloud Library (PCL) - www.pointclouds.org
  * Copyright (c) 2009-2012, Willow Garage, Inc.
  * Copyright (c) 2012-, Open Perception, Inc.
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *  * Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  *  * Redistributions in binary form must reproduce the above
@@ -20,7 +20,7 @@
  *  * Neither the name of the copyright holder(s) nor the names of its
  *    contributors may be used to endorse or promote products derived
  *    from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -44,9 +44,11 @@
 #include <pcl/console/print.h>
 
 
-///////////////////////////////////////////////////////////////////////////////////////////
+namespace pcl
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation (
+JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation (
     PointCloudSource &output, const Matrix4 &guess)
 {
   // Point clouds containing the correspondences of each point in <input, indices>
@@ -63,7 +65,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
     correspondence_estimations_.resize (sources_.size ());
     for (std::size_t i = 0; i < sources_.size (); i++)
     {
-      correspondence_estimations_[i] = correspondence_estimation_->clone ();      
+      correspondence_estimations_[i] = correspondence_estimation_->clone ();
       KdTreeReciprocalPtr src_tree (new KdTreeReciprocal);
       KdTreePtr tgt_tree (new KdTree);
       correspondence_estimations_[i]->setSearchMethodTarget (tgt_tree);
@@ -117,8 +119,6 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
     target_offset += targets_[i]->size ();
   }
 
-
- 
   transformation_ = Matrix4::Identity ();
   // Make blobs if necessary
   determineRequiredBlobData ();
@@ -176,7 +176,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
         toPCLPointCloud2 (*inputs_transformed[i], *input_transformed_blob);
         correspondence_estimations_[i]->setSourceNormals (input_transformed_blob);
       }
-      
+
       // Estimate correspondences on each cloud pair separately
       if (use_reciprocal_correspondence_)
       {
@@ -186,8 +186,8 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
       {
         correspondence_estimations_[i]->determineCorrespondences (*partial_correspondences_[i], corr_dist_threshold_);
       }
-      PCL_DEBUG ("[pcl::%s::computeTransformation] Found %d partial correspondences for cloud [%d]\n", 
-          getClassName ().c_str (), 
+      PCL_DEBUG ("[pcl::%s::computeTransformation] Found %d partial correspondences for cloud [%d]\n",
+          getClassName ().c_str (),
           partial_correspondences_[i]->size (), i);
       for (std::size_t j = 0; j < partial_correspondences_[i]->size (); j++)
       {
@@ -199,7 +199,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
       }
     }
     PCL_DEBUG ("[pcl::%s::computeTransformation] Total correspondences: %d\n", getClassName ().c_str (), correspondences_->size ());
-    
+
     PCLPointCloud2::Ptr inputs_transformed_combined_blob;
     if (need_source_blob_)
     {
@@ -244,7 +244,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
       this->transformCloud (*inputs_transformed[i], *inputs_transformed[i], transformation_);
     }
 
-    // Obtain the final transformation    
+    // Obtain the final transformation
     final_transformation_ = transformation_ * final_transformation_;
 
     ++nr_iterations_;
@@ -257,7 +257,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
   }
   while (!converged_);
 
-  PCL_DEBUG ("Transformation is:\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n", 
+  PCL_DEBUG ("Transformation is:\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n",
       final_transformation_ (0, 0), final_transformation_ (0, 1), final_transformation_ (0, 2), final_transformation_ (0, 3),
       final_transformation_ (1, 0), final_transformation_ (1, 1), final_transformation_ (1, 2), final_transformation_ (1, 3),
       final_transformation_ (2, 0), final_transformation_ (2, 1), final_transformation_ (2, 2), final_transformation_ (2, 3),
@@ -274,13 +274,14 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransf
   }
 
 
-  // By definition, this method will return an empty cloud (for compliance with the ICP API). 
+  // By definition, this method will return an empty cloud (for compliance with the ICP API).
   // We can figure out a better solution, if necessary.
   output = PointCloudSource ();
 }
 
-  template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::determineRequiredBlobData ()
+
+template <typename PointSource, typename PointTarget, typename Scalar> void
+JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::determineRequiredBlobData ()
 {
   need_source_blob_ = false;
   need_target_blob_ = false;
@@ -320,7 +321,7 @@ pcl::JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::determineRequ
   }
 }
 
+} // namespace pcl
 
 #endif /* PCL_REGISTRATION_IMPL_JOINT_ICP_HPP_ */
-
 

--- a/registration/include/pcl/registration/impl/lum.hpp
+++ b/registration/include/pcl/registration/impl/lum.hpp
@@ -43,58 +43,64 @@
 
 #include <tuple>
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template<typename PointT> inline void
-pcl::registration::LUM<PointT>::setLoopGraph (const SLAMGraphPtr &slam_graph)
+LUM<PointT>::setLoopGraph (const SLAMGraphPtr &slam_graph)
 {
   slam_graph_ = slam_graph;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> inline typename pcl::registration::LUM<PointT>::SLAMGraphPtr
-pcl::registration::LUM<PointT>::getLoopGraph () const
+
+template<typename PointT> inline typename LUM<PointT>::SLAMGraphPtr
+LUM<PointT>::getLoopGraph () const
 {
   return (slam_graph_);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> typename pcl::registration::LUM<PointT>::SLAMGraph::vertices_size_type
-pcl::registration::LUM<PointT>::getNumVertices () const
+
+template<typename PointT> typename LUM<PointT>::SLAMGraph::vertices_size_type
+LUM<PointT>::getNumVertices () const
 {
   return (num_vertices (*slam_graph_));
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> void
-pcl::registration::LUM<PointT>::setMaxIterations (int max_iterations)
+LUM<PointT>::setMaxIterations (int max_iterations)
 {
   max_iterations_ = max_iterations;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline int
-pcl::registration::LUM<PointT>::getMaxIterations () const
+LUM<PointT>::getMaxIterations () const
 {
   return (max_iterations_);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> void
-pcl::registration::LUM<PointT>::setConvergenceThreshold (float convergence_threshold)
+LUM<PointT>::setConvergenceThreshold (float convergence_threshold)
 {
   convergence_threshold_ = convergence_threshold;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline float
-pcl::registration::LUM<PointT>::getConvergenceThreshold () const
+LUM<PointT>::getConvergenceThreshold () const
 {
   return (convergence_threshold_);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> typename pcl::registration::LUM<PointT>::Vertex
-pcl::registration::LUM<PointT>::addPointCloud (const PointCloudPtr &cloud, const Eigen::Vector6f &pose)
+
+template<typename PointT> typename LUM<PointT>::Vertex
+LUM<PointT>::addPointCloud (const PointCloudPtr &cloud, const Eigen::Vector6f &pose)
 {
   Vertex v = add_vertex (*slam_graph_);
   (*slam_graph_)[v].cloud_ = cloud;
@@ -108,9 +114,9 @@ pcl::registration::LUM<PointT>::addPointCloud (const PointCloudPtr &cloud, const
   return (v);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline void
-pcl::registration::LUM<PointT>::setPointCloud (const Vertex &vertex, const PointCloudPtr &cloud)
+LUM<PointT>::setPointCloud (const Vertex &vertex, const PointCloudPtr &cloud)
 {
   if (vertex >= getNumVertices ())
   {
@@ -120,9 +126,9 @@ pcl::registration::LUM<PointT>::setPointCloud (const Vertex &vertex, const Point
   (*slam_graph_)[vertex].cloud_ = cloud;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> inline typename pcl::registration::LUM<PointT>::PointCloudPtr
-pcl::registration::LUM<PointT>::getPointCloud (const Vertex &vertex) const
+
+template<typename PointT> inline typename LUM<PointT>::PointCloudPtr
+LUM<PointT>::getPointCloud (const Vertex &vertex) const
 {
   if (vertex >= getNumVertices ())
   {
@@ -132,9 +138,9 @@ pcl::registration::LUM<PointT>::getPointCloud (const Vertex &vertex) const
   return ((*slam_graph_)[vertex].cloud_);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline void
-pcl::registration::LUM<PointT>::setPose (const Vertex &vertex, const Eigen::Vector6f &pose)
+LUM<PointT>::setPose (const Vertex &vertex, const Eigen::Vector6f &pose)
 {
   if (vertex >= getNumVertices ())
   {
@@ -149,9 +155,9 @@ pcl::registration::LUM<PointT>::setPose (const Vertex &vertex, const Eigen::Vect
   (*slam_graph_)[vertex].pose_ = pose;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline Eigen::Vector6f
-pcl::registration::LUM<PointT>::getPose (const Vertex &vertex) const
+LUM<PointT>::getPose (const Vertex &vertex) const
 {
   if (vertex >= getNumVertices ())
   {
@@ -161,17 +167,17 @@ pcl::registration::LUM<PointT>::getPose (const Vertex &vertex) const
   return ((*slam_graph_)[vertex].pose_);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline Eigen::Affine3f
-pcl::registration::LUM<PointT>::getTransformation (const Vertex &vertex) const
+LUM<PointT>::getTransformation (const Vertex &vertex) const
 {
   Eigen::Vector6f pose = getPose (vertex);
   return (pcl::getTransformation (pose (0), pose (1), pose (2), pose (3), pose (4), pose (5)));
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> void
-pcl::registration::LUM<PointT>::setCorrespondences (const Vertex &source_vertex, const Vertex &target_vertex, const pcl::CorrespondencesPtr &corrs)
+LUM<PointT>::setCorrespondences (const Vertex &source_vertex, const Vertex &target_vertex, const pcl::CorrespondencesPtr &corrs)
 {
   if (source_vertex >= getNumVertices () || target_vertex >= getNumVertices () || source_vertex == target_vertex)
   {
@@ -186,9 +192,9 @@ pcl::registration::LUM<PointT>::setCorrespondences (const Vertex &source_vertex,
   (*slam_graph_)[e].corrs_ = corrs;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline pcl::CorrespondencesPtr
-pcl::registration::LUM<PointT>::getCorrespondences (const Vertex &source_vertex, const Vertex &target_vertex) const
+LUM<PointT>::getCorrespondences (const Vertex &source_vertex, const Vertex &target_vertex) const
 {
   if (source_vertex >= getNumVertices () || target_vertex >= getNumVertices ())
   {
@@ -206,9 +212,9 @@ pcl::registration::LUM<PointT>::getCorrespondences (const Vertex &source_vertex,
   return ((*slam_graph_)[e].corrs_);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> void
-pcl::registration::LUM<PointT>::compute ()
+LUM<PointT>::compute ()
 {
   int n = static_cast<int> (getNumVertices ());
   if (n < 2)
@@ -271,18 +277,18 @@ pcl::registration::LUM<PointT>::compute ()
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> typename pcl::registration::LUM<PointT>::PointCloudPtr
-pcl::registration::LUM<PointT>::getTransformedCloud (const Vertex &vertex) const
+
+template<typename PointT> typename LUM<PointT>::PointCloudPtr
+LUM<PointT>::getTransformedCloud (const Vertex &vertex) const
 {
   PointCloudPtr out (new PointCloud);
   pcl::transformPointCloud (*getPointCloud (vertex), *out, getTransformation (vertex));
   return (out);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> typename pcl::registration::LUM<PointT>::PointCloudPtr
-pcl::registration::LUM<PointT>::getConcatenatedCloud () const
+
+template<typename PointT> typename LUM<PointT>::PointCloudPtr
+LUM<PointT>::getConcatenatedCloud () const
 {
   PointCloudPtr out (new PointCloud);
   typename SLAMGraph::vertex_iterator v, v_end;
@@ -295,9 +301,9 @@ pcl::registration::LUM<PointT>::getConcatenatedCloud () const
   return (out);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> void
-pcl::registration::LUM<PointT>::computeEdge (const Edge &e)
+LUM<PointT>::computeEdge (const Edge &e)
 {
   // Get necessary local data from graph
   PointCloudPtr source_cloud = (*slam_graph_)[source (e, *slam_graph_)].cloud_;
@@ -399,9 +405,9 @@ pcl::registration::LUM<PointT>::computeEdge (const Edge &e)
   (*slam_graph_)[e].cinvd_ = MZ * (1.0f / ss);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointT> inline Eigen::Matrix6f
-pcl::registration::LUM<PointT>::incidenceCorrection (const Eigen::Vector6f &pose)
+LUM<PointT>::incidenceCorrection (const Eigen::Vector6f &pose)
 {
   Eigen::Matrix6f out = Eigen::Matrix6f::Identity ();
   float cx = std::cos (pose (3)), sx = sinf (pose (3)), cy = std::cos (pose (4)), sy = sinf (pose (4));
@@ -420,6 +426,9 @@ pcl::registration::LUM<PointT>::incidenceCorrection (const Eigen::Vector6f &pose
   out (5, 5) = -sx * cy;
   return (out);
 }
+
+} // namespace registration
+} // namespace pcl
 
 #define PCL_INSTANTIATE_LUM(T) template class PCL_EXPORTS pcl::registration::LUM<T>;
 

--- a/registration/include/pcl/registration/impl/meta_registration.hpp
+++ b/registration/include/pcl/registration/impl/meta_registration.hpp
@@ -38,13 +38,20 @@
 #ifndef PCL_REGISTRATION_IMPL_META_REGISTRATION_HPP_
 #define PCL_REGISTRATION_IMPL_META_REGISTRATION_HPP_
 
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointT, typename Scalar>
-pcl::registration::MetaRegistration<PointT, Scalar>::MetaRegistration () :
+MetaRegistration<PointT, Scalar>::MetaRegistration () :
   abs_transform_ (Matrix4::Identity ())
 {}
 
 template <typename PointT, typename Scalar> bool
-pcl::registration::MetaRegistration<PointT, Scalar>::registerCloud (const PointCloudConstPtr& new_cloud, const Matrix4& delta_estimate)
+MetaRegistration<PointT, Scalar>::registerCloud (const PointCloudConstPtr& new_cloud, const Matrix4& delta_estimate)
 {
   assert (registration_);
 
@@ -74,28 +81,33 @@ pcl::registration::MetaRegistration<PointT, Scalar>::registerCloud (const PointC
   return (converged);
 }
 
-template <typename PointT, typename Scalar> inline typename pcl::registration::MetaRegistration<PointT, Scalar>::Matrix4
-pcl::registration::MetaRegistration<PointT, Scalar>::getAbsoluteTransform () const
+template <typename PointT, typename Scalar> inline typename MetaRegistration<PointT, Scalar>::Matrix4
+MetaRegistration<PointT, Scalar>::getAbsoluteTransform () const
 {
   return (abs_transform_);
 }
 
 template <typename PointT, typename Scalar> inline void
-pcl::registration::MetaRegistration<PointT, Scalar>::reset ()
+MetaRegistration<PointT, Scalar>::reset ()
 {
   full_cloud_.reset ();
   abs_transform_ = Matrix4::Identity ();
 }
 
 template <typename PointT, typename Scalar> inline void
-pcl::registration::MetaRegistration<PointT, Scalar>::setRegistration (RegistrationPtr reg)
+MetaRegistration<PointT, Scalar>::setRegistration (RegistrationPtr reg)
 {
   registration_ = reg;
 }
 
-template <typename PointT, typename Scalar> inline typename pcl::registration::MetaRegistration<PointT, Scalar>::PointCloudConstPtr
-pcl::registration::MetaRegistration<PointT, Scalar>::getMetaCloud () const
+template <typename PointT, typename Scalar> inline typename MetaRegistration<PointT, Scalar>::PointCloudConstPtr
+MetaRegistration<PointT, Scalar>::getMetaCloud () const
 {
   return full_cloud_;
 }
+
+} // namespace registration
+} // namespace pcl
+
 #endif /*PCL_REGISTRATION_IMPL_META_REGISTRATION_HPP_*/
+

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -41,9 +41,12 @@
 #ifndef PCL_REGISTRATION_NDT_IMPL_H_
 #define PCL_REGISTRATION_NDT_IMPL_H_
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template<typename PointSource, typename PointTarget>
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTransform () 
+NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTransform ()
   : target_cells_ ()
   , resolution_ (1.0f)
   , step_size_ (0.1)
@@ -67,9 +70,9 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributions
   max_iterations_ = 35;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f &guess)
+NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f &guess)
 {
   nr_iterations_ = 0;
   converged_ = false;
@@ -171,13 +174,13 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeTransformati
   trans_probability_ = score / static_cast<double> (input_->points.size ());
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> double
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives (Eigen::Matrix<double, 6, 1> &score_gradient,
-                                                                                 Eigen::Matrix<double, 6, 6> &hessian,
-                                                                                 PointCloudSource &trans_cloud,
-                                                                                 Eigen::Matrix<double, 6, 1> &p,
-                                                                                 bool compute_hessian)
+NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives (Eigen::Matrix<double, 6, 1> &score_gradient,
+                                                                            Eigen::Matrix<double, 6, 6> &hessian,
+                                                                            PointCloudSource &trans_cloud,
+                                                                            Eigen::Matrix<double, 6, 1> &p,
+                                                                            bool compute_hessian)
 {
   // Original Point and Transformed Point
   PointSource x_pt, x_trans_pt;
@@ -228,9 +231,9 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives 
   return (score);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives (Eigen::Matrix<double, 6, 1> &p, bool compute_hessian)
+NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives (Eigen::Matrix<double, 6, 1> &p, bool compute_hessian)
 {
   // Simplified math for near 0 angles
   double cx, cy, cz, sx, sy, sz;
@@ -305,9 +308,9 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivat
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives (Eigen::Vector3d &x, bool compute_hessian)
+NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives (Eigen::Vector3d &x, bool compute_hessian)
 {
   // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
   // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
@@ -346,12 +349,12 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivat
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> double
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (Eigen::Matrix<double, 6, 1> &score_gradient,
-                                                                                Eigen::Matrix<double, 6, 6> &hessian,
-                                                                                Eigen::Vector3d &x_trans, Eigen::Matrix3d &c_inv,
-                                                                                bool compute_hessian)
+NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (Eigen::Matrix<double, 6, 1> &score_gradient,
+                                                                           Eigen::Matrix<double, 6, 6> &hessian,
+                                                                           Eigen::Vector3d &x_trans, Eigen::Matrix3d &c_inv,
+                                                                           bool compute_hessian)
 {
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
@@ -392,10 +395,10 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (
   return (score_inc);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeHessian (Eigen::Matrix<double, 6, 6> &hessian,
-                                                                             PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &)
+NormalDistributionsTransform<PointSource, PointTarget>::computeHessian (Eigen::Matrix<double, 6, 6> &hessian,
+                                                                        PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &)
 {
   // Original Point and Transformed Point
   PointSource x_pt, x_trans_pt;
@@ -444,9 +447,9 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeHessian (Eig
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Matrix<double, 6, 6> &hessian, Eigen::Vector3d &x_trans, Eigen::Matrix3d &c_inv)
+NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Matrix<double, 6, 6> &hessian, Eigen::Vector3d &x_trans, Eigen::Matrix3d &c_inv)
 {
   Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
@@ -475,11 +478,11 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eige
 
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> bool
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double &a_l, double &f_l, double &g_l,
-                                                                               double &a_u, double &f_u, double &g_u,
-                                                                               double a_t, double f_t, double g_t)
+NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double &a_l, double &f_l, double &g_l,
+                                                                          double &a_u, double &f_u, double &g_u,
+                                                                          double a_t, double f_t, double g_t)
 {
   // Case U1 in Update Algorithm and Case a in Modified Update Algorithm [More, Thuente 1994]
   if (f_t > f_l)
@@ -513,11 +516,11 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (d
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> double
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT (double a_l, double f_l, double g_l,
-                                                                                    double a_u, double f_u, double g_u,
-                                                                                    double a_t, double f_t, double g_t)
+NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT (double a_l, double f_l, double g_l,
+                                                                               double a_u, double f_u, double g_u,
+                                                                               double a_t, double f_t, double g_t)
 {
   // Case 1 in Trial Value Selection [More, Thuente 1994]
   if (f_t > f_l)
@@ -588,11 +591,11 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelection
   return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> double
-pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max,
-                                                                                  double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian,
-                                                                                  PointCloudSource &trans_cloud)
+NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max,
+                                                                             double step_min, double &score, Eigen::Matrix<double, 6, 1> &score_gradient, Eigen::Matrix<double, 6, 6> &hessian,
+                                                                             PointCloudSource &trans_cloud)
 {
   // Set the value of phi(0), Equation 1.3 [More, Thuente 1994]
   double phi_0 = -score;
@@ -748,4 +751,7 @@ pcl::NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT
   return (a_t);
 }
 
+} // namespace pcl
+
 #endif // PCL_REGISTRATION_NDT_IMPL_H_
+

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -1,42 +1,43 @@
 /*
- * Software License Agreement (BSD License)
- *
- *  Point Cloud Library (PCL) - www.pointclouds.org
- *  Copyright (c) 2011-2012, Willow Garage, Inc.
- *  Copyright (c) 2012-, Open Perception, Inc.
- *
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the copyright holder(s) nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *
- * $Id$
- *
- */
+* Software License Agreement (BSD License)
+*
+*  Point Cloud Library (PCL) - www.pointclouds.org
+*  Copyright (c) 2011-2012, Willow Garage, Inc.
+*  Copyright (c) 2012-, Open Perception, Inc.
+*
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the copyright holder(s) nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* $Id$
+*
+*/
+
 #ifndef PCL_NDT_2D_IMPL_H_
 #define PCL_NDT_2D_IMPL_H_
 
@@ -48,332 +49,340 @@
 
 namespace pcl
 {
-  namespace ndt2d
+
+namespace ndt2d
+{
+/** \brief Class to store vector value and first and second derivatives
+  * (grad vector and hessian matrix), so they can be returned easily from
+  * functions
+  */
+template<unsigned N=3, typename T=double>
+struct ValueAndDerivatives
+{
+  ValueAndDerivatives () : hessian (), grad (), value () {}
+
+  Eigen::Matrix<T, N, N> hessian;
+  Eigen::Matrix<T, N, 1>    grad;
+  T value;
+
+  static ValueAndDerivatives<N,T>
+  Zero ()
   {
-    /** \brief Class to store vector value and first and second derivatives
-      * (grad vector and hessian matrix), so they can be returned easily from
-      * functions
-      */
-    template<unsigned N=3, typename T=double>
-    struct ValueAndDerivatives
-    {
-      ValueAndDerivatives () : hessian (), grad (), value () {}
+    ValueAndDerivatives<N,T> r;
+    r.hessian = Eigen::Matrix<T, N, N>::Zero ();
+    r.grad    = Eigen::Matrix<T, N, 1>::Zero ();
+    r.value   = 0;
+    return r;
+  }
 
-      Eigen::Matrix<T, N, N> hessian;
-      Eigen::Matrix<T, N, 1>    grad;
-      T value;
-      
-      static ValueAndDerivatives<N,T>
-      Zero ()
+  ValueAndDerivatives<N,T>&
+  operator+= (ValueAndDerivatives<N,T> const& r)
+  {
+    hessian += r.hessian;
+    grad    += r.grad;
+    value   += r.value;
+    return *this;
+  }
+};
+
+/** \brief A normal distribution estimation class.
+  *
+  * First the indices of of the points from a point cloud that should be
+  * modelled by the distribution are added with addIdx (...).
+  *
+  * Then estimateParams (...) uses the stored point indices to estimate the
+  * parameters of a normal distribution, and discards the stored indices.
+  *
+  * Finally the distriubution, and its derivatives, may be evaluated at any
+  * point using test (...).
+  */
+template <typename PointT>
+class NormalDist
+{
+  using PointCloud = pcl::PointCloud<PointT>;
+
+public:
+  NormalDist ()
+    : min_n_ (3), n_ (0)
+  {
+  }
+
+  /** \brief Store a point index to use later for estimating distribution parameters.
+    * \param[in] i Point index to store
+    */
+  void
+  addIdx (std::size_t i)
+  {
+    pt_indices_.push_back (i);
+  }
+
+  /** \brief Estimate the normal distribution parameters given the point indices provided. Memory of point indices is cleared.
+    * \param[in] cloud                    Point cloud corresponding to indices passed to addIdx.
+    * \param[in] min_covar_eigvalue_mult  Set the smallest eigenvalue to this times the largest.
+    */
+  void
+  estimateParams (const PointCloud& cloud, double min_covar_eigvalue_mult = 0.001)
+  {
+    Eigen::Vector2d sx  = Eigen::Vector2d::Zero ();
+    Eigen::Matrix2d sxx = Eigen::Matrix2d::Zero ();
+
+    for (auto i = pt_indices_.cbegin (); i != pt_indices_.cend (); i++)
+    {
+      Eigen::Vector2d p (cloud[*i]. x, cloud[*i]. y);
+      sx  += p;
+      sxx += p * p.transpose ();
+    }
+
+    n_ = pt_indices_.size ();
+
+    if (n_ >= min_n_)
+    {
+      mean_ = sx / static_cast<double> (n_);
+      // Using maximum likelihood estimation as in the original paper
+      Eigen::Matrix2d covar = (sxx - 2 * (sx * mean_.transpose ())) / static_cast<double> (n_) + mean_ * mean_.transpose ();
+
+      Eigen::SelfAdjointEigenSolver<Eigen::Matrix2d> solver (covar);
+      if (solver.eigenvalues ()[0] < min_covar_eigvalue_mult * solver.eigenvalues ()[1])
       {
-        ValueAndDerivatives<N,T> r;
-        r.hessian = Eigen::Matrix<T, N, N>::Zero ();
-        r.grad    = Eigen::Matrix<T, N, 1>::Zero ();
-        r.value   = 0;
-        return r;
+        PCL_DEBUG ("[pcl::NormalDist::estimateParams] NDT normal fit: adjusting eigenvalue %f\n", solver.eigenvalues ()[0]);
+        Eigen::Matrix2d l = solver.eigenvalues ().asDiagonal ();
+        Eigen::Matrix2d q = solver.eigenvectors ();
+        // set minimum smallest eigenvalue:
+        l (0,0) = l (1,1) * min_covar_eigvalue_mult;
+        covar = q * l * q.transpose ();
       }
+      covar_inv_ = covar.inverse ();
+    }
 
-      ValueAndDerivatives<N,T>&
-      operator+= (ValueAndDerivatives<N,T> const& r)
-      {
-        hessian += r.hessian;
-        grad    += r.grad;
-        value   += r.value;
-        return *this;
-      }
-    };
+    pt_indices_.clear ();
+  }
 
-    /** \brief A normal distribution estimation class.
-      *
-      * First the indices of of the points from a point cloud that should be
-      * modelled by the distribution are added with addIdx (...).
-      *
-      * Then estimateParams (...) uses the stored point indices to estimate the
-      * parameters of a normal distribution, and discards the stored indices.
-      *
-      * Finally the distriubution, and its derivatives, may be evaluated at any
-      * point using test (...).
-      */
-    template <typename PointT>
-    class NormalDist
+  /** \brief Return the 'score' (denormalised likelihood) and derivatives of score of the point p given this distribution.
+    * \param[in] transformed_pt   Location to evaluate at.
+    * \param[in] cos_theta        sin(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
+    * \param[in] sin_theta        cos(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
+    * estimateParams must have been called after at least three points were provided, or this will return zero.
+    *
+    */
+  ValueAndDerivatives<3,double>
+  test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
+  {
+    if (n_ < min_n_)
+      return ValueAndDerivatives<3,double>::Zero ();
+
+    ValueAndDerivatives<3,double> r;
+    const double x = transformed_pt.x;
+    const double y = transformed_pt.y;
+    const Eigen::Vector2d p_xy (transformed_pt.x, transformed_pt.y);
+    const Eigen::Vector2d q = p_xy - mean_;
+    const Eigen::RowVector2d qt_cvi (q.transpose () * covar_inv_);
+    const double exp_qt_cvi_q = std::exp (-0.5 * double (qt_cvi * q));
+    r.value = -exp_qt_cvi_q;
+
+    Eigen::Matrix<double, 2, 3> jacobian;
+    jacobian <<
+      1, 0, -(x * sin_theta + y*cos_theta),
+      0, 1,   x * cos_theta - y*sin_theta;
+
+    for (std::size_t i = 0; i < 3; i++)
+      r.grad[i] = double (qt_cvi * jacobian.col (i)) * exp_qt_cvi_q;
+
+    // second derivative only for i == j == 2:
+    const Eigen::Vector2d d2q_didj (
+        y * sin_theta - x*cos_theta,
+      -(x * sin_theta + y*cos_theta)
+    );
+
+    for (std::size_t i = 0; i < 3; i++)
+      for (std::size_t j = 0; j < 3; j++)
+        r.hessian (i,j) = -exp_qt_cvi_q * (
+          double (-qt_cvi*jacobian.col (i)) * double (-qt_cvi*jacobian.col (j)) +
+          (-qt_cvi * ((i==2 && j==2)? d2q_didj : Eigen::Vector2d::Zero ())) +
+          (-jacobian.col (j).transpose () * covar_inv_ * jacobian.col (i))
+        );
+
+    return r;
+  }
+
+protected:
+  const std::size_t min_n_;
+
+  std::size_t n_;
+  std::vector<std::size_t> pt_indices_;
+  Eigen::Vector2d mean_;
+  Eigen::Matrix2d covar_inv_;
+};
+
+/** \brief Build a set of normal distributions modelling a 2D point cloud,
+  * and provide the value and derivatives of the model at any point via the
+  * test (...) function.
+  */
+template <typename PointT>
+class NDTSingleGrid: public boost::noncopyable
+{
+  using PointCloud = pcl::PointCloud<PointT>;
+  using PointCloudConstPtr = typename PointCloud::ConstPtr;
+  using NormalDist = pcl::ndt2d::NormalDist<PointT>;
+
+public:
+  NDTSingleGrid (PointCloudConstPtr cloud,
+                 const Eigen::Vector2f& about,
+                 const Eigen::Vector2f& extent,
+                 const Eigen::Vector2f& step)
+      : min_ (about - extent), max_ (min_ + 2*extent), step_ (step),
+        cells_ ((max_[0]-min_[0]) / step_[0],
+                (max_[1]-min_[1]) / step_[1]),
+        normal_distributions_ (cells_[0], cells_[1])
+  {
+    // sort through all points, assigning them to distributions:
+    std::size_t used_points = 0;
+    for (std::size_t i = 0; i < cloud->size (); i++)
+    if (NormalDist* n = normalDistForPoint (cloud->at (i)))
     {
-      using PointCloud = pcl::PointCloud<PointT>;
+      n->addIdx (i);
+      used_points++;
+    }
 
-      public:
-        NormalDist ()
-          : min_n_ (3), n_ (0)
-        {
-        }
-        
-        /** \brief Store a point index to use later for estimating distribution parameters.
-          * \param[in] i Point index to store
-          */
-        void
-        addIdx (std::size_t i)
-        {
-          pt_indices_.push_back (i);
-        }
-        
-        /** \brief Estimate the normal distribution parameters given the point indices provided. Memory of point indices is cleared.
-          * \param[in] cloud                    Point cloud corresponding to indices passed to addIdx.
-          * \param[in] min_covar_eigvalue_mult  Set the smallest eigenvalue to this times the largest.
-          */
-        void
-        estimateParams (const PointCloud& cloud, double min_covar_eigvalue_mult = 0.001)
-        {
-          Eigen::Vector2d sx  = Eigen::Vector2d::Zero ();
-          Eigen::Matrix2d sxx = Eigen::Matrix2d::Zero ();
-          
-          for (auto i = pt_indices_.cbegin (); i != pt_indices_.cend (); i++)
-          {
-            Eigen::Vector2d p (cloud[*i]. x, cloud[*i]. y);
-            sx  += p;
-            sxx += p * p.transpose ();
-          }
-          
-          n_ = pt_indices_.size ();
+    PCL_DEBUG ("[pcl::NDTSingleGrid] NDT single grid %dx%d using %d/%d points\n", cells_[0], cells_[1], used_points, cloud->size ());
 
-          if (n_ >= min_n_)
-          {
-            mean_ = sx / static_cast<double> (n_);
-            // Using maximum likelihood estimation as in the original paper
-            Eigen::Matrix2d covar = (sxx - 2 * (sx * mean_.transpose ())) / static_cast<double> (n_) + mean_ * mean_.transpose ();
+    // then bake the distributions such that they approximate the
+    // points (and throw away memory of the points)
+    for (int x = 0; x < cells_[0]; x++)
+      for (int y = 0; y < cells_[1]; y++)
+        normal_distributions_.coeffRef (x,y).estimateParams (*cloud);
+  }
 
-            Eigen::SelfAdjointEigenSolver<Eigen::Matrix2d> solver (covar);
-            if (solver.eigenvalues ()[0] < min_covar_eigvalue_mult * solver.eigenvalues ()[1])
-            {
-              PCL_DEBUG ("[pcl::NormalDist::estimateParams] NDT normal fit: adjusting eigenvalue %f\n", solver.eigenvalues ()[0]);
-              Eigen::Matrix2d l = solver.eigenvalues ().asDiagonal ();
-              Eigen::Matrix2d q = solver.eigenvectors ();
-              // set minimum smallest eigenvalue:
-              l (0,0) = l (1,1) * min_covar_eigvalue_mult;
-              covar = q * l * q.transpose ();
-            }
-            covar_inv_ = covar.inverse ();
-          }
+  /** \brief Return the 'score' (denormalised likelihood) and derivatives of score of the point p given this distribution.
+    * \param[in] transformed_pt   Location to evaluate at.
+    * \param[in] cos_theta        sin(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
+    * \param[in] sin_theta        cos(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
+    */
+  ValueAndDerivatives<3,double>
+  test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
+  {
+    const NormalDist* n = normalDistForPoint (transformed_pt);
+    // index is in grid, return score from the normal distribution from
+    // the correct part of the grid:
+    if (n)
+      return n->test (transformed_pt, cos_theta, sin_theta);
+    return ValueAndDerivatives<3,double>::Zero ();
+  }
 
-          pt_indices_.clear ();
-        }
+protected:
+  /** \brief Return the normal distribution covering the location of point p
+    * \param[in] p a point
+    */
+  NormalDist*
+  normalDistForPoint (PointT const& p) const
+  {
+    // this would be neater in 3d...
+    Eigen::Vector2f idxf;
+    for (std::size_t i = 0; i < 2; i++)
+      idxf[i] = (p.getVector3fMap ()[i] - min_[i]) / step_[i];
+    Eigen::Vector2i idxi = idxf.cast<int> ();
+    for (std::size_t i = 0; i < 2; i++)
+      if (idxi[i] >= cells_[i] || idxi[i] < 0)
+        return nullptr;
+    // const cast to avoid duplicating this function in const and
+    // non-const variants...
+    return const_cast<NormalDist*> (&normal_distributions_.coeffRef (idxi[0], idxi[1]));
+  }
 
-        /** \brief Return the 'score' (denormalised likelihood) and derivatives of score of the point p given this distribution.
-          * \param[in] transformed_pt   Location to evaluate at.
-          * \param[in] cos_theta        sin(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
-          * \param[in] sin_theta        cos(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
-          * estimateParams must have been called after at least three points were provided, or this will return zero.
-          *
-          */
-        ValueAndDerivatives<3,double>
-        test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
-        {
-          if (n_ < min_n_)
-            return ValueAndDerivatives<3,double>::Zero ();
-          
-          ValueAndDerivatives<3,double> r;
-          const double x = transformed_pt.x;
-          const double y = transformed_pt.y;
-          const Eigen::Vector2d p_xy (transformed_pt.x, transformed_pt.y);
-          const Eigen::Vector2d q = p_xy - mean_;
-          const Eigen::RowVector2d qt_cvi (q.transpose () * covar_inv_);
-          const double exp_qt_cvi_q = std::exp (-0.5 * double (qt_cvi * q));
-          r.value = -exp_qt_cvi_q;
+  Eigen::Vector2f min_;
+  Eigen::Vector2f max_;
+  Eigen::Vector2f step_;
+  Eigen::Vector2i cells_;
 
-          Eigen::Matrix<double, 2, 3> jacobian;
-          jacobian <<
-            1, 0, -(x * sin_theta + y*cos_theta),
-            0, 1,   x * cos_theta - y*sin_theta;
-          
-          for (std::size_t i = 0; i < 3; i++)
-            r.grad[i] = double (qt_cvi * jacobian.col (i)) * exp_qt_cvi_q;
-          
-          // second derivative only for i == j == 2:
-          const Eigen::Vector2d d2q_didj (
-              y * sin_theta - x*cos_theta,
-            -(x * sin_theta + y*cos_theta)
-          );
+  Eigen::Matrix<NormalDist, Eigen::Dynamic, Eigen::Dynamic> normal_distributions_;
+};
 
-          for (std::size_t i = 0; i < 3; i++)
-            for (std::size_t j = 0; j < 3; j++)
-              r.hessian (i,j) = -exp_qt_cvi_q * (
-                double (-qt_cvi*jacobian.col (i)) * double (-qt_cvi*jacobian.col (j)) +
-                (-qt_cvi * ((i==2 && j==2)? d2q_didj : Eigen::Vector2d::Zero ())) +
-                (-jacobian.col (j).transpose () * covar_inv_ * jacobian.col (i))
-              );
-          
-          return r;
-        }
+/** \brief Build a Normal Distributions Transform of a 2D point cloud. This
+  * consists of the sum of four overlapping models of the original points
+  * with normal distributions.
+  * The value and derivatives of the model at any point can be evaluated
+  * with the test (...) function.
+  */
+template <typename PointT>
+class NDT2D: public boost::noncopyable
+{
+  using PointCloud = pcl::PointCloud<PointT>;
+  using PointCloudConstPtr = typename PointCloud::ConstPtr;
+  using SingleGrid = NDTSingleGrid<PointT>;
 
-    protected:
-        const std::size_t min_n_;
+public:
+  /** \brief
+    * \param[in] cloud the input point cloud
+    * \param[in] about Centre of the grid for normal distributions model
+    * \param[in] extent Extent of grid for normal distributions model
+    * \param[in] step Size of region that each normal distribution will model
+    */
+  NDT2D (PointCloudConstPtr cloud,
+       const Eigen::Vector2f& about,
+       const Eigen::Vector2f& extent,
+       const Eigen::Vector2f& step)
+  {
+    Eigen::Vector2f dx (step[0]/2, 0);
+    Eigen::Vector2f dy (0, step[1]/2);
+    single_grids_[0].reset(new SingleGrid (cloud, about,        extent, step));
+    single_grids_[1].reset(new SingleGrid (cloud, about +dx,    extent, step));
+    single_grids_[2].reset(new SingleGrid (cloud, about +dy,    extent, step));
+    single_grids_[3].reset(new SingleGrid (cloud, about +dx+dy, extent, step));
+  }
 
-        std::size_t n_;
-        std::vector<std::size_t> pt_indices_;
-        Eigen::Vector2d mean_;
-        Eigen::Matrix2d covar_inv_;
-    };
-    
-    /** \brief Build a set of normal distributions modelling a 2D point cloud,
-      * and provide the value and derivatives of the model at any point via the
-      * test (...) function.
-      */
-    template <typename PointT> 
-    class NDTSingleGrid: public boost::noncopyable
-    {
-      using PointCloud = pcl::PointCloud<PointT>;
-      using PointCloudConstPtr = typename PointCloud::ConstPtr;
-      using NormalDist = pcl::ndt2d::NormalDist<PointT>;
+  /** \brief Return the 'score' (denormalised likelihood) and derivatives of score of the point p given this distribution.
+    * \param[in] transformed_pt   Location to evaluate at.
+    * \param[in] cos_theta        sin(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
+    * \param[in] sin_theta        cos(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
+    */
+  ValueAndDerivatives<3,double>
+  test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
+  {
+    ValueAndDerivatives<3,double> r = ValueAndDerivatives<3,double>::Zero ();
+    for (const auto &single_grid : single_grids_)
+        r += single_grid->test (transformed_pt, cos_theta, sin_theta);
+    return r;
+  }
 
-      public:
-        NDTSingleGrid (PointCloudConstPtr cloud,
-                       const Eigen::Vector2f& about,
-                       const Eigen::Vector2f& extent,
-                       const Eigen::Vector2f& step)
-            : min_ (about - extent), max_ (min_ + 2*extent), step_ (step),
-              cells_ ((max_[0]-min_[0]) / step_[0],
-                      (max_[1]-min_[1]) / step_[1]),
-              normal_distributions_ (cells_[0], cells_[1])
-        {
-          // sort through all points, assigning them to distributions:
-          std::size_t used_points = 0;
-          for (std::size_t i = 0; i < cloud->size (); i++)
-          if (NormalDist* n = normalDistForPoint (cloud->at (i)))
-          {
-            n->addIdx (i);
-            used_points++;
-          }
+protected:
+  std::shared_ptr<SingleGrid> single_grids_[4];
+};
 
-          PCL_DEBUG ("[pcl::NDTSingleGrid] NDT single grid %dx%d using %d/%d points\n", cells_[0], cells_[1], used_points, cloud->size ());
-
-          // then bake the distributions such that they approximate the
-          // points (and throw away memory of the points)
-          for (int x = 0; x < cells_[0]; x++)
-            for (int y = 0; y < cells_[1]; y++)
-              normal_distributions_.coeffRef (x,y).estimateParams (*cloud);
-        }
-        
-        /** \brief Return the 'score' (denormalised likelihood) and derivatives of score of the point p given this distribution.
-          * \param[in] transformed_pt   Location to evaluate at.
-          * \param[in] cos_theta        sin(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
-          * \param[in] sin_theta        cos(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
-          */
-        ValueAndDerivatives<3,double>
-        test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
-        {
-          const NormalDist* n = normalDistForPoint (transformed_pt);
-          // index is in grid, return score from the normal distribution from
-          // the correct part of the grid:
-          if (n)
-            return n->test (transformed_pt, cos_theta, sin_theta);
-          return ValueAndDerivatives<3,double>::Zero ();
-        }
-
-      protected:
-        /** \brief Return the normal distribution covering the location of point p
-          * \param[in] p a point
-          */
-        NormalDist* 
-        normalDistForPoint (PointT const& p) const
-        {
-          // this would be neater in 3d...
-          Eigen::Vector2f idxf;
-          for (std::size_t i = 0; i < 2; i++)
-            idxf[i] = (p.getVector3fMap ()[i] - min_[i]) / step_[i];
-          Eigen::Vector2i idxi = idxf.cast<int> ();
-          for (std::size_t i = 0; i < 2; i++)
-            if (idxi[i] >= cells_[i] || idxi[i] < 0)
-              return nullptr;
-          // const cast to avoid duplicating this function in const and
-          // non-const variants...
-          return const_cast<NormalDist*> (&normal_distributions_.coeffRef (idxi[0], idxi[1]));
-        }
-
-        Eigen::Vector2f min_;
-        Eigen::Vector2f max_;
-        Eigen::Vector2f step_;
-        Eigen::Vector2i cells_;
-
-        Eigen::Matrix<NormalDist, Eigen::Dynamic, Eigen::Dynamic> normal_distributions_;
-    };
-
-    /** \brief Build a Normal Distributions Transform of a 2D point cloud. This
-      * consists of the sum of four overlapping models of the original points
-      * with normal distributions.
-      * The value and derivatives of the model at any point can be evaluated
-      * with the test (...) function.
-      */
-    template <typename PointT> 
-    class NDT2D: public boost::noncopyable
-    {
-      using PointCloud = pcl::PointCloud<PointT>;
-      using PointCloudConstPtr = typename PointCloud::ConstPtr;
-      using SingleGrid = NDTSingleGrid<PointT>;
-
-      public:
-        /** \brief
-          * \param[in] cloud the input point cloud
-          * \param[in] about Centre of the grid for normal distributions model
-          * \param[in] extent Extent of grid for normal distributions model
-          * \param[in] step Size of region that each normal distribution will model
-          */
-        NDT2D (PointCloudConstPtr cloud,
-             const Eigen::Vector2f& about,
-             const Eigen::Vector2f& extent,
-             const Eigen::Vector2f& step)
-        {
-          Eigen::Vector2f dx (step[0]/2, 0);
-          Eigen::Vector2f dy (0, step[1]/2);
-          single_grids_[0].reset(new SingleGrid (cloud, about,        extent, step));
-          single_grids_[1].reset(new SingleGrid (cloud, about +dx,    extent, step));
-          single_grids_[2].reset(new SingleGrid (cloud, about +dy,    extent, step));
-          single_grids_[3].reset(new SingleGrid (cloud, about +dx+dy, extent, step));
-        }
-        
-        /** \brief Return the 'score' (denormalised likelihood) and derivatives of score of the point p given this distribution.
-          * \param[in] transformed_pt   Location to evaluate at.
-          * \param[in] cos_theta        sin(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
-          * \param[in] sin_theta        cos(theta) of the current rotation angle of rigid transformation: to avoid repeated evaluation
-          */
-        ValueAndDerivatives<3,double>
-        test (const PointT& transformed_pt, const double& cos_theta, const double& sin_theta) const
-        {
-          ValueAndDerivatives<3,double> r = ValueAndDerivatives<3,double>::Zero ();
-          for (const auto &single_grid : single_grids_)
-              r += single_grid->test (transformed_pt, cos_theta, sin_theta);
-          return r;
-        }
-
-      protected:
-        std::shared_ptr<SingleGrid> single_grids_[4];
-    };
-
-  } // namespace ndt2d
+} // namespace ndt2d
 } // namespace pcl
 
 
 namespace Eigen
 {
-  /* This NumTraits specialisation is necessary because NormalDist is used as
-   * the element type of an Eigen Matrix.
-   */
-  template<typename PointT> struct NumTraits<pcl::ndt2d::NormalDist<PointT> >
-  {
-    using Real = double;
-    using Literal = double;
-    static Real dummy_precision () { return 1.0; }
-    enum {
-      IsComplex = 0,
-      IsInteger = 0,
-      IsSigned = 0,
-      RequireInitialization = 1,
-      ReadCost = 1,
-      AddCost = 1,
-      MulCost = 1
-    };
-  };
-}
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/* This NumTraits specialisation is necessary because NormalDist is used as
+* the element type of an Eigen Matrix.
+*/
+template<typename PointT>
+struct NumTraits<pcl::ndt2d::NormalDist<PointT> >
+{
+  using Real = double;
+  using Literal = double;
+  static Real dummy_precision () { return 1.0; }
+  enum
+  {
+    IsComplex = 0,
+    IsInteger = 0,
+    IsSigned = 0,
+    RequireInitialization = 1,
+    ReadCost = 1,
+    AddCost = 1,
+    MulCost = 1
+  };
+};
+
+} // namespace Eigen
+
+
+namespace pcl
+{
+
 template <typename PointSource, typename PointTarget> void
-pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f &guess)
+NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransformation (PointCloudSource &output, const Eigen::Matrix4f &guess)
 {
   PointCloudSource intm_cloud = output;
 
@@ -384,13 +393,13 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
   {
     transformation_ = guess;
     transformPointCloud (output, intm_cloud, transformation_);
-  } 
+  }
 
   // build Normal Distribution Transform of target cloud:
   ndt2d::NDT2D<PointTarget> target_ndt (target_, grid_centre_, grid_extent_, grid_step_);
-  
+
   // can't seem to use .block<> () member function on transformation_
-  // directly... gcc bug? 
+  // directly... gcc bug?
   Eigen::Matrix4f& transformation = transformation_;
 
 
@@ -410,12 +419,12 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
   {
     const double cos_theta = std::cos (xytheta_transformation[2]);
     const double sin_theta = std::sin (xytheta_transformation[2]);
-    previous_transformation_ = transformation;    
+    previous_transformation_ = transformation;
 
     ndt2d::ValueAndDerivatives<3, double> score = ndt2d::ValueAndDerivatives<3, double>::Zero ();
     for (std::size_t i = 0; i < intm_cloud.size (); i++)
       score += target_ndt.test (intm_cloud[i], cos_theta, sin_theta);
-    
+
     PCL_DEBUG ("[pcl::NormalDistributionsTransform2D::computeTransformation] NDT score %f (x=%f,y=%f,r=%f)\n",
       float (score.value), xytheta_transformation[0], xytheta_transformation[1], xytheta_transformation[2]
     );
@@ -447,12 +456,12 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
       assert (solver.eigenvalues ()[0].real () >= 0 &&
               solver.eigenvalues ()[1].real () >= 0 &&
               solver.eigenvalues ()[2].real () >= 0);
-      
+
       Eigen::Vector3d delta_transformation (-score.hessian.inverse () * score.grad);
       Eigen::Vector3d new_transformation = xytheta_transformation + newton_lambda_.cwiseProduct (delta_transformation);
 
       xytheta_transformation = new_transformation;
-      
+
       // update transformation matrix from x, y, theta:
       transformation.block<3,3> (0,0).matrix () = Eigen::Matrix3f (Eigen::AngleAxisf (static_cast<float> (xytheta_transformation[2]), Eigen::Vector3f::UnitZ ()));
       transformation.block<3,1> (0,3).matrix () = Eigen::Vector3f (static_cast<float> (xytheta_transformation[0]), static_cast<float> (xytheta_transformation[1]), 0.0f);
@@ -464,11 +473,11 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
       PCL_ERROR ("[pcl::NormalDistributionsTransform2D::computeTransformation] no overlap: try increasing the size or reducing the step of the grid\n");
       break;
     }
-    
+
     transformPointCloud (output, intm_cloud, transformation);
 
     nr_iterations_++;
-    
+
     if (update_visualizer_)
       update_visualizer_ (output, *indices_, *target_, *indices_);
 
@@ -492,5 +501,7 @@ pcl::NormalDistributionsTransform2D<PointSource, PointTarget>::computeTransforma
   output = intm_cloud;
 }
 
+} // namespace pcl
+
 #endif    // PCL_NDT_2D_IMPL_H_
- 
+

--- a/registration/include/pcl/registration/impl/pairwise_graph_registration.hpp
+++ b/registration/include/pcl/registration/impl/pairwise_graph_registration.hpp
@@ -37,11 +37,16 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_IMPL_PAIRWISE_GRAPH_REGISTRATION_HPP_
 #define PCL_REGISTRATION_IMPL_PAIRWISE_GRAPH_REGISTRATION_HPP_
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+namespace pcl
+{
+
 template <typename GraphT, typename PointT> void
-pcl::PairwiseGraphRegistration<GraphT, PointT>::computeRegistration ()
+PairwiseGraphRegistration<GraphT, PointT>::computeRegistration ()
 {
   if (!registration_method_)
   {
@@ -76,4 +81,8 @@ pcl::PairwiseGraphRegistration<GraphT, PointT>::computeRegistration ()
     registration_method_->setInputTarget (boost::get_cloud<PointT> (last_aligned_vertex_, *(graph_handler_->getGraph ())));
   }
 }
+
+} // namespace pcl
+
 #endif //PCL_REGISTRATION_IMPL_PAIRWISE_GRAPH_REGISTRATION_HPP_
+

--- a/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
+++ b/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
@@ -45,10 +45,13 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/console/print.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointFeature> float
-pcl::PyramidFeatureHistogram<PointFeature>::comparePyramidFeatureHistograms (const PyramidFeatureHistogramPtr &pyramid_a,
-                                                                             const PyramidFeatureHistogramPtr &pyramid_b)
+PyramidFeatureHistogram<PointFeature>::comparePyramidFeatureHistograms (const PyramidFeatureHistogramPtr &pyramid_a,
+                                                                        const PyramidFeatureHistogramPtr &pyramid_b)
 {
   // do a few consistency checks before and during the computation
   if (pyramid_a->nr_dimensions != pyramid_b->nr_dimensions)
@@ -113,9 +116,8 @@ pcl::PyramidFeatureHistogram<PointFeature>::comparePyramidFeatureHistograms (con
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointFeature>
-pcl::PyramidFeatureHistogram<PointFeature>::PyramidFeatureHistogram () :
+PyramidFeatureHistogram<PointFeature>::PyramidFeatureHistogram () :
   nr_dimensions (0), nr_levels (0), nr_features (0),
   feature_representation_ (new DefaultPointRepresentation<PointFeature>),
   is_computed_ (false),
@@ -123,9 +125,9 @@ pcl::PyramidFeatureHistogram<PointFeature>::PyramidFeatureHistogram () :
 {
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointFeature> void
-pcl::PyramidFeatureHistogram<PointFeature>::PyramidFeatureHistogramLevel::initializeHistogramLevel ()
+PyramidFeatureHistogram<PointFeature>::PyramidFeatureHistogramLevel::initializeHistogramLevel ()
 {
   std::size_t total_vector_size = 1;
   for (std::vector<std::size_t>::iterator dim_it = bins_per_dimension.begin (); dim_it != bins_per_dimension.end (); ++dim_it)
@@ -135,9 +137,8 @@ pcl::PyramidFeatureHistogram<PointFeature>::PyramidFeatureHistogramLevel::initia
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointFeature> bool
-pcl::PyramidFeatureHistogram<PointFeature>::initializeHistogram ()
+PyramidFeatureHistogram<PointFeature>::initializeHistogram ()
 {
   // a few consistency checks before starting the computations
   if (!PCLBase<PointFeature>::initCompute ())
@@ -202,10 +203,9 @@ pcl::PyramidFeatureHistogram<PointFeature>::initializeHistogram ()
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointFeature> unsigned int&
-pcl::PyramidFeatureHistogram<PointFeature>::at (std::vector<std::size_t> &access,
-                                                std::size_t &level)
+PyramidFeatureHistogram<PointFeature>::at (std::vector<std::size_t> &access,
+                                           std::size_t &level)
 {
   if (access.size () != nr_dimensions)
   {
@@ -231,10 +231,9 @@ pcl::PyramidFeatureHistogram<PointFeature>::at (std::vector<std::size_t> &access
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointFeature> unsigned int&
-pcl::PyramidFeatureHistogram<PointFeature>::at (std::vector<float> &feature,
-                                                std::size_t &level)
+PyramidFeatureHistogram<PointFeature>::at (std::vector<float> &feature,
+                                           std::size_t &level)
 {
   if (feature.size () != nr_dimensions)
   {
@@ -255,10 +254,9 @@ pcl::PyramidFeatureHistogram<PointFeature>::at (std::vector<float> &feature,
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointFeature> void
-pcl::PyramidFeatureHistogram<PointFeature>::convertFeatureToVector (const PointFeature &feature,
-                                                                    std::vector<float> &feature_vector)
+PyramidFeatureHistogram<PointFeature>::convertFeatureToVector (const PointFeature &feature,
+                                                               std::vector<float> &feature_vector)
 {
   // convert feature to vector representation
   feature_vector.resize (feature_representation_->getNumberOfDimensions ());
@@ -271,9 +269,8 @@ pcl::PyramidFeatureHistogram<PointFeature>::convertFeatureToVector (const PointF
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointFeature> void
-pcl::PyramidFeatureHistogram<PointFeature>::compute ()
+PyramidFeatureHistogram<PointFeature>::compute ()
 {
   if (!initializeHistogram ())
     return;
@@ -289,14 +286,16 @@ pcl::PyramidFeatureHistogram<PointFeature>::compute ()
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointFeature> void
-pcl::PyramidFeatureHistogram<PointFeature>::addFeature (std::vector<float> &feature)
+PyramidFeatureHistogram<PointFeature>::addFeature (std::vector<float> &feature)
 {
   for (std::size_t level_i = 0; level_i < nr_levels; ++level_i)
     at (feature, level_i) ++;
 }
 
+} // namespace pcl
+
 #define PCL_INSTANTIATE_PyramidFeatureHistogram(PointFeature) template class PCL_EXPORTS pcl::PyramidFeatureHistogram<PointFeature>;
 
 #endif /* PCL_REGISTRATION_IMPL_PYRAMID_FEATURE_MATCHING_H_ */
+

--- a/registration/include/pcl/registration/impl/registration.hpp
+++ b/registration/include/pcl/registration/impl/registration.hpp
@@ -38,9 +38,13 @@
  *
  */
 
-///////////////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+namespace pcl
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::Registration<PointSource, PointTarget, Scalar>::setInputTarget (const PointCloudTargetConstPtr &cloud)
+Registration<PointSource, PointTarget, Scalar>::setInputTarget (const PointCloudTargetConstPtr &cloud)
 {
   if (cloud->points.empty ())
   {
@@ -51,9 +55,9 @@ pcl::Registration<PointSource, PointTarget, Scalar>::setInputTarget (const Point
   target_cloud_updated_ = true;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> bool
-pcl::Registration<PointSource, PointTarget, Scalar>::initCompute ()
+Registration<PointSource, PointTarget, Scalar>::initCompute ()
 {
   if (!target_)
   {
@@ -68,23 +72,22 @@ pcl::Registration<PointSource, PointTarget, Scalar>::initCompute ()
     target_cloud_updated_ = false;
   }
 
-  
   // Update the correspondence estimation
   if (correspondence_estimation_)
   {
     correspondence_estimation_->setSearchMethodTarget (tree_, force_no_recompute_);
     correspondence_estimation_->setSearchMethodSource (tree_reciprocal_, force_no_recompute_reciprocal_);
   }
-  
+
   // Note: we /cannot/ update the search method on all correspondence rejectors, because we know 
   // nothing about them. If they should be cached, they must be cached individually.
 
   return (PCLBase<PointSource>::initCompute ());
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> bool
-pcl::Registration<PointSource, PointTarget, Scalar>::initComputeReciprocal ()
+Registration<PointSource, PointTarget, Scalar>::initComputeReciprocal ()
 {
   if (!input_)
   {
@@ -100,9 +103,9 @@ pcl::Registration<PointSource, PointTarget, Scalar>::initComputeReciprocal ()
   return (true);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline double
-pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (
+Registration<PointSource, PointTarget, Scalar>::getFitnessScore (
     const std::vector<float> &distances_a,
     const std::vector<float> &distances_b)
 {
@@ -112,11 +115,10 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (
   return (static_cast<double> ((map_a - map_b).sum ()) / static_cast<double> (nr_elem));
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename Scalar> inline double
-pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max_range)
-{
 
+template <typename PointSource, typename PointTarget, typename Scalar> inline double
+Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max_range)
+{
   double fitness_score = 0.0;
 
   // Transform the input dataset using the final transformation
@@ -132,7 +134,7 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max
   {
     // Find its nearest neighbor in the target
     tree_->nearestKSearch (input_transformed.points[i], 1, nn_indices, nn_dists);
-    
+
     // Deal with occlusions (incomplete targets)
     if (nn_dists[0] <= max_range)
     {
@@ -148,18 +150,18 @@ pcl::Registration<PointSource, PointTarget, Scalar>::getFitnessScore (double max
 
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::Registration<PointSource, PointTarget, Scalar>::align (PointCloudSource &output)
+Registration<PointSource, PointTarget, Scalar>::align (PointCloudSource &output)
 {
   align (output, Matrix4::Identity ());
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::Registration<PointSource, PointTarget, Scalar>::align (PointCloudSource &output, const Matrix4& guess)
+Registration<PointSource, PointTarget, Scalar>::align (PointCloudSource &output, const Matrix4& guess)
 {
-  if (!initCompute ()) 
+  if (!initCompute ())
     return;
 
   // Resize the output dataset
@@ -201,4 +203,6 @@ pcl::Registration<PointSource, PointTarget, Scalar>::align (PointCloudSource &ou
 
   deinitCompute ();
 }
+
+} // namespace pcl
 

--- a/registration/include/pcl/registration/impl/transformation_estimation_2D.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_2D.hpp
@@ -34,12 +34,19 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_2D_HPP_
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_2D_HPP_
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     Matrix4 &transformation_matrix) const
@@ -56,9 +63,9 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -76,9 +83,8 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
 }
 
 
-///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -96,9 +102,9 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     const pcl::Correspondences &correspondences,
@@ -109,9 +115,9 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimation2D<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     ConstCloudIterator<PointSource>& source_it,
     ConstCloudIterator<PointTarget>& target_it,
     Matrix4 &transformation_matrix) const
@@ -135,9 +141,9 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
   getTransformationFromCorrelation (cloud_src_demean, centroid_src, cloud_tgt_demean, centroid_tgt, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>::getTransformationFromCorrelation (
+TransformationEstimation2D<PointSource, PointTarget, Scalar>::getTransformationFromCorrelation (
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_src_demean,
     const Eigen::Matrix<Scalar, 4, 1> &centroid_src,
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_tgt_demean,
@@ -148,9 +154,9 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
 
   // Assemble the correlation matrix H = source * target'
   Eigen::Matrix<Scalar, 3, 3> H = (cloud_src_demean * cloud_tgt_demean.transpose ()).topLeftCorner (3, 3);
-  
+
   float angle = std::atan2 ((H (0, 1) - H (1, 0)), (H(0, 0) + H (1, 1)));
-  
+
   Eigen::Matrix<Scalar, 3, 3> R (Eigen::Matrix<Scalar, 3, 3>::Identity ());
   R (0, 0) = R (1, 1) = std::cos (angle);
   R (0, 1) = -std::sin (angle);
@@ -162,4 +168,8 @@ pcl::registration::TransformationEstimation2D<PointSource, PointTarget, Scalar>:
   transformation_matrix.block (0, 3, 3, 1).matrix () = centroid_tgt.head (3) - Rc;
 }
 
+} // namespace registration
+} // namespace pcl
+
 #endif    // PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_2D_HPP_
+

--- a/registration/include/pcl/registration/impl/transformation_estimation_dq.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_dq.hpp
@@ -36,14 +36,21 @@
  *
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_DQ_HPP_
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_DQ_HPP_
 
 #include <pcl/common/eigen.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     Matrix4 &transformation_matrix) const
@@ -60,9 +67,9 @@ pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>:
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -79,9 +86,9 @@ pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>:
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -99,9 +106,9 @@ pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>:
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     const pcl::Correspondences &correspondences,
@@ -112,9 +119,9 @@ pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>:
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDQ<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     ConstCloudIterator<PointSource>& source_it,
     ConstCloudIterator<PointTarget>& target_it,
     Matrix4 &transformation_matrix) const
@@ -203,4 +210,8 @@ pcl::registration::TransformationEstimationDQ<PointSource, PointTarget, Scalar>:
   transformation_matrix(2,3) = -t.z();
 }
 
+} // namespace registration
+} // namespace pcl
+
 #endif /* PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_DQ_HPP_ */
+

--- a/registration/include/pcl/registration/impl/transformation_estimation_dual_quaternion.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_dual_quaternion.hpp
@@ -36,14 +36,21 @@
  *
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_DQ_HPP_
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_DQ_HPP_
 
 #include <pcl/common/eigen.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     Matrix4 &transformation_matrix) const
@@ -60,9 +67,9 @@ pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarg
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -79,9 +86,9 @@ pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarg
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -99,9 +106,9 @@ pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarg
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     const pcl::Correspondences &correspondences,
@@ -112,9 +119,9 @@ pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarg
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationDualQuaternion<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     ConstCloudIterator<PointSource>& source_it,
     ConstCloudIterator<PointTarget>& target_it,
     Matrix4 &transformation_matrix) const
@@ -204,4 +211,8 @@ pcl::registration::TransformationEstimationDualQuaternion<PointSource, PointTarg
   transformation_matrix (2, 3) = - t.z ();
 }
 
+} // namespace registration
+} // namespace pcl
+
 #endif /* PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_DQ_HPP_ */
+

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
@@ -37,13 +37,21 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_LLS_HPP_
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_LLS_HPP_
+
 #include <pcl/cloud_iterator.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
                              Matrix4 &transformation_matrix) const
@@ -57,12 +65,12 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
 
   ConstCloudIterator<PointSource> source_it (cloud_src);
   ConstCloudIterator<PointTarget> target_it (cloud_tgt);
-  estimateRigidTransformation (source_it, target_it, transformation_matrix);  
+  estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const std::vector<int> &indices_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -77,13 +85,12 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
 
   ConstCloudIterator<PointSource> source_it (cloud_src, indices_src);
   ConstCloudIterator<PointTarget> target_it (cloud_tgt);
-  estimateRigidTransformation (source_it, target_it, transformation_matrix);  
+  estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const std::vector<int> &indices_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -99,12 +106,12 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
 
   ConstCloudIterator<PointSource> source_it (cloud_src, indices_src);
   ConstCloudIterator<PointTarget> target_it (cloud_tgt, indices_tgt);
-  estimateRigidTransformation (source_it, target_it, transformation_matrix);  
+  estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
                              const pcl::Correspondences &correspondences,
@@ -115,14 +122,14 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 constructTransformationMatrix (const double & alpha, const double & beta, const double & gamma,
                                const double & tx,    const double & ty,   const double & tz,
                                Matrix4 &transformation_matrix) const
 {
-  // Construct the transformation matrix from rotation and translation 
+  // Construct the transformation matrix from rotation and translation
   transformation_matrix = Eigen::Matrix<Scalar, 4, 4>::Zero ();
   transformation_matrix (0, 0) = static_cast<Scalar> ( std::cos (gamma) * std::cos (beta));
   transformation_matrix (0, 1) = static_cast<Scalar> (-sin (gamma) * std::cos (alpha) + std::cos (gamma) * sin (beta) * sin (alpha));
@@ -140,9 +147,9 @@ constructTransformationMatrix (const double & alpha, const double & beta, const 
   transformation_matrix (3, 3) = static_cast<Scalar> (1);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCloudIterator<PointTarget>& target_it, Matrix4 &transformation_matrix) const
 {
   using Vector6d = Eigen::Matrix<double, 6, 1>;
@@ -167,7 +174,7 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCl
         !std::isfinite (target_it->normal_z))
     {
       ++target_it;
-      ++source_it;    
+      ++source_it;
       continue;
     }
 
@@ -182,16 +189,16 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCl
     const float & nz = target_it->normal[2];
 
     double a = nz*sy - ny*sz;
-    double b = nx*sz - nz*sx; 
+    double b = nx*sz - nz*sx;
     double c = ny*sx - nx*sy;
-   
+
     //    0  1  2  3  4  5
     //    6  7  8  9 10 11
     //   12 13 14 15 16 17
     //   18 19 20 21 22 23
     //   24 25 26 27 28 29
     //   30 31 32 33 34 35
-   
+
     ATA.coeffRef (0) += a * a;
     ATA.coeffRef (1) += a * b;
     ATA.coeffRef (2) += a * c;
@@ -223,8 +230,9 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCl
     ATb.coeffRef (5) += nz * d;
 
     ++target_it;
-    ++source_it;    
+    ++source_it;
   }
+
   ATA.coeffRef (6) = ATA.coeff (1);
   ATA.coeffRef (12) = ATA.coeff (2);
   ATA.coeffRef (13) = ATA.coeff (8);
@@ -243,8 +251,13 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCl
 
   // Solve A*x = b
   Vector6d x = static_cast<Vector6d> (ATA.inverse () * ATb);
-  
+
   // Construct the transformation matrix from x
   constructTransformationMatrix (x (0), x (1), x (2), x (3), x (4), x (5), transformation_matrix);
 }
+
+} // namespace registration
+} // namespace pcl
+
 #endif /* PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_LLS_HPP_ */
+

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
@@ -36,13 +36,21 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_LLS_WEIGHTED_HPP_
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_LLS_WEIGHTED_HPP_
+
 #include <pcl/cloud_iterator.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
                              Matrix4 &transformation_matrix) const
@@ -66,9 +74,9 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
   estimateRigidTransformation (source_it, target_it, weights_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const std::vector<int> &indices_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -95,9 +103,8 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const std::vector<int> &indices_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -123,9 +130,9 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
   estimateRigidTransformation (source_it, target_it, weights_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
                              const pcl::Correspondences &correspondences,
@@ -140,14 +147,14 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
   estimateRigidTransformation (source_it, target_it, weights_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
 constructTransformationMatrix (const double & alpha, const double & beta, const double & gamma,
                                const double & tx,    const double & ty,   const double & tz,
                                Matrix4 &transformation_matrix) const
 {
-  // Construct the transformation matrix from rotation and translation 
+  // Construct the transformation matrix from rotation and translation
   transformation_matrix = Eigen::Matrix<Scalar, 4, 4>::Zero ();
   transformation_matrix (0, 0) = static_cast<Scalar> ( std::cos (gamma) * std::cos (beta));
   transformation_matrix (0, 1) = static_cast<Scalar> (-sin (gamma) * std::cos (alpha) + std::cos (gamma) * sin (beta) * sin (alpha));
@@ -165,9 +172,9 @@ constructTransformationMatrix (const double & alpha, const double & beta, const 
   transformation_matrix (3, 3) = static_cast<Scalar> (1);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
+TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it,
                              ConstCloudIterator<PointTarget>& target_it,
                              typename std::vector<Scalar>::const_iterator& weights_it,
@@ -277,4 +284,9 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it,
   // Construct the transformation matrix from x
   constructTransformationMatrix (x (0), x (1), x (2), x (3), x (4), x (5), transformation_matrix);
 }
+
+} // namespace registration
+} // namespace pcl
+
 #endif /* PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_LLS_WEIGHTED_HPP_ */
+

--- a/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
@@ -37,14 +37,21 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_SVD_HPP_
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_SVD_HPP_
 
 #include <pcl/common/eigen.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     Matrix4 &transformation_matrix) const
@@ -61,9 +68,9 @@ pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -80,9 +87,9 @@ pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -100,9 +107,9 @@ pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     const pcl::PointCloud<PointSource> &cloud_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
     const pcl::Correspondences &correspondences,
@@ -113,9 +120,9 @@ pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
+TransformationEstimationSVD<PointSource, PointTarget, Scalar>::estimateRigidTransformation (
     ConstCloudIterator<PointSource>& source_it,
     ConstCloudIterator<PointTarget>& target_it,
     Matrix4 &transformation_matrix) const
@@ -142,7 +149,7 @@ pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>
       cloud_tgt (2, i) = target_it->z;
       ++target_it;
     }
-    
+
     // Call Umeyama directly from Eigen (PCL patched version until Eigen is released)
     transformation_matrix = pcl::umeyama (cloud_src, cloud_tgt, false);
   }
@@ -167,9 +174,9 @@ pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>::getTransformationFromCorrelation (
+TransformationEstimationSVD<PointSource, PointTarget, Scalar>::getTransformationFromCorrelation (
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_src_demean,
     const Eigen::Matrix<Scalar, 4, 1> &centroid_src,
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_tgt_demean,
@@ -201,6 +208,10 @@ pcl::registration::TransformationEstimationSVD<PointSource, PointTarget, Scalar>
   transformation_matrix.block (0, 3, 3, 1) = centroid_tgt.head (3) - Rc;
 }
 
+} // namespace registration
+} // namespace pcl
+
 //#define PCL_INSTANTIATE_TransformationEstimationSVD(T,U) template class PCL_EXPORTS pcl::registration::TransformationEstimationSVD<T,U>;
 
 #endif /* PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_SVD_HPP_ */
+

--- a/registration/include/pcl/registration/impl/transformation_estimation_svd_scale.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_svd_scale.hpp
@@ -36,12 +36,19 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_SVD_SCALE_HPP_
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_SVD_SCALE_HPP_
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationSVDScale<PointSource, PointTarget, Scalar>::getTransformationFromCorrelation (
+TransformationEstimationSVDScale<PointSource, PointTarget, Scalar>::getTransformationFromCorrelation (
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_src_demean,
     const Eigen::Matrix<Scalar, 4, 1> &centroid_src,
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_tgt_demean,
@@ -68,7 +75,7 @@ pcl::registration::TransformationEstimationSVDScale<PointSource, PointTarget, Sc
   Eigen::Matrix<Scalar, 3, 3> R = v * u.transpose ();
 
   // rotated cloud
-  Eigen::Matrix<Scalar, 4, 4> R4; 
+  Eigen::Matrix<Scalar, 4, 4> R4;
   R4.block (0, 0, 3, 3) = R;
   R4 (0, 3) = 0;
   R4 (1, 3) = 0;
@@ -76,24 +83,27 @@ pcl::registration::TransformationEstimationSVDScale<PointSource, PointTarget, Sc
   R4 (3, 3) = 1;
 
   Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> src_ = R4 * cloud_src_demean;
-  
+
   double sum_ss = 0.0f, sum_tt = 0.0f;
   for (unsigned corrIdx = 0; corrIdx < cloud_src_demean.cols (); ++corrIdx)
   {
     sum_ss += cloud_src_demean (0, corrIdx) * cloud_src_demean (0, corrIdx);
     sum_ss += cloud_src_demean (1, corrIdx) * cloud_src_demean (1, corrIdx);
     sum_ss += cloud_src_demean (2, corrIdx) * cloud_src_demean (2, corrIdx);
-    
+
     sum_tt += cloud_tgt_demean (0, corrIdx) * src_ (0, corrIdx);
     sum_tt += cloud_tgt_demean (1, corrIdx) * src_ (1, corrIdx);
     sum_tt += cloud_tgt_demean (2, corrIdx) * src_ (2, corrIdx);
   }
-  
+
   float scale = sum_tt / sum_ss;
   transformation_matrix.topLeftCorner (3, 3) = scale * R;
   const Eigen::Matrix<Scalar, 3, 1> Rc (scale * R * centroid_src.head (3));
   transformation_matrix.block (0, 3, 3, 1) = centroid_tgt. head (3) - Rc;
 }
+
+} // namespace registration
+} // namespace pcl
 
 //#define PCL_INSTANTIATE_TransformationEstimationSVD(T,U) template class PCL_EXPORTS pcl::registration::TransformationEstimationSVD<T,U>;
 

--- a/registration/include/pcl/registration/impl/transformation_estimation_symmetric_point_to_plane_lls.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_symmetric_point_to_plane_lls.hpp
@@ -39,9 +39,15 @@
 
 #include <pcl/cloud_iterator.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
                              Matrix4 &transformation_matrix) const
@@ -55,12 +61,12 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
 
   ConstCloudIterator<PointSource> source_it (cloud_src);
   ConstCloudIterator<PointTarget> target_it (cloud_tgt);
-  estimateRigidTransformation (source_it, target_it, transformation_matrix);  
+  estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> void
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const std::vector<int> &indices_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -75,13 +81,12 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
 
   ConstCloudIterator<PointSource> source_it (cloud_src, indices_src);
   ConstCloudIterator<PointTarget> target_it (cloud_tgt);
-  estimateRigidTransformation (source_it, target_it, transformation_matrix);  
+  estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const std::vector<int> &indices_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -97,12 +102,12 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
 
   ConstCloudIterator<PointSource> source_it (cloud_src, indices_src);
   ConstCloudIterator<PointTarget> target_it (cloud_tgt, indices_tgt);
-  estimateRigidTransformation (source_it, target_it, transformation_matrix);  
+  estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
                              const pcl::PointCloud<PointTarget> &cloud_tgt,
                              const pcl::Correspondences &correspondences,
@@ -113,13 +118,13 @@ estimateRigidTransformation (const pcl::PointCloud<PointSource> &cloud_src,
   estimateRigidTransformation (source_it, target_it, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 constructTransformationMatrix (const Vector6 &parameters,
                                Matrix4 &transformation_matrix) const
 {
-  // Construct the transformation matrix from rotation and translation 
+  // Construct the transformation matrix from rotation and translation
   const Eigen::AngleAxis<Scalar> rotation_z (parameters (2), Eigen::Matrix<Scalar, 3, 1>::UnitZ ());
   const Eigen::AngleAxis<Scalar> rotation_y (parameters (1), Eigen::Matrix<Scalar, 3, 1>::UnitY ());
   const Eigen::AngleAxis<Scalar> rotation_x (parameters (0), Eigen::Matrix<Scalar, 3, 1>::UnitX ());
@@ -130,9 +135,9 @@ constructTransformationMatrix (const Vector6 &parameters,
   transformation_matrix = transform.matrix ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCloudIterator<PointTarget>& target_it, Matrix4 &transformation_matrix) const
 {
   using Matrix6 = Eigen::Matrix<Scalar, 6, 6>;
@@ -176,29 +181,33 @@ estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it, ConstCl
     Vector6 v;
     v << (p + q).cross (n), n;
     M.rankUpdate (v);
-   
+
     ATb += v * (q - p).dot (n);
   }
 
   // Solve A*x = b
   const Vector6 x = M.ldlt ().solve (ATb);
-  
+
   // Construct the transformation matrix from x
   constructTransformationMatrix (x, transformation_matrix);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 setEnforceSameDirectionNormals (bool enforce_same_direction_normals)
 {
     enforce_same_direction_normals_ = enforce_same_direction_normals;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointSource, typename PointTarget, typename Scalar> inline bool 
-pcl::registration::TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
+
+template <typename PointSource, typename PointTarget, typename Scalar> inline bool
+TransformationEstimationSymmetricPointToPlaneLLS<PointSource, PointTarget, Scalar>::
 getEnforceSameDirectionNormals ()
 {
     return enforce_same_direction_normals_;
 }
+
+} // namespace registration
+} // namespace pcl
+

--- a/registration/include/pcl/registration/impl/transformation_validation_euclidean.hpp
+++ b/registration/include/pcl/registration/impl/transformation_validation_euclidean.hpp
@@ -37,12 +37,19 @@
  * $Id$
  *
  */
+
 #ifndef PCL_REGISTRATION_TRANSFORMATION_VALIDATION_EUCLIDEAN_IMPL_H_
 #define PCL_REGISTRATION_TRANSFORMATION_VALIDATION_EUCLIDEAN_IMPL_H_
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace registration
+{
+
 template <typename PointSource, typename PointTarget, typename Scalar> double
-pcl::registration::TransformationValidationEuclidean<PointSource, PointTarget, Scalar>::validateTransformation (
+TransformationValidationEuclidean<PointSource, PointTarget, Scalar>::validateTransformation (
   const PointCloudSourceConstPtr &cloud_src,
   const PointCloudTargetConstPtr &cloud_tgt,
   const Matrix4 &transformation_matrix) const
@@ -78,7 +85,7 @@ pcl::registration::TransformationValidationEuclidean<PointSource, PointTarget, S
   {
     // Find its nearest neighbor in the target
     tree_->nearestKSearch (input_transformed.points[i], 1, nn_indices, nn_dists);
-    
+
     // Deal with occlusions (incomplete targets)
     if (nn_dists[0] > max_range_)
       continue;
@@ -92,6 +99,9 @@ pcl::registration::TransformationValidationEuclidean<PointSource, PointTarget, S
     return (fitness_score / nr);
   return (std::numeric_limits<double>::max ());
 }
+
+} // namespace registration
+} // namespace pcl
 
 #endif    // PCL_REGISTRATION_TRANSFORMATION_VALIDATION_EUCLIDEAN_IMPL_H_
 

--- a/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
@@ -44,16 +44,19 @@
 
 namespace pcl
 {
-  template <>
-  float squaredEuclideanDistance (const pcl::segmentation::grabcut::Color &c1,
-                                  const pcl::segmentation::grabcut::Color &c2)
-  {
-    return ((c1.r-c2.r)*(c1.r-c2.r)+(c1.g-c2.g)*(c1.g-c2.g)+(c1.b-c2.b)*(c1.b-c2.b));
-  }
+
+template <>
+float squaredEuclideanDistance (const pcl::segmentation::grabcut::Color &c1,
+                                const pcl::segmentation::grabcut::Color &c2)
+{
+  return ((c1.r-c2.r)*(c1.r-c2.r)+(c1.g-c2.g)*(c1.g-c2.g)+(c1.b-c2.b)*(c1.b-c2.b));
 }
 
+namespace segmentation
+{
+
 template <typename PointT>
-pcl::segmentation::grabcut::Color::Color (const PointT& p)
+grabcut::Color::Color (const PointT& p)
 {
   r = static_cast<float> (p.r) / 255.0;
   g = static_cast<float> (p.g) / 255.0;
@@ -61,7 +64,7 @@ pcl::segmentation::grabcut::Color::Color (const PointT& p)
 }
 
 template <typename PointT>
-pcl::segmentation::grabcut::Color::operator PointT () const
+grabcut::Color::operator PointT () const
 {
   PointT p;
   p.r = static_cast<std::uint32_t> (r * 255);
@@ -70,14 +73,16 @@ pcl::segmentation::grabcut::Color::operator PointT () const
   return (p);
 }
 
+} // namespace segmentation
+
 template <typename PointT> void
-pcl::GrabCut<PointT>::setInputCloud (const PointCloudConstPtr &cloud)
+GrabCut<PointT>::setInputCloud (const PointCloudConstPtr &cloud)
 {
   input_ = cloud;
 }
 
 template <typename PointT> bool
-pcl::GrabCut<PointT>::initCompute ()
+GrabCut<PointT>::initCompute ()
 {
   using namespace pcl::segmentation::grabcut;
   if (!pcl::PCLBase<PointT>::initCompute ())
@@ -140,20 +145,20 @@ pcl::GrabCut<PointT>::initCompute ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::addEdge (vertex_descriptor v1, vertex_descriptor v2, float capacity, float rev_capacity)
+GrabCut<PointT>::addEdge (vertex_descriptor v1, vertex_descriptor v2, float capacity, float rev_capacity)
 {
   graph_.addEdge (v1, v2, capacity, rev_capacity);
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::setTerminalWeights (vertex_descriptor v, float source_capacity, float sink_capacity)
+GrabCut<PointT>::setTerminalWeights (vertex_descriptor v, float source_capacity, float sink_capacity)
 {
   graph_.addSourceEdge (v, source_capacity);
   graph_.addTargetEdge (v, sink_capacity);
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::setBackgroundPointsIndices (const PointIndicesConstPtr &indices)
+GrabCut<PointT>::setBackgroundPointsIndices (const PointIndicesConstPtr &indices)
 {
   using namespace pcl::segmentation::grabcut;
   if (!initCompute ())
@@ -175,7 +180,7 @@ pcl::GrabCut<PointT>::setBackgroundPointsIndices (const PointIndicesConstPtr &in
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::fitGMMs ()
+GrabCut<PointT>::fitGMMs ()
 {
   // Step 3: Build GMMs using Orchard-Bouman clustering algorithm
   buildGMMs (*image_, *indices_, hard_segmentation_, GMM_component_, background_GMM_, foreground_GMM_);
@@ -185,7 +190,7 @@ pcl::GrabCut<PointT>::fitGMMs ()
 }
 
 template <typename PointT> int
-pcl::GrabCut<PointT>::refineOnce ()
+GrabCut<PointT>::refineOnce ()
 {
   // Steps 4 and 5: Learn new GMMs from current segmentation
   learnGMMs (*image_, *indices_, hard_segmentation_, GMM_component_, background_GMM_, foreground_GMM_);
@@ -202,7 +207,7 @@ pcl::GrabCut<PointT>::refineOnce ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::refine ()
+GrabCut<PointT>::refine ()
 {
   std::size_t changed = indices_->size ();
 
@@ -211,7 +216,7 @@ pcl::GrabCut<PointT>::refine ()
 }
 
 template <typename PointT> int
-pcl::GrabCut<PointT>::updateHardSegmentation ()
+GrabCut<PointT>::updateHardSegmentation ()
 {
   using namespace pcl::segmentation::grabcut;
 
@@ -242,7 +247,7 @@ pcl::GrabCut<PointT>::updateHardSegmentation ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::setTrimap (const PointIndicesConstPtr &indices, segmentation::grabcut::TrimapValue t)
+GrabCut<PointT>::setTrimap (const PointIndicesConstPtr &indices, segmentation::grabcut::TrimapValue t)
 {
   using namespace pcl::segmentation::grabcut;
   for (const int &index : indices->indices)
@@ -259,7 +264,7 @@ pcl::GrabCut<PointT>::setTrimap (const PointIndicesConstPtr &indices, segmentati
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::initGraph ()
+GrabCut<PointT>::initGraph ()
 {
   using namespace pcl::segmentation::grabcut;
   const int number_of_indices = static_cast<int> (indices_->size ());
@@ -324,7 +329,7 @@ pcl::GrabCut<PointT>::initGraph ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::computeNLinksNonOrganized ()
+GrabCut<PointT>::computeNLinksNonOrganized ()
 {
   const int number_of_indices = static_cast<int> (indices_->size ());
   for (int i_point = 0; i_point < number_of_indices; ++i_point)
@@ -350,7 +355,7 @@ pcl::GrabCut<PointT>::computeNLinksNonOrganized ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::computeNLinksOrganized ()
+GrabCut<PointT>::computeNLinksOrganized ()
 {
 	for( unsigned int y = 0; y < image_->height; ++y )
 	{
@@ -377,7 +382,7 @@ pcl::GrabCut<PointT>::computeNLinksOrganized ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::computeBetaNonOrganized ()
+GrabCut<PointT>::computeBetaNonOrganized ()
 {
   float result = 0;
   std::size_t edges = 0;
@@ -416,7 +421,7 @@ pcl::GrabCut<PointT>::computeBetaNonOrganized ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::computeBetaOrganized ()
+GrabCut<PointT>::computeBetaOrganized ()
 {
   float result = 0;
   std::size_t edges = 0;
@@ -486,13 +491,13 @@ pcl::GrabCut<PointT>::computeBetaOrganized ()
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::computeL ()
+GrabCut<PointT>::computeL ()
 {
   L_ = 8*lambda_ + 1;
 }
 
 template <typename PointT> void
-pcl::GrabCut<PointT>::extract (std::vector<pcl::PointIndices>& clusters)
+GrabCut<PointT>::extract (std::vector<pcl::PointIndices>& clusters)
 {
   using namespace pcl::segmentation::grabcut;
   clusters.clear ();
@@ -509,4 +514,7 @@ pcl::GrabCut<PointT>::extract (std::vector<pcl::PointIndices>& clusters)
       clusters[0].indices.push_back (i);
 }
 
+} // namespace pcl
+
 #endif
+

--- a/surface/include/pcl/surface/impl/processing.hpp
+++ b/surface/include/pcl/surface/impl/processing.hpp
@@ -37,10 +37,14 @@
  *
  */
 
+#pragma once
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointInT, typename PointOutT> void
-pcl::CloudSurfaceProcessing<PointInT, PointOutT>::process (pcl::PointCloud<PointOutT> &output)
+CloudSurfaceProcessing<PointInT, PointOutT>::process (pcl::PointCloud<PointOutT> &output)
 {
   // Copy the header
   output.header = input_->header;
@@ -57,3 +61,6 @@ pcl::CloudSurfaceProcessing<PointInT, PointOutT>::process (pcl::PointCloud<Point
 
   deinitCompute ();
 }
+
+} // namespace pcl
+

--- a/surface/include/pcl/surface/impl/reconstruction.hpp
+++ b/surface/include/pcl/surface/impl/reconstruction.hpp
@@ -39,16 +39,20 @@
 
 #ifndef PCL_SURFACE_RECONSTRUCTION_IMPL_H_
 #define PCL_SURFACE_RECONSTRUCTION_IMPL_H_
+
 #include <pcl/search/pcl_search.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template <typename PointInT> void
-pcl::SurfaceReconstruction<PointInT>::reconstruct (pcl::PolygonMesh &output)
+SurfaceReconstruction<PointInT>::reconstruct (pcl::PolygonMesh &output)
 {
   // Copy the header
   output.header = input_->header;
 
-  if (!initCompute ()) 
+  if (!initCompute ())
   {
     output.cloud.width = output.cloud.height = 0;
     output.cloud.data.clear ();
@@ -81,15 +85,15 @@ pcl::SurfaceReconstruction<PointInT>::reconstruct (pcl::PolygonMesh &output)
   deinitCompute ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT> void
-pcl::SurfaceReconstruction<PointInT>::reconstruct (pcl::PointCloud<PointInT> &points,
-                                                   std::vector<pcl::Vertices> &polygons)
+SurfaceReconstruction<PointInT>::reconstruct (pcl::PointCloud<PointInT> &points,
+                                              std::vector<pcl::Vertices> &polygons)
 {
   // Copy the header
   points.header = input_->header;
 
-  if (!initCompute ()) 
+  if (!initCompute ())
   {
     points.width = points.height = 0;
     points.clear ();
@@ -121,14 +125,14 @@ pcl::SurfaceReconstruction<PointInT>::reconstruct (pcl::PointCloud<PointInT> &po
   deinitCompute ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT> void
-pcl::MeshConstruction<PointInT>::reconstruct (pcl::PolygonMesh &output)
+MeshConstruction<PointInT>::reconstruct (pcl::PolygonMesh &output)
 {
   // Copy the header
   output.header = input_->header;
 
-  if (!initCompute ()) 
+  if (!initCompute ())
   {
     output.cloud.width = output.cloud.height = 1;
     output.cloud.data.clear ();
@@ -161,11 +165,11 @@ pcl::MeshConstruction<PointInT>::reconstruct (pcl::PolygonMesh &output)
   deinitCompute ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT> void
-pcl::MeshConstruction<PointInT>::reconstruct (std::vector<pcl::Vertices> &polygons)
+MeshConstruction<PointInT>::reconstruct (std::vector<pcl::Vertices> &polygons)
 {
-  if (!initCompute ()) 
+  if (!initCompute ())
   {
     polygons.clear ();
     return;
@@ -195,6 +199,7 @@ pcl::MeshConstruction<PointInT>::reconstruct (std::vector<pcl::Vertices> &polygo
   deinitCompute ();
 }
 
+} // namespace pcl
 
 #endif  // PCL_SURFACE_RECONSTRUCTION_IMPL_H_
 

--- a/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
+++ b/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
@@ -43,17 +43,23 @@
 #include <pcl/common/io.h>
 #include <pcl/common/utils.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace tracking
+{
+
 template <typename PointInT, typename IntensityT> inline void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::setTrackingWindowSize (int width, int height)
+PyramidalKLTTracker<PointInT, IntensityT>::setTrackingWindowSize (int width, int height)
 {
   track_width_ = width;
   track_height_ = height;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> inline void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::setPointsToTrack (const pcl::PointCloud<pcl::PointUV>::ConstPtr& keypoints)
+PyramidalKLTTracker<PointInT, IntensityT>::setPointsToTrack (const pcl::PointCloud<pcl::PointUV>::ConstPtr& keypoints)
 {
   if (keypoints->size () <= keypoints_nbr_)
     keypoints_ = keypoints;
@@ -70,9 +76,9 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::setPointsToTrack (cons
   keypoints_status_->indices.resize (keypoints_->size (), 0);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> inline void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::setPointsToTrack (const pcl::PointIndicesConstPtr& points)
+PyramidalKLTTracker<PointInT, IntensityT>::setPointsToTrack (const pcl::PointIndicesConstPtr& points)
 {
   assert ((input_ || ref_) && "[pcl::tracking::PyramidalKLTTracker] CALL setInputCloud FIRST!");
 
@@ -88,9 +94,9 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::setPointsToTrack (cons
   setPointsToTrack (keypoints);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> bool
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::initCompute ()
+PyramidalKLTTracker<PointInT, IntensityT>::initCompute ()
 {
   // std::cout << ">>> [PyramidalKLTTracker::initCompute]" << std::endl;
   if (!PCLBase<PointInT>::initCompute ())
@@ -154,14 +160,15 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::initCompute ()
     computePyramids (ref_, ref_pyramid_, pcl::BORDER_REFLECT_101);
     return (true);
   }
+
   initialized_ = true;
 
   return (true);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::derivatives (const FloatImage& src, FloatImage& grad_x, FloatImage& grad_y) const
+PyramidalKLTTracker<PointInT, IntensityT>::derivatives (const FloatImage& src, FloatImage& grad_x, FloatImage& grad_y) const
 {
   // std::cout << ">>> derivatives" << std::endl;
   ////////////////////////////////////////////////////////
@@ -214,9 +221,9 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::derivatives (const Flo
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::downsample (const FloatImageConstPtr& input,
+PyramidalKLTTracker<PointInT, IntensityT>::downsample (const FloatImageConstPtr& input,
                                                                FloatImageConstPtr& output) const
 {
   FloatImage smoothed (input->width, input->height);
@@ -244,12 +251,12 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::downsample (const Floa
   output = down;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::downsample (const FloatImageConstPtr& input,
-                                                                      FloatImageConstPtr& output,
-                                                                      FloatImageConstPtr& output_grad_x,
-                                                                      FloatImageConstPtr& output_grad_y) const
+PyramidalKLTTracker<PointInT, IntensityT>::downsample (const FloatImageConstPtr& input,
+                                                             FloatImageConstPtr& output,
+                                                             FloatImageConstPtr& output_grad_x,
+                                                             FloatImageConstPtr& output_grad_y) const
 {
   downsample (input, output);
   FloatImagePtr grad_x (new FloatImage (input->width, input->height));
@@ -259,18 +266,18 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::downsample (const Floa
   output_grad_y = grad_y;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::convolve (const FloatImageConstPtr& input, FloatImage& output) const
+PyramidalKLTTracker<PointInT, IntensityT>::convolve (const FloatImageConstPtr& input, FloatImage& output) const
 {
   FloatImagePtr tmp (new FloatImage (input->width, input->height));
   convolveRows (input, *tmp);
   convolveCols (tmp, output);
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::convolveRows (const FloatImageConstPtr& input, FloatImage& output) const
+PyramidalKLTTracker<PointInT, IntensityT>::convolveRows (const FloatImageConstPtr& input, FloatImage& output) const
 {
   int width = input->width;
   int height = input->height;
@@ -300,9 +307,9 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::convolveRows (const Fl
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::convolveCols (const FloatImageConstPtr& input, FloatImage& output) const
+PyramidalKLTTracker<PointInT, IntensityT>::convolveCols (const FloatImageConstPtr& input, FloatImage& output) const
 {
   output = FloatImage (input->width, input->height);
 
@@ -333,11 +340,11 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::convolveCols (const Fl
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::computePyramids (const PointCloudInConstPtr& input,
-                                                                    std::vector<FloatImageConstPtr>& pyramid,
-                                                                    pcl::InterpolationType border_type) const
+PyramidalKLTTracker<PointInT, IntensityT>::computePyramids (const PointCloudInConstPtr& input,
+                                                            std::vector<FloatImageConstPtr>& pyramid,
+                                                            pcl::InterpolationType border_type) const
 {
   int step = 3;
   pyramid.resize (step * nb_levels_);
@@ -402,17 +409,17 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::computePyramids (const
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::spatialGradient (const FloatImage& img,
-                                                                    const FloatImage& grad_x,
-                                                                    const FloatImage& grad_y,
-                                                                    const Eigen::Array2i& location,
-                                                                    const Eigen::Array4f& weight,
-                                                                    Eigen::ArrayXXf& win,
-                                                                    Eigen::ArrayXXf& grad_x_win,
-                                                                    Eigen::ArrayXXf& grad_y_win,
-                                                                    Eigen::Array3f &covariance) const
+PyramidalKLTTracker<PointInT, IntensityT>::spatialGradient (const FloatImage& img,
+                                                            const FloatImage& grad_x,
+                                                            const FloatImage& grad_y,
+                                                            const Eigen::Array2i& location,
+                                                            const Eigen::Array4f& weight,
+                                                            Eigen::ArrayXXf& win,
+                                                            Eigen::ArrayXXf& grad_x_win,
+                                                            Eigen::ArrayXXf& grad_y_win,
+                                                            Eigen::Array3f &covariance) const
 {
   const int step = img.width;
   covariance.setZero ();
@@ -443,15 +450,15 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::spatialGradient (const
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::mismatchVector (const Eigen::ArrayXXf& prev,
-                                                                   const Eigen::ArrayXXf& prev_grad_x,
-                                                                   const Eigen::ArrayXXf& prev_grad_y,
-                                                                   const FloatImage& next,
-                                                                   const Eigen::Array2i& location,
-                                                                   const Eigen::Array4f& weight,
-                                                                   Eigen::Array2f &b) const
+PyramidalKLTTracker<PointInT, IntensityT>::mismatchVector (const Eigen::ArrayXXf& prev,
+                                                           const Eigen::ArrayXXf& prev_grad_x,
+                                                           const Eigen::ArrayXXf& prev_grad_y,
+                                                           const FloatImage& next,
+                                                           const Eigen::Array2i& location,
+                                                           const Eigen::Array4f& weight,
+                                                           Eigen::Array2f &b) const
 {
   const int step = next.width;
   b.setZero ();
@@ -472,16 +479,16 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::mismatchVector (const 
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::track (const PointCloudInConstPtr& prev_input,
-                                                                 const PointCloudInConstPtr& input,
-                                                                 const std::vector<FloatImageConstPtr>& prev_pyramid,
-                                                                 const std::vector<FloatImageConstPtr>& pyramid,
-                                                                 const pcl::PointCloud<pcl::PointUV>::ConstPtr& prev_keypoints,
-                                                                 pcl::PointCloud<pcl::PointUV>::Ptr& keypoints,
-                                                                 std::vector<int>& status,
-                                                                 Eigen::Affine3f& motion) const
+PyramidalKLTTracker<PointInT, IntensityT>::track (const PointCloudInConstPtr& prev_input,
+                                                  const PointCloudInConstPtr& input,
+                                                  const std::vector<FloatImageConstPtr>& prev_pyramid,
+                                                  const std::vector<FloatImageConstPtr>& pyramid,
+                                                  const pcl::PointCloud<pcl::PointUV>::ConstPtr& prev_keypoints,
+                                                  pcl::PointCloud<pcl::PointUV>::Ptr& keypoints,
+                                                  std::vector<int>& status,
+                                                  Eigen::Affine3f& motion) const
 {
   std::vector<Eigen::Array2f, Eigen::aligned_allocator<Eigen::Array2f> > next_pts (prev_keypoints->size ());
   Eigen::Array2f half_win ((track_width_-1)*0.5f, (track_height_-1)*0.5f);
@@ -619,12 +626,13 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::track (const PointClou
       }
     }
   }
+
   motion = transformation_computer.getTransformation ();
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointInT, typename IntensityT> void
-pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::computeTracking ()
+PyramidalKLTTracker<PointInT, IntensityT>::computeTracking ()
 {
   if (!initialized_)
     return;
@@ -642,4 +650,8 @@ pcl::tracking::PyramidalKLTTracker<PointInT, IntensityT>::computeTracking ()
   keypoints_status_->indices = status;
 }
 
+} // namespace tracking
+} // namespace pcl
+
 #endif
+

--- a/visualization/include/pcl/visualization/common/impl/shapes.hpp
+++ b/visualization/include/pcl/visualization/common/impl/shapes.hpp
@@ -37,14 +37,21 @@
  */
 
 #pragma once
+
 #include <vtkSmartPointer.h>
 #include <vtkPoints.h>
 #include <vtkPolygon.h>
 #include <vtkUnstructuredGrid.h>
 
-////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace visualization
+{
+
 template <typename PointT> vtkSmartPointer<vtkDataSet> 
-pcl::visualization::createPolygon (const typename pcl::PointCloud<PointT>::ConstPtr &cloud)
+createPolygon (const typename pcl::PointCloud<PointT>::ConstPtr &cloud)
 {
   vtkSmartPointer<vtkUnstructuredGrid> poly_grid;
   if (cloud->points.empty ())
@@ -70,9 +77,9 @@ pcl::visualization::createPolygon (const typename pcl::PointCloud<PointT>::Const
   return (poly_grid);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> vtkSmartPointer<vtkDataSet> 
-pcl::visualization::createPolygon (const pcl::PlanarPolygon<PointT> &planar_polygon)
+createPolygon (const pcl::PlanarPolygon<PointT> &planar_polygon)
 {
   vtkSmartPointer<vtkUnstructuredGrid> poly_grid;
   if (planar_polygon.getContour ().empty ())
@@ -86,19 +93,19 @@ pcl::visualization::createPolygon (const pcl::PlanarPolygon<PointT> &planar_poly
 
   for (std::size_t i = 0; i < planar_polygon.getContour ().size (); ++i)
   {
-    poly_points->SetPoint (i, planar_polygon.getContour ()[i].x, 
-                              planar_polygon.getContour ()[i].y, 
+    poly_points->SetPoint (i, planar_polygon.getContour ()[i].x,
+                              planar_polygon.getContour ()[i].y,
                               planar_polygon.getContour ()[i].z);
     polygon->GetPointIds ()->SetId (i, i);
   }
 
   std::size_t closingContourId = planar_polygon.getContour ().size ();
   auto firstContour = planar_polygon.getContour ()[0];
-  poly_points->SetPoint (closingContourId, firstContour.x, 
-                                           firstContour.y, 
+  poly_points->SetPoint (closingContourId, firstContour.x,
+                                           firstContour.y,
                                            firstContour.z);
   polygon->GetPointIds ()->SetId (closingContourId, closingContourId);
-  
+
   allocVtkUnstructuredGrid (poly_grid);
   poly_grid->Allocate (1, 1);
   poly_grid->InsertNextCell (polygon->GetCellType (), polygon->GetPointIds ());
@@ -106,4 +113,7 @@ pcl::visualization::createPolygon (const pcl::PlanarPolygon<PointT> &planar_poly
 
   return (poly_grid);
 }
+
+} // namespace visualization
+} // namespace pcl
 

--- a/visualization/include/pcl/visualization/impl/histogram_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/histogram_visualizer.hpp
@@ -41,10 +41,16 @@
 
 #include <vtkDoubleArray.h>
 
-////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace visualization
+{
+
 template <typename PointT> bool
-pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
-    const pcl::PointCloud<PointT> &cloud, int hsize, 
+PCLHistogramVisualizer::addFeatureHistogram (
+    const pcl::PointCloud<PointT> &cloud, int hsize,
     const std::string &id, int win_width, int win_height)
 {
   RenWinInteractMap::iterator am_it = wins_.find (id);
@@ -75,12 +81,12 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
   return (true);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
-    const pcl::PointCloud<PointT> &cloud, 
+PCLHistogramVisualizer::addFeatureHistogram (
+    const pcl::PointCloud<PointT> &cloud,
     const std::string &field_name,
-    const int index, 
+    const int index,
     const std::string &id, int win_width, int win_height)
 {
   if (index < 0 || index >= cloud.points.size ())
@@ -129,10 +135,10 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
   return (true);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
-    const pcl::PointCloud<PointT> &cloud, int hsize, 
+PCLHistogramVisualizer::updateFeatureHistogram (
+    const pcl::PointCloud<PointT> &cloud, int hsize,
     const std::string &id)
 {
   RenWinInteractMap::iterator am_it = wins_.find (id);
@@ -142,11 +148,11 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
     return (false);
   }
   RenWinInteract* renwinupd = &wins_[id];
-  
+
   vtkSmartPointer<vtkDoubleArray> xy_array = vtkSmartPointer<vtkDoubleArray>::New ();
   xy_array->SetNumberOfComponents (2);
   xy_array->SetNumberOfTuples (hsize);
-  
+
   // Parse the cloud data and store it in the array
   double xy[2];
   for (int d = 0; d < hsize; ++d)
@@ -159,10 +165,10 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
   return (true);
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> bool
-pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
-    const pcl::PointCloud<PointT> &cloud, const std::string &field_name, const int index, 
+PCLHistogramVisualizer::updateFeatureHistogram (
+    const pcl::PointCloud<PointT> &cloud, const std::string &field_name, const int index,
     const std::string &id)
 {
   if (index < 0 || index >= cloud.points.size ())
@@ -170,7 +176,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
     PCL_ERROR ("[updateFeatureHistogram] Invalid point index (%d) given!\n", index);
     return (false);
   }
-  
+
   // Get the fields present in this cloud
   std::vector<pcl::PCLPointField> fields;
   // Check if our field exists
@@ -188,7 +194,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
     return (false);
   }
   RenWinInteract* renwinupd = &wins_[id];
-    
+
   vtkSmartPointer<vtkDoubleArray> xy_array = vtkSmartPointer<vtkDoubleArray>::New ();
   xy_array->SetNumberOfComponents (2);
   xy_array->SetNumberOfTuples (fields[field_idx].count);
@@ -204,10 +210,13 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
     xy[1] = data;
     xy_array->SetTuple (d, xy);
   }
-  
+
   reCreateActor (xy_array, renwinupd, cloud.fields[field_idx].count - 1);
   return (true);
 }
+
+} // namespace visualization
+} // namespace pcl
 
 #endif
 

--- a/visualization/include/pcl/visualization/impl/pcl_plotter.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_plotter.hpp
@@ -38,20 +38,27 @@
 #ifndef PCL_VISUALUALIZATION_PCL_PLOTTER_IMPL_H_
 #define	PCL_VISUALUALIZATION_PCL_PLOTTER_IMPL_H_
 
+
+namespace pcl
+{
+
+namespace visualization
+{
+
 template <typename PointT> bool
-pcl::visualization::PCLPlotter::addFeatureHistogram (
-    const pcl::PointCloud<PointT> &cloud, int hsize, 
+PCLPlotter::addFeatureHistogram (
+    const pcl::PointCloud<PointT> &cloud, int hsize,
     const std::string &id, int win_width, int win_height)
 {
   std::vector<double> array_x(hsize), array_y(hsize);
-  
+
   // Parse the cloud data and store it in the array
   for (int i = 0; i < hsize; ++i)
   {
     array_x[i] = i;
     array_y[i] = cloud.points[0].histogram[i];
   }
-  
+
   this->addPlotData(array_x, array_y, id.c_str(), vtkChart::LINE);
   setWindowSize (win_width, win_height);
   return true;
@@ -59,10 +66,10 @@ pcl::visualization::PCLPlotter::addFeatureHistogram (
 
 
 template <typename PointT> bool
-pcl::visualization::PCLPlotter::addFeatureHistogram (
-    const pcl::PointCloud<PointT> &cloud, 
+PCLPlotter::addFeatureHistogram (
+    const pcl::PointCloud<PointT> &cloud,
     const std::string &field_name,
-    const int index, 
+    const int index,
     const std::string &id, int win_width, int win_height)
 {
   if (index < 0 || index >= cloud.points.size ())
@@ -83,7 +90,7 @@ pcl::visualization::PCLPlotter::addFeatureHistogram (
 
   int hsize = fields[field_idx].count;
   std::vector<double> array_x (hsize), array_y (hsize);
-  
+
   for (int i = 0; i < hsize; ++i)
   {
     array_x[i] = i;
@@ -92,11 +99,14 @@ pcl::visualization::PCLPlotter::addFeatureHistogram (
     memcpy (&data, reinterpret_cast<const char*> (&cloud.points[index]) + fields[field_idx].offset + i * sizeof (float), sizeof (float));
     array_y[i] = data;
   }
-  
+
   this->addPlotData(array_x, array_y, id.c_str(), vtkChart::LINE);
   setWindowSize (win_width, win_height);
   return (true);
 }
+
+} // namespace visualization
+} // namespace pcl
 
 #endif	/* PCL_VISUALUALIZATION_PCL_PLOTTER_IMPL_H_ */
 

--- a/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
+++ b/visualization/include/pcl/visualization/impl/point_cloud_color_handlers.hpp
@@ -44,9 +44,15 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/common/colors.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace visualization
+{
+
 template <typename PointT> vtkSmartPointer<vtkDataArray>
-pcl::visualization::PointCloudColorHandlerCustom<PointT>::getColor () const
+PointCloudColorHandlerCustom<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
     return nullptr;
@@ -71,9 +77,9 @@ pcl::visualization::PointCloudColorHandlerCustom<PointT>::getColor () const
   return scalars;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> vtkSmartPointer<vtkDataArray>
-pcl::visualization::PointCloudColorHandlerRandom<PointT>::getColor () const
+PointCloudColorHandlerRandom<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
     return nullptr;
@@ -89,8 +95,8 @@ pcl::visualization::PointCloudColorHandlerRandom<PointT>::getColor () const
   double r, g, b;
   pcl::visualization::getRandomColors (r, g, b);
 
-  int r_ = static_cast<int> (pcl_lrint (r * 255.0)), 
-      g_ = static_cast<int> (pcl_lrint (g * 255.0)), 
+  int r_ = static_cast<int> (pcl_lrint (r * 255.0)),
+      g_ = static_cast<int> (pcl_lrint (g * 255.0)),
       b_ = static_cast<int> (pcl_lrint (b * 255.0));
 
   // Color every point
@@ -104,9 +110,9 @@ pcl::visualization::PointCloudColorHandlerRandom<PointT>::getColor () const
   return scalars;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::visualization::PointCloudColorHandlerRGBField<PointT>::setInputCloud (
+PointCloudColorHandlerRGBField<PointT>::setInputCloud (
     const PointCloudConstPtr &cloud)
 {
   PointCloudColorHandler<PointT>::setInputCloud (cloud);
@@ -127,9 +133,9 @@ pcl::visualization::PointCloudColorHandlerRGBField<PointT>::setInputCloud (
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> vtkSmartPointer<vtkDataArray>
-pcl::visualization::PointCloudColorHandlerRGBField<PointT>::getColor () const
+PointCloudColorHandlerRGBField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
     return nullptr;
@@ -165,7 +171,7 @@ pcl::visualization::PointCloudColorHandlerRGBField<PointT>::getColor () const
     {
       // Copy the value at the specified field
       if (!std::isfinite (cloud_->points[cp].x) ||
-          !std::isfinite (cloud_->points[cp].y) || 
+          !std::isfinite (cloud_->points[cp].y) ||
           !std::isfinite (cloud_->points[cp].z))
         continue;
 
@@ -191,10 +197,10 @@ pcl::visualization::PointCloudColorHandlerRGBField<PointT>::getColor () const
   return scalars;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT>
-pcl::visualization::PointCloudColorHandlerHSVField<PointT>::PointCloudColorHandlerHSVField (const PointCloudConstPtr &cloud) : 
-  pcl::visualization::PointCloudColorHandler<PointT>::PointCloudColorHandler (cloud)
+PointCloudColorHandlerHSVField<PointT>::PointCloudColorHandlerHSVField (const PointCloudConstPtr &cloud) :
+  PointCloudColorHandler<PointT>::PointCloudColorHandler (cloud)
 {
   // Check for the presence of the "H" field
   field_idx_ = pcl::getFieldIndex<PointT> ("h", fields_);
@@ -222,9 +228,9 @@ pcl::visualization::PointCloudColorHandlerHSVField<PointT>::PointCloudColorHandl
   capable_ = true;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> vtkSmartPointer<vtkDataArray>
-pcl::visualization::PointCloudColorHandlerHSVField<PointT>::getColor () const
+PointCloudColorHandlerHSVField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
     return nullptr;
@@ -359,9 +365,9 @@ pcl::visualization::PointCloudColorHandlerHSVField<PointT>::getColor () const
   return scalars;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::visualization::PointCloudColorHandlerGenericField<PointT>::setInputCloud (
+PointCloudColorHandlerGenericField<PointT>::setInputCloud (
     const PointCloudConstPtr &cloud)
 {
   PointCloudColorHandler<PointT>::setInputCloud (cloud);
@@ -372,9 +378,9 @@ pcl::visualization::PointCloudColorHandlerGenericField<PointT>::setInputCloud (
     capable_ = false;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> vtkSmartPointer<vtkDataArray>
-pcl::visualization::PointCloudColorHandlerGenericField<PointT>::getColor () const
+PointCloudColorHandlerGenericField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
     return nullptr;
@@ -432,9 +438,9 @@ pcl::visualization::PointCloudColorHandlerGenericField<PointT>::getColor () cons
   return scalars;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::setInputCloud (
+PointCloudColorHandlerRGBAField<PointT>::setInputCloud (
     const PointCloudConstPtr &cloud)
 {
   PointCloudColorHandler<PointT>::setInputCloud (cloud);
@@ -446,9 +452,9 @@ pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::setInputCloud (
     capable_ = false;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> vtkSmartPointer<vtkDataArray>
-pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::getColor () const
+PointCloudColorHandlerRGBAField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
     return nullptr;
@@ -500,9 +506,9 @@ pcl::visualization::PointCloudColorHandlerRGBAField<PointT>::getColor () const
   return scalars;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> void
-pcl::visualization::PointCloudColorHandlerLabelField<PointT>::setInputCloud (const PointCloudConstPtr &cloud)
+PointCloudColorHandlerLabelField<PointT>::setInputCloud (const PointCloudConstPtr &cloud)
 {
   PointCloudColorHandler<PointT>::setInputCloud (cloud);
   field_idx_ = pcl::getFieldIndex<PointT> ("label", fields_);
@@ -513,9 +519,9 @@ pcl::visualization::PointCloudColorHandlerLabelField<PointT>::setInputCloud (con
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT> vtkSmartPointer<vtkDataArray>
-pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor () const
+PointCloudColorHandlerLabelField<PointT>::getColor () const
 {
   if (!capable_ || !cloud_)
     return nullptr;
@@ -557,6 +563,9 @@ pcl::visualization::PointCloudColorHandlerLabelField<PointT>::getColor () const
 
   return scalars;
 }
+
+} // namespace visualization
+} // namespace pcl
 
 #endif      // PCL_POINT_CLOUD_COLOR_HANDLERS_IMPL_HPP_
 

--- a/visualization/include/pcl/visualization/impl/point_cloud_geometry_handlers.hpp
+++ b/visualization/include/pcl/visualization/impl/point_cloud_geometry_handlers.hpp
@@ -36,15 +36,22 @@
  * $Id: point_cloud_handlers.hpp 7678 2012-10-22 20:54:04Z rusu $
  *
  */
+
 #ifndef PCL_POINT_CLOUD_GEOMETRY_HANDLERS_IMPL_HPP_
 #define PCL_POINT_CLOUD_GEOMETRY_HANDLERS_IMPL_HPP_
 
 #include <pcl/pcl_macros.h>
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
+namespace visualization
+{
+
 template <typename PointT>
-pcl::visualization::PointCloudGeometryHandlerXYZ<PointT>::PointCloudGeometryHandlerXYZ (const PointCloudConstPtr &cloud) 
-  : pcl::visualization::PointCloudGeometryHandler<PointT>::PointCloudGeometryHandler (cloud)
+PointCloudGeometryHandlerXYZ<PointT>::PointCloudGeometryHandlerXYZ (const PointCloudConstPtr &cloud)
+  : PointCloudGeometryHandler<PointT>::PointCloudGeometryHandler (cloud)
 {
   field_x_idx_ = pcl::getFieldIndex<PointT> ("x", fields_);
   if (field_x_idx_ == -1)
@@ -58,9 +65,9 @@ pcl::visualization::PointCloudGeometryHandlerXYZ<PointT>::PointCloudGeometryHand
   capable_ = true;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void 
-pcl::visualization::PointCloudGeometryHandlerXYZ<PointT>::getGeometry (vtkSmartPointer<vtkPoints> &points) const
+
+template <typename PointT> void
+PointCloudGeometryHandlerXYZ<PointT>::getGeometry (vtkSmartPointer<vtkPoints> &points) const
 {
   if (!capable_)
     return;
@@ -109,10 +116,10 @@ pcl::visualization::PointCloudGeometryHandlerXYZ<PointT>::getGeometry (vtkSmartP
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
+
 template <typename PointT>
-pcl::visualization::PointCloudGeometryHandlerSurfaceNormal<PointT>::PointCloudGeometryHandlerSurfaceNormal (const PointCloudConstPtr &cloud) 
-  : pcl::visualization::PointCloudGeometryHandler<PointT>::PointCloudGeometryHandler (cloud)
+PointCloudGeometryHandlerSurfaceNormal<PointT>::PointCloudGeometryHandlerSurfaceNormal (const PointCloudConstPtr &cloud)
+  : PointCloudGeometryHandler<PointT>::PointCloudGeometryHandler (cloud)
 {
   field_x_idx_ = pcl::getFieldIndex<PointT> ("normal_x", fields_);
   if (field_x_idx_ == -1)
@@ -126,9 +133,9 @@ pcl::visualization::PointCloudGeometryHandlerSurfaceNormal<PointT>::PointCloudGe
   capable_ = true;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void 
-pcl::visualization::PointCloudGeometryHandlerSurfaceNormal<PointT>::getGeometry (vtkSmartPointer<vtkPoints> &points) const
+
+template <typename PointT> void
+PointCloudGeometryHandlerSurfaceNormal<PointT>::getGeometry (vtkSmartPointer<vtkPoints> &points) const
 {
   if (!capable_)
     return;
@@ -149,6 +156,9 @@ pcl::visualization::PointCloudGeometryHandlerSurfaceNormal<PointT>::getGeometry 
     points->SetPoint (i, p);
   }
 }
+
+} // namespace visualization
+} // namespace pcl
 
 #define PCL_INSTANTIATE_PointCloudGeometryHandlerXYZ(T) template class PCL_EXPORTS pcl::visualization::PointCloudGeometryHandlerXYZ<T>;
 #define PCL_INSTANTIATE_PointCloudGeometryHandlerSurfaceNormal(T) template class PCL_EXPORTS pcl::visualization::PointCloudGeometryHandlerSurfaceNormal<T>;

--- a/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
@@ -36,27 +36,32 @@
  *
  */
 
+#pragma once
+
 #include <thread>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace pcl
+{
+
 template<typename PointSource, typename PointTarget> void
-pcl::RegistrationVisualizer<PointSource, PointTarget>::startDisplay ()
+RegistrationVisualizer<PointSource, PointTarget>::startDisplay ()
 {
   // Create and start the rendering thread. This will open the display window.
   viewer_thread_ = std::thread (&pcl::RegistrationVisualizer<PointSource, PointTarget>::runDisplay, this);
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::RegistrationVisualizer<PointSource, PointTarget>::stopDisplay ()
+RegistrationVisualizer<PointSource, PointTarget>::stopDisplay ()
 {
   // Stop the rendering thread. This will kill the display window.
   viewer_thread_.~thread ();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::RegistrationVisualizer<PointSource, PointTarget>::runDisplay ()
+RegistrationVisualizer<PointSource, PointTarget>::runDisplay ()
 {
   // Open 3D viewer
   viewer_
@@ -179,9 +184,9 @@ pcl::RegistrationVisualizer<PointSource, PointTarget>::runDisplay ()
   }
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
+
 template<typename PointSource, typename PointTarget> void
-pcl::RegistrationVisualizer<PointSource, PointTarget>::updateIntermediateCloud (
+RegistrationVisualizer<PointSource, PointTarget>::updateIntermediateCloud (
     const pcl::PointCloud<PointSource> &cloud_src,
     const std::vector<int> &indices_src,
     const pcl::PointCloud<PointTarget> &cloud_tgt,
@@ -212,3 +217,6 @@ pcl::RegistrationVisualizer<PointSource, PointTarget>::updateIntermediateCloud (
   // Unlock local buffers
   visualizer_updating_mutex_.unlock ();
 }
+
+} // namespace pcl
+


### PR DESCRIPTION
Continuing from #3744 with the clang fixes. This one is about `error: use of undeclared identifier 'pcl' [clang]` and is solved by introducing `namespace xxx` instead of following the guideline from PCL which wants `xxx::ClassName::methodName` in implementation files.

This seemed a good PR to also modify that guideline.

The log is actually increased from this fix by 708 lines, which means many warnings were hidden by these, as we've previously experienced in #3701. No more of them are present now, you can check here 
[output_use_clang_parser_on_top_of_fix_doc_warnings_fix_std_fix_pcl1.txt](https://github.com/PointCloudLibrary/pcl/files/4342409/output_use_clang_parser_on_top_of_fix_doc_warnings_fix_std_fix_pcl1.txt)
