### PR TITLE
[tracking] made ParticleFilterTracker API user friendly

### DIFF
--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -293,7 +293,7 @@ public:
   inline void
   setUseNormal(bool use_normal)
   {
-    if (traits::has_normal_v<PointInT>) {
+    if (traits::has_normal_v<PointInT> || !use_normal) {
       use_normal_ = use_normal;
       return;
     }

--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -287,14 +287,34 @@ public:
     return alpha_;
   }
 
+#ifdef DOXYGEN_ONLY
   /** \brief Set the value of use_normal_.
    * \param[in] use_normal the value of use_normal_.
-   */
+   **/
   inline void
   setUseNormal(bool use_normal)
   {
     use_normal_ = use_normal;
   }
+#else
+  template <typename PointT = PointInT, traits::HasNormal<PointT> = true>
+  inline void
+  setUseNormal(bool use_normal)
+  {
+    use_normal_ = use_normal;
+  }
+
+  template <typename PointT = PointInT, traits::HasNoNormal<PointT> = true>
+  inline void
+  setUseNormal(bool use_normal)
+  {
+    PCL_WARN("[pcl::%s::setUseNormal] "
+             "use_normal_ == true is not supported in this Point Type.\n",
+             getClassName().c_str());
+    use_normal_ = false;
+  }
+
+#endif
 
   /** \brief Get the value of use_normal_. */
   inline bool
@@ -461,7 +481,7 @@ protected:
   void
   computeTransformedPointCloudWithNormal(const StateT&, pcl::Indices&, PointCloudIn&)
   {
-    PCL_WARN("[pcl::%s::computeTransformedPointCloudWithoutNormal] "
+    PCL_WARN("[pcl::%s::computeTransformedPointCloudWithNormal] "
              "use_normal_ == true is not supported in this Point Type.\n",
              getClassName().c_str());
   }

--- a/tracking/include/pcl/tracking/particle_filter.h
+++ b/tracking/include/pcl/tracking/particle_filter.h
@@ -287,34 +287,21 @@ public:
     return alpha_;
   }
 
-#ifdef DOXYGEN_ONLY
   /** \brief Set the value of use_normal_.
    * \param[in] use_normal the value of use_normal_.
-   **/
+   */
   inline void
   setUseNormal(bool use_normal)
   {
-    use_normal_ = use_normal;
-  }
-#else
-  template <typename PointT = PointInT, traits::HasNormal<PointT> = true>
-  inline void
-  setUseNormal(bool use_normal)
-  {
-    use_normal_ = use_normal;
-  }
-
-  template <typename PointT = PointInT, traits::HasNoNormal<PointT> = true>
-  inline void
-  setUseNormal(bool use_normal)
-  {
+    if (traits::has_normal_v<PointInT>) {
+      use_normal_ = use_normal;
+      return;
+    }
     PCL_WARN("[pcl::%s::setUseNormal] "
              "use_normal_ == true is not supported in this Point Type.\n",
              getClassName().c_str());
     use_normal_ = false;
   }
-
-#endif
 
   /** \brief Get the value of use_normal_. */
   inline bool


### PR DESCRIPTION
The solution for the issue defined [here](https://github.com/PointCloudLibrary/pcl/issues/4655). Used SFINAE in `setUseNormal` method. This way if users won't be able to set `use_normal_` variable to true, if they use pointcloud type which does not include normal.