### PR TITLE
Clean up code duplication in `FilterIndices` derived classes

### DIFF
--- a/filters/include/pcl/filters/crop_box.h
+++ b/filters/include/pcl/filters/crop_box.h
@@ -70,7 +70,7 @@ namespace pcl
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).
         */
       CropBox (bool extract_removed_indices = false) :
-        FilterIndices<PointT>::FilterIndices (extract_removed_indices),
+        FilterIndices<PointT> (extract_removed_indices),
         min_pt_ (Eigen::Vector4f (-1, -1, -1, 1)),
         max_pt_ (Eigen::Vector4f (1, 1, 1, 1)),
         rotation_ (Eigen::Vector3f::Zero ()),
@@ -173,12 +173,6 @@ namespace pcl
       using FilterIndices<PointT>::user_filter_value_;
       using FilterIndices<PointT>::extract_removed_indices_;
       using FilterIndices<PointT>::removed_indices_;
-
-      /** \brief Sample of point indices into a separate PointCloud
-        * \param[out] output the resultant point cloud
-        */
-      void
-      applyFilter (PointCloud &output) override;
 
       /** \brief Sample of point indices
         * \param[out] indices the resultant point cloud indices

--- a/filters/include/pcl/filters/filter_indices.h
+++ b/filters/include/pcl/filters/filter_indices.h
@@ -171,6 +171,8 @@ namespace pcl
 
       using Filter<PointT>::initCompute;
       using Filter<PointT>::deinitCompute;
+      using Filter<PointT>::input_;
+      using Filter<PointT>::removed_indices_;
 
       /** \brief False = normal filter behavior (default), true = inverted behavior. */
       bool negative_;
@@ -187,7 +189,7 @@ namespace pcl
 
       /** \brief Abstract filter method for point cloud. */
       void
-      applyFilter (PointCloud &output) override = 0;
+      applyFilter (PointCloud &output) override;
   };
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -90,7 +90,7 @@ namespace pcl
       using Filter<PointT>::getClassName;
 
       FrustumCulling (bool extract_removed_indices = false) 
-        : FilterIndices<PointT>::FilterIndices (extract_removed_indices)
+        : FilterIndices<PointT> (extract_removed_indices)
         , camera_pose_ (Eigen::Matrix4f::Identity ())
         , hfov_ (60.0f)
         , vfov_ (60.0f)
@@ -204,12 +204,6 @@ namespace pcl
       using FilterIndices<PointT>::user_filter_value_;
       using FilterIndices<PointT>::extract_removed_indices_;
       using FilterIndices<PointT>::removed_indices_;
