### PR TITLE
remove_outliers tutorial: make the output of -r and -c consistent

### DIFF
--- a/doc/tutorials/content/remove_outliers.rst
+++ b/doc/tutorials/content/remove_outliers.rst
@@ -52,7 +52,7 @@ For the *RadiusOutlierRemoval*, the user must specify '-r' as the command line a
 
 .. literalinclude:: sources/remove_outliers/remove_outliers.cpp
    :language: cpp
-   :lines: 29-37
+   :lines: 29-38
 
 Basically, we create the RadiusOutlierRemoval filter object, set its parameters and apply it to our input cloud.  The radius of search is set to 0.8, and a point must have a minimum of 2 neighbors in that radius to be kept as part of the PointCloud.
 
@@ -60,7 +60,7 @@ For the *ConditionalRemoval* class, the user must specify '-c' as the command li
 
 .. literalinclude:: sources/remove_outliers/remove_outliers.cpp
    :language: cpp
-   :lines: 38-53
+   :lines: 39-54
 
 Basically, we create the condition which a given point must satisfy for it to remain in our PointCloud.  In this example, we use add two comparisons to the condition: greater than (GT) 0.0 and less than (LT) 0.8.  This condition is then used to build the filter. 
 
@@ -70,7 +70,7 @@ The following code just outputs PointCloud before filtering and then after apply
 
 .. literalinclude:: sources/remove_outliers/remove_outliers.cpp
    :language: cpp
-   :lines: 58-68
+   :lines: 59-69
 
 Compiling and running remove_outliers.cpp
 ---------------------------------------------

--- a/doc/tutorials/content/sources/remove_outliers/remove_outliers.cpp
+++ b/doc/tutorials/content/sources/remove_outliers/remove_outliers.cpp
@@ -32,6 +32,7 @@ int
     outrem.setInputCloud(cloud);
     outrem.setRadiusSearch(0.8);
     outrem.setMinNeighborsInRadius (2);
+    outrem.setKeepOrganized(true);
     // apply filter
     outrem.filter (*cloud_filtered);
   }


### PR DESCRIPTION
Output of `./remove_outliers -r`:
Before:
```
Cloud before filtering: 
    0.352222 -0.151883 -0.106395
    -0.397406 -0.473106 0.292602
    -0.731898 0.667105 0.441304
    -0.734766 0.854581 -0.0361733
    -0.4607 -0.277468 -0.916762
Cloud after filtering:
```
After this PR:
```
Cloud before filtering: 
    0.352222 -0.151883 -0.106395
    -0.397406 -0.473106 0.292602
    -0.731898 0.667105 0.441304
    -0.734766 0.854581 -0.0361733
    -0.4607 -0.277468 -0.916762
Cloud after filtering: 
    nan nan nan
    nan nan nan
    nan nan nan
    nan nan nan
    nan nan nan
```
This PR makes the output of `-r` and `-c` look alike.