### PR TITLE
Fix OpenMP code for Clang 10 

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -68,7 +68,7 @@
 // We need to check for GCC version, because GCC releases before 9 were implementing an
 // OpenMP 3.1 data sharing rule, even OpenMP 4 is supported, so a plain OpenMP version 4 check
 // isn't enough (see https://www.gnu.org/software/gcc/gcc-9/porting_to.html#ompdatasharing)
-#if defined _OPENMP && (_OPENMP <= 201307) || (__GNUC__ < 9)
+#if (defined _OPENMP && (_OPENMP <= 201307)) || (defined ___GNUC__ && (__GNUC__ >= 6 && __GNUC__ < 9))
   #define OPENMP_LEGACY_CONST_DATA_SHARING_RULE 1
 #else
   #define OPENMP_LEGACY_CONST_DATA_SHARING_RULE 0

--- a/common/src/fft/kiss_fft.c
+++ b/common/src/fft/kiss_fft.c
@@ -257,7 +257,7 @@ void kf_work(
         // execute the p different work units in different threads
 // We cannot use OPENMP_LEGACY_CONST_DATA_SHARING_RULE here, because we cannot include
 // pcl_macros.h in this file as this is a C file.
-#if defined _OPENMP && (_OPENMP <= 201307) || (__GNUC__ < 9)
+#if (defined _OPENMP && (_OPENMP <= 201307)) || (defined ___GNUC__ && (__GNUC__ >= 6 && __GNUC__ < 9))
 #pragma omp parallel for \
   default(none) \
   shared(f, factors, Fout, in_stride)


### PR DESCRIPTION
Starting with Clang 10 ([released some days ago](https://releases.llvm.org/10.0.0/tools/clang/docs/ReleaseNotes.html#openmp-support-in-clang)) clang supports OpenMP 4.5 (201511) instead of 3.1 (201107). As value of __GNUC_ is still 4, we need to extend our exception for GCC, so that Clang can use the newer data sharing model.

Note: Clang 10 can OpenMP 5.0, too, if you add compiler flag `-fopenmp-version=50`. But as far as I can see we don't get additional compiler errors with OpenMP 5.0 (only short check via godbolt).