### PR TITLE
Add google benchmark library to docker images

### DIFF
--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
       libflann-dev \
       libglew-dev \
       libgtest-dev \
+      libbenchmark-dev \
       libopenni-dev \
       libopenni2-dev \
       libproj-dev \


### PR DESCRIPTION
As a preparation for benchmarks.