### PR TITLE
Add deprecation for incorrectly installed headers

### DIFF
--- a/recognition/CMakeLists.txt
+++ b/recognition/CMakeLists.txt
@@ -38,20 +38,20 @@ set(incs
   "include/pcl/${SUBSYS_NAME}/dense_quantized_multi_mod_template.h"
   "include/pcl/${SUBSYS_NAME}/sparse_quantized_multi_mod_template.h"
   "include/pcl/${SUBSYS_NAME}/surface_normal_modality.h"
-  "include/pcl/${SUBSYS_NAME}/linemod/line_rgbd.h"
+  "include/pcl/${SUBSYS_NAME}/line_rgbd.h"
   "include/pcl/${SUBSYS_NAME}/implicit_shape_model.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/auxiliary.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/hypothesis.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/model_library.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/rigid_transform_space.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/obj_rec_ransac.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/orr_graph.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/orr_octree_zprojection.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/trimmed_icp.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/orr_octree.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/simple_octree.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/voxel_structure.h"
-  "include/pcl/${SUBSYS_NAME}/ransac_based/bvh.h"
+  "include/pcl/${SUBSYS_NAME}/auxiliary.h"
+  "include/pcl/${SUBSYS_NAME}/hypothesis.h"
+  "include/pcl/${SUBSYS_NAME}/model_library.h"
+  "include/pcl/${SUBSYS_NAME}/rigid_transform_space.h"
+  "include/pcl/${SUBSYS_NAME}/obj_rec_ransac.h"
+  "include/pcl/${SUBSYS_NAME}/orr_graph.h"
+  "include/pcl/${SUBSYS_NAME}/orr_octree_zprojection.h"
+  "include/pcl/${SUBSYS_NAME}/trimmed_icp.h"
+  "include/pcl/${SUBSYS_NAME}/orr_octree.h"
+  "include/pcl/${SUBSYS_NAME}/simple_octree.h"
+  "include/pcl/${SUBSYS_NAME}/voxel_structure.h"
+  "include/pcl/${SUBSYS_NAME}/bvh.h"
 )
 
 set(ransac_based_incs
@@ -91,9 +91,9 @@ set(cg_incs
 )
 
 set(impl_incs
-  "include/pcl/${SUBSYS_NAME}/impl/linemod/line_rgbd.hpp"
-  "include/pcl/${SUBSYS_NAME}/impl/ransac_based/simple_octree.hpp"
-  "include/pcl/${SUBSYS_NAME}/impl/ransac_based/voxel_structure.hpp"
+  "include/pcl/${SUBSYS_NAME}/impl/line_rgbd.hpp"
+  "include/pcl/${SUBSYS_NAME}/impl/simple_octree.hpp"
+  "include/pcl/${SUBSYS_NAME}/impl/voxel_structure.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/implicit_shape_model.hpp"
 )
 

--- a/recognition/include/pcl/recognition/auxiliary.h
+++ b/recognition/include/pcl/recognition/auxiliary.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/auxiliary.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/auxiliary.h> instead")

--- a/recognition/include/pcl/recognition/bvh.h
+++ b/recognition/include/pcl/recognition/bvh.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/bvh.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/bvh.h> instead")

--- a/recognition/include/pcl/recognition/hypothesis.h
+++ b/recognition/include/pcl/recognition/hypothesis.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/hypothesis.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/hypothesis.h> instead")

--- a/recognition/include/pcl/recognition/impl/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/line_rgbd.hpp
@@ -1,0 +1,2 @@
+#include <pcl/recognition/impl/linemod/line_rgbd.hpp>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/impl/linemod/line_rgbd.hpp> instead")

--- a/recognition/include/pcl/recognition/impl/simple_octree.hpp
+++ b/recognition/include/pcl/recognition/impl/simple_octree.hpp
@@ -1,0 +1,2 @@
+#include <pcl/recognition/impl/ransac_based/simple_octree.hpp>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/impl/ransac_based/simple_octree.hpp> instead")

--- a/recognition/include/pcl/recognition/impl/voxel_structure.hpp
+++ b/recognition/include/pcl/recognition/impl/voxel_structure.hpp
@@ -1,0 +1,2 @@
+#include <pcl/recognition/impl/ransac_based/voxel_structure.hpp>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/impl/ransac_based/voxel_structure.hpp> instead")

--- a/recognition/include/pcl/recognition/line_rgbd.h
+++ b/recognition/include/pcl/recognition/line_rgbd.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/linemod/line_rgbd.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/linemod/line_rgbd.h> instead")

--- a/recognition/include/pcl/recognition/model_library.h
+++ b/recognition/include/pcl/recognition/model_library.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/model_library.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/model_library.h> instead")

--- a/recognition/include/pcl/recognition/obj_rec_ransac.h
+++ b/recognition/include/pcl/recognition/obj_rec_ransac.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/obj_rec_ransac.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/obj_rec_ransac.h> instead")

--- a/recognition/include/pcl/recognition/orr_graph.h
+++ b/recognition/include/pcl/recognition/orr_graph.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/orr_graph.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/orr_graph.h> instead")

--- a/recognition/include/pcl/recognition/orr_octree.h
+++ b/recognition/include/pcl/recognition/orr_octree.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/orr_octree.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/orr_octree.h> instead")

--- a/recognition/include/pcl/recognition/orr_octree_zprojection.h
+++ b/recognition/include/pcl/recognition/orr_octree_zprojection.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/orr_octree_zprojection.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/orr_octree_zprojection.h> instead")

--- a/recognition/include/pcl/recognition/rigid_transform_space.h
+++ b/recognition/include/pcl/recognition/rigid_transform_space.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/rigid_transform_space.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/rigid_transform_space.h> instead")

--- a/recognition/include/pcl/recognition/simple_octree.h
+++ b/recognition/include/pcl/recognition/simple_octree.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/simple_octree.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/simple_octree.h> instead")

--- a/recognition/include/pcl/recognition/trimmed_icp.h
+++ b/recognition/include/pcl/recognition/trimmed_icp.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/trimmed_icp.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/trimmed_icp.h> instead")

--- a/recognition/include/pcl/recognition/voxel_structure.h
+++ b/recognition/include/pcl/recognition/voxel_structure.h
@@ -1,0 +1,2 @@
+#include <pcl/recognition/ransac_based/voxel_structure.h>
+PCL_DEPRECATED_HEADER(1, 15, "Please use <pcl/recognition/ransac_based/voxel_structure.h> instead")


### PR DESCRIPTION
- Problem: some headers are currently installed twice
- Add deprecation/redirection headers
- Install these headers instead of one set of the "full" headers (so deprecation headers+full headers instead of full headers twice)
- If user includes the wrong header (wrong path), it still works, but they get the deprecation notice

PR #245 actually added similar deprecation headers before, but they were never installed (so users never got the error/deprecation notice), and later removed.
Fixes issue #3625