### PR TITLE
Refactoring and Bugfix of NDT

### DIFF
--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -57,12 +57,10 @@ NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTrans
 {
   reg_name_ = "NormalDistributionsTransform";
 
-  double gauss_c1, gauss_c2, gauss_d3;
-
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
-  gauss_c1 = 10.0 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
-  gauss_d3 = -std::log (gauss_c2);
+  const double gauss_c1 = 10.0 * (1 - outlier_ratio_);
+  const double gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
+  const double gauss_d3 = -std::log (gauss_c2);
   gauss_d1_ = -std::log ( gauss_c1 + gauss_c2 ) - gauss_d3;
   gauss_d2_ = -2 * std::log ((-std::log ( gauss_c1 * std::exp ( -0.5 ) + gauss_c2 ) - gauss_d3) / gauss_d1_);
 
@@ -77,12 +75,10 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (P
   nr_iterations_ = 0;
   converged_ = false;
 
-  double gauss_c1, gauss_c2, gauss_d3;
-
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
-  gauss_c1 = 10 * (1 - outlier_ratio_);
-  gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
-  gauss_d3 = -std::log (gauss_c2);
+  const double gauss_c1 = 10 * (1 - outlier_ratio_);
+  const double gauss_c2 = outlier_ratio_ / pow (resolution_, 3);
+  const double gauss_d3 = -std::log (gauss_c2);
   gauss_d1_ = -std::log ( gauss_c1 + gauss_c2 ) - gauss_d3;
   gauss_d2_ = -2 * std::log ((-std::log ( gauss_c1 * std::exp ( -0.5 ) + gauss_c2 ) - gauss_d3) / gauss_d1_);
 
@@ -95,26 +91,23 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (P
   }
 
   // Initialize Point Gradient and Hessian
-  point_gradient_.setZero ();
-  point_gradient_.block<3, 3>(0, 0).setIdentity ();
+  point_jacobian_.setZero ();
+  point_jacobian_.block<3, 3>(0, 0).setIdentity ();
   point_hessian_.setZero ();
 
   Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> eig_transformation;
   eig_transformation.matrix () = final_transformation_;
 
   // Convert initial guess matrix to 6 element transformation vector
-  Eigen::Matrix<double, 6, 1> p, delta_p, score_gradient;
+  Eigen::Matrix<double, 6, 1> transform, score_gradient;
   Eigen::Vector3f init_translation = eig_transformation.translation ();
   Eigen::Vector3f init_rotation = eig_transformation.rotation ().eulerAngles (0, 1, 2);
-  p << init_translation (0), init_translation (1), init_translation (2),
-  init_rotation (0), init_rotation (1), init_rotation (2);
+  transform << init_translation.cast<double>(), init_rotation.cast<double>();
 
   Eigen::Matrix<double, 6, 6> hessian;
 
-  double score = 0;
-
   // Calculate derivates of initial transform vector, subsequent derivative calculations are done in the step length determination.
-  score = computeDerivatives (score_gradient, hessian, output, p);
+  double score = computeDerivatives (score_gradient, hessian, output, transform);
 
   while (!converged_)
   {
@@ -124,39 +117,33 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (P
     // Solve for decent direction using newton method, line 23 in Algorithm 2 [Magnusson 2009]
     Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > sv (hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
     // Negative for maximization as opposed to minimization
-    delta_p = sv.solve (-score_gradient);
+    Eigen::Matrix<double, 6, 1> delta = sv.solve (-score_gradient);
 
     //Calculate step length with guarnteed sufficient decrease [More, Thuente 1994]
-    double delta_p_norm = delta_p.norm ();
+    double delta_norm = delta.norm ();
 
-    if (delta_p_norm == 0 || std::isnan(delta_p_norm))
+    if (delta_norm == 0 || std::isnan(delta_norm))
     {
       trans_probability_ = score / static_cast<double> (input_->size ());
-      converged_ = delta_p_norm == delta_p_norm;
+      converged_ = delta_norm == 0;
       return;
     }
 
-    delta_p.normalize ();
-    delta_p_norm = computeStepLengthMT (p, delta_p, delta_p_norm, step_size_, transformation_epsilon_ / 2, score, score_gradient, hessian, output);
-    delta_p *= delta_p_norm;
+    delta /= delta_norm;
+    delta_norm = computeStepLengthMT (transform, delta, delta_norm, step_size_, transformation_epsilon_ / 2, score, score_gradient, hessian, output);
+    delta *= delta_norm;
 
+    // Convert delta into matrix form
+    convertTransform(delta, transformation_);
 
-    transformation_ = (Eigen::Translation<float, 3> (static_cast<float> (delta_p (0)), static_cast<float> (delta_p (1)), static_cast<float> (delta_p (2))) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (3)), Eigen::Vector3f::UnitX ()) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (4)), Eigen::Vector3f::UnitY ()) *
-                       Eigen::AngleAxis<float> (static_cast<float> (delta_p (5)), Eigen::Vector3f::UnitZ ())).matrix ();
-
-
-    p += delta_p;
+    transform += delta;
 
     // Update Visualizer (untested)
     if (update_visualizer_)
       update_visualizer_ (output, std::vector<int>(), *target_, std::vector<int>() );
 
-    double cos_angle = 0.5 * (transformation_.coeff (0, 0) + transformation_.coeff (1, 1) + transformation_.coeff (2, 2) - 1);
-    double translation_sqr = transformation_.coeff (0, 3) * transformation_.coeff (0, 3) +
-                             transformation_.coeff (1, 3) * transformation_.coeff (1, 3) +
-                             transformation_.coeff (2, 3) * transformation_.coeff (2, 3);
+    const double cos_angle = 0.5 * transformation_.template block<3, 3>(0, 0).trace() - 1;
+    const double translation_sqr = transformation_.template block<3, 1>(0, 3).squaredNorm();
 
     nr_iterations_++;
 
@@ -178,164 +165,140 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation (P
 template<typename PointSource, typename PointTarget> double
 NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives (Eigen::Matrix<double, 6, 1> &score_gradient,
                                                                             Eigen::Matrix<double, 6, 6> &hessian,
-                                                                            PointCloudSource &trans_cloud,
-                                                                            Eigen::Matrix<double, 6, 1> &p,
+                                                                            const PointCloudSource &trans_cloud,
+                                                                            const Eigen::Matrix<double, 6, 1> &transform,
                                                                             bool compute_hessian)
 {
-  // Original Point and Transformed Point
-  PointSource x_pt, x_trans_pt;
-  // Original Point and Transformed Point (for math)
-  Eigen::Vector3d x, x_trans;
-  // Occupied Voxel
-  TargetGridLeafConstPtr cell;
-  // Inverse Covariance of Occupied Voxel
-  Eigen::Matrix3d c_inv;
-
   score_gradient.setZero ();
   hessian.setZero ();
   double score = 0;
 
   // Precompute Angular Derivatives (eq. 6.19 and 6.21)[Magnusson 2009]
-  computeAngleDerivatives (p);
+  computeAngleDerivatives (transform);
 
   // Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
   for (std::size_t idx = 0; idx < input_->size (); idx++)
   {
-    x_trans_pt = trans_cloud[idx];
+  // Transformed Point
+    const auto& x_trans_pt = trans_cloud[idx];
 
-    // Find nieghbors (Radius search has been experimentally faster than direct neighbor checking.
+    // Find neighbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
     std::vector<float> distances;
     target_cells_.radiusSearch (x_trans_pt, resolution_, neighborhood, distances);
 
-    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin (); neighborhood_it != neighborhood.end (); ++neighborhood_it)
+    for (const auto& cell: neighborhood)
     {
-      cell = *neighborhood_it;
-      x_pt = (*input_)[idx];
-      x = Eigen::Vector3d (x_pt.x, x_pt.y, x_pt.z);
-
-      x_trans = Eigen::Vector3d (x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
+      // Original Point
+      const auto& x_pt = (*input_)[idx];
+      const Eigen::Vector3d x = x_pt.getVector3fMap().template cast<double>();
 
       // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-      x_trans -= cell->getMean ();
+      const Eigen::Vector3d x_trans = x_trans_pt.getVector3fMap().template cast<double>() - cell->getMean ();
+      // Inverse Covariance of Occupied Voxel
       // Uses precomputed covariance for speed.
-      c_inv = cell->getInverseCov ();
+      const Eigen::Matrix3d c_inv = cell->getInverseCov ();
 
       // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
       computePointDerivatives (x);
       // Update score, gradient and hessian, lines 19-21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
       score += updateDerivatives (score_gradient, hessian, x_trans, c_inv, compute_hessian);
-
     }
   }
-  return (score);
+  return score;
 }
 
 
 template<typename PointSource, typename PointTarget> void
-NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives (Eigen::Matrix<double, 6, 1> &p, bool compute_hessian)
+NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives (const Eigen::Matrix<double, 6, 1> &transform, bool compute_hessian)
 {
   // Simplified math for near 0 angles
+  const auto calculate_cos_sin = [](double angle, double& c, double &s) {
+    if(std::abs(angle) < 10e-5)
+    {
+      c = 1.0;
+      s = 0.0;
+    }
+    else
+    {
+      c = std::cos(angle);
+      s = std::sin(angle);
+    }
+  };
+
   double cx, cy, cz, sx, sy, sz;
-  if (std::abs (p (3)) < 10e-5)
-  {
-    //p(3) = 0;
-    cx = 1.0;
-    sx = 0.0;
-  }
-  else
-  {
-    cx = std::cos (p (3));
-    sx = sin (p (3));
-  }
-  if (std::abs (p (4)) < 10e-5)
-  {
-    //p(4) = 0;
-    cy = 1.0;
-    sy = 0.0;
-  }
-  else
-  {
-    cy = std::cos (p (4));
-    sy = sin (p (4));
-  }
+  calculate_cos_sin(transform(3), cx, sx);
+  calculate_cos_sin(transform(4), cy, sy);
+  calculate_cos_sin(transform(5), cz, sz);
 
-  if (std::abs (p (5)) < 10e-5)
-  {
-    //p(5) = 0;
-    cz = 1.0;
-    sz = 0.0;
-  }
-  else
-  {
-    cz = std::cos (p (5));
-    sz = sin (p (5));
-  }
+  // Precomputed angular gradient components. Letters correspond to Equation 6.19 [Magnusson 2009]
+  angular_jacobian_.setZero();
+  angular_jacobian_.row(0).noalias() = Eigen::Vector4d((-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy), 1.0);  // a
+  angular_jacobian_.row(1).noalias() = Eigen::Vector4d((cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy), 1.0);    // b
+  angular_jacobian_.row(2).noalias() = Eigen::Vector4d((-sy * cz), sy * sz, cy, 1.0);                                           // c
+  angular_jacobian_.row(3).noalias() = Eigen::Vector4d(sx * cy * cz, (-sx * cy * sz), sx * sy, 1.0);                            // d
+  angular_jacobian_.row(4).noalias() = Eigen::Vector4d((-cx * cy * cz), cx * cy * sz, (-cx * sy), 1.0);                         // e
+  angular_jacobian_.row(5).noalias() = Eigen::Vector4d((-cy * sz), (-cy * cz), 0, 1.0);                                         // f
+  angular_jacobian_.row(6).noalias() = Eigen::Vector4d((cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0, 1.0);            // g
+  angular_jacobian_.row(7).noalias() = Eigen::Vector4d((sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0, 1.0);             // h
 
-  // Precomputed angular gradiant components. Letters correspond to Equation 6.19 [Magnusson 2009]
-  j_ang_a_ << (-sx * sz + cx * sy * cz), (-sx * cz - cx * sy * sz), (-cx * cy);
-  j_ang_b_ << (cx * sz + sx * sy * cz), (cx * cz - sx * sy * sz), (-sx * cy);
-  j_ang_c_ << (-sy * cz), sy * sz, cy;
-  j_ang_d_ << sx * cy * cz, (-sx * cy * sz), sx * sy;
-  j_ang_e_ << (-cx * cy * cz), cx * cy * sz, (-cx * sy);
-  j_ang_f_ << (-cy * sz), (-cy * cz), 0;
-  j_ang_g_ << (cx * cz - sx * sy * sz), (-cx * sz - sx * sy * cz), 0;
-  j_ang_h_ << (sx * cz + cx * sy * sz), (cx * sy * cz - sx * sz), 0;
 
   if (compute_hessian)
   {
     // Precomputed angular hessian components. Letters correspond to Equation 6.21 and numbers correspond to row index [Magnusson 2009]
-    h_ang_a2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy;
-    h_ang_a3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy);
+    angular_hessian_.setZero();
+    angular_hessian_.row(0).noalias() = Eigen::Vector4d((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), sx * cy, 0.0f); // a2
+    angular_hessian_.row(1).noalias() = Eigen::Vector4d((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), (-cx * cy), 0.0f); // a3
 
-    h_ang_b2_ << (cx * cy * cz), (-cx * cy * sz), (cx * sy);
-    h_ang_b3_ << (sx * cy * cz), (-sx * cy * sz), (sx * sy);
+    angular_hessian_.row(2).noalias() = Eigen::Vector4d((cx * cy * cz), (-cx * cy * sz), (cx * sy), 0.0f); // b2
+    angular_hessian_.row(3).noalias() = Eigen::Vector4d((sx * cy * cz), (-sx * cy * sz), (sx * sy), 0.0f); // b3
 
-    h_ang_c2_ << (-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0;
-    h_ang_c3_ << (cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0;
+    angular_hessian_.row(4).noalias() = Eigen::Vector4d((-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0, 0.0f); // c2
+    angular_hessian_.row(5).noalias() = Eigen::Vector4d((cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0, 0.0f); // c3
 
-    h_ang_d1_ << (-cy * cz), (cy * sz), (sy);
-    h_ang_d2_ << (-sx * sy * cz), (sx * sy * sz), (sx * cy);
-    h_ang_d3_ << (cx * sy * cz), (-cx * sy * sz), (-cx * cy);
+    angular_hessian_.row(6).noalias() = Eigen::Vector4d((-cy * cz), (cy * sz), (sy), 0.0f); // d1
+    angular_hessian_.row(7).noalias() = Eigen::Vector4d((-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f); // d2
+    angular_hessian_.row(8).noalias() = Eigen::Vector4d((cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f); // d3
 
-    h_ang_e1_ << (sy * sz), (sy * cz), 0;
-    h_ang_e2_ << (-sx * cy * sz), (-sx * cy * cz), 0;
-    h_ang_e3_ << (cx * cy * sz), (cx * cy * cz), 0;
+    angular_hessian_.row(9).noalias() = Eigen::Vector4d((sy * sz), (sy * cz), 0, 0.0f); // e1
+    angular_hessian_.row(10).noalias() = Eigen::Vector4d((-sx * cy * sz), (-sx * cy * cz), 0, 0.0f); // e2
+    angular_hessian_.row(11).noalias() = Eigen::Vector4d((cx * cy * sz), (cx * cy * cz), 0, 0.0f); // e3
 
-    h_ang_f1_ << (-cy * cz), (cy * sz), 0;
-    h_ang_f2_ << (-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0;
-    h_ang_f3_ << (-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0;
+    angular_hessian_.row(12).noalias() = Eigen::Vector4d((-cy * cz), (cy * sz), 0, 0.0f); // f1
+    angular_hessian_.row(13).noalias() = Eigen::Vector4d((-cx * sz - sx * sy * cz), (-cx * cz + sx * sy * sz), 0, 0.0f); // f2
+    angular_hessian_.row(14).noalias() = Eigen::Vector4d((-sx * sz + cx * sy * cz), (-cx * sy * sz - sx * cz), 0, 0.0f); // f3
   }
 }
 
 
 template<typename PointSource, typename PointTarget> void
-NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives (Eigen::Vector3d &x, bool compute_hessian)
+NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives (const Eigen::Vector3d &x, bool compute_hessian)
 {
-  // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+  // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector.
   // Derivative w.r.t. ith element of transform vector corresponds to column i, Equation 6.18 and 6.19 [Magnusson 2009]
-  point_gradient_ (1, 3) = x.dot (j_ang_a_);
-  point_gradient_ (2, 3) = x.dot (j_ang_b_);
-  point_gradient_ (0, 4) = x.dot (j_ang_c_);
-  point_gradient_ (1, 4) = x.dot (j_ang_d_);
-  point_gradient_ (2, 4) = x.dot (j_ang_e_);
-  point_gradient_ (0, 5) = x.dot (j_ang_f_);
-  point_gradient_ (1, 5) = x.dot (j_ang_g_);
-  point_gradient_ (2, 5) = x.dot (j_ang_h_);
+  Eigen::Matrix<double, 8, 1> point_angular_jacobian = angular_jacobian_ * Eigen::Vector4d(x[0], x[1], x[2], 0.0);
+  point_jacobian_ (1, 3) = point_angular_jacobian[0];
+  point_jacobian_ (2, 3) = point_angular_jacobian[1];
+  point_jacobian_ (0, 4) = point_angular_jacobian[2];
+  point_jacobian_ (1, 4) = point_angular_jacobian[3];
+  point_jacobian_ (2, 4) = point_angular_jacobian[4];
+  point_jacobian_ (0, 5) = point_angular_jacobian[5];
+  point_jacobian_ (1, 5) = point_angular_jacobian[6];
+  point_jacobian_ (2, 5) = point_angular_jacobian[7];
 
   if (compute_hessian)
   {
+    Eigen::Matrix<double, 15, 1> point_angular_hessian = angular_hessian_ * Eigen::Vector4d(x[0], x[1], x[2], 0.0);
+
     // Vectors from Equation 6.21 [Magnusson 2009]
-    Eigen::Vector3d a, b, c, d, e, f;
+    const Eigen::Vector3d a(0, point_angular_hessian[0], point_angular_hessian[1]);
+    const Eigen::Vector3d b(0, point_angular_hessian[2], point_angular_hessian[3]);
+    const Eigen::Vector3d c(0, point_angular_hessian[4], point_angular_hessian[5]);
+    const Eigen::Vector3d d = point_angular_hessian.block<3, 1>(6, 0);
+    const Eigen::Vector3d e = point_angular_hessian.block<3, 1>(9, 0);
+    const Eigen::Vector3d f = point_angular_hessian.block<3, 1>(12, 0);
 
-    a << 0, x.dot (h_ang_a2_), x.dot (h_ang_a3_);
-    b << 0, x.dot (h_ang_b2_), x.dot (h_ang_b3_);
-    c << 0, x.dot (h_ang_c2_), x.dot (h_ang_c3_);
-    d << x.dot (h_ang_d1_), x.dot (h_ang_d2_), x.dot (h_ang_d3_);
-    e << x.dot (h_ang_e1_), x.dot (h_ang_e2_), x.dot (h_ang_e3_);
-    f << x.dot (h_ang_f1_), x.dot (h_ang_f2_), x.dot (h_ang_f3_);
-
-    // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector p.
+    // Calculate second derivative of Transformation Equation 6.17 w.r.t. transform vector.
     // Derivative w.r.t. ith and jth elements of transform vector corresponds to the 3x1 block matrix starting at (3i,j), Equation 6.20 and 6.21 [Magnusson 2009]
     point_hessian_.block<3, 1>(9, 3) = a;
     point_hessian_.block<3, 1>(12, 3) = b;
@@ -353,29 +316,29 @@ NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives 
 template<typename PointSource, typename PointTarget> double
 NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (Eigen::Matrix<double, 6, 1> &score_gradient,
                                                                            Eigen::Matrix<double, 6, 6> &hessian,
-                                                                           Eigen::Vector3d &x_trans, Eigen::Matrix3d &c_inv,
-                                                                           bool compute_hessian)
+                                                                           const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv,
+                                                                           bool compute_hessian) const
 {
-  Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
   double e_x_cov_x = std::exp (-gauss_d2_ * x_trans.dot (c_inv * x_trans) / 2);
   // Calculate probability of transformed points existence, Equation 6.9 [Magnusson 2009]
-  double score_inc = -gauss_d1_ * e_x_cov_x;
+  const double score_inc = -gauss_d1_ * e_x_cov_x;
 
   e_x_cov_x = gauss_d2_ * e_x_cov_x;
 
   // Error checking for invalid values.
   if (e_x_cov_x > 1 || e_x_cov_x < 0 || std::isnan(e_x_cov_x))
-    return (0);
+  {
+    return 0;
+  }
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
 
-
   for (int i = 0; i < 6; i++)
   {
     // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-    cov_dxd_pi = c_inv * point_gradient_.col (i);
+    const Eigen::Vector3d cov_dxd_pi = c_inv * point_jacobian_.col (i);
 
     // Update gradient, Equation 6.12 [Magnusson 2009]
     score_gradient (i) += x_trans.dot (cov_dxd_pi) * e_x_cov_x;
@@ -385,79 +348,67 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives (Eigen
       for (Eigen::Index j = 0; j < hessian.cols (); j++)
       {
         // Update hessian, Equation 6.13 [Magnusson 2009]
-        hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_gradient_.col (j)) +
+        hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_jacobian_.col (j)) +
                                     x_trans.dot (c_inv * point_hessian_.block<3, 1>(3 * i, j)) +
-                                    point_gradient_.col (j).dot (cov_dxd_pi) );
+                                    point_jacobian_.col (j).dot (cov_dxd_pi) );
       }
     }
   }
 
-  return (score_inc);
+  return score_inc;
 }
 
 
 template<typename PointSource, typename PointTarget> void
 NormalDistributionsTransform<PointSource, PointTarget>::computeHessian (Eigen::Matrix<double, 6, 6> &hessian,
-                                                                        PointCloudSource &trans_cloud, Eigen::Matrix<double, 6, 1> &)
+                                                                        const PointCloudSource &trans_cloud)
 {
-  // Original Point and Transformed Point
-  PointSource x_pt, x_trans_pt;
-  // Original Point and Transformed Point (for math)
-  Eigen::Vector3d x, x_trans;
-  // Occupied Voxel
-  TargetGridLeafConstPtr cell;
-  // Inverse Covariance of Occupied Voxel
-  Eigen::Matrix3d c_inv;
-
   hessian.setZero ();
 
   // Precompute Angular Derivatives unessisary because only used after regular derivative calculation
-
   // Update hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
   for (std::size_t idx = 0; idx < input_->size (); idx++)
   {
-    x_trans_pt = trans_cloud[idx];
+    // Transformed Point
+    const auto& x_trans_pt = trans_cloud[idx];
 
     // Find nieghbors (Radius search has been experimentally faster than direct neighbor checking.
     std::vector<TargetGridLeafConstPtr> neighborhood;
     std::vector<float> distances;
     target_cells_.radiusSearch (x_trans_pt, resolution_, neighborhood, distances);
 
-    for (typename std::vector<TargetGridLeafConstPtr>::iterator neighborhood_it = neighborhood.begin (); neighborhood_it != neighborhood.end (); ++neighborhood_it)
+    for (const auto& cell: neighborhood)
     {
-      cell = *neighborhood_it;
+      // Original Point
+      const auto& x_pt = (*input_)[idx];
+      const Eigen::Vector3d x = x_pt.getVector3fMap().template cast<double>();
 
-      {
-        x_pt = (*input_)[idx];
-        x = Eigen::Vector3d (x_pt.x, x_pt.y, x_pt.z);
+      // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
+      const Eigen::Vector3d x_trans = x_trans_pt.getVector3fMap().template cast<double>() - cell->getMean ();
+      // Inverse Covariance of Occupied Voxel
+      // Uses precomputed covariance for speed.
+      const Eigen::Matrix3d c_inv = cell->getInverseCov ();
 
-        x_trans = Eigen::Vector3d (x_trans_pt.x, x_trans_pt.y, x_trans_pt.z);
-
-        // Denorm point, x_k' in Equations 6.12 and 6.13 [Magnusson 2009]
-        x_trans -= cell->getMean ();
-        // Uses precomputed covariance for speed.
-        c_inv = cell->getInverseCov ();
-
-        // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
-        computePointDerivatives (x);
-        // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
-        updateHessian (hessian, x_trans, c_inv);
-      }
+      // Compute derivative of transform function w.r.t. transform vector, J_E and H_E in Equations 6.18 and 6.20 [Magnusson 2009]
+      computePointDerivatives (x);
+      // Update hessian, lines 21 in Algorithm 2, according to Equations 6.10, 6.12 and 6.13, respectively [Magnusson 2009]
+      updateHessian (hessian, x_trans, c_inv);
     }
   }
 }
 
 
 template<typename PointSource, typename PointTarget> void
-NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Matrix<double, 6, 6> &hessian, Eigen::Vector3d &x_trans, Eigen::Matrix3d &c_inv)
+NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Matrix<double, 6, 6> &hessian, const Eigen::Vector3d &x_trans, const Eigen::Matrix3d &c_inv) const
 {
-  Eigen::Vector3d cov_dxd_pi;
   // e^(-d_2/2 * (x_k - mu_k)^T Sigma_k^-1 (x_k - mu_k)) Equation 6.9 [Magnusson 2009]
   double e_x_cov_x = gauss_d2_ * std::exp (-gauss_d2_ * x_trans.dot (c_inv * x_trans) / 2);
 
   // Error checking for invalid values.
   if (e_x_cov_x > 1 || e_x_cov_x < 0 || std::isnan(e_x_cov_x))
+  {
     return;
+  }
 
   // Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
   e_x_cov_x *= gauss_d1_;
@@ -465,14 +416,14 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Ma
   for (int i = 0; i < 6; i++)
   {
     // Sigma_k^-1 d(T(x,p))/dpi, Reusable portion of Equation 6.12 and 6.13 [Magnusson 2009]
-    cov_dxd_pi = c_inv * point_gradient_.col (i);
+    const Eigen::Vector3d cov_dxd_pi = c_inv * point_jacobian_.col (i);
 
     for (Eigen::Index j = 0; j < hessian.cols (); j++)
     {
       // Update hessian, Equation 6.13 [Magnusson 2009]
-      hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_gradient_.col (j)) +
+      hessian (i, j) += e_x_cov_x * (-gauss_d2_ * x_trans.dot (cov_dxd_pi) * x_trans.dot (c_inv * point_jacobian_.col (j)) +
                                   x_trans.dot (c_inv * point_hessian_.block<3, 1>(3 * i, j)) +
-                                  point_gradient_.col (j).dot (cov_dxd_pi) );
+                                  point_jacobian_.col (j).dot (cov_dxd_pi) );
     }
   }
 
@@ -482,7 +433,7 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateHessian (Eigen::Ma
 template<typename PointSource, typename PointTarget> bool
 NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double &a_l, double &f_l, double &g_l,
                                                                           double &a_u, double &f_u, double &g_u,
-                                                                          double a_t, double f_t, double g_t)
+                                                                          double a_t, double f_t, double g_t) const
 {
   // Case U1 in Update Algorithm and Case a in Modified Update Algorithm [More, Thuente 1994]
   if (f_t > f_l)
@@ -490,7 +441,7 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double
     a_u = a_t;
     f_u = f_t;
     g_u = g_t;
-    return (false);
+    return false;
   }
   // Case U2 in Update Algorithm and Case b in Modified Update Algorithm [More, Thuente 1994]
   if (g_t * (a_l - a_t) > 0)
@@ -498,7 +449,7 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
-    return (false);
+    return false;
   }
   // Case U3 in Update Algorithm and Case c in Modified Update Algorithm [More, Thuente 1994]
   if (g_t * (a_l - a_t) < 0)
@@ -510,87 +461,96 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT (double
     a_l = a_t;
     f_l = f_t;
     g_l = g_t;
-    return (false);
+    return false;
   }
   // Interval Converged
-  return (true);
+  return true;
 }
 
 
 template<typename PointSource, typename PointTarget> double
 NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT (double a_l, double f_l, double g_l,
                                                                                double a_u, double f_u, double g_u,
-                                                                               double a_t, double f_t, double g_t)
+                                                                               double a_t, double f_t, double g_t) const
 {
   // Case 1 in Trial Value Selection [More, Thuente 1994]
   if (f_t > f_l)
   {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
-    double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    const double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
+    const double w = std::sqrt (z * z - g_t * g_l);
     // Equation 2.4.56 [Sun, Yuan 2006]
-    double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
+    const double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
     // Calculate the minimizer of the quadratic that interpolates f_l, f_t and g_l
     // Equation 2.4.2 [Sun, Yuan 2006]
-    double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
+    const double a_q = a_l - 0.5 * (a_l - a_t) * g_l / (g_l - (f_l - f_t) / (a_l - a_t));
 
     if (std::fabs (a_c - a_l) < std::fabs (a_q - a_l))
-      return (a_c);
-    return (0.5 * (a_q + a_c));
+    {
+      return a_c;
+    }
+    return 0.5 * (a_q + a_c);
   }
   // Case 2 in Trial Value Selection [More, Thuente 1994]
   if (g_t * g_l < 0)
   {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
-    double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
+    const double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
+    const double w = std::sqrt (z * z - g_t * g_l);
     // Equation 2.4.56 [Sun, Yuan 2006]
-    double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
+    const double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
     // Calculate the minimizer of the quadratic that interpolates f_l, g_l and g_t
     // Equation 2.4.5 [Sun, Yuan 2006]
-    double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
+    const double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
     if (std::fabs (a_c - a_t) >= std::fabs (a_s - a_t))
-      return (a_c);
-    return (a_s);
+    {
+      return a_c;
+    }
+    return a_s;
   }
   // Case 3 in Trial Value Selection [More, Thuente 1994]
   if (std::fabs (g_t) <= std::fabs (g_l))
   {
     // Calculate the minimizer of the cubic that interpolates f_l, f_t, g_l and g_t
     // Equation 2.4.52 [Sun, Yuan 2006]
-    double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
-    double w = std::sqrt (z * z - g_t * g_l);
-    double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
+    const double z = 3 * (f_t - f_l) / (a_t - a_l) - g_t - g_l;
+    const double w = std::sqrt (z * z - g_t * g_l);
+    const double a_c = a_l + (a_t - a_l) * (w - g_l - z) / (g_t - g_l + 2 * w);
 
     // Calculate the minimizer of the quadratic that interpolates g_l and g_t
     // Equation 2.4.5 [Sun, Yuan 2006]
-    double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
+    const double a_s = a_l - (a_l - a_t) / (g_l - g_t) * g_l;
 
     double a_t_next;
 
     if (std::fabs (a_c - a_t) < std::fabs (a_s - a_t))
+    {
       a_t_next = a_c;
+    }
     else
+    {
       a_t_next = a_s;
+    }
 
     if (a_t > a_l)
-      return (std::min (a_t + 0.66 * (a_u - a_t), a_t_next));
-    return (std::max (a_t + 0.66 * (a_u - a_t), a_t_next));
+    {
+      return std::min (a_t + 0.66 * (a_u - a_t), a_t_next);
+    }
+    return std::max (a_t + 0.66 * (a_u - a_t), a_t_next);
   }
   // Case 4 in Trial Value Selection [More, Thuente 1994]
   // Calculate the minimizer of the cubic that interpolates f_u, f_t, g_u and g_t
   // Equation 2.4.52 [Sun, Yuan 2006]
-  double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
-  double w = std::sqrt (z * z - g_t * g_u);
+  const double z = 3 * (f_t - f_u) / (a_t - a_u) - g_t - g_u;
+  const double w = std::sqrt (z * z - g_t * g_u);
   // Equation 2.4.56 [Sun, Yuan 2006]
-  return (a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w));
+  return a_u + (a_t - a_u) * (w - g_u - z) / (g_t - g_u + 2 * w);
 }
