### PR TITLE
Fix typos in planar segmentation tutorial

### DIFF
--- a/doc/tutorials/content/planar_segmentation.rst
+++ b/doc/tutorials/content/planar_segmentation.rst
@@ -3,8 +3,8 @@
 Plane model segmentation
 -------------------------
 
-In this tutorial we will learn how do a simple plane segmentation of a set of
-points, that is find all the points within a point cloud that support a plane
+In this tutorial we will learn how to do a simple plane segmentation of a set of
+points, that is to find all the points within a point cloud that support a plane
 model. This tutorial supports the :ref:`extract_indices` tutorial, presented in
 the **filtering** section.
 
@@ -58,8 +58,7 @@ Then, lines:
 
    
 create the :pcl:`SACSegmentation <pcl::SACSegmentation>` object and set the model and method type.  
-This is also where we specify the "distance threshold", which  determines how close a point must be to the model 
-in order to be considered an inlier. 
+This is also where we specify the "distance threshold", which determines how close a point must be to the model in order to be considered an inlier. 
 In this tutorial, we will use the RANSAC method (pcl::SAC_RANSAC) as the robust estimator of choice. 
 Our decision is motivated by RANSAC's simplicity (other robust estimators use it as
 a base and add additional, more complicated concepts). For more information
@@ -127,7 +126,7 @@ A graphical display of the segmentation process is shown below.
 
 .. image:: images/planar_segmentation_2.png
 
-Note that the coordinate axis are represented as red (x), green (y), and blue
+Note that the coordinate axes are represented as red (x), green (y), and blue
 (z). The points are represented with red as the outliers, and green as the
 inliers of the plane model found.
 


### PR DESCRIPTION
1. fix grammar
2. fix the plural format of "axis"