### PR TITLE
Fix application of setMinimumPointsNumberPerVoxel for PCLPointCloud2 implementation of VoxelGrid

### DIFF
--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -42,6 +42,7 @@
 #include <pcl/common/io.h>
 #include <pcl/filters/impl/voxel_grid.hpp>
 #include <boost/sort/spreadsort/integer_sort.hpp>
+#include <array>
 
 using Array4size_t = Eigen::Array<std::size_t, 4, 1>;
 
@@ -385,12 +386,22 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
   // we need to skip all the same, adjacenent idx values
   std::size_t total = 0;
   std::size_t index = 0;
+  // first_and_last_indices_vector[i] represents the index in index_vector of the first point in
+  // index_vector belonging to the voxel which corresponds to the i-th output point,
+  // and of the first point not belonging to.
+  std::vector<std::pair<index_t, index_t> > first_and_last_indices_vector;
+  // Worst case size
+  first_and_last_indices_vector.reserve (index_vector.size ());
   while (index < index_vector.size ()) 
   {
     std::size_t i = index + 1;
     while (i < index_vector.size () && index_vector[i].idx == index_vector[index].idx) 
       ++i;
-    ++total;
+    if ((i - index) >= min_points_per_voxel_)
+    {
+      ++total;
+      first_and_last_indices_vector.emplace_back(index, i);
+    }
     index = i;
   }
 
@@ -436,93 +447,66 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
     xyz_offset = Array4size_t (0, 4, 8, 12);
 
   index=0;
-  Eigen::VectorXf centroid = Eigen::VectorXf::Zero (centroid_size);
   Eigen::VectorXf temporary = Eigen::VectorXf::Zero (centroid_size);
+  const std::array<index_t, 3> field_indices {x_idx_, y_idx_, z_idx_};
 
