### PR TITLE
Remove boost shared pointer usage and headers in favor of `pcl/memory.h`

### DIFF
--- a/common/include/pcl/Vertices.h
+++ b/common/include/pcl/Vertices.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <pcl/memory.h>
+#include <pcl/pcl_macros.h>
+
 #include <string>
 #include <vector>
 #include <ostream>
-#include <boost/shared_ptr.hpp>
-#include <pcl/memory.h>
-#include <pcl/pcl_macros.h>
 
 namespace pcl
 {

--- a/common/include/pcl/common/boost.h
+++ b/common/include/pcl/common/boost.h
@@ -45,8 +45,6 @@
 #ifndef Q_MOC_RUN
 // Marking all Boost headers as system headers to remove warnings
 #include <boost/fusion/sequence/intrinsic/at_key.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/signals2.hpp>

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -46,7 +46,6 @@
 #include <pcl/memory.h>
 #include <pcl/pcl_macros.h>
 
-#include <boost/shared_ptr.hpp>
 #include <Eigen/StdVector>
 #include <Eigen/Core>
 

--- a/cuda/apps/src/kinect_debayering.cpp
+++ b/cuda/apps/src/kinect_debayering.cpp
@@ -35,18 +35,18 @@
  *
  */
 
-#include <pcl_cuda/io/cloud_to_pcl.h>
-#include <pcl_cuda/io/debayering.h>
-#include <pcl_cuda/time_cpu.h>
+#include <pcl/memory.h>
+#include <pcl/cuda/io/cloud_to_pcl.h>
+#include <pcl/cuda/io/debayering.h>
+#include <pcl/cuda/time_cpu.h>
 #include <pcl/io/kinect_grabber.h>
 
 #include <opencv2/opencv.hpp>
 
-#include <boost/shared_ptr.hpp>
-
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 class SimpleKinectTool
 {

--- a/cuda/apps/src/kinect_dediscretize.cpp
+++ b/cuda/apps/src/kinect_dediscretize.cpp
@@ -35,22 +35,21 @@
  *
  */
 
-#include <pcl_cuda/io/cloud_to_pcl.h>
-#include <pcl_cuda/io/disparity_to_cloud.h>
-#include <pcl_cuda/sample_consensus/sac_model_plane.h>
-#include <pcl_cuda/sample_consensus/ransac.h>
-#include <pcl_cuda/time_cpu.h>
-
-#include <pcl/io/openni_grabber.h>
+#include <pcl/memory.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <pcl/cuda/io/cloud_to_pcl.h>
+#include <pcl/cuda/io/disparity_to_cloud.h>
+#include <pcl/cuda/sample_consensus/ransac.h>
+#include <pcl/cuda/sample_consensus/sac_model_plane.h>
+#include <pcl/cuda/time_cpu.h>
+#include <pcl/io/openni_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-
-#include <boost/shared_ptr.hpp>
 
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 class SimpleKinectTool
 {

--- a/cuda/apps/src/kinect_mapping.cpp
+++ b/cuda/apps/src/kinect_mapping.cpp
@@ -35,36 +35,36 @@
  *
  */
 
-#include <pcl_cuda/io/cloud_to_pcl.h>
-#include <pcl_cuda/io/extract_indices.h>
-#include <pcl_cuda/io/disparity_to_cloud.h>
-#include <pcl_cuda/sample_consensus/sac_model_1point_plane.h>
-#include <pcl_cuda/sample_consensus/multi_ransac.h>
-#include <pcl_cuda/segmentation/connected_components.h>
-#include <pcl_cuda/time_cpu.h>
-#include <pcl_cuda/time_gpu.h>
-
+#include <pcl/memory.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl/common/transform.h>
+#include <pcl/cuda/io/cloud_to_pcl.h>
+#include <pcl/cuda/io/disparity_to_cloud.h>
+#include <pcl/cuda/io/extract_indices.h>
+#include <pcl/cuda/sample_consensus/multi_ransac.h>
+#include <pcl/cuda/sample_consensus/sac_model_1point_plane.h>
+#include <pcl/cuda/segmentation/connected_components.h>
+#include <pcl/cuda/time_cpu.h>
+#include <pcl/cuda/time_gpu.h>
 #include <pcl/io/openni_grabber.h>
 #include <pcl/io/pcd_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-#include <pcl/visualization/point_cloud_handlers.h>
 #include <pcl/visualization/pcl_visualizer.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
+#include <pcl/visualization/point_cloud_handlers.h>
 
-#include <opencv2/opencv.hpp>
-#include <opencv2/gpu/gpu.hpp>
+#include <boost/filesystem.hpp>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <boost/filesystem.hpp>
-#include <boost/shared_ptr.hpp>
+#include <opencv2/opencv.hpp>
+#include <opencv2/gpu/gpu.hpp>
 
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 using namespace pcl_cuda;
 

--- a/cuda/apps/src/kinect_normals_cuda.cpp
+++ b/cuda/apps/src/kinect_normals_cuda.cpp
@@ -35,6 +35,10 @@
  *
  */
 
+#include <pcl/memory.h>
+#include <pcl/pcl_macros.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl/cuda/features/normal_3d.h>
 #include <pcl/cuda/time_cpu.h>
 #include <pcl/cuda/time_gpu.h>
@@ -45,18 +49,14 @@
 #include <pcl/io/openni_grabber.h>
 #include <pcl/io/pcd_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-#include <pcl/pcl_macros.h>
 
 #include <opencv2/opencv.hpp>
 #include <opencv2/gpu/gpu.hpp>
 
-#include <boost/shared_ptr.hpp>
-
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 using namespace pcl::cuda;
 

--- a/cuda/apps/src/kinect_ransac.cpp
+++ b/cuda/apps/src/kinect_ransac.cpp
@@ -35,26 +35,25 @@
  *
  */
 
-#include <pcl_cuda/time_cpu.h>
-#include <pcl_cuda/time_gpu.h>
-#include <pcl_cuda/io/cloud_to_pcl.h>
-#include <pcl_cuda/io/extract_indices.h>
-#include <pcl_cuda/io/disparity_to_cloud.h>
-#include <pcl_cuda/io/host_device.h>
-#include <pcl_cuda/sample_consensus/sac_model_1point_plane.h>
-#include <pcl_cuda/sample_consensus/ransac.h>
-
+#include <pcl/memory.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/cuda/time_cpu.h>
+#include <pcl/cuda/time_gpu.h>
+#include <pcl/cuda/io/cloud_to_pcl.h>
+#include <pcl/cuda/io/disparity_to_cloud.h>
+#include <pcl/cuda/io/extract_indices.h>
+#include <pcl/cuda/io/host_device.h>
+#include <pcl/cuda/sample_consensus/ransac.h>
+#include <pcl/cuda/sample_consensus/sac_model_1point_plane.h>
 #include <pcl/io/openni_grabber.h>
 #include <pcl/io/pcd_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
-#include <boost/shared_ptr.hpp>
 
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 using namespace pcl_cuda;
 

--- a/cuda/apps/src/kinect_segmentation_cuda.cpp
+++ b/cuda/apps/src/kinect_segmentation_cuda.cpp
@@ -35,6 +35,10 @@
  *
  */
 
+#include <pcl/memory.h>
+#include <pcl/pcl_macros.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl/cuda/features/normal_3d.h>
 #include <pcl/cuda/time_cpu.h>
 #include <pcl/cuda/time_gpu.h>
@@ -48,19 +52,15 @@
 #include <pcl/io/openni_grabber.h>
 #include <pcl/io/pcd_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-#include <pcl/pcl_macros.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/highgui/highgui_c.h>
 #include <opencv2/gpu/gpu.hpp>
 
-#include <boost/shared_ptr.hpp>
-
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 using namespace pcl::cuda;
 

--- a/cuda/apps/src/kinect_segmentation_planes_cuda.cpp
+++ b/cuda/apps/src/kinect_segmentation_planes_cuda.cpp
@@ -35,30 +35,30 @@
  *
  */
 
-#include <pcl/cuda/features/normal_3d.h>
+#include <pcl/memory.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl/cuda/time_cpu.h>
 #include <pcl/cuda/time_gpu.h>
+#include <pcl/cuda/features/normal_3d.h>
 #include <pcl/cuda/io/cloud_to_pcl.h>
-#include <pcl/cuda/io/extract_indices.h>
 #include <pcl/cuda/io/disparity_to_cloud.h>
+#include <pcl/cuda/io/extract_indices.h>
 #include <pcl/cuda/io/host_device.h>
 #include <pcl/cuda/segmentation/connected_components.h>
 #include <pcl/cuda/segmentation/mssegmentation.h>
 #include <pcl/io/openni_grabber.h>
 #include <pcl/io/pcd_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/gpu/gpu.hpp>
 
-#include <boost/shared_ptr.hpp>
-
-#include <iostream>
 #include <fstream>
 #include <functional>
+#include <iostream>
 #include <mutex>
+
 
 using namespace pcl::cuda;
 

--- a/cuda/apps/src/kinect_tool_standalone.cpp
+++ b/cuda/apps/src/kinect_tool_standalone.cpp
@@ -35,19 +35,19 @@
  *
  */
 
+#include <pcl/memory.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl/cuda/io/cloud_to_pcl.h>
 #include <pcl/cuda/io/disparity_to_cloud.h>
 #include <pcl/cuda/time_cpu.h>
 #include <pcl/io/openni_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
-#include <boost/shared_ptr.hpp>
 
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 using pcl::cuda::PointCloudAOS;
 using pcl::cuda::Device;

--- a/cuda/apps/src/kinect_viewer_cuda.cpp
+++ b/cuda/apps/src/kinect_viewer_cuda.cpp
@@ -35,19 +35,19 @@
  *
  */
 
+#include <pcl/memory.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl/cuda/io/cloud_to_pcl.h>
 #include <pcl/cuda/io/disparity_to_cloud.h>
 #include <pcl/cuda/time_cpu.h>
 #include <pcl/io/openni_grabber.h>
 #include <pcl/visualization/cloud_viewer.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
-#include <boost/shared_ptr.hpp>
 
 #include <functional>
 #include <iostream>
 #include <mutex>
+
 
 using pcl::cuda::PointCloudAOS;
 using pcl::cuda::Device;

--- a/cuda/common/include/pcl/cuda/pcl_cuda_base.h
+++ b/cuda/common/include/pcl/cuda/pcl_cuda_base.h
@@ -35,8 +35,9 @@
 
 #pragma once
 
-#include <boost/shared_ptr.hpp>
+#include <pcl/memory.h>
 #include <pcl/cuda/point_cloud.h>
+
 
 namespace pcl
 {

--- a/doc/tutorials/content/sources/iccv2011/include/surface.h
+++ b/doc/tutorials/content/sources/iccv2011/include/surface.h
@@ -18,7 +18,7 @@ class Mesh
     std::vector<pcl::Vertices> faces;
 };
 
-typedef boost::shared_ptr<Mesh> MeshPtr;
+using MeshPtr = std::shared_ptr<Mesh>;
 
 PointCloudPtr
 smoothPointCloud (const PointCloudPtr & input, float radius, int polynomial_order)

--- a/doc/tutorials/content/sources/iros2011/include/solution/surface.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/surface.h
@@ -18,7 +18,7 @@ class Mesh
     std::vector<pcl::Vertices> faces;
 };
 
-typedef boost::shared_ptr<Mesh> MeshPtr;
+using MeshPtr = std::shared_ptr<Mesh>;
 
 PointCloudPtr
 smoothPointCloud (const PointCloudPtr & input, float radius, int polynomial_order)

--- a/doc/tutorials/content/sources/iros2011/include/surface.h
+++ b/doc/tutorials/content/sources/iros2011/include/surface.h
@@ -18,7 +18,7 @@ public:
   std::vector<pcl::Vertices> faces;
 };
 
-typedef boost::shared_ptr<Mesh> MeshPtr;
+using MeshPtr = std::shared_ptr<Mesh>;
 
 PointCloudPtr
 smoothPointCloud (const PointCloudPtr & input, float radius, int polynomial_order)

--- a/features/include/pcl/features/integral_image2D.h
+++ b/features/include/pcl/features/integral_image2D.h
@@ -39,9 +39,10 @@
 
 #pragma once
 
+#include <pcl/memory.h>
+
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
 
 namespace pcl
 {

--- a/filters/include/pcl/filters/boost.h
+++ b/filters/include/pcl/filters/boost.h
@@ -47,8 +47,6 @@
 // Marking all Boost headers as system headers to remove warnings
 #include <boost/random.hpp>
 #include <boost/random/normal_distribution.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/fusion/sequence/intrinsic/at_key.hpp>

--- a/geometry/include/pcl/geometry/boost.h
+++ b/geometry/include/pcl/geometry/boost.h
@@ -45,5 +45,4 @@
 #endif
 
 #include <boost/operators.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/version.hpp>

--- a/gpu/examples/octree/src/octree_search.cpp
+++ b/gpu/examples/octree/src/octree_search.cpp
@@ -3,10 +3,11 @@
 
 #include <pcl/io/openni_grabber.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/memory.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <boost/shared_ptr.hpp>
 #include <pcl/visualization/cloud_viewer.h>
+
 #include <iostream>
 
 int main (int argc, char** argv)

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/raycaster.h
@@ -42,7 +42,6 @@
 #include <pcl/point_types.h>
 #include <pcl/gpu/containers/device_array.h>
 #include <pcl/gpu/kinfu_large_scale/pixel_rgb.h>
-#include <boost/shared_ptr.hpp>
 //#include <boost/graph/buffer_concepts.hpp>
 #include <Eigen/Geometry>
 

--- a/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfu_app_sim.cpp
@@ -99,7 +99,6 @@ using ScopeTimeT = pcl::ScopeTime;
 #include <Eigen/Dense>
 #include <cmath>
 #include <iostream>
-#include <boost/shared_ptr.hpp>
 #ifdef _WIN32
 # define WIN32_LEAN_AND_MEAN
 # include <windows.h>

--- a/gpu/people/include/pcl/gpu/people/bodyparts_detector.h
+++ b/gpu/people/include/pcl/gpu/people/bodyparts_detector.h
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <pcl/memory.h>
 #include <pcl/pcl_exports.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -44,8 +45,7 @@
 #include <pcl/gpu/people/label_blob2.h>
 #include <pcl/gpu/people/label_common.h>
 #include "pcl/gpu/people/person_attribs.h"
-#include <boost/shared_ptr.hpp>
-#include <memory>
+
 #include <string>
 #include <vector>
 

--- a/gpu/people/include/pcl/gpu/people/face_detector.h
+++ b/gpu/people/include/pcl/gpu/people/face_detector.h
@@ -36,11 +36,12 @@
 
 #pragma once
 
+#include <pcl/memory.h>
 #include <pcl/pcl_exports.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 
-#include <boost/shared_ptr.hpp>
+
 #include <string>
 #include <vector>
 

--- a/gpu/people/include/pcl/gpu/people/organized_plane_detector.h
+++ b/gpu/people/include/pcl/gpu/people/organized_plane_detector.h
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <pcl/memory.h>
 #include <pcl/pcl_exports.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
@@ -45,7 +46,6 @@
 #include <pcl/common/transforms.h>
 #include <pcl/gpu/people/label_common.h>
 
-#include <boost/shared_ptr.hpp>
 #include <string>
 #include <vector>
 

--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -38,7 +38,7 @@
 #pragma once
 
 #if defined __GNUC__
-#  pragma GCC system_header 
+#  pragma GCC system_header
 #endif
 //https://bugreports.qt-project.org/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
@@ -46,7 +46,6 @@
 #include <boost/version.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/mpl/fold.hpp>
 #include <boost/mpl/inherit.hpp>

--- a/io/include/pcl/io/image_grabber.h
+++ b/io/include/pcl/io/image_grabber.h
@@ -40,16 +40,16 @@
 
 #pragma once
 
+#include <pcl/conversions.h>
+#include <pcl/memory.h>
 #include <pcl/pcl_config.h>
+#include <pcl/common/time_trigger.h>
 #include <pcl/io/grabber.h>
 #include <pcl/io/file_grabber.h>
-#include <pcl/common/time_trigger.h>
-#include <pcl/conversions.h>
-
-#include <boost/shared_ptr.hpp>
 
 #include <string>
 #include <vector>
+
 
 namespace pcl
 {

--- a/io/include/pcl/io/openni2/openni2_device.h
+++ b/io/include/pcl/io/openni2/openni2_device.h
@@ -30,24 +30,24 @@
 
 #pragma once
 
+#include <pcl/memory.h>
 #include <pcl/pcl_exports.h>
-#include "openni.h"
-#include "pcl/io/openni2/openni2_video_mode.h"
-#include "pcl/io/io_exception.h"
-
-#include <boost/shared_ptr.hpp>
 
 // Template frame wrappers
 #include <pcl/io/image.h>
 #include <pcl/io/image_depth.h>
 #include <pcl/io/image_ir.h>
 
+#include <pcl/io/io_exception.h>
+#include <pcl/io/openni2/openni2_video_mode.h>
+
+#include "openni.h"
+
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
-
 
 
 namespace openni

--- a/io/src/openni2/openni2_convert.cpp
+++ b/io/src/openni2/openni2_convert.cpp
@@ -29,12 +29,12 @@
  *      Author: Julius Kammerl (jkammerl@willowgarage.com)
  */
 
-#include "pcl/io/openni2/openni2_convert.h"
-#include "pcl/io/io_exception.h"
-
-#include <boost/make_shared.hpp>
+#include <pcl/memory.h>
+#include <pcl/io/io_exception.h>
+#include <pcl/io/openni2/openni2_convert.h>
 
 #include <string>
+
 
 namespace pcl
 {

--- a/ml/include/pcl/ml/dt/decision_tree_data_provider.h
+++ b/ml/include/pcl/ml/dt/decision_tree_data_provider.h
@@ -37,9 +37,9 @@
 
 #pragma once
 
-#include <boost/shared_ptr.hpp>
-
 #include <pcl/common/common.h>
+#include <pcl/memory.h>
+#include <pcl/pcl_macros.h> // for PCL_EXPORTS
 
 namespace pcl {
 template <class FeatureType,

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -38,8 +38,7 @@
 
 #pragma once
 
-#include <boost/shared_ptr.hpp>
-
+#include <pcl/memory.h>
 #include <pcl/octree/octree2buf_base.h>
 #include <pcl/octree/octree_pointcloud.h>
 

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -7,17 +7,18 @@
 
 #pragma once
 
+#include <pcl/memory.h>
+#include <pcl/common/common.h>
+#include <pcl/ml/dt/decision_tree_data_provider.h>
+#include <pcl/recognition/face_detection/face_common.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem/operations.hpp>
+
 #include <iostream>
 #include <fstream>
 #include <string>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/algorithm/string.hpp>
-
-#include <pcl/common/common.h>
-#include <pcl/recognition/face_detection/face_common.h>
-#include <pcl/ml/dt/decision_tree_data_provider.h>
 
 namespace bf = boost::filesystem;
 

--- a/registration/include/pcl/registration/boost.h
+++ b/registration/include/pcl/registration/boost.h
@@ -49,4 +49,3 @@
 #include <boost/property_map/property_map.hpp>
 
 #include <boost/noncopyable.hpp>
-#include <boost/make_shared.hpp>

--- a/segmentation/include/pcl/segmentation/boost.h
+++ b/segmentation/include/pcl/segmentation/boost.h
@@ -47,7 +47,6 @@
 #ifndef Q_MOC_RUN
 // Marking all Boost headers as system headers to remove warnings
 #include <boost/version.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/multi_array.hpp>
 #include <boost/ptr_container/ptr_list.hpp>

--- a/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
+++ b/segmentation/include/pcl/segmentation/euclidean_cluster_comparator.h
@@ -39,10 +39,12 @@
 
 #pragma once
 
+#include <pcl/memory.h>
 #include <pcl/pcl_macros.h>
+#include <pcl/point_types.h>
 #include <pcl/segmentation/boost.h>
 #include <pcl/segmentation/comparator.h>
-#include <pcl/point_types.h>
+
 
 namespace pcl
 {
@@ -251,7 +253,7 @@ namespace pcl
       void
       setExcludeLabels (const std::vector<bool>& exclude_labels)
       {
-        exclude_labels_ = boost::make_shared<std::set<std::uint32_t> > ();
+        exclude_labels_ = pcl::make_shared<std::set<std::uint32_t> > ();
         for (std::size_t i = 0; i < exclude_labels.size (); ++i)
           if (exclude_labels[i])
             exclude_labels_->insert (i);

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -39,11 +39,11 @@
 
 #pragma once
 
-#include <pcl/common/angles.h>
 #include <pcl/memory.h>
 #include <pcl/pcl_macros.h>
+#include <pcl/common/angles.h>
 #include <pcl/segmentation/comparator.h>
-#include <boost/make_shared.hpp>
+
 
 namespace pcl
 {
@@ -140,7 +140,7 @@ namespace pcl
       void
       setPlaneCoeffD (std::vector<float>& plane_coeff_d)
       {
-        plane_coeff_d_ = boost::make_shared<std::vector<float> >(plane_coeff_d);
+        plane_coeff_d_ = pcl::make_shared<std::vector<float> >(plane_coeff_d);
       }
       
       /** \brief Get a pointer to the vector of the d-coefficient of the planes' hessian normal form. */

--- a/simulation/include/pcl/simulation/model.h
+++ b/simulation/include/pcl/simulation/model.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <pcl/PolygonMesh.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/memory.h>
+#include <pcl/pcl_config.h>
+#include <pcl/pcl_macros.h>
+#include <pcl/point_types.h>
+#include <pcl/simulation/glsl_shader.h>
+
 #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__)
 #define WIN32_LEAN_AND_MEAN 1
 #include <windows.h>
@@ -7,7 +15,6 @@
 
 #include <GL/glew.h>
 
-#include <pcl/pcl_config.h>
 #ifdef OPENGL_IS_A_FRAMEWORK
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>
@@ -15,14 +22,6 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #endif
-
-#include <boost/shared_ptr.hpp>
-#include <pcl/PolygonMesh.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/memory.h>
-#include <pcl/pcl_macros.h>
-#include <pcl/point_types.h>
-#include <pcl/simulation/glsl_shader.h>
 
 namespace pcl {
 namespace simulation {

--- a/simulation/include/pcl/simulation/scene.h
+++ b/simulation/include/pcl/simulation/scene.h
@@ -7,12 +7,9 @@
 
 #pragma once
 
-#include <boost/shared_ptr.hpp>
-
 #include <pcl/memory.h>
 #include <pcl/pcl_macros.h>
 //#include <pcl/win32_macros.h>
-
 #include <pcl/simulation/camera.h>
 #include <pcl/simulation/model.h>
 

--- a/simulation/tools/sim_terminal_demo.cpp
+++ b/simulation/tools/sim_terminal_demo.cpp
@@ -10,16 +10,19 @@
  * pcl_sim_terminal_demo 2 ../../../../kmcl/models/table_models/meta_model.ply
  */
 
+#include "simulation_io.hpp"
+
+#include <pcl/memory.h>
+
 #include <Eigen/Dense>
-#include <boost/shared_ptr.hpp>
-#include <cmath>
-#include <iostream>
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 
-#include "simulation_io.hpp"
+#include <cmath>
+#include <iostream>
 
 using namespace Eigen;
 using namespace pcl;

--- a/simulation/tools/sim_test_performance.cpp
+++ b/simulation/tools/sim_test_performance.cpp
@@ -5,17 +5,32 @@
  *
  */
 
-#include <Eigen/Dense>
-#include <boost/shared_ptr.hpp>
-#include <cmath>
-#include <iostream>
+#include <pcl/common/common.h>
+#include <pcl/common/transforms.h>
+#include <pcl/console/parse.h>
+#include <pcl/console/print.h>
+#include <pcl/console/time.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/memory.h>
+#include <pcl/pcl_config.h>
+#include <pcl/point_types.h>
+#include <pcl/simulation/camera.h>
+#include <pcl/simulation/model.h>
+#include <pcl/simulation/range_likelihood.h>
+#include <pcl/simulation/scene.h>
+#include <pcl/surface/gp3.h>
+
+// define the following in order to eliminate the deprecated headers warning
+#define VTK_EXCLUDE_STRSTREAM_HEADERS
+#include <pcl/io/vtk_lib_io.h>
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 #include <GL/glew.h>
 
-#include <pcl/pcl_config.h>
 #ifdef OPENGL_IS_A_FRAMEWORK
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>
@@ -29,29 +44,10 @@
 #include <GL/glut.h>
 #endif
 
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
+#include <Eigen/Dense>
 
-#include <pcl/common/common.h>
-#include <pcl/common/transforms.h>
-
-#include <pcl/features/normal_3d.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/surface/gp3.h>
-
-// define the following in order to eliminate the deprecated headers warning
-#define VTK_EXCLUDE_STRSTREAM_HEADERS
-#include <pcl/io/vtk_lib_io.h>
-
-#include <pcl/simulation/camera.h>
-#include <pcl/simulation/model.h>
-#include <pcl/simulation/range_likelihood.h>
-#include <pcl/simulation/scene.h>
-
-#include <pcl/console/parse.h>
-#include <pcl/console/print.h>
-#include <pcl/console/time.h>
+#include <cmath>
+#include <iostream>
 
 using namespace Eigen;
 using namespace pcl;

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -16,18 +16,35 @@
  *
  */
 
+#include <pcl/common/common.h>
+#include <pcl/common/transforms.h>
+#include <pcl/console/parse.h>
+#include <pcl/console/print.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/memory.h>
+#include <pcl/pcl_config.h>
+#include <pcl/point_types.h>
+#include <pcl/range_image/range_image_planar.h> // RangeImage
+#include <pcl/simulation/camera.h>
+#include <pcl/simulation/model.h>
+#include <pcl/simulation/range_likelihood.h>
+#include <pcl/simulation/scene.h>
+#include <pcl/surface/gp3.h>
+#include <pcl/visualization/cloud_viewer.h> // Pop-up viewer
+
+// define the following in order to eliminate the deprecated headers warning
+#define VTK_EXCLUDE_STRSTREAM_HEADERS
+#include <pcl/io/vtk_lib_io.h>
+
 #include <Eigen/Dense>
-#include <boost/shared_ptr.hpp>
-#include <cmath>
-#include <iostream>
-#include <thread>
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 #include <GL/glew.h>
 
-#include <pcl/pcl_config.h>
 #ifdef OPENGL_IS_A_FRAMEWORK
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>
@@ -41,34 +58,9 @@
 #include <GL/glut.h>
 #endif
 
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-
-#include "pcl/common/common.h"
-#include "pcl/common/transforms.h"
-
-#include <pcl/features/normal_3d.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/surface/gp3.h>
-
-// define the following in order to eliminate the deprecated headers warning
-#define VTK_EXCLUDE_STRSTREAM_HEADERS
-#include <pcl/io/vtk_lib_io.h>
-
-#include "pcl/simulation/camera.h"
-#include "pcl/simulation/model.h"
-#include "pcl/simulation/range_likelihood.h"
-#include "pcl/simulation/scene.h"
-
-#include <pcl/console/parse.h>
-#include <pcl/console/print.h>
-
-// RangeImage:
-#include <pcl/range_image/range_image_planar.h>
-
-// Pop-up viewer
-#include <pcl/visualization/cloud_viewer.h>
+#include <cmath>
+#include <iostream>
+#include <thread>
 
 using namespace Eigen;
 using namespace pcl;

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -36,11 +36,37 @@
  * $Id: pcd_viewer.cpp 5094 2012-03-15 01:03:51Z rusu $
  *
  */
+
+#include <pcl/common/common.h>
+#include <pcl/common/transforms.h>
+#include <pcl/console/parse.h>
+#include <pcl/console/print.h>
+#include <pcl/console/time.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/memory.h>
+#include <pcl/pcl_config.h>
+#include <pcl/point_types.h>
+#include <pcl/range_image/range_image_planar.h> // RangeImage
+#include <pcl/simulation/camera.h>
+#include <pcl/simulation/model.h>
+#include <pcl/simulation/range_likelihood.h>
+#include <pcl/simulation/scene.h>
+#include <pcl/surface/gp3.h>
+#include <pcl/visualization/cloud_viewer.h> // Pop-up viewer
+#include <pcl/visualization/histogram_visualizer.h>
+#include <pcl/visualization/keyboard_event.h>
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/visualization/point_cloud_handlers.h>
+#include <pcl/visualization/point_picking_event.h>
+
+// define the following in order to eliminate the deprecated headers warning
+#define VTK_EXCLUDE_STRSTREAM_HEADERS
+#include <pcl/io/vtk_lib_io.h>
+
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
-#include <boost/shared_ptr.hpp>
-#include <cmath>
-#include <iostream>
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -48,55 +74,17 @@
 
 #include <GL/glew.h>
 
-#include <pcl/pcl_config.h>
 #ifdef OPENGL_IS_A_FRAMEWORK
 #include <OpenGL/gl.h>
 #else
 #include <GL/gl.h>
 #endif
 
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-
-#include "pcl/common/common.h"
-#include "pcl/common/transforms.h"
-
-#include <pcl/features/normal_3d.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/surface/gp3.h>
-
-// define the following in order to eliminate the deprecated headers warning
-#define VTK_EXCLUDE_STRSTREAM_HEADERS
-#include <pcl/io/vtk_lib_io.h>
-
-#include "pcl/simulation/camera.h"
-#include "pcl/simulation/model.h"
-#include "pcl/simulation/range_likelihood.h"
-#include "pcl/simulation/scene.h"
-
-#include <pcl/console/parse.h>
-#include <pcl/console/print.h>
-#include <pcl/console/time.h>
-
-// RangeImage:
-#include <pcl/range_image/range_image_planar.h>
-
-// Pop-up viewer
-#include <pcl/visualization/cloud_viewer.h>
+#include <vtkPolyDataReader.h>
 
 #include <cfloat>
-#include <pcl/common/common.h>
-#include <pcl/console/parse.h>
-#include <pcl/console/print.h>
-#include <pcl/console/time.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/visualization/histogram_visualizer.h>
-#include <pcl/visualization/keyboard_event.h>
-#include <pcl/visualization/pcl_visualizer.h>
-#include <pcl/visualization/point_cloud_handlers.h>
-#include <pcl/visualization/point_picking_event.h>
-#include <vtkPolyDataReader.h>
+#include <cmath>
+#include <iostream>
 
 using namespace Eigen;
 using namespace pcl;

--- a/simulation/tools/simulation_io.hpp
+++ b/simulation/tools/simulation_io.hpp
@@ -1,10 +1,19 @@
 #pragma once
 
-#include <boost/shared_ptr.hpp>
+#include <pcl/io/pcd_io.h>
+#include <pcl/memory.h>
+#include <pcl/pcl_config.h>
+#include <pcl/point_types.h>
+#include <pcl/simulation/camera.h>
+#include <pcl/simulation/range_likelihood.h>
+#include <pcl/simulation/scene.h>
+
+// define the following in order to eliminate the deprecated headers warning
+#define VTK_EXCLUDE_STRSTREAM_HEADERS
+#include <pcl/io/vtk_lib_io.h>
 
 #include <GL/glew.h>
 
-#include <pcl/pcl_config.h>
 #ifdef OPENGL_IS_A_FRAMEWORK
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>
@@ -17,16 +26,6 @@
 #else
 #include <GL/glut.h>
 #endif
-
-// define the following in order to eliminate the deprecated headers warning
-#define VTK_EXCLUDE_STRSTREAM_HEADERS
-#include <pcl/io/pcd_io.h>
-#include <pcl/io/vtk_lib_io.h>
-#include <pcl/point_types.h>
-
-#include <pcl/simulation/camera.h>
-#include <pcl/simulation/range_likelihood.h>
-#include <pcl/simulation/scene.h>
 
 namespace pcl {
 namespace simulation {

--- a/surface/include/pcl/surface/boost.h
+++ b/surface/include/pcl/surface/boost.h
@@ -40,8 +40,7 @@
 #pragma once
 
 #if defined __GNUC__
-#  pragma GCC system_header 
+#  pragma GCC system_header
 #endif
 
 #include <boost/dynamic_bitset/dynamic_bitset.hpp>
-#include <boost/shared_ptr.hpp>

--- a/tools/boost.h
+++ b/tools/boost.h
@@ -46,7 +46,6 @@
 
 #ifndef Q_MOC_RUN
 // Marking all Boost headers as system headers to remove warnings
-#include <boost/make_shared.hpp>
 #include <boost/date_time/gregorian/gregorian_types.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>

--- a/tools/depth_sense_viewer.cpp
+++ b/tools/depth_sense_viewer.cpp
@@ -35,6 +35,7 @@
  *
  */
 
+#include <pcl/memory.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/common/time.h>
 #include <pcl/console/print.h>
@@ -43,7 +44,6 @@
 #include <pcl/io/depth_sense_grabber.h>
 #include <pcl/visualization/pcl_visualizer.h>
 
-#include <boost/shared_ptr.hpp>
 #include <boost/format.hpp>
 
 #include <iostream>

--- a/tools/real_sense_viewer.cpp
+++ b/tools/real_sense_viewer.cpp
@@ -35,6 +35,7 @@
  *
  */
 
+#include <pcl/memory.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/common/time.h>
 #include <pcl/console/print.h>
@@ -44,7 +45,6 @@
 #include <pcl/visualization/pcl_visualizer.h>
 
 #include <boost/format.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <iostream>
 #include <mutex>

--- a/tracking/include/pcl/tracking/distance_coherence.h
+++ b/tracking/include/pcl/tracking/distance_coherence.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <boost/shared_ptr.hpp>
-
+#include <pcl/memory.h>
 #include <pcl/tracking/coherence.h>
+
 
 namespace pcl
 {

--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <boost/shared_ptr.hpp>
-
-#include <pcl/tracking/tracking.h>
-#include <pcl/tracking/tracker.h>
-#include <pcl/tracking/coherence.h>
+#include <pcl/memory.h>
 #include <pcl/filters/passthrough.h>
 #include <pcl/octree/octree_pointcloud_changedetector.h>
+#include <pcl/tracking/coherence.h>
+#include <pcl/tracking/tracker.h>
+#include <pcl/tracking/tracking.h>
 
 #include <Eigen/Dense>
+
 
 namespace pcl
 {

--- a/visualization/include/pcl/visualization/boost.h
+++ b/visualization/include/pcl/visualization/boost.h
@@ -48,7 +48,6 @@
 #include <boost/shared_array.hpp>
 #define BOOST_PARAMETER_MAX_ARITY 7
 #include <boost/signals2.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>


### PR DESCRIPTION
Stems from #3750. I found more `boost::shared_ptr`s in the codebase. This should be the last of them, before the switch can happen. With this PR they all should be controlled from the switch in `pcl/memory.h`.