### PR TITLE
Fix feature histogram constructor bug

### DIFF
--- a/common/src/feature_histogram.cpp
+++ b/common/src/feature_histogram.cpp
@@ -49,7 +49,7 @@ pcl::FeatureHistogram::FeatureHistogram (std::size_t const number_of_bins,
   {
     threshold_min_ = min;
     threshold_max_ = max;
-    step_ = (max - min) / static_cast<float> (number_of_bins_);
+    step_ = (max - min) / static_cast<float> (number_of_bins);
   }
   else
   {


### PR DESCRIPTION
This fix a bug in the constructor where `number_of_bins_` was used to compute `step_` before it is defined on [L66](https://github.com/PointCloudLibrary/pcl/blob/0dde8ff82ddd7ebaeb47a5bcadf71a26da3ae640/common/src/feature_histogram.cpp#L66)