### PR TITLE
[CI] Make windows build on c:\ drive to fix out-of-disk-space errors

### DIFF
--- a/.ci/azure-pipelines/azure-pipelines.yaml
+++ b/.ci/azure-pipelines/azure-pipelines.yaml
@@ -138,7 +138,7 @@ stages:
               GENERATOR: 'Visual Studio 15 2017 Win64'
         timeoutInMinutes: 0
         variables:
-          BUILD_DIR: '$(Agent.WorkFolder)\build'
+          BUILD_DIR: 'c:\build'
           CONFIGURATION: 'Release'
           VCPKG_ROOT: 'C:\vcpkg'
         steps:

--- a/.ci/azure-pipelines/build/windows.yaml
+++ b/.ci/azure-pipelines/build/windows.yaml
@@ -14,7 +14,7 @@ steps:
       vcpkg.exe install eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
     displayName: 'Install C++ Dependencies Via Vcpkg'
   - script: |
-      c: && mkdir %BUILD_DIR% && cd %BUILD_DIR%
+      mkdir %BUILD_DIR% && cd %BUILD_DIR%
       cmake $(Build.SourcesDirectory) ^
         -G"%GENERATOR%" ^
         -DCMAKE_BUILD_TYPE="MinSizeRel" ^
@@ -27,16 +27,19 @@ steps:
         -DBUILD_tools=OFF ^
         -DBUILD_surface_on_nurbs=ON
     displayName: 'CMake Configuration'
+    workingDirectory: 'c:'
   - script: |
-      c: && cd %BUILD_DIR% && cmake --build . --config %CONFIGURATION%
+      cd %BUILD_DIR% && cmake --build . --config %CONFIGURATION%
     displayName: 'Build Library'
+    workingDirectory: 'c:'
   - script: |
-      c: && cd %BUILD_DIR% && cmake --build . --target tests --config %CONFIGURATION%
-    displayName: 'Run Unit Tests'  
+      cd %BUILD_DIR% && cmake --build . --target tests --config %CONFIGURATION%
+    displayName: 'Run Unit Tests'
+    workingDirectory: 'c:'
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'CTest'
       testResultsFiles: '**/Test*.xml'
-      searchFolder: 'c:\build'
+      searchFolder: '%BUILD_DIR%'
     condition: succeededOrFailed()
 

--- a/.ci/azure-pipelines/build/windows.yaml
+++ b/.ci/azure-pipelines/build/windows.yaml
@@ -8,6 +8,8 @@ steps:
   - script: |
       echo ##vso[task.prependpath]%BOOST_ROOT_1_69_0%\lib
     displayName: 'Include Boost Libraries In System PATH'
+  - pwsh: Get-PSDrive
+    displayName: "Check free space"
   - script: |
       vcpkg.exe install eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
     displayName: 'Install C++ Dependencies Via Vcpkg'
@@ -30,7 +32,7 @@ steps:
     displayName: 'Build Library'
   - script: |
       c: && cd %BUILD_DIR% && cmake --build . --target tests --config %CONFIGURATION%
-    displayName: 'Run Unit Tests'
+    displayName: 'Run Unit Tests'  
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'CTest'

--- a/.ci/azure-pipelines/build/windows.yaml
+++ b/.ci/azure-pipelines/build/windows.yaml
@@ -9,17 +9,10 @@ steps:
       echo ##vso[task.prependpath]%BOOST_ROOT_1_69_0%\lib
     displayName: 'Include Boost Libraries In System PATH'
   - script: |
-      set
-    displayName: 'Print Environment Variables'
-  - script: |
       vcpkg.exe install eigen3 flann gtest qhull --triplet %PLATFORM%-windows && vcpkg.exe list
     displayName: 'Install C++ Dependencies Via Vcpkg'
   - script: |
-      rmdir %VCPKG_ROOT%\downloads /S /Q
-      rmdir %VCPKG_ROOT%\packages /S /Q
-    displayName: 'Free Up Space'
-  - script: |
-      mkdir %BUILD_DIR% && cd %BUILD_DIR%
+      c: && mkdir %BUILD_DIR% && cd %BUILD_DIR%
       cmake $(Build.SourcesDirectory) ^
         -G"%GENERATOR%" ^
         -DCMAKE_BUILD_TYPE="MinSizeRel" ^
@@ -32,14 +25,16 @@ steps:
         -DBUILD_tools=OFF ^
         -DBUILD_surface_on_nurbs=ON
     displayName: 'CMake Configuration'
-  - script: cd %BUILD_DIR% && cmake --build . --config %CONFIGURATION%
+  - script: |
+      c: && cd %BUILD_DIR% && cmake --build . --config %CONFIGURATION%
     displayName: 'Build Library'
-  - script: cd %BUILD_DIR% && cmake --build . --target tests --config %CONFIGURATION%
+  - script: |
+      c: && cd %BUILD_DIR% && cmake --build . --target tests --config %CONFIGURATION%
     displayName: 'Run Unit Tests'
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'CTest'
       testResultsFiles: '**/Test*.xml'
-      searchFolder: '$(Agent.WorkFolder)\build'
+      searchFolder: 'c:\build'
     condition: succeededOrFailed()
 


### PR DESCRIPTION
C: drive has about 77GB free space, so we shouldn't have trouble with this anymore.