### PR TITLE
add missing \n in PCL_WARN and PCL_ERROR

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
@@ -198,7 +198,7 @@ public:
         }
 
         if (j != static_cast<pcl::index_t>(out->size())) {
-          PCL_ERROR("Contain nans...");
+          PCL_ERROR("Contain nans...\n");
         }
 
         out->points.resize(j);

--- a/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp
+++ b/apps/include/pcl/apps/impl/dominant_plane_segmentation.hpp
@@ -83,7 +83,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_table_plane()
   pass_.filter(*cloud_filtered_);
 
   if (int(cloud_filtered_->size()) < k_) {
-    PCL_WARN("[DominantPlaneSegmentation] Filtering returned %lu points! Aborting.",
+    PCL_WARN("[DominantPlaneSegmentation] Filtering returned %lu points! Aborting.\n",
              cloud_filtered_->size());
     return;
   }
@@ -104,7 +104,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_table_plane()
   seg_.segment(*table_inliers_, *table_coefficients_);
 
   if (table_inliers_->indices.empty()) {
-    PCL_WARN("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.");
+    PCL_WARN("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.\n");
     return;
   }
 
@@ -235,7 +235,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_fast(
   seg_.segment(*table_inliers_, *table_coefficients_);
 
   if (table_inliers_->indices.empty()) {
-    PCL_WARN("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.");
+    PCL_WARN("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.\n");
     return;
   }
 
@@ -748,7 +748,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_full(
   pass_.filter(*cloud_filtered_);
 
   if (int(cloud_filtered_->size()) < k_) {
-    PCL_WARN("[DominantPlaneSegmentation] Filtering returned %lu points! Aborting.",
+    PCL_WARN("[DominantPlaneSegmentation] Filtering returned %lu points! Aborting.\n",
              cloud_filtered_->size());
     return;
   }
@@ -779,7 +779,7 @@ pcl::apps::DominantPlaneSegmentation<PointType>::compute_full(
   seg_.segment(*table_inliers_, *table_coefficients_);
 
   if (table_inliers_->indices.empty()) {
-    PCL_WARN("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.");
+    PCL_WARN("[DominantPlaneSegmentation] No Plane Inliers points! Aborting.\n");
     return;
   }
 

--- a/common/include/pcl/common/geometry.h
+++ b/common/include/pcl/common/geometry.h
@@ -149,7 +149,7 @@ namespace pcl
       }
       else
       {
-        PCL_WARN ("[pcl::randomOrthogonalAxis] provided axis has norm < 1E-8f");
+        PCL_WARN ("[pcl::randomOrthogonalAxis] provided axis has norm < 1E-8f\n");
       }
 
       rand_ortho_axis.normalize ();

--- a/common/include/pcl/impl/pcl_base.hpp
+++ b/common/include/pcl/impl/pcl_base.hpp
@@ -100,27 +100,27 @@ pcl::PCLBase<PointT>::setIndices (std::size_t row_start, std::size_t col_start, 
 {
   if ((nb_rows > input_->height) || (row_start > input_->height))
   {
-    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d height", input_->height);
+    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d height\n", input_->height);
     return;
   }
 
   if ((nb_cols > input_->width) || (col_start > input_->width))
   {
-    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d width", input_->width);
+    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d width\n", input_->width);
     return;
   }
 
   std::size_t row_end = row_start + nb_rows;
   if (row_end > input_->height)
   {
-    PCL_ERROR ("[PCLBase::setIndices] %d is out of rows range %d", row_end, input_->height);
+    PCL_ERROR ("[PCLBase::setIndices] %d is out of rows range %d\n", row_end, input_->height);
     return;
   }
 
   std::size_t col_end = col_start + nb_cols;
   if (col_end > input_->width)
   {
-    PCL_ERROR ("[PCLBase::setIndices] %d is out of columns range %d", col_end, input_->width);
+    PCL_ERROR ("[PCLBase::setIndices] %d is out of columns range %d\n", col_end, input_->width);
     return;
   }
 

--- a/cuda/nn/organized_neighbor_search.hpp
+++ b/cuda/nn/organized_neighbor_search.hpp
@@ -43,7 +43,7 @@ namespace pcl
     {
       if (input_->height == 1)
       {
-        PCL_ERROR ("[pcl::%s::radiusSearch] Input dataset is not organized!", getName ().c_str ());
+        PCL_ERROR ("[pcl::%s::radiusSearch] Input dataset is not organized!\n", getName ().c_str ());
         return 0;
       }
 
@@ -171,7 +171,7 @@ namespace pcl
 
       if (input_->height == 1)
       {
-        PCL_ERROR ("[pcl::%s::nearestKSearch] Input dataset is not organized!", getName ().c_str ());
+        PCL_ERROR ("[pcl::%s::nearestKSearch] Input dataset is not organized!\n", getName ().c_str ());
         return 0;
       }
 

--- a/doc/tutorials/content/sources/pairwise_incremental_registration/pairwise_incremental_registration.cpp
+++ b/doc/tutorials/content/sources/pairwise_incremental_registration/pairwise_incremental_registration.cpp
@@ -143,11 +143,11 @@ void showCloudsRight(const PointCloudWithNormals::Ptr cloud_target, const PointC
 
   PointCloudColorHandlerGenericField<PointNormalT> tgt_color_handler (cloud_target, "curvature");
   if (!tgt_color_handler.isCapable ())
-      PCL_WARN ("Cannot create curvature color handler!");
+      PCL_WARN ("Cannot create curvature color handler!\n");
 
   PointCloudColorHandlerGenericField<PointNormalT> src_color_handler (cloud_source, "curvature");
   if (!src_color_handler.isCapable ())
-      PCL_WARN ("Cannot create curvature color handler!");
+      PCL_WARN ("Cannot create curvature color handler!\n");
 
 
   p->addPointCloud (cloud_target, tgt_color_handler, "target", vp_2);
@@ -332,11 +332,11 @@ int main (int argc, char** argv)
   // Check user input
   if (data.empty ())
   {
-    PCL_ERROR ("Syntax is: %s <source.pcd> <target.pcd> [*]", argv[0]);
-    PCL_ERROR ("[*] - multiple files can be added. The registration results of (i, i+1) will be registered against (i+2), etc");
+    PCL_ERROR ("Syntax is: %s <source.pcd> <target.pcd> [*]\n", argv[0]);
+    PCL_ERROR ("[*] - multiple files can be added. The registration results of (i, i+1) will be registered against (i+2), etc\n");
     return (-1);
   }
-  PCL_INFO ("Loaded %d datasets.", (int)data.size ());
+  PCL_INFO ("Loaded %d datasets.\n", (int)data.size ());
   
   // Create a PCLVisualizer object
   p = new pcl::visualization::PCLVisualizer (argc, argv, "Pairwise Incremental Registration example");

--- a/doc/tutorials/content/sources/planar_segmentation/planar_segmentation.cpp
+++ b/doc/tutorials/content/sources/planar_segmentation/planar_segmentation.cpp
@@ -51,7 +51,7 @@ int
 
   if (inliers->indices.size () == 0)
   {
-    PCL_ERROR ("Could not estimate a planar model for the given dataset.");
+    PCL_ERROR ("Could not estimate a planar model for the given dataset.\n");
     return (-1);
   }
 

--- a/examples/features/example_fast_point_feature_histograms.cpp
+++ b/examples/features/example_fast_point_feature_histograms.cpp
@@ -58,7 +58,7 @@ main (int argc, char** argv)
 
   if (pcl::io::loadPCDFile<pcl::PointXYZ> (fileName, *cloud) == -1) // load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR ("Couldn't read file\n");
     return (-1);
   }
 

--- a/examples/features/example_normal_estimation.cpp
+++ b/examples/features/example_normal_estimation.cpp
@@ -52,7 +52,7 @@ main (int, char** argv)
 
   if (pcl::io::loadPCDFile<pcl::PointXYZ> (filename, *cloud) == -1) // load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR ("Couldn't read file\n");
     return -1;
   }
 

--- a/examples/features/example_point_feature_histograms.cpp
+++ b/examples/features/example_point_feature_histograms.cpp
@@ -53,7 +53,7 @@ main (int, char** argv)
 
   if (pcl::io::loadPCDFile<pcl::PointXYZ> (filename, *cloud) == -1) //* load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR ("Couldn't read file\n");
     return (-1);
   }
 

--- a/examples/features/example_principal_curvatures_estimation.cpp
+++ b/examples/features/example_principal_curvatures_estimation.cpp
@@ -53,7 +53,7 @@ main (int, char** argv)
 
   if (pcl::io::loadPCDFile<pcl::PointXYZ> (filename, *cloud) == -1) //* load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR ("Couldn't read file\n");
     return (-1);
   }
 

--- a/examples/features/example_rift_estimation.cpp
+++ b/examples/features/example_rift_estimation.cpp
@@ -55,7 +55,7 @@ main (int, char** argv)
 
   if (pcl::io::loadPCDFile<pcl::PointXYZI> (filename, *cloud) == -1) // load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR ("Couldn't read file\n");
     return -1;
   }
 

--- a/examples/features/example_shape_contexts.cpp
+++ b/examples/features/example_shape_contexts.cpp
@@ -53,7 +53,7 @@ main (int, char** argv)
   if (pcl::io::loadPCDFile <pcl::PointXYZ> (filename, *cloud) == -1)
   // load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR ("Couldn't read file\n");
     return (-1);
   }
   std::cout << "Loaded " << cloud->size () << " points." << std::endl;

--- a/examples/features/example_spin_images.cpp
+++ b/examples/features/example_spin_images.cpp
@@ -53,7 +53,7 @@ main (int, char** argv)
   if (pcl::io::loadPCDFile <pcl::PointXYZ> (filename, *cloud) == -1)
   // load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR("Couldn't read file\n");
     return (-1);
   }
   std::cout << "Loaded " << cloud->size () << " points." << std::endl;

--- a/examples/keypoints/example_sift_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_keypoint_estimation.cpp
@@ -51,7 +51,7 @@ main(int, char** argv)
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
   if(pcl::io::loadPCDFile<pcl::PointXYZRGB> (filename, *cloud) == -1) // load the file
   {
-  PCL_ERROR ("Couldn't read file");
+  PCL_ERROR ("Couldn't read file\n");
   return -1;
   }
   std::cout << "points: " << cloud->size () <<std::endl;

--- a/examples/keypoints/example_sift_normal_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_normal_keypoint_estimation.cpp
@@ -57,7 +57,7 @@ main(int, char** argv)
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_xyz (new pcl::PointCloud<pcl::PointXYZ>);
   if(pcl::io::loadPCDFile<pcl::PointXYZ> (filename, *cloud_xyz) == -1) // load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR("Couldn't read file\n");
     return -1;
   }
   std::cout << "points: " << cloud_xyz->size () <<std::endl;

