### PR TITLE
Deprecate `TransformationEstimationDQ` in favor of `TransformationEstimationDualQuaternion`

### DIFF
--- a/registration/include/pcl/registration/impl/transformation_estimation_dq.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_dq.hpp
@@ -41,6 +41,10 @@
 #define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_DQ_HPP_
 
 #include <pcl/common/eigen.h>
+PCL_DEPRECATED_HEADER(1,
+                      15,
+                      "TransformationEstimationDQ has been renamed to "
+                      "TransformationEstimationDualQuaternion.");
 
 
 namespace pcl

--- a/registration/include/pcl/registration/transformation_estimation_dq.h
+++ b/registration/include/pcl/registration/transformation_estimation_dq.h
@@ -41,100 +41,97 @@
 
 #include <pcl/registration/transformation_estimation.h>
 #include <pcl/cloud_iterator.h>
+PCL_DEPRECATED_HEADER(1,
+                      15,
+                      "TransformationEstimationDQ has been renamed to "
+                      "TransformationEstimationDualQuaternion.");
 
-namespace pcl
-{
-  namespace registration
-  {
-    /** @b TransformationEstimationDQ implements dual quaternion based estimation of
-      * the transformation aligning the given correspondences.
-      *
-      * \note The class is templated on the source and target point types as well as on the output scalar of the transformation matrix (i.e., float or double). Default: float.
-      * \author Sergey Zagoruyko
-      * \ingroup registration
-      */
-    template <typename PointSource, typename PointTarget, typename Scalar = float>
-    class TransformationEstimationDQ : public TransformationEstimation<PointSource, PointTarget, Scalar>
-    {
-      public:
-        using Ptr = shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
-        using ConstPtr = shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
+namespace pcl {
+namespace registration {
+/** @b TransformationEstimationDQ implements dual quaternion based estimation of
+ * the transformation aligning the given correspondences.
+ *
+ * \note The class is templated on the source and target point types as well as on the
+ * output scalar of the transformation matrix (i.e., float or double). Default: float.
+ * \author Sergey Zagoruyko
+ * \ingroup registration
+ */
+template <typename PointSource, typename PointTarget, typename Scalar = float>
+class TransformationEstimationDQ
+: public TransformationEstimation<PointSource, PointTarget, Scalar> {
+public:
+  using Ptr = shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar>>;
+  using ConstPtr =
+      shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar>>;
 
-        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
+  using Matrix4 =
+      typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 
-        TransformationEstimationDQ () {};
-        virtual ~TransformationEstimationDQ () {};
+  TransformationEstimationDQ(){};
+  virtual ~TransformationEstimationDQ(){};
 
-        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
-          * dual quaternion optimization
-          * \param[in] cloud_src the source point cloud dataset
-          * \param[in] cloud_tgt the target point cloud dataset
-          * \param[out] transformation_matrix the resultant transformation matrix
-          */
-        inline void
-        estimateRigidTransformation (
-            const pcl::PointCloud<PointSource> &cloud_src,
-            const pcl::PointCloud<PointTarget> &cloud_tgt,
-            Matrix4 &transformation_matrix) const;
+  /** \brief Estimate a rigid rotation transformation between a source and a target
+   * point cloud using dual quaternion optimization \param[in] cloud_src the source
+   * point cloud dataset \param[in] cloud_tgt the target point cloud dataset \param[out]
+   * transformation_matrix the resultant transformation matrix
+   */
+  inline void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              Matrix4& transformation_matrix) const;
 
-        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
-          * dual quaternion optimization
-          * \param[in] cloud_src the source point cloud dataset
-          * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
-          * \param[in] cloud_tgt the target point cloud dataset
-          * \param[out] transformation_matrix the resultant transformation matrix
-          */
-        inline void
-        estimateRigidTransformation (
-            const pcl::PointCloud<PointSource> &cloud_src,
-            const std::vector<int> &indices_src,
-            const pcl::PointCloud<PointTarget> &cloud_tgt,
-            Matrix4 &transformation_matrix) const;
+  /** \brief Estimate a rigid rotation transformation between a source and a target
+   * point cloud using dual quaternion optimization \param[in] cloud_src the source
+   * point cloud dataset \param[in] indices_src the vector of indices describing the
+   * points of interest in \a cloud_src \param[in] cloud_tgt the target point cloud
+   * dataset \param[out] transformation_matrix the resultant transformation matrix
+   */
+  inline void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const std::vector<int>& indices_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              Matrix4& transformation_matrix) const;
 
-        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
-          * dual quaternion optimization
-          * \param[in] cloud_src the source point cloud dataset
-          * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
-          * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
-          * \param[out] transformation_matrix the resultant transformation matrix
-          */
-        inline void
-        estimateRigidTransformation (
-            const pcl::PointCloud<PointSource> &cloud_src,
-            const std::vector<int> &indices_src,
-            const pcl::PointCloud<PointTarget> &cloud_tgt,
-            const std::vector<int> &indices_tgt,
-            Matrix4 &transformation_matrix) const;
+  /** \brief Estimate a rigid rotation transformation between a source and a target
+   * point cloud using dual quaternion optimization \param[in] cloud_src the source
+   * point cloud dataset \param[in] indices_src the vector of indices describing the
+   * points of interest in \a cloud_src \param[in] cloud_tgt the target point cloud
+   * dataset \param[in] indices_tgt the vector of indices describing the correspondences
+   * of the interest points from \a indices_src \param[out] transformation_matrix the
+   * resultant transformation matrix
+   */
+  inline void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const std::vector<int>& indices_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              const std::vector<int>& indices_tgt,
+                              Matrix4& transformation_matrix) const;
 
-        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
-          * dual quaternion optimization
-          * \param[in] cloud_src the source point cloud dataset
-          * \param[in] cloud_tgt the target point cloud dataset
-          * \param[in] correspondences the vector of correspondences between source and target point cloud
-          * \param[out] transformation_matrix the resultant transformation matrix
-          */
-        void
-        estimateRigidTransformation (
-            const pcl::PointCloud<PointSource> &cloud_src,
-            const pcl::PointCloud<PointTarget> &cloud_tgt,
-            const pcl::Correspondences &correspondences,
-            Matrix4 &transformation_matrix) const;
+  /** \brief Estimate a rigid rotation transformation between a source and a target
+   * point cloud using dual quaternion optimization \param[in] cloud_src the source
+   * point cloud dataset \param[in] cloud_tgt the target point cloud dataset \param[in]
+   * correspondences the vector of correspondences between source and target point cloud
+   * \param[out] transformation_matrix the resultant transformation matrix
+   */
+  void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              const pcl::Correspondences& correspondences,
+                              Matrix4& transformation_matrix) const;
 
-      protected:
+protected:
+  /** \brief Estimate a rigid rotation transformation between a source and a target
+   * \param[in] source_it an iterator over the source point cloud dataset
+   * \param[in] target_it an iterator over the target point cloud dataset
+   * \param[out] transformation_matrix the resultant transformation matrix
+   */
+  void
+  estimateRigidTransformation(ConstCloudIterator<PointSource>& source_it,
+                              ConstCloudIterator<PointTarget>& target_it,
+                              Matrix4& transformation_matrix) const;
+};
 
-        /** \brief Estimate a rigid rotation transformation between a source and a target
-          * \param[in] source_it an iterator over the source point cloud dataset
-          * \param[in] target_it an iterator over the target point cloud dataset
-          * \param[out] transformation_matrix the resultant transformation matrix
-          */
-        void
-        estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it,
-                                     ConstCloudIterator<PointTarget>& target_it,
-                                     Matrix4 &transformation_matrix) const;
-     };
-
-  }
-}
+} // namespace registration
+} // namespace pcl
 
 #include <pcl/registration/impl/transformation_estimation_dq.hpp>

