### PR TITLE
[gpu] Add square distances to ApproxNearestSearch

### DIFF
--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -159,7 +159,6 @@ namespace pcl
               * \param[in] k number of neighbors (only k == 1 is supported)
               * \param[out] results array of results
               */
-            PCL_DEPRECATED(1, 14, "use nearestKSearchBatch() which returns square distances instead")
             void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const;
 
             /** \brief Batch exact k-nearest search on GPU for k == 1 only!

--- a/gpu/octree/include/pcl/gpu/octree/octree.hpp
+++ b/gpu/octree/include/pcl/gpu/octree/octree.hpp
@@ -144,7 +144,15 @@ namespace pcl
               * \param[in] queries array of centers
               * \param[out] result array of results ( one index for each query ) 
               */
+            PCL_DEPRECATED(1, 14, "use approxNearestSearch() which returns square distances instead")
             void approxNearestSearch(const Queries& queries, NeighborIndices& result) const;
+
+            /** \brief Batch approximate nearest search on GPU
+              * \param[in] queries array of centers
+              * \param[out] result array of results ( one index for each query )
+              * \param[out] sqr_distances corresponding square distances to results from query point
+              */
+            void approxNearestSearch(const Queries& queries, NeighborIndices& result, ResultSqrDists& sqr_distance) const;
 
             /** \brief Batch exact k-nearest search on GPU for k == 1 only!
               * \param[in] queries array of centers

--- a/gpu/octree/src/internal.hpp
+++ b/gpu/octree/src/internal.hpp
@@ -97,7 +97,7 @@ namespace pcl
 
             void radiusSearch(const Queries& queries, const Indices& indices, float radius, NeighborIndices& results);
 
-            void approxNearestSearch(const Queries& queries, NeighborIndices& results) const;
+            void approxNearestSearch(const Queries& queries, NeighborIndices& results, BatchResultSqrDists& sqr_distance) const;
             
             void nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results, BatchResultSqrDists& sqr_distances) const;
             

--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -163,11 +163,18 @@ void pcl::gpu::Octree::radiusSearch(const Queries& queries, const Indices& indic
 
 void pcl::gpu::Octree::approxNearestSearch(const Queries& queries, NeighborIndices& results) const
 {
+    ResultSqrDists sqr_distance;
+    approxNearestSearch(queries, results, sqr_distance);
+}
+
+void pcl::gpu::Octree::approxNearestSearch(const Queries& queries, NeighborIndices& results, ResultSqrDists& sqr_distance) const
+{
     assert(queries.size() > 0);    
     results.create(static_cast<int> (queries.size()), 1);
+    sqr_distance.create(queries.size());
     
     const OctreeImpl::Queries& q = (const OctreeImpl::Queries&)queries;
-    static_cast<OctreeImpl*>(impl)->approxNearestSearch(q, results);
+    static_cast<OctreeImpl*>(impl)->approxNearestSearch(q, results, sqr_distance);
 }
 
 void pcl::gpu::Octree::nearestKSearchBatch(const Queries& queries, int k, NeighborIndices& results) const

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -11,6 +11,7 @@
 #include <pcl/gpu/octree/octree.hpp>
 #include <pcl/octree/octree_search.h>
 #include <pcl/point_cloud.h>
+#include <pcl/common/distances.h>
 
 #include <gtest/gtest.h>
 
@@ -37,7 +38,7 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
   |       | y      |                 |
   |       |        |                 |
   ------------------------------------
-  the final two point are positioned such that point 'x' is father from query point 'q'
+  the final two point are positioned such that point 'x' is farther from query point 'q'
   than 'y', but the voxel containing 'x' is closer to  'q' than the voxel containing 'y'
   */
 
@@ -114,9 +115,14 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
 
   ASSERT_EQ(downloaded, result_host_gpu);
 
+  const std::vector<float> expected_sqr_dists = {pcl::squaredEuclideanDistance(coords[8], queries[0]),
+                                                 pcl::squaredEuclideanDistance(coords[8], queries[1]),
+                                                 pcl::squaredEuclideanDistance(coords[7], queries[2]) };
+
   for (size_t i = 0; i < queries.size(); ++i) {
     ASSERT_EQ(dists_pcl[i], dists_gpu[i]);
     ASSERT_NEAR(dists_gpu[i], dists_device_downloaded[i], 0.001);
+    ASSERT_NEAR(dists_device_downloaded[i], expected_sqr_dists[i], 0.001);
   }
 }
 

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -115,9 +115,9 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
 
   ASSERT_EQ(downloaded, result_host_gpu);
 
-  const std::vector<float> expected_sqr_dists = {pcl::squaredEuclideanDistance(coords[8], queries[0]),
-                                                 pcl::squaredEuclideanDistance(coords[8], queries[1]),
-                                                 pcl::squaredEuclideanDistance(coords[7], queries[2]) };
+  const std::array<float, 3> expected_sqr_dists {pcl::squaredEuclideanDistance(coords[8], queries[0]),
+                                                  pcl::squaredEuclideanDistance(coords[8], queries[1]),
+                                                  pcl::squaredEuclideanDistance(coords[7], queries[2]) };
 
   for (size_t i = 0; i < queries.size(); ++i) {
     ASSERT_EQ(dists_pcl[i], dists_gpu[i]);


### PR DESCRIPTION
Fairly straightforward compared to the previous PR for radius search for the same purpose.

This requires the same 
```cpp
    ASSERT_NEAR(dists_gpu[i], dists_device_downloaded[i], 0.001);
```
workaround when comparing distances to those returned by the host counterpart.

Also, once this is merged the function
```cpp
  __device__ std::pair<int, float>
  NearestWarpKernel(const int beg,
                    const int field_step,
                    const int length,
                    const float3& active_query)
```
will be exactly the same across both KNN search and approx Nearest serach, and can be coalesced in another PR.