### PR TITLE
Fix Findlibusb-1.0.cmake on Windows

### DIFF
--- a/cmake/Modules/Findlibusb-1.0.cmake
+++ b/cmake/Modules/Findlibusb-1.0.cmake
@@ -56,7 +56,7 @@ else()
             PATH_SUFFIXES libusb-1.0)
 
   find_library(LIBUSB_1_LIBRARY
-               NAMES usb-1.0
+               NAMES usb-1.0 libusb-1.0
                PATHS /usr/lib /usr/local/lib /opt/local/lib /sw/lib)
 
   set(LIBUSB_1_INCLUDE_DIRS ${LIBUSB_1_INCLUDE_DIR})

--- a/cmake/Modules/Findlibusb-1.0.cmake
+++ b/cmake/Modules/Findlibusb-1.0.cmake
@@ -55,6 +55,8 @@ else()
             PATHS /usr/include /usr/local/include /opt/local/include /sw/include
             PATH_SUFFIXES libusb-1.0)
 
+  # We need to look for libusb-1.0 too because find_library does not attempt to find
+  # library files with a "lib" prefix implicitly on Windows
   find_library(LIBUSB_1_LIBRARY
                NAMES usb-1.0 libusb-1.0
                PATHS /usr/lib /usr/local/lib /opt/local/lib /sw/lib)


### PR DESCRIPTION
libusb-1.0 sometimes exists as `libusb-1.0.lib` on Windows and the `find_library` logic doesn't try to add a `lib` prefix on Windows - this is notably the case with the libusb Conan package.

This change allows the Conan-provided libusb to be found on Windows without further configuration.