### PR TITLE
Use `pcl::utils::ignore` instead of `(void)` casts

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/metrics.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/utils/metrics.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
 #include <cmath>
 #include <cstdlib>
 
@@ -68,7 +70,7 @@ namespace Metrics
         ResultType
         operator() (Iterator1 a, Iterator2 b, std::size_t size, ResultType worst_dist = -1) const
         {
-          (void)worst_dist;
+          pcl::utils::ignore(worst_dist);
           ResultType result = ResultType ();
           ResultType min0, min1, min2, min3;
           ResultType max0, max1, max2, max3;

--- a/features/include/pcl/features/impl/normal_based_signature.hpp
+++ b/features/include/pcl/features/impl/normal_based_signature.hpp
@@ -48,7 +48,6 @@ pcl::NormalBasedSignatureEstimation<PointT, PointNT, PointFeature>::computeFeatu
   // do a few checks before starting the computations
 
   PointFeature test_feature;
-  (void)test_feature;
   if (N_prime_ * M_prime_ != sizeof (test_feature.values) / sizeof (float))
   {
     PCL_ERROR ("NormalBasedSignatureEstimation: not using the proper signature size: %u vs %u\n", N_prime_ * M_prime_, sizeof (test_feature.values) / sizeof (float));

--- a/gpu/kinfu/src/cuda/utils.hpp
+++ b/gpu/kinfu/src/cuda/utils.hpp
@@ -39,6 +39,8 @@
 #ifndef PCL_GPU_KINFU_CUDA_UTILS_HPP_
 #define PCL_GPU_KINFU_CUDA_UTILS_HPP_
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
 #include <limits>
 
 #include <cuda.h>
@@ -577,27 +579,25 @@ namespace pcl
         return ptr[tid - lane];
       }
 
-	  static __forceinline__ __device__ int 
+      static __forceinline__ __device__ int 
       Ballot(int predicate, volatile int* cta_buffer)
-	  {
+      {
+        pcl::utils::ignore(cta_buffer);
 #if CUDA_VERSION >= 9000
-      (void)cta_buffer;
-      return __ballot_sync (__activemask (), predicate);
+        return __ballot_sync (__activemask (), predicate);
 #else
-	    (void)cta_buffer;
-		  return __ballot(predicate);
+        return __ballot(predicate);
 #endif
       }
 
       static __forceinline__ __device__ bool
       All(int predicate, volatile int* cta_buffer)
       {
+        pcl::utils::ignore(cta_buffer);
 #if CUDA_VERSION >= 9000
-      (void)cta_buffer;
-      return __all_sync (__activemask (), predicate);
+        return __all_sync (__activemask (), predicate);
 #else
-	    (void)cta_buffer;
-		return __all(predicate);
+        return __all(predicate);
 #endif
       }
     };

--- a/gpu/kinfu_large_scale/src/cuda/utils.hpp
+++ b/gpu/kinfu_large_scale/src/cuda/utils.hpp
@@ -39,6 +39,8 @@
 #ifndef PCL_GPU_KINFU_CUDA_UTILS_HPP_
 #define PCL_GPU_KINFU_CUDA_UTILS_HPP_
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
 #include <limits>
 
 #include <cuda.h>
@@ -579,27 +581,25 @@ namespace pcl
           return ptr[tid - lane];
         }
 
-            static __forceinline__ __device__ int 
+        static __forceinline__ __device__ int 
         Ballot(int predicate, volatile int* cta_buffer)
-            {
+        {
+          pcl::utils::ignore(cta_buffer);
   #if CUDA_VERSION >= 9000
-              (void)cta_buffer;
-                  return __ballot_sync (__activemask (), predicate);
+          return __ballot_sync (__activemask (), predicate);
   #else
-              (void)cta_buffer;
-                  return __ballot (predicate);
+          return __ballot (predicate);
   #endif
         }
 
         static __forceinline__ __device__ bool
         All(int predicate, volatile int* cta_buffer)
         {
+          pcl::utils::ignore(cta_buffer);
   #if CUDA_VERSION >= 9000
-              (void)cta_buffer;
-                  return __all_sync (__activemask (), predicate);
+          return __all_sync (__activemask (), predicate);
   #else
-              (void)cta_buffer;
-                  return __all (predicate);
+          return __all (predicate);
   #endif
         }
       };

