### PR TITLE
Improve compatibility of PCLConfig.cmake

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -383,12 +383,15 @@ endif()
 find_package(PkgConfig QUIET)
 
 file(TO_CMAKE_PATH "${PCL_DIR}" PCL_DIR)
+get_filename_component(PCL_DIR "${PCL_DIR}" REALPATH)
+
 if(WIN32 AND NOT MINGW)
 # PCLConfig.cmake is installed to PCL_ROOT/cmake
   get_filename_component(PCL_ROOT "${PCL_DIR}" PATH)
 else()
 # PCLConfig.cmake is installed to PCL_ROOT/share/pcl-x.y
-  get_filename_component(PCL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+  get_filename_component(PCL_CONFIG_PATH "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
+  get_filename_component(PCL_ROOT "${PCL_CONFIG_PATH}/../../../../" ABSOLUTE)
 endif()
 
 # check whether PCLConfig.cmake is found into a PCL installation or in a build tree

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -391,7 +391,7 @@ if(WIN32 AND NOT MINGW)
 else()
 # PCLConfig.cmake is installed to PCL_ROOT/share/pcl-x.y
   get_filename_component(PCL_CONFIG_PATH "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
-  get_filename_component(PCL_ROOT "${PCL_CONFIG_PATH}/../../../../" ABSOLUTE)
+  get_filename_component(PCL_ROOT "${PCL_CONFIG_PATH}/../.." ABSOLUTE)
 endif()
 
 # check whether PCLConfig.cmake is found into a PCL installation or in a build tree


### PR DESCRIPTION

Fixes #4661 
Make PCLConfig.cmake go well on some special platform described as #4661.
