### PR TITLE
Link pcl_io against `ws2_32` when building with MinGW

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -204,6 +204,10 @@ set(PLY_INCLUDES
 )
 
 PCL_ADD_LIBRARY(pcl_io_ply COMPONENT ${SUBSYS_NAME} SOURCES ${PLY_SOURCES} ${PLY_INCLUDES})
+if(MINGW)
+  # libws2_32 isn't added by default for MinGW
+  target_link_libraries(pcl_io_ply ws2_32)
+endif()
 PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/ply" ${PLY_INCLUDES})
 target_include_directories(pcl_io_ply PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 


### PR DESCRIPTION
When cross-building PCL for Windows with MinGW I had to do this, otherwise I'd
get

```
[ 21%] Linking CXX shared library ../bin/libpcl_io.dll
cd /workspace/srcdir/pcl/build/io && /usr/bin/cmake -E cmake_link_script CMakeFiles/pcl_io.dir/link.txt --verbose=true
/usr/bin/cmake -E rm -f CMakeFiles/pcl_io.dir/objects.a
/opt/bin/x86_64-w64-mingw32-libgfortran4-cxx11/x86_64-w64-mingw32-ar cr CMakeFiles/pcl_io.dir/objects.a @CMakeFiles/pcl_io.dir/objects1.rsp
/opt/bin/x86_64-w64-mingw32-libgfortran4-cxx11/x86_64-w64-mingw32-g++ --sysroot=/opt/x86_64-w64-mingw32/x86_64-w64-mingw32/sys-root/   -Wabi=11 -Wall -Wextra -Wno-unknown-pragmas -fno-strict-aliasing -Wno-format-extra-args -Wno-sign-compare -Wno-invalid-offsetof -Wno-conversion  -O3 -DNDEBUG -Wl,--as-needed -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--allow-multiple-definition -shared -o ../bin/libpcl_io.dll -Wl,--out-implib,../lib/libpcl_io.dll.a -Wl,--major-image-version,1,--minor-image-version,11 -Wl,--whole-archive CMakeFiles/pcl_io.dir/objects.a -Wl,--no-whole-archive @CMakeFiles/pcl_io.dir/linklibs.rsp
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x172): undefined reference to `__imp_WSAStartup'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x203): undefined reference to `__imp_bind'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x213): undefined reference to `__imp_setsockopt'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x1409): undefined reference to `__imp_ntohl'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x1871): undefined reference to `__imp_WSARecvFrom'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x1882): undefined reference to `__imp_WSAGetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x1cf2): undefined reference to `__imp_ntohs'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text+0x1d48): undefined reference to `__imp_ntohl'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail17winsock_init_base7cleanupERNS2_4dataE[_ZN5boost4asio6detail17winsock_init_base7cleanupERNS2_4dataE]+0x13): undefined reference to `__imp_WSACleanup'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops16clear_last_errorEv[_ZN5boost4asio6detail10socket_ops16clear_last_errorEv]+0x5): undefined reference to `__imp_WSASetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops4bindEyPK8sockaddryRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops4bindEyPK8sockaddryRNS_6system10error_codeE]+0x41): undefined reference to `__imp_WSAGetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops4sendEyPK7_WSABUFyiRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops4sendEyPK7_WSABUFyiRNS_6system10error_codeE]+0x52): undefined reference to `__imp_WSASend'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops4sendEyPK7_WSABUFyiRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops4sendEyPK7_WSABUFyiRNS_6system10error_codeE]+0x62): undefined reference to `__imp_WSAGetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops9poll_readEyhiRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops9poll_readEyhiRNS_6system10error_codeE]+0x89): undefined reference to `__imp_select'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops9poll_readEyhiRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops9poll_readEyhiRNS_6system10error_codeE]+0x99): undefined reference to `__imp_WSAGetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops20network_to_host_longEm[_ZN5boost4asio6detail10socket_ops20network_to_host_longEm]+0x3): undefined reference to `__imp_ntohl'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops20host_to_network_longEm[_ZN5boost4asio6detail10socket_ops20host_to_network_longEm]+0x3): undefined reference to `__imp_htonl'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops21host_to_network_shortEt[_ZN5boost4asio6detail10socket_ops21host_to_network_shortEt]+0x6): undefined reference to `__imp_htons'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio2ip10address_v4C1Ej[_ZN5boost4asio2ip10address_v4C1Ej]+0xc): undefined reference to `__imp_htonl'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZNK5boost4asio2ip10address_v47to_uintEv[_ZNK5boost4asio2ip10address_v47to_uintEv]+0x5): undefined reference to `__imp_ntohl'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZNK5boost4asio2ip7address14is_unspecifiedEv[_ZNK5boost4asio2ip7address14is_unspecifiedEv]+0x39): undefined reference to `__imp_ntohl'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZNK5boost4asio2ip6detail8endpoint4portEv[_ZNK5boost4asio2ip6detail8endpoint4portEv]+0x7): undefined reference to `__imp_ntohs'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio2ip6detail8endpoint4portEt[_ZN5boost4asio2ip6detail8endpoint4portEt]+0xd): undefined reference to `__imp_htons'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio2ip6detail8endpoint7addressERKNS1_7addressE[_ZN5boost4asio2ip6detail8endpoint7addressERKNS1_7addressE]+0x12): undefined reference to `__imp_ntohs'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops13error_wrapperIiEET_S4_RNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops13error_wrapperIiEET_S4_RNS_6system10error_codeE]+0x17): undefined reference to `__imp_WSAGetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops9inet_ptonEiPKcPvPmRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops9inet_ptonEiPKcPvPmRNS_6system10error_codeE]+0x5e): undefined reference to `__imp_WSAStringToAddressA'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio2ip12make_addressEPKcRNS_6system10error_codeE[_ZN5boost4asio2ip12make_addressEPKcRNS_6system10error_codeE]+0x48): undefined reference to `__imp_WSAStringToAddressA'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio2ip12make_addressEPKcRNS_6system10error_codeE[_ZN5boost4asio2ip12make_addressEPKcRNS_6system10error_codeE]+0x59): undefined reference to `__imp_WSAGetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops5closeEyRhbRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops5closeEyRhbRNS_6system10error_codeE]+0x34): undefined reference to `__imp_closesocket'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail10socket_ops5closeEyRhbRNS_6system10error_codeE[_ZN5boost4asio6detail10socket_ops5closeEyRhbRNS_6system10error_codeE]+0x183): undefined reference to `__imp_ioctlsocket'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail23win_iocp_socket_serviceINS0_2ip3udpEE4openERNS5_19implementation_typeERKS4_RNS_6system10error_codeE[_ZN5boost4asio6detail23win_iocp_socket_serviceINS0_2ip3udpEE4openERNS5_19implementation_typeERKS4_RNS_6system10error_codeE]+0x77): undefined reference to `__imp_WSASocketW'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail23win_iocp_socket_serviceINS0_2ip3udpEE4openERNS5_19implementation_typeERKS4_RNS_6system10error_codeE[_ZN5boost4asio6detail23win_iocp_socket_serviceINS0_2ip3udpEE4openERNS5_19implementation_typeERKS4_RNS_6system10error_codeE]+0x88): undefined reference to `__imp_WSAGetLastError'
CMakeFiles/pcl_io.dir/objects.a(hdl_grabber.cpp.obj):hdl_grabber.cpp:(.text$_ZN5boost4asio6detail23win_iocp_socket_serviceINS0_2ip3udpEE4openERNS5_19implementation_typeERKS4_RNS_6system10error_codeE[_ZN5boost4asio6detail23win_iocp_socket_serviceINS0_2ip3udpEE4openERNS5_19implementation_typeERKS4_RNS_6system10error_codeE]+0x2f4): undefined reference to `__imp_setsockopt'
CMakeFiles/pcl_io.dir/objects.a(vlp_grabber.cpp.obj):vlp_grabber.cpp:(.text+0x102): undefined reference to `__imp_WSAStartup'
CMakeFiles/pcl_io.dir/objects.a(robot_eye_grabber.cpp.obj):robot_eye_grabber.cpp:(.text+0x102): undefined reference to `__imp_WSAStartup'
CMakeFiles/pcl_io.dir/objects.a(robot_eye_grabber.cpp.obj):robot_eye_grabber.cpp:(.text+0x193): undefined reference to `__imp_bind'
CMakeFiles/pcl_io.dir/objects.a(robot_eye_grabber.cpp.obj):robot_eye_grabber.cpp:(.text+0x1a3): undefined reference to `__imp_setsockopt'
CMakeFiles/pcl_io.dir/objects.a(robot_eye_grabber.cpp.obj):robot_eye_grabber.cpp:(.text+0x11bc): undefined reference to `__imp_WSACleanup'
CMakeFiles/pcl_io.dir/objects.a(robot_eye_grabber.cpp.obj):robot_eye_grabber.cpp:(.text$_ZN5boost4asio6detail28win_iocp_socket_service_base21start_receive_from_opERNS2_24base_implementation_typeEP7_WSABUFyP8sockaddriPiPNS1_18win_iocp_operationE[_ZN5boost4asio6detail28win_iocp_socket_service_base21start_receive_from_opERNS2_24base_implementation_typeEP7_WSABUFyP8sockaddriPiPNS1_18win_iocp_operationE]+0x86): undefined reference to `__imp_WSARecvFrom'
CMakeFiles/pcl_io.dir/objects.a(robot_eye_grabber.cpp.obj):robot_eye_grabber.cpp:(.text$_ZN5boost4asio6detail28win_iocp_socket_service_base21start_receive_from_opERNS2_24base_implementation_typeEP7_WSABUFyP8sockaddriPiPNS1_18win_iocp_operationE[_ZN5boost4asio6detail28win_iocp_socket_service_base21start_receive_from_opERNS2_24base_implementation_typeEP7_WSABUFyP8sockaddriPiPNS1_18win_iocp_operationE]+0x8e): undefined reference to `__imp_WSAGetLastError'
collect2: error: ld returned 1 exit status
make[2]: *** [io/CMakeFiles/pcl_io.dir/build.make:391: bin/libpcl_io.dll] Error 1
make[2]: Leaving directory '/workspace/srcdir/pcl/build'
make[1]: *** [CMakeFiles/Makefile2:1165: io/CMakeFiles/pcl_io.dir/all] Error 2
make[1]: Leaving directory '/workspace/srcdir/pcl/build'
make: *** [Makefile:172: all] Error 2
```

I can't test it with MSVC, but I assume it should be safe to add this library
also in that case.