### PR TITLE
Add compatibility note for clang-format and fix a small issue in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ---
 AlwaysBreakAfterReturnType: All
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:

--- a/doc/advanced/content/pcl_style_guide.rst
+++ b/doc/advanced/content/pcl_style_guide.rst
@@ -328,6 +328,8 @@ For the integration of clang-format with various text editors and IDE's, refer t
 Details about the style options used can be found `here
 <https://clang.llvm.org/docs/ClangFormatStyleOptions.html>`_.
 
+Note: We are currently supporting clang-format 7-9. Version 10 of clang-format contains changes we cannot control with the .clang-format file. So we cannot force clang-format 10 to give same output like version 7-9 of clang-format.
+
 2.6.1. Script usage
 """""""""""""""""""
 


### PR DESCRIPTION
I tried to make clang-format 10 compatible to 7-9, but I didn't found a way to do so. So basically I compared result of `clang-format-8 -dump-config > .clang-format8` with `clang-format-10 -dump-config > .clang-format10`. As no default value of an option was changed and we cannot use newer options, as defining them breaks clang-tidy for old version (you can't tell clang-tidy to ignore unknown options) and even no new option sounds like it is the reason for the slightly other formatting, I added a note that PCL is only compatible to clang-tidy 7-9 and not 10. 

Example of difference between clang-tidy 8 and 10:
![image](https://user-images.githubusercontent.com/483922/78685691-66c7a480-78f2-11ea-92c8-4b1a61276233.png)
