### PR TITLE
Be explicit about no indendation in namespace

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,6 +17,7 @@ ColumnLimit: 88
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 0
 Language: Cpp
+NamespaceIndentation: None
 PointerAlignment: Left
 Standard: Cpp11
 TabWidth: 2


### PR DESCRIPTION
Already in the coding style guide, just making part of format job