### PR TITLE
Towards one-click release

### DIFF
--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -159,10 +159,10 @@ stages:
     - checkout: none
     - script: |
         cat > $(CHANGELOG) <<EOF
-        <Insert Summary Here>
+        ## Insert Summary Here
 
-        For an exhustive list of newly added features, deprecations and other changes
-        in PCL $(VERSION), please see [CHANGES.md](https://github.com/PointCloudLibrary/pcl/blob/master/CHANGES.md). <Remember to edit the URL>
+        For an exhaustive list of newly added features, deprecations and other changes
+        in PCL $(VERSION), please see [CHANGES.md](https://github.com/PointCloudLibrary/pcl/blob/master/CHANGES.md). **Remember to edit the URL**
         EOF
       displayName: 'Generate Changelog'
     - task: PublishBuildArtifacts@1

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -13,12 +13,29 @@ resources:
 - repo: self
 
 variables:
-  dockerHub: "PersonalDockerHub"
-  dockerHubID: "kunaltyagi"
+  dockerHub: "PointCloudLibrary@hub.docker.com"
+  dockerHubID: "pointcloudlibrary"
+  isPreRelease: 0  # number of pre-release
 
 stages:
+- stage: Info
+  displayName: "PCL-rc${{variables.isPreRelease}}"
+  jobs:
+  - job: additional_info
+    displayName: "More Info"
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      # find the commit hash on a quick non-forced update too
+      fetchDepth: 10
+    - script: |
+        echo "Prev release: $(git tag | sort -rV | head -1 | cut -d- -f 2)"
+        echo "Current release: "$(version)
+        # can't test easily if version variable is empty or not
+      displayName: "Test for and display version info"
 - stage: Debian
-  dependsOn: []
+  dependsOn: ["Info"]
   jobs:
   - job: BuildDebian
     displayName: "Build Debian Latest"
@@ -41,7 +58,7 @@ stages:
         dockerfile: '$(Build.SourcesDirectory)/.dev/docker/release/Dockerfile'
         tags: "$(tag)"
 - stage: ROS
-  dependsOn: []
+  dependsOn: ["Info"]
   jobs:
   - job: PerceptionPCL
     displayName: "perception_pcl compile"
@@ -80,7 +97,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
     variables:
-      SOURCE_TAR: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
+      PUBLISH_LOCATION: '$(Build.ArtifactStagingDirectory)'
     steps:
     - checkout: self
       # find the commit hash on a quick non-forced update too
@@ -93,19 +110,38 @@ stages:
         workingDirectory: '$(Build.SourcesDirectory)'
         failOnStderr: true
     - task: ArchiveFiles@2
-      displayName: "Create release archive"
+      displayName: "Create release archive (.tar.gz)"
       inputs:
         rootFolderOrFile: '$(Build.SourcesDirectory)'
         includeRootFolder: true
         archiveType: 'tar'
-        archiveFile: '$(SOURCE_TAR)'
+        archiveFile: '$(PUBLISH_LOCATION)/source.tar.gz'
         replaceExistingArchive: true
         verbose: true
+    - task: ArchiveFiles@2
+      displayName: "Create release archive (.zip)"
+      inputs:
+        rootFolderOrFile: '$(Build.SourcesDirectory)'
+        includeRootFolder: true
+        archiveType: 'zip'
+        archiveFile: '$(PUBLISH_LOCATION)/source.zip'
+        replaceExistingArchive: true
+        verbose: true
+    - script: |
+        for file in $(ls "$(PUBLISH_LOCATION)/"); do
+          sha256sum "$(PUBLISH_LOCATION)"/"${file}" >> $(PUBLISH_LOCATION)/sha256_checksums.txt
+          sha512sum "$(PUBLISH_LOCATION)"/"${file}" >> $(PUBLISH_LOCATION)/sha512_checksums.txt
+        done
+        echo "SHA 256 Checksums:"
+        cat $(PUBLISH_LOCATION)/sha256_checksums.txt
+        echo "SHA 512 Checksums:"
+        cat $(PUBLISH_LOCATION)/sha512_checksums.txt
+      displayName: "Generate checksum"
     - task: PublishBuildArtifacts@1
       displayName: "Publish archive"
       inputs:
-        PathtoPublish: '$(SOURCE_TAR)'
-        ArtifactName: 'source.tar.gz'
+        PathtoPublish: '$(PUBLISH_LOCATION)/'
+        ArtifactName: 'source'
         publishLocation: 'Container'
   - job: documentation
     displayName: Generate Documentation
@@ -121,12 +157,47 @@ stages:
       # find the commit hash on a quick non-forced update too
       fetchDepth: 10
     - script: |
-        $(Build.SourcesDirectory)/.dev/scripts/generate_changelog.py --with-misc > $(CHANGELOG)
+        $(Build.SourcesDirectory)/.dev/scripts/generate_changelog.py > $(CHANGELOG)
         pandoc -f markdown -t plain --wrap=none $(CHANGELOG)
       displayName: 'Generate Changelog'
     - task: PublishBuildArtifacts@1
       displayName: "Publish Changelog"
       inputs:
         PathtoPublish: '$(CHANGELOG)'
-        ArtifactName: 'changelog.md'
+        ArtifactName: 'changelog'
         publishLocation: 'Container'
+- stage: Release
+  dependsOn: ["Prepare"]
+  jobs:
+  - job: release
+    displayName: "Release the kraken"
+    timeoutInMinutes: 360
+    variables:
+      DOWNLOAD_LOCATION: '$(Build.ArtifactStagingDirectory)'
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      # find the commit hash on a quick non-forced update too
+      fetchDepth: 10
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        downloadType: 'all'  # can be anything except single
+        downloadPath: '$(DOWNLOAD_LOCATION)'
+    - task: GitHubRelease@1
+      inputs:
+        action: 'create'
+        addChangeLog: false
+        # assets, one pattern per line
+        assets: |
+          $(DOWNLOAD_LOCATION)/source/*
+        isDraft: true
+        isPreRelease: $(isPreRelease)
+        gitHubConnection: 'Release to GitHub'
+        releaseNotesFilePath: '$(DOWNLOAD_LOCATION)/changelog/changelog.md'
+        repositoryName: 'kunaltyagi/pcl'
+        tagSource: 'userSpecifiedTag'
+        tag: "pcl-${{variables.version}}-rc${{variables.isPreRelease}}"
+        tagPattern: 'pcl-*'
+        target: '$(Build.SourceVersion)'
+        title: 'PCL $(version)'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -15,10 +15,10 @@ resources:
 variables:
   dockerHub: "PointCloudLibrary@hub.docker.com"
   dockerHubID: "pointcloudlibrary"
-  # version and isPreRelease need to be provided via the UI
+  # VERSION and RC need to be provided via the UI
   # UI priority is the lowest and can't override the file data
-  # isPreRelease: 0  # number of pre-release
-  # version: 1.99
+  # RC: 0  # number of pre-release
+  # VERSION: 1.99
 
 stages:
 - stage: Info
@@ -34,8 +34,11 @@ stages:
       fetchDepth: 10
     - script: |
         echo "Prev release: $(git tag | sort -rV | head -1 | cut -d- -f 2)"
-        echo "Current release: "$(version)-rc$(isPreRelease)
-        # @TODO: test if variables are empty or not
+        echo "Current release: "$(VERSION)-rc$(RC)
+        if [ -z $VERSION ] || [ -z $RC ]; then
+          echo "Bad version and release candidate number"
+          exit 3
+        fi
       displayName: "Test for and display version info"
 - stage: Debian
   dependsOn: ["Info"]
@@ -159,7 +162,7 @@ stages:
         <Insert Summary Here>
 
         For an exhustive list of newly added features, deprecations and other changes
-        in PCL $(version), please see [CHANGES.md](https://github.com/PointCloudLibrary/pcl/blob/master/CHANGES.md). <Remember to edit the URL>
+        in PCL $(VERSION), please see [CHANGES.md](https://github.com/PointCloudLibrary/pcl/blob/master/CHANGES.md). <Remember to edit the URL>
         EOF
       displayName: 'Generate Changelog'
     - task: PublishBuildArtifacts@1
@@ -182,6 +185,9 @@ stages:
     - checkout: self
       # find the commit hash on a quick non-forced update too
       fetchDepth: 10
+    - bash: |
+        if [ -z $RC ] || [ $RC -eq 0 ]; then isPreRelease=false; else isPreRelease=true; fi
+        echo "##vso[task.setvariable variable=isPreRelease]${isPreRelease}"
     - task: DownloadBuildArtifacts@0
       inputs:
         downloadType: 'all'  # can be anything except single
@@ -199,7 +205,7 @@ stages:
         releaseNotesFilePath: '$(DOWNLOAD_LOCATION)/changelog/changelog.md'
         repositoryName: $(Build.Repository.Name)
         tagSource: 'userSpecifiedTag'
-        tag: "pcl-$(version)-rc$(isPreRelease)"
+        tag: "pcl-$(VERSION)-rc$(RC)"
         tagPattern: 'pcl-*'
         target: '$(Build.SourceVersion)'
-        title: 'PCL $(version)'
+        title: 'PCL $(VERSION)'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -144,22 +144,21 @@ stages:
         PathtoPublish: '$(PUBLISH_LOCATION)/'
         ArtifactName: 'source'
         publishLocation: 'Container'
-  - job: documentation
-    displayName: Generate Documentation
-    container:
-      image: pointcloudlibrary/doc
+  - job: changelog
+    displayName: Generate Change Log
     pool:
       vmImage: 'ubuntu-latest'
     variables:
-      BUILD_DIR: '$(Agent.BuildDirectory)/build'
       CHANGELOG: '$(Build.ArtifactStagingDirectory)/changelog.md'
     steps:
-    - checkout: self
-      # find the commit hash on a quick non-forced update too
-      fetchDepth: 10
+    - checkout: none
     - script: |
-        $(Build.SourcesDirectory)/.dev/scripts/generate_changelog.py > $(CHANGELOG)
-        pandoc -f markdown -t plain --wrap=none $(CHANGELOG)
+        cat > $(CHANGELOG) <<EOF
+        <Insert Summary Here>
+
+        For an exhustive list of newly added features, deprecations and other changes
+        in PCL $(version), please see [CHANGES.md](https://github.com/PointCloudLibrary/pcl/blob/master/CHANGES.md). <Remember to edit the URL>
+        EOF
       displayName: 'Generate Changelog'
     - task: PublishBuildArtifacts@1
       displayName: "Publish Changelog"

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -16,6 +16,7 @@ variables:
   dockerHub: "PointCloudLibrary@hub.docker.com"
   dockerHubID: "pointcloudlibrary"
   isPreRelease: 0  # number of pre-release
+  # version needs to be provided via the UI
 
 stages:
 - stage: Info
@@ -195,7 +196,7 @@ stages:
         isPreRelease: $(isPreRelease)
         gitHubConnection: 'Release to GitHub'
         releaseNotesFilePath: '$(DOWNLOAD_LOCATION)/changelog/changelog.md'
-        repositoryName: 'kunaltyagi/pcl'
+        repositoryName: $(Build.Repository.Name)
         tagSource: 'userSpecifiedTag'
         tag: "pcl-${{variables.version}}-rc${{variables.isPreRelease}}"
         tagPattern: 'pcl-*'

--- a/.ci/azure-pipelines/release.yaml
+++ b/.ci/azure-pipelines/release.yaml
@@ -15,12 +15,14 @@ resources:
 variables:
   dockerHub: "PointCloudLibrary@hub.docker.com"
   dockerHubID: "pointcloudlibrary"
-  isPreRelease: 0  # number of pre-release
-  # version needs to be provided via the UI
+  # version and isPreRelease need to be provided via the UI
+  # UI priority is the lowest and can't override the file data
+  # isPreRelease: 0  # number of pre-release
+  # version: 1.99
 
 stages:
 - stage: Info
-  displayName: "PCL-rc${{variables.isPreRelease}}"
+  displayName: "Version"
   jobs:
   - job: additional_info
     displayName: "More Info"
@@ -32,8 +34,8 @@ stages:
       fetchDepth: 10
     - script: |
         echo "Prev release: $(git tag | sort -rV | head -1 | cut -d- -f 2)"
-        echo "Current release: "$(version)
-        # can't test easily if version variable is empty or not
+        echo "Current release: "$(version)-rc$(isPreRelease)
+        # @TODO: test if variables are empty or not
       displayName: "Test for and display version info"
 - stage: Debian
   dependsOn: ["Info"]
@@ -197,7 +199,7 @@ stages:
         releaseNotesFilePath: '$(DOWNLOAD_LOCATION)/changelog/changelog.md'
         repositoryName: $(Build.Repository.Name)
         tagSource: 'userSpecifiedTag'
-        tag: "pcl-${{variables.version}}-rc${{variables.isPreRelease}}"
+        tag: "pcl-$(version)-rc$(isPreRelease)"
         tagPattern: 'pcl-*'
         target: '$(Build.SourceVersion)'
         title: 'PCL $(version)'

--- a/.dev/docker/perception_pcl_ros/colcon.Dockerfile
+++ b/.dev/docker/perception_pcl_ros/colcon.Dockerfile
@@ -1,29 +1,27 @@
 # flavor appears twice, once for the FOR, once for the contents since
 # Dockerfile seems to reset arguments after a FOR appears
-ARG flavor="melodic"
-FROM ros:${flavor}-robot
+ARG flavor="dashing"
+FROM ros:${flavor}-ros-base
 
-ARG flavor="melodic"
+ARG flavor="dashing"
 ARG workspace="/root/catkin_ws"
 
 COPY ${flavor}_rosinstall.yaml ${workspace}/src/.rosinstall
 
 # Be careful:
-# * ROS uses Python2
 # * source ROS setup file in evey RUN snippet
 #
-# The dependencies of PCL can be reduced since
+# TODO: The dependencies of PCL can be reduced since
 # * we don't need to build visualization or docs
 RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \
  && apt update \
  && apt install -y \
     libeigen3-dev \
     libflann-dev \
-    libqhull-dev \
-    python-pip \
     ros-${flavor}-tf2-eigen \
- && pip install -U pip \
- && pip install catkin_tools \
+ && apt build-dep pcl -y \
+ && pip3 install -U pip \
+ && pip3 install wstool \
  && cd ${workspace}/src \
  && . "/opt/ros/${flavor}/setup.sh" \
  && catkin_init_workspace \
@@ -34,7 +32,6 @@ COPY package.xml ${workspace}/src/pcl/
 
 RUN cd ${workspace} \
  && . "/opt/ros/${flavor}/setup.sh" \
- && catkin config --install --link-devel \
+ && catkin config --install \
  && catkin build -j2 libpcl-all-dev --cmake-args -DWITH_OPENGL:BOOL=OFF \
- && rm -fr build/libpcl-all-dev \
- && catkin build --start-with pcl_msgs
+ && catkin build

--- a/.dev/docker/release/Dockerfile
+++ b/.dev/docker/release/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:testing
 
+ARG VTK_VERSION=7
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Add sources so we can just install build-dependencies of PCL
@@ -10,12 +11,30 @@ RUN sed -i 's/^deb \(.*\)$/deb \1\ndeb-src \1/' /etc/apt/sources.list \
     cmake \
     dpkg-dev \
     git \
- && apt build-dep pcl -y \
+    g++ \
+    libboost-date-time-dev \
+    libboost-filesystem-dev \
+    libboost-iostreams-dev \
+    libeigen3-dev \
+    libflann-dev \
+    libglew-dev \
+    libgtest-dev \
+    libopenni-dev \
+    libopenni2-dev \
+    libproj-dev \
+    libqhull-dev \
+    libqt5opengl5-dev \
+    libusb-1.0-0-dev \
+    libvtk${VTK_VERSION}-dev \
+    libvtk${VTK_VERSION}-qt-dev \
+    qtbase5-dev \
+    wget \
  && rm -rf /var/lib/apt/lists/*
 
 # CMake flags are from dpkg helper
 # PCL config is from debian repo:
 # https://salsa.debian.org/science-team/pcl/-/blob/master/debian/rules
+# MinSizeRel is used for the CI and should have no impact on releaseability
 RUN cd \
  && git clone --depth=1 https://github.com/PointCloudLibrary/pcl \
  && mkdir pcl/build \
@@ -24,19 +43,20 @@ RUN cd \
  && export DEB_CFLAGS_MAINT_APPEND="-Wall -pedantic" \
  && export DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed" \
  && cmake .. \
-    -DCMAKE_CXX_FLAGS="`dpkg-buildflags --get CXXFLAGS`" \
-    -DCMAKE_EXE_LINKER_FLAGS:STRING="`dpkg-buildflags --get LDFLAGS`" \
+    -DCMAKE_BUILD_TYPE=MinSizeRel \
+    -DCMAKE_CXX_FLAGS:STRING="`dpkg-buildflags --get CXXFLAGS`"          \
+    -DCMAKE_EXE_LINKER_FLAGS:STRING="`dpkg-buildflags --get LDFLAGS`"    \
     -DCMAKE_SHARED_LINKER_FLAGS:STRING="`dpkg-buildflags --get LDFLAGS`" \
-    -DCMAKE_SKIP_RPATH=ON -DPCL_ENABLE_SSE=OFF         \
-    -DBUILD_TESTS=OFF -DBUILD_apps=ON -DBUILD_common=ON     \
-    -DBUILD_examples=ON -DBUILD_features=ON -DBUILD_filters=ON  \
-    -DBUILD_geometry=ON -DBUILD_global_tests=OFF -DBUILD_io=ON  \
-    -DBUILD_kdtree=ON -DBUILD_keypoints=ON -DBUILD_octree=ON    \
-    -DBUILD_registration=ON -DBUILD_sample_consensus=ON     \
-    -DBUILD_search=ON -DBUILD_segmentation=ON -DBUILD_surface=ON    \
-    -DBUILD_tools=ON -DBUILD_tracking=ON -DBUILD_visualization=ON   \
-    -DBUILD_apps_cloud_composer=OFF -DBUILD_apps_modeler=ON            \
-    -DBUILD_apps_point_cloud_editor=ON -DBUILD_apps_in_hand_scanner=ON \
+    -DCMAKE_SKIP_RPATH=ON -DPCL_ENABLE_SSE=OFF                          \
+    -DBUILD_TESTS=OFF -DBUILD_apps=ON -DBUILD_common=ON                 \
+    -DBUILD_examples=ON -DBUILD_features=ON -DBUILD_filters=ON           \
+    -DBUILD_geometry=ON -DBUILD_global_tests=OFF -DBUILD_io=ON          \
+    -DBUILD_kdtree=ON -DBUILD_keypoints=ON -DBUILD_octree=ON            \
+    -DBUILD_registration=ON -DBUILD_sample_consensus=ON                 \
+    -DBUILD_search=ON -DBUILD_segmentation=ON -DBUILD_surface=ON        \
+    -DBUILD_tools=ON -DBUILD_tracking=ON -DBUILD_visualization=ON       \
+    -DBUILD_apps_cloud_composer=OFF -DBUILD_apps_modeler=ON             \
+    -DBUILD_apps_point_cloud_editor=ON -DBUILD_apps_in_hand_scanner=ON  \
  && make install -j2 \
  && cd \
  && rm -fr pcl

--- a/.dev/scripts/bump_post_release.bash
+++ b/.dev/scripts/bump_post_release.bash
@@ -2,6 +2,7 @@
 
 new_version=$(git tag | sort -rV | head -1 | cut -d- -f 2).99
 
+# Mac users either use gsed or add "" after -i
 if ls | grep README -q; then
     sed -i "s,VERSION [0-9.]*),VERSION ${new_version})," CMakeLists.txt
 else

--- a/.dev/scripts/bump_post_release.bash
+++ b/.dev/scripts/bump_post_release.bash
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+
+new_version=$(git tag | sort -rV | head -1 | cut -d- -f 2).99
+
+if ls | grep README -q; then
+    gsed -i "s,VERSION [0-9.]*),VERSION ${new_version})," CMakeLists.txt
+else
+    echo "Don't think this is the root directory" 1>&2
+    exit 4
+fi

--- a/.dev/scripts/bump_post_release.bash
+++ b/.dev/scripts/bump_post_release.bash
@@ -3,7 +3,7 @@
 new_version=$(git tag | sort -rV | head -1 | cut -d- -f 2).99
 
 if ls | grep README -q; then
-    gsed -i "s,VERSION [0-9.]*),VERSION ${new_version})," CMakeLists.txt
+    sed -i "s,VERSION [0-9.]*),VERSION ${new_version})," CMakeLists.txt
 else
     echo "Don't think this is the root directory" 1>&2
     exit 4

--- a/.dev/scripts/bump_release.bash
+++ b/.dev/scripts/bump_release.bash
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+if [ $# != 1 ]; then
+    echo "Need (only) the release version" 1>&2
+    exit 3
+fi
+
+new_version="$1"
+if ls | grep README -q; then
+    sed -i "s,[0-9]\+\.[0-9]\+\.[0-9]\+,${new_version}," README.md
+    sed -i "s,VERSION [0-9.]*),VERSION ${new_version})," CMakeLists.txt
+else
+    echo "Don't think this is the root directory" 1>&2
+    exit 4
+fi

--- a/.dev/scripts/bump_release.bash
+++ b/.dev/scripts/bump_release.bash
@@ -5,6 +5,7 @@ if [ $# != 1 ]; then
     exit 3
 fi
 
+# Mac users either use gsed or add "" after -i
 new_version="$1"
 if ls | grep README -q; then
     sed -i "s,[0-9]\+\.[0-9]\+\.[0-9]\+,${new_version}," README.md

--- a/.dev/scripts/generate_changelog.py
+++ b/.dev/scripts/generate_changelog.py
@@ -46,7 +46,7 @@ import re
 
 
 CATEGORIES = {
-    "new feature": ("New features", ""),
+    "new feature": ("New features", "added to PCL"),
     "deprecation": (
         "Deprecation",
         "of public APIs, scheduled to be removed after two minor releases",


### PR DESCRIPTION
[CI](https://kunaltyagi.visualstudio.com/pcl/_build/results?buildId=394&view=results)
[Created Release](https://github.com/kunaltyagi/pcl/releases/tag/pcl-1.11.1-rc0)

Pre-release:
1. Bump version: using `.dev/scripts/bump_release.bash <version>`
2. Modify `CHANGES.md` (from documentation job or a release candidate)
3. Create PR, merge it

Release:
1. Start CI on master
2. Add variable:
  * `VERSION`: self-explanatory
  * `RC`: number with the pre-release wanted, 0 for final release
3. Run CI
4. Goto the releases, **edit tag** and Changelog, then finalize the release

Post Release: (Can be done with a CI, but would need to push someplace)
1. Bump version using `.dev/scripts/bump_post_release.bash`
2. Create PR, merge

---
~Missing:~
* ~Git tag~
* ~Git commit for pre and post release~

~@SergioRAgostinho @taketwo Shall we use the same SSH key (taketwo's I gather) used for documentation job for pushing updates?~

TODO in this PR:
* ~Make changes to CHANGES.md~
* ~Use git tag instead of user provided tag~
* Limit to 
  * ~Tagged ~commits on master, dividing release PR in 2 parts:
    * Pre-release: bump version in CMake and README, tag it, push it, PR it
    * Release: test, prepare, release, bump version