### PR TITLE
Tests: use better asserts and expects

### DIFF
--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -71,7 +71,7 @@ TEST(UniformSampling, extractRemovedIndices)
   ASSERT_EQ(output.size(), 1000);
   EXPECT_EQ(removed_indices->size(), xyz->size() - 1000);
   std::set<int> removed_indices_set(removed_indices->begin(), removed_indices->end());
-  ASSERT_TRUE(removed_indices_set.size() == removed_indices->size());
+  ASSERT_EQ(removed_indices_set.size(), removed_indices->size());
 }
 
 int

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -499,7 +499,7 @@ TEST_F (PLYTest, NoEndofLine)
   pcl::PLYReader Reader;
   Reader.read(PLYTest::mesh_file_ply_, cloud);
 
-  ASSERT_EQ (cloud.empty(), false);
+  ASSERT_FALSE (cloud.empty());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -529,7 +529,7 @@ TEST_F (PLYTest, CommentAtTheEnd)
   pcl::PLYReader Reader;
   Reader.read(PLYTest::mesh_file_ply_, cloud);
 
-  ASSERT_EQ (cloud.empty(), false);
+  ASSERT_FALSE (cloud.empty());
 }
 
 /* ---[ */

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -900,7 +900,7 @@ TEST (PCL, Octree_Pointcloud_Iterator_Test)
   for (auto bfIt = octreeA.breadth_begin(); bfIt != octreeA.breadth_end(); ++bfIt)
   {
     // tree depth of visited nodes must grow
-    ASSERT_TRUE (bfIt.getCurrentOctreeDepth () >= lastDepth);
+    ASSERT_GE (bfIt.getCurrentOctreeDepth (), lastDepth);
     lastDepth = bfIt.getCurrentOctreeDepth ();
 
     if (bfIt.isBranchNode ())
@@ -1018,7 +1018,7 @@ TEST (PCL, Octree_Pointcloud_Change_Detector_Test)
   // all point indices found should have an index of >= 1000
   for (std::size_t i = 0; i < 1000; i++)
   {
-    ASSERT_TRUE (newPointIdxVector[i] >= 1000);
+    ASSERT_GE (newPointIdxVector[i], 1000);
   }
 }
 
@@ -1358,7 +1358,7 @@ TEST(PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
   }
 
   // we should have found the absolute nearest neighbor at least once
-  ASSERT_TRUE (bestMatchCount > 0);
+  ASSERT_GT (bestMatchCount, 0);
 }
 
 TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
@@ -1432,7 +1432,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
               + ((*cloudIn)[*current].y - searchPoint.y) * ((*cloudIn)[*current].y - searchPoint.y)
               + ((*cloudIn)[*current].z - searchPoint.z) * ((*cloudIn)[*current].z - searchPoint.z));
 
-      ASSERT_TRUE (pointDist <= searchRadius);
+      ASSERT_LE (pointDist, searchRadius);
 
       ++current;
     }
@@ -1440,7 +1440,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
     // check if result limitation works
     octree.radiusSearch (searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius, 5);
 
-    ASSERT_TRUE (cloudNWRRadius.size () <= 5);
+    ASSERT_LE (cloudNWRRadius.size (), 5);
 
   }
 

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -184,7 +184,7 @@ TEST(PCL, ICP_translated)
   icp.align(Final);
 
   // Check that we have sucessfully converged
-  ASSERT_EQ(icp.hasConverged(), true);
+  ASSERT_TRUE(icp.hasConverged());
 
   // Test that the fitness score is below acceptable threshold
   EXPECT_LT(icp.getFitnessScore(), 1e-6);

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -165,8 +165,8 @@ TEST (PCL, FlannSearch_differentPointT)
     for (std::size_t j = 0; j< no_of_neighbors; j++)
     {
       EXPECT_TRUE (k_indices[j] == indices[i][j] || k_distances[j] == dists[i][j]);
-      //EXPECT_TRUE (k_indices[j] == k_indices_t[j]);
-      //EXPECT_TRUE (k_distances[j] == k_distances_t[j]);
+      //EXPECT_EQ (k_indices[j], k_indices_t[j]);
+      //EXPECT_EQ (k_distances[j], k_distances_t[j]);
     }
 
   }

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -159,8 +159,8 @@ TEST (PCL, KdTree_differentPointT)
     for (std::size_t j=0; j< no_of_neighbors; j++)
     {
       EXPECT_TRUE (k_indices[j] == indices[i][j] || k_distances[j] == dists[i][j]);
-      EXPECT_TRUE (k_indices[j] == k_indices_t[j]);
-      EXPECT_TRUE (k_distances[j] == k_distances_t[j]);
+      EXPECT_EQ (k_indices[j], k_indices_t[j]);
+      EXPECT_EQ (k_distances[j], k_distances_t[j]);
     }
   }
 }

