### PR TITLE
[GPU] Export and template extract clusters

### DIFF
--- a/gpu/segmentation/CMakeLists.txt
+++ b/gpu/segmentation/CMakeLists.txt
@@ -33,7 +33,7 @@ set(impl_incs
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})
-target_link_libraries("${LIB_NAME}" pcl_gpu_octree pcl_gpu_utils pcl_gpu_containers)
+target_link_libraries("${LIB_NAME}" pcl_common pcl_gpu_octree pcl_gpu_utils pcl_gpu_containers)
 PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS})
 
 # Install include files

--- a/gpu/segmentation/CMakeLists.txt
+++ b/gpu/segmentation/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SUBSYS_DEPS common gpu_containers gpu_utils gpu_octree)
 set(build TRUE)
 PCL_SUBSYS_OPTION(build "${SUBSYS_NAME}" "${SUBSYS_DESC}" ON)
 PCL_SUBSYS_DEPEND(build "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS})
+PCL_SET_SUBSYS_INCLUDE_DIR("${SUBSYS_NAME}" "${SUBSYS_PATH}")
 mark_as_advanced("BUILD_${SUBSYS_NAME}")
 
 PCL_ADD_DOC("${SUBSYS_NAME}")

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
@@ -50,8 +50,8 @@ namespace pcl
 {
   namespace gpu
   {
-    void
-    extractEuclideanClusters (const pcl::PointCloud<pcl::PointXYZ>::Ptr &host_cloud_,
+    template <typename PointT> void
+    extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr &host_cloud_,
                               const pcl::gpu::Octree::Ptr               &tree,
                               float                                     tolerance,
                               std::vector<PointIndices>                 &clusters,
@@ -62,13 +62,13 @@ namespace pcl
     * \author Koen Buys, Radu Bogdan Rusu
     * \ingroup segmentation
     */
+    template <typename PointT>
     class EuclideanClusterExtraction
     {
       public:
-        using PointType = pcl::PointXYZ;
-        using PointCloudHost = pcl::PointCloud<pcl::PointXYZ>;
-        using PointCloudHostPtr = PointCloudHost::Ptr;
-        using PointCloudHostConstPtr = PointCloudHost::ConstPtr;
+        using PointCloudHost = pcl::PointCloud<PointT>;
+        using PointCloudHostPtr = typename PointCloudHost::Ptr;
+        using PointCloudHostConstPtr = typename PointCloudHost::ConstPtr;
 
         using PointIndicesPtr = PointIndices::Ptr;
         using PointIndicesConstPtr = PointIndices::ConstPtr;
@@ -80,7 +80,7 @@ namespace pcl
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         /** \brief Empty constructor. */
-        EuclideanClusterExtraction () : min_pts_per_cluster_ (1), max_pts_per_cluster_ (std::numeric_limits<int>::max ())
+        EuclideanClusterExtraction ()
         {};
 
         /** \brief the destructor */
@@ -143,13 +143,13 @@ namespace pcl
         GPUTreePtr tree_;
 
         /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
-        double cluster_tolerance_;
+        double cluster_tolerance_ {0};
 
         /** \brief The minimum number of points that a cluster needs to contain in order to be considered valid (default = 1). */
-        int min_pts_per_cluster_;
+        int min_pts_per_cluster_ {1};
 
         /** \brief The maximum number of points that a cluster needs to contain in order to be considered valid (default = MAXINT). */
-        int max_pts_per_cluster_;
+        int max_pts_per_cluster_ {std::numeric_limits<int>::max()};
 
         /** \brief Class getName method. */
         virtual std::string getClassName () const { return ("gpu::EuclideanClusterExtraction"); }

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
@@ -80,8 +80,7 @@ namespace pcl
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         /** \brief Empty constructor. */
-        EuclideanClusterExtraction ()
-        {};
+        EuclideanClusterExtraction () = default;
 
         /** \brief the destructor */
 /*        ~EuclideanClusterExtraction ()

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_labeled_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_labeled_clusters.h
@@ -80,8 +80,7 @@ namespace pcl
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         /** \brief Empty constructor. */
-        EuclideanLabeledClusterExtraction () : min_pts_per_cluster_ (1), max_pts_per_cluster_ (std::numeric_limits<int>::max ())
-        {};
+        EuclideanLabeledClusterExtraction () = default;
 
         /** \brief Provide a pointer to the search object.
           * \param tree a pointer to the spatial search object.
@@ -137,13 +136,13 @@ namespace pcl
         GPUTreePtr tree_;
 
         /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
-        double cluster_tolerance_;
+        double cluster_tolerance_ {0};
 
         /** \brief The minimum number of points that a cluster needs to contain in order to be considered valid (default = 1). */
-        int min_pts_per_cluster_;
+        int min_pts_per_cluster_ {1};
 
         /** \brief The maximum number of points that a cluster needs to contain in order to be considered valid (default = MAXINT). */
-        int max_pts_per_cluster_;
+        int max_pts_per_cluster_ {std::numeric_limits<int>::max()};
 
         /** \brief Class getName method. */
         virtual std::string getClassName () const { return ("gpu::EuclideanLabeledClusterExtraction"); }

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_seeded_hue_segmentation.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_seeded_hue_segmentation.h
@@ -74,8 +74,7 @@ namespace pcl
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         /** \brief Empty constructor. */
-        SeededHueSegmentation () : delta_hue_ (0.0) 
-        {};
+        SeededHueSegmentation () = default;
 
         /** \brief Provide a pointer to the search object.
           * \param tree a pointer to the spatial search object.
@@ -126,10 +125,10 @@ namespace pcl
         GPUTreePtr tree_;
 
         /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
-        double cluster_tolerance_;
+        double cluster_tolerance_ {0};
 
         /** \brief The allowed difference on the hue*/
-        float delta_hue_;
+        float delta_hue_ {0.0};
 
         /** \brief Class getName method. */
         virtual std::string getClassName () const { return ("gpu::SeededHueSegmentation"); }

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_labeled_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_labeled_clusters.hpp
@@ -36,8 +36,7 @@
  *
  */
 
-#ifndef PCL_GPU_SEGMENTATION_IMPL_EXTRACT_LABELED_CLUSTERS_H_
-#define PCL_GPU_SEGMENTATION_IMPL_EXTRACT_LABELED_CLUSTERS_H_
+#pragma once
 
 #include <pcl/gpu/segmentation/gpu_extract_labeled_clusters.h>
 
@@ -176,4 +175,3 @@ pcl::gpu::EuclideanLabeledClusterExtraction<PointT>::extract (std::vector<PointI
 
 #define PCL_INSTANTIATE_extractLabeledEuclideanClusters(T) template void PCL_EXPORTS pcl::gpu::extractLabeledEuclideanClusters<T> (const typename pcl::PointCloud<T>::Ptr  &, const pcl::gpu::Octree::Ptr &,float, std::vector<PointIndices> &, unsigned int, unsigned int);
 #define PCL_INSTANTIATE_EuclideanLabeledClusterExtraction(T) template class PCL_EXPORTS pcl::gpu::EuclideanLabeledClusterExtraction<T>;
-#endif //PCL_GPU_SEGMENTATION_IMPL_EXTRACT_LABELED_CLUSTERS_H_

--- a/gpu/segmentation/src/extract_clusters.cpp
+++ b/gpu/segmentation/src/extract_clusters.cpp
@@ -38,8 +38,11 @@
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>
 //#include <pcl/gpu/segmentation/gpu_extract_labeled_clusters.h>
+#include <pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp>
 #include <pcl/gpu/segmentation/impl/gpu_extract_labeled_clusters.hpp>
 
 // Instantiations of specific point types
+PCL_INSTANTIATE(extractEuclideanClusters, PCL_XYZ_POINT_TYPES);
+PCL_INSTANTIATE(EuclideanClusterExtraction, PCL_XYZ_POINT_TYPES);
 PCL_INSTANTIATE(extractLabeledEuclideanClusters, PCL_XYZL_POINT_TYPES);
 PCL_INSTANTIATE(EuclideanLabeledClusterExtraction, PCL_XYZL_POINT_TYPES);


### PR DESCRIPTION
Make gpu_extract_clusters templated.

Make gpu_extract_clusters exported.

Are there a better way than:

```
    // Buffer in a new PointXYZ type
    PointT t = host_cloud_->points[i];
    PointXYZ p;
    p.x = t.x; p.y = t.y; p.z = t.z;
```

When using various point types, to get the XYZ part?