### PR TITLE
[common] Add more operators to `PointCloud` to prevent perf regression in refactoring

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -465,7 +465,7 @@ namespace pcl
       /**
        * \brief Resizes the container to contain `new_width * new_height` elements
        * \details
-       * * If the current size is greater then the requested size, the pointcloud
+       * * If the current size is greater than the requested size, the pointcloud
        * is reduced to its first requested elements
        * * If the current size is less then the requested size, additional
        * default-inserted points are appended
@@ -647,7 +647,7 @@ namespace pcl
       }
 
       /** \brief Insert a new point in the cloud, at the end of the container.
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] pt the point to insert
         */
       inline void
@@ -671,7 +671,7 @@ namespace pcl
       }
 
       /** \brief Emplace a new point in the cloud, at the end of the container.
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] args the parameters to forward to the point to construct
         * \return reference to the emplaced point
         */
@@ -698,7 +698,7 @@ namespace pcl
       }
 
       /** \brief Insert a new point in the cloud, given an iterator.
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] position where to insert the point
         * \param[in] pt the point to insert
         * \return returns the new position iterator
@@ -725,7 +725,7 @@ namespace pcl
       }
 
       /** \brief Insert a new point in the cloud N times, given an iterator.
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] position where to insert the point
         * \param[in] n the number of times to insert the point
         * \param[in] pt the point to insert
@@ -751,7 +751,7 @@ namespace pcl
       }
 
       /** \brief Insert a new range of points in the cloud, at a certain position.
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] position where to insert the data
         * \param[in] first where to start inserting the points from
         * \param[in] last where to stop inserting the points from
@@ -778,7 +778,7 @@ namespace pcl
       }
 
       /** \brief Emplace a new point in the cloud, given an iterator.
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] position iterator before which the point will be emplaced
         * \param[in] args the parameters to forward to the point to construct
         * \return returns the new position iterator
@@ -805,7 +805,7 @@ namespace pcl
       }
 
       /** \brief Erase a point in the cloud.
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] position what data point to erase
         * \return returns the new position iterator
         */
@@ -832,7 +832,7 @@ namespace pcl
       }
 
       /** \brief Erase a set of points given by a (first, last) iterator pair
-        * \note This assumes the user would correct the details later on!
+        * \note This assumes the user would correct the width and height later on!
         * \param[in] first where to start erasing points from
         * \param[in] last where to stop erasing points from
         * \return returns the new position iterator

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -50,6 +50,7 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/type_traits.h>
 #include <pcl/types.h>
+#include <pcl/console/print.h>
 
 #include <utility>
 #include <vector>

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -435,11 +435,11 @@ namespace pcl
 
       //capacity
       inline std::size_t size () const { return points.size (); }
-      index_t max_size() const noexcept { return static_cast<index_t>(points.max_size()); }
+      inline index_t max_size() const noexcept { return static_cast<index_t>(points.max_size()); }
       inline void reserve (std::size_t n) { points.reserve (n); }
       inline bool empty () const { return points.empty (); }
-      PointT* data() noexcept { return points.data(); }
-      const PointT* data() const noexcept { return points.data(); }
+      inline PointT* data() noexcept { return points.data(); }
+      inline const PointT* data() const noexcept { return points.data(); }
 
       /**
        * \brief Resizes the container to contain `count` elements
@@ -492,7 +492,7 @@ namespace pcl
        * \param[in] count new size of the point cloud
        * \param[in] value the value to initialize the new points with
        */
