### PR TITLE
[ci] Add surface module back on the CI (depends on VTK PRs: 4046, 4096)

### DIFF
--- a/.ci/azure-pipelines/build-macos.yaml
+++ b/.ci/azure-pipelines/build-macos.yaml
@@ -29,7 +29,7 @@ jobs:
         displayName: 'Install Dependencies'
       - script: |
           mkdir $BUILD_DIR && cd $BUILD_DIR
-          # Surface switched off due to OpenGL deprecation on Mac
+          # Simulation switched off due to OpenGL deprecation on Mac
           cmake $(Build.SourcesDirectory) \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX$(OSX_VERSION).sdk" \

--- a/.ci/azure-pipelines/build-macos.yaml
+++ b/.ci/azure-pipelines/build-macos.yaml
@@ -38,7 +38,7 @@ jobs:
             -DGTEST_INCLUDE_DIR="$GOOGLE_TEST_DIR/googletest/include" \
             -DQt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5 \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
-            -DBUILD_simulation=ON \
+            -DBUILD_simulation=OFF \
             -DBUILD_surface=ON \
             -DBUILD_global_tests=ON \
             -DBUILD_examples=ON \

--- a/.ci/azure-pipelines/build-macos.yaml
+++ b/.ci/azure-pipelines/build-macos.yaml
@@ -39,7 +39,7 @@ jobs:
             -DQt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5 \
             -DPCL_ONLY_CORE_POINT_TYPES=ON \
             -DBUILD_simulation=ON \
-            -DBUILD_surface=OFF \
+            -DBUILD_surface=ON \
             -DBUILD_global_tests=ON \
             -DBUILD_examples=ON \
             -DBUILD_tools=ON \

--- a/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.h
+++ b/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.h
@@ -133,9 +133,9 @@ namespace pcl
         {
           for( int i=0 ; i<this->size() ; i++ )
           {
-            printf( "%d]" , i );
-            for( int j=0 ; j<=Degree ; j++ ) printf( " %d" , (*this)[i][j] );
-            printf( " (%d)\n" , denominator );
+            fprintf(fp, "%d]" , i );
+            for( int j=0 ; j<=Degree ; j++ ) fprintf(fp, " %d" , (*this)[i][j] );
+            fprintf(fp, " (%d)\n" , denominator );
           }
         }
     };

--- a/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.hpp
+++ b/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.hpp
@@ -26,6 +26,8 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
 DAMAGE.
 */
 
+#include <pcl/common/utils.h>
+
 #include "poisson_exceptions.h"
 #include "binary_node.h"
 
@@ -58,6 +60,7 @@ namespace pcl
     // <=>		i < r + 0.5 * Degree
     template< int Degree > inline bool LeftOverlap( unsigned int depth , int offset )
     {
+      pcl::utils::ignore(depth);
       offset <<= 1;
       if( Degree & 1 ) return (offset < 1+Degree) && (offset > -1-Degree );
       else             return (offset <   Degree) && (offset > -2-Degree );
@@ -65,12 +68,13 @@ namespace pcl
     template< int Degree > inline bool RightOverlap( unsigned int depth , int offset )
     {
       offset <<= 1;
-      int r = 1<<(depth+1);
+      pcl::utils::ignore(depth);
       if( Degree & 1 ) return (offset > 2-1-Degree) && (offset < 2+1+Degree );
       else             return (offset > 2-2-Degree) && (offset < 2+  Degree );
     }
     template< int Degree > inline int ReflectLeft( unsigned int depth , int offset )
     {
+      pcl::utils::ignore(depth);
       if( Degree&1 ) return   -offset;
       else           return -1-offset;
     }
@@ -447,6 +451,7 @@ namespace pcl
     template< int Degree >
     void BSplineElements< Degree >::upSample( BSplineElements< Degree >& high ) const
     {
+      pcl::utils::ignore(high);
       POISSON_THROW_EXCEPTION (pcl::poisson::PoissonBadArgumentException, "B-spline up-sampling not supported for degree " << Degree);
     }
     template<>


### PR DESCRIPTION
Explicitly switching off simulation. If simulation is switched on, surface can't be built.

Draft, will resolve warnings and errors as they come by.