### PR TITLE
Add a deprecation notice to empty function `kiss_fft_cleanup`

### DIFF
--- a/common/include/pcl/common/fft/kiss_fft.h
+++ b/common/include/pcl/common/fft/kiss_fft.h
@@ -109,8 +109,9 @@ kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int 
  Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up 
  your compiler output to call this before you exit.
 */
+PCL_DEPRECATED(1, 13, "This function does nothing, you can safely not use it.")
 void PCL_EXPORTS 
-kiss_fft_cleanup(void);
+kiss_fft_cleanup(void) {};
 
 /*
  * Returns the smallest integer k, such that k>=n and k has only "fast" factors (2,3,5)

--- a/common/src/fft/kiss_fft.c
+++ b/common/src/fft/kiss_fft.c
@@ -395,12 +395,6 @@ void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout)
     kiss_fft_stride(cfg,fin,fout,1);
 }
 
-
-void kiss_fft_cleanup(void)
-{
-    // nothing needed any more
-}
-
 int kiss_fft_next_fast_size(int n)
 {
     while(1) {


### PR DESCRIPTION
Add a deprecation notice to a public function just in case someone was using it for whatever reason.

Found this branch lying around while cleaning up my fork. Seems harmless enough, maybe I wanted to add onto this, but there seems to be no need to.