### PR TITLE
[registration] Removing deprecated method `setInputCloud`  from public API

### DIFF
--- a/doc/tutorials/content/sources/iccv2011/include/registration.h
+++ b/doc/tutorials/content/sources/iccv2011/include/registration.h
@@ -34,7 +34,7 @@ computeInitialAlignment (const PointCloudPtr & source_points, const LocalDescrip
   sac_ia.setMaxCorrespondenceDistance (max_correspondence_distance);
   sac_ia.setMaximumIterations (nr_iterations);
   
-  sac_ia.setInputCloud (source_points);
+  sac_ia.setInputSource (source_points);
   sac_ia.setSourceFeatures (source_descriptors);
 
   sac_ia.setInputTarget (target_points);
@@ -81,7 +81,7 @@ refineAlignment (const PointCloudPtr & source_points, const PointCloudPtr & targ
   PointCloudPtr source_points_transformed (new PointCloud);
   pcl::transformPointCloud (*source_points, *source_points_transformed, initial_alignment);
 
-  icp.setInputCloud (source_points_transformed);
+  icp.setInputSource (source_points_transformed);
   icp.setInputTarget (target_points);
 
   PointCloud registration_output;

--- a/doc/tutorials/content/sources/iccv2011/src/tutorial.cpp
+++ b/doc/tutorials/content/sources/iccv2011/src/tutorial.cpp
@@ -344,7 +344,7 @@ void ICCVTutorial<FeatureType>::determineFinalTransformation ()
 {
   std::cout << "final registration..." << std::flush;
   pcl::Registration<pcl::PointXYZRGB, pcl::PointXYZRGB>::Ptr registration (new pcl::IterativeClosestPoint<pcl::PointXYZRGB, pcl::PointXYZRGB>);
-  registration->setInputCloud(source_transformed_);
+  registration->setInputSource(source_transformed_);
   //registration->setInputCloud(source_segmented_);
   registration->setInputTarget (target_segmented_);
   registration->setMaxCorrespondenceDistance(0.05);

--- a/doc/tutorials/content/sources/iros2011/include/solution/registration.h
+++ b/doc/tutorials/content/sources/iros2011/include/solution/registration.h
@@ -34,7 +34,7 @@ computeInitialAlignment (const PointCloudPtr & source_points, const LocalDescrip
   sac_ia.setMaxCorrespondenceDistance (max_correspondence_distance);
   sac_ia.setMaximumIterations (nr_iterations);
   
-  sac_ia.setInputCloud (source_points);
+  sac_ia.setInputSource (source_points);
   sac_ia.setSourceFeatures (source_descriptors);
 
   sac_ia.setInputTarget (target_points);
@@ -81,7 +81,7 @@ refineAlignment (const PointCloudPtr & source_points, const PointCloudPtr & targ
   PointCloudPtr source_points_transformed (new PointCloud);
   pcl::transformPointCloud (*source_points, *source_points_transformed, initial_alignment);
 
-  icp.setInputCloud (source_points_transformed);
+  icp.setInputSource (source_points_transformed);
   icp.setInputTarget (target_points);
 
   PointCloud registration_output;

--- a/doc/tutorials/content/sources/template_alignment/template_alignment.cpp
+++ b/doc/tutorials/content/sources/template_alignment/template_alignment.cpp
@@ -162,7 +162,7 @@ class TemplateAlignment
     void
     align (FeatureCloud &template_cloud, TemplateAlignment::Result &result)
     {
-      sac_ia_.setInputCloud (template_cloud.getPointCloud ());
+      sac_ia_.setInputSource (template_cloud.getPointCloud ());
       sac_ia_.setSourceFeatures (template_cloud.getLocalFeatures ());
 
       pcl::PointCloud<pcl::PointXYZ> registration_output;

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -612,8 +612,15 @@ namespace pcl
 
       /**
        * \brief Remove from public API in favor of \ref setInputSource
+       *
+       * Still gives the correct result (with a warning)
        */
-      using PCLBase<PointSource>::setInputCloud;
+      void setInputCloud (const PointCloudSourceConstPtr &cloud) override
+      {
+          PCL_WARN ("[pcl::registration::Registration] setInputCloud is deprecated."
+                    "Please use setInputSource instead.\n");
+          setInputSource (cloud);
+      }
 
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -609,6 +609,12 @@ namespace pcl
     private:
       /** \brief The point representation used (internal). */
       PointRepresentationConstPtr point_representation_;
+
+      /**
+       * \brief Remove from public API in favor of \ref setInputSource
+       */
+      using PCLBase<PointSource>::setInputCloud;
+
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW
    };


### PR DESCRIPTION
Fixes #2724 by making compiler emit compile error if previously deprecated method is used