### PR TITLE
KdTree: handle 0 or negative k for nearestKSearch

### DIFF
--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -58,7 +58,7 @@ pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (bool sorted)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename Dist>
-pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (const KdTreeFLANN<PointT, Dist> &k) 
+pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (const KdTreeFLANN<PointT, Dist> &k)
   : pcl::KdTree<PointT> (false)
   , flann_index_ ()
   , identity_mapping_ (false)
@@ -70,7 +70,7 @@ pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (const KdTreeFLANN<PointT, Dist> &k)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setEpsilon (float eps)
 {
   epsilon_ = eps;
@@ -79,7 +79,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setEpsilon (float eps)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setSortedResults (bool sorted)
 {
   sorted_ = sorted;
@@ -88,7 +88,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setSortedResults (bool sorted)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, const IndicesConstPtr &indices)
 {
   cleanup ();   // Perform an automatic cleanup of structures
@@ -98,7 +98,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, 
 
   input_   = cloud;
   indices_ = indices;
-  
+
   // Allocate enough data
   if (!input_)
   {
@@ -120,17 +120,17 @@ pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, 
     return;
   }
 
-  flann_index_.reset (new FLANNIndex (::flann::Matrix<float> (cloud_.get (), 
-                                                              index_mapping_.size (), 
+  flann_index_.reset (new FLANNIndex (::flann::Matrix<float> (cloud_.get (),
+                                                              index_mapping_.size (),
                                                               dim_),
                                       ::flann::KDTreeSingleIndexParams (15))); // max 15 points/leaf
   flann_index_->buildIndex ();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> int 
-pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k, 
-                                                std::vector<int> &k_indices, 
+template <typename PointT, typename Dist> int
+pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
+                                                std::vector<int> &k_indices,
                                                 std::vector<float> &k_distances) const
 {
   assert (point_representation_->isValid (point) && "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
@@ -147,12 +147,12 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
   ::flann::Matrix<int> k_indices_mat (&k_indices[0], 1, k);
   ::flann::Matrix<float> k_distances_mat (&k_distances[0], 1, k);
   // Wrap the k_indices and k_distances vectors (no data copy)
-  flann_index_->knnSearch (::flann::Matrix<float> (&query[0], 1, dim_), 
+  flann_index_->knnSearch (::flann::Matrix<float> (&query[0], 1, dim_),
                            k_indices_mat, k_distances_mat,
                            k, param_k_);
 
   // Do mapping to original point cloud
-  if (!identity_mapping_) 
+  if (!identity_mapping_)
   {
     for (std::size_t i = 0; i < static_cast<std::size_t> (k); ++i)
     {
@@ -165,7 +165,7 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> int 
+template <typename PointT, typename Dist> int
 pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius, std::vector<int> &k_indices,
                                               std::vector<float> &k_sqr_dists, unsigned int max_nn) const
 {
@@ -190,14 +190,14 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
   int neighbors_in_radius = flann_index_->radiusSearch (::flann::Matrix<float> (&query[0], 1, dim_),
       indices,
       dists,
-      static_cast<float> (radius * radius), 
+      static_cast<float> (radius * radius),
       params);
 
   k_indices = indices[0];
   k_sqr_dists = dists[0];
 
   // Do mapping to original point cloud
-  if (!identity_mapping_) 
+  if (!identity_mapping_)
   {
     for (int i = 0; i < neighbors_in_radius; ++i)
     {
@@ -210,7 +210,7 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::cleanup ()
 {
   // Data array cleanup
@@ -221,7 +221,7 @@ pcl::KdTreeFLANN<PointT, Dist>::cleanup ()
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud)
 {
   // No point in doing anything if the array is empty
@@ -255,7 +255,7 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename Dist> void 
+template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, const std::vector<int> &indices)
 {
   // No point in doing anything if the array is empty
@@ -271,14 +271,14 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, co
   float* cloud_ptr = cloud_.get ();
   index_mapping_.reserve (original_no_of_points);
   // its a subcloud -> false
-  // true only identity: 
+  // true only identity:
   //     - indices size equals cloud size
   //     - indices only contain values between 0 and cloud.size - 1
   //     - no index is multiple times in the list
   //     => index is complete
   // But we can not guarantee that => identity_mapping_ = false
   identity_mapping_ = false;
-  
+
   for (const int &index : indices)
   {
     // Check if the point is invalid
@@ -287,7 +287,7 @@ pcl::KdTreeFLANN<PointT, Dist>::convertCloudToArray (const PointCloud &cloud, co
 
     // map from 0 - N -> indices [0] - indices [N]
     index_mapping_.push_back (index);  // If the returned index should be for the indices vector
-    
+
     point_representation_->vectorize (cloud[index], cloud_ptr);
     cloud_ptr += dim_;
   }

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -113,7 +113,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, 
   {
     convertCloudToArray (*input_);
   }
-  total_nr_points_ = static_cast<int> (index_mapping_.size ());
+  total_nr_points_ = static_cast<uindex_t> (index_mapping_.size ());
   if (total_nr_points_ == 0)
   {
     PCL_ERROR ("[pcl::KdTreeFLANN::setInputCloud] Cannot create a KDTree with an empty input cloud!\n");
@@ -178,14 +178,14 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
   point_representation_->vectorize (static_cast<PointT> (point), query);
 
   // Has max_nn been set properly?
-  if (max_nn == 0 || max_nn > static_cast<unsigned int> (total_nr_points_))
+  if (max_nn == 0 || max_nn > total_nr_points_)
     max_nn = total_nr_points_;
 
   std::vector<std::vector<int> > indices(1);
   std::vector<std::vector<float> > dists(1);
 
   ::flann::SearchParams params (param_radius_);
-  if (max_nn == static_cast<unsigned int>(total_nr_points_))
+  if (max_nn == total_nr_points_)
     params.max_neighbors = -1;  // return all neighbors in radius
   else
     params.max_neighbors = max_nn;

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -129,7 +129,7 @@ pcl::KdTreeFLANN<PointT, Dist>::setInputCloud (const PointCloudConstPtr &cloud, 
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename Dist> int
-pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
+pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, unsigned int k,
                                                 std::vector<int> &k_indices,
                                                 std::vector<float> &k_distances) const
 {
@@ -140,6 +140,9 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, int k,
 
   k_indices.resize (k);
   k_distances.resize (k);
+
+  if (k==0)
+    return 0;
 
   std::vector<float> query (dim_);
   point_representation_->vectorize (static_cast<PointT> (point), query);

--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -132,7 +132,7 @@ namespace pcl
         * \return number of neighbors found
         */
       virtual int
-      nearestKSearch (const PointT &p_q, int k,
+      nearestKSearch (const PointT &p_q, unsigned int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const = 0;
 
       /** \brief Search for k-nearest neighbors for the given query point.
@@ -152,7 +152,7 @@ namespace pcl
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
       virtual int
-      nearestKSearch (const PointCloud &cloud, int index, int k,
+      nearestKSearch (const PointCloud &cloud, int index, unsigned int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
       {
         assert (index >= 0 && index < static_cast<int> (cloud.size ()) && "Out-of-bounds error in nearestKSearch!");
@@ -169,7 +169,7 @@ namespace pcl
         * \return number of neighbors found
         */
       template <typename PointTDiff> inline int
-      nearestKSearchT (const PointTDiff &point, int k,
+      nearestKSearchT (const PointTDiff &point, unsigned int k,
                        std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
       {
         PointT p;
@@ -195,7 +195,7 @@ namespace pcl
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
       virtual int
-      nearestKSearch (int index, int k,
+      nearestKSearch (int index, unsigned int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
       {
         if (indices_ == nullptr)

--- a/kdtree/include/pcl/kdtree/kdtree.h
+++ b/kdtree/include/pcl/kdtree/kdtree.h
@@ -68,11 +68,11 @@ namespace pcl
       using Ptr = shared_ptr<KdTree<PointT> >;
       using ConstPtr = shared_ptr<const KdTree<PointT> >;
 
-      /** \brief Empty constructor for KdTree. Sets some internal values to their defaults. 
-        * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise. 
+      /** \brief Empty constructor for KdTree. Sets some internal values to their defaults.
+        * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise.
         */
       KdTree (bool sorted = true) : input_(),
-                                    epsilon_(0.0f), min_pts_(1), sorted_(sorted), 
+                                    epsilon_(0.0f), min_pts_(1), sorted_(sorted),
                                     point_representation_ (new DefaultPointRepresentation<PointT>)
       {
       };
@@ -102,7 +102,7 @@ namespace pcl
         return (input_);
       }
 
-      /** \brief Provide a pointer to the point representation to use to convert points into k-D vectors. 
+      /** \brief Provide a pointer to the point representation to use to convert points into k-D vectors.
         * \param[in] point_representation the const boost shared pointer to a PointRepresentation
         */
       inline void
@@ -127,49 +127,49 @@ namespace pcl
         * \param[in] p_q the given query point
         * \param[in] k the number of neighbors to search for
         * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k 
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
         * a priori!)
         * \return number of neighbors found
         */
-      virtual int 
-      nearestKSearch (const PointT &p_q, int k, 
+      virtual int
+      nearestKSearch (const PointT &p_q, int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const = 0;
 
       /** \brief Search for k-nearest neighbors for the given query point.
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
+        *
         * \param[in] cloud the point cloud data
         * \param[in] index a \a valid index in \a cloud representing a \a valid (i.e., finite) query point
         * \param[in] k the number of neighbors to search for
         * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k 
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
         * a priori!)
-        * 
+        *
         * \return number of neighbors found
-        * 
+        *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      virtual int 
-      nearestKSearch (const PointCloud &cloud, int index, int k, 
+      virtual int
+      nearestKSearch (const PointCloud &cloud, int index, int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
       {
         assert (index >= 0 && index < static_cast<int> (cloud.size ()) && "Out-of-bounds error in nearestKSearch!");
         return (nearestKSearch (cloud[index], k, k_indices, k_sqr_distances));
       }
 
-      /** \brief Search for k-nearest neighbors for the given query point. 
+      /** \brief Search for k-nearest neighbors for the given query point.
         * This method accepts a different template parameter for the point type.
         * \param[in] point the given query point
         * \param[in] k the number of neighbors to search for
         * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k 
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
         * a priori!)
         * \return number of neighbors found
         */
-      template <typename PointTDiff> inline int 
-      nearestKSearchT (const PointTDiff &point, int k, 
+      template <typename PointTDiff> inline int
+      nearestKSearchT (const PointTDiff &point, int k,
                        std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
       {
         PointT p;
@@ -178,24 +178,24 @@ namespace pcl
       }
 
       /** \brief Search for k-nearest neighbors for the given query point (zero-copy).
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
-        * \param[in] index a \a valid index representing a \a valid query point in the dataset given 
-        * by \a setInputCloud. If indices were given in setInputCloud, index will be the position in 
+        *
+        * \param[in] index a \a valid index representing a \a valid query point in the dataset given
+        * by \a setInputCloud. If indices were given in setInputCloud, index will be the position in
         * the indices vector.
-        * 
+        *
         * \param[in] k the number of neighbors to search for
         * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k 
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
         * a priori!)
         * \return number of neighbors found
-        * 
+        *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      virtual int 
-      nearestKSearch (int index, int k, 
+      virtual int
+      nearestKSearch (int index, int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const
       {
         if (indices_ == nullptr)
@@ -218,15 +218,15 @@ namespace pcl
         * returned.
         * \return number of neighbors found in radius
         */
-      virtual int 
+      virtual int
       radiusSearch (const PointT &p_q, double radius, std::vector<int> &k_indices,
                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const = 0;
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
+        *
         * \param[in] cloud the point cloud data
         * \param[in] index a \a valid index in \a cloud representing a \a valid (i.e., finite) query point
         * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
@@ -236,12 +236,12 @@ namespace pcl
         * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
         * returned.
         * \return number of neighbors found in radius
-        * 
+        *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      virtual int 
-      radiusSearch (const PointCloud &cloud, int index, double radius, 
-                    std::vector<int> &k_indices, std::vector<float> &k_sqr_distances, 
+      virtual int
+      radiusSearch (const PointCloud &cloud, int index, double radius,
+                    std::vector<int> &k_indices, std::vector<float> &k_sqr_distances,
                     unsigned int max_nn = 0) const
       {
         assert (index >= 0 && index < static_cast<int> (cloud.size ()) && "Out-of-bounds error in radiusSearch!");
@@ -258,7 +258,7 @@ namespace pcl
         * returned.
         * \return number of neighbors found in radius
         */
-      template <typename PointTDiff> inline int 
+      template <typename PointTDiff> inline int
       radiusSearchT (const PointTDiff &point, double radius, std::vector<int> &k_indices,
                      std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
       {
@@ -268,14 +268,14 @@ namespace pcl
       }
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius (zero-copy).
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
-        * \param[in] index a \a valid index representing a \a valid query point in the dataset given 
-        * by \a setInputCloud. If indices were given in setInputCloud, index will be the position in 
+        *
+        * \param[in] index a \a valid index representing a \a valid query point in the dataset given
+        * by \a setInputCloud. If indices were given in setInputCloud, index will be the position in
         * the indices vector.
-        * 
+        *
         * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
         * \param[out] k_indices the resultant indices of the neighboring points
         * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
@@ -283,10 +283,10 @@ namespace pcl
         * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
         * returned.
         * \return number of neighbors found in radius
-        * 
+        *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      virtual int 
+      virtual int
       radiusSearch (int index, double radius, std::vector<int> &k_indices,
                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const
       {
@@ -315,8 +315,8 @@ namespace pcl
         return (epsilon_);
       }
 
-      /** \brief Minimum allowed number of k nearest neighbors points that a viable result must contain. 
-        * \param[in] min_pts the minimum number of neighbors in a viable neighborhood 
+      /** \brief Minimum allowed number of k nearest neighbors points that a viable result must contain.
+        * \param[in] min_pts the minimum number of neighbors in a viable neighborhood
         */
       inline void
       setMinPts (int min_pts)
@@ -351,7 +351,7 @@ namespace pcl
       PointRepresentationConstPtr point_representation_;
 
       /** \brief Class getName method. */
-      virtual std::string 
+      virtual std::string
       getName () const = 0;
   };
 }

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -58,7 +58,7 @@ namespace pcl
     * the FLANN (Fast Library for Approximate Nearest Neighbor) project by Marius Muja and David Lowe.
     *
     * \author Radu B. Rusu, Marius Muja
-    * \ingroup kdtree 
+    * \ingroup kdtree
     */
   template <typename PointT, typename Dist = ::flann::L2_Simple<float> >
   class KdTreeFLANN : public pcl::KdTree<PointT>
@@ -85,7 +85,7 @@ namespace pcl
       using ConstPtr = shared_ptr<const KdTreeFLANN<PointT, Dist> >;
 
       /** \brief Default Constructor for KdTreeFLANN.
-        * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise. 
+        * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise.
         *
         * By setting sorted to false, the \ref radiusSearch operations will be faster.
         */
@@ -98,7 +98,7 @@ namespace pcl
 
       /** \brief Copy operator
         * \param[in] k the tree to copy into this
-        */ 
+        */
       inline KdTreeFLANN<PointT, Dist>&
       operator = (const KdTreeFLANN<PointT, Dist>& k)
       {
@@ -120,13 +120,13 @@ namespace pcl
       void
       setEpsilon (float eps) override;
 
-      void 
+      void
       setSortedResults (bool sorted);
-      
-      inline Ptr makeShared () { return Ptr (new KdTreeFLANN<PointT, Dist> (*this)); } 
 
-      /** \brief Destructor for KdTreeFLANN. 
-        * Deletes all allocated data arrays and destroys the kd-tree structures. 
+      inline Ptr makeShared () { return Ptr (new KdTreeFLANN<PointT, Dist> (*this)); }
+
+      /** \brief Destructor for KdTreeFLANN.
+        * Deletes all allocated data arrays and destroys the kd-tree structures.
         */
       ~KdTreeFLANN ()
       {
@@ -137,32 +137,32 @@ namespace pcl
         * \param[in] cloud the const boost shared pointer to a PointCloud message
         * \param[in] indices the point indices subset that is to be used from \a cloud - if NULL the whole cloud is used
         */
-      void 
+      void
       setInputCloud (const PointCloudConstPtr &cloud, const IndicesConstPtr &indices = IndicesConstPtr ()) override;
 
       /** \brief Search for k-nearest neighbors for the given query point.
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
+        *
         * \param[in] point a given \a valid (i.e., finite) query point
         * \param[in] k the number of neighbors to search for
         * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k 
+        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
         * a priori!)
         * \return number of neighbors found
-        * 
+        *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      int 
-      nearestKSearch (const PointT &point, int k, 
+      int
+      nearestKSearch (const PointT &point, int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const override;
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.
-        * 
+        *
         * \attention This method does not do any bounds checking for the input index
         * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        * 
+        *
         * \param[in] point a given \a valid (i.e., finite) query point
         * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
         * \param[out] k_indices the resultant indices of the neighboring points
@@ -174,20 +174,20 @@ namespace pcl
         *
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
-      int 
+      int
       radiusSearch (const PointT &point, double radius, std::vector<int> &k_indices,
                     std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const override;
 
     private:
       /** \brief Internal cleanup method. */
-      void 
+      void
       cleanup ();
 
       /** \brief Converts a PointCloud to the internal FLANN point array representation. Returns the number
         * of points.
-        * \param cloud the PointCloud 
+        * \param cloud the PointCloud
         */
-      void 
+      void
       convertCloudToArray (const PointCloud &cloud);
 
       /** \brief Converts a PointCloud with a given set of indices to the internal FLANN point array
@@ -195,12 +195,12 @@ namespace pcl
         * \param[in] cloud the PointCloud data
         * \param[in] indices the point cloud indices
        */
-      void 
+      void
       convertCloudToArray (const PointCloud &cloud, const std::vector<int> &indices);
 
     private:
       /** \brief Class getName method. */
-      std::string 
+      std::string
       getName () const override { return ("KdTreeFLANN"); }
 
       /** \brief A FLANN index object. */

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -155,7 +155,7 @@ namespace pcl
         * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
         */
       int
-      nearestKSearch (const PointT &point, int k,
+      nearestKSearch (const PointT &point, unsigned int k,
                       std::vector<int> &k_indices, std::vector<float> &k_sqr_distances) const override;
 
       /** \brief Search for all the nearest neighbors of the query point in a given radius.

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -219,7 +219,7 @@ namespace pcl
       int dim_;
 
       /** \brief The total size of the data (either equal to the number of points in the input cloud or to the number of indices - if passed). */
-      int total_nr_points_;
+      uindex_t total_nr_points_;
 
       /** \brief The KdTree search parameters for K-nearest neighbors. */
       ::flann::SearchParams param_k_;


### PR DESCRIPTION
While working on #4414 I mistakenly searched for 0 nearest neighbors, and the method segfaulted. This handles that situation better, as well as if a negative k is passed (the argument is a signed integer). Also, my editor automatically removes trailing whitespace, so that's in here too. I could revert all those changes if desired.