### PR TITLE
Adapt doc Dockerfile to use 20.04 dependencies

### DIFF
--- a/.dev/docker/doc/Dockerfile
+++ b/.dev/docker/doc/Dockerfile
@@ -13,3 +13,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install Jinja2 sphinx sphinxcontrib-doxylink sphinx_rtd_theme requests grip
+
+# Use eps2eps to solve https://github.com/doxygen/doxygen/issues/7484 before Doxygen 1.8.18
+RUN update-alternatives --install /usr/local/bin/ps2epsi ps2epsi /usr/bin/ps2epsi 1 \
+ && update-alternatives --install /usr/local/bin/ps2epsi ps2epsi /usr/bin/eps2eps 1000

--- a/.dev/docker/doc/Dockerfile
+++ b/.dev/docker/doc/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
  && apt-get install -y \
       doxygen-latex \
       dvipng \
+      graphviz \
       git \
       python3-pip \
       pandoc \


### PR DESCRIPTION
Cherry-picks from  #4048 which are independent from that PR.

The change to 20.04:
- highlighted a missing transitive dependency which caused the `missing components: dot` to appear in documentation builds like [here](https://dev.azure.com/PointCloudLibrary/pcl/_build/results?buildId=16359&view=logs&j=d0d530cd-2c5d-5eb2-7bb0-02dfe64fb679&t=5a603e19-1cb1-547b-beb6-7fb29829b993&l=132) as `-- Found Doxygen: /usr/bin/doxygen (found version "1.8.17") found components: doxygen missing components: dot` during CMake configuration;
- introduced Doxygen 1.8.17 which has an issue with ghostscript that is linked and documented in 
6fd8df8.