### PR TITLE
[doc] Modify Major.Minor for doxygen in place (and not show on stdout)

### DIFF
--- a/.ci/azure-pipelines/documentation.yaml
+++ b/.ci/azure-pipelines/documentation.yaml
@@ -34,7 +34,7 @@ jobs:
         displayName: 'Build Documentation'
       - script: |
           cd $BUILD_DIR
-          sed -r -e 's/([0-9]+)\s\.\s([0-9]+)\s/\1.\2/' doc/doxygen/html/deprecated.html
+          sed -i -r -e 's/([0-9]+)\s\.\s([0-9]+)\s/\1.\2/' doc/doxygen/html/deprecated.html
         displayName: 'Remove extra spaces in Doxygen''s Deprecated List'
       - script: |
           git config --global user.email "documentation@pointclouds.org"


### PR DESCRIPTION
…f output to stdout

An oopsie on #3905 as the deprecation list doesn't seem to have the `sed` command run on it, and in fact it's only outputting to stdout where it's working correctly.

```
[...]

<dt><a class="anchor" id="_deprecated000020"></a>Member <a class="el" href="classpcl_1_1_a_s_c_i_i_reader.html#a598c81fb5c3697abe3cbe8131ae6c1a1">pcl::ASCIIReader::setInputFields</a>  (const PointT p)</dt>
<dd>Scheduled for removal in version 1.12: "use parameterless setInputFields&lt;PointT&gt;() instead"  </dd>
<dt><a class="anchor" id="_deprecated000012"></a>Member <a class="el" href="namespacepcl.html#ab613e1f38731c3438c9b668876ce7d73">pcl::computeRSD</a>  (typename <a class="el" href="classpcl_1_1_point_cloud.html#af70fd81ce582ccabf683dd782ed3f032">pcl::PointCloud&lt; PointInT &gt;::ConstPtr</a> &amp;surface, typename <a class="el" href="classpcl_1_1_point_cloud.html#af70fd81ce582ccabf683dd782ed3f032">pcl::PointCloud&lt; PointNT &gt;::ConstPtr</a> &amp;normals, const std::vector&lt; int &gt; &amp;indices, double max_dist, int nr_subdiv, double plane_radius, PointOutT &amp;radii, bool compute_histogram=false)</dt>
<dd>Scheduled for removal in version 1.12: "use computeRSD() overload that takes input point clouds by const reference"  </dd>

[...]
```
([link](https://dev.azure.com/PointCloudLibrary/pcl/_build/results?buildId=15749&view=logs&j=d0d530cd-2c5d-5eb2-7bb0-02dfe64fb679&t=1b6c22eb-cc7e-5e50-103d-0684bc177d1a&l=81))

Should there also be a `cat doc/doxygen/html/deprecated.html` to check the modification, since like this it will appear as an empty build phase happens?