--- a/gpu/octree/src/utils/emulation.hpp
+++ b/gpu/octree/src/utils/emulation.hpp
@@ -37,6 +37,8 @@
 #ifndef PCL_GPU_EMULATION
 #define PCL_GPU_EMULATION
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
 #include "utils/warp_reduce.hpp"
 
 namespace pcl
@@ -47,7 +49,7 @@ namespace pcl
 		{
 			static __forceinline__ __device__ int Ballot(int predicate, volatile int* cta_buffer)
 			{
-				(void)cta_buffer;
+				pcl::utils::ignore(cta_buffer);
 				return __ballot(predicate);
 			}
 		};

--- a/gpu/utils/include/pcl/gpu/utils/device/emulation.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/emulation.hpp
@@ -37,6 +37,8 @@
 #ifndef PCL_GPU_DEVICE_EMULATION_HPP_
 #define PCL_GPU_DEVICE_EMULATION_HPP_
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
 #include <pcl/gpu/device/warp_reduce.hpp>
 
 namespace pcl
@@ -47,7 +49,7 @@ namespace pcl
 		{
 			static __forceinline__ __device__ int ballot(int predicate, volatile int* cta_buffer)
 			{
-				(void)cta_buffer;
+				pcl::utils::ignore(cta_buffer);
 				return __ballot(predicate);
 			}          
 		};

--- a/io/include/pcl/io/ascii_io.h
+++ b/io/include/pcl/io/ascii_io.h
@@ -41,6 +41,7 @@
 #include <pcl/io/file_io.h>
 #include <pcl/PCLPointField.h>
 #include <pcl/common/io.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 
 
 namespace pcl
@@ -120,7 +121,7 @@ namespace pcl
       PCL_DEPRECATED(1, 12, "use parameterless setInputFields<PointT>() instead")
       inline void setInputFields (const PointT p)
       {
-        (void) p;
+        pcl::utils::ignore(p);
         setInputFields<PointT> ();
       }
 

--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -39,6 +39,7 @@
 #define PCL_LZF_IMAGE_IO_HPP_
 
 #include <pcl/console/print.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/io/debayer.h>
 
 #include <cstddef>
