### PR TITLE
[docs] Improve output to match the text in tutorial by adding a newline

### DIFF
--- a/doc/tutorials/content/sources/voxel_grid/voxel_grid.cpp
+++ b/doc/tutorials/content/sources/voxel_grid/voxel_grid.cpp
@@ -15,7 +15,7 @@ main (int argc, char** argv)
   reader.read ("table_scene_lms400.pcd", *cloud); // Remember to download the file first!
 
   std::cerr << "PointCloud before filtering: " << cloud->width * cloud->height 
-       << " data points (" << pcl::getFieldsList (*cloud) << ").";
+       << " data points (" << pcl::getFieldsList (*cloud) << ")." << std::endl;
 
   // Create the filtering object
   pcl::VoxelGrid<pcl::PCLPointCloud2> sor;
@@ -24,7 +24,7 @@ main (int argc, char** argv)
   sor.filter (*cloud_filtered);
 
   std::cerr << "PointCloud after filtering: " << cloud_filtered->width * cloud_filtered->height 
-       << " data points (" << pcl::getFieldsList (*cloud_filtered) << ").";
+       << " data points (" << pcl::getFieldsList (*cloud_filtered) << ")." << std::endl;
 
   pcl::PCDWriter writer;
   writer.write ("table_scene_lms400_downsampled.pcd", *cloud_filtered, 


### PR DESCRIPTION
The output of this file is originally 

> PointCloud before filtering: 460400 data points (x y z intensity distance sid).PointCloud after filtering: 41049 data points (x y z intensity distance sid).

This PR adds std::endl so that its output looks just like the output in the tutorial.