### PR TITLE
Moved `PointXYZLAB` to common point types

### DIFF
--- a/common/include/pcl/common/colors.h
+++ b/common/include/pcl/common/colors.h
@@ -41,6 +41,7 @@
 #include <pcl/point_types.h>
 
 #include <type_traits>  // for is_floating_point
+#include <array>        // for std::array especially in Clang Darwin and MSVC
 
 namespace pcl
 {

--- a/common/include/pcl/common/impl/intensity.hpp
+++ b/common/include/pcl/common/impl/intensity.hpp
@@ -277,6 +277,40 @@ namespace pcl
     };
 
     template<>
+    struct IntensityFieldAccessor<pcl::PointXYZLAB>
+    {
+      inline float
+      operator () (const pcl::PointXYZLAB &p) const
+      {
+        return (p.L);
+      }
+
+      inline void
+      get (const pcl::PointXYZLAB &p, float &intensity) const
+      {
+        intensity = p.L;
+      }
+
+      inline void
+      set (pcl::PointXYZLAB &p, float intensity) const
+      {
+        p.L = intensity;
+      }
+
+      inline void
+      demean (pcl::PointXYZLAB& p, float value) const
+      {
+        p.L -= value;
+      }
+
+      inline void
+      add (pcl::PointXYZLAB& p, float value) const
+      {
+        p.L += value;
+      }
+    };
+
+    template<>
     struct IntensityFieldAccessor<pcl::PointXYZHSV>
     {
       inline float

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -68,6 +68,7 @@
   (pcl::PointXYZRGBA)           \
   (pcl::PointXYZRGB)            \
   (pcl::PointXYZRGBL)           \
+  (pcl::PointXYZLAB)            \
   (pcl::PointXYZHSV)            \
   (pcl::PointXY)                \
   (pcl::InterestPoint)          \
@@ -125,6 +126,7 @@
   (pcl::PointXYZRGBA)         \
   (pcl::PointXYZRGB)          \
   (pcl::PointXYZRGBL)         \
+  (pcl::PointXYZLAB)          \
   (pcl::PointXYZHSV)          \
   (pcl::InterestPoint)        \
   (pcl::PointNormal)          \
@@ -686,6 +688,41 @@ namespace pcl
     }
 
     friend std::ostream& operator << (std::ostream& os, const PointXYZRGBL& p);
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
+  };
+
+
+  struct EIGEN_ALIGN16 _PointXYZLAB
+  {
+    PCL_ADD_POINT4D; // this adds the members x,y,z
+    union
+    {
+      struct
+      {
+        float L;
+        float a;
+        float b;
+      };
+      float data_lab[4];
+    };
+    PCL_MAKE_ALIGNED_OPERATOR_NEW
+  };
+
+  PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZLAB& p);
+  /** \brief A point structure representing Euclidean xyz coordinates, and the CIELAB color.
+    * \ingroup common
+  */
+  struct PointXYZLAB : public _PointXYZLAB
+  {
+    inline PointXYZLAB()
+    {
+      x = y = z = 0.0f;
+      data[3] = 1.0f; // important for homogeneous coordinates
+      L = a = b = 0.0f;
+      data_lab[3] = 0.0f;
+    }
+
+    friend std::ostream& operator << (std::ostream& os, const PointXYZLAB& p);
     PCL_MAKE_ALIGNED_OPERATOR_NEW
   };
 
@@ -1881,6 +1918,16 @@ POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::_PointXYZRGBL,
     (std::uint32_t, label, label)
 )
 POINT_CLOUD_REGISTER_POINT_WRAPPER(pcl::PointXYZRGBL, pcl::_PointXYZRGBL)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::_PointXYZLAB,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, L, L)
