### PR TITLE
Pointer fix for forward-definitions in kdtree_flann.h

### DIFF
--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -225,10 +225,10 @@ namespace pcl
       int total_nr_points_;
 
       /** \brief The KdTree search parameters for K-nearest neighbors. */
-      ::flann::SearchParams param_k_;
+      ::flann::SearchParams *param_k_;
 
       /** \brief The KdTree search parameters for radius search. */
-      ::flann::SearchParams param_radius_;
+      ::flann::SearchParams *param_radius_;
   };
 }
 


### PR DESCRIPTION
Per issue #1481, this small fix avoids a problem where two variables in kdtree_flann.h are forward-declared, causing programs that include both the kdtree_flann header and OpenCV libraries to fail to compile. This issue occurs when the latest version of pcl is installed along with OpenCV 3.4.

In the issue, I noted that it occurs when installing pcl from apt, but I've since checked that the problem also occurs when building and installing pcl from source. 