### PR TITLE
Prevent CXX11 ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(CMAKE_VERSION VERSION_LESS 3.8)
   set(PCL_CXX_COMPILE_FEATURES cxx_attribute_deprecated)
 else()
   set(PCL_CXX_COMPILE_FEATURES cxx_std_14)
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 endif()
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "possible configurations" FORCE)


### PR DESCRIPTION
Setting the -Wabi=11 flag to prevent ABI warnings has the side-effect of putting certain calls into the CXX11 ABI standard which causes link errors due to cxx11-suffixed symbols. This change prevents CXX11 whilst keeping the warnings suppressed.

This is related to: https://github.com/PointCloudLibrary/pcl/issues/2406