### PR TITLE
Fix error: misplaced deprecation attributes in `vtkVertexBufferObject{,Mapper}`

### DIFF
--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObject.h
@@ -42,8 +42,8 @@ class vtkUnsignedCharArray;
 class vtkOpenGLExtensionManager;
 class vtkRenderWindow;
 
-PCL_DEPRECATED(1, 13, "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")
-class PCL_EXPORTS vtkVertexBufferObject : public vtkObject
+class PCL_DEPRECATED(1, 13, "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")
+PCL_EXPORTS vtkVertexBufferObject : public vtkObject
 {
 public:
   

--- a/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
+++ b/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h
@@ -35,8 +35,8 @@ class vtkShader2;
 class vtkShaderProgram2;
 class vtkVertexBufferObject;
 
-PCL_DEPRECATED(1, 13, "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")
-class PCL_EXPORTS vtkVertexBufferObjectMapper : public vtkMapper
+class PCL_DEPRECATED(1, 13, "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")
+PCL_EXPORTS vtkVertexBufferObjectMapper : public vtkMapper
 {
 public:
   static vtkVertexBufferObjectMapper *New();


### PR DESCRIPTION
Fixes an issue introduced in #4065. Didn't saw it earlier as gcc8 doesn't complain and my Clang 10 build is still broken.
```
/home/sunblack/dev/pcl/visualization/include/pcl/visualization/vtk/vtkVertexBufferObjectMapper.h:39:6: error: misplaced attributes; expected attributes here
class PCL_EXPORTS vtkVertexBufferObjectMapper : public vtkMapper
     ^
     PCL_DEPRECATED(1, 13, "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")

```

Note: Running clang-format will be fun for this:
```
class PCL_DEPRECATED(
    1,
    13,
    "The OpenGL backend of VTK is deprecated. Please switch to the OpenGL2 backend.")
    PCL_EXPORTS vtkVertexBufferObject : public vtkObject {
```