### PR TITLE
[gpu] Replace volatile shared memory with shfl_sync in ApproxNearestSearch

### DIFF
--- a/gpu/octree/src/cuda/approx_nsearch.cu
+++ b/gpu/octree/src/cuda/approx_nsearch.cu
@@ -172,7 +172,7 @@ namespace pcl { namespace device { namespace appnearest_search
 
 					if (voxel_traversal)    // empty voxel already encountered, performing nearest-centroid based traversal
 					{
-						auto nearest_voxel = nearestVoxel(query, level, mask, minp, maxp, index);
+						const auto nearest_voxel = nearestVoxel(query, level, mask, minp, maxp, index);
 						index = nearest_voxel.first;
 						mask_pos = nearest_voxel.second;
 					}
@@ -188,7 +188,7 @@ namespace pcl { namespace device { namespace appnearest_search
 							index.z >>= remaining_depth;
 
 							voxel_traversal = true;
-							auto nearest_voxel = nearestVoxel(query, level, mask, minp, maxp, index);
+							const auto nearest_voxel = nearestVoxel(query, level, mask, minp, maxp, index);
 							index = nearest_voxel.first;
 							mask_pos = nearest_voxel.second;
 						}

--- a/gpu/octree/src/cuda/approx_nsearch.hpp
+++ b/gpu/octree/src/cuda/approx_nsearch.hpp
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2020-, Open Perception
+ *
+ *  All rights reserved
+ */
+
+#ifndef PCL_GPU_APPROX_NSEARCH
+#define PCL_GPU_APPROX_NSEARCH
+
+namespace pcl
+{
+    namespace device
+    {
+        namespace appnearest_search
+        {
+            std::pair<uint3, std::uint8_t> nearestVoxel(const float3 query, const unsigned& level, const std::uint8_t& mask, const float3& minp, const float3& maxp, const uint3& index);
+        }
+    }
+}
+
+#endif /* PCL_GPU_APPROX_NSEARCH */

--- a/gpu/octree/src/cuda/octree_host.cu
+++ b/gpu/octree/src/cuda/octree_host.cu
@@ -197,7 +197,7 @@ namespace
 void pcl::device::OctreeImpl::radiusSearchHost(const PointType& query, float radius, std::vector<int>& out, int max_nn) const
 {            
     out.clear();  
-    
+
     float3 center = make_float3(query.x, query.y, query.z);
 
     OctreeIteratorHost iterator;

--- a/gpu/octree/src/cuda/octree_host.cu
+++ b/gpu/octree/src/cuda/octree_host.cu
@@ -60,6 +60,14 @@ namespace pcl
         {
             uint3 index;
             std::uint8_t mask_pos;
+
+            ChildNode(){}
+
+            ChildNode(uint3 i, uint8_t mp)
+            {
+                index = i;
+                mask_pos = mp;
+            }
         };
     }
 }
@@ -147,11 +155,8 @@ namespace
                 closest.z = child.z;
             }
         }
-        ChildNode child_node;
-        child_node.index = make_uint3(closest.x, closest.y, closest.z);
-        child_node.mask_pos = (1<<closest_index);
 
-        return child_node;
+        return ChildNode(make_uint3(closest.x, closest.y, closest.z), (1<<closest_index));
     }
 
     struct OctreeIteratorHost

