### PR TITLE
Bump version post 1.11.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "")
   set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "build type default to RelWithDebInfo, set to Release to improve performance" FORCE)
 endif()
 
-project(PCL VERSION 1.11.1)
+project(PCL VERSION 1.11.1.99)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
 ### ---[ Find universal dependencies


### PR DESCRIPTION
** Please don't merge till after #4323 **

Simple version bump in CMakeLists.txt

Generated by:
```
$ ./.dev/scripts/bump_post_release.bash
```

This will mark 1.11.1 as the first release with most of the work being automated.

PS: note to self: rebase after 1.11.1 release