### PR TITLE
Speeding up GPU clustering using smarter download strategy and memory allocations

### DIFF
--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
@@ -48,6 +48,18 @@
 
 namespace pcl
 {
+namespace detail {
+/** brief Fast data download from the device to host
+ * param source_indices gpu memory buffer from which to download
+ * param buffer_indices indices denoting positions to download
+ * param buffer_size length of a memory buffer
+ * param downloaded_indices memory buffer of the downloaded indices */
+void
+economical_download(const pcl::gpu::NeighborIndices& source_indices,
+                    const pcl::Indices& buffer_indices,
+                    std::size_t buffer_size,
+                    pcl::Indices& downloaded_indices);
+} // namespace detail
   namespace gpu
   {
     template <typename PointT> void
@@ -131,16 +143,6 @@ namespace pcl
           */
         void extract (std::vector<pcl::PointIndices> &clusters);
 
-        /** brief Fast data download from the device to host
-         * param source_indices gpu memory buffer from which to download
-         * param buffer_indices indices denoting positions to download
-         * param buffer_size length of a memory buffer
-         * param downloaded_indices memory buffer of the downloaded indices */
-        static void
-        economical_download(const pcl::gpu::NeighborIndices& source_indices,
-                            const pcl::Indices& buffer_indices,
-                            std::size_t buffer_size,
-                            pcl::Indices& downloaded_indices);
 
       protected:
         /** \brief the input cloud on the GPU */

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
@@ -131,6 +131,17 @@ namespace pcl
           */
         void extract (std::vector<pcl::PointIndices> &clusters);
 
+        /** brief Fast data download from the device to host
+         * param source_indices gpu memory buffer from which to download
+         * param buffer_indices indices denoting positions to download
+         * param buffer_size length of a memory buffer
+         * param downloaded_indices memory buffer of the downloaded indices */
+        static void
+        economical_download(const pcl::gpu::NeighborIndices& source_indices,
+                            const pcl::Indices& buffer_indices,
+                            std::size_t buffer_size,
+                            pcl::Indices& downloaded_indices);
+
       protected:
         /** \brief the input cloud on the GPU */
         CloudDevice input_;

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
@@ -48,18 +48,6 @@
 
 namespace pcl
 {
-namespace detail {
-/** brief Fast data download from the device to host
- * param source_indices gpu memory buffer from which to download
- * param buffer_indices indices denoting positions to download
- * param buffer_size length of a memory buffer
- * param downloaded_indices memory buffer of the downloaded indices */
-void
-economical_download(const pcl::gpu::NeighborIndices& source_indices,
-                    const pcl::Indices& buffer_indices,
-                    std::size_t buffer_size,
-                    pcl::Indices& downloaded_indices);
-} // namespace detail
   namespace gpu
   {
     template <typename PointT> void

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
@@ -131,7 +131,6 @@ namespace pcl
           */
         void extract (std::vector<pcl::PointIndices> &clusters);
 
-
       protected:
         /** \brief the input cloud on the GPU */
         CloudDevice input_;

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -124,13 +124,16 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
     do
     {
       // if the number of queries is not high enough implement search on Host here
-      if(queries_host.size () <= 0) ///@todo: adjust this to a variable number settable with method
+      if(queries_host.size () <= 10) ///@todo: adjust this to a variable number settable with method
       {
         PCL_DEBUG(" CPU: ");
+        data.clear();
         for(std::size_t p = 0; p < queries_host.size (); p++)
         {
           // Execute the radiusSearch on the host
-          tree->radiusSearchHost(queries_host[p], tolerance, data, max_answers);
+          std::vector<int> tmp;
+          tree->radiusSearchHost(queries_host[p], tolerance, tmp, max_answers);
+          std::copy(tmp.begin(), tmp.end(), std::back_inserter(data));
         }
         // Store the previously found number of points
         previous_found_points = found_points;

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -207,7 +207,7 @@ pcl::gpu::EuclideanClusterExtraction<PointT>::extract (std::vector<pcl::PointInd
 */
   // Extract the actual clusters
   extractEuclideanClusters<PointT> (host_cloud_, tree_, cluster_tolerance_, clusters, min_pts_per_cluster_, max_pts_per_cluster_);
-  PCL_DEBUG("INFO: end of extractEuclideanClusters ");
+  PCL_DEBUG("INFO: end of extractEuclideanClusters\n");
   // Sort the clusters based on their size (largest one first)
   //std::sort (clusters.rbegin (), clusters.rend (), comparePointClusters);
 }

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -207,7 +207,7 @@ pcl::gpu::EuclideanClusterExtraction<PointT>::extract (std::vector<pcl::PointInd
 */
   // Extract the actual clusters
   extractEuclideanClusters<PointT> (host_cloud_, tree_, cluster_tolerance_, clusters, min_pts_per_cluster_, max_pts_per_cluster_);
-  std::cout << "INFO: end of extractEuclideanClusters " << std::endl;
+  PCL_DEBUG("INFO: end of extractEuclideanClusters ");
   // Sort the clusters based on their size (largest one first)
   //std::sort (clusters.rbegin (), clusters.rend (), comparePointClusters);
 }

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -120,7 +120,6 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
       if(queries_host.size () <= 10) ///@todo: adjust this to a variable number settable with method
       {
         PCL_DEBUG(" CPU: ");
-        //data.clear();
         for(std::size_t p = 0; p < queries_host.size (); p++)
         {
           // Execute the radiusSearch on the host

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -98,10 +98,12 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
     pcl::gpu::NeighborIndices result_device;
 
     // once the area stop growing, stop also iterating.
+    std::vector<int> sizes, data;
+    sizes.reserve(host_cloud_->size());
+    data.reserve(host_cloud_->size());
     do
     {
       // Host buffer for results
-      std::vector<int> sizes, data;
 
       // if the number of queries is not high enough implement search on Host here
       if(queries_host.size () <= 10) ///@todo: adjust this to a variable number settable with method

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -153,7 +153,8 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
         tree->radiusSearch(queries_device, tolerance, max_answers, result_device);
         // Copy results from GPU to Host
         result_device.sizes.download(sizes);
-        pcl::detail::economical_download(result_device, sizes, max_answers, data);
+        pcl::detail::economical_download(
+            result_device, sizes, max_answers, data);
       }
       // Store the previously found number of points
       previous_found_points = found_points;

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -164,8 +164,8 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
         continue;
 
       // Process the results
-      for(int idx : data)
-        {
+      for(auto idx : data)
+      {  
         if(processed[idx])
           continue;
         processed[idx] = true;

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -39,27 +39,16 @@
 #pragma once
 #include <pcl/common/copy_point.h>
 #include <pcl/gpu/segmentation/gpu_extract_clusters.h>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
 
 namespace pcl {
 namespace detail {
 
-// Downloads only the neccssary cluster indices from the device to the host.
-void economical_download(const pcl::gpu::NeighborIndices& source_indices,
-        const pcl::Indices& buffer_indices, std::size_t buffer_size,
-        pcl::Indices& downloaded_indices) {
-    std::vector<int> tmp;
-    for (std::size_t qp = 0; qp < buffer_indices.size(); qp++) {
-        std::size_t begin = qp * buffer_size;
-        const int* const pdata = source_indices.data.ptr() + begin;
-        tmp.resize(buffer_indices[qp]);
-        const std::size_t bytes = (buffer_indices[qp]) * sizeof(int);
-        cudaMemcpy(&tmp[0], pdata, bytes, cudaMemcpyDeviceToHost);
-        cudaDeviceSynchronize();
-        downloaded_indices.insert(downloaded_indices.end(), tmp.begin(), tmp.end());
-    }
-}
+//// Downloads only the neccssary cluster indices from the device to the host.
+void
+economical_download(const pcl::gpu::NeighborIndices& source_indices,
+                    const pcl::Indices& buffer_indices,
+                    std::size_t buffer_size,
+                    pcl::Indices& downloaded_indices);
 } // namespace detail
 } // namespace pcl
 

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -153,8 +153,7 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
         tree->radiusSearch(queries_device, tolerance, max_answers, result_device);
         // Copy results from GPU to Host
         result_device.sizes.download(sizes);
-        pcl::detail::economical_download(
-            result_device, sizes, max_answers, data);
+        pcl::detail::economical_download(result_device, sizes, max_answers, data);
       }
       // Store the previously found number of points
       previous_found_points = found_points;

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -74,6 +74,8 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
   // Process all points in the cloud
   for (std::size_t i = 0; i < host_cloud_->size (); ++i)
   {
+    sizes.clear();
+    data.clear();
     // if we already processed this point continue with the next one
     if (processed[i])
       continue;
@@ -118,7 +120,6 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
         // Clear queries list
         queries_host.clear();
 
-        //std::unique(data.begin(), data.end());
         if(data.size () == 1)
           continue;
 
@@ -143,7 +144,6 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
       else
       {
         PCL_DEBUG(" GPU: ");
-        std::cout << "GPU " << std::endl;
         // Copy buffer
         queries_device = DeviceArray<PointXYZ>(queries_device_buffer.ptr(),queries_host.size());
         // Move queries to GPU

--- a/gpu/segmentation/src/extract_clusters.cpp
+++ b/gpu/segmentation/src/extract_clusters.cpp
@@ -51,11 +51,10 @@ PCL_INSTANTIATE(extractLabeledEuclideanClusters, PCL_XYZL_POINT_TYPES);
 PCL_INSTANTIATE(EuclideanLabeledClusterExtraction, PCL_XYZL_POINT_TYPES);
 
 void
-pcl::gpu::EuclideanClusterExtraction::economical_download(
-    const pcl::gpu::NeighborIndices& source_indices,
-    const pcl::Indices& buffer_indices,
-    std::size_t buffer_size,
-    pcl::Indices& downloaded_indices)
+pcl::detail::economical_download(const pcl::gpu::NeighborIndices& source_indices,
+                                 const pcl::Indices& buffer_indices,
+                                 std::size_t buffer_size,
+                                 pcl::Indices& downloaded_indices)
 {
   std::vector<int> tmp;
   for (std::size_t qp = 0; qp < buffer_indices.size(); qp++) {

--- a/gpu/segmentation/src/extract_clusters.cpp
+++ b/gpu/segmentation/src/extract_clusters.cpp
@@ -55,9 +55,8 @@ pcl::detail::economical_download(const pcl::gpu::NeighborIndices& source_indices
   std::vector<int> tmp;
   for (std::size_t qp = 0; qp < buffer_indices.size(); qp++) {
     std::size_t begin = qp * buffer_size;
-    std::size_t end = begin + buffer_indices[qp];
     tmp.resize(buffer_indices[qp]);
-    source_indices.data.download(&tmp[0], begin, end);
+    source_indices.data.download(&tmp[0], begin, buffer_indices[qp]);
     downloaded_indices.insert(downloaded_indices.end(), tmp.begin(), tmp.end());
   }
 }

--- a/gpu/segmentation/src/extract_clusters.cpp
+++ b/gpu/segmentation/src/extract_clusters.cpp
@@ -37,12 +37,8 @@
 
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>
-//#include <pcl/gpu/segmentation/gpu_extract_labeled_clusters.h>
-#include <pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp>
 #include <pcl/gpu/segmentation/impl/gpu_extract_labeled_clusters.hpp>
 #include <pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp>
-#include <cuda_runtime_api.h>
-#include <cuda.h>
 
 // Instantiations of specific point types
 PCL_INSTANTIATE(extractEuclideanClusters, PCL_XYZ_POINT_TYPES);
@@ -59,11 +55,9 @@ pcl::detail::economical_download(const pcl::gpu::NeighborIndices& source_indices
   std::vector<int> tmp;
   for (std::size_t qp = 0; qp < buffer_indices.size(); qp++) {
     std::size_t begin = qp * buffer_size;
-    const int* const pdata = source_indices.data.ptr() + begin;
+    std::size_t end = begin + buffer_indices[qp];
     tmp.resize(buffer_indices[qp]);
-    const std::size_t bytes = (buffer_indices[qp]) * sizeof(int);
-    cudaMemcpy(&tmp[0], pdata, bytes, cudaMemcpyDeviceToHost);
-    cudaDeviceSynchronize();
+    source_indices.data.download(&tmp[0], begin, end);
     downloaded_indices.insert(downloaded_indices.end(), tmp.begin(), tmp.end());
   }
 }

--- a/gpu/segmentation/src/extract_clusters.cpp
+++ b/gpu/segmentation/src/extract_clusters.cpp
@@ -35,10 +35,10 @@
  *
  */
 
+#include <pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp>
+#include <pcl/gpu/segmentation/impl/gpu_extract_labeled_clusters.hpp>
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>
-#include <pcl/gpu/segmentation/impl/gpu_extract_labeled_clusters.hpp>
-#include <pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp>
 
 // Instantiations of specific point types
 PCL_INSTANTIATE(extractEuclideanClusters, PCL_XYZ_POINT_TYPES);


### PR DESCRIPTION
I stumbled upon the same issue mentioned in #2703 while familiarizing myself with the GPU-related codebase of PCL. A CPU flamegraph showed  about 1/3 of the runtime is spent on resizing a vector: 
![perf_orig](https://user-images.githubusercontent.com/10357496/112655136-63556200-8e50-11eb-8479-a832527e09d9.jpg)
The resize function is located in the [device_array.hpp](https://github.com/PointCloudLibrary/pcl/blob/97cb436308e240c34f49559ba3b89b6cdfc2e5ca/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp#L79) codebase. The arrays are constructed in the loop (line 100) of [gpu_extract_custer.hpp](https://github.com/PointCloudLibrary/pcl/blob/97cb436308e240c34f49559ba3b89b6cdfc2e5ca/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp#L100). Pre-allocating the array to the maximum possible size can mostly eliminate the memory allocations as documented by the flamegraph with the revised code:
![perf](https://user-images.githubusercontent.com/10357496/112656122-5d13b580-8e51-11eb-9b96-dafba606bb47.jpg)  I tried to optimize the Cuda memcopies that also incur significant times by using pinned host memory, but that did not lead to a noticeable improvement.  The GPU code is still significantly slower than the CPU version, though. I believe this is due to the sequential nature of the program, and data copies between the host and device memory.

I would be happy to work more on this issue if further PRs are welcome in this field. Maybe somebody also has an idea for improving GPU-based segmentation or other ideas to work on the GPU-related codebase of PCL! 

P.S. The function [pcl::gpu::extractEuclideanClusters](https://github.com/PointCloudLibrary/pcl/blob/97cb436308e240c34f49559ba3b89b6cdfc2e5ca/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp#L45) is verbose by default, should we maybe also change this? 