### PR TITLE
Define `PointIndices` based on the global `Indices` type alias

### DIFF
--- a/common/include/pcl/PointIndices.h
+++ b/common/include/pcl/PointIndices.h
@@ -6,21 +6,22 @@
 
 // Include the correct Header path here
 #include <pcl/PCLHeader.h>
+#include <pcl/types.h>
 
 namespace pcl
 {
   struct PointIndices
   {
+    using Indices = std::vector<index_t>;
+    using Ptr = shared_ptr< ::pcl::PointIndices>;
+    using ConstPtr = shared_ptr<const ::pcl::PointIndices>;
+
     PointIndices ()
     {}
 
     ::pcl::PCLHeader header;
 
-    std::vector<int> indices;
-
-    public:
-      using Ptr = shared_ptr< ::pcl::PointIndices>;
-      using ConstPtr = shared_ptr<const ::pcl::PointIndices>;
+    Indices indices;
   }; // struct PointIndices
 
   using PointIndicesPtr = PointIndices::Ptr;

--- a/common/include/pcl/PointIndices.h
+++ b/common/include/pcl/PointIndices.h
@@ -12,7 +12,6 @@ namespace pcl
 {
   struct PointIndices
   {
-    using Indices = std::vector<index_t>;
     using Ptr = shared_ptr< ::pcl::PointIndices>;
     using ConstPtr = shared_ptr<const ::pcl::PointIndices>;
 

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -54,11 +54,12 @@
 #include <pcl/point_cloud.h>
 #include <pcl/PointIndices.h>
 #include <pcl/PCLPointCloud2.h>
+#include <pcl/types.h>
 
 namespace pcl
 {
   // definitions used everywhere
-  using Indices = std::vector<int>;
+  using Indices = PointIndices::Indices;
   using IndicesPtr = shared_ptr<Indices>;
   using IndicesConstPtr = shared_ptr<const Indices>;
 

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -59,7 +59,6 @@
 namespace pcl
 {
   // definitions used everywhere
-  using Indices = PointIndices::Indices;
   using IndicesPtr = shared_ptr<Indices>;
   using IndicesConstPtr = shared_ptr<const Indices>;
 

--- a/common/include/pcl/types.h
+++ b/common/include/pcl/types.h
@@ -132,6 +132,6 @@ namespace pcl
    * Default index_t = int for PCL 1.11, std::int32_t for PCL >= 1.12
    */
   using index_t = detail::int_type_t<detail::index_type_size, detail::index_type_signed>;
-  static_assert(!std::is_void<index_t>::value, "Index can't be void");
+  static_assert(!std::is_void<index_t>::value, "`index_t` can't have type `void`");
 }  // namespace pcl
 

--- a/common/include/pcl/types.h
+++ b/common/include/pcl/types.h
@@ -63,7 +63,8 @@ namespace pcl
 // Aim is to remove macros and instead allow multiple index types to coexist together
 #ifndef PCL_INDEX_SIZE
 #if PCL_MINOR_VERSION <= 11
-#define PCL_INDEX_SIZE sizeof(int)
+// sizeof returns bytes, while we measure size by bits in the template
+#define PCL_INDEX_SIZE (sizeof(int) * 8)
 #else
 #define PCL_INDEX_SIZE 32
 #endif  // PCL_MINOR_VERSION

--- a/common/include/pcl/types.h
+++ b/common/include/pcl/types.h
@@ -131,5 +131,6 @@ namespace pcl
    * Default index_t = int for PCL 1.11, std::int32_t for PCL >= 1.12
    */
   using index_t = detail::int_type_t<detail::index_type_size, detail::index_type_signed>;
+  static_assert(!std::is_void<index_t>::value, "Index can't be void");
 }  // namespace pcl
 

--- a/common/include/pcl/types.h
+++ b/common/include/pcl/types.h
@@ -45,6 +45,8 @@
 
 #include <pcl/pcl_macros.h>
 
+#include <vector>
+
 #include <cstdint>
 
 namespace pcl
@@ -127,11 +129,16 @@ namespace pcl
 }  // namespace detail
 
   /**
-   * \brief Type used for indices in PCL
+   * \brief Type used for an index in PCL
    *
    * Default index_t = int for PCL 1.11, std::int32_t for PCL >= 1.12
    */
   using index_t = detail::int_type_t<detail::index_type_size, detail::index_type_signed>;
   static_assert(!std::is_void<index_t>::value, "`index_t` can't have type `void`");
+
+  /**
+   * \brief Type used for indices in PCL
+   */
+  using Indices = std::vector<index_t>;
 }  // namespace pcl
 


### PR DESCRIPTION
This PR changes nothing on the surface but it enables someone to locally change the `PCL_INDEX_SIGNED` to `false` and find the places where `Indices` typedef isn't being used (There should be lots of such instances, but this can only find those that are "tested").

Rest can be done via `grep`