@@ -162,7 +163,7 @@ LZFDepth16ImageReader::readOMP (const std::string &filename,
   shared(cloud, constant_x, constant_y, uncompressed_data) \
   num_threads(num_threads)
 #else
-  (void) num_threads; // suppress warning if OMP is not present
+  pcl::utils::ignore(num_threads); // suppress warning if OMP is not present
 #endif
   for (int i = 0; i < static_cast< int> (cloud.size ()); ++i)
   {
@@ -293,7 +294,7 @@ LZFRGB24ImageReader::readOMP (
   shared(cloud, color_b, color_g, color_r) \
   num_threads(num_threads)
 #else
-  (void) num_threads; // suppress warning if OMP is not present
+  pcl::utils::ignore(num_threads); // suppress warning if OMP is not present
 #endif//_OPENMP
   for (long int i = 0; i < cloud.size (); ++i)
   {
@@ -408,7 +409,7 @@ LZFYUV422ImageReader::readOMP (
   shared(cloud, color_u, color_v, color_y, wh2) \
   num_threads(num_threads)
 #else
-  (void) num_threads; //suppress warning if OMP is not present
+  pcl::utils::ignore(num_threads); //suppress warning if OMP is not present
 #endif//_OPENMP
   for (int i = 0; i < wh2; ++i)
   {
@@ -523,7 +524,7 @@ LZFBayer8ImageReader::readOMP (
   default(none)          \
   num_threads(num_threads)
 #else
-  (void) num_threads; //suppress warning if OMP is not present
+  pcl::utils::ignore(num_threads); //suppress warning if OMP is not present
 #endif//_OPENMP
   for (long int i = 0; i < cloud.size (); ++i)
   {

--- a/io/src/ascii_io.cpp
+++ b/io/src/ascii_io.cpp
@@ -35,6 +35,7 @@
  *
  */
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/io/ascii_io.h>
 #include <istream>
 #include <fstream>
@@ -88,7 +89,7 @@ pcl::ASCIIReader::readHeader (const std::string& file_name,
   Eigen::Quaternionf& orientation, int& file_version, int& data_type,
   unsigned int& data_idx, const int offset)
 {
-	(void)offset; //offset is not used for ascii file implementation
+  pcl::utils::ignore(offset); //offset is not used for ascii file implementation
 	
   boost::filesystem::path fpath = file_name;
 

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -42,6 +42,7 @@
 #include <string>
 #include <cstdlib>
 #include <pcl/io/boost.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/common/io.h>
 #include <pcl/io/low_level_io.h>
 #include <pcl/io/lzf.h>
@@ -58,8 +59,8 @@ void
 pcl::PCDWriter::setLockingPermissions (const std::string &file_name,
                                        boost::interprocess::file_lock &lock)
 {
-  (void)file_name;
-  (void)lock;
+  pcl::utils::ignore(file_name);
+  pcl::utils::ignore(lock);
 #ifndef WIN32
 #ifndef NO_MANDATORY_LOCKING
   // Attempt to lock the file.
@@ -88,11 +89,10 @@ void
 pcl::PCDWriter::resetLockingPermissions (const std::string &file_name,
                                          boost::interprocess::file_lock &lock)
 {
-  (void)file_name;
-  (void)lock;
+  pcl::utils::ignore(file_name);
+  pcl::utils::ignore(lock);
 #ifndef WIN32
 #ifndef NO_MANDATORY_LOCKING
-  (void)file_name;
   namespace fs = boost::filesystem;
   try
   {

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -41,6 +41,7 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/keypoints/brisk_2d.h>
 #include <pcl/point_types.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/impl/instantiate.hpp>
 #if defined(__SSSE3__) && !defined(__i386__)
 #include <tmmintrin.h>
@@ -1445,7 +1446,7 @@ pcl::keypoints::brisk::Layer::getValue (
     int width, int height,
     float xf, float yf, float scale)
 {
-  (void)height;
+  pcl::utils::ignore(height);
   assert (!mat.empty ());
   // get the position
   const int x = int (std::floor (xf));
@@ -1559,7 +1560,7 @@ pcl::keypoints::brisk::Layer::halfsample (
     std::vector<unsigned char>& dstimg,
     int dstwidth, int dstheight)
 {
-  (void)dstheight;
+  pcl::utils::ignore(dstheight);
 #if defined(__SSSE3__) && !defined(__i386__)
   const unsigned short leftoverCols = static_cast<unsigned short> ((srcwidth % 16) / 2); // take care with border...
   const bool noleftover = (srcwidth % 16) == 0; // note: leftoverCols can be zero but this still false...
@@ -1699,11 +1700,11 @@ pcl::keypoints::brisk::Layer::halfsample (
     }
   }
 #else
-  (void) (srcimg);
-  (void) (srcwidth);
-  (void) (srcheight);
-  (void) (dstimg); 
-  (void) (dstwidth);
+  pcl::utils::ignore(srcimg);
+  pcl::utils::ignore(srcwidth);
+  pcl::utils::ignore(srcheight);
+  pcl::utils::ignore(dstimg); 
+  pcl::utils::ignore(dstwidth);
   PCL_ERROR("brisk without SSSE3 support not implemented");
 #endif
 }
@@ -1716,7 +1717,7 @@ pcl::keypoints::brisk::Layer::twothirdsample (
     std::vector<unsigned char>& dstimg,
     int dstwidth, int dstheight)
 {
-  (void)dstheight;
+  pcl::utils::ignore(dstheight);
 #if defined(__SSSE3__) && !defined(__i386__)
   const unsigned short leftoverCols = static_cast<unsigned short> (((srcwidth / 3) * 3) % 15);// take care with border...
 
@@ -1813,11 +1814,11 @@ pcl::keypoints::brisk::Layer::twothirdsample (
     p_dest2 = p_dest1 + dstwidth;
   }
 #else
-  (void) (srcimg);
-  (void) (srcwidth);
-  (void) (srcheight);
-  (void) (dstimg); 
-  (void) (dstwidth);
+  pcl::utils::ignore(srcimg);
+  pcl::utils::ignore(srcwidth);
+  pcl::utils::ignore(srcheight);
+  pcl::utils::ignore(dstimg); 
+  pcl::utils::ignore(dstwidth);
   PCL_ERROR("brisk without SSSE3 support not implemented");
 #endif
 }

--- a/ml/include/pcl/ml/branch_estimator.h
+++ b/ml/include/pcl/ml/branch_estimator.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <pcl/common/common.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/ml/stats_estimator.h>
 
 #include <istream>
@@ -98,7 +99,7 @@ public:
                      const float threshold,
                      unsigned char& branch_index) const override
   {
-    (void)flag;
+    pcl::utils::ignore(flag);
     branch_index = (result > threshold) ? 1 : 0;
   }
 };

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -39,6 +39,7 @@
 #ifndef _LIBSVM_HPP_
 #define _LIBSVM_HPP_
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/ml/svm.h>
 
 #include <cctype>
@@ -3304,7 +3305,7 @@ svm_load_model(const char* model_file_name)
       free(model);
       return nullptr;
     }
-    (void)res; // to inform clang-tidy to ignore the dead-stores
+    pcl::utils::ignore(res); // to inform clang-tidy to ignore the dead-stores
   }
 
   // read sv_coef and SV

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -50,6 +50,7 @@
 #include <exception>
 
 #include <pcl/common/common.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/visualization/common/common.h>
 #include <pcl/outofcore/octree_base_node.h>
 #include <pcl/filters/random_sample.h>
@@ -1422,7 +1423,7 @@ namespace pcl
               PCL_DEBUG ("[pcl::outofocre::OutofcoreOctreeBaseNode::%s] Size of cloud before: %lu\n", __FUNCTION__, dst_blob->width*dst_blob->height );
               PCL_DEBUG ("[pcl::outofcore::OutofcoreOctreeBaseNode::%s] Concatenating point cloud\n", __FUNCTION__);
               int res = pcl::concatenate (*dst_blob, *tmp_blob, *dst_blob);
-              (void)res;
+              pcl::utils::ignore(res);
               assert (res == 1);
 
               PCL_DEBUG ("[pcl::outofocre::OutofcoreOctreeBaseNode::%s] Size of cloud after: %lu\n", __FUNCTION__, dst_blob->width*dst_blob->height );
@@ -1470,9 +1471,9 @@ namespace pcl
               //concatenate those points into the returned dst_blob
               PCL_DEBUG ("[pcl::outofcore::OutofcoreOctreeBaseNode::%s] Concatenating point cloud in place\n", __FUNCTION__);
               std::uint64_t orig_points_in_destination = dst_blob->width*dst_blob->height;
-              (void)orig_points_in_destination;
+              pcl::utils::ignore(orig_points_in_destination);
               int res = pcl::concatenate (*dst_blob, *tmp_blob_within_bb, *dst_blob);
-              (void)res;
+              pcl::utils::ignore(res);
               assert (res == 1);
               assert (dst_blob->width*dst_blob->height == indices.size () + orig_points_in_destination);
 

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -52,6 +52,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 // PCL
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl/PCLPointCloud2.h>
@@ -183,7 +184,7 @@ namespace pcl
         
         // Write ascii for now to debug
         int res = writer.writeBinaryCompressed (disk_storage_filename_, *cloud);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res == 0);
         if (force_cache_dealloc)
         {
@@ -209,15 +210,15 @@ namespace pcl
 
         //seek the right length; 
         int seekret = _fseeki64 (f, idx * sizeof(PointT), SEEK_SET);
-        (void)seekret;
+        pcl::utils::ignore(seekret);
         assert (seekret == 0);
 
         std::size_t readlen = fread (&temp, 1, sizeof(PointT), f);
-        (void)readlen;
+        pcl::utils::ignore(readlen);
         assert (readlen == sizeof (PointT));
 
         int res = fclose (f);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res == 0);
 
         return (temp);
@@ -252,7 +253,7 @@ namespace pcl
       typename pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT> ());
       
       int res = reader.read (disk_storage_filename_, *cloud);
-      (void)res;
+      pcl::utils::ignore(res);
       assert (res == 0);
       
       for (std::size_t i=0; i < cloud->points.size (); i++)
@@ -339,10 +340,10 @@ namespace pcl
         for (std::uint64_t i = 0; i < filesamp; i++)
         {
           int seekret = _fseeki64 (f, offsets[i] * static_cast<std::uint64_t> (sizeof(PointT)), SEEK_SET);
-          (void)seekret;
+          pcl::utils::ignore(seekret);
           assert (seekret == 0);
           std::size_t readlen = fread (loc, sizeof(PointT), 1, f);
-          (void)readlen;
+          pcl::utils::ignore(readlen);
           assert (readlen == 1);
 
           dst.push_back (p);
@@ -436,16 +437,16 @@ namespace pcl
         for (std::uint64_t i = 0; i < filesamp; i++)
         {
           int seekret = _fseeki64 (f, offsets[i] * static_cast<std::uint64_t> (sizeof(PointT)), SEEK_SET);
-          (void)seekret;
+          pcl::utils::ignore(seekret);
           assert (seekret == 0);
           std::size_t readlen = fread (loc, sizeof(PointT), 1, f);
-          (void)readlen;
+          pcl::utils::ignore(readlen);
           assert (readlen == 1);
 
           dst.push_back (p);
         }
         int res = fclose (f);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res == 0);
       }
     }
@@ -475,7 +476,7 @@ namespace pcl
         // Open the existing file
         pcl::PCDReader reader;
         int res = reader.read (disk_storage_filename_, *tmp_cloud);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res == 0);
       }
       // Otherwise create the point cloud which will be saved to the pcd file for the first time
@@ -501,7 +502,7 @@ namespace pcl
       PCDWriter writer;
       
       int res = writer.writeBinaryCompressed (disk_storage_filename_, *tmp_cloud);
-      (void)res;
+      pcl::utils::ignore(res);
       assert (res == 0);
     }
   
@@ -518,7 +519,7 @@ namespace pcl
         //open the existing file
         pcl::PCDReader reader;
         int res = reader.read (disk_storage_filename_, *tmp_cloud);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res == 0);
         pcl::PCDWriter writer;
         PCL_DEBUG ("[pcl::outofcore::OutofcoreOctreeDiskContainer::%s] Concatenating point cloud from %s to new cloud\n", __FUNCTION__, disk_storage_filename_.c_str ());