-
-      /** \brief Sample of point indices into a separate PointCloud
-        * \param[out] output the resultant point cloud
-        */
-      void
-      applyFilter (PointCloud &output) override;
 
       /** \brief Sample of point indices
         * \param[out] indices the resultant point cloud indices

--- a/filters/include/pcl/filters/impl/crop_box.hpp
+++ b/filters/include/pcl/filters/impl/crop_box.hpp
@@ -46,32 +46,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 template<typename PointT> void
-pcl::CropBox<PointT>::applyFilter (PointCloud &output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilter (indices);
-    extract_removed_indices_ = temp;
-
-    output = *input_;
-    for (const auto ri : *removed_indices_)  // ri = removed index
-      output.points[ri].x = output.points[ri].y = output.points[ri].z = user_filter_value_;
-    if (!std::isfinite (user_filter_value_))
-      output.is_dense = false;
-  }
-  else
-  {
-    output.is_dense = true;
-    applyFilter (indices);
-    pcl::copyPointCloud (*input_, indices, output);
-  }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
 pcl::CropBox<PointT>::applyFilter (std::vector<int> &indices)
 {
   indices.resize (input_->points.size ());

--- a/filters/include/pcl/filters/impl/filter_indices.hpp
+++ b/filters/include/pcl/filters/impl/filter_indices.hpp
@@ -74,7 +74,42 @@ pcl::removeNaNFromPointCloud (const pcl::PointCloud<PointT> &cloud_in,
   }
 }
 
+template<typename PointT> void
+pcl::FilterIndices<PointT>::applyFilter (PointCloud &output)
+{
+  std::vector<int> indices;
+  if (keep_organized_)
+  {
+    if (!extract_removed_indices_)
+    {
+      PCL_WARN ("[pcl::FilterIndices<PointT>::applyFilter] extract_removed_indices_ was set to 'true' to keep the point cloud organized.\n");
+      extract_removed_indices_ = true;
+    }
+    applyFilter (indices);
+
+    output = *input_;
+
+    // To preserve legacy behavior, only coordinates xyz are filtered.
+    // Copying a PointXYZ initialized with the user_filter_value_ into a generic
+    // PointT, ensures only the xyz coordinates, if they exist at destination,
+    // are overwritten.
+    const PointXYZ ufv (user_filter_value_, user_filter_value_, user_filter_value_);
+    for (const auto ri : *removed_indices_)  // ri = removed index
+      copyPoint(ufv, output[ri]);
+    if (!std::isfinite (user_filter_value_))
+      output.is_dense = false;
+  }
+  else
+  {
+    output.is_dense = true;
+    applyFilter (indices);
+    pcl::copyPointCloud (*input_, indices, output);
+  }
+}
+
+
 #define PCL_INSTANTIATE_removeNanFromPointCloud(T) template PCL_EXPORTS void pcl::removeNaNFromPointCloud<T>(const pcl::PointCloud<T>&, std::vector<int>&);
+#define PCL_INSTANTIATE_FilterIndices(T) template class PCL_EXPORTS  pcl::FilterIndices<T>;
 
 #endif    // PCL_FILTERS_IMPL_FILTER_INDICES_H_
 

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -44,35 +44,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::FrustumCulling<PointT>::applyFilter (PointCloud& output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilter (indices);
-    extract_removed_indices_ = temp;
-    copyPointCloud (*input_, output);
-
-    for (std::size_t rii = 0; rii < removed_indices_->size (); ++rii)
-    {
-      PointT &pt_to_remove = output.at ((*removed_indices_)[rii]);
-      pt_to_remove.x = pt_to_remove.y = pt_to_remove.z = user_filter_value_;
-      if (!std::isfinite (user_filter_value_))
-        output.is_dense = false;
-    }
-  }
-  else
-  {
-    output.is_dense = true;
-    applyFilter (indices);
-    copyPointCloud (*input_, indices, output);
-  }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
 pcl::FrustumCulling<PointT>::applyFilter (std::vector<int> &indices)
 {
   Eigen::Vector4f pl_n; // near plane 

--- a/filters/include/pcl/filters/impl/model_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/model_outlier_removal.hpp
@@ -143,31 +143,6 @@ pcl::ModelOutlierRemoval<PointT>::initSACModel (pcl::SacModel model_type)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::ModelOutlierRemoval<PointT>::applyFilter (PointCloud &output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilterIndices (indices);
-    extract_removed_indices_ = temp;
-
-    output = *input_;
-    for (int rii = 0; rii < static_cast<int> (removed_indices_->size ()); ++rii)  // rii = removed indices iterator
-      output.points[ (*removed_indices_)[rii]].x = output.points[ (*removed_indices_)[rii]].y = output.points[ (*removed_indices_)[rii]].z = user_filter_value_;
-    if (!std::isfinite (user_filter_value_))
-      output.is_dense = false;
-  }
-  else
-  {
-    applyFilterIndices (indices);
-    copyPointCloud (*input_, indices, output);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
 pcl::ModelOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &indices)
 {
   //The arrays to be used

--- a/filters/include/pcl/filters/impl/normal_space.hpp
+++ b/filters/include/pcl/filters/impl/normal_space.hpp
@@ -68,32 +68,6 @@ pcl::NormalSpaceSampling<PointT, NormalT>::initCompute ()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template<typename PointT, typename NormalT> void
-pcl::NormalSpaceSampling<PointT, NormalT>::applyFilter (PointCloud &output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilter (indices);
-    extract_removed_indices_ = temp;
-
-    output = *input_;
-    for (int rii = 0; rii < static_cast<int> (removed_indices_->size ()); ++rii)  // rii = removed indices iterator
-      output.points[(*removed_indices_)[rii]].x = output.points[(*removed_indices_)[rii]].y = output.points[(*removed_indices_)[rii]].z = user_filter_value_;
-    if (!std::isfinite (user_filter_value_))
-      output.is_dense = false;
-  }
-  else
-  {
-    output.is_dense = true;
-    applyFilter (indices);
-    pcl::copyPointCloud (*input_, indices, output);
-  }
-}
-
-///////////////////////////////////////////////////////////////////////////////
 template<typename PointT, typename NormalT> bool 
 pcl::NormalSpaceSampling<PointT, NormalT>::isEntireBinSampled (boost::dynamic_bitset<> &array,
                                                                unsigned int start_index,

--- a/filters/include/pcl/filters/impl/passthrough.hpp
+++ b/filters/include/pcl/filters/impl/passthrough.hpp
@@ -45,32 +45,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::PassThrough<PointT>::applyFilter (PointCloud &output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilterIndices (indices);
-    extract_removed_indices_ = temp;
-
-    output = *input_;
-    for (const auto ri : *removed_indices_)  // ri = removed index
-      output.points[ri].x = output.points[ri].y = output.points[ri].z = user_filter_value_;
-    if (!std::isfinite (user_filter_value_))
-      output.is_dense = false;
-  }
-  else
-  {
-    output.is_dense = true;
-    applyFilterIndices (indices);
-    copyPointCloud (*input_, indices, output);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
 pcl::PassThrough<PointT>::applyFilterIndices (std::vector<int> &indices)
 {
   // The arrays to be used

--- a/filters/include/pcl/filters/impl/radius_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/radius_outlier_removal.hpp
@@ -45,31 +45,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::RadiusOutlierRemoval<PointT>::applyFilter (PointCloud &output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilterIndices (indices);
-    extract_removed_indices_ = temp;
-
-    output = *input_;
-    for (const auto ri : *removed_indices_)  // ri = removed index
-      output.points[ri].x = output.points[ri].y = output.points[ri].z = user_filter_value_;
-    if (!std::isfinite (user_filter_value_))
-      output.is_dense = false;
-  }
-  else
-  {
-    applyFilterIndices (indices);
-    copyPointCloud (*input_, indices, output);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
 pcl::RadiusOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &indices)
 {
   if (search_radius_ == 0.0)

--- a/filters/include/pcl/filters/impl/random_sample.hpp
+++ b/filters/include/pcl/filters/impl/random_sample.hpp
@@ -44,49 +44,6 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
-pcl::RandomSample<PointT>::applyFilter (PointCloud &output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilter (indices);
-    extract_removed_indices_ = temp;
-    copyPointCloud (*input_, output);
-    // Get X, Y, Z fields
-    const auto fields = pcl::getFields<PointT> ();
-    std::vector<std::size_t> offsets;
-    for (const auto &field : fields)
-    {
-      if (field.name == "x" ||
-          field.name == "y" ||
-          field.name == "z")
-        offsets.push_back (field.offset);
-    }
-    // For every "removed" point, set the x,y,z fields to user_filter_value_
-    const static float user_filter_value = user_filter_value_;
-    for (const auto ri : *removed_indices_)  // ri = removed index
-    {
-      std::uint8_t* pt_data = reinterpret_cast<std::uint8_t*> (&output[ri]);
-      for (const unsigned long &offset : offsets)
-      {
-        memcpy (pt_data + offset, &user_filter_value, sizeof (float));
-      }
-    }
-    if (!std::isfinite (user_filter_value_))
-      output.is_dense = false;
-  }
-  else
-  {
-    output.is_dense = true;
-    applyFilter (indices);
-    copyPointCloud (*input_, indices, output);
-  }
-}
-
-///////////////////////////////////////////////////////////////////////////////
 template<typename PointT>
 void
 pcl::RandomSample<PointT>::applyFilter (std::vector<int> &indices)

--- a/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
@@ -45,31 +45,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::StatisticalOutlierRemoval<PointT>::applyFilter (PointCloud &output)
-{
-  std::vector<int> indices;
-  if (keep_organized_)
-  {
-    bool temp = extract_removed_indices_;
-    extract_removed_indices_ = true;
-    applyFilterIndices (indices);
-    extract_removed_indices_ = temp;
-
-    output = *input_;
-    for (const auto ri : *removed_indices_)  // ri = removed index
-      output.points[ri].x = output.points[ri].y = output.points[ri].z = user_filter_value_;
-    if (!std::isfinite (user_filter_value_))
-      output.is_dense = false;
-  }
-  else
-  {
-    applyFilterIndices (indices);
-    copyPointCloud (*input_, indices, output);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
 pcl::StatisticalOutlierRemoval<PointT>::applyFilterIndices (std::vector<int> &indices)
 {
   // Initialize the search class

--- a/filters/include/pcl/filters/model_outlier_removal.h
+++ b/filters/include/pcl/filters/model_outlier_removal.h
@@ -82,7 +82,7 @@ namespace pcl
        */
       inline
       ModelOutlierRemoval (bool extract_removed_indices = false) :
