### PR TITLE
[visualization] Replace std::stringstream by std::string

### DIFF
--- a/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
@@ -143,10 +143,9 @@ RegistrationVisualizer<PointSource, PointTarget>::runDisplay ()
     std::size_t correspondences_new_size = cloud_intermediate_indices_.size ();
 
 
-    std::stringstream stream_;
-    stream_ << "Random -> correspondences " << correspondences_new_size;
+    const std::string correspondences_text = "Random -> correspondences " + std::to_string(correspondences_new_size);
     viewer_->removeShape ("correspondences_size", 0);
-    viewer_->addText (stream_.str(), 10, 70, 0.0, 1.0, 0.0, "correspondences_size", v2);
+    viewer_->addText (correspondences_text, 10, 70, 0.0, 1.0, 0.0, "correspondences_size", v2);
 
     // Display entire set of correspondece lines if no maximum displayed correspondences is set
     if( ( 0 < maximum_displayed_correspondences_ ) &&

--- a/visualization/include/pcl/visualization/registration_visualizer.h
+++ b/visualization/include/pcl/visualization/registration_visualizer.h
@@ -157,10 +157,7 @@ namespace pcl
       inline std::string
       getIndexedName (std::string &root_name, std::size_t &id)
       {
-        std::stringstream id_stream_;
-        id_stream_ << id;
-        std::string indexed_name_ = root_name + id_stream_.str ();
-        return indexed_name_;
+        return root_name + std::to_string(id);
       }
 
       /** \brief The registration viewer. */

--- a/visualization/src/common/io.cpp
+++ b/visualization/src/common/io.cpp
@@ -137,10 +137,9 @@ pcl::visualization::savePointData (vtkPolyData* data, const std::string &out_fil
     // Copy the indices and save the file
     pcl::PCLPointCloud2 cloud_out;
     pcl::copyPointCloud (cloud, indices, cloud_out);
-    std::stringstream ss;
-    ss << out_file << i++ << ".pcd";
-    pcl::console::print_debug ("  Save: %s ... ", ss.str ().c_str ());
-    if (pcl::io::savePCDFile (ss.str (), cloud_out, Eigen::Vector4f::Zero (),
+    const std::string out_filename = out_file + std::to_string(i++) + ".pcd";
+    pcl::console::print_debug ("  Save: %s ... ", out_filename.c_str ());
+    if (pcl::io::savePCDFile (out_filename, cloud_out, Eigen::Vector4f::Zero (),
                               Eigen::Quaternionf::Identity (), true) == -1)
     {
       pcl::console::print_error (stdout, "[failed]\n");

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3400,8 +3400,7 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
     // add a texture coordinates array per texture
     vtkSmartPointer<vtkFloatArray> coordinates = vtkSmartPointer<vtkFloatArray>::New ();
     coordinates->SetNumberOfComponents (2);
-    std::stringstream ss; ss << "TCoords" << tex_id;
-    std::string this_coordinates_name = ss.str ();
+    const std::string this_coordinates_name = "TCoords" + std::to_string(tex_id);
     coordinates->SetName (this_coordinates_name.c_str ());
 
     for (std::size_t t = 0; t < mesh.tex_coordinates.size (); ++t)


### PR DESCRIPTION
As far as I read this transition doesn't really has a big negative performance impact and it increases the readability as `.str ()` is not anymore necessary and we can add `const` qualifier.

Only one left, where `std::stringstream` is used when it should be really used ;-)
https://github.com/PointCloudLibrary/pcl/blob/eebd3018e54a522cb71dd8ff517d9f82a880252f/visualization/src/pcl_plotter.cpp#L246-L258