### PR TITLE
[CI] Fixed simple typo in `doc/` to test docs-pipeline

### DIFF
--- a/doc/advanced/content/exceptions_guide.rst
+++ b/doc/advanced/content/exceptions_guide.rst
@@ -102,6 +102,6 @@ rule that can be applied but here are some of the most used guidelines:
 
   * exit with some error if the exception is critical
   * modify the parameters for the function that threw the exception and recall it again
-  * throw an exception with a meaningful message saying that you encountred an exception
+  * throw an exception with a meaningful message saying that you encountered an exception
   * continue (really bad)
 

--- a/doc/advanced/content/pcl_style_guide.rst
+++ b/doc/advanced/content/pcl_style_guide.rst
@@ -397,7 +397,7 @@ For get/set type methods the following rules apply:
 * If large amounts of data needs to be set (usually the case with input data
   in PCL) it is preferred to pass a boost shared pointer instead of the actual
   data.
-* Getters always need to pass exactly the same types as their repsective setters
+* Getters always need to pass exactly the same types as their respective setters
   and vice versa.
 * For getters, if only one argument needs to be passed this will be done via
   the return keyword. If two or more arguments need to be passed they will

--- a/doc/tutorials/content/benchmark.rst
+++ b/doc/tutorials/content/benchmark.rst
@@ -6,7 +6,7 @@ Benchmarking 3D
 This document introduces benchmarking concepts for 3D algorithms. By
 *benchmarking* here we refer to the possibility of testing different
 computational pipelines in an **easy manner**. The goal is to test their
-reproductibility with respect to a particular problem of general interest.
+reproducibility with respect to a particular problem of general interest.
 
 Benchmarking Object Recognition
 -------------------------------

--- a/doc/tutorials/content/qt_visualizer.rst
+++ b/doc/tutorials/content/qt_visualizer.rst
@@ -52,7 +52,7 @@ Use relative paths like this is better than absolute paths; this project should 
 We specify in the general section that we want to build in the folder ``../build`` (this is a relative path from the ``.pro`` file).
 
 The first step of the building is to call ``cmake`` (from the ``build`` folder) with argument ``../src``; this is gonna create all files in the
-``build`` folder without modifying anything in the ``src`` foler; thus keeping it clean.
+``build`` folder without modifying anything in the ``src`` folder; thus keeping it clean.
 
 Then we just have to compile our program; the argument ``-j2`` allow to specify how many thread of your CPU you want to use for compilation. The more thread you use
 the faster the compilation will be (especially on big projects); but if you take all threads from the CPU your OS will likely be unresponsive during 

--- a/doc/tutorials/content/writing_new_classes.rst
+++ b/doc/tutorials/content/writing_new_classes.rst
@@ -1061,7 +1061,7 @@ class look like:
 
           /** \brief Compute the intensity average for a single point
             * \param[in] pid the point index to compute the weight for
-            * \param[in] indices the set of nearest neighor indices 
+            * \param[in] indices the set of nearest neighbor indices 
             * \param[in] distances the set of nearest neighbor distances
             * \return the intensity average at a given point index
             */


### PR DESCRIPTION
Current docs pipeline seems to work well for push/PR which contains code changes(i.e. files excluding `doc/*` and `*.md` in root directory), according to the [Azure Pipeline Dashboard](https://dev.azure.com/PointCloudLibrary/pcl/_build?view=runs).

To test only doc changes, which will **only trigger docs-pipeline**, I fixed some simple typo in `doc/` I've found with spell check plugin open when skimming through the documentations before.

Expected behavior of the pipelines at present:
- Doc changes: format -> generate doc -> run tutorials stage
- Code changes: format -> run build -> (if build_gcc stage passed) [generate doc -> run tutorials stage]

