### PR TITLE
[ci] Shift to clang-format-10 to resolve bug in clang-format-{7-9}

### DIFF
--- a/.ci/azure-pipelines/formatting.yaml
+++ b/.ci/azure-pipelines/formatting.yaml
@@ -5,7 +5,7 @@ jobs:
       vmImage: 'Ubuntu 16.04'
     container: fmt
     steps:
-      - script: ./.dev/format.sh $(which clang-format-8) .
+      - script: ./.dev/format.sh $(which clang-format-10) .
         displayName: 'Run clang-format'
       - script: git diff > formatting.patch
         displayName: 'Compute diff'

--- a/.clang-format
+++ b/.clang-format
@@ -19,6 +19,6 @@ ConstructorInitializerIndentWidth: 0
 Language: Cpp
 NamespaceIndentation: None
 PointerAlignment: Left
-Standard: Cpp11
+Standard: Latest
 TabWidth: 2
 UseTab: Never

--- a/.dev/docker/fmt/Dockerfile
+++ b/.dev/docker/fmt/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:19.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG CLANG_FORMAT_VERSION=8
+ARG CLANG_FORMAT_VERSION=10
 
 RUN apt-get update \
  && apt-get install -y \

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,10 +1,10 @@
-find_package(ClangFormat 7)
+find_package(ClangFormat 10)
 # search for version number in clang-format without version number
 if(ClangFormat_FOUND)
   message(STATUS "Adding target 'format'")
   add_custom_target(
   format
-  COMMAND sh 
+  COMMAND sh
     ${PCL_SOURCE_DIR}/.dev/format.sh
     ${ClangFormat_EXECUTABLE}
     ${PCL_SOURCE_DIR}

--- a/ml/include/pcl/ml/ferns/fern.h
+++ b/ml/include/pcl/ml/ferns/fern.h
@@ -142,7 +142,8 @@ public:
    *
    * \param node_index the index of the node to access
    */
-  inline NodeType& operator[](const std::size_t node_index)
+  inline NodeType&
+  operator[](const std::size_t node_index)
   {
     return nodes_[node_index];
   }
@@ -151,7 +152,8 @@ public:
    *
    * \param node_index the index of the node to access
    */
-  inline const NodeType& operator[](const std::size_t node_index) const
+  inline const NodeType&
+  operator[](const std::size_t node_index) const
   {
     return nodes_[node_index];
   }

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -139,16 +139,32 @@ public:
   }
 
   /** \brief Get const pointer to container */
-  const ContainerT* operator->() const { return &container_; }
+  const ContainerT*
+  operator->() const
+  {
+    return &container_;
+  }
 
   /** \brief Get pointer to container */
-  ContainerT* operator->() { return &container_; }
+  ContainerT*
+  operator->()
+  {
+    return &container_;
+  }
 
   /** \brief Get const reference to container */
-  const ContainerT& operator*() const { return container_; }
+  const ContainerT&
+  operator*() const
+  {
+    return container_;
+  }
 
   /** \brief Get reference to container */
-  ContainerT& operator*() { return container_; }
+  ContainerT&
+  operator*()
+  {
+    return container_;
+  }
 
   /** \brief Get const reference to container */
   const ContainerT&

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -218,7 +218,8 @@ public:
   /** \brief *operator.
    * \return pointer to the current octree node
    */
-  inline OctreeNode* operator*() const
+  inline OctreeNode*
+  operator*() const
   { // return designated object
     if (octree_ && current_state_) {
       return (current_state_->node_);
@@ -728,7 +729,8 @@ public:
   /** \brief *operator.
    * \return pointer to the current octree leaf node
    */
-  OctreeNode* operator*() const
+  OctreeNode*
+  operator*() const
   {
     // return designated object
     OctreeNode* ret = 0;

--- a/octree/include/pcl/octree/octree_nodes.h
+++ b/octree/include/pcl/octree/octree_nodes.h
@@ -112,16 +112,32 @@ public:
   }
 
   /** \brief Get const pointer to container */
-  const ContainerT* operator->() const { return &container_; }
+  const ContainerT*
+  operator->() const
+  {
+    return &container_;
+  }
 
   /** \brief Get pointer to container */
-  ContainerT* operator->() { return &container_; }
+  ContainerT*
+  operator->()
+  {
+    return &container_;
+  }
 
   /** \brief Get const reference to container */
-  const ContainerT& operator*() const { return container_; }
+  const ContainerT&
+  operator*() const
+  {
+    return container_;
+  }
 
   /** \brief Get reference to container */
-  ContainerT& operator*() { return container_; }
+  ContainerT&
+  operator*()
+  {
+    return container_;
+  }
 
   /** \brief Get const reference to container */
   const ContainerT&
@@ -211,7 +227,8 @@ public:
    *  \param child_idx_arg: index to child node
    *  \return OctreeNode pointer
    * */
-  inline OctreeNode*& operator[](unsigned char child_idx_arg)
+  inline OctreeNode*&
+  operator[](unsigned char child_idx_arg)
   {
     assert(child_idx_arg < 8);
     return child_node_array_[child_idx_arg];
@@ -288,16 +305,32 @@ public:
   }
 
   /** \brief Get const pointer to container */
-  const ContainerT* operator->() const { return &container_; }
+  const ContainerT*
+  operator->() const
+  {
+    return &container_;
+  }
 
   /** \brief Get pointer to container */
-  ContainerT* operator->() { return &container_; }
+  ContainerT*
+  operator->()
+  {
+    return &container_;
+  }
 
   /** \brief Get const reference to container */
-  const ContainerT& operator*() const { return container_; }
+  const ContainerT&
+  operator*() const
+  {
+    return container_;
+  }
 
   /** \brief Get reference to container */
-  ContainerT& operator*() { return container_; }
+  ContainerT&
+  operator*()
+  {
+    return container_;
+  }
 
   /** \brief Get const reference to container */
   const ContainerT&


### PR DESCRIPTION
`clang-format-8` has a bug which causes some incorrect formatting. Shifting to v10 would resolve that.

Also modified is the cpp standard in the `.clang-format`. Should that be `Cpp14` instead of `Latest`?