### PR TITLE
Correct typo in `transformPlane`

### DIFF
--- a/common/include/pcl/common/eigen.h
+++ b/common/include/pcl/common/eigen.h
@@ -543,12 +543,12 @@ namespace pcl
   * \warning ModelCoefficients stores floats only !
   */
   template<typename Scalar> void
-  transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
+  transformPlane (const pcl::ModelCoefficients::ConstPtr plane_in,
                         pcl::ModelCoefficients::Ptr plane_out,
                   const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation);
 
   inline void
-  transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
+  transformPlane (const pcl::ModelCoefficients::ConstPtr plane_in,
                         pcl::ModelCoefficients::Ptr plane_out,
                   const Eigen::Transform<double, 3, Eigen::Affine> &transformation)
   {
@@ -556,7 +556,7 @@ namespace pcl
   }
 
   inline void
-  transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
+  transformPlane (const pcl::ModelCoefficients::ConstPtr plane_in,
                         pcl::ModelCoefficients::Ptr plane_out,
                   const Eigen::Transform<float, 3, Eigen::Affine> &transformation)
   {

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -780,7 +780,7 @@ transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
   Eigen::Matrix < Scalar, 4, 1 > v_plane_in (values.data ());
   pcl::transformPlane (v_plane_in, v_plane_in, transformation);
   plane_out->values.resize (4);
-  std::copy_n(v_plane_in.data (), 4, plane_in->values.begin ());
+  std::copy_n(v_plane_in.data (), 4, plane_out->values.begin ());
 }
 
 

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -772,7 +772,7 @@ transformPlane (const Eigen::Matrix<Scalar, 4, 1> &plane_in,
 
 
 template <typename Scalar> void
-transformPlane (const pcl::ModelCoefficients::Ptr plane_in,
+transformPlane (const pcl::ModelCoefficients::ConstPtr plane_in,
                       pcl::ModelCoefficients::Ptr plane_out,
                 const Eigen::Transform<Scalar, 3, Eigen::Affine> &transformation)
 {


### PR DESCRIPTION
Pointed out by `@B3nni#3946` on discord