### PR TITLE
Formatting and CI optimizations

### DIFF
--- a/.ci/azure-pipelines/build-macos.yaml
+++ b/.ci/azure-pipelines/build-macos.yaml
@@ -15,6 +15,9 @@ jobs:
       GOOGLE_TEST_DIR: '$(Agent.WorkFolder)/googletest'
       CMAKE_CXX_FLAGS: '-Wall -Wextra -Werror -Wabi'
     steps:
+      - checkout: self
+        # find the commit hash on a quick non-forced update too
+        fetchDepth: 10
       - script: |
           brew install pkg-config qt5 libpcap brewsci/science/openni libomp
           brew install vtk --with-qt --without-python@2

--- a/.ci/azure-pipelines/build-ubuntu.yaml
+++ b/.ci/azure-pipelines/build-ubuntu.yaml
@@ -31,6 +31,9 @@ jobs:
       BUILD_DIR: '$(Agent.BuildDirectory)/build'
       CMAKE_CXX_FLAGS: '-Wall -Wextra'
     steps:
+      - checkout: self
+        # find the commit hash on a quick non-forced update too
+        fetchDepth: 10
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR
           cmake $(Build.SourcesDirectory) $(CMAKE_ARGS) \

--- a/.ci/azure-pipelines/build-windows.yaml
+++ b/.ci/azure-pipelines/build-windows.yaml
@@ -19,6 +19,9 @@ jobs:
       CONFIGURATION: 'Release'
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
+      - checkout: self
+        # find the commit hash on a quick non-forced update too
+        fetchDepth: 10
       - script: |
           echo ##vso[task.setvariable variable=BOOST_ROOT]%BOOST_ROOT_1_69_0%
         displayName: 'Set BOOST_ROOT Environment Variable'

--- a/.ci/azure-pipelines/documentation.yaml
+++ b/.ci/azure-pipelines/documentation.yaml
@@ -9,6 +9,9 @@ jobs:
       DOC_DIR: '$(Agent.BuildDirectory)/documentation'
       CHANGELOG: '$(Agent.TempDirectory)/changelog'
     steps:
+      - checkout: self
+        # find the commit hash on a quick non-forced update too
+        fetchDepth: 10
       - task: InstallSSHKey@0
         inputs:
           hostName: github.com

--- a/.ci/azure-pipelines/formatting.yaml
+++ b/.ci/azure-pipelines/formatting.yaml
@@ -5,7 +5,10 @@ jobs:
       vmImage: 'Ubuntu 16.04'
     container: fmt
     steps:
-      - script: ./.dev/format.sh $(which clang-format-10) .
+      - checkout: self
+        # find the commit hash on a quick non-forced update too
+        fetchDepth: 10
+      - script: ./.dev/format.sh $(which clang-format) .
         displayName: 'Run clang-format'
       - script: git diff > formatting.patch
         displayName: 'Compute diff'

--- a/.ci/azure-pipelines/tutorials.yaml
+++ b/.ci/azure-pipelines/tutorials.yaml
@@ -11,6 +11,9 @@ jobs:
       CMAKE_CXX_FLAGS: '-Wall -Wextra -Wabi'
       EXCLUDE_TUTORIALS: 'davidsdk,ensenso_cameras,gpu'
     steps:
+      - checkout: self
+        # find the commit hash on a quick non-forced update too
+        fetchDepth: 10
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR
           cmake $(Build.SourcesDirectory) \

--- a/.dev/docker/fmt/Dockerfile
+++ b/.dev/docker/fmt/Dockerfile
@@ -1,11 +1,3 @@
-FROM ubuntu:20.04
+FROM alpine:edge
 
-ENV DEBIAN_FRONTEND=noninteractive
-ARG CLANG_FORMAT_VERSION=10
-
-RUN apt-get update \
- && apt-get install -y \
-      clang-format-${CLANG_FORMAT_VERSION} \
-      bash \
-      git \
- && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash clang git

--- a/cmake/Modules/FindClangFormat.cmake
+++ b/cmake/Modules/FindClangFormat.cmake
@@ -12,16 +12,23 @@
 #
 # .. code-block:: cmake
 #
-# find_package(ClangFormat) 
+# find_package(ClangFormat)
 # if(ClangFormat_FOUND)
 # message("clang-format executable found: ${ClangFormat_EXECUTABLE}\n"
-#         "version: ${ClangFormat_VERSION}") 
+#         "version: ${ClangFormat_VERSION}")
 # endif()
 
 find_program(ClangFormat_EXECUTABLE
              NAMES
+             # unreleased versions
+                   clang-format-14
+                   clang-format-13
+                   clang-format-12
+                   clang-format-11
+             # current latest
+                   clang-format-10
                    clang-format-9
-                   clang-format-9.0
+             # since clang-format-8, only major version is prefixed
                    clang-format-8
                    clang-format-8.0
                    clang-format-7


### PR DESCRIPTION
* Format-CI uses alpine container instead
* clang-format search only finds the acceptable versions (instead of all)
* shallow checkout (for all CI), reduces 90% of objects transferred (more in future)