### PR TITLE
Run indices and GPU CI in parallel

### DIFF
--- a/.ci/azure-pipelines/azure-pipelines.yaml
+++ b/.ci/azure-pipelines/azure-pipelines.yaml
@@ -97,7 +97,7 @@ stages:
       - job: ubuntu_indices
         displayName: Ubuntu Indices
         # Test 64 bit & unsigned indices
-        dependsOn: ubuntu
+        dependsOn: osx
         condition: succeededOrFailed()
         pool:
           vmImage: 'Ubuntu 16.04'


### PR DESCRIPTION
Running after GPU wastes time needlessly since the configuration is independent of GPU CI