### PR TITLE
[features] Use correct cloud for checking finite-ness in fpfh

### DIFF
--- a/features/include/pcl/features/impl/fpfh_omp.hpp
+++ b/features/include/pcl/features/impl/fpfh_omp.hpp
@@ -119,7 +119,7 @@ pcl::FPFHEstimationOMP<PointInT, PointNT, PointOutT>::computeFeature (PointCloud
     int p_idx = spfh_indices_vec[i];
 
     // Find the neighborhood around p_idx
-    if (!isFinite ((*input_)[p_idx]) ||
+    if (!isFinite ((*surface_)[p_idx]) ||
         this->searchForNeighbors (*surface_, p_idx, search_parameter_, nn_indices, nn_dists) == 0)
       continue;
 


### PR DESCRIPTION
This caused segfaults. Seems like the check is done on the wrong dataset. 

Occurs when `setSearchSurface` is set, so `input_->size()` != `surface_->size()`.

Maybe consider to use `.at()` in debug configurations instead of indexing operator so these kinds of issues can be spot earlier. 