### PR TITLE
Update pcl_find_cuda.cmake to contain all supported architectures

### DIFF
--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -31,11 +31,11 @@ if(CUDA_FOUND)
   # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-features
   
   if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "11.0")
-    set(__cuda_arch_bin "5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5")
+    set(__cuda_arch_bin "3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5 8.0 8.6")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "10.0")
-    set(__cuda_arch_bin "3.0 3.5 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5")
+    set(__cuda_arch_bin "3.0 3.2 3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "9.0")
-    set(__cuda_arch_bin "3.0 3.5 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2")
+    set(__cuda_arch_bin "3.0 3.2 3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2")
   endif()
 
   set(CUDA_ARCH_BIN ${__cuda_arch_bin} CACHE STRING "Specify 'real' GPU architectures to build binaries for, BIN(PTX) format is supported")

--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -31,7 +31,7 @@ if(CUDA_FOUND)
   # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-features
   
   if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "11.0")
-    set(__cuda_arch_bin "3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5 8.0 8.6")
+    set(__cuda_arch_bin "3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5 8.0")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "10.0")
     set(__cuda_arch_bin "3.0 3.2 3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "9.0")

--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -31,11 +31,11 @@ if(CUDA_FOUND)
   # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-features
   
   if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "11.0")
-    set(__cuda_arch_bin "5.2 5.3 6.0 6.1 7.0 7.2 7.5")
+    set(__cuda_arch_bin "5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "10.0")
-    set(__cuda_arch_bin "3.0 3.5 5.0 5.2 5.3 6.0 6.1 7.0 7.2 7.5")
+    set(__cuda_arch_bin "3.0 3.5 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "9.0")
-    set(__cuda_arch_bin "3.0 3.5 5.0 5.2 5.3 6.0 6.1 7.0 7.2")
+    set(__cuda_arch_bin "3.0 3.5 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2")
   endif()
 
   set(CUDA_ARCH_BIN ${__cuda_arch_bin} CACHE STRING "Specify 'real' GPU architectures to build binaries for, BIN(PTX) format is supported")


### PR DESCRIPTION
The [NVIDIA jetson tx2 platform](https://developer.nvidia.com/embedded/jetson-tx2) is a single-board computer that contains a few ARM cores and a small NVIDIA GPU. In order to allow PCL to leverage the GPU capabilities of this board, the library needs to be built for cuda architecture 6.2. 

Update the cmake files to build for this architecture. Make it match the list [here](https://en.wikipedia.org/wiki/CUDA#GPUs_supported).

This change was tested by building from source on the device, then verifying that the [pcl::gpu::NormalEstimation](https://pointclouds.org/documentation/classpcl_1_1gpu_1_1_normal_estimation.html) class works on the device. 