### PR TITLE
Add dockerfiles for testing before release

### DIFF
--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -62,3 +62,37 @@ stages:
         dockerfile: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros/Dockerfile'
         buildContext: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros'
         tags: "$(tag)"
+- stage: Source
+  dependsOn: ["Debian", "ROS"]
+  jobs:
+  - job: src_code
+    displayName: "Package Source Code"
+    timeoutInMinutes: 360
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      # find the commit hash on a quick non-forced update too
+      fetchDepth: 10
+    - task: Bash@3
+      displayName: "Remove git files"
+      inputs:
+        targetType: 'inline'
+        script: 'rm -fr ./.git'
+        workingDirectory: '$(Build.SourcesDirectory)'
+        failOnStderr: true
+    - task: ArchiveFiles@2
+      displayName: "Create release archive"
+      inputs:
+        rootFolderOrFile: '$(Build.SourcesDirectory)'
+        includeRootFolder: true
+        archiveType: 'tar'
+        archiveFile: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
+        replaceExistingArchive: true
+        verbose: true
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish archive"
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: 'source.tar.gz'
+          publishLocation: 'Container'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -50,8 +50,8 @@ stages:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        ROS Kinetic:
-          flavor: "kinetic"
+        # Only ROS Melodic works with current releases of PCL
+        # Kinetic has stopped supporting any version later than PCL 1.7.2
         ROS Melodic:
           flavor: "melodic"
     variables:

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -12,6 +12,10 @@ trigger: none
 resources:
 - repo: self
 
+variables:
+  dockerHub: "PersonalDockerHub"
+  dockerHubID: "kunaltyagi"
+
 stages:
 - stage: Debian
   dependsOn: []

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -1,0 +1,64 @@
+# Release PCL steps:
+# 1. Check tests:
+#   * debian:latest
+#   * perception_pcl
+# 2. Package for
+#   * MacOS
+#   * tar source release
+#   * Windows Installers
+
+resources:
+- repo: self
+
+variables:
+  dockerHub: "PersonalDockerHub"
+  dockerHubID: "kunaltyagi"
+
+stages:
+- stage: Debian
+  jobs:
+  - job: BuildDebian
+    displayName: "Build Debian Latest"
+    dependsOn: []
+    timeoutInMinutes: 360
+    variables:
+      tag: "release"
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      # find the commit hash on a quick non-forced update too
+      fetchDepth: 10
+    - task: Docker@2
+      displayName: "Build docker image"
+      inputs:
+        command: build
+        arguments: |
+          --no-cache
+          -t $(dockerHubID)/release:$(tag)
+        dockerfile: '$(Build.SourcesDirectory)/.dev/docker/release/Dockerfile'
+        tags: "$(tag)"
+- stage: ROS
+  jobs:
+  - job: PerceptionPCL
+    displayName: "perception_pcl compile"
+    dependsOn: []
+    timeoutInMinutes: 360
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+      tag: "ros"
+    steps:
+    - checkout: self
+      # find the commit hash on a quick non-forced update too
+      fetchDepth: 10
+    - task: Docker@2
+      displayName: "Build docker image"
+      inputs:
+        command: build
+        arguments: |
+          --no-cache
+          -t $(dockerHubID)/release:$(tag)
+        dockerfile: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl/Dockerfile'
+        buildContext: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl'
+        tags: "$(tag)"

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -16,10 +16,10 @@ variables:
 
 stages:
 - stage: Debian
+  dependsOn: []
   jobs:
   - job: BuildDebian
     displayName: "Build Debian Latest"
-    dependsOn: []
     timeoutInMinutes: 360
     variables:
       tag: "release"
@@ -39,10 +39,10 @@ stages:
         dockerfile: '$(Build.SourcesDirectory)/.dev/docker/release/Dockerfile'
         tags: "$(tag)"
 - stage: ROS
+  dependsOn: []
   jobs:
   - job: PerceptionPCL
     displayName: "perception_pcl compile"
-    dependsOn: []
     timeoutInMinutes: 360
     pool:
       vmImage: 'ubuntu-latest'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -90,9 +90,9 @@ stages:
         archiveFile: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
         replaceExistingArchive: true
         verbose: true
