### PR TITLE
[gpu] Add square distances to GPU knnSearch API

### DIFF
--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -146,7 +146,7 @@ namespace pcl
               */
             void approxNearestSearch(const Queries& queries, NeighborIndices& result) const;
 
-             /** \brief Batch exact k-nearest search on GPU for k == 1 only!
+            /** \brief Batch exact k-nearest search on GPU for k == 1 only!
               * \param[in] queries array of centers
               * \param[in] k number of neighbors (only k == 1 is supported)
               * \param[out] results array of results
@@ -158,7 +158,7 @@ namespace pcl
               * \param[in] queries array of centers
               * \param[in] k number of neighbors (only k == 1 is supported)
               * \param[out] results array of results
-              * \param[out] sqr_distances square distances to results (must be resized to (k * num of queries) a priori!)
+              * \param[out] sqr_distances square distances to results
               */
             void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results, ResultSqrDists& sqr_distances) const;
 

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -151,7 +151,7 @@ namespace pcl
               * \param[in] k number of neighbors (only k == 1 is supported)
               * \param[out] results array of results
               */
-            PCL_DEPRECATED(1, 14, "use nearestKSearchBatch() wihich returns square distances instead")
+            PCL_DEPRECATED(1, 14, "use nearestKSearchBatch() which returns square distances instead")
             void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const;
 
             /** \brief Batch exact k-nearest search on GPU for k == 1 only!

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -150,8 +150,9 @@ namespace pcl
               * \param[in] queries array of centers
               * \param[in] k number of neighbors (only k == 1 is supported)
               * \param[out] results array of results
+              * \param[out] sqr_distances square distances to results (must be resized to (k * num of queries) a priori!)
               */
-            void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const;
+            void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results, ResultSqrDists& sqr_distances) const;
 
             /** \brief Desroys octree and release all resources */
             void clear();            

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -146,6 +146,14 @@ namespace pcl
               */
             void approxNearestSearch(const Queries& queries, NeighborIndices& result) const;
 
