### PR TITLE
Mark non-const and non-modifying member functions as const

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/tools/openni_frame_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/tools/openni_frame_source.h
@@ -23,7 +23,7 @@ namespace OpenNIFrameSource
     const PointCloudPtr
     snap ();
     bool
-    isActive ();
+    isActive () const;
     void
     onKeyboardEvent (const pcl::visualization::KeyboardEvent & event);
 

--- a/apps/3d_rec_framework/src/tools/openni_frame_source.cpp
+++ b/apps/3d_rec_framework/src/tools/openni_frame_source.cpp
@@ -21,7 +21,7 @@ namespace OpenNIFrameSource
   }
 
   bool
-  OpenNIFrameSource::isActive ()
+  OpenNIFrameSource::isActive () const
   {
     return active_;
   }

--- a/apps/include/pcl/apps/face_detection/openni_frame_source.h
+++ b/apps/include/pcl/apps/face_detection/openni_frame_source.h
@@ -23,7 +23,7 @@ namespace OpenNIFrameSource
     const PointCloudPtr
     snap ();
     bool
-    isActive ();
+    isActive () const;
     void
     onKeyboardEvent (const pcl::visualization::KeyboardEvent & event);
 

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudTransformTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudTransformTool.h
@@ -116,7 +116,7 @@ class CloudTransformTool : public ToolInterface
 
     /// generate scale matrix
     void
-    getScaleMatrix (int dy, float* matrix);
+    getScaleMatrix (int dy, float* matrix) const;
 
     /// the transform matrix to be used for updating the coordinates of all
     /// the points in the cloud

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/trackball.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/trackball.h
@@ -62,7 +62,7 @@ class TrackBall
     
   private:
     
-    void getPointFromScreenPoint(int s_x, int s_y, float &x, float &y, float &z);
+    void getPointFromScreenPoint(int s_x, int s_y, float &x, float &y, float &z) const;
 
     /// the quaternion representing the current orientation of the trackball
     boost::math::quaternion<float> quat_;

--- a/apps/point_cloud_editor/src/cloudTransformTool.cpp
+++ b/apps/point_cloud_editor/src/cloudTransformTool.cpp
@@ -114,7 +114,7 @@ CloudTransformTool::getZTranslateMatrix (int dy, float* matrix)
 }
 
 void
-CloudTransformTool::getScaleMatrix (int dy, float* matrix)
+CloudTransformTool::getScaleMatrix (int dy, float* matrix) const
 {
   setIdentity(matrix);
   float scale = dy > 0 ? scale_factor_ : 1.0 / scale_factor_;

--- a/apps/point_cloud_editor/src/trackball.cpp
+++ b/apps/point_cloud_editor/src/trackball.cpp
@@ -221,7 +221,7 @@ TrackBall::reset()
 
 void
 TrackBall::getPointFromScreenPoint(int s_x, int s_y,
-                                   float &x, float &y, float &z)
+                                   float &x, float &y, float &z) const
 {
   // See http://www.opengl.org/wiki/Trackball for more info
     

--- a/apps/src/face_detection/openni_frame_source.cpp
+++ b/apps/src/face_detection/openni_frame_source.cpp
@@ -19,7 +19,7 @@ namespace OpenNIFrameSource
     grabber_.stop ();
   }
 
-  bool OpenNIFrameSource::isActive()
+  bool OpenNIFrameSource::isActive() const
   {
     return active_;
   }

--- a/common/include/pcl/common/transformation_from_correspondences.h
+++ b/common/include/pcl/common/transformation_from_correspondences.h
@@ -64,7 +64,7 @@ namespace pcl
         
         /** Get the number of added vectors */
         inline unsigned int 
-        getNoOfSamples () { return no_of_samples_;}
+        getNoOfSamples () const { return no_of_samples_;}
         
         /** Add a new sample */
         inline void 

--- a/cuda/common/include/pcl/cuda/common/point_type_rgb.h
+++ b/cuda/common/include/pcl/cuda/common/point_type_rgb.h
@@ -64,7 +64,7 @@ namespace cuda
     inline __host__ __device__ RGB (char _r, char _g, char _b, char _alpha) :
                                        r(_r), g(_g), b(_b), alpha(_alpha) {}
 
-    inline __host__ __device__ bool operator == (const RGB &rhs)
+    inline __host__ __device__ bool operator == (const RGB &rhs) const
     {
       return (r == rhs.r && g == rhs.g && b == rhs.b && alpha == rhs.alpha);
     }

--- a/gpu/features/include/pcl/gpu/features/features.hpp
+++ b/gpu/features/include/pcl/gpu/features/features.hpp
@@ -99,7 +99,7 @@ namespace pcl
             NormalEstimation();
             void compute(Normals& normals);
             void setViewPoint(float  vpx, float  vpy, float  vpz);  
-            void getViewPoint(float& vpx, float& vpy, float& vpz);      
+            void getViewPoint(float& vpx, float& vpy, float& vpz) const;
 
             static void computeNormals(const PointCloud& cloud, const NeighborIndices& nn_indices, Normals& normals);
             static void flipNormalTowardsViewpoint(const PointCloud& cloud, float vp_x, float vp_y, float vp_z, Normals& normals);            
@@ -223,7 +223,7 @@ namespace pcl
             VFHEstimation();
 
             void setViewPoint(float  vpx, float  vpy, float  vpz);  
-            void getViewPoint(float& vpx, float& vpy, float& vpz);      
+            void getViewPoint(float& vpx, float& vpy, float& vpz) const;      
 
             void setUseGivenNormal (bool use);
             void setNormalToUse (const NormalType& normal);

--- a/gpu/features/src/features.cpp
+++ b/gpu/features/src/features.cpp
@@ -94,7 +94,7 @@ void pcl::gpu::NormalEstimation::setViewPoint (float vpx, float vpy, float vpz)
     vpx_ = vpx; vpy_ = vpy; vpz_ = vpz;
 }
 
-void pcl::gpu::NormalEstimation::getViewPoint (float &vpx, float &vpy, float &vpz)
+void pcl::gpu::NormalEstimation::getViewPoint (float &vpx, float &vpy, float &vpz) const
 {
     vpx = vpx_; vpy = vpy_; vpz = vpz_;
 }
@@ -383,7 +383,7 @@ pcl::gpu::VFHEstimation::VFHEstimation()
 }
 
 void pcl::gpu::VFHEstimation::setViewPoint(float  vpx, float  vpy, float  vpz) { vpx_ = vpx; vpy_ = vpy; vpz_ = vpz; }