-      - task: PublishBuildArtifacts@1
-        displayName: "Publish archive"
-        inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-          ArtifactName: 'source.tar.gz'
-          publishLocation: 'Container'
+    - task: PublishBuildArtifacts@1
+      displayName: "Publish archive"
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'source.tar.gz'
+        publishLocation: 'Container'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -12,10 +12,6 @@ trigger: None
 resources:
 - repo: self
 
-variables:
-  dockerHub: "PersonalDockerHub"
-  dockerHubID: "kunaltyagi"
-
 stages:
 - stage: Debian
   dependsOn: []
@@ -23,10 +19,10 @@ stages:
   - job: BuildDebian
     displayName: "Build Debian Latest"
     timeoutInMinutes: 360
-    variables:
-      tag: "release"
     pool:
       vmImage: 'ubuntu-latest'
+    variables:
+      tag: "release"
     steps:
     - checkout: self
       # find the commit hash on a quick non-forced update too
@@ -46,14 +42,14 @@ stages:
   - job: PerceptionPCL
     displayName: "perception_pcl compile"
     timeoutInMinutes: 360
+    pool:
+      vmImage: 'ubuntu-latest'
     strategy:
       matrix:
         ROS Kinetic:
           flavor: "kinetic"
         ROS Melodic:
           flavor: "melodic"
-    pool:
-      vmImage: 'ubuntu-latest'
     variables:
       tag: "ros"
     steps:
@@ -71,7 +67,7 @@ stages:
         dockerfile: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros/Dockerfile'
         buildContext: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros'
         tags: "$(tag)"
-- stage: Source
+- stage: Prepare
   dependsOn: ["Debian", "ROS"]
   jobs:
   - job: src_code
@@ -79,6 +75,8 @@ stages:
     timeoutInMinutes: 360
     pool:
       vmImage: 'ubuntu-latest'
+    variables:
+      SOURCE_TAR: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
     steps:
     - checkout: self
       # find the commit hash on a quick non-forced update too
@@ -96,12 +94,57 @@ stages:
         rootFolderOrFile: '$(Build.SourcesDirectory)'
         includeRootFolder: true
         archiveType: 'tar'
-        archiveFile: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
+        archiveFile: '$(SOURCE_TAR)'
         replaceExistingArchive: true
         verbose: true
     - task: PublishBuildArtifacts@1
       displayName: "Publish archive"
       inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        PathtoPublish: '$(SOURCE_TAR)'
         ArtifactName: 'source.tar.gz'
         publishLocation: 'Container'
+  - job: documentation
+    displayName: Generate Documentation
+    container: pointcloudlibrary/doc
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+      BUILD_DIR: '$(Agent.BuildDirectory)/build'
+      CHANGELOG: '$(Build.ArtifactStagingDirectory)/changelog.md'
+    steps:
+    - checkout: self
+      # find the commit hash on a quick non-forced update too
+      fetchDepth: 10
+    - script: |
+        $(Build.SourcesDirectory)/.dev/scripts/generate_changelog.py --with-misc > $(CHANGELOG)
+        pandoc -f markdown -t plain --wrap=none $(CHANGELOG)
+      displayName: 'Generate Changelog'
+    - task: PublishBuildArtifacts@1
+      displayName: "Publish Changelog"
+      inputs:
+        PathtoPublish: '$(CHANGELOG)'
+        ArtifactName: 'changelog.md'
+        publishLocation: 'Container'
+#- stage: Release
+#  dependsOn: ["Source"]
+#  jobs:
+#  - job: release
+#    displayName: "Release the kraken"
+#    timeoutInMinutes: 360
+#    pool:
+#      vmImage: 'ubuntu-latest'
+#    steps:
+#    - task: GitHubRelease@1
+#      inputs:
+#        gitHubConnection: 'Release to GitHub'
+#        repositoryName: 'kunaltyagi/pcl'
+#        action: 'create'
+#        target: '$(Build.SourceVersion)'
+#        tagSource: 'gitTag'
+#        tagPattern: 'pcl-*'
+#        releaseNotesFilePath: '$(Build.ArtifactStagingDirectory)/release.md'
+#        isDraft: true
+#        isPreRelease: true
+#        changeLogCompareToRelease: 'lastFullRelease'
+#        changeLogType: 'issueBased'
+#        changeLogLabels: '[{ "label" : "changelog: new feature", "displayName" : "New", "state" : "closed" }]'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -59,6 +59,6 @@ stages:
         arguments: |
           --no-cache
           -t $(dockerHubID)/release:$(tag)