@@ -528,8 +529,8 @@ namespace pcl
         pcl::concatenate (*tmp_cloud, *input_cloud, *tmp_cloud);
         std::size_t res_pts = tmp_cloud->width*tmp_cloud->height;
         
-        (void)previous_num_pts;
-        (void)res_pts;
+        pcl::utils::ignore(previous_num_pts);
+        pcl::utils::ignore(res_pts);
         
         assert (previous_num_pts == res_pts);
         
@@ -540,7 +541,7 @@ namespace pcl
       {
         pcl::PCDWriter writer;
         int res = writer.writeBinaryCompressed (disk_storage_filename_, *input_cloud);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res == 0);
       }            
 
@@ -561,7 +562,7 @@ namespace pcl
 //            PCL_INFO ("[pcl::outofcore::OutofcoreOctreeDiskContainer::%s] Reading points from disk from %s.\n", __FUNCTION__ , disk_storage_filename_->c_str ());
         int  pcd_version;
         int res = reader.read (disk_storage_filename_, *dst, origin, orientation, pcd_version);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res != -1);
       }
       else
@@ -581,7 +582,7 @@ namespace pcl
       {
 //            PCL_INFO ("[pcl::outofcore::OutofcoreOctreeDiskContainer::%s] Reading points from disk from %s.\n", __FUNCTION__ , disk_storage_filename_->c_str ());
         int res = pcl::io::loadPCDFile (disk_storage_filename_, *temp_output_cloud);
-        (void)res;
+        pcl::utils::ignore(res);
         assert (res != -1);
         if(res == -1)
           return (-1);
@@ -635,7 +636,7 @@ namespace pcl
         pcl::PCDReader reader;
         // Open it
         int res = reader.read (disk_storage_filename_, *tmp_cloud);
-        (void)res; 
+        pcl::utils::ignore(res); 
         assert (res == 0);
       }
       else //otherwise create the pcd file
