### PR TITLE
Fixup: Fix ubuntu CI badges after CI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Continuous integration
 
 Build Platform           | Status
 ------------------------ | ------------------------------------------------------------------------------------------------- |
-Ubuntu                   | [![Status][ci-ubuntu-16.04]][ci-latest-build] <br> [![Status][ci-ubuntu-18.04]][ci-latest-build]                              <br> [![Status][ci-ubuntu-20.04]][ci-latest-build]                                                |
+Ubuntu                   | [![Status][ci-ubuntu-18.04]][ci-latest-build] <br> [![Status][ci-ubuntu-20.04]][ci-latest-build]                              <br> [![Status][ci-ubuntu-20.10]][ci-latest-build]                                                |
 Windows                  | [![Status][ci-windows-x86]][ci-latest-build]  <br> [![Status][ci-windows-x64]][ci-latest-build]   |
 macOS                    | [![Status][ci-macos-10.14]][ci-latest-build]  <br> [![Status][ci-macos-10.15]][ci-latest-build]   |
 


### PR DESCRIPTION
Fixup to https://github.com/PointCloudLibrary/pcl/commit/eb7447dbc4031b6eed989471f6b93895a81ac132