### PR TITLE
[tools] Replace std::stringstream by std::string

### DIFF
--- a/tools/fast_bilateral_filter.cpp
+++ b/tools/fast_bilateral_filter.cpp
@@ -128,13 +128,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, sigma_s, sigma_r);
 
     // Prepare output file name
-    std::string filename = pcd_files[i];
-    boost::trim (filename);
-    std::vector<std::string> st;
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
+    std::string filename = boost::filesystem::path(pcd_files[i]).filename().string();
     
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output, translation, rotation);
   }
   return (0);

--- a/tools/fast_bilateral_filter.cpp
+++ b/tools/fast_bilateral_filter.cpp
@@ -134,9 +134,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output, translation, rotation);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output, translation, rotation);
   }
   return (0);
 }

--- a/tools/grid_min.cpp
+++ b/tools/grid_min.cpp
@@ -133,9 +133,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output);
   }
   return (0);
 }

--- a/tools/grid_min.cpp
+++ b/tools/grid_min.cpp
@@ -128,12 +128,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, resolution);
 
     // Prepare output file name
-    std::string filename = pcd_file;
-    boost::trim (filename);
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
+    std::string filename = boost::filesystem::path(pcd_file).filename().string();
     
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output);
   }
   return (0);

--- a/tools/image_grabber_saver.cpp
+++ b/tools/image_grabber_saver.cpp
@@ -67,9 +67,8 @@ struct EventHelper
   void 
   cloud_cb (const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr & cloud)
   {
-    std::stringstream ss;
-    ss << out_folder << "/" << grabber->getPrevDepthFileName() << ".pcd";
-    pcl::io::savePCDFileASCII (ss.str(), *cloud);
+    const std::string filepath = out_folder + '/' + grabber->getPrevDepthFileName() + ".pcd";
+    pcl::io::savePCDFileASCII (filepath, *cloud);
   }
 };
 

--- a/tools/local_max.cpp
+++ b/tools/local_max.cpp
@@ -129,12 +129,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, radius);
 
     // Prepare output file name
-    std::string filename = pcd_file;
-    boost::trim (filename);
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
+    std::string filename = boost::filesystem::path(pcd_file).filename().string();
     
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output);
   }
   return (0);

--- a/tools/local_max.cpp
+++ b/tools/local_max.cpp
@@ -134,9 +134,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output);
   }
   return (0);
 }

--- a/tools/morph.cpp
+++ b/tools/morph.cpp
@@ -155,9 +155,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
 
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output);
   }
   return (0);
 }

--- a/tools/morph.cpp
+++ b/tools/morph.cpp
@@ -150,12 +150,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, resolution, method);
 
     // Prepare output file name
-    std::string filename = pcd_file;
-    boost::trim (filename);
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
-
+    std::string filename = boost::filesystem::path(pcd_file).filename().string();
+    
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output);
   }
   return (0);

--- a/tools/normal_estimation.cpp
+++ b/tools/normal_estimation.cpp
@@ -153,9 +153,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output, translation, rotation);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output, translation, rotation);
   }
   return (0);
 }

--- a/tools/normal_estimation.cpp
+++ b/tools/normal_estimation.cpp
@@ -147,13 +147,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, k, radius);
 
     // Prepare output file name
-    std::string filename = pcd_files[i];
-    boost::trim (filename);
-    std::vector<std::string> st;
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
+    std::string filename = boost::filesystem::path(pcd_files[i]).filename().string();
     
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output, translation, rotation);
   }
   return (0);

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -267,45 +267,43 @@ class Writer
       FPS_CALC_WRITER ("data write   ", buf_);
       nr_frames_total++;
       
-      std::stringstream ss1, ss2, ss3;
-
       std::string time_string = boost::posix_time::to_iso_string (frame->time);
       // Save RGB data