--- a/examples/keypoints/example_sift_z_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_z_keypoint_estimation.cpp
@@ -69,7 +69,7 @@ main(int, char** argv)
   pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_xyz (new pcl::PointCloud<pcl::PointXYZ>);
   if(pcl::io::loadPCDFile<pcl::PointXYZ> (filename, *cloud_xyz) == -1) // load the file
   {
-    PCL_ERROR ("Couldn't read file");
+    PCL_ERROR("Couldn't read file\n");
     return -1;
   }
   std::cout << "points: " << cloud_xyz->size () <<std::endl;

--- a/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
+++ b/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
@@ -611,27 +611,27 @@ pcl::MomentOfInertiaEstimation<PointT>::setIndices (std::size_t row_start, std::
 {
   if ((nb_rows > input_->height) || (row_start > input_->height))
   {
-    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d height", input_->height);
+    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d height\n", input_->height);
     return;
   }
 
   if ((nb_cols > input_->width) || (col_start > input_->width))
   {
-    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d width", input_->width);
+    PCL_ERROR ("[PCLBase::setIndices] cloud is only %d width\n", input_->width);
     return;
   }
 
   const std::size_t row_end = row_start + nb_rows;
   if (row_end > input_->height)
   {
-    PCL_ERROR ("[PCLBase::setIndices] %d is out of rows range %d", row_end, input_->height);
+    PCL_ERROR ("[PCLBase::setIndices] %d is out of rows range %d\n", row_end, input_->height);
     return;
   }
 
   const std::size_t col_end = col_start + nb_cols;
   if (col_end > input_->width)
   {
-    PCL_ERROR ("[PCLBase::setIndices] %d is out of columns range %d", col_end, input_->width);
+    PCL_ERROR ("[PCLBase::setIndices] %d is out of columns range %d\n", col_end, input_->width);
     return;
   }
 

--- a/filters/include/pcl/filters/impl/convolution_3d.hpp
+++ b/filters/include/pcl/filters/impl/convolution_3d.hpp
@@ -204,14 +204,14 @@ pcl::filters::Convolution3D<PointInT, PointOutT, KernelT>::initCompute ()
   // Do a fast check to see if the search parameters are well defined
   if (search_radius_ <= 0.0)
   {
-    PCL_ERROR ("[pcl::filters::Convlution3D::initCompute] search radius (%f) must be > 0",
+    PCL_ERROR ("[pcl::filters::Convlution3D::initCompute] search radius (%f) must be > 0\n",
                search_radius_);
     return (false);
   }
   // Make sure the provided kernel implements the required interface
   if (dynamic_cast<ConvolvingKernel<PointInT, PointOutT>* > (&kernel_) == 0)
   {
-    PCL_ERROR ("[pcl::filters::Convlution3D::initCompute] init failed");
+    PCL_ERROR ("[pcl::filters::Convlution3D::initCompute] init failed : ");
     PCL_ERROR ("kernel_ must implement ConvolvingKernel interface\n!");
     return (false);
   }

--- a/filters/include/pcl/filters/impl/pyramid.hpp
+++ b/filters/include/pcl/filters/impl/pyramid.hpp
@@ -53,13 +53,13 @@ Pyramid<PointT>::initCompute ()
 {
   if (!input_->isOrganized ())
   {
-    PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should be at least 2!", getClassName ().c_str ());
+    PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should be at least 2!\n", getClassName ().c_str ());
     return (false);
   }
 
   if (levels_ < 2)
   {
-    PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should be at least 2!", getClassName ().c_str ());
+    PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should be at least 2!\n", getClassName ().c_str ());
     return (false);
   }
 
@@ -69,7 +69,7 @@ Pyramid<PointT>::initCompute ()
 
   if (levels_ > 4)
   {
-    PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should not exceed 4!", getClassName ().c_str ());
+    PCL_ERROR ("[pcl::fileters::%s::initCompute] Number of levels should not exceed 4!\n", getClassName ().c_str ());
     return (false);
   }
 

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -1034,7 +1034,7 @@ struct KinFuLSApp
         c = capture_.registerCallback (func2);
       }
       #else
-      PCL_ERROR ("OpenNI2 is disabled in this PCL. Please build PCL with OpenNI2 feature.");
+      PCL_ERROR ("OpenNI2 is disabled in this PCL. Please build PCL with OpenNI2 feature.\n");
       #endif
     }
     else
@@ -1065,7 +1065,7 @@ struct KinFuLSApp
         c = capture_.registerCallback (func2);
       }
       #else
-      PCL_ERROR ("OpenNI is disabled in this PCL. Please build PCL with OpenNI feature.");
+      PCL_ERROR ("OpenNI is disabled in this PCL. Please build PCL with OpenNI feature.\n");
       #endif
     }
 

