### PR TITLE
Remove unused variables from exceptions

### DIFF
--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -423,7 +423,7 @@ copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, pcl::PointCloud<PointT>
                     cloud_out.width * sizeof (PointT));
           }
         }
-        catch (pcl::BadArgumentException &e)
+        catch (pcl::BadArgumentException&)
         {
           PCL_ERROR ("[pcl::copyPointCloud] Unhandled interpolation type %d!\n", border_type);
         }

--- a/gpu/people/src/face_detector.cpp
+++ b/gpu/people/src/face_detector.cpp
@@ -102,7 +102,7 @@ pcl::gpu::people::FaceDetector::loadFromXML2(const std::string                  
   {
     read_xml(filename,pt);
   }
-  catch(boost::exception const&  exb)
+  catch(boost::exception const&)
   {
     PCL_DEBUG("[pcl::gpu::people::FaceDetector::loadFromXML2] : (D) : Unable to read filename with boost exception\n");
     return NCV_HAAR_XML_LOADING_EXCEPTION;
@@ -301,7 +301,7 @@ pcl::gpu::people::FaceDetector::loadFromXML2(const std::string                  
       level1++;
     }
   }
-  catch(boost::exception const&  exb)
+  catch(boost::exception const&)
   {
     PCL_DEBUG("[pcl::gpu::people::FaceDetector::loadFromXML2] : (D) : Unable to process content with boost exception\n");
     return (NCV_HAAR_XML_LOADING_EXCEPTION);

--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -507,7 +507,7 @@ pcl::HDLGrabber::start ()
         }
         hdl_read_socket_ = new udp::socket (hdl_read_socket_service_, udp_listener_endpoint_);
       }
-      catch (const std::exception& bind)
+      catch (const std::exception&)
       {
         delete hdl_read_socket_;
         hdl_read_socket_ = new udp::socket (hdl_read_socket_service_, udp::endpoint (boost::asio::ip::address_v4::any (), udp_listener_endpoint_.port ()));

--- a/io/src/lzf_image_io.cpp
+++ b/io/src/lzf_image_io.cpp
@@ -187,7 +187,7 @@ pcl::io::LZFImageWriter::writeParameter (const double &parameter,
   {
     boost::property_tree::xml_parser::read_xml (filename, pt, boost::property_tree::xml_parser::trim_whitespace);
   }
-  catch (std::exception& e)
+  catch (std::exception&)
   {}
 
   pt.put (tag, parameter);
@@ -206,7 +206,7 @@ pcl::io::LZFDepth16ImageWriter::writeParameters (const pcl::io::CameraParameters
   {
     boost::property_tree::xml_parser::read_xml (filename, pt, boost::property_tree::xml_parser::trim_whitespace);
   }
-  catch (std::exception& e)
+  catch (std::exception&)
   {}
 
   pt.put ("depth.focal_length_x", parameters.focal_length_x);
@@ -266,7 +266,7 @@ pcl::io::LZFRGB24ImageWriter::writeParameters (const pcl::io::CameraParameters &
   {
     boost::property_tree::xml_parser::read_xml (filename, pt, boost::property_tree::xml_parser::trim_whitespace);
   }
-  catch (std::exception& e)
+  catch (std::exception&)
   {}
 
   pt.put ("rgb.focal_length_x", parameters.focal_length_x);

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -573,7 +573,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
           }
           ++point_idx;
         }
-        catch (const boost::bad_lexical_cast &e)
+        catch (const boost::bad_lexical_cast&)
         {
           PCL_ERROR ("Unable to convert %s to vertex coordinates!", line.c_str ());
           return (-1);
@@ -602,7 +602,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
           }
           ++normal_idx;
         }
-        catch (const boost::bad_lexical_cast &e)
+        catch (const boost::bad_lexical_cast&)
         {
           PCL_ERROR ("Unable to convert line %s to vertex normal!", line.c_str ());
           return (-1);
@@ -715,7 +715,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
           }
           ++v_idx;
         }
-        catch (const boost::bad_lexical_cast &e)
+        catch (const boost::bad_lexical_cast&)
         {
           PCL_ERROR ("Unable to convert %s to vertex coordinates!", line.c_str ());
           return (-1);
@@ -736,7 +736,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
           }
           ++vn_idx;
         }
-        catch (const boost::bad_lexical_cast &e)
+        catch (const boost::bad_lexical_cast&)
         {
           PCL_ERROR ("Unable to convert line %s to vertex normal!", line.c_str ());
           return (-1);
@@ -757,7 +757,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
             coordinates.emplace_back(c[0]/c[2], c[1]/c[2]);
           ++vt_idx;
         }
-        catch (const boost::bad_lexical_cast &e)
+        catch (const boost::bad_lexical_cast&)
         {
           PCL_ERROR ("Unable to convert line %s to texture coordinates!", line.c_str ());
           return (-1);
@@ -905,7 +905,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
           }
           ++v_idx;
         }
-        catch (const boost::bad_lexical_cast &e)
+        catch (const boost::bad_lexical_cast&)
         {
           PCL_ERROR ("Unable to convert %s to vertex coordinates!", line.c_str ());
           return (-1);
@@ -927,7 +927,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
           }
           ++vn_idx;
         }
-        catch (const boost::bad_lexical_cast &e)
+        catch (const boost::bad_lexical_cast&)
         {
           PCL_ERROR ("Unable to convert line %s to vertex normal!", line.c_str ());
           return (-1);


### PR DESCRIPTION
This fixes warnings like:
```
D:\a\1\s\io\src\lzf_image_io.cpp(190): warning C4101: 'e': unreferenced local variable [D:\a\build\io\pcl_io.vcxproj]
D:\a\1\s\io\src\lzf_image_io.cpp(209): warning C4101: 'e': unreferenced local variable [D:\a\build\io\pcl_io.vcxproj]
D:\a\1\s\io\src\lzf_image_io.cpp(269): warning C4101: 'e': unreferenced local variable [D:\a\build\io\pcl_io.vcxproj]
```