### PR TITLE
filtered out incorrect indices from nearestKSearch

### DIFF
--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -151,12 +151,14 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
                            k_indices_mat, k_distances_mat,
                            k, param_k_);
 
+  // Filter out invalid indices, which can occur when infinite or NaN values are in the cloud
   const size_t& max_index = identity_mapping_ ? total_nr_points_ : index_mapping_.size();
-  k_indices.erase(std::remove_if(k_indices.begin(), k_indices.end(),
+  auto it = std::remove_if(k_indices.begin(), k_indices.end(),
                                  [max_index](int idx) {
                                    return idx < 0 || idx >= max_index;
-                                 }),
-                  k_indices.end());
+                                 });
+  k_indices.erase(it, k_indices.end());
+  // Update k if any indices were removed
   k = static_cast<int>(k_indices.size());
 
   // Do mapping to original point cloud

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -151,6 +151,14 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
                            k_indices_mat, k_distances_mat,
                            k, param_k_);
 
+  const size_t& max_index = identity_mapping_ ? total_nr_points_ : index_mapping_.size();
+  k_indices.erase(std::remove_if(k_indices.begin(), k_indices.end(),
+                                 [max_index](int idx) {
+                                   return idx < 0 || idx >= max_index;
+                                 }),
+                  k_indices.end());
+  k = static_cast<int>(k_indices.size());
+
   // Do mapping to original point cloud
   if (!identity_mapping_) 
   {

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -152,10 +152,10 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
                            k, param_k_);
 
   // Filter out invalid indices, which can occur when infinite or NaN values are in the cloud
-  const size_t& max_index = identity_mapping_ ? total_nr_points_ : index_mapping_.size();
+  const index_t& max_index = identity_mapping_ ? total_nr_points_ : index_mapping_.size();
   auto it = std::remove_if(k_indices.begin(), k_indices.end(),
-                                 [max_index](index_t idx) {
-                                   return idx < 0 || static_cast<size_t>(idx) >= max_index;
+                                 [max_index](auto idx) {
+                                   return idx < 0 || idx >= max_index;
                                  });
   k_indices.erase(it, k_indices.end());
   // Update k if any indices were removed

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -154,8 +154,8 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
   // Filter out invalid indices, which can occur when infinite or NaN values are in the cloud
   const size_t& max_index = identity_mapping_ ? total_nr_points_ : index_mapping_.size();
   auto it = std::remove_if(k_indices.begin(), k_indices.end(),
-                                 [max_index](int idx) {
-                                   return idx < 0 || idx >= max_index;
+                                 [max_index](index_t idx) {
+                                   return idx < 0 || static_cast<size_t>(idx) >= max_index;
                                  });
   k_indices.erase(it, k_indices.end());
   // Update k if any indices were removed

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -75,6 +75,7 @@ init ()
     for (float y = -0.5f; y <= 0.5f; y += resolution)
       for (float x = -0.5f; x <= 0.5f; x += resolution)
         cloud.emplace_back(x, y, z);
+  cloud.emplace_back(std::numeric_limits<float>::infinity(), 0, 0);
   cloud.width  = cloud.size ();
   cloud.height = 1;
 
@@ -163,6 +164,7 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
   KdTreeFLANN<MyPoint> kdtree;
   kdtree.setInputCloud (cloud.makeShared ());
   MyPoint test_point (0.01f, 0.01f, 0.01f);
+  MyPoint inf_test_point (std::numeric_limits<float>::infinity(), 0.f, 0.f);
   unsigned int no_of_neighbors = 20;
   std::multimap<float, int> sorted_brute_force_result;
   for (std::size_t i = 0; i < cloud.size (); ++i)
@@ -182,6 +184,7 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
   k_indices.resize (no_of_neighbors);
   std::vector<float> k_distances;
   k_distances.resize (no_of_neighbors);
+  kdtree.nearestKSearch (inf_test_point, no_of_neighbors, k_indices, k_distances);
   kdtree.nearestKSearch (test_point, no_of_neighbors, k_indices, k_distances);
   //if (k_indices.size() != no_of_neighbors)  std::cerr << "Found "<<k_indices.size()<<" instead of "<<no_of_neighbors<<" neighbors.\n";
   EXPECT_EQ (k_indices.size (), no_of_neighbors);


### PR DESCRIPTION
Fix (or maybe just a workaround) for #4345. I wasn't able to actually track down what was going wrong, but this at least prevents the crash. Maybe it should print a warning if any kdtree results are filtered out?

I can also write a test for this. I have code to test it, but I haven't incorporated it into the PCL tests.