### PR TITLE
Fix GNUC macro name

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -68,7 +68,7 @@
 // We need to check for GCC version, because GCC releases before 9 were implementing an
 // OpenMP 3.1 data sharing rule, even OpenMP 4 is supported, so a plain OpenMP version 4 check
 // isn't enough (see https://www.gnu.org/software/gcc/gcc-9/porting_to.html#ompdatasharing)
-#if (defined _OPENMP && (_OPENMP <= 201307)) || (defined ___GNUC__ && (__GNUC__ >= 6 && __GNUC__ < 9))
+#if (defined _OPENMP && (_OPENMP <= 201307)) || (defined __GNUC__ && (__GNUC__ >= 6 && __GNUC__ < 9))
   #define OPENMP_LEGACY_CONST_DATA_SHARING_RULE 1
 #else
   #define OPENMP_LEGACY_CONST_DATA_SHARING_RULE 0

--- a/common/src/fft/kiss_fft.c
+++ b/common/src/fft/kiss_fft.c
@@ -257,7 +257,7 @@ void kf_work(
         // execute the p different work units in different threads
 // We cannot use OPENMP_LEGACY_CONST_DATA_SHARING_RULE here, because we cannot include
 // pcl_macros.h in this file as this is a C file.
-#if (defined _OPENMP && (_OPENMP <= 201307)) || (defined ___GNUC__ && (__GNUC__ >= 6 && __GNUC__ < 9))
+#if (defined _OPENMP && (_OPENMP <= 201307)) || (defined __GNUC__ && (__GNUC__ >= 6 && __GNUC__ < 9))
 #pragma omp parallel for \
   default(none) \
   shared(f, factors, Fout, in_stride)


### PR DESCRIPTION
It seems like there was an underscore too much each, or am I missing something here?
Introduced in #3823