### PR TITLE
Remove sign-compare, loop-analysis and unused-parameter warnings

### DIFF
--- a/.ci/azure-pipelines/build-macos.yaml
+++ b/.ci/azure-pipelines/build-macos.yaml
@@ -13,7 +13,7 @@ jobs:
     variables:
       BUILD_DIR: '$(Agent.WorkFolder)/build'
       GOOGLE_TEST_DIR: '$(Agent.WorkFolder)/googletest'
-      CMAKE_CXX_FLAGS: '-Wall -Wextra -Wabi'
+      CMAKE_CXX_FLAGS: '-Wall -Wextra -Werror -Wabi'
     steps:
       - script: |
           brew install pkg-config qt5 libpcap brewsci/science/openni libomp

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -136,7 +136,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
     {
       // this is the rotation of the feature
       double theta = double (rot) * 2 * M_PI / double (n_rot_);
-      for (int ring = 0; ring < rings; ++ring)
+      for (int ring = 0; ring < static_cast<int>(rings); ++ring)
       {
         for (int num = 0; num < number_list[ring]; ++num)
         {
@@ -453,8 +453,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   }
 
   // image size
-  const int width = int (input_cloud_->width);
-  const int height = int (input_cloud_->height);
+  const index_t width = static_cast<index_t>(input_cloud_->width);
+  const index_t height = static_cast<index_t>(input_cloud_->height);
 
   // destination for intensity data; will be forwarded to BRISK
   std::vector<unsigned char> image_data (width*height);
@@ -521,9 +521,9 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   // current integral image
   std::vector<int> integral ((width+1)*(height+1), 0);    // the integral image
 
-  for (std::size_t row_index = 1; row_index < height; ++row_index)
+  for (index_t row_index = 1; row_index < height; ++row_index)
   {
-    for (std::size_t col_index = 1; col_index < width; ++col_index)
+    for (index_t col_index = 1; col_index < width; ++col_index)
     {
       const std::size_t index = row_index*width+col_index;
       const std::size_t index2 = (row_index)*(width+1)+(col_index);

--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -171,30 +171,32 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
 {
   const int hb=h/bin_size, wb=w/bin_size, h0=hb*bin_size, w0=wb*bin_size, nb=wb*hb;
   const float s=(float)bin_size, sInv=1/s, sInv2=1/s/s;
-  float *H0, *H1, *M0, *M1; int x, y; int *O0, *O1;
+  float *H0, *H1, *M0, *M1; int *O0, *O1;
   O0=(int*)alMalloc(h*sizeof(int),16); M0=(float*) alMalloc(h*sizeof(float),16);
   O1=(int*)alMalloc(h*sizeof(int),16); M1=(float*) alMalloc(h*sizeof(float),16);
 
   // main loop
   float xb = 0;
   float init = 0;
-  for( x=0; x<w0; x++ ) {
+  for(int x=0; x<w0; x++ ) {
     // compute target orientation bins for entire column - very fast
     gradQuantize( O+x*h, M+x*h, O0, O1, M0, M1, n_orients, nb, h0, sInv2 );
 
     if( !soft_bin || bin_size==1 ) {
       // interpolate w.r.t. orientation only, not spatial bin_size
-      H1=H+(x/bin_size)*hb;
-      const auto GH = [&H1, &O0, &O1, &y, &M0, &M1]()
-      {
-          H1[O0[y]]+=M0[y]; H1[O1[y]]+=M1[y]; y++;
-      };
-      if( bin_size==1 )      for(y=0; y<h0;) { GH(); H1++; }
-      else if( bin_size==2 ) for(y=0; y<h0;) { GH(); GH(); H1++; }
-      else if( bin_size==3 ) for(y=0; y<h0;) { GH(); GH(); GH(); H1++; }
-      else if( bin_size==4 ) for(y=0; y<h0;) { GH(); GH(); GH(); GH(); H1++; }
-      else for( y=0; y<h0;) { for( int y1=0; y1<bin_size; y1++ ) { GH(); } H1++; }
+      H1 = H + (x / bin_size) * hb;
 
+      const auto GH = [&H1, &O0, &O1, &M0, &M1](int y) {
+        H1[O0[y]] += M0[y];
+        H1[O1[y]] += M1[y];
+      };
+
+      for (int y = 0; y < h0;) {
+        for (int inner_loop = 0; inner_loop < bin_size; ++inner_loop, ++y) {
+          GH(y);
+        }
+        H1++;
+      }
     } else {
       // interpolate using trilinear interpolation
 #if defined(__SSE2__)
@@ -202,7 +204,8 @@ pcl::people::HOG::gradHist( float *M, float *O, int h, int w, int bin_size, int 
       bool hasLf, hasRt; int xb0, yb0;
       if( x==0 ) { init=(0+.5f)*sInv-0.5f; xb=init; }
       hasLf = xb>=0; xb0 = hasLf?(int)xb:-1; hasRt = xb0 < wb-1;
-      xd=xb-xb0; xb+=sInv; yb=init; y=0;
+      xd=xb-xb0; xb+=sInv; yb=init;
+      int y=0;
       // lambda for code conciseness
       // @TODO: remove the very generic closure for specific variable one
       const auto GHinit = [&]()

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -41,12 +41,13 @@
 #include <pcl/registration/ia_fpcs.h>
 #include <pcl/common/time.h>
 #include <pcl/common/distances.h>
+#include <pcl/common/utils.h>
 #include <pcl/sample_consensus/sac_model_plane.h>
 #include <pcl/registration/transformation_estimation_3point.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> inline float
-pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &cloud, float max_dist, int /*nr_threads*/)
+pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &cloud, float max_dist, int nr_threads)
 {
   const float max_dist_sqr = max_dist * max_dist;
   const std::size_t s = cloud.size ();
@@ -59,6 +60,7 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
   std::vector <int> ids (2);
   std::vector <float> dists_sqr (2);
 
+  pcl::utils::ignore(nr_threads);
 #pragma omp parallel for \
   default(none) \
   shared(tree, cloud) \
@@ -83,7 +85,7 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> inline float
 pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &cloud, const std::vector <int> &indices,
-  float max_dist, int /*nr_threads*/)
+  float max_dist, int nr_threads)
 {
   const float max_dist_sqr = max_dist * max_dist;
   const std::size_t s = indices.size ();
@@ -96,6 +98,7 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
   std::vector <int> ids (2);
   std::vector <float> dists_sqr (2);
 
+  pcl::utils::ignore(nr_threads);
 #pragma omp parallel for \
   default(none) \
   shared(tree, cloud, indices) \

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -46,7 +46,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> inline float
-pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &cloud, float max_dist, int nr_threads)
+pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &cloud, float max_dist, int /*nr_threads*/)
 {
   const float max_dist_sqr = max_dist * max_dist;
   const std::size_t s = cloud.size ();
@@ -83,7 +83,7 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> inline float
 pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &cloud, const std::vector <int> &indices,
-  float max_dist, int nr_threads)
+  float max_dist, int /*nr_threads*/)
 {
   const float max_dist_sqr = max_dist * max_dist;
   const std::size_t s = indices.size ();

--- a/search/include/pcl/search/impl/brute_force.hpp
+++ b/search/include/pcl/search/impl/brute_force.hpp
@@ -100,7 +100,7 @@ pcl::search::BruteForce<PointT>::denseKSearch (
   else
   {
     Entry entry;
-    for (entry.index = 0; entry.index < std::min (static_cast<unsigned> (k), static_cast<unsigned> (input_->size ())); ++entry.index)
+    for (entry.index = 0; entry.index < std::min<pcl::index_t> (k, input_->size ()); ++entry.index)
     {
       entry.distance = getDistSqr (input_->points[entry.index], point);
       result.push_back (entry);
@@ -109,7 +109,7 @@ pcl::search::BruteForce<PointT>::denseKSearch (
     queue = std::priority_queue<Entry> (result.begin (), result.end ());
 
     // add the rest
-    for (; entry.index < input_->size (); ++entry.index)
+    for (; entry.index < static_cast<pcl::index_t>(input_->size ()); ++entry.index)
     {
       entry.distance = getDistSqr (input_->points[entry.index], point);
       if (queue.top ().distance > entry.distance)
@@ -175,7 +175,7 @@ pcl::search::BruteForce<PointT>::sparseKSearch (
   else
   {
     Entry entry;
-    for (entry.index = 0; entry.index < input_->size () && result.size () < static_cast<unsigned> (k); ++entry.index)
+    for (entry.index = 0; (entry.index < static_cast<pcl::index_t>(input_->size ())) && (result.size () < static_cast<std::size_t> (k)); ++entry.index)
     {
       if (std::isfinite (input_->points[entry.index].x))
       {
@@ -186,7 +186,7 @@ pcl::search::BruteForce<PointT>::sparseKSearch (
     queue = std::priority_queue<Entry> (result.begin (), result.end ());
     
     // add the rest
-    for (; entry.index < input_->size (); ++entry.index)
+    for (; entry.index < static_cast<pcl::index_t>(input_->size ()); ++entry.index)
     {
       if (!std::isfinite (input_->points[entry.index].x))
         continue;

--- a/test/common/test_type_traits.cpp
+++ b/test/common/test_type_traits.cpp
@@ -47,7 +47,15 @@ TEST (TypeTraits, HasCustomAllocatorTrait)
   struct Foo
   {
   public:
+    // Manually ignore warnings here because of an issue in Eigen which
+    // results in a local typedef being unused inside the new and delete
+    // operators added by Eigen for C++14 or lower standards
+    /** \todo Remove for C++17 (or future standards)
+     */
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-local-typedef"
     PCL_MAKE_ALIGNED_OPERATOR_NEW
+    #pragma clang diagnostic pop
   };
 
   struct Bar

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -308,7 +308,7 @@ TEST (PCL, IntegralImageNormalEstimationIndexingIssue)
 
   pcl::IndicesPtr indicesptr (new pcl::Indices ());
   indicesptr->resize(cloudptr->size() / 2);
-  for (int i = 0; i < cloudptr->size() / 2; ++i)
+  for (std::size_t i = 0; i < cloudptr->size() / 2; ++i)
   {
     (*indicesptr)[i] = i + cloudptr->size() / 2;
   }
@@ -328,7 +328,7 @@ TEST (PCL, IntegralImageNormalEstimationIndexingIssue)
 
   std::vector<PointXYZ> normalsVec;
   normalsVec.resize(normals->size());
-  for( int i = 0; i < normals->size(); ++i )
+  for(std::size_t i = 0; i < normals->size(); ++i )
   {
     normalsVec[i].x = normals->points[i].normal_x;
     normalsVec[i].y = normals->points[i].normal_y;

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -266,7 +266,7 @@ TEST (ExtractIndices, Filters)
   ps.setFilterLimits (0.99, 2.01);
   for (int i = 0; i < 2; i++)
   {
-    ps.setFilterLimitsNegative ((bool)i);
+    ps.setNegative ((bool)i);
     ps.filter (scf);
     std::cerr << scf.points.size () << std::endl;
     for (std::size_t j = 0; j < scf.points.size (); ++j)
@@ -306,7 +306,7 @@ TEST (PassThrough, Filters)
   EXPECT_NEAR (output.points[41].y, 0.039749, 1e-5);
   EXPECT_NEAR (output.points[41].z, 0.052133, 1e-5);
 
-  pt.setFilterLimitsNegative (true);
+  pt.setNegative (true);
   pt.filter (output);
 
   EXPECT_EQ (int (output.points.size ()), 355);
@@ -350,7 +350,7 @@ TEST (PassThrough, Filters)
   EXPECT_NEAR (output.points[41].y, 0.039749, 1e-5);
   EXPECT_NEAR (output.points[41].z, 0.052133, 1e-5);
 
-  pt_.setFilterLimitsNegative (true);
+  pt_.setNegative (true);
   pt_.filter (output);
 
   EXPECT_EQ (int (output.points.size ()), 355);
@@ -380,7 +380,7 @@ TEST (PassThrough, Filters)
   EXPECT_NEAR (output.points[output.points.size () - 1].x, cloud->points[cloud->points.size () - 1].x, 1e-5);
 
   pt.setFilterFieldName ("z");
-  pt.setFilterLimitsNegative (false);
+  pt.setNegative (false);
   pt.setKeepOrganized (true);
   pt.filter (output);
 
@@ -396,7 +396,7 @@ TEST (PassThrough, Filters)
   EXPECT_TRUE (std::isnan (output.points[41].y));
   EXPECT_TRUE (std::isnan (output.points[41].z));
 
-  pt.setFilterLimitsNegative (true);
+  pt.setNegative (true);
   pt.filter (output);
 
   EXPECT_EQ (output.points.size (), cloud->points.size ());


### PR DESCRIPTION
Adds `-Werror` on AppleClang