-          FilterIndices<PointT>::FilterIndices (extract_removed_indices)
+          FilterIndices<PointT> (extract_removed_indices)
       {
         thresh_ = 0;
         normals_distance_weight_ = 0;
@@ -198,12 +198,6 @@ namespace pcl
       using FilterIndices<PointT>::user_filter_value_;
       using FilterIndices<PointT>::extract_removed_indices_;
       using FilterIndices<PointT>::removed_indices_;
-
-      /** \brief Filtered results are stored in a separate point cloud.
-       * \param[out] output The resultant point cloud.
-       */
-      void
-      applyFilter (PointCloud &output) override;
 
       /** \brief Filtered results are indexed by an indices array.
        * \param[out] indices The resultant indices.

--- a/filters/include/pcl/filters/normal_space.h
+++ b/filters/include/pcl/filters/normal_space.h
@@ -164,12 +164,6 @@ namespace pcl
       /** \brief The normals computed at each point in the input cloud */
       NormalsConstPtr input_normals_;
 
-      /** \brief Sample of point indices into a separate PointCloud
-        * \param[out] output the resultant point cloud
-        */
-      void
-      applyFilter (PointCloud &output) override;
-
       /** \brief Sample of point indices
         * \param[out] indices the resultant point cloud indices
         */

--- a/filters/include/pcl/filters/passthrough.h
+++ b/filters/include/pcl/filters/passthrough.h
@@ -95,7 +95,7 @@ namespace pcl
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).
         */
       PassThrough (bool extract_removed_indices = false) :