-
 
 template<typename PointSource, typename PointTarget> double
 NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (const Eigen::Matrix<double, 6, 1> &x, Eigen::Matrix<double, 6, 1> &step_dir, double step_init, double step_max,
@@ -598,32 +558,31 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (con
                                                                              PointCloudSource &trans_cloud)
 {
   // Set the value of phi(0), Equation 1.3 [More, Thuente 1994]
-  double phi_0 = -score;
+  const double phi_0 = -score;
   // Set the value of phi'(0), Equation 1.3 [More, Thuente 1994]
   double d_phi_0 = -(score_gradient.dot (step_dir));
-
-  Eigen::Matrix<double, 6, 1>  x_t;
 
   if (d_phi_0 >= 0)
   {
     // Not a decent direction
     if (d_phi_0 == 0)
+    {
       return 0;
+    }
     // Reverse step direction and calculate optimal step.
     d_phi_0 *= -1;
     step_dir *= -1;
-
   }
 
   // The Search Algorithm for T(mu) [More, Thuente 1994]
 
-  int max_step_iterations = 10;
+  const int max_step_iterations = 10;
   int step_iterations = 0;
 
   // Sufficient decreace constant, Equation 1.1 [More, Thuete 1994]
-  double mu = 1.e-4;
+  const double mu = 1.e-4;
   // Curvature condition constant, Equation 1.2 [More, Thuete 1994]
-  double nu = 0.9;
+  const double nu = 0.9;
 
   // Initial endpoints of Interval I,
   double a_l = 0, a_u = 0;
@@ -642,12 +601,10 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (con
   a_t = std::min (a_t, step_max);
   a_t = std::max (a_t, step_min);
 
-  x_t = x + step_dir * a_t;
+  Eigen::Matrix<double, 6, 1> x_t = x + step_dir * a_t;
 
-  final_transformation_ = (Eigen::Translation<float, 3>(static_cast<float> (x_t (0)), static_cast<float> (x_t (1)), static_cast<float> (x_t (2))) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (3)), Eigen::Vector3f::UnitX ()) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (4)), Eigen::Vector3f::UnitY ()) *
-                           Eigen::AngleAxis<float> (static_cast<float> (x_t (5)), Eigen::Vector3f::UnitZ ())).matrix ();
+  // Convert x_t into matrix form
+  convertTransform(x_t, final_transformation_);
 
   // New transformed point cloud
   transformPointCloud (*input_, trans_cloud, final_transformation_);
