### PR TITLE
Allow PCL_DEPRECATED to detect and help remove deprecations before release

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -73,6 +73,7 @@
 
 #include <pcl/pcl_config.h>
 
+#include <boost/preprocessor/arithmetic/add.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 #include <boost/preprocessor/comparison/less.hpp>
 #include <boost/preprocessor/control/if.hpp>
@@ -123,15 +124,23 @@
 
 /**
  * \brief Tests for Minor < PCL_MINOR_VERSION
+ * \details When PCL VERSION is of format `34.12.99`, this macro behaves as if it is
+ * already `34.13.0`, and allows for smoother transition for maintainers
  */
 #define _PCL_COMPAT_MINOR_VERSION(Minor, IfPass, IfFail)                                \
-  BOOST_PP_IF(BOOST_PP_LESS(PCL_MINOR_VERSION, Minor), IfPass, IfFail)
+  BOOST_PP_IF(BOOST_PP_EQUAL(PCL_REVISION_VERSION, 99),                                 \
+    BOOST_PP_IF(BOOST_PP_LESS(BOOST_PP_ADD(PCL_MINOR_VERSION, 1), Minor), IfPass, IfFail),           \
+    BOOST_PP_IF(BOOST_PP_LESS(PCL_MINOR_VERSION, Minor), IfPass, IfFail))
 
 /**
  * \brief Tests for Major == PCL_MAJOR_VERSION
+ * \details When PCL VERSION is of format `34.99.12`, this macro behaves as if it is
+ * already `35.0.0`, and allows for smoother transition for maintainers
  */
 #define _PCL_COMPAT_MAJOR_VERSION(Major, IfPass, IfFail)                                \
-  BOOST_PP_IF(BOOST_PP_EQUAL(PCL_MAJOR_VERSION, Major), IfPass, IfFail)
+  BOOST_PP_IF(BOOST_PP_EQUAL(PCL_MINOR_VERSION, 99),                                    \
+    BOOST_PP_IF(BOOST_PP_EQUAL(BOOST_PP_ADD(PCL_MAJOR_VERSION, 1), Major), IfPass, IfFail),          \
+    BOOST_PP_IF(BOOST_PP_EQUAL(PCL_MAJOR_VERSION, Major), IfPass, IfFail))
 
 /**
  * \brief macro for compatibility across compilers and help remove old deprecated


### PR DESCRIPTION
This allows `PCL_DEREPCATED` and related macros to see the following pairs of versions as similar:
* 1.11.99, 1.12.0
* 1.99.8, 2.0.0
(and also the following but these wouldn't occur in a normal maintainer-ship)
* 1.11.99, 1.12.78
* 1.99.99, 2.5.4