### PR TITLE
Suppress unavoidable deprecated warning in clang

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -613,7 +613,9 @@ namespace pcl
       makeShared () const { return Ptr (new PointCloud<PointT> (*this)); }
 
     protected:
-      // This is motivated by ROS integration. Users should not need to access mapping_.
+      /** \brief This is motivated by ROS integration. Users should not need to access mapping_.
+        * \todo Once mapping_ is removed, erase the explicitly defined copy constructor in PointCloud.
+        */
       PCL_DEPRECATED(1, 12, "rewrite your code to avoid using this protected field") shared_ptr<MsgFieldMap> mapping_;
 
       friend shared_ptr<MsgFieldMap>& detail::getMapping<PointT>(pcl::PointCloud<PointT> &p);

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -185,6 +185,15 @@ namespace pcl
         */
       PointCloud () = default;
 
+      /** \brief Copy constructor.
+        * \param[in] pc the cloud to copy into this
+        * \todo Erase once mapping_ is removed.
+        */
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      PointCloud (const PointCloud<PointT> &pc) = default;
+      #pragma clang diagnostic pop
+
       /** \brief Copy constructor from point cloud subset
         * \param[in] pc the cloud to copy into this
         * \param[in] indices the subset to copy


### PR DESCRIPTION
The following PR is tackling an unavoidable deprecation warning we're currently emitting while compiling the library in macos catalina. This is being triggered by the implicit copy constructor of `PointCloud`. To work around it, I declared the copy constructor explicit to the default implementation and surrounded it with pragmas to discard the warning in clang.
```
[ 43%] Building CXX object surface/CMakeFiles/pcl_surface.dir/src/surfel_smoothing.cpp.o
In file included from /Users/neglective/Development/3rdparty/pcl/surface/src/surfel_smoothing.cpp:40:
In file included from /Users/neglective/Development/3rdparty/pcl/surface/include/pcl/surface/surfel_smoothing.h:41:
In file included from /Users/neglective/Development/3rdparty/pcl/search/include/pcl/search/pcl_search.h:45:
In file included from /Users/neglective/Development/3rdparty/pcl/search/include/pcl/search/organized.h:52:
/Users/neglective/Development/3rdparty/pcl/common/include/pcl/common/projection_matrix.h:52:31: warning: 'mapping_' is deprecated: rewrite your
      code to avoid using this protected field (It will be removed in PCL 1.12) [-Wdeprecated-declarations]
  template <typename T> class PointCloud;
                              ^
/Users/neglective/Development/3rdparty/pcl/surface/include/pcl/surface/impl/surfel_smoothing.hpp:74:41: note: in implicit copy constructor for
      'pcl::PointCloud<pcl::Normal>' first required here
  interm_normals_ = NormalCloudPtr (new NormalCloud (*normals_));
                                        ^
/Users/neglective/Development/3rdparty/pcl/surface/src/surfel_smoothing.cpp:43:1: note: in instantiation of member function
      'pcl::SurfelSmoothing<pcl::PointXYZ, pcl::Normal>::initCompute' requested here
PCL_INSTANTIATE_PRODUCT(SurfelSmoothing, (PCL_XYZ_POINT_TYPES)(PCL_NORMAL_POINT_TYPES))
^
/Users/neglective/Development/3rdparty/pcl/common/include/pcl/impl/instantiate.hpp:110:33: note: expanded from macro 'PCL_INSTANTIATE_PRODUCT'
  BOOST_PP_SEQ_FOR_EACH_PRODUCT(PCL_INSTANTIATE_PRODUCT_IMPL, ((TEMPLATE))PRODUCT)
                                ^
/Users/neglective/Development/3rdparty/pcl/common/include/pcl/point_cloud.h:608:7: note: 'mapping_' has been explicitly marked deprecated here
      PCL_DEPRECATED(1, 12, "rewrite your code to avoid using this protected field") shared_ptr<MsgFieldMap> mapping_;
      ^
/Users/neglective/Development/3rdparty/pcl/common/include/pcl/pcl_macros.h:122:17: note: expanded from macro 'PCL_DEPRECATED'
                PCL_DEPRECATED_MINOR(Minor,                             \
                ^
/Users/neglective/Development/3rdparty/pcl/common/include/pcl/pcl_macros.h:108:17: note: expanded from macro 'PCL_DEPRECATED_MINOR'
                PCL_DEPRECATED_IMPL(Msg),           \
                ^
/Users/neglective/Development/3rdparty/pcl/common/include/pcl/pcl_macros.h:89:42: note: expanded from macro 'PCL_DEPRECATED_IMPL'
  #define PCL_DEPRECATED_IMPL(message) [[deprecated(message)]]
                                         ^
```