### PR TITLE
Move the init of static variables to library load time

### DIFF
--- a/common/include/pcl/common/colors.h
+++ b/common/include/pcl/common/colors.h
@@ -40,6 +40,8 @@
 #include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 
+#include <type_traits>  // for is_floating_point
+
 namespace pcl
 {
 
@@ -83,4 +85,86 @@ namespace pcl
   using GlasbeyLUT = ColorLUT<pcl::LUT_GLASBEY>;
   using ViridisLUT = ColorLUT<pcl::LUT_VIRIDIS>;
 
-}
+  /**
+   * @brief Returns a Look-Up Table useful in converting RGB to sRGB
+   * @tparam T floating point type with resultant value
+   * @tparam bits depth of RGB
+   * @return 1-D LUT for converting R, G or B into Rs, Gs or Bs
+   * @remarks sRGB was proposed by Stokes et al. as a uniform default color
+   * space for the internet
+   * M. Stokes, M. Anderson, S. Chandrasekar, and R. Motta: A standard default colorspace for the internet - sRGB (Nov 1996)
+   * IEC 61966-2.1 Default RGB Colour Space - sRGB (International Electrotechnical Commission, Geneva, Switzerland, 1999)
+   * www.srgb.com, www.color.org/srgb.html
+   */
+  template <typename T, std::uint8_t bits = 8>
+  inline std::array<T, 1 << bits>
+  RGB2sRGB_LUT() noexcept
+  {
+    static_assert(std::is_floating_point<T>::value, "LUT value must be a floating point");
+
+    constexpr std::size_t size = 1 << bits;
+
+    static const std::array<T, size> sRGB_LUT = [&]() {
+      std::array<T, size> LUT;
+      for (std::size_t i = 0; i < size; ++i) {
+        T f = static_cast<T>(i) / static_cast<T>(size - 1);
+        if (f > 0.04045) {
+          // ((f + 0.055)/1.055)^2.4
+          LUT[i] = static_cast<T>(
+              std::pow((f + static_cast<T>(0.055)) / static_cast<T>(1.055),
+                       static_cast<T>(2.4)));
+        }
+        else {
+          // f / 12.92
+          LUT[i] = f / static_cast<T>(12.92);
+        }
+      }
+      return LUT;
+    }();
+    return sRGB_LUT;
+  }
+
+  /**
+   * @brief Returns a Look-Up Table useful in converting scaled CIE XYZ into CIE L*a*b*
+   * @details The function assumes that the XYZ values are
+   *   * not normalized using reference illuminant
+   *   * scaled such that reference illuminant has Xn = Yn = Zn = discretizations
+   * @tparam T floating point type with resultant value
+   * @tparam discretizations number of levels for the LUT
+   * @return 1-D LUT with results of f(X/Xn)
+   * @note This function doesn't convert from CIE XYZ to CIE L*a*b*. The actual conversion
+   * is as follows:
+   * L* = 116 * [f(Y/Yn) - 16/116]
+   * a* = 500 * [f(X/Xn) - f(Y/Yn)]
+   * b* = 200 * [f(Y/Yn) - f(Z/Zn)]
+   * Where, Xn, Yn and Zn are values of the reference illuminant (at prescribed angle)
+   *        f is appropriate function such that L* = 100, a* = b* = 0 for white color
+   * Reference: Billmeyer and Saltzman’s Principles of Color Technology
+   */
+  template <typename T, std::size_t discretizations = 4000>
+  inline const std::array<T, discretizations>&
+  XYZ2LAB_LUT() noexcept
+  {
+    static_assert(std::is_floating_point<T>::value, "LUT value must be a floating point");
+
+    constexpr std::size_t size = discretizations;
+
+    static const std::array<T, size> f_LUT = [&]() {
+      std::array<T, size> LUT;
+      for (std::size_t i = 0; i < size; ++i) {
+        T f = static_cast<T>(i) / static_cast<T>(size);
+        if (f > static_cast<T>(0.008856)) {
+          // f^(1/3)
+          LUT[i] = static_cast<T>(std::pow(f, (static_cast<T>(1) / static_cast<T>(3))));
+        }
+        else {
+          // 7.87 * f + 16/116
+          LUT[i] =
+              static_cast<T>(7.87) * f + (static_cast<T>(16) / static_cast<T>(116));
+        }
+      }
+      return LUT;
+    }();
+    return f_LUT;
+  }
+}  // namespace pcl

--- a/common/include/pcl/common/colors.h
+++ b/common/include/pcl/common/colors.h
@@ -97,15 +97,16 @@ namespace pcl
    * www.srgb.com, www.color.org/srgb.html
    */
   template <typename T, std::uint8_t bits = 8>