--- a/gpu/people/tools/people_app.cpp
+++ b/gpu/people/tools/people_app.cpp
@@ -433,7 +433,7 @@ int main(int argc, char** argv)
   tree_files.resize(num_trees);
   if (num_trees == 0 || num_trees > 4)
   {
-    PCL_ERROR("[Main] : Invalid number of trees");
+    PCL_ERROR("[Main] : Invalid number of trees\n");
     print_help();
     return -1;
   }

--- a/io/include/pcl/io/impl/auto_io.hpp
+++ b/io/include/pcl/io/impl/auto_io.hpp
@@ -65,7 +65,7 @@ namespace pcl
         result = pcl::io::loadIFSFile (file_name, cloud);
       else
       {
-        PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s", extension.c_str ());
+        PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s\n", extension.c_str ());
         result = -1;
       }
       return (result);
@@ -85,7 +85,7 @@ namespace pcl
         result = pcl::io::saveIFSFile (file_name, cloud);
       else
       {
-        PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s", extension.c_str ());
+        PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s\n", extension.c_str ());
         result = -1;
       }
       return (result);

--- a/io/src/auto_io.cpp
+++ b/io/src/auto_io.cpp
@@ -59,7 +59,7 @@ pcl::io::load (const std::string& file_name, pcl::PCLPointCloud2& blob)
     result = pcl::io::loadOBJFile (file_name, blob);
   else
   {
-    PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s", extension.c_str ());
+    PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s\n", extension.c_str ());
     result = -1;
   }
   return (result);
@@ -79,7 +79,7 @@ pcl::io::load (const std::string& file_name, pcl::PolygonMesh& mesh)
     result = pcl::io::loadOBJFile (file_name, mesh);
   else
   {
-    PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s", extension.c_str ());
+    PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s\n", extension.c_str ());
     result = -1;
   }
   return (result);
@@ -95,7 +95,7 @@ pcl::io::load (const std::string& file_name, pcl::TextureMesh& mesh)
     result = pcl::io::loadOBJFile (file_name, mesh);
   else
   {
-    PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s", extension.c_str ());
+    PCL_ERROR ("[pcl::io::load] Don't know how to handle file with extension %s\n", extension.c_str ());
     result = -1;
   }
   return (result);