-        FilterIndices<PointT>::FilterIndices (extract_removed_indices),
+        FilterIndices<PointT> (extract_removed_indices),
         filter_field_name_ (""),
         filter_limit_min_ (FLT_MIN),
         filter_limit_max_ (FLT_MAX)
@@ -186,12 +186,6 @@ namespace pcl
       using FilterIndices<PointT>::user_filter_value_;
       using FilterIndices<PointT>::extract_removed_indices_;
       using FilterIndices<PointT>::removed_indices_;
-
-      /** \brief Filtered results are stored in a separate point cloud.
-        * \param[out] output The resultant point cloud.
-        */
-      void
-      applyFilter (PointCloud &output) override;
 
       /** \brief Filtered results are indexed by an indices array.
         * \param[out] indices The resultant indices.

--- a/filters/include/pcl/filters/radius_outlier_removal.h
+++ b/filters/include/pcl/filters/radius_outlier_removal.h
@@ -86,7 +86,7 @@ namespace pcl
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).
         */
       RadiusOutlierRemoval (bool extract_removed_indices = false) :
-        FilterIndices<PointT>::FilterIndices (extract_removed_indices),
+        FilterIndices<PointT> (extract_removed_indices),
         searcher_ (),
         search_radius_ (0.0),
         min_pts_radius_ (1)
