### PR TITLE
Fix compile issue in OutofcoreOctreeBase::setLODFilter after switching from boost::shared_ptr to std::shared_ptr

### DIFF
--- a/outofcore/include/pcl/outofcore/impl/octree_base.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base.hpp
@@ -518,7 +518,7 @@ namespace pcl
     template<typename ContainerT, typename PointT> void
     OutofcoreOctreeBase<ContainerT, PointT>::setLODFilter (const pcl::Filter<pcl::PCLPointCloud2>::Ptr& filter_arg)
     {
-      lod_filter_ptr_ = filter_arg;
+      lod_filter_ptr_ = std::static_pointer_cast<decltype(lod_filter_ptr_)>(filter_arg);
     }
 
     ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #4033.

Short explanation: Since #3750 we are using `std::shared_ptr` instead of `boost::shared_ptr` and it seems automatic downcasting does not work there anymore.