### PR TITLE
[octree] Replace usage of `std::vector<int>` with `Indices` in octree module & tests

### DIFF
--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -78,8 +78,8 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     addPointsFromInputCloud()
 {
   if (indices_) {
-    for (const int& index : *indices_) {
-      assert((index >= 0) && (index < static_cast<int>(input_->points.size())));
+    for (const auto& index : *indices_) {
+      assert((index >= 0) && (index < static_cast<index_t>(input_->points.size())));
 
       if (isFinite(input_->points[index])) {
         // add points to octree
@@ -91,7 +91,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     for (std::size_t i = 0; i < input_->points.size(); i++) {
       if (isFinite(input_->points[i])) {
         // add points to octree
-        this->addPointIdx(static_cast<unsigned int>(i));
+        this->addPointIdx(static_cast<unsigned index_t>(i));
       }
     }
   }
@@ -104,7 +104,7 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    addPointFromCloud(const int point_idx_arg, IndicesPtr indices_arg)
+    addPointFromCloud(const index_t point_idx_arg, IndicesPtr indices_arg)
 {
   this->addPointIdx(point_idx_arg);
   if (indices_arg)
@@ -124,7 +124,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
   cloud_arg->push_back(point_arg);
 
-  this->addPointIdx(static_cast<const int>(cloud_arg->points.size()) - 1);
+  this->addPointIdx(static_cast<const index_t>(cloud_arg->points.size()) - 1);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -143,7 +143,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
   cloud_arg->push_back(point_arg);
 
-  this->addPointFromCloud(static_cast<const int>(cloud_arg->points.size()) - 1,
+  this->addPointFromCloud(static_cast<const index_t>(cloud_arg->points.size()) - 1,
                           indices_arg);
 }
 
@@ -176,7 +176,7 @@ template <typename PointT,
           typename OctreeT>
 bool
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    isVoxelOccupiedAtPoint(const int& point_idx_arg) const
+    isVoxelOccupiedAtPoint(const index_t& point_idx_arg) const
 {
   // retrieve point from input cloud
   const PointT& point = this->input_->points[point_idx_arg];
@@ -234,7 +234,7 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    deleteVoxelAtPoint(const int& point_idx_arg)
+    deleteVoxelAtPoint(const index_t& point_idx_arg)
 {
   // retrieve point from input cloud
   const PointT& point = this->input_->points[point_idx_arg];
@@ -613,7 +613,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     std::size_t leaf_obj_count = (*leaf_node)->getSize();
 
     // copy leaf data
-    std::vector<int> leafIndices;
+    Indices leafIndices;
     leafIndices.reserve(leaf_obj_count);
 
     (*leaf_node)->getPointIndices(leafIndices);
@@ -629,7 +629,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     // add data to new branch
     OctreeKey new_index_key;
 
-    for (const int& leafIndex : leafIndices) {
+    for (const auto& leafIndex : leafIndices) {
 
       const PointT& point_from_index = input_->points[leafIndex];
       // generate key
@@ -652,11 +652,11 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    addPointIdx(const int point_idx_arg)
+    addPointIdx(const index_t point_idx_arg)
 {
   OctreeKey key;
 
-  assert(point_idx_arg < static_cast<int>(input_->points.size()));
+  assert(point_idx_arg < static_cast<index_t>(input_->points.size()));
 
   const PointT& point = input_->points[point_idx_arg];
 
@@ -700,10 +700,10 @@ template <typename PointT,
           typename OctreeT>
 const PointT&
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    getPointByIndex(const unsigned int index_arg) const
+    getPointByIndex(const index_t index_arg) const
 {
   // retrieve point from input cloud
-  assert(index_arg < static_cast<unsigned int>(input_->points.size()));
+  assert(index_arg < static_cast<unsigned index_t>(input_->points.size()));
   return (this->input_->points[index_arg]);
 }
 
@@ -834,7 +834,7 @@ template <typename PointT,
           typename OctreeT>
 bool
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    genOctreeKeyForDataT(const int& data_arg, OctreeKey& key_arg) const
+    genOctreeKeyForDataT(const index_t& data_arg, OctreeKey& key_arg) const
 {
   const PointT temp_point = getPointByIndex(data_arg);
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -91,7 +91,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     for (std::size_t i = 0; i < input_->points.size(); i++) {
       if (isFinite(input_->points[i])) {
         // add points to octree
-        this->addPointIdx(static_cast<unsigned index_t>(i));
+        this->addPointIdx(static_cast<index_t>(i));
       }
     }
   }
@@ -703,7 +703,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     getPointByIndex(const index_t index_arg) const
 {
   // retrieve point from input cloud
-  assert(index_arg < static_cast<unsigned index_t>(input_->points.size()));
+  assert(index_arg < static_cast<index_t>(input_->points.size()));
   return (this->input_->points[index_arg]);
 }
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -154,11 +154,11 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>::
-    addPointIdx(const int pointIdx_arg)
+    addPointIdx(const index_t pointIdx_arg)
 {
   OctreeKey key;
 
-  assert(pointIdx_arg < static_cast<int>(this->input_->points.size()));
+  assert(pointIdx_arg < static_cast<index_t>(this->input_->points.size()));
 
   const PointT& point = this->input_->points[pointIdx_arg];
   if (!pcl::isFinite(point))

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -48,7 +48,7 @@ namespace octree {
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
-    const PointT& point, std::vector<int>& point_idx_data)
+    const PointT& point, Indices& point_idx_data)
 {
   assert(isFinite(point) &&
          "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -71,7 +71,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
-    const int index, std::vector<int>& point_idx_data)
+    const index_t index, Indices& point_idx_data)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (this->voxelSearch(search_point, point_idx_data));
@@ -82,7 +82,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
     const PointT& p_q,
     int k,
-    std::vector<int>& k_indices,
+    Indices& k_indices,
     std::vector<float>& k_sqr_distances)
 {
   assert(this->leaf_count_ > 0);
@@ -117,13 +117,13 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch
     k_sqr_distances[i] = point_candidates[i].point_distance_;
   }
 
-  return static_cast<int>(k_indices.size());
+  return static_cast<index_t>(k_indices.size());
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
-    int index, int k, std::vector<int>& k_indices, std::vector<float>& k_sqr_distances)
+    index_t index, int k, Indices& k_indices, std::vector<float>& k_sqr_distances)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (nearestKSearch(search_point, k, k_indices, k_sqr_distances));
@@ -132,7 +132,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestSearch(
-    const PointT& p_q, int& result_index, float& sqr_distance)
+    const PointT& p_q, index_t& result_index, float& sqr_distance)
 {
   assert(this->leaf_count_ > 0);
   assert(isFinite(p_q) &&
@@ -150,7 +150,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestS
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestSearch(
-    int query_index, int& result_index, float& sqr_distance)
+    index_t query_index, index_t& result_index, float& sqr_distance)
 {
   const PointT search_point = this->getPointByIndex(query_index);
 
@@ -162,7 +162,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
     const PointT& p_q,
     const double radius,
-    std::vector<int>& k_indices,
+    Indices& k_indices,
     std::vector<float>& k_sqr_distances,
     unsigned int max_nn) const
 {
@@ -183,15 +183,15 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
                                     k_sqr_distances,
                                     max_nn);
 
-  return (static_cast<int>(k_indices.size()));
+  return (static_cast<index_t>(k_indices.size()));
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
-    int index,
+    index_t index,
     const double radius,
-    std::vector<int>& k_indices,
+    Indices& k_indices,
     std::vector<float>& k_sqr_distances,
     unsigned int max_nn) const
 {
@@ -205,7 +205,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearch(
     const Eigen::Vector3f& min_pt,
     const Eigen::Vector3f& max_pt,
-    std::vector<int>& k_indices) const
+    Indices& k_indices) const
 {
 
   OctreeKey key;
@@ -215,7 +215,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearch(
 
   boxSearchRecursive(min_pt, max_pt, this->root_node_, key, 1, k_indices);
 
-  return (static_cast<int>(k_indices.size()));
+  return (static_cast<index_t>(k_indices.size()));
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
@@ -290,7 +290,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     }
     else {
       // we reached leaf node level
-      std::vector<int> decoded_point_vector;
+      Indices decoded_point_vector;
 
       const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
 
@@ -298,7 +298,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
       (*child_leaf)->getPointIndices(decoded_point_vector);
 
       // Linearly iterate over all decoded (unsorted) points
-      for (const int& point_index : decoded_point_vector) {
+      for (const index_t& point_index : decoded_point_vector) {
 
         const PointT& candidate_point = this->getPointByIndex(point_index);
 
@@ -338,7 +338,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                       const BranchNode* node,
                                       const OctreeKey& key,
                                       unsigned int tree_depth,
-                                      std::vector<int>& k_indices,
+                                      Indices& k_indices,
                                       std::vector<float>& k_sqr_distances,
                                       unsigned int max_nn) const
 {
@@ -389,13 +389,13 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
       else {
         // we reached leaf node level
         const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
-        std::vector<int> decoded_point_vector;
+        Indices decoded_point_vector;
 
         // decode leaf node into decoded_point_vector
         (*child_leaf)->getPointIndices(decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (const int& index : decoded_point_vector) {
+        for (const auto& index : decoded_point_vector) {
           const PointT& candidate_point = this->getPointByIndex(index);
 
           // calculate point distance to search point
@@ -424,7 +424,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                  const BranchNode* node,
                                  const OctreeKey& key,
                                  unsigned int tree_depth,
-                                 int& result_index,
+                                 index_t& result_index,
                                  float& sqr_distance)
 {
   OctreeKey minChildKey;
@@ -479,7 +479,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   }
   else {
     // we reached leaf node level
-    std::vector<int> decoded_point_vector;
+    Indices decoded_point_vector;
 
     const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
 
@@ -489,7 +489,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     (**child_leaf).getPointIndices(decoded_point_vector);
 
     // Linearly iterate over all decoded (unsorted) points
-    for (const int& index : decoded_point_vector) {
+    for (const auto& index : decoded_point_vector) {
       const PointT& candidate_point = this->getPointByIndex(index);
 
       // calculate point distance to search point
@@ -522,7 +522,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
     const BranchNode* node,
     const OctreeKey& key,
     unsigned int tree_depth,
-    std::vector<int>& k_indices) const
+    Indices& k_indices) const
 {
   // iterate over all children
   for (unsigned char child_idx = 0; child_idx < 8; child_idx++) {
@@ -563,7 +563,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
       }
       else {
         // we reached leaf node level
-        std::vector<int> decoded_point_vector;
+        Indices decoded_point_vector;
 
         const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
 
@@ -571,7 +571,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
         (**child_leaf).getPointIndices(decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (const int& index : decoded_point_vector) {
+        for (const auto& index : decoded_point_vector) {
           const PointT& candidate_point = this->getPointByIndex(index);
 
           // check if point falls within search box
@@ -630,7 +630,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelIndices(Eigen::Vector3f origin,
                                Eigen::Vector3f direction,
-                               std::vector<int>& k_indices,
+                               Indices& k_indices,
                                int max_voxel_count) const
 {
   OctreeKey key;
@@ -867,7 +867,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                         unsigned char a,
                                         const OctreeNode* node,
                                         const OctreeKey& key,
-                                        std::vector<int>& k_indices,
+                                        Indices& k_indices,
                                         int max_voxel_count) const
 {
   if (max_x < 0.0 || max_y < 0.0 || max_z < 0.0)

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -88,21 +88,21 @@ public:
    * indices.
    */
   void
-  addPointIndex(const int&)
+  addPointIndex(const index_t&)
   {}
 
   /** \brief Empty getPointIndex implementation as this leaf node does not store any
    * point indices.
    */
   void
-  getPointIndex(int&) const
+  getPointIndex(index_t&) const
   {}
 
   /** \brief Empty getPointIndices implementation as this leaf node does not store any
    * data. \
    */
   void
-  getPointIndices(std::vector<int>&) const
+  getPointIndices(Indices&) const
   {}
 };
 
@@ -140,13 +140,13 @@ public:
    * indices.
    */
   void
-  addPointIndex(int)
+  addPointIndex(index_t)
   {}
 
   /** \brief Empty getPointIndex implementation as this leaf node does not store any
    * point indices.
    */
-  int
+  index_t
   getPointIndex() const
   {
     assert("getPointIndex: undefined point index");
@@ -157,7 +157,7 @@ public:
    * data.
    */
   void
-  getPointIndices(std::vector<int>&) const
+  getPointIndices(Indices&) const
   {}
 };
 
@@ -195,7 +195,7 @@ public:
    * \param[in] data_arg index to be stored within leaf node.
    */
   void
-  addPointIndex(int data_arg)
+  addPointIndex(index_t data_arg)
   {
     data_ = data_arg;
   }
@@ -204,7 +204,7 @@ public:
    * point index
    * \return index stored within container.
    */
-  int
+  index_t
   getPointIndex() const
   {
     return data_;
@@ -216,7 +216,7 @@ public:
    * data vector
    */
   void
-  getPointIndices(std::vector<int>& data_vector_arg) const
+  getPointIndices(Indices& data_vector_arg) const
   {
     if (data_ >= 0)
       data_vector_arg.push_back(data_);
@@ -240,7 +240,7 @@ public:
 
 protected:
   /** \brief Point index stored in octree. */
-  int data_;
+  index_t data_;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -274,7 +274,7 @@ public:
    * \param[in] data_arg index to be stored within leaf node.
    */
   void
-  addPointIndex(int data_arg)
+  addPointIndex(index_t data_arg)
   {
     leafDataTVector_.push_back(data_arg);
   }
@@ -283,7 +283,7 @@ public:
    * point indices.
    * \return index stored within container.
    */
-  int
+  index_t
   getPointIndex() const
   {
     return leafDataTVector_.back();
@@ -295,7 +295,7 @@ public:
    * within data vector
    */
   void
-  getPointIndices(std::vector<int>& data_vector_arg) const
+  getPointIndices(Indices& data_vector_arg) const
   {
     data_vector_arg.insert(
         data_vector_arg.end(), leafDataTVector_.begin(), leafDataTVector_.end());
@@ -305,7 +305,7 @@ public:
    * of point indices.
    * \return reference to vector of point indices to be stored within data vector
    */
-  std::vector<int>&
+  Indices&
   getPointIndicesVector()
   {
     return leafDataTVector_;
@@ -329,7 +329,7 @@ public:
 
 protected:
   /** \brief Leaf node DataT vector. */
-  std::vector<int> leafDataTVector_;
+  Indices leafDataTVector_;
 };
 
 } // namespace octree

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <pcl/types.h>
+
 #include <cassert>
 #include <cstddef>
 #include <vector>

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -82,8 +82,8 @@ public:
   OctreePointCloud(const double resolution_arg);
 
   // public typedefs
-  using IndicesPtr = shared_ptr<std::vector<int>>;
-  using IndicesConstPtr = shared_ptr<const std::vector<int>>;
+  using IndicesPtr = pcl::IndicesPtr;
+  using IndicesConstPtr = pcl::IndicesConstPtr;
 
   using PointCloud = pcl::PointCloud<PointT>;
   using PointCloudPtr = typename PointCloud::Ptr;
@@ -200,7 +200,7 @@ public:
    * setInputCloud)
    */
   void
-  addPointFromCloud(const int point_idx_arg, IndicesPtr indices_arg);
+  addPointFromCloud(const index_t point_idx_arg, IndicesPtr indices_arg);
 
   /** \brief Add point simultaneously to octree and input point cloud.
    *  \param[in] point_arg point to be added
@@ -258,7 +258,7 @@ public:
    * \return "true" if voxel exist; "false" otherwise
    */
   bool
-  isVoxelOccupiedAtPoint(const int& point_idx_arg) const;
+  isVoxelOccupiedAtPoint(const index_t& point_idx_arg) const;
 
   /** \brief Get a PointT vector of centers of all occupied voxels.
    * \param[out] voxel_center_list_arg results are written to this vector of PointT
@@ -295,7 +295,7 @@ public:
    *  \param[in] point_idx_arg index of point addressing the voxel to be deleted.
    */
   void
-  deleteVoxelAtPoint(const int& point_idx_arg);
+  deleteVoxelAtPoint(const index_t& point_idx_arg);
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Bounding box methods
@@ -428,7 +428,7 @@ protected:
    * \a setInputCloud to be added
    */
   virtual void
-  addPointIdx(const int point_idx_arg);
+  addPointIdx(const index_t point_idx_arg);
 
   /** \brief Add point at index from input pointcloud dataset to octree
    * \param[in] leaf_node to be expanded
@@ -448,7 +448,7 @@ protected:
    * \return PointT from input pointcloud dataset
    */
   const PointT&
-  getPointByIndex(const unsigned int index_arg) const;
+  getPointByIndex(const index_t index_arg) const;
 
   /** \brief Find octree leaf node at a given point
    * \param[in] point_arg query point
@@ -520,7 +520,7 @@ protected:
    * are assignable
    */
   virtual bool
-  genOctreeKeyForDataT(const int& data_arg, OctreeKey& key_arg) const;
+  genOctreeKeyForDataT(const index_t& data_arg, OctreeKey& key_arg) const;
 
   /** \brief Generate a point at center of leaf node voxel
    * \param[in] key_arg octree key addressing a leaf node.

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <pcl/octree/octree_base.h>
+#include <pcl/pcl_base.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency.h
@@ -197,7 +197,7 @@ protected:
    * \note This virtual implementation allows the use of a transform function to compute
    * keys. */
   void
-  addPointIdx(const int point_idx_arg) override;
+  addPointIdx(const index_t point_idx_arg) override;
 
   /** \brief Fills in the neighbors fields for new voxels.
    *

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -91,7 +91,7 @@ public:
    * \return number of point indices
    */
   std::size_t
-  getPointIndicesFromNewVoxels(std::vector<int>& indicesVector_arg,
+  getPointIndicesFromNewVoxels(Indices& indicesVector_arg,
                                const int minPointsPerLeaf_arg = 0)
   {
 

--- a/octree/include/pcl/octree/octree_pointcloud_density.h
+++ b/octree/include/pcl/octree/octree_pointcloud_density.h
@@ -77,7 +77,7 @@ public:
   /** \brief Read input data. Only an internal counter is increased.
    */
   void
-  addPointIndex(int)
+  addPointIndex(index_t)
   {
     point_counter_++;
   }

--- a/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
+++ b/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
@@ -156,11 +156,11 @@ public:
    * \param pointIdx_arg
    */
   void
-  addPointIdx(const int pointIdx_arg) override
+  addPointIdx(const index_t pointIdx_arg) override
   {
     OctreeKey key;
 
-    assert(pointIdx_arg < static_cast<int>(this->input_->points.size()));
+    assert(pointIdx_arg < static_cast<index_t>(this->input_->points.size()));
 
     const PointT& point = this->input_->points[pointIdx_arg];
 
@@ -190,7 +190,7 @@ public:
    * \return "true" if voxel is found; "false" otherwise
    */
   inline bool
-  getVoxelCentroidAtPoint(const int& point_idx_arg, PointT& voxel_centroid_arg) const
+  getVoxelCentroidAtPoint(const index_t& point_idx_arg, PointT& voxel_centroid_arg) const
   {
     // get centroid at point
     return (this->getVoxelCentroidAtPoint(this->input_->points[point_idx_arg],

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -342,7 +342,7 @@ protected:
      * \param[in] point_idx index for a dataset point given by \a setInputCloud
      * \param[in] point_distance distance of query point to voxel center
      */
-    prioPointQueueEntry(unsigned index_t& point_idx, float point_distance)
+    prioPointQueueEntry(index_t& point_idx, float point_distance)
     : point_idx_(point_idx), point_distance_(point_distance)
     {}
 

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -58,8 +58,8 @@ class OctreePointCloudSearch
 : public OctreePointCloud<PointT, LeafContainerT, BranchContainerT> {
 public:
   // public typedefs
-  using IndicesPtr = shared_ptr<std::vector<int>>;
-  using IndicesConstPtr = shared_ptr<const std::vector<int>>;
+  using IndicesPtr = pcl::IndicesPtr;
+  using IndicesConstPtr = pcl::IndicesConstPtr;
 
   using PointCloud = pcl::PointCloud<PointT>;
   using PointCloudPtr = typename PointCloud::Ptr;
@@ -91,7 +91,7 @@ public:
    * \return "true" if leaf node exist; "false" otherwise
    */
   bool
-  voxelSearch(const PointT& point, std::vector<int>& point_idx_data);
+  voxelSearch(const PointT& point, Indices& point_idx_data);
 
   /** \brief Search for neighbors within a voxel at given point referenced by a point
    * index
@@ -100,7 +100,7 @@ public:
    * \return "true" if leaf node exist; "false" otherwise
    */
   bool
-  voxelSearch(const int index, std::vector<int>& point_idx_data);
+  voxelSearch(const index_t index, Indices& point_idx_data);
 
   /** \brief Search for k-nearest neighbors at the query point.
    * \param[in] cloud the point cloud data
@@ -114,9 +114,9 @@ public:
    */
   inline int
   nearestKSearch(const PointCloud& cloud,
-                 int index,
+                 index_t index,
                  int k,
-                 std::vector<int>& k_indices,
+                 Indices& k_indices,
                  std::vector<float>& k_sqr_distances)
   {
     return (nearestKSearch(cloud[index], k, k_indices, k_sqr_distances));
@@ -134,7 +134,7 @@ public:
   int
   nearestKSearch(const PointT& p_q,
                  int k,
-                 std::vector<int>& k_indices,
+                 Indices& k_indices,
                  std::vector<float>& k_sqr_distances);
 
   /** \brief Search for k-nearest neighbors at query point
@@ -149,9 +149,9 @@ public:
    * \return number of neighbors found
    */
   int
-  nearestKSearch(int index,
+  nearestKSearch(index_t index,
                  int k,
-                 std::vector<int>& k_indices,
+                 Indices& k_indices,
                  std::vector<float>& k_sqr_distances);
 
   /** \brief Search for approx. nearest neighbor at the query point.
@@ -163,8 +163,8 @@ public:
    */
   inline void
   approxNearestSearch(const PointCloud& cloud,
-                      int query_index,
-                      int& result_index,
+                      index_t query_index,
+                      index_t& result_index,
                       float& sqr_distance)
   {
     return (approxNearestSearch(cloud.points[query_index], result_index, sqr_distance));
@@ -176,7 +176,7 @@ public:
    * \param[out] sqr_distance the resultant squared distance to the neighboring point
    */
   void
-  approxNearestSearch(const PointT& p_q, int& result_index, float& sqr_distance);
+  approxNearestSearch(const PointT& p_q, index_t& result_index, float& sqr_distance);
 
   /** \brief Search for approx. nearest neighbor at the query point.
    * \param[in] query_index index representing the query point in the dataset given by
@@ -187,7 +187,7 @@ public:
    * \return number of neighbors found
    */
   void
-  approxNearestSearch(int query_index, int& result_index, float& sqr_distance);
+  approxNearestSearch(index_t query_index, index_t& result_index, float& sqr_distance);
 
   /** \brief Search for all neighbors of query point that are within a given radius.
    * \param[in] cloud the point cloud data
@@ -201,9 +201,9 @@ public:
    */
   int
   radiusSearch(const PointCloud& cloud,
-               int index,
+               index_t index,
                double radius,
-               std::vector<int>& k_indices,
+               Indices& k_indices,
                std::vector<float>& k_sqr_distances,
                unsigned int max_nn = 0)
   {
@@ -223,7 +223,7 @@ public:
   int
   radiusSearch(const PointT& p_q,
                const double radius,
-               std::vector<int>& k_indices,
+               Indices& k_indices,
                std::vector<float>& k_sqr_distances,
                unsigned int max_nn = 0) const;
 
@@ -239,9 +239,9 @@ public:
    * \return number of neighbors found in radius
    */
   int
-  radiusSearch(int index,
+  radiusSearch(index_t index,
                const double radius,
-               std::vector<int>& k_indices,
+               Indices& k_indices,
                std::vector<float>& k_sqr_distances,
                unsigned int max_nn = 0) const;
 
@@ -271,7 +271,7 @@ public:
   int
   getIntersectedVoxelIndices(Eigen::Vector3f origin,
                              Eigen::Vector3f direction,
-                             std::vector<int>& k_indices,
+                             Indices& k_indices,
                              int max_voxel_count = 0) const;
 
   /** \brief Search for points within rectangular search area
@@ -284,7 +284,7 @@ public:
   int
   boxSearch(const Eigen::Vector3f& min_pt,
             const Eigen::Vector3f& max_pt,
-            std::vector<int>& k_indices) const;
+            Indices& k_indices) const;
 
 protected:
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -342,7 +342,7 @@ protected:
      * \param[in] point_idx index for a dataset point given by \a setInputCloud
      * \param[in] point_distance distance of query point to voxel center
      */
-    prioPointQueueEntry(unsigned int& point_idx, float point_distance)
+    prioPointQueueEntry(unsigned index_t& point_idx, float point_distance)
     : point_idx_(point_idx), point_distance_(point_distance)
     {}
 
@@ -356,7 +356,7 @@ protected:
     }
 
     /** \brief Index representing a point in the dataset given by \a setInputCloud. */
-    int point_idx_;
+    index_t point_idx_;
 
     /** \brief Distance to query point. */
     float point_distance_;
@@ -390,7 +390,7 @@ protected:
                                     const BranchNode* node,
                                     const OctreeKey& key,
                                     unsigned int tree_depth,
-                                    std::vector<int>& k_indices,
+                                    Indices& k_indices,
                                     std::vector<float>& k_sqr_distances,
                                     unsigned int max_nn) const;
 
@@ -429,7 +429,7 @@ protected:
                                const BranchNode* node,
                                const OctreeKey& key,
                                unsigned int tree_depth,
-                               int& result_index,
+                               index_t& result_index,
                                float& sqr_distance);
 
   /** \brief Recursively search the tree for all intersected leaf nodes and return a
@@ -478,7 +478,7 @@ protected:
                      const BranchNode* node,
                      const OctreeKey& key,
                      unsigned int tree_depth,
-                     std::vector<int>& k_indices) const;
+                     Indices& k_indices) const;
 
   /** \brief Recursively search the tree for all intersected leaf nodes and return a
    * vector of indices. This algorithm is based off the paper An Efficient Parametric
@@ -507,7 +507,7 @@ protected:
                                       unsigned char a,
                                       const OctreeNode* node,
                                       const OctreeKey& key,
-                                      std::vector<int>& k_indices,
+                                      Indices& k_indices,
                                       int max_voxel_count) const;
 
   /** \brief Initialize raytracing algorithm

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -312,7 +312,7 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
     //  test iterator
     unsigned int leaf_count = 0;
 
-    std::vector<int> indexVector;
+    Indices indexVector;
 
     // iterate over tree
     for (auto it = octree.leaf_depth_begin(), it_end = octree.leaf_depth_end(); it != it_end; ++it)
@@ -333,13 +333,13 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
       container.getPointIndices (indexVector);
 
       // test points against bounding box of leaf node
-      std::vector<int> tmpVector;
+      Indices tmpVector;
       container.getPointIndices (tmpVector);
 
       Eigen::Vector3f min_pt, max_pt;
       octree.getVoxelBounds (it, min_pt, max_pt);
 
-      for (const int &i : tmpVector)
+      for (const index_t &i : tmpVector)
       {
         ASSERT_GE (cloud->points[i].x, min_pt(0));
         ASSERT_GE (cloud->points[i].y, min_pt(1));
@@ -794,14 +794,14 @@ TEST (PCL, Octree_Pointcloud_Test)
 
     for (std::size_t i = 0; i < cloudB->points.size (); i++)
     {
-      std::vector<int> pointIdxVec;
+      Indices pointIdxVec;
       octreeB.voxelSearch (cloudB->points[i], pointIdxVec);
 
       bool bIdxFound = false;
-      std::vector<int>::const_iterator current = pointIdxVec.begin ();
-      while (current != pointIdxVec.end ())
+      auto current = pointIdxVec.cbegin ();
+      while (current != pointIdxVec.cend ())
       {
-        if (*current == static_cast<int> (i))
+        if (*current == static_cast<index_t> (i))
         {
           bIdxFound = true;
           break;
@@ -873,7 +873,7 @@ TEST (PCL, Octree_Pointcloud_Iterator_Test)
   octreeA.setInputCloud (cloudIn);
   octreeA.addPointsFromInputCloud ();
 
-  std::vector<int> indexVector;
+  Indices indexVector;
   unsigned int leafNodeCounter = 0;
 
   for (auto it1 = octreeA.leaf_depth_begin(), it1_end = octreeA.leaf_depth_end(); it1 != it1_end; ++it1)
@@ -1011,7 +1011,7 @@ TEST (PCL, Octree_Pointcloud_Change_Detector_Test)
         cloudIn);
   }
 
-  std::vector<int> newPointIdxVector;
+  Indices newPointIdxVector;
 
   // get a vector of new points, which did not exist in previous buffer
   octree.getPointIndicesFromNewVoxels (newPointIdxVector);
@@ -1106,7 +1106,7 @@ public:
   prioPointQueueEntry () : pointDistance_ (), pointIdx_ ()
   {
   }
-  prioPointQueueEntry (PointXYZ& point_arg, double pointDistance_arg, int pointIdx_arg) :
+  prioPointQueueEntry (PointXYZ& point_arg, double pointDistance_arg, index_t pointIdx_arg) :
     point_ (point_arg),
     pointDistance_ (pointDistance_arg),
     pointIdx_ (pointIdx_arg)
@@ -1121,7 +1121,7 @@ public:
 
   PointXYZ point_;
   double pointDistance_;
-  int pointIdx_;
+  index_t pointIdx_;
 
 };
 
@@ -1140,10 +1140,10 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
   OctreePointCloudSearch<PointXYZ> octree (0.1);
   octree.setInputCloud (cloudIn);
 
-  std::vector<int> k_indices;
+  Indices k_indices;
   std::vector<float> k_sqr_distances;
 
-  std::vector<int> k_indices_bruteforce;
+  Indices k_indices_bruteforce;
   std::vector<float> k_sqr_distances_bruteforce;
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
@@ -1180,7 +1180,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
                           (cloudIn->points[i].y - searchPoint.y) * (cloudIn->points[i].y - searchPoint.y) +
                           (cloudIn->points[i].z - searchPoint.z) * (cloudIn->points[i].z - searchPoint.z));
 
-      prioPointQueueEntry pointEntry (cloudIn->points[i], pointDist, static_cast<int> (i));
+      prioPointQueueEntry pointEntry (cloudIn->points[i], pointDist, static_cast<index_t> (i));
 
       pointCandidates.push (pointEntry);
     }
@@ -1190,7 +1190,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
       pointCandidates.pop ();
 
     // copy results into vectors
-    unsigned idx = static_cast<unsigned> (pointCandidates.size ());
+    index_t idx = static_cast<index_t> (pointCandidates.size ());
     k_indices_bruteforce.resize (idx);
     k_sqr_distances_bruteforce.resize (idx);
     while (!pointCandidates.empty ())
@@ -1239,7 +1239,7 @@ TEST (PCL, Octree_Pointcloud_Box_Search)
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
   {
-    std::vector<int> k_indices;
+    Indices k_indices;
 
     // generate point cloud
     cloudIn->width = 300;
@@ -1282,7 +1282,7 @@ TEST (PCL, Octree_Pointcloud_Box_Search)
       idxInResults = false;
       for (std::size_t j = 0; (j < k_indices.size ()) && (!idxInResults); ++j)
       {
-        if (i == static_cast<unsigned int> (k_indices[j]))
+        if (i == static_cast<index_t> (k_indices[j]))
           idxInResults = true;
       }
 
@@ -1329,7 +1329,7 @@ TEST(PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
 
     // brute force search
     double BFdistance = std::numeric_limits<double>::max ();
-    int BFindex = 0;
+    index_t BFindex = 0;
 
     for (std::size_t i = 0; i < cloudIn->points.size (); i++)
     {
@@ -1339,13 +1339,13 @@ TEST(PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
 
       if (pointDist < BFdistance)
       {
-        BFindex = static_cast<int> (i);
+        BFindex = static_cast<index_t> (i);
         BFdistance = pointDist;
       }
 
     }
 
-    int ANNindex;
+    index_t ANNindex;
     float ANNdistance;
 
     // octree approx. nearest neighbor search
@@ -1404,7 +1404,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
     double searchRadius = 5.0 * static_cast<float> (rand () / RAND_MAX);
 
     // bruteforce radius search
-    std::vector<int> cloudSearchBruteforce;
+    Indices cloudSearchBruteforce;
     for (std::size_t i = 0; i < cloudIn->points.size (); i++)
     {
       pointDist = sqrt (
@@ -1415,11 +1415,11 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
       if (pointDist <= searchRadius)
       {
         // add point candidates to vector list
-        cloudSearchBruteforce.push_back (static_cast<int> (i));
+        cloudSearchBruteforce.push_back (static_cast<index_t> (i));
       }
     }
 
-    std::vector<int> cloudNWRSearch;
+    Indices cloudNWRSearch;
     std::vector<float> cloudNWRRadius;
 
     // execute octree radius search
@@ -1428,8 +1428,8 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
     ASSERT_EQ (cloudSearchBruteforce.size (), cloudNWRRadius.size ());
 
     // check if result from octree radius search can be also found in bruteforce search
-    std::vector<int>::const_iterator current = cloudNWRSearch.begin ();
-    while (current != cloudNWRSearch.end ())
+    auto current = cloudNWRSearch.cbegin ();
+    while (current != cloudNWRSearch.cend ())
     {
       pointDist = sqrt (
           (cloudIn->points[*current].x - searchPoint.x) * (cloudIn->points[*current].x - searchPoint.x)
@@ -1463,7 +1463,7 @@ TEST (PCL, Octree_Pointcloud_Ray_Traversal)
   pcl::PointCloud<pcl::PointXYZ>::VectorType voxelsInRay, voxelsInRay2;
 
   // Indices in ray
-  std::vector<int> indicesInRay, indicesInRay2;
+  Indices indicesInRay, indicesInRay2;
 
   srand (static_cast<unsigned int> (time (nullptr)));
 
@@ -1524,7 +1524,7 @@ TEST (PCL, Octree_Pointcloud_Ray_Traversal)
     Eigen::Vector3f d = Eigen::Vector3f (pt.x, pt.y, pt.z) - o;
     float min_dist = d.norm ();
 
-    for (unsigned int i = 0; i < cloudIn->width * cloudIn->height; i++)
+    for (index_t i = 0; i < cloudIn->width * cloudIn->height; i++)
     {
       pt = cloudIn->points[i];
       d = Eigen::Vector3f (pt.x, pt.y, pt.z) - o;


### PR DESCRIPTION
Instances of `std::size_t` ignored for now. 
Need to address requirement for returning negative indices.
Use of `uint32_t` for width ignored for now.