### PR TITLE
Fix missing closing parenthesis in cutil_inline_runtime.h

### DIFF
--- a/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
@@ -127,7 +127,7 @@ inline int cutGetMaxGflopsDeviceId()
 	while( current_device < device_count ) {
               cudaDeviceProp deviceProp;
 		cudaGetDeviceProperties( &deviceProp, current_device );
-              int sm_per_multiproc = (deviceProp.major == 9999 && deviceProp.minor == 9999 ? 1 : _ConvertSMVer2Cores(deviceProp.major, deviceProp.minor);
+              int sm_per_multiproc = (deviceProp.major == 9999 && deviceProp.minor == 9999) ? 1 : _ConvertSMVer2Cores(deviceProp.major, deviceProp.minor);
 
 		int compute_perf  = deviceProp.multiProcessorCount * sm_per_multiproc * deviceProp.clockRate;
 		if( compute_perf  > max_compute_perf ) {


### PR DESCRIPTION
Issue introduced in #3804:
```
[ 44%] Linking CXX shared library ../../lib/libpcl_gpu_features.so
/home/sunblack/dev/pcl/cuda/common/include/pcl/cuda/cutil_inline_runtime.h(130): error: expected a ")"
```

