### PR TITLE
Fix typos in cluster extraction tutorial

### DIFF
--- a/doc/tutorials/content/cluster_extraction.rst
+++ b/doc/tutorials/content/cluster_extraction.rst
@@ -16,7 +16,7 @@ A clustering method needs to divide an unorganized point cloud model :math:`P`
 into smaller parts so that the overall processing time for :math:`P` is
 significantly reduced. A simple data clustering approach in an Euclidean sense
 can be implemented by making use of a 3D grid subdivision of the space using
-fixed width boxes, or more generally, an octree data structure. This particular
+fixed-width boxes, or more generally, an octree data structure. This particular
 representation is very fast to build and is useful for situations where either
 a volumetric representation of the occupied space is needed, or the data in
 each resultant 3D box (or octree leaf) can be approximated with a different
@@ -24,7 +24,7 @@ structure. In a more general sense however, we can make use of nearest
 neighbors and implement a clustering technique that is essentially similar to a
 flood fill algorithm.
 
-Let's assume we have given a point cloud with a table and objects on top of it.
+Let's assume we are given a point cloud with a table and objects on top of it.
 We want to find and segment the individual object point clusters lying on the
 plane. Assuming that we use a Kd-tree structure for finding the nearest
 neighbors, the algorithmic steps for that would be (from [RusuDissertation]_):
@@ -41,7 +41,7 @@ neighbors, the algorithmic steps for that would be (from [RusuDissertation]_):
 
      * *for every point* :math:`\boldsymbol{p}_i \in Q` *do:*
 
-        * *search for the set* :math:`P^i_k` *of point neighbors of* :math:`\boldsymbol{p}_i` *in a sphere with radius* :math:`r < d_{th}`;
+        * *search for the set* :math:`P^k_i` *of point neighbors of* :math:`\boldsymbol{p}_i` *in a sphere with radius* :math:`r < d_{th}`;
 
         * *for every neighbor* :math:`\boldsymbol{p}^k_i \in P^k_i`, *check if the point has already been processed, and if not add it to* :math:`Q`;
 


### PR DESCRIPTION
Look around its context, `P^i_k` should be `P^k_i`.