### PR TITLE
Moving functor filter to experimental

### DIFF
--- a/filters/CMakeLists.txt
+++ b/filters/CMakeLists.txt
@@ -58,7 +58,7 @@ set(incs
   "include/pcl/${SUBSYS_NAME}/extract_indices.h"
   "include/pcl/${SUBSYS_NAME}/filter.h"
   "include/pcl/${SUBSYS_NAME}/filter_indices.h"
-  "include/pcl/${SUBSYS_NAME}/functor_filter.h"
+  "include/pcl/${SUBSYS_NAME}/experimental/functor_filter.h"
   "include/pcl/${SUBSYS_NAME}/passthrough.h"
   "include/pcl/${SUBSYS_NAME}/shadowpoints.h"
   "include/pcl/${SUBSYS_NAME}/project_inliers.h"

--- a/filters/include/pcl/filters/experimental/functor_filter.h
+++ b/filters/include/pcl/filters/experimental/functor_filter.h
@@ -13,6 +13,7 @@
 #include <pcl/type_traits.h> // for is_invocable
 
 namespace pcl {
+namespace experimental {
 template <typename PointT, typename Function>
 constexpr static bool is_functor_for_filter_v =
     pcl::is_invocable_r_v<bool,
@@ -95,4 +96,5 @@ public:
     }
   }
 };
+} // namespace experimental
 } // namespace pcl

--- a/test/filters/test_functor_filter.cpp
+++ b/test/filters/test_functor_filter.cpp
@@ -8,11 +8,12 @@
  */
 
 #include <pcl/common/generate.h>
-#include <pcl/filters/functor_filter.h>
+#include <pcl/filters/experimental/functor_filter.h>
 #include <pcl/test/gtest.h>
 #include <pcl/point_types.h>
 
 using namespace pcl;
+using namespace pcl::experimental;
 
 TEST(FunctorFilterTrait, CheckCompatibility)
 {


### PR DESCRIPTION
This will prevent bad API haunting PCL in the future.

Adding to milestone so we don't ship bad API