### PR TITLE
Check and warn user about missing normals in `OrganizedMultiPlaneSegmentation`

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
@@ -91,6 +91,20 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segment (std::ve
   if (!initCompute ())
     return;
 
+  // Check that the input cloud is present
+  if (!input_)
+  {
+    PCL_ERROR( "[pcl::%s::segment] Must specify input cloud.\n", getClassName().c_str());
+    return;
+  }
+
+  // Check that the normals are present
+  if (!normals_)
+  {
+    PCL_ERROR( "[pcl::%s::segment] Must specify normals.\n", getClassName().c_str());
+    return;
+  }
+
   // Check that we got the same number of points and normals
   if (static_cast<int> (normals_->points.size ()) != static_cast<int> (input_->points.size ()))
   {

--- a/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/organized_multi_plane_segmentation.hpp
@@ -91,13 +91,6 @@ pcl::OrganizedMultiPlaneSegmentation<PointT, PointNT, PointLT>::segment (std::ve
   if (!initCompute ())
     return;
 
-  // Check that the input cloud is present
-  if (!input_)
-  {
-    PCL_ERROR( "[pcl::%s::segment] Must specify input cloud.\n", getClassName().c_str());
-    return;
-  }
-
   // Check that the normals are present
   if (!normals_)
   {


### PR DESCRIPTION
fixes #3855 

Add guard clauses and error messages as described in the related issue.