### PR TITLE
[registration] Input size check for Registration::setInputSource

### DIFF
--- a/registration/include/pcl/registration/impl/registration.hpp
+++ b/registration/include/pcl/registration/impl/registration.hpp
@@ -44,6 +44,18 @@ namespace pcl
 {
 
 template <typename PointSource, typename PointTarget, typename Scalar> inline void
+Registration<PointSource, PointTarget, Scalar>::setInputSource (const PointCloudSourceConstPtr &cloud)
+{
+  if (cloud->points.empty ())
+  {
+    PCL_ERROR ("[pcl::%s::setInputSource] Invalid or empty point cloud dataset given!\n", getClassName ().c_str ());
+    return;
+  }
+  source_cloud_updated_ = true;
+  PCLBase<PointSource>::setInputCloud (cloud);
+}
+
+template <typename PointSource, typename PointTarget, typename Scalar> inline void
 Registration<PointSource, PointTarget, Scalar>::setInputTarget (const PointCloudTargetConstPtr &cloud)
 {
   if (cloud->points.empty ())

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -187,11 +187,7 @@ namespace pcl
         * \param[in] cloud the input point cloud source
         */
       virtual void
-      setInputSource (const PointCloudSourceConstPtr &cloud)
-      {
-        source_cloud_updated_ = true;
-        PCLBase<PointSource>::setInputCloud (cloud);
-      }
+      setInputSource (const PointCloudSourceConstPtr &cloud);
 
       /** \brief Get a pointer to the input point cloud dataset target. */
       inline PointCloudSourceConstPtr const


### PR DESCRIPTION
While ```Registration::setInputTarget``` checks if the input cloud is not empty, no size check exists in ```setInputSource```. This PR adds an input size check for ```setInputSource```.

Reference: https://github.com/PointCloudLibrary/pcl/pull/4433