### PR TITLE
Change fields of PCLPointCloud2 and PCLImage to uindex_t

### DIFF
--- a/common/include/pcl/PCLImage.h
+++ b/common/include/pcl/PCLImage.h
@@ -13,12 +13,12 @@ namespace pcl
   {
      ::pcl::PCLHeader  header;
 
-    index_t height = 0;
-    index_t width = 0;
+    uindex_t height = 0;
+    uindex_t width = 0;
     std::string encoding;
 
     std::uint8_t is_bigendian = 0;
-    index_t step = 0;
+    uindex_t step = 0;
 
     std::vector<std::uint8_t> data;
 

--- a/common/include/pcl/PCLPointCloud2.h
+++ b/common/include/pcl/PCLPointCloud2.h
@@ -17,15 +17,15 @@ namespace pcl
   {
     ::pcl::PCLHeader header;
 
-    index_t height = 0;
-    index_t width = 0;
+    uindex_t height = 0;
+    uindex_t width = 0;
 
     std::vector<::pcl::PCLPointField>  fields;
 
     static_assert(BOOST_ENDIAN_BIG_BYTE || BOOST_ENDIAN_LITTLE_BYTE, "unable to determine system endianness");
     std::uint8_t is_bigendian = BOOST_ENDIAN_BIG_BYTE;
-    index_t point_step = 0;
-    index_t row_step = 0;
+    uindex_t point_step = 0;
+    uindex_t row_step = 0;
 
     std::vector<std::uint8_t> data;
 

--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -149,7 +149,7 @@ pcl::PCLPointCloud2::concatenate (pcl::PCLPointCloud2 &cloud1, const pcl::PCLPoi
   }
   const auto data1_size = cloud1.data.size ();
   cloud1.data.resize(data1_size + cloud2.data.size ());
-  for (index_t cp = 0; cp < size2; ++cp)
+  for (uindex_t cp = 0; cp < size2; ++cp)
   {
     for (const auto& field_data: valid_fields)
     {

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -181,7 +181,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
  
   // Iterate over each point and perform the appropriate memcpys
   int point_offset = 0;
-  for (index_t cp = 0; cp < cloud_out.width * cloud_out.height; ++cp)
+  for (uindex_t cp = 0; cp < cloud_out.width * cloud_out.height; ++cp)
   {
     memcpy (&cloud_out.data[point_offset], &cloud2.data[cp * cloud2.point_step], cloud2.point_step);
     int field_offset = cloud2.point_step;
@@ -276,7 +276,7 @@ pcl::concatenatePointCloud (const pcl::PCLPointCloud2 &cloud1,
     cloud_out.data.resize (nrpts + (cloud2.width * cloud2.height) * cloud_out.point_step);
 
     // Copy the second cloud
-    for (index_t cp = 0; cp < cloud2.width * cloud2.height; ++cp)
+    for (uindex_t cp = 0; cp < cloud2.width * cloud2.height; ++cp)
     {
       int i = 0;
       for (std::size_t j = 0; j < fields2.size (); ++j)

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -126,7 +126,7 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   }
 
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
-  if (fake_indices_ && indices_->size () != static_cast<uindex_t>((input_->width * input_->height)))
+  if (fake_indices_ && indices_->size () != (input_->width * input_->height))
   {
     const auto indices_size = indices_->size ();
     try

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -833,7 +833,7 @@ RangeImage::extractFarRanges (const pcl::PCLPointCloud2& point_cloud_data,
       vp_z_offset = point_cloud_data.fields[vp_z_idx].offset,
       distance_offset = point_cloud_data.fields[distance_idx].offset;
   
-  for (index_t point_idx = 0; point_idx < point_cloud_data.width*point_cloud_data.height; ++point_idx)
+  for (uindex_t point_idx = 0; point_idx < point_cloud_data.width*point_cloud_data.height; ++point_idx)
   {
     float x = *reinterpret_cast<const float*> (data+x_offset), 
           y = *reinterpret_cast<const float*> (data+y_offset), 

--- a/filters/src/extract_indices.cpp
+++ b/filters/src/extract_indices.cpp
@@ -89,7 +89,7 @@ pcl::ExtractIndices<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
       output = *input_;
     return;
   }
-  if (indices_->size () == static_cast<uindex_t>(input_->width * input_->height))
+  if (indices_->size () == (input_->width * input_->height))
   {
     // If negative, then return an empty cloud
     if (negative_)
@@ -146,7 +146,7 @@ pcl::ExtractIndices<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
 void
 pcl::ExtractIndices<pcl::PCLPointCloud2>::applyFilter (Indices &indices)
 {
-  if (indices_->size () > static_cast<uindex_t>(input_->width * input_->height))
+  if (indices_->size () > (input_->width * input_->height))
   {
     PCL_ERROR ("[pcl::%s::applyFilter] The indices size exceeds the size of the input.\n", getClassName ().c_str ());
     indices.clear ();

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -536,8 +536,8 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
   std::vector<std::string> st;
   try
   {
-    index_t point_idx = 0;
-    index_t normal_idx = 0;
+    uindex_t point_idx = 0;
+    uindex_t normal_idx = 0;
 
     while (!fs.eof ())
     {

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -361,7 +361,7 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
     }
   }
 
-  if (static_cast<uindex_t>(cloud.width * cloud.height) != nr_points)
+  if (cloud.width * cloud.height != nr_points)
   {
     PCL_ERROR ("[pcl::PCDReader::readHeader] HEIGHT (%d) x WIDTH (%d) != number of points (%d)\n", cloud.height, cloud.width, nr_points);
     return (-1);
@@ -611,7 +611,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
       toff += fields_sizes[i] * cloud.width * cloud.height;
     }
     // Copy it to the cloud
-    for (index_t i = 0; i < cloud.width * cloud.height; ++i)
+    for (uindex_t i = 0; i < cloud.width * cloud.height; ++i)
     {
       for (std::size_t j = 0; j < pters.size (); ++j)
       {
@@ -629,7 +629,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
   // Extra checks (not needed for ASCII)
   int point_size = static_cast<int> (cloud.data.size () / (cloud.height * cloud.width));
   // Once copied, we need to go over each field and check if it has NaN/Inf values and assign cloud.is_dense to true or false
-  for (index_t i = 0; i < cloud.width * cloud.height; ++i)
+  for (uindex_t i = 0; i < cloud.width * cloud.height; ++i)
   {
     for (unsigned int d = 0; d < static_cast<unsigned int> (cloud.fields.size ()); ++d)
     {
@@ -986,7 +986,7 @@ pcl::PCDWriter::generateHeaderBinary (const pcl::PCLPointCloud2 &cloud,
     fsize += field.count * getFieldSize (field.datatype);
 
   // The size of the fields cannot be larger than point_step
-  if (fsize > static_cast<uindex_t>(cloud.point_step))
+  if (fsize > cloud.point_step)
   {
     PCL_ERROR ("[pcl::PCDWriter::generateHeaderBinary] The size of the fields (%d) is larger than point_step (%d)! Something is wrong here...\n", fsize, cloud.point_step);
     return ("");
@@ -1028,7 +1028,7 @@ pcl::PCDWriter::generateHeaderBinary (const pcl::PCLPointCloud2 &cloud,
     field_counts << " " << count;
   }
   // Check extra padding
-  if (toffset < static_cast<uindex_t>(cloud.point_step))
+  if (toffset < cloud.point_step)
   {
     field_names << " _";  // By convention, _ is an invalid field name
     field_sizes << " 1";  // Make size = 1
@@ -1068,7 +1068,7 @@ pcl::PCDWriter::generateHeaderBinaryCompressed (std::ostream &os,
     fsize += field.count * getFieldSize (field.datatype);
 
   // The size of the fields cannot be larger than point_step
-  if (fsize > static_cast<uindex_t>(cloud.point_step))
+  if (fsize > cloud.point_step)
   {
     PCL_ERROR ("[pcl::PCDWriter::generateHeaderBinaryCompressed] The size of the fields (%d) is larger than point_step (%d)! Something is wrong here...\n", fsize, cloud.point_step);
     return (-1);
@@ -1415,7 +1415,7 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
   }
 
   // Go over all the points, and copy the data in the appropriate places
-  for (index_t i = 0; i < cloud.width * cloud.height; ++i)
+  for (uindex_t i = 0; i < cloud.width * cloud.height; ++i)
   {
     for (std::size_t j = 0; j < pters.size (); ++j)
     {

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -413,7 +413,7 @@ pcl::io::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::TextureMe
 int
 pcl::io::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyData>& poly_data)
 {
-  unsigned int nr_points = mesh.cloud.width * mesh.cloud.height;
+  auto nr_points = mesh.cloud.width * mesh.cloud.height;
   unsigned int nr_polygons = static_cast<unsigned int> (mesh.polygons.size ());
 
   // reset vtkPolyData object
@@ -556,12 +556,12 @@ pcl::io::pointCloudTovtkPolyData(const pcl::PCLPointCloud2Ptr& cloud, vtkSmartPo
   vtkSmartPointer<vtkCellArray> cloud_vertices = vtkSmartPointer<vtkCellArray>::New ();
 
   vtkIdType pid[1];
-  for (index_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
+  for (uindex_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
   {
     float point[3];
 
-    int point_offset = (int (point_idx) * cloud->point_step);
-    int offset = point_offset + cloud->fields[x_idx].offset;
+    auto point_offset = (point_idx * cloud->point_step);
+    auto offset = point_offset + cloud->fields[x_idx].offset;
     memcpy (&point, &cloud->data[offset], sizeof (float)*3);
 
     pid[0] = cloud_points->InsertNextPoint (point);
@@ -582,12 +582,12 @@ pcl::io::pointCloudTovtkPolyData(const pcl::PCLPointCloud2Ptr& cloud, vtkSmartPo
     colors->SetNumberOfComponents (3);
     colors->SetName ("rgb");
 
-    for (index_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
+    for (uindex_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
     {
       unsigned char bgr[3];
 
-      int point_offset = (int (point_idx) * cloud->point_step);
-      int offset = point_offset + cloud->fields[rgb_idx].offset;
+      auto point_offset = (point_idx * cloud->point_step);
+      auto offset = point_offset + cloud->fields[rgb_idx].offset;
       memcpy (&bgr, &cloud->data[offset], sizeof (unsigned char)*3);
 
       colors->InsertNextTuple3(bgr[2], bgr[1], bgr[0]);
@@ -605,12 +605,12 @@ pcl::io::pointCloudTovtkPolyData(const pcl::PCLPointCloud2Ptr& cloud, vtkSmartPo
     cloud_intensity->SetNumberOfComponents (1);
     cloud_intensity->SetName("intensity");
 
-    for (index_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
+    for (uindex_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
     {
       float intensity;
 
-      int point_offset = (int (point_idx) * cloud->point_step);
-      int offset = point_offset + cloud->fields[intensity_idx].offset;
+      auto point_offset = (point_idx * cloud->point_step);
+      auto offset = point_offset + cloud->fields[intensity_idx].offset;
       memcpy (&intensity, &cloud->data[offset], sizeof(float));
 
       cloud_intensity->InsertNextValue(intensity);
@@ -630,12 +630,12 @@ pcl::io::pointCloudTovtkPolyData(const pcl::PCLPointCloud2Ptr& cloud, vtkSmartPo
     normals->SetNumberOfComponents(3); //3d normals (ie x,y,z)
     normals->SetName("normals");
 
-    for (index_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
+    for (uindex_t point_idx = 0; point_idx < cloud->width * cloud->height; point_idx ++)
     {
       float normal[3];
 
-      int point_offset = (int (point_idx) * cloud->point_step);
-      int offset = point_offset + cloud->fields[normal_x_idx].offset;
+      auto point_offset = (point_idx * cloud->point_step);
+      auto offset = point_offset + cloud->fields[normal_x_idx].offset;
       memcpy (&normal, &cloud->data[offset], sizeof (float)*3);
 
       normals->InsertNextTuple(normal);

--- a/tools/transform_point_cloud.cpp
+++ b/tools/transform_point_cloud.cpp
@@ -199,7 +199,7 @@ scaleInPlace (pcl::PCLPointCloud2 &cloud, double* multiplier)
   int z_idx = pcl::getFieldIndex (cloud, "z");
   Eigen::Array3i xyz_offset (cloud.fields[x_idx].offset, cloud.fields[y_idx].offset, cloud.fields[z_idx].offset);
  
-  for (index_t cp = 0; cp < cloud.width * cloud.height; ++cp)
+  for (uindex_t cp = 0; cp < cloud.width * cloud.height; ++cp)
   {
     // Assume all 3 fields are the same (XYZ)
     assert ((cloud.fields[x_idx].datatype == cloud.fields[y_idx].datatype));


### PR DESCRIPTION
- with unsigned, the numbers have twice the capacity before having to switch to a bigger datatype
- consistent with ROS messages (sensor_msgs/PointCloud2 and sensor_msgs/Image)
- rules out the possibility to have negative width/height/steps
The other changes are follow-ups, to avoid sign-compare warnings, and removing unnecessary casts