### PR TITLE
Disable deprecation warnings on MSVC, where they are already disabled for clang

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -190,15 +190,15 @@ namespace pcl
         * \param[in] pc the cloud to copy into this
         * \todo Erase once mapping_ is removed.
         */
-      // Ignore unknown pragma warning on MSVC (4996)
-      #pragma warning(push)
-      #pragma warning(disable: 4068)
-      // Ignore deprecated warning on clang compilers
-      #pragma clang diagnostic push
-      #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      // Ignore deprecation warnings GNU C Compiler
+      #ifdef __GNUC__
+      #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      #pragma GCC diagnostic push
+      #endif
       PointCloud (const PointCloud<PointT> &pc) = default;
-      #pragma clang diagnostic pop
-      #pragma warning(pop)
+      #ifdef __GNUC__
+      #pragma GCC diagnostic pop
+      #endif
 
       /** \brief Copy constructor from point cloud subset
         * \param[in] pc the cloud to copy into this

--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -130,13 +130,14 @@ TEST (PCL, copyPointCloud)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-// Ignore unknown pragma warning on MSVC (4996)
+// Ignore deprecation warnings on MSVC and GNU C Compiler
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4068)
-#endif
+#pragma warning(disable: 4996)
+#elif defined __GNUC__
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic push
+#endif
 TEST (PCL, concatenatePointCloud)
 {
   CloudXYZRGBA cloud_xyz_rgba;
@@ -321,9 +322,10 @@ TEST (PCL, concatenatePointCloud)
     EXPECT_EQ (cloud_all[cloud_xyz_rgb.size () + i].rgba, 0);
   }
 }
-#pragma GCC diagnostic pop
 #ifdef _MSC_VER
 #pragma warning(pop)
+#elif defined __GNUC__
+#pragma GCC diagnostic pop
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
~~Disable warnings like~~ (didn't worked for the first case)
```
'pcl::PointCloud<PointT>::mapping_':   rewrite your code to avoid using this protected field (It will be removed in   PCL 1.12)
```

and

```
'pcl::concatenatePointCloud':   use pcl::concatenate() instead, but beware of subtle difference in behavior   (see documentation) (It will be removed in PCL 1.12)
```

Interesting fact: The comments before said they are disabling C4996, instead they disabled C4068 - the combination is correct ;-)