### PR TITLE
Get macos CIs running again

### DIFF
--- a/.ci/azure-pipelines/build/macos.yaml
+++ b/.ci/azure-pipelines/build/macos.yaml
@@ -3,7 +3,8 @@ steps:
     # find the commit hash on a quick non-forced update too
     fetchDepth: 10
   - script: |
-      brew install cmake pkg-config boost eigen flann glew libusb qhull vtk glew qt5 libpcap libomp brewsci/science/openni
+      brew install cmake pkg-config boost eigen flann glew libusb qhull vtk glew qt5 libpcap libomp
+      brew install brewsci/science/openni
       git clone https://github.com/abseil/googletest.git $GOOGLE_TEST_DIR # the official endpoint changed to abseil/googletest
       cd $GOOGLE_TEST_DIR && git checkout release-1.8.1
     displayName: 'Install Dependencies'


### PR DESCRIPTION
It seems like OpenNI has not been installed for longer than the problems with depends_on java exist (and just fixing these dependency problems does not result in OpenNI being installed again). I suggest we open an issue to investigate those problems.