### PR TITLE
[CI] Make CI find test.xml again.

### DIFF
--- a/.ci/azure-pipelines/build/windows.yaml
+++ b/.ci/azure-pipelines/build/windows.yaml
@@ -40,6 +40,6 @@ steps:
     inputs:
       testResultsFormat: 'CTest'
       testResultsFiles: '**/Test*.xml'
-      searchFolder: '%BUILD_DIR%'
+      searchFolder: '$(BUILD_DIR)'
     condition: succeededOrFailed()
 


### PR DESCRIPTION
It seems that %BUILD_DIR% is not evaluated properly, since hardcoded paths works.