### PR TITLE
Fix PCL_DEPRECATED usage in doxygen for a proper Deprecation List in documentation

### DIFF
--- a/.ci/azure-pipelines/documentation.yaml
+++ b/.ci/azure-pipelines/documentation.yaml
@@ -33,6 +33,10 @@ jobs:
           cmake --build . -- doc tutorials advanced
         displayName: 'Build Documentation'
       - script: |
+          cd $BUILD_DIR
+          sed -r -e 's/([0-9]+)\s\.\s([0-9]+)\s/\1.\2/' doc/doxygen/html/deprecated.html
+        displayName: 'Remove extra spaces in Doxygen''s Deprecated List'
+      - script: |
           git config --global user.email "documentation@pointclouds.org"
           git config --global user.name "PointCloudLibrary (via Azure Pipelines)"
           echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config

--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -312,7 +312,7 @@ PREDEFINED =           = "HAVE_QHULL=1" \
                          "HAVE_RSSDK=1" \
                          "DOXYGEN_ONLY=1" \
                          "_WIN32=1" \
-                         "PCL_DEPRECATED(1, 12, x)=/** \deprecated x */"
+                         "PCL_DEPRECATED(major,minor,message)=/** \deprecated Scheduled for removal in version major.\ minor: message */"
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 


### PR DESCRIPTION
Close #3825

> So the error itself is because "." ends the period if [`JAVADOC_AUTOBRIEF`](http://www.doxygen.nl/manual/config.html#cfg_javadoc_autobrief)`= YES` so the solution is either to set it to `= NO` or escape the dot like `.\ ` (notice the trailing whitespace). In both cases the version number becomes "1 . 12" which is ugly and I think there is no solution to inserted whitespace since I found the unresolved [doxygen/doxygen#6154](https://github.com/doxygen/doxygen/issues/6154) bug report.

from https://github.com/PointCloudLibrary/pcl/issues/3825#issuecomment-612433423

I also added a sed invocation to deal with the whitespace, thanks Sergey.