### PR TITLE
Including a missing VTK dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,7 @@ if(WITH_VTK AND NOT ANDROID)
     vtkFiltersModeling
     vtkImagingCore
     vtkImagingSources
+    vtkInteractionImage
     vtkInteractionStyle
     vtkInteractionWidgets
     vtkIOCore


### PR DESCRIPTION
There was a build time error related to the file "vtkImageViewer.h". This problem is solved with a new component in the CMakeLists file.