### PR TITLE
Adding `max_size` to PointCloud

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -456,6 +456,7 @@ namespace pcl
       inline const_reverse_iterator crend () const noexcept { return (points.crend ()); }
 
       //capacity
+      index_t max_size() const noexcept { return static_cast<index_t>(points.max_size()); }
       inline std::size_t size () const { return (points.size ()); }
       inline void reserve (std::size_t n) { points.reserve (n); }
       inline bool empty () const { return points.empty (); }


### PR DESCRIPTION
This brings PointCloud another step closer to the end goal of being a replacement of `std::vector` (currently used to represent points) in order to hide the internal implementation details