--- a/test/search/test_octree.cpp
+++ b/test/search/test_octree.cpp
@@ -225,7 +225,7 @@ TEST (PCL, Octree_Pointcloud_Approx_Nearest_Neighbour_Search)
     }
   }
   // we should have found the absolute nearest neighbor at least once
-  //ASSERT_EQ ( (bestMatchCount > 0) , true);
+  //ASSERT_GT (bestMatchCount, 0);
 }
 #endif
 #if 0
@@ -336,12 +336,12 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
           ((*cloudIn)[current].z-searchPoint.z) * ((*cloudIn)[current].z-searchPoint.z)
       );
 
-      ASSERT_EQ ( (pointDist<=searchRadius) , true);
+      ASSERT_LE (pointDist, searchRadius);
     }
 
     // check if result limitation works
     octree->radiusSearch(searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius, 5);
-    ASSERT_EQ ( cloudNWRRadius.size() <= 5, true);
+    ASSERT_LE (cloudNWRRadius.size(), 5);
   }
 }
 

--- a/test/search/test_organized.cpp
+++ b/test/search/test_organized.cpp
@@ -252,7 +252,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Neighbours_Within_Radius_Search)
           ((*cloudIn)[current].z-searchPoint.z) * ((*cloudIn)[current].z-searchPoint.z)
       );
 
-      ASSERT_EQ ( (pointDist<=searchRadius) , true);
+      ASSERT_LE (pointDist, searchRadius);
     }
 
 
@@ -265,7 +265,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Neighbours_Within_Radius_Search)
           ((*cloudIn)[current].z-searchPoint.z) * ((*cloudIn)[current].z-searchPoint.z)
       );
 
-      ASSERT_EQ ( (pointDist<=searchRadius) , true);
+      ASSERT_LE (pointDist, searchRadius);
     }
 
     ASSERT_EQ (cloudNWRRadius.size() , cloudSearchBruteforce.size ());
@@ -273,7 +273,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Neighbours_Within_Radius_Search)
     // check if result limitation works
     organizedNeighborSearch.radiusSearch (searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius, 5);
 
-    ASSERT_EQ (cloudNWRRadius.size () <= 5, true);
+    ASSERT_LE (cloudNWRRadius.size (), 5);
   }
 }
 

--- a/test/search/test_organized_index.cpp
+++ b/test/search/test_organized_index.cpp
@@ -320,7 +320,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search)
     for (const auto it : cloudNWRSearch)
     {
       auto const pointDist = geometry::distance((*cloudIn)[it], searchPoint);
-      ASSERT_EQ ( (pointDist <= searchRadius) , true);
+      ASSERT_LE (pointDist, searchRadius);
     }
 
 
@@ -328,7 +328,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search)
     for (const auto it : cloudSearchBruteforce)
     {
       const auto pointDist = geometry::distance((*cloudIn)[it], searchPoint);
-      ASSERT_EQ ( (pointDist <= searchRadius) , true);
+      ASSERT_LE (pointDist, searchRadius);
     }
 
     ASSERT_EQ (cloudNWRRadius.size() , cloudSearchBruteforce.size ());
@@ -336,7 +336,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search)
     // check if result limitation works
     organizedNeighborSearch.radiusSearch (searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius, 5);
 
-    ASSERT_EQ (cloudNWRRadius.size () <= 5, true);
+    ASSERT_LE (cloudNWRRadius.size (), 5);
   }
 }
 
@@ -523,7 +523,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
     for (const auto it : cloudNWRSearch)
     {
       double pointDist = geometry::distance((*cloudIn)[it], searchPoint);
-      ASSERT_EQ ( (pointDist <= searchRadius) , true);
+      ASSERT_LE (pointDist, searchRadius);
     }
 
 
@@ -531,7 +531,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
     for (const auto it : cloudSearchBruteforce)
     {
       double pointDist = geometry::distance((*cloudIn)[it], searchPoint);
-      ASSERT_EQ ( (pointDist <= searchRadius) , true);
+      ASSERT_LE (pointDist, searchRadius);
     }
 
     ASSERT_EQ (cloudNWRRadius.size() , cloudSearchBruteforce.size ());
@@ -539,7 +539,7 @@ TEST (PCL, Organized_Neighbor_Search_Pointcloud_Neighbours_Within_Radius_Search_
     // check if result limitation works
     organizedNeighborSearch.radiusSearch (searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius, 5);
 
-    ASSERT_EQ (cloudNWRRadius.size () <= 5, true);
+    ASSERT_LE (cloudNWRRadius.size (), 5);
   }
 }
 


### PR DESCRIPTION
- Use e.g. ASSERT_LE(a, b) instead of ASSERT_TRUE(a<=b) because in a failure case, the former reports the values of a and b, while the latter only reports the failure. Similar for greater, equal, etc
- Use ASSERT_TRUE(a) instead of ASSERT_EQ(a, true) for better readability