### PR TITLE
[CMake] Vtk is not a hard requirement for surface

### DIFF
--- a/surface/CMakeLists.txt
+++ b/surface/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SUBSYS_DEPS common search kdtree octree)
 
 set(build TRUE)
 PCL_SUBSYS_OPTION(build "${SUBSYS_NAME}" "${SUBSYS_DESC}" ON)
-PCL_SUBSYS_DEPEND(build "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS} EXT_DEPS vtk OPT_DEPS qhull)
+PCL_SUBSYS_DEPEND(build "${SUBSYS_NAME}" DEPS ${SUBSYS_DEPS} OPT_DEPS qhull vtk)
 
 PCL_ADD_DOC("${SUBSYS_NAME}")
 


### PR DESCRIPTION
Was a mistake in previous PR #4262.