### PR TITLE
[filters] reduce computations involved in iterating over the pointcloud for `FastBilateral{OMP}`

### DIFF
--- a/filters/include/pcl/filters/impl/fast_bilateral.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral.hpp
@@ -60,18 +60,13 @@ FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
   float base_max = -std::numeric_limits<float>::max (),
         base_min = std::numeric_limits<float>::max ();
   bool found_finite = false;
-  for (std::size_t x = 0; x < output.width; ++x)
+  for (const auto& pt: output)
   {
-    for (std::size_t y = 0; y < output.height; ++y)
+    if (std::isfinite(pt.z))
     {
-      if (std::isfinite (output (x, y).z))
-      {
-        if (base_max < output (x, y).z)
-          base_max = output (x, y).z;
-        if (base_min > output (x, y).z)
-          base_min = output (x, y).z;
-        found_finite = true;
-      }
+      base_max = std::max<float>(pt.z, base_max);
+      base_min = std::min<float>(pt.z, base_min);
+      found_finite = true;
     }
   }
   if (!found_finite)
@@ -80,10 +75,13 @@ FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
     return;
   }
 
-  for (std::size_t x = 0; x < output.width; ++x)
-      for (std::size_t y = 0; y < output.height; ++y)
-        if (!std::isfinite (output (x, y).z))
-          output (x, y).z = base_max;
+  for (auto& pt: output)
+  {
+    if (!std::isfinite(pt.z))
+    {
+      pt.z = base_max;
+    }
+  }
 
   const float base_delta = base_max - base_min;
 

--- a/filters/include/pcl/filters/impl/fast_bilateral_omp.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral_omp.hpp
@@ -72,18 +72,13 @@ pcl::FastBilateralFilterOMP<PointT>::applyFilter (PointCloud &output)
   float base_max = -std::numeric_limits<float>::max (),
         base_min = std::numeric_limits<float>::max ();
   bool found_finite = false;
-  for (std::size_t x = 0; x < output.width; ++x)
+  for (const auto& pt: output)
   {
-    for (std::size_t y = 0; y < output.height; ++y)
+    if (std::isfinite(pt.z))
     {
-      if (std::isfinite (output (x, y).z))
-      {
-        if (base_max < output (x, y).z)
-          base_max = output (x, y).z;
-        if (base_min > output (x, y).z)
-          base_min = output (x, y).z;
-        found_finite = true;
-      }
+      base_max = std::max<float>(pt.z, base_max);
+      base_min = std::min<float>(pt.z, base_min);
+      found_finite = true;
     }
   }
   if (!found_finite)


### PR DESCRIPTION
No need to perform a 2 variable iteration when 1 suffices