### PR TITLE
tar xvfj cannot work for xxx.tar.gz

### DIFF
--- a/doc/tutorials/content/compiling_pcl_posix.rst
+++ b/doc/tutorials/content/compiling_pcl_posix.rst
@@ -18,9 +18,9 @@ Stable
 
 For systems for which we do not offer precompiled binaries, you need to compile Point Cloud Library (PCL) from source. Here are the steps that you need to take:
 Go to `Github <https://github.com/PointCloudLibrary/pcl/releases>`_ and download the version number of your choice.
-Uncompress the tar-bzip archive, e.g. (replace 1.7.2 with the correct version number)::
+Uncompress the tar-gzip archive, e.g. (replace 1.7.2 with the correct version number)::
 
-  tar xvfj pcl-pcl-1.7.2.tar.gz
+  tar xvf pcl-pcl-1.7.2.tar.gz
 
 Change the directory to the pcl-pcl-1.7.2 (replace 1.7.2 with the correct version number) directory, and create a build directory in there::
 


### PR DESCRIPTION
`pcl-pcl-1.7.2.tar.gz` is not a bzip2 file, if using `tar xvfj` to extract it, it will show the following error message:
```
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```