-      ss1 << "frame_" << time_string << "_rgb.pclzf";
+      const std::string rgb_filename = "frame_" + time_string + "_rgb.pclzf";
       switch (frame->image->getEncoding ())
       {
         case openni_wrapper::Image::YUV422:
         {
           io::LZFYUV422ImageWriter lrgb;
-          lrgb.write (reinterpret_cast<const char*> (&frame->image->getMetaData ().Data ()[0]), frame->image->getWidth (), frame->image->getHeight (), ss1.str ());
+          lrgb.write (reinterpret_cast<const char*> (&frame->image->getMetaData ().Data ()[0]), frame->image->getWidth (), frame->image->getHeight (), rgb_filename);
           break;
         }
         case openni_wrapper::Image::RGB:
         {
           io::LZFRGB24ImageWriter lrgb;
-          lrgb.write (reinterpret_cast<const char*> (&frame->image->getMetaData ().Data ()[0]), frame->image->getWidth (), frame->image->getHeight (), ss1.str ());
+          lrgb.write (reinterpret_cast<const char*> (&frame->image->getMetaData ().Data ()[0]), frame->image->getWidth (), frame->image->getHeight (), rgb_filename);
           break;
         }
         case openni_wrapper::Image::BAYER_GRBG:
         {
           io::LZFBayer8ImageWriter lrgb;
-          lrgb.write (reinterpret_cast<const char*> (&frame->image->getMetaData ().Data ()[0]), frame->image->getWidth (), frame->image->getHeight (), ss1.str ());
+          lrgb.write (reinterpret_cast<const char*> (&frame->image->getMetaData ().Data ()[0]), frame->image->getWidth (), frame->image->getHeight (), rgb_filename);
           break;
         }
       }
 
       // Save depth data
-      ss2 << "frame_" + time_string + "_depth.pclzf";
+      const std::string depth_filename = "frame_" + time_string + "_depth.pclzf";
       io::LZFDepth16ImageWriter ld;
       //io::LZFShift11ImageWriter ld;
-      ld.write (reinterpret_cast<const char*> (&frame->depth_image->getDepthMetaData ().Data ()[0]), frame->depth_image->getWidth (), frame->depth_image->getHeight (), ss2.str ());
+      ld.write (reinterpret_cast<const char*> (&frame->depth_image->getDepthMetaData ().Data ()[0]), frame->depth_image->getWidth (), frame->depth_image->getHeight (), depth_filename);
       
       // Save depth data
-      ss3 << "frame_" << time_string << ".xml";
+      const std::string xml_filename = "frame_" + time_string + ".xml";
          
       io::LZFRGB24ImageWriter lrgb;
-      lrgb.writeParameters (frame->parameters_rgb, ss3.str ());
-      ld.writeParameters (frame->parameters_depth, ss3.str ());
+      lrgb.writeParameters (frame->parameters_rgb, xml_filename);
+      ld.writeParameters (frame->parameters_depth, xml_filename);
       // By default, the z-value depth multiplication factor is written as part of the LZFDepthImageWriter's writeParameters as 0.001
       // If you want to change that, uncomment the next line and change the value
       //ld.writeParameter (0.001, "depth.z_multiplication_factor", ss3.str ());

--- a/tools/openni_save_image.cpp
+++ b/tools/openni_save_image.cpp
@@ -148,13 +148,12 @@ class SimpleOpenNIViewer
             data = reinterpret_cast<const void*> (rgb_data);
           }
 
-          std::stringstream ss;
-          ss << "frame_" + time + "_rgb.tiff";
+          const std::string filename = "frame_" + time + "_rgb.tiff";
           importer_->SetImportVoidPointer (const_cast<void*>(data), 1);
           importer_->Update ();
           flipper_->SetInputConnection (importer_->GetOutputPort ());
           flipper_->Update ();
-          writer_->SetFileName (ss.str ().c_str ());
+          writer_->SetFileName (filename.c_str ());
           writer_->SetInputConnection (flipper_->GetOutputPort ());
           writer_->Write ();
         }
@@ -164,8 +163,7 @@ class SimpleOpenNIViewer
           openni_wrapper::DepthImage::Ptr depth_image;
           depth_image.swap (depth_image_);
 
-          std::stringstream ss;
-          ss << "frame_" + time + "_depth.tiff";
+          const std::string filename = "frame_" + time + "_depth.tiff";
 
           depth_importer_->SetWholeExtent (0, depth_image->getWidth () - 1, 0, depth_image->getHeight () - 1, 0, 0);
           depth_importer_->SetDataExtentToWholeExtent ();
@@ -173,7 +171,7 @@ class SimpleOpenNIViewer
           depth_importer_->Update ();
           flipper_->SetInputConnection (depth_importer_->GetOutputPort ());
           flipper_->Update ();
