### PR TITLE
[meta] Adding `kind: todo` to exempt list for stale-bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,7 @@ onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
+  - "kind: todo"
   - "needs: code review"
   - "needs: feedback"
   - "needs: pr merge"


### PR DESCRIPTION
I don't know if this is controversial, but `kind: todo` is essentially backlog, and needs to be exempt, unlike `kind: request` and `kind: proposal`.

* `kind: request` implies "Please add this to backlog"
* `kind: proposal` implies "This is how I'll create a PR to add this feature"

Considering this, and not exempting `kind: compile error` and `kind: bug` make sense since they can be labelled with a `needs` label. For `kind: question`, I think a similar rule applies, but I'm not sure.

Please feel free to give feedback