### PR TITLE
Add windows container.

### DIFF
--- a/.ci/azure-pipelines/build/windows.yaml
+++ b/.ci/azure-pipelines/build/windows.yaml
@@ -22,6 +22,7 @@ steps:
       mkdir %BUILD_DIR% && cd %BUILD_DIR%
       cmake $(Build.SourcesDirectory) ^
         -G"%GENERATOR%" ^
+        -DPCL_ONLY_CORE_POINT_TYPES=ON ^
         -DCMAKE_BUILD_TYPE="MinSizeRel" ^
         -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake ^
         -DVCPKG_APPLOCAL_DEPS=ON ^


### PR DESCRIPTION
Currently it fetches master vcpkg, whenever the docker containers are build.

The compressed docker is about 8GB, so it takes some time for fetching them. Can we add the to azure container register or is it only for paid users - I have a hard time figuring it out :)

Should we add additional dependcies?

Docker builds are [here](https://hub.docker.com/repository/docker/larshg/pclwindows)

Updated to visual studio 2019.