### PR TITLE
Change a function's name in conditional euclidean clustering tutorial

### DIFF
--- a/doc/tutorials/content/sources/conditional_euclidean_clustering/conditional_euclidean_clustering.cpp
+++ b/doc/tutorials/content/sources/conditional_euclidean_clustering/conditional_euclidean_clustering.cpp
@@ -24,7 +24,7 @@ enforceNormalOrIntensitySimilarity (const PointTypeFull& point_a, const PointTyp
   Eigen::Map<const Eigen::Vector3f> point_a_normal = point_a.getNormalVector3fMap (), point_b_normal = point_b.getNormalVector3fMap ();
   if (std::abs (point_a.intensity - point_b.intensity) < 5.0f)
     return (true);
-  if (std::abs (point_a_normal.dot (point_b_normal)) < 0.05)
+  if (std::abs (point_a_normal.dot (point_b_normal)) > std::cos (30.0f / 180.0f * static_cast<float> (M_PI)))
     return (true);
   return (false);
 }

--- a/doc/tutorials/content/sources/conditional_euclidean_clustering/conditional_euclidean_clustering.cpp
+++ b/doc/tutorials/content/sources/conditional_euclidean_clustering/conditional_euclidean_clustering.cpp
@@ -19,7 +19,7 @@ enforceIntensitySimilarity (const PointTypeFull& point_a, const PointTypeFull& p
 }
 
 bool
-enforceCurvatureOrIntensitySimilarity (const PointTypeFull& point_a, const PointTypeFull& point_b, float squared_distance)
+enforceNormalOrIntensitySimilarity (const PointTypeFull& point_a, const PointTypeFull& point_b, float squared_distance)
 {
   Eigen::Map<const Eigen::Vector3f> point_a_normal = point_a.getNormalVector3fMap (), point_b_normal = point_b.getNormalVector3fMap ();
   if (std::abs (point_a.intensity - point_b.intensity) < 5.0f)


### PR DESCRIPTION
The function `enforceCurvatureOrIntensitySimilarity` has nothing to do with curvature, actually it uses normals as its condition.

Also `std::abs (point_a_normal.dot (point_b_normal)) < 0.05` seems weird, it adds a point if its normal's direction is largely different from that of the seed.