### PR TITLE
Enable conversion from PCLPointCloud2 to PointCloud<PointT> for clouds with greater than 2^28 points 

### DIFF
--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -205,10 +205,10 @@ namespace pcl
     else
     {
       // If not, memcpy each group of contiguous fields separately
-      for (std::uint32_t row = 0; row < msg.height; ++row)
+      for (std::size_t row = 0; row < msg.height; ++row)
       {
         const std::uint8_t* row_data = &msg.data[row * msg.row_step];
-        for (std::uint32_t col = 0; col < msg.width; ++col)
+        for (std::size_t col = 0; col < msg.width; ++col)
         {
           const std::uint8_t* msg_data = row_data + col * msg.point_step;
           for (const detail::FieldMapping& mapping : field_map)

--- a/io/include/pcl/io/file_io.h
+++ b/io/include/pcl/io/file_io.h
@@ -234,7 +234,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_floating_point<Type>::value>
   copyValueString (const pcl::PCLPointCloud2 &cloud,
-                   const std::size_t point_index, 
+                   const pcl::index_t point_index, 
                    const int point_size, 
                    const unsigned int field_idx, 
                    const unsigned int fields_count, 
@@ -251,7 +251,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_integral<Type>::value>
   copyValueString (const pcl::PCLPointCloud2 &cloud,
-                   const std::size_t point_index, 
+                   const pcl::index_t point_index, 
                    const int point_size, 
                    const unsigned int field_idx, 
                    const unsigned int fields_count, 
@@ -264,7 +264,7 @@ namespace pcl
 
   template <> inline void
   copyValueString<std::int8_t> (const pcl::PCLPointCloud2 &cloud,
-                           const std::size_t point_index, 
+                           const pcl::index_t point_index, 
                            const int point_size, 
                            const unsigned int field_idx, 
                            const unsigned int fields_count, 
@@ -278,7 +278,7 @@ namespace pcl
 
   template <> inline void
   copyValueString<std::uint8_t> (const pcl::PCLPointCloud2 &cloud,
-                            const std::size_t point_index, 
+                            const pcl::index_t point_index, 
                             const int point_size, 
                             const unsigned int field_idx, 
                             const unsigned int fields_count, 
@@ -303,7 +303,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_floating_point<Type>::value, bool>
   isValueFinite (const pcl::PCLPointCloud2 &cloud,
-                 const std::size_t point_index, 
+                 const pcl::index_t point_index, 
                  const int point_size, 
                  const unsigned int field_idx, 
                  const unsigned int fields_count)
@@ -316,7 +316,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_integral<Type>::value, bool>
   isValueFinite (const pcl::PCLPointCloud2& /* cloud */,
-                 const std::size_t /* point_index */,
+                 const pcl::index_t /* point_index */,
                  const int /* point_size */,
                  const unsigned int /* field_idx */,
                  const unsigned int /* fields_count */)
@@ -337,7 +337,7 @@ namespace pcl
     */
   template <typename Type> inline void
   copyStringValue (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                   std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
+                   pcl::index_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     Type value;
     if (boost::iequals(st, "nan"))
@@ -360,7 +360,7 @@ namespace pcl
 
   template <> inline void
   copyStringValue<std::int8_t> (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                           std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
+                           pcl::index_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     std::int8_t value;
     if (boost::iequals(st, "nan"))
@@ -386,7 +386,7 @@ namespace pcl
 
   template <> inline void
   copyStringValue<std::uint8_t> (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                           std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
+                           pcl::index_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     std::uint8_t value;
     if (boost::iequals(st, "nan"))

--- a/io/include/pcl/io/file_io.h
+++ b/io/include/pcl/io/file_io.h
@@ -234,7 +234,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_floating_point<Type>::value>
   copyValueString (const pcl::PCLPointCloud2 &cloud,
-                   const unsigned int point_index, 
+                   const std::size_t point_index, 
                    const int point_size, 
                    const unsigned int field_idx, 
                    const unsigned int fields_count, 
@@ -251,7 +251,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_integral<Type>::value>
   copyValueString (const pcl::PCLPointCloud2 &cloud,
-                   const unsigned int point_index, 
+                   const std::size_t point_index, 
                    const int point_size, 
                    const unsigned int field_idx, 
                    const unsigned int fields_count, 
@@ -264,7 +264,7 @@ namespace pcl
 
   template <> inline void
   copyValueString<std::int8_t> (const pcl::PCLPointCloud2 &cloud,
-                           const unsigned int point_index, 
+                           const std::size_t point_index, 
                            const int point_size, 
                            const unsigned int field_idx, 
                            const unsigned int fields_count, 
@@ -278,7 +278,7 @@ namespace pcl
 
   template <> inline void
   copyValueString<std::uint8_t> (const pcl::PCLPointCloud2 &cloud,
-                            const unsigned int point_index, 
+                            const std::size_t point_index, 
                             const int point_size, 
                             const unsigned int field_idx, 
                             const unsigned int fields_count, 
@@ -303,7 +303,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_floating_point<Type>::value, bool>
   isValueFinite (const pcl::PCLPointCloud2 &cloud,
-                 const unsigned int point_index, 
+                 const std::size_t point_index, 
                  const int point_size, 
                  const unsigned int field_idx, 
                  const unsigned int fields_count)
@@ -316,7 +316,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_integral<Type>::value, bool>
   isValueFinite (const pcl::PCLPointCloud2& /* cloud */,
-                 const unsigned int /* point_index */,
+                 const std::size_t /* point_index */,
                  const int /* point_size */,
                  const unsigned int /* field_idx */,
                  const unsigned int /* fields_count */)
@@ -337,7 +337,7 @@ namespace pcl
     */
   template <typename Type> inline void
   copyStringValue (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                   unsigned int point_index, unsigned int field_idx, unsigned int fields_count)
+                   std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     Type value;
     if (boost::iequals(st, "nan"))
@@ -360,7 +360,7 @@ namespace pcl
 
   template <> inline void
   copyStringValue<std::int8_t> (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                           unsigned int point_index, unsigned int field_idx, unsigned int fields_count)
+                           std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     std::int8_t value;
     if (boost::iequals(st, "nan"))
@@ -386,7 +386,7 @@ namespace pcl
 
   template <> inline void
   copyStringValue<std::uint8_t> (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                           unsigned int point_index, unsigned int field_idx, unsigned int fields_count)
+                           std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     std::uint8_t value;
     if (boost::iequals(st, "nan"))


### PR DESCRIPTION
Changed std::uint32_t to std::size_t on lines 208 and 211 of conversions.h to enable conversion from PCLPointCloud2 to PointCloud<PointT> for clouds with more than 2^28 points. Related to issue #4326