### PR TITLE
Mark optional boost components as such for CMake

### DIFF
--- a/cmake/pcl_find_boost.cmake
+++ b/cmake/pcl_find_boost.cmake
@@ -23,7 +23,7 @@ set(Boost_ADDITIONAL_VERSIONS
 set(Boost_NO_BOOST_CMAKE ON)
 
 # Optional boost modules
-find_package(Boost 1.55.0 QUIET COMPONENTS serialization mpi)
+find_package(Boost 1.55.0 QUIET OPTIONAL_COMPONENTS serialization mpi)
 if(Boost_SERIALIZATION_FOUND)
   set(BOOST_SERIALIZATION_FOUND TRUE)
 endif()

--- a/cmake/pcl_find_boost.cmake
+++ b/cmake/pcl_find_boost.cmake
@@ -22,15 +22,14 @@ set(Boost_ADDITIONAL_VERSIONS
 # Disable the config mode of find_package(Boost)
 set(Boost_NO_BOOST_CMAKE ON)
 
-# Optional boost modules
-find_package(Boost 1.55.0 QUIET OPTIONAL_COMPONENTS serialization mpi)
+set(BOOST_REQUIRED_MODULES filesystem date_time iostreams system)
+find_package(Boost 1.55.0 REQUIRED 
+    COMPONENTS ${BOOST_REQUIRED_MODULES}
+    OPTIONAL_COMPONENTS serialization mpi
+)
 if(Boost_SERIALIZATION_FOUND)
   set(BOOST_SERIALIZATION_FOUND TRUE)
 endif()
-
-# Required boost modules
-set(BOOST_REQUIRED_MODULES filesystem date_time iostreams system)
-find_package(Boost 1.55.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_MODULES})
 
 if(Boost_FOUND)
   set(BOOST_FOUND TRUE)


### PR DESCRIPTION
According to CMake [find_package](https://cmake.org/cmake/help/latest/command/find_package.html) documentation, package components are always required unless otherwise specified:

> A package-specific list of required components may be listed after the COMPONENTS option (or after the REQUIRED option if present). Additional optional components may be listed after OPTIONAL_COMPONENTS. 

This was causing a fatal error in CMake due to the mpi library not being present.