### PR TITLE
[segmentation] Deprecate unused `max_label` in `extractLabeledEuclideanClusters`

### DIFF
--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -35,175 +35,217 @@
 
 #pragma once
 
+#include <pcl/search/pcl_search.h>
 #include <pcl/pcl_base.h>
-#include <pcl/search/search.h> // for Search
 
-namespace pcl
-{
+namespace pcl {
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/** \brief Decompose a region of space into clusters based on the Euclidean distance
+ * between points \param[in] cloud the point cloud message \param[in] tree the spatial
+ * locator (e.g., kd-tree) used for nearest neighbors searching \note the tree has to be
+ * created as a spatial locator on \a cloud \param[in] tolerance the spatial cluster
+ * tolerance as a measure in L2 Euclidean space \param[out] labeled_clusters the
+ * resultant clusters containing point indices (as a vector of PointIndices) \param[in]
+ * min_pts_per_cluster minimum number of points that a cluster may contain (default: 1)
+ * \param[in] max_pts_per_cluster maximum number of points that a cluster may contain
+ * (default: max int) \param[in] max_label \ingroup segmentation
+ */
+template <typename PointT>
+PCL_DEPRECATED(1, 14, "Use of max_label is deprecated")
+void extractLabeledEuclideanClusters(
+    const PointCloud<PointT>& cloud,
+    const typename search::Search<PointT>::Ptr& tree,
+    float tolerance,
+    std::vector<std::vector<PointIndices>>& labeled_clusters,
+    unsigned int min_pts_per_cluster,
+    unsigned int max_pts_per_cluster,
+    unsigned int max_label);
+
+/** \brief Decompose a region of space into clusters based on the Euclidean distance
+ * between points \param[in] cloud the point cloud message \param[in] tree the spatial
+ * locator (e.g., kd-tree) used for nearest neighbors searching \note the tree has to be
+ * created as a spatial locator on \a cloud \param[in] tolerance the spatial cluster
+ * tolerance as a measure in L2 Euclidean space \param[out] labeled_clusters the
+ * resultant clusters containing point indices (as a vector of PointIndices) \param[in]
+ * min_pts_per_cluster minimum number of points that a cluster may contain (default: 1)
+ * \param[in] max_pts_per_cluster maximum number of points that a cluster may contain
+ * (default: max int) \ingroup segmentation
+ */
+template <typename PointT>
+void
+extractLabeledEuclideanClusters(
+    const PointCloud<PointT>& cloud,
+    const typename search::Search<PointT>::Ptr& tree,
+    float tolerance,
+    std::vector<std::vector<PointIndices>>& labeled_clusters,
+    unsigned int min_pts_per_cluster = 1,
+    unsigned int max_pts_per_cluster = std::numeric_limits<unsigned int>::max());
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/** \brief @b LabeledEuclideanClusterExtraction represents a segmentation class for
+ * cluster extraction in an Euclidean sense, with label info. \author Koen Buys \ingroup
+ * segmentation
+ */
+template <typename PointT>
+class LabeledEuclideanClusterExtraction : public PCLBase<PointT> {
+  using BasePCLBase = PCLBase<PointT>;
+
+public:
+  using PointCloud = pcl::PointCloud<PointT>;
+  using PointCloudPtr = typename PointCloud::Ptr;
+  using PointCloudConstPtr = typename PointCloud::ConstPtr;
+
+  using KdTree = pcl::search::Search<PointT>;
+  using KdTreePtr = typename KdTree::Ptr;
+
+  using PointIndicesPtr = PointIndices::Ptr;
+  using PointIndicesConstPtr = PointIndices::ConstPtr;
+
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  /** \brief Decompose a region of space into clusters based on the Euclidean distance between points
-    * \param[in] cloud the point cloud message
-    * \param[in] tree the spatial locator (e.g., kd-tree) used for nearest neighbors searching
-    * \note the tree has to be created as a spatial locator on \a cloud
-    * \param[in] tolerance the spatial cluster tolerance as a measure in L2 Euclidean space
-    * \param[out] labeled_clusters the resultant clusters containing point indices (as a vector of PointIndices)
-    * \param[in] min_pts_per_cluster minimum number of points that a cluster may contain (default: 1)
-    * \param[in] max_pts_per_cluster maximum number of points that a cluster may contain (default: max int)
-    * \param[in] max_label
-    * \ingroup segmentation
-    */
-  template <typename PointT>
-  PCL_DEPRECATED(1, 14, "Use of max_label is deprecated")
-  void
-  extractLabeledEuclideanClusters (
-      const PointCloud<PointT> &cloud, const typename search::Search<PointT>::Ptr &tree,
-      float tolerance, std::vector<std::vector<PointIndices> > &labeled_clusters,
-      unsigned int min_pts_per_cluster, unsigned int max_pts_per_cluster,
-      unsigned int max_label);
+  /** \brief Empty constructor. */
+  LabeledEuclideanClusterExtraction()
+  : tree_()
+  , cluster_tolerance_(0)
+  , min_pts_per_cluster_(1)
+  , max_pts_per_cluster_(std::numeric_limits<int>::max())
+  , max_label_(std::numeric_limits<int>::max()){};
 
-  /** \brief Decompose a region of space into clusters based on the Euclidean distance between points
-    * \param[in] cloud the point cloud message
-    * \param[in] tree the spatial locator (e.g., kd-tree) used for nearest neighbors searching
-    * \note the tree has to be created as a spatial locator on \a cloud
-    * \param[in] tolerance the spatial cluster tolerance as a measure in L2 Euclidean space
-    * \param[out] labeled_clusters the resultant clusters containing point indices (as a vector of PointIndices)
-    * \param[in] min_pts_per_cluster minimum number of points that a cluster may contain (default: 1)
-    * \param[in] max_pts_per_cluster maximum number of points that a cluster may contain (default: max int)
-    * \ingroup segmentation
-    */
-  template <typename PointT> void
-  extractLabeledEuclideanClusters (
-      const PointCloud<PointT> &cloud, const typename search::Search<PointT>::Ptr &tree,
-      float tolerance, std::vector<std::vector<PointIndices> > &labeled_clusters,
-      unsigned int min_pts_per_cluster = 1, unsigned int max_pts_per_cluster = std::numeric_limits<unsigned int>::max ());
-
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  /** \brief @b LabeledEuclideanClusterExtraction represents a segmentation class for cluster extraction in an Euclidean sense, with label info.
-    * \author Koen Buys
-    * \ingroup segmentation
-    */
-  template <typename PointT>
-  class LabeledEuclideanClusterExtraction: public PCLBase<PointT>
+  /** \brief Provide a pointer to the search object.
+   * \param[in] tree a pointer to the spatial search object.
+   */
+  inline void
+  setSearchMethod(const KdTreePtr& tree)
   {
-    using BasePCLBase = PCLBase<PointT>;
-
-    public:
-      using PointCloud = pcl::PointCloud<PointT>;
-      using PointCloudPtr = typename PointCloud::Ptr;
-      using PointCloudConstPtr = typename PointCloud::ConstPtr;
-
-      using KdTree = pcl::search::Search<PointT>;
-      using KdTreePtr = typename KdTree::Ptr;
-
-      using PointIndicesPtr = PointIndices::Ptr;
-      using PointIndicesConstPtr = PointIndices::ConstPtr;
-
-      //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      /** \brief Empty constructor. */
-      LabeledEuclideanClusterExtraction () : 
-        tree_ (), 
-        cluster_tolerance_ (0),
-        min_pts_per_cluster_ (1), 
-        max_pts_per_cluster_ (std::numeric_limits<int>::max ()),
-        max_label_ (std::numeric_limits<int>::max ())
-      {};
-
-      /** \brief Provide a pointer to the search object.
-        * \param[in] tree a pointer to the spatial search object.
-        */
-      inline void 
-      setSearchMethod (const KdTreePtr &tree) { tree_ = tree; }
-
-      /** \brief Get a pointer to the search method used. */
-      inline KdTreePtr 
-      getSearchMethod () const { return (tree_); }
-
-      /** \brief Set the spatial cluster tolerance as a measure in the L2 Euclidean space
-        * \param[in] tolerance the spatial cluster tolerance as a measure in the L2 Euclidean space
-        */
-      inline void 
-      setClusterTolerance (double tolerance) { cluster_tolerance_ = tolerance; }
-
-      /** \brief Get the spatial cluster tolerance as a measure in the L2 Euclidean space. */
-      inline double 
-      getClusterTolerance () const { return (cluster_tolerance_); }
-
-      /** \brief Set the minimum number of points that a cluster needs to contain in order to be considered valid.
-        * \param[in] min_cluster_size the minimum cluster size
-        */
-      inline void 
-      setMinClusterSize (int min_cluster_size) { min_pts_per_cluster_ = min_cluster_size; }
-
-      /** \brief Get the minimum number of points that a cluster needs to contain in order to be considered valid. */
-      inline int 
-      getMinClusterSize () const { return (min_pts_per_cluster_); }
-
-      /** \brief Set the maximum number of points that a cluster needs to contain in order to be considered valid.
-        * \param[in] max_cluster_size the maximum cluster size
-        */
-      inline void 
-      setMaxClusterSize (int max_cluster_size) { max_pts_per_cluster_ = max_cluster_size; }
-
-      /** \brief Get the maximum number of points that a cluster needs to contain in order to be considered valid. */
-      inline int 
-      getMaxClusterSize () const { return (max_pts_per_cluster_); }
-
-      /** \brief Set the maximum number of labels in the cloud.
-        * \param[in] max_label the maximum
-        */
-      PCL_DEPRECATED(1, 14, "Max label is being deprecated")
-      inline void 
-      setMaxLabels (unsigned int max_label) { max_label_ = max_label; }
-
-      /** \brief Get the maximum number of labels */
-      PCL_DEPRECATED(1, 14, "Max label is being deprecated")
-      inline unsigned int 
-      getMaxLabels () const { return (max_label_); }
-
-      /** \brief Cluster extraction in a PointCloud given by <setInputCloud (), setIndices ()>
-        * \param[out] labeled_clusters the resultant point clusters
-        */
-      void 
-      extract (std::vector<std::vector<PointIndices> > &labeled_clusters);
-
-    protected:
-      // Members derived from the base class
-      using BasePCLBase::input_;
-      using BasePCLBase::indices_;
-      using BasePCLBase::initCompute;
-      using BasePCLBase::deinitCompute;
-
-      /** \brief A pointer to the spatial search object. */
-      KdTreePtr tree_;
-
-      /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
-      double cluster_tolerance_;
-
-      /** \brief The minimum number of points that a cluster needs to contain in order to be considered valid (default = 1). */
-      int min_pts_per_cluster_;
-
-      /** \brief The maximum number of points that a cluster needs to contain in order to be considered valid (default = MAXINT). */
-      int max_pts_per_cluster_;
-
-      /** \brief The maximum number of labels we can find in this pointcloud (default = MAXINT)*/
-      unsigned int max_label_;
-
-      /** \brief Class getName method. */
-      virtual std::string getClassName () const { return ("LabeledEuclideanClusterExtraction"); }
-
-  };
-
-  /** \brief Sort clusters method (for std::sort). 
-    * \ingroup segmentation
-    */
-  inline bool 
-    compareLabeledPointClusters (const pcl::PointIndices &a, const pcl::PointIndices &b)
-  {
-    return (a.indices.size () < b.indices.size ());
+    tree_ = tree;
   }
+
+  /** \brief Get a pointer to the search method used. */
+  inline KdTreePtr
+  getSearchMethod() const
+  {
+    return (tree_);
+  }
+
+  /** \brief Set the spatial cluster tolerance as a measure in the L2 Euclidean space
+   * \param[in] tolerance the spatial cluster tolerance as a measure in the L2 Euclidean
+   * space
+   */
+  inline void
+  setClusterTolerance(double tolerance)
+  {
+    cluster_tolerance_ = tolerance;
+  }
+
+  /** \brief Get the spatial cluster tolerance as a measure in the L2 Euclidean space.
+   */
+  inline double
+  getClusterTolerance() const
+  {
+    return (cluster_tolerance_);
+  }
+
+  /** \brief Set the minimum number of points that a cluster needs to contain in order
+   * to be considered valid. \param[in] min_cluster_size the minimum cluster size
+   */
+  inline void
+  setMinClusterSize(int min_cluster_size)
+  {
+    min_pts_per_cluster_ = min_cluster_size;
+  }
+
+  /** \brief Get the minimum number of points that a cluster needs to contain in order
+   * to be considered valid. */
+  inline int
+  getMinClusterSize() const
+  {
+    return (min_pts_per_cluster_);
+  }
+
+  /** \brief Set the maximum number of points that a cluster needs to contain in order
+   * to be considered valid. \param[in] max_cluster_size the maximum cluster size
+   */
+  inline void
+  setMaxClusterSize(int max_cluster_size)
+  {
+    max_pts_per_cluster_ = max_cluster_size;
+  }
+
+  /** \brief Get the maximum number of points that a cluster needs to contain in order
+   * to be considered valid. */
+  inline int
+  getMaxClusterSize() const
+  {
+    return (max_pts_per_cluster_);
+  }
+
+  /** \brief Set the maximum number of labels in the cloud.
+   * \param[in] max_label the maximum
+   */
+  PCL_DEPRECATED(1, 14, "Max label is being deprecated")
+  inline void
+  setMaxLabels(unsigned int max_label)
+  {
+    max_label_ = max_label;
+  }
+
+  /** \brief Get the maximum number of labels */
+  PCL_DEPRECATED(1, 14, "Max label is being deprecated")
+  inline unsigned int
+  getMaxLabels() const
+  {
+    return (max_label_);
+  }
+
+  /** \brief Cluster extraction in a PointCloud given by <setInputCloud (), setIndices
+   * ()> \param[out] labeled_clusters the resultant point clusters
+   */
+  void
+  extract(std::vector<std::vector<PointIndices>>& labeled_clusters);
+
+protected:
+  // Members derived from the base class
+  using BasePCLBase::deinitCompute;
+  using BasePCLBase::indices_;
+  using BasePCLBase::initCompute;
+  using BasePCLBase::input_;
+
+  /** \brief A pointer to the spatial search object. */
+  KdTreePtr tree_;
+
+  /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
+  double cluster_tolerance_;
+
+  /** \brief The minimum number of points that a cluster needs to contain in order to be
+   * considered valid (default = 1). */
+  int min_pts_per_cluster_;
+
+  /** \brief The maximum number of points that a cluster needs to contain in order to be
+   * considered valid (default = MAXINT). */
+  int max_pts_per_cluster_;
+
+  /** \brief The maximum number of labels we can find in this pointcloud (default =
+   * MAXINT)*/
+  unsigned int max_label_;
+
+  /** \brief Class getName method. */
+  virtual std::string
+  getClassName() const
+  {
+    return ("LabeledEuclideanClusterExtraction");
+  }
+};
+
+/** \brief Sort clusters method (for std::sort).
+ * \ingroup segmentation
+ */
+inline bool
+compareLabeledPointClusters(const pcl::PointIndices& a, const pcl::PointIndices& b)
+{
+  return (a.indices.size() < b.indices.size());
 }
+} // namespace pcl
 
 #ifdef PCL_NO_PRECOMPILE
 #include <pcl/segmentation/impl/extract_labeled_clusters.hpp>

--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -35,20 +35,26 @@
 
 #pragma once
 
-#include <pcl/search/pcl_search.h>
+#include <pcl/search/search.h>
 #include <pcl/pcl_base.h>
 
 namespace pcl {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /** \brief Decompose a region of space into clusters based on the Euclidean distance
- * between points \param[in] cloud the point cloud message \param[in] tree the spatial
- * locator (e.g., kd-tree) used for nearest neighbors searching \note the tree has to be
- * created as a spatial locator on \a cloud \param[in] tolerance the spatial cluster
- * tolerance as a measure in L2 Euclidean space \param[out] labeled_clusters the
- * resultant clusters containing point indices (as a vector of PointIndices) \param[in]
- * min_pts_per_cluster minimum number of points that a cluster may contain (default: 1)
+ * between points
+ * \param[in] cloud the point cloud message
+ * \param[in] tree the spatial locator (e.g., kd-tree) used for nearest neighbors
+ * searching
+ * \note the tree has to be created as a spatial locator on \a cloud
+ * \param[in] tolerance the spatial cluster tolerance as a measure in L2 Euclidean space
+ * \param[out] labeled_clusters the resultant clusters containing point indices (as a
+ * vector of PointIndices)
+ * \param[in] min_pts_per_cluster minimum number of points that a cluster may contain
+ * (default: 1)
  * \param[in] max_pts_per_cluster maximum number of points that a cluster may contain
- * (default: max int) \param[in] max_label \ingroup segmentation
+ * (default: max int)
+ * \param[in] max_label
+ * \ingroup segmentation
  */
 template <typename PointT>
 PCL_DEPRECATED(1, 14, "Use of max_label is deprecated")

--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -52,12 +52,30 @@ namespace pcl
     * \param[in] max_label
     * \ingroup segmentation
     */
-  template <typename PointT> void 
+  template <typename PointT>
+  PCL_DEPRECATED(1, 14, "Use of max_label is deprecated")
+  void
   extractLabeledEuclideanClusters (
       const PointCloud<PointT> &cloud, const typename search::Search<PointT>::Ptr &tree,
       float tolerance, std::vector<std::vector<PointIndices> > &labeled_clusters,
-      unsigned int min_pts_per_cluster = 1, unsigned int max_pts_per_cluster = std::numeric_limits<unsigned int>::max (),
-      unsigned int max_label = std::numeric_limits<unsigned int>::max ());
+      unsigned int min_pts_per_cluster, unsigned int max_pts_per_cluster,
+      unsigned int max_label);
+
+  /** \brief Decompose a region of space into clusters based on the Euclidean distance between points
+    * \param[in] cloud the point cloud message
+    * \param[in] tree the spatial locator (e.g., kd-tree) used for nearest neighbors searching
+    * \note the tree has to be created as a spatial locator on \a cloud
+    * \param[in] tolerance the spatial cluster tolerance as a measure in L2 Euclidean space
+    * \param[out] labeled_clusters the resultant clusters containing point indices (as a vector of PointIndices)
+    * \param[in] min_pts_per_cluster minimum number of points that a cluster may contain (default: 1)
+    * \param[in] max_pts_per_cluster maximum number of points that a cluster may contain (default: max int)
+    * \ingroup segmentation
+    */
+  template <typename PointT> void
+  extractLabeledEuclideanClusters (
+      const PointCloud<PointT> &cloud, const typename search::Search<PointT>::Ptr &tree,
+      float tolerance, std::vector<std::vector<PointIndices> > &labeled_clusters,
+      unsigned int min_pts_per_cluster = 1, unsigned int max_pts_per_cluster = std::numeric_limits<unsigned int>::max ());
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -135,10 +153,12 @@ namespace pcl
       /** \brief Set the maximum number of labels in the cloud.
         * \param[in] max_label the maximum
         */
+      PCL_DEPRECATED(1, 14, "Max label is being deprecated")
       inline void 
       setMaxLabels (unsigned int max_label) { max_label_ = max_label; }
 
       /** \brief Get the maximum number of labels */
+      PCL_DEPRECATED(1, 14, "Max label is being deprecated")
       inline unsigned int 
       getMaxLabels () const { return (max_label_); }
 

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -144,7 +144,7 @@ pcl::LabeledEuclideanClusterExtraction<PointT>::extract (std::vector<std::vector
 
   // Send the input dataset to the spatial locator
   tree_->setInputCloud (input_);
-  extractLabeledEuclideanClusters (*input_, tree_, static_cast<float> (cluster_tolerance_), labeled_clusters, min_pts_per_cluster_, max_pts_per_cluster_, max_label_);
+  extractLabeledEuclideanClusters (*input_, tree_, static_cast<float> (cluster_tolerance_), labeled_clusters, min_pts_per_cluster_, max_pts_per_cluster_);
 
   // Sort the clusters based on their size (largest one first)
   for (auto &labeled_cluster : labeled_clusters)
@@ -154,6 +154,7 @@ pcl::LabeledEuclideanClusterExtraction<PointT>::extract (std::vector<std::vector
 }
 
 #define PCL_INSTANTIATE_LabeledEuclideanClusterExtraction(T) template class PCL_EXPORTS pcl::LabeledEuclideanClusterExtraction<T>;
-#define PCL_INSTANTIATE_extractLabeledEuclideanClusters(T) template void PCL_EXPORTS pcl::extractLabeledEuclideanClusters<T>(const pcl::PointCloud<T> &, const typename pcl::search::Search<T>::Ptr &, float , std::vector<std::vector<pcl::PointIndices> > &, unsigned int, unsigned int, unsigned int);
+#define PCL_INSTANTIATE_extractLabeledEuclideanClusters_deprecated(T) template void PCL_EXPORTS pcl::extractLabeledEuclideanClusters<T>(const pcl::PointCloud<T> &, const typename pcl::search::Search<T>::Ptr &, float , std::vector<std::vector<pcl::PointIndices> > &, unsigned int, unsigned int, unsigned int);
+#define PCL_INSTANTIATE_extractLabeledEuclideanClusters(T) template void PCL_EXPORTS pcl::extractLabeledEuclideanClusters<T>(const pcl::PointCloud<T> &, const typename pcl::search::Search<T>::Ptr &, float , std::vector<std::vector<pcl::PointIndices> > &, unsigned int, unsigned int);
 
 #endif        // PCL_EXTRACT_CLUSTERS_IMPL_H_

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -40,25 +40,44 @@
 #include <pcl/segmentation/extract_labeled_clusters.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::extractLabeledEuclideanClusters (const PointCloud<PointT> &cloud,
-                                      const typename search::Search<PointT>::Ptr &tree,
-                                      float tolerance,
-                                      std::vector<std::vector<PointIndices> > &labeled_clusters,
-                                      unsigned int min_pts_per_cluster,
-                                      unsigned int max_pts_per_cluster,
-                                      unsigned int)
+template <typename PointT>
+void
+pcl::extractLabeledEuclideanClusters(
+    const PointCloud<PointT>& cloud,
+    const typename search::Search<PointT>::Ptr& tree,
+    float tolerance,
+    std::vector<std::vector<PointIndices>>& labeled_clusters,
+    unsigned int min_pts_per_cluster,
+    unsigned int max_pts_per_cluster,
+    unsigned int)
 {
-  if (tree->getInputCloud ()->size () != cloud.size ())
-  {
+  pcl::extractLabeledEuclideanClusters<PointT>(cloud,
+                                               tree,
+                                               tolerance,
+                                               labeled_clusters,
+                                               min_pts_per_cluster,
+                                               max_pts_per_cluster);
+}
+
+template <typename PointT>
+void
+pcl::extractLabeledEuclideanClusters(
+    const PointCloud<PointT>& cloud,
+    const typename search::Search<PointT>::Ptr& tree,
+    float tolerance,
+    std::vector<std::vector<PointIndices>>& labeled_clusters,
+    unsigned int min_pts_per_cluster,
+    unsigned int max_pts_per_cluster)
+{
+  if (tree->getInputCloud()->points.size() != cloud.points.size()) {
     PCL_ERROR("[pcl::extractLabeledEuclideanClusters] Tree built for a different point "
-              "cloud dataset (%zu) than the input cloud (%zu)!\n",
-              static_cast<std::size_t>(tree->getInputCloud()->size()),
-              static_cast<std::size_t>(cloud.size()));
+              "cloud dataset (%lu) than the input cloud (%lu)!\n",
+              tree->getInputCloud()->points.size(),
+              cloud.points.size());
     return;
   }
   // Create a bool vector of processed point indices, and initialize it to false
-  std::vector<bool> processed (cloud.size (), false);
+  std::vector<bool> processed(cloud.size(), false);
 
   Indices nn_indices;
   std::vector<float> nn_distances;
@@ -71,30 +90,32 @@ pcl::extractLabeledEuclideanClusters (const PointCloud<PointT> &cloud,
 
     Indices seed_queue;
     int sq_idx = 0;
-    seed_queue.push_back (i);
+    seed_queue.push_back(i);
 
     processed[i] = true;
 
-    while (sq_idx < static_cast<int> (seed_queue.size ()))
-    {
+    while (sq_idx < static_cast<int>(seed_queue.size())) {
       // Search for sq_idx
-      int ret = tree->radiusSearch (seed_queue[sq_idx], tolerance, nn_indices, nn_distances, std::numeric_limits<int>::max());
-      if(ret == -1)
-        PCL_ERROR("radiusSearch on tree came back with error -1\n");
-      if (!ret)
-      {
+      int ret = tree->radiusSearch(seed_queue[sq_idx],
+                                   tolerance,
+                                   nn_indices,
+                                   nn_distances,
+                                   std::numeric_limits<int>::max());
+      if (ret == -1)
+        PCL_ERROR("radiusSearch on tree came back with error -1");
+      if (!ret) {
         sq_idx++;
         continue;
       }
 
-      for (std::size_t j = 1; j < nn_indices.size (); ++j)             // nn_indices[0] should be sq_idx
+      for (std::size_t j = 1; j < nn_indices.size();
+           ++j) // nn_indices[0] should be sq_idx
       {
-        if (processed[nn_indices[j]])                             // Has this point been processed before ?
+        if (processed[nn_indices[j]]) // Has this point been processed before ?
           continue;
-        if (cloud[i].label == cloud[nn_indices[j]].label)
-        {
+        if (cloud[i].label == cloud[nn_indices[j]].label) {
           // Perform a simple Euclidean clustering
-          seed_queue.push_back (nn_indices[j]);
+          seed_queue.push_back(nn_indices[j]);
           processed[nn_indices[j]] = true;
         }
       }
@@ -103,18 +124,19 @@ pcl::extractLabeledEuclideanClusters (const PointCloud<PointT> &cloud,
     }
 
     // If this queue is satisfactory, add to the clusters
-    if (seed_queue.size () >= min_pts_per_cluster && seed_queue.size () <= max_pts_per_cluster)
-    {
+    if (seed_queue.size() >= min_pts_per_cluster &&
+        seed_queue.size() <= max_pts_per_cluster) {
       pcl::PointIndices r;
-      r.indices.resize (seed_queue.size ());
-      for (std::size_t j = 0; j < seed_queue.size (); ++j)
+      r.indices.resize(seed_queue.size());
+      for (std::size_t j = 0; j < seed_queue.size(); ++j)
         r.indices[j] = seed_queue[j];
 
-      std::sort (r.indices.begin (), r.indices.end ());
-      r.indices.erase (std::unique (r.indices.begin (), r.indices.end ()), r.indices.end ());
+      std::sort(r.indices.begin(), r.indices.end());
+      r.indices.erase(std::unique(r.indices.begin(), r.indices.end()), r.indices.end());
 
       r.header = cloud.header;
-      labeled_clusters[cloud[i].label].push_back (r);   // We could avoid a copy by working directly in the vector
+      labeled_clusters[cloud[i].label].push_back(
+          r); // We could avoid a copy by working directly in the vector
     }
   }
 }
@@ -122,39 +144,59 @@ pcl::extractLabeledEuclideanClusters (const PointCloud<PointT> &cloud,
 //////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename PointT> void 
-pcl::LabeledEuclideanClusterExtraction<PointT>::extract (std::vector<std::vector<PointIndices> > &labeled_clusters)
+template <typename PointT>
+void
+pcl::LabeledEuclideanClusterExtraction<PointT>::extract(
+    std::vector<std::vector<PointIndices>>& labeled_clusters)
 {
-  if (!initCompute () || 
-      (input_   && input_->points.empty ()) ||
-      (indices_ && indices_->empty ()))
-  {
-    labeled_clusters.clear ();
+  if (!initCompute() || (input_ && input_->points.empty()) ||
+      (indices_ && indices_->empty())) {
+    labeled_clusters.clear();
     return;
   }
 
   // Initialize the spatial locator
-  if (!tree_)
-  {
-    if (input_->isOrganized ())
-      tree_.reset (new pcl::search::OrganizedNeighbor<PointT> ());
+  if (!tree_) {
+    if (input_->isOrganized())
+      tree_.reset(new pcl::search::OrganizedNeighbor<PointT>());
     else
-      tree_.reset (new pcl::search::KdTree<PointT> (false));
+      tree_.reset(new pcl::search::KdTree<PointT>(false));
   }
 
   // Send the input dataset to the spatial locator
-  tree_->setInputCloud (input_);
-  extractLabeledEuclideanClusters (*input_, tree_, static_cast<float> (cluster_tolerance_), labeled_clusters, min_pts_per_cluster_, max_pts_per_cluster_);
+  tree_->setInputCloud(input_);
+  extractLabeledEuclideanClusters(*input_,
+                                  tree_,
+                                  static_cast<float>(cluster_tolerance_),
+                                  labeled_clusters,
+                                  min_pts_per_cluster_,
+                                  max_pts_per_cluster_);
 
   // Sort the clusters based on their size (largest one first)
-  for (auto &labeled_cluster : labeled_clusters)
-    std::sort (labeled_cluster.rbegin (), labeled_cluster.rend (), comparePointClusters);
+  for (auto& labeled_cluster : labeled_clusters)
+    std::sort(labeled_cluster.rbegin(), labeled_cluster.rend(), comparePointClusters);
 
-  deinitCompute ();
+  deinitCompute();
 }
 
-#define PCL_INSTANTIATE_LabeledEuclideanClusterExtraction(T) template class PCL_EXPORTS pcl::LabeledEuclideanClusterExtraction<T>;
-#define PCL_INSTANTIATE_extractLabeledEuclideanClusters_deprecated(T) template void PCL_EXPORTS pcl::extractLabeledEuclideanClusters<T>(const pcl::PointCloud<T> &, const typename pcl::search::Search<T>::Ptr &, float , std::vector<std::vector<pcl::PointIndices> > &, unsigned int, unsigned int, unsigned int);
-#define PCL_INSTANTIATE_extractLabeledEuclideanClusters(T) template void PCL_EXPORTS pcl::extractLabeledEuclideanClusters<T>(const pcl::PointCloud<T> &, const typename pcl::search::Search<T>::Ptr &, float , std::vector<std::vector<pcl::PointIndices> > &, unsigned int, unsigned int);
+#define PCL_INSTANTIATE_LabeledEuclideanClusterExtraction(T)                           \
+  template class PCL_EXPORTS pcl::LabeledEuclideanClusterExtraction<T>;
+#define PCL_INSTANTIATE_extractLabeledEuclideanClusters_deprecated(T)                  \
+  template void PCL_EXPORTS pcl::extractLabeledEuclideanClusters<T>(                   \
+      const pcl::PointCloud<T>&,                                                       \
+      const typename pcl::search::Search<T>::Ptr&,                                     \
+      float,                                                                           \
+      std::vector<std::vector<pcl::PointIndices>>&,                                    \
+      unsigned int,                                                                    \
+      unsigned int,                                                                    \
+      unsigned int);
+#define PCL_INSTANTIATE_extractLabeledEuclideanClusters(T)                             \
+  template void PCL_EXPORTS pcl::extractLabeledEuclideanClusters<T>(                   \
+      const pcl::PointCloud<T>&,                                                       \
+      const typename pcl::search::Search<T>::Ptr&,                                     \
+      float,                                                                           \
+      std::vector<std::vector<pcl::PointIndices>>&,                                    \
+      unsigned int,                                                                    \
+      unsigned int);
 
-#endif        // PCL_EXTRACT_CLUSTERS_IMPL_H_
+#endif // PCL_EXTRACT_CLUSTERS_IMPL_H_

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -69,11 +69,11 @@ pcl::extractLabeledEuclideanClusters(
     unsigned int min_pts_per_cluster,
     unsigned int max_pts_per_cluster)
 {
-  if (tree->getInputCloud()->points.size() != cloud.points.size()) {
+  if (tree->getInputCloud()->size() != cloud.size()) {
     PCL_ERROR("[pcl::extractLabeledEuclideanClusters] Tree built for a different point "
               "cloud dataset (%lu) than the input cloud (%lu)!\n",
-              tree->getInputCloud()->points.size(),
-              cloud.points.size());
+              tree->getInputCloud()->size(),
+              cloud.size());
     return;
   }
   // Create a bool vector of processed point indices, and initialize it to false
@@ -83,8 +83,7 @@ pcl::extractLabeledEuclideanClusters(
   std::vector<float> nn_distances;
 
   // Process all points in the indices vector
-  for (index_t i = 0; i < static_cast<index_t> (cloud.size ()); ++i)
-  {
+  for (index_t i = 0; i < static_cast<index_t>(cloud.size()); ++i) {
     if (processed[i])
       continue;
 
@@ -149,7 +148,7 @@ void
 pcl::LabeledEuclideanClusterExtraction<PointT>::extract(
     std::vector<std::vector<PointIndices>>& labeled_clusters)
 {
-  if (!initCompute() || (input_ && input_->points.empty()) ||
+  if (!initCompute() || (input_ && input_->empty()) ||
       (indices_ && indices_->empty())) {
     labeled_clusters.clear();
     return;

--- a/segmentation/src/extract_clusters.cpp
+++ b/segmentation/src/extract_clusters.cpp
@@ -53,5 +53,6 @@
   PCL_INSTANTIATE(extractEuclideanClusters_indices, PCL_XYZ_POINT_TYPES)
 #endif
 PCL_INSTANTIATE(LabeledEuclideanClusterExtraction, PCL_XYZL_POINT_TYPES)
+PCL_INSTANTIATE(extractLabeledEuclideanClusters_deprecated, PCL_XYZL_POINT_TYPES)
 PCL_INSTANTIATE(extractLabeledEuclideanClusters, PCL_XYZL_POINT_TYPES)
 

--- a/segmentation/src/extract_clusters.cpp
+++ b/segmentation/src/extract_clusters.cpp
@@ -38,19 +38,22 @@
  */
 
 #include <pcl/impl/instantiate.hpp>
-#include <pcl/point_types.h>
 #include <pcl/segmentation/impl/extract_clusters.hpp>
 #include <pcl/segmentation/impl/extract_labeled_clusters.hpp>
+#include <pcl/point_types.h>
 
 // Instantiations of specific point types
 #ifdef PCL_ONLY_CORE_POINT_TYPES
-  PCL_INSTANTIATE(EuclideanClusterExtraction, (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA)(pcl::PointXYZRGB))
-  PCL_INSTANTIATE(extractEuclideanClusters, (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA)(pcl::PointXYZRGB))
-  PCL_INSTANTIATE(extractEuclideanClusters_indices, (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA)(pcl::PointXYZRGB))
+PCL_INSTANTIATE(EuclideanClusterExtraction,
+                (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA)(pcl::PointXYZRGB))
+PCL_INSTANTIATE(extractEuclideanClusters,
+                (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA)(pcl::PointXYZRGB))
+PCL_INSTANTIATE(extractEuclideanClusters_indices,
+                (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGBA)(pcl::PointXYZRGB))
 #else
-  PCL_INSTANTIATE(EuclideanClusterExtraction, PCL_XYZ_POINT_TYPES)
-  PCL_INSTANTIATE(extractEuclideanClusters, PCL_XYZ_POINT_TYPES)
-  PCL_INSTANTIATE(extractEuclideanClusters_indices, PCL_XYZ_POINT_TYPES)
+PCL_INSTANTIATE(EuclideanClusterExtraction, PCL_XYZ_POINT_TYPES)
+PCL_INSTANTIATE(extractEuclideanClusters, PCL_XYZ_POINT_TYPES)
+PCL_INSTANTIATE(extractEuclideanClusters_indices, PCL_XYZ_POINT_TYPES)
 #endif
 PCL_INSTANTIATE(LabeledEuclideanClusterExtraction, PCL_XYZL_POINT_TYPES)
 PCL_INSTANTIATE(extractLabeledEuclideanClusters_deprecated, PCL_XYZL_POINT_TYPES)


### PR DESCRIPTION
Originated in discussion at #4084

Clang-format commit is separate to ease code review, can be removed completely