-void pcl::gpu::VFHEstimation::getViewPoint(float& vpx, float& vpy, float& vpz) { vpx = vpx_; vpy = vpy_; vpz = vpz_; }      
+void pcl::gpu::VFHEstimation::getViewPoint(float& vpx, float& vpy, float& vpz) const { vpx = vpx_; vpy = vpy_; vpz = vpz_; }      
 
 void pcl::gpu::VFHEstimation::setUseGivenNormal (bool use) { use_given_normal_ = use; }
 void pcl::gpu::VFHEstimation::setNormalToUse (const NormalType& normal)   { normal_to_use_ = normal; }

--- a/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
+++ b/gpu/kinfu/include/pcl/gpu/kinfu/kinfu.h
@@ -98,7 +98,7 @@ namespace pcl
           * \param[out] cy principal point y
           */
         void
-        getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy);
+        getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy) const;
         
 
         /** \brief Sets initial camera pose relative to volume coordinate space

--- a/gpu/kinfu/src/kinfu.cpp
+++ b/gpu/kinfu/src/kinfu.cpp
@@ -114,7 +114,7 @@ pcl::gpu::KinfuTracker::setDepthIntrinsics (float fx, float fy, float cx, float 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl::gpu::KinfuTracker::getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy)
+pcl::gpu::KinfuTracker::getDepthIntrinsics (float& fx, float& fy, float& cx, float& cy) const
 {
   fx = fx_;
   fy = fy_;

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -404,7 +404,7 @@ struct ImageView
   }
 
   void
-  showDepth (const PtrStepSz<const unsigned short>& depth) 
+  showDepth (const PtrStepSz<const unsigned short>& depth) const 
   { 
      if (viz_)
        viewerDepth_->showShortImage (depth.data, depth.cols, depth.rows, 0, 5000, true, "short_image"); 
@@ -582,7 +582,7 @@ struct SceneCloudView
   }
 
   void
-  clearClouds (bool print_message = false)
+  clearClouds (bool print_message = false) const
   {
     if (!viz_)
         return;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/screenshot_manager.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/screenshot_manager.h
@@ -91,7 +91,7 @@ namespace pcl
 
           /**Write camera pose to file*/
           void 
-          writePose(const std::string &filename_pose, const Eigen::Vector3f &teVecs, const Eigen::Matrix<float, 3, 3, Eigen::RowMajor> &erreMats);
+          writePose(const std::string &filename_pose, const Eigen::Vector3f &teVecs, const Eigen::Matrix<float, 3, 3, Eigen::RowMajor> &erreMats) const;
 
           /**Counter of the number of screenshots taken*/
           int screenshot_counter;

--- a/gpu/kinfu_large_scale/src/screenshot_manager.cpp
+++ b/gpu/kinfu_large_scale/src/screenshot_manager.cpp
@@ -97,7 +97,7 @@ namespace pcl
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       
       void 
-      ScreenshotManager::writePose(const std::string &filename_pose, const Eigen::Vector3f &teVecs, const Eigen::Matrix<float, 3, 3, Eigen::RowMajor> &erreMats)
+      ScreenshotManager::writePose(const std::string &filename_pose, const Eigen::Vector3f &teVecs, const Eigen::Matrix<float, 3, 3, Eigen::RowMajor> &erreMats) const
       {
           std::ofstream poseFile;
           poseFile.open (filename_pose.c_str());

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -95,7 +95,7 @@ namespace pcl
 			void build();
 
             /** \brief Returns true if tree has been built */
-            bool isBuilt();
+            bool isBuilt() const;
 
             /** \brief Downloads Octree from GPU to search using CPU function. It use useful for single (not-batch) search */
             void internalDownload();

--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -95,7 +95,7 @@ void pcl::gpu::Octree::build()
     built_ = true;
 }
 
-bool pcl::gpu::Octree::isBuilt()
+bool pcl::gpu::Octree::isBuilt() const
 {
     return built_;
 }

--- a/gpu/people/include/pcl/gpu/people/face_detector.h
+++ b/gpu/people/include/pcl/gpu/people/face_detector.h
@@ -162,7 +162,7 @@ namespace pcl
 
           /** \brief Get the cuda GPU device id in use **/
           int
-          getDeviceId() {return cuda_dev_id_;}
+          getDeviceId() const {return cuda_dev_id_;}
 
         private:
           bool                largest_object_;      /** \brief only give back largest object **/

--- a/gpu/people/src/cuda/nvidia/NCVHaarObjectDetection.hpp
+++ b/gpu/people/src/cuda/nvidia/NCVHaarObjectDetection.hpp
@@ -138,27 +138,27 @@ struct HaarFeatureDescriptor32
       return NCV_SUCCESS;
     }
 
-    __device__ __host__ NcvBool isTilted()
+    __device__ __host__ NcvBool isTilted() const
     {
       return (this->desc & HaarFeatureDescriptor32_Interpret_MaskFlagTilted) != 0;
     }
 
-    __device__ __host__ NcvBool isLeftNodeLeaf()
+    __device__ __host__ NcvBool isLeftNodeLeaf() const
     {
       return (this->desc & HaarFeatureDescriptor32_Interpret_MaskFlagLeftNodeLeaf) != 0;
     }
 
-    __device__ __host__ NcvBool isRightNodeLeaf()
+    __device__ __host__ NcvBool isRightNodeLeaf() const
     {
       return (this->desc & HaarFeatureDescriptor32_Interpret_MaskFlagRightNodeLeaf) != 0;
     }
 
-    __device__ __host__ Ncv32u getNumFeatures()
+    __device__ __host__ Ncv32u getNumFeatures() const
     {
       return (this->desc >> HaarFeatureDescriptor32_NumFeatures_Shift) & HaarFeatureDescriptor32_CreateCheck_MaxNumFeatures;
     }
 
-    __device__ __host__ Ncv32u getFeaturesOffset()
+    __device__ __host__ Ncv32u getFeaturesOffset() const
     {
       return this->desc & HaarFeatureDescriptor32_CreateCheck_MaxFeatureOffset;
     }
@@ -185,7 +185,7 @@ struct HaarClassifierNodeDescriptor32
       return (*(Ncv32f *)&this->_ui1.x);
     }
 
-    __host__ bool isLeaf()                                  // TODO: check this hack don't know if is correct
+    __host__ bool isLeaf() const                                  // TODO: check this hack don't know if is correct
     {
       return ( _ui1.x != 0);
     }
@@ -291,12 +291,12 @@ struct HaarStage64
       return *(Ncv32f*)&this->_ui2.x;
     }
 
-    __host__ __device__ Ncv32u getStartClassifierRootNodeOffset()
+    __host__ __device__ Ncv32u getStartClassifierRootNodeOffset() const
     {
       return (this->_ui2.y >> HaarStage64_Interpret_ShiftRootNodeOffset);
     }
 
-    __host__ __device__ Ncv32u getNumClassifierRootNodes()
+    __host__ __device__ Ncv32u getNumClassifierRootNodes() const
     {
       return (this->_ui2.y & HaarStage64_Interpret_MaskRootNodes);
     }

