### PR TITLE
[Search] Add include for `pcl::isFinite` for compilation on VS2019

### DIFF
--- a/search/include/pcl/search/impl/brute_force.hpp
+++ b/search/include/pcl/search/impl/brute_force.hpp
@@ -35,9 +35,9 @@
  *
  */
 
-#ifndef PCL_SEARCH_IMPL_BRUTE_FORCE_SEARCH_H_
-#define PCL_SEARCH_IMPL_BRUTE_FORCE_SEARCH_H_
+#pragma once
 
+#include <pcl/common/point_tests.h> // for pcl::isFinite
 #include <pcl/search/brute_force.h>
 #include <queue>
 
@@ -348,5 +348,3 @@ pcl::search::BruteForce<PointT>::radiusSearch (
 }
 
 #define PCL_INSTANTIATE_BruteForce(T) template class PCL_EXPORTS pcl::search::BruteForce<T>;
-
-#endif //PCL_SEARCH_IMPL_BRUTE_FORCE_SEARCH_H_


### PR DESCRIPTION
Fixes #4055