### PR TITLE
Use pcl::io::raw_read instead of direct call to POSIX function read

### DIFF
--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -52,7 +52,7 @@ template <typename PointXYZT, typename PointRGBT> bool
 LineRGBD<PointXYZT, PointRGBT>::readLTMHeader (int fd, pcl::io::TARHeader &header)
 {
   // Read in the header
-  int result = static_cast<int> (::read (fd, reinterpret_cast<char*> (&header.file_name[0]), 512));
+  int result = static_cast<int> (io::raw_read (fd, reinterpret_cast<char*> (&header.file_name[0]), 512));
   if (result == -1)
     return (false);
 
@@ -118,7 +118,7 @@ LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name, con
 
       unsigned int fsize = ltm_header.getFileSize ();
       char *buffer = new char[fsize];
-      int result = static_cast<int> (::read (ltm_fd, reinterpret_cast<char*> (&buffer[0]), fsize));
+      int result = static_cast<int> (io::raw_read (ltm_fd, reinterpret_cast<char*> (&buffer[0]), fsize));
       if (result == -1)
       {
         delete [] buffer;


### PR DESCRIPTION
Use `pcl::io::read` instead of direct call to POSIX function read, to suppress the warning on MSVC: `'read': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name`