### PR TITLE
Consistently use lowercase for headers and libs for Windows

### DIFF
--- a/io/include/pcl/io/low_level_io.h
+++ b/io/include/pcl/io/low_level_io.h
@@ -51,7 +51,7 @@
 # endif
 # include <io.h>
 # include <windows.h>
-# include <BaseTsd.h>
+# include <basetsd.h>
 using ssize_t = SSIZE_T;
 #else
 # include <unistd.h>

--- a/surface/CMakeLists.txt
+++ b/surface/CMakeLists.txt
@@ -193,5 +193,5 @@ if(VTK_FOUND AND NOT ANDROID)
 endif()
 
 if(WIN32)
-  target_link_libraries("${LIB_NAME}" Rpcrt4.lib)
+  target_link_libraries("${LIB_NAME}" rpcrt4.lib)
 endif()


### PR DESCRIPTION
When building on Windows, a case-insensitive file-system is usually employed,
but when cross-compiling on a Linux host for a Windows target case-senstive
file-systems are more common.  MinGW is the most common cross-compiler and
consistently uses lowercase names for all libraries and header files.