@@ -125,7 +125,7 @@ pcl::io::save (const std::string& file_name, const pcl::PCLPointCloud2& blob, un
     result = pcl::io::saveVTKFile (file_name, blob, precision);
   else
   {
-    PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s", extension.c_str ());
+    PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s\n", extension.c_str ());
     result = -1;
   }
   return (result);
@@ -141,7 +141,7 @@ pcl::io::save (const std::string &file_name, const pcl::TextureMesh &tex_mesh, u
     result = pcl::io::saveOBJFile (file_name, tex_mesh, precision);
   else
   {
-    PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s", extension.c_str ());
+    PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s\n", extension.c_str ());
     result = -1;
   }
   return (result);
@@ -161,7 +161,7 @@ pcl::io::save (const std::string &file_name, const pcl::PolygonMesh &poly_mesh, 
     result = pcl::io::saveVTKFile (file_name, poly_mesh, precision);
   else
   {
-    PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s", extension.c_str ());
+    PCL_ERROR ("[pcl::io::save] Don't know how to handle file with extension %s\n", extension.c_str ());
     result = -1;
   }
   return (result);

--- a/io/src/image_grabber.cpp
+++ b/io/src/image_grabber.cpp
@@ -288,7 +288,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
   if (!boost::filesystem::exists (dir) || !boost::filesystem::is_directory (dir))
   {
     PCL_ERROR ("[pcl::ImageGrabber::loadDepthAndRGBFiles] Error: attempted to instantiate a pcl::ImageGrabber from a path which"
-               " is not a directory: %s", dir.c_str ());
+               " is not a directory: %s\n", dir.c_str ());
     return;
   }
   std::string pathname;
@@ -324,13 +324,13 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
   if (!boost::filesystem::exists (depth_dir) || !boost::filesystem::is_directory (depth_dir))
   {
     PCL_ERROR ("[pcl::ImageGrabber::loadDepthAndRGBFiles] Error: attempted to instantiate a pcl::ImageGrabber from a path which"
-               " is not a directory: %s", depth_dir.c_str ());
+               " is not a directory: %s\n", depth_dir.c_str ());
     return;
   }
   if (!boost::filesystem::exists (rgb_dir) || !boost::filesystem::is_directory (rgb_dir))
   {
     PCL_ERROR ("[pcl::ImageGrabber::loadDepthAndRGBFiles] Error: attempted to instantiate a pcl::ImageGrabber from a path which"
-               " is not a directory: %s", rgb_dir.c_str ());
+               " is not a directory: %s\n", rgb_dir.c_str ());
     return;
   }
   std::string pathname;
@@ -368,15 +368,15 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles (const std::string
     }
   }
   if (depth_image_files_.size () != rgb_image_files_.size () )
-    PCL_WARN ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : Watch out not same amount of depth and rgb images");
+    PCL_WARN ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : Watch out not same amount of depth and rgb images\n");
   if (!depth_image_files_.empty ())
     sort (depth_image_files_.begin (), depth_image_files_.end ());
   else
-    PCL_ERROR ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : no depth images added");
+    PCL_ERROR ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : no depth images added\n");
   if (!rgb_image_files_.empty ())
     sort (rgb_image_files_.begin (), rgb_image_files_.end ());
   else
-    PCL_ERROR ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : no rgb images added");
+    PCL_ERROR ("[pcl::ImageGrabberBase::ImageGrabberImpl::loadDepthAndRGBFiles] : no rgb images added\n");
 }
 
 
@@ -387,7 +387,7 @@ pcl::ImageGrabberBase::ImageGrabberImpl::loadPCLZFFiles (const std::string &dir)
   if (!boost::filesystem::exists (dir) || !boost::filesystem::is_directory (dir))
   {
     PCL_ERROR ("[pcl::ImageGrabber::loadPCLZFFiles] Error: attempted to instantiate a pcl::ImageGrabber from a path which"
-               " is not a directory: %s", dir.c_str ());
+               " is not a directory: %s\n", dir.c_str ());
     return;
   }
   std::string pathname;

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -230,7 +230,7 @@ pcl::MTLReader::read (const std::string& mtl_file_path)
         {
           if (fillRGBfromXYZ (st, *rgb))
           {
-            PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values",
+            PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values\n",
                        line.c_str ());
             mtl_file.close ();
             materials_.clear ();
@@ -241,7 +241,7 @@ pcl::MTLReader::read (const std::string& mtl_file_path)
         {
           if (fillRGBfromRGB (st, *rgb))
           {
-            PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values",
+            PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to RGB values\n",
                        line.c_str ());
             mtl_file.close ();
             materials_.clear ();
@@ -259,7 +259,7 @@ pcl::MTLReader::read (const std::string& mtl_file_path)
         }
         catch (boost::bad_lexical_cast &)
         {
-          PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to illumination model",
+          PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to illumination model\n",
                      line.c_str ());
           mtl_file.close ();
           materials_.clear ();
@@ -279,7 +279,7 @@ pcl::MTLReader::read (const std::string& mtl_file_path)
         }
         catch (boost::bad_lexical_cast &)
         {
-          PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to transparency value",
+          PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to transparency value\n",
                      line.c_str ());
           mtl_file.close ();
           materials_.clear ();
@@ -296,7 +296,7 @@ pcl::MTLReader::read (const std::string& mtl_file_path)
         }
         catch (boost::bad_lexical_cast &)
         {
-          PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to shininess value",
+          PCL_ERROR ("[pcl::MTLReader::read] Could not convert %s to shininess value\n",
                      line.c_str ());
           mtl_file.close ();
           materials_.clear ();
@@ -574,7 +574,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
         }
         catch (const boost::bad_lexical_cast&)
         {
-          PCL_ERROR ("Unable to convert %s to vertex coordinates!", line.c_str ());
+          PCL_ERROR ("Unable to convert %s to vertex coordinates!\n", line.c_str ());
           return (-1);
         }
         continue;
@@ -603,7 +603,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
         }
         catch (const boost::bad_lexical_cast&)
         {
-          PCL_ERROR ("Unable to convert line %s to vertex normal!", line.c_str ());
+          PCL_ERROR ("Unable to convert line %s to vertex normal!\n", line.c_str ());
           return (-1);
         }
         continue;
