### PR TITLE
[test] Replace std::stringstream by std::string

### DIFF
--- a/test/geometry/test_quad_mesh.cpp
+++ b/test/geometry/test_quad_mesh.cpp
@@ -345,9 +345,7 @@ TYPED_TEST (TestQuadMesh, NineQuads)
   ASSERT_EQ (9, faces.size ());
   for (std::size_t i=0; i<order_vec.size (); ++i)
   {
-    std::stringstream ss;
-    ss << "Configuration " << i;
-    SCOPED_TRACE (ss.str ());
+    SCOPED_TRACE ("Configuration " + std::to_string(i));
 
     const std::vector <int> order = order_vec [i];
 


### PR DESCRIPTION
There are a lot of more hits related `stringstream`, but they are all IO related so okay, except here:

https://github.com/PointCloudLibrary/pcl/blob/b25612f8ff0318724f3a6caae4e9e753adc2b74c/test/geometry/test_mesh.cpp#L475-L489

But this string looks a bit confusing (no spaces between the vertex indicies?), so I didn't touched it.