### PR TITLE
[filters] Refatoring VoxelGridCovariance to make it multi-thread safe (and more)

### DIFF
--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -371,7 +371,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
-pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
+pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
   neighbors.clear ();
 

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -373,27 +373,27 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
 template<typename PointT> int
 pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-  neighbors.clear();
+  neighbors.clear ();
 
   // Find displacement coordinates
   Eigen::Vector4i ijk = (reference_point.getArray4fMap() / leaf_size_.array()).template cast<int>();
   ijk[3] = 0;
   Eigen::Array4i diff2min = min_b_ - ijk;
   Eigen::Array4i diff2max = max_b_ - ijk;
-  neighbors.reserve(relative_coordinates.cols());
+  neighbors.reserve (relative_coordinates.cols ());
 
   // Check each neighbor to see if it is occupied and contains sufficient points
-  for (Eigen::Index ni = 0; ni < relative_coordinates.cols(); ni++)
+  for (Eigen::Index ni = 0; ni < relative_coordinates.cols (); ni++)
   {
-    Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
+    Eigen::Vector4i displacement = (Eigen::Vector4i () << relative_coordinates.col (ni), 0).finished ();
     // Checking if the specified cell is in the grid
-    if ((diff2min <= displacement.array ()).all() && (diff2max >= displacement.array ()).all())
+    if ((diff2min <= displacement.array ()).all () && (diff2max >= displacement.array ()).all ())
     {
       typename std::map<std::size_t, Leaf>::const_iterator leaf_iter = leaves_.find (((ijk + displacement - min_b_).dot (divb_mul_)));
-      if (leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_)
+      if (leaf_iter != leaves_.end () && leaf_iter->second.nr_points >= min_points_per_voxel_)
       {
         LeafConstPtr leaf = &(leaf_iter->second);
-        neighbors.push_back(leaf);
+        neighbors.push_back (leaf);
       }
     }
   }

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -373,63 +373,63 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
 template<typename PointT> int
 pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-	neighbors.clear();
+  neighbors.clear();
 
-	// Find displacement coordinates
+  // Find displacement coordinates
   Eigen::Vector4i ijk = (reference_point.getArray4fMap() / leaf_size_.array()).template cast<int>();
   ijk[3] = 0;
-	Eigen::Array4i diff2min = min_b_ - ijk;
-	Eigen::Array4i diff2max = max_b_ - ijk;
-	neighbors.reserve(relative_coordinates.cols());
+  Eigen::Array4i diff2min = min_b_ - ijk;
+  Eigen::Array4i diff2max = max_b_ - ijk;
+  neighbors.reserve(relative_coordinates.cols());
 
-	// Check each neighbor to see if it is occupied and contains sufficient points
-	for (Eigen::Index ni = 0; ni < relative_coordinates.cols(); ni++)
-	{
-		Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
-		// Checking if the specified cell is in the grid
-		if ((diff2min <= displacement.array ()).all() && (diff2max >= displacement.array ()).all())
-		{
+  // Check each neighbor to see if it is occupied and contains sufficient points
+  for (Eigen::Index ni = 0; ni < relative_coordinates.cols(); ni++)
+  {
+    Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
+    // Checking if the specified cell is in the grid
+    if ((diff2min <= displacement.array ()).all() && (diff2max >= displacement.array ()).all())
+    {
       typename std::map<std::size_t, Leaf>::const_iterator leaf_iter = leaves_.find (((ijk + displacement - min_b_).dot (divb_mul_)));
-			if (leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_)
-			{
-				LeafConstPtr leaf = &(leaf_iter->second);
-				neighbors.push_back(leaf);
-			}
-		}
-	}
+      if (leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_)
+      {
+        LeafConstPtr leaf = &(leaf_iter->second);
+        neighbors.push_back(leaf);
+      }
+    }
+  }
 
