### PR TITLE
[surface] Reduce time taken in `TextureMapping::sortFacesByCamera` from `O(faces*points)` to `O(faces)`

### DIFF
--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -593,7 +593,7 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
       // iterate over face's vertex
       const auto faceIsVisible = std::all_of(tex_mesh.tex_polygons[0][faces].vertices.cbegin(),
                                              tex_mesh.tex_polygons[0][faces].vertices.cend(),
-                                             [this, occluded_set, transformed_cloud, camera](const auto& vertex)
+                                             [&](const auto& vertex)
       {
           if (occluded_set.find(vertex) != occluded_set.cend()) {
             return false;  // point is occluded

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -577,15 +577,11 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
 
     // find occlusions on transformed cloud
     std::vector<int> visible, occluded;
-    std::unordered_set<int> occluded_set;
     removeOccludedPoints (transformed_cloud, filtered_cloud, octree_voxel_size, visible, occluded);
     visible_pts = *filtered_cloud;
 
     // pushing occluded idxs into a set for faster lookup
-    for (int occluded_idx = 0; occluded_idx < (int)occluded.size(); ++occluded_idx)
-    {
-      occluded_set.insert(occluded[occluded_idx]);
-    }
+    std::unordered_set<int> occluded_set(occluded.begin(), occluded.end());
 
     // find visible faces => add them to polygon N for camera N
     // add polygon group for current camera in clean

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -600,7 +600,7 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
           }
           // is the point visible to the camera?
           Eigen::Vector2f dummy_UV;
-          return this->getPointUVCoordinates (transformed_cloud->points[vertex], camera, dummy_UV);
+          return this->getPointUVCoordinates ((*transformed_cloud)[vertex], camera, dummy_UV);
       });
 
       if (faceIsVisible)

--- a/surface/include/pcl/surface/impl/texture_mapping.hpp
+++ b/surface/include/pcl/surface/impl/texture_mapping.hpp
@@ -581,7 +581,7 @@ pcl::TextureMapping<PointInT>::sortFacesByCamera (pcl::TextureMesh &tex_mesh, pc
     visible_pts = *filtered_cloud;
 
     // pushing occluded idxs into a set for faster lookup
-    std::unordered_set<int> occluded_set(occluded.begin(), occluded.end());
+    std::unordered_set<index_t> occluded_set(occluded.cbegin(), occluded.cend());
 
     // find visible faces => add them to polygon N for camera N
     // add polygon group for current camera in clean
@@ -1089,4 +1089,3 @@ pcl::TextureMapping<PointInT>::isFaceProjected (const Camera &camera, const Poin
     template class PCL_EXPORTS pcl::TextureMapping<T>;
 
 #endif /* TEXTURE_MAPPING_HPP_ */
-


### PR DESCRIPTION
For large meshes, the old code was prohibitively slow, and had a TODO to address that. Changing from a vector to an unordered_set reduces the outer loop's complexity from O(N*M) to O(N) where N is the number of faces in a mesh and M is the number of points in the point cloud. 

On the sample mesh I was using, I reduced the processing time for 3 test images from over 20 minutes to under 2. 