-        dockerfile: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl/Dockerfile'
-        buildContext: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl'
+        dockerfile: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros/Dockerfile'
+        buildContext: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros'
         tags: "$(tag)"

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -7,6 +7,8 @@
 #   * tar source release
 #   * Windows Installers
 
+trigger: None
+
 resources:
 - repo: self
 

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -44,6 +44,12 @@ stages:
   - job: PerceptionPCL
     displayName: "perception_pcl compile"
     timeoutInMinutes: 360
+    strategy:
+      matrix:
+        ROS Kinetic:
+          flavor: "kinetic"
+        ROS Melodic:
+          flavor: "melodic"
     pool:
       vmImage: 'ubuntu-latest'
     variables:
@@ -58,6 +64,7 @@ stages:
         command: build
         arguments: |
           --no-cache
+          --build-arg flavor=$(flavor)
           -t $(dockerHubID)/release:$(tag)
         dockerfile: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros/Dockerfile'
         buildContext: '$(Build.SourcesDirectory)/.dev/docker/perception_pcl_ros'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -7,7 +7,7 @@
 #   * tar source release
 #   * Windows Installers
 
-trigger: None
+trigger: none
 
 resources:
 - repo: self

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -109,7 +109,8 @@ stages:
         publishLocation: 'Container'
   - job: documentation
     displayName: Generate Documentation
-    container: pointcloudlibrary/doc
+    container:
+      image: pointcloudlibrary/doc
     pool:
       vmImage: 'ubuntu-latest'
     variables:
@@ -129,26 +130,3 @@ stages:
         PathtoPublish: '$(CHANGELOG)'
         ArtifactName: 'changelog.md'
         publishLocation: 'Container'
-#- stage: Release
-#  dependsOn: ["Source"]
-#  jobs:
-#  - job: release
-#    displayName: "Release the kraken"
-#    timeoutInMinutes: 360
-#    pool:
-#      vmImage: 'ubuntu-latest'
-#    steps:
-#    - task: GitHubRelease@1
-#      inputs:
-#        gitHubConnection: 'Release to GitHub'
-#        repositoryName: 'kunaltyagi/pcl'
-#        action: 'create'
-#        target: '$(Build.SourceVersion)'
-#        tagSource: 'gitTag'
-#        tagPattern: 'pcl-*'
-#        releaseNotesFilePath: '$(Build.ArtifactStagingDirectory)/release.md'
-#        isDraft: true
-#        isPreRelease: true
-#        changeLogCompareToRelease: 'lastFullRelease'
-#        changeLogType: 'issueBased'
-#        changeLogLabels: '[{ "label" : "changelog: new feature", "displayName" : "New", "state" : "closed" }]'

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -1,11 +1,17 @@
+# flavor appears twice, once for the FOR, once for the contents since
+# Dockerfile seems to reset arguments after a FOR appears
 ARG flavor="melodic"
+FROM ros:${flavor}-ros-core
 
+ARG flavor="melodic"
 ARG workspace="/root/catkin_ws"
 
-FROM ros:${flavor}-ros-core
 COPY ${flavor}_rosinstall.yaml ${workspace}/src/.rosinstall
 
-# Be careful, ROS uses Python2
+# Be careful:
+# * ROS uses Python2
+# * source ROS setup file in evey RUN snippet
+#
 # The dependencies of PCL can be reduced since
 # * we don't need to build visualization or docs
 RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -20,6 +20,7 @@ RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \
     libeigen3-dev \
     libflann-dev \
     python-pip \
+    ros-${flavor}-tf2-eigen \
  && apt build-dep pcl -y \
  && pip install -U pip \
  && pip install catkin_tools \
