### PR TITLE
Update conversions.h

### DIFF
--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -205,10 +205,10 @@ namespace pcl
     else
     {
       // If not, memcpy each group of contiguous fields separately
-      for (std::uint32_t row = 0; row < msg.height; ++row)
+      for (std::size_t row = 0; row < msg.height; ++row)
       {
         const std::uint8_t* row_data = &msg.data[row * msg.row_step];
-        for (std::uint32_t col = 0; col < msg.width; ++col)
+        for (std::size_t col = 0; col < msg.width; ++col)
         {
           const std::uint8_t* msg_data = row_data + col * msg.point_step;
           for (const detail::FieldMapping& mapping : field_map)


### PR DESCRIPTION
Enable conversion of PCLPointCloud2 to PointCloud<PointT> for clouds with more than 2^28 points.