### PR TITLE
[CI] Exclude doc files from CI to save CI time

### DIFF
--- a/.ci/azure-pipelines/azure-pipelines.yaml
+++ b/.ci/azure-pipelines/azure-pipelines.yaml
@@ -24,8 +24,6 @@ resources:
       image: pointcloudlibrary/env:20.04
     - container: env2010
       image: pointcloudlibrary/env:20.10
-    - container: doc
-      image: pointcloudlibrary/doc
 
 stages:
   - stage: formatting
@@ -163,16 +161,3 @@ stages:
           VCPKG_ROOT: 'C:\vcpkg'
         steps:
           - template: build/windows.yaml
-
-  - stage: documentation
-    displayName: Documentation
-    dependsOn: []
-    jobs:
-      - template: documentation.yaml
-
-  - stage: tutorials
-    displayName: Tutorials
-    dependsOn: build_gcc
-    jobs:
-      - template: tutorials.yaml
-

--- a/.ci/azure-pipelines/azure-pipelines.yaml
+++ b/.ci/azure-pipelines/azure-pipelines.yaml
@@ -1,3 +1,19 @@
+trigger:
+  paths:
+    exclude:
+    - doc
+    - README.md
+    - CHANGES.md
+    - CONTRIBUTING.md
+
+pr:
+  paths:
+    exclude:
+    - doc
+    - README.md
+    - CHANGES.md
+    - CONTRIBUTING.md
+
 resources:
   containers:
     - container: fmt

--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -22,12 +22,23 @@ resources:
         stages:
         - build_gcc
   containers:
+    - container: fmt # for formatting.yaml
+      image: pointcloudlibrary/fmt
     - container: doc # for documentation.yaml
       image: pointcloudlibrary/doc
     - container: env1804 # for tutorials.yaml
       image: pointcloudlibrary/env:18.04
 
 stages:
+  - stage: formatting
+    displayName: Formatting
+    # if docs pipeline triggered by build_gcc stage,
+    # the formatting stage has already run, thus it
+    # won't run for a second time here.
+    condition: not(eq(variables['Build.Reason'], 'ResourceTrigger'))
+    jobs:
+      - template: formatting.yaml
+
   - stage: documentation
     displayName: Documentation
     jobs:
@@ -35,7 +46,5 @@ stages:
 
   - stage: tutorials
     displayName: Tutorials
-    # triggered only by build_gcc stage
-    condition: eq(variables['Build.Reason'], 'ResourceTrigger')
     jobs:
       - template: tutorials.yaml

--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -2,9 +2,6 @@ trigger:
   paths:
     include:
     - doc
-    - README.md
-    - CHANGES.md
-    - CONTRIBUTING.md
 
 pr:
   paths:

--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -7,9 +7,6 @@ pr:
   paths:
     include:
     - doc
-    - README.md
-    - CHANGES.md
-    - CONTRIBUTING.md
 
 resources:
   pipelines:
@@ -38,10 +35,12 @@ stages:
 
   - stage: documentation
     displayName: Documentation
+    condition: in(dependencies.formatting.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     jobs:
       - template: documentation.yaml
 
   - stage: tutorials
     displayName: Tutorials
+    condition: in(dependencies.documentation.result, 'Succeeded', 'SucceededWithIssues')
     jobs:
       - template: tutorials.yaml

--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -16,8 +16,8 @@ pr:
 
 resources:
   pipelines:
-    - pipeline: Build
-      source: Build-CI
+    - pipeline: Build-CI
+      source: Build
       trigger:
         stages:
         - build_gcc

--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -1,0 +1,41 @@
+trigger:
+  paths:
+    include:
+    - doc
+    - README.md
+    - CHANGES.md
+    - CONTRIBUTING.md
+
+pr:
+  paths:
+    include:
+    - doc
+    - README.md
+    - CHANGES.md
+    - CONTRIBUTING.md
+
+resources:
+  pipelines:
+    - pipeline: Build
+      source: Build-CI
+      trigger:
+        stages:
+        - build_gcc
+  containers:
+    - container: doc # for documentation.yaml
+      image: pointcloudlibrary/doc
+    - container: env1804 # for tutorials.yaml
+      image: pointcloudlibrary/env:18.04
+
+stages:
+  - stage: documentation
+    displayName: Documentation
+    jobs:
+      - template: documentation.yaml
+
+  - stage: tutorials
+    displayName: Tutorials
+    # triggered only by build_gcc stage
+    condition: eq(variables['Build.Reason'], 'ResourceTrigger')
+    jobs:
+      - template: tutorials.yaml

--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -29,7 +29,7 @@ stages:
     # if docs pipeline triggered by build_gcc stage,
     # the formatting stage has already run, thus it
     # won't run for a second time here.
-    condition: not(eq(variables['Build.Reason'], 'ResourceTrigger'))
+    condition: ne(variables['Build.Reason'], 'ResourceTrigger'))
     jobs:
       - template: formatting.yaml
 


### PR DESCRIPTION
Added the exclude rules for push and PR triggers. So updates to doc, README, etc. won't cause the formatting + main CI to run.