### PR TITLE
Add iterator include for  back_iterator to support VS2019

### DIFF
--- a/io/src/libpng_wrapper.cpp
+++ b/io/src/libpng_wrapper.cpp
@@ -44,6 +44,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <cstring> // for memcpy
+#include <iterator> // for back_inserter
 
 
 // user defined I/O callback methods for libPNG


### PR DESCRIPTION
Support VS2019 16.7.1.

version 14.27.29110.

On my other pc its defined in xutility...