@@ -716,7 +716,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
         }
         catch (const boost::bad_lexical_cast&)
         {
-          PCL_ERROR ("Unable to convert %s to vertex coordinates!", line.c_str ());
+          PCL_ERROR ("Unable to convert %s to vertex coordinates!\n", line.c_str ());
           return (-1);
         }
         continue;
@@ -737,7 +737,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
         }
         catch (const boost::bad_lexical_cast&)
         {
-          PCL_ERROR ("Unable to convert line %s to vertex normal!", line.c_str ());
+          PCL_ERROR ("Unable to convert line %s to vertex normal!\n", line.c_str ());
           return (-1);
         }
         continue;
@@ -758,7 +758,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
         }
         catch (const boost::bad_lexical_cast&)
         {
-          PCL_ERROR ("Unable to convert line %s to texture coordinates!", line.c_str ());
+          PCL_ERROR ("Unable to convert line %s to texture coordinates!\n", line.c_str ());
           return (-1);
         }
         continue;
@@ -906,7 +906,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
         }
         catch (const boost::bad_lexical_cast&)
         {
-          PCL_ERROR ("Unable to convert %s to vertex coordinates!", line.c_str ());
+          PCL_ERROR ("Unable to convert %s to vertex coordinates!\n", line.c_str ());
           return (-1);
         }
         continue;
@@ -928,7 +928,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
         }
         catch (const boost::bad_lexical_cast&)
         {
-          PCL_ERROR ("Unable to convert line %s to vertex normal!", line.c_str ());
+          PCL_ERROR ("Unable to convert line %s to vertex normal!\n", line.c_str ());
           return (-1);
         }
         continue;

--- a/io/src/oni_grabber.cpp
+++ b/io/src/oni_grabber.cpp
@@ -313,7 +313,7 @@ ONIGrabber::imageDepthImageCallback(const openni_wrapper::Image::Ptr &image, con
   // check if we have color point cloud slots
   if (point_cloud_rgb_signal_->num_slots () > 0)
   {
-    PCL_WARN ("PointXYZRGB callbacks deprecated. Use PointXYZRGBA instead.");
+    PCL_WARN ("PointXYZRGB callbacks deprecated. Use PointXYZRGBA instead.\n");
     point_cloud_rgb_signal_->operator() (convertToXYZRGBPointCloud (image, depth_image));
   }
 

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -807,7 +807,7 @@ pcl::PLYWriter::generateHeader (const pcl::PCLPointCloud2 &cloud,
         case pcl::PCLPointField::FLOAT64 : oss << " double "; break;
         default :
         {
-          PCL_ERROR ("[pcl::PLYWriter::generateHeader] unknown data field type!");
+          PCL_ERROR ("[pcl::PLYWriter::generateHeader] unknown data field type!\n");
           return ("");
         }
       }

--- a/io/src/real_sense_grabber.cpp
+++ b/io/src/real_sense_grabber.cpp
@@ -203,7 +203,7 @@ pcl::RealSenseGrabber::setConfidenceThreshold (unsigned int threshold)
 {
   if (threshold > 15)
   {
-    PCL_WARN ("[pcl::RealSenseGrabber::setConfidenceThreshold] Attempted to set threshold outside valid range (0-15)");
+    PCL_WARN ("[pcl::RealSenseGrabber::setConfidenceThreshold] Attempted to set threshold outside valid range (0-15)\n");
   }
   else
   {

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -1701,7 +1701,7 @@ pcl::keypoints::brisk::Layer::halfsample (
   }
 #else
   pcl::utils::ignore(srcimg, srcwidth, srcheight, dstimg, dstwidth);
-  PCL_ERROR("brisk without SSSE3 support not implemented");
+  PCL_ERROR("brisk without SSSE3 support not implemented\n");
 #endif
 }
 
@@ -1811,7 +1811,7 @@ pcl::keypoints::brisk::Layer::twothirdsample (
   }
 #else
   pcl::utils::ignore(srcimg, srcwidth, srcheight, dstimg, dstwidth);
-  PCL_ERROR("brisk without SSSE3 support not implemented");
+  PCL_ERROR("brisk without SSSE3 support not implemented\n");
 #endif
 }
 

--- a/ml/include/pcl/ml/impl/dt/decision_tree_trainer.hpp
+++ b/ml/include/pcl/ml/impl/dt/decision_tree_trainer.hpp
@@ -119,7 +119,7 @@ DecisionTreeTrainer<FeatureType, DataSet, LabelType, ExampleIndex, NodeType>::
   const std::size_t num_of_examples = examples.size();
   if (num_of_examples == 0) {
     PCL_ERROR(
-        "Reached invalid point in decision tree training: Number of examples is 0!");
+        "Reached invalid point in decision tree training: Number of examples is 0!\n");
     return;
   };
 

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -864,7 +864,7 @@ namespace pcl
       //if already has 8 children, return
       if (children_[idx] || (num_children_ == 8))
       {
-        PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeBaseNode::createChild] Not allowed to create a 9th child of %s",this->node_metadata_->getMetadataFilename ().c_str ());
+        PCL_ERROR ("[pcl::outofcore::OutofcoreOctreeBaseNode::createChild] Not allowed to create a 9th child of %s\n",this->node_metadata_->getMetadataFilename ().c_str ());
         return;
       }
 
@@ -1999,7 +1999,7 @@ namespace pcl
 
         if(!this->pointInBoundingBox (local_pt))
         {
-          PCL_ERROR ("pcl::outofcore::OutofcoreOctreeBaseNode::%s] Point %2.lf %.2lf %.2lf not in bounding box", __FUNCTION__, local_pt.x, local_pt.y, local_pt.z);
+          PCL_ERROR ("pcl::outofcore::OutofcoreOctreeBaseNode::%s] Point %2.lf %.2lf %.2lf not in bounding box\n", __FUNCTION__, local_pt.x, local_pt.y, local_pt.z);
         }
         
         assert (this->pointInBoundingBox (local_pt) == true);

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -308,7 +308,7 @@ main (int argc, char* argv[])
     boost::filesystem::path pcd_path (argv[file_arg_index]);
     if (!boost::filesystem::exists (pcd_path))
     {
-      PCL_WARN ("File %s doesn't exist", pcd_path.string ().c_str ());
+      PCL_WARN ("File %s doesn't exist\n", pcd_path.string ().c_str ());
       continue;
     }
     pcd_paths.push_back (pcd_path);