--- a/gpu/people/src/trees.cpp
+++ b/gpu/people/src/trees.cpp
@@ -65,7 +65,7 @@ namespace pcl
         {
 	  	  Tex2Dfetcher( const std::uint16_t* dmap, int W, int H ) : m_dmap(dmap), m_W(W), m_H(H) {}
 
-          inline std::uint16_t operator () ( float uf, float vf ) 
+          inline std::uint16_t operator () ( float uf, float vf ) const 
           {
             int u = static_cast<int>(uf);
             int v = static_cast<int>(vf);

--- a/gpu/people/tools/people_pcd_prob.cpp
+++ b/gpu/people/tools/people_pcd_prob.cpp
@@ -139,7 +139,7 @@ class PeoplePCDApp
     }
 
     void
-    writeXMLFile(std::string& filename)
+    writeXMLFile(std::string& filename) const
     {
       filebuf fb;
       fb.open (filename.c_str(), ios::out);
@@ -149,7 +149,7 @@ class PeoplePCDApp
     }
 
     void
-    readXMLFile(std::string& filename)
+    readXMLFile(std::string& filename) const
     {
       filebuf fb;
       fb.open (filename.c_str(), ios::in);

--- a/gpu/surface/src/convex_hull.cpp
+++ b/gpu/surface/src/convex_hull.cpp
@@ -59,7 +59,7 @@ pcl::device::FacetStream::FacetStream(std::size_t buffer_size)
 }
 
 bool 
-pcl::device::FacetStream::canSplit()
+pcl::device::FacetStream::canSplit() const
 {
   return facet_count * 3 < verts_inds.cols();
 }

--- a/gpu/surface/src/internal.h
+++ b/gpu/surface/src/internal.h
@@ -80,7 +80,7 @@ namespace pcl
 
 		  void compactFacets();
 
-		  bool canSplit();
+		  bool canSplit() const;
 		  void splitFacets();
 	  private:
 		  

--- a/gpu/utils/include/pcl/gpu/utils/timers_cuda.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/timers_cuda.hpp
@@ -60,10 +60,10 @@ namespace pcl
                 cudaEventDestroy(stop_);
             }
 
-            void start() { cudaEventRecord(start_, 0); }
+            void start() const { cudaEventRecord(start_, 0); }
             Timer& stop()  { cudaEventRecord(stop_, 0); cudaEventSynchronize(stop_); return *this; }
 
-            float time()
+            float time() const
             {
                 float elapsed_time; 
                 cudaEventElapsedTime(&elapsed_time, start_, stop_);

--- a/io/include/pcl/io/ensenso_grabber.h
+++ b/io/include/pcl/io/ensenso_grabber.h
@@ -169,7 +169,7 @@ namespace pcl
        * @return True if successful, false otherwise
        * @warning A device must be opened and not running */
       bool
-      grabSingleCloud (pcl::PointCloud<pcl::PointXYZ> &cloud);
+      grabSingleCloud (pcl::PointCloud<pcl::PointXYZ> &cloud) const;
 
       /** @brief Set up the Ensenso sensor and API to do 3D extrinsic calibration using the Ensenso 2D patterns
        * @param[in] grid_spacing
@@ -256,7 +256,7 @@ namespace pcl
       setExtrinsicCalibration (const double euler_angle,
                                Eigen::Vector3d &rotation_axis,
                                const Eigen::Vector3d &translation,
-                               const std::string target = "Hand");
+                               const std::string target = "Hand") const;
 
       /** @brief Update Link node in NxLib tree with an identity matrix
        * @param[in] target "Hand" or "Workspace" for example

--- a/io/include/pcl/io/hdl_grabber.h
+++ b/io/include/pcl/io/hdl_grabber.h
@@ -270,7 +270,7 @@ namespace pcl
       computeXYZI (pcl::PointXYZI& pointXYZI,
                    std::uint16_t azimuth,
                    HDLLaserReturn laserReturn,
-                   HDLLaserCorrection correction);
+                   HDLLaserCorrection correction) const;
 
 
     private:

--- a/io/include/pcl/io/openni2/openni2_device_manager.h
+++ b/io/include/pcl/io/openni2/openni2_device_manager.h
@@ -80,7 +80,7 @@ namespace pcl
         getDevice (const std::string& device_URI);
 
         OpenNI2Device::Ptr
-        getDeviceByIndex (int index);
+        getDeviceByIndex (int index) const;
 
         OpenNI2Device::Ptr
         getFileDevice (const std::string& path);

--- a/io/src/ensenso_grabber.cpp
+++ b/io/src/ensenso_grabber.cpp
@@ -290,7 +290,7 @@ pcl::EnsensoGrabber::configureCapture (const bool auto_exposure,
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::EnsensoGrabber::grabSingleCloud (pcl::PointCloud<pcl::PointXYZ> &cloud)
+pcl::EnsensoGrabber::grabSingleCloud (pcl::PointCloud<pcl::PointXYZ> &cloud) const
 {
   if (!device_open_)
     return (false);
@@ -575,7 +575,7 @@ bool
 pcl::EnsensoGrabber::setExtrinsicCalibration (const double euler_angle,
                                               Eigen::Vector3d &rotation_axis,
                                               const Eigen::Vector3d &translation,
-                                              const std::string target)
+                                              const std::string target) const
 {
   if (!device_open_)
     return (false);

--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -396,7 +396,7 @@ void
 pcl::HDLGrabber::computeXYZI (pcl::PointXYZI& point,
                               std::uint16_t azimuth,
                               HDLLaserReturn laserReturn,
-                              HDLLaserCorrection correction)
+                              HDLLaserCorrection correction) const
 {
   double cos_azimuth, sin_azimuth;
 

--- a/io/src/image_grabber.cpp
+++ b/io/src/image_grabber.cpp
@@ -111,7 +111,7 @@ struct pcl::ImageGrabberBase::ImageGrabberImpl
 
   //! True if it is an image we know how to read
   bool
-  isValidExtension (const std::string &extension);
+  isValidExtension (const std::string &extension) const;
 
   //! Convenience function to rewind to the last frame
   void
@@ -430,7 +430,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadPCLZFFiles (const std::string &dir)
 }
 ///////////////////////////////////////////////////////////////////////////////////////////
 bool
-pcl::ImageGrabberBase::ImageGrabberImpl::isValidExtension (const std::string &extension)
+pcl::ImageGrabberBase::ImageGrabberImpl::isValidExtension (const std::string &extension) const
 {
   bool valid;
   if(pclzf_mode_)

--- a/io/src/openni2/openni2_device_manager.cpp
+++ b/io/src/openni2/openni2_device_manager.cpp
@@ -226,7 +226,7 @@ pcl::io::openni2::OpenNI2DeviceManager::getDevice (const std::string& device_URI
 }
 
 OpenNI2Device::Ptr
-pcl::io::openni2::OpenNI2DeviceManager::getDeviceByIndex (int index)
+pcl::io::openni2::OpenNI2DeviceManager::getDeviceByIndex (int index) const
 {
   auto URIs = getConnectedDeviceURIs ();
   return pcl::make_shared<OpenNI2Device>( URIs->at (index) );

--- a/io/tools/openni_grabber_example.cpp
+++ b/io/tools/openni_grabber_example.cpp
@@ -50,7 +50,7 @@ class SimpleOpenNIProcessor
     SimpleOpenNIProcessor (openni_wrapper::OpenNIDevice::DepthMode depth_mode = openni_wrapper::OpenNIDevice::OpenNI_12_bit_depth) : mode (depth_mode) {}
 
     void 
-    cloud_cb_ (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr &cloud)
+    cloud_cb_ (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr &cloud) const
     {
       static unsigned count = 0;
       static double last = pcl::getTime ();

--- a/keypoints/include/pcl/keypoints/agast_2d.h
+++ b/keypoints/include/pcl/keypoints/agast_2d.h
@@ -92,7 +92,7 @@ namespace pcl
             */
           void 
           detectKeypoints (const std::vector<unsigned char> &intensity_data, 
-                           pcl::PointCloud<pcl::PointUV> &output);
+                           pcl::PointCloud<pcl::PointUV> &output) const;
 
           /** \brief Detects corner points. 
             * \param intensity_data
@@ -100,7 +100,7 @@ namespace pcl
             */
           void 
           detectKeypoints (const std::vector<float> &intensity_data, 
-                           pcl::PointCloud<pcl::PointUV> &output);
+                           pcl::PointCloud<pcl::PointUV> &output) const;
 
           /** \brief Applies non-max-suppression. 
             * \param[in] intensity_data the image data
@@ -227,7 +227,7 @@ namespace pcl
           void 
           computeCornerScores (const unsigned char* im, 
                                const std::vector<pcl::PointUV, Eigen::aligned_allocator<pcl::PointUV> > & corners_all, 
-                               std::vector<ScoreIndex> & scores);
+                               std::vector<ScoreIndex> & scores) const;
 
           /** \brief Computes corner scores for the specified points. 
             * \param im
@@ -237,7 +237,7 @@ namespace pcl
           void 
           computeCornerScores (const float* im, 
                                const std::vector<pcl::PointUV, Eigen::aligned_allocator<pcl::PointUV> > & corners_all, 
-                               std::vector<ScoreIndex> & scores);
+                               std::vector<ScoreIndex> & scores) const;
 
           /** \brief Width of the image to process. */
           std::size_t width_;

