### PR TITLE
Add missing include to nurbs_solve_umfpack.cpp

### DIFF
--- a/surface/src/on_nurbs/nurbs_solve_umfpack.cpp
+++ b/surface/src/on_nurbs/nurbs_solve_umfpack.cpp
@@ -39,6 +39,7 @@
 #include <suitesparse/umfpack.h>
 #include <iostream>
 #include <stdio.h>
+#include <time.h>
 #include <stdexcept>
 
 #include <pcl/surface/on_nurbs/nurbs_solve.h>

--- a/surface/src/on_nurbs/nurbs_solve_umfpack.cpp
+++ b/surface/src/on_nurbs/nurbs_solve_umfpack.cpp
@@ -39,7 +39,7 @@
 #include <suitesparse/umfpack.h>
 #include <iostream>
 #include <stdio.h>
-#include <time.h>
+#include <time.h> // for clock, clock_t
 #include <stdexcept>
 
 #include <pcl/surface/on_nurbs/nurbs_solve.h>


### PR DESCRIPTION
PCL 1.11 in Windows 10 does not compile because the header is missing