### PR TITLE
Fix NSIS Template for NSIS3

### DIFF
--- a/cmake/Modules/NSIS.template.in
+++ b/cmake/Modules/NSIS.template.in
@@ -40,6 +40,7 @@
 @CPACK_NSIS_DEFINES@
 
   !include Sections.nsh
+  !macroundef RemoveSection
 
 ;--- Component support macros: ---
 ; The code for the add/remove functionality is from:


### PR DESCRIPTION
NSIS2 is end of support in CPacks of CMake 3.17 or later.
We should be migrate to NSIS3 for generate PCL All-in-one Installer.

> The CPack NSIS Generator now requires NSIS 3.0 or later.
https://cmake.org/cmake/help/v3.17/release/3.17.html#deprecated-and-removed-features

The template of PCL All-in-one Installer generally works as it is on NSIS2, but one error occurs with NSIS3. That means multiple definitions of "RemoveSection" macro.

```
# Run command: "C:/Program Files (x86)/NSIS/makensis.exe" "C:/pcl-1.11.0/build/_CPack_Packages/win64/NSIS/project.nsi"
# Output:
Processing config: C:\Program Files (x86)\NSIS\nsisconf.nsh

Processing script file: "C:/pcl-1.11.0/build/_CPack_Packages/win64/NSIS/project.nsi" (ACP)

!macro: macro named "RemoveSection" already exists!

Error in script "C:/pcl-1.11.0/build/_CPack_Packages/win64/NSIS/project.nsi" on line 182 -- aborting creation process
```

It is already defined in Sections.nsh of NSIS3.
Therefor, This pull request will fix by undefine "RemoveSection" macro in the first.