-          writer_->SetFileName (ss.str ().c_str ());
+          writer_->SetFileName (filename.c_str ());
           writer_->SetInputConnection (flipper_->GetOutputPort ());
           writer_->Write ();
         }

--- a/tools/passthrough_filter.cpp
+++ b/tools/passthrough_filter.cpp
@@ -143,9 +143,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output);
   }
   return (0);
 }

--- a/tools/passthrough_filter.cpp
+++ b/tools/passthrough_filter.cpp
@@ -138,12 +138,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, field_name, min, max, inside, keep_organized);
 
     // Prepare output file name
-    std::string filename = pcd_file;
-    boost::trim (filename);
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
+    std::string filename = boost::filesystem::path(pcd_file).filename().string();
     
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output);
   }
   return (0);

--- a/tools/pcd_viewer.cpp
+++ b/tools/pcd_viewer.cpp
@@ -191,22 +191,21 @@ pp_callback (const pcl::visualization::PointPickingEvent& event, void* cookie)
   }
 
   // Else, if a single point has been selected
-  std::stringstream ss;
-  ss << idx;
+  const std::string idx_string = std::to_string(idx);
   // Get the cloud's fields
   for (std::size_t i = 0; i < cloud->fields.size (); ++i)
   {
     if (!isMultiDimensionalFeatureField (cloud->fields[i]))
       continue;
     PCL_INFO ("Multidimensional field found: %s\n", cloud->fields[i].name.c_str ());
-    ph_global.addFeatureHistogram (*cloud, cloud->fields[i].name, idx, ss.str ());
+    ph_global.addFeatureHistogram (*cloud, cloud->fields[i].name, idx, idx_string);
     ph_global.renderOnce ();
   }
   if (p)
   {
     pcl::PointXYZ pos;
     event.getPoint (pos.x, pos.y, pos.z);
-    p->addText3D<pcl::PointXYZ> (ss.str (), pos, 0.0005, 1.0, 1.0, 1.0, ss.str ());
+    p->addText3D<pcl::PointXYZ> (idx_string, pos, 0.0005, 1.0, 1.0, 1.0, idx_string);
   }
   
 }
@@ -377,21 +376,20 @@ main (int argc, char** argv)
     }
 
     // Add as actor
-    std::stringstream cloud_name ("vtk-");
-    cloud_name << argv[vtk_file_indices.at (i)] << "-" << i;
-    p->addModelFromPolyData (polydata, cloud_name.str (), viewport);
+    const std::string cloud_name = "vtk-" + std::string(argv[vtk_file_indices.at (i)]) + "-" + std::to_string(i);
+    p->addModelFromPolyData (polydata, cloud_name, viewport);
 
     // Change the shape rendered color
     if (fcolorparam && fcolor_r.size () > i && fcolor_g.size () > i && fcolor_b.size () > i)
-      p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_COLOR, fcolor_r[i], fcolor_g[i], fcolor_b[i], cloud_name.str ());
+      p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_COLOR, fcolor_r[i], fcolor_g[i], fcolor_b[i], cloud_name);
 
     // Change the shape rendered point size
     if (!psize.empty ())
-      p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name.str ());
+      p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name);
 
     // Change the shape rendered opacity
     if (!opaque.empty ())
-      p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name.str ());
+      p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name);
 
     // Change the shape rendered shading
     if (!shadings.empty ())
@@ -399,17 +397,17 @@ main (int argc, char** argv)
       if (shadings[i] == "flat")
       {
         print_highlight (stderr, "Setting shading property for %s to FLAT.\n", argv[vtk_file_indices.at (i)]);
-        p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_SHADING, pcl::visualization::PCL_VISUALIZER_SHADING_FLAT, cloud_name.str ());
+        p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_SHADING, pcl::visualization::PCL_VISUALIZER_SHADING_FLAT, cloud_name);
       }
       else if (shadings[i] == "gouraud")
       {
         print_highlight (stderr, "Setting shading property for %s to GOURAUD.\n", argv[vtk_file_indices.at (i)]);
-        p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_SHADING, pcl::visualization::PCL_VISUALIZER_SHADING_GOURAUD, cloud_name.str ());
+        p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_SHADING, pcl::visualization::PCL_VISUALIZER_SHADING_GOURAUD, cloud_name);
       }
       else if (shadings[i] == "phong")
       {
         print_highlight (stderr, "Setting shading property for %s to PHONG.\n", argv[vtk_file_indices.at (i)]);
-        p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_SHADING, pcl::visualization::PCL_VISUALIZER_SHADING_PHONG, cloud_name.str ());
+        p->setShapeRenderingProperties (pcl::visualization::PCL_VISUALIZER_SHADING, pcl::visualization::PCL_VISUALIZER_SHADING_PHONG, cloud_name);
       }
     }
   }
