### PR TITLE
[CMake] Select only possible values to PCL_INDEX_SIZE

### DIFF
--- a/cmake/pcl_options.cmake
+++ b/cmake/pcl_options.cmake
@@ -67,6 +67,7 @@ option(WITH_DOCS "Build doxygen documentation" OFF)
 
 # set index size
 set(PCL_INDEX_SIZE -1 CACHE STRING "Set index size. Available options are: 8 16 32 64. A negative value indicates default size (32 for PCL >= 1.12, 8*sizeof(int) i.e., the number of bits in int, otherwise)")
+set_property(CACHE PCL_INDEX_SIZE PROPERTY STRINGS -1 8 16 32 64)
 
 #set whether indices are signed or unsigned
 set(PCL_INDEX_SIGNED true CACHE BOOL "Set whether indices need to be signed or unsigned. Signed by default.")


### PR DESCRIPTION
See image of cmake-gui:
![image](https://user-images.githubusercontent.com/1165340/84597665-d1064380-ae65-11ea-8a79-d41f69b66f65.png)

Before it was a "free" field which could contain any characters.