@@ -34,5 +35,5 @@ COPY package.xml ${workspace}/src/pcl/
 RUN cd ${workspace} \
  && . "/opt/ros/${flavor}/setup.sh" \
  && catkin config --install \
- && catkin build libpcl-all-dev --cmake-args -DWITH_OPENGL:BOOL=OFF \
+ && catkin build -j2 libpcl-all-dev --cmake-args -DWITH_OPENGL:BOOL=OFF \
  && catkin build

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -26,5 +26,6 @@ RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \
 COPY package.xml ${workspace}/src/pcl/
 
 RUN cd ${workspace} \
+ && . "/opt/ros/${flavor}/setup.sh" \
  && catkin build libpcl-all-dev --cmake-args -DWITH_OPENGL:BOOL=OFF \
  && catkin build

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -1,7 +1,7 @@
 # flavor appears twice, once for the FOR, once for the contents since
 # Dockerfile seems to reset arguments after a FOR appears
 ARG flavor="melodic"
-FROM ros:${flavor}-ros-core
+FROM ros:${flavor}-robot
 
 ARG flavor="melodic"
 ARG workspace="/root/catkin_ws"

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -1,0 +1,29 @@
+ARG flavor="melodic"
+
+ARG workspace="/root/catkin_ws"
+
+FROM ros:${flavor}-ros-core
+COPY ${flavor}_rosinstall.yaml ${workspace}/src/.rosinstall
+
+# Be careful, ROS uses Python2
+# The dependencies of PCL can be reduced since
+# * we don't need to build visualization or docs
+RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \
+ && apt update \
+ && apt install -y \
+    libeigen3-dev \
+    libflann-dev \
+    python-pip \
+ && apt build-dep pcl -y \
+ && pip install -U pip \
+ && pip install catkin_tools \
+ && cd ${workspace}/src \
+ && catkin_init_workspace \
+ && cd .. \
+ && wstool update -t src
+
+COPY package.xml ${workspace}/src/pcl/
+
+RUN cd ${workspace} \
+ && catkin build libpcl-all-dev --cmake-args -DWITH_OPENGL:BOOL=OFF \
+ && catkin build

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \
  && pip install -U pip \
  && pip install catkin_tools \
  && cd ${workspace}/src \
+ && source "/opt/ros/${flavor}/setup.sh" \
  && catkin_init_workspace \
  && cd .. \
  && wstool update -t src

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -33,5 +33,6 @@ COPY package.xml ${workspace}/src/pcl/
 
 RUN cd ${workspace} \
  && . "/opt/ros/${flavor}/setup.sh" \
+ && catkin config --install \
  && catkin build libpcl-all-dev --cmake-args -DWITH_OPENGL:BOOL=OFF \
  && catkin build

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -18,7 +18,7 @@ RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \
  && pip install -U pip \
  && pip install catkin_tools \
  && cd ${workspace}/src \
- && source "/opt/ros/${flavor}/setup.sh" \
+ && . "/opt/ros/${flavor}/setup.sh" \
  && catkin_init_workspace \
  && cd .. \
  && wstool update -t src

--- a/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
@@ -12,7 +12,7 @@
     version: 'indigo-devel'
 - git:
     local-name: 'kinetic/dynamic_reconfigure'
-    uti: 'https://github.com/ros/dynamic_reconfigure'
+    uri: 'https://github.com/ros/dynamic_reconfigure'
     version: 'master'
 - git:
     local-name: 'pcl'

--- a/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
@@ -11,6 +11,10 @@
     uri: 'https://github.com/ros-perception/pcl_msgs'
     version: 'indigo-devel'
 - git:
+    local-name: 'kinetic/dynamic_reconfigure'
+    uti: 'https://github.com/ros/dynamic_reconfigure'
+    version: 'master'
+- git:
     local-name: 'pcl'
     uri: 'https://github.com/PointCloudLibrary/pcl'
     version: 'master'

