### PR TITLE
Fix warning C4067: unexpected tokens following preprocessor directive- expected a newline

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -81,19 +81,19 @@
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
-// It seems that __has_cpp_attribute doesn't work correctly
-// when compiling with some versions of nvcc so we
-// additionally check if nvcc is used before setting the
-// PCL_DEPRECATED_IMPL macro to [[deprecated]].
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(deprecated) && !defined(__CUDACC__)
+// MSVC < 2019 have issues:
+// * can't short-circuiting logic in macros
+// * don't define standard macros
+// => this leads to annyoing C4067 warnings (see https://developercommunity.visualstudio.com/content/problem/327796/-has-cpp-attribute-emits-warning-is-wrong-highligh.html)
+#if defined(_MSC_VER)
+  // nvcc on msvc can't work with [[deprecated]]
+  #if !defined(__CUDACC__)
+    #define PCL_DEPRECATED_IMPL(message) [[deprecated(message)]]
+  #else
+    #define PCL_DEPRECATED_IMPL(message)
+  #endif
+#elif __has_cpp_attribute(deprecated)
   #define PCL_DEPRECATED_IMPL(message) [[deprecated(message)]]
-#elif defined(__GNUC__) || defined(__clang__)
-  #define PCL_DEPRECATED_IMPL(message) __attribute__((deprecated(message)))
-#elif defined(_MSC_VER)
-  // Until Visual Studio 2013 you had to use __declspec(deprecated).
-  // However, we decided to ignore the deprecation for these version because
-  // of simplicity reasons. See PR #3634 for the details.
-  #define PCL_DEPRECATED_IMPL(message)
 #else
   #warning "You need to implement PCL_DEPRECATED_IMPL for this compiler"
   #define PCL_DEPRECATED_IMPL(message)


### PR DESCRIPTION
Since #3634 I'm getting a C4067 warning (see Windows Azure builds):
> pcl_macros.h(88): warning C4067: unexpected tokens following preprocessor directive - expected a newline 

This is caused due to [this bug](https://developercommunity.visualstudio.com/content/problem/327796/-has-cpp-attribute-emits-warning-is-wrong-highligh.html).

Now I played a bit with godbolt and saw that #3634 even destroyed the deprecated warning for MSVC 2015 & 2017, as `__has_cpp_attribute` is only supportd since MSVC 2019. You can try it [here](https://godbolt.org/z/Z27ZVu) (MSVC 19.1X => 2017, 19.2X => 2019).

As @taketwo mentioned [here](https://github.com/PointCloudLibrary/pcl/pull/3634#issuecomment-586461711) MSVC 2015 is the base line is not MSVC 2013 and MSVC 2015 (19.0) already supports `[[deprecated]]` see [here](https://en.cppreference.com/w/cpp/compiler_support#cpp14) I solved it by always using `[[deprecated]]` for MSVC.

Even I could not reproduce the issue from @office-florian-hubner with CUDA 10.2 on my MSVC 2017 (15.9.21) machine, I added the check again with `__CUDACC__` (@office-florian-hubner If you see this: which environment you are using?)