@@ -148,12 +148,6 @@ namespace pcl
       using FilterIndices<PointT>::user_filter_value_;
       using FilterIndices<PointT>::extract_removed_indices_;
       using FilterIndices<PointT>::removed_indices_;
-
-      /** \brief Filtered results are stored in a separate point cloud.
-        * \param[out] output The resultant point cloud.
-        */
-      void
-      applyFilter (PointCloud &output) override;
 
       /** \brief Filtered results are indexed by an indices array.
         * \param[out] indices The resultant indices.

--- a/filters/include/pcl/filters/random_sample.h
+++ b/filters/include/pcl/filters/random_sample.h
@@ -123,12 +123,6 @@ namespace pcl
       /** \brief Random number seed. */
       unsigned int seed_;
 
-      /** \brief Sample of point indices into a separate PointCloud
-        * \param output the resultant point cloud
-        */
-      void
-      applyFilter (PointCloud &output) override;
-
       /** \brief Sample of point indices
         * \param indices the resultant point cloud indices
         */

--- a/filters/include/pcl/filters/statistical_outlier_removal.h
+++ b/filters/include/pcl/filters/statistical_outlier_removal.h
@@ -95,7 +95,7 @@ namespace pcl
         * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of points being removed (default = false).
         */
       StatisticalOutlierRemoval (bool extract_removed_indices = false) :
-        FilterIndices<PointT>::FilterIndices (extract_removed_indices),
+        FilterIndices<PointT> (extract_removed_indices),
         searcher_ (),
         mean_k_ (1),
         std_mul_ (0.0)
@@ -152,12 +152,6 @@ namespace pcl
       using FilterIndices<PointT>::user_filter_value_;
       using FilterIndices<PointT>::extract_removed_indices_;
       using FilterIndices<PointT>::removed_indices_;
-
-      /** \brief Filtered results are stored in a separate point cloud.
-        * \param[out] output The resultant point cloud.
-        */
-      void
-      applyFilter (PointCloud &output) override;
 
       /** \brief Filtered results are indexed by an indices array.
         * \param[out] indices The resultant indices.

--- a/filters/src/filter_indices.cpp
+++ b/filters/src/filter_indices.cpp
@@ -62,6 +62,7 @@ pcl::FilterIndices<pcl::PCLPointCloud2>::filter (std::vector<int> &indices)
 
 // Instantiations of specific point types
 PCL_INSTANTIATE(removeNanFromPointCloud, PCL_XYZ_POINT_TYPES)
+PCL_INSTANTIATE(FilterIndices, PCL_POINT_TYPES)
 
 #endif    // PCL_NO_PRECOMPILE
 


### PR DESCRIPTION
Here's a first POC to close #3798. To avoid having to define the intermediate class we would need a solution which does not make an assumption that the `user_filter_value_` needs to be applied to the  `xzy` coordinates.

Some examples on how that is achieved in some other classes, although they all look mildly inefficient
https://github.com/PointCloudLibrary/pcl/blob/d6ac1e88412f07d7f34e69a7ab87355326cf5f07/filters/include/pcl/filters/impl/random_sample.hpp#L46-L87
https://github.com/PointCloudLibrary/pcl/blob/d6ac1e88412f07d7f34e69a7ab87355326cf5f07/filters/include/pcl/filters/impl/extract_indices.hpp#L46-L75

This last one has actually a bug. It assumes all fields are actually floats.