### PR TITLE
[filters] Fix voxel index calculation bug in VoxelGridCovariance

### DIFF
--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -369,7 +369,7 @@ pcl::VoxelGridCovariance<PointT>::getNeighborhoodAtPoint (const Eigen::Matrix<in
   neighbors.clear ();
 
   // Find displacement coordinates
-  Eigen::Vector4i ijk = (reference_point.getArray4fMap() * inverse_leaf_size_).template cast<int>();
+  Eigen::Vector4i ijk = Eigen::floor(reference_point.getArray4fMap() * inverse_leaf_size_).template cast<int>();
   ijk[3] = 0;
   const Eigen::Array4i diff2min = min_b_ - ijk;
   const Eigen::Array4i diff2max = max_b_ - ijk;


### PR DESCRIPTION
While I was benchmarking multi-threaded NDT, I found that https://github.com/PointCloudLibrary/pcl/pull/4251 changed the behavior of the voxel index calculation in VoxelGridCovariance. A floor is necessary to make the behavior same as before the PR.

Before the PR:
https://github.com/PointCloudLibrary/pcl/blob/6aaade34381fbb608208172e623f71719565fd33/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp#L380-L382