### PR TITLE
Fix warnings present on Ubuntu

### DIFF
--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -133,13 +133,30 @@ copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
   if (cloud_in.points.empty ())
     return;
 
-  if (isSamePointType<PointInT, PointOutT> ())
-    // Copy the whole memory block
-    memcpy (&cloud_out.points[0], &cloud_in.points[0], cloud_in.points.size () * sizeof (PointInT));
-  else
-    // Iterate over each point
-    for (std::size_t i = 0; i < cloud_in.points.size (); ++i)
-      copyPoint (cloud_in.points[i], cloud_out.points[i]);
+  // Iterate over each point
+  for (std::size_t i = 0; i < cloud_in.points.size (); ++i)
+    copyPoint (cloud_in.points[i], cloud_out.points[i]);
+}
+
+template <typename PointInT, typename PointOutT> void
+copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
+                pcl::PointCloud<PointInT> &cloud_out)
+{
+  // Allocate enough space and copy the basics
+  cloud_out.header   = cloud_in.header;
+  cloud_out.width    = cloud_in.width;
+  cloud_out.height   = cloud_in.height;
+  cloud_out.is_dense = cloud_in.is_dense;
+  cloud_out.sensor_orientation_ = cloud_in.sensor_orientation_;
+  cloud_out.sensor_origin_ = cloud_in.sensor_origin_;
+  cloud_out.points.resize (cloud_in.points.size ());
+
+  if (cloud_in.points.empty ())
+    return;
+
+  // Copy the whole memory block
+  cloud_out.points = cloud_in.points;
+
 }
 
 

--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -69,7 +69,7 @@ TEST(PCL, PCLVisualizer_updatePointCloud)
   pcl::common::CloudGenerator<pcl::PointXYZRGB, pcl::common::UniformGenerator<float> > generator;
 
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>());
-  int result = generator.fill(3, 1, *cloud);
+  generator.fill(3, 1, *cloud);
 
   // Setup a basic viewport window
   pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));


### PR DESCRIPTION
A lot of warning regarding `uint*_t` present even though `std::unit*_t` is used, not sure why that is the case.