### PR TITLE
Enabled multithreading in Poisson surface reconstruction

### DIFF
--- a/surface/include/pcl/surface/impl/poisson.hpp
+++ b/surface/include/pcl/surface/impl/poisson.hpp
@@ -81,6 +81,7 @@ pcl::Poisson<PointNT>::Poisson ()
   , show_residual_ (false)
   , min_iterations_ (8)
   , solver_accuracy_ (1e-3f)
+  , threads_(1)
 {
 }
 
@@ -91,6 +92,20 @@ pcl::Poisson<PointNT>::~Poisson ()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointNT> void
+pcl::Poisson<PointNT>::setThreads (int threads)
+{
+  if (threads == 0)
+#ifdef _OPENMP
+    threads_ = omp_get_num_procs();
+#else
+    threads_ = 1;
+#endif
+  else
+    threads_ = threads;
+}
+      
+//////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointNT> template <int Degree> void
 pcl::Poisson<PointNT>::execute (poisson::CoredVectorMeshData &mesh,
                                 poisson::Point3D<float> &center,
@@ -100,8 +115,8 @@ pcl::Poisson<PointNT>::execute (poisson::CoredVectorMeshData &mesh,
   poisson::TreeNodeData::UseIndex = 1;
   poisson::Octree<Degree> tree;
 
-  /// TODO OPENMP stuff
-  //    tree.threads = Threads.value;
+  
+  tree.threads = threads_;
   center.coords[0] = center.coords[1] = center.coords[2] = 0;
 
 

--- a/surface/include/pcl/surface/poisson.h
+++ b/surface/include/pcl/surface/poisson.h
@@ -216,6 +216,20 @@ namespace pcl
       inline bool
       getManifold () { return manifold_; }
 
+      /** \brief Set the number of threads to use.
+       * \param[in] threads the number of threads
+       */
+      void
+      setThreads(int threads);
+      
+
+      /** \brief Get the number of threads*/
+      inline int
+      getThreads()
+      {
+        return threads_;
+      }
+
     protected:
       /** \brief Class get name method. */
       std::string
@@ -243,6 +257,7 @@ namespace pcl
       bool show_residual_;
       int min_iterations_;
       float solver_accuracy_;
+      int threads_;
 
       template<int Degree> void
       execute (poisson::CoredVectorMeshData &mesh,


### PR DESCRIPTION
As pointed out in issue #1799, despite the fact that exists a
multithread implementation of the Poisson reconstruction algorithm, it
was not used. Now it is enabled and it is possible to set the number of
threads to use.