### PR TITLE
Alias `ssize_t` to `SSIZE_T` only for MSVC (fix for mingw)

### DIFF
--- a/io/include/pcl/io/low_level_io.h
+++ b/io/include/pcl/io/low_level_io.h
@@ -51,8 +51,12 @@
 # endif
 # include <io.h>
 # include <windows.h>
-# include <basetsd.h>
+# ifdef _MSC_VER
+// ssize_t is already defined in MinGW and its definition conflicts with that of
+// SSIZE_T on a 32-bit target, so do this only for MSVC.
+#  include <basetsd.h>
 using ssize_t = SSIZE_T;
+# endif /* _MSC_VER */
 #else
 # include <unistd.h>
 # include <sys/mman.h>


### PR DESCRIPTION
MinGW defines [`ssize_t`](https://github.com/mirror/mingw-w64/blob/c6e13e0c105eab7797c2373819b49fff6b05566c/mingw-w64-headers/crt/time.h#L76-L80) as `int` for a 32-bit target, which conflicts with the definition of `SSIZE_T`, which is [`LONG_PTR`](https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types), i.e. `long` for a 32-bit target.