### PR TITLE
[tracking] pyramidal klt: switch keypoints_status_ to int vector

### DIFF
--- a/apps/src/openni_klt.cpp
+++ b/apps/src/openni_klt.cpp
@@ -251,14 +251,14 @@ public:
       if (tracker_->getInitialized() && cloud_) {
         if (points_mutex_.try_lock()) {
           keypoints_ = tracker_->getTrackedPoints();
-          points_status_ = tracker_->getPointsToTrackStatus();
+          points_status_ = tracker_->getStatusOfPointsToTrack();
           points_mutex_.unlock();
         }
 
         std::vector<float> markers;
         markers.reserve(keypoints_->size() * 2);
         for (std::size_t i = 0; i < keypoints_->size(); ++i) {
-          if (points_status_->indices[i] < 0)
+          if ((*points_status_)[i] < 0)
             continue;
           const pcl::PointUV& uv = (*keypoints_)[i];
           markers.push_back(uv.u);
@@ -295,7 +295,7 @@ public:
   typename pcl::tracking::PyramidalKLTTracker<PointType>::Ptr tracker_;
   pcl::PointCloud<pcl::PointUV>::ConstPtr keypoints_;
   pcl::PointIndicesConstPtr points_;
-  pcl::PointIndicesConstPtr points_status_;
+  pcl::shared_ptr<const std::vector<int>> points_status_;
   int counter_;
 };
 

--- a/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
+++ b/tracking/include/pcl/tracking/impl/pyramidal_klt.hpp
@@ -69,8 +69,8 @@ PyramidalKLTTracker<PointInT, IntensityT>::setPointsToTrack(
     keypoints_ = p;
   }
 
-  keypoints_status_.reset(new pcl::PointIndices);
-  keypoints_status_->indices.resize(keypoints_->size(), 0);
+  keypoints_status_.reset(new std::vector<int>);
+  keypoints_status_->resize(keypoints_->size(), 0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -723,7 +723,7 @@ PyramidalKLTTracker<PointInT, IntensityT>::computeTracking()
   ref_ = input_;
   ref_pyramid_ = pyramid;
   keypoints_ = keypoints;
-  keypoints_status_->indices = status;
+  *keypoints_status_ = status;
 }
 
 } // namespace tracking

--- a/tracking/include/pcl/tracking/pyramidal_klt.h
+++ b/tracking/include/pcl/tracking/pyramidal_klt.h
@@ -260,8 +260,24 @@ public:
    * Status == -1 --> point is out of bond;
    * Status == -2 --> optical flow can not be computed for this point.
    */
+  PCL_DEPRECATED(1, 15, "use getStatusOfPointsToTrack instead")
   inline pcl::PointIndicesConstPtr
   getPointsToTrackStatus() const
+  {
+    pcl::PointIndicesPtr res(new pcl::PointIndices);
+    res->indices.insert(
+        res->indices.end(), keypoints_status_->begin(), keypoints_status_->end());
+    return (res);
+  }
+
+  /** \return the status of points to track.
+   * Status == 0  --> points successfully tracked;
+   * Status < 0   --> point is lost;
+   * Status == -1 --> point is out of bond;
+   * Status == -2 --> optical flow can not be computed for this point.
+   */
+  inline pcl::shared_ptr<const std::vector<int>>
+  getStatusOfPointsToTrack() const
   {
     return (keypoints_status_);
   }
@@ -398,7 +414,7 @@ protected:
   /** \brief detected keypoints 2D coordinates */
   pcl::PointCloud<pcl::PointUV>::ConstPtr keypoints_;
   /** \brief status of keypoints of t-1 at t */
-  pcl::PointIndicesPtr keypoints_status_;
+  pcl::shared_ptr<std::vector<int>> keypoints_status_;
   /** \brief number of points to detect */
   std::size_t keypoints_nbr_;
   /** \brief tracking width */


### PR DESCRIPTION
It has nothing to do with indices, the elements of the vector are not and should not be used as indices. Furthermore, the status can be negative (-1, -2).
This commit also deprecates a getter-function with a PointIndices return type and adds a replacement.