### PR TITLE
[io] Throw error if the device bluffs about its capability

### DIFF
--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -501,6 +501,8 @@ pcl::io::openni2::OpenNI2Device::getDefaultIRMode () const
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
       return mode;
   }
+  if (modeList.empty())
+      THROW_IO_EXCEPTION("Device claims to have a IR sensor, but doesn't have any IR streaming mode");
   return (modeList.at (0)); // Return first mode if we can't find VGA
 }
 
@@ -514,6 +516,8 @@ pcl::io::openni2::OpenNI2Device::getDefaultColorMode () const
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
       return mode;
   }
+  if (modeList.empty())
+      THROW_IO_EXCEPTION("Device claims to have a color sensor, but doesn't have any color streaming mode");
   return (modeList.at (0)); // Return first mode if we can't find VGA
 }
 
@@ -527,6 +531,8 @@ pcl::io::openni2::OpenNI2Device::getDefaultDepthMode () const
     if ( (mode.x_resolution_ == 640) && (mode.y_resolution_ == 480) && (mode.frame_rate_ == 30.0) )
       return mode;
   }
+  if (modeList.empty())
+      THROW_IO_EXCEPTION("Device claims to have a depth sensor, but doesn't have any depth streaming mode");
   return (modeList.at (0)); // Return first mode if we can't find VGA
 }
 


### PR DESCRIPTION
Closes #757, but doesn't go deep into the fix (why does the device actually claim to have a color sensor?)