### PR TITLE
Remove redundant checking for existence in STL maps/sets

### DIFF
--- a/visualization/src/cloud_viewer.cpp
+++ b/visualization/src/cloud_viewer.cpp
@@ -247,8 +247,7 @@ struct pcl::visualization::CloudViewer::CloudViewer_impl
   remove (const std::string &key)
   {
     std::lock_guard<std::mutex> lock (c_mtx);
-    if (callables.find (key) != callables.end ())
-      callables.erase (key);
+    callables.erase (key);
   }
 
   std::string window_name_;


### PR DESCRIPTION
STL maps/sets don't require check before erase