-	return static_cast<int> (neighbors.size());
+  return static_cast<int> (neighbors.size());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
 pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-	Eigen::MatrixXi relative_coordinates = pcl::getAllNeighborCellIndices();
-	return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
+  Eigen::MatrixXi relative_coordinates = pcl::getAllNeighborCellIndices();
+  return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
 pcl::VoxelGridCovariance<PointT>::getVoxelAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-	return getNeighborhoodAtPoint(Eigen::MatrixXi::Zero(3,1), reference_point, neighbors);
+  return getNeighborhoodAtPoint(Eigen::MatrixXi::Zero(3,1), reference_point, neighbors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
 pcl::VoxelGridCovariance<PointT>::getAdjacentVoxelsAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-	Eigen::MatrixXi relative_coordinates(3, 7);
-	relative_coordinates.setZero();
-	relative_coordinates(0, 1) = 1;
-	relative_coordinates(0, 2) = -1;
-	relative_coordinates(1, 3) = 1;
-	relative_coordinates(1, 4) = -1;
-	relative_coordinates(2, 5) = 1;
-	relative_coordinates(2, 6) = -1;
+  Eigen::MatrixXi relative_coordinates(3, 7);
+  relative_coordinates.setZero();
+  relative_coordinates(0, 1) = 1;
+  relative_coordinates(0, 2) = -1;
+  relative_coordinates(1, 3) = 1;
+  relative_coordinates(1, 4) = -1;
+  relative_coordinates(2, 5) = 1;
+  relative_coordinates(2, 6) = -1;
 
-	return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
+  return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -376,7 +376,7 @@ pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const Eigen::Matrix<in
   neighbors.clear ();
 
   // Find displacement coordinates
-  Eigen::Vector4i ijk = (reference_point.getArray4fMap() / leaf_size_.array()).template cast<int>();
+  Eigen::Vector4i ijk = (reference_point.getArray4fMap() * inverse_leaf_size_).template cast<int>();
   ijk[3] = 0;
   Eigen::Array4i diff2min = min_b_ - ijk;
   Eigen::Array4i diff2max = max_b_ - ijk;
@@ -413,14 +413,14 @@ pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const PointT& referenc
 template<typename PointT> int
 pcl::VoxelGridCovariance<PointT>::getVoxelAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-  return getNeighborhoodAtPoint(Eigen::MatrixXi::Zero(3,1), reference_point, neighbors);
+  return getNeighborhoodAtPoint(Eigen::Matrix<int, 3, Eigen::Dynamic>::Zero(3,1), reference_point, neighbors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
 pcl::VoxelGridCovariance<PointT>::getAdjacentVoxelsAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-  Eigen::MatrixXi relative_coordinates(3, 7);
+  Eigen::Matrix<int, 3, Eigen::Dynamic> relative_coordinates(3, 7);
   relative_coordinates.setZero();
   relative_coordinates(0, 1) = 1;
   relative_coordinates(0, 2) = -1;

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -371,37 +371,65 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
-pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors)
+pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint(const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
-  neighbors.clear ();
+	neighbors.clear();
 
-  // Find displacement coordinates
-  Eigen::MatrixXi relative_coordinates = pcl::getAllNeighborCellIndices ();
-  Eigen::Vector4i ijk (static_cast<int> (std::floor (reference_point.x / leaf_size_[0])), 
-                       static_cast<int> (std::floor (reference_point.y / leaf_size_[1])), 
-                       static_cast<int> (std::floor (reference_point.z / leaf_size_[2])), 0);
-  Eigen::Array4i diff2min = min_b_ - ijk;
-  Eigen::Array4i diff2max = max_b_ - ijk;
-  neighbors.reserve (relative_coordinates.cols ());
+	// Find displacement coordinates
+  Eigen::Vector4i ijk = (reference_point.getArray4fMap() / leaf_size_.array()).template cast<int>();
+  ijk[3] = 0;
+	Eigen::Array4i diff2min = min_b_ - ijk;
+	Eigen::Array4i diff2max = max_b_ - ijk;
+	neighbors.reserve(relative_coordinates.cols());
 
-  // Check each neighbor to see if it is occupied and contains sufficient points
-  // Slower than radius search because needs to check 26 indices
-  for (Eigen::Index ni = 0; ni < relative_coordinates.cols (); ni++)
-  {
-    Eigen::Vector4i displacement = (Eigen::Vector4i () << relative_coordinates.col (ni), 0).finished ();
-    // Checking if the specified cell is in the grid
-    if ((diff2min <= displacement.array ()).all () && (diff2max >= displacement.array ()).all ())
-    {
-      typename std::map<std::size_t, Leaf>::iterator leaf_iter = leaves_.find (((ijk + displacement - min_b_).dot (divb_mul_)));
-      if (leaf_iter != leaves_.end () && leaf_iter->second.nr_points >= min_points_per_voxel_)
-      {
-        LeafConstPtr leaf = &(leaf_iter->second);
-        neighbors.push_back (leaf);
-      }
-    }
-  }
+	// Check each neighbor to see if it is occupied and contains sufficient points
+	for (Eigen::Index ni = 0; ni < relative_coordinates.cols(); ni++)
+	{
+		Eigen::Vector4i displacement = (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
+		// Checking if the specified cell is in the grid
+		if ((diff2min <= displacement.array ()).all() && (diff2max >= displacement.array ()).all())
+		{
+      typename std::map<std::size_t, Leaf>::const_iterator leaf_iter = leaves_.find (((ijk + displacement - min_b_).dot (divb_mul_)));
+			if (leaf_iter != leaves_.end() && leaf_iter->second.nr_points >= min_points_per_voxel_)
+			{
+				LeafConstPtr leaf = &(leaf_iter->second);
+				neighbors.push_back(leaf);
+			}
+		}
+	}
 
-  return (static_cast<int> (neighbors.size ()));
+	return static_cast<int> (neighbors.size());
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointT> int
+pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
+{
+	Eigen::MatrixXi relative_coordinates = pcl::getAllNeighborCellIndices();
+	return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointT> int
+pcl::VoxelGridCovariance<PointT>::getVoxelAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
+{
+	return getNeighborhoodAtPoint(Eigen::MatrixXi::Zero(3,1), reference_point, neighbors);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointT> int
+pcl::VoxelGridCovariance<PointT>::getAdjacentVoxelsAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
+{
+	Eigen::MatrixXi relative_coordinates(3, 7);
+	relative_coordinates.setZero();
+	relative_coordinates(0, 1) = 1;
+	relative_coordinates(0, 2) = -1;
+	relative_coordinates(1, 3) = 1;
+	relative_coordinates(1, 4) = -1;
+	relative_coordinates(2, 5) = 1;
+	relative_coordinates(2, 6) = -1;
+
+	return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -378,14 +378,14 @@ pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const Eigen::Matrix<in
   // Find displacement coordinates
   Eigen::Vector4i ijk = (reference_point.getArray4fMap() * inverse_leaf_size_).template cast<int>();
   ijk[3] = 0;
-  Eigen::Array4i diff2min = min_b_ - ijk;
-  Eigen::Array4i diff2max = max_b_ - ijk;
+  const Eigen::Array4i diff2min = min_b_ - ijk;
+  const Eigen::Array4i diff2max = max_b_ - ijk;
   neighbors.reserve (relative_coordinates.cols ());
 
   // Check each neighbor to see if it is occupied and contains sufficient points
   for (Eigen::Index ni = 0; ni < relative_coordinates.cols (); ni++)
   {
-    Eigen::Vector4i displacement = (Eigen::Vector4i () << relative_coordinates.col (ni), 0).finished ();
+    const Eigen::Vector4i displacement = (Eigen::Vector4i () << relative_coordinates.col (ni), 0).finished ();
     // Checking if the specified cell is in the grid
     if ((diff2min <= displacement.array ()).all () && (diff2max >= displacement.array ()).all ())
     {
@@ -418,7 +418,7 @@ pcl::VoxelGridCovariance<PointT>::getVoxelAtPoint(const PointT& reference_point,
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
-pcl::VoxelGridCovariance<PointT>::getAdjacentVoxelsAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
+pcl::VoxelGridCovariance<PointT>::getFaceNeighborsAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
   Eigen::Matrix<int, 3, Eigen::Dynamic> relative_coordinates(3, 7);
   relative_coordinates.setZero();
@@ -428,6 +428,17 @@ pcl::VoxelGridCovariance<PointT>::getAdjacentVoxelsAtPoint(const PointT& referen
   relative_coordinates(1, 4) = -1;
   relative_coordinates(2, 5) = 1;
   relative_coordinates(2, 6) = -1;
+
+  return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointT> int
+pcl::VoxelGridCovariance<PointT>::getAllNeighborsAtPoint(const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
+{
+  Eigen::Matrix<int, 3, Eigen::Dynamic> relative_coordinates(3, 27);
+  relative_coordinates.col(0).setZero();
+  relative_coordinates.rightCols(26) = pcl::getAllNeighborCellIndices();
 
   return getNeighborhoodAtPoint(relative_coordinates, reference_point, neighbors);
 }

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -371,7 +371,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> int
-pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
+pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const Eigen::Matrix<int, 3, Eigen::Dynamic>& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const
 {
   neighbors.clear ();
 
@@ -389,7 +389,7 @@ pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const Eigen::MatrixXi&
     // Checking if the specified cell is in the grid
     if ((diff2min <= displacement.array ()).all () && (diff2max >= displacement.array ()).all ())
     {
-      typename std::map<std::size_t, Leaf>::const_iterator leaf_iter = leaves_.find (((ijk + displacement - min_b_).dot (divb_mul_)));
+      const auto leaf_iter = leaves_.find (((ijk + displacement - min_b_).dot (divb_mul_)));
       if (leaf_iter != leaves_.end () && leaf_iter->second.nr_points >= min_points_per_voxel_)
       {
         LeafConstPtr leaf = &(leaf_iter->second);

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -361,14 +361,43 @@ namespace pcl
 
       }
 
-      /** \brief Get the voxels surrounding point p, not including the voxel containing point p.
-       * \note Only voxels containing a sufficient number of points are used (slower than radius search in practice).
+      /** \brief Get the voxels surrounding point p designated by #relative_coordinates.
+       * \note Only voxels containing a sufficient number of points are used.
+       * \param[in] relative_coordinates relative coordinates of neighboring voxels
        * \param[in] reference_point the point to get the leaf structure at
        * \param[out] neighbors
        * \return number of neighbors found
        */
       int
-      getNeighborhoodAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors);
+      getNeighborhoodAtPoint (const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
+
+      /** \brief Get the voxels surrounding point p, not including the voxel containing point p.
+       * \note Only voxels containing a sufficient number of points are used.
+       * \param[in] reference_point the point to get the leaf structure at
+       * \param[out] neighbors
+       * \return number of neighbors found
+       */
+      int
+      getNeighborhoodAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
+
+      /** \brief Get the voxel at p.
+       * \note Only voxels containing a sufficient number of points are used.
+       * \param[in] reference_point the point to get the leaf structure at
+       * \param[out] neighbors
+       * \return number of neighbors found
+       */
+      int
+      getVoxelAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
+
+      /** \brief Get the voxel at p and its adjacent voxels.
+       * \note Only voxels containing a sufficient number of points are used.
+       * \param[in] reference_point the point to get the leaf structure at
+       * \param[out] neighbors
+       * \return number of neighbors found
+       */
+      int
+      getAdjacentVoxelsAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
+
 
       /** \brief Get the leaf structure map
        * \return a map contataining all leaves
@@ -406,7 +435,7 @@ namespace pcl
        */
       int
       nearestKSearch (const PointT &point, int k,
-                      std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances)
+                      std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances) const
       {
         k_leaves.clear ();
 
@@ -425,7 +454,13 @@ namespace pcl
         k_leaves.reserve (k);
         for (const int &k_index : k_indices)
         {
-          k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[k_index]]);
+          auto voxel = leaves_.find(voxel_centroids_leaf_indices_[k_index]);
+          if (voxel == leaves_.end()) {
+            PCL_WARN("Accessing to non-existent voxel");
+            continue;
+          }
+
+          k_leaves.push_back(&voxel->second);
         }
         return k;
       }
@@ -441,7 +476,7 @@ namespace pcl
        */
       inline int
       nearestKSearch (const PointCloud &cloud, int index, int k,
-                      std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances)
+                      std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances) const
       {
         if (index >= static_cast<int> (cloud.points.size ()) || index < 0)
           return (0);
@@ -460,7 +495,7 @@ namespace pcl
        */
       int
       radiusSearch (const PointT &point, double radius, std::vector<LeafConstPtr> &k_leaves,
-                    std::vector<float> &k_sqr_distances, unsigned int max_nn = 0)
+                    std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
       {
         k_leaves.clear ();
 
@@ -479,7 +514,13 @@ namespace pcl
         k_leaves.reserve (k);
         for (const int &k_index : k_indices)
         {
-          k_leaves.push_back (&leaves_[voxel_centroids_leaf_indices_[k_index]]);
+          auto voxel = leaves_.find(voxel_centroids_leaf_indices_[k_index]);
+          if(voxel == leaves_.end()) {
+            PCL_WARN("Accessing to non-existent voxel");
+            continue;
+          }
+
+          k_leaves.push_back(&voxel->second);
         }
         return k;
       }
@@ -497,7 +538,7 @@ namespace pcl
       inline int
       radiusSearch (const PointCloud &cloud, int index, double radius,
                     std::vector<LeafConstPtr> &k_leaves, std::vector<float> &k_sqr_distances,
-                    unsigned int max_nn = 0)
+                    unsigned int max_nn = 0) const
       {
         if (index >= static_cast<int> (cloud.points.size ()) || index < 0)
           return (0);

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -363,13 +363,13 @@ namespace pcl
 
       /** \brief Get the voxels surrounding point p designated by #relative_coordinates.
        * \note Only voxels containing a sufficient number of points are used.
-       * \param[in] relative_coordinates relative coordinates of neighboring voxels
+       * \param[in] relative_coordinates 3xN matrix that represents relative coordinates of N neighboring voxels with respect to the center voxel
        * \param[in] reference_point the point to get the leaf structure at
        * \param[out] neighbors
        * \return number of neighbors found
        */
       int
-      getNeighborhoodAtPoint (const Eigen::MatrixXi& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
+      getNeighborhoodAtPoint (const Eigen::Matrix<int, 3, Eigen::Dynamic>& relative_coordinates, const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
 
       /** \brief Get the voxels surrounding point p, not including the voxel containing point p.
        * \note Only voxels containing a sufficient number of points are used.
@@ -456,7 +456,6 @@ namespace pcl
         {
           auto voxel = leaves_.find(voxel_centroids_leaf_indices_[k_index]);
           if (voxel == leaves_.end()) {
-            PCL_WARN("Accessing to non-existent voxel");
             continue;
           }
 
@@ -516,7 +515,6 @@ namespace pcl
         {
           auto voxel = leaves_.find(voxel_centroids_leaf_indices_[k_index]);
           if(voxel == leaves_.end()) {
-            PCL_WARN("Accessing to non-existent voxel");
             continue;
           }
 

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -389,15 +389,23 @@ namespace pcl
       int
       getVoxelAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
 
-      /** \brief Get the voxel at p and its adjacent voxels.
+      /** \brief Get the voxel at p and its facing voxels (up to 7 voxels).
        * \note Only voxels containing a sufficient number of points are used.
        * \param[in] reference_point the point to get the leaf structure at
        * \param[out] neighbors
        * \return number of neighbors found (up to 7)
        */
       int
-      getAdjacentVoxelsAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
+      getFaceNeighborsAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
 
+      /** \brief Get all 3x3x3 neighbor voxels of p (up to 27 voxels).
+       * \note Only voxels containing a sufficient number of points are used.
+       * \param[in] reference_point the point to get the leaf structure at
+       * \param[out] neighbors
+       * \return number of neighbors found (up to 27)
+       */
+      int
+      getAllNeighborsAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
 
       /** \brief Get the leaf structure map
        * \return a map contataining all leaves
@@ -507,13 +515,13 @@ namespace pcl
 
         // Find neighbors within radius in the occupied voxel centroid cloud
         std::vector<int> k_indices;
-        int k = kdtree_.radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
+        const int k = kdtree_.radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
 
         // Find leaves corresponding to neighbors
         k_leaves.reserve (k);
         for (const int &k_index : k_indices)
         {
-          auto voxel = leaves_.find(voxel_centroids_leaf_indices_[k_index]);
+          const auto voxel = leaves_.find(voxel_centroids_leaf_indices_[k_index]);
           if(voxel == leaves_.end()) {
             continue;
           }

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -375,7 +375,7 @@ namespace pcl
        * \note Only voxels containing a sufficient number of points are used.
        * \param[in] reference_point the point to get the leaf structure at
        * \param[out] neighbors
-       * \return number of neighbors found
+       * \return number of neighbors found (up to 26)
        */
       int
       getNeighborhoodAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
@@ -384,7 +384,7 @@ namespace pcl
        * \note Only voxels containing a sufficient number of points are used.
        * \param[in] reference_point the point to get the leaf structure at
        * \param[out] neighbors
-       * \return number of neighbors found
+       * \return number of neighbors found (up to 1)
        */
       int
       getVoxelAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
@@ -393,7 +393,7 @@ namespace pcl
        * \note Only voxels containing a sufficient number of points are used.
        * \param[in] reference_point the point to get the leaf structure at
        * \param[out] neighbors
-       * \return number of neighbors found
+       * \return number of neighbors found (up to 7)
        */
       int
       getAdjacentVoxelsAtPoint (const PointT& reference_point, std::vector<LeafConstPtr> &neighbors) const;
@@ -461,7 +461,7 @@ namespace pcl
 
           k_leaves.push_back(&voxel->second);
         }
-        return k;
+        return k_leaves.size();
       }
 
       /** \brief Search for the k-nearest occupied voxels for the given query point.
@@ -520,7 +520,7 @@ namespace pcl
 
           k_leaves.push_back(&voxel->second);
         }
-        return k;
+        return k_leaves.size();
       }
 
       /** \brief Search for all the nearest occupied voxels of the query point in a given radius.


### PR DESCRIPTION
This PR updates VoxelGridCovariance so that it can be used in multi-threaded NDT https://github.com/PointCloudLibrary/pcl/pull/4135

- getNeighborhoodAtPoint is generalized so that any neighborhood patterns can be designated
- const qualifiers are added to getNeighborhoodAtPoint, nearestKSearch, and radiusSearch to clarify that they are thread-safe

Although the second modification slightly changes the behavior of the methods in case a voxel found by ```kdtree_``` doesn't exist in ```leaves_```, this condition never happens because ```kdtree_``` is built from voxel coordinates in ```leaves_```.

Regarding https://github.com/PointCloudLibrary/pcl/pull/4180#discussion_r449546738:
I empirically found that using adjacent + center voxels (7 voxels) is the best for accuracy. I updated the doc comment of getAdjacentVoxelsAtPoint to clarify that it retrieves 7 voxels.