### PR TITLE
Fix for openni_wrapper::DeviceXtionPro::getCurrentImage returns null pointer #681

### DIFF
--- a/io/src/openni_camera/openni_device_xtion.cpp
+++ b/io/src/openni_camera/openni_device_xtion.cpp
@@ -116,9 +116,9 @@ openni_wrapper::DeviceXtionPro::enumAvailableModes () noexcept
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 openni_wrapper::Image::Ptr 
-openni_wrapper::DeviceXtionPro::getCurrentImage (pcl::shared_ptr<xn::ImageMetaData>) const throw ()
+openni_wrapper::DeviceXtionPro::getCurrentImage (pcl::shared_ptr<xn::ImageMetaData> image_data) const throw ()
 {
-  return (Image::Ptr (reinterpret_cast<Image*> (0)));
+  return (boost::shared_ptr<openni_wrapper::Image> (new ImageYUV422 (image_data)));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Based on discussion [here](https://github.com/PointCloudLibrary/pcl/issues/681#issuecomment-800952091) did the changes, please review and merge it.