### PR TITLE
Fix UniformSampling filter by correcting distance calculation to voxel center

### DIFF
--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -111,9 +111,11 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
       continue;
     }
 
+	// Compute the voxel center
+	Eigen::Vector4f voxel_center((ijk[0] + 0.5) * leaf_size_[0], (ijk[1] + 0.5) * leaf_size_[1], (ijk[2] + 0.5) * leaf_size_[2], 1);
     // Check to see if this point is closer to the leaf center than the previous one we saved
-    float diff_cur   = ((*input_)[(*indices_)[cp]].getVector4fMap () - ijk.cast<float> ()).squaredNorm ();
-    float diff_prev  = ((*input_)[leaf.idx].getVector4fMap ()        - ijk.cast<float> ()).squaredNorm ();
+    float diff_cur   = ((*input_)[(*indices_)[cp]].getVector4fMap () - voxel_center).squaredNorm ();
+    float diff_prev  = ((*input_)[leaf.idx].getVector4fMap ()        - voxel_center).squaredNorm ();
 
     // If current point is closer, copy its index instead
     if (diff_cur < diff_prev)

--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -111,8 +111,9 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
       continue;
     }
 
-	// Compute the voxel center
-	Eigen::Vector4f voxel_center((ijk[0] + 0.5) * leaf_size_[0], (ijk[1] + 0.5) * leaf_size_[1], (ijk[2] + 0.5) * leaf_size_[2], 1);
+    // Compute the voxel center
+    Eigen::Vector4f voxel_center = (ijk.cast<float>() + Eigen::Vector4f::Constant(0.5)) * search_radius_;
+    voxel_center[3] = 0;
     // Check to see if this point is closer to the leaf center than the previous one we saved
     float diff_cur   = ((*input_)[(*indices_)[cp]].getVector4fMap () - voxel_center).squaredNorm ();
     float diff_prev  = ((*input_)[leaf.idx].getVector4fMap ()        - voxel_center).squaredNorm ();

--- a/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
+++ b/recognition/include/pcl/recognition/impl/cg/geometric_consistency.hpp
@@ -71,6 +71,10 @@ pcl::GeometricConsistencyGrouping<PointModelT, PointSceneT>::clusterCorresponden
   std::sort (sorted_corrs->begin (), sorted_corrs->end (), gcCorrespSorter);
 
   model_scene_corrs_ = sorted_corrs;
+  PCL_DEBUG_STREAM("[pcl::GeometricConsistencyGrouping::clusterCorrespondences] Five best correspondences: ");
+  for(std::size_t i=0; i<std::min<std::size_t>(model_scene_corrs_->size(), 5); ++i)
+    PCL_DEBUG_STREAM("[" << (*input_)[(*model_scene_corrs_)[i].index_query] << " " << (*scene_)[(*model_scene_corrs_)[i].index_match] << " " << (*model_scene_corrs_)[i].distance << "] ");
+  PCL_DEBUG_STREAM(std::endl);
 
   std::vector<int> consensus_set;
   std::vector<bool> taken_corresps (model_scene_corrs_->size (), false);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
@@ -238,6 +238,7 @@ pcl::SampleConsensusModelRegistration<PointT>::countWithinDistance (
     if ((p_tr - pt_tgt).squaredNorm () < thresh)
       nr_p++;
   }
+  PCL_DEBUG ("[pcl::SampleConsensusModelRegistration::countWithinDistance] %zu inliers of %zu total points, threshold=%g\n", nr_p, indices_->size(), threshold);
   return (nr_p);
 } 
 
@@ -296,6 +297,7 @@ pcl::SampleConsensusModelRegistration<PointT>::estimateRigidTransformationSVD (
   }
 
   // Call Umeyama directly from Eigen
+  PCL_DEBUG_STREAM("[pcl::SampleConsensusModelRegistration::estimateRigidTransformationSVD] src and tgt:" << std::endl << src << std::endl << std::endl << tgt << std::endl);
   Eigen::Matrix4d transformation_matrix = pcl::umeyama (src, tgt, false);
 
   // Return the correct transformation

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -155,7 +155,7 @@ TEST (PCL, GeometricConsistencyGrouping)
 
   //Assertions
   EXPECT_EQ (rototranslations.size (), 1);
-  EXPECT_LT (computeRmsE (model_, scene_, rototranslations[0]), 1E-4);
+  EXPECT_LT (computeRmsE (model_, scene_, rototranslations[0]), 1E-4) << std::endl << rototranslations[0] << std::endl << model_downsampled_->size() << std::endl << scene_downsampled_->size() << std::endl << model_scene_corrs_->size() << std::endl;
 }
 
 

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -150,7 +150,7 @@ TEST (PCL, GeometricConsistencyGrouping)
   clusterer.setInputCloud (model_downsampled_);
   clusterer.setSceneCloud (scene_downsampled_);
   clusterer.setModelSceneCorrespondences (model_scene_corrs_);
-  clusterer.setGCSize (0.015);
+  clusterer.setGCSize (0.001);
   clusterer.setGCThreshold (25);
   EXPECT_TRUE (clusterer.recognize (rototranslations));
 

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -143,7 +143,6 @@ TEST (PCL, Hough3DGrouping)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, GeometricConsistencyGrouping)
 {
-  pcl::console::setVerbosityLevel(pcl::console::L_VERBOSE);
   std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > rototranslations;
 
   GeometricConsistencyGrouping<PointType, PointType> clusterer;

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -143,6 +143,7 @@ TEST (PCL, Hough3DGrouping)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, GeometricConsistencyGrouping)
 {
+  pcl::console::setVerbosityLevel(pcl::console::L_VERBOSE);
   std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f> > rototranslations;
 
   GeometricConsistencyGrouping<PointType, PointType> clusterer;


### PR DESCRIPTION
UniformSampling uses the closest point to every voxel center as the sample point. But it uses the point closest to the voxel index as the sample point in the repo.
https://github.com/PointCloudLibrary/pcl/blob/3cb0cf4a2120a16c8527abcb366b76372fcf54ba/filters/include/pcl/filters/impl/uniform_sampling.hpp#L115