### PR TITLE
Optimize VoxelGrid Filter

### DIFF
--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -211,10 +211,6 @@ struct cloud_point_index_idx
   bool operator < (const cloud_point_index_idx &p) const { return (idx < p.idx); }
 };
 
-struct cloud_point_index_rightshift {
-  inline int operator()(const cloud_point_index_idx &p, const unsigned offset) { return p.idx >> offset; }
-};
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -206,8 +206,8 @@ struct cloud_point_index_idx
   unsigned int idx;
   unsigned int cloud_point_index;
 
-  cloud_point_index_idx(){}
-  cloud_point_index_idx (int idx_, unsigned int cloud_point_index_) : idx (idx_), cloud_point_index (cloud_point_index_) {}
+  cloud_point_index_idx() = default;
+  cloud_point_index_idx (unsigned int idx_, unsigned int cloud_point_index_) : idx (idx_), cloud_point_index (cloud_point_index_) {}
   bool operator < (const cloud_point_index_idx &p) const { return (idx < p.idx); }
 };
 
@@ -345,10 +345,9 @@ pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
 
   // Second pass: sort the index_vector vector using value representing target cell as index
   // in effect all points belonging to the same output cell will be next to each other
-  //std::sort (index_vector.begin (), index_vector.end (), std::less<cloud_point_index_idx> ());
-  boost::sort::spreadsort::integer_sort(index_vector.begin (), index_vector.end (),
-                                        cloud_point_index_rightshift (), std::less<cloud_point_index_idx> ());
-
+  auto rightshift_func = [](const cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
+  boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift);
+  
   // Third pass: count output cells
   // we need to skip all the same, adjacent idx values
   unsigned int total = 0;

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -342,7 +342,7 @@ pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
   // Second pass: sort the index_vector vector using value representing target cell as index
   // in effect all points belonging to the same output cell will be next to each other
   auto rightshift_func = [](const cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
-  boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift);
+  boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift_func);
   
   // Third pass: count output cells
   // we need to skip all the same, adjacent idx values

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -203,7 +203,7 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
 
 struct cloud_point_index_idx 
 {
-  int idx;
+  unsigned int idx;
   unsigned int cloud_point_index;
 
   cloud_point_index_idx(){}

--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -380,7 +380,7 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
   // in effect all points belonging to the same output cell will be next to each other
   //std::sort (index_vector.begin (), index_vector.end (), std::less<cloud_point_index_idx> ());
   auto rightshift_func = [](const cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
-  boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift);
+  boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift_func);
 
   // Third pass: count output cells
   // we need to skip all the same, adjacenent idx values

--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -379,9 +379,8 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
   // Second pass: sort the index_vector vector using value representing target cell as index
   // in effect all points belonging to the same output cell will be next to each other
   //std::sort (index_vector.begin (), index_vector.end (), std::less<cloud_point_index_idx> ());
-
-  boost::sort::spreadsort::integer_sort(index_vector.begin (), index_vector.end (),
-                                        cloud_point_index_rightshift (), std::less<cloud_point_index_idx> ());
+  auto rightshift_func = [](const cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
+  boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift);
 
   // Third pass: count output cells
   // we need to skip all the same, adjacenent idx values

--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -378,7 +378,6 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
 
   // Second pass: sort the index_vector vector using value representing target cell as index
   // in effect all points belonging to the same output cell will be next to each other
-  //std::sort (index_vector.begin (), index_vector.end (), std::less<cloud_point_index_idx> ());
   auto rightshift_func = [](const cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
   boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift_func);
 
@@ -552,4 +551,3 @@ PCL_INSTANTIATE(getMinMax3D, PCL_XYZ_POINT_TYPES)
 PCL_INSTANTIATE(VoxelGrid, PCL_XYZ_POINT_TYPES)
 
 #endif    // PCL_NO_PRECOMPILE
-

--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -41,6 +41,7 @@
 #include <iostream>
 #include <pcl/common/io.h>
 #include <pcl/filters/impl/voxel_grid.hpp>
+#include <boost/sort/spreadsort/integer_sort.hpp>
 
 using Array4size_t = Eigen::Array<std::size_t, 4, 1>;
 
@@ -377,7 +378,10 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
 
   // Second pass: sort the index_vector vector using value representing target cell as index
   // in effect all points belonging to the same output cell will be next to each other
-  std::sort (index_vector.begin (), index_vector.end (), std::less<cloud_point_index_idx> ());
+  //std::sort (index_vector.begin (), index_vector.end (), std::less<cloud_point_index_idx> ());
+
+  boost::sort::spreadsort::integer_sort(index_vector.begin (), index_vector.end (),
+                                        cloud_point_index_rightshift (), std::less<cloud_point_index_idx> ());
 
   // Third pass: count output cells
   // we need to skip all the same, adjacenent idx values


### PR DESCRIPTION
VoxelGrid spends a lot of time sorting.

Spread sort implemented in boost seems to be faster than std::sort.

I get an average speed improvement of 20%, but it would be nice if anyone can reproduce this.