--- a/gpu/octree/src/cuda/octree_host.cu
+++ b/gpu/octree/src/cuda/octree_host.cu
@@ -296,8 +296,10 @@ void  pcl::device::OctreeImpl::approxNearestSearchHost(const PointType& query, i
         query_point.z = query.z;
 
         if(getBitsNum(mask) == 0)  // leaf
+        {
+            //printf ("node %d\n", node_idx);
             break;
-
+        }
         if (!centroid_traversal)    // no empty voxel encountered yet, performing morton code based traversal
         {
             mask_pos = 1 << Morton::extractLevelCode(code, level);

--- a/gpu/octree/src/utils/morton.hpp
+++ b/gpu/octree/src/utils/morton.hpp
@@ -91,12 +91,7 @@ namespace pcl
             __device__ __host__ __forceinline__
                 static uint3 decomposeCode(code_t code)
             {
-                uint3 cell;
-
-                cell.x = compactBits(code, 0);
-                cell.y = compactBits(code, 1);
-                cell.z = compactBits(code, 2);
-                return cell;
+                return make_uint3 (compactBits(code, 0), compactBits(code, 1), compactBits(code, 2));
             }
 
             __host__ __device__ __forceinline__ 
@@ -128,9 +123,9 @@ namespace pcl
 
             __device__ __host__ __forceinline__ Morton::code_t operator()(const float3& p) const
             {			
-                int cellx = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.x - minp_.x)/dims_.x))), depth_mult - 1);
-                int celly = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.y - minp_.y)/dims_.y))), depth_mult - 1);
-                int cellz = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.z - minp_.z)/dims_.z))), depth_mult - 1);
+                const int cellx = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.x - minp_.x)/dims_.x))), depth_mult - 1);
+                const int celly = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.y - minp_.y)/dims_.y))), depth_mult - 1);
+                const int cellz = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.z - minp_.z)/dims_.z))), depth_mult - 1);
 
                 return Morton::createCode(cellx, celly, cellz);
             }	

--- a/gpu/octree/src/utils/morton.hpp
+++ b/gpu/octree/src/utils/morton.hpp
@@ -88,6 +88,17 @@ namespace pcl
                 cell_z = compactBits(code, 2);        
             }
 
+            __device__ __host__ __forceinline__
+                static uint3 decomposeCode(code_t code)
+            {
+                uint3 cell;
+
+                cell.x = compactBits(code, 0);
+                cell.y = compactBits(code, 1);
+                cell.z = compactBits(code, 2);
+                return cell;
+            }
+
             __host__ __device__ __forceinline__ 
                 static code_t extractLevelCode(code_t code, int level) 
             {

--- a/gpu/octree/src/utils/morton.hpp
+++ b/gpu/octree/src/utils/morton.hpp
@@ -117,9 +117,9 @@ namespace pcl
 
             __device__ __host__ __forceinline__ Morton::code_t operator()(const float3& p) const
             {			
-                int cellx = min((int)std::floor(depth_mult * (p.x - minp_.x)/dims_.x), depth_mult - 1);
-                int celly = min((int)std::floor(depth_mult * (p.y - minp_.y)/dims_.y), depth_mult - 1);
-                int cellz = min((int)std::floor(depth_mult * (p.z - minp_.z)/dims_.z), depth_mult - 1); 
+                int cellx = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.x - minp_.x)/dims_.x))), depth_mult - 1);
+                int celly = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.y - minp_.y)/dims_.y))), depth_mult - 1);
+                int cellz = min((int)std::floor(depth_mult * min(1.f, max(0.f, (p.z - minp_.z)/dims_.z))), depth_mult - 1);
 
                 return Morton::createCode(cellx, celly, cellz);
             }	

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -65,7 +65,8 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
 
     // Fill in cloud data
-    cloud->width    = 10000;
+    const pcl::index_t point_size = 10000;
+    cloud->width    = point_size;
     cloud->height   = 1;
     cloud->is_dense = false;
     cloud->points.resize (cloud->width * cloud->height);
@@ -88,11 +89,11 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
     the final two point are positioned such that point 'x' is father from query point 'q' than 'y',
     but the voxel containing 'x' is closer to  'q' than the voxel containing 'y'
     */
-    const float x_cords[cloud->size()] = {-1, -1, -1, 1, -1, 1, 1, 1, -0.9, -0.4};
-    const float y_cords[cloud->size()] = {-1, -1, 1, -1, 1, -1, 1, 1, -0.2, -0.6};
-    const float z_cords[cloud->size()] = {-1, 1, -1, -1, 1, 1, -1, 1, -0.75, -0.75};
+    const float x_cords[point_size] = {-1, -1, -1, 1, -1, 1, 1, 1, -0.9, -0.4};
+    const float y_cords[point_size] = {-1, -1, 1, -1, 1, -1, 1, 1, -0.2, -0.6};
+    const float z_cords[point_size] = {-1, 1, -1, -1, 1, 1, -1, 1, -0.75, -0.75};
 
