### PR TITLE
Fix description for `UniformSampling`

### DIFF
--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -50,13 +50,11 @@ namespace pcl
     * The @b UniformSampling class creates a *3D voxel grid* (think about a voxel
     * grid as a set of tiny 3D boxes in space) over the input point cloud data.
     * Then, in each *voxel* (i.e., 3D box), all the points present will be
-    * approximated (i.e., *downsampled*) with their centroid. This approach is
-    * a bit slower than approximating them with the center of the voxel, but it
-    * represents the underlying surface more accurately.
+    * approximated (i.e., *downsampled*) with the closest point to the center of the voxel.
     *
     * \author Radu Bogdan Rusu
     * \ingroup filters
-    */
+    */ 
   template <typename PointT>
   class UniformSampling: public Filter<PointT>
   {


### PR DESCRIPTION
Please check filters/impl/uniform_sampling.hpp where the removed_indices are set. The implementation does smell a bit but the comments say that all the points present will be approximated (i.e., *downsampled*) with the closest point to the center of the voxel.

Maybe its also worth to mention that it calculates point indices and is not producing a new cloud like the VoxelGrid Class.