### PR TITLE
[common] Modify index type for PCLPointField

### DIFF
--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -2,6 +2,7 @@
 
 #include <pcl/memory.h>       // for shared_ptr
 #include <pcl/type_traits.h>  // for asEnum_v
+#include <pcl/types.h>        // for index_t
 
 #include <string>   // for string
 #include <ostream>  // for ostream
@@ -12,9 +13,9 @@ namespace pcl
   {
     std::string name;
 
-    std::uint32_t offset = 0;
+    index_t offset = 0;
     std::uint8_t datatype = 0;
-    std::uint32_t count = 0;
+    index_t count = 0;
 
     enum PointFieldTypes { INT8 = traits::asEnum_v<std::int8_t>,
                            UINT8 = traits::asEnum_v<std::uint8_t>,

--- a/common/include/pcl/PCLPointField.h
+++ b/common/include/pcl/PCLPointField.h
@@ -13,9 +13,9 @@ namespace pcl
   {
     std::string name;
 
-    index_t offset = 0;
+    uindex_t offset = 0;
     std::uint8_t datatype = 0;
-    index_t count = 0;
+    uindex_t count = 0;
 
     enum PointFieldTypes { INT8 = traits::asEnum_v<std::int8_t>,
                            UINT8 = traits::asEnum_v<std::uint8_t>,

--- a/common/include/pcl/pcl_base.h
+++ b/common/include/pcl/pcl_base.h
@@ -237,7 +237,7 @@ namespace pcl
       bool fake_indices_;
 
       /** \brief The size of each individual field. */
-      std::vector<int> field_sizes_;
+      std::vector<uindex_t> field_sizes_;
 
       /** \brief The x-y-z fields indices. */
       index_t x_idx_, y_idx_, z_idx_;

--- a/common/src/common.cpp
+++ b/common/src/common.cpp
@@ -59,7 +59,7 @@ pcl::getMinMax (const pcl::PCLPointCloud2 &cloud, int,
   }
   const auto field_idx = std::distance(cloud.fields.begin (), result);
 
-  for (index_t i = 0; i < cloud.fields[field_idx].count; ++i)
+  for (uindex_t i = 0; i < cloud.fields[field_idx].count; ++i)
   {
     float data;
     // TODO: replace float with the real data type

--- a/common/src/common.cpp
+++ b/common/src/common.cpp
@@ -59,7 +59,7 @@ pcl::getMinMax (const pcl::PCLPointCloud2 &cloud, int,
   }
   const auto field_idx = std::distance(cloud.fields.begin (), result);
 
-  for (unsigned int i = 0; i < cloud.fields[field_idx].count; ++i)
+  for (index_t i = 0; i < cloud.fields[field_idx].count; ++i)
   {
     float data;
     // TODO: replace float with the real data type

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -988,7 +988,7 @@ pcl::PCDWriter::generateHeaderBinary (const pcl::PCLPointCloud2 &cloud,
   for (std::size_t i = 0; i < cloud.fields.size (); ++i)
   {
     // If field offsets do not match, then we need to create fake fields
-    if (toffset != static_cast<uindex_t>(cloud.fields[i].offset))
+    if (toffset != cloud.fields[i].offset)
     {
       // If we're at the last "valid" field
       int fake_offset = (i == 0) ?

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -465,7 +465,7 @@ pcl::PCDReader::readBodyASCII (std::istream &fs, pcl::PCLPointCloud2 &cloud, int
           total += cloud.fields[d].count; // jump over this many elements in the string token
           continue;
         }
-        for (index_t c = 0; c < cloud.fields[d].count; ++c)
+        for (uindex_t c = 0; c < cloud.fields[d].count; ++c)
         {
           switch (cloud.fields[d].datatype)
           {
@@ -623,7 +623,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
   {
     for (unsigned int d = 0; d < static_cast<unsigned int> (cloud.fields.size ()); ++d)
     {
-      for (index_t c = 0; c < cloud.fields[d].count; ++c)
+      for (uindex_t c = 0; c < cloud.fields[d].count; ++c)
       {
         switch (cloud.fields[d].datatype)
         {

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -465,7 +465,7 @@ pcl::PCDReader::readBodyASCII (std::istream &fs, pcl::PCLPointCloud2 &cloud, int
           total += cloud.fields[d].count; // jump over this many elements in the string token
           continue;
         }
-        for (unsigned int c = 0; c < cloud.fields[d].count; ++c)
+        for (index_t c = 0; c < cloud.fields[d].count; ++c)
         {
           switch (cloud.fields[d].datatype)
           {
@@ -623,7 +623,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
   {
     for (unsigned int d = 0; d < static_cast<unsigned int> (cloud.fields.size ()); ++d)
     {
-      for (std::uint32_t c = 0; c < cloud.fields[d].count; ++c)
+      for (index_t c = 0; c < cloud.fields[d].count; ++c)
       {
         switch (cloud.fields[d].datatype)
         {
@@ -988,7 +988,7 @@ pcl::PCDWriter::generateHeaderBinary (const pcl::PCLPointCloud2 &cloud,
   for (std::size_t i = 0; i < cloud.fields.size (); ++i)
   {
     // If field offsets do not match, then we need to create fake fields
-    if (toffset != cloud.fields[i].offset)
+    if (toffset != static_cast<uindex_t>(cloud.fields[i].offset))
     {
       // If we're at the last "valid" field
       int fake_offset = (i == 0) ?

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -121,7 +121,7 @@ TEST (PCL, ComplexPCDFileASCII)
   int fpfh_idx = pcl::getFieldIndex (blob, "fpfh");
   EXPECT_EQ (fpfh_idx, 0);
   float val[33];
-  for (index_t i = 0; i < blob.fields[fpfh_idx].count; ++i)
+  for (uindex_t i = 0; i < blob.fields[fpfh_idx].count; ++i)
     memcpy (&val[i], &blob.data[0 * blob.point_step + blob.fields[fpfh_idx + 0].offset + i * sizeof (float)], sizeof (float));
 
   EXPECT_EQ (val[0], 0); 

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -121,7 +121,7 @@ TEST (PCL, ComplexPCDFileASCII)
   int fpfh_idx = pcl::getFieldIndex (blob, "fpfh");
   EXPECT_EQ (fpfh_idx, 0);
   float val[33];
-  for (std::size_t i = 0; i < blob.fields[fpfh_idx].count; ++i)
+  for (index_t i = 0; i < blob.fields[fpfh_idx].count; ++i)
     memcpy (&val[i], &blob.data[0 * blob.point_step + blob.fields[fpfh_idx + 0].offset + i * sizeof (float)], sizeof (float));
 
   EXPECT_EQ (val[0], 0); 

--- a/visualization/include/pcl/visualization/impl/histogram_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/histogram_visualizer.hpp
@@ -118,7 +118,7 @@ PCLHistogramVisualizer::addFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (std::uint32_t d = 0; d < fields[field_idx].count; ++d)
+  for (uindex_t d = 0; d < fields[field_idx].count; ++d)
   {
     xy[0] = d;
     //xy[1] = cloud.points[index].histogram[d];

--- a/visualization/src/histogram_visualizer.cpp
+++ b/visualization/src/histogram_visualizer.cpp
@@ -304,7 +304,7 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (unsigned int d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;
@@ -361,7 +361,7 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (unsigned int d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;
@@ -405,7 +405,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (unsigned int d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;
@@ -456,7 +456,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (unsigned int d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;

--- a/visualization/src/histogram_visualizer.cpp
+++ b/visualization/src/histogram_visualizer.cpp
@@ -304,7 +304,7 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (uindex_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;
@@ -361,7 +361,7 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (uindex_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;
@@ -405,7 +405,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (uindex_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;
@@ -456,7 +456,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
 
   // Parse the cloud data and store it in the array
   double xy[2];
-  for (index_t d = 0; d < cloud.fields[field_idx].count; ++d)
+  for (uindex_t d = 0; d < cloud.fields[field_idx].count; ++d)
   {
     xy[0] = d;
     float data;


### PR DESCRIPTION
I added @kunaltyagi's request from #4211 regarding switching `std::vector<int> field_sizes_;` to `uindex_t`to this PR, since `field_sizes_` refers to the size of `PCLPointField`. If that's inappropriate, I'll move that to a seperate PR.