### PR TITLE
Add a better error message in pcl::gpu::Octree if not built with proper CUDA support

### DIFF
--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -69,8 +69,8 @@ pcl::gpu::Octree::Octree() : cloud_(nullptr), impl(nullptr)
     if (bin < 0 || ptx < 0)
     {
         pcl::gpu::error(R"(cudaFuncGetAttributes() returned a value < 0.
-                This is likely a build configuration error.
-                Ensure that the proper compute capability is specified in the CUDA_ARCH_BIN cmake variable when building for your GPU.)",
+This is likely a build configuration error.
+Ensure that the proper compute capability is specified in the CUDA_ARCH_BIN cmake variable when building for your GPU.)",
             __FILE__, __LINE__);
     }
 

--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -68,7 +68,10 @@ pcl::gpu::Octree::Octree() : cloud_(nullptr), impl(nullptr)
 
     if (bin < 0 || ptx < 0)
     {
-        pcl::gpu::error("cudaFuncGetAttributes() returned a value < 0.\nThis is likely a build configuration error.\nEnsure that the proper compute capability is specified in the CUDA_ARCH_BIN cmake variable when building for your GPU.", __FILE__, __LINE__);
+        pcl::gpu::error(R"(cudaFuncGetAttributes() returned a value < 0.
+                This is likely a build configuration error.
+                Ensure that the proper compute capability is specified in the CUDA_ARCH_BIN cmake variable when building for your GPU.)",
+            __FILE__, __LINE__);
     }
 
     if (bin < 20 && ptx < 20)

--- a/gpu/octree/src/octree.cpp
+++ b/gpu/octree/src/octree.cpp
@@ -66,6 +66,11 @@ pcl::gpu::Octree::Octree() : cloud_(nullptr), impl(nullptr)
     int bin, ptx;
     OctreeImpl::get_gpu_arch_compiled_for(bin, ptx);
 
+    if (bin < 0 || ptx < 0)
+    {
+        pcl::gpu::error("cudaFuncGetAttributes() returned a value < 0.\nThis is likely a build configuration error.\nEnsure that the proper compute capability is specified in the CUDA_ARCH_BIN cmake variable when building for your GPU.", __FILE__, __LINE__);
+    }
+
     if (bin < 20 && ptx < 20)
         pcl::gpu::error("This must be compiled for compute capability >= 2.0", __FILE__, __LINE__);    
 


### PR DESCRIPTION
Based off of discussion in [this PR](https://github.com/PointCloudLibrary/pcl/pull/4400), it is possible to misconfigure the CUDA compute capabilities supported by PCL. When this happens, the code will build, but fail at runtime with a message stating that "the compute capability of the card is too low." This error message is inaccurate; the card is actually supported but PCL was configured incorrectly. 

Add an additional check for a misconfigured build, and emit a more descriptive error message.  