### PR TITLE
Enable arbitary size Indices for Octree module

### DIFF
--- a/.ci/azure-pipelines/build/ubuntu_indices.yaml
+++ b/.ci/azure-pipelines/build/ubuntu_indices.yaml
@@ -14,7 +14,7 @@ steps:
       -DBUILD_tools=OFF \
       -DBUILD_kdtree=OFF \
       -DBUILD_ml=OFF \
-      -DBUILD_octree=OFF \
+      -DBUILD_octree=ON \
       -DBUILD_global_tests=ON 
       # Temporary fix to ensure no tests are skipped
       cmake $(Build.SourcesDirectory)

--- a/.ci/azure-pipelines/build/ubuntu_indices.yaml
+++ b/.ci/azure-pipelines/build/ubuntu_indices.yaml
@@ -11,10 +11,11 @@ steps:
       -DPCL_INDEX_SIGNED=$INDEX_SIGNED \
       -DPCL_INDEX_SIZE=$INDEX_SIZE \
       -DBUILD_geometry=OFF \
+      -DBUILD_io=OFF \
       -DBUILD_tools=OFF \
       -DBUILD_kdtree=OFF \
       -DBUILD_ml=OFF \
-      -DBUILD_octree=ON \
+      -DBUILD_stereo=OFF \
       -DBUILD_global_tests=ON 
       # Temporary fix to ensure no tests are skipped
       cmake $(Build.SourcesDirectory)

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -347,7 +347,7 @@ namespace pcl
     * \note Assumes unique indices.
     * \ingroup common
     */
-  template <typename PointT, typename IndicesVectorAllocator = std::allocator<int>> void
+  template <typename PointT, typename IndicesVectorAllocator = std::allocator<index_t>> void
   copyPointCloud (const pcl::PointCloud<PointT> &cloud_in,
                   const IndicesAllocator< IndicesVectorAllocator> &indices,
                   pcl::PointCloud<PointT> &cloud_out);
@@ -392,7 +392,7 @@ namespace pcl
     * \note Assumes unique indices.
     * \ingroup common
     */
