### PR TITLE
Set height to 1 instead of width

### DIFF
--- a/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
+++ b/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
@@ -59,7 +59,7 @@ pcl::SamplingSurfaceNormal<PointT>::applyFilter (PointCloud &output)
   PointCloud data = *input_;
   partition (data, 0, npts, min_vec, max_vec, indices, output);
   output.height = 1;
-  output.width = std::uint32_t (output.size ());
+  output.width = output.size ();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -174,7 +174,7 @@ pcl::SamplingSurfaceNormal<PointT>::samplePartition (
     cloud.points.push_back (pt);
   }
   cloud.height = 1;
-  cloud.width = std::uint32_t (cloud.size ());
+  cloud.width = cloud.size ();
 
   Eigen::Vector4f normal;
   float curvature = 0;

--- a/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
+++ b/filters/include/pcl/filters/impl/sampling_surface_normal.hpp
@@ -58,8 +58,8 @@ pcl::SamplingSurfaceNormal<PointT>::applyFilter (PointCloud &output)
   findXYZMaxMin (*input_, max_vec, min_vec);
   PointCloud data = *input_;
   partition (data, 0, npts, min_vec, max_vec, indices, output);
-  output.width = 1;
-  output.height = std::uint32_t (output.points.size ());
+  output.height = 1;
+  output.width = std::uint32_t (output.size ());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -173,8 +173,8 @@ pcl::SamplingSurfaceNormal<PointT>::samplePartition (
     pt.z = data[indices[i]].z;
     cloud.points.push_back (pt);
   }
-  cloud.width = 1;
-  cloud.height = std::uint32_t (cloud.points.size ());
+  cloud.height = 1;
+  cloud.width = std::uint32_t (cloud.size ());
 
   Eigen::Vector4f normal;
   float curvature = 0;

--- a/filters/include/pcl/filters/impl/shadowpoints.hpp
+++ b/filters/include/pcl/filters/impl/shadowpoints.hpp
@@ -75,8 +75,8 @@ pcl::ShadowPoints<PointT, NormalT>::applyFilter (PointCloud &output)
   }
   output.points.resize (cp);
   removed_indices_->resize (ri);
-  output.width = 1;
-  output.height = static_cast<std::uint32_t> (output.points.size ());
+  output.height = 1;
+  output.width = static_cast<std::uint32_t> (output.size ());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/filters/include/pcl/filters/impl/shadowpoints.hpp
+++ b/filters/include/pcl/filters/impl/shadowpoints.hpp
@@ -76,7 +76,7 @@ pcl::ShadowPoints<PointT, NormalT>::applyFilter (PointCloud &output)
   output.points.resize (cp);
   removed_indices_->resize (ri);
   output.height = 1;
-  output.width = static_cast<std::uint32_t> (output.size ());
+  output.width = output.size ();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -881,8 +881,8 @@ pcl::simulation::RangeLikelihood::getPointCloud(
   }
 
   if (!organized) {
-    pc->width = 1;
-    pc->height = points_added;
+    pc->height = 1;
+    pc->width = points_added;
     pc->points.resize(points_added);
   }
 

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -1779,8 +1779,8 @@ TEST (SamplingSurfaceNormal, Filters)
       incloud->points.push_back (pt);
     }
   }
-  incloud->width = 1;
-  incloud->height = std::uint32_t (incloud->points.size ());
+  incloud->height = 1;
+  incloud->width = std::uint32_t (incloud->size ());
 
   pcl::SamplingSurfaceNormal <pcl::PointNormal> ssn_filter;
   ssn_filter.setInputCloud (incloud);
@@ -1813,8 +1813,8 @@ TEST (ShadowPoints, Filters)
   PointXYZ pt (.0f, .0f, .1f);
   input->points.push_back (pt);
 
-  input->width = 1;
-  input->height = static_cast<std::uint32_t> (input->points.size ());
+  input->height = 1;
+  input->width = static_cast<std::uint32_t> (input->size ());
 
 	NormalEstimation<PointXYZ, PointNormal> ne;
 	ne.setInputCloud (input);
@@ -1880,8 +1880,8 @@ TEST (FrustumCulling, Filters)
       }
     }
   }
-  input->width = 1;
-  input->height = static_cast<std::uint32_t> (input->points.size ());
+  input->height = 1;
+  input->width = static_cast<std::uint32_t> (input->size ());
 
   pcl::FrustumCulling<pcl::PointXYZ> fc (true); // Extract removed indices
   fc.setInputCloud (input);

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -1780,7 +1780,7 @@ TEST (SamplingSurfaceNormal, Filters)
     }
   }
   incloud->height = 1;
-  incloud->width = std::uint32_t (incloud->size ());
+  incloud->width = incloud->size ();
 
   pcl::SamplingSurfaceNormal <pcl::PointNormal> ssn_filter;
   ssn_filter.setInputCloud (incloud);
@@ -1814,7 +1814,7 @@ TEST (ShadowPoints, Filters)
   input->points.push_back (pt);
 
   input->height = 1;
-  input->width = static_cast<std::uint32_t> (input->size ());
+  input->width = input->size ();
 
 	NormalEstimation<PointXYZ, PointNormal> ne;
 	ne.setInputCloud (input);
@@ -1881,7 +1881,7 @@ TEST (FrustumCulling, Filters)
     }
   }
   input->height = 1;
-  input->width = static_cast<std::uint32_t> (input->size ());
+  input->width = input->size ();
 
   pcl::FrustumCulling<pcl::PointXYZ> fc (true); // Extract removed indices
   fc.setInputCloud (input);


### PR DESCRIPTION
Use the following to find other instances of `width = 1;`. I don' believe they should be replace, but just for completeness sake:
```bash
$ grep 'width\s*=\s*1;' * -nriH
```