--- a/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
@@ -1,0 +1,16 @@
+- git:
+    local-name: 'kinetic/perception_pcl'
+    uri: 'https://github.com/ros-perception/perception_pcl'
+    version: 'kinetic-devel'
+- git:
+    local-name: 'kinetic/common_msgs'
+    uri: 'https://github.com/ros/common_msgs'
+    version: 'jade-devel'
+- git:
+    local-name: 'kinetic/pcl_msgs'
+    uri: 'https://github.com/ros-perception/pcl_msgs'
+    version: 'indigo-devel'
+- git:
+    local-name: 'pcl'
+    uri: 'https://github.com/PointCloudLibrary/pcl'
+    version: 'master'

--- a/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
@@ -3,6 +3,10 @@
     uri: 'https://github.com/ros-perception/perception_pcl'
     version: 'kinetic-devel'
 - git:
+    local-name: 'kinetic/pcl_conversions'
+    uri: 'https://github.com/ros-perception/pcl_conversions'
+    version: 'indigo-devel'
+- git:
     local-name: 'kinetic/pcl_msgs'
     uri: 'https://github.com/ros-perception/pcl_msgs'
     version: 'indigo-devel'

--- a/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
@@ -13,4 +13,5 @@
 - git:
     local-name: 'pcl'
     uri: 'https://github.com/PointCloudLibrary/pcl'
-    version: 'master'
+    # Kinetic doesn't support PCL 1.8 onwards
+    version: '1.7.2'

--- a/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/kinetic_rosinstall.yaml
@@ -3,17 +3,9 @@
     uri: 'https://github.com/ros-perception/perception_pcl'
     version: 'kinetic-devel'
 - git:
-    local-name: 'kinetic/common_msgs'
-    uri: 'https://github.com/ros/common_msgs'
-    version: 'jade-devel'
-- git:
     local-name: 'kinetic/pcl_msgs'
     uri: 'https://github.com/ros-perception/pcl_msgs'
     version: 'indigo-devel'
-- git:
-    local-name: 'kinetic/dynamic_reconfigure'
-    uri: 'https://github.com/ros/dynamic_reconfigure'
-    version: 'master'
 - git:
     local-name: 'pcl'
     uri: 'https://github.com/PointCloudLibrary/pcl'

--- a/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
@@ -3,17 +3,9 @@
     uri: 'https://github.com/ros-perception/perception_pcl'
     version: 'melodic-devel'
 - git:
-    local-name: 'melodic/common_msgs'
-    uri: 'https://github.com/ros/common_msgs'
-    version: 'jade-devel'
-- git:
     local-name: 'melodic/pcl_msgs'
     uri: 'https://github.com/ros-perception/pcl_msgs'
     version: 'indigo-devel'
-- git:
-    local-name: 'melodic/dynamic_reconfigure'
-    uri: 'https://github.com/ros/dynamic_reconfigure'
-    version: 'melodic-devel'
 - git:
     local-name: 'pcl'
     uri: 'https://github.com/PointCloudLibrary/pcl'

--- a/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
@@ -11,6 +11,10 @@
     uri: 'https://github.com/ros-perception/pcl_msgs'
     version: 'indigo-devel'
 - git:
+    local-name: 'melodic/dynamic_reconfigure'
+    uti: 'https://github.com/ros/dynamic_reconfigure'
+    version: 'melodic-devel'
+- git:
     local-name: 'pcl'
     uri: 'https://github.com/PointCloudLibrary/pcl'
     version: 'master'

--- a/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
@@ -1,0 +1,16 @@
+- git:
+    local-name: 'melodic/perception_pcl'
+    uri: 'https://github.com/ros-perception/perception_pcl'
+    version: 'melodic-devel'
+- git:
+    local-name: 'melodic/common_msgs'
+    uri: 'https://github.com/ros/common_msgs'
+    version: 'jade-devel'
+- git:
+    local-name: 'melodic/pcl_msgs'
+    uri: 'https://github.com/ros-perception/pcl_msgs'
+    version: 'indigo-devel'
+- git:
+    local-name: 'pcl'
+    uri: 'https://github.com/PointCloudLibrary/pcl'
+    version: 'master'

--- a/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/melodic_rosinstall.yaml
@@ -12,7 +12,7 @@
     version: 'indigo-devel'
 - git:
     local-name: 'melodic/dynamic_reconfigure'
