### PR TITLE
Fix bug in `SampleModelConsensusCylinder::projectPoints()`

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -316,10 +316,11 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
   projected_points.header = input_->header;
   projected_points.is_dense = input_->is_dense;
 
-  Eigen::Vector4f line_pt  (model_coefficients[0], model_coefficients[1], model_coefficients[2], 0.0f);
-  Eigen::Vector4f line_dir (model_coefficients[3], model_coefficients[4], model_coefficients[5], 0.0f);
+  Eigen::Vector3f line_pt  (model_coefficients[0], model_coefficients[1], model_coefficients[2]);
+  Eigen::Vector3f line_dir (model_coefficients[3], model_coefficients[4], model_coefficients[5]);
   float ptdotdir = line_pt.dot (line_dir);
   float dirdotdir = 1.0f / line_dir.dot (line_dir);
+
   // Copy all the data fields from the input cloud to the projected one?
   if (copy_data_fields)
   {
@@ -350,17 +351,16 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
   // Iterate through the 3d points and calculate the distances from them to the cylinder
   for (std::size_t i = 0; i < inliers.size (); ++i)
   {
-    pcl::Vector4fMap pp = projected_points.points[i].getVector4fMap();
-    Eigen::Vector4f p(input_->points[inliers[i]].x,
+    pcl::Vector3fMap pp = projected_points.points[i].getVector3fMap();
+    Eigen::Vector3f p(input_->points[inliers[i]].x,
                       input_->points[inliers[i]].y,
-                      input_->points[inliers[i]].z,
-                      0);
+                      input_->points[inliers[i]].z);
 
     float k = (p.dot (line_dir) - ptdotdir) * dirdotdir;
     // Calculate the projection of the point on the line
     pp.matrix () = line_pt + k * line_dir;
 
-    Eigen::Vector4f dir = p - pp;
+    Eigen::Vector3f dir = p - pp;
     dir.normalize ();
 
     // Calculate the projection of the point onto the cylinder
@@ -452,4 +452,3 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::isModelValid (const Eigen::V
 #define PCL_INSTANTIATE_SampleConsensusModelCylinder(PointT, PointNT)	template class PCL_EXPORTS pcl::SampleConsensusModelCylinder<PointT, PointNT>;
 
 #endif    // PCL_SAMPLE_CONSENSUS_IMPL_SAC_MODEL_CYLINDER_H_
-

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -301,7 +301,6 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::optimizeModelCoefficients (
   optimized_coefficients[4] = line_dir[1];
   optimized_coefficients[5] = line_dir[2];
 }
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename PointNT> void
 pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
@@ -333,7 +332,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
     // Iterate over each point
     for (std::size_t i = 0; i < projected_points.points.size (); ++i)
       // Iterate over each dimension
-    pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
+      pcl::for_each_type <FieldList> (NdConcatenateFunctor <PointT, PointT> (input_->points[i], projected_points.points[i]));
   }
   else
   {
@@ -352,9 +351,9 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
   for (std::size_t i = 0; i < inliers.size (); ++i)
   {
     pcl::Vector4fMap pp = projected_points.points[i].getVector4fMap();
-    Eigen::Vector4f p(input_->points[inlier].x,
-                      input_->points[inlier].y,
-                      input_->points[inlier].z,
+    Eigen::Vector4f p(input_->points[inliers[i]].x,
+                      input_->points[inliers[i]].y,
+                      input_->points[inliers[i]].z,
                       0);
 
     float k = (p.dot (line_dir) - ptdotdir) * dirdotdir;

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -451,8 +451,4 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::isModelValid (const Eigen::V
 
 #define PCL_INSTANTIATE_SampleConsensusModelCylinder(PointT, PointNT)	template class PCL_EXPORTS pcl::SampleConsensusModelCylinder<PointT, PointNT>;
 
-<<<<<<< HEAD
 #endif    // PCL_SAMPLE_CONSENSUS_IMPL_SAC_MODEL_CYLINDER_H_
-=======
-#endif    // PCL_SAMPLE_CONSENSUS_IMPL_SAC_MODEL_CYLINDER_H_
->>>>>>> 4e8edefb0d280b4923ad563457f74f57a7fff595

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -342,7 +342,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
       Eigen::Vector4f p (input_->points[inlier].x,
                          input_->points[inlier].y,
                          input_->points[inlier].z,
-                         1);
+                         0);
 
       float k = (p.dot (line_dir) - ptdotdir) * dirdotdir;
 


### PR DESCRIPTION
As proposed by @kunaltyagi in #3876 .

I am unsure about the math behind it but this change does it for me.
However, if `copy_data_fields` is false, this change does not help.