-      void
+      inline void
       resize(index_t count, const PointT& value)
       {
         points.resize(count, value);
@@ -513,7 +513,7 @@ namespace pcl
        * \param[in] new_height new height of the point cloud
        * \param[in] value the value to initialize the new points with
        */
-      void
+      inline void
       resize(index_t new_width, index_t new_height, const PointT& value)
       {
         points.resize(new_width * new_height, value);
@@ -537,7 +537,7 @@ namespace pcl
        * 1!
        * \param[in] count new size of the point cloud
        */
-      void
+      inline void
       assign(index_t count, const PointT& value)
       {
         points.assign(count, value);
@@ -550,7 +550,7 @@ namespace pcl
        * \param[in] new_width new width of the point cloud
        * \param[in] new_height new height of the point cloud
        */
-      void
+      inline void
       assign(index_t new_width, index_t new_height, const PointT& value)
       {
         points.assign(new_width * new_height, value);
@@ -566,7 +566,7 @@ namespace pcl
        * 1!
        */
       template <class InputIterator>
-      void
+      inline void
       assign(InputIterator first, InputIterator last)
       {
         points.assign(std::move(first), std::move(last));
@@ -583,7 +583,7 @@ namespace pcl
        * \param[in] new_width new width of the point cloud
        */
       template <class InputIterator>
-      void
+      inline void
       assign(InputIterator first, InputIterator last, index_t new_width)
       {
         points.assign(std::move(first), std::move(last));
@@ -605,7 +605,7 @@ namespace pcl
        * 1!
        */
       void
-      assign(std::initializer_list<PointT> ilist)
+      inline assign(std::initializer_list<PointT> ilist)
       {
         points.assign(std::move(ilist));
         width = static_cast<std::uint32_t>(size());
@@ -619,7 +619,7 @@ namespace pcl
        * \param[in] new_width new width of the point cloud
        */
       void
-      assign(std::initializer_list<PointT> ilist, index_t new_width)
+      inline assign(std::initializer_list<PointT> ilist, index_t new_width)
       {
         points.assign(std::move(ilist));
         width = new_width;

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -50,7 +50,7 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/type_traits.h>
 #include <pcl/types.h>
-#include <pcl/console/print.h>
+#include <pcl/console/print.h>  // for PCL_WARN
 
 #include <utility>
 #include <vector>
@@ -465,15 +465,15 @@ namespace pcl
       /**
        * \brief Resizes the container to contain `new_width * new_height` elements
        * \details
-       * * If the current size is greater than requested, the pointcloud is reduced to its
-       * first requested elements
-       * * If the current size is less than requested, additional default-inserted points
-       * are appended
+       * * If the current size is greater then the requested size, the pointcloud
+       * is reduced to its first requested elements
+       * * If the current size is less then the requested size, additional
+       * default-inserted points are appended
        * \param[in] new_width new width of the point cloud
        * \param[in] new_height new height of the point cloud
        */
       inline void
-      resize(index_t new_width, index_t new_height)
+      resize(uindex_t new_width, uindex_t new_height)
       {
         points.resize(new_width * new_height);
         width = new_width;
@@ -505,10 +505,10 @@ namespace pcl
       /**
        * \brief Resizes the container to contain count elements
        * \details
-       * * If the current size is greater than requested, the pointcloud is reduced to its
-       * first requested elements
-       * * If the current size is less than requested, additional default-inserted points
-       * are appended
+       * * If the current size is greater then the requested size, the pointcloud
+       * is reduced to its first requested elements
+       * * If the current size is less then the requested size, additional
+       * default-inserted points are appended
        * \param[in] new_width new width of the point cloud
        * \param[in] new_height new height of the point cloud
        * \param[in] value the value to initialize the new points with

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -564,9 +564,9 @@ namespace pcl
        * \note This breaks the organized structure of the cloud by setting the height to
        * 1!
        */
-      template <class InputIt>
+      template <class InputIterator>
       void
-      assign(InputIt first, InputIt last)
+      assign(InputIterator first, InputIterator last)
       {
         points.assign(std::move(first), std::move(last));
         width = static_cast<std::uint32_t>(size());
@@ -580,9 +580,9 @@ namespace pcl
        * \note This calculates the height based on size and width provided
        * \param[in] new_width new width of the point cloud
        */
-      template <class InputIt>
+      template <class InputIterator>
       void
-      assign(InputIt first, InputIt last, index_t new_width)
+      assign(InputIterator first, InputIterator last, index_t new_width)
       {
         points.assign(std::move(first), std::move(last));
         width = new_width;

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -462,6 +462,24 @@ namespace pcl
       }
 
       /**
+       * \brief Resizes the container to contain `new_width * new_height` elements
+       * \details
+       * * If the current size is greater than requested, the pointcloud is reduced to its
+       * first requested elements
+       * * If the current size is less than requested, additional default-inserted points
+       * are appended
+       * \param[in] new_width new width of the point cloud
+       * \param[in] new_height new height of the point cloud
+       */
+      inline void
+      resize(index_t new_width, index_t new_height)
+      {
+        points.resize(new_width * new_height);
+        width = new_width;
+        height = new_height;
+      }
+
+      /**
        * \brief Resizes the container to contain count elements
        * \details
        * * If the current size is greater than `count`, the pointcloud is reduced to its
@@ -483,6 +501,25 @@ namespace pcl
         }
       }
 
+      /**
+       * \brief Resizes the container to contain count elements
+       * \details
+       * * If the current size is greater than requested, the pointcloud is reduced to its
+       * first requested elements
+       * * If the current size is less than requested, additional default-inserted points
+       * are appended
+       * \param[in] new_width new width of the point cloud
+       * \param[in] new_height new height of the point cloud
+       * \param[in] value the value to initialize the new points with
+       */
+      void
+      resize(index_t new_width, index_t new_height, const PointT& value)
+      {
+        points.resize(new_width * new_height, value);
+        width = new_width;
+        height = new_height;
+      }
+
       //element access
       inline const PointT& operator[] (std::size_t n) const { return (points[n]); }
       inline PointT& operator[] (std::size_t n) { return (points[n]); }
@@ -497,6 +534,7 @@ namespace pcl
        * \brief Replaces the points with `count` copies of `value`
        * \note This breaks the organized structure of the cloud by setting the height to
        * 1!
+       * \param[in] count new size of the point cloud
        */
       void
       assign(index_t count, const PointT& value)
@@ -504,6 +542,19 @@ namespace pcl
         points.assign(count, value);
         width = static_cast<std::uint32_t>(size());
         height = 1;
+      }
+
+      /**
+       * \brief Replaces the points with `new_width * new_height` copies of `value`
+       * \param[in] new_width new width of the point cloud
+       * \param[in] new_height new height of the point cloud
+       */
+      void
+      assign(index_t new_width, index_t new_height, const PointT& value)
+      {
+        points.assign(new_width * new_height, value);
+        width = new_width;
+        height = new_height;
       }
 
       /**
@@ -523,6 +574,22 @@ namespace pcl
       }
 
       /**
+       * \brief Replaces the points with copies of those in the range `[first, last)`
+       * \details The behavior is undefined if either argument is an iterator into
+       * `*this`
+       * \note This calculates the height based on size and width provided
+       * \param[in] new_width new width of the point cloud
+       */
+      template <class InputIt>
+      void
+      assign(InputIt first, InputIt last, index_t new_width)
+      {
+        points.assign(std::move(first), std::move(last));
+        width = new_width;
+        height = size() / width;
+      }
+
+      /**
        * \brief Replaces the points with the elements from the initializer list `ilist`
        * \note This breaks the organized structure of the cloud by setting the height to
        * 1!
@@ -533,6 +600,19 @@ namespace pcl
         points.assign(std::move(ilist));
         width = static_cast<std::uint32_t>(size());
         height = 1;
+      }
+
+      /**
+       * \brief Replaces the points with the elements from the initializer list `ilist`
+       * \note This calculates the height based on size and width provided
+       * \param[in] new_width new width of the point cloud
+       */
+      void
+      assign(std::initializer_list<PointT> ilist, index_t new_width)
+      {
+        points.assign(std::move(ilist));
+        width = new_width;
+        height = size() / width;
       }
 
       /** \brief Insert a new point in the cloud, at the end of the container.
@@ -547,6 +627,16 @@ namespace pcl
         height = 1;
       }
 
+      /** \brief Insert a new point in the cloud, at the end of the container.
+        * \note This assumes the user would correct the details later on!
+        * \param[in] pt the point to insert
+        */
+      inline void
+      transient_push_back (const PointT& pt)
+      {
+        points.push_back (pt);
+      }
+
       /** \brief Emplace a new point in the cloud, at the end of the container.
         * \note This breaks the organized structure of the cloud by setting the height to 1!
         * \param[in] args the parameters to forward to the point to construct
@@ -558,6 +648,18 @@ namespace pcl
         points.emplace_back (std::forward<Args> (args)...);
         width = size ();
         height = 1;
+        return points.back();
+      }
+
+      /** \brief Emplace a new point in the cloud, at the end of the container.
+        * \note This assumes the user would correct the details later on!
+        * \param[in] args the parameters to forward to the point to construct
+        * \return reference to the emplaced point
+        */
+      template <class... Args> inline reference
+      transient_emplace_back (Args&& ...args)
+      {
+        points.emplace_back (std::forward<Args> (args)...);
         return points.back();
       }
 
@@ -576,6 +678,19 @@ namespace pcl
         return (it);
       }
 
+      /** \brief Insert a new point in the cloud, given an iterator.
+        * \note This assumes the user would correct the details later on!
+        * \param[in] position where to insert the point
+        * \param[in] pt the point to insert
+        * \return returns the new position iterator
+        */
+      inline iterator
+      transient_insert (iterator position, const PointT& pt)
+      {
+        iterator it = points.insert (position, pt);
+        return (it);
+      }
+
       /** \brief Insert a new point in the cloud N times, given an iterator.
         * \note This breaks the organized structure of the cloud by setting the height to 1!
         * \param[in] position where to insert the point
@@ -590,6 +705,18 @@ namespace pcl
         height = 1;
       }
 
+      /** \brief Insert a new point in the cloud N times, given an iterator.
+        * \note This assumes the user would correct the details later on!
+        * \param[in] position where to insert the point
+        * \param[in] n the number of times to insert the point
+        * \param[in] pt the point to insert
+        */
+      inline void
+      transient_insert (iterator position, std::size_t n, const PointT& pt)
+      {
+        points.insert (position, n, pt);
+      }
+
       /** \brief Insert a new range of points in the cloud, at a certain position.
         * \note This breaks the organized structure of the cloud by setting the height to 1!
         * \param[in] position where to insert the data
@@ -602,6 +729,18 @@ namespace pcl
         points.insert (position, first, last);
         width = size ();
         height = 1;
+      }
+
+      /** \brief Insert a new range of points in the cloud, at a certain position.
+        * \note This assumes the user would correct the details later on!
+        * \param[in] position where to insert the data
+        * \param[in] first where to start inserting the points from
+        * \param[in] last where to stop inserting the points from
+        */
+      template <class InputIterator> inline void
+      transient_insert (iterator position, InputIterator first, InputIterator last)
+      {
+        points.insert (position, first, last);
       }
 
       /** \brief Emplace a new point in the cloud, given an iterator.
@@ -619,6 +758,19 @@ namespace pcl
         return (it);
       }
 
+      /** \brief Emplace a new point in the cloud, given an iterator.
+        * \note This assumes the user would correct the details later on!
+        * \param[in] position iterator before which the point will be emplaced
+        * \param[in] args the parameters to forward to the point to construct
+        * \return returns the new position iterator
+        */
+      template <class... Args> inline iterator
+      transient_emplace (iterator position, Args&& ...args)
+      {
+        iterator it = points.emplace (position, std::forward<Args> (args)...);
+        return (it);
+      }
+
       /** \brief Erase a point in the cloud.
         * \note This breaks the organized structure of the cloud by setting the height to 1!
         * \param[in] position what data point to erase
@@ -630,6 +782,18 @@ namespace pcl
         iterator it = points.erase (position);
         width = size ();
         height = 1;
+        return (it);
+      }
+
+      /** \brief Erase a point in the cloud.
+        * \note This assumes the user would correct the details later on!
+        * \param[in] position what data point to erase
+        * \return returns the new position iterator
+        */
+      inline iterator
+      transient_erase (iterator position)
+      {
+        iterator it = points.erase (position);
         return (it);
       }
 
@@ -645,6 +809,19 @@ namespace pcl
         iterator it = points.erase (first, last);
         width = size ();
         height = 1;
+        return (it);
+      }
+
+      /** \brief Erase a set of points given by a (first, last) iterator pair
+        * \note This assumes the user would correct the details later on!
+        * \param[in] first where to start erasing points from
+        * \param[in] last where to stop erasing points from
+        * \return returns the new position iterator
+        */
+      inline iterator
+      transient_erase (iterator first, iterator last)
+      {
+        iterator it = points.erase (first, last);
         return (it);
       }
 

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -592,7 +592,7 @@ namespace pcl
           PCL_WARN("Mismatch in assignment. Requested width (%zu) doesn't divide "
                    "provided size (%zu) cleanly. Setting height to 1",
                    static_cast<std::size_t>(width),
-                   static_cast<std::size>(size()));
+                   static_cast<std::size_t>(size()));
           width = size();
           height = 1;
         }

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -672,7 +672,7 @@ namespace pcl
       inline iterator
       insert (iterator position, const PointT& pt)
       {
-        iterator it = points.insert (position, pt);
+        iterator it = points.insert (std::move(position), pt);
         width = size ();
         height = 1;
         return (it);
@@ -687,7 +687,7 @@ namespace pcl
       inline iterator
       transient_insert (iterator position, const PointT& pt)
       {
-        iterator it = points.insert (position, pt);
+        iterator it = points.insert (std::move(position), pt);
         return (it);
       }
 
@@ -700,7 +700,7 @@ namespace pcl
       inline void
       insert (iterator position, std::size_t n, const PointT& pt)
       {
-        points.insert (position, n, pt);
+        points.insert (std::move(position), n, pt);
         width = size ();
         height = 1;
       }
@@ -714,7 +714,7 @@ namespace pcl
       inline void
       transient_insert (iterator position, std::size_t n, const PointT& pt)
       {
-        points.insert (position, n, pt);
+        points.insert (std::move(position), n, pt);
       }
 
       /** \brief Insert a new range of points in the cloud, at a certain position.
@@ -726,7 +726,7 @@ namespace pcl
       template <class InputIterator> inline void
       insert (iterator position, InputIterator first, InputIterator last)
       {
-        points.insert (position, first, last);
+        points.insert (std::move(position), std::move(first), std::move(last));
         width = size ();
         height = 1;
       }
@@ -740,7 +740,7 @@ namespace pcl
       template <class InputIterator> inline void
       transient_insert (iterator position, InputIterator first, InputIterator last)
       {
-        points.insert (position, first, last);
+        points.insert (std::move(position), std::move(first), std::move(last));
       }
 
       /** \brief Emplace a new point in the cloud, given an iterator.
@@ -752,7 +752,7 @@ namespace pcl
       template <class... Args> inline iterator
       emplace (iterator position, Args&& ...args)
       {
-        iterator it = points.emplace (position, std::forward<Args> (args)...);
+        iterator it = points.emplace (std::move(position), std::forward<Args> (args)...);
         width = size ();
         height = 1;
         return (it);
@@ -767,7 +767,7 @@ namespace pcl
       template <class... Args> inline iterator
       transient_emplace (iterator position, Args&& ...args)
       {
-        iterator it = points.emplace (position, std::forward<Args> (args)...);
+        iterator it = points.emplace (std::move(position), std::forward<Args> (args)...);
         return (it);
       }
 
@@ -779,7 +779,7 @@ namespace pcl
       inline iterator
       erase (iterator position)
       {
-        iterator it = points.erase (position);
+        iterator it = points.erase (std::move(position));
         width = size ();
         height = 1;
         return (it);
@@ -793,7 +793,7 @@ namespace pcl
       inline iterator
       transient_erase (iterator position)
       {
-        iterator it = points.erase (position);
+        iterator it = points.erase (std::move(position));
         return (it);
       }
 
@@ -806,7 +806,7 @@ namespace pcl
       inline iterator
       erase (iterator first, iterator last)
       {
-        iterator it = points.erase (first, last);
+        iterator it = points.erase (std::move(first), std::move(last));
         width = size ();
         height = 1;
         return (it);
@@ -821,7 +821,7 @@ namespace pcl
       inline iterator
       transient_erase (iterator first, iterator last)
       {
-        iterator it = points.erase (first, last);
+        iterator it = points.erase (std::move(first), std::move(last));
         return (it);
       }
 

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -591,7 +591,7 @@ namespace pcl
         if (width * height != size()) {
           PCL_WARN("Mismatch in assignment. Requested width (%zu) doesn't divide "
                    "provided size (%zu) cleanly. Setting height to 1",
-                   static_cast<std::size>(width),
+                   static_cast<std::size_t>(width),
                    static_cast<std::size>(size()));
           width = size();
           height = 1;

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -626,8 +626,8 @@ namespace pcl
         if (width * height != size()) {
           PCL_WARN("Mismatch in assignment. Requested width (%zu) doesn't divide "
                    "provided size (%zu) cleanly. Setting height to 1",
-                   static_cast<std::size>(width),
-                   static_cast<std::size>(size()));
+                   static_cast<std::size_t>(width),
+                   static_cast<std::size_t>(size()));
           width = size();
           height = 1;
         }

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -577,7 +577,8 @@ namespace pcl
        * \brief Replaces the points with copies of those in the range `[first, last)`
        * \details The behavior is undefined if either argument is an iterator into
        * `*this`
-       * \note This calculates the height based on size and width provided
+       * \note This calculates the height based on size and width provided. This means
+       * the assignment happens even if the size is not perfectly divisible by width
        * \param[in] new_width new width of the point cloud
        */
       template <class InputIterator>
@@ -587,6 +588,14 @@ namespace pcl
         points.assign(std::move(first), std::move(last));
         width = new_width;
         height = size() / width;
+        if (width * height != size()) {
+          PCL_WARN("Mismatch in assignment. Requested width (%zu) doesn't divide "
+                   "provided size (%zu) cleanly. Setting height to 1",
+                   static_cast<std::size>(width),
+                   static_cast<std::size>(size()));
+          width = size();
+          height = 1;
+        }
       }
 
       /**
@@ -604,7 +613,8 @@ namespace pcl
 
       /**
        * \brief Replaces the points with the elements from the initializer list `ilist`
-       * \note This calculates the height based on size and width provided
+       * \note This calculates the height based on size and width provided. This means
+       * the assignment happens even if the size is not perfectly divisible by width
        * \param[in] new_width new width of the point cloud
        */
       void
@@ -613,6 +623,14 @@ namespace pcl
         points.assign(std::move(ilist));
         width = new_width;
         height = size() / width;
+        if (width * height != size()) {
+          PCL_WARN("Mismatch in assignment. Requested width (%zu) doesn't divide "
+                   "provided size (%zu) cleanly. Setting height to 1",
+                   static_cast<std::size>(width),
+                   static_cast<std::size>(size()));
+          width = size();
+          height = 1;
+        }
       }
 
       /** \brief Insert a new point in the cloud, at the end of the container.


### PR DESCRIPTION
2 major additions:
* `transient_{push_back,emplace_back,insert,erase}` for direct access to points
* addition of width and height info in `resize` and `assign`