### PR TITLE
Allow user to apply arbitrary constraint on models in sample consensus

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -386,6 +386,16 @@ namespace pcl
         max_radius = radius_max_;
       }
 
+      /** \brief This can be used to impose any kind of constraint on the model,
+        * e.g. that it has a specific direction, size, or anything else.
+        * \param[in] function A function that gets model coefficients and returns whether the model is acceptable or not.
+        */
+      inline void
+      setIsModelValidUserDefined(std::function<bool(const Eigen::VectorXf &)> function)
+      {
+        is_model_valid_user_defined_ = function;
+      }
+
       /** \brief Set the maximum distance allowed when drawing random samples
         * \param[in] radius the maximum distance (L2 norm)
         * \param search
@@ -511,6 +521,11 @@ namespace pcl
           PCL_ERROR ("[pcl::%s::isModelValid] Invalid number of model coefficients given (is %lu, should be %lu)!\n", getClassName ().c_str (), model_coefficients.size (), model_size_);
           return (false);
         }
+        if (is_model_valid_user_defined_ && !is_model_valid_user_defined_(model_coefficients))
+        {
+          PCL_DEBUG ("[pcl::%s::isModelValid] The user defined isModelValid function returned false.\n", getClassName ().c_str ());
+          return (false);
+        }
         return (true);
       }
 
@@ -571,6 +586,9 @@ namespace pcl
       {
         return ((*rng_gen_) ());
       }
+
+      /** \brief A user defined function that takes model coefficients and returns whether the model is acceptable or not. */
+      std::function<bool(const Eigen::VectorXf &)> is_model_valid_user_defined_;
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW
  };

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -391,7 +391,7 @@ namespace pcl
         * \param[in] function A function that gets model coefficients and returns whether the model is acceptable or not.
         */
       inline void
-      setIsModelValidUserDefined(std::function<bool(const Eigen::VectorXf &)> function)
+      setModelConstraints (std::function<bool(const Eigen::VectorXf &)> function)
       {
         is_model_valid_user_defined_ = std::move (function);
       }

--- a/sample_consensus/include/pcl/sample_consensus/sac_model.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model.h
@@ -393,7 +393,7 @@ namespace pcl
       inline void
       setIsModelValidUserDefined(std::function<bool(const Eigen::VectorXf &)> function)
       {
-        is_model_valid_user_defined_ = function;
+        is_model_valid_user_defined_ = std::move (function);
       }
 
       /** \brief Set the maximum distance allowed when drawing random samples


### PR DESCRIPTION
I used a `std::function` to make `SACModel` more versatile. This allows:

- finding a plane that is horizontal _or_ vertical (parallel _or_ perpendicular to the ground). With this PR, there is a nicer solution than first searching for horizontal planes (possibly without success), then vertical planes.
- restricting to perpendicular planes, i.e. providing a `SampleConsensusModelNormalPerpendicularPlane`, similar to `SampleConsensusModelNormalParallelPlane`
- control over the position of circles and spheres
- define arbitary constraints for the models, the current options (radius, direction, ...) are a bit limiting