-  inline std::array<T, 1 << bits>
+  PCL_EXPORTS inline std::array<T, 1 << bits>
   RGB2sRGB_LUT() noexcept
   {
     static_assert(std::is_floating_point<T>::value, "LUT value must be a floating point");
 
-    constexpr std::size_t size = 1 << bits;
+    constexpr const std::size_t size = 1 << bits;
 
-    static const std::array<T, size> sRGB_LUT = [&]() {
-      std::array<T, size> LUT;
+    static const auto sRGB_LUT = [&]() {
+      // MSVC wouldn't take `size` here instead of the expression
+      std::array<T, 1 << bits> LUT;
       for (std::size_t i = 0; i < size; ++i) {
         T f = static_cast<T>(i) / static_cast<T>(size - 1);
         if (f > 0.04045) {
@@ -142,17 +143,15 @@ namespace pcl
    * Reference: Billmeyer and Saltzman’s Principles of Color Technology
    */
   template <typename T, std::size_t discretizations = 4000>
-  inline const std::array<T, discretizations>&
+  PCL_EXPORTS inline const std::array<T, discretizations>&
   XYZ2LAB_LUT() noexcept
   {
     static_assert(std::is_floating_point<T>::value, "LUT value must be a floating point");
 
-    constexpr std::size_t size = discretizations;
-
-    static const std::array<T, size> f_LUT = [&]() {
-      std::array<T, size> LUT;
-      for (std::size_t i = 0; i < size; ++i) {
-        T f = static_cast<T>(i) / static_cast<T>(size);
+    static const auto f_LUT = [&]() {
+      std::array<T, discretizations> LUT;
+      for (std::size_t i = 0; i < discretizations; ++i) {
+        T f = static_cast<T>(i) / static_cast<T>(discretizations);
         if (f > static_cast<T>(0.008856)) {
           // f^(1/3)
           LUT[i] = static_cast<T>(std::pow(f, (static_cast<T>(1) / static_cast<T>(3))));

--- a/features/include/pcl/features/impl/shot.hpp
+++ b/features/include/pcl/features/impl/shot.hpp
@@ -43,6 +43,8 @@
 #include <pcl/features/shot.h>
 #include <pcl/features/shot_lrf.h>
 
+#include <pcl/common/colors.h>  // for RGB2sRGB_LUT, XYZ2LAB_LUT
+
 // Useful constants.
 #define PST_PI 3.1415926535897932384626433832795
 #define PST_RAD_45 0.78539816339744830961566084581988
@@ -84,12 +86,14 @@ areEquals (float val1, float val2, float zeroFloatEps = zeroFloatEps8)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointNT, typename PointOutT, typename PointRFT> float
-pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::sRGB_LUT[256] = {- 1};
+template <typename PointInT, typename PointNT, typename PointOutT, typename PointRFT>
+std::array<float, 256>
+    pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::sRGB_LUT = pcl::RGB2sRGB_LUT<float, 8>();
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointInT, typename PointNT, typename PointOutT, typename PointRFT> float
-pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::sXYZ_LUT[4000] = {- 1};
+template <typename PointInT, typename PointNT, typename PointOutT, typename PointRFT>
+std::array<float, 4000>
+    pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::sXYZ_LUT = pcl::XYZ2LAB_LUT<float, 4000>();
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointNT, typename PointOutT, typename PointRFT> void
@@ -97,28 +101,6 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::RGB2CIELAB (un
                                                                               unsigned char B, float &L, float &A,
                                                                               float &B2)
 {
-  // @TODO: C++17 supports constexpr lambda for compile time init
-  if (sRGB_LUT[0] < 0)
-  {
-    for (int i = 0; i < 256; i++)
-    {
-      float f = static_cast<float> (i) / 255.0f;
-      if (f > 0.04045)
-        sRGB_LUT[i] = powf ((f + 0.055f) / 1.055f, 2.4f);
-      else
-        sRGB_LUT[i] = f / 12.92f;
-    }
-
-    for (int i = 0; i < 4000; i++)
-    {
-      float f = static_cast<float> (i) / 4000.0f;
-      if (f > 0.008856)
-        sXYZ_LUT[i] = static_cast<float> (powf (f, 0.3333f));
-      else
-        sXYZ_LUT[i] = static_cast<float>((7.787 * f) + (16.0 / 116.0));
-    }
-  }
-
   float fr = sRGB_LUT[R];
   float fg = sRGB_LUT[G];
   float fb = sRGB_LUT[B];

--- a/features/include/pcl/features/shot.h
+++ b/features/include/pcl/features/shot.h
@@ -42,6 +42,8 @@
 #include <pcl/point_types.h>
 #include <pcl/features/feature.h>
 
+#include <array>  // for sRGB_LUT, sXYZ_LUT
+
 namespace pcl
 {
   /** \brief SHOTEstimation estimates the Signature of Histograms of OrienTations (SHOT) descriptor for
@@ -98,7 +100,6 @@ namespace pcl
       {
         feature_name_ = "SHOTEstimation";
       };
-      
 
     public:
 
@@ -400,8 +401,8 @@ namespace pcl
       static void
       RGB2CIELAB (unsigned char R, unsigned char G, unsigned char B, float &L, float &A, float &B2);
 
-      static float sRGB_LUT[256];
-      static float sXYZ_LUT[4000];
+      static std::array<float, 256> sRGB_LUT;
+      static std::array<float, 4000> sXYZ_LUT;
   };
 }
 


### PR DESCRIPTION
Possibly fixes #1593 (race condition in OMP implementation of SHOT)