--- a/keypoints/src/agast_2d.cpp
+++ b/keypoints/src/agast_2d.cpp
@@ -79,7 +79,7 @@ pcl::AgastKeypoint2D<pcl::PointXYZ, pcl::PointUV>::detectKeypoints (pcl::PointCl
 void
 pcl::keypoints::agast::AbstractAgastDetector::detectKeypoints (
     const std::vector<unsigned char> & intensity_data,
-    pcl::PointCloud<pcl::PointUV> &output)
+    pcl::PointCloud<pcl::PointUV> &output) const
 {
   detect (&(intensity_data[0]), output.points);
 
@@ -91,7 +91,7 @@ pcl::keypoints::agast::AbstractAgastDetector::detectKeypoints (
 void
 pcl::keypoints::agast::AbstractAgastDetector::detectKeypoints (
     const std::vector<float> & intensity_data,
-    pcl::PointCloud<pcl::PointUV> &output)
+    pcl::PointCloud<pcl::PointUV> &output) const
 {
   detect (&(intensity_data[0]), output.points);
 
@@ -297,7 +297,7 @@ void
 pcl::keypoints::agast::AbstractAgastDetector::computeCornerScores (
   const unsigned char* im,
   const std::vector<pcl::PointUV, Eigen::aligned_allocator<pcl::PointUV> > &corners_all,
-  std::vector<ScoreIndex> &scores)
+  std::vector<ScoreIndex> &scores) const
 {
   unsigned int num_corners = static_cast<unsigned int> (corners_all.size ());
 
@@ -327,7 +327,7 @@ void
 pcl::keypoints::agast::AbstractAgastDetector::computeCornerScores (
   const float* im,
   const std::vector<pcl::PointUV, Eigen::aligned_allocator<pcl::PointUV> > &corners_all,
-  std::vector<ScoreIndex> &scores)
+  std::vector<ScoreIndex> &scores) const
 {
   unsigned int num_corners = static_cast<unsigned int> (corners_all.size ());
 

--- a/ml/include/pcl/ml/densecrf.h
+++ b/ml/include/pcl/ml/densecrf.h
@@ -108,7 +108,7 @@ public:
   expAndNormalize(std::vector<float>& out,
                   const std::vector<float>& in,
                   float scale,
-                  float relax = 1.0f);
+                  float relax = 1.0f) const;
 
   void
   expAndNormalizeORI(float* out,

--- a/ml/include/pcl/ml/svm_wrapper.h
+++ b/ml/include/pcl/ml/svm_wrapper.h
@@ -163,7 +163,7 @@ protected:
 
   /** Convert the libSVM format (svm_problem) into a easier output format. */
   void
-  adaptLibSVMToInput(std::vector<SVMData>& training_set, svm_problem prob);
+  adaptLibSVMToInput(std::vector<SVMData>& training_set, svm_problem prob) const;
 
   /** Load a problem from an extern file. */
   bool

--- a/ml/src/densecrf.cpp
+++ b/ml/src/densecrf.cpp
@@ -235,7 +235,7 @@ void
 pcl::DenseCrf::expAndNormalize(std::vector<float>& out,
                                const std::vector<float>& in,
                                float scale,
-                               float relax)
+                               float relax) const
 {
   std::vector<float> V(N_ + 10);
   for (int i = 0; i < N_; i++) {

--- a/ml/src/svm_wrapper.cpp
+++ b/ml/src/svm_wrapper.cpp
@@ -145,7 +145,7 @@ pcl::SVMTrain::scaleFactors(std::vector<SVMData> training_set, svm_scaling& scal
 };
 
 void
-pcl::SVM::adaptLibSVMToInput(std::vector<SVMData>& training_set, svm_problem prob)
+pcl::SVM::adaptLibSVMToInput(std::vector<SVMData>& training_set, svm_problem prob) const
 {
   training_set.clear(); // Reset input
 

--- a/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
+++ b/outofcore/include/pcl/outofcore/visualization/outofcore_cloud.h
@@ -208,7 +208,7 @@ class OutofcoreCloud : public Object
     }
 
     int
-    getLodPixelThreshold ()
+    getLodPixelThreshold () const
     {
       return lod_pixel_threshold_;
     }

--- a/recognition/include/pcl/recognition/3rdparty/metslib/termination-criteria.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/termination-criteria.hh
@@ -163,9 +163,9 @@ namespace mets {
       termination_criteria_chain::reset();      
     }
 
-    int second_guess() { return second_guess_m; }
-    int iteration() { return total_iterations_m; }
-    int resets() { return resets_m; }
+    int second_guess() const { return second_guess_m; }
+    int iteration() const { return total_iterations_m; }
+    int resets() const { return resets_m; }
 
   protected:
     gol_type best_cost_m;

--- a/recognition/include/pcl/recognition/point_types.h
+++ b/recognition/include/pcl/recognition/point_types.h
@@ -64,7 +64,7 @@ namespace pcl
     };
     PCL_MAKE_ALIGNED_OPERATOR_NEW
 
-    inline bool operator< (const GradientXY & rhs)
+    inline bool operator< (const GradientXY & rhs) const
     {
       return (magnitude > rhs.magnitude);
     }

--- a/recognition/include/pcl/recognition/ransac_based/orr_octree.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_octree.h
@@ -234,7 +234,7 @@ namespace pcl
 
             /** \brief Computes the "radius" of the node which is half the diagonal length. */
             inline float
-            getRadius (){ return radius_;}
+            getRadius () const{ return radius_;}
 
             bool
             createChildren ();

--- a/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
+++ b/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
@@ -65,7 +65,7 @@ namespace pcl
       * \param[in] base the feature to compare to.
       */
     bool
-    compareForEquality (const QuantizedMultiModFeature & base)
+    compareForEquality (const QuantizedMultiModFeature & base) const
     {
       if (base.x != x)
         return false;

--- a/registration/include/pcl/registration/correspondence_rejection_distance.h
+++ b/registration/include/pcl/registration/correspondence_rejection_distance.h
@@ -95,7 +95,7 @@ namespace pcl
 
         /** \brief Get the maximum distance used for thresholding in correspondence rejection. */
         inline float 
-        getMaximumDistance () { return std::sqrt (max_distance_); };
+        getMaximumDistance () const { return std::sqrt (max_distance_); };
 
         /** \brief Provide a source point cloud dataset (must contain XYZ
           * data!), used to compute the correspondence distance.  

--- a/registration/include/pcl/registration/correspondence_rejection_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_trimmed.h
@@ -91,7 +91,7 @@ namespace pcl
 
         /** \brief Get the maximum distance used for thresholding in correspondence rejection. */
         inline float 
-        getOverlapRatio () { return overlap_ratio_; };
+        getOverlapRatio () const { return overlap_ratio_; };
 
         /** \brief Set a minimum number of correspondences. If the specified overlap ratio causes to have
           * less correspondences,  \a CorrespondenceRejectorTrimmed will try to return at least
@@ -104,7 +104,7 @@ namespace pcl
 
         /** \brief Get the minimum number of correspondences. */
         inline unsigned int 
-        getMinCorrespondences () { return nr_min_correspondences_; };
+        getMinCorrespondences () const { return nr_min_correspondences_; };
 
 
         /** \brief Get a list of valid correspondences after rejection from the original set of correspondences.

--- a/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
+++ b/registration/include/pcl/registration/correspondence_rejection_var_trimmed.h
@@ -244,7 +244,7 @@ namespace pcl
 
         /** \brief finds the optimal inlier ratio. This is based on the paper 'Outlier Robust ICP for minimizing Fractional RMSD, J. M. Philips et al'
          */
-        inline float optimizeInlierRatio (std::vector <double> &dists);
+        inline float optimizeInlierRatio (std::vector <double> &dists) const;
     };
   }
 }

