### PR TITLE
[registration] Fix bug in NDT step interval convergence criteria

### DIFF
--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -636,7 +636,7 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT (con
   double g_u = auxilaryFunction_dPsiMT (d_phi_0, d_phi_0, mu);
 
   // Check used to allow More-Thuente step length calculation to be skipped by making step_min == step_max
-  bool interval_converged = (step_max - step_min) > 0, open_interval = true;
+  bool interval_converged = (step_max - step_min) < 0, open_interval = true;
 
   double a_t = step_init;
   a_t = std::min (a_t, step_max);


### PR DESCRIPTION
This PR fixes a range condition check bug in NDT that prevents step size search being performed and affects the registration accuracy. See https://github.com/PointCloudLibrary/pcl/pull/4180 for the details. This PR resolves https://github.com/PointCloudLibrary/pcl/issues/3832. 
