### PR TITLE
Switching from private to firstprivate in OpenMP pragma

### DIFF
--- a/features/include/pcl/features/impl/fpfh_omp.hpp
+++ b/features/include/pcl/features/impl/fpfh_omp.hpp
@@ -111,7 +111,7 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
 #pragma omp parallel for \
   default(none) \
   shared(spfh_hist_lookup, spfh_indices_vec) \
-  private(nn_indices, nn_dists) \
+  firstprivate(nn_indices, nn_dists) \
   num_threads(threads_)
   for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t> (spfh_indices_vec.size ()); ++i)
   {
@@ -140,7 +140,7 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
 #pragma omp parallel for \
   default(none) \
   shared(nr_bins, output, spfh_hist_lookup) \
-  private(nn_dists, nn_indices) \
+  firstprivate(nn_dists, nn_indices) \
   num_threads(threads_)
   for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
   {

--- a/features/include/pcl/features/impl/intensity_gradient.hpp
+++ b/features/include/pcl/features/impl/intensity_gradient.hpp
@@ -154,7 +154,7 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
 #pragma omp parallel for \
   default(none) \
   shared(output) \
-  private(nn_indices, nn_dists) \
+  firstprivate(nn_indices, nn_dists) \
   num_threads(threads_)
     // Iterating over the entire index vector
     for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)
@@ -194,7 +194,7 @@ pcl::IntensityGradientEstimation<PointInT, PointNT, PointOutT, IntensitySelector
 #pragma omp parallel for \
   default(none) \
   shared(output) \
-  private(nn_indices, nn_dists) \
+  firstprivate(nn_indices, nn_dists) \
   num_threads(threads_)
     // Iterating over the entire index vector
     for (std::ptrdiff_t idx = 0; idx < static_cast<std::ptrdiff_t> (indices_->size ()); ++idx)

--- a/filters/include/pcl/filters/impl/convolution_3d.hpp
+++ b/filters/include/pcl/filters/impl/convolution_3d.hpp
@@ -244,7 +244,7 @@ pcl::filters::Convolution3D<PointInT, PointOutT, KernelT>::convolve (PointCloudO
 #pragma omp parallel for \
   default(none) \
   shared(output) \
-  private(nn_indices, nn_distances) \
+  firstprivate(nn_indices, nn_distances) \
   num_threads(threads_)
   for (std::int64_t point_idx = 0; point_idx < static_cast<std::int64_t> (surface_->size ()); ++point_idx)
   {

--- a/keypoints/include/pcl/keypoints/impl/harris_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_2d.hpp
@@ -312,13 +312,13 @@ HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseHarris (PointCloudOut
 #pragma omp parallel for      \
   default(none)               \
   shared(output)              \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #else
 #pragma omp parallel for      \
   default(none)               \
   shared(output, output_size) \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #endif
   for (int index = 0; index < output_size; ++index)
@@ -358,13 +358,13 @@ HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseNoble (PointCloudOut 
 #pragma omp parallel for      \
   default(none)               \
   shared(output)              \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #else
 #pragma omp parallel for      \
   default(none)               \
   shared(output, output_size) \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #endif
   for (int index = 0; index < output_size; ++index)
@@ -404,13 +404,13 @@ HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseLowe (PointCloudOut &
 #pragma omp parallel for      \
   default(none)               \
   shared(output)              \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #else
 #pragma omp parallel for      \
   default(none)               \
   shared(output, output_size) \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #endif
   for (int index = 0; index < output_size; ++index)
@@ -450,13 +450,13 @@ HarrisKeypoint2D<PointInT, PointOutT, IntensityT>::responseTomasi (PointCloudOut
 #pragma omp parallel for      \
   default(none)               \
   shared(output)              \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #else
 #pragma omp parallel for      \
   default(none)               \
   shared(output, output_size) \
-  private(covar)              \
+  firstprivate(covar)              \
   num_threads(threads_)
 #endif
   for (int index = 0; index < output_size; ++index)

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -325,7 +325,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseHarris (PointCloudO
 #pragma omp parallel for \
   default(none) \
   shared(output) \
-  private(covar) \
+  firstprivate(covar) \
   num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
@@ -366,7 +366,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseNoble (PointCloudOu
 #pragma omp parallel \
   for default(none) \
   shared(output) \
-  private(covar) \
+  firstprivate(covar) \
   num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
@@ -406,7 +406,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseLowe (PointCloudOut
 #pragma omp parallel for \
   default(none) \
   shared(output) \
-  private(covar) \
+  firstprivate(covar) \
   num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
@@ -465,7 +465,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::responseTomasi (PointCloudO
 #pragma omp parallel for \
   default(none) \
   shared(output) \
-  private(covar, covariance_matrix) \
+  firstprivate(covar, covariance_matrix) \
   num_threads(threads_)
   for (int pIdx = 0; pIdx < static_cast<int> (input_->size ()); ++pIdx)
   {
@@ -513,7 +513,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::refineCorners (PointCloudOu
 #pragma omp parallel for \
   default(none) \
   shared(corners) \
-  private(nnT, NNT, NNTInv, NNTp, diff) \
+  firstprivate(nnT, NNT, NNTInv, NNTp, diff) \
   num_threads(threads_)
   for (int cIdx = 0; cIdx < static_cast<int> (corners.size ()); ++cIdx)
   {

--- a/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_6d.hpp
@@ -275,7 +275,7 @@ pcl::HarrisKeypoint6D<PointInT, PointOutT, NormalT>::responseTomasi (PointCloudO
 
 #pragma omp parallel for \
   default(none) \
-  private(pointOut, covar, covariance, solver) \
+  firstprivate(pointOut, covar, covariance, solver) \
   num_threads(threads_)
   for (unsigned pIdx = 0; pIdx < input_->size (); ++pIdx)
   {

--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -115,7 +115,7 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::getBoundaryPoints (PointCloudI
 #pragma omp parallel for \
   default(none) \
   shared(angle_threshold, boundary_estimator, border_radius, edge_points, input) \
-  private(u, v) \
+  firstprivate(u, v) \
   num_threads(threads_)
   for (int index = 0; index < int (input.points.size ()); index++)
   {

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -64,7 +64,7 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
 #pragma omp parallel for \
   default(none) \
   shared(tree, cloud) \
-  private(ids, dists_sqr) \
+  firstprivate(ids, dists_sqr) \
   reduction(+:mean_dist, num) \
   firstprivate(s, max_dist_sqr) \
   num_threads(nr_threads)
@@ -103,14 +103,14 @@ pcl::getMeanPointDensity (const typename pcl::PointCloud<PointT>::ConstPtr &clou
 #pragma omp parallel for \
   default(none) \
   shared(tree, cloud, indices) \
-  private(ids, dists_sqr) \
+  firstprivate(ids, dists_sqr) \
   reduction(+:mean_dist, num) \
   num_threads(nr_threads)
 #else
 #pragma omp parallel for \
   default(none) \
   shared(tree, cloud, indices, s, max_dist_sqr) \
-  private(ids, dists_sqr) \
+  firstprivate(ids, dists_sqr) \
   reduction(+:mean_dist, num) \
   num_threads(nr_threads)
 #endif

--- a/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
@@ -96,7 +96,7 @@ pcl::RandomSampleConsensus<PointT>::computeModel (int)
   }
 
 #if OPENMP_AVAILABLE_RANSAC
-#pragma omp parallel if(threads > 0) num_threads(threads) shared(k, skipped_count, n_best_inliers_count) private(selection, model_coefficients, n_inliers_count) // would be nice to have a default(none)-clause here, but then some compilers complain about the shared const variables
+#pragma omp parallel if(threads > 0) num_threads(threads) shared(k, skipped_count, n_best_inliers_count) firstprivate(selection, model_coefficients, n_inliers_count) // would be nice to have a default(none)-clause here, but then some compilers complain about the shared const variables
 #endif
   {
 #if OPENMP_AVAILABLE_RANSAC

--- a/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/ransac.hpp
@@ -73,7 +73,6 @@ pcl::RandomSampleConsensus<PointT>::computeModel (int)
   const double log_probability  = std::log (1.0 - probability_);
   const double one_over_indices = 1.0 / static_cast<double> (sac_model_->getIndices ()->size ());
 
-  std::size_t n_inliers_count;
   unsigned skipped_count = 0;
 
   // suppress infinite loops by just allowing 10 x maximum allowed iterations for invalid model parameters!
@@ -96,7 +95,7 @@ pcl::RandomSampleConsensus<PointT>::computeModel (int)
   }
 
 #if OPENMP_AVAILABLE_RANSAC
-#pragma omp parallel if(threads > 0) num_threads(threads) shared(k, skipped_count, n_best_inliers_count) firstprivate(selection, model_coefficients, n_inliers_count) // would be nice to have a default(none)-clause here, but then some compilers complain about the shared const variables
+#pragma omp parallel if(threads > 0) num_threads(threads) shared(k, skipped_count, n_best_inliers_count) firstprivate(selection, model_coefficients) // would be nice to have a default(none)-clause here, but then some compilers complain about the shared const variables
 #endif
   {
 #if OPENMP_AVAILABLE_RANSAC
@@ -144,7 +143,7 @@ pcl::RandomSampleConsensus<PointT>::computeModel (int)
       //if (inliers.empty () && k > 1.0)
       //  continue;
 
-      n_inliers_count = sac_model_->countWithinDistance (model_coefficients, threshold_); // This functions has to be thread-safe. Most work is done here
+      std::size_t n_inliers_count = sac_model_->countWithinDistance (model_coefficients, threshold_); // This functions has to be thread-safe. Most work is done here
 
       std::size_t n_best_inliers_count_tmp;
 #if OPENMP_AVAILABLE_RANSAC


### PR DESCRIPTION
See https://stackoverflow.com/a/15309556 for details. `firstprivate` is initialized via copy ctor, while `private` is uninitialized