--- a/registration/include/pcl/registration/ppf_registration.h
+++ b/registration/include/pcl/registration/ppf_registration.h
@@ -121,15 +121,15 @@ namespace pcl
 
       /** \brief Returns the angle discretization step parameter (the step value between each bin of the hash map for the angular values) */
       inline float
-      getAngleDiscretizationStep () { return angle_discretization_step_; }
+      getAngleDiscretizationStep () const { return angle_discretization_step_; }
 
       /** \brief Returns the distance discretization step parameter (the step value between each bin of the hash map for the distance values) */
       inline float
-      getDistanceDiscretizationStep () { return distance_discretization_step_; }
+      getDistanceDiscretizationStep () const { return distance_discretization_step_; }
 
       /** \brief Returns the maximum distance found between any feature pair in the given input feature cloud */
       inline float
-      getModelDiameter () { return max_dist_; }
+      getModelDiameter () const { return max_dist_; }
 
       std::vector <std::vector <float> > alpha_m_;
     private:

--- a/registration/src/correspondence_rejection_var_trimmed.cpp
+++ b/registration/src/correspondence_rejection_var_trimmed.cpp
@@ -79,7 +79,7 @@ pcl::registration::CorrespondenceRejectorVarTrimmed::getRemainingCorrespondences
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 float
-pcl::registration::CorrespondenceRejectorVarTrimmed::optimizeInlierRatio (std::vector <double>&  dists)
+pcl::registration::CorrespondenceRejectorVarTrimmed::optimizeInlierRatio (std::vector <double>&  dists) const
 {
   unsigned int points_nbr = static_cast<unsigned int> (dists.size ());
   std::sort (dists.begin (), dists.end ());

--- a/simulation/include/pcl/simulation/camera.h
+++ b/simulation/include/pcl/simulation/camera.h
@@ -138,7 +138,7 @@ public:
 
   // Return the pose of the camera:
   Eigen::Vector3d
-  getYPR()
+  getYPR() const
   {
     return Eigen::Vector3d(yaw_, pitch_, roll_);
   }

--- a/simulation/include/pcl/simulation/glsl_shader.h
+++ b/simulation/include/pcl/simulation/glsl_shader.h
@@ -39,7 +39,7 @@ public:
 
   /** Add a new shader object to the program.  */
   bool
-  addShaderText(const std::string& text, ShaderType shader_type);
+  addShaderText(const std::string& text, ShaderType shader_type) const;
 
   /** Add a new shader object to the program.  */
   bool
@@ -47,7 +47,7 @@ public:
 
   /** Link the program.  */
   bool
-  link();
+  link() const;
 
   /** Return true if the program is linked.  */
   bool
@@ -55,7 +55,7 @@ public:
 
   /** Use the program.  */
   void
-  use();
+  use() const;
 
   // Set uniforms
   void
@@ -86,7 +86,7 @@ public:
   setUniform(const std::string& name, bool v);
 
   int
-  getUniformLocation(const std::string& name);
+  getUniformLocation(const std::string& name) const;
 
   void
   printActiveUniforms();
@@ -94,7 +94,7 @@ public:
   printActiveAttribs();
 
   GLuint
-  programId()
+  programId() const
   {
     return program_id_;
   }

--- a/simulation/include/pcl/simulation/model.h
+++ b/simulation/include/pcl/simulation/model.h
@@ -162,7 +162,7 @@ public:
 
   /** Render the quad. */
   void
-  render();
+  render() const;
 
 private:
   GLuint quad_vbo_;
@@ -177,7 +177,7 @@ public:
   ~TexturedQuad();
 
   void
-  setTexture(const std::uint8_t* data);
+  setTexture(const std::uint8_t* data) const;
 
   void
   render();

--- a/simulation/include/pcl/simulation/range_likelihood.h
+++ b/simulation/include/pcl/simulation/range_likelihood.h
@@ -253,7 +253,7 @@ private:
   applyCameraTransform(const Camera& camera);
 
   void
-  setupProjectionMatrix();
+  setupProjectionMatrix() const;
 
   Scene::Ptr scene_;
   int rows_;

--- a/simulation/src/glsl_shader.cpp
+++ b/simulation/src/glsl_shader.cpp
@@ -35,7 +35,7 @@ pcl::simulation::gllib::Program::Program() { program_id_ = glCreateProgram(); }
 pcl::simulation::gllib::Program::~Program() {}
 
 int
-pcl::simulation::gllib::Program::getUniformLocation(const std::string& name)
+pcl::simulation::gllib::Program::getUniformLocation(const std::string& name) const
 {
   return glGetUniformLocation(program_id_, name.c_str());
 }
@@ -103,7 +103,7 @@ pcl::simulation::gllib::Program::setUniform(const std::string& name, bool v)
 
 bool
 pcl::simulation::gllib::Program::addShaderText(const std::string& text,
-                                               ShaderType shader_type)
+                                               ShaderType shader_type) const
 {
   GLuint id;
   GLint compile_status;
@@ -139,7 +139,7 @@ pcl::simulation::gllib::Program::addShaderFile(const std::string& filename,
 }
 
 bool
-pcl::simulation::gllib::Program::link()
+pcl::simulation::gllib::Program::link() const
 {
   glLinkProgram(program_id_);
   printProgramInfoLog(program_id_);
@@ -148,7 +148,7 @@ pcl::simulation::gllib::Program::link()
 }
 
 void
-pcl::simulation::gllib::Program::use()
+pcl::simulation::gllib::Program::use() const
 {
   glUseProgram(program_id_);
 }

--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -271,7 +271,7 @@ pcl::simulation::Quad::Quad()
 pcl::simulation::Quad::~Quad() { glDeleteBuffers(1, &quad_vbo_); }
 
 void
-pcl::simulation::Quad::render()
+pcl::simulation::Quad::render() const
 {
   glBindBuffer(GL_ARRAY_BUFFER, quad_vbo_);
   glEnableVertexAttribArray(0);
@@ -313,7 +313,7 @@ pcl::simulation::TexturedQuad::TexturedQuad(int width, int height)
 pcl::simulation::TexturedQuad::~TexturedQuad() { glDeleteTextures(1, &texture_); }
 
 void
-pcl::simulation::TexturedQuad::setTexture(const std::uint8_t* data)
+pcl::simulation::TexturedQuad::setTexture(const std::uint8_t* data) const
 {
   glBindTexture(GL_TEXTURE_2D, texture_);
   glTexImage2D(

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -512,7 +512,7 @@ pcl::simulation::RangeLikelihood::sampleNormal(double sigma)
 }
 
 void
-pcl::simulation::RangeLikelihood::setupProjectionMatrix()
+pcl::simulation::RangeLikelihood::setupProjectionMatrix() const
 {
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();

--- a/surface/include/pcl/surface/on_nurbs/fitting_cylinder_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_cylinder_pdm.h
@@ -197,12 +197,12 @@ namespace pcl
         return grc2gl (E + i, F + j);
       } // local row/col index to global lexicographic index
       int
-      gl2gr (int A)
+      gl2gr (int A) const
       {
         return (A / m_nurbs.CVCount (1));
       } // global lexicographic in global row index
       int
-      gl2gc (int A)
+      gl2gc (int A) const
       {
         return (A % m_nurbs.CVCount (1));
       } // global lexicographic in global col index

--- a/surface/include/pcl/surface/on_nurbs/fitting_sphere_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_sphere_pdm.h
@@ -175,12 +175,12 @@ namespace pcl
         return grc2gl (E + i, F + j);
       } // local row/col index to global lexicographic index
       int
-      gl2gr (int A)
+      gl2gr (int A) const
       {
         return (A / m_nurbs.CVCount (1));
       } // global lexicographic in global row index
       int
-      gl2gc (int A)
+      gl2gc (int A) const
       {
         return (A % m_nurbs.CVCount (1));
       } // global lexicographic in global col index

--- a/surface/include/pcl/surface/on_nurbs/fitting_surface_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_surface_pdm.h
@@ -291,7 +291,7 @@ namespace pcl
 
       // index routines
       int
-      grc2gl (int I, int J)
+      grc2gl (int I, int J) const
       {
         return m_nurbs.CVCount (1) * I + J;
       } // global row/col index to global lexicographic index
@@ -301,12 +301,12 @@ namespace pcl
         return grc2gl (E + i, F + j);
       } // local row/col index to global lexicographic index
       int
-      gl2gr (int A)
+      gl2gr (int A) const
       {
         return (static_cast<int> (A / m_nurbs.CVCount (1)));
       } // global lexicographic in global row index
       int
-      gl2gc (int A)
+      gl2gc (int A) const
       {
         return (static_cast<int> (A % m_nurbs.CVCount (1)));
       } // global lexicographic in global col index

--- a/surface/include/pcl/surface/on_nurbs/sequential_fitter.h
+++ b/surface/include/pcl/surface/on_nurbs/sequential_fitter.h
@@ -106,11 +106,11 @@ namespace pcl
         void
         compute_quadfit ();
         void
-        compute_refinement (FittingSurface* fitting);
+        compute_refinement (FittingSurface* fitting) const;
         void
-        compute_boundary (FittingSurface* fitting);
+        compute_boundary (FittingSurface* fitting) const;
         void
-        compute_interior (FittingSurface* fitting);
+        compute_interior (FittingSurface* fitting) const;
 
         Eigen::Vector2d
         project (const Eigen::Vector3d &pt);
@@ -176,27 +176,27 @@ namespace pcl
 
         /** \brief Get error of each interior point (L2-norm of point to closest point on surface) and square-error */
         void
-        getInteriorError (std::vector<double> &error);
+        getInteriorError (std::vector<double> &error) const;
 
         /** \brief Get error of each boundary point (L2-norm of point to closest point on surface) and square-error */
         void
-        getBoundaryError (std::vector<double> &error);
+        getBoundaryError (std::vector<double> &error) const;
 
         /** \brief Get parameter of each interior point */
         void
-        getInteriorParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params);
+        getInteriorParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params) const;
 
         /** \brief Get parameter of each boundary point */
         void