--- a/recognition/include/pcl/recognition/hv/hypotheses_verification.h
+++ b/recognition/include/pcl/recognition/hv/hypotheses_verification.h
@@ -231,7 +231,7 @@ namespace pcl
         //we need to reason about occlusions before setting the model
         if (scene_cloud_ == nullptr)
         {
-          PCL_ERROR("setSceneCloud should be called before adding the model if reasoning about occlusions...");
+          PCL_ERROR("setSceneCloud should be called before adding the model if reasoning about occlusions...\n");
         }
 
         if (!occlusion_cloud_->isOrganized ())

--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -147,7 +147,7 @@ namespace pcl
         virtual void
         setSourceNormals (pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
         {
-          PCL_WARN ("[pcl::registration::%s::setSourceNormals] This class does not require input source normals", getClassName ().c_str ());
+          PCL_WARN ("[pcl::registration::%s::setSourceNormals] This class does not require input source normals\n", getClassName ().c_str ());
         }
         
         /** \brief See if this rejector requires target normals */
@@ -159,7 +159,7 @@ namespace pcl
         virtual void
         setTargetNormals (pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
         {
-          PCL_WARN ("[pcl::registration::%s::setTargetNormals] This class does not require input target normals", getClassName ().c_str ());
+          PCL_WARN ("[pcl::registration::%s::setTargetNormals] This class does not require input target normals\n", getClassName ().c_str ());
         }
 
         /** \brief Provide a pointer to the vector of indices that represent the 

--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -140,7 +140,7 @@ namespace pcl
         virtual void
         setSourcePoints (pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
         {
-          PCL_WARN ("[pcl::registration::%s::setSourcePoints] This class does not require an input source cloud", getClassName ().c_str ());
+          PCL_WARN ("[pcl::registration::%s::setSourcePoints] This class does not require an input source cloud\n", getClassName ().c_str ());
         }
         
         /** \brief See if this rejector requires source normals */
@@ -152,7 +152,7 @@ namespace pcl
         virtual void
         setSourceNormals (pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
         { 
-          PCL_WARN ("[pcl::registration::%s::setSourceNormals] This class does not require input source normals", getClassName ().c_str ());
+          PCL_WARN ("[pcl::registration::%s::setSourceNormals] This class does not require input source normals\n", getClassName ().c_str ());
         }
         /** \brief See if this rejector requires a target cloud */
         virtual bool
@@ -163,7 +163,7 @@ namespace pcl
         virtual void
         setTargetPoints (pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
         {
-          PCL_WARN ("[pcl::registration::%s::setTargetPoints] This class does not require an input target cloud", getClassName ().c_str ());
+          PCL_WARN ("[pcl::registration::%s::setTargetPoints] This class does not require an input target cloud\n", getClassName ().c_str ());
         }
         
         /** \brief See if this rejector requires target normals */
@@ -175,7 +175,7 @@ namespace pcl
         virtual void
         setTargetNormals (pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
         {
-          PCL_WARN ("[pcl::registration::%s::setTargetNormals] This class does not require input target normals", getClassName ().c_str ());
+          PCL_WARN ("[pcl::registration::%s::setTargetNormals] This class does not require input target normals\n", getClassName ().c_str ());
         }
 
       protected:

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -60,7 +60,7 @@ KFPCSInitialAlignment<PointSource, PointTarget, NormalT, Scalar>::initCompute()
   // due to sparse keypoint cloud, do not normalize delta with estimated point density
   if (normalize_delta_) {
     PCL_WARN("[%s::initCompute] Delta should be set according to keypoint precision! "
-             "Normalization according to point cloud density is ignored.",
+             "Normalization according to point cloud density is ignored.\n",
              reg_name_.c_str());
     normalize_delta_ = false;
   }

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_weighted.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_weighted.hpp
@@ -194,7 +194,7 @@ pcl::registration::
   {
     PCL_ERROR("[pcl::IterativeClosestPointNonLinear::estimateRigidTransformationLM] ");
     PCL_ERROR("Need at least 4 points to estimate a transform! Source and target have "
-              "%lu points!",
+              "%lu points!\n",
               indices_src.size());
     return;
   }

--- a/registration/include/pcl/registration/joint_icp.h
+++ b/registration/include/pcl/registration/joint_icp.h
@@ -131,7 +131,7 @@ namespace pcl
       void
       setInputSource (const PointCloudSourceConstPtr& /*cloud*/) override
       {
-        PCL_WARN ("[pcl::%s::setInputSource] Warning; JointIterativeClosestPoint expects multiple clouds. Please use addInputSource.", 
+        PCL_WARN ("[pcl::%s::setInputSource] Warning; JointIterativeClosestPoint expects multiple clouds. Please use addInputSource.\n", 
             getClassName ().c_str ());
         return;
       }
@@ -155,7 +155,7 @@ namespace pcl
       void
       setInputTarget (const PointCloudTargetConstPtr& /*cloud*/) override
       {
-        PCL_WARN ("[pcl::%s::setInputTarget] Warning; JointIterativeClosestPoint expects multiple clouds. Please use addInputTarget.", 
+        PCL_WARN ("[pcl::%s::setInputTarget] Warning; JointIterativeClosestPoint expects multiple clouds. Please use addInputTarget.\n", 
             getClassName ().c_str ());
         return;
       }

--- a/registration/include/pcl/registration/transformation_validation_euclidean.h
+++ b/registration/include/pcl/registration/transformation_validation_euclidean.h
@@ -206,7 +206,7 @@ namespace pcl
         {
           if (std::isnan (threshold_))
           {
-            PCL_ERROR ("[pcl::TransformationValidationEuclidean::isValid] Threshold not set! Please use setThreshold () before continuing.");
+            PCL_ERROR ("[pcl::TransformationValidationEuclidean::isValid] Threshold not set! Please use setThreshold () before continuing.\n");
             return (false);
           }
 

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -80,7 +80,7 @@ pcl::extractLabeledEuclideanClusters (const PointCloud<PointT> &cloud,
       // Search for sq_idx
       int ret = tree->radiusSearch (seed_queue[sq_idx], tolerance, nn_indices, nn_distances, std::numeric_limits<int>::max());
       if(ret == -1)
-        PCL_ERROR("radiusSearch on tree came back with error -1");
+        PCL_ERROR("radiusSearch on tree came back with error -1\n");
       if (!ret)
       {
         sq_idx++;

--- a/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
@@ -89,7 +89,7 @@ GrabCut<PointT>::initCompute ()
   using namespace pcl::segmentation::grabcut;
   if (!pcl::PCLBase<PointT>::initCompute ())
   {
-    PCL_ERROR ("[pcl::GrabCut::initCompute ()] Init failed!");
+    PCL_ERROR ("[pcl::GrabCut::initCompute ()] Init failed!\n");
     return (false);
   }
 
@@ -97,7 +97,7 @@ GrabCut<PointT>::initCompute ()
   if ((pcl::getFieldIndex<PointT> ("rgb", in_fields_) == -1) &&
       (pcl::getFieldIndex<PointT> ("rgba", in_fields_) == -1))
   {
-    PCL_ERROR ("[pcl::GrabCut::initCompute ()] No RGB data available, aborting!");
+    PCL_ERROR ("[pcl::GrabCut::initCompute ()] No RGB data available, aborting!\n");
     return (false);
   }
 

--- a/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
@@ -88,7 +88,7 @@ pcl::seededHueSegmentation (const PointCloud<PointXYZRGB>          &cloud,
     {
       int ret = tree->radiusSearch (seed_queue[sq_idx], tolerance, nn_indices, nn_distances, std::numeric_limits<int>::max());
       if(ret == -1)
-        PCL_ERROR("[pcl::seededHueSegmentation] radiusSearch returned error code -1");
+        PCL_ERROR("[pcl::seededHueSegmentation] radiusSearch returned error code -1\n");
       // Search for sq_idx
       if (!ret)
       {
@@ -166,7 +166,7 @@ pcl::seededHueSegmentation (const PointCloud<PointXYZRGB>            &cloud,
     {
       int ret = tree->radiusSearch (seed_queue[sq_idx], tolerance, nn_indices, nn_distances, std::numeric_limits<int>::max());
       if(ret == -1)
-        PCL_ERROR("[pcl::seededHueSegmentation] radiusSearch returned error code -1");
+        PCL_ERROR("[pcl::seededHueSegmentation] radiusSearch returned error code -1\n");
       // Search for sq_idx
       if (!ret)
       {

--- a/tools/mesh_sampling.cpp
+++ b/tools/mesh_sampling.cpp
@@ -124,7 +124,7 @@ randPSurface (vtkPolyData * polydata, std::vector<double> * cumulativeAreas, dou
     {
       static bool printed_once = false;
       if (!printed_once)
-        PCL_WARN ("Mesh has no vertex colors, or vertex colors are not RGB!");
+        PCL_WARN ("Mesh has no vertex colors, or vertex colors are not RGB!\n");
       printed_once = true;
     }
   }

--- a/tracking/include/pcl/tracking/impl/particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/particle_filter.hpp
@@ -320,7 +320,7 @@ ParticleFilterTracker<PointInT, StateT>::computeTransformedPointCloudWithNormal(
   }
 #else
   PCL_WARN("[pcl::%s::computeTransformedPointCloudWithoutNormal] "
-           "use_normal_ == true is not supported in this Point Type.",
+           "use_normal_ == true is not supported in this Point Type.\n",
            getClassName().c_str());
 #endif
 }

--- a/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
+++ b/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
@@ -105,13 +105,13 @@ PyramidalKLTTracker<PointInT, IntensityT>::initCompute()
 
   if (!input_->isOrganized()) {
     PCL_ERROR(
-        "[pcl::tracking::%s::initCompute] Need an organized point cloud to proceed!",
+        "[pcl::tracking::%s::initCompute] Need an organized point cloud to proceed!\n",
         tracker_name_.c_str());
     return (false);
   }
 
   if (!keypoints_ || keypoints_->empty()) {
-    PCL_ERROR("[pcl::tracking::%s::initCompute] No keypoints aborting!",
+    PCL_ERROR("[pcl::tracking::%s::initCompute] No keypoints aborting!\n",
               tracker_name_.c_str());
     return (false);
   }
@@ -144,14 +144,14 @@ PyramidalKLTTracker<PointInT, IntensityT>::initCompute()
 
     if (nb_levels_ < 2) {
       PCL_ERROR("[pcl::tracking::%s::initCompute] Number of pyramid levels should be "
-                "at least 2!",
+                "at least 2!\n",
                 tracker_name_.c_str());
       return (false);
     }
 
     if (nb_levels_ > 5) {
       PCL_ERROR("[pcl::tracking::%s::initCompute] Number of pyramid levels should not "
-                "exceed 5!",
+                "exceed 5!\n",
                 tracker_name_.c_str());
       return (false);
     }

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -651,7 +651,7 @@ pcl::visualization::PCLVisualizer::addText3D (
   // If there is no custom viewport and the viewport number is not 0, exit
   if (rens_->GetNumberOfItems () <= viewport)
   {
-    PCL_ERROR ("[addText3D] The viewport [%d] doesn't exist (id <%s>)! ",
+    PCL_ERROR ("[addText3D] The viewport [%d] doesn't exist (id <%s>)! \n",
                viewport,
                tid.c_str ());
     return false;
@@ -664,7 +664,7 @@ pcl::visualization::PCLVisualizer::addText3D (
     const std::string uid = tid + std::string (i, '*');
     if (contains (uid))
     {
-      PCL_ERROR ( "[addText3D] The id <%s> already exists in viewport [%d]! "
+      PCL_ERROR ( "[addText3D] The id <%s> already exists in viewport [%d]! \n"
                   "Please choose a different id and retry.\n",
                   tid.c_str (),
                   i);
@@ -738,7 +738,7 @@ pcl::visualization::PCLVisualizer::addText3D (
   // If there is no custom viewport and the viewport number is not 0, exit
   if (rens_->GetNumberOfItems () <= viewport)
   {
-    PCL_ERROR ("[addText3D] The viewport [%d] doesn't exist (id <%s>)! ",
+    PCL_ERROR ("[addText3D] The viewport [%d] doesn't exist (id <%s>)!\n",
                viewport,
                tid.c_str ());
     return false;

--- a/visualization/src/histogram_visualizer.cpp
+++ b/visualization/src/histogram_visualizer.cpp
@@ -287,7 +287,7 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
   int field_idx = pcl::getFieldIndex (cloud, field_name);
   if (field_idx == -1)
   {
-    PCL_ERROR ("[addFeatureHistogram] Invalid field (%s) given!", field_name.c_str ());
+    PCL_ERROR ("[addFeatureHistogram] Invalid field (%s) given!\n", field_name.c_str ());
     return (false);
   }
 

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -1067,7 +1067,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         if(CurrentRenderer)
           CurrentRenderer->ResetCamera ();
         else
-          PCL_WARN ("no current renderer on the interactor style.");
+          PCL_WARN ("no current renderer on the interactor style.\n");
 
         CurrentRenderer->Render ();
         break;

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -303,7 +303,7 @@ pcl::visualization::PCLPlotter::addFeatureHistogram (
   int field_idx = pcl::getFieldIndex (cloud, field_name);
   if (field_idx == -1)
   {
-    PCL_ERROR ("[addFeatureHistogram] Invalid field (%s) given!", field_name.c_str ());
+    PCL_ERROR ("[addFeatureHistogram] Invalid field (%s) given!\n", field_name.c_str ());
     return (false);
   }
 
@@ -343,7 +343,7 @@ pcl::visualization::PCLPlotter::addFeatureHistogram (
   int field_idx = pcl::getFieldIndex (cloud, field_name);
   if (field_idx == -1)
   {
-    PCL_ERROR ("[addFeatureHistogram] Invalid field (%s) given!", field_name.c_str ());
+    PCL_ERROR ("[addFeatureHistogram] Invalid field (%s) given!\n", field_name.c_str ());
     return (false);
   }
 

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -335,7 +335,7 @@ pcl::visualization::PCLVisualizer::setupInteractor (
 void pcl::visualization::PCLVisualizer::setupRenderer (vtkSmartPointer<vtkRenderer> ren)
 {
   if (!ren)
-    PCL_ERROR ("Passed pointer to renderer is null");
+    PCL_ERROR ("Passed pointer to renderer is null\n");
 
   ren->AddObserver (vtkCommand::EndEvent, update_fps_);
   // Add it to the list of renderers
@@ -346,7 +346,7 @@ void pcl::visualization::PCLVisualizer::setupRenderer (vtkSmartPointer<vtkRender
 void pcl::visualization::PCLVisualizer::setupFPSCallback (const vtkSmartPointer<vtkRenderer>& ren)
 {
   if (!ren)
-    PCL_ERROR ("Passed pointer to renderer is null");
+    PCL_ERROR ("Passed pointer to renderer is null\n");
   // FPS callback
   vtkSmartPointer<vtkTextActor> txt = vtkSmartPointer<vtkTextActor>::New ();
   update_fps_->actor = txt;
@@ -360,7 +360,7 @@ void pcl::visualization::PCLVisualizer::setupFPSCallback (const vtkSmartPointer<
 void pcl::visualization::PCLVisualizer::setupRenderWindow (const std::string& name)
 {
   if (!win_)
-    PCL_ERROR ("Pointer to render window is null");
+    PCL_ERROR ("Pointer to render window is null\n");
 
   // This is temporary measures for disable display of deprecated warnings
   #if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2
@@ -383,7 +383,7 @@ void pcl::visualization::PCLVisualizer::setupRenderWindow (const std::string& na
 void pcl::visualization::PCLVisualizer::setupStyle ()
 {
   if (!style_)
-    PCL_ERROR ("Pointer to style is null");
+    PCL_ERROR ("Pointer to style is null\n");
 
   // Set rend erer window in case no interactor is created
   style_->setRenderWindow (win_);
@@ -401,7 +401,7 @@ void pcl::visualization::PCLVisualizer::setupStyle ()
 void pcl::visualization::PCLVisualizer::setDefaultWindowSizeAndPos ()
 {
   if (!win_)
-    PCL_ERROR ("Pointer to render window is null");
+    PCL_ERROR ("Pointer to render window is null\n");
   int scr_size_x = win_->GetScreenSize ()[0];
   int scr_size_y = win_->GetScreenSize ()[1];
   win_->SetSize (scr_size_x / 2, scr_size_y / 2);
@@ -855,7 +855,7 @@ pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int view
   // If there is no custom viewport and the viewport number is not 0, exit
   if (rens_->GetNumberOfItems () <= viewport)
   {
-    PCL_ERROR ("[removeText3D] The viewport [%d] doesn't exist (id <%s>)! ",
+    PCL_ERROR ("[removeText3D] The viewport [%d] doesn't exist (id <%s>)!\n",
                viewport,
                id.c_str ());
     return false;

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -691,7 +691,7 @@ pcl::visualization::PointCloudGeometryHandler<pcl::PCLPointCloud2>::getGeometry 
   
   if (!data->Resize(nr_points))
   {
-    PCL_ERROR("[point_cloud_handlers::getGeometry] Failed to allocate space for points in VTK array.");
+    PCL_ERROR("[point_cloud_handlers::getGeometry] Failed to allocate space for points in VTK array.\n");
     throw std::bad_alloc();
   }
     


### PR DESCRIPTION
~90% of the calls to PCL_WARN and PCL_ERROR already have an \n and the end, but some were missing
some terminal emulators won't show the warnings/errors if it isn't flushed with an \n