### PR TITLE
[tracking] Use SFINAE instead of relying on macro `PCL_TRACKING_NORMAL_SUPPORTED`

### DIFF
--- a/tracking/include/pcl/tracking/impl/particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/particle_filter.hpp
@@ -317,17 +317,6 @@ ParticleFilterTracker<PointInT, StateT>::computeTransformedPointCloudWithNormal(
 }
 
 template <typename PointInT, typename StateT>
-template <typename PointT, pcl::traits::HasNoNormal<PointT>>
-void
-ParticleFilterTracker<PointInT, StateT>::computeTransformedPointCloudWithNormal(
-    const StateT&, pcl::Indices&, PointCloudIn&)
-{
-  PCL_WARN("[pcl::%s::computeTransformedPointCloudWithoutNormal] "
-           "use_normal_ == true is not supported in this Point Type.\n",
-           getClassName().c_str());
-}
-
-template <typename PointInT, typename StateT>
 void
 ParticleFilterTracker<PointInT, StateT>::resample()
 {

--- a/tracking/include/pcl/tracking/impl/particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/particle_filter.hpp
@@ -293,15 +293,11 @@ ParticleFilterTracker<PointInT, StateT>::computeTransformedPointCloudWithoutNorm
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename StateT>
+template <typename PointT, pcl::traits::HasNormal<PointT>>
 void
 ParticleFilterTracker<PointInT, StateT>::computeTransformedPointCloudWithNormal(
-#ifdef PCL_TRACKING_NORMAL_SUPPORTED
     const StateT& hypothesis, pcl::Indices& indices, PointCloudIn& cloud)
-#else
-    const StateT&, pcl::Indices&, PointCloudIn&)
-#endif
 {
-#ifdef PCL_TRACKING_NORMAL_SUPPORTED
   const Eigen::Affine3f trans = toEigenMatrix(hypothesis);
   // destructively assigns to cloud
   pcl::transformPointCloudWithNormals<PointInT>(*ref_, cloud, trans);
@@ -318,11 +314,17 @@ ParticleFilterTracker<PointInT, StateT>::computeTransformedPointCloudWithNormal(
     if (theta > occlusion_angle_thr_)
       indices.push_back(i);
   }
-#else
+}
+
+template <typename PointInT, typename StateT>
+template <typename PointT, pcl::traits::HasNoNormal<PointT>>
+void
+ParticleFilterTracker<PointInT, StateT>::computeTransformedPointCloudWithNormal(
+    const StateT&, pcl::Indices&, PointCloudIn&)
+{
   PCL_WARN("[pcl::%s::computeTransformedPointCloudWithoutNormal] "
            "use_normal_ == true is not supported in this Point Type.\n",
            getClassName().c_str());
-#endif
 }
 
 template <typename PointInT, typename StateT>

--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -459,7 +459,12 @@ protected:
                                          PointCloudIn& cloud);
   template <typename PointT = PointInT, traits::HasNoNormal<PointT> = true>
   void
