### PR TITLE
[CI] Try reduce size of binaries on the CI

### DIFF
--- a/.ci/azure-pipelines/build-macos.yaml
+++ b/.ci/azure-pipelines/build-macos.yaml
@@ -31,7 +31,7 @@ jobs:
           mkdir $BUILD_DIR && cd $BUILD_DIR
           # Surface switched off due to OpenGL deprecation on Mac
           cmake $(Build.SourcesDirectory) \
-            -DCMAKE_BUILD_TYPE="Release" \
+            -DCMAKE_BUILD_TYPE="MinSizeRel" \
             -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX$(OSX_VERSION).sdk" \
             -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
             -DGTEST_SRC_DIR="$GOOGLE_TEST_DIR/googletest" \

--- a/.ci/azure-pipelines/build-ubuntu.yaml
+++ b/.ci/azure-pipelines/build-ubuntu.yaml
@@ -37,7 +37,7 @@ jobs:
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR
           cmake $(Build.SourcesDirectory) $(CMAKE_ARGS) \
-          -DCMAKE_BUILD_TYPE="Release" \
+          -DCMAKE_BUILD_TYPE="MinSizeRel" \
           -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
           -DPCL_ONLY_CORE_POINT_TYPES=ON \
           -DBUILD_simulation=ON \

--- a/.ci/azure-pipelines/build-windows.yaml
+++ b/.ci/azure-pipelines/build-windows.yaml
@@ -16,7 +16,7 @@ jobs:
     timeoutInMinutes: 0
     variables:
       BUILD_DIR: '$(Agent.WorkFolder)\build'
-      CONFIGURATION: 'Release'
+      CONFIGURATION: 'MinSizeRel'
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
       - checkout: self
@@ -42,7 +42,7 @@ jobs:
           mkdir %BUILD_DIR% && cd %BUILD_DIR%
           cmake $(Build.SourcesDirectory) ^
             -G"%GENERATOR%" ^
-            -DCMAKE_BUILD_TYPE="Release" ^
+            -DCMAKE_BUILD_TYPE="MinSizeRel" ^
             -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake ^
             -DVCPKG_APPLOCAL_DEPS=ON ^
             -DPCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32=ON ^

--- a/.ci/azure-pipelines/build-windows.yaml
+++ b/.ci/azure-pipelines/build-windows.yaml
@@ -16,7 +16,7 @@ jobs:
     timeoutInMinutes: 0
     variables:
       BUILD_DIR: '$(Agent.WorkFolder)\build'
-      CONFIGURATION: 'MinSizeRel'
+      CONFIGURATION: 'Release'
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
       - checkout: self


### PR DESCRIPTION
Uses CMake mode `MinSizeRel` instead of `Release`. Should not affect anything except codegen