-  for (std::size_t cp = 0; cp < index_vector.size ();)
+  for (const auto &cp : first_and_last_indices_vector)
   {
-    std::size_t point_offset = index_vector[cp].cloud_point_index * input_->point_step;
-    // Do we need to process all the fields?
-    if (!downsample_all_data_) 
+    // calculate centroid - sum values from all input points, that have the same idx value in index_vector array
+    index_t first_index = cp.first;
+    index_t last_index = cp.second;
+
+    // index is centroid final position in resulting PointCloud
+    if (save_leaf_layout_)
+      leaf_layout_[index_vector[first_index].idx] = index;
+
+    //Limit downsampling to coords
+    if (!downsample_all_data_)
     {
-      memcpy (&pt[0], &input_->data[point_offset+input_->fields[x_idx_].offset], sizeof (float));
-      memcpy (&pt[1], &input_->data[point_offset+input_->fields[y_idx_].offset], sizeof (float));
-      memcpy (&pt[2], &input_->data[point_offset+input_->fields[z_idx_].offset], sizeof (float));
-      centroid[0] = pt[0];
-      centroid[1] = pt[1];
-      centroid[2] = pt[2];
-      centroid[3] = 0;
+      Eigen::Vector4f centroid (Eigen::Vector4f::Zero ());
+
+      for (index_t li = first_index; li < last_index; ++li)
+      {
+        std::size_t point_offset = index_vector[li].cloud_point_index * input_->point_step;
+        for (uint8_t ind=0; ind<3; ++ind)
+        {
+          memcpy (&pt[ind], &input_->data[point_offset+input_->fields[field_indices[ind]].offset], sizeof (float));
+        }
+        centroid += pt;
+      }
+
+      centroid /= static_cast<float> (last_index - first_index);
+      for (uint8_t ind=0; ind<3; ++ind)
+      {
+        memcpy (&output.data[xyz_offset[ind]], &centroid[ind], sizeof (float));
+      }
+      xyz_offset += output.point_step;
     }
     else
     {
-      // ---[ RGB special case
-      // fill extra r/g/b centroid field
-      if (rgba_index >= 0)
-      {
-        pcl::RGB rgb;
-        memcpy (&rgb, &input_->data[point_offset + input_->fields[rgba_index].offset], sizeof (RGB));
-        centroid[centroid_size-4] = rgb.r;
-        centroid[centroid_size-3] = rgb.g;
-        centroid[centroid_size-2] = rgb.b;
-        centroid[centroid_size-1] = rgb.a;
-      }
-      // Copy all the fields
-      for (std::size_t d = 0; d < input_->fields.size (); ++d)
-        memcpy (&centroid[d], &input_->data[point_offset + input_->fields[d].offset], field_sizes_[d]);
-    }
 
-    std::size_t i = cp + 1;
-    while (i < index_vector.size () && index_vector[i].idx == index_vector[cp].idx) 
-    {
-      std::size_t point_offset = index_vector[i].cloud_point_index * input_->point_step;
-      if (!downsample_all_data_) 
-      {
-        memcpy (&pt[0], &input_->data[point_offset+input_->fields[x_idx_].offset], sizeof (float));
-        memcpy (&pt[1], &input_->data[point_offset+input_->fields[y_idx_].offset], sizeof (float));
-        memcpy (&pt[2], &input_->data[point_offset+input_->fields[z_idx_].offset], sizeof (float));
-        centroid[0] += pt[0];
-        centroid[1] += pt[1];
-        centroid[2] += pt[2];
-      }
-      else
-      {
+      Eigen::VectorXf centroid = Eigen::VectorXf::Zero (centroid_size);
+      // fill in the accumulator with leaf points
+      for (index_t li = first_index; li < last_index; ++li) {
+        std::size_t point_offset = index_vector[li].cloud_point_index * input_->point_step;
         // ---[ RGB special case
         // fill extra r/g/b centroid field
         if (rgba_index >= 0)
         {
-          pcl::RGB rgb;
-          memcpy (&rgb, &input_->data[point_offset + input_->fields[rgba_index].offset], sizeof (RGB));
-          temporary[centroid_size-4] = rgb.r;
-          temporary[centroid_size-3] = rgb.g;
-          temporary[centroid_size-2] = rgb.b;
-          temporary[centroid_size-1] = rgb.a;
+            pcl::RGB rgb;
+            memcpy (&rgb, &input_->data[point_offset + input_->fields[rgba_index].offset], sizeof (RGB));
+            temporary[centroid_size-4] = rgb.r;
+            temporary[centroid_size-3] = rgb.g;
+            temporary[centroid_size-2] = rgb.b;
+            temporary[centroid_size-1] = rgb.a;
         }
         // Copy all the fields
         for (std::size_t d = 0; d < input_->fields.size (); ++d)
           memcpy (&temporary[d], &input_->data[point_offset + input_->fields[d].offset], field_sizes_[d]);
         centroid += temporary;
       }
-      ++i;
-    }
-
-	  // Save leaf layout information for fast access to cells relative to current position
-    if (save_leaf_layout_)
-      leaf_layout_[index_vector[cp].idx] = static_cast<int> (index);
-
-    // Normalize the centroid
-    centroid /= static_cast<float> (i - cp);
-
-    // Do we need to process all the fields?
-    if (!downsample_all_data_)
-    {
-      // Copy the data
-      memcpy (&output.data[xyz_offset[0]], &centroid[0], sizeof (float));
-      memcpy (&output.data[xyz_offset[1]], &centroid[1], sizeof (float));
-      memcpy (&output.data[xyz_offset[2]], &centroid[2], sizeof (float));
-      xyz_offset += output.point_step;
-    }
-    else
-    {
+      centroid /= static_cast<float> (last_index - first_index);
+      
       std::size_t point_offset = index * output.point_step;
       // Copy all the fields
       for (std::size_t d = 0; d < output.fields.size (); ++d)
@@ -537,7 +521,7 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
         memcpy (&output.data[point_offset + output.fields[rgba_index].offset], &rgb, sizeof (float));
       }
     }
-    cp = i;
+     
     ++index;
   }
 }

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -1327,6 +1327,107 @@ TEST (VoxelGridCovariance, Filters)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST (VoxelGridMinPoints, Filters)
+{
+  // Setup input with 4 clusters, single point at 0,0,0 and 1,1,1 with 5 point cluster around 0.11,0.11,0.11 and 6 point cluster around 0.31,0.31,0.31
+  PointCloud<PointXYZRGB>::Ptr input(new PointCloud<PointXYZRGB>());
+
+  input->emplace_back(0.0f, 0.0f, 0.0f);
+  std::vector<float> offsets {0.001, 0.002, 0.003, -0.001, -0.002, -0.003};
+  for (unsigned int i=0; i<5; ++i) {
+    input->emplace_back(0.11f+offsets[i], 0.11f+offsets[i], 0.11f+offsets[i],200,0,0);
+    input->emplace_back(0.31f+offsets[i], 0.31f+offsets[i], 0.31f+offsets[i],0,127,127);
+  }
+  input->emplace_back(0.31f+offsets[5], 0.31f+offsets[5], 0.31f+offsets[5],0,127,127);
+  input->emplace_back(1.0f, 1.0f, 1.0f);
+
+  // Test the PointCloud<PointT> VoxelGrid filter method
+  PointCloud<PointXYZRGB> outputMin4;
+  VoxelGrid<PointXYZRGB> grid;
+  // Run filter on input with MinimumPoints threshold at 4
+  grid.setLeafSize (0.02f, 0.02f, 0.02f);
+  grid.setInputCloud (input);
+  grid.setMinimumPointsNumberPerVoxel(4);
+  grid.setDownsampleAllData(true);
+  grid.filter (outputMin4);
+
+  // Verify 2 clusters (0.11 and 0.31) passed threshold and verify their location and color
+  EXPECT_EQ (outputMin4.size (), 2);
+  // Offset noise applied by offsets vec are 1e-3 magnitude, so check within 1e-2 
+  EXPECT_NEAR (outputMin4[0].x, input->at(1).x, 1e-2);
+  EXPECT_NEAR (outputMin4[0].y, input->at(1).y, 1e-2);
+  EXPECT_NEAR (outputMin4[0].z, input->at(1).z, 1e-2);
+  EXPECT_NEAR (outputMin4[0].r, input->at(1).r, 1);
+
+  EXPECT_NEAR (outputMin4[1].x, input->at(2).x, 1e-2);
+  EXPECT_NEAR (outputMin4[1].y, input->at(2).y, 1e-2);
+  EXPECT_NEAR (outputMin4[1].z, input->at(2).z, 1e-2);
+  EXPECT_NEAR (outputMin4[1].g, input->at(2).g, 1);
+  EXPECT_NEAR (outputMin4[1].b, input->at(2).b, 1);
+
+  // Run filter again on input with MinimumPoints threshold at 6
+  PointCloud<PointXYZRGB> outputMin6;
+  grid.setMinimumPointsNumberPerVoxel(6);
+  grid.setDownsampleAllData(false);
+  grid.filter (outputMin6);
+
+  // Verify 1 cluster (0.31) passed threshold and verify location
+  EXPECT_EQ (outputMin6.size (), 1);
+
+  EXPECT_NEAR (outputMin6[0].x, input->at(2).x, 1e-2);
+  EXPECT_NEAR (outputMin6[0].y, input->at(2).y, 1e-2);
+  EXPECT_NEAR (outputMin6[0].z, input->at(2).z, 1e-2);
+
+  // Test the pcl::PCLPointCloud2 VoxelGrid filter method
+  PCLPointCloud2 output_pc2;
+  VoxelGrid<PCLPointCloud2> grid_pc2;
+  PCLPointCloud2::Ptr input_pc2(new PCLPointCloud2());
+
+  // Use same input as above converted to PCLPointCloud2
+  toPCLPointCloud2(*input, *input_pc2);
+
+  // Run filter on input with MinimumPoints threshold at 4
+  grid_pc2.setLeafSize (0.02f, 0.02f, 0.02f);
+  grid_pc2.setInputCloud (input_pc2);
+  grid_pc2.setMinimumPointsNumberPerVoxel(4);
+  grid_pc2.setDownsampleAllData(true);
+  grid_pc2.filter (output_pc2);
+
+  // Convert back to PointXYZRGB for easier data access
+  PointCloud<pcl::PointXYZRGB>::Ptr out_pc( new pcl::PointCloud<pcl::PointXYZRGB> );
+  pcl::fromPCLPointCloud2( output_pc2, *out_pc );
+
+  // Verify 2 clusters (0.11 and 0.31) passed threshold and verify their location and color
+  // PCLPointCloud2 output should be same as PointCloudXYZRGB, account for floating point rounding error with 1e-4
+  EXPECT_EQ (out_pc->points.size (), outputMin4.size());
+
+  EXPECT_NEAR (out_pc->at(0).x, outputMin4[0].x, 1e-4);
+  EXPECT_NEAR (out_pc->at(0).y, outputMin4[0].y, 1e-4);
+  EXPECT_NEAR (out_pc->at(0).z, outputMin4[0].z, 1e-4);
+  EXPECT_NEAR (out_pc->at(0).r, outputMin4[0].r, 1);
+
+  EXPECT_NEAR (out_pc->at(1).x, outputMin4[1].x, 1e-4);
+  EXPECT_NEAR (out_pc->at(1).y, outputMin4[1].y, 1e-4);
+  EXPECT_NEAR (out_pc->at(1).z, outputMin4[1].z, 1e-4);
+  EXPECT_NEAR (out_pc->at(1).g, outputMin4[1].g, 1);
+  EXPECT_NEAR (out_pc->at(1).b, outputMin4[1].b, 1);
+
+  // Run filter again on input with MinimumPoints threshold at 6
+  grid_pc2.setMinimumPointsNumberPerVoxel(6);
+  grid_pc2.setDownsampleAllData(false);
+  grid_pc2.filter (output_pc2);
+
+  // Convert back to PointXYZRGB for easier data access
+  pcl::fromPCLPointCloud2( output_pc2, *out_pc );
+
+  // Verify 1 cluster (0.31) passed threshold and verify location
+  EXPECT_EQ (out_pc->points.size (), outputMin6.size());
+
+  EXPECT_NEAR (out_pc->at(0).x, outputMin6[0].x, 1e-4);
+  EXPECT_NEAR (out_pc->at(0).y, outputMin6[0].y, 1e-4);
+  EXPECT_NEAR (out_pc->at(0).z, outputMin6[0].z, 1e-4);
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (ProjectInliers, Filters)
 {
   // Test the PointCloud<PointT> method


### PR DESCRIPTION
VoxelGrid applyFilter implementation for PCLPointCloud2 wasn't applying min_points_per_voxel_, as described in this issue: https://github.com/PointCloudLibrary/pcl/issues/4388

This PR fixes the implementation of applyFilter for PCLPointCloud2 to be more similar to implementation of applyFilter for 
```
template <typename PointT> void
pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
```
Additionally, added unit test for setMinimumPointsNumberPerVoxel for both cases.

With current code, added unit test passes for 
VoxelGrid<PointXYZRGB> grid
and fails for
VoxelGrid<PCLPointCloud2> grid_pc2

With changes to filters/src/voxel_grid.cpp in this PR, unit test fully passes