-  template <typename PointInT, typename PointOutT, typename IndicesVectorAllocator = std::allocator<int>> void
+  template <typename PointInT, typename PointOutT, typename IndicesVectorAllocator = std::allocator<index_t>> void
   copyPointCloud (const pcl::PointCloud<PointInT> &cloud_in,
                   const IndicesAllocator<IndicesVectorAllocator> &indices,
                   pcl::PointCloud<PointOutT> &cloud_out);

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -438,7 +438,7 @@ pcl::copyPointCloud (
 void 
 pcl::copyPointCloud (
     const pcl::PCLPointCloud2 &cloud_in,
-    const IndicesAllocator< Eigen::aligned_allocator<pcl::index_t> > &indices,
+    const IndicesAllocator< Eigen::aligned_allocator<index_t> > &indices,
     pcl::PCLPointCloud2 &cloud_out)
 {
   cloud_out.header       = cloud_in.header;

--- a/io/include/pcl/compression/color_coding.h
+++ b/io/include/pcl/compression/color_coding.h
@@ -155,7 +155,7 @@ public:
    * \param inputCloud_arg input point cloud
    * */
   void
-  encodeAverageOfPoints (const typename std::vector<int>& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
+  encodeAverageOfPoints (const Indices& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
   {
     unsigned int avgRed = 0;
     unsigned int avgGreen = 0;
@@ -202,7 +202,7 @@ public:
    * \param inputCloud_arg input point cloud
    * */
   void
-  encodePoints (const typename std::vector<int>& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
+  encodePoints (const Indices& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
   {
     unsigned int avgRed;
     unsigned int avgGreen;

--- a/io/include/pcl/compression/color_coding.h
+++ b/io/include/pcl/compression/color_coding.h
@@ -157,16 +157,14 @@ public:
   void
   encodeAverageOfPoints (const Indices& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
   {
-    unsigned int avgRed = 0;
-    unsigned int avgGreen = 0;
-    unsigned int avgBlue = 0;
+    uindex_t avgRed = 0;
+    uindex_t avgGreen = 0;
+    uindex_t avgBlue = 0;
 
     // iterate over points
-    std::size_t len = indexVector_arg.size ();
-    for (std::size_t i = 0; i < len; i++)
+    for (const auto& idx: indexVector_arg)
     {
       // get color information from points
-      const int& idx = indexVector_arg[i];
       const char* idxPointPtr = reinterpret_cast<const char*> (&(*inputCloud_arg)[idx]);
       const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
 
@@ -177,12 +175,13 @@ public:
 
     }
 
+    const uindex_t len = static_cast<uindex_t> (indexVector_arg.size());
     // calculated average color information
     if (len > 1)
     {
-      avgRed   /= static_cast<unsigned int> (len);
-      avgGreen /= static_cast<unsigned int> (len);
-      avgBlue  /= static_cast<unsigned int> (len);
+      avgRed   /= len;
+      avgGreen /= len;
+      avgBlue  /= len;
     }
 
     // remove least significant bits
@@ -204,19 +203,17 @@ public:
   void
   encodePoints (const Indices& indexVector_arg, unsigned char rgba_offset_arg, PointCloudConstPtr inputCloud_arg)
   {
-    unsigned int avgRed;
-    unsigned int avgGreen;
-    unsigned int avgBlue;
+    uindex_t avgRed;
+    uindex_t avgGreen;
+    uindex_t avgBlue;
 
     // initialize
     avgRed = avgGreen = avgBlue = 0;
 
     // iterate over points
-    std::size_t len = indexVector_arg.size ();
-    for (std::size_t i = 0; i < len; i++)
+    for (const auto& idx: indexVector_arg)
     {
       // get color information from point
-      const int& idx = indexVector_arg[i];
       const char* idxPointPtr = reinterpret_cast<const char*> (&(*inputCloud_arg)[idx]);
       const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
 
@@ -227,6 +224,7 @@ public:
 
     }
 
+    const uindex_t len = static_cast<uindex_t> (indexVector_arg.size());
     if (len > 1)
     {
       unsigned char diffRed;
@@ -234,14 +232,13 @@ public:
       unsigned char diffBlue;
 
       // calculated average color information
-      avgRed   /= static_cast<unsigned int> (len);
-      avgGreen /= static_cast<unsigned int> (len);
-      avgBlue  /= static_cast<unsigned int> (len);
+      avgRed   /= len;
+      avgGreen /= len;
+      avgBlue  /= len;
 
       // iterate over points for differential encoding
-      for (std::size_t i = 0; i < len; i++)
+      for (const auto& idx: indexVector_arg)
       {
-        const int& idx = indexVector_arg[i];
         const char* idxPointPtr = reinterpret_cast<const char*> (&(*inputCloud_arg)[idx]);
         const int& colorInt = *reinterpret_cast<const int*> (idxPointPtr+rgba_offset_arg);
 
@@ -281,12 +278,12 @@ public:
     * \param rgba_offset_arg offset to color information
     */
   void
-  decodePoints (PointCloudPtr outputCloud_arg, std::size_t beginIdx_arg, std::size_t endIdx_arg, unsigned char rgba_offset_arg)
+  decodePoints (PointCloudPtr outputCloud_arg, uindex_t beginIdx_arg, uindex_t endIdx_arg, unsigned char rgba_offset_arg)
   {
     assert (beginIdx_arg <= endIdx_arg);
 
     // amount of points to be decoded
-    unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
+    const index_t pointCount = endIdx_arg - beginIdx_arg;
 
     // get averaged color information for current voxel
     unsigned char avgRed = *(pointAvgColorDataVector_Iterator_++);
@@ -299,7 +296,7 @@ public:
     avgBlue = static_cast<unsigned char> (avgBlue << colorBitReduction_);
 
     // iterate over points
-    for (std::size_t i = 0; i < pointCount; i++)
+    for (index_t i = 0; i < pointCount; i++)
     {
       unsigned int colorInt;
       if (pointCount > 1)

--- a/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
@@ -473,7 +473,7 @@ namespace pcl
         LeafT &leaf_arg, const OctreeKey & key_arg)
     {
       // reference to point indices vector stored within octree leaf
-      const std::vector<int>& leafIdx = leaf_arg.getPointIndicesVector();
+      const auto& leafIdx = leaf_arg.getPointIndicesVector();
 
       if (!do_voxel_grid_enDecoding_)
       {

--- a/io/include/pcl/compression/octree_pointcloud_compression.h
+++ b/io/include/pcl/compression/octree_pointcloud_compression.h
@@ -158,7 +158,7 @@ namespace pcl
          * \param[in] pointIdx_arg the index representing the point in the dataset given by \a setInputCloud to be added
          */
         void
-        addPointIdx (const index_t pointIdx_arg) override
+        addPointIdx (const uindex_t pointIdx_arg) override
         {
           ++object_count_;
           OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::addPointIdx(pointIdx_arg);

--- a/io/include/pcl/compression/octree_pointcloud_compression.h
+++ b/io/include/pcl/compression/octree_pointcloud_compression.h
@@ -158,7 +158,7 @@ namespace pcl
          * \param[in] pointIdx_arg the index representing the point in the dataset given by \a setInputCloud to be added
          */
         void
-        addPointIdx (const int pointIdx_arg) override
+        addPointIdx (const index_t pointIdx_arg) override
         {
           ++object_count_;
           OctreePointCloud<PointT, LeafT, BranchT, OctreeT>::addPointIdx(pointIdx_arg);

--- a/io/include/pcl/compression/point_coding.h
+++ b/io/include/pcl/compression/point_coding.h
@@ -129,15 +129,12 @@ class PointCoding
     encodePoints (const Indices& indexVector_arg, const double* referencePoint_arg,
                   PointCloudConstPtr inputCloud_arg)
     {
-      std::size_t len = indexVector_arg.size ();
-
       // iterate over points within current voxel
-      for (std::size_t i = 0; i < len; i++)
+      for (const auto& idx: indexVector_arg)
       {
         unsigned char diffX, diffY, diffZ;
 
         // retrieve point from cloud
-        const int& idx = indexVector_arg[i];
         const PointT& idxPoint = (*inputCloud_arg)[idx];
 
         // differentially encode point coordinates and truncate overflow
@@ -159,15 +156,15 @@ class PointCoding
       * \param endIdx_arg index indicating last point to be assigned with color information
       */
     void
-    decodePoints (PointCloudPtr outputCloud_arg, const double* referencePoint_arg, std::size_t beginIdx_arg,
-                  std::size_t endIdx_arg)
+    decodePoints (PointCloudPtr outputCloud_arg, const double* referencePoint_arg, uindex_t beginIdx_arg,
+                  uindex_t endIdx_arg)
     {
       assert (beginIdx_arg <= endIdx_arg);
 
-      unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
+      const uindex_t pointCount = endIdx_arg - beginIdx_arg;
 
       // iterate over points within current voxel
-      for (std::size_t i = 0; i < pointCount; i++)
+      for (uindex_t i = 0; i < pointCount; i++)
       {
         // retrieve differential point information
         const unsigned char& diffX = static_cast<unsigned char> (*(pointDiffDataVectorIterator_++));

--- a/io/include/pcl/compression/point_coding.h
+++ b/io/include/pcl/compression/point_coding.h
@@ -126,7 +126,7 @@ class PointCoding
       * \param inputCloud_arg input point cloud
       */
     void
-    encodePoints (const typename std::vector<int>& indexVector_arg, const double* referencePoint_arg,
+    encodePoints (const Indices& indexVector_arg, const double* referencePoint_arg,
                   PointCloudConstPtr inputCloud_arg)
     {
       std::size_t len = indexVector_arg.size ();

--- a/kdtree/include/pcl/kdtree/impl/io.hpp
+++ b/kdtree/include/pcl/kdtree/impl/io.hpp
@@ -47,12 +47,12 @@ template <typename Point1T, typename Point2T> void
 pcl::getApproximateIndices (
     const typename pcl::PointCloud<Point1T>::ConstPtr &cloud_in,
     const typename pcl::PointCloud<Point2T>::ConstPtr &cloud_ref,
-    std::vector<int> &indices)
+    Indices &indices)
 {
   pcl::KdTreeFLANN<Point2T> tree;
   tree.setInputCloud (cloud_ref);
 
-  std::vector<int> nn_idx (1);
+  Indices nn_idx (1);
   std::vector<float> nn_dists (1);
   indices.resize (cloud_in->size ());
   for (std::size_t i = 0; i < cloud_in->size (); ++i)
@@ -67,12 +67,12 @@ template <typename PointT> void
 pcl::getApproximateIndices (
     const typename pcl::PointCloud<PointT>::ConstPtr &cloud_in,
     const typename pcl::PointCloud<PointT>::ConstPtr &cloud_ref,
-    std::vector<int> &indices)
+    Indices &indices)
 {
   pcl::KdTreeFLANN<PointT> tree;
   tree.setInputCloud (cloud_ref);
 
-  std::vector<int> nn_idx (1);
+  Indices nn_idx (1);
   std::vector<float> nn_dists (1);
   indices.resize (cloud_in->size ());
   for (std::size_t i = 0; i < cloud_in->size (); ++i)

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -128,9 +128,9 @@ pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, 
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> int
+template <typename PointT, typename Dist> int 
 pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, unsigned int k,
-                                                std::vector<int> &k_indices,
+                                                Indices &k_indices,
                                                 std::vector<float> &k_distances) const
 {
   assert (point_representation_->isValid (point) && "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -147,7 +147,7 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, unsigned in
   std::vector<float> query (dim_);
   point_representation_->vectorize (static_cast<PointT> (point), query);
 
-  ::flann::Matrix<int> k_indices_mat (&k_indices[0], 1, k);
+  ::flann::Matrix<index_t> k_indices_mat (&k_indices[0], 1, k);
   ::flann::Matrix<float> k_distances_mat (&k_distances[0], 1, k);
   // Wrap the k_indices and k_distances vectors (no data copy)
   flann_index_->knnSearch (::flann::Matrix<float> (&query[0], 1, dim_),
@@ -159,7 +159,7 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, unsigned in
   {
     for (std::size_t i = 0; i < static_cast<std::size_t> (k); ++i)
     {
-      int& neighbor_index = k_indices[i];
+      auto& neighbor_index = k_indices[i];
       neighbor_index = index_mapping_[neighbor_index];
     }
   }
@@ -169,7 +169,7 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, unsigned in
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename Dist> int
-pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius, std::vector<int> &k_indices,
+pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius, Indices &k_indices,
                                               std::vector<float> &k_sqr_dists, unsigned int max_nn) const
 {
   assert (point_representation_->isValid (point) && "Invalid (NaN, Inf) point coordinates given to radiusSearch!");
@@ -181,7 +181,7 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
   if (max_nn == 0 || max_nn > total_nr_points_)
     max_nn = total_nr_points_;
 
-  std::vector<std::vector<int> > indices(1);
+  std::vector<Indices > indices(1);
   std::vector<std::vector<float> > dists(1);
 
   ::flann::SearchParams params (param_radius_);
@@ -204,7 +204,7 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
   {
     for (int i = 0; i < neighbors_in_radius; ++i)
     {
-      int& neighbor_index = k_indices[i];
+      auto& neighbor_index = k_indices[i];
       neighbor_index = index_mapping_[neighbor_index];
     }
   }
@@ -259,7 +259,7 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename Dist> void
-pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, const std::vector<int> &indices)
+pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, const Indices &indices)
 {
   // No point in doing anything if the array is empty
   if (cloud.empty ())

--- a/kdtree/include/pcl/kdtree/io.h
+++ b/kdtree/include/pcl/kdtree/io.h
@@ -55,7 +55,7 @@ namespace pcl
   template <typename PointT> void
   getApproximateIndices (const typename pcl::PointCloud<PointT>::ConstPtr &cloud_in,
                          const typename pcl::PointCloud<PointT>::ConstPtr &cloud_ref,
-                         std::vector<int> &indices);
+                         Indices &indices);
 
   /** \brief Get a set of approximate indices for a given point cloud into a reference point cloud. 
     * The coordinates of the two point clouds can differ. The method uses an internal KdTree for 
@@ -69,7 +69,7 @@ namespace pcl
   template <typename Point1T, typename Point2T> void
   getApproximateIndices (const typename pcl::PointCloud<Point1T>::ConstPtr &cloud_in,
                          const typename pcl::PointCloud<Point2T>::ConstPtr &cloud_ref,
-                         std::vector<int> &indices);
+                         Indices &indices);
 }
 
 #include <pcl/kdtree/impl/io.hpp>

--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -54,8 +54,8 @@ namespace pcl
   class KdTree
   {
     public:
-      using IndicesPtr = shared_ptr<std::vector<int> >;
-      using IndicesConstPtr = shared_ptr<const std::vector<int> >;
+      using IndicesPtr = shared_ptr<Indices >;
+      using IndicesConstPtr = shared_ptr<const Indices >;
 
       using PointCloud = pcl::PointCloud<PointT>;
       using PointCloudPtr = typename PointCloud::Ptr;
@@ -133,7 +133,7 @@ namespace pcl
         */
       virtual int
       nearestKSearch (const PointT &p_q, unsigned int k,
-                      std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const = 0;
+                      Indices &k_indices, std::vector<float> &k_sqr_distances) const = 0;
 
       /** \brief Search for k-nearest neighbors for the given query point.
         *
@@ -153,7 +153,7 @@ namespace pcl
         */
       virtual int
       nearestKSearch (const PointCloud &cloud, int index, unsigned int k,
-                      std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
+                      Indices &k_indices, std::vector<float> &k_sqr_distances) const
       {
         assert (index >= 0 && index < static_cast<int> (cloud.size ()) && "Out-of-bounds error in nearestKSearch!");
         return (nearestKSearch (cloud[index], k, k_indices, k_sqr_distances));
@@ -170,7 +170,7 @@ namespace pcl
         */
       template <typename PointTDiff> inline int
       nearestKSearchT (const PointTDiff &point, unsigned int k,
-                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
+                       Indices &k_indices, std::vector<float> &k_sqr_distances) const
       {
         PointT p;
         copyPoint (point, p);
@@ -196,7 +196,7 @@ namespace pcl
         */
       virtual int
       nearestKSearch (int index, unsigned int k,
-                      std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
+                      Indices &k_indices, std::vector<float> &k_sqr_distances) const
       {
         if (indices_ == nullptr)
         {
@@ -219,7 +219,7 @@ namespace pcl
         * \return number of neighbors found in radius
         */
       virtual int
-      radiusSearch (const PointT &p_q, double radius, std::vector<int> &k_indices,
+      radiusSearch (const PointT &p_q, double radius, Indices &k_indices,
                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const = 0;
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.
@@ -241,7 +241,7 @@ namespace pcl
         */
       virtual int
       radiusSearch (const PointCloud &cloud, int index, double radius,
-                    std::vector<int> &k_indices, std::vector<float> &k_sqr_distances,
+                    Indices &k_indices, std::vector<float> &k_sqr_distances,
                     unsigned int max_nn = 0) const
       {
         assert (index >= 0 && index < static_cast<int> (cloud.size ()) && "Out-of-bounds error in radiusSearch!");
@@ -259,7 +259,7 @@ namespace pcl
         * \return number of neighbors found in radius
         */
       template <typename PointTDiff> inline int
-      radiusSearchT (const PointTDiff &point, double radius, std::vector<int> &k_indices,
+      radiusSearchT (const PointTDiff &point, double radius, Indices &k_indices,
                      std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
       {
         PointT p;
@@ -287,7 +287,7 @@ namespace pcl
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
       virtual int
-      radiusSearch (int index, double radius, std::vector<int> &k_indices,
+      radiusSearch (int index, double radius, Indices &k_indices,
                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
       {
         if (indices_ == nullptr)

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -75,8 +75,8 @@ namespace pcl
       using PointCloud = typename KdTree<PointT>::PointCloud;
       using PointCloudConstPtr = typename KdTree<PointT>::PointCloudConstPtr;
 
-      using IndicesPtr = shared_ptr<std::vector<int> >;
-      using IndicesConstPtr = shared_ptr<const std::vector<int> >;
+      using IndicesPtr = shared_ptr<Indices >;
+      using IndicesConstPtr = shared_ptr<const Indices >;
 
       using FLANNIndex = ::flann::Index<Dist>;
 
@@ -154,9 +154,9 @@ namespace pcl
         *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      int
+      int 
       nearestKSearch (const PointT &point, unsigned int k,
-                      std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const override;
+                      Indices &k_indices, std::vector<float> &k_sqr_distances) const override;
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.
         *
@@ -175,7 +175,7 @@ namespace pcl
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
       int
-      radiusSearch (const PointT &point, double radius, std::vector<int> &k_indices,
+      radiusSearch (const PointT &point, double radius, Indices &k_indices,
                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const override;
 
     private:
@@ -196,7 +196,7 @@ namespace pcl
         * \param[in] indices the point cloud indices
        */
       void
-      convertCloudToArray (const PointCloud &cloud, const std::vector<int> &indices);
+      convertCloudToArray (const PointCloud &cloud, const Indices &indices);
 
     private:
       /** \brief Class getName method. */

--- a/octree/include/pcl/octree/impl/octree2buf_base.hpp
+++ b/octree/include/pcl/octree/impl/octree2buf_base.hpp
@@ -67,17 +67,17 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::~Octree2BufBase()
 template <typename LeafContainerT, typename BranchContainerT>
 void
 Octree2BufBase<LeafContainerT, BranchContainerT>::setMaxVoxelIndex(
-    unsigned int max_voxel_index_arg)
+    uindex_t max_voxel_index_arg)
 {
-  unsigned int treeDepth;
+  uindex_t treeDepth;
 
   assert(max_voxel_index_arg > 0);
 
   // tree depth == amount of bits of maxVoxels
-  treeDepth = std::max(
-      (std::min(static_cast<unsigned int>(OctreeKey::maxDepth),
-                static_cast<unsigned int>(std::ceil(std::log2(max_voxel_index_arg))))),
-      static_cast<unsigned int>(0));
+  treeDepth =
+      std::max<uindex_t>(std::min<uindex_t>(OctreeKey::maxDepth,
+                                            std::ceil(std::log2(max_voxel_index_arg))),
+                         0);
 
   // define depthMask_ by setting a single bit to 1 at bit position == tree depth
   depth_mask_ = (1 << (treeDepth - 1));
@@ -86,7 +86,7 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::setMaxVoxelIndex(
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 void
-Octree2BufBase<LeafContainerT, BranchContainerT>::setTreeDepth(unsigned int depth_arg)
+Octree2BufBase<LeafContainerT, BranchContainerT>::setTreeDepth(uindex_t depth_arg)
 {
   assert(depth_arg > 0);
 
@@ -103,9 +103,9 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::setTreeDepth(unsigned int dept
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 LeafContainerT*
-Octree2BufBase<LeafContainerT, BranchContainerT>::findLeaf(unsigned int idx_x_arg,
-                                                           unsigned int idx_y_arg,
-                                                           unsigned int idx_z_arg)
+Octree2BufBase<LeafContainerT, BranchContainerT>::findLeaf(uindex_t idx_x_arg,
+                                                           uindex_t idx_y_arg,
+                                                           uindex_t idx_z_arg)
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -117,9 +117,9 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::findLeaf(unsigned int idx_x_ar
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 LeafContainerT*
-Octree2BufBase<LeafContainerT, BranchContainerT>::createLeaf(unsigned int idx_x_arg,
-                                                             unsigned int idx_y_arg,
-                                                             unsigned int idx_z_arg)
+Octree2BufBase<LeafContainerT, BranchContainerT>::createLeaf(uindex_t idx_x_arg,
+                                                             uindex_t idx_y_arg,
+                                                             uindex_t idx_z_arg)
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -131,8 +131,9 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::createLeaf(unsigned int idx_x_
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 bool
-Octree2BufBase<LeafContainerT, BranchContainerT>::existLeaf(
-    unsigned int idx_x_arg, unsigned int idx_y_arg, unsigned int idx_z_arg) const
+Octree2BufBase<LeafContainerT, BranchContainerT>::existLeaf(uindex_t idx_x_arg,
+                                                            uindex_t idx_y_arg,
+                                                            uindex_t idx_z_arg) const
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -144,9 +145,9 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::existLeaf(
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 void
-Octree2BufBase<LeafContainerT, BranchContainerT>::removeLeaf(unsigned int idx_x_arg,
-                                                             unsigned int idx_y_arg,
-                                                             unsigned int idx_z_arg)
+Octree2BufBase<LeafContainerT, BranchContainerT>::removeLeaf(uindex_t idx_x_arg,
+                                                             uindex_t idx_y_arg,
+                                                             uindex_t idx_z_arg)
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -352,10 +353,10 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::serializeNewLeafs(
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
-unsigned int
+uindex_t
 Octree2BufBase<LeafContainerT, BranchContainerT>::createLeafRecursive(
     const OctreeKey& key_arg,
-    unsigned int depth_mask_arg,
+    uindex_t depth_mask_arg,
     BranchNode* branch_arg,
     LeafNode*& return_leaf_arg,
     BranchNode*& parent_of_leaf_arg,
@@ -465,7 +466,7 @@ template <typename LeafContainerT, typename BranchContainerT>
 void
 Octree2BufBase<LeafContainerT, BranchContainerT>::findLeafRecursive(
     const OctreeKey& key_arg,
-    unsigned int depth_mask_arg,
+    uindex_t depth_mask_arg,
     BranchNode* branch_arg,
     LeafContainerT*& result_arg) const
 {
@@ -500,7 +501,7 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::findLeafRecursive(
 template <typename LeafContainerT, typename BranchContainerT>
 bool
 Octree2BufBase<LeafContainerT, BranchContainerT>::deleteLeafRecursive(
-    const OctreeKey& key_arg, unsigned int depth_mask_arg, BranchNode* branch_arg)
+    const OctreeKey& key_arg, uindex_t depth_mask_arg, BranchNode* branch_arg)
 {
   // index to branch child
   unsigned char child_idx;
@@ -642,7 +643,7 @@ template <typename LeafContainerT, typename BranchContainerT>
 void
 Octree2BufBase<LeafContainerT, BranchContainerT>::deserializeTreeRecursive(
     BranchNode* branch_arg,
-    unsigned int depth_mask_arg,
+    uindex_t depth_mask_arg,
     OctreeKey& key_arg,
     typename std::vector<char>::const_iterator& binaryTreeIT_arg,
     typename std::vector<char>::const_iterator& binaryTreeIT_End_arg,

--- a/octree/include/pcl/octree/impl/octree_base.hpp
+++ b/octree/include/pcl/octree/impl/octree_base.hpp
@@ -67,16 +67,16 @@ OctreeBase<LeafContainerT, BranchContainerT>::~OctreeBase()
 template <typename LeafContainerT, typename BranchContainerT>
 void
 OctreeBase<LeafContainerT, BranchContainerT>::setMaxVoxelIndex(
-    unsigned int max_voxel_index_arg)
+    uindex_t max_voxel_index_arg)
 {
-  unsigned int tree_depth;
+  uindex_t tree_depth;
 
   assert(max_voxel_index_arg > 0);
 
   // tree depth == bitlength of maxVoxels
   tree_depth =
-      std::min(static_cast<unsigned int>(OctreeKey::maxDepth),
-               static_cast<unsigned int>(std::ceil(std::log2(max_voxel_index_arg))));
+      std::min(static_cast<uindex_t>(OctreeKey::maxDepth),
+               static_cast<uindex_t>(std::ceil(std::log2(max_voxel_index_arg))));
 
   // define depthMask_ by setting a single bit to 1 at bit position == tree depth
   depth_mask_ = (1 << (tree_depth - 1));
@@ -85,7 +85,7 @@ OctreeBase<LeafContainerT, BranchContainerT>::setMaxVoxelIndex(
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 void
-OctreeBase<LeafContainerT, BranchContainerT>::setTreeDepth(unsigned int depth_arg)
+OctreeBase<LeafContainerT, BranchContainerT>::setTreeDepth(uindex_t depth_arg)
 {
   assert(depth_arg > 0);
 
@@ -102,9 +102,9 @@ OctreeBase<LeafContainerT, BranchContainerT>::setTreeDepth(unsigned int depth_ar
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 LeafContainerT*
-OctreeBase<LeafContainerT, BranchContainerT>::findLeaf(unsigned int idx_x_arg,
-                                                       unsigned int idx_y_arg,
-                                                       unsigned int idx_z_arg)
+OctreeBase<LeafContainerT, BranchContainerT>::findLeaf(uindex_t idx_x_arg,
+                                                       uindex_t idx_y_arg,
+                                                       uindex_t idx_z_arg)
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -116,9 +116,9 @@ OctreeBase<LeafContainerT, BranchContainerT>::findLeaf(unsigned int idx_x_arg,
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 LeafContainerT*
-OctreeBase<LeafContainerT, BranchContainerT>::createLeaf(unsigned int idx_x_arg,
-                                                         unsigned int idx_y_arg,
-                                                         unsigned int idx_z_arg)
+OctreeBase<LeafContainerT, BranchContainerT>::createLeaf(uindex_t idx_x_arg,
+                                                         uindex_t idx_y_arg,
+                                                         uindex_t idx_z_arg)
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -130,9 +130,9 @@ OctreeBase<LeafContainerT, BranchContainerT>::createLeaf(unsigned int idx_x_arg,
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 bool
-OctreeBase<LeafContainerT, BranchContainerT>::existLeaf(unsigned int idx_x_arg,
-                                                        unsigned int idx_y_arg,
-                                                        unsigned int idx_z_arg) const
+OctreeBase<LeafContainerT, BranchContainerT>::existLeaf(uindex_t idx_x_arg,
+                                                        uindex_t idx_y_arg,
+                                                        uindex_t idx_z_arg) const
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -144,9 +144,9 @@ OctreeBase<LeafContainerT, BranchContainerT>::existLeaf(unsigned int idx_x_arg,
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
 void
-OctreeBase<LeafContainerT, BranchContainerT>::removeLeaf(unsigned int idx_x_arg,
-                                                         unsigned int idx_y_arg,
-                                                         unsigned int idx_z_arg)
+OctreeBase<LeafContainerT, BranchContainerT>::removeLeaf(uindex_t idx_x_arg,
+                                                         uindex_t idx_y_arg,
+                                                         uindex_t idx_z_arg)
 {
   // generate key
   OctreeKey key(idx_x_arg, idx_y_arg, idx_z_arg);
@@ -281,10 +281,10 @@ OctreeBase<LeafContainerT, BranchContainerT>::deserializeTree(
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename LeafContainerT, typename BranchContainerT>
-unsigned int
+uindex_t
 OctreeBase<LeafContainerT, BranchContainerT>::createLeafRecursive(
     const OctreeKey& key_arg,
-    unsigned int depth_mask_arg,
+    uindex_t depth_mask_arg,
     BranchNode* branch_arg,
     LeafNode*& return_leaf_arg,
     BranchNode*& parent_of_leaf_arg)
@@ -344,7 +344,7 @@ template <typename LeafContainerT, typename BranchContainerT>
 void
 OctreeBase<LeafContainerT, BranchContainerT>::findLeafRecursive(
     const OctreeKey& key_arg,
-    unsigned int depth_mask_arg,
+    uindex_t depth_mask_arg,
     BranchNode* branch_arg,
     LeafContainerT*& result_arg) const
 {
@@ -381,7 +381,7 @@ OctreeBase<LeafContainerT, BranchContainerT>::findLeafRecursive(
 template <typename LeafContainerT, typename BranchContainerT>
 bool
 OctreeBase<LeafContainerT, BranchContainerT>::deleteLeafRecursive(
-    const OctreeKey& key_arg, unsigned int depth_mask_arg, BranchNode* branch_arg)
+    const OctreeKey& key_arg, uindex_t depth_mask_arg, BranchNode* branch_arg)
 {
   // index to branch child
   unsigned char child_idx;
@@ -491,7 +491,7 @@ template <typename LeafContainerT, typename BranchContainerT>
 void
 OctreeBase<LeafContainerT, BranchContainerT>::deserializeTreeRecursive(
     BranchNode* branch_arg,
-    unsigned int depth_mask_arg,
+    uindex_t depth_mask_arg,
     OctreeKey& key_arg,
     typename std::vector<char>::const_iterator& binary_tree_input_it_arg,
     typename std::vector<char>::const_iterator& binary_tree_input_it_end_arg,

--- a/octree/include/pcl/octree/impl/octree_iterator.hpp
+++ b/octree/include/pcl/octree/impl/octree_iterator.hpp
@@ -257,7 +257,8 @@ OctreeBreadthFirstIterator<OctreeT>::operator++()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
-OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator() : fixed_depth_(0u)
+OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator()
+: OctreeBreadthFirstIterator<OctreeT>(nullptr, 0), fixed_depth_(0u)
 {}
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/octree/include/pcl/octree/impl/octree_iterator.hpp
+++ b/octree/include/pcl/octree/impl/octree_iterator.hpp
@@ -45,7 +45,7 @@ namespace pcl {
 namespace octree {
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
-OctreeDepthFirstIterator<OctreeT>::OctreeDepthFirstIterator(unsigned int max_depth_arg)
+OctreeDepthFirstIterator<OctreeT>::OctreeDepthFirstIterator(uindex_t max_depth_arg)
 : OctreeIteratorBase<OctreeT>(max_depth_arg), stack_()
 {
   // initialize iterator
@@ -55,7 +55,7 @@ OctreeDepthFirstIterator<OctreeT>::OctreeDepthFirstIterator(unsigned int max_dep
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
 OctreeDepthFirstIterator<OctreeT>::OctreeDepthFirstIterator(OctreeT* octree_arg,
-                                                            unsigned int max_depth_arg)
+                                                            uindex_t max_depth_arg)
 : OctreeIteratorBase<OctreeT>(octree_arg, max_depth_arg), stack_()
 {
   // initialize iterator
@@ -163,8 +163,7 @@ OctreeDepthFirstIterator<OctreeT>::operator++()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
-OctreeBreadthFirstIterator<OctreeT>::OctreeBreadthFirstIterator(
-    unsigned int max_depth_arg)
+OctreeBreadthFirstIterator<OctreeT>::OctreeBreadthFirstIterator(uindex_t max_depth_arg)
 : OctreeIteratorBase<OctreeT>(max_depth_arg), FIFO_()
 {
   OctreeIteratorBase<OctreeT>::reset();
@@ -175,8 +174,8 @@ OctreeBreadthFirstIterator<OctreeT>::OctreeBreadthFirstIterator(
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
-OctreeBreadthFirstIterator<OctreeT>::OctreeBreadthFirstIterator(
-    OctreeT* octree_arg, unsigned int max_depth_arg)
+OctreeBreadthFirstIterator<OctreeT>::OctreeBreadthFirstIterator(OctreeT* octree_arg,
+                                                                uindex_t max_depth_arg)
 : OctreeIteratorBase<OctreeT>(octree_arg, max_depth_arg), FIFO_()
 {
   OctreeIteratorBase<OctreeT>::reset();
@@ -264,8 +263,8 @@ OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
-OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator(
-    OctreeT* octree_arg, unsigned int fixed_depth_arg)
+OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator(OctreeT* octree_arg,
+                                                            uindex_t fixed_depth_arg)
 : OctreeBreadthFirstIterator<OctreeT>(octree_arg, fixed_depth_arg)
 , fixed_depth_(fixed_depth_arg)
 {
@@ -275,7 +274,7 @@ OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator(
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
 void
-OctreeFixedDepthIterator<OctreeT>::reset(unsigned int fixed_depth_arg)
+OctreeFixedDepthIterator<OctreeT>::reset(uindex_t fixed_depth_arg)
 {
   // Set the desired depth to walk through
   fixed_depth_ = fixed_depth_arg;
@@ -315,7 +314,7 @@ OctreeFixedDepthIterator<OctreeT>::reset(unsigned int fixed_depth_arg)
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
 OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator(
-    unsigned int max_depth_arg)
+    uindex_t max_depth_arg)
 : OctreeBreadthFirstIterator<OctreeT>(max_depth_arg)
 {
   reset();
@@ -324,7 +323,7 @@ OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator(
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
 OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator(
-    OctreeT* octree_arg, unsigned int max_depth_arg)
+    OctreeT* octree_arg, uindex_t max_depth_arg)
 : OctreeBreadthFirstIterator<OctreeT>(octree_arg, max_depth_arg)
 {
   reset();
@@ -334,7 +333,7 @@ OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator(
 template <typename OctreeT>
 OctreeLeafNodeBreadthFirstIterator<OctreeT>::OctreeLeafNodeBreadthFirstIterator(
     OctreeT* octree_arg,
-    unsigned int max_depth_arg,
+    uindex_t max_depth_arg,
     IteratorState* current_state,
     const std::deque<IteratorState>& fifo)
 : OctreeBreadthFirstIterator<OctreeT>(octree_arg, max_depth_arg, current_state, fifo)

--- a/octree/include/pcl/octree/impl/octree_iterator.hpp
+++ b/octree/include/pcl/octree/impl/octree_iterator.hpp
@@ -257,8 +257,7 @@ OctreeBreadthFirstIterator<OctreeT>::operator++()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename OctreeT>
-OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator()
-: OctreeBreadthFirstIterator<OctreeT>(0u), fixed_depth_(0u)
+OctreeFixedDepthIterator<OctreeT>::OctreeFixedDepthIterator() : fixed_depth_(0u)
 {}
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -41,6 +41,7 @@
 #include <pcl/common/common.h>
 #include <pcl/common/point_tests.h> // for pcl::isFinite
 #include <pcl/octree/impl/octree_base.hpp>
+#include <pcl/types.h>
 
 #include <cassert>
 
@@ -78,8 +79,8 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     addPointsFromInputCloud()
 {
   if (indices_) {
-    for (const int& index : *indices_) {
-      assert((index >= 0) && (index < static_cast<int>(input_->size())));
+    for (const auto& index : *indices_) {
+      assert((index >= 0) && (index < input_->size()));
 
       if (isFinite((*input_)[index])) {
         // add points to octree
@@ -88,10 +89,10 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     }
   }
   else {
-    for (std::size_t i = 0; i < input_->size(); i++) {
+    for (index_t i = 0; i < static_cast<index_t>(input_->size()); i++) {
       if (isFinite((*input_)[i])) {
         // add points to octree
-        this->addPointIdx(static_cast<unsigned int>(i));
+        this->addPointIdx(i);
       }
     }
   }
@@ -104,7 +105,7 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    addPointFromCloud(const int point_idx_arg, IndicesPtr indices_arg)
+    addPointFromCloud(const index_t point_idx_arg, IndicesPtr indices_arg)
 {
   this->addPointIdx(point_idx_arg);
   if (indices_arg)
@@ -124,7 +125,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
   cloud_arg->push_back(point_arg);
 
-  this->addPointIdx(static_cast<const int>(cloud_arg->size()) - 1);
+  this->addPointIdx(cloud_arg->size() - 1);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -143,7 +144,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
   cloud_arg->push_back(point_arg);
 
-  this->addPointFromCloud(static_cast<const int>(cloud_arg->size()) - 1, indices_arg);
+  this->addPointFromCloud(cloud_arg->size() - 1, indices_arg);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -175,7 +176,7 @@ template <typename PointT,
           typename OctreeT>
 bool
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    isVoxelOccupiedAtPoint(const int& point_idx_arg) const
+    isVoxelOccupiedAtPoint(const index_t& point_idx_arg) const
 {
   // retrieve point from input cloud
   const PointT& point = (*this->input_)[point_idx_arg];
@@ -233,7 +234,7 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    deleteVoxelAtPoint(const int& point_idx_arg)
+    deleteVoxelAtPoint(const index_t& point_idx_arg)
 {
   // retrieve point from input cloud
   const PointT& point = (*this->input_)[point_idx_arg];
@@ -247,7 +248,7 @@ template <typename PointT,
           typename LeafContainerT,
           typename BranchContainerT,
           typename OctreeT>
-int
+pcl::uindex_t
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     getOccupiedVoxelCenters(AlignedPointTVector& voxel_center_list_arg) const
 {
@@ -628,7 +629,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     // add data to new branch
     OctreeKey new_index_key;
 
-    for (const int& leafIndex : leafIndices) {
+    for (const auto& leafIndex : leafIndices) {
 
       const PointT& point_from_index = (*input_)[leafIndex];
       // generate key
@@ -651,11 +652,11 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    addPointIdx(const int point_idx_arg)
+    addPointIdx(const index_t point_idx_arg)
 {
   OctreeKey key;
 
-  assert(point_idx_arg < static_cast<int>(input_->size()));
+  assert(point_idx_arg < input_->size());
 
   const PointT& point = (*input_)[point_idx_arg];
 
@@ -699,10 +700,10 @@ template <typename PointT,
           typename OctreeT>
 const PointT&
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    getPointByIndex(const unsigned int index_arg) const
+    getPointByIndex(const index_t index_arg) const
 {
   // retrieve point from input cloud
-  assert(index_arg < static_cast<unsigned int>(input_->size()));
+  assert(index_arg < input_->size());
   return ((*this->input_)[index_arg]);
 }
 
@@ -833,7 +834,7 @@ template <typename PointT,
           typename OctreeT>
 bool
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    genOctreeKeyForDataT(const int& data_arg, OctreeKey& key_arg) const
+    genOctreeKeyForDataT(const index_t& data_arg, OctreeKey& key_arg) const
 {
   const PointT temp_point = getPointByIndex(data_arg);
 
@@ -962,13 +963,13 @@ template <typename PointT,
           typename LeafContainerT,
           typename BranchContainerT,
           typename OctreeT>
-int
+pcl::uindex_t
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     getOccupiedVoxelCentersRecursive(const BranchNode* node_arg,
                                      const OctreeKey& key_arg,
                                      AlignedPointTVector& voxel_center_list_arg) const
 {
-  int voxel_count = 0;
+  uindex_t voxel_count = 0;
 
   // iterate over all children
   for (unsigned char child_idx = 0; child_idx < 8; child_idx++) {

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -105,7 +105,7 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    addPointFromCloud(const index_t point_idx_arg, IndicesPtr indices_arg)
+    addPointFromCloud(const uindex_t point_idx_arg, IndicesPtr indices_arg)
 {
   this->addPointIdx(point_idx_arg);
   if (indices_arg)
@@ -652,7 +652,7 @@ template <typename PointT,
           typename OctreeT>
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    addPointIdx(const index_t point_idx_arg)
+    addPointIdx(const uindex_t point_idx_arg)
 {
   OctreeKey key;
 
@@ -700,7 +700,7 @@ template <typename PointT,
           typename OctreeT>
 const PointT&
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    getPointByIndex(const index_t index_arg) const
+    getPointByIndex(const uindex_t index_arg) const
 {
   // retrieve point from input cloud
   assert(index_arg < input_->size());

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -612,7 +612,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     std::size_t leaf_obj_count = (*leaf_node)->getSize();
 
     // copy leaf data
-    std::vector<int> leafIndices;
+    Indices leafIndices;
     leafIndices.reserve(leaf_obj_count);
 
     (*leaf_node)->getPointIndices(leafIndices);

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -859,7 +859,7 @@ template <typename PointT,
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     genVoxelCenterFromOctreeKey(const OctreeKey& key_arg,
-                                unsigned int tree_depth_arg,
+                                uindex_t tree_depth_arg,
                                 PointT& point_arg) const
 {
   // generate point for voxel center defined by treedepth (bitLen) and key
@@ -888,7 +888,7 @@ template <typename PointT,
 void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     genVoxelBoundsFromOctreeKey(const OctreeKey& key_arg,
-                                unsigned int tree_depth_arg,
+                                uindex_t tree_depth_arg,
                                 Eigen::Vector3f& min_pt,
                                 Eigen::Vector3f& max_pt) const
 {
@@ -920,7 +920,7 @@ template <typename PointT,
           typename OctreeT>
 double
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    getVoxelSquaredSideLen(unsigned int tree_depth_arg) const
+    getVoxelSquaredSideLen(uindex_t tree_depth_arg) const
 {
   double side_len;
 
@@ -941,7 +941,7 @@ template <typename PointT,
           typename OctreeT>
 double
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
-    getVoxelSquaredDiameter(unsigned int tree_depth_arg) const
+    getVoxelSquaredDiameter(uindex_t tree_depth_arg) const
 {
   // return the squared side length of the voxel cube as a function of the octree depth
   return (getVoxelSquaredSideLen(tree_depth_arg) * 3);

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -265,7 +265,7 @@ template <typename PointT,
           typename LeafContainerT,
           typename BranchContainerT,
           typename OctreeT>
-pcl::index_t
+pcl::uindex_t
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     getApproxIntersectedVoxelCentersBySegment(const Eigen::Vector3f& origin,
                                               const Eigen::Vector3f& end,
@@ -320,7 +320,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     voxel_center_list.push_back(center);
   }
 
-  return (static_cast<index_t>(voxel_center_list.size()));
+  return (static_cast<uindex_t>(voxel_center_list.size()));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -278,14 +278,14 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
   const float step_size = static_cast<float>(resolution_) * precision;
   // Ensure we get at least one step for the first voxel.
-  const int nsteps = std::max(1, static_cast<int>(norm / step_size));
+  const auto nsteps = std::max<std::size_t>(1, norm / step_size);
 
   OctreeKey prev_key;
 
   bool bkeyDefined = false;
 
   // Walk along the line segment with small steps.
-  for (int i = 0; i < nsteps; ++i) {
+  for (std::size_t i = 0; i < nsteps; ++i) {
     Eigen::Vector3f p = origin + (direction * step_size * static_cast<float>(i));
 
     PointT octree_p;
@@ -668,7 +668,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
   LeafNode* leaf_node;
   BranchNode* parent_branch_of_leaf_node;
-  unsigned int depth_mask = this->createLeafRecursive(
+  auto depth_mask = this->createLeafRecursive(
       key, this->depth_mask_, this->root_node_, leaf_node, parent_branch_of_leaf_node);
 
   if (this->dynamic_depth_enabled_ && depth_mask) {
@@ -716,36 +716,28 @@ void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     getKeyBitSize()
 {
-  unsigned int max_voxels;
-
-  unsigned int max_key_x;
-  unsigned int max_key_y;
-  unsigned int max_key_z;
-
-  double octree_side_len;
-
   const float minValue = std::numeric_limits<float>::epsilon();
 
   // find maximum key values for x, y, z
-  max_key_x =
-      static_cast<unsigned int>(std::ceil((max_x_ - min_x_ - minValue) / resolution_));
-  max_key_y =
-      static_cast<unsigned int>(std::ceil((max_y_ - min_y_ - minValue) / resolution_));
-  max_key_z =
-      static_cast<unsigned int>(std::ceil((max_z_ - min_z_ - minValue) / resolution_));
+  const auto max_key_x =
+      static_cast<uindex_t>(std::ceil((max_x_ - min_x_ - minValue) / resolution_));
+  const auto max_key_y =
+      static_cast<uindex_t>(std::ceil((max_y_ - min_y_ - minValue) / resolution_));
+  const auto max_key_z =
+      static_cast<uindex_t>(std::ceil((max_z_ - min_z_ - minValue) / resolution_));
 
   // find maximum amount of keys
-  max_voxels = std::max(std::max(std::max(max_key_x, max_key_y), max_key_z),
-                        static_cast<unsigned int>(2));
+  const auto max_voxels =
+      std::max<uindex_t>(std::max(std::max(max_key_x, max_key_y), max_key_z), 2);
 
   // tree depth == amount of bits of max_voxels
-  this->octree_depth_ =
-      std::max((std::min(static_cast<unsigned int>(OctreeKey::maxDepth),
-                         static_cast<unsigned int>(
-                             std::ceil(std::log2(max_voxels) - minValue)))),
-               static_cast<unsigned int>(0));
+  this->octree_depth_ = std::max<uindex_t>(
+      std::min<uindex_t>(OctreeKey::maxDepth,
+                         std::ceil(std::log2(max_voxels) - minValue)),
+      0);
 
-  octree_side_len = static_cast<double>(1 << this->octree_depth_) * resolution_;
+  const auto octree_side_len =
+      static_cast<double>(1 << this->octree_depth_) * resolution_;
 
   if (this->leaf_count_ == 0) {
     double octree_oversize_x;
@@ -793,12 +785,9 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     genOctreeKeyforPoint(const PointT& point_arg, OctreeKey& key_arg) const
 {
   // calculate integer key for point coordinates
-  key_arg.x =
-      static_cast<unsigned int>((point_arg.x - this->min_x_) / this->resolution_);
-  key_arg.y =
-      static_cast<unsigned int>((point_arg.y - this->min_y_) / this->resolution_);
-  key_arg.z =
-      static_cast<unsigned int>((point_arg.z - this->min_z_) / this->resolution_);
+  key_arg.x = static_cast<uindex_t>((point_arg.x - this->min_x_) / this->resolution_);
+  key_arg.y = static_cast<uindex_t>((point_arg.y - this->min_y_) / this->resolution_);
+  key_arg.z = static_cast<uindex_t>((point_arg.z - this->min_z_) / this->resolution_);
 
   assert(key_arg.x <= this->max_key_.x);
   assert(key_arg.y <= this->max_key_.y);

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -265,7 +265,7 @@ template <typename PointT,
           typename LeafContainerT,
           typename BranchContainerT,
           typename OctreeT>
-int
+pcl::index_t
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     getApproxIntersectedVoxelCentersBySegment(const Eigen::Vector3f& origin,
                                               const Eigen::Vector3f& end,
@@ -320,7 +320,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     voxel_center_list.push_back(center);
   }
 
-  return (static_cast<int>(voxel_center_list.size()));
+  return (static_cast<index_t>(voxel_center_list.size()));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -605,7 +605,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     expandLeafNode(LeafNode* leaf_node,
                    BranchNode* parent_branch,
                    unsigned char child_idx,
-                   unsigned int depth_mask)
+                   uindex_t depth_mask)
 {
 
   if (depth_mask) {

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -153,11 +153,11 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>::
-    addPointIdx(const int pointIdx_arg)
+    addPointIdx(const index_t pointIdx_arg)
 {
   OctreeKey key;
 
-  assert(pointIdx_arg < static_cast<int>(this->input_->size()));
+  assert(pointIdx_arg < this->input_->size());
 
   const PointT& point = (*this->input_)[pointIdx_arg];
   if (!pcl::isFinite(point))

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -127,12 +127,9 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
     if (pcl::isFinite(temp)) // Make sure transformed point is finite - if it is not, it
                              // gets default key
     {
-      key_arg.x =
-          static_cast<unsigned int>((temp.x - this->min_x_) / this->resolution_);
-      key_arg.y =
-          static_cast<unsigned int>((temp.y - this->min_y_) / this->resolution_);
-      key_arg.z =
-          static_cast<unsigned int>((temp.z - this->min_z_) / this->resolution_);
+      key_arg.x = static_cast<uindex_t>((temp.x - this->min_x_) / this->resolution_);
+      key_arg.y = static_cast<uindex_t>((temp.y - this->min_y_) / this->resolution_);
+      key_arg.z = static_cast<uindex_t>((temp.z - this->min_z_) / this->resolution_);
     }
     else {
       key_arg = OctreeKey();
@@ -140,12 +137,9 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
   }
   else {
     // calculate integer key for point coordinates
-    key_arg.x =
-        static_cast<unsigned int>((point_arg.x - this->min_x_) / this->resolution_);
-    key_arg.y =
-        static_cast<unsigned int>((point_arg.y - this->min_y_) / this->resolution_);
-    key_arg.z =
-        static_cast<unsigned int>((point_arg.z - this->min_z_) / this->resolution_);
+    key_arg.x = static_cast<uindex_t>((point_arg.x - this->min_x_) / this->resolution_);
+    key_arg.y = static_cast<uindex_t>((point_arg.y - this->min_y_) / this->resolution_);
+    key_arg.z = static_cast<uindex_t>((point_arg.z - this->min_z_) / this->resolution_);
   }
 }
 
@@ -294,13 +288,13 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
   direction.normalize();
   float precision = 1.0f;
   const float step_size = static_cast<const float>(resolution_) * precision;
-  const int nsteps = std::max(1, static_cast<int>(norm / step_size));
+  const auto nsteps = std::max<uindex_t>(1, norm / step_size);
 
   OctreeKey prev_key = key;
   // Walk along the line segment with small steps.
   Eigen::Vector3f p = leaf_centroid;
   PointT octree_p;
-  for (int i = 0; i < nsteps; ++i) {
+  for (uindex_t i = 0; i < nsteps; ++i) {
     // Start at the leaf voxel, and move back towards sensor.
     p += (direction * step_size);
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -147,7 +147,7 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>::
-    addPointIdx(const index_t pointIdx_arg)
+    addPointIdx(const uindex_t pointIdx_arg)
 {
   OctreeKey key;
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -288,13 +288,13 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
   direction.normalize();
   float precision = 1.0f;
   const float step_size = static_cast<const float>(resolution_) * precision;
-  const auto nsteps = std::max<uindex_t>(1, norm / step_size);
+  const auto nsteps = std::max<std::size_t>(1, norm / step_size);
 
   OctreeKey prev_key = key;
   // Walk along the line segment with small steps.
   Eigen::Vector3f p = leaf_centroid;
   PointT octree_p;
-  for (uindex_t i = 0; i < nsteps; ++i) {
+  for (std::size_t i = 0; i < nsteps; ++i) {
     // Start at the leaf voxel, and move back towards sensor.
     p += (direction * step_size);
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud_voxelcentroid.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_voxelcentroid.hpp
@@ -70,7 +70,7 @@ pcl::octree::OctreePointCloudVoxelCentroid<PointT, LeafContainerT, BranchContain
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-std::size_t
+pcl::uindex_t
 pcl::octree::OctreePointCloudVoxelCentroid<PointT, LeafContainerT, BranchContainerT>::
     getVoxelCentroids(
         typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -71,16 +71,19 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
-    const int index, Indices& point_idx_data)
+    const index_t index, Indices& point_idx_data)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (this->voxelSearch(search_point, point_idx_data));
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
-    const PointT& p_q, int k, Indices& k_indices, std::vector<float>& k_sqr_distances)
+    const PointT& p_q,
+    uindex_t k,
+    Indices& k_indices,
+    std::vector<float>& k_sqr_distances)
 {
   assert(this->leaf_count_ > 0);
   assert(isFinite(p_q) &&
@@ -104,23 +107,23 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch
   getKNearestNeighborRecursive(
       p_q, k, this->root_node_, key, 1, smallest_dist, point_candidates);
 
-  unsigned int result_count = static_cast<unsigned int>(point_candidates.size());
+  index_t result_count = static_cast<index_t>(point_candidates.size());
 
   k_indices.resize(result_count);
   k_sqr_distances.resize(result_count);
 
-  for (unsigned int i = 0; i < result_count; ++i) {
+  for (index_t i = 0; i < result_count; ++i) {
     k_indices[i] = point_candidates[i].point_idx_;
     k_sqr_distances[i] = point_candidates[i].point_distance_;
   }
 
-  return static_cast<int>(k_indices.size());
+  return k_indices.size();
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
-    int index, int k, Indices& k_indices, std::vector<float>& k_sqr_distances)
+    index_t index, uindex_t k, Indices& k_indices, std::vector<float>& k_sqr_distances)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (nearestKSearch(search_point, k, k_indices, k_sqr_distances));
@@ -129,7 +132,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestSearch(
-    const PointT& p_q, int& result_index, float& sqr_distance)
+    const PointT& p_q, index_t& result_index, float& sqr_distance)
 {
   assert(this->leaf_count_ > 0);
   assert(isFinite(p_q) &&
@@ -147,7 +150,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestS
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestSearch(
-    int query_index, int& result_index, float& sqr_distance)
+    index_t query_index, index_t& result_index, float& sqr_distance)
 {
   const PointT search_point = this->getPointByIndex(query_index);
 
@@ -155,13 +158,13 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestS
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
     const PointT& p_q,
     const double radius,
     Indices& k_indices,
     std::vector<float>& k_sqr_distances,
-    unsigned int max_nn) const
+    uindex_t max_nn) const
 {
   assert(isFinite(p_q) &&
          "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -180,17 +183,17 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
                                     k_sqr_distances,
                                     max_nn);
 
-  return (static_cast<int>(k_indices.size()));
+  return k_indices.size();
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
-    int index,
+    index_t index,
     const double radius,
     Indices& k_indices,
     std::vector<float>& k_sqr_distances,
-    unsigned int max_nn) const
+    uindex_t max_nn) const
 {
   const PointT search_point = this->getPointByIndex(index);
 
@@ -198,7 +201,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearch(
     const Eigen::Vector3f& min_pt,
     const Eigen::Vector3f& max_pt,
@@ -212,7 +215,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearch(
 
   boxSearchRecursive(min_pt, max_pt, this->root_node_, key, 1, k_indices);
 
-  return (static_cast<int>(k_indices.size()));
+  return k_indices.size();
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
@@ -220,7 +223,7 @@ double
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getKNearestNeighborRecursive(
         const PointT& point,
-        unsigned int K,
+        uindex_t K,
         const BranchNode* node,
         const OctreeKey& key,
         unsigned int tree_depth,
@@ -295,7 +298,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
       (*child_leaf)->getPointIndices(decoded_point_vector);
 
       // Linearly iterate over all decoded (unsorted) points
-      for (const int& point_index : decoded_point_vector) {
+      for (const auto& point_index : decoded_point_vector) {
 
         const PointT& candidate_point = this->getPointByIndex(point_index);
 
@@ -337,7 +340,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                       unsigned int tree_depth,
                                       Indices& k_indices,
                                       std::vector<float>& k_sqr_distances,
-                                      unsigned int max_nn) const
+                                      uindex_t max_nn) const
 {
   // get spatial voxel information
   double voxel_squared_diameter = this->getVoxelSquaredDiameter(tree_depth);
@@ -380,7 +383,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                           k_indices,
                                           k_sqr_distances,
                                           max_nn);
-        if (max_nn != 0 && k_indices.size() == static_cast<unsigned int>(max_nn))
+        if (max_nn != 0 && k_indices.size() == max_nn)
           return;
       }
       else {
@@ -392,7 +395,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
         (*child_leaf)->getPointIndices(decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (const int& index : decoded_point_vector) {
+        for (const auto& index : decoded_point_vector) {
           const PointT& candidate_point = this->getPointByIndex(index);
 
           // calculate point distance to search point
@@ -406,7 +409,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
           k_indices.push_back(index);
           k_sqr_distances.push_back(squared_dist);
 
-          if (max_nn != 0 && k_indices.size() == static_cast<unsigned int>(max_nn))
+          if (max_nn != 0 && k_indices.size() == max_nn)
             return;
         }
       }
@@ -421,7 +424,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                  const BranchNode* node,
                                  const OctreeKey& key,
                                  unsigned int tree_depth,
-                                 int& result_index,
+                                 index_t& result_index,
                                  float& sqr_distance)
 {
   OctreeKey minChildKey;
@@ -486,7 +489,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     (**child_leaf).getPointIndices(decoded_point_vector);
 
     // Linearly iterate over all decoded (unsorted) points
-    for (const int& index : decoded_point_vector) {
+    for (const auto& index : decoded_point_vector) {
       const PointT& candidate_point = this->getPointByIndex(index);
 
       // calculate point distance to search point
@@ -568,7 +571,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
         (**child_leaf).getPointIndices(decoded_point_vector);
 
         // Linearly iterate over all decoded (unsorted) points
-        for (const int& index : decoded_point_vector) {
+        for (const auto& index : decoded_point_vector) {
           const PointT& candidate_point = this->getPointByIndex(index);
 
           // check if point falls within search box
@@ -587,12 +590,12 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelCenters(Eigen::Vector3f origin,
                                Eigen::Vector3f direction,
                                AlignedPointTVector& voxel_center_list,
-                               int max_voxel_count) const
+                               uindex_t max_voxel_count) const
 {
   OctreeKey key;
   key.x = key.y = key.z = 0;
@@ -623,12 +626,12 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelIndices(Eigen::Vector3f origin,
                                Eigen::Vector3f direction,
                                Indices& k_indices,
-                               int max_voxel_count) const
+                               uindex_t max_voxel_count) const
 {
   OctreeKey key;
   key.x = key.y = key.z = 0;
@@ -657,7 +660,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelCentersRecursive(double min_x,
                                         double min_y,
@@ -669,7 +672,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                         const OctreeNode* node,
                                         const OctreeKey& key,
                                         AlignedPointTVector& voxel_center_list,
-                                        int max_voxel_count) const
+                                        uindex_t max_voxel_count) const
 {
   if (max_x < 0.0 || max_y < 0.0 || max_z < 0.0)
     return (0);
@@ -686,7 +689,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   }
 
   // Voxel intersection count for branches children
-  int voxel_count = 0;
+  uindex_t voxel_count = 0;
 
   // Voxel mid lines
   double mid_x = 0.5 * (min_x + max_x);
@@ -694,7 +697,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   double mid_z = 0.5 * (min_z + max_z);
 
   // First voxel node ray will intersect
-  int curr_node = getFirstIntersectedNode(min_x, min_y, min_z, mid_x, mid_y, mid_z);
+  auto curr_node = getFirstIntersectedNode(min_x, min_y, min_z, mid_x, mid_y, mid_z);
 
   // Child index, node and key
   unsigned char child_idx;
@@ -853,7 +856,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
 }
 
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
-int
+uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelIndicesRecursive(double min_x,
                                         double min_y,
@@ -865,7 +868,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                         const OctreeNode* node,
                                         const OctreeKey& key,
                                         Indices& k_indices,
-                                        int max_voxel_count) const
+                                        uindex_t max_voxel_count) const
 {
   if (max_x < 0.0 || max_y < 0.0 || max_z < 0.0)
     return (0);
@@ -881,7 +884,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   }
 
   // Voxel intersection count for branches children
-  int voxel_count = 0;
+  uindex_t voxel_count = 0;
 
   // Voxel mid lines
   double mid_x = 0.5 * (min_x + max_x);
@@ -889,7 +892,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   double mid_z = 0.5 * (min_z + max_z);
 
   // First voxel node ray will intersect
-  int curr_node = getFirstIntersectedNode(min_x, min_y, min_z, mid_x, mid_y, mid_z);
+  auto curr_node = getFirstIntersectedNode(min_x, min_y, min_z, mid_x, mid_y, mid_z);
 
   // Child index, node and key
   unsigned char child_idx;

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -226,7 +226,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
         uindex_t K,
         const BranchNode* node,
         const OctreeKey& key,
-        unsigned int tree_depth,
+        uindex_t tree_depth,
         const double squared_search_radius,
         std::vector<prioPointQueueEntry>& point_candidates) const
 {
@@ -337,7 +337,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                       const double radiusSquared,
                                       const BranchNode* node,
                                       const OctreeKey& key,
-                                      unsigned int tree_depth,
+                                      uindex_t tree_depth,
                                       Indices& k_indices,
                                       std::vector<float>& k_sqr_distances,
                                       uindex_t max_nn) const
@@ -423,7 +423,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     approxNearestSearchRecursive(const PointT& point,
                                  const BranchNode* node,
                                  const OctreeKey& key,
-                                 unsigned int tree_depth,
+                                 uindex_t tree_depth,
                                  index_t& result_index,
                                  float& sqr_distance)
 {
@@ -521,7 +521,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
     const Eigen::Vector3f& max_pt,
     const BranchNode* node,
     const OctreeKey& key,
-    unsigned int tree_depth,
+    uindex_t tree_depth,
     Indices& k_indices) const
 {
   // iterate over all children

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -48,7 +48,7 @@ namespace octree {
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
-    const PointT& point, std::vector<int>& point_idx_data)
+    const PointT& point, Indices& point_idx_data)
 {
   assert(isFinite(point) &&
          "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -71,7 +71,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
-    const int index, std::vector<int>& point_idx_data)
+    const int index, Indices& point_idx_data)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (this->voxelSearch(search_point, point_idx_data));
@@ -80,10 +80,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
-    const PointT& p_q,
-    int k,
-    std::vector<int>& k_indices,
-    std::vector<float>& k_sqr_distances)
+    const PointT& p_q, int k, Indices& k_indices, std::vector<float>& k_sqr_distances)
 {
   assert(this->leaf_count_ > 0);
   assert(isFinite(p_q) &&
@@ -123,7 +120,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
-    int index, int k, std::vector<int>& k_indices, std::vector<float>& k_sqr_distances)
+    int index, int k, Indices& k_indices, std::vector<float>& k_sqr_distances)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (nearestKSearch(search_point, k, k_indices, k_sqr_distances));
@@ -162,7 +159,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
     const PointT& p_q,
     const double radius,
-    std::vector<int>& k_indices,
+    Indices& k_indices,
     std::vector<float>& k_sqr_distances,
     unsigned int max_nn) const
 {
@@ -191,7 +188,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
     int index,
     const double radius,
-    std::vector<int>& k_indices,
+    Indices& k_indices,
     std::vector<float>& k_sqr_distances,
     unsigned int max_nn) const
 {
@@ -205,7 +202,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearch(
     const Eigen::Vector3f& min_pt,
     const Eigen::Vector3f& max_pt,
-    std::vector<int>& k_indices) const
+    Indices& k_indices) const
 {
 
   OctreeKey key;
@@ -290,7 +287,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     }
     else {
       // we reached leaf node level
-      std::vector<int> decoded_point_vector;
+      Indices decoded_point_vector;
 
       const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
 
@@ -338,7 +335,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                       const BranchNode* node,
                                       const OctreeKey& key,
                                       unsigned int tree_depth,
-                                      std::vector<int>& k_indices,
+                                      Indices& k_indices,
                                       std::vector<float>& k_sqr_distances,
                                       unsigned int max_nn) const
 {
@@ -389,7 +386,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
       else {
         // we reached leaf node level
         const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
-        std::vector<int> decoded_point_vector;
+        Indices decoded_point_vector;
 
         // decode leaf node into decoded_point_vector
         (*child_leaf)->getPointIndices(decoded_point_vector);
@@ -479,7 +476,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
   }
   else {
     // we reached leaf node level
-    std::vector<int> decoded_point_vector;
+    Indices decoded_point_vector;
 
     const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
 
@@ -522,7 +519,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
     const BranchNode* node,
     const OctreeKey& key,
     unsigned int tree_depth,
-    std::vector<int>& k_indices) const
+    Indices& k_indices) const
 {
   // iterate over all children
   for (unsigned char child_idx = 0; child_idx < 8; child_idx++) {
@@ -563,7 +560,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
       }
       else {
         // we reached leaf node level
-        std::vector<int> decoded_point_vector;
+        Indices decoded_point_vector;
 
         const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
 
@@ -630,7 +627,7 @@ int
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     getIntersectedVoxelIndices(Eigen::Vector3f origin,
                                Eigen::Vector3f direction,
-                               std::vector<int>& k_indices,
+                               Indices& k_indices,
                                int max_voxel_count) const
 {
   OctreeKey key;
@@ -867,7 +864,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
                                         unsigned char a,
                                         const OctreeNode* node,
                                         const OctreeKey& key,
-                                        std::vector<int>& k_indices,
+                                        Indices& k_indices,
                                         int max_voxel_count) const
 {
   if (max_x < 0.0 || max_y < 0.0 || max_z < 0.0)

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -107,12 +107,12 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch
   getKNearestNeighborRecursive(
       p_q, k, this->root_node_, key, 1, smallest_dist, point_candidates);
 
-  index_t result_count = static_cast<index_t>(point_candidates.size());
+  const auto result_count = static_cast<uindex_t>(point_candidates.size());
 
   k_indices.resize(result_count);
   k_sqr_distances.resize(result_count);
 
-  for (index_t i = 0; i < result_count; ++i) {
+  for (uindex_t i = 0; i < result_count; ++i) {
     k_indices[i] = point_candidates[i].point_idx_;
     k_sqr_distances[i] = point_candidates[i].point_distance_;
   }

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -71,7 +71,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
-    const index_t index, Indices& point_idx_data)
+    const uindex_t index, Indices& point_idx_data)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (this->voxelSearch(search_point, point_idx_data));
@@ -123,7 +123,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::nearestKSearch(
-    index_t index, uindex_t k, Indices& k_indices, std::vector<float>& k_sqr_distances)
+    uindex_t index, uindex_t k, Indices& k_indices, std::vector<float>& k_sqr_distances)
 {
   const PointT search_point = this->getPointByIndex(index);
   return (nearestKSearch(search_point, k, k_indices, k_sqr_distances));
@@ -150,7 +150,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestS
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 void
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::approxNearestSearch(
-    index_t query_index, index_t& result_index, float& sqr_distance)
+    uindex_t query_index, index_t& result_index, float& sqr_distance)
 {
   const PointT search_point = this->getPointByIndex(query_index);
 
@@ -189,7 +189,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 uindex_t
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::radiusSearch(
-    index_t index,
+    uindex_t index,
     const double radius,
     Indices& k_indices,
     std::vector<float>& k_sqr_distances,

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -212,7 +212,7 @@ protected:
  * \ingroup octree
  * \author Julius Kammerl (julius@kammerl.de)
  */
-template <typename LeafContainerT = int,
+template <typename LeafContainerT = index_t,
           typename BranchContainerT = OctreeContainerEmpty>
 class Octree2BufBase {
 
@@ -236,7 +236,7 @@ public:
   using Iterator = OctreeDepthFirstIterator<OctreeT>;
   using ConstIterator = const OctreeDepthFirstIterator<OctreeT>;
   Iterator
-  begin(unsigned int max_depth_arg = 0)
+  begin(uindex_t max_depth_arg = 0)
   {
     return Iterator(this, max_depth_arg);
   };
@@ -258,7 +258,7 @@ public:
   using ConstLeafNodeDepthFirstIterator =
       const OctreeLeafNodeDepthFirstIterator<OctreeT>;
   LeafNodeDepthFirstIterator
-  leaf_depth_begin(unsigned int max_depth_arg = 0)
+  leaf_depth_begin(uindex_t max_depth_arg = 0)
   {
     return LeafNodeDepthFirstIterator(this, max_depth_arg);
   };
@@ -273,7 +273,7 @@ public:
   using DepthFirstIterator = OctreeDepthFirstIterator<OctreeT>;
   using ConstDepthFirstIterator = const OctreeDepthFirstIterator<OctreeT>;
   DepthFirstIterator
-  depth_begin(unsigned int maxDepth_arg = 0)
+  depth_begin(uindex_t maxDepth_arg = 0)
   {
     return DepthFirstIterator(this, maxDepth_arg);
   };
@@ -287,7 +287,7 @@ public:
   using BreadthFirstIterator = OctreeBreadthFirstIterator<OctreeT>;
   using ConstBreadthFirstIterator = const OctreeBreadthFirstIterator<OctreeT>;
   BreadthFirstIterator
-  breadth_begin(unsigned int max_depth_arg = 0)
+  breadth_begin(uindex_t max_depth_arg = 0)
   {
     return BreadthFirstIterator(this, max_depth_arg);
   };
@@ -303,7 +303,7 @@ public:
       const OctreeLeafNodeBreadthFirstIterator<OctreeT>;
 
   LeafNodeBreadthIterator
-  leaf_breadth_begin(unsigned int max_depth_arg = 0u)
+  leaf_breadth_begin(uindex_t max_depth_arg = 0u)
   {
     return LeafNodeBreadthIterator(this,
                                    max_depth_arg ? max_depth_arg : this->octree_depth_);
@@ -354,18 +354,18 @@ public:
    *  \param max_voxel_index_arg: maximum amount of voxels per dimension
    */
   void
-  setMaxVoxelIndex(unsigned int max_voxel_index_arg);
+  setMaxVoxelIndex(uindex_t max_voxel_index_arg);
 
   /** \brief Set the maximum depth of the octree.
    *  \param depth_arg: maximum depth of octree
    */
   void
-  setTreeDepth(unsigned int depth_arg);
+  setTreeDepth(uindex_t depth_arg);
 
   /** \brief Get the maximum depth of the octree.
    *  \return depth_arg: maximum depth of octree
    */
-  inline unsigned int
+  inline uindex_t
   getTreeDepth() const
   {
     return this->octree_depth_;
@@ -379,7 +379,7 @@ public:
    *  \return pointer to new leaf node container.
    */
   LeafContainerT*
-  createLeaf(unsigned int idx_x_arg, unsigned int idx_y_arg, unsigned int idx_z_arg);
+  createLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg);
 
   /** \brief Find leaf node at (idx_x_arg, idx_y_arg, idx_z_arg).
    *  \note If leaf node already exist, this method returns the existing node
@@ -389,7 +389,7 @@ public:
    *  \return pointer to leaf node container if found, null pointer otherwise.
    */
   LeafContainerT*
-  findLeaf(unsigned int idx_x_arg, unsigned int idx_y_arg, unsigned int idx_z_arg);
+  findLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg);
 
   /** \brief Check for the existence of leaf node at (idx_x_arg, idx_y_arg, idx_z_arg).
    *  \param idx_x_arg: index of leaf node in the X axis.
@@ -398,9 +398,7 @@ public:
    *  \return "true" if leaf node search is successful, otherwise it returns "false".
    */
   bool
-  existLeaf(unsigned int idx_x_arg,
-            unsigned int idx_y_arg,
-            unsigned int idx_z_arg) const;
+  existLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg) const;
 
   /** \brief Remove leaf node at (idx_x_arg, idx_y_arg, idx_z_arg).
    *  \param idx_x_arg: index of leaf node in the X axis.
@@ -408,7 +406,7 @@ public:
    *  \param idx_z_arg: index of leaf node in the Z axis.
    */
   void
-  removeLeaf(unsigned int idx_x_arg, unsigned int idx_y_arg, unsigned int idx_z_arg);
+  removeLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg);
 
   /** \brief Return the amount of existing leafs in the octree.
    *  \return amount of registered leaf nodes.
@@ -825,9 +823,9 @@ protected:
    * \param branch_reset_arg: Reset pointer array of current branch
    * \return depth mask at which leaf node was created/found
    **/
-  unsigned int
+  uindex_t
   createLeafRecursive(const OctreeKey& key_arg,
-                      unsigned int depth_mask_arg,
+                      uindex_t depth_mask_arg,
                       BranchNode* branch_arg,
                       LeafNode*& return_leaf_arg,
                       BranchNode*& parent_of_leaf_arg,
@@ -843,7 +841,7 @@ protected:
    **/
   void
   findLeafRecursive(const OctreeKey& key_arg,
-                    unsigned int depth_mask_arg,
+                    uindex_t depth_mask_arg,
                     BranchNode* branch_arg,
                     LeafContainerT*& result_arg) const;
 
@@ -857,7 +855,7 @@ protected:
    **/
   bool
   deleteLeafRecursive(const OctreeKey& key_arg,
-                      unsigned int depth_mask_arg,
+                      uindex_t depth_mask_arg,
                       BranchNode* branch_arg);
 
   /** \brief Recursively explore the octree and output binary octree description
@@ -901,7 +899,7 @@ protected:
   void
   deserializeTreeRecursive(
       BranchNode* branch_arg,
-      unsigned int depth_mask_arg,
+      uindex_t depth_mask_arg,
       OctreeKey& key_arg,
       typename std::vector<char>::const_iterator& binary_tree_in_it_arg,
       typename std::vector<char>::const_iterator& binary_tree_in_it_end_arg,
@@ -978,7 +976,7 @@ protected:
   BranchNode* root_node_;
 
   /** \brief Depth mask based on octree depth   **/
-  unsigned int depth_mask_;
+  uindex_t depth_mask_;
 
   /** \brief key range */
   OctreeKey max_key_;
@@ -990,7 +988,7 @@ protected:
   bool tree_dirty_flag_;
 
   /** \brief Octree depth */
-  unsigned int octree_depth_;
+  uindex_t octree_depth_;
 
   /** \brief Enable dynamic_depth
    *  \note Note that this parameter is ignored in octree2buf! */

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -57,7 +57,7 @@ namespace octree {
  * \ingroup octree
  * \author Julius Kammerl (julius@kammerl.de)
  */
-template <typename LeafContainerT = int,
+template <typename LeafContainerT = index_t,
           typename BranchContainerT = OctreeContainerEmpty>
 class OctreeBase {
 public:
@@ -84,10 +84,10 @@ protected:
   BranchNode* root_node_;
 
   /** \brief Depth mask based on octree depth   **/
-  unsigned int depth_mask_;
+  uindex_t depth_mask_;
 
   /** \brief Octree depth */
-  unsigned int octree_depth_;
+  uindex_t octree_depth_;
 
   /** \brief Enable dynamic_depth **/
   bool dynamic_depth_enabled_;
@@ -109,7 +109,7 @@ public:
   using ConstIterator = const OctreeDepthFirstIterator<OctreeT>;
 
   Iterator
-  begin(unsigned int max_depth_arg = 0u)
+  begin(uindex_t max_depth_arg = 0u)
   {
     return Iterator(this, max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
@@ -133,7 +133,7 @@ public:
       const OctreeLeafNodeDepthFirstIterator<OctreeT>;
 
   LeafNodeDepthFirstIterator
-  leaf_depth_begin(unsigned int max_depth_arg = 0u)
+  leaf_depth_begin(uindex_t max_depth_arg = 0u)
   {
     return LeafNodeDepthFirstIterator(
         this, max_depth_arg ? max_depth_arg : this->octree_depth_);
@@ -150,7 +150,7 @@ public:
   using ConstDepthFirstIterator = const OctreeDepthFirstIterator<OctreeT>;
 
   DepthFirstIterator
-  depth_begin(unsigned int max_depth_arg = 0u)
+  depth_begin(uindex_t max_depth_arg = 0u)
   {
     return DepthFirstIterator(this,
                               max_depth_arg ? max_depth_arg : this->octree_depth_);
@@ -167,7 +167,7 @@ public:
   using ConstBreadthFirstIterator = const OctreeBreadthFirstIterator<OctreeT>;
 
   BreadthFirstIterator
-  breadth_begin(unsigned int max_depth_arg = 0u)
+  breadth_begin(uindex_t max_depth_arg = 0u)
   {
     return BreadthFirstIterator(this,
                                 max_depth_arg ? max_depth_arg : this->octree_depth_);
@@ -184,7 +184,7 @@ public:
   using ConstFixedDepthIterator = const OctreeFixedDepthIterator<OctreeT>;
 
   FixedDepthIterator
-  fixed_depth_begin(unsigned int fixed_depth_arg = 0u)
+  fixed_depth_begin(uindex_t fixed_depth_arg = 0u)
   {
     return FixedDepthIterator(this, fixed_depth_arg);
   };
@@ -201,7 +201,7 @@ public:
       const OctreeLeafNodeBreadthFirstIterator<OctreeT>;
 
   LeafNodeBreadthFirstIterator
-  leaf_breadth_begin(unsigned int max_depth_arg = 0u)
+  leaf_breadth_begin(uindex_t max_depth_arg = 0u)
   {
     return LeafNodeBreadthFirstIterator(
         this, max_depth_arg ? max_depth_arg : this->octree_depth_);
@@ -249,18 +249,18 @@ public:
    * \param[in] max_voxel_index_arg maximum amount of voxels per dimension
    */
   void
-  setMaxVoxelIndex(unsigned int max_voxel_index_arg);
+  setMaxVoxelIndex(uindex_t max_voxel_index_arg);
 
   /** \brief Set the maximum depth of the octree.
    *  \param max_depth_arg: maximum depth of octree
    */
   void
-  setTreeDepth(unsigned int max_depth_arg);
+  setTreeDepth(uindex_t max_depth_arg);
 
   /** \brief Get the maximum depth of the octree.
    *  \return depth_arg: maximum depth of octree
    */
-  unsigned int
+  uindex_t
   getTreeDepth() const
   {
     return this->octree_depth_;
@@ -274,7 +274,7 @@ public:
    *  \return pointer to new leaf node container.
    */
   LeafContainerT*
-  createLeaf(unsigned int idx_x_arg, unsigned int idx_y_arg, unsigned int idx_z_arg);
+  createLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg);
 
   /** \brief Find leaf node at (idx_x_arg, idx_y_arg, idx_z_arg).
    *  \note If leaf node already exist, this method returns the existing node
@@ -284,7 +284,7 @@ public:
    *  \return pointer to leaf node container if found, null pointer otherwise.
    */
   LeafContainerT*
-  findLeaf(unsigned int idx_x_arg, unsigned int idx_y_arg, unsigned int idx_z_arg);
+  findLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg);
 
   /** \brief idx_x_arg for the existence of leaf node at (idx_x_arg, idx_y_arg,
    * idx_z_arg).
@@ -294,9 +294,7 @@ public:
    * \return "true" if leaf node search is successful, otherwise it returns "false".
    */
   bool
-  existLeaf(unsigned int idx_x_arg,
-            unsigned int idx_y_arg,
-            unsigned int idx_z_arg) const;
+  existLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg) const;
 
   /** \brief Remove leaf node at (idx_x_arg, idx_y_arg, idx_z_arg).
    *  \param idx_x_arg: index of leaf node in the X axis.
@@ -304,7 +302,7 @@ public:
    *  \param idx_z_arg: index of leaf node in the Z axis.
    */
   void
-  removeLeaf(unsigned int idx_x_arg, unsigned int idx_y_arg, unsigned int idx_z_arg);
+  removeLeaf(uindex_t idx_x_arg, uindex_t idx_y_arg, uindex_t idx_z_arg);
 
   /** \brief Return the amount of existing leafs in the octree.
    *  \return amount of registered leaf nodes.
@@ -580,9 +578,9 @@ protected:
    * \param parent_of_leaf_arg: return pointer to parent of leaf node
    * \return depth mask at which leaf node was created
    **/
-  unsigned int
+  uindex_t
   createLeafRecursive(const OctreeKey& key_arg,
-                      unsigned int depth_mask_arg,
+                      uindex_t depth_mask_arg,
                       BranchNode* branch_arg,
                       LeafNode*& return_leaf_arg,
                       BranchNode*& parent_of_leaf_arg);
@@ -597,7 +595,7 @@ protected:
    **/
   void
   findLeafRecursive(const OctreeKey& key_arg,
-                    unsigned int depth_mask_arg,
+                    uindex_t depth_mask_arg,
                     BranchNode* branch_arg,
                     LeafContainerT*& result_arg) const;
 
@@ -611,7 +609,7 @@ protected:
    **/
   bool
   deleteLeafRecursive(const OctreeKey& key_arg,
-                      unsigned int depth_mask_arg,
+                      uindex_t depth_mask_arg,
                       BranchNode* branch_arg);
 
   /** \brief Recursively explore the octree and output binary octree description
@@ -644,7 +642,7 @@ protected:
   void
   deserializeTreeRecursive(
       BranchNode* branch_arg,
-      unsigned int depth_mask_arg,
+      uindex_t depth_mask_arg,
       OctreeKey& key_arg,
       typename std::vector<char>::const_iterator& binary_tree_input_it_arg,
       typename std::vector<char>::const_iterator& binary_tree_input_it_end_arg,

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -76,7 +76,7 @@ public:
   /** \brief Pure abstract method to get size of container (number of indices)
    * \return number of points/indices stored in leaf node container.
    */
-  virtual std::size_t
+  virtual index_t
   getSize() const
   {
     return 0u;

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -141,9 +141,7 @@ public:
   /** \brief Empty addPointIndex implementation. This leaf node does not store any point
    * indices.
    */
-  void
-  addPointIndex(int)
-  {}
+  void addPointIndex(index_t) {}
 
   /** \brief Empty getPointIndex implementation as this leaf node does not store any
    * point indices.

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -127,7 +127,7 @@ public:
   /** \brief Abstract get size of container (number of DataT objects)
    * \return number of DataT elements in leaf node container.
    */
-  std::size_t
+  index_t
   getSize() const override
   {
     return 0;
@@ -220,24 +220,24 @@ public:
   void
   getPointIndices(Indices& data_vector_arg) const
   {
-    if (data_ >= 0)
+    if (data_ != static_cast<index_t>(-1))
       data_vector_arg.push_back(data_);
   }
 
   /** \brief Get size of container (number of DataT objects)
    * \return number of DataT elements in leaf node container.
    */
-  std::size_t
+  index_t
   getSize() const override
   {
-    return data_ < 0 ? 0 : 1;
+    return data_ != static_cast<index_t>(-1) ? 0 : 1;
   }
 
   /** \brief Reset leaf node memory to zero. */
   void
   reset() override
   {
-    data_ = -1;
+    data_ = static_cast<index_t>(-1);
   }
 
 protected:
@@ -316,10 +316,10 @@ public:
   /** \brief Get size of container (number of indices)
    * \return number of point indices in container.
    */
-  std::size_t
+  index_t
   getSize() const override
   {
-    return leafDataTVector_.size();
+    return static_cast<index_t>(leafDataTVector_.size());
   }
 
   /** \brief Reset leaf node. Clear DataT vector.*/

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -76,7 +76,7 @@ public:
   /** \brief Pure abstract method to get size of container (number of indices)
    * \return number of points/indices stored in leaf node container.
    */
-  virtual index_t
+  virtual uindex_t
   getSize() const
   {
     return 0u;
@@ -127,7 +127,7 @@ public:
   /** \brief Abstract get size of container (number of DataT objects)
    * \return number of DataT elements in leaf node container.
    */
-  index_t
+  uindex_t
   getSize() const override
   {
     return 0;
@@ -225,7 +225,7 @@ public:
   /** \brief Get size of container (number of DataT objects)
    * \return number of DataT elements in leaf node container.
    */
-  index_t
+  uindex_t
   getSize() const override
   {
     return data_ != static_cast<index_t>(-1) ? 0 : 1;
@@ -314,10 +314,10 @@ public:
   /** \brief Get size of container (number of indices)
    * \return number of point indices in container.
    */
-  index_t
+  uindex_t
   getSize() const override
   {
-    return static_cast<index_t>(leafDataTVector_.size());
+    return static_cast<uindex_t>(leafDataTVector_.size());
   }
 
   /** \brief Reset leaf node. Clear DataT vector.*/

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -90,14 +90,14 @@ public:
    * indices.
    */
   void
-  addPointIndex(const int&)
+  addPointIndex(const index_t&)
   {}
 
   /** \brief Empty getPointIndex implementation as this leaf node does not store any
    * point indices.
    */
   void
-  getPointIndex(int&) const
+  getPointIndex(index_t&) const
   {}
 
   /** \brief Empty getPointIndices implementation as this leaf node does not store any
@@ -148,7 +148,7 @@ public:
   /** \brief Empty getPointIndex implementation as this leaf node does not store any
    * point indices.
    */
-  int
+  index_t
   getPointIndex() const
   {
     assert("getPointIndex: undefined point index");
@@ -197,7 +197,7 @@ public:
    * \param[in] data_arg index to be stored within leaf node.
    */
   void
-  addPointIndex(int data_arg)
+  addPointIndex(index_t data_arg)
   {
     data_ = data_arg;
   }
@@ -206,7 +206,7 @@ public:
    * point index
    * \return index stored within container.
    */
-  int
+  index_t
   getPointIndex() const
   {
     return data_;
@@ -242,7 +242,7 @@ public:
 
 protected:
   /** \brief Point index stored in octree. */
-  int data_;
+  index_t data_;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -276,7 +276,7 @@ public:
    * \param[in] data_arg index to be stored within leaf node.
    */
   void
-  addPointIndex(int data_arg)
+  addPointIndex(index_t data_arg)
   {
     leafDataTVector_.push_back(data_arg);
   }
@@ -285,7 +285,7 @@ public:
    * point indices.
    * \return index stored within container.
    */
-  int
+  index_t
   getPointIndex() const
   {
     return leafDataTVector_.back();

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <pcl/types.h>
+
 #include <cassert>
 #include <cstddef>
 #include <vector>
@@ -102,7 +104,7 @@ public:
    * data. \
    */
   void
-  getPointIndices(std::vector<int>&) const
+  getPointIndices(Indices&) const
   {}
 };
 
@@ -157,7 +159,7 @@ public:
    * data.
    */
   void
-  getPointIndices(std::vector<int>&) const
+  getPointIndices(Indices&) const
   {}
 };
 
@@ -216,7 +218,7 @@ public:
    * data vector
    */
   void
-  getPointIndices(std::vector<int>& data_vector_arg) const
+  getPointIndices(Indices& data_vector_arg) const
   {
     if (data_ >= 0)
       data_vector_arg.push_back(data_);
@@ -295,7 +297,7 @@ public:
    * within data vector
    */
   void
-  getPointIndices(std::vector<int>& data_vector_arg) const
+  getPointIndices(Indices& data_vector_arg) const
   {
     data_vector_arg.insert(
         data_vector_arg.end(), leafDataTVector_.begin(), leafDataTVector_.end());
@@ -305,7 +307,7 @@ public:
    * of point indices.
    * \return reference to vector of point indices to be stored within data vector
    */
-  std::vector<int>&
+  Indices&
   getPointIndicesVector()
   {
     return leafDataTVector_;
@@ -329,7 +331,7 @@ public:
 
 protected:
   /** \brief Leaf node DataT vector. */
-  std::vector<int> leafDataTVector_;
+  Indices leafDataTVector_;
 };
 
 } // namespace octree

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -82,8 +82,13 @@ public:
 
   /** \brief Empty constructor.
    */
-  explicit OctreeIteratorBase(uindex_t max_depth_arg = 0)
-  : octree_(0), current_state_(0), max_octree_depth_(max_depth_arg)
+  OctreeIteratorBase() : OctreeIteratorBase(nullptr, 0u) {}
+
+  /** \brief Constructor.
+   * \param[in] max_depth_arg Depth limitation during traversal
+   */
+  explicit OctreeIteratorBase(uindex_t max_depth_arg)
+  : octree_(nullptr), current_state_(nullptr), max_octree_depth_(max_depth_arg)
   {
     this->reset();
   }
@@ -93,7 +98,14 @@ public:
    * root node.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeIteratorBase(OctreeT* octree_arg, uindex_t max_depth_arg = 0)
+  OctreeIteratorBase(OctreeT* octree_arg) : OctreeIteratorBase(octree_arg, 0u) {}
+
+  /** \brief Constructor.
+   * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
+   * root node.
+   * \param[in] max_depth_arg Depth limitation during traversal
+   */
+  explicit OctreeIteratorBase(OctreeT* octree_arg, uindex_t max_depth_arg)
   : octree_(octree_arg), current_state_(0), max_octree_depth_(max_depth_arg)
   {
     this->reset();

--- a/octree/include/pcl/octree/octree_iterator.h
+++ b/octree/include/pcl/octree/octree_iterator.h
@@ -59,7 +59,7 @@ namespace octree {
 struct IteratorState {
   OctreeNode* node_;
   OctreeKey key_;
-  unsigned int depth_;
+  uindex_t depth_;
 };
 
 /** \brief @b Abstract octree iterator class
@@ -82,7 +82,7 @@ public:
 
   /** \brief Empty constructor.
    */
-  explicit OctreeIteratorBase(unsigned int max_depth_arg = 0)
+  explicit OctreeIteratorBase(uindex_t max_depth_arg = 0)
   : octree_(0), current_state_(0), max_octree_depth_(max_depth_arg)
   {
     this->reset();
@@ -93,7 +93,7 @@ public:
    * root node.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeIteratorBase(OctreeT* octree_arg, unsigned int max_depth_arg = 0)
+  explicit OctreeIteratorBase(OctreeT* octree_arg, uindex_t max_depth_arg = 0)
   : octree_(octree_arg), current_state_(0), max_octree_depth_(max_depth_arg)
   {
     this->reset();
@@ -108,7 +108,7 @@ public:
    *  \warning For advanced users only.
    */
   explicit OctreeIteratorBase(OctreeT* octree_arg,
-                              unsigned int max_depth_arg,
+                              uindex_t max_depth_arg,
                               IteratorState* current_state)
   : octree_(octree_arg), current_state_(current_state), max_octree_depth_(max_depth_arg)
   {}
@@ -169,7 +169,7 @@ public:
   /** \brief Get the current depth level of octree
    * \return depth level
    */
-  inline unsigned int
+  inline uindex_t
   getCurrentOctreeDepth() const
   {
     assert(octree_ != 0);
@@ -327,7 +327,7 @@ public:
     if (current_state_) {
       const OctreeKey& key = getCurrentOctreeKey();
       // calculate integer id with respect to octree key
-      unsigned int depth = octree_->getTreeDepth();
+      uindex_t depth = octree_->getTreeDepth();
       id = static_cast<unsigned long>(key.x) << (depth * 2) |
            static_cast<unsigned long>(key.y) << (depth * 1) |
            static_cast<unsigned long>(key.z) << (depth * 0);
@@ -344,7 +344,7 @@ protected:
   IteratorState* current_state_;
 
   /** \brief Maximum octree depth */
-  unsigned int max_octree_depth_;
+  uindex_t max_octree_depth_;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -364,15 +364,14 @@ public:
   /** \brief Empty constructor.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeDepthFirstIterator(unsigned int max_depth_arg = 0);
+  explicit OctreeDepthFirstIterator(uindex_t max_depth_arg = 0);
 
   /** \brief Constructor.
    * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
    * root node.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeDepthFirstIterator(OctreeT* octree_arg,
-                                    unsigned int max_depth_arg = 0);
+  explicit OctreeDepthFirstIterator(OctreeT* octree_arg, uindex_t max_depth_arg = 0);
 
   /** \brief Constructor.
    * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
@@ -384,7 +383,7 @@ public:
    */
   explicit OctreeDepthFirstIterator(
       OctreeT* octree_arg,
-      unsigned int max_depth_arg,
+      uindex_t max_depth_arg,
       IteratorState* current_state,
       const std::vector<IteratorState>& stack = std::vector<IteratorState>())
   : OctreeIteratorBase<OctreeT>(octree_arg, max_depth_arg, current_state), stack_(stack)
@@ -469,15 +468,14 @@ public:
   /** \brief Empty constructor.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeBreadthFirstIterator(unsigned int max_depth_arg = 0);
+  explicit OctreeBreadthFirstIterator(uindex_t max_depth_arg = 0);
 
   /** \brief Constructor.
    * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
    * root node.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeBreadthFirstIterator(OctreeT* octree_arg,
-                                      unsigned int max_depth_arg = 0);
+  explicit OctreeBreadthFirstIterator(OctreeT* octree_arg, uindex_t max_depth_arg = 0);
 
   /** \brief Constructor.
    * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
@@ -489,7 +487,7 @@ public:
    */
   explicit OctreeBreadthFirstIterator(
       OctreeT* octree_arg,
-      unsigned int max_depth_arg,
+      uindex_t max_depth_arg,
       IteratorState* current_state,
       const std::deque<IteratorState>& fifo = std::deque<IteratorState>())
   : OctreeIteratorBase<OctreeT>(octree_arg, max_depth_arg, current_state), FIFO_(fifo)
@@ -575,8 +573,7 @@ public:
    * root node.
    * \param[in] fixed_depth_arg Depth level during traversal
    */
-  explicit OctreeFixedDepthIterator(OctreeT* octree_arg,
-                                    unsigned int fixed_depth_arg = 0);
+  explicit OctreeFixedDepthIterator(OctreeT* octree_arg, uindex_t fixed_depth_arg = 0);
 
   /** \brief Constructor.
    * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
@@ -589,7 +586,7 @@ public:
    */
   OctreeFixedDepthIterator(
       OctreeT* octree_arg,
-      unsigned int fixed_depth_arg,
+      uindex_t fixed_depth_arg,
       IteratorState* current_state,
       const std::deque<IteratorState>& fifo = std::deque<IteratorState>())
   : OctreeBreadthFirstIterator<OctreeT>(
@@ -623,7 +620,7 @@ public:
    * \param[in] fixed_depth_arg Depth level during traversal
    */
   void
-  reset(unsigned int fixed_depth_arg);
+  reset(uindex_t fixed_depth_arg);
 
   /** \brief Reset the iterator to the first node at the current depth
    */
@@ -637,7 +634,7 @@ protected:
   using OctreeBreadthFirstIterator<OctreeT>::FIFO_;
 
   /** \brief Given level of the node to be iterated */
-  unsigned int fixed_depth_;
+  uindex_t fixed_depth_;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -657,7 +654,7 @@ public:
   /** \brief Empty constructor.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeLeafNodeDepthFirstIterator(unsigned int max_depth_arg = 0)
+  explicit OctreeLeafNodeDepthFirstIterator(uindex_t max_depth_arg = 0)
   : OctreeDepthFirstIterator<OctreeT>(max_depth_arg)
   {
     reset();
@@ -669,7 +666,7 @@ public:
    * \param[in] max_depth_arg Depth limitation during traversal
    */
   explicit OctreeLeafNodeDepthFirstIterator(OctreeT* octree_arg,
-                                            unsigned int max_depth_arg = 0)
+                                            uindex_t max_depth_arg = 0)
   : OctreeDepthFirstIterator<OctreeT>(octree_arg, max_depth_arg)
   {
     reset();
@@ -685,7 +682,7 @@ public:
    */
   explicit OctreeLeafNodeDepthFirstIterator(
       OctreeT* octree_arg,
-      unsigned int max_depth_arg,
+      uindex_t max_depth_arg,
       IteratorState* current_state,
       const std::vector<IteratorState>& stack = std::vector<IteratorState>())
   : OctreeDepthFirstIterator<OctreeT>(octree_arg, max_depth_arg, current_state, stack)
@@ -759,7 +756,7 @@ public:
   /** \brief Empty constructor.
    * \param[in] max_depth_arg Depth limitation during traversal
    */
-  explicit OctreeLeafNodeBreadthFirstIterator(unsigned int max_depth_arg = 0);
+  explicit OctreeLeafNodeBreadthFirstIterator(uindex_t max_depth_arg = 0);
 
   /** \brief Constructor.
    * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
@@ -767,7 +764,7 @@ public:
    * \param[in] max_depth_arg Depth limitation during traversal
    */
   explicit OctreeLeafNodeBreadthFirstIterator(OctreeT* octree_arg,
-                                              unsigned int max_depth_arg = 0);
+                                              uindex_t max_depth_arg = 0);
 
   /** \brief Copy constructor.
    * \param[in] octree_arg Octree to be iterated. Initially the iterator is set to its
@@ -780,7 +777,7 @@ public:
    */
   explicit OctreeLeafNodeBreadthFirstIterator(
       OctreeT* octree_arg,
-      unsigned int max_depth_arg,
+      uindex_t max_depth_arg,
       IteratorState* current_state,
       const std::deque<IteratorState>& fifo = std::deque<IteratorState>());
 

--- a/octree/include/pcl/octree/octree_key.h
+++ b/octree/include/pcl/octree/octree_key.h
@@ -55,9 +55,7 @@ public:
   OctreeKey() : x(0), y(0), z(0) {}
 
   /** \brief Constructor for key initialization. */
-  OctreeKey(unsigned int keyX, unsigned int keyY, unsigned int keyZ)
-  : x(keyX), y(keyY), z(keyZ)
-  {}
+  OctreeKey(uindex_t keyX, uindex_t keyY, uindex_t keyZ) : x(keyX), y(keyY), z(keyZ) {}
 
   /** \brief Copy constructor. */
   OctreeKey(const OctreeKey& source) { std::memcpy(key_, source.key_, sizeof(key_)); }
@@ -131,7 +129,7 @@ public:
    *  \return child node index
    * */
   inline unsigned char
-  getChildIdxWithDepthMask(unsigned int depthMask) const
+  getChildIdxWithDepthMask(uindex_t depthMask) const
   {
     return static_cast<unsigned char>(((!!(this->x & depthMask)) << 2) |
                                       ((!!(this->y & depthMask)) << 1) |

--- a/octree/include/pcl/octree/octree_key.h
+++ b/octree/include/pcl/octree/octree_key.h
@@ -140,17 +140,17 @@ public:
 
   /* \brief maximum depth that can be addressed */
   static const unsigned char maxDepth =
-      static_cast<unsigned char>(sizeof(std::uint32_t) * 8);
+      static_cast<unsigned char>(sizeof(uindex_t) * 8);
 
   // Indices addressing a voxel at (X, Y, Z)
 
   union {
     struct {
-      std::uint32_t x;
-      std::uint32_t y;
-      std::uint32_t z;
+      uindex_t x;
+      uindex_t y;
+      uindex_t z;
     };
-    std::uint32_t key_[3];
+    uindex_t key_[3];
   };
 };
 } // namespace octree

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -82,8 +82,8 @@ public:
   OctreePointCloud(const double resolution_arg);
 
   // public typedefs
-  using IndicesPtr = shared_ptr<std::vector<int>>;
-  using IndicesConstPtr = shared_ptr<const std::vector<int>>;
+  using IndicesPtr = shared_ptr<Indices>;
+  using IndicesConstPtr = shared_ptr<const Indices>;
 
   using PointCloud = pcl::PointCloud<PointT>;
   using PointCloudPtr = typename PointCloud::Ptr;

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -200,7 +200,7 @@ public:
    * setInputCloud)
    */
   void
-  addPointFromCloud(const int point_idx_arg, IndicesPtr indices_arg);
+  addPointFromCloud(index_t point_idx_arg, IndicesPtr indices_arg);
 
   /** \brief Add point simultaneously to octree and input point cloud.
    *  \param[in] point_arg point to be added
@@ -258,14 +258,14 @@ public:
    * \return "true" if voxel exist; "false" otherwise
    */
   bool
-  isVoxelOccupiedAtPoint(const int& point_idx_arg) const;
+  isVoxelOccupiedAtPoint(const index_t& point_idx_arg) const;
 
   /** \brief Get a PointT vector of centers of all occupied voxels.
    * \param[out] voxel_center_list_arg results are written to this vector of PointT
    * elements
    * \return number of occupied voxels
    */
-  int
+  uindex_t
   getOccupiedVoxelCenters(AlignedPointTVector& voxel_center_list_arg) const;
 
   /** \brief Get a PointT vector of centers of voxels intersected by a line segment.
@@ -295,7 +295,7 @@ public:
    *  \param[in] point_idx_arg index of point addressing the voxel to be deleted.
    */
   void
-  deleteVoxelAtPoint(const int& point_idx_arg);
+  deleteVoxelAtPoint(const index_t& point_idx_arg);
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Bounding box methods
@@ -428,7 +428,7 @@ protected:
    * \a setInputCloud to be added
    */
   virtual void
-  addPointIdx(const int point_idx_arg);
+  addPointIdx(index_t point_idx_arg);
 
   /** \brief Add point at index from input pointcloud dataset to octree
    * \param[in] leaf_node to be expanded
@@ -448,7 +448,7 @@ protected:
    * \return PointT from input pointcloud dataset
    */
   const PointT&
-  getPointByIndex(const unsigned int index_arg) const;
+  getPointByIndex(index_t index_arg) const;
 
   /** \brief Find octree leaf node at a given point
    * \param[in] point_arg query point
@@ -520,7 +520,7 @@ protected:
    * are assignable
    */
   virtual bool
-  genOctreeKeyForDataT(const int& data_arg, OctreeKey& key_arg) const;
+  genOctreeKeyForDataT(const index_t& data_arg, OctreeKey& key_arg) const;
 
   /** \brief Generate a point at center of leaf node voxel
    * \param[in] key_arg octree key addressing a leaf node.
@@ -560,7 +560,7 @@ protected:
    * elements
    * \return number of voxels found
    */
-  int
+  uindex_t
   getOccupiedVoxelCentersRecursive(const BranchNode* node_arg,
                                    const OctreeKey& key_arg,
                                    AlignedPointTVector& voxel_center_list_arg) const;

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -200,7 +200,7 @@ public:
    * setInputCloud)
    */
   void
-  addPointFromCloud(index_t point_idx_arg, IndicesPtr indices_arg);
+  addPointFromCloud(uindex_t point_idx_arg, IndicesPtr indices_arg);
 
   /** \brief Add point simultaneously to octree and input point cloud.
    *  \param[in] point_arg point to be added
@@ -428,7 +428,7 @@ protected:
    * \a setInputCloud to be added
    */
   virtual void
-  addPointIdx(index_t point_idx_arg);
+  addPointIdx(uindex_t point_idx_arg);
 
   /** \brief Add point at index from input pointcloud dataset to octree
    * \param[in] leaf_node to be expanded
@@ -448,7 +448,7 @@ protected:
    * \return PointT from input pointcloud dataset
    */
   const PointT&
-  getPointByIndex(index_t index_arg) const;
+  getPointByIndex(uindex_t index_arg) const;
 
   /** \brief Find octree leaf node at a given point
    * \param[in] point_arg query point

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -279,7 +279,7 @@ public:
    * octree_resolution x precision
    * \return number of intersected voxels
    */
-  int
+  index_t
   getApproxIntersectedVoxelCentersBySegment(const Eigen::Vector3f& origin,
                                             const Eigen::Vector3f& end,
                                             AlignedPointTVector& voxel_center_list,

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -279,7 +279,7 @@ public:
    * octree_resolution x precision
    * \return number of intersected voxels
    */
-  index_t
+  uindex_t
   getApproxIntersectedVoxelCentersBySegment(const Eigen::Vector3f& origin,
                                             const Eigen::Vector3f& end,
                                             AlignedPointTVector& voxel_center_list,

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -365,7 +365,7 @@ public:
    * \return squared diameter
    */
   double
-  getVoxelSquaredDiameter(unsigned int tree_depth_arg) const;
+  getVoxelSquaredDiameter(uindex_t tree_depth_arg) const;
 
   /** \brief Calculates the squared diameter of a voxel at leaf depth
    * \return squared diameter
@@ -381,7 +381,7 @@ public:
    * \return squared voxel cube side length
    */
   double
-  getVoxelSquaredSideLen(unsigned int tree_depth_arg) const;
+  getVoxelSquaredSideLen(uindex_t tree_depth_arg) const;
 
   /** \brief Calculates the squared voxel cube side length at leaf level
    * \return squared voxel cube side length
@@ -536,7 +536,7 @@ protected:
    */
   void
   genVoxelCenterFromOctreeKey(const OctreeKey& key_arg,
-                              unsigned int tree_depth_arg,
+                              uindex_t tree_depth_arg,
                               PointT& point_arg) const;
 
   /** \brief Generate bounds of an octree voxel using octree key and tree depth
@@ -548,7 +548,7 @@ protected:
    */
   void
   genVoxelBoundsFromOctreeKey(const OctreeKey& key_arg,
-                              unsigned int tree_depth_arg,
+                              uindex_t tree_depth_arg,
                               Eigen::Vector3f& min_pt,
                               Eigen::Vector3f& max_pt) const;
 

--- a/octree/include/pcl/octree/octree_pointcloud.h
+++ b/octree/include/pcl/octree/octree_pointcloud.h
@@ -183,7 +183,7 @@ public:
   /** \brief Get the maximum depth of the octree.
    *  \return depth_arg: maximum depth of octree
    * */
-  inline unsigned int
+  inline uindex_t
   getTreeDepth() const
   {
     return this->octree_depth_;
@@ -440,7 +440,7 @@ protected:
   expandLeafNode(LeafNode* leaf_node,
                  BranchNode* parent_branch,
                  unsigned char child_idx,
-                 unsigned int depth_mask);
+                 uindex_t depth_mask);
 
   /** \brief Get point at index from input pointcloud dataset
    * \param[in] index_arg index representing the point in the dataset given by \a

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency.h
@@ -195,7 +195,7 @@ protected:
    * \note This virtual implementation allows the use of a transform function to compute
    * keys. */
   void
-  addPointIdx(index_t point_idx_arg) override;
+  addPointIdx(uindex_t point_idx_arg) override;
 
   /** \brief Fills in the neighbors fields for new voxels.
    *

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency.h
@@ -195,7 +195,7 @@ protected:
    * \note This virtual implementation allows the use of a transform function to compute
    * keys. */
   void
-  addPointIdx(const int point_idx_arg) override;
+  addPointIdx(index_t point_idx_arg) override;
 
   /** \brief Fills in the neighbors fields for new voxels.
    *

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
@@ -94,7 +94,7 @@ public:
   }
 
   /** \brief Gets the number of points contributing to this leaf */
-  int
+  uindex_t
   getPointCounter() const
   {
     return num_points_;
@@ -122,7 +122,7 @@ public:
   index_t
   getSize() const override
   {
-    return num_points_;
+    return static_cast<index_t>(num_points_);
   }
 
 protected:

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
@@ -119,7 +119,7 @@ public:
   /** \brief  virtual method to get size of container
    * \return number of points added to leaf node container.
    */
-  std::size_t
+  index_t
   getSize() const override
   {
     return num_points_;

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
@@ -170,7 +170,7 @@ protected:
 
   /** \brief Sets the number of points contributing to this leaf */
   void
-  setPointCounter(int points_arg)
+  setPointCounter(uindex_t points_arg)
   {
     num_points_ = points_arg;
   }
@@ -218,7 +218,7 @@ protected:
   }
 
 private:
-  int num_points_;
+  uindex_t num_points_;
   NeighborListT neighbors_;
   DataT data_;
 };

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
@@ -119,10 +119,10 @@ public:
   /** \brief  virtual method to get size of container
    * \return number of points added to leaf node container.
    */
-  index_t
+  uindex_t
   getSize() const override
   {
-    return static_cast<index_t>(num_points_);
+    return num_points_;
   }
 
 protected:

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -92,14 +92,14 @@ public:
    */
   std::size_t
   getPointIndicesFromNewVoxels(Indices& indicesVector_arg,
-                               const int minPointsPerLeaf_arg = 0)
+                               const index_t minPointsPerLeaf_arg = 0)
   {
 
     std::vector<OctreeContainerPointIndices*> leaf_containers;
     this->serializeNewLeafs(leaf_containers);
 
     for (const auto& leaf_container : leaf_containers) {
-      if (static_cast<int>(leaf_container->getSize()) >= minPointsPerLeaf_arg)
+      if (static_cast<index_t>(leaf_container->getSize()) >= minPointsPerLeaf_arg)
         leaf_container->getPointIndices(indicesVector_arg);
     }
 

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -92,14 +92,14 @@ public:
    */
   std::size_t
   getPointIndicesFromNewVoxels(Indices& indicesVector_arg,
-                               const index_t minPointsPerLeaf_arg = 0)
+                               const uindex_t minPointsPerLeaf_arg = 0)
   {
 
     std::vector<OctreeContainerPointIndices*> leaf_containers;
     this->serializeNewLeafs(leaf_containers);
 
     for (const auto& leaf_container : leaf_containers) {
-      if (static_cast<index_t>(leaf_container->getSize()) >= minPointsPerLeaf_arg)
+      if (static_cast<uindex_t>(leaf_container->getSize()) >= minPointsPerLeaf_arg)
         leaf_container->getPointIndices(indicesVector_arg);
     }
 

--- a/octree/include/pcl/octree/octree_pointcloud_changedetector.h
+++ b/octree/include/pcl/octree/octree_pointcloud_changedetector.h
@@ -91,7 +91,7 @@ public:
    * \return number of point indices
    */
   std::size_t
-  getPointIndicesFromNewVoxels(std::vector<int>& indicesVector_arg,
+  getPointIndicesFromNewVoxels(Indices& indicesVector_arg,
                                const int minPointsPerLeaf_arg = 0)
   {
 

--- a/octree/include/pcl/octree/octree_pointcloud_density.h
+++ b/octree/include/pcl/octree/octree_pointcloud_density.h
@@ -76,12 +76,12 @@ public:
 
   /** \brief Read input data. Only an internal counter is increased.
    */
-  void addPointIndex(index_t) { point_counter_++; }
+  void addPointIndex(uindex_t) { point_counter_++; }
 
   /** \brief Return point counter.
    * \return Amount of points
    */
-  unsigned int
+  uindex_t
   getPointCounter()
   {
     return (point_counter_);

--- a/octree/include/pcl/octree/octree_pointcloud_density.h
+++ b/octree/include/pcl/octree/octree_pointcloud_density.h
@@ -76,11 +76,7 @@ public:
 
   /** \brief Read input data. Only an internal counter is increased.
    */
-  void
-  addPointIndex(int)
-  {
-    point_counter_++;
-  }
+  void addPointIndex(index_t) { point_counter_++; }
 
   /** \brief Return point counter.
    * \return Amount of points
@@ -99,7 +95,7 @@ public:
   }
 
 private:
-  unsigned int point_counter_;
+  uindex_t point_counter_;
 };
 
 /** \brief @b Octree pointcloud density class
@@ -136,7 +132,7 @@ public:
   unsigned int
   getVoxelDensityAtPoint(const PointT& point_arg) const
   {
-    unsigned int point_count = 0;
+    uindex_t point_count = 0;
 
     OctreePointCloudDensityContainer* leaf = this->findLeafAtPoint(point_arg);
 

--- a/octree/include/pcl/octree/octree_pointcloud_density.h
+++ b/octree/include/pcl/octree/octree_pointcloud_density.h
@@ -129,7 +129,7 @@ public:
    * \param[in] point_arg: a point addressing a voxel \return amount of points
    * that fall within leaf node voxel
    */
-  unsigned int
+  uindex_t
   getVoxelDensityAtPoint(const PointT& point_arg) const
   {
     uindex_t point_count = 0;

--- a/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
+++ b/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
@@ -114,7 +114,7 @@ public:
   }
 
 private:
-  unsigned int point_counter_;
+  uindex_t point_counter_;
   PointT point_sum_;
 };
 
@@ -156,11 +156,11 @@ public:
    * \param pointIdx_arg
    */
   void
-  addPointIdx(const int pointIdx_arg) override
+  addPointIdx(const index_t pointIdx_arg) override
   {
     OctreeKey key;
 
-    assert(pointIdx_arg < static_cast<int>(this->input_->size()));
+    assert(pointIdx_arg < this->input_->size());
 
     const PointT& point = (*this->input_)[pointIdx_arg];
 
@@ -190,7 +190,8 @@ public:
    * \return "true" if voxel is found; "false" otherwise
    */
   inline bool
-  getVoxelCentroidAtPoint(const int& point_idx_arg, PointT& voxel_centroid_arg) const
+  getVoxelCentroidAtPoint(const index_t& point_idx_arg,
+                          PointT& voxel_centroid_arg) const
   {
     // get centroid at point
     return (this->getVoxelCentroidAtPoint((*this->input_)[point_idx_arg],
@@ -202,7 +203,7 @@ public:
    * elements
    * \return number of occupied voxels
    */
-  std::size_t
+  uindex_t
   getVoxelCentroids(
       typename OctreePointCloud<PointT, LeafContainerT, BranchContainerT>::
           AlignedPointTVector& voxel_centroid_list_arg) const;

--- a/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
+++ b/octree/include/pcl/octree/octree_pointcloud_voxelcentroid.h
@@ -156,7 +156,7 @@ public:
    * \param pointIdx_arg
    */
   void
-  addPointIdx(const index_t pointIdx_arg) override
+  addPointIdx(const uindex_t pointIdx_arg) override
   {
     OctreeKey key;
 

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -58,8 +58,8 @@ class OctreePointCloudSearch
 : public OctreePointCloud<PointT, LeafContainerT, BranchContainerT> {
 public:
   // public typedefs
-  using IndicesPtr = shared_ptr<std::vector<int>>;
-  using IndicesConstPtr = shared_ptr<const std::vector<int>>;
+  using IndicesPtr = shared_ptr<Indices>;
+  using IndicesConstPtr = shared_ptr<const Indices>;
 
   using PointCloud = pcl::PointCloud<PointT>;
   using PointCloudPtr = typename PointCloud::Ptr;
@@ -91,7 +91,7 @@ public:
    * \return "true" if leaf node exist; "false" otherwise
    */
   bool
-  voxelSearch(const PointT& point, std::vector<int>& point_idx_data);
+  voxelSearch(const PointT& point, Indices& point_idx_data);
 
   /** \brief Search for neighbors within a voxel at given point referenced by a point
    * index
@@ -100,7 +100,7 @@ public:
    * \return "true" if leaf node exist; "false" otherwise
    */
   bool
-  voxelSearch(const int index, std::vector<int>& point_idx_data);
+  voxelSearch(const int index, Indices& point_idx_data);
 
   /** \brief Search for k-nearest neighbors at the query point.
    * \param[in] cloud the point cloud data
@@ -116,7 +116,7 @@ public:
   nearestKSearch(const PointCloud& cloud,
                  int index,
                  int k,
-                 std::vector<int>& k_indices,
+                 Indices& k_indices,
                  std::vector<float>& k_sqr_distances)
   {
     return (nearestKSearch(cloud[index], k, k_indices, k_sqr_distances));
@@ -134,7 +134,7 @@ public:
   int
   nearestKSearch(const PointT& p_q,
                  int k,
-                 std::vector<int>& k_indices,
+                 Indices& k_indices,
                  std::vector<float>& k_sqr_distances);
 
   /** \brief Search for k-nearest neighbors at query point
@@ -151,7 +151,7 @@ public:
   int
   nearestKSearch(int index,
                  int k,
-                 std::vector<int>& k_indices,
+                 Indices& k_indices,
                  std::vector<float>& k_sqr_distances);
 
   /** \brief Search for approx. nearest neighbor at the query point.
@@ -203,7 +203,7 @@ public:
   radiusSearch(const PointCloud& cloud,
                int index,
                double radius,
-               std::vector<int>& k_indices,
+               Indices& k_indices,
                std::vector<float>& k_sqr_distances,
                unsigned int max_nn = 0)
   {
@@ -222,7 +222,7 @@ public:
   int
   radiusSearch(const PointT& p_q,
                const double radius,
-               std::vector<int>& k_indices,
+               Indices& k_indices,
                std::vector<float>& k_sqr_distances,
                unsigned int max_nn = 0) const;
 
@@ -240,7 +240,7 @@ public:
   int
   radiusSearch(int index,
                const double radius,
-               std::vector<int>& k_indices,
+               Indices& k_indices,
                std::vector<float>& k_sqr_distances,
                unsigned int max_nn = 0) const;
 
@@ -270,7 +270,7 @@ public:
   int
   getIntersectedVoxelIndices(Eigen::Vector3f origin,
                              Eigen::Vector3f direction,
-                             std::vector<int>& k_indices,
+                             Indices& k_indices,
                              int max_voxel_count = 0) const;
 
   /** \brief Search for points within rectangular search area
@@ -283,7 +283,7 @@ public:
   int
   boxSearch(const Eigen::Vector3f& min_pt,
             const Eigen::Vector3f& max_pt,
-            std::vector<int>& k_indices) const;
+            Indices& k_indices) const;
 
 protected:
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -389,7 +389,7 @@ protected:
                                     const BranchNode* node,
                                     const OctreeKey& key,
                                     unsigned int tree_depth,
-                                    std::vector<int>& k_indices,
+                                    Indices& k_indices,
                                     std::vector<float>& k_sqr_distances,
                                     unsigned int max_nn) const;
 
@@ -477,7 +477,7 @@ protected:
                      const BranchNode* node,
                      const OctreeKey& key,
                      unsigned int tree_depth,
-                     std::vector<int>& k_indices) const;
+                     Indices& k_indices) const;
 
   /** \brief Recursively search the tree for all intersected leaf nodes and return a
    * vector of indices. This algorithm is based off the paper An Efficient Parametric
@@ -506,7 +506,7 @@ protected:
                                       unsigned char a,
                                       const OctreeNode* node,
                                       const OctreeKey& key,
-                                      std::vector<int>& k_indices,
+                                      Indices& k_indices,
                                       int max_voxel_count) const;
 
   /** \brief Initialize raytracing algorithm

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -388,7 +388,7 @@ protected:
                                     const double radiusSquared,
                                     const BranchNode* node,
                                     const OctreeKey& key,
-                                    unsigned int tree_depth,
+                                    uindex_t tree_depth,
                                     Indices& k_indices,
                                     std::vector<float>& k_sqr_distances,
                                     uindex_t max_nn) const;
@@ -410,7 +410,7 @@ protected:
       uindex_t K,
       const BranchNode* node,
       const OctreeKey& key,
-      unsigned int tree_depth,
+      uindex_t tree_depth,
       const double squared_search_radius,
       std::vector<prioPointQueueEntry>& point_candidates) const;
 
@@ -427,7 +427,7 @@ protected:
   approxNearestSearchRecursive(const PointT& point,
                                const BranchNode* node,
                                const OctreeKey& key,
-                               unsigned int tree_depth,
+                               uindex_t tree_depth,
                                index_t& result_index,
                                float& sqr_distance);
 
@@ -476,7 +476,7 @@ protected:
                      const Eigen::Vector3f& max_pt,
                      const BranchNode* node,
                      const OctreeKey& key,
-                     unsigned int tree_depth,
+                     uindex_t tree_depth,
                      Indices& k_indices) const;
 
   /** \brief Recursively search the tree for all intersected leaf nodes and return a

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -100,7 +100,7 @@ public:
    * \return "true" if leaf node exist; "false" otherwise
    */
   bool
-  voxelSearch(const int index, Indices& point_idx_data);
+  voxelSearch(const index_t index, Indices& point_idx_data);
 
   /** \brief Search for k-nearest neighbors at the query point.
    * \param[in] cloud the point cloud data
@@ -112,10 +112,10 @@ public:
    * points (must be resized to \a k a priori!)
    * \return number of neighbors found
    */
-  inline int
+  inline uindex_t
   nearestKSearch(const PointCloud& cloud,
-                 int index,
-                 int k,
+                 index_t index,
+                 uindex_t k,
                  Indices& k_indices,
                  std::vector<float>& k_sqr_distances)
   {
@@ -131,9 +131,9 @@ public:
    * points (must be resized to k a priori!)
    * \return number of neighbors found
    */
-  int
+  uindex_t
   nearestKSearch(const PointT& p_q,
-                 int k,
+                 uindex_t k,
                  Indices& k_indices,
                  std::vector<float>& k_sqr_distances);
 
@@ -148,9 +148,9 @@ public:
    * points (must be resized to \a k a priori!)
    * \return number of neighbors found
    */
-  int
-  nearestKSearch(int index,
-                 int k,
+  uindex_t
+  nearestKSearch(index_t index,
+                 uindex_t k,
                  Indices& k_indices,
                  std::vector<float>& k_sqr_distances);
 
@@ -163,8 +163,8 @@ public:
    */
   inline void
   approxNearestSearch(const PointCloud& cloud,
-                      int query_index,
-                      int& result_index,
+                      index_t query_index,
+                      index_t& result_index,
                       float& sqr_distance)
   {
     return (approxNearestSearch(cloud[query_index], result_index, sqr_distance));
@@ -176,7 +176,7 @@ public:
    * \param[out] sqr_distance the resultant squared distance to the neighboring point
    */
   void
-  approxNearestSearch(const PointT& p_q, int& result_index, float& sqr_distance);
+  approxNearestSearch(const PointT& p_q, index_t& result_index, float& sqr_distance);
 
   /** \brief Search for approx. nearest neighbor at the query point.
    * \param[in] query_index index representing the query point in the dataset given by
@@ -187,7 +187,7 @@ public:
    * \return number of neighbors found
    */
   void
-  approxNearestSearch(int query_index, int& result_index, float& sqr_distance);
+  approxNearestSearch(index_t query_index, index_t& result_index, float& sqr_distance);
 
   /** \brief Search for all neighbors of query point that are within a given radius.
    * \param[in] cloud the point cloud data
@@ -199,13 +199,13 @@ public:
    * \param[in] max_nn if given, bounds the maximum returned neighbors to this value
    * \return number of neighbors found in radius
    */
-  int
+  uindex_t
   radiusSearch(const PointCloud& cloud,
-               int index,
+               index_t index,
                double radius,
                Indices& k_indices,
                std::vector<float>& k_sqr_distances,
-               unsigned int max_nn = 0)
+               index_t max_nn = 0)
   {
     return (radiusSearch(cloud[index], radius, k_indices, k_sqr_distances, max_nn));
   }
@@ -219,12 +219,12 @@ public:
    * \param[in] max_nn if given, bounds the maximum returned neighbors to this value
    * \return number of neighbors found in radius
    */
-  int
+  uindex_t
   radiusSearch(const PointT& p_q,
                const double radius,
                Indices& k_indices,
                std::vector<float>& k_sqr_distances,
-               unsigned int max_nn = 0) const;
+               uindex_t max_nn = 0) const;
 
   /** \brief Search for all neighbors of query point that are within a given radius.
    * \param[in] index index representing the query point in the dataset given by \a
@@ -237,12 +237,12 @@ public:
    * \param[in] max_nn if given, bounds the maximum returned neighbors to this value
    * \return number of neighbors found in radius
    */
-  int
-  radiusSearch(int index,
+  uindex_t
+  radiusSearch(index_t index,
                const double radius,
                Indices& k_indices,
                std::vector<float>& k_sqr_distances,
-               unsigned int max_nn = 0) const;
+               uindex_t max_nn = 0) const;
 
   /** \brief Get a PointT vector of centers of all voxels that intersected by a ray
    * (origin, direction).
@@ -253,11 +253,11 @@ public:
    * disable)
    * \return number of intersected voxels
    */
-  int
+  uindex_t
   getIntersectedVoxelCenters(Eigen::Vector3f origin,
                              Eigen::Vector3f direction,
                              AlignedPointTVector& voxel_center_list,
-                             int max_voxel_count = 0) const;
+                             uindex_t max_voxel_count = 0) const;
 
   /** \brief Get indices of all voxels that are intersected by a ray (origin,
    * direction).
@@ -267,11 +267,11 @@ public:
    * disable)
    * \return number of intersected voxels
    */
-  int
+  uindex_t
   getIntersectedVoxelIndices(Eigen::Vector3f origin,
                              Eigen::Vector3f direction,
                              Indices& k_indices,
-                             int max_voxel_count = 0) const;
+                             uindex_t max_voxel_count = 0) const;
 
   /** \brief Search for points within rectangular search area
    * Points exactly on the edges of the search rectangle are included.
@@ -280,7 +280,7 @@ public:
    * \param[out] k_indices the resultant point indices
    * \return number of points found within search area
    */
-  int
+  uindex_t
   boxSearch(const Eigen::Vector3f& min_pt,
             const Eigen::Vector3f& max_pt,
             Indices& k_indices) const;
@@ -341,7 +341,7 @@ protected:
      * \param[in] point_idx index for a dataset point given by \a setInputCloud
      * \param[in] point_distance distance of query point to voxel center
      */
-    prioPointQueueEntry(unsigned int& point_idx, float point_distance)
+    prioPointQueueEntry(index_t point_idx, float point_distance)
     : point_idx_(point_idx), point_distance_(point_distance)
     {}
 
@@ -355,7 +355,7 @@ protected:
     }
 
     /** \brief Index representing a point in the dataset given by \a setInputCloud. */
-    int point_idx_;
+    index_t point_idx_;
 
     /** \brief Distance to query point. */
     float point_distance_;
@@ -391,7 +391,7 @@ protected:
                                     unsigned int tree_depth,
                                     Indices& k_indices,
                                     std::vector<float>& k_sqr_distances,
-                                    unsigned int max_nn) const;
+                                    uindex_t max_nn) const;
 
   /** \brief Recursive search method that explores the octree and finds the K nearest
    * neighbors
@@ -407,7 +407,7 @@ protected:
   double
   getKNearestNeighborRecursive(
       const PointT& point,
-      unsigned int K,
+      uindex_t K,
       const BranchNode* node,
       const OctreeKey& key,
       unsigned int tree_depth,
@@ -428,7 +428,7 @@ protected:
                                const BranchNode* node,
                                const OctreeKey& key,
                                unsigned int tree_depth,
-                               int& result_index,
+                               index_t& result_index,
                                float& sqr_distance);
 
   /** \brief Recursively search the tree for all intersected leaf nodes and return a
@@ -449,7 +449,7 @@ protected:
    * disable)
    * \return number of voxels found
    */
-  int
+  uindex_t
   getIntersectedVoxelCentersRecursive(double min_x,
                                       double min_y,
                                       double min_z,
@@ -460,7 +460,7 @@ protected:
                                       const OctreeNode* node,
                                       const OctreeKey& key,
                                       AlignedPointTVector& voxel_center_list,
-                                      int max_voxel_count) const;
+                                      uindex_t max_voxel_count) const;
 
   /** \brief Recursive search method that explores the octree and finds points within a
    * rectangular search area
@@ -496,7 +496,7 @@ protected:
    * disable)
    * \return number of voxels found
    */
-  int
+  uindex_t
   getIntersectedVoxelIndicesRecursive(double min_x,
                                       double min_y,
                                       double min_z,
@@ -507,7 +507,7 @@ protected:
                                       const OctreeNode* node,
                                       const OctreeKey& key,
                                       Indices& k_indices,
-                                      int max_voxel_count) const;
+                                      uindex_t max_voxel_count) const;
 
   /** \brief Initialize raytracing algorithm
    * \param origin

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -100,7 +100,7 @@ public:
    * \return "true" if leaf node exist; "false" otherwise
    */
   bool
-  voxelSearch(const index_t index, Indices& point_idx_data);
+  voxelSearch(uindex_t index, Indices& point_idx_data);
 
   /** \brief Search for k-nearest neighbors at the query point.
    * \param[in] cloud the point cloud data
@@ -114,7 +114,7 @@ public:
    */
   inline uindex_t
   nearestKSearch(const PointCloud& cloud,
-                 index_t index,
+                 uindex_t index,
                  uindex_t k,
                  Indices& k_indices,
                  std::vector<float>& k_sqr_distances)
@@ -149,7 +149,7 @@ public:
    * \return number of neighbors found
    */
   uindex_t
-  nearestKSearch(index_t index,
+  nearestKSearch(uindex_t index,
                  uindex_t k,
                  Indices& k_indices,
                  std::vector<float>& k_sqr_distances);
@@ -163,7 +163,7 @@ public:
    */
   inline void
   approxNearestSearch(const PointCloud& cloud,
-                      index_t query_index,
+                      uindex_t query_index,
                       index_t& result_index,
                       float& sqr_distance)
   {
@@ -187,7 +187,7 @@ public:
    * \return number of neighbors found
    */
   void
-  approxNearestSearch(index_t query_index, index_t& result_index, float& sqr_distance);
+  approxNearestSearch(uindex_t query_index, index_t& result_index, float& sqr_distance);
 
   /** \brief Search for all neighbors of query point that are within a given radius.
    * \param[in] cloud the point cloud data
@@ -201,7 +201,7 @@ public:
    */
   uindex_t
   radiusSearch(const PointCloud& cloud,
-               index_t index,
+               uindex_t index,
                double radius,
                Indices& k_indices,
                std::vector<float>& k_sqr_distances,
@@ -238,7 +238,7 @@ public:
    * \return number of neighbors found in radius
    */
   uindex_t
-  radiusSearch(index_t index,
+  radiusSearch(uindex_t index,
                const double radius,
                Indices& k_indices,
                std::vector<float>& k_sqr_distances,
@@ -341,7 +341,7 @@ protected:
      * \param[in] point_idx index for a dataset point given by \a setInputCloud
      * \param[in] point_distance distance of query point to voxel center
      */
-    prioPointQueueEntry(index_t point_idx, float point_distance)
+    prioPointQueueEntry(uindex_t point_idx, float point_distance)
     : point_idx_(point_idx), point_distance_(point_distance)
     {}
 
@@ -355,7 +355,7 @@ protected:
     }
 
     /** \brief Index representing a point in the dataset given by \a setInputCloud. */
-    index_t point_idx_;
+    uindex_t point_idx_;
 
     /** \brief Distance to query point. */
     float point_distance_;

--- a/octree/src/octree_inst.cpp
+++ b/octree/src/octree_inst.cpp
@@ -39,8 +39,8 @@
 
 // Instantiations of specific point types
 
-template class PCL_EXPORTS pcl::octree::OctreeBase<int>;
-template class PCL_EXPORTS pcl::octree::Octree2BufBase<int>;
+template class PCL_EXPORTS pcl::octree::OctreeBase<pcl::index_t>;
+template class PCL_EXPORTS pcl::octree::Octree2BufBase<pcl::index_t>;
 
 template class PCL_EXPORTS
     pcl::octree::OctreeBase<pcl::octree::OctreeContainerPointIndices,

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -308,7 +308,7 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
     //  test iterator
     unsigned int leaf_count = 0;
 
-    std::vector<int> indexVector;
+    Indices indexVector;
 
     // iterate over tree
     for (auto it = octree.leaf_depth_begin(), it_end = octree.leaf_depth_end(); it != it_end; ++it)
@@ -329,13 +329,13 @@ TEST (PCL, Octree_Dynamic_Depth_Test)
       container.getPointIndices (indexVector);
 
       // test points against bounding box of leaf node
-      std::vector<int> tmpVector;
+      Indices tmpVector;
       container.getPointIndices (tmpVector);
 
       Eigen::Vector3f min_pt, max_pt;
       octree.getVoxelBounds (it, min_pt, max_pt);
 
-      for (const int &i : tmpVector)
+      for (const auto &i : tmpVector)
       {
         ASSERT_GE ((*cloud)[i].x, min_pt(0));
         ASSERT_GE ((*cloud)[i].y, min_pt(1));
@@ -477,7 +477,7 @@ TEST (PCL, Octree2Buf_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (const int &value : data)
+    for (const auto &value : data)
       if (value == leafInt)
       {
         bFound = true;
@@ -496,7 +496,7 @@ TEST (PCL, Octree2Buf_Test)
     leafVectorA.pop_back ();
 
     bool bFound = false;
-    for (const int &value : data)
+    for (const auto &value : data)
       if (value == leafInt)
       {
         bFound = true;
@@ -790,12 +790,12 @@ TEST (PCL, Octree_Pointcloud_Test)
 
     for (std::size_t i = 0; i < cloudB->size (); i++)
     {
-      std::vector<int> pointIdxVec;
+      Indices pointIdxVec;
       octreeB.voxelSearch ((*cloudB)[i], pointIdxVec);
 
       bool bIdxFound = false;
-      std::vector<int>::const_iterator current = pointIdxVec.begin ();
-      while (current != pointIdxVec.end ())
+      auto current = pointIdxVec.cbegin ();
+      while (current != pointIdxVec.cend ())
       {
         if (*current == static_cast<int> (i))
         {
@@ -869,7 +869,7 @@ TEST (PCL, Octree_Pointcloud_Iterator_Test)
   octreeA.setInputCloud (cloudIn);
   octreeA.addPointsFromInputCloud ();
 
-  std::vector<int> indexVector;
+  Indices indexVector;
   unsigned int leafNodeCounter = 0;
 
   for (auto it1 = octreeA.leaf_depth_begin(), it1_end = octreeA.leaf_depth_end(); it1 != it1_end; ++it1)
@@ -1007,7 +1007,7 @@ TEST (PCL, Octree_Pointcloud_Change_Detector_Test)
         cloudIn);
   }
 
-  std::vector<int> newPointIdxVector;
+  Indices newPointIdxVector;
 
   // get a vector of new points, which did not exist in previous buffer
   octree.getPointIndicesFromNewVoxels (newPointIdxVector);
@@ -1136,10 +1136,10 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
   OctreePointCloudSearch<PointXYZ> octree (0.1);
   octree.setInputCloud (cloudIn);
 
-  std::vector<int> k_indices;
+  Indices k_indices;
   std::vector<float> k_sqr_distances;
 
-  std::vector<int> k_indices_bruteforce;
+  Indices k_indices_bruteforce;
   std::vector<float> k_sqr_distances_bruteforce;
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
@@ -1235,7 +1235,7 @@ TEST (PCL, Octree_Pointcloud_Box_Search)
 
   for (unsigned int test_id = 0; test_id < test_runs; test_id++)
   {
-    std::vector<int> k_indices;
+    Indices k_indices;
 
     // generate point cloud
     cloudIn->width = 300;
@@ -1341,7 +1341,7 @@ TEST(PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
 
     }
 
-    int ANNindex;
+    index_t ANNindex;
     float ANNdistance;
 
     // octree approx. nearest neighbor search
@@ -1415,7 +1415,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
       }
     }
 
-    std::vector<int> cloudNWRSearch;
+    Indices cloudNWRSearch;
     std::vector<float> cloudNWRRadius;
 
     // execute octree radius search
@@ -1424,8 +1424,8 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
     ASSERT_EQ (cloudSearchBruteforce.size (), cloudNWRRadius.size ());
 
     // check if result from octree radius search can be also found in bruteforce search
-    std::vector<int>::const_iterator current = cloudNWRSearch.begin ();
-    while (current != cloudNWRSearch.end ())
+    auto current = cloudNWRSearch.cbegin ();
+    while (current != cloudNWRSearch.cend ())
     {
       pointDist = sqrt (
           ((*cloudIn)[*current].x - searchPoint.x) * ((*cloudIn)[*current].x - searchPoint.x)
@@ -1459,7 +1459,7 @@ TEST (PCL, Octree_Pointcloud_Ray_Traversal)
   pcl::PointCloud<pcl::PointXYZ>::VectorType voxelsInRay, voxelsInRay2;
 
   // Indices in ray
-  std::vector<int> indicesInRay, indicesInRay2;
+  Indices indicesInRay, indicesInRay2;
 
   srand (static_cast<unsigned int> (time (nullptr)));
 
@@ -1620,7 +1620,7 @@ TEST (PCL, Octree_Pointcloud_Bounds)
     const double LARGE_MAX = 1e7-5*SOME_RESOLUTION;
     tree.defineBoundingBox (LARGE_MIN, LARGE_MIN, LARGE_MIN, LARGE_MAX, LARGE_MAX, LARGE_MAX);
     tree.getBoundingBox (min_x, min_y, min_z, max_x, max_y, max_z);
-    const unsigned int depth = tree.getTreeDepth ();
+    const auto depth = tree.getTreeDepth ();
     tree.defineBoundingBox (min_x, min_y, min_z, max_x, max_y, max_z);
 
     ASSERT_EQ (depth, tree.getTreeDepth ());

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -797,7 +797,7 @@ TEST (PCL, Octree_Pointcloud_Test)
       auto current = pointIdxVec.cbegin ();
       while (current != pointIdxVec.cend ())
       {
-        if (*current == static_cast<int> (i))
+        if (*current == static_cast<pcl::index_t> (i))
         {
           bIdxFound = true;
           break;
@@ -1325,7 +1325,7 @@ TEST(PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
 
     // brute force search
     double BFdistance = std::numeric_limits<double>::max ();
-    int BFindex = 0;
+    pcl::index_t BFindex = 0;
 
     for (std::size_t i = 0; i < cloudIn->size (); i++)
     {
@@ -1335,7 +1335,7 @@ TEST(PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
 
       if (pointDist < BFdistance)
       {
-        BFindex = static_cast<int> (i);
+        BFindex = static_cast<pcl::index_t> (i);
         BFdistance = pointDist;
       }
 


### PR DESCRIPTION
And a bug fix for common module

This brings up the modules ready to:
* common, octree
* ml (since it is mostly independent of common)

Next targets: kdtree, sample_consensus, io