-    for (pcl::index_t i = 0; i < cloud->size (); ++i)
+    for (std::size_t i = 0; i < cloud->size (); ++i)
     {
         (*cloud)[i].x = x_cords[i%10];
         (*cloud)[i].y = y_cords[i%10];
@@ -149,9 +150,9 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
     ASSERT_EQ ((downloaded == result_host_gpu), true);
 
     //find inconsistencies with gpu and cpu cuda impementation
-    int count_gpu_better = 0;
-    int count_pcl_better = 0;
-    int count_different = 0;
+    //int count_gpu_better = 0;
+    //int count_pcl_better = 0;
+    //int count_different = 0;
     for(size_t i = 0; i < queries.size(); ++i)
     {
         ASSERT_EQ ((dists_pcl[i] == dists_gpu[i]), true);

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -106,18 +106,9 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
     queries.push_back(pcl::PointXYZ(-0.6, -0.2, -0.75));     //should be same across CPU and GPU
     queries.push_back(pcl::PointXYZ(1.1, 1.1, 1.1));         //out of range query
 
-<<<<<<< HEAD:test/gpu/octree/test_approx_nearest.cpp
-    //prepare host cloud
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_host(new pcl::PointCloud<pcl::PointXYZ>);	
-    cloud_host->width = data.points.size();
-    cloud_host->height = 1;
-    cloud_host->points.resize (cloud_host->width * cloud_host->height);    
-    std::transform(data.points.begin(), data.points.end(), cloud_host->points.begin(), DataGenerator::ConvPoint<pcl::PointXYZ>());
-=======
     //prepare device cloud
     pcl::gpu::Octree::PointCloud cloud_device;
     cloud_device.upload(cloud->points);
->>>>>>> add new traversal for  gpuApproxNearestSearch & modify tests:gpu/octree/test/test_approx_nearest.cpp
 
     //gpu build
     pcl::gpu::Octree octree_device;

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -70,10 +70,27 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
     cloud->is_dense = false;
     cloud->points.resize (cloud->width * cloud->height);
 
-
-    float x_cords[cloud->size()] = {-1, -1, -1, 1, -1, 1, 1, 1, -0.9, -0.4};
-    float y_cords[cloud->size()] = {-1, -1, 1, -1, 1, -1, 1, 1, -0.2, -0.6};
-    float z_cords[cloud->size()] = {-1, 1, -1, -1, 1, 1, -1, 1, -0.75, -0.75};
+    /*
+    //the test points create an octree with bounds (-1, -1, -1) and (1, 1, 1).
+    ------------------------------------
+    |                |                 |
+    |                |                 |
+    |                |                 |
+    |                |                 |
+    |                |                 |
+    |----------------------------------|
+    | x     | q      |                 |
+    |       |        |                 |
+    |-------|--------|                 |
+    |       | y      |                 |
+    |       |        |                 |
+    ------------------------------------
+    the final two point are positioned such that point 'x' is father from query point 'q' than 'y',
+    but the voxel containing 'x' is closer to  'q' than the voxel containing 'y'
+    */
+    const float x_cords[cloud->size()] = {-1, -1, -1, 1, -1, 1, 1, 1, -0.9, -0.4};
+    const float y_cords[cloud->size()] = {-1, -1, 1, -1, 1, -1, 1, 1, -0.2, -0.6};
+    const float z_cords[cloud->size()] = {-1, 1, -1, -1, 1, 1, -1, 1, -0.75, -0.75};
 
     for (pcl::index_t i = 0; i < cloud->size (); ++i)
     {

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -70,6 +70,7 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
     cloud->is_dense = false;
     cloud->points.resize (cloud->width * cloud->height);
 
+
     float x_cords[cloud->size()] = {-1, -1, -1, 1, -1, 1, 1, 1, -0.9, -0.4};
     float y_cords[cloud->size()] = {-1, -1, 1, -1, 1, -1, 1, 1, -0.2, -0.6};
     float z_cords[cloud->size()] = {-1, 1, -1, -1, 1, 1, -1, 1, -0.75, -0.75};
@@ -82,7 +83,9 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
     }
 
     std::vector<pcl::PointXYZ> queries;
-    queries.push_back(pcl::PointXYZ(-0.4, -0.2, -0.75));     //should be different across CPU and GPU for smaller clouds
+    //While the GPU implementation has a fixed depth of 10 levels, octree depth in the CPU implementation can vary based on
+    //the leaf size set by the user, which can affect the results. Therefore results would only tally if depths match.
+    queries.push_back(pcl::PointXYZ(-0.4, -0.2, -0.75));     //should be different across CPU and GPU if different traversal methods are used
     queries.push_back(pcl::PointXYZ(-0.6, -0.2, -0.75));     //should be same across CPU and GPU
     queries.push_back(pcl::PointXYZ(1.1, 1.1, 1.1));         //out of range query
 

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -1,171 +1,132 @@
 /*
- * Software License Agreement (BSD License)
+ * SPDX-License-Identifier: BSD-3-Clause
  *
- *  Copyright (c) 2011, Willow Garage, Inc.
- *  All rights reserved.
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2020-, Open Perception
  *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of Willow Garage, Inc. nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *
- *  Author: Anatoly Baskeheev, Itseez Ltd, (myname.mysurname@mycompany.com)
+ *  All rights reserved
  */
 
-#if defined _MSC_VER
-    #pragma warning (disable : 4996 4530)
-#endif
+#include <pcl/gpu/containers/device_array.h>
+#include <pcl/gpu/octree/octree.hpp>
+#include <pcl/octree/octree_search.h>
+#include <pcl/point_cloud.h>
 
 #include <gtest/gtest.h>
 
-#include <iostream>
-#include <fstream>
 #include <algorithm>
+#include <fstream>
+#include <iostream>
 
-#if defined _MSC_VER
-    #pragma warning (disable: 4521)
-#endif
-#include <pcl/point_cloud.h>
-#include <pcl/octree/octree_search.h>
-#if defined _MSC_VER
-    #pragma warning (default: 4521)
-#endif
-
-#include <pcl/gpu/octree/octree.hpp>
-#include <pcl/gpu/containers/device_array.h>
-
-using namespace pcl::gpu;
-
-//TEST(PCL_OctreeGPU, DISABLED_approxNearesSearch)
 TEST(PCL_OctreeGPU, approxNearesSearch)
 {
-    //generate custom pointcloud
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
 
-    // Fill in cloud data
-    const pcl::index_t point_size = 10000;
-    cloud->width    = point_size;
-    cloud->height   = 1;
-    cloud->is_dense = false;
-    cloud->points.resize (cloud->width * cloud->height);
+  /*
+  the test points create an octree with bounds (-1, -1, -1) and (1, 1, 1).
+  point q, represents a query point
+  ------------------------------------
+  |                |                 |
+  |                |                 |
+  |                |                 |
+  |                |                 |
+  |                |                 |
+  |----------------------------------|
+  | x     | q      |                 |
+  |       |        |                 |
+  |-------|--------|                 |
+  |       | y      |                 |
+  |       |        |                 |
+  ------------------------------------
+  the final two point are positioned such that point 'x' is father from query point 'q'
+  than 'y', but the voxel containing 'x' is closer to  'q' than the voxel containing 'y'
+  */
 
-    /*
-    //the test points create an octree with bounds (-1, -1, -1) and (1, 1, 1).
-    ------------------------------------
-    |                |                 |
-    |                |                 |
-    |                |                 |
-    |                |                 |
-    |                |                 |
-    |----------------------------------|
-    | x     | q      |                 |
-    |       |        |                 |
-    |-------|--------|                 |
-    |       | y      |                 |
-    |       |        |                 |
-    ------------------------------------
-    the final two point are positioned such that point 'x' is father from query point 'q' than 'y',
-    but the voxel containing 'x' is closer to  'q' than the voxel containing 'y'
-    */
-    const float x_cords[point_size] = {-1, -1, -1, 1, -1, 1, 1, 1, -0.9, -0.4};
-    const float y_cords[point_size] = {-1, -1, 1, -1, 1, -1, 1, 1, -0.2, -0.6};
-    const float z_cords[point_size] = {-1, 1, -1, -1, 1, 1, -1, 1, -0.75, -0.75};
+  const std::array<pcl::PointXYZ, 10> coords{
+      pcl::PointXYZ{-1.f, -1.f, -1.f},
+      pcl::PointXYZ{-1.f, -1.f, 1.f},
+      pcl::PointXYZ{-1.f, 1.f, -1.f},
+      pcl::PointXYZ{-1.f, 1.f, 1.f},
+      pcl::PointXYZ{1.f, -1.f, -1.f},
+      pcl::PointXYZ{1.f, -1.f, 1.f},
+      pcl::PointXYZ{1.f, 1.f, -1.f},
+      pcl::PointXYZ{1.f, 1.f, 1.f},
+      pcl::PointXYZ{-0.9f, -0.2f, -0.75f},
+      pcl::PointXYZ{-0.4f, -0.6f, -0.75f},
+  };
 
-    for (std::size_t i = 0; i < cloud->size (); ++i)
-    {
-        (*cloud)[i].x = x_cords[i%10];
-        (*cloud)[i].y = y_cords[i%10];
-        (*cloud)[i].z = z_cords[i%10];
-    }
+  // While the GPU implementation has a fixed depth of 10 levels, octree depth in the
+  // CPU implementation can vary based on the leaf size set by the user, which can
+  // affect the results. Therefore results would only tally if depths match.
+  //generate custom pointcloud
+  constexpr pcl::index_t point_size = 1000 * coords.size();
+  auto cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(point_size, 1);
 
-    std::vector<pcl::PointXYZ> queries;
-    //While the GPU implementation has a fixed depth of 10 levels, octree depth in the CPU implementation can vary based on
-    //the leaf size set by the user, which can affect the results. Therefore results would only tally if depths match.
-    queries.push_back(pcl::PointXYZ(-0.4, -0.2, -0.75));     //should be different across CPU and GPU if different traversal methods are used
-    queries.push_back(pcl::PointXYZ(-0.6, -0.2, -0.75));     //should be same across CPU and GPU
-    queries.push_back(pcl::PointXYZ(1.1, 1.1, 1.1));         //out of range query
+  // copy chunks of 10 points at the same time
+  for (auto it = cloud->begin(); it != cloud->cend(); it += coords.size())
+    std::copy(coords.cbegin(), coords.cend(), it);
 
-    //prepare device cloud
-    pcl::gpu::Octree::PointCloud cloud_device;
-    cloud_device.upload(cloud->points);
+  const std::vector<pcl::PointXYZ> queries = {
+      {-0.4, -0.2, -0.75}, // should be different across CPU and GPU if different
+                           // traversal methods are used
+      {-0.6, -0.2, -0.75}, // should be same across CPU and GPU
+      {1.1, 1.1, 1.1},     // out of range query
+  };
 
-    //gpu build
-    pcl::gpu::Octree octree_device;
-    octree_device.setCloud(cloud_device);
-    octree_device.build();
+  // prepare device cloud
+  pcl::gpu::Octree::PointCloud cloud_device;
+  cloud_device.upload(cloud->points);
 
-    //build host octree
-    float host_octree_resolution = 0.05;
-    pcl::octree::OctreePointCloudSearch<pcl::PointXYZ> octree_host(host_octree_resolution);
-    octree_host.setInputCloud (cloud);
-    octree_host.addPointsFromInputCloud();
+  // gpu build
+  pcl::gpu::Octree octree_device;
+  octree_device.setCloud(cloud_device);
+  octree_device.build();
 
-    //upload queries
-    pcl::gpu::Octree::Queries queries_device;
-    queries_device.upload(queries);
-    //pcl::gpu::Octree::ResultSqrDists distances_device(queries.size());
+  // build host octree
+  constexpr float host_octree_resolution = 0.05;
+  pcl::octree::OctreePointCloudSearch<pcl::PointXYZ> octree_host(
+      host_octree_resolution);
+  octree_host.setInputCloud(cloud);
+  octree_host.addPointsFromInputCloud();
 
-    //prepare output buffers on device
-    pcl::gpu::NeighborIndices result_device(queries.size(), 1);
-    std::vector<int> result_host_pcl(queries.size());
-    std::vector<int> result_host_gpu(queries.size());
-    std::vector<float> dists_pcl(queries.size());
-    std::vector<float> dists_gpu(queries.size());
+  // upload queries
+  pcl::gpu::Octree::Queries queries_device;
+  queries_device.upload(queries);
+  // pcl::gpu::Octree::ResultSqrDists distances_device(queries.size());
 
-    //search GPU shared
-    octree_device.approxNearestSearch(queries_device, result_device);
-    std::vector<int> downloaded;
-    std::vector<float>distances;
-    result_device.data.download(downloaded);
-    //distances_device.download(dists_gpu_direct);
+  // prepare output buffers on device
+  pcl::gpu::NeighborIndices result_device(queries.size(), 1);
+  std::vector<int> result_host_pcl(queries.size());
+  std::vector<int> result_host_gpu(queries.size());
+  std::vector<float> dists_pcl(queries.size());
+  std::vector<float> dists_gpu(queries.size());
 
-    for(size_t i = 0; i < queries.size(); ++i)
-    {
-        octree_host.approxNearestSearch(queries[i], result_host_pcl[i], dists_pcl[i]);
-        octree_device.approxNearestSearchHost(queries[i], result_host_gpu[i], dists_gpu[i]);
-    }
+  // search GPU shared
+  octree_device.approxNearestSearch(queries_device, result_device);
+  std::vector<int> downloaded;
+  result_device.data.download(downloaded);
 
-    ASSERT_EQ ((downloaded == result_host_gpu), true);
+  for (size_t i = 0; i < queries.size(); ++i) {
+    octree_host.approxNearestSearch(queries[i], result_host_pcl[i], dists_pcl[i]);
+    octree_device.approxNearestSearchHost(queries[i], result_host_gpu[i], dists_gpu[i]);
+  }
 
-    //find inconsistencies with gpu and cpu cuda impementation
-    //int count_gpu_better = 0;
-    //int count_pcl_better = 0;
-    //int count_different = 0;
-    for(size_t i = 0; i < queries.size(); ++i)
-    {
-        ASSERT_EQ ((dists_pcl[i] == dists_gpu[i]), true);
-    }
+  ASSERT_EQ(downloaded, result_host_gpu);
 
+  // find inconsistencies with gpu and cpu cuda impementation
+  // int count_gpu_better = 0;
+  // int count_pcl_better = 0;
+  // int count_different = 0;
+  for (size_t i = 0; i < queries.size(); ++i) {
+    ASSERT_EQ(dists_pcl[i], dists_gpu[i]);
+    ASSERT_EQ(dists_pcl[i], dists_gpu[i]);
+  }
 }
 
 /* ---[ */
 int
-main (int argc, char** argv)
+main(int argc, char** argv)
 {
-  testing::InitGoogleTest (&argc, argv);
-  return (RUN_ALL_TESTS ());
+  testing::InitGoogleTest(&argc, argv);
+  return (RUN_ALL_TESTS());
 }
 /* ]--- */
-


### PR DESCRIPTION
Very similar to changes in #4306. This PR is built on top of #4294 so only the final commit needs to be reviewed.

The `NearestWarpKernel()` function is the exact same function from #4306, will make it common once it's merged. This function returns the distance which is currently discarded, but will be used when the API is modified to return distances as well.