@@ -442,18 +440,18 @@ main (int argc, char** argv)
       origin.block<3, 1> (0, 0) = (pose * Eigen::Translation3f (origin.block<3, 1> (0, 0))).translation ();
     }
 
-    std::stringstream cloud_name;
+    std::string cloud_name;
 
     // ---[ Special check for 1-point multi-dimension histograms
     if (cloud->fields.size () == 1 && isMultiDimensionalFeatureField (cloud->fields[0]))
     {
-      cloud_name << argv[p_file_indices.at (i)];
+      cloud_name = argv[p_file_indices.at (i)];
 
       if (!ph)
         ph.reset (new pcl::visualization::PCLPlotter);
 
       pcl::getMinMax (*cloud, 0, cloud->fields[0].name, min_p, max_p);
-      ph->addFeatureHistogram (*cloud, cloud->fields[0].name, cloud_name.str ());
+      ph->addFeatureHistogram (*cloud, cloud->fields[0].name, cloud_name);
       print_info ("[done, "); print_value ("%g", tt.toc ()); print_info (" ms : "); print_value ("%d", cloud->fields[0].count); print_info (" points]\n");
       continue;
     }
@@ -464,9 +462,8 @@ main (int argc, char** argv)
       print_info ("[done, "); print_value ("%g", tt.toc ()); print_info (" ms : "); print_value ("%u", cloud->width * cloud->height); print_info (" points]\n");
       print_info ("Available dimensions: "); print_value ("%s\n", pcl::getFieldsList (*cloud).c_str ());
       
-      std::stringstream name;
-      name << "PCD Viewer :: " << argv[p_file_indices.at (i)];
-      pcl::visualization::ImageViewer::Ptr img (new pcl::visualization::ImageViewer (name.str ()));
+      std::string name = "PCD Viewer :: " + std::string(argv[p_file_indices.at (i)]);
+      pcl::visualization::ImageViewer::Ptr img (new pcl::visualization::ImageViewer (name));
       pcl::PointCloud<pcl::RGB> rgb_cloud;
       pcl::fromPCLPointCloud2 (*cloud, rgb_cloud);
 
@@ -476,7 +473,7 @@ main (int argc, char** argv)
       continue;
     }
 
-    cloud_name << argv[p_file_indices.at (i)] << "-" << i;
+    cloud_name += std::string(argv[p_file_indices.at (i)]) + "-" + std::to_string(i);
 
     // Create the PCLVisualizer object here on the first encountered XYZ file
     if (!p)
@@ -530,8 +527,8 @@ main (int argc, char** argv)
     // Add the dataset with a XYZ and a random handler
     geometry_handler.reset (new pcl::visualization::PointCloudGeometryHandlerXYZ<pcl::PCLPointCloud2> (cloud));
     // Add the cloud to the renderer
-    //p->addPointCloud<pcl::PointXYZ> (cloud_xyz, geometry_handler, color_handler, cloud_name.str (), viewport);
-    p->addPointCloud (cloud, geometry_handler, color_handler, origin, orientation, cloud_name.str (), viewport);
+    //p->addPointCloud<pcl::PointXYZ> (cloud_xyz, geometry_handler, color_handler, cloud_name, viewport);
+    p->addPointCloud (cloud, geometry_handler, color_handler, origin, orientation, cloud_name, viewport);
 
 
     if (mview)
@@ -557,9 +554,8 @@ main (int argc, char** argv)
 
       pcl::PointCloud<pcl::Normal>::Ptr cloud_normals (new pcl::PointCloud<pcl::Normal>);
       pcl::fromPCLPointCloud2 (*cloud, *cloud_normals);
-      std::stringstream cloud_name_normals;
-      cloud_name_normals << argv[p_file_indices.at (i)] << "-" << i << "-normals";
-      p->addPointCloudNormals<pcl::PointXYZ, pcl::Normal> (cloud_xyz, cloud_normals, normals, normals_scale, cloud_name_normals.str (), viewport);
+      const std::string cloud_name_normals = std::string(argv[p_file_indices.at (i)]) + "-" + std::to_string(i) + "-normals";
+      p->addPointCloudNormals<pcl::PointXYZ, pcl::Normal> (cloud_xyz, cloud_normals, normals, normals_scale, cloud_name_normals, viewport);
     }
 
     // If principal curvature lines are enabled
