### PR TITLE
[sample_consensus] Use better types for indices: `int` -> `index_t`, `std::vector<int>` ->`Indices`

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/lmeds.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/lmeds.hpp
@@ -57,7 +57,7 @@ pcl::LeastMedianSquares<PointT>::computeModel (int debug_verbosity_level)
   iterations_ = 0;
   double d_best_penalty = std::numeric_limits<double>::max();
 
-  std::vector<int> selection;
+  Indices selection;
   Eigen::VectorXf model_coefficients;
   std::vector<double> distances;
 
@@ -169,7 +169,7 @@ pcl::LeastMedianSquares<PointT>::computeModel (int debug_verbosity_level)
     return (false);
   }
 
-  std::vector<int> &indices = *sac_model_->getIndices ();
+  Indices &indices = *sac_model_->getIndices ();
 
   if (distances.size () != indices.size ())
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/mlesac.hpp
@@ -59,7 +59,7 @@ pcl::MaximumLikelihoodSampleConsensus<PointT>::computeModel (int debug_verbosity
   double d_best_penalty = std::numeric_limits<double>::max();
   double k = 1.0;
 
-  std::vector<int> selection;
+  Indices selection;
   Eigen::VectorXf model_coefficients;
   std::vector<double> distances;
 
@@ -178,7 +178,7 @@ pcl::MaximumLikelihoodSampleConsensus<PointT>::computeModel (int debug_verbosity
 
   // Iterate through the 3d points and calculate the distances from them to the model again
   sac_model_->getDistancesToModel (model_coefficients_, distances);
-  std::vector<int> &indices = *sac_model_->getIndices ();
+  Indices &indices = *sac_model_->getIndices ();
   if (distances.size () != indices.size ())
   {
     PCL_ERROR ("[pcl::MaximumLikelihoodSampleConsensus::computeModel] Estimated distances (%lu) differs than the normal of indices (%lu).\n", distances.size (), indices.size ());

--- a/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
@@ -58,7 +58,7 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
   double d_best_penalty = std::numeric_limits<double>::max();
   double k = 1.0;
 
-  std::vector<int> selection;
+  Indices selection;
   Eigen::VectorXf model_coefficients;
   std::vector<double> distances;
 
@@ -136,7 +136,7 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
 
   // Iterate through the 3d points and calculate the distances from them to the model again
   sac_model_->getDistancesToModel (model_coefficients_, distances);
-  std::vector<int> &indices = *sac_model_->getIndices ();
+  Indices &indices = *sac_model_->getIndices ();
 
   if (distances.size () != indices.size ())
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/prosac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/prosac.hpp
@@ -82,12 +82,12 @@ pcl::ProgressiveSampleConsensus<PointT>::computeModel (int debug_verbosity_level
   // Initialize the usual RANSAC parameters
   iterations_ = 0;
 
-  std::vector<int> inliers;
-  std::vector<int> selection;
+  Indices inliers;
+  Indices selection;
   Eigen::VectorXf model_coefficients;
 
   // We will increase the pool so the indices_ vector can only contain m elements at first
-  std::vector<int> index_pool;
+  Indices index_pool;
   index_pool.reserve (N);
   for (unsigned int i = 0; i < n; ++i)
     index_pool.push_back (sac_model_->indices_->operator[](i));
@@ -164,7 +164,7 @@ pcl::ProgressiveSampleConsensus<PointT>::computeModel (int debug_verbosity_level
 
       // We only need to compute possible better epsilon_n_star for when _n is just about to be removed an inlier
       std::size_t I_possible_n_star = I_N;
-      for (std::vector<int>::const_reverse_iterator last_inlier = inliers.rbegin (), 
+      for (Indices::const_reverse_iterator last_inlier = inliers.rbegin (),
                                                     inliers_end = inliers.rend (); 
            last_inlier != inliers_end; 
            ++last_inlier, --I_possible_n_star)

--- a/sample_consensus/include/pcl/sample_consensus/impl/prosac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/prosac.hpp
@@ -164,8 +164,7 @@ pcl::ProgressiveSampleConsensus<PointT>::computeModel (int debug_verbosity_level
 
       // We only need to compute possible better epsilon_n_star for when _n is just about to be removed an inlier
       std::size_t I_possible_n_star = I_N;
-      for (Indices::const_reverse_iterator last_inlier = inliers.rbegin (),
-                                                    inliers_end = inliers.rend (); 
+      for (auto last_inlier = inliers.crbegin (), inliers_end = inliers.crend ();
            last_inlier != inliers_end; 
            ++last_inlier, --I_possible_n_star)
       {

--- a/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
@@ -67,7 +67,7 @@ pcl::RandomSampleConsensus<PointT>::computeModel (int)
   std::size_t n_best_inliers_count = 0;
   double k = std::numeric_limits<double>::max();
 
-  std::vector<int> selection;
+  Indices selection;
   Eigen::VectorXf model_coefficients;
 
   const double log_probability  = std::log (1.0 - probability_);

--- a/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
@@ -58,10 +58,10 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
   double d_best_penalty = std::numeric_limits<double>::max();
   double k = 1.0;
 
-  std::vector<int> selection;
+  Indices selection;
   Eigen::VectorXf model_coefficients;
   std::vector<double> distances;
-  std::set<int> indices_subset;
+  std::set<index_t> indices_subset;
 
   int n_inliers_count = 0;
   unsigned skipped_count = 0;
@@ -154,7 +154,7 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
 
   // Iterate through the 3d points and calculate the distances from them to the model again
   sac_model_->getDistancesToModel (model_coefficients_, distances);
-  std::vector<int> &indices = *sac_model_->getIndices ();
+  Indices &indices = *sac_model_->getIndices ();
   if (distances.size () != indices.size ())
   {
     PCL_ERROR ("[pcl::RandomizedMEstimatorSampleConsensus::computeModel] Estimated distances (%lu) differs than the normal of indices (%lu).\n", distances.size (), indices.size ());

--- a/sample_consensus/include/pcl/sample_consensus/impl/rransac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rransac.hpp
@@ -58,9 +58,9 @@ pcl::RandomizedRandomSampleConsensus<PointT>::computeModel (int debug_verbosity_
   std::size_t n_best_inliers_count = 0;
   double k = std::numeric_limits<double>::max();
 
-  std::vector<int> selection;
+  Indices selection;
   Eigen::VectorXf model_coefficients;
-  std::set<int> indices_subset;
+  std::set<index_t> indices_subset;
 
   const double log_probability  = std::log (1.0 - probability_);
   const double one_over_indices = 1.0 / static_cast<double> (sac_model_->getIndices ()->size ());

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle.hpp
@@ -47,7 +47,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelCircle2D<PointT>::isSampleGood(const std::vector<int> &samples) const
+pcl::SampleConsensusModelCircle2D<PointT>::isSampleGood(const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -71,7 +71,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::isSampleGood(const std::vector<int> &
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelCircle2D<PointT>::computeModelCoefficients (const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+pcl::SampleConsensusModelCircle2D<PointT>::computeModelCoefficients (const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 3 samples
   if (samples.size () != sample_size_)
@@ -134,7 +134,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::getDistancesToModel (const Eigen::Vec
 template <typename PointT> void
 pcl::SampleConsensusModelCircle2D<PointT>::selectWithinDistance (
     const Eigen::VectorXf &model_coefficients, const double threshold, 
-    std::vector<int> &inliers)
+    Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))
@@ -199,7 +199,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelCircle2D<PointT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   optimized_coefficients = model_coefficients;
 
@@ -230,7 +230,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients,
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients,
       PointCloud &projected_points, bool copy_data_fields) const
 {
   // Needs a valid set of model coefficients
@@ -258,7 +258,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the points and project them to the circle
-    for (const int &inlier : inliers)
+    for (const auto &inlier : inliers)
     {
       float dx = input_->points[inlier].x - model_coefficients[0];
       float dy = input_->points[inlier].y - model_coefficients[1];
@@ -297,7 +297,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
-      const std::set<int> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
+      const std::set<index_t> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
 {
   // Needs a valid model coefficients
   if (!isModelValid (model_coefficients))
@@ -306,7 +306,7 @@ pcl::SampleConsensusModelCircle2D<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int &index : indices)
+  for (const auto &index : indices)
     // Calculate the distance from the point to the circle as the difference between
     //dist(point,circle_origin) and circle_radius
     if (std::abs (std::sqrt (

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_circle3d.hpp
@@ -46,7 +46,7 @@
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelCircle3D<PointT>::isSampleGood (
-    const std::vector<int> &samples) const
+    const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -67,7 +67,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::isSampleGood (
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelCircle3D<PointT>::computeModelCoefficients (const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+pcl::SampleConsensusModelCircle3D<PointT>::computeModelCoefficients (const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 3 samples
   if (samples.size () != sample_size_)
@@ -166,7 +166,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::getDistancesToModel (const Eigen::Vec
 template <typename PointT> void
 pcl::SampleConsensusModelCircle3D<PointT>::selectWithinDistance (
     const Eigen::VectorXf &model_coefficients, const double threshold,
-    std::vector<int> &inliers)
+    Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))
@@ -253,7 +253,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelCircle3D<PointT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers,
+      const Indices &inliers,
       const Eigen::VectorXf &model_coefficients,
       Eigen::VectorXf &optimized_coefficients) const
 {
@@ -289,7 +289,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelCircle3D<PointT>::projectPoints (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients,
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients,
       PointCloud &projected_points, bool copy_data_fields) const
 {
   // Needs a valid set of model coefficients
@@ -391,7 +391,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelCircle3D<PointT>::doSamplesVerifyModel (
-      const std::set<int> &indices,
+      const std::set<index_t> &indices,
       const Eigen::VectorXf &model_coefficients,
       const double threshold) const
 {
@@ -402,7 +402,7 @@ pcl::SampleConsensusModelCircle3D<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int &index : indices)
+  for (const auto &index : indices)
   {
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cone.hpp
@@ -45,7 +45,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> bool
-pcl::SampleConsensusModelCone<PointT, PointNT>::isSampleGood(const std::vector<int> &samples) const
+pcl::SampleConsensusModelCone<PointT, PointNT>::isSampleGood(const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -58,7 +58,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::isSampleGood(const std::vector<i
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> bool
 pcl::SampleConsensusModelCone<PointT, PointNT>::computeModelCoefficients (
-    const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+    const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 3 samples
   if (samples.size () != sample_size_)
@@ -192,7 +192,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::getDistancesToModel (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelCone<PointT, PointNT>::selectWithinDistance (
-    const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+    const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))
@@ -310,7 +310,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelCone<PointT, PointNT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   optimized_coefficients = model_coefficients;
 
@@ -348,7 +348,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelCone<PointT, PointNT>::projectPoints (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -382,7 +382,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the cone
-    for (const int &inlier : inliers)
+    for (const auto &inlier : inliers)
     {
       Eigen::Vector4f pt (input_->points[inlier].x, 
                           input_->points[inlier].y, 
@@ -444,7 +444,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> bool
 pcl::SampleConsensusModelCone<PointT, PointNT>::doSamplesVerifyModel (
-      const std::set<int> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
+      const std::set<index_t> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
 {
   // Needs a valid model coefficients
   if (!isModelValid (model_coefficients))
@@ -461,7 +461,7 @@ pcl::SampleConsensusModelCone<PointT, PointNT>::doSamplesVerifyModel (
   float dirdotdir = 1.0f / axis_dir.dot (axis_dir);
 
   // Iterate through the 3d points and calculate the distances from them to the cone
-  for (const int &index : indices)
+  for (const auto &index : indices)
   {
     Eigen::Vector4f pt (input_->points[index].x, input_->points[index].y, input_->points[index].z, 0.0f);
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -47,7 +47,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> bool
-pcl::SampleConsensusModelCylinder<PointT, PointNT>::isSampleGood (const std::vector<int> &samples) const
+pcl::SampleConsensusModelCylinder<PointT, PointNT>::isSampleGood (const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -60,7 +60,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::isSampleGood (const std::vec
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> bool
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::computeModelCoefficients (
-      const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+      const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 2 samples
   if (samples.size () != sample_size_)
@@ -177,7 +177,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::getDistancesToModel (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))
@@ -267,7 +267,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   optimized_coefficients = model_coefficients;
 
@@ -305,7 +305,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -337,7 +337,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the cylinder
-    for (const int &inlier : inliers)
+    for (const auto &inlier : inliers)
     {
       Eigen::Vector4f p (input_->points[inlier].x,
                          input_->points[inlier].y,
@@ -391,7 +391,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> bool
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::doSamplesVerifyModel (
-      const std::set<int> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
+      const std::set<index_t> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
 {
   // Needs a valid model coefficients
   if (!isModelValid (model_coefficients))
@@ -400,7 +400,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int &index : indices)
+  for (const auto &index : indices)
   {
     // Approximate the distance from the point to the cylinder as the difference between
     // dist(point,cylinder_axis) and cylinder radius

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -47,7 +47,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelLine<PointT>::isSampleGood (const std::vector<int> &samples) const
+pcl::SampleConsensusModelLine<PointT>::isSampleGood (const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -71,7 +71,7 @@ pcl::SampleConsensusModelLine<PointT>::isSampleGood (const std::vector<int> &sam
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelLine<PointT>::computeModelCoefficients (
-      const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+      const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 2 samples
   if (samples.size () != sample_size_)
@@ -131,7 +131,7 @@ pcl::SampleConsensusModelLine<PointT>::getDistancesToModel (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelLine<PointT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -199,7 +199,7 @@ pcl::SampleConsensusModelLine<PointT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelLine<PointT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -240,7 +240,7 @@ pcl::SampleConsensusModelLine<PointT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelLine<PointT>::projectPoints (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
 {
   // Needs a valid model coefficients
   if (!isModelValid (model_coefficients))
@@ -268,7 +268,7 @@ pcl::SampleConsensusModelLine<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the line
-    for (const int &inlier : inliers)
+    for (const auto &inlier : inliers)
     {
       Eigen::Vector4f pt (input_->points[inlier].x, input_->points[inlier].y, input_->points[inlier].z, 0.0f);
       // double k = (DOT_PROD_3D (points[i], p21) - dotA_B) / dotB_B;
@@ -313,7 +313,7 @@ pcl::SampleConsensusModelLine<PointT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelLine<PointT>::doSamplesVerifyModel (
-      const std::set<int> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
+      const std::set<index_t> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -326,7 +326,7 @@ pcl::SampleConsensusModelLine<PointT>::doSamplesVerifyModel (
 
   double sqr_threshold = threshold * threshold;
   // Iterate through the 3d points and calculate the distances from them to the line
-  for (const int &index : indices)
+  for (const auto &index : indices)
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_plane.hpp
@@ -46,7 +46,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelNormalPlane<PointT, PointNT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   if (!normals_)
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_sphere.hpp
@@ -46,7 +46,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelNormalSphere<PointT, PointNT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   if (!normals_)
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_line.hpp
@@ -47,7 +47,7 @@
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelParallelLine<PointT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_parallel_plane.hpp
@@ -46,7 +46,7 @@
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelParallelPlane<PointT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_perpendicular_plane.hpp
@@ -46,7 +46,7 @@
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelPerpendicularPlane<PointT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
@@ -49,7 +49,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelPlane<PointT>::isSampleGood (const std::vector<int> &samples) const
+pcl::SampleConsensusModelPlane<PointT>::isSampleGood (const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -69,7 +69,7 @@ pcl::SampleConsensusModelPlane<PointT>::isSampleGood (const std::vector<int> &sa
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelPlane<PointT>::computeModelCoefficients (
-      const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+      const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 3 samples
   if (samples.size () != sample_size_)
@@ -145,7 +145,7 @@ pcl::SampleConsensusModelPlane<PointT>::getDistancesToModel (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelPlane<PointT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -214,7 +214,7 @@ pcl::SampleConsensusModelPlane<PointT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelPlane<PointT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -263,7 +263,7 @@ pcl::SampleConsensusModelPlane<PointT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelPlane<PointT>::projectPoints (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -300,7 +300,7 @@ pcl::SampleConsensusModelPlane<PointT>::projectPoints (
       pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
 
     // Iterate through the 3d points and calculate the distances from them to the plane
-    for (const int &inlier : inliers)
+    for (const auto &inlier : inliers)
     {
       // Calculate the distance from the point to the plane
       Eigen::Vector4f p (input_->points[inlier].x,
@@ -349,7 +349,7 @@ pcl::SampleConsensusModelPlane<PointT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelPlane<PointT>::doSamplesVerifyModel (
-      const std::set<int> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
+      const std::set<index_t> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -358,7 +358,7 @@ pcl::SampleConsensusModelPlane<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int &index : indices)
+  for (const auto &index : indices)
   {
     Eigen::Vector4f pt (input_->points[index].x,
                         input_->points[index].y,

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
@@ -48,7 +48,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelRegistration<PointT>::isSampleGood (const std::vector<int> &samples) const
+pcl::SampleConsensusModelRegistration<PointT>::isSampleGood (const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -69,7 +69,7 @@ pcl::SampleConsensusModelRegistration<PointT>::isSampleGood (const std::vector<i
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelRegistration<PointT>::computeModelCoefficients (const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+pcl::SampleConsensusModelRegistration<PointT>::computeModelCoefficients (const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   if (!target_)
   {
@@ -82,7 +82,7 @@ pcl::SampleConsensusModelRegistration<PointT>::computeModelCoefficients (const s
     return (false);
   }
 
-  std::vector<int> indices_tgt (3);
+  Indices indices_tgt (3);
   for (int i = 0; i < 3; ++i)
   {
     indices_tgt[i] = correspondences_.at (samples[i]);
@@ -140,7 +140,7 @@ pcl::SampleConsensusModelRegistration<PointT>::getDistancesToModel (const Eigen:
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::SampleConsensusModelRegistration<PointT>::selectWithinDistance (const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers) 
+pcl::SampleConsensusModelRegistration<PointT>::selectWithinDistance (const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   if (indices_->size () != indices_tgt_->size ())
   {
@@ -245,7 +245,7 @@ pcl::SampleConsensusModelRegistration<PointT>::countWithinDistance (
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::SampleConsensusModelRegistration<PointT>::optimizeModelCoefficients (const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+pcl::SampleConsensusModelRegistration<PointT>::optimizeModelCoefficients (const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   if (indices_->size () != indices_tgt_->size ())
   {
@@ -261,8 +261,8 @@ pcl::SampleConsensusModelRegistration<PointT>::optimizeModelCoefficients (const 
     return;
   }
 
-  std::vector<int> indices_src (inliers.size ());
-  std::vector<int> indices_tgt (inliers.size ());
+  Indices indices_src (inliers.size ());
+  Indices indices_tgt (inliers.size ());
   for (std::size_t i = 0; i < inliers.size (); ++i)
   {
     indices_src[i] = inliers[i];
@@ -276,9 +276,9 @@ pcl::SampleConsensusModelRegistration<PointT>::optimizeModelCoefficients (const 
 template <typename PointT> void
 pcl::SampleConsensusModelRegistration<PointT>::estimateRigidTransformationSVD (
     const pcl::PointCloud<PointT> &cloud_src,
-    const std::vector<int> &indices_src,
+    const Indices &indices_src,
     const pcl::PointCloud<PointT> &cloud_tgt,
-    const std::vector<int> &indices_tgt,
+    const Indices &indices_tgt,
     Eigen::VectorXf &transform) const
 {
   transform.resize (16);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration_2d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration_2d.hpp
@@ -44,7 +44,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelRegistration2D<PointT>::isSampleGood (const std::vector<int>&samples) const
+pcl::SampleConsensusModelRegistration2D<PointT>::isSampleGood (const Indices&samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -120,7 +120,7 @@ pcl::SampleConsensusModelRegistration2D<PointT>::getDistancesToModel (const Eige
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::SampleConsensusModelRegistration2D<PointT>::selectWithinDistance (const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers) 
+pcl::SampleConsensusModelRegistration2D<PointT>::selectWithinDistance (const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   if (indices_->size () != indices_tgt_->size ())
   {

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_sphere.hpp
@@ -46,7 +46,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelSphere<PointT>::isSampleGood (const std::vector<int> &samples) const
+pcl::SampleConsensusModelSphere<PointT>::isSampleGood (const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -59,7 +59,7 @@ pcl::SampleConsensusModelSphere<PointT>::isSampleGood (const std::vector<int> &s
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelSphere<PointT>::computeModelCoefficients (
-      const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+      const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 4 samples
   if (samples.size () != sample_size_)
@@ -160,7 +160,7 @@ pcl::SampleConsensusModelSphere<PointT>::getDistancesToModel (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelSphere<PointT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Check if the model is valid given the user constraints
   if (!isModelValid (model_coefficients))
@@ -232,7 +232,7 @@ pcl::SampleConsensusModelSphere<PointT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelSphere<PointT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   optimized_coefficients = model_coefficients;
 
@@ -263,7 +263,7 @@ pcl::SampleConsensusModelSphere<PointT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelSphere<PointT>::projectPoints (
-      const std::vector<int> &, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool) const
+      const Indices &, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool) const
 {
   // Needs a valid model coefficients
   if (!isModelValid (model_coefficients))
@@ -286,7 +286,7 @@ pcl::SampleConsensusModelSphere<PointT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelSphere<PointT>::doSamplesVerifyModel (
-      const std::set<int> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
+      const std::set<index_t> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
 {
   // Needs a valid model coefficients
   if (!isModelValid (model_coefficients))
@@ -295,7 +295,7 @@ pcl::SampleConsensusModelSphere<PointT>::doSamplesVerifyModel (
     return (false);
   }
 
-  for (const int &index : indices)
+  for (const auto &index : indices)
   {
     // Calculate the distance from the point to the sphere as the difference between
     //dist(point,sphere_origin) and sphere_radius

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
@@ -47,7 +47,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
-pcl::SampleConsensusModelStick<PointT>::isSampleGood (const std::vector<int> &samples) const
+pcl::SampleConsensusModelStick<PointT>::isSampleGood (const Indices &samples) const
 {
   if (samples.size () != sample_size_)
   {
@@ -70,7 +70,7 @@ pcl::SampleConsensusModelStick<PointT>::isSampleGood (const std::vector<int> &sa
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelStick<PointT>::computeModelCoefficients (
-      const std::vector<int> &samples, Eigen::VectorXf &model_coefficients) const
+      const Indices &samples, Eigen::VectorXf &model_coefficients) const
 {
   // Need 2 samples
   if (samples.size () != sample_size_)
@@ -141,7 +141,7 @@ pcl::SampleConsensusModelStick<PointT>::getDistancesToModel (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelStick<PointT>::selectWithinDistance (
-      const Eigen::VectorXf &model_coefficients, const double threshold, std::vector<int> &inliers)
+      const Eigen::VectorXf &model_coefficients, const double threshold, Indices &inliers)
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -243,7 +243,7 @@ pcl::SampleConsensusModelStick<PointT>::countWithinDistance (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelStick<PointT>::optimizeModelCoefficients (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, Eigen::VectorXf &optimized_coefficients) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -284,7 +284,7 @@ pcl::SampleConsensusModelStick<PointT>::optimizeModelCoefficients (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelStick<PointT>::projectPoints (
-      const std::vector<int> &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
+      const Indices &inliers, const Eigen::VectorXf &model_coefficients, PointCloud &projected_points, bool copy_data_fields) const
 {
   // Needs a valid model coefficients
   if (!isModelValid (model_coefficients))
@@ -317,7 +317,7 @@ pcl::SampleConsensusModelStick<PointT>::projectPoints (
     }
 
     // Iterate through the 3d points and calculate the distances from them to the line
-    for (const int &inlier : inliers)
+    for (const auto &inlier : inliers)
     {
       Eigen::Vector4f pt (input_->points[inlier].x, input_->points[inlier].y, input_->points[inlier].z, 0.0f);
       // double k = (DOT_PROD_3D (points[i], p21) - dotA_B) / dotB_B;
@@ -364,7 +364,7 @@ pcl::SampleConsensusModelStick<PointT>::projectPoints (
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> bool
 pcl::SampleConsensusModelStick<PointT>::doSamplesVerifyModel (
-      const std::set<int> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
+      const std::set<index_t> &indices, const Eigen::VectorXf &model_coefficients, const double threshold) const
 {
   // Needs a valid set of model coefficients
   if (!isModelValid (model_coefficients))
@@ -381,7 +381,7 @@ pcl::SampleConsensusModelStick<PointT>::doSamplesVerifyModel (
 
   float sqr_threshold = static_cast<float> (threshold * threshold);
   // Iterate through the 3d points and calculate the distances from them to the line
-  for (const int &index : indices)
+  for (const auto &index : indices)
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)

--- a/sample_consensus/include/pcl/sample_consensus/sac.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac.h
@@ -197,7 +197,7 @@ namespace pcl
         double sigma_sqr = sigma * sigma;
         unsigned int refine_iterations = 0;
         bool inlier_changed = false, oscillating = false;
-        std::vector<int> new_inliers, prev_inliers = inliers_;
+        Indices new_inliers, prev_inliers = inliers_;
         std::vector<std::size_t> inliers_sizes;
         Eigen::VectorXf new_model_coefficients = model_coefficients_;
         do
@@ -287,25 +287,25 @@ namespace pcl
       inline void
       getRandomSamples (const IndicesPtr &indices,
                         std::size_t nr_samples, 
-                        std::set<int> &indices_subset)
+                        std::set<index_t> &indices_subset)
       {
         indices_subset.clear ();
         while (indices_subset.size () < nr_samples)
-          //indices_subset.insert ((*indices)[(int) (indices->size () * (rand () / (RAND_MAX + 1.0)))]);
-          indices_subset.insert ((*indices)[static_cast<int> (static_cast<double>(indices->size ()) * rnd ())]);
+          //indices_subset.insert ((*indices)[(index_t) (indices->size () * (rand () / (RAND_MAX + 1.0)))]);
+          indices_subset.insert ((*indices)[static_cast<index_t> (static_cast<double>(indices->size ()) * rnd ())]);
       }
 
       /** \brief Return the best model found so far. 
         * \param[out] model the resultant model
         */
       inline void 
-      getModel (std::vector<int> &model) const { model = model_; }
+      getModel (Indices &model) const { model = model_; }
 
       /** \brief Return the best set of inliers found so far for this model. 
         * \param[out] inliers the resultant set of inliers
         */
       inline void 
-      getInliers (std::vector<int> &inliers) const { inliers = inliers_; }
+      getInliers (Indices &inliers) const { inliers = inliers_; }
 
       /** \brief Return the model coefficients of the best model found so far. 
         * \param[out] model_coefficients the resultant model coefficients, as documented in \ref sample_consensus
@@ -318,10 +318,10 @@ namespace pcl
       SampleConsensusModelPtr sac_model_;
 
       /** \brief The model found after the last computeModel () as point cloud indices. */
-      std::vector<int> model_;
+      Indices model_;
 
       /** \brief The indices of the points that were chosen as inliers after the last computeModel () call. */
-      std::vector<int> inliers_;
+      Indices inliers_;
 
       /** \brief The coefficients of our model computed directly from the model found. */
       Eigen::VectorXf model_coefficients_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -51,6 +51,7 @@
 #include <pcl/pcl_base.h>
 #include <pcl/console/print.h>
 #include <pcl/point_cloud.h>
+#include <pcl/types.h> // for index_t, Indices
 #include <pcl/sample_consensus/boost.h>
 #include <pcl/sample_consensus/model_types.h>
 
@@ -129,10 +130,10 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModel (const PointCloudConstPtr &cloud, 
-                            const std::vector<int> &indices, 
+                            const Indices &indices,
                             bool random = false) 
         : input_ (cloud)
-        , indices_ (new std::vector<int> (indices))
+        , indices_ (new Indices (indices))
         , radius_min_ (-std::numeric_limits<double>::max ())
         , radius_max_ (std::numeric_limits<double>::max ())
         , samples_radius_ (0.)
@@ -164,7 +165,7 @@ namespace pcl
         * \param[out] samples the resultant model samples
         */
       virtual void 
-      getSamples (int &iterations, std::vector<int> &samples)
+      getSamples (int &iterations, Indices &samples)
       {
         // We're assuming that indices_ have already been set in the constructor
         if (indices_->size () < getSampleSize ())
@@ -207,7 +208,7 @@ namespace pcl
         * \param[out] model_coefficients the computed model coefficients
         */
       virtual bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const = 0;
 
       /** \brief Recompute the model coefficients using the given inlier set
@@ -221,7 +222,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization
         */
       virtual void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const = 0;
 
@@ -245,7 +246,7 @@ namespace pcl
       virtual void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold,
-                            std::vector<int> &inliers) = 0;
+                            Indices &inliers) = 0;
 
       /** \brief Count all the points which respect the given model
         * coefficients as inliers. Pure virtual.
@@ -269,7 +270,7 @@ namespace pcl
         * the point projections on the plane model
         */
       virtual void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const = 0;
@@ -283,7 +284,7 @@ namespace pcl
         * determining the inliers from the outliers
         */
       virtual bool 
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const = 0;
 
@@ -295,13 +296,13 @@ namespace pcl
       {
         input_ = cloud;
         if (!indices_)
-          indices_.reset (new std::vector<int> ());
+          indices_.reset (new Indices ());
         if (indices_->empty ())
         {
           // Prepare a set of indices to be used (entire cloud)
           indices_->resize (cloud->points.size ());
           for (std::size_t i = 0; i < cloud->points.size (); ++i) 
-            (*indices_)[i] = static_cast<int> (i);
+            (*indices_)[i] = static_cast<index_t> (i);
         }
         shuffled_indices_ = *indices_;
        }
@@ -324,9 +325,9 @@ namespace pcl
         * \param[out] indices the vector of indices that represents the input data.
         */
       inline void 
-      setIndices (const std::vector<int> &indices) 
+      setIndices (const Indices &indices)
       { 
-        indices_.reset (new std::vector<int> (indices));
+        indices_.reset (new Indices (indices));
         shuffled_indices_ = indices;
        }
 
@@ -442,7 +443,7 @@ namespace pcl
         * \param[out] sample the set of indices of target_ to analyze
         */
       inline void
-      drawIndexSample (std::vector<int> &sample)
+      drawIndexSample (Indices &sample)
       {
         std::size_t sample_size = sample.size ();
         std::size_t index_size = shuffled_indices_.size ();
@@ -459,7 +460,7 @@ namespace pcl
         * \param[out] sample the set of indices of target_ to analyze
         */
       inline void
-      drawIndexSampleRadius (std::vector<int> &sample)
+      drawIndexSampleRadius (Indices &sample)
       {
         std::size_t sample_size = sample.size ();
         std::size_t index_size = shuffled_indices_.size ();
@@ -467,7 +468,7 @@ namespace pcl
         std::swap (shuffled_indices_[0], shuffled_indices_[0 + (rnd () % (index_size - 0))]);
         //const PointT& pt0 = (*input_)[shuffled_indices_[0]];
 
-        std::vector<int> indices;
+        Indices indices;
         std::vector<float> sqr_dists;
 
         // If indices have been set when the search object was constructed,
@@ -518,7 +519,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       virtual bool
-      isSampleGood (const std::vector<int> &samples) const = 0;
+      isSampleGood (const Indices &samples) const = 0;
 
       /** \brief The model name. */
       std::string model_name_;
@@ -544,7 +545,7 @@ namespace pcl
       SearchPtr samples_radius_search_;
 
       /** Data containing a shuffled version of the indices. This is used and modified when drawing samples. */
-      std::vector<int> shuffled_indices_;
+      Indices shuffled_indices_;
 
       /** \brief Boost-based random number generator algorithm. */
       boost::mt19937 rng_alg_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -91,7 +91,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelCircle2D (const PointCloudConstPtr &cloud, 
-                                    const std::vector<int> &indices,
+                                    const Indices &indices,
                                     bool random = false)
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
@@ -129,7 +129,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all distances from the cloud data to a given 2D circle model.
@@ -148,7 +148,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 
@@ -167,7 +167,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -178,7 +178,7 @@ namespace pcl
         * \param[in] copy_data_fields set to true if we need to copy the other data fields
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -189,7 +189,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -211,7 +211,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood(const std::vector<int> &samples) const override;
+      isSampleGood(const Indices &samples) const override;
 
     private:
       /** \brief Functor for the optimization function */
@@ -221,7 +221,7 @@ namespace pcl
           * \param[in] indices the indices of data points to evaluate
           * \param[in] estimator pointer to the estimator object
           */
-        OptimizationFunctor (const pcl::SampleConsensusModelCircle2D<PointT> *model, const std::vector<int>& indices) :
+        OptimizationFunctor (const pcl::SampleConsensusModelCircle2D<PointT> *model, const Indices& indices) :
           pcl::Functor<float> (indices.size ()), model_ (model), indices_ (indices) {}
 
         /** Cost function to be minimized
@@ -245,7 +245,7 @@ namespace pcl
         }
 
         const pcl::SampleConsensusModelCircle2D<PointT> *model_;
-        const std::vector<int> &indices_;
+        const Indices &indices_;
       };
   };
 }

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -92,7 +92,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelCircle3D (const PointCloudConstPtr &cloud, 
-                                    const std::vector<int> &indices,
+                                    const Indices &indices,
                                     bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
@@ -130,7 +130,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all distances from the cloud data to a given 3D circle model.
@@ -149,7 +149,7 @@ namespace pcl
       void
       selectWithinDistance (const Eigen::VectorXf &model_coefficients,
                             const double threshold,
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers.
         *
@@ -168,7 +168,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -179,7 +179,7 @@ namespace pcl
         * \param[in] copy_data_fields set to true if we need to copy the other data fields
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -190,7 +190,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -212,7 +212,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood(const std::vector<int> &samples) const override;
+      isSampleGood(const Indices &samples) const override;
 
     private:
       /** \brief Functor for the optimization function */
@@ -222,7 +222,7 @@ namespace pcl
           * \param[in] indices the indices of data points to evaluate
           * \param[in] estimator pointer to the estimator object
           */
-        OptimizationFunctor (const pcl::SampleConsensusModelCircle3D<PointT> *model, const std::vector<int>& indices) :
+        OptimizationFunctor (const pcl::SampleConsensusModelCircle3D<PointT> *model, const Indices& indices) :
           pcl::Functor<double> (indices.size ()), model_ (model), indices_ (indices) {}
 
        /** Cost function to be minimized
@@ -262,7 +262,7 @@ namespace pcl
         }
 
         const pcl::SampleConsensusModelCircle3D<PointT> *model_;
-        const std::vector<int> &indices_;
+        const Indices &indices_;
       };
   };
 }

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -103,7 +103,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelCone (const PointCloudConstPtr &cloud, 
-                                const std::vector<int> &indices,
+                                const Indices &indices,
                                 bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
@@ -197,7 +197,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all distances from the cloud data to a given cone model.
@@ -216,7 +216,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 
@@ -236,7 +236,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -248,7 +248,7 @@ namespace pcl
         * \param[in] copy_data_fields set to true if we need to copy the other data fields
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -259,7 +259,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -289,7 +289,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood (const std::vector<int> &samples) const override;
+      isSampleGood (const Indices &samples) const override;
 
     private:
       /** \brief The axis along which we need to search for a cone direction. */
@@ -309,7 +309,7 @@ namespace pcl
           * \param[in] indices the indices of data points to evaluate
           * \param[in] estimator pointer to the estimator object
           */
-        OptimizationFunctor (const pcl::SampleConsensusModelCone<PointT, PointNT> *model, const std::vector<int>& indices) :
+        OptimizationFunctor (const pcl::SampleConsensusModelCone<PointT, PointNT> *model, const Indices& indices) :
           pcl::Functor<float> (indices.size ()), model_ (model), indices_ (indices) {}
 
         /** Cost function to be minimized
@@ -348,7 +348,7 @@ namespace pcl
         }
 
         const pcl::SampleConsensusModelCone<PointT, PointNT> *model_;
-        const std::vector<int> &indices_;
+        const Indices &indices_;
       };
   };
 }

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -101,7 +101,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelCylinder (const PointCloudConstPtr &cloud, 
-                                    const std::vector<int> &indices,
+                                    const Indices &indices,
                                     bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
@@ -169,7 +169,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all distances from the cloud data to a given cylinder model.
@@ -188,7 +188,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 
@@ -207,7 +207,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -219,7 +219,7 @@ namespace pcl
         * \param[in] copy_data_fields set to true if we need to copy the other data fields
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -230,7 +230,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -288,7 +288,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood (const std::vector<int> &samples) const override;
+      isSampleGood (const Indices &samples) const override;
 
     private:
       /** \brief The axis along which we need to search for a cylinder direction. */
@@ -304,7 +304,7 @@ namespace pcl
           * \param[in] indices the indices of data points to evaluate
           * \param[in] estimator pointer to the estimator object
           */
-        OptimizationFunctor (const pcl::SampleConsensusModelCylinder<PointT, PointNT> *model, const std::vector<int>& indices) :
+        OptimizationFunctor (const pcl::SampleConsensusModelCylinder<PointT, PointNT> *model, const Indices& indices) :
           pcl::Functor<float> (indices.size ()), model_ (model), indices_ (indices) {}
 
         /** Cost function to be minimized
@@ -331,7 +331,7 @@ namespace pcl
         }
 
         const pcl::SampleConsensusModelCylinder<PointT, PointNT> *model_;
-        const std::vector<int> &indices_;
+        const Indices &indices_;
       };
   };
 }

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -93,7 +93,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelLine (const PointCloudConstPtr &cloud, 
-                                const std::vector<int> &indices,
+                                const Indices &indices,
                                 bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
@@ -112,7 +112,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all squared distances from the cloud data to a given line model.
@@ -131,7 +131,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 
@@ -150,7 +150,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -161,7 +161,7 @@ namespace pcl
         * \param[in] copy_data_fields set to true if we need to copy the other data fields
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -172,7 +172,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -189,7 +189,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood (const std::vector<int> &samples) const override;
+      isSampleGood (const Indices &samples) const override;
   };
 }
 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -127,7 +127,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelNormalParallelPlane (const PointCloudConstPtr &cloud, 
-                                               const std::vector<int> &indices,
+                                               const Indices &indices,
                                                bool random = false) 
         : SampleConsensusModelNormalPlane<PointT, PointNT> (cloud, indices, random)
         , axis_ (Eigen::Vector4f::Zero ())

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -115,7 +115,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelNormalPlane (const PointCloudConstPtr &cloud, 
-                                       const std::vector<int> &indices,
+                                       const Indices &indices,
                                        bool random = false) 
         : SampleConsensusModelPlane<PointT> (cloud, indices, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
@@ -136,7 +136,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -109,7 +109,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelNormalSphere (const PointCloudConstPtr &cloud, 
-                                        const std::vector<int> &indices,
+                                        const Indices &indices,
                                         bool random = false) 
         : SampleConsensusModelSphere<PointT> (cloud, indices, random)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
@@ -130,7 +130,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * \param[in] model_coefficients the coefficients of a model that we need to compute distances to

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -95,7 +95,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelParallelLine (const PointCloudConstPtr &cloud,
-                                        const std::vector<int> &indices,
+                                        const Indices &indices,
                                         bool random = false)
         : SampleConsensusModelLine<PointT> (cloud, indices, random)
         , axis_ (Eigen::Vector3f::Zero ())
@@ -136,7 +136,7 @@ namespace pcl
       void
       selectWithinDistance (const Eigen::VectorXf &model_coefficients,
                             const double threshold,
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers.
         *

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -97,7 +97,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelParallelPlane (const PointCloudConstPtr &cloud, 
-                                         const std::vector<int> &indices,
+                                         const Indices &indices,
                                          bool random = false) 
         : SampleConsensusModelPlane<PointT> (cloud, indices, random)
         , axis_ (Eigen::Vector3f::Zero ())
@@ -141,7 +141,7 @@ namespace pcl
       void
       selectWithinDistance (const Eigen::VectorXf &model_coefficients,
                             const double threshold,
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers.
         *

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -101,7 +101,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelPerpendicularPlane (const PointCloudConstPtr &cloud, 
-                                              const std::vector<int> &indices,
+                                              const Indices &indices,
                                               bool random = false) 
         : SampleConsensusModelPlane<PointT> (cloud, indices, random)
         , axis_ (Eigen::Vector3f::Zero ())
@@ -144,7 +144,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -166,7 +166,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelPlane (const PointCloudConstPtr &cloud, 
-                                 const std::vector<int> &indices,
+                                 const Indices &indices,
                                  bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
@@ -185,7 +185,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all distances from the cloud data to a given plane model.
@@ -204,7 +204,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 
@@ -223,7 +223,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -234,7 +234,7 @@ namespace pcl
         * \param[in] copy_data_fields set to true if we need to copy the other data fields
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -245,7 +245,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -263,7 +263,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood (const std::vector<int> &samples) const override;
+      isSampleGood (const Indices &samples) const override;
   };
 }
 

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -96,7 +96,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelRegistration (const PointCloudConstPtr &cloud,
-                                        const std::vector<int> &indices,
+                                        const Indices &indices,
                                         bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random)
         , target_ ()
@@ -130,7 +130,7 @@ namespace pcl
       setInputTarget (const PointCloudConstPtr &target)
       {
         target_ = target;
-        indices_tgt_.reset (new std::vector<int>);
+        indices_tgt_.reset (new Indices);
         // Cache the size and fill the target indices
         int target_size = static_cast<int> (target->size ());
         indices_tgt_->resize (target_size);
@@ -145,10 +145,10 @@ namespace pcl
         * \param[in] indices_tgt a vector of point indices to be used from \a target
         */
       inline void
-      setInputTarget (const PointCloudConstPtr &target, const std::vector<int> &indices_tgt)
+      setInputTarget (const PointCloudConstPtr &target, const Indices &indices_tgt)
       {
         target_ = target;
-        indices_tgt_.reset (new std::vector<int> (indices_tgt));
+        indices_tgt_.reset (new Indices (indices_tgt));
         computeOriginalIndexMapping ();
       }
 
@@ -157,7 +157,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all distances from the transformed points to their correspondences
@@ -176,7 +176,7 @@ namespace pcl
       void
       selectWithinDistance (const Eigen::VectorXf &model_coefficients,
                             const double threshold,
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers.
         *
@@ -194,19 +194,19 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed transformation
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
       void
-      projectPoints (const std::vector<int> &,
+      projectPoints (const Indices &,
                      const Eigen::VectorXf &,
                      PointCloud &, bool = true) const override
       {
       };
 
       bool
-      doSamplesVerifyModel (const std::set<int> &,
+      doSamplesVerifyModel (const std::set<index_t> &,
                             const Eigen::VectorXf &,
                             const double) const override
       {
@@ -226,7 +226,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood (const std::vector<int> &samples) const override;
+      isSampleGood (const Indices &samples) const override;
 
       /** \brief Computes an "optimal" sample distance threshold based on the
         * principal directions of the input cloud.
@@ -263,7 +263,7 @@ namespace pcl
         */
       inline void
       computeSampleDistanceThreshold (const PointCloudConstPtr &cloud,
-                                      const std::vector<int> &indices)
+                                      const Indices &indices)
       {
         // Compute the principal directions via PCA
         Eigen::Vector4f xyz_centroid;
@@ -298,9 +298,9 @@ namespace pcl
       */
       void
       estimateRigidTransformationSVD (const pcl::PointCloud<PointT> &cloud_src,
-                                      const std::vector<int> &indices_src,
+                                      const Indices &indices_src,
                                       const pcl::PointCloud<PointT> &cloud_tgt,
-                                      const std::vector<int> &indices_tgt,
+                                      const Indices &indices_tgt,
                                       Eigen::VectorXf &transform) const;
 
       /** \brief Compute mappings between original indices of the input_/target_ clouds. */

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -92,7 +92,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelRegistration2D (const PointCloudConstPtr &cloud,
-                                          const std::vector<int> &indices,
+                                          const Indices &indices,
                                           bool random = false)
         : pcl::SampleConsensusModelRegistration<PointT> (cloud, indices, random)
         , projection_matrix_ (Eigen::Matrix3f::Identity ())
@@ -123,7 +123,7 @@ namespace pcl
       void
       selectWithinDistance (const Eigen::VectorXf &model_coefficients,
                             const double threshold,
-                            std::vector<int> &inliers);
+                            Indices &inliers);
 
       /** \brief Count all the points which respect the given model coefficients as inliers.
         *
@@ -156,7 +156,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood (const std::vector<int> &samples) const;
+      isSampleGood (const Indices &samples) const;
 
       /** \brief Computes an "optimal" sample distance threshold based on the
         * principal directions of the input cloud.
@@ -190,7 +190,7 @@ namespace pcl
         */
       inline void
       computeSampleDistanceThreshold (const PointCloudConstPtr&,
-                                      const std::vector<int>&)
+                                      const Indices&)
       {
         //// Compute the principal directions via PCA
         //Eigen::Vector4f xyz_centroid;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -92,7 +92,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelSphere (const PointCloudConstPtr &cloud,
-                                  const std::vector<int> &indices,
+                                  const Indices &indices,
                                   bool random = false)
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
@@ -131,7 +131,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all distances from the cloud data to a given sphere model.
@@ -150,7 +150,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 
@@ -169,7 +169,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after non-linear optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -181,7 +181,7 @@ namespace pcl
         * \todo implement this.
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -192,7 +192,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -225,7 +225,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood(const std::vector<int> &samples) const override;
+      isSampleGood(const Indices &samples) const override;
 
     private:
       struct OptimizationFunctor : pcl::Functor<float>
@@ -234,7 +234,7 @@ namespace pcl
           * \param[in] indices the indices of data points to evaluate
           * \param[in] estimator pointer to the estimator object
           */
-        OptimizationFunctor (const pcl::SampleConsensusModelSphere<PointT> *model, const std::vector<int>& indices) :
+        OptimizationFunctor (const pcl::SampleConsensusModelSphere<PointT> *model, const Indices& indices) :
           pcl::Functor<float> (indices.size ()), model_ (model), indices_ (indices) {}
 
         /** Cost function to be minimized
@@ -261,7 +261,7 @@ namespace pcl
         }
 
         const pcl::SampleConsensusModelSphere<PointT> *model_;
-        const std::vector<int> &indices_;
+        const Indices &indices_;
       };
    };
 }

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -98,7 +98,7 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelStick (const PointCloudConstPtr &cloud, 
-                                 const std::vector<int> &indices,
+                                 const Indices &indices,
                                  bool random = false) 
         : SampleConsensusModel<PointT> (cloud, indices, random)
       {
@@ -117,7 +117,7 @@ namespace pcl
         * \param[out] model_coefficients the resultant model coefficients
         */
       bool
-      computeModelCoefficients (const std::vector<int> &samples,
+      computeModelCoefficients (const Indices &samples,
                                 Eigen::VectorXf &model_coefficients) const override;
 
       /** \brief Compute all squared distances from the cloud data to a given stick model.
@@ -136,7 +136,7 @@ namespace pcl
       void 
       selectWithinDistance (const Eigen::VectorXf &model_coefficients, 
                             const double threshold, 
-                            std::vector<int> &inliers) override;
+                            Indices &inliers) override;
 
       /** \brief Count all the points which respect the given model coefficients as inliers. 
         * 
@@ -155,7 +155,7 @@ namespace pcl
         * \param[out] optimized_coefficients the resultant recomputed coefficients after optimization
         */
       void
-      optimizeModelCoefficients (const std::vector<int> &inliers,
+      optimizeModelCoefficients (const Indices &inliers,
                                  const Eigen::VectorXf &model_coefficients,
                                  Eigen::VectorXf &optimized_coefficients) const override;
 
@@ -166,7 +166,7 @@ namespace pcl
         * \param[in] copy_data_fields set to true if we need to copy the other data fields
         */
       void
-      projectPoints (const std::vector<int> &inliers,
+      projectPoints (const Indices &inliers,
                      const Eigen::VectorXf &model_coefficients,
                      PointCloud &projected_points,
                      bool copy_data_fields = true) const override;
@@ -177,7 +177,7 @@ namespace pcl
         * \param[in] threshold a maximum admissible distance threshold for determining the inliers from the outliers
         */
       bool
-      doSamplesVerifyModel (const std::set<int> &indices,
+      doSamplesVerifyModel (const std::set<index_t> &indices,
                             const Eigen::VectorXf &model_coefficients,
                             const double threshold) const override;
 
@@ -194,7 +194,7 @@ namespace pcl
         * \param[in] samples the resultant index samples
         */
       bool
-      isSampleGood (const std::vector<int> &samples) const override;
+      isSampleGood (const Indices &samples) const override;
   };
 }
 


### PR DESCRIPTION
Sorry for the big commit, I didn't see a way to divide that logically.