@@ -688,10 +645,8 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (con
 
     x_t = x + step_dir * a_t;
 
-    final_transformation_ = (Eigen::Translation<float, 3> (static_cast<float> (x_t (0)), static_cast<float> (x_t (1)), static_cast<float> (x_t (2))) *
-                             Eigen::AngleAxis<float> (static_cast<float> (x_t (3)), Eigen::Vector3f::UnitX ()) *
-                             Eigen::AngleAxis<float> (static_cast<float> (x_t (4)), Eigen::Vector3f::UnitY ()) *
-                             Eigen::AngleAxis<float> (static_cast<float> (x_t (5)), Eigen::Vector3f::UnitZ ())).matrix ();
+    // Convert x_t into matrix form
+    convertTransform(x_t, final_transformation_);
 
     // New transformed point cloud
     // Done on final cloud to prevent wasted computation
@@ -746,9 +701,11 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (con
   // Hessian is unnessisary for step length determination but gradients are required
   // so derivative and transform data is stored for the next iteration.
   if (step_iterations)
-    computeHessian (hessian, trans_cloud, x_t);
+  {
+    computeHessian (hessian, trans_cloud);
+  }
 
-  return (a_t);
+  return a_t;
 }
 
 } // namespace pcl

--- a/registration/src/ndt.cpp
+++ b/registration/src/ndt.cpp
@@ -37,6 +37,7 @@
  *
  */
 
