### PR TITLE
Issue #3875 using crop box inside crop hull

### DIFF
--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -45,25 +45,9 @@ template<typename PointT> void
 pcl::CropHull<PointT>::applyFilter (PointCloud &output)
 {
   output.resize(0);
-  if (dim_ == 2)
-  {
-    // in this case we are assuming all the points lie in the same plane as the
-    // 2D convex hull, so the choice of projection just changes the
-    // conditioning of the problem: choose to squash the XYZ component of the
-    // hull-points that has least variation - this will also give reasonable
-    // results if the points don't lie exactly in the same plane
-    const Eigen::Vector3f range = getHullCloudRange ();
-    if (range[0] <= range[1] && range[0] <= range[2])
-      applyFilter2D<1,2> (output);
-    else if (range[1] <= range[2] && range[1] <= range[0])
-      applyFilter2D<2,0> (output);
-    else
-      applyFilter2D<0,1> (output);
-  }
-  else
-  {
-    applyFilter3D (output);
-  }
+  std::vector<int> indices;
+  applyFilter(indices);
+  pcl::copyPointCloud(*input_, indices, output);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -124,6 +108,15 @@ pcl::CropHull<PointT>::getHullCloudRange ()
 template<typename PointT> template<unsigned PlaneDim1, unsigned PlaneDim2> void 
 pcl::CropHull<PointT>::applyFilter2D (PointCloud &output)
 {
+  std::vector<int> indices;
+  applyFilter2D<PlaneDim1, PlaneDim2>(indices);
+  pcl::copyPointCloud(*input_, indices, output);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointT> template<unsigned PlaneDim1, unsigned PlaneDim2> void 
+pcl::CropHull<PointT>::applyFilter2D (std::vector<int> &indices)
+{
   for (std::size_t index = 0; index < indices_->size (); index++)
   {
     // iterate over polygons faster than points because we expect this data
@@ -135,8 +128,9 @@ pcl::CropHull<PointT>::applyFilter2D (PointCloud &output)
               input_->points[(*indices_)[index]], hull_polygons_[poly], *hull_cloud_
          ))
       {
-        if (crop_outside_)
-          output.push_back (input_->points[(*indices_)[index]]);
+        if (crop_outside_) {
+          indices.push_back ((*indices_)[index]);
+        }
         // once a point has tested +ve for being inside one polygon, we can
         // stop checking the others:
         break;
@@ -145,30 +139,6 @@ pcl::CropHull<PointT>::applyFilter2D (PointCloud &output)
     // If we're removing points *inside* the hull, only remove points that
     // haven't been found inside any polygons
     if (poly == hull_polygons_.size () && !crop_outside_)
-      output.push_back (input_->points[(*indices_)[index]]);
-  }
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> template<unsigned PlaneDim1, unsigned PlaneDim2> void 
-pcl::CropHull<PointT>::applyFilter2D (std::vector<int> &indices)
-{
-  // see comments in (PointCloud& output) overload
-  for (std::size_t index = 0; index < indices_->size (); index++)
-  {
-    std::size_t poly;
-    for (poly = 0; poly < hull_polygons_.size (); poly++)
-    {
-      if (isPointIn2DPolyWithVertIndices<PlaneDim1,PlaneDim2> (
-              input_->points[(*indices_)[index]], hull_polygons_[poly], *hull_cloud_
-         ))
-      {
-        if (crop_outside_)      
-          indices.push_back ((*indices_)[index]);
-        break;
-      }
-    }
-    if (poly == hull_polygons_.size () && !crop_outside_)
       indices.push_back ((*indices_)[index]);
   }
 }
@@ -176,6 +146,15 @@ pcl::CropHull<PointT>::applyFilter2D (std::vector<int> &indices)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> void 
 pcl::CropHull<PointT>::applyFilter3D (PointCloud &output)
+{
+  std::vector<int> indices;
+  applyFilter3D(indices);
+  pcl::copyPointCloud(*input_, indices, output);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointT> void 
+pcl::CropHull<PointT>::applyFilter3D (std::vector<int> &indices)
 {
   // This algorithm could definitely be sped up using kdtree/octree
   // information, if that is available!
@@ -189,33 +168,6 @@ pcl::CropHull<PointT>::applyFilter3D (PointCloud &output)
     // 'random' rays are arbitrary - basically anything that is less likely to
     // hit the edge between polygons than coordinate-axis aligned rays would
     // be.
-    std::size_t crossings[3] = {0,0,0};
-    Eigen::Vector3f rays[3] = 
-    {
-      Eigen::Vector3f (0.264882f,  0.688399f, 0.675237f),
-      Eigen::Vector3f (0.0145419f, 0.732901f, 0.68018f),
-      Eigen::Vector3f (0.856514f,  0.508771f, 0.0868081f)
-    };
-
-    for (std::size_t poly = 0; poly < hull_polygons_.size (); poly++)
-      for (std::size_t ray = 0; ray < 3; ray++)
-        crossings[ray] += rayTriangleIntersect
-          (input_->points[(*indices_)[index]], rays[ray], hull_polygons_[poly], *hull_cloud_);
-
-    bool isPointInsideHull = (crossings[0]&1) + (crossings[1]&1) + (crossings[2]&1) > 1;
-    if ((crop_outside_ && isPointInsideHull) || (!crop_outside_ && !isPointInsideHull)) {
-      output.push_back (input_->points[(*indices_)[index]]);
-    }
-  }
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void 
-pcl::CropHull<PointT>::applyFilter3D (std::vector<int> &indices)
-{
-  // see comments in applyFilter3D (PointCloud& output)
-  for (std::size_t index = 0; index < indices_->size (); index++)
-  {
     std::size_t crossings[3] = {0,0,0};
     Eigen::Vector3f rays[3] = 
     {

--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -44,6 +44,7 @@
 template<typename PointT> void
 pcl::CropHull<PointT>::applyFilter (PointCloud &output)
 {
+  output.resize(0);
   if (dim_ == 2)
   {
     // in this case we are assuming all the points lie in the same plane as the
@@ -69,6 +70,8 @@ pcl::CropHull<PointT>::applyFilter (PointCloud &output)
 template<typename PointT> void
 pcl::CropHull<PointT>::applyFilter (std::vector<int> &indices)
 {
+  indices.resize(0);
+  indices.reserve(indices_->size());
   if (dim_ == 2)
   {
     // in this case we are assuming all the points lie in the same plane as the
@@ -113,7 +116,7 @@ pcl::CropHull<PointT>::getHullCloudRange ()
       if (pt[i] > cloud_max[i]) cloud_max[i] = pt[i];
     }
   }
-  
+
   return (cloud_max - cloud_min);
 }
 
@@ -199,10 +202,10 @@ pcl::CropHull<PointT>::applyFilter3D (PointCloud &output)
         crossings[ray] += rayTriangleIntersect
           (input_->points[(*indices_)[index]], rays[ray], hull_polygons_[poly], *hull_cloud_);
 
-    if (crop_outside_ && (crossings[0]&1) + (crossings[1]&1) + (crossings[2]&1) > 1)
+    bool isPointInsideHull = (crossings[0]&1) + (crossings[1]&1) + (crossings[2]&1) > 1;
+    if ((crop_outside_ && isPointInsideHull) || (!crop_outside_ && !isPointInsideHull)) {
       output.push_back (input_->points[(*indices_)[index]]);
-    else if (!crop_outside_)
-      output.push_back (input_->points[(*indices_)[index]]);
+    }
   }
 }
 
@@ -226,10 +229,10 @@ pcl::CropHull<PointT>::applyFilter3D (std::vector<int> &indices)
         crossings[ray] += rayTriangleIntersect
           (input_->points[(*indices_)[index]], rays[ray], hull_polygons_[poly], *hull_cloud_);
 
-    if (crop_outside_ && (crossings[0]&1) + (crossings[1]&1) + (crossings[2]&1) > 1)
+    bool isPointInsideHull = (crossings[0]&1) + (crossings[1]&1) + (crossings[2]&1) > 1;
+    if ((crop_outside_ && isPointInsideHull) || (!crop_outside_ && !isPointInsideHull)) {
       indices.push_back ((*indices_)[index]);
-    else if (!crop_outside_)
-      indices.push_back ((*indices_)[index]);
+    }
   }
 }
 

--- a/test/filters/CMakeLists.txt
+++ b/test/filters/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSYS_NAME tests_filters)
 set(SUBSYS_DESC "Point cloud library filters module unit tests")
 PCL_SET_TEST_DEPENDENCIES(SUBSYS_DEPS filters)
-set(OPT_DEPS io features segmentation)
+set(OPT_DEPS io features segmentation surface)
 
 set(DEFAULT ON)
 set(build TRUE)
@@ -28,6 +28,12 @@ PCL_ADD_TEST(filters_local_maximum test_filters_local_maximum
 PCL_ADD_TEST(filters_uniform_sampling test_uniform_sampling
              FILES test_uniform_sampling.cpp
              LINK_WITH pcl_gtest pcl_common pcl_filters)
+
+if (BUILD_surface AND QHULL_FOUND)
+  PCL_ADD_TEST(filters_crop_hull test_crop_hull
+               FILES test_crop_hull.cpp
+               LINK_WITH pcl_gtest pcl_surface pcl_filters)
+endif()
 
 if(BUILD_io)
   PCL_ADD_TEST(filters_bilateral test_filters_bilateral

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -1,0 +1,306 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id: test_filters.cpp 7683 2012-10-23 02:49:03Z rusu $
+ *
+ */
+
+#include <pcl/test/gtest.h>
+
+#include <random>
+
+#include <pcl/point_types.h>
+#include <pcl/surface/convex_hull.h>
+#include <pcl/common/common.h>
+#include <pcl/filters/crop_hull.h>
+
+
+namespace
+{
+  template <class PointGenerator1, class PointGenerator2>
+  void complexTest(
+      pcl::CropHull<pcl::PointXYZ> cropHullFilter,
+      PointGenerator1 insidePointGenerator,
+      PointGenerator2 outsidePointGenerator)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr emptyCloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr insideCubeCloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr outsideCubeCloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr mixedCubeCloud(new pcl::PointCloud<pcl::PointXYZ>);
+    size_t const chunkSize = 100;
+    {
+      for (size_t i = 0; i < chunkSize; ++i)
+      {
+        insideCubeCloud->push_back(insidePointGenerator());
+        outsideCubeCloud->push_back(outsidePointGenerator());
+      }
+      *mixedCubeCloud = (*insideCubeCloud) + (*outsideCubeCloud);
+    }
+
+    struct CheckEquals {
+      pcl::CropHull<pcl::PointXYZ> cropHullFilter;
+      CheckEquals(pcl::CropHull<pcl::PointXYZ> const & cropHullFilter)
+        : cropHullFilter(cropHullFilter)
+      {}
+      void check(
+          pcl::PointCloud<pcl::PointXYZ>::ConstPtr expectedCloud,
+          pcl::PointCloud<pcl::PointXYZ>::ConstPtr inputCloud,
+          int idxOffset = 0)
+      {
+        cropHullFilter.setInputCloud(inputCloud);
+
+        std::vector<int> filteredIndices;
+        cropHullFilter.filter(filteredIndices);
+        ASSERT_EQ (expectedCloud->size(), filteredIndices.size());
+        std::sort(filteredIndices.begin(), filteredIndices.end());
+        for (int i = 0; i < filteredIndices.size(); ++i)
+        {
+          ASSERT_EQ (idxOffset + i, filteredIndices[i]);
+        }
+
+        pcl::PointCloud<pcl::PointXYZ> filteredCloud;
+        cropHullFilter.filter(filteredCloud);
+        ASSERT_EQ (expectedCloud->size(), filteredCloud.size());
+        for (int i = 0; i < expectedCloud->size(); ++i)
+        {
+          Eigen::Vector3f expectedPoint = expectedCloud->at(i).getVector3fMap();
+          Eigen::Vector3f actualPoint = filteredCloud.at(i).getVector3fMap();
+          EXPECT_NEAR((expectedPoint - actualPoint).norm(), 0.0, 1e-5);
+        }
+      }
+    };
+
+    {
+      CheckEquals checker(cropHullFilter);
+      checker.check(insideCubeCloud, insideCubeCloud);
+      checker.check(emptyCloud, outsideCubeCloud);
+      checker.check(insideCubeCloud, mixedCubeCloud);
+    }
+
+    {
+      cropHullFilter.setCropOutside(false);
+      CheckEquals checker(cropHullFilter);
+      checker.check(emptyCloud, insideCubeCloud);
+      checker.check(outsideCubeCloud, outsideCubeCloud);
+      checker.check(outsideCubeCloud, mixedCubeCloud, insideCubeCloud->size());
+    }
+  }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (PCL, ConvexHull_2dsquare)
+{
+  pcl::CropHull<pcl::PointXYZ> cropHullFilter;
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr inputCloud (new pcl::PointCloud<pcl::PointXYZ> ());
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 0.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 1.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 0.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 1.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 0.0f, 0.1f));
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 1.0f, 0.1f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 0.0f, 0.1f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 1.0f, 0.1f));
+
+    pcl::ConvexHull<pcl::PointXYZ> convexHull;
+    convexHull.setDimension(3);
+    convexHull.setInputCloud(inputCloud);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr hullCloudPtr(new pcl::PointCloud<pcl::PointXYZ>);
+    std::vector<pcl::Vertices> hullPolygons;
+    convexHull.reconstruct(*hullCloudPtr, hullPolygons);
+
+    cropHullFilter.setHullIndices(hullPolygons);
+    cropHullFilter.setHullCloud(hullCloudPtr);
+    cropHullFilter.setDim(2);
+    cropHullFilter.setCropOutside(true);
+  }
+
+  std::mt19937 gen(12345u);
+  std::uniform_real_distribution<float> rd (0.0f, 1.0f);
+  auto insidePointGenerator = [&rd, &gen] () {
+    return pcl::PointXYZ(rd(gen), rd(gen), 1.0);
+  };
+  auto outsidePointGenerator = [&rd, &gen] () {
+    return pcl::PointXYZ(rd(gen) + 2., rd(gen) + 2., rd(gen) + 2.);
+  };
+
+  complexTest(cropHullFilter, insidePointGenerator, outsidePointGenerator);
+}
+
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (PCL, issue_1657_CropHull3d_not_cropping_inside)
+{
+  typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
+
+  pcl::CropHull<pcl::PointXYZ> cropHullFilter;
+  PointCloud::Ptr hullCloud(new PointCloud());
+  PointCloud::Ptr hullPoints(new PointCloud());
+  std::vector<pcl::Vertices> hullPolygons;
+
+  hullCloud->clear();
+  {
+    pcl::PointXYZ p;
+    p.x = -1;
+    p.y = -1;
+    p.z = -1;
+    hullCloud->push_back(p);
+    p.z = 1;
+    hullCloud->push_back(p);
+  }
+  {
+    pcl::PointXYZ p;
+    p.x = -1;
+    p.y = 1;
+    p.z = -1;
+    hullCloud->push_back(p);
+    p.z = 1;
+    hullCloud->push_back(p);
+  }
+  {
+    pcl::PointXYZ p;
+    p.x = 1;
+    p.y = 1;
+    p.z = -1;
+    hullCloud->push_back(p);
+    p.z = 1;
+    hullCloud->push_back(p);
+  }
+  {
+    pcl::PointXYZ p;
+    p.x = 1;
+    p.y = -1;
+    p.z = -1;
+    hullCloud->push_back(p);
+    p.z = 1;
+    hullCloud->push_back(p);
+  }
+
+  // setup hull filter
+  pcl::ConvexHull<pcl::PointXYZ> cHull;
+  cHull.setInputCloud(hullCloud);
+  cHull.reconstruct(*hullPoints, hullPolygons);
+
+  cropHullFilter.setHullIndices(hullPolygons);
+  cropHullFilter.setHullCloud(hullPoints);
+  //cropHullFilter.setDim(2); // if you uncomment this, it will work
+  cropHullFilter.setCropOutside(false); // this will remove points inside the hull
+
+  // create point cloud
+  PointCloud::Ptr pc(new PointCloud());
+
+  // a point inside the hull
+  {
+    pcl::PointXYZ p;
+    p.x = 0;
+    p.y = 0;
+    p.z = 0;
+    pc->push_back(p);
+  }
+
+  // and a point outside the hull
+  {
+    pcl::PointXYZ p;
+    p.x = 10;
+    p.y = 10;
+    p.z = 10;
+    pc->push_back(p);
+  }
+
+  //filter points
+  cropHullFilter.setInputCloud(pc);
+  PointCloud::Ptr filtered(new PointCloud());
+  cropHullFilter.filter(*filtered);
+
+  ASSERT_EQ(1, filtered->size());
+
+  EXPECT_NEAR(
+      (filtered->front().getVector3fMap() - Eigen::Vector3f(10.0, 10.0, 10.0)).norm(),
+      0.0,
+      1e-5);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (PCL, ConvexHull_3dcube)
+{
+  pcl::CropHull<pcl::PointXYZ> cropHullFilter;
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr inputCloud (new pcl::PointCloud<pcl::PointXYZ> ());
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 0.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 0.0f, 1.0f));
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 1.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(0.0f, 1.0f, 1.0f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 0.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 0.0f, 1.0f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 1.0f, 0.0f));
+    inputCloud->push_back(pcl::PointXYZ(1.0f, 1.0f, 1.0f));
+
+    pcl::ConvexHull<pcl::PointXYZ> convexHull;
+    convexHull.setDimension(3);
+    convexHull.setInputCloud(inputCloud);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr hullCloudPtr(new pcl::PointCloud<pcl::PointXYZ>);
+    std::vector<pcl::Vertices> hullPolygons;
+    convexHull.reconstruct(*hullCloudPtr, hullPolygons);
+
+    cropHullFilter.setHullIndices(hullPolygons);
+    cropHullFilter.setHullCloud(hullCloudPtr);
+    cropHullFilter.setDim(3);
+    cropHullFilter.setCropOutside(true);
+  }
+
+  std::mt19937 gen(12345u);
+  std::uniform_real_distribution<float> rd (0.0f, 1.0f);
+  auto insidePointGenerator = [&rd, &gen] () {
+    return pcl::PointXYZ(rd(gen), rd(gen), rd(gen));
+  };
+  auto outsidePointGenerator = [&rd, &gen] () {
+    return pcl::PointXYZ(rd(gen) + 2., rd(gen) + 2., rd(gen) + 2.);
+  };
+
+  complexTest(cropHullFilter, insidePointGenerator, outsidePointGenerator);
+}
+
+
+/* ---[ */
+int
+main (int argc, char** argv)
+{
+  // Testing
+  testing::InitGoogleTest (&argc, argv);
+  return (RUN_ALL_TESTS ());
+}
+/* ]--- */


### PR DESCRIPTION
Firstly reason for PR was only issue #3875: add CropBox inside CropHull for increasing performance.

In progress was founded and fixed some bugs:

1. issue #1657.  [Solving](https://github.com/piaggiofastforward/pcl/commit/b8a8a2b266a16e5cf2c7a786f86f007d04d5a530) for this bug was founded in comments in #1657.
1. function applyFilter didn't clear output data before start adding new
point or indices.

Added unit tests for CropHull. (only ConvexHull case).

Also was deleted some duplicated code. Implementation for cloud ind indices filtering was equals, but duplicates.