-        getBoundaryParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params);
+        getBoundaryParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params) const;
 
         /** \brief get the normals to the interior points given by setInterior() */
         void
-        getInteriorNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normal);
+        getInteriorNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normal) const;
 
         /** \brief get the normals to the boundary points given by setBoundary() */
         void
-        getBoundaryNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normals);
+        getBoundaryNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normals) const;
 
         /** \brief Get the closest point on a NURBS from a point pt in parameter space
          *  \param[in] nurbs  The NURBS surface

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_quadric_decimation.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_quadric_decimation.h
@@ -65,7 +65,7 @@ namespace pcl
 
       /** \brief Get the target reduction factor */
       inline float
-      getTargetReductionFactor ()
+      getTargetReductionFactor () const
       {
         return target_reduction_factor_;
       }

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_laplacian.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_laplacian.h
@@ -73,7 +73,7 @@ namespace pcl
 
       /** \brief Get the number of iterations. */
       inline int
-      getNumIter ()
+      getNumIter () const
       {
         return num_iter_;
       };
@@ -89,7 +89,7 @@ namespace pcl
 
       /** \brief Get the convergence criterion. */
       inline float
-      getConvergence ()
+      getConvergence () const
       {
         return convergence_;
       };
@@ -108,7 +108,7 @@ namespace pcl
 
       /** \brief Get the relaxation factor of the Laplacian smoothing */
       inline float