@@ -663,7 +664,7 @@ namespace pcl
       PCDWriter writer;
 
       int res = writer.writeBinaryCompressed (disk_storage_filename_, *tmp_cloud);
-      (void)res;
+      pcl::utils::ignore(res);
       assert (res == 0);
     }
     ////////////////////////////////////////////////////////////////////////////////

--- a/outofcore/include/pcl/outofcore/octree_disk_container.h
+++ b/outofcore/include/pcl/outofcore/octree_disk_container.h
@@ -47,6 +47,7 @@
 // Boost
 #include <boost/uuid/random_generator.hpp>
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/outofcore/boost.h>
 #include <pcl/outofcore/octree_abstract_node_container.h>
 #include <pcl/io/pcd_io.h>
@@ -237,10 +238,10 @@ namespace pcl
             for (std::uint64_t i = 0; i < num; i++)
             {
               int seekret = _fseeki64 (f, i * sizeof (PointT), SEEK_SET);
-              (void)seekret;
+              pcl::utils::ignore(seekret);
               assert (seekret == 0);
               std::size_t readlen = fread (loc, sizeof (PointT), 1, f);
-              (void)readlen;
+              pcl::utils::ignore(readlen);
               assert (readlen == 1);
 
               //of << p.x << "\t" << p.y << "\t" << p.z << "\n";
@@ -252,7 +253,7 @@ namespace pcl
               fwrite (ss.str ().c_str (), 1, ss.str ().size (), fxyz);
             }
             int res = fclose (f);
