### PR TITLE
Make `concave_hull_2d.cpp` consistent with the Hull2D tutorial

### DIFF
--- a/doc/tutorials/content/hull_2d.rst
+++ b/doc/tutorials/content/hull_2d.rst
@@ -15,7 +15,7 @@ First, download the dataset `table_scene_mug_stereo_textured.pcd
 and save it somewhere to disk.
 
 Then, create a file, let's say, ``concave_hull_2d.cpp`` or
-``convex_hull2d.cpp`` in your favorite editor and place the following inside:
+``convex_hull_2d.cpp`` in your favorite editor and place the following inside:
 
 .. literalinclude:: sources/concave_hull_2d/concave_hull_2d.cpp
    :language: cpp

--- a/doc/tutorials/content/sources/concave_hull_2d/concave_hull_2d.cpp
+++ b/doc/tutorials/content/sources/concave_hull_2d/concave_hull_2d.cpp
@@ -45,7 +45,7 @@ main (int argc, char** argv)
   // Project the model inliers
   pcl::ProjectInliers<pcl::PointXYZ> proj;
   proj.setModelType (pcl::SACMODEL_PLANE);
-  proj.setIndices (inliers);
+  // proj.setIndices (inliers);
   proj.setInputCloud (cloud_filtered);
   proj.setModelCoefficients (coefficients);
   proj.filter (*cloud_projected);


### PR DESCRIPTION
From https://pcl-tutorials.readthedocs.io/en/master/hull_2d.html:

> The next bit of code projects the inliers onto the plane model and creates another cloud. One way that we could do this is by just extracting the inliers that we found before, but in this case we are going to use the coefficients we found before.

And the result:

> PointCloud after filtering has: 139656 data points.
PointCloud after segmentation has: 123727 inliers.
PointCloud after projection has: 139656 data points.
Concave hull has: 457 data points.

It seems that the author didn't mean to use `proj.setIndices (inliers);` here. This PR comment that line so as to make the program consistent with what the text in tutorial says and generates the same output showed in the tutorial.