### PR TITLE
Enable Real Sense 2 grabber for all platforms

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -160,8 +160,7 @@ if(WITH_RSSDK)
   )
 endif()
 
-# RSSDK2 is restricted to Windows until it is functional under other OSs
-if(WIN32 AND WITH_RSSDK2)
+if(WITH_RSSDK2)
   set(RSSDK2_GRABBER_INCLUDES
       include/pcl/io/real_sense_2_grabber.h
   )
@@ -373,8 +372,7 @@ if(WITH_RSSDK)
   target_link_libraries(${LIB_NAME} ${RSSDK_LIBRARIES})
 endif()
 
-# RSSDK2 is restricted to Windows until it is functional under other OSs
-if(WIN32 AND WITH_RSSDK2)
+if(WITH_RSSDK2)
   target_link_libraries(${LIB_NAME} ${RSSDK2_LIBRARIES})
 endif()
 

--- a/io/include/pcl/io/real_sense_2_grabber.h
+++ b/io/include/pcl/io/real_sense_2_grabber.h
@@ -66,7 +66,7 @@ namespace pcl
     RealSense2Grabber ( const std::string& file_name_or_serial_number = "", const bool repeat_playback = true );
 
     /** \brief virtual Destructor inherited from the Grabber interface. It never throws. */
-    virtual ~RealSense2Grabber () noexcept;
+    ~RealSense2Grabber ();
 
     /** \brief Set the device options
     * \param[in] width resolution

--- a/io/src/real_sense_2_grabber.cpp
+++ b/io/src/real_sense_2_grabber.cpp
@@ -286,15 +286,21 @@ namespace pcl
     cloud->width = sp.width ();
     cloud->height = sp.height ();
     cloud->is_dense = false;
-    cloud->points.resize ( size () );
+    cloud->resize ( points.size () );
 
     const auto cloud_vertices_ptr = points.get_vertices ();
     const auto cloud_texture_ptr = points.get_texture_coordinates ();
 
+#if OPENMP_LEGACY_CONST_DATA_SHARING_RULE
 #pragma omp parallel for \
   default(none) \
-  shared(cloud, cloud_vertices_ptr, mapColorFunc)
-    for (int index = 0; index < cloud->size (); ++index)
+  shared(cloud, mapColorFunc)
+#else
+#pragma omp parallel for \
+  default(none) \
+  shared(cloud, cloud_texture_ptr, cloud_vertices_ptr, mapColorFunc)
+#endif
+    for (std::size_t index = 0; index < cloud->size (); ++index)
     {
       const auto ptr = cloud_vertices_ptr + index;
       const auto uvptr = cloud_texture_ptr + index;


### PR DESCRIPTION
I setup a new VM and wondered why neither Clang or GCC needed to build anything after adding lbrealsense dependency like in the docker image. As I [don't see any reason](https://github.com/IntelRealSense/librealsense/tree/v2.0.0#compatible-platforms) why it is limited to Windows I removed the check for `Win32` (interesting that no one noticed it during creating the Dockerfile).

Remove limitation of librealsense 2.x to Windows only, including several fixes:
* Fix warning: function previously declared with an explicit exception specification redeclared with an implicit exception specification [-Wimplicit-exception-spec-mismatch] RealSense2Grabber::~RealSense2Grabber ()
* Fix warning: comparison of integers of different signs: 'int' and 'std::size_t'
* Fix error: use of undeclared identifier 'size' (issue introduced in #4190)
* Fix error: variable 'cloud_texture_ptr' must have explicitly specified data sharing attributes