### PR TITLE
Fix regression in Organized Edge Detection (introduced in PCL 1.10.1)

### DIFF
--- a/features/include/pcl/features/impl/organized_edge_detection.hpp
+++ b/features/include/pcl/features/impl/organized_edge_detection.hpp
@@ -132,7 +132,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
           std::tie (min_itr, max_itr) = std::minmax_element (nghr_dist.cbegin (), nghr_dist.cend ());
           float nghr_dist_min = *min_itr;
           float nghr_dist_max = *max_itr;
-          float dist_dominant = std::max(std::abs (nghr_dist_min),std::abs (nghr_dist_max));
+          float dist_dominant = std::abs (nghr_dist_min) > std::abs (nghr_dist_max) ? nghr_dist_min : nghr_dist_max;
           if (std::abs (dist_dominant) > th_depth_discon_*std::abs (curr_depth))
           {
             // Found a depth discontinuity

--- a/features/include/pcl/features/organized_edge_detection.h
+++ b/features/include/pcl/features/organized_edge_detection.h
@@ -42,9 +42,9 @@
 
 namespace pcl
 {
-  /** \brief OrganizedEdgeBase, OrganizedEdgeFromRGB, OrganizedEdgeFromNormals, 
-    * and OrganizedEdgeFromRGBNormals find 3D edges from an organized point 
-    * cloud data. Given an organized point cloud, they will output a PointCloud 
+  /** \brief OrganizedEdgeBase, OrganizedEdgeFromRGB, OrganizedEdgeFromNormals,
+    * and OrganizedEdgeFromRGBNormals find 3D edges from an organized point
+    * cloud data. Given an organized point cloud, they will output a PointCloud
     * of edge labels and a vector of PointIndices.
     * OrganizedEdgeBase accepts PCL_XYZ_POINT_TYPES and returns EDGELABEL_NAN_BOUNDARY, EDGELABEL_OCCLUDING, and EDGELABEL_OCCLUDED.
     * OrganizedEdgeFromRGB accepts PCL_RGB_POINT_TYPES and returns EDGELABEL_NAN_BOUNDARY, EDGELABEL_OCCLUDING, EDGELABEL_OCCLUDED, and EDGELABEL_RGB_CANNY.
@@ -59,7 +59,7 @@ namespace pcl
     using PointCloud = pcl::PointCloud<PointT>;
     using PointCloudPtr = typename PointCloud::Ptr;
     using PointCloudConstPtr = typename PointCloud::ConstPtr;
-      
+
     using PointCloudL = pcl::PointCloud<PointLT>;
     using PointCloudLPtr = typename PointCloudL::Ptr;
     using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
@@ -81,7 +81,7 @@ namespace pcl
       }
 
       /** \brief Destructor for OrganizedEdgeBase */
-      
+
       ~OrganizedEdgeBase ()
       {
       }
@@ -92,19 +92,17 @@ namespace pcl
         */
       void
       compute (pcl::PointCloud<PointLT>& labels, std::vector<pcl::PointIndices>& label_indices) const;
-      
-      /** \brief Set the tolerance in meters for difference in depth values between neighboring points.
-        * (The value is set for 1 meter and is adapted with respect to depth value linearly.
-        * (e.g. 2.0*th_depth_discon_ in 2 meter depth)) */
+
+      /** \brief Set the tolerance in meters for the relative difference in depth values between neighboring points.
+        * e.g. If a point has a depth (z) value of 2.0 meters, a neighboring point is discontinuous if its depth differs by > 2.0 * th_depth_discon_. */
       inline void
       setDepthDisconThreshold (const float th)
       {
         th_depth_discon_ = th;
       }
 
-      /** \brief Get the tolerance in meters for difference in depth values between neighboring points.
-        * (The value is set for 1 meter and is adapted with respect to depth value linearly.
-        * (e.g. 2.0*th_depth_discon_ in 2 meter depth)) */
+      /** \brief Get the tolerance in meters for the relative difference in depth values between neighboring points.
+        * e.g. If a point has a depth (z) value of 2.0 meters, a neighboring point is discontinuous if its depth differs by > 2.0 * th_depth_discon_. */
       inline float
       getDepthDisconThreshold () const
       {
@@ -138,7 +136,7 @@ namespace pcl
       {
         return detecting_edge_types_;
       }
-      
+
       enum {EDGELABEL_NAN_BOUNDARY=1, EDGELABEL_OCCLUDING=2, EDGELABEL_OCCLUDED=4, EDGELABEL_HIGH_CURVATURE=8, EDGELABEL_RGB_CANNY=16};
       static const int num_of_edgetype_ = 5;
 
@@ -148,14 +146,14 @@ namespace pcl
         */
       void
       extractEdges (pcl::PointCloud<PointLT>& labels) const;
-      
+
       /** \brief Assign point indices for each edge label
         * \param[out] labels a PointCloud of edge labels
         * \param[out] label_indices a vector of PointIndices corresponding to each edge label
         */
       void
       assignLabelIndices (pcl::PointCloud<PointLT>& labels, std::vector<pcl::PointIndices>& label_indices) const;
-      
+
       struct Neighbor
       {
         Neighbor (int dx, int dy, int didx)
@@ -163,16 +161,15 @@ namespace pcl
         , d_y (dy)
         , d_index (didx)
         {}
-        
+
         int d_x;
         int d_y;
         int d_index; // = dy * width + dx: pre-calculated
       };
 
-      /** \brief The tolerance in meters for difference in depth values between neighboring points 
-        * (The value is set for 1 meter and is adapted with respect to depth value linearly. 
-        * (e.g. 2.0*th_depth_discon_ in 2 meter depth)) 
-        */
+      /** \brief The tolerance in meters for the relative difference in depth values between neighboring points
+        * (The default value is set for .02 meters and is adapted with respect to depth value linearly.
+        * e.g. If a point has a depth (z) value of 2.0 meters, a neighboring point is discontinuous if its depth differs by > 2.0 * th_depth_discon_. */
       float th_depth_discon_;
 
       /** \brief The max search distance for deciding occluding and occluded edges */
@@ -188,7 +185,7 @@ namespace pcl
     using PointCloud = pcl::PointCloud<PointT>;
     using PointCloudPtr = typename PointCloud::Ptr;
     using PointCloudConstPtr = typename PointCloud::ConstPtr;
-      
+
     using PointCloudL = pcl::PointCloud<PointLT>;
     using PointCloudLPtr = typename PointCloudL::Ptr;
     using PointCloudLConstPtr = typename PointCloudL::ConstPtr;
@@ -214,7 +211,7 @@ namespace pcl
       }
 
       /** \brief Destructor for OrganizedEdgeFromRGB */
-      
+
       ~OrganizedEdgeFromRGB ()
       {
       }
@@ -225,7 +222,7 @@ namespace pcl
         */
       void
       compute (pcl::PointCloud<PointLT>& labels, std::vector<pcl::PointIndices>& label_indices) const;
-      
+
       /** \brief Set the low threshold value for RGB Canny edge detection */
       inline void
       setRGBCannyLowThreshold (const float th)
@@ -274,7 +271,7 @@ namespace pcl
     using PointCloud = pcl::PointCloud<PointT>;
     using PointCloudPtr = typename PointCloud::Ptr;
     using PointCloudConstPtr = typename PointCloud::ConstPtr;
-      
+
     using PointCloudN = pcl::PointCloud<PointNT>;
     using PointCloudNPtr = typename PointCloudN::Ptr;
     using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
@@ -295,7 +292,7 @@ namespace pcl
       using OrganizedEdgeBase<PointT, PointLT>::EDGELABEL_HIGH_CURVATURE;
 
       /** \brief Constructor for OrganizedEdgeFromNormals */
-      OrganizedEdgeFromNormals () 
+      OrganizedEdgeFromNormals ()
         : OrganizedEdgeBase<PointT, PointLT> ()
         , normals_ ()
         , th_hc_canny_low_ (0.4f)
@@ -305,7 +302,7 @@ namespace pcl
       }
 
       /** \brief Destructor for OrganizedEdgeFromNormals */
-      
+
       ~OrganizedEdgeFromNormals ()
       {
       }
@@ -321,7 +318,7 @@ namespace pcl
         * \param[in] normals the input normal cloud
         */
       inline void
-      setInputNormals (const PointCloudNConstPtr &normals) 
+      setInputNormals (const PointCloudNConstPtr &normals)
       {
         normals_ = normals;
       }
@@ -360,7 +357,7 @@ namespace pcl
       {
         return (th_hc_canny_high_);
       }
-      
+
     protected:
       /** \brief Perform the 3D edge detection (edges from depth discontinuities and high curvature regions)
         * \param[out] labels a PointCloud of edge labels
@@ -384,7 +381,7 @@ namespace pcl
     using PointCloud = pcl::PointCloud<PointT>;
     using PointCloudPtr = typename PointCloud::Ptr;
     using PointCloudConstPtr = typename PointCloud::ConstPtr;
-      
+
     using PointCloudN = pcl::PointCloud<PointNT>;
     using PointCloudNPtr = typename PointCloudN::Ptr;
     using PointCloudNConstPtr = typename PointCloudN::ConstPtr;
@@ -404,9 +401,9 @@ namespace pcl
       using OrganizedEdgeBase<PointT, PointLT>::EDGELABEL_OCCLUDED;
       using OrganizedEdgeBase<PointT, PointLT>::EDGELABEL_HIGH_CURVATURE;
       using OrganizedEdgeBase<PointT, PointLT>::EDGELABEL_RGB_CANNY;
-      
+
       /** \brief Constructor for OrganizedEdgeFromRGBNormals */
-      OrganizedEdgeFromRGBNormals () 
+      OrganizedEdgeFromRGBNormals ()
         : OrganizedEdgeFromRGB<PointT, PointLT> ()
         , OrganizedEdgeFromNormals<PointT, PointNT, PointLT> ()
       {
@@ -414,7 +411,7 @@ namespace pcl
       }
 
       /** \brief Destructor for OrganizedEdgeFromRGBNormals */
-      
+
       ~OrganizedEdgeFromRGBNormals ()
       {
       }

--- a/features/include/pcl/features/organized_edge_detection.h
+++ b/features/include/pcl/features/organized_edge_detection.h
@@ -93,14 +93,18 @@ namespace pcl
       void
       compute (pcl::PointCloud<PointLT>& labels, std::vector<pcl::PointIndices>& label_indices) const;
       
-      /** \brief Set the tolerance in meters for difference in depth values between neighboring points. */
+      /** \brief Set the tolerance in meters for difference in depth values between neighboring points.
+        * (The value is set for 1 meter and is adapted with respect to depth value linearly.
+        * (e.g. 2.0*th_depth_discon_ in 2 meter depth)) */
       inline void
       setDepthDisconThreshold (const float th)
       {
         th_depth_discon_ = th;
       }
 
-      /** \brief Get the tolerance in meters for difference in depth values between neighboring points. */
+      /** \brief Get the tolerance in meters for difference in depth values between neighboring points.
+        * (The value is set for 1 meter and is adapted with respect to depth value linearly.
+        * (e.g. 2.0*th_depth_discon_ in 2 meter depth)) */
       inline float
       getDepthDisconThreshold () const
       {

--- a/test/features/CMakeLists.txt
+++ b/test/features/CMakeLists.txt
@@ -108,6 +108,9 @@ if(BUILD_io)
                FILES test_gasd_estimation.cpp
                LINK_WITH pcl_gtest pcl_io pcl_features
                ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
+  PCL_ADD_TEST(feature_organized_edge_detection test_organized_edge_detection
+               FILES test_organized_edge_detection.cpp
+               LINK_WITH pcl_gtest pcl_features pcl_io)
   if(BUILD_keypoints)
     PCL_ADD_TEST(feature_brisk test_brisk
                  FILES test_brisk.cpp

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -8,9 +8,9 @@
  */
 
 #include <pcl/features/organized_edge_detection.h>
-#include <pcl/point_cloud.h>
-#include <pcl/test/gtest.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/test/gtest.h>
+#include <pcl/point_cloud.h>
 
 namespace {
 class OrganizedPlaneDetectionTestFixture : public ::testing::Test {
@@ -21,7 +21,7 @@ protected:
   const float SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY = .02f;
   const float SYNTHETIC_CLOUD_RESOLUTION = 0.01f;
 
-  pcl::PointCloud<pcl::PointXYZRGBA>::Ptr cloud_;
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_;
   pcl::PointIndicesPtr indices_;
 
   void
@@ -34,13 +34,13 @@ protected:
   {}
 
 private:
-  pcl::PointCloud<pcl::PointXYZRGBA>::Ptr
+  pcl::PointCloud<pcl::PointXYZ>::Ptr
   generateSyntheticEdgeDetectionCloud()
   {
-    auto organized_test_cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZRGBA>>(
+    auto organized_test_cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(
         OUTER_SQUARE_EDGE_LENGTH, OUTER_SQUARE_EDGE_LENGTH);
 
-    // Draw a smaller red square in front of a larger green square both centered on the
+    // Draw a smaller square in front of a larger square both centered on the
     // view axis to generate synthetic occluding and occluded edges based on depth
     // discontinuity between neighboring pixels.  The base depth and resolution are
     // arbitrary and useful for visualizing the cloud.  The discontinuity of the
@@ -55,8 +55,6 @@ private:
         const auto inner_square_ctr = INNER_SQUARE_EDGE_LENGTH / 2;
 
         auto depth = SYNTHETIC_CLOUD_BASE_DEPTH;
-        auto r = 0;
-        auto g = 255;
 
         // If pixels correspond to smaller box, then set depth and color appropriately
         if (col > outer_square_ctr - inner_square_ctr &&
@@ -64,18 +62,12 @@ private:
           if (row > outer_square_ctr - inner_square_ctr &&
               row < outer_square_ctr + inner_square_ctr) {
             depth = SYNTHETIC_CLOUD_BASE_DEPTH - SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY;
-            r = 255;
-            g = 0;
           }
         }
 
         organized_test_cloud->at(col, row).x = x * SYNTHETIC_CLOUD_RESOLUTION;
         organized_test_cloud->at(col, row).y = y * SYNTHETIC_CLOUD_RESOLUTION;
         organized_test_cloud->at(col, row).z = depth;
-        organized_test_cloud->at(col, row).r = r;
-        organized_test_cloud->at(col, row).g = g;
-        organized_test_cloud->at(col, row).b = 0;
-        organized_test_cloud->at(col, row).a = 255;
       }
     }
 
@@ -108,7 +100,7 @@ TEST_F(OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)
   const int EXPECTED_OCCLUDING_EDGE_POINTS = INNER_SQUARE_EDGE_LENGTH * 4 - 8;
   const int EXPECTED_OCCLUDED_EDGE_POINTS = INNER_SQUARE_EDGE_LENGTH * 4;
 
-  auto oed = pcl::OrganizedEdgeFromRGB<pcl::PointXYZRGBA, pcl::Label>();
+  auto oed = pcl::OrganizedEdgeBase<pcl::PointXYZ, pcl::Label>();
   auto labels = pcl::PointCloud<pcl::Label>();
   auto label_indices = std::vector<pcl::PointIndices>();
 

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -7,125 +7,128 @@
  *  All rights reserved
  */
 
-#include <pcl/test/gtest.h>
-#include <pcl/point_cloud.h>
 #include <pcl/features/organized_edge_detection.h>
+#include <pcl/point_cloud.h>
+#include <pcl/test/gtest.h>
 #include <pcl/io/pcd_io.h>
 
-namespace
-{
-  class OrganizedPlaneDetectionTestFixture : public ::testing::Test
+namespace {
+class OrganizedPlaneDetectionTestFixture : public ::testing::Test {
+protected:
+  const int INNER_SQUARE_EDGE_LENGTH = 50;
+  const int OUTER_SQUARE_EDGE_LENGTH = INNER_SQUARE_EDGE_LENGTH * 2;
+  const float SYNTHETIC_CLOUD_BASE_DEPTH = 2.0;
+  const float SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY = .02f;
+  const float SYNTHETIC_CLOUD_RESOLUTION = 0.01f;
+
+  pcl::PointCloud<pcl::PointXYZRGBA>::Ptr cloud_;
+  pcl::PointIndicesPtr indices_;
+
+  void
+  SetUp() override
   {
-   protected:
-     const int kSyntheticCloudInnerSquareEdgeLength = 124;
-     const int kSyntheticCloudOuterSquareEdgeLength = kSyntheticCloudInnerSquareEdgeLength * 2;
+    cloud_ = generateSyntheticEdgeDetectionCloud();
+  }
+  void
+  TearDown() override
+  {}
 
-     const int kExpectedOccludingEdgePoints = kSyntheticCloudInnerSquareEdgeLength * 4 - 8;  // Empirically determined
-     const int kExpectedOccludedEdgePoints = kSyntheticCloudInnerSquareEdgeLength * 4;       // Each edge pixed of inner square should generate an occluded point
+private:
+  pcl::PointCloud<pcl::PointXYZRGBA>::Ptr
+  generateSyntheticEdgeDetectionCloud()
+  {
+    auto organized_test_cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZRGBA>>(
+        OUTER_SQUARE_EDGE_LENGTH, OUTER_SQUARE_EDGE_LENGTH);
 
-     const float kSyntheticCloudDisparity = .03f;
-     const float kSyntheticCloudResolution = 0.01f;
+    // Draw a smaller red square in front of a larger green square both centered on the
+    // view axis to generate synthetic occluding and occluded edges based on depth
+    // discontinuity between neighboring pixels.  The base depth and resolution are
+    // arbitrary and useful for visualizing the cloud.  The discontinuity of the
+    // generated cloud must be greater than the threshold set when running the
+    // organized edge detection algorithm.
+    for (auto row = 0; row < OUTER_SQUARE_EDGE_LENGTH; ++row) {
+      for (auto col = 0; col < OUTER_SQUARE_EDGE_LENGTH; ++col) {
+        float x = col - (OUTER_SQUARE_EDGE_LENGTH / 2);
+        float y = row - (OUTER_SQUARE_EDGE_LENGTH / 2);
 
-     pcl::PointCloud <pcl::PointXYZRGBA>::Ptr cloud_;
-     pcl::PointIndicesPtr indices_;
+        const auto outer_square_ctr = OUTER_SQUARE_EDGE_LENGTH / 2;
+        const auto inner_square_ctr = INNER_SQUARE_EDGE_LENGTH / 2;
 
-     OrganizedPlaneDetectionTestFixture() = default;
-     virtual ~OrganizedPlaneDetectionTestFixture() = default;
-     virtual void SetUp()
-     {
-       cloud_ = GenerateSyntheticEdgeDetectionCloud(kSyntheticCloudDisparity);
-     }
-     virtual void TearDown()
-     {
-       cloud_.reset();
-     }
+        auto depth = SYNTHETIC_CLOUD_BASE_DEPTH;
+        auto r = 0;
+        auto g = 255;
 
-   private:
-     pcl::PointCloud<pcl::PointXYZRGBA>::Ptr GenerateSyntheticEdgeDetectionCloud(const float &disparity)
-     {
-	auto organized_test_cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZRGBA>>(kSyntheticCloudOuterSquareEdgeLength, kSyntheticCloudOuterSquareEdgeLength);
-        organized_test_cloud->is_dense = true;
+        // If pixels correspond to smaller box, then set depth and color appropriately
+        if (col > outer_square_ctr - inner_square_ctr &&
+            col < outer_square_ctr + inner_square_ctr) {
+          if (row > outer_square_ctr - inner_square_ctr &&
+              row < outer_square_ctr + inner_square_ctr) {
+            depth = SYNTHETIC_CLOUD_BASE_DEPTH - SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY;
+            r = 255;
+            g = 0;
+          }
+        }
 
-        const auto kBaseDepth = 2.0f;
+        organized_test_cloud->at(col, row).x = x * SYNTHETIC_CLOUD_RESOLUTION;
+        organized_test_cloud->at(col, row).y = y * SYNTHETIC_CLOUD_RESOLUTION;
+        organized_test_cloud->at(col, row).z = depth;
+        organized_test_cloud->at(col, row).r = r;
+        organized_test_cloud->at(col, row).g = g;
+        organized_test_cloud->at(col, row).b = 0;
+        organized_test_cloud->at(col, row).a = 255;
+      }
+    }
 
-        // Draw a smaller red square in front of a larger green square both centered on the view axis to generate synthetic occluding and occluded edges based on depth disparity between neighboring pixels
-	for(auto row = 0; row < kSyntheticCloudOuterSquareEdgeLength; row++)
-	{
-		for(auto col = 0; col < kSyntheticCloudOuterSquareEdgeLength; col++)
-                {
-                        float x = col - (kSyntheticCloudOuterSquareEdgeLength / 2);
-                        float y = row - (kSyntheticCloudOuterSquareEdgeLength / 2);
-
-                        const auto outer_square_ctr = kSyntheticCloudOuterSquareEdgeLength / 2;
-                        const auto inner_square_ctr = kSyntheticCloudInnerSquareEdgeLength / 2;
-
-                        auto depth = kBaseDepth + (disparity * 2);
-                        auto r = 0;
-                        auto g = 255;
-
-                        // If pixels correspond to smaller box, then set depth and color appropriately
-                        if (col > outer_square_ctr - inner_square_ctr && col < outer_square_ctr + inner_square_ctr)
-                        {
-                          if (row > outer_square_ctr - inner_square_ctr && row < outer_square_ctr + inner_square_ctr)
-                          {
-                            depth = kBaseDepth;
-                            r = 255;
-                            g = 0;
-                          }
-                        }
-
-			organized_test_cloud->at(col, row).x = x * kSyntheticCloudResolution;
-			organized_test_cloud->at(col, row).y = y * kSyntheticCloudResolution;
-			organized_test_cloud->at(col, row).z = depth;
-			organized_test_cloud->at(col, row).r = r;
-			organized_test_cloud->at(col, row).g = g;
-			organized_test_cloud->at(col, row).b = 0;
-			organized_test_cloud->at(col, row).a = 255;
-		}
-	}
-
-
-	return organized_test_cloud;
-     }
-  };
-}
+    return organized_test_cloud;
+  }
+};
+} // namespace
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /*
-This test is designed to ensure that the organized edge detection appropriately classifies occluding and occluding 
-edges and to speifically detect the type of regression detailed in PR 4275
-(https://github.com/PointCloudLibrary/pcl/pull/4275).  This test works by generating a synthentic cloud of one 
-square slightly in front of another square, so that occluding edges and occluded edges are generated.  The 
-regression introduced in PCL 1.10.1 was a logic bug that caused both occluding and occluded edges to erroneously 
-be categorized as occluding edges.  This test should catch this and similar bugs.
+This test is designed to ensure that the organized edge detection appropriately
+classifies occluding and occluding edges and to specifically detect the type of
+regression detailed in PR 4275 (https://github.com/PointCloudLibrary/pcl/pull/4275).
+This test works by generating a synthetic cloud of one square slightly in front of
+another square, so that occluding edges and occluded edges are generated.  The
+regression introduced in PCL 1.10.1 was a logic bug that caused both occluding and
+occluded edges to erroneously be categorized as occluding edges.  This test should catch
+this and similar bugs.
 */
-TEST_F (OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)
+TEST_F(OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)
 {
-  const auto kMaxSearchNeighbors = 50;
-  const auto kDepthDiscontinuity = .02f;
+  pcl::io::savePCDFileBinaryCompressed("/home/perception/VagrantProjects/synthe.pcd", *cloud_);
+
+  const auto MAX_SEARCH_NEIGHBORS = 50;
+  const auto DEPTH_DISCONTINUITY_THRESHOLD = SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY / 2.1f;
+
+  // The expected number of occluded edge points is the number of pixels along the
+  // perimeter of the inner square, subject to certain conditions including that the
+  // inner square edge length is an even number.  The expected number of occluding edge
+  // points is similar, but as empirically determined to be 8 less than the number
+  // of perimeter points.
+  const int EXPECTED_OCCLUDING_EDGE_POINTS = INNER_SQUARE_EDGE_LENGTH * 4 - 8;
+  const int EXPECTED_OCCLUDED_EDGE_POINTS = INNER_SQUARE_EDGE_LENGTH * 4;
 
   auto oed = pcl::OrganizedEdgeFromRGB<pcl::PointXYZRGBA, pcl::Label>();
-
-  oed.setEdgeType(oed.EDGELABEL_OCCLUDING | oed.EDGELABEL_OCCLUDED);
-  oed.setInputCloud(cloud_);
-  oed.setDepthDisconThreshold(kDepthDiscontinuity);
-  oed.setMaxSearchNeighbors(kMaxSearchNeighbors);
-
   auto labels = pcl::PointCloud<pcl::Label>();
   auto label_indices = std::vector<pcl::PointIndices>();
 
+  oed.setEdgeType(oed.EDGELABEL_OCCLUDING | oed.EDGELABEL_OCCLUDED);
+  oed.setInputCloud(cloud_);
+  oed.setDepthDisconThreshold(DEPTH_DISCONTINUITY_THRESHOLD);
+  oed.setMaxSearchNeighbors(MAX_SEARCH_NEIGHBORS);
   oed.compute(labels, label_indices);
 
-  EXPECT_EQ (kExpectedOccludingEdgePoints, label_indices[1].indices.size());  // Occluding Edges Indices Size should be 395 for synthetic cloud
-  EXPECT_EQ (kExpectedOccludedEdgePoints, label_indices[2].indices.size());  // Occluded Edge Indices should be 401 for synthentic cloud
+  EXPECT_EQ(EXPECTED_OCCLUDING_EDGE_POINTS, label_indices[1].indices.size());
+  EXPECT_EQ(EXPECTED_OCCLUDED_EDGE_POINTS, label_indices[2].indices.size());
 }
-
 
 /* ---[ */
 int
-main (int argc, char** argv)
+main(int argc, char** argv)
 {
-  testing::InitGoogleTest (&argc, argv);
-  return (RUN_ALL_TESTS ());
+  testing::InitGoogleTest(&argc, argv);
+  return (RUN_ALL_TESTS());
 }
 /* ]--- */

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -92,7 +92,7 @@ regression detailed in PR 4275 (https://github.com/PointCloudLibrary/pcl/pull/42
 This test works by generating a synthetic cloud of one square slightly in front of
 another square, so that occluding edges and occluded edges are generated.  The
 regression introduced in PCL 1.10.1 was a logic bug that caused both occluding and
-occluded edges to erroneously be categorized as occluding edges.  This test should catch
+occluded edges to be miscategorized as occluding edges.  This test should catch
 this and similar bugs.
 */
 TEST_F(OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -1,0 +1,126 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ *
+ */
+
+#include <pcl/test/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/features/organized_edge_detection.h>
+#include <pcl/io/pcd_io.h>
+
+pcl::PointCloud <pcl::PointXYZRGBA>::Ptr cloud;
+pcl::PointIndicesPtr indices;
+std::vector <pcl::Vertices> triangles;
+
+pcl::PointCloud<pcl::PointXYZRGBA>::Ptr GenerateSyntheticEdgeDetectionCloud(const float &disparity)
+{
+	auto resolution = .005;
+	auto box_width = 50;
+
+	auto organized_test_cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZRGBA>>();
+	organized_test_cloud->width = box_width * 4;
+	organized_test_cloud->height = box_width * 4;
+	organized_test_cloud->is_dense = false;
+	organized_test_cloud->points.resize(organized_test_cloud->height * organized_test_cloud->width);
+  
+	for(std::size_t i = 0; i < box_width * 2; i++)
+	{
+		for(std::size_t j = 0; j < box_width * 2; j++)
+		{
+			organized_test_cloud->at(j, i).x = i * resolution - (box_width / 2 * resolution);
+			organized_test_cloud->at(j, i).y = j * resolution;
+			organized_test_cloud->at(j, i).z = 2.0 + (disparity * 4);
+			organized_test_cloud->at(j, i).r = 128;
+			organized_test_cloud->at(j, i).g = 128;
+			organized_test_cloud->at(j, i).b = 128;
+			organized_test_cloud->at(j, i).a = 255;
+		}
+	}
+
+	for(std::size_t i = box_width / 2; i < box_width / 2 + box_width; i++)
+	{
+		for(std::size_t j = box_width / 2; j < box_width / 2 + box_width; j++)
+		{
+			organized_test_cloud->at(j, i).x = i * resolution - (box_width / 2 * resolution);
+			organized_test_cloud->at(j, i).y = j * resolution;
+			organized_test_cloud->at(j, i).z = 2.0;
+			organized_test_cloud->at(j, i).r = 192;
+			organized_test_cloud->at(j, i).g = 192;
+			organized_test_cloud->at(j, i).b = 192;
+			organized_test_cloud->at(j, i).a = 255;
+		}
+	}
+	
+	return organized_test_cloud;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (OrganizedPlaneDetection, OccludedAndOccludingEdges )
+{
+  float support_radius = 0.0285f;
+  unsigned int number_of_partition_bins = 5;
+  unsigned int number_of_rotations = 3;
+  auto MaxSearchNeighbors = 50; 
+  auto DepthDiscontinuity = .02f;
+
+  cloud = GenerateSyntheticEdgeDetectionCloud(DepthDiscontinuity);
+
+  auto oed = pcl::OrganizedEdgeFromRGB<pcl::PointXYZRGBA, pcl::Label>();
+
+  oed.setEdgeType(oed.EDGELABEL_OCCLUDING | oed.EDGELABEL_OCCLUDED);
+  oed.setInputCloud(cloud);
+  oed.setDepthDisconThreshold(DepthDiscontinuity);
+  oed.setMaxSearchNeighbors(MaxSearchNeighbors);
+
+  auto labels = pcl::PointCloud<pcl::Label>();
+  auto label_indices = std::vector<pcl::PointIndices>();
+
+  oed.compute(labels, label_indices);
+
+  EXPECT_EQ (395, label_indices[1].indices.size());  // Occluding Edges Indices Size should be 395 for synthetic cloud
+  EXPECT_EQ (401, label_indices[2].indices.size());  // Occluded Edge Indices should be 401 for synthentic cloud
+}
+
+
+/* ---[ */
+int
+main (int argc, char** argv)
+{
+  testing::InitGoogleTest (&argc, argv);
+  return (RUN_ALL_TESTS ());
+}
+/* ]--- */

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -97,8 +97,6 @@ this and similar bugs.
 */
 TEST_F(OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)
 {
-  pcl::io::savePCDFileBinaryCompressed("/home/perception/VagrantProjects/synthe.pcd", *cloud_);
-
   const auto MAX_SEARCH_NEIGHBORS = 50;
   const auto DEPTH_DISCONTINUITY_THRESHOLD = SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY / 2.1f;
 

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -8,9 +8,9 @@
  */
 
 #include <pcl/features/organized_edge_detection.h>
-#include <pcl/io/pcd_io.h>
 #include <pcl/test/gtest.h>
 #include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 
 namespace {
 class OrganizedPlaneDetectionTestFixture : public ::testing::Test {
@@ -29,9 +29,6 @@ protected:
   {
     cloud_ = generateSyntheticEdgeDetectionCloud();
   }
-  void
-  TearDown() override
-  {}
 
 private:
   pcl::PointCloud<pcl::PointXYZ>::Ptr
@@ -90,7 +87,16 @@ this and similar bugs.
 TEST_F(OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)
 {
   const auto MAX_SEARCH_NEIGHBORS = 50;
-  const auto DEPTH_DISCONTINUITY_THRESHOLD = SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY / 2.1f;
+
+  // The depth discontinuity check to determine whether an edge exists is linearly
+  // dependent on the depth of the points in the cloud (not a fixed distance).  The
+  // algorithm iterates through each point in the cloud and finding the neighboring
+  // point with largest discontinuity value.  That value is compared against a threshold
+  // multiplied by the actual depth value of the point. Therefore:
+  // abs(SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY) must be greater than
+  // DEPTH_DISCONTINUITY_THRESHOLD * abs(SYNTHETIC_CLOUD_BASE_DEPTH)
+  const auto DEPTH_DISCONTINUITY_THRESHOLD =
+      SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY / (SYNTHETIC_CLOUD_BASE_DEPTH * 1.1f);
 
   // The expected number of occluded edge points is the number of pixels along the
   // perimeter of the inner square, subject to certain conditions including that the

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -17,11 +17,14 @@ namespace
   class OrganizedPlaneDetectionTestFixture : public ::testing::Test
   {
    protected:
-     static const int kExpectedOccludingEdgePoints = 395;
-     static const int kExpectedOccludedEdgePoints = 401;
-     static const int kSyntheticCloudDisparity = .03;
-     static const int kSyntheticCloudResolution = .005;
-     static const int kSyntheticCloudInnerBoxWidth = 50;
+     const int kSyntheticCloudInnerSquareEdgeLength = 124;
+     const int kSyntheticCloudOuterSquareEdgeLength = kSyntheticCloudInnerSquareEdgeLength * 2;
+
+     const int kExpectedOccludingEdgePoints = kSyntheticCloudInnerSquareEdgeLength * 4 - 8;  // Empirically determined
+     const int kExpectedOccludedEdgePoints = kSyntheticCloudInnerSquareEdgeLength * 4;       // Each edge pixed of inner square should generate an occluded point
+
+     const float kSyntheticCloudDisparity = .03f;
+     const float kSyntheticCloudResolution = 0.01f;
 
      pcl::PointCloud <pcl::PointXYZRGBA>::Ptr cloud_;
      pcl::PointIndicesPtr indices_;
@@ -40,66 +43,81 @@ namespace
    private:
      pcl::PointCloud<pcl::PointXYZRGBA>::Ptr GenerateSyntheticEdgeDetectionCloud(const float &disparity)
      {
-	auto organized_test_cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZRGBA>>();
-	organized_test_cloud->width = kSyntheticCloudInnerBoxWidth * 4;
-	organized_test_cloud->height = kSyntheticCloudInnerBoxWidth * 4;
-	organized_test_cloud->is_dense = false;
-	organized_test_cloud->points.resize(organized_test_cloud->height * organized_test_cloud->width);
+	auto organized_test_cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZRGBA>>(kSyntheticCloudOuterSquareEdgeLength, kSyntheticCloudOuterSquareEdgeLength);
+        organized_test_cloud->is_dense = true;
 
-	for(std::size_t i = 0; i < kSyntheticCloudInnerBoxWidth * 2; i++)
+        const auto kBaseDepth = 2.0f;
+
+        // Draw a smaller red square in front of a larger green square both centered on the view axis to generate synthetic occluding and occluded edges based on depth disparity between neighboring pixels
+	for(auto row = 0; row < kSyntheticCloudOuterSquareEdgeLength; row++)
 	{
-		for(std::size_t j = 0; j < kSyntheticCloudInnerBoxWidth * 2; j++)
-		{
-			organized_test_cloud->at(j, i).x = i * kSyntheticCloudResolution - (kSyntheticCloudInnerBoxWidth / 2 * kSyntheticCloudResolution);
-			organized_test_cloud->at(j, i).y = j * kSyntheticCloudResolution;
-			organized_test_cloud->at(j, i).z = 2.0 + (disparity * 4);
-			organized_test_cloud->at(j, i).r = 128;
-			organized_test_cloud->at(j, i).g = 128;
-			organized_test_cloud->at(j, i).b = 128;
-			organized_test_cloud->at(j, i).a = 255;
+		for(auto col = 0; col < kSyntheticCloudOuterSquareEdgeLength; col++)
+                {
+                        float x = col - (kSyntheticCloudOuterSquareEdgeLength / 2);
+                        float y = row - (kSyntheticCloudOuterSquareEdgeLength / 2);
+
+                        const auto outer_square_ctr = kSyntheticCloudOuterSquareEdgeLength / 2;
+                        const auto inner_square_ctr = kSyntheticCloudInnerSquareEdgeLength / 2;
+
+                        auto depth = kBaseDepth + (disparity * 2);
+                        auto r = 0;
+                        auto g = 255;
+
+                        // If pixels correspond to smaller box, then set depth and color appropriately
+                        if (col > outer_square_ctr - inner_square_ctr && col < outer_square_ctr + inner_square_ctr)
+                        {
+                          if (row > outer_square_ctr - inner_square_ctr && row < outer_square_ctr + inner_square_ctr)
+                          {
+                            depth = kBaseDepth;
+                            r = 255;
+                            g = 0;
+                          }
+                        }
+
+			organized_test_cloud->at(col, row).x = x * kSyntheticCloudResolution;
+			organized_test_cloud->at(col, row).y = y * kSyntheticCloudResolution;
+			organized_test_cloud->at(col, row).z = depth;
+			organized_test_cloud->at(col, row).r = r;
+			organized_test_cloud->at(col, row).g = g;
+			organized_test_cloud->at(col, row).b = 0;
+			organized_test_cloud->at(col, row).a = 255;
 		}
 	}
 
-	for(std::size_t i = kSyntheticCloudInnerBoxWidth / 2; i < kSyntheticCloudInnerBoxWidth / 2 + kSyntheticCloudInnerBoxWidth; i++)
-	{
-		for(std::size_t j = kSyntheticCloudInnerBoxWidth / 2; j < kSyntheticCloudInnerBoxWidth / 2 + kSyntheticCloudInnerBoxWidth; j++)
-		{
-			organized_test_cloud->at(j, i).x = i * kSyntheticCloudResolution - (kSyntheticCloudInnerBoxWidth / 2 * kSyntheticCloudResolution);
-			organized_test_cloud->at(j, i).y = j * kSyntheticCloudResolution;
-			organized_test_cloud->at(j, i).z = 2.0;
-			organized_test_cloud->at(j, i).r = 192;
-			organized_test_cloud->at(j, i).g = 192;
-			organized_test_cloud->at(j, i).b = 192;
-			organized_test_cloud->at(j, i).a = 255;
-		}
-	}
+
 	return organized_test_cloud;
      }
-
-
   };
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+This test is designed to ensure that the organized edge detection appropriately classifies occluding and occluding 
+edges and to speifically detect the type of regression detailed in PR 4275
+(https://github.com/PointCloudLibrary/pcl/pull/4275).  This test works by generating a synthentic cloud of one 
+square slightly in front of another square, so that occluding edges and occluded edges are generated.  The 
+regression introduced in PCL 1.10.1 was a logic bug that caused both occluding and occluded edges to erroneously 
+be categorized as occluding edges.  This test should catch this and similar bugs.
+*/
 TEST_F (OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)
 {
-  auto MaxSearchNeighbors = 50;
-  auto DepthDiscontinuity = .02f;
+  const auto kMaxSearchNeighbors = 50;
+  const auto kDepthDiscontinuity = .02f;
 
   auto oed = pcl::OrganizedEdgeFromRGB<pcl::PointXYZRGBA, pcl::Label>();
 
   oed.setEdgeType(oed.EDGELABEL_OCCLUDING | oed.EDGELABEL_OCCLUDED);
   oed.setInputCloud(cloud_);
-  oed.setDepthDisconThreshold(DepthDiscontinuity);
-  oed.setMaxSearchNeighbors(MaxSearchNeighbors);
+  oed.setDepthDisconThreshold(kDepthDiscontinuity);
+  oed.setMaxSearchNeighbors(kMaxSearchNeighbors);
 
   auto labels = pcl::PointCloud<pcl::Label>();
   auto label_indices = std::vector<pcl::PointIndices>();
 
   oed.compute(labels, label_indices);
 
-  EXPECT_EQ (395, label_indices[1].indices.size());  // Occluding Edges Indices Size should be 395 for synthetic cloud
-  EXPECT_EQ (401, label_indices[2].indices.size());  // Occluded Edge Indices should be 401 for synthentic cloud
+  EXPECT_EQ (kExpectedOccludingEdgePoints, label_indices[1].indices.size());  // Occluding Edges Indices Size should be 395 for synthetic cloud
+  EXPECT_EQ (kExpectedOccludedEdgePoints, label_indices[2].indices.size());  // Occluded Edge Indices should be 401 for synthentic cloud
 }
 
 

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -54,9 +54,9 @@ private:
         auto depth = SYNTHETIC_CLOUD_BASE_DEPTH;
 
         // If pixels correspond to smaller box, then set depth and color appropriately
-        if (col > outer_square_ctr - inner_square_ctr &&
+        if (col >= outer_square_ctr - inner_square_ctr &&
             col < outer_square_ctr + inner_square_ctr) {
-          if (row > outer_square_ctr - inner_square_ctr &&
+          if (row >= outer_square_ctr - inner_square_ctr &&
               row < outer_square_ctr + inner_square_ctr) {
             depth = SYNTHETIC_CLOUD_BASE_DEPTH - SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY;
           }
@@ -98,13 +98,8 @@ TEST_F(OrganizedPlaneDetectionTestFixture, OccludedAndOccludingEdges)
   const auto DEPTH_DISCONTINUITY_THRESHOLD =
       SYNTHETIC_CLOUD_DEPTH_DISCONTINUITY / (SYNTHETIC_CLOUD_BASE_DEPTH * 1.1f);
 
-  // The expected number of occluded edge points is the number of pixels along the
-  // perimeter of the inner square, subject to certain conditions including that the
-  // inner square edge length is an even number.  The expected number of occluding edge
-  // points is similar, but as empirically determined to be 8 less than the number
-  // of perimeter points.
-  const int EXPECTED_OCCLUDING_EDGE_POINTS = INNER_SQUARE_EDGE_LENGTH * 4 - 8;
-  const int EXPECTED_OCCLUDED_EDGE_POINTS = INNER_SQUARE_EDGE_LENGTH * 4;
+  const int EXPECTED_OCCLUDING_EDGE_POINTS = (INNER_SQUARE_EDGE_LENGTH - 1) * 4;
+  const int EXPECTED_OCCLUDED_EDGE_POINTS = (INNER_SQUARE_EDGE_LENGTH + 1) * 4;
 
   auto oed = pcl::OrganizedEdgeBase<pcl::PointXYZ, pcl::Label>();
   auto labels = pcl::PointCloud<pcl::Label>();

--- a/test/features/test_organized_edge_detection.cpp
+++ b/test/features/test_organized_edge_detection.cpp
@@ -1,40 +1,10 @@
 /*
- * Software License Agreement (BSD License)
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *  Point Cloud Library (PCL) - www.pointclouds.org
- *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  Copyright (c) 2020-, Open Perception
  *
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the copyright holder(s) nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *
- * $Id$
- *
+ *  All rights reserved
  */
 
 #include <pcl/test/gtest.h>


### PR DESCRIPTION
A bug was introduced in commit 8092d6529eed0b489f3c7ab50be018f20b6da2bb
that inadvertantly changed behavior of edge feature extraction for
occluding and occluded edges.  This commit reverts to previous logic