@@ -592,15 +588,14 @@ main (int argc, char** argv)
       pcl::fromPCLPointCloud2 (*cloud, *cloud_normals);
       pcl::PointCloud<pcl::PrincipalCurvatures>::Ptr cloud_pc (new pcl::PointCloud<pcl::PrincipalCurvatures>);
       pcl::fromPCLPointCloud2 (*cloud, *cloud_pc);
-      std::stringstream cloud_name_normals_pc;
-      cloud_name_normals_pc << argv[p_file_indices.at (i)] << "-" << i << "-normals";
+      std::string cloud_name_normals_pc = std::string(argv[p_file_indices.at (i)]) + "-" + std::to_string(i) + "-normals";
       int factor = (std::min)(normals, pc);
-      p->addPointCloudNormals<pcl::PointXYZ, pcl::Normal> (cloud_xyz, cloud_normals, factor, normals_scale, cloud_name_normals_pc.str (), viewport);
-      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_COLOR, 1.0, 0.0, 0.0, cloud_name_normals_pc.str ());
-      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 3, cloud_name_normals_pc.str ());
-      cloud_name_normals_pc << "-pc";
-      p->addPointCloudPrincipalCurvatures<pcl::PointXYZ, pcl::Normal> (cloud_xyz, cloud_normals, cloud_pc, factor, pc_scale, cloud_name_normals_pc.str (), viewport);
-      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 3, cloud_name_normals_pc.str ());
+      p->addPointCloudNormals<pcl::PointXYZ, pcl::Normal> (cloud_xyz, cloud_normals, factor, normals_scale, cloud_name_normals_pc, viewport);
+      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_COLOR, 1.0, 0.0, 0.0, cloud_name_normals_pc);
+      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 3, cloud_name_normals_pc);
+      cloud_name_normals_pc += "-pc";
+      p->addPointCloudPrincipalCurvatures<pcl::PointXYZ, pcl::Normal> (cloud_xyz, cloud_normals, cloud_pc, factor, pc_scale, cloud_name_normals_pc, viewport);
+      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_LINE_WIDTH, 3, cloud_name_normals_pc);
     }
 
     // Add every dimension as a possible color
@@ -631,35 +626,35 @@ main (int argc, char** argv)
           color_handler.reset (new pcl::visualization::PointCloudColorHandlerGenericField<pcl::PCLPointCloud2> (cloud, cloud->fields[f].name));
         }
         // Add the cloud to the renderer
-        //p->addPointCloud<pcl::PointXYZ> (cloud_xyz, color_handler, cloud_name.str (), viewport);
-        p->addPointCloud (cloud, color_handler, origin, orientation, cloud_name.str (), viewport);
+        //p->addPointCloud<pcl::PointXYZ> (cloud_xyz, color_handler, cloud_name, viewport);
+        p->addPointCloud (cloud, color_handler, origin, orientation, cloud_name, viewport);
       }
       // Set RGB color handler or label handler as default
-      p->updateColorHandlerIndex (cloud_name.str (), (rgb_idx ? rgb_idx : label_idx));
+      p->updateColorHandlerIndex (cloud_name, (rgb_idx ? rgb_idx : label_idx));
     }
 
     // Additionally, add normals as a handler
     geometry_handler.reset (new pcl::visualization::PointCloudGeometryHandlerSurfaceNormal<pcl::PCLPointCloud2> (cloud));
     if (geometry_handler->isCapable ())
-      //p->addPointCloud<pcl::PointXYZ> (cloud_xyz, geometry_handler, cloud_name.str (), viewport);
-      p->addPointCloud (cloud, geometry_handler, origin, orientation, cloud_name.str (), viewport);
+      //p->addPointCloud<pcl::PointXYZ> (cloud_xyz, geometry_handler, cloud_name, viewport);
+      p->addPointCloud (cloud, geometry_handler, origin, orientation, cloud_name, viewport);
 
     if (use_immediate_rendering)
       // Set immediate mode rendering ON