-    uti: 'https://github.com/ros/dynamic_reconfigure'
+    uri: 'https://github.com/ros/dynamic_reconfigure'
     version: 'melodic-devel'
 - git:
     local-name: 'pcl'

--- a/.dev/docker/perception_pcl_ros/package.xml
+++ b/.dev/docker/perception_pcl_ros/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>libpcl-all-dev</name>
+  <version>0.1.0</version>
+  <description>
+    Standalone, large scale, open project for 2D/3D image and point cloud processing
+  </description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <maintainer email="tyagi.kunal@live.com">kunal_tyagi</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://github.com/PointCloudLibrary/pcl</url>
+
+  <author email="tyagi.kunal@live.com">kunal_tyagi</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>libeigen3-dev</build_depend>
+  <build_depend>libflann-dev</build_depend>
+      <!--libvtk6-dev -->
+  <test_depend>gtest</test_depend>
+  <doc_depend>doxygen</doc_depend>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+  </export>
+</package>

--- a/.dev/docker/release/Dockerfile
+++ b/.dev/docker/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:testing
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.dev/docker/release/Dockerfile
+++ b/.dev/docker/release/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Add sources so we can just install build-dependencies of PCL
+RUN sed -i 's/^deb \(.*\)$/deb \1\ndeb-src \1/' /etc/apt/sources.list \
+ && apt update \
+ && apt install -y \
+    bash \
+    cmake \
+    dpkg-dev \
+    git \
+ && apt build-dep pcl -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# CMake flags are from dpkg helper
+# PCL config is from debian repo:
+# https://salsa.debian.org/science-team/pcl/-/blob/master/debian/rules
+RUN cd \
+ && git clone --depth=1 https://github.com/PointCloudLibrary/pcl \
+ && mkdir pcl/build \
+ && cd pcl/build \
+ && export DEB_BUILD_MAINT_OPTIONS='hardening=+all' \
+ && export DEB_CFLAGS_MAINT_APPEND="-Wall -pedantic" \
+ && export DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed" \
+ && cmake .. \
+    -DCMAKE_CXX_FLAGS="`dpkg-buildflags --get CXXFLAGS`" \
+    -DCMAKE_EXE_LINKER_FLAGS:STRING="`dpkg-buildflags --get LDFLAGS`" \
+    -DCMAKE_SHARED_LINKER_FLAGS:STRING="`dpkg-buildflags --get LDFLAGS`" \
+    -DCMAKE_SKIP_RPATH=ON -DPCL_ENABLE_SSE=OFF         \
+    -DBUILD_TESTS=OFF -DBUILD_apps=ON -DBUILD_common=ON     \
+    -DBUILD_examples=ON -DBUILD_features=ON -DBUILD_filters=ON  \
+    -DBUILD_geometry=ON -DBUILD_global_tests=OFF -DBUILD_io=ON  \
+    -DBUILD_kdtree=ON -DBUILD_keypoints=ON -DBUILD_octree=ON    \
+    -DBUILD_registration=ON -DBUILD_sample_consensus=ON     \
+    -DBUILD_search=ON -DBUILD_segmentation=ON -DBUILD_surface=ON    \
+    -DBUILD_tools=ON -DBUILD_tracking=ON -DBUILD_visualization=ON   \
+    -DBUILD_apps_cloud_composer=OFF -DBUILD_apps_modeler=ON            \
+    -DBUILD_apps_point_cloud_editor=ON -DBUILD_apps_in_hand_scanner=ON \
+ && make install -j2 \
+ && cd \
+ && rm -fr pcl


### PR DESCRIPTION
* Adds a dockerfile for building PCL on `debian:testing`
* Adds a dockerfile for building PCL and `perception_pcl` on `kinetic` and `melodic` flavors of ROS
* Adds a CI to perform some tasks of the release with a manual trigger
* Kinetic `perception_pcl` is broken since 1.10, and can't be targeted by PCL
* Tested manually for melodic

Offshoots of this PR:
* PR ros-perception/perception_pcl#273 to address changes in downstream project to handle change of pointers

TODO after this PR:
* Test CI