### PR TITLE
Fix compile issue of visualization::details::fillCells under MSVC due to missing symbol export

### DIFF
--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -80,7 +80,7 @@ namespace pcl
   {
     namespace details
     {
-      vtkIdType fillCells(std::vector<int>& lookup, const std::vector<pcl::Vertices>& vertices, vtkSmartPointer<vtkCellArray> cell_array, int max_size_of_polygon);
+      PCL_EXPORTS vtkIdType fillCells(std::vector<int>& lookup, const std::vector<pcl::Vertices>& vertices, vtkSmartPointer<vtkCellArray> cell_array, int max_size_of_polygon);
     }
 
     /** \brief PCL Visualizer main class.


### PR DESCRIPTION
Fixes:

```
1>------ Build started: Project: pcl_example_nurbs_fitting_surface, Configuration: Debug x64 ------
1>example_nurbs_fitting_surface.obj : error LNK2019: unresolved external symbol "__int64 __cdecl pcl::visualization::details::fillCells(class std::vector<int,class std::allocator<int> > &,class std::vector<struct pcl::Vertices,class std::allocator<struct pcl::Vertices> > const &,class vtkSmartPointer<class vtkCellArray>,int)" (?fillCells@details@visualization@pcl@@YA_JAEAV?$vector@HV?$allocator@H@std@@@std@@AEBV?$vector@UVertices@pcl@@V?$allocator@UVertices@pcl@@@std@@@5@V?$vtkSmartPointer@VvtkCellArray@@@@H@Z) referenced in function "public: bool __cdecl pcl::visualization::PCLVisualizer::updatePolygonMesh<struct pcl::PointXYZ>(class std::shared_ptr<class pcl::PointCloud<struct pcl::PointXYZ> const > const &,class std::vector<struct pcl::Vertices,class std::allocator<struct pcl::Vertices> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (??$updatePolygonMesh@UPointXYZ@pcl@@@PCLVisualizer@visualization@pcl@@QEAA_NAEBV?$shared_ptr@$$CBV?$PointCloud@UPointXYZ@pcl@@@pcl@@@std@@AEBV?$vector@UVertices@pcl@@V?$allocator@UVertices@pcl@@@std@@@4@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@4@@Z)
1>C:\dev\pcl_build\bin\pcl_example_nurbs_fitting_surfaced.exe : fatal error LNK1120: 1 unresolved externals
1>Done building project "pcl_example_nurbs_fitting_surface.vcxproj" -- FAILED.
```

Issue introduced in #4262