--- a/registration/include/pcl/registration/transformation_estimation_dq.h
+++ b/registration/include/pcl/registration/transformation_estimation_dq.h
@@ -41,97 +41,101 @@
 
 #include <pcl/registration/transformation_estimation.h>
 #include <pcl/cloud_iterator.h>
-PCL_DEPRECATED_HEADER(1,
-                      15,
-                      "TransformationEstimationDQ has been renamed to "
-                      "TransformationEstimationDualQuaternion.");
+PCL_DEPRECATED_HEADER(1, 15, "TransformationEstimationDQ has been renamed to TransformationEstimationDualQuaternion.");
 
-namespace pcl {
-namespace registration {
-/** @b TransformationEstimationDQ implements dual quaternion based estimation of
- * the transformation aligning the given correspondences.
- *
- * \note The class is templated on the source and target point types as well as on the
- * output scalar of the transformation matrix (i.e., float or double). Default: float.
- * \author Sergey Zagoruyko
- * \ingroup registration
- */
-template <typename PointSource, typename PointTarget, typename Scalar = float>
-class TransformationEstimationDQ
-: public TransformationEstimation<PointSource, PointTarget, Scalar> {
-public:
-  using Ptr = shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar>>;
-  using ConstPtr =
-      shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar>>;
+namespace pcl
+{
+  namespace registration
+  {
+    /** @b TransformationEstimationDQ implements dual quaternion based estimation of
+      * the transformation aligning the given correspondences.
+      *
+      * \note The class is templated on the source and target point types as well as on the output scalar of the transformation matrix (i.e., float or double). Default: float.
+      * \author Sergey Zagoruyko
+      * \ingroup registration
+      */
+    template <typename PointSource, typename PointTarget, typename Scalar = float>
+    class TransformationEstimationDQ : public TransformationEstimation<PointSource, PointTarget, Scalar>
+    {
+      public:
+        using Ptr = shared_ptr<TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
+        using ConstPtr = shared_ptr<const TransformationEstimationDQ<PointSource, PointTarget, Scalar> >;
 
-  using Matrix4 =
-      typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
+        using Matrix4 = typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
 
-  TransformationEstimationDQ(){};
-  virtual ~TransformationEstimationDQ(){};
+        TransformationEstimationDQ () {};
+        virtual ~TransformationEstimationDQ () {};
 
-  /** \brief Estimate a rigid rotation transformation between a source and a target
-   * point cloud using dual quaternion optimization \param[in] cloud_src the source
-   * point cloud dataset \param[in] cloud_tgt the target point cloud dataset \param[out]
-   * transformation_matrix the resultant transformation matrix
-   */
-  inline void
-  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const pcl::PointCloud<PointTarget>& cloud_tgt,
-                              Matrix4& transformation_matrix) const;
+        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
+          * dual quaternion optimization
+          * \param[in] cloud_src the source point cloud dataset
+          * \param[in] cloud_tgt the target point cloud dataset
+          * \param[out] transformation_matrix the resultant transformation matrix
+          */
+        inline void
+        estimateRigidTransformation (
+            const pcl::PointCloud<PointSource> &cloud_src,
+            const pcl::PointCloud<PointTarget> &cloud_tgt,
+            Matrix4 &transformation_matrix) const;
 
-  /** \brief Estimate a rigid rotation transformation between a source and a target
-   * point cloud using dual quaternion optimization \param[in] cloud_src the source
-   * point cloud dataset \param[in] indices_src the vector of indices describing the
-   * points of interest in \a cloud_src \param[in] cloud_tgt the target point cloud
-   * dataset \param[out] transformation_matrix the resultant transformation matrix
-   */
-  inline void
-  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const std::vector<int>& indices_src,
-                              const pcl::PointCloud<PointTarget>& cloud_tgt,
-                              Matrix4& transformation_matrix) const;
+        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
+          * dual quaternion optimization
+          * \param[in] cloud_src the source point cloud dataset
+          * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
+          * \param[in] cloud_tgt the target point cloud dataset
+          * \param[out] transformation_matrix the resultant transformation matrix
+          */
+        inline void
+        estimateRigidTransformation (
+            const pcl::PointCloud<PointSource> &cloud_src,
+            const std::vector<int> &indices_src,
+            const pcl::PointCloud<PointTarget> &cloud_tgt,
+            Matrix4 &transformation_matrix) const;
 
-  /** \brief Estimate a rigid rotation transformation between a source and a target
-   * point cloud using dual quaternion optimization \param[in] cloud_src the source
-   * point cloud dataset \param[in] indices_src the vector of indices describing the
-   * points of interest in \a cloud_src \param[in] cloud_tgt the target point cloud
-   * dataset \param[in] indices_tgt the vector of indices describing the correspondences
-   * of the interest points from \a indices_src \param[out] transformation_matrix the
-   * resultant transformation matrix
-   */
-  inline void
-  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const std::vector<int>& indices_src,
-                              const pcl::PointCloud<PointTarget>& cloud_tgt,
-                              const std::vector<int>& indices_tgt,
-                              Matrix4& transformation_matrix) const;
+        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
+          * dual quaternion optimization
+          * \param[in] cloud_src the source point cloud dataset
+          * \param[in] indices_src the vector of indices describing the points of interest in \a cloud_src
+          * \param[in] cloud_tgt the target point cloud dataset
+          * \param[in] indices_tgt the vector of indices describing the correspondences of the interest points from \a indices_src
+          * \param[out] transformation_matrix the resultant transformation matrix
+          */
+        inline void
+        estimateRigidTransformation (
+            const pcl::PointCloud<PointSource> &cloud_src,
+            const std::vector<int> &indices_src,
+            const pcl::PointCloud<PointTarget> &cloud_tgt,
+            const std::vector<int> &indices_tgt,
+            Matrix4 &transformation_matrix) const;
 
-  /** \brief Estimate a rigid rotation transformation between a source and a target
-   * point cloud using dual quaternion optimization \param[in] cloud_src the source
-   * point cloud dataset \param[in] cloud_tgt the target point cloud dataset \param[in]
-   * correspondences the vector of correspondences between source and target point cloud
-   * \param[out] transformation_matrix the resultant transformation matrix
-   */
-  void
-  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const pcl::PointCloud<PointTarget>& cloud_tgt,
-                              const pcl::Correspondences& correspondences,
-                              Matrix4& transformation_matrix) const;
+        /** \brief Estimate a rigid rotation transformation between a source and a target point cloud using
+          * dual quaternion optimization
+          * \param[in] cloud_src the source point cloud dataset
+          * \param[in] cloud_tgt the target point cloud dataset
+          * \param[in] correspondences the vector of correspondences between source and target point cloud
+          * \param[out] transformation_matrix the resultant transformation matrix
+          */
+        void
+        estimateRigidTransformation (
+            const pcl::PointCloud<PointSource> &cloud_src,
+            const pcl::PointCloud<PointTarget> &cloud_tgt,
+            const pcl::Correspondences &correspondences,
+            Matrix4 &transformation_matrix) const;
 
-protected:
-  /** \brief Estimate a rigid rotation transformation between a source and a target
-   * \param[in] source_it an iterator over the source point cloud dataset
-   * \param[in] target_it an iterator over the target point cloud dataset
-   * \param[out] transformation_matrix the resultant transformation matrix
-   */
-  void
-  estimateRigidTransformation(ConstCloudIterator<PointSource>& source_it,
-                              ConstCloudIterator<PointTarget>& target_it,
-                              Matrix4& transformation_matrix) const;
-};
+      protected:
 
-} // namespace registration
-} // namespace pcl
+        /** \brief Estimate a rigid rotation transformation between a source and a target
+          * \param[in] source_it an iterator over the source point cloud dataset
+          * \param[in] target_it an iterator over the target point cloud dataset
+          * \param[out] transformation_matrix the resultant transformation matrix
+          */
+        void
+        estimateRigidTransformation (ConstCloudIterator<PointSource>& source_it,
+                                     ConstCloudIterator<PointTarget>& target_it,
+                                     Matrix4 &transformation_matrix) const;
+     };
+
+  }
+}
 
 #include <pcl/registration/impl/transformation_estimation_dq.hpp>


### PR DESCRIPTION
It looks like sometime in 2013, `pcl::registration::TransformationEstimationDQ` was being renamed to `pcl::registration::TransformationEstimationDualQuaternion`, but the original name was never removed. This deprecates the `transformation_estimation_dq.h` header, so it can be removed later. I wasn't sure what version to target for removal, so I chose 1.15 based on #4367 .