### PR TITLE
Added sanity checks before allocating memory after reads

### DIFF
--- a/common/include/pcl/common/impl/bivariate_polynomial.hpp
+++ b/common/include/pcl/common/impl/bivariate_polynomial.hpp
@@ -289,9 +289,20 @@ pcl::BivariatePolynomialT<real>::readBinary (std::istream& os)
 {
   memoryCleanUp ();
   os.read (reinterpret_cast<char*> (&this->degree), sizeof (int));
-  unsigned int paramCnt = getNoOfParametersFromDegree (this->degree);
-  parameters = new real[paramCnt];
-  os.read (reinterpret_cast<char*> (&(*this->parameters)), paramCnt * sizeof (real));
+  if (os.bad())
+  {
+    PCL_THROW_EXCEPTION (pcl::IOException, "Failure in reading degree from file");
+  }
+  else if (os.fail())
+  {
+    PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading degree (formatting or extraction error");
+  }
+  else
+  {
+    unsigned int paramCnt = getNoOfParametersFromDegree (this->degree);
+    parameters = new real[paramCnt];
+    os.read (reinterpret_cast<char*> (&(*this->parameters)), paramCnt * sizeof (real));
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -574,16 +574,38 @@ Narf::loadBinary (std::istream& file)
   pcl::loadBinary(position_.matrix(), file);
   pcl::loadBinary(transformation_.matrix(), file);
   file.read(reinterpret_cast<char*>(&surface_patch_pixel_size_), sizeof(surface_patch_pixel_size_));
-  surface_patch_ = new float[surface_patch_pixel_size_*surface_patch_pixel_size_];
-  file.read(reinterpret_cast<char*>(surface_patch_),
-            surface_patch_pixel_size_*surface_patch_pixel_size_*sizeof(*surface_patch_));
-  file.read(reinterpret_cast<char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
-  file.read(reinterpret_cast<char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
-  file.read(reinterpret_cast<char*>(&descriptor_size_), sizeof(descriptor_size_));
-  descriptor_ = new float[descriptor_size_];
-  if (file.eof())
-    std::cout << ":-(\n";
-  file.read (reinterpret_cast<char*>(descriptor_), descriptor_size_*sizeof(*descriptor_));
+  if (file.bad())
+  {
+    PCL_THROW_EXCEPTION (pcl::IOException, "Failure reading surface_patch_pixel_size_ from file");
+  }
+  else if (file.fail())
+  {
+    PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading surface_patch_pixel_size_ (formatting or extraction error)");
+  }
+  else
+  {
+    surface_patch_ = new float[surface_patch_pixel_size_*surface_patch_pixel_size_];
+    file.read(reinterpret_cast<char*>(surface_patch_),
+          surface_patch_pixel_size_*surface_patch_pixel_size_*sizeof(*surface_patch_));
+    file.read(reinterpret_cast<char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
+    file.read(reinterpret_cast<char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
+    file.read(reinterpret_cast<char*>(&descriptor_size_), sizeof(descriptor_size_));
+    if (file.bad())
+    {
+      PCL_THROW_EXCEPTION (pcl::IOException, "Failure reading descriptor_size_ from file");
+    }
+    else if (file.fail())
+    {
+      PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading descriptor_size_ (formatting or extraction error)");
+    }
+    else
+    {
+      descriptor_ = new float[descriptor_size_];
+      if (file.eof())
+      std::cout << ":-(\n";
+      file.read (reinterpret_cast<char*>(descriptor_), descriptor_size_*sizeof(*descriptor_));
+    }
+  }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
@@ -359,9 +359,16 @@ namespace pcl
           // decode differential color information
           std::vector<char>& pointDiffColorDataVector = color_coder_.getDifferentialDataVector ();
           compressed_tree_data_in_arg.read (reinterpret_cast<char*> (&point_diff_color_data_vector_size), sizeof (point_diff_color_data_vector_size));
-          pointDiffColorDataVector.resize (static_cast<std::size_t> (point_diff_color_data_vector_size));
-          compressed_color_data_len_ += entropy_coder_.decodeStreamToCharVector (compressed_tree_data_in_arg,
+          if (point_diff_color_data_vector_size > 0)
+          {
+            pointDiffColorDataVector.resize (static_cast<std::size_t> (point_diff_color_data_vector_size));
+            compressed_color_data_len_ += entropy_coder_.decodeStreamToCharVector (compressed_tree_data_in_arg,
                                                                              pointDiffColorDataVector);
+          }
+          else
+          {
+            PCL_THROW_EXCEPTION (pcl::IOException, "Failed to read point_diff_color_data_vector_size from file");
+          }
         }
       }
     }

--- a/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
@@ -332,7 +332,14 @@ namespace pcl
 
         // reading compressed rgb data
         compressedDataIn_arg.read (reinterpret_cast<char*> (&compressedColorSize), sizeof (compressedColorSize));
-        compressedColor.resize (compressedColorSize);
+        if (compressedColorSize > 0)
+        {
+          compressedColor.resize (compressedColorSize);
+        }
+        else
+        {
+          PCL_THROW_EXCEPTION (pcl::IOException, "Failed to read compressedColorSize from file");
+        }
         compressedDataIn_arg.read (reinterpret_cast<char*> (&compressedColor[0]), compressedColorSize * sizeof(std::uint8_t));
 
         // decode PNG compressed disparity data

--- a/ml/include/pcl/ml/dt/decision_forest.h
+++ b/ml/include/pcl/ml/dt/decision_forest.h
@@ -90,7 +90,14 @@ public:
   {
     int num_of_trees;
     stream.read(reinterpret_cast<char*>(&num_of_trees), sizeof(num_of_trees));
-    this->resize(num_of_trees);
+    if (num_of_trees > 0)
+    {
+      this->resize(num_of_trees);
+    }
+    else
+    {
+      PCL_THROW_EXCEPTION (pcl::IOException, "Failed in reading num_of_trees from file");
+    }
 
     for (std::size_t tree_index = 0; tree_index < this->size(); ++tree_index) {
       (*this)[tree_index].deserialize(stream);

--- a/ml/include/pcl/ml/ferns/fern.h
+++ b/ml/include/pcl/ml/ferns/fern.h
@@ -117,24 +117,35 @@ public:
   deserialize(::std::istream& stream)
   {
     stream.read(reinterpret_cast<char*>(&num_of_decisions_), sizeof(num_of_decisions_));
-
-    features_.resize(num_of_decisions_);
-    thresholds_.resize(num_of_decisions_);
-    nodes_.resize(0x1 << num_of_decisions_);
-
-    for (std::size_t feature_index = 0; feature_index < features_.size();
-         ++feature_index) {
-      features_[feature_index].deserialize(stream);
+    if (stream.bad())
+    {
+      PCL_THROW_EXCEPTION (pcl::IOException, "Failure reading num_of_decisions_ from file");
     }
-
-    for (std::size_t threshold_index = 0; threshold_index < thresholds_.size();
-         ++threshold_index) {
-      stream.read(reinterpret_cast<char*>(&(thresholds_[threshold_index])),
-                  sizeof(thresholds_[threshold_index]));
+    else if (stream.fail())
+    {
+      PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading num_of_decisions_ (formatting or extraction error");
     }
+    else
+    {
 
-    for (std::size_t node_index = 0; node_index < nodes_.size(); ++node_index) {
-      nodes_[node_index].deserialize(stream);
+      features_.resize(num_of_decisions_);
+      thresholds_.resize(num_of_decisions_);
+      nodes_.resize(0x1 << num_of_decisions_);
+
+      for (std::size_t feature_index = 0; feature_index < features_.size();
+           ++feature_index) {
+        features_[feature_index].deserialize(stream);
+      }
+
+      for (std::size_t threshold_index = 0; threshold_index < thresholds_.size();
+           ++threshold_index) {
+        stream.read(reinterpret_cast<char*>(&(thresholds_[threshold_index])),
+                    sizeof(thresholds_[threshold_index]));
+      }
+
+      for (std::size_t node_index = 0; node_index < nodes_.size(); ++node_index) {
+        nodes_[node_index].deserialize(stream);
+      }
     }
   }
 

--- a/ml/include/pcl/ml/regression_variance_stats_estimator.h
+++ b/ml/include/pcl/ml/regression_variance_stats_estimator.h
@@ -94,12 +94,23 @@ public:
 
     int num_of_sub_nodes;
     stream.read(reinterpret_cast<char*>(&num_of_sub_nodes), sizeof(num_of_sub_nodes));
-    sub_nodes.resize(num_of_sub_nodes);
+    if (stream.bad())
+    {
+      PCL_THROW_EXCEPTION (pcl::IOException, "Failure reading num_of_sub_nodes from file");
+    }
+    else if (stream.fail())
+    {
+      PCL_THROW_EXCEPTION (pcl:IOEXCEPTION, "failbit set while reading num_of_sub_nodes (formatting or extraction error");
+    }
+    else
+    {
+      sub_nodes.resize(num_of_sub_nodes);
 
-    if (num_of_sub_nodes > 0) {
+      if (num_of_sub_nodes > 0) {
       for (int sub_node_index = 0; sub_node_index < num_of_sub_nodes;
-           ++sub_node_index) {
-        sub_nodes[sub_node_index].deserialize(stream);
+             ++sub_node_index) {
+          sub_nodes[sub_node_index].deserialize(stream);
+        }
       }
     }
   }

--- a/recognition/include/pcl/recognition/dense_quantized_multi_mod_template.h
+++ b/recognition/include/pcl/recognition/dense_quantized_multi_mod_template.h
@@ -39,6 +39,7 @@
 
 #include <vector>
 
+#include <pcl/common/common.h>
 #include <pcl/recognition/region_xy.h>
 
 namespace pcl
@@ -66,10 +67,21 @@ namespace pcl
 
       std::size_t num_of_features;
       read (stream, num_of_features);
-      features.resize (num_of_features);
-      for (std::size_t feature_index = 0; feature_index < num_of_features; ++feature_index)
+      if (stream.bad())
       {
-        read (stream, features[feature_index]);
+        PCL_THROW_EXCEPTION (pcl::IOException, "Failure in num_of_features from file");
+      }
+      else if (stream.fail())
+      {
+        PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading num_of_features(formatting or extraction error");
+      }
+      else
+      {
+        features.resize (num_of_features);
+        for (std::size_t feature_index = 0; feature_index < num_of_features; ++feature_index)
+        {
+          read (stream, features[feature_index]);
+        }
       }
     }
   };

--- a/recognition/include/pcl/recognition/face_detection/face_common.h
+++ b/recognition/include/pcl/recognition/face_detection/face_common.h
@@ -151,10 +151,11 @@ namespace pcl
             for (std::size_t j = 0; j < 3; j++)
               stream.read (reinterpret_cast<char*> (&covariance_rot_ (i, j)), sizeof(covariance_rot_ (i, j)));
 
-          sub_nodes.resize (num_of_sub_nodes);
-
           if (num_of_sub_nodes > 0)
           {
+
+            sub_nodes.resize (num_of_sub_nodes);
+
             for (int sub_node_index = 0; sub_node_index < num_of_sub_nodes; ++sub_node_index)
             {
               sub_nodes[sub_node_index].deserialize (stream);

--- a/recognition/include/pcl/recognition/quantized_map.h
+++ b/recognition/include/pcl/recognition/quantized_map.h
@@ -39,6 +39,7 @@
 
 #include <vector>
 #include <pcl/pcl_macros.h>
+#include <pcl/common/common.h>
 
 namespace pcl
 {
@@ -121,24 +122,56 @@ namespace pcl
         }
       }
 
-      void 
+      void
       deserialize (std::istream & stream)
       {
         int width;
         int height;
 
         stream.read (reinterpret_cast<char*> (&width), sizeof (width));
+        if (stream.bad())
+        {
+          PCL_THROW_EXCEPTION (pcl::IOException, "Failure reading width from file");
+        }
+        else if (stream.fail())
+        {
+          PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading width(formatting or extraction error");
+        }
+        else
+        {
+          width_ = static_cast<std::size_t> (width);
+        }
         stream.read (reinterpret_cast<char*> (&height), sizeof (height));
-
-        width_ = static_cast<std::size_t> (width);
-        height_ = static_cast<std::size_t> (height);
+        if (stream.bad())
+        {
+          PCL_THROW_EXCEPTION (pcl::IOException, "Failure reading height from file");
+        }
+        else if (stream.fail())
+        {
+          PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading height(formatting or extraction error");
+        }
+        else
+        {
+          height_ = static_cast<std::size_t> (height);
+        }
 
         int num_of_elements;
         stream.read (reinterpret_cast<char*> (&num_of_elements), sizeof (num_of_elements));
-        data_.resize (num_of_elements);
-        for (int element_index = 0; element_index < num_of_elements; ++element_index)
+        if (stream.bad())
         {
-          stream.read (reinterpret_cast<char*> (&(data_[element_index])), sizeof (data_[element_index]));
+          PCL_THROW_EXCEPTION (pcl::IOException, "Failure reading num_of_elements from file");
+        }
+        else if (stream.fail())
+        {
+          PCL_THROW_EXCEPTION (pcl::IOException, "failbit set while reading num_of_elements(formatting or extraction error");
+        }
+        else
+        {
+          data_.resize (num_of_elements);
+          for (int element_index = 0; element_index < num_of_elements; ++element_index)
+          {
+            stream.read (reinterpret_cast<char*> (&(data_[element_index])), sizeof (data_[element_index]));
+          }
         }
       }
 
@@ -146,7 +179,7 @@ namespace pcl
     //private:
       std::vector<unsigned char> data_;
       std::size_t width_;
-      std::size_t height_;  
-    
+      std::size_t height_;
+
   };
 }

--- a/recognition/src/dotmod.cpp
+++ b/recognition/src/dotmod.cpp
@@ -245,7 +245,14 @@ deserialize (std::istream & stream)
 
   int nr_templates;
   read (stream, nr_templates);
-  templates_.resize (nr_templates);
-  for (int template_index = 0; template_index < nr_templates; ++template_index)
-    templates_[template_index].deserialize (stream);
+  if (nr_templates > 0)
+  {
+    templates_.resize (nr_templates);
+    for (int template_index = 0; template_index < nr_templates; ++template_index)
+      templates_[template_index].deserialize (stream);
+  }
+  else
+  {
+    PCL_THROW_EXCEPTION (pcl::IOException, "Failed in reading nr_templates from file");
+  }
 }


### PR DESCRIPTION
Aims to fix #3606 . Went through the 273 instances and added sanity checks. Many of these instances already had sanity checks and all of them vary a lot, so I have adapted what I thought would be optimal for the ones that did not have any checks.