### PR TITLE
Fix a memory leak in `OctreeBase::operator=`

### DIFF
--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -247,9 +247,8 @@ public:
   {
     leaf_count_ = source.leaf_count_;
     branch_count_ = source.branch_count_;
-    if (root_node_)
-    {
-        delete root_node_;
+    if (root_node_) {
+      delete root_node_;
     }
     root_node_ = new (BranchNode)(*(source.root_node_));
     depth_mask_ = source.depth_mask_;

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -247,6 +247,10 @@ public:
   {
     leaf_count_ = source.leaf_count_;
     branch_count_ = source.branch_count_;
+    if (root_node_)
+    {
+        delete root_node_;
+    }
     root_node_ = new (BranchNode)(*(source.root_node_));
     depth_mask_ = source.depth_mask_;
     max_key_ = source.max_key_;


### PR DESCRIPTION
Reported by: @maciejmatuszak

---
A better approach would be `unique_ptr` but grepping for `root_node_` shows that it'd not be a simple task