### PR TITLE
Remove unnecessary includes in examples

### DIFF
--- a/examples/common/example_check_if_point_is_valid.cpp
+++ b/examples/common/example_check_if_point_is_valid.cpp
@@ -40,10 +40,6 @@
 #include <pcl/point_types.h>
 #include <pcl/common/point_tests.h> // for pcl::isFinite
 
-#include <iostream>
-#include <limits>
-
-
 int
 main ()
 {

--- a/examples/common/example_copy_point_cloud.cpp
+++ b/examples/common/example_copy_point_cloud.cpp
@@ -43,12 +43,8 @@
  * members of the source PointType.
  */
 
-// STL
 #include <iostream>
 
-// PCL
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/common/io.h>
 
 static void

--- a/examples/common/example_get_max_min_coordinates.cpp
+++ b/examples/common/example_get_max_min_coordinates.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl/common/common.h>
 
 int 

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -5,19 +5,13 @@
  * @author Yani Ioannou
  * @date 2012-03-11
  */
+
 #include <string>
 
-#include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/common/io.h>
-#include <pcl/search/organized.h>
-#include <pcl/search/octree.h>
-#include <pcl/search/kdtree.h>
 #include <pcl/features/normal_3d_omp.h>
 #include <pcl/filters/conditional_removal.h>
-#include <pcl/segmentation/sac_segmentation.h>
 #include <pcl/segmentation/extract_clusters.h>
-#include <pcl/io/vtk_io.h>
 #include <pcl/filters/voxel_grid.h>
 
 #include <pcl/features/don.h>

--- a/examples/features/example_fast_point_feature_histograms.cpp
+++ b/examples/features/example_fast_point_feature_histograms.cpp
@@ -37,12 +37,9 @@
  *
  */
 
-
 #include <iostream>
-#include <vector>
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl/features/fpfh.h>
 #include <pcl/features/normal_3d.h>
 

--- a/examples/features/example_normal_estimation.cpp
+++ b/examples/features/example_normal_estimation.cpp
@@ -40,7 +40,6 @@
 #include <iostream>
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl/features/normal_3d.h>
 
 int

--- a/examples/features/example_point_feature_histograms.cpp
+++ b/examples/features/example_point_feature_histograms.cpp
@@ -38,10 +38,8 @@
  */
 
 #include <iostream>
-#include <vector>
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl/features/pfh.h>
 #include <pcl/features/normal_3d.h>
 

--- a/examples/features/example_principal_curvatures_estimation.cpp
+++ b/examples/features/example_principal_curvatures_estimation.cpp
@@ -37,15 +37,11 @@
  *
  */
 
-
 #include <iostream>
-#include <vector>
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/principal_curvatures.h>
-
 
 int
 main (int, char** argv)

--- a/examples/features/example_rift_estimation.cpp
+++ b/examples/features/example_rift_estimation.cpp
@@ -37,13 +37,10 @@
  *
  *
  */
-// STL
+
 #include <iostream>
 
-// PCL
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/common/io.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/rift.h>
 #include <pcl/features/intensity_gradient.h>

--- a/examples/features/example_shape_contexts.cpp
+++ b/examples/features/example_shape_contexts.cpp
@@ -38,12 +38,9 @@
  */
 
 #include <iostream>
-#include <vector>
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl/features/3dsc.h>
-#include <pcl/features/impl/3dsc.hpp>
 #include <pcl/features/normal_3d.h>
 
 int

--- a/examples/features/example_spin_images.cpp
+++ b/examples/features/example_spin_images.cpp
@@ -37,13 +37,9 @@
  *
  */
 
-
-
 #include <iostream>
-#include <vector>
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/spin_image.h>
 

--- a/examples/filters/example_extract_indices.cpp
+++ b/examples/filters/example_extract_indices.cpp
@@ -37,12 +37,8 @@
  *
  */
 
-// STL
 #include <iostream>
 
-// PCL
-#include <pcl/memory.h>  // for pcl::make_shared
-#include <pcl/point_types.h>
 #include <pcl/filters/extract_indices.h>
 
 int

--- a/examples/filters/example_remove_nan_from_point_cloud.cpp
+++ b/examples/filters/example_remove_nan_from_point_cloud.cpp
@@ -37,13 +37,8 @@
  *
  */
 
-// STL
 #include <iostream>
-#include <limits>
 
-// PCL
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/filters/filter.h>
 
 int

--- a/examples/keypoints/example_get_keypoints_indices.cpp
+++ b/examples/keypoints/example_get_keypoints_indices.cpp
@@ -37,10 +37,6 @@
 
 #include <iostream>
 
-#include <pcl/console/parse.h>
-#include <pcl/console/print.h>
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/keypoints/harris_3d.h>
 

--- a/examples/keypoints/example_sift_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_keypoint_estimation.cpp
@@ -38,18 +38,11 @@
  *
  */
 
-// STL
 #include <iostream>
 
-// PCL
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/common/io.h>
 #include <pcl/keypoints/sift_keypoint.h>
-#include <pcl/keypoints/impl/sift_keypoint.hpp>
-#include <pcl/features/normal_3d.h>
-// #include <pcl/visualization/pcl_visualizer.h>
-	
+
 int
 main(int, char** argv)
 {

--- a/examples/keypoints/example_sift_normal_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_normal_keypoint_estimation.cpp
@@ -38,16 +38,11 @@
  *
  */
 
-// STL
 #include <iostream>
 
-// PCL
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/common/io.h>
 #include <pcl/keypoints/sift_keypoint.h>
 #include <pcl/features/normal_3d.h>
-// #include <pcl/visualization/pcl_visualizer.h>
 
 /* This example shows how to estimate the SIFT points based on the
  * Normal gradients i.e. curvature than using the Intensity gradient

--- a/examples/keypoints/example_sift_z_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_z_keypoint_estimation.cpp
@@ -38,16 +38,10 @@
  *
  */
 
-// STL
 #include <iostream>
 
-// PCL
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/common/io.h>
 #include <pcl/keypoints/sift_keypoint.h>
-#include <pcl/features/normal_3d.h>
-// #include <pcl/visualization/pcl_visualizer.h>
 
 /* This examples shows how to estimate the SIFT points based on the 
  * z gradient of the 3D points than using the Intensity gradient as

--- a/examples/outofcore/example_outofcore.cpp
+++ b/examples/outofcore/example_outofcore.cpp
@@ -37,14 +37,9 @@
  */
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/console/print.h>
-
-#include <pcl/point_types.h>
-#include <pcl/PCLPointCloud2.h>
 
 #include <pcl/outofcore/outofcore.h>
 #include <pcl/outofcore/outofcore_impl.h>
-#include <pcl/outofcore/boost.h>
 
 using namespace pcl::outofcore;
 

--- a/examples/outofcore/example_outofcore_with_lod.cpp
+++ b/examples/outofcore/example_outofcore_with_lod.cpp
@@ -37,15 +37,9 @@
  */
 
 #include <pcl/io/pcd_io.h>
-#include <pcl/console/print.h>
 
 #include <pcl/outofcore/outofcore.h>
 #include <pcl/outofcore/outofcore_impl.h>
-
-#include <pcl/outofcore/boost.h>
-
-#include<pcl/point_types.h>
-#include <pcl/PCLPointCloud2.h>
 
 using namespace pcl::outofcore;
 

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -35,33 +35,17 @@
  *
  */
 
-// Stdlib
 #include <cstdlib>
-#include <cmath>
-#include <climits>
 #include <thread>
 
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
 
-// PCL input/output
 #include <pcl/console/parse.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/visualization/pcl_visualizer.h>
-#include <pcl/visualization/point_cloud_color_handlers.h>
 
-//PCL other
-#include <pcl/filters/passthrough.h>
-#include <pcl/segmentation/supervoxel_clustering.h>
-
-// The segmentation class this example is for
 #include <pcl/segmentation/cpc_segmentation.h>
 
-// VTK
-#include <vtkImageReader2Factory.h>
-#include <vtkImageReader2.h>
-#include <vtkImageData.h>
-#include <vtkImageFlip.h>
 #include <vtkPolyLine.h>
 
 using namespace std::chrono_literals;

--- a/examples/segmentation/example_extract_clusters_normals.cpp
+++ b/examples/segmentation/example_extract_clusters_normals.cpp
@@ -38,17 +38,11 @@
  *
  */
 
-// STL
 #include <iostream>
 
-// PCL
-#include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/filters/extract_indices.h>
 #include <pcl/features/normal_3d.h>
-#include <pcl/kdtree/kdtree.h>
 #include <pcl/segmentation/extract_clusters.h>
-
 
 int 
 main (int, char **argv)

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -35,33 +35,17 @@
  *
  */
 
-// Stdlib
 #include <cstdlib>
-#include <cmath>
-#include <climits>
 #include <thread>
 
 #include <boost/format.hpp>
 
-
-// PCL input/output
 #include <pcl/console/parse.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/visualization/pcl_visualizer.h>
-#include <pcl/visualization/point_cloud_color_handlers.h>
 
-//PCL other
-#include <pcl/filters/passthrough.h>
-#include <pcl/segmentation/supervoxel_clustering.h>
-
-// The segmentation class this example is for
 #include <pcl/segmentation/lccp_segmentation.h>
 
-// VTK
-#include <vtkImageReader2Factory.h>
-#include <vtkImageReader2.h>
-#include <vtkImageData.h>
-#include <vtkImageFlip.h>
 #include <vtkPolyLine.h>
 
 using namespace std::chrono_literals;

--- a/examples/segmentation/example_region_growing.cpp
+++ b/examples/segmentation/example_region_growing.cpp
@@ -37,17 +37,12 @@
  *
  */
 
-// STL
 #include <iostream>
 
-// PCL
 #include <pcl/filters/filter.h>
 #include <pcl/features/normal_3d.h>
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/segmentation/region_growing.h>
-#include <pcl/kdtree/kdtree.h>
 #include <pcl/common/time.h>
 #include <pcl/console/parse.h>
 

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -1,9 +1,6 @@
 #include <thread>
 
-#include <pcl/common/time.h>
 #include <pcl/console/parse.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/io/png_io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/visualization/pcl_visualizer.h>

--- a/examples/surface/example_nurbs_fitting_closed_curve.cpp
+++ b/examples/surface/example_nurbs_fitting_closed_curve.cpp
@@ -3,8 +3,6 @@
 #include <pcl/surface/on_nurbs/fitting_curve_2d_sdm.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 
 #include <pcl/visualization/pcl_visualizer.h>

--- a/examples/surface/example_nurbs_fitting_closed_curve3d.cpp
+++ b/examples/surface/example_nurbs_fitting_closed_curve3d.cpp
@@ -1,8 +1,6 @@
 #include <pcl/surface/on_nurbs/fitting_curve_pdm.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 
 #include <pcl/visualization/pcl_visualizer.h>

--- a/examples/surface/example_nurbs_fitting_curve2d.cpp
+++ b/examples/surface/example_nurbs_fitting_curve2d.cpp
@@ -1,8 +1,6 @@
 #include <pcl/surface/on_nurbs/fitting_curve_2d.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 
 #include <pcl/visualization/pcl_visualizer.h>

--- a/examples/surface/example_nurbs_fitting_surface.cpp
+++ b/examples/surface/example_nurbs_fitting_surface.cpp
@@ -1,5 +1,4 @@
 #include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 
 #include <pcl/visualization/pcl_visualizer.h>

--- a/examples/surface/example_nurbs_viewer_surface.cpp
+++ b/examples/surface/example_nurbs_viewer_surface.cpp
@@ -1,10 +1,6 @@
 #include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-#include <pcl/io/pcd_io.h>
 
 #include <pcl/visualization/pcl_visualizer.h>
-#include <pcl/surface/on_nurbs/fitting_surface_tdm.h>
-#include <pcl/surface/on_nurbs/fitting_curve_2d_asdm.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 
 using Point = pcl::PointXYZ;

--- a/examples/surface/test_nurbs_fitting_surface.cpp
+++ b/examples/surface/test_nurbs_fitting_surface.cpp
@@ -1,6 +1,4 @@
 #include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-#include <pcl/common/io.h>
 
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/surface/on_nurbs/fitting_surface_tdm.h>


### PR DESCRIPTION
Tested with:
- MSVC 2017 + VTK legacy OpenGL backend
- GCC 8 + VTK OpenGL2 backend