-      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_IMMEDIATE_RENDERING, 1.0, cloud_name.str ());
+      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_IMMEDIATE_RENDERING, 1.0, cloud_name);
 
     // Change the cloud rendered point size
     if (!psize.empty ())
-      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name.str ());
+      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, psize.at (i), cloud_name);
 
     // Change the cloud rendered opacity
     if (!opaque.empty ())
-      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name.str ());
+      p->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_OPACITY, opaque.at (i), cloud_name);
 
     // Reset camera viewpoint to center of cloud if camera parameters were not passed manually and this is the first loaded cloud
     if (i == 0 && !p->cameraParamsSet () && !p->cameraFileLoaded ())
     {
-      p->resetCameraViewpoint (cloud_name.str ());
+      p->resetCameraViewpoint (cloud_name);
       p->resetCamera ();
     }
 
@@ -673,9 +668,9 @@ main (int argc, char** argv)
   {
     std::string str;
     if (!p_file_indices.empty ())
-      str = std::string (argv[p_file_indices.at (0)]);
+      str = argv[p_file_indices.at (0)];
     else if (!vtk_file_indices.empty ())
-      str = std::string (argv[vtk_file_indices.at (0)]);
+      str = argv[vtk_file_indices.at (0)];
 
     for (std::size_t i = 1; i < p_file_indices.size (); ++i)
       str += ", " + std::string (argv[p_file_indices.at (i)]);

--- a/tools/progressive_morphological_filter.cpp
+++ b/tools/progressive_morphological_filter.cpp
@@ -192,9 +192,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
 
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output);
   }
   return (0);
 }

--- a/tools/progressive_morphological_filter.cpp
+++ b/tools/progressive_morphological_filter.cpp
@@ -187,12 +187,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, max_window_size, slope, max_distance, initial_distance, cell_size, base, exponential, approximate);
 
     // Prepare output file name
-    std::string filename = pcd_file;
-    boost::trim (filename);
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
-
+    std::string filename = boost::filesystem::path(pcd_file).filename().string();
+    
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output);
   }
   return (0);

--- a/tools/radius_filter.cpp
+++ b/tools/radius_filter.cpp
@@ -130,12 +130,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, radius, inside, keep_organized);
 
     // Prepare output file name
-    std::string filename = pcd_file;
-    boost::trim (filename);
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
-
+    std::string filename = boost::filesystem::path(pcd_file).filename().string();
+    
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output);
   }
   return (0);

--- a/tools/radius_filter.cpp
+++ b/tools/radius_filter.cpp
@@ -135,9 +135,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
 
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output);
   }
   return (0);
 }

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -190,12 +190,10 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     compute (cloud, output, max_it, thresh, negative);
 
     // Prepare output file name
-    std::string filename = pcd_file;
-    boost::trim (filename);
-    boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
+    std::string filename = boost::filesystem::path(pcd_file).filename().string();
     
     // Save into the second file
-    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    const std::string filepath = output_dir + '/' + filename;
     saveCloud (filepath, output);
   }
   return (0);

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -195,9 +195,8 @@ batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
     
     // Save into the second file
-    std::stringstream ss;
-    ss << output_dir << "/" << st.at (st.size () - 1);
-    saveCloud (ss.str (), output);
+    const std::string filepath = output_dir + '/' + st.at (st.size () - 1);
+    saveCloud (filepath, output);
   }
   return (0);
 }

--- a/tools/tiff2pcd.cpp
+++ b/tools/tiff2pcd.cpp
@@ -148,33 +148,25 @@ void processAndSave( vtkSmartPointer<vtkImageData>  depth_data,
     } // for u
   } // for v
 
-  std::stringstream ss;
-
   if(depth)
   {
+    std::string depth_filename = "frame_" + time + "_depth.pcd";
     if(use_output_path)
-      ss << output_path << "/frame_" << time << "_depth.pcd";
-    else
-      ss << "frame_" << time << "_depth.pcd";
-    pcl::io::savePCDFile (ss.str(), pc_depth, format);
-    ss.str(""); //empty
+      depth_filename = output_path + '/' + depth_filename;
+    pcl::io::savePCDFile (depth_filename, pc_depth, format);
   }
 
   if(color)
   {
+    std::string color_filename = "frame_" + time + "_color.pcd";
     if(use_output_path)
-      ss << output_path << "/frame_" << time << "_color.pcd";
-    else
-      ss << "frame_" << time << "_color.pcd";
-    pcl::io::savePCDFile (ss.str(), pc_image, format);
-    ss.str(""); //empty
+      color_filename = output_path + '/' + color_filename;
+    pcl::io::savePCDFile (color_filename, pc_image, format);
   }
