### PR TITLE
Add `ignore` function to remove Doxygen warnings for unused arguments

### DIFF
--- a/common/include/pcl/common/utils.h
+++ b/common/include/pcl/common/utils.h
@@ -56,5 +56,11 @@ namespace pcl
     {
       return (std::fabs (val1 - val2) < eps);
     }
-  }
-}
+
+   /** \brief Utility function to eliminate unused variable warnings. */
+    template<typename T> void
+    ignore(const T&)
+    {
+    }
+  } // namespace utils
+} // namespace pcl

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -128,9 +128,14 @@
  *
  * \param x A parameter which will be used without being evaluated.
  *
- * Slightly better than `(void)x` as explained [here](https://stackoverflow.com/a/4030983/9926122).
+ * Slightly better than `(void)(x)` as explained [here](https://stackoverflow.com/a/4030983/9926122)
+ * but only works on MSVC so fall back on the classic version for other cases.
  */
-#define PCL_UNUSED(x) ((void)(true ? 0 : ((x), void(), 0)))
+#if defined _MSC_VER
+  #define PCL_UNUSED(x) ((void)(true ? 0 : ((x), void(), 0)))
+#else
+  #define PCL_UNUSED(x) ((void)(x))
+#endif
 
 #if defined _WIN32
 // Define math constants, without including math.h, to prevent polluting global namespace with old math methods

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -123,20 +123,6 @@
                     PCL_DEPRECATED_MODIFY_MSG(Major, Minor, Message)),  \
                 major_version_mismatch)
 
-/**
- * \brief Utility macro to eliminate unused variable warnings.
- *
- * \param x A parameter which will be used without being evaluated.
- *
- * Slightly better than `(void)(x)` as explained [here](https://stackoverflow.com/a/4030983/9926122)
- * but only works on MSVC so fall back on the classic version for other cases.
- */
-#if defined _MSC_VER
-  #define PCL_UNUSED(x) ((void)(true ? 0 : ((x), void(), 0)))
-#else
-  #define PCL_UNUSED(x) ((void)(x))
-#endif
-
 #if defined _WIN32
 // Define math constants, without including math.h, to prevent polluting global namespace with old math methods
 // Copied from math.h

--- a/filters/include/pcl/filters/normal_refinement.h
+++ b/filters/include/pcl/filters/normal_refinement.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/pcl_macros.h>
+#include <pcl/common/utils.h>
 #include <pcl/filters/filter.h>
 
 namespace pcl
@@ -57,8 +58,8 @@ namespace pcl
                        const std::vector<int>& k_indices,
                        const std::vector<float>& k_sqr_distances)
   {
-    PCL_UNUSED(cloud);
-    PCL_UNUSED(index);
+    pcl::utils::ignore(cloud);
+    pcl::utils::ignore(index);
     // Check inputs
     if (k_indices.size () != k_sqr_distances.size ())
       PCL_ERROR("[pcl::assignNormalWeights] inequal size of neighbor indices and distances!\n");

--- a/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
@@ -43,6 +43,7 @@
 #include <pcl/pcl_base.h>
 #include <pcl/pcl_macros.h>
 #include <pcl/common/angles.h>
+#include <pcl/common/utils.h>
 #include <pcl/PointIndices.h>
 #include <pcl/ModelCoefficients.h>
 #include <pcl/segmentation/plane_coefficient_comparator.h>
@@ -294,8 +295,8 @@ namespace pcl
               PointCloudLPtr& labels,
               std::vector<pcl::PointIndices>& label_indices)
       {
-        PCL_UNUSED(centroids);
-        PCL_UNUSED(covariances);
+        pcl::utils::ignore(centroids);
+        pcl::utils::ignore(covariances);
         refine(model_coefficients, inlier_indices, labels, label_indices);
       }
 


### PR DESCRIPTION
As I was discussing in https://github.com/PointCloudLibrary/pcl/pull/3932#issuecomment-615452741 adding `PCL_UNUSED` as it was was causing `-Wunused-value`s in GCC, Clang and XCode. This solves the issue at least for the first two, so if XCode is ok with it I'm too.