-  computeTransformedPointCloudWithNormal(const StateT&, pcl::Indices&, PointCloudIn&);
+  computeTransformedPointCloudWithNormal(const StateT&, pcl::Indices&, PointCloudIn&)
+  {
+    PCL_WARN("[pcl::%s::computeTransformedPointCloudWithoutNormal] "
+            "use_normal_ == true is not supported in this Point Type.\n",
+            getClassName().c_str());
+  }
 #endif
 
   /** \brief Compute a reference pointcloud transformed to the pose that hypothesis

--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -6,6 +6,7 @@
 #include <pcl/tracking/tracker.h>
 #include <pcl/tracking/tracking.h>
 #include <pcl/memory.h>
+#include <pcl/point_types.h>
 
 namespace pcl {
 namespace tracking {
@@ -438,6 +439,7 @@ protected:
                                pcl::Indices& indices,
                                PointCloudIn& cloud);
 
+#ifdef DOXYGEN_ONLY
   /** \brief Compute a reference pointcloud transformed to the pose that hypothesis
    * represents and calculate indices taking occlusion into account.
    * \param[in] hypothesis a particle which represents a hypothesis.
@@ -449,6 +451,16 @@ protected:
   computeTransformedPointCloudWithNormal(const StateT& hypothesis,
                                          pcl::Indices& indices,
                                          PointCloudIn& cloud);
+#else
+  template <typename PointT = PointInT, traits::HasNormal<PointT> = true>
+  void
+  computeTransformedPointCloudWithNormal(const StateT& hypothesis,
+                                         pcl::Indices& indices,
+                                         PointCloudIn& cloud);
+  template <typename PointT = PointInT, traits::HasNoNormal<PointT> = true>
+  void
+  computeTransformedPointCloudWithNormal(const StateT&, pcl::Indices&, PointCloudIn&);
+#endif
 
   /** \brief Compute a reference pointcloud transformed to the pose that hypothesis
    * represents and calculate indices without taking occlusion into account.

--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -462,8 +462,8 @@ protected:
   computeTransformedPointCloudWithNormal(const StateT&, pcl::Indices&, PointCloudIn&)
   {
     PCL_WARN("[pcl::%s::computeTransformedPointCloudWithoutNormal] "
-            "use_normal_ == true is not supported in this Point Type.\n",
-            getClassName().c_str());
+             "use_normal_ == true is not supported in this Point Type.\n",
+             getClassName().c_str());
   }
 #endif
 

--- a/tracking/src/kld_adaptive_particle_filter.cpp
+++ b/tracking/src/kld_adaptive_particle_filter.cpp
@@ -40,7 +40,6 @@
 #ifndef PCL_NO_PRECOMPILE
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>
-#define PCL_TRACKING_NORMAL_SUPPORTED
 
 // clang-format off
 PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterTracker,
@@ -53,9 +52,6 @@ PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterOMPTracker,
                          (pcl::PointXYZINormal)
                          (pcl::PointXYZRGBNormal))
                         (PCL_STATE_POINT_TYPES))
-// clang-format on
-#undef PCL_TRACKING_NORMAL_SUPPORTED
-// clang-format off
 PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterOMPTracker,
                         ((pcl::PointXYZ)
                          (pcl::PointXYZI)

--- a/tracking/src/kld_adaptive_particle_filter.cpp
+++ b/tracking/src/kld_adaptive_particle_filter.cpp
@@ -45,15 +45,8 @@
 PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterTracker,
                         ((pcl::PointNormal)
                          (pcl::PointXYZINormal)
-                         (pcl::PointXYZRGBNormal))
-                        (PCL_STATE_POINT_TYPES))
-PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterOMPTracker,
-                        ((pcl::PointNormal)
-                         (pcl::PointXYZINormal)
-                         (pcl::PointXYZRGBNormal))
-                        (PCL_STATE_POINT_TYPES))
-PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterOMPTracker,
-                        ((pcl::PointXYZ)
+                         (pcl::PointXYZRGBNormal)
+                         (pcl::PointXYZ)
                          (pcl::PointXYZI)
                          (pcl::PointXYZRGBA)
                          (pcl::PointXYZRGB)
@@ -62,8 +55,12 @@ PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterOMPTracker,
                          (pcl::PointWithViewpoint)
                          (pcl::PointWithScale))
                         (PCL_STATE_POINT_TYPES))
-PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterTracker,
-                        ((pcl::PointXYZ)
+
+PCL_INSTANTIATE_PRODUCT(KLDAdaptiveParticleFilterOMPTracker,
+                        ((pcl::PointNormal)
+                         (pcl::PointXYZINormal)
+                         (pcl::PointXYZRGBNormal)
+                         (pcl::PointXYZ)
                          (pcl::PointXYZI)
                          (pcl::PointXYZRGBA)
                          (pcl::PointXYZRGB)

--- a/tracking/src/particle_filter.cpp
+++ b/tracking/src/particle_filter.cpp
@@ -45,15 +45,8 @@
 PCL_INSTANTIATE_PRODUCT(ParticleFilterTracker,
                         ((pcl::PointNormal)
                          (pcl::PointXYZINormal)
-                         (pcl::PointXYZRGBNormal))
-                        (PCL_STATE_POINT_TYPES))
-PCL_INSTANTIATE_PRODUCT(ParticleFilterOMPTracker,
-                        ((pcl::PointNormal)
-                         (pcl::PointXYZINormal)
-                         (pcl::PointXYZRGBNormal))
-                        (PCL_STATE_POINT_TYPES))
-PCL_INSTANTIATE_PRODUCT(ParticleFilterTracker,
-                        ((pcl::PointXYZ)
+                         (pcl::PointXYZRGBNormal)
+                         (pcl::PointXYZ)
                          (pcl::PointXYZI)
                          (pcl::PointXYZRGBA)
                          (pcl::PointXYZRGB)
@@ -62,8 +55,12 @@ PCL_INSTANTIATE_PRODUCT(ParticleFilterTracker,
                          (pcl::PointWithViewpoint)
                          (pcl::PointWithScale))
                         (PCL_STATE_POINT_TYPES))
+
 PCL_INSTANTIATE_PRODUCT(ParticleFilterOMPTracker,
-                        ((pcl::PointXYZ)
+                        ((pcl::PointNormal)
+                         (pcl::PointXYZINormal)
+                         (pcl::PointXYZRGBNormal)
+                         (pcl::PointXYZ)
                          (pcl::PointXYZI)
                          (pcl::PointXYZRGBA)
                          (pcl::PointXYZRGB)

--- a/tracking/src/particle_filter.cpp
+++ b/tracking/src/particle_filter.cpp
@@ -40,7 +40,6 @@
 #ifndef PCL_NO_PRECOMPILE
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>
-#define PCL_TRACKING_NORMAL_SUPPORTED
 
 // clang-format off
 PCL_INSTANTIATE_PRODUCT(ParticleFilterTracker,
@@ -53,9 +52,6 @@ PCL_INSTANTIATE_PRODUCT(ParticleFilterOMPTracker,
                          (pcl::PointXYZINormal)
                          (pcl::PointXYZRGBNormal))
                         (PCL_STATE_POINT_TYPES))
-// clang-format on
-#undef PCL_TRACKING_NORMAL_SUPPORTED
-// clang-format off
 PCL_INSTANTIATE_PRODUCT(ParticleFilterTracker,
                         ((pcl::PointXYZ)
                          (pcl::PointXYZI)


### PR DESCRIPTION
Eliminates the need for macro `PCL_TRACKING_NORMAL_SUPPORTED`

Possibly fixes #4630