+    (float, a, a)
+    (float, b, b)
+)
+POINT_CLOUD_REGISTER_POINT_WRAPPER(pcl::PointXYZLAB, pcl::_PointXYZLAB)
 
 POINT_CLOUD_REGISTER_POINT_STRUCT (pcl::_PointXYZHSV,
     (float, x, x)

--- a/common/include/pcl/point_types.h
+++ b/common/include/pcl/point_types.h
@@ -111,6 +111,11 @@ namespace pcl
     */
   struct PointXYZRGBL;
 
+  /** \brief Members: float x, y, z, L, a, b
+    * \ingroup common
+    */
+  struct PointXYZLAB;
+
   /** \brief Members: float x, y, z, h, s, v
     * \ingroup common
     */

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -43,7 +43,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include <pcl/common/colors.h>
+#include <pcl/common/colors.h> // for RGB2sRGB_LUT
 
 namespace pcl
 {
@@ -143,7 +143,7 @@ namespace pcl
   template <typename PointT, traits::HasColor<PointT> = true>
   inline void
   PointXYZRGBtoXYZLAB (const PointT& in,
-                        PointXYZLAB&        out)
+                       PointXYZLAB&  out)
   {
     out.x = in.x;
     out.y = in.y;
@@ -151,17 +151,15 @@ namespace pcl
     out.data[3] = 1.0; // important for homogeneous coordinates
 
     // convert sRGB to CIELAB
-    const Eigen::Vector3i colorRGB = in.getRGBVector3i();
-
     // for sRGB   -> CIEXYZ see http://www.easyrgb.com/index.php?X=MATH&H=02#text2
     // for CIEXYZ -> CIELAB see http://www.easyrgb.com/index.php?X=MATH&H=07#text7
     // an overview at: https://www.comp.nus.edu.sg/~leowwk/papers/colordiff.pdf
 
     const auto& sRGB_LUT = RGB2sRGB_LUT<double, 8>();
 
-    const double R = sRGB_LUT[colorRGB[0]];
-    const double G = sRGB_LUT[colorRGB[1]];
-    const double B = sRGB_LUT[colorRGB[2]];
+    const double R = sRGB_LUT[in.r];
+    const double G = sRGB_LUT[in.g];
+    const double B = sRGB_LUT[in.b];
 
     // linear sRGB -> CIEXYZ, D65 illuminant, observer at 2 degrees
     const double X = R * 0.4124 + G * 0.3576 + B * 0.1805;

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -140,9 +140,9 @@ namespace pcl
     * \param[in] in the input XYZRGB(XYZRGBA, XYZRGBL, etc.) point
     * \param[out] out the output XYZLAB point
     */
-  template <typename PointT, HasColor<PointT> = true>
+  template <typename PointT, traits::HasColor<PointT> = true>
   inline void
-  PointXYZRGBtoXYZLAB (const PointXYZRGBTypes& in,
+  PointXYZRGBtoXYZLAB (const PointT& in,
                         PointXYZLAB&        out)
   {
     out.x = in.x;

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -43,6 +43,8 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
+#include <pcl/common/colors.h>
+
 namespace pcl
 {
   // r,g,b, i values are from 0 to 255
@@ -132,6 +134,58 @@ namespace pcl
     else                  out.h = 60.f * (4.f + static_cast <float> (in.r - in.g) / diff); // max == b
 
     if (out.h < 0.f) out.h += 360.f;
+  }
+
+  /** \brief Convert a XYZRGBA point type to a XYZLAB
+    * \param[in] in the input XYZRGBA point
+    * \param[out] out the output XYZLAB point
+    */
+  inline void
+  PointXYZRGBAtoXYZLAB (const PointXYZRGBA& in,
+                        PointXYZLAB&        out)
+  {
+    out.x = in.x;
+    out.y = in.y;
+    out.z = in.z;
+    out.data[3] = 1.0; // important for homogeneous coordinates
+
+    // convert sRGB to CIELAB
+    const Eigen::Vector3i colorRGB = in.getRGBVector3i();
+
+    // for sRGB   -> CIEXYZ see http://www.easyrgb.com/index.php?X=MATH&H=02#text2
+    // for CIEXYZ -> CIELAB see http://www.easyrgb.com/index.php?X=MATH&H=07#text7
+    // an overview at: https://www.comp.nus.edu.sg/~leowwk/papers/colordiff.pdf
+
+    const auto& sRGB_LUT = RGB2sRGB_LUT<double, 8>();
+
+    const double R = sRGB_LUT[colorRGB[0]];
+    const double G = sRGB_LUT[colorRGB[1]];
+    const double B = sRGB_LUT[colorRGB[2]];
+
+    // linear sRGB -> CIEXYZ, D65 illuminant, observer at 2 degrees
+    const double X = R * 0.4124 + G * 0.3576 + B * 0.1805;
+    const double Y = R * 0.2126 + G * 0.7152 + B * 0.0722;
+    const double Z = R * 0.0193 + G * 0.1192 + B * 0.9505;
+
+    // normalize X, Y, Z with tristimulus values for Xn, Yn, Zn
+    float f[3] = {static_cast<float>(X), static_cast<float>(Y), static_cast<float>(Z)};
+    f[0] /= 0.95047;
+    f[1] /= 1;
+    f[2] /= 1.08883;
+
+    // CIEXYZ -> CIELAB
+    for (int i = 0; i < 3; ++i) {
+      if (f[i] > 0.008856) {
+        f[i] = std::pow(f[i], 1.0 / 3.0);
+      }
+      else {
+        f[i] = 7.787 * f[i] + 16.0 / 116.0;
+      }
+    }
+
+    out.L = 116.0f * f[1] - 16.0f;
+    out.a = 500.0f * (f[0] - f[1]);
+    out.b = 200.0f * (f[1] - f[2]);
   }
 
   /** \brief Convert a XYZRGBA point type to a XYZHSV

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -136,12 +136,13 @@ namespace pcl
     if (out.h < 0.f) out.h += 360.f;
   }
 
-  /** \brief Convert a XYZRGBA point type to a XYZLAB
-    * \param[in] in the input XYZRGBA point
+  /** \brief Convert a XYZRGB-based point type to a XYZLAB
+    * \param[in] in the input XYZRGB(XYZRGBA, XYZRGBL, etc.) point
     * \param[out] out the output XYZLAB point
     */
+  template <typename PointXYZRGBTypes>
   inline void
-  PointXYZRGBAtoXYZLAB (const PointXYZRGBA& in,
+  PointXYZRGBtoXYZLAB (const PointXYZRGBTypes& in,
                         PointXYZLAB&        out)
   {
     out.x = in.x;

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -140,7 +140,7 @@ namespace pcl
     * \param[in] in the input XYZRGB(XYZRGBA, XYZRGBL, etc.) point
     * \param[out] out the output XYZLAB point
     */
-  template <typename PointXYZRGBTypes>
+  template <typename PointT, HasColor<PointT> = true>
   inline void
   PointXYZRGBtoXYZLAB (const PointXYZRGBTypes& in,
                         PointXYZLAB&        out)

--- a/common/src/point_types.cpp
+++ b/common/src/point_types.cpp
@@ -131,6 +131,13 @@ namespace pcl
   }
 
   std::ostream& 
+  operator << (std::ostream& os, const PointXYZLAB& p)
+  {
+    os << "(" << p.x << "," << p.y << "," << p.z << " - " << p.L << " , " <<  p.a << " , " << p.b << ")";
+    return (os);
+  }
+
+  std::ostream& 
   operator << (std::ostream& os, const PointXYZHSV& p)
   {
     os << "(" << p.x << "," << p.y << "," << p.z << " - " << p.h << " , " <<  p.s << " , " << p.v << ")";

--- a/registration/include/pcl/registration/gicp6d.h
+++ b/registration/include/pcl/registration/gicp6d.h
@@ -45,38 +45,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_representation.h>
 #include <pcl/point_types.h>
-
-namespace pcl {
-struct EIGEN_ALIGN16 _PointXYZLAB {
-  PCL_ADD_POINT4D; // this adds the members x,y,z
-  union {
-    struct {
-      float L;
-      float a;
-      float b;
-    };
-    float data_lab[4];
-  };
-  PCL_MAKE_ALIGNED_OPERATOR_NEW
-};
-
-/** \brief A custom point type for position and CIELAB color value */
-struct PointXYZLAB : public _PointXYZLAB {
-  inline PointXYZLAB()
-  {
-    x = y = z = 0.0f;
-    data[3] = 1.0f; // important for homogeneous coordinates
-    L = a = b = 0.0f;
-    data_lab[3] = 0.0f;
-  }
-};
-} // namespace pcl
-
-// register the custom point type in PCL
-POINT_CLOUD_REGISTER_POINT_STRUCT(
-    pcl::_PointXYZLAB,
-    (float, x, x)(float, y, y)(float, z, z)(float, L, L)(float, a, a)(float, b, b))
-POINT_CLOUD_REGISTER_POINT_WRAPPER(pcl::PointXYZLAB, pcl::_PointXYZLAB)
+#include <pcl/point_types_conversion.h>
 
 namespace pcl {
 /** \brief GeneralizedIterativeClosestPoint6D integrates L*a*b* color space information

--- a/registration/include/pcl/registration/gicp6d.h
+++ b/registration/include/pcl/registration/gicp6d.h
@@ -45,7 +45,6 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_representation.h>
 #include <pcl/point_types.h>
-#include <pcl/point_types_conversion.h>
 
 namespace pcl {
 /** \brief GeneralizedIterativeClosestPoint6D integrates L*a*b* color space information

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -36,9 +36,9 @@
  *
  */
 
-#include <pcl/common/colors.h> // for RGB2sRGB_LUT, XYZ2LAB_LUT
 #include <pcl/registration/gicp6d.h>
 #include <pcl/memory.h> // for pcl::make_shared
+#include <pcl/point_types_conversion.h> // for PointXYZRGBtoXYZLAB
 
 namespace pcl {
 

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -60,7 +60,8 @@ GeneralizedIterativeClosestPoint6D::setInputSource(
   GeneralizedIterativeClosestPoint<PointSource, PointTarget>::setInputSource(cloud);
 
   // in addition, convert colors of the cloud to CIELAB
-  for (std::size_t point_idx = 0; point_idx < cloud->points.size (); ++point_idx) {
+  cloud_lab_->resize( cloud->size () );
+  for (std::size_t point_idx = 0; point_idx < cloud->size (); ++point_idx) {
     PointXYZRGBAtoXYZLAB((*cloud)[point_idx], (*cloud_lab_)[point_idx]);
   }
 }
@@ -73,7 +74,8 @@ GeneralizedIterativeClosestPoint6D::setInputTarget(
   GeneralizedIterativeClosestPoint<PointSource, PointTarget>::setInputTarget(target);
 
   // in addition, convert colors of the cloud to CIELAB...
-  for (std::size_t point_idx = 0; point_idx < target->points.size (); ++point_idx) {
+  target_lab_->resize( target->size () );
+  for (std::size_t point_idx = 0; point_idx < target->size (); ++point_idx) {
     PointXYZRGBAtoXYZLAB((*target)[point_idx], (*target_lab_)[point_idx]);
   }
 

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -37,7 +37,7 @@
  */
 
 #include <pcl/registration/gicp6d.h>
-#include <pcl/memory.h> // for pcl::make_shared
+#include <pcl/memory.h>                 // for pcl::make_shared
 #include <pcl/point_types_conversion.h> // for PointXYZRGBtoXYZLAB
 
 namespace pcl {

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -62,7 +62,7 @@ GeneralizedIterativeClosestPoint6D::setInputSource(
   // in addition, convert colors of the cloud to CIELAB
   cloud_lab_->resize(cloud->size());
   for (std::size_t point_idx = 0; point_idx < cloud->size(); ++point_idx) {
-    PointXYZRGBAtoXYZLAB((*cloud)[point_idx], (*cloud_lab_)[point_idx]);
+    PointXYZRGBtoXYZLAB((*cloud)[point_idx], (*cloud_lab_)[point_idx]);
   }
 }
 
@@ -76,7 +76,7 @@ GeneralizedIterativeClosestPoint6D::setInputTarget(
   // in addition, convert colors of the cloud to CIELAB...
   target_lab_->resize(target->size());
   for (std::size_t point_idx = 0; point_idx < target->size(); ++point_idx) {
-    PointXYZRGBAtoXYZLAB((*target)[point_idx], (*target_lab_)[point_idx]);
+    PointXYZRGBtoXYZLAB((*target)[point_idx], (*target_lab_)[point_idx]);
   }
 
   // ...and build 6d-tree

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -60,8 +60,8 @@ GeneralizedIterativeClosestPoint6D::setInputSource(
   GeneralizedIterativeClosestPoint<PointSource, PointTarget>::setInputSource(cloud);
 
   // in addition, convert colors of the cloud to CIELAB
-  cloud_lab_->resize( cloud->size () );
-  for (std::size_t point_idx = 0; point_idx < cloud->size (); ++point_idx) {
+  cloud_lab_->resize(cloud->size());
+  for (std::size_t point_idx = 0; point_idx < cloud->size(); ++point_idx) {
     PointXYZRGBAtoXYZLAB((*cloud)[point_idx], (*cloud_lab_)[point_idx]);
   }
 }
@@ -74,8 +74,8 @@ GeneralizedIterativeClosestPoint6D::setInputTarget(
   GeneralizedIterativeClosestPoint<PointSource, PointTarget>::setInputTarget(target);
 
   // in addition, convert colors of the cloud to CIELAB...
-  target_lab_->resize( target->size () );
-  for (std::size_t point_idx = 0; point_idx < target->size (); ++point_idx) {
+  target_lab_->resize(target->size());
+  for (std::size_t point_idx = 0; point_idx < target->size(); ++point_idx) {
     PointXYZRGBAtoXYZLAB((*target)[point_idx], (*target_lab_)[point_idx]);
   }
 


### PR DESCRIPTION
Fixes #4600 
* moved `PointXYZLAB` definition **from** [gicp6d.h](https://github.com/PointCloudLibrary/pcl/blob/master/registration/include/pcl/registration/gicp6d.h) **to** [point_types.hpp](https://github.com/PointCloudLibrary/pcl/blob/master/common/include/pcl/impl/point_types.hpp)
* added struct `PointXYZLAB` declaration in [point_types.h](https://github.com/PointCloudLibrary/pcl/blob/master/common/include/pcl/point_types.h)
* moved function `RGB2Lab` & `convertRGBAToLAB` (refactored) **from** [gicp6d.h](https://github.com/PointCloudLibrary/pcl/blob/master/registration/include/pcl/registration/gicp6d.h) **to** [point_types_conversion.h](https://github.com/PointCloudLibrary/pcl/blob/master/common/include/pcl/point_types_conversion.h), in line with other conversions.
* overloaded output stream operator for `PointXYZLAB` in [point_types.cpp](https://github.com/PointCloudLibrary/pcl/blob/master/common/src/point_types.cpp)
* added `IntensityFieldAccessor` class for `PointXYZLAB` in [intensity.hpp](https://github.com/PointCloudLibrary/pcl/blob/master/common/include/pcl/common/impl/intensity.hpp)
  * I learned the basic knowledge of color space from [this tutorial](https://learnopencv.com/color-spaces-in-opencv-cpp-python/) , and not very sure whether my implementation is exactly correct.

I've compiled this branch on Ubuntu 20.10 GCC and passed all unit tests :satisfied:. I'd be grateful if you could have a review on it. Thank you!