+             /** \brief Batch exact k-nearest search on GPU for k == 1 only!
+              * \param[in] queries array of centers
+              * \param[in] k number of neighbors (only k == 1 is supported)
+              * \param[out] results array of results
+              */
+            PCL_DEPRECATED(1, 14, "use nearestKSearchBatch() wihich returns square distances instead")
+            void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const;
+
             /** \brief Batch exact k-nearest search on GPU for k == 1 only!
               * \param[in] queries array of centers
               * \param[in] k number of neighbors (only k == 1 is supported)

--- a/gpu/octree/src/cuda/knn_search.cu
+++ b/gpu/octree/src/cuda/knn_search.cu
@@ -91,7 +91,8 @@ namespace pcl { namespace device { namespace knn_search
         int query_index;        
         float3 query;  
         
-        float min_distance, min_distance_squared;
+        float min_distance;
+        float min_distance_squared;
         int min_idx;
 
         OctreeIterator iterator;     

--- a/gpu/octree/src/cuda/knn_search.cu
+++ b/gpu/octree/src/cuda/knn_search.cu
@@ -91,13 +91,13 @@ namespace pcl { namespace device { namespace knn_search
         int query_index;        
         float3 query;  
         
-        float min_distance, min_distance2;
+        float min_distance, min_distance_squared;
         int min_idx;
 
         OctreeIterator iterator;     
 
         __device__ __forceinline__ Warp_knnSearch(const Batch& batch_arg, const int query_index_arg)
-            : batch(batch_arg), query_index(query_index_arg), min_distance(std::numeric_limits<float>::max()), min_distance2(std::numeric_limits<float>::max()), min_idx(0), iterator(batch.octree) { }
+            : batch(batch_arg), query_index(query_index_arg), min_distance(std::numeric_limits<float>::max()), min_distance_squared(std::numeric_limits<float>::max()), min_idx(0), iterator(batch.octree) { }
 
         __device__ __forceinline__ void launch(bool active)
         {              
@@ -123,7 +123,7 @@ namespace pcl { namespace device { namespace knn_search
             if (query_index != -1)
             {
                 batch.output[query_index] = batch.indices[min_idx];
-                batch.sqr_distances[query_index] = min_distance2;
+                batch.sqr_distances[query_index] = min_distance_squared;
 
                 if (batch.sizes)
                     batch.sizes[query_index]  = 1;
@@ -199,9 +199,9 @@ namespace pcl { namespace device { namespace knn_search
                 const auto nearestPoint = NearestWarpKernel<KernelPolicy::CTA_SIZE>(beg, batch.points_step, end - beg, active_query);
 
                 if (active_lane == laneId)
-                    if (min_distance2 > nearestPoint.second)
+                    if (min_distance_squared > nearestPoint.second)
                     {
-                       min_distance2 = nearestPoint.second;
+                        min_distance_squared = nearestPoint.second;
                        min_idx = beg + nearestPoint.first;
                        min_distance = sqrt(nearestPoint.second);
                     }
@@ -217,7 +217,7 @@ namespace pcl { namespace device { namespace knn_search
 
         {
           int index = 0;
-          float dist2 = std::numeric_limits<float>::max();
+          float dist_squared = std::numeric_limits<float>::max();
 
           // serial step
           for (int idx = Warp::laneId(); idx < length; idx += Warp::STRIDE) {
@@ -227,8 +227,8 @@ namespace pcl { namespace device { namespace knn_search
 
             const float d2 = dx * dx + dy * dy + dz * dz;
 
-            if (dist2 > d2) {
-              dist2 = d2;
+            if (dist_squared > d2) {
+                dist_squared = d2;
               index = idx;
             }
           }
@@ -239,20 +239,20 @@ namespace pcl { namespace device { namespace knn_search
 
           for (unsigned int bit_offset = KernelPolicy::WARP_SIZE / 2; bit_offset > 0;
                bit_offset /= 2) {
-            const float next = __shfl_down_sync(FULL_MASK, dist2, bit_offset);
+            const float next = __shfl_down_sync(FULL_MASK, dist_squared, bit_offset);
             const int next_index = __shfl_down_sync(FULL_MASK, index, bit_offset);
 
-            if (dist2 > next) {
-              dist2 = next;
+            if (dist_squared > next) {
+                dist_squared = next;
               index = next_index;
             }
           }
 
           // retrieve index and distance
           index = __shfl_sync(FULL_MASK, index, 0);
-          dist2 = __shfl_sync(FULL_MASK, dist2, 0);
+          dist_squared = __shfl_sync(FULL_MASK, dist_squared, 0);
 
-          return std::make_pair(index, dist2);
+          return {index, dist_squared};
         }
     };
     

--- a/gpu/octree/src/cuda/knn_search.cu
+++ b/gpu/octree/src/cuda/knn_search.cu
@@ -68,6 +68,7 @@ namespace pcl { namespace device { namespace knn_search
         int queries_num;                
         mutable int* output;                        
         mutable int* sizes;
+        mutable float* sqr_distances;
     };
 
     struct KernelPolicy
@@ -121,7 +122,8 @@ namespace pcl { namespace device { namespace knn_search
             }
             if (query_index != -1)
             {
-				batch.output[query_index] = batch.indices[min_idx];
+                batch.output[query_index] = batch.indices[min_idx];
+                batch.sqr_distances[query_index] = min_distance*min_distance;
 
                 if (batch.sizes)
                     batch.sizes[query_index]  = 1;
@@ -269,7 +271,7 @@ namespace pcl { namespace device { namespace knn_search
 } } }
 
 
-void pcl::device::OctreeImpl::nearestKSearchBatch(const Queries& queries, int /*k*/, NeighborIndices& results) const
+void pcl::device::OctreeImpl::nearestKSearchBatch(const Queries& queries, int /*k*/, NeighborIndices& results, BatchResultSqrDists& sqr_distances) const
 {              
     using BatchType = pcl::device::knn_search::Batch;
 
@@ -282,6 +284,7 @@ void pcl::device::OctreeImpl::nearestKSearchBatch(const Queries& queries, int /*
     
     batch.output = results.data;
     batch.sizes  = results.sizes;
+    batch.sqr_distances = sqr_distances;
     
     batch.points = points_sorted;
     batch.points_step = points_sorted.step()/points_sorted.elem_size;

--- a/gpu/octree/src/internal.hpp
+++ b/gpu/octree/src/internal.hpp
@@ -99,7 +99,7 @@ namespace pcl
 
             void approxNearestSearch(const Queries& queries, NeighborIndices& results) const;
             
-            void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const;
+            void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results, BatchResultSqrDists& sqr_distances) const;
             
             //just reference 
             PointCloud points;

--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -170,7 +170,7 @@ void pcl::gpu::Octree::approxNearestSearch(const Queries& queries, NeighborIndic
     static_cast<OctreeImpl*>(impl)->approxNearestSearch(q, results);
 }
 
-void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const
+void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results, ResultSqrDists& sqr_distances) const
 {    
     if (k != 1)
         throw pcl::PCLException("OctreeGPU::knnSearch is supported only for k == 1", __FILE__, "", __LINE__);
@@ -180,7 +180,7 @@ void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, Neighb
 
 	const OctreeImpl::Queries& q = (const OctreeImpl::Queries&)queries;
 
-    static_cast<OctreeImpl*>(impl)->nearestKSearchBatch(q, k, results);
+    static_cast<OctreeImpl*>(impl)->nearestKSearchBatch(q, k, results, sqr_distances);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////

--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -172,7 +172,7 @@ void pcl::gpu::Octree::approxNearestSearch(const Queries& queries, NeighborIndic
 
 void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const
 {
-    ResultSqrDists sqr_distances(queries.size() * k);
+    ResultSqrDists sqr_distances;
     nearestKSearchBatch(queries, k, results, sqr_distances);
 }
 
@@ -183,6 +183,7 @@ void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, Neighb
     
     assert(queries.size() > 0);
     results.create(static_cast<int> (queries.size()), k);	    
+    sqr_distances.create(queries.size() * k);
 
 	const OctreeImpl::Queries& q = (const OctreeImpl::Queries&)queries;
 

--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -170,6 +170,12 @@ void pcl::gpu::Octree::approxNearestSearch(const Queries& queries, NeighborIndic
     static_cast<OctreeImpl*>(impl)->approxNearestSearch(q, results);
 }
 
+void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const
+{
+    ResultSqrDists sqr_distances(queries.size() * k);
+    nearestKSearchBatch(queries, k, results, sqr_distances);
+}
+
 void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results, ResultSqrDists& sqr_distances) const
 {    
     if (k != 1)

--- a/test/gpu/octree/test_knn_search.cpp
+++ b/test/gpu/octree/test_knn_search.cpp
@@ -114,8 +114,7 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
             
     //prepare output buffers on device
     pcl::gpu::NeighborIndices result_device(data.tests_num, k);    
-    pcl::gpu::Octree::ResultSqrDists result_sqr_distances;
-    result_sqr_distances.create(data.tests_num * k);
+    pcl::gpu::Octree::ResultSqrDists result_sqr_distances(data.tests_num * k);
 
     //prepare output buffers on host
     std::vector<std::vector<  int> > result_host(data.tests_num);   
@@ -132,10 +131,10 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
         octree_device.nearestKSearchBatch(queries_device, k, result_device, result_sqr_distances);
     }
 
-    std::vector<int> downloaded, downloaded_cur;
+    std::vector<int> downloaded;
     result_device.data.download(downloaded);
 
-    std::vector<float> downloaded_sqr_dists, downloaded_sqr_dists_cur;
+    std::vector<float> downloaded_sqr_dists;
     result_sqr_distances.download(downloaded_sqr_dists);
 
     {
@@ -154,11 +153,11 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
         int beg = i * k;
         int end = beg + k;
 
-        const std::vector<float>::iterator beg_dist2 = downloaded_sqr_dists.begin() + beg;
-        const std::vector<float>::iterator end_dist2 = downloaded_sqr_dists.begin() + end;
+        const auto beg_dist2 = downloaded_sqr_dists.cbegin() + beg;
+        const auto end_dist2 = downloaded_sqr_dists.cbegin() + end;
 
-        downloaded_cur.assign(downloaded.begin() + beg, downloaded.begin() + end);
-        downloaded_sqr_dists_cur.assign(beg_dist2, end_dist2);
+        const std::vector<int> downloaded_cur (downloaded.cbegin() + beg, downloaded.cbegin() + end);
+        const std::vector<float> downloaded_sqr_dists_cur (beg_dist2, end_dist2);
 
         std::vector<PriorityPair> pairs_host;
         std::vector<PriorityPair> pairs_gpu;

--- a/test/gpu/octree/test_knn_search.cpp
+++ b/test/gpu/octree/test_knn_search.cpp
@@ -113,8 +113,8 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     queries_device.upload(data.queries);
             
     //prepare output buffers on device
-    pcl::gpu::NeighborIndices result_device(data.tests_num, k);    
-    pcl::gpu::Octree::ResultSqrDists result_sqr_distances(data.tests_num * k);
+    pcl::gpu::NeighborIndices result_device;
+    pcl::gpu::Octree::ResultSqrDists result_sqr_distances;
 
     //prepare output buffers on host
     std::vector<std::vector<  int> > result_host(data.tests_num);   

--- a/test/gpu/octree/test_knn_search.cpp
+++ b/test/gpu/octree/test_knn_search.cpp
@@ -111,10 +111,6 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     //upload queries
     pcl::gpu::Octree::Queries queries_device;
     queries_device.upload(data.queries);
-            
-    //prepare output buffers on device
-    pcl::gpu::NeighborIndices result_device;
-    pcl::gpu::Octree::ResultSqrDists result_sqr_distances;
 
     //prepare output buffers on host
     std::vector<std::vector<  int> > result_host(data.tests_num);   
@@ -124,7 +120,11 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
         result_host[i].reserve(k);
         dists_host[i].reserve(k);
     }
-        
+
+    //prepare output buffers on device
+    pcl::gpu::NeighborIndices result_device;
+    pcl::gpu::Octree::ResultSqrDists result_sqr_distances;
+
     //search GPU shared
     {
         pcl::ScopeTime time("1nn-gpu");


### PR DESCRIPTION
The second commit merely keeps track of the square distances directly rather than regular distances. I'm not too sure if that's more efficient than calculating the square before returning distances.