### PR TITLE
Fix excessive warnings on MSVC

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -189,9 +189,9 @@ namespace pcl
         * \param[in] pc the cloud to copy into this
         * \todo Erase once mapping_ is removed.
         */
-      // Ignore unknown pragma warning on MSVC (4996) and use of deprecated
+      // Ignore unknown pragma warning on MSVC (4996)
       #pragma warning(push)
-      #pragma warning(disable: 4068 4996)
+      #pragma warning(disable: 4068)
       // Ignore deprecated warning on clang compilers
       #pragma clang diagnostic push
       #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -189,9 +189,9 @@ namespace pcl
         * \param[in] pc the cloud to copy into this
         * \todo Erase once mapping_ is removed.
         */
-      // Ignore unknown pragma warning on MSVC
+      // Ignore unknown pragma warning on MSVC (4996) and use of deprecated
       #pragma warning(push)
-      #pragma warning(disable: 4068)
+      #pragma warning(disable: 4068 4996)
       // Ignore deprecated warning on clang compilers
       #pragma clang diagnostic push
       #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -189,10 +189,15 @@ namespace pcl
         * \param[in] pc the cloud to copy into this
         * \todo Erase once mapping_ is removed.
         */
+      // Ignore unknown pragma warning on MSVC
+      #pragma warning(push)
+      #pragma warning(disable: 4068)
+      // Ignore deprecated warning on clang compilers
       #pragma clang diagnostic push
       #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       PointCloud (const PointCloud<PointT> &pc) = default;
       #pragma clang diagnostic pop
+      #pragma warning(pop)
 
       /** \brief Copy constructor from point cloud subset
         * \param[in] pc the cloud to copy into this

--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -130,6 +130,9 @@ TEST (PCL, copyPointCloud)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
+// Ignore unknown pragma warning on MSVC (4996)
+#pragma warning(push)
+#pragma warning(disable: 4068)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic push
 TEST (PCL, concatenatePointCloud)
@@ -317,6 +320,7 @@ TEST (PCL, concatenatePointCloud)
   }
 }
 #pragma GCC diagnostic pop
+#pragma warning(pop)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, concatenatePointCloud2)


### PR DESCRIPTION
Another small PR to workaround MSVC's non-standard behavior.

MSVC doesn't ignore unknown pragma. So this PR disables that particular warning for one particular occurrence of the unknown pragma.