### PR TITLE
delete 'brew tap homebrew/science'

### DIFF
--- a/doc/tutorials/content/installing_homebrew.rst
+++ b/doc/tutorials/content/installing_homebrew.rst
@@ -37,7 +37,6 @@ which parts of PCL are installed.
 
    #. Install Homebrew. See the Homebrew website for instructions.
    #. Execute ``brew update``.
-   #. Execute ``brew tap homebrew/science``.
 
 To install the latest version using the formula, execute the following command::
 


### PR DESCRIPTION
homebrew/science was deprecated. This tap is now empty as all its formulae were migrated. 
Therefore, it suffices to run 'brew update' only.