-      getRelaxationFactor ()
+      getRelaxationFactor () const
       {
         return relaxation_factor_;
       };
@@ -124,7 +124,7 @@ namespace pcl
 
       /** \brief Get the status of the feature edge smoothing */
       inline bool
-      getFeatureEdgeSmoothing ()
+      getFeatureEdgeSmoothing () const
       {
         return feature_edge_smoothing_;
       };
@@ -140,7 +140,7 @@ namespace pcl
 
       /** \brief Get the angle threshold for considering an edge to be sharp */
       inline float
-      getFeatureAngle ()
+      getFeatureAngle () const
       {
         return feature_angle_;
       };
@@ -156,7 +156,7 @@ namespace pcl
 
       /** \brief Get the edge angle to control smoothing along edges */
       inline float
-      getEdgeAngle ()
+      getEdgeAngle () const
       {
         return edge_angle_;
       };
@@ -172,7 +172,7 @@ namespace pcl
 
       /** \brief Get the status of the boundary smoothing */
       inline bool
-      getBoundarySmoothing ()
+      getBoundarySmoothing () const
       {
         return boundary_smoothing_;
       }

--- a/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_windowed_sinc.h
+++ b/surface/include/pcl/surface/vtk_smoothing/vtk_mesh_smoothing_windowed_sinc.h
@@ -73,7 +73,7 @@ namespace pcl
 
       /** \brief Get the number of iterations. */
       inline int
-      getNumIter ()
+      getNumIter () const
       {
         return num_iter_;
       };
@@ -89,7 +89,7 @@ namespace pcl
 
       /** \brief Get the pass band value. */
       inline float
-      getPassBand ()
+      getPassBand () const
       {
         return pass_band_;
       };
@@ -108,7 +108,7 @@ namespace pcl
 
       /** \brief Get whether the coordinate normalization is active or not */
       inline bool
-      getNormalizeCoordinates ()
+      getNormalizeCoordinates () const
       {
         return normalize_coordinates_;
       }
@@ -124,7 +124,7 @@ namespace pcl
 
       /** \brief Get the status of the feature edge smoothing */
       inline bool
-      getFeatureEdgeSmoothing ()
+      getFeatureEdgeSmoothing () const
       {
         return feature_edge_smoothing_;
       };
@@ -140,7 +140,7 @@ namespace pcl
 
       /** \brief Get the angle threshold for considering an edge to be sharp */
       inline float
-      getFeatureAngle ()
+      getFeatureAngle () const
       {
         return feature_angle_;
       };
@@ -156,7 +156,7 @@ namespace pcl
 
       /** \brief Get the edge angle to control smoothing along edges */
       inline float
-      getEdgeAngle ()
+      getEdgeAngle () const
       {
         return edge_angle_;
       };
@@ -173,7 +173,7 @@ namespace pcl
 
       /** \brief Get the status of the boundary smoothing */
       inline bool
-      getBoundarySmoothing ()
+      getBoundarySmoothing () const
       {
         return boundary_smoothing_;
       }

--- a/surface/src/3rdparty/opennurbs/opennurbs_evaluate_nurbs.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_evaluate_nurbs.cpp
@@ -509,10 +509,10 @@ RELATED FUNCTIONS:
 {
   unsigned char stack_buffer[4*64*sizeof(double)];
   double delta_t;
-  register double alpha0;
-  register double alpha1;
-  register double *cv0, *cv1;
-  register int i, j, k; 
+  double alpha0;
+  double alpha1;
+  double *cv0, *cv1;
+  int i, j, k; 
   double* CV, *tmp;
   void* free_me = 0;
   const int degree = order-1;
@@ -733,11 +733,11 @@ RELATED FUNCTIONS:
   TL_EvNurbBasis
   TL_EvNurbBasisDer
 *****************************************************************************/
-  register double a0, a1, x, y;
+  double a0, a1, x, y;
   const double *k0;
   double *t_k, *k_t, *N0;
   const int d = order-1;
-  register int j, r;
+  int j, r;
 
   t_k = (double*)alloca( d<<4 );
   k_t = t_k + d;

--- a/surface/src/on_nurbs/sequential_fitter.cpp
+++ b/surface/src/on_nurbs/sequential_fitter.cpp
@@ -122,7 +122,7 @@ SequentialFitter::compute_quadfit ()
 }
 
 void
-SequentialFitter::compute_refinement (FittingSurface* fitting)
+SequentialFitter::compute_refinement (FittingSurface* fitting) const
 {
   // Refinement
   FittingSurface::Parameter paramFP (0.0, 1.0, 0.0, m_params.forceBoundary, m_params.stiffnessBoundary, 0.0);
@@ -137,7 +137,7 @@ SequentialFitter::compute_refinement (FittingSurface* fitting)
 }
 
 void
-SequentialFitter::compute_boundary (FittingSurface* fitting)
+SequentialFitter::compute_boundary (FittingSurface* fitting) const
 {
   FittingSurface::Parameter paramFP (0.0, 1.0, 0.0, m_params.forceBoundary, m_params.stiffnessBoundary, 0.0);
 
@@ -149,7 +149,7 @@ SequentialFitter::compute_boundary (FittingSurface* fitting)
   }
 }
 void
