### PR TITLE
[visualization] Deprecate legacy OpenGL backend of VTK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,9 @@ if(WITH_VTK AND NOT ANDROID)
       endif()
       if(${VTK_RENDERING_BACKEND} STREQUAL "OpenGL")
         set(VTK_RENDERING_BACKEND_OPENGL_VERSION "1")
+        message(DEPRECATION "The rendering backend OpenGL is deprecated and not available anymore since VTK 8.2."
+                            "Please switch to the OpenGL2 backend instead, which is available since VTK 6.2."
+                            "Support of the deprecated backend will be dropped with PCL 1.13.")
       elseif(${VTK_RENDERING_BACKEND} STREQUAL "OpenGL2")
         set(VTK_RENDERING_BACKEND_OPENGL_VERSION "2")
       endif()

--- a/outofcore/tools/outofcore_viewer.cpp
+++ b/outofcore/tools/outofcore_viewer.cpp
@@ -56,7 +56,9 @@
 // PCL - visualziation
 //#include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/visualization/common/common.h>
+#if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2
 #include <pcl/visualization/vtk/vtkVertexBufferObjectMapper.h>
+#endif
 
 //#include "vtkVBOPolyDataMapper.h"
 

--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
@@ -42,6 +42,7 @@ class vtkUnsignedCharArray;
 class vtkOpenGLExtensionManager;
 class vtkRenderWindow;
 
+PCL_DEPRECATED(1, 13, "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")
 class PCL_EXPORTS vtkVertexBufferObject : public vtkObject
 {
 public:

--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <pcl/pcl_exports.h>
+#include <pcl/pcl_macros.h>
 
 #include "vtkMapper.h"
 #include "vtkSmartPointer.h"
@@ -34,6 +35,7 @@ class vtkShader2;
 class vtkShaderProgram2;
 class vtkVertexBufferObject;
 
+PCL_DEPRECATED(1, 13, "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")
 class PCL_EXPORTS vtkVertexBufferObjectMapper : public vtkMapper
 {
 public:


### PR DESCRIPTION
The OpenGL backend of VTK is deprecated and not available anymore since VTK 8.2. As the OpenGL2 backend is already supported since VTK 6.2 (our current minimal supported VTK version), we don't lose any compatibility by dropping support of old backend.

Note: Ubuntu 16.04 has only OpenGL1 backend precompiled in it's repo, during 18.04 already has OpenGL2. As the Standard Support of Ubuntu 16.04 ends April 2021 it is now a good time to deprecate the old backend - we will see if we have PCL 1.13 before April 2021 or not (even if I don't mind to drop a components a few month before end of it's release) 😉.