### PR TITLE
changed from pcl::index_t to std::size_t to eliminate issues associated with reading and converting large point clouds with more than 2^28 points

### DIFF
--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -204,10 +204,10 @@ namespace pcl
     else
     {
       // If not, memcpy each group of contiguous fields separately
-      for (index_t row = 0; row < msg.height; ++row)
+      for (std::size_t row = 0; row < msg.height; ++row)
       {
         const std::uint8_t* row_data = &msg.data[row * msg.row_step];
-        for (index_t col = 0; col < msg.width; ++col)
+        for (std::size_t col = 0; col < msg.width; ++col)
         {
           const std::uint8_t* msg_data = row_data + col * msg.point_step;
           for (const detail::FieldMapping& mapping : field_map)

--- a/io/include/pcl/io/file_io.h
+++ b/io/include/pcl/io/file_io.h
@@ -234,7 +234,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_floating_point<Type>::value>
   copyValueString (const pcl::PCLPointCloud2 &cloud,
-                   const pcl::index_t point_index, 
+                   const std::size_t point_index, 
                    const int point_size, 
                    const unsigned int field_idx, 
                    const unsigned int fields_count, 
@@ -251,7 +251,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_integral<Type>::value>
   copyValueString (const pcl::PCLPointCloud2 &cloud,
-                   const pcl::index_t point_index, 
+                   const std::size_t point_index, 
                    const int point_size, 
                    const unsigned int field_idx, 
                    const unsigned int fields_count, 
@@ -264,7 +264,7 @@ namespace pcl
 
   template <> inline void
   copyValueString<std::int8_t> (const pcl::PCLPointCloud2 &cloud,
-                           const pcl::index_t point_index, 
+                           const std::size_t point_index, 
                            const int point_size, 
                            const unsigned int field_idx, 
                            const unsigned int fields_count, 
@@ -278,7 +278,7 @@ namespace pcl
 
   template <> inline void
   copyValueString<std::uint8_t> (const pcl::PCLPointCloud2 &cloud,
-                            const pcl::index_t point_index, 
+                            const std::size_t point_index, 
                             const int point_size, 
                             const unsigned int field_idx, 
                             const unsigned int fields_count, 
@@ -303,7 +303,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_floating_point<Type>::value, bool>
   isValueFinite (const pcl::PCLPointCloud2 &cloud,
-                 const pcl::index_t point_index, 
+                 const std::size_t point_index, 
                  const int point_size, 
                  const unsigned int field_idx, 
                  const unsigned int fields_count)
@@ -316,7 +316,7 @@ namespace pcl
   template <typename Type> inline
   std::enable_if_t<std::is_integral<Type>::value, bool>
   isValueFinite (const pcl::PCLPointCloud2& /* cloud */,
-                 const pcl::index_t /* point_index */,
+                 const std::size_t /* point_index */,
                  const int /* point_size */,
                  const unsigned int /* field_idx */,
                  const unsigned int /* fields_count */)
@@ -337,7 +337,7 @@ namespace pcl
     */
   template <typename Type> inline void
   copyStringValue (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                   pcl::index_t point_index, unsigned int field_idx, unsigned int fields_count)
+                   std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     Type value;
     if (boost::iequals(st, "nan"))
@@ -360,7 +360,7 @@ namespace pcl
 
   template <> inline void
   copyStringValue<std::int8_t> (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                           pcl::index_t point_index, unsigned int field_idx, unsigned int fields_count)
+                           std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     std::int8_t value;
     if (boost::iequals(st, "nan"))
@@ -386,7 +386,7 @@ namespace pcl
 
   template <> inline void
   copyStringValue<std::uint8_t> (const std::string &st, pcl::PCLPointCloud2 &cloud,
-                           pcl::index_t point_index, unsigned int field_idx, unsigned int fields_count)
+                           std::size_t point_index, unsigned int field_idx, unsigned int fields_count)
   {
     std::uint8_t value;
     if (boost::iequals(st, "nan"))


### PR DESCRIPTION
Despite recent commits to pcl/conversions.h and pcl/io/file_io.h to improve the reading and conversion of PCLPointCloud2 clouds with more than 2^28 points, issues still persist. These issues are resolved by changing from pcl::index_t to std::size_t. Related to issue #4326