### PR TITLE
Reduce flakiness of a sample consensus model test

### DIFF
--- a/test/sample_consensus/test_sample_consensus.cpp
+++ b/test/sample_consensus/test_sample_consensus.cpp
@@ -131,8 +131,10 @@ TYPED_TEST(SacTest, InfiniteLoop)
   #if defined(DEBUG) || defined(_DEBUG)
     EXPECT_EQ (std::cv_status::no_timeout, cv.wait_for (lock, 15s));
   #else
-    EXPECT_EQ (std::cv_status::no_timeout, cv.wait_for (lock, 1s));
+    EXPECT_EQ (std::cv_status::no_timeout, cv.wait_for (lock, 2s));
   #endif
+  // release lock to avoid deadlock
+  lock.unlock();
   thread.join ();
 }
 


### PR DESCRIPTION
A go at fixing:
https://dev.azure.com/PointCloudLibrary/pcl/_build/results?buildId=16619&view=logs&j=b2e91478-826b-5668-35a1-2ffb6cc2ce81&t=22c5e2d5-98d8-5ead-0f8b-b95a043b17d5&l=4433-4441

<details>
<summary>Copy of unit test</summary>
<p>

```
2020-06-14T13:27:11.5443097Z   116: [----------] 1 test from SacTest/1, where TypeParam = class pcl::LeastMedianSquares<struct pcl::PointXYZ>
2020-06-14T13:27:11.5443685Z   116: [ RUN      ] SacTest/1.InfiniteLoop
2020-06-14T13:27:12.5455046Z   116: D:\a\1\s\test\sample_consensus\test_sample_consensus.cpp(134): error: Expected equality of these values:
2020-06-14T13:27:12.5456522Z   116:   std::cv_status::no_timeout
2020-06-14T13:27:12.5458037Z   116:     Which is: 4-byte object <00-00 00-00>
2020-06-14T13:27:12.5458671Z   116:   cv.wait_for (lock, 1s)
2020-06-14T13:27:12.5459363Z   116:     Which is: 4-byte object <01-00 00-00>
2020-06-14T13:27:12.5460230Z   116: [  FAILED  ] SacTest/1.InfiniteLoop, where TypeParam = class pcl::LeastMedianSquares<struct pcl::PointXYZ> (1001 ms)
2020-06-14T13:27:12.5461127Z   116: [----------] 1 test from SacTest/1 (1001 ms total)
```

</p>
</details>
