### PR TITLE
[common] Fix undefined behavior by 'protecting' the non-virtual dtor of `PointCloud`

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -618,6 +618,14 @@ namespace pcl
       makeShared () const { return Ptr (new PointCloud<PointT> (*this)); }
 
     protected:
+      /**
+       * \brief Protected, non-virtual destructor
+       * \details This prevents deletion of a sub-class via pointer to the base-class. It is
+       * needed to throw a compile-time error when such undefined behavior is detected.
+       * The bitter alternative is to use a public virtual destructor
+       */
+      ~PointCloud = default;
+
       /** \brief This is motivated by ROS integration. Users should not need to access mapping_.
         * \todo Once mapping_ is removed, erase the explicitly defined copy constructor in PointCloud.
         */

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -624,7 +624,7 @@ namespace pcl
        * needed to throw a compile-time error when such undefined behavior is detected.
        * The bitter alternative is to use a public virtual destructor
        */
-      ~PointCloud = default;
+      ~PointCloud() = default;
 
       /** \brief This is motivated by ROS integration. Users should not need to access mapping_.
         * \todo Once mapping_ is removed, erase the explicitly defined copy constructor in PointCloud.


### PR DESCRIPTION
Arose from discussion in #4036

This is an API breakage (you can no longer get reference to the dtor of `PointCloud`), but doesn't change change behavior. I'd vote for merge after 1.12.0 release, not 1.11.X