+#ifndef PCL_NO_PRECOMPILE
 
 #include <pcl/point_types.h>
 #include <pcl/impl/instantiate.hpp>
@@ -47,3 +48,5 @@
 template class PCL_EXPORTS pcl::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>;
 template class PCL_EXPORTS pcl::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>;
 template class PCL_EXPORTS pcl::NormalDistributionsTransform<pcl::PointXYZRGB, pcl::PointXYZRGB>;
+
+#endif


### PR DESCRIPTION
@kunaltyagi 
Sorry for being late to open this PR. I refactored the NDT code according to #4135 and took a look at the suspicious code mentioned at #3832. 

***Refactoring*** https://github.com/PointCloudLibrary/pcl/pull/4135#pullrequestreview-416692504
- PCL_NO_COMPILE condition check is added to ```ndt.cpp```
- Unneeded codes are removed
- I left the arguments of ```updateIntervalMT``` and ```trialValueSelectionMT``` as they are because these methods have different in/out argument combinations, and putting them in a struct would hide this information
- ```h_ang_*``` are concatenated into one matrix for simplicity and Eigen's SSE optimization (it brings about 1% speedup)
- Parentheses are removed from return statements
- ```point_gradient``` is renamed to ```point_jacobian```
- Transformation vector ```p``` is renamed to ```transform```
- Typo fixed

All the above modifications don't change the behavior of NDT, and the registration result will be exactly the same as before refactoring.

***Bugfix*** https://github.com/PointCloudLibrary/pcl/issues/3832#issue-590696667
```(step_max - step_min) > 0``` must be ```(step_max - step_min) < 0``` because this code is intended to check the validity of the range. As  @atom2003 pointed out, ```(step_max - step_min) > 0``` is always true, and this prevents the step length calculation being performed. This bug affects the registration accuracy in particular when we set a small ```transformation_epsilon``` for fine registration. 

After resolving this bug, the fitness score of the registration result of the unit test (```test_ndt.cpp```) is slightly improved (before: 5.05433e-05, after: 4.68033e-05).

I also confirmed the accuracy improvement on my own dataset. The following figures show sensor trajectories estimated by frame-by-frame NDT registration, and the one before the bugfix has a large drift.

After Bugfix
![after1](https://user-images.githubusercontent.com/31344317/84518037-09ddd580-ad0b-11ea-8f7d-6eda1fe63c3e.jpg)

Before Bugfix
![before1](https://user-images.githubusercontent.com/31344317/84518047-0e09f300-ad0b-11ea-9fd6-df29009fbac0.jpg)