-
+  std::string xyzrgba_filename = "frame_" + time + "_xyzrgba.pcd";
   if(use_output_path)
-    ss << output_path << "/frame_" << time << "_xyzrgba.pcd";
-  else
-    ss << "frame_" << time << "_xyzrgba.pcd";
-  pcl::io::savePCDFile (ss.str(), pc_xyzrgba, format);
+    xyzrgba_filename = output_path + '/' + xyzrgba_filename;
+  pcl::io::savePCDFile (xyzrgba_filename, pc_xyzrgba, format);
 
   std::cout << "Saved " << time << " to pcd" << std::endl;
   return;

--- a/tools/unary_classifier_segment.cpp
+++ b/tools/unary_classifier_segment.cpp
@@ -84,13 +84,12 @@ loadTrainedFeatures (std::vector<FeatureT::Ptr> &out,
     if (!boost::filesystem::is_directory (it->status ()) &&
         boost::filesystem::extension (it->path ()) == ".pcd")
     {   
-      std::stringstream ss;
-      ss << it->path ().string ();
+      const std::string path = it->path ().string ();
 
-      print_highlight ("Loading %s \n", ss.str ().c_str ());
+      print_highlight ("Loading %s \n", path.c_str ());
       
       FeatureT::Ptr features (new FeatureT);
-      if (loadPCDFile (ss.str (), *features) < 0)
+      if (loadPCDFile (path, *features) < 0)
         return false;
 
       out.push_back (features);

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -116,7 +116,7 @@ main (int argc, char** argv)
               "");
     return (-1);
   }
-  std::string filename;
+
   // Parse the command line arguments for .vtk or .ply files
   std::vector<int> p_file_indices_vtk = console::parse_file_extension_argument (argc, argv, ".vtk");
   std::vector<int> p_file_indices_ply = console::parse_file_extension_argument (argc, argv, ".ply");
@@ -143,13 +143,11 @@ main (int argc, char** argv)
     return (-1);
   }
 
-  std::stringstream filename_stream;
+  std::string filename;
   if (!p_file_indices_ply.empty ())
-    filename_stream << argv[p_file_indices_ply.at (0)];
+    filename = argv[p_file_indices_ply.at (0)];
   else
-    filename_stream << argv[p_file_indices_vtk.at (0)];
-
-  filename = filename_stream.str ();
+    filename = argv[p_file_indices_vtk.at (0)];
 
   data = loadDataSet (filename.c_str ());
 
@@ -405,22 +403,20 @@ main (int argc, char** argv)
     boost::trim (filename);
     boost::split (st, filename, boost::is_any_of ("/\\"), boost::token_compress_on);
 
-    std::stringstream ss;
-    std::string output_dir = st.at (st.size () - 1);
-    ss << output_dir << "_output";
+    const std::string output_dir = st.at (st.size () - 1) + "_output";
 
-    boost::filesystem::path outpath (ss.str ());
+    boost::filesystem::path outpath (output_dir);
     if (!boost::filesystem::exists (outpath))
     {
       if (!boost::filesystem::create_directories (outpath))
       {
-        PCL_ERROR ("Error creating directory %s.\n", ss.str ().c_str ());
+        PCL_ERROR ("Error creating directory %s.\n", output_dir.c_str ());
         return (-1);
       }
-      PCL_INFO ("Creating directory %s\n", ss.str ().c_str ());
+      PCL_INFO ("Creating directory %s\n", output_dir.c_str ());
     }
 
-    fname = ss.str () + "/" + seq + ".pcd";
+    fname = output_dir + '/' + seq + ".pcd";
 
     if (organized)
     {


### PR DESCRIPTION
As far as I read this transition doesn't really has a big negative performance impact and it increases the readability as `.str ()` is not anymore necessary and we can add `const` qualifier.

Only one left, which I can't replace as there is no already implemented way from `PointXYZ` to `std::string`
https://github.com/PointCloudLibrary/pcl/blob/eebd3018e54a522cb71dd8ff517d9f82a880252f/tools/pcd_viewer.cpp#L184-L191