### PR TITLE
Set BOOST_ROOT to BOOST_ROOT_1_69_0 in Azure Windows job

### DIFF
--- a/.ci/azure-pipelines/build-windows.yaml
+++ b/.ci/azure-pipelines/build-windows.yaml
@@ -19,11 +19,15 @@ jobs:
       CONFIGURATION: 'Release'
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
-      - script: set
-        displayName: 'Print Environment Variables'
       - script: |
-          echo ##vso[task.prependpath]%BOOST_ROOT%\lib
-        displayName: 'Update System PATH'
+          echo ##vso[task.setvariable variable=BOOST_ROOT]%BOOST_ROOT_1_69_0%
+        displayName: 'Set BOOST_ROOT Environment Variable'
+      - script: |
+          echo ##vso[task.prependpath]%BOOST_ROOT_1_69_0%\lib
+        displayName: 'Include Boost Libraries In System PATH'
+      - script: |
+          set
+        displayName: 'Print Environment Variables'
       - script: |
           vcpkg.exe install eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
         displayName: 'Install c++ dependencies via vcpkg'

--- a/.ci/azure-pipelines/build-windows.yaml
+++ b/.ci/azure-pipelines/build-windows.yaml
@@ -30,7 +30,7 @@ jobs:
         displayName: 'Print Environment Variables'
       - script: |
           vcpkg.exe install eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
-        displayName: 'Install c++ dependencies via vcpkg'
+        displayName: 'Install C++ Dependencies Via Vcpkg'
       - script: |
           rmdir %VCPKG_ROOT%\downloads /S /Q
           rmdir %VCPKG_ROOT%\packages /S /Q


### PR DESCRIPTION
One of the recent updates to the agent images used on Azure removed BOOST_ROOT variable: https://github.com/actions/virtual-environments/commit/e91f2138c0b7304831e9aaa43ea47279d4160ef4