### PR TITLE
Use pixel ratio to scale mouse events on HiDpi monitors

### DIFF
--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -490,7 +490,7 @@ CloudEditorWidget::resizeGL (int width, int height)
 void
 CloudEditorWidget::mousePressEvent (QMouseEvent *event)
 {
-  auto ratio = QApplication::desktop()->devicePixelRatio();
+  auto ratio = this->devicePixelRatio();
   if (!tool_ptr_)
     return;
   tool_ptr_ -> start(event -> x()*ratio, event -> y()*ratio,
@@ -501,7 +501,7 @@ CloudEditorWidget::mousePressEvent (QMouseEvent *event)
 void
 CloudEditorWidget::mouseMoveEvent (QMouseEvent *event)
 {
-  auto ratio = QApplication::desktop()->devicePixelRatio();
+  auto ratio = this->devicePixelRatio();
   if (!tool_ptr_)
     return;
   tool_ptr_ -> update(event -> x()*ratio, event -> y()*ratio,
@@ -512,7 +512,7 @@ CloudEditorWidget::mouseMoveEvent (QMouseEvent *event)
 void
 CloudEditorWidget::mouseReleaseEvent (QMouseEvent *event)
 {
-  auto ratio = QApplication::desktop()->devicePixelRatio();
+  auto ratio = this->devicePixelRatio();
   if (!tool_ptr_)
     return;
   tool_ptr_ -> end(event -> x()*ratio, event -> y()*ratio,

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -41,6 +41,8 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QMouseEvent>
+#include <QApplication>
+#include <QDesktopWidget>
 #include <qgl.h>
 
 #include <pcl/pcl_config.h>
@@ -102,7 +104,7 @@ void
 CloudEditorWidget::load ()
 {
   QString file_path = QFileDialog::getOpenFileName(this, tr("Open File"));
-    
+
   if (file_path.isEmpty())
     return;
 
@@ -130,7 +132,7 @@ CloudEditorWidget::save ()
   }
 
   QString file_path = QFileDialog::getSaveFileName(this,tr("Save point cloud"));
-  
+
   std::string file_path_std = file_path.toStdString();
   if ( (file_path_std.empty()) || (!cloud_ptr_) )
     return;
@@ -488,9 +490,10 @@ CloudEditorWidget::resizeGL (int width, int height)
 void
 CloudEditorWidget::mousePressEvent (QMouseEvent *event)
 {
+  auto ratio = QApplication::desktop()->devicePixelRatio();
   if (!tool_ptr_)
     return;
-  tool_ptr_ -> start(event -> x(), event -> y(),
+  tool_ptr_ -> start(event -> x()*ratio, event -> y()*ratio,
                      event -> modifiers(), event -> buttons());
   update();
 }
@@ -498,9 +501,10 @@ CloudEditorWidget::mousePressEvent (QMouseEvent *event)
 void
 CloudEditorWidget::mouseMoveEvent (QMouseEvent *event)
 {
+  auto ratio = QApplication::desktop()->devicePixelRatio();
   if (!tool_ptr_)
     return;
-  tool_ptr_ -> update(event -> x(), event -> y(),
+  tool_ptr_ -> update(event -> x()*ratio, event -> y()*ratio,
                       event -> modifiers(), event -> buttons());
   update();
 }
@@ -508,9 +512,10 @@ CloudEditorWidget::mouseMoveEvent (QMouseEvent *event)
 void
 CloudEditorWidget::mouseReleaseEvent (QMouseEvent *event)
 {
+  auto ratio = QApplication::desktop()->devicePixelRatio();
   if (!tool_ptr_)
     return;
-  tool_ptr_ -> end(event -> x(), event -> y(),
+  tool_ptr_ -> end(event -> x()*ratio, event -> y()*ratio,
                    event -> modifiers(), event -> button());
   update();
 }
@@ -529,7 +534,7 @@ CloudEditorWidget::keyPressEvent (QKeyEvent *event)
 
 void
 CloudEditorWidget::loadFilePCD(const std::string &filename)
-{   
+{
   PclCloudPtr pcl_cloud_ptr;
   Cloud3D tmp;
   if (pcl::io::loadPCDFile<Point3D>(filename, tmp) == -1)
@@ -598,7 +603,7 @@ CloudEditorWidget::swapRBValues ()
 
 void
 CloudEditorWidget::initKeyMap ()
-{   
+{
   key_map_[Qt::Key_1] = &CloudEditorWidget::colorByPure;
   key_map_[Qt::Key_2] = &CloudEditorWidget::colorByX;
   key_map_[Qt::Key_3] = &CloudEditorWidget::colorByY;


### PR DESCRIPTION
Fixes #4239

It says [here](https://stackoverflow.com/a/39467033/2397253) that one should use `devicePixelRatio()` to scale everything that uses pixel values, such as mouse click events. I don't quite get the [documentation](https://doc.qt.io/qt-5/highdpi.html), but it seems to do the trick here.

Could somebody with a Mac or HiDpi display test this?