### PR TITLE
[gpu] Replace volatile shared memory with shfl_sync in KNNSearch

### DIFF
--- a/gpu/octree/src/cuda/knn_search.cu
+++ b/gpu/octree/src/cuda/knn_search.cu
@@ -232,7 +232,7 @@ namespace pcl { namespace device { namespace knn_search
 
           // find minimum distance among warp threads
           constexpr unsigned FULL_MASK = 0xFFFFFFFF;
-          static_assert(sizeof(KernelPolicy::WARP_SIZE) <= sizeof(unsigned int));
+          static_assert(KernelPolicy::WARP_SIZE <= 8*sizeof(unsigned int));
 
           for (unsigned int bit_offset = KernelPolicy::WARP_SIZE / 2; bit_offset > 0;
                bit_offset /= 2) {

--- a/gpu/octree/src/cuda/knn_search.cu
+++ b/gpu/octree/src/cuda/knn_search.cu
@@ -232,7 +232,7 @@ namespace pcl { namespace device { namespace knn_search
 
           // find minimum distance among warp threads
           constexpr unsigned FULL_MASK = 0xFFFFFFFF;
-          static_assert(KernelPolicy::WARP_SIZE <= 8*sizeof(unsigned int));
+          static_assert(KernelPolicy::WARP_SIZE <= 8*sizeof(unsigned int), "WARP_SIZE exceeds size of bit_offset.");
 
           for (unsigned int bit_offset = KernelPolicy::WARP_SIZE / 2; bit_offset > 0;
                bit_offset /= 2) {


### PR DESCRIPTION
Fix for distance calculation issue caused by the use of volatile shared memory in GPU K nearest neighbour search. 