### PR TITLE
Error in concatenate function of PolygonMesh.h when merging two mesh files

### DIFF
--- a/common/include/pcl/PolygonMesh.h
+++ b/common/include/pcl/PolygonMesh.h
@@ -30,6 +30,8 @@ namespace pcl
     static bool
     concatenate (pcl::PolygonMesh &mesh1, const pcl::PolygonMesh &mesh2)
     {
+      const auto point_offset = mesh1.cloud.width * mesh1.cloud.height;
+      
       bool success = pcl::PCLPointCloud2::concatenate(mesh1.cloud, mesh2.cloud);
       if (success == false) {
         return false;
@@ -37,7 +39,6 @@ namespace pcl
       // Make the resultant polygon mesh take the newest stamp
       mesh1.header.stamp = std::max(mesh1.header.stamp, mesh2.header.stamp);
 
-      const auto point_offset = mesh1.cloud.width * mesh1.cloud.height;
       std::transform(mesh2.polygons.begin (),
                      mesh2.polygons.end (),
                      std::back_inserter (mesh1.polygons),


### PR DESCRIPTION
Hello! I find a error in concatenate function of  PolygonMesh.h file when I am merging two mesh files;

The maximum value of  faces' index in merged OBJ file is equal to the sum of number of vertices in mesh1 file and twice as large as number of vertices in mesh2 file. So I get a malformed OBJ file that can not be opened by CloudCompare!

And I found the following code positions should be placed at the top of concatenate function in PolygonMesh.h file

bool concatenateRepaired (pcl::PolygonMesh &mesh1, const pcl::PolygonMesh &mesh2) {
         const auto point_offset = mesh1.cloud.width * mesh1.cloud.height;    
         ......

Then I get the correct merged mesh file and it can be opened sucessfully by CloudCompare!
