### PR TITLE
Fix "warning: Found unknown command `\detail'" from doxygen

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -112,7 +112,7 @@
  * \brief macro for compatibility across compilers and help remove old deprecated
  *        items for the Major.Minor release
  *
- * \detail compiler errors of `unneeded_deprecation` and `major_version_mismatch`
+ * \details compiler errors of `unneeded_deprecation` and `major_version_mismatch`
  * are hints to the developer that those items can be safely removed.
  * Warning message with PCL_DEPRECATED(1, 99, "Not needed anymore") till PCL 1.98:
  * "Slated for removal in PCL 1.99: Not needed anymore"

--- a/common/include/pcl/type_traits.h
+++ b/common/include/pcl/type_traits.h
@@ -71,7 +71,7 @@ namespace pcl
     /**
      * \brief Enumeration for different numerical types
      *
-     * \detail struct used to enable scope and implicit conversion to int
+     * \details struct used to enable scope and implicit conversion to int
      */
     struct PointFieldTypes {
         static const std::uint8_t INT8 = 1,    UINT8 = 2,


### PR DESCRIPTION
The special command is [`\details`](http://www.doxygen.nl/manual/commands.html#cmddetails).