-SequentialFitter::compute_interior (FittingSurface* fitting)
+SequentialFitter::compute_interior (FittingSurface* fitting) const
 {
   // iterate interior points
   //std::vector<double> wInt(m_data.interior.PointCount(), m_params.forceInterior);
@@ -420,37 +420,37 @@ SequentialFitter::compute_interior (const ON_NurbsSurface &nurbs)
 }
 
 void
-SequentialFitter::getInteriorError (std::vector<double> &error)
+SequentialFitter::getInteriorError (std::vector<double> &error) const
 {
   error = m_data.interior_error;
 }
 
 void
-SequentialFitter::getBoundaryError (std::vector<double> &error)
+SequentialFitter::getBoundaryError (std::vector<double> &error) const
 {
   error = m_data.boundary_error;
 }
 
 void
-SequentialFitter::getInteriorParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params)
+SequentialFitter::getInteriorParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params) const
 {
   params = m_data.interior_param;
 }
 
 void
-SequentialFitter::getBoundaryParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params)
+SequentialFitter::getBoundaryParams (std::vector<Eigen::Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > &params) const
 {
   params = m_data.boundary_param;
 }
 
 void
-SequentialFitter::getInteriorNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normals)
+SequentialFitter::getInteriorNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normals) const
 {
   normals = m_data.interior_normals;
 }
 
 void
-SequentialFitter::getBoundaryNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normals)
+SequentialFitter::getBoundaryNormals (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &normals) const
 {
   normals = m_data.boundary_normals;
 }

--- a/visualization/include/pcl/visualization/pcl_painter2D.h
+++ b/visualization/include/pcl/visualization/pcl_painter2D.h
@@ -98,7 +98,7 @@ namespace pcl
         this->transform_->SetMatrix (t->GetMatrix());
       }
       
-      void applyInternals (vtkContext2D *painter)
+      void applyInternals (vtkContext2D *painter) const
       {
         painter->ApplyPen (pen_);
         painter->ApplyBrush (brush_);
@@ -397,7 +397,7 @@ namespace pcl
        * \return[in] array containing the width and height of the window
        */
       int *
-      getWindowSize ();
+      getWindowSize () const;
 
       /** \brief displays all the figures added in a window.
        */    

--- a/visualization/include/pcl/visualization/pcl_plotter.h
+++ b/visualization/include/pcl/visualization/pcl_plotter.h
@@ -373,7 +373,7 @@ namespace pcl
           * \return[in] array containing the width and height of the window
           */
         int*
-        getWindowSize ();
+        getWindowSize () const;
 
         /** \brief Return a pointer to the underlying VTK RenderWindow used. */
         vtkSmartPointer<vtkRenderWindow>

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -2136,7 +2136,7 @@ namespace pcl
         void
         createActorFromVTKDataSet (const vtkSmartPointer<vtkDataSet> &data,
                                    vtkSmartPointer<vtkActor> &actor,
-                                   bool use_scalars = true);
+                                   bool use_scalars = true) const;
 
         /** \brief Internal method. Creates a vtk actor from a vtk polydata object.
           * \param[in] data the vtk polydata object to create an actor for
@@ -2146,7 +2146,7 @@ namespace pcl
         void
         createActorFromVTKDataSet (const vtkSmartPointer<vtkDataSet> &data,
                                    vtkSmartPointer<vtkLODActor> &actor,
-                                   bool use_scalars = true);
+                                   bool use_scalars = true) const;
 
         /** \brief Converts a PCL templated PointCloud object to a vtk polydata object.
           * \param[in] cloud the input PCL PointCloud dataset

--- a/visualization/include/pcl/visualization/point_picking_event.h
+++ b/visualization/include/pcl/visualization/point_picking_event.h
@@ -71,7 +71,7 @@ namespace pcl
         performSinglePick (vtkRenderWindowInteractor *iren, float &x, float &y, float &z);
 
         int
-        performAreaPick (vtkRenderWindowInteractor *iren, std::vector<int> &indices);
+        performAreaPick (vtkRenderWindowInteractor *iren, std::vector<int> &indices) const;
 
       private:
         float x_, y_, z_;

--- a/visualization/src/pcl_painter2D.cpp
+++ b/visualization/src/pcl_painter2D.cpp
@@ -349,7 +349,7 @@ pcl::visualization::PCLPainter2D::setWindowSize (int w, int h)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 int*
-pcl::visualization::PCLPainter2D::getWindowSize ()
+pcl::visualization::PCLPainter2D::getWindowSize () const
 {
   int *sz = new int[2];
   sz[0] = win_width_;

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -542,7 +542,7 @@ pcl::visualization::PCLPlotter::setWindowSize (int w, int h)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 int*
-pcl::visualization::PCLPlotter::getWindowSize ()
+pcl::visualization::PCLPlotter::getWindowSize () const
 {
   int *sz = new int[2];
   sz[0] = win_width_;

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1107,7 +1107,7 @@ getDefaultScalarInterpolationForDataSet (vtkDataSet* data)
 void
 pcl::visualization::PCLVisualizer::createActorFromVTKDataSet (const vtkSmartPointer<vtkDataSet> &data,
                                                               vtkSmartPointer<vtkLODActor> &actor,
-                                                              bool use_scalars)
+                                                              bool use_scalars) const
 {
   // If actor is not initialized, initialize it here
   if (!actor)
@@ -1185,7 +1185,7 @@ pcl::visualization::PCLVisualizer::createActorFromVTKDataSet (const vtkSmartPoin
 void
 pcl::visualization::PCLVisualizer::createActorFromVTKDataSet (const vtkSmartPointer<vtkDataSet> &data,
                                                               vtkSmartPointer<vtkActor> &actor,
-                                                              bool use_scalars)
+                                                              bool use_scalars) const
 {
   // If actor is not initialized, initialize it here
   if (!actor)

--- a/visualization/src/point_picking_event.cpp
+++ b/visualization/src/point_picking_event.cpp
@@ -167,7 +167,7 @@ pcl::visualization::PointPickingCallback::performSinglePick (
 /////////////////////////////////////////////////////////////////////////////////////////////
 int
 pcl::visualization::PointPickingCallback::performAreaPick (vtkRenderWindowInteractor *iren,
-                                                           std::vector<int> &indices)
+                                                           std::vector<int> &indices) const
 {
   vtkAreaPicker *picker = static_cast<vtkAreaPicker*> (iren->GetPicker ());
   vtkRenderer *ren = iren->FindPokedRenderer (iren->GetEventPosition ()[0], iren->GetEventPosition ()[1]);


### PR DESCRIPTION
Changes are done by: `run-clang-tidy -header-filter='.' -checks='-,readability-make-member-function-const' -fix`

//edit: I touched a few 3rd-Party code. As you have started to touch sometimes 3rd-Part code: It is okay or should I revert this?