-            (void)res;
+            pcl::utils::ignore(res);
             assert (res == 0);
             res = fclose (fxyz);
             assert (res == 0);

--- a/outofcore/src/outofcore_base_data.cpp
+++ b/outofcore/src/outofcore_base_data.cpp
@@ -42,6 +42,7 @@
 
 #include <pcl/pcl_macros.h>
 #include <pcl/exceptions.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/console/print.h>
 
 #include <fstream>
@@ -367,7 +368,7 @@ namespace pcl
     void
     OutofcoreOctreeBaseMetadata::writeMetadataString (std::vector<char>& buf)
     {
-      (void)buf;
+      pcl::utils::ignore(buf);
       PCL_THROW_EXCEPTION (PCLException, "Not implemented\n");
     }
 
@@ -376,7 +377,7 @@ namespace pcl
     std::ostream& 
     operator<<(std::ostream& os, const OutofcoreOctreeBaseMetadata& metadata_arg)
     {
-      (void) metadata_arg;
+      pcl::utils::ignore(metadata_arg);
       return (os);
     }
 

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -16,6 +16,9 @@
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
+
 FILE* ON_FileStream::Open( const wchar_t* filename, const wchar_t* mode )
 {
   FILE* fp = 0;
@@ -13305,7 +13308,7 @@ bool ON_BinaryFile::AtEnd() const
       {
         int buffer;
         std::size_t res = fread( &buffer, 1, 1, m_fp );
-        (void) res;
+        pcl::utils::ignore(res);
         if ( feof( m_fp ) ) 
         {
           rc = true;

--- a/surface/src/3rdparty/opennurbs/opennurbs_font.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_font.cpp
@@ -16,6 +16,9 @@
 
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
+
 ON_OBJECT_IMPLEMENT( ON_Font, ON_Object, "4F0F51FB-35D0-4865-9998-6D2C6A99721D" );
 
 ON_Font::ON_Font()
@@ -277,7 +280,7 @@ int CALLBACK ON__IsSymbolFontFaceNameHelper( ENUMLOGFONTEX*, NEWTEXTMETRICEX*, D
 bool ON_Font::IsSymbolFontFaceName( const wchar_t* s)
 {
   bool rc = false;
-  (void) s; // no op to supress warning
+  pcl::utils::ignore(s);
 #if defined(ON_OS_WINDOWS_GDI)
   if( s && s[0])
   {

--- a/surface/src/3rdparty/opennurbs/opennurbs_sort.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_sort.cpp
@@ -1,5 +1,8 @@
 #include "pcl/surface/3rdparty/opennurbs/opennurbs.h"
 
+#include <pcl/common/utils.h> // pcl::utils::ignore
+
+
 /*
 If the speed of ON_qsort() functions on arrays that
 are nearly sorted is as good as heap sort, then define
@@ -43,8 +46,11 @@ ON__QSORT_FASTER_THAN_HSORT.
 void 
 ON_qsort( void *base, std::size_t nel, std::size_t width, int (*compar)(void*,const void *, const void *),void* context)
 {
-  // no-op to suppress warning on all compilers
-  (void) base; (void) nel; (void) width; (void) compar; (void) context;
+  pcl::utils::ignore(base);
+  pcl::utils::ignore(nel);
+  pcl::utils::ignore(width);
+  pcl::utils::ignore(compar);
+  pcl::utils::ignore(context);
 #if defined(ON__HAVE_RELIABLE_SYSTEM_CONTEXT_QSORT)
   // The call here must be a thread safe system qsort
   // that is faster than the alternative code in this function.

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -39,6 +39,7 @@
 
 #include <pcl/test/gtest.h>
 #include <pcl/point_cloud.h>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/normal_3d_omp.h>
 #include <pcl/features/integral_image_normal.h>
@@ -195,7 +196,7 @@ class DummySearch : public pcl::search::Search<PointT>
     virtual int nearestKSearch (const PointT &point, int k, std::vector<int> &k_indices,
                                 std::vector<float> &k_sqr_distances ) const
     {
-      (void)point;
+      pcl::utils::ignore(point);
 
       EXPECT_GE (k_indices.size(), k);
       EXPECT_GE (k_sqr_distances.size(), k);
@@ -206,10 +207,10 @@ class DummySearch : public pcl::search::Search<PointT>
     virtual int radiusSearch (const PointT& point, double radius, std::vector<int>& k_indices,
                               std::vector<float>& k_sqr_distances, unsigned int max_nn = 0 ) const
     {
-      (void)point;
-      (void)radius;
-      (void)k_indices;
-      (void)k_sqr_distances;
+      pcl::utils::ignore(point);
+      pcl::utils::ignore(radius);
+      pcl::utils::ignore(k_indices);
+      pcl::utils::ignore(k_sqr_distances);
 
       return max_nn;
     }

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -106,6 +106,7 @@
 #include <boost/uuid/sha1.hpp>
 #endif
 #include <boost/filesystem.hpp>
+#include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/console/parse.h>
 
 // Support for VTK 7.1 upwards
@@ -4382,7 +4383,7 @@ pcl::visualization::PCLVisualizer::setUseVbos (bool use_vbos)
   style_->setUseVbos (use_vbos_);
 #else
   PCL_WARN ("[PCLVisualizer::setUseVbos] Has no effect when OpenGL version is ≥ 2\n");
-  (void) use_vbos;
+  pcl::utils::ignore(use_vbos);
 #endif
 }
 


### PR DESCRIPTION
Closes #3950 

Left a separate commit for 3rdparty code but it should be fine.

What other `(void)` instance remains in the codebase is documented in the related issue. Lots of it in 3rdparty as well.