### PR TITLE
Fix unknown pragma warning on MSVC in test_type_traits.cpp

### DIFF
--- a/test/common/test_type_traits.cpp
+++ b/test/common/test_type_traits.cpp
@@ -53,10 +53,14 @@ TEST (TypeTraits, HasCustomAllocatorTrait)
     // operators added by Eigen for C++14 or lower standards
     /** \todo Remove for C++17 (or future standards)
      */
+    #ifdef __clang__
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wunused-local-typedef"
+    #endif
     PCL_MAKE_ALIGNED_OPERATOR_NEW
+    #ifdef __clang__
     #pragma clang diagnostic pop
+    #endif
   };
 
   struct Bar


### PR DESCRIPTION
Should fix MSVC warning on Azure:
```
D:\a\1\s\test\common\test_type_traits.cpp(56): warning C4068: unknown pragma [D:\a\build\test\common\test_type_traits.vcxproj]
D:\a\1\s\test\common\test_type_traits.cpp(57): warning C4068: unknown pragma [D:\a\build\test\common\test_type_traits.vcxproj]
D:\a\1\s\test\common\test_type_traits.cpp(59): warning C4068: unknown pragma [D:\a\build\test\common\test_type_traits.vcxproj]
```