### PR TITLE
Fix dataset link in conditional euclidean clustering tutorial

### DIFF
--- a/doc/tutorials/content/conditional_euclidean_clustering.rst
+++ b/doc/tutorials/content/conditional_euclidean_clustering.rst
@@ -26,7 +26,7 @@ The clusters classified as too small or too large can still be retrieved afterwa
 The Code
 --------
 
-First, download the dataset `Statues_4.pcd <https://sourceforge.net/projects/pointclouds/files/PCD datasets/Trimble/Outdoor1/Statues_4.pcd.zip>`_ and extract the PCD file from the archive.
+First, download the dataset `Statues_4.pcd <https://sourceforge.net/projects/pointclouds/files/PCD%20datasets/Trimble/Outdoor1/Statues_4.pcd.zip>`_ and extract the PCD file from the archive.
 This is a very large data set of an outdoor environment where we aim to cluster the separate objects and also want to separate the building from the ground plane even though it is attached in a Euclidean sense.
 
 Now create a file, let's say, ``conditional_euclidean_clustering.cpp`` in your favorite editor, and place the following inside it:


### PR DESCRIPTION
The original hyperlink: `https://sourceforge.net/projects/pointclouds/files/PCD datasets/Trimble/Outdoor1/Statues_4.pcd.zip` works if you copy and paste it to the address bar, but fails if you click on it on the document.
And what I found is that when you click on the original hyperlink, it will go to `https://sourceforge.net/projects/pointclouds/files/PCDdatasets/Trimble/Outdoor1/Statues_4.pcd.zip`(note that ` ` between `PCD` and `datasets` is missing).
This PR replaces ` ` with `%20` so the ` ` won't be missing.