### PR TITLE
Add PCL_UNUSED to fix doxygen warnings

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -123,6 +123,14 @@
                     PCL_DEPRECATED_MODIFY_MSG(Major, Minor, Message)),  \
                 major_version_mismatch)
 
+/**
+ * \brief Utility macro to eliminate unused variable warnings.
+ *
+ * \param x A parameter which will be used without being evaluated.
+ *
+ * Slightly better than `(void)x` as explained [here](https://stackoverflow.com/a/4030983/9926122).
+ */
+#define PCL_UNUSED(x) ((void)(true ? 0 : ((x), void(), 0)))
 
 #if defined _WIN32
 // Define math constants, without including math.h, to prevent polluting global namespace with old math methods

--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -312,7 +312,8 @@ PREDEFINED =           = "HAVE_QHULL=1" \
                          "HAVE_RSSDK=1" \
                          "DOXYGEN_ONLY=1" \
                          "_WIN32=1" \
-                         "PCL_DEPRECATED(major,minor,message)=/** \deprecated Scheduled for removal in version major.\ minor: message */"
+                         "PCL_DEPRECATED(major,minor,message)=/** \deprecated Scheduled for removal in version major.\ minor: message */" \
+                         "PCL_UNUSED(x)=x"
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 

--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -313,7 +313,7 @@ PREDEFINED =           = "HAVE_QHULL=1" \
                          "DOXYGEN_ONLY=1" \
                          "_WIN32=1" \
                          "PCL_DEPRECATED(major,minor,message)=/** \deprecated Scheduled for removal in version major.\ minor: message */" \
-                         "PCL_UNUSED(x)=x"
+                         "PCL_UNUSED(x)=/** \remark Parameter \a x is unused */"
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 

--- a/filters/include/pcl/filters/normal_refinement.h
+++ b/filters/include/pcl/filters/normal_refinement.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/filters/filter.h>
 
 namespace pcl
@@ -51,11 +52,13 @@ namespace pcl
    * \ingroup filters
    */
   template <typename NormalT> inline std::vector<float>
-  assignNormalWeights (const PointCloud<NormalT>&,
-                       int,
+  assignNormalWeights (const PointCloud<NormalT>& cloud,
+                       int index,
                        const std::vector<int>& k_indices,
                        const std::vector<float>& k_sqr_distances)
   {
+    PCL_UNUSED(cloud);
+    PCL_UNUSED(index);
     // Check inputs
     if (k_indices.size () != k_sqr_distances.size ())
       PCL_ERROR("[pcl::assignNormalWeights] inequal size of neighbor indices and distances!\n");

--- a/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
@@ -289,11 +289,13 @@ namespace pcl
       void
       refine (std::vector<ModelCoefficients>& model_coefficients, 
               std::vector<PointIndices>& inlier_indices,
-              std::vector<Eigen::Vector4f, Eigen::aligned_allocator<Eigen::Vector4f> >& /*centroids*/,
-              std::vector <Eigen::Matrix3f, Eigen::aligned_allocator<Eigen::Matrix3f> >& /*covariances*/,
+              std::vector<Eigen::Vector4f, Eigen::aligned_allocator<Eigen::Vector4f> >& centroids,
+              std::vector <Eigen::Matrix3f, Eigen::aligned_allocator<Eigen::Matrix3f> >& covariances,
               PointCloudLPtr& labels,
               std::vector<pcl::PointIndices>& label_indices)
       {
+        PCL_UNUSED(centroids);
+        PCL_UNUSED(covariances);
         refine(model_coefficients, inlier_indices, labels, label_indices);
       }
 


### PR DESCRIPTION
Fixes `warning: argument <arg> of command @param is not found in the argument list of <function>`

If this seems reasonable I'll follow up with a PR aiming at using this macro instead of all the naked `(void)` casts.