### PR TITLE
Add `constexpr` to static member functions for point types, add macro for `if constexpr`

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -1301,7 +1301,7 @@ namespace pcl
   struct PFHSignature125
   {
     float histogram[125] = {0.f};
-    static int descriptorSize () { return 125; }
+    static constexpr int descriptorSize () const { return 125; }
 
     inline PFHSignature125 () = default;
 
@@ -1315,7 +1315,7 @@ namespace pcl
   struct PFHRGBSignature250
   {
     float histogram[250] = {0.f};
-    static int descriptorSize () { return 250; }
+    static constexpr int descriptorSize () const { return 250; }
 
     inline PFHRGBSignature250 () = default;
 
@@ -1402,7 +1402,7 @@ namespace pcl
   {
     float descriptor[1980] = {0.f};
     float rf[9] = {0.f};
-    static int descriptorSize () { return 1980; }
+    static constexpr int descriptorSize () const { return 1980; }
 
     inline ShapeContext1980 () = default;
 
@@ -1417,7 +1417,7 @@ namespace pcl
   {
     float descriptor[1960] = {0.f};
     float rf[9] = {0.f};
-    static int descriptorSize () { return 1960; }
+    static constexpr int descriptorSize () const { return 1960; }
 
     inline UniqueShapeContext1960 () = default;
 
@@ -1432,7 +1432,7 @@ namespace pcl
   {
     float descriptor[352] = {0.f};
     float rf[9] = {0.f};
-    static int descriptorSize () { return 352; }
+    static constexpr int descriptorSize () const { return 352; }
 
     inline SHOT352 () = default;
 
@@ -1448,7 +1448,7 @@ namespace pcl
   {
     float descriptor[1344] = {0.f};
     float rf[9] = {0.f};
-    static int descriptorSize () { return 1344; }
+    static constexpr int descriptorSize () const { return 1344; }
 
     inline SHOT1344 () = default;
 
@@ -1513,7 +1513,7 @@ namespace pcl
   struct FPFHSignature33
   {
     float histogram[33] = {0.f};
-    static int descriptorSize () { return 33; }
+    static constexpr int descriptorSize () const { return 33; }
 
     inline FPFHSignature33 () = default;
 
@@ -1527,7 +1527,7 @@ namespace pcl
   struct VFHSignature308
   {
     float histogram[308] = {0.f};
-    static int descriptorSize () { return 308; }
+    static constexpr int descriptorSize () const { return 308; }
 
     inline VFHSignature308 () = default;
 
@@ -1541,7 +1541,7 @@ namespace pcl
   struct GRSDSignature21
   {
     float histogram[21] = {0.f};
-    static int descriptorSize () { return 21; }
+    static constexpr int descriptorSize () const { return 21; }
 
     inline GRSDSignature21 () = default;
 
@@ -1557,7 +1557,7 @@ namespace pcl
     float scale = 0.f;
     float orientation = 0.f;
     unsigned char descriptor[64] = {0};
-    static int descriptorSize () { return 64; }
+    static constexpr int descriptorSize () const { return 64; }
 
     inline BRISKSignature512 () = default;
 
@@ -1573,7 +1573,7 @@ namespace pcl
   struct ESFSignature640
   {
     float histogram[640] = {0.f};
-    static int descriptorSize () { return 640; }
+    static constexpr int descriptorSize () const { return 640; }
 
     inline ESFSignature640 () = default;
 
@@ -1587,7 +1587,7 @@ namespace pcl
   struct GASDSignature512
   {
     float histogram[512] = {0.f};
-    static int descriptorSize() { return 512; }
+    static constexpr int descriptorSize() const { return 512; }
 
     inline GASDSignature512 () = default;
 
@@ -1601,7 +1601,7 @@ namespace pcl
   struct GASDSignature984
   {
     float histogram[984] = {0.f};
-    static int descriptorSize() { return 984; }
+    static constexpr int descriptorSize() const { return 984; }
 
     inline GASDSignature984 () = default;
 
@@ -1615,7 +1615,7 @@ namespace pcl
   struct GASDSignature7992
   {
     float histogram[7992] = {0.f};
-    static int descriptorSize() { return 7992; }
+    static constexpr int descriptorSize() const { return 7992; }
 
     inline GASDSignature7992 () = default;
 
@@ -1629,7 +1629,7 @@ namespace pcl
   struct GFPFHSignature16
   {
     float histogram[16] = {0.f};
-    static int descriptorSize () { return 16; }
+    static constexpr int descriptorSize () const { return 16; }
 
     inline GFPFHSignature16 () = default;
 
@@ -1644,7 +1644,7 @@ namespace pcl
   {
     float x = 0.f, y = 0.f, z = 0.f, roll = 0.f, pitch = 0.f, yaw = 0.f;
     float descriptor[36] = {0.f};
-    static int descriptorSize () { return 36; }
+    static constexpr int descriptorSize () const { return 36; }
 
     inline Narf36 () = default;
 
@@ -1706,7 +1706,7 @@ namespace pcl
   struct Histogram
   {
     float histogram[N];
-    static int descriptorSize () { return N; }
+    static constexpr int descriptorSize () const { return N; }
   };
 
   struct EIGEN_ALIGN16 _PointWithScale
@@ -1855,7 +1855,7 @@ namespace pcl
   operator << (std::ostream& os, const Histogram<N>& p)
   {
     // make constexpr
-    if (N > 0)
+    PCL_IF_CONSTEXPR(N > 0)
     {
         os << "(" << p.histogram[0];
         std::for_each(p.histogram + 1, std::end(p.histogram),

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -1301,7 +1301,7 @@ namespace pcl
   struct PFHSignature125
   {
     float histogram[125] = {0.f};
-    static constexpr int descriptorSize () const { return 125; }
+    static constexpr int descriptorSize () { return 125; }
 
     inline PFHSignature125 () = default;
 
@@ -1315,7 +1315,7 @@ namespace pcl
   struct PFHRGBSignature250
   {
     float histogram[250] = {0.f};
-    static constexpr int descriptorSize () const { return 250; }
+    static constexpr int descriptorSize () { return 250; }
 
     inline PFHRGBSignature250 () = default;
 
@@ -1402,7 +1402,7 @@ namespace pcl
   {
     float descriptor[1980] = {0.f};
     float rf[9] = {0.f};
-    static constexpr int descriptorSize () const { return 1980; }
+    static constexpr int descriptorSize () { return 1980; }
 
     inline ShapeContext1980 () = default;
 
@@ -1417,7 +1417,7 @@ namespace pcl
   {
     float descriptor[1960] = {0.f};
     float rf[9] = {0.f};
-    static constexpr int descriptorSize () const { return 1960; }
+    static constexpr int descriptorSize () { return 1960; }
 
     inline UniqueShapeContext1960 () = default;
 
@@ -1432,7 +1432,7 @@ namespace pcl
   {
     float descriptor[352] = {0.f};
     float rf[9] = {0.f};
-    static constexpr int descriptorSize () const { return 352; }
+    static constexpr int descriptorSize () { return 352; }
 
     inline SHOT352 () = default;
 
@@ -1448,7 +1448,7 @@ namespace pcl
   {
     float descriptor[1344] = {0.f};
     float rf[9] = {0.f};
-    static constexpr int descriptorSize () const { return 1344; }
+    static constexpr int descriptorSize () { return 1344; }
 
     inline SHOT1344 () = default;
 
@@ -1513,7 +1513,7 @@ namespace pcl
   struct FPFHSignature33
   {
     float histogram[33] = {0.f};
-    static constexpr int descriptorSize () const { return 33; }
+    static constexpr int descriptorSize () { return 33; }
 
     inline FPFHSignature33 () = default;
 
@@ -1527,7 +1527,7 @@ namespace pcl
   struct VFHSignature308
   {
     float histogram[308] = {0.f};
-    static constexpr int descriptorSize () const { return 308; }
+    static constexpr int descriptorSize () { return 308; }
 
     inline VFHSignature308 () = default;
 
@@ -1541,7 +1541,7 @@ namespace pcl
   struct GRSDSignature21
   {
     float histogram[21] = {0.f};
-    static constexpr int descriptorSize () const { return 21; }
+    static constexpr int descriptorSize () { return 21; }
 
     inline GRSDSignature21 () = default;
 
@@ -1557,7 +1557,7 @@ namespace pcl
     float scale = 0.f;
     float orientation = 0.f;
     unsigned char descriptor[64] = {0};
-    static constexpr int descriptorSize () const { return 64; }
+    static constexpr int descriptorSize () { return 64; }
 
     inline BRISKSignature512 () = default;
 
@@ -1573,7 +1573,7 @@ namespace pcl
   struct ESFSignature640
   {
     float histogram[640] = {0.f};
-    static constexpr int descriptorSize () const { return 640; }
+    static constexpr int descriptorSize () { return 640; }
 
     inline ESFSignature640 () = default;
 
@@ -1587,7 +1587,7 @@ namespace pcl
   struct GASDSignature512
   {
     float histogram[512] = {0.f};
-    static constexpr int descriptorSize() const { return 512; }
+    static constexpr int descriptorSize() { return 512; }
 
     inline GASDSignature512 () = default;
 
@@ -1601,7 +1601,7 @@ namespace pcl
   struct GASDSignature984
   {
     float histogram[984] = {0.f};
-    static constexpr int descriptorSize() const { return 984; }
+    static constexpr int descriptorSize() { return 984; }
 
     inline GASDSignature984 () = default;
 
@@ -1615,7 +1615,7 @@ namespace pcl
   struct GASDSignature7992
   {
     float histogram[7992] = {0.f};
-    static constexpr int descriptorSize() const { return 7992; }
+    static constexpr int descriptorSize() { return 7992; }
 
     inline GASDSignature7992 () = default;
 
@@ -1629,7 +1629,7 @@ namespace pcl
   struct GFPFHSignature16
   {
     float histogram[16] = {0.f};
-    static constexpr int descriptorSize () const { return 16; }
+    static constexpr int descriptorSize () { return 16; }
 
     inline GFPFHSignature16 () = default;
 
@@ -1644,7 +1644,7 @@ namespace pcl
   {
     float x = 0.f, y = 0.f, z = 0.f, roll = 0.f, pitch = 0.f, yaw = 0.f;
     float descriptor[36] = {0.f};
-    static constexpr int descriptorSize () const { return 36; }
+    static constexpr int descriptorSize () { return 36; }
 
     inline Narf36 () = default;
 
@@ -1706,7 +1706,7 @@ namespace pcl
   struct Histogram
   {
     float histogram[N];
-    static constexpr int descriptorSize () const { return N; }
+    static constexpr int descriptorSize () { return N; }
   };
 
   struct EIGEN_ALIGN16 _PointWithScale

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -438,3 +438,9 @@ aligned_free (void* ptr)
 #else
   #define PCL_NODISCARD
 #endif
+
+#if (__cplusplus >= 201703L) || (defined(_MSC_VER) && (_MSC_VER >= 1910) && (_MSVC_LANG >= 201703L))
+  #define PCL_IF_CONSTEXPR(x) if constexpr(x)
+#else
+  #define PCL_IF_CONSTEXPR(x) if (x)
+#endif

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -439,7 +439,7 @@ aligned_free (void* ptr)
   #define PCL_NODISCARD
 #endif
 
-#if (__cplusplus >= 201703L) || (defined(_MSC_VER) && (_MSC_VER >= 1910) && (_MSVC_LANG >= 201703L))
+#ifdef __cpp_if_constexpr
   #define PCL_IF_CONSTEXPR(x) if constexpr(x)
 #else
   #define PCL_IF_CONSTEXPR(x) if (x)

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
@@ -55,12 +55,9 @@ pcl::SampleConsensusModelRegistration<PointT>::isSampleGood (const Indices &samp
   using namespace pcl::common;
   using namespace pcl::traits;
 
-  PointT p10;
-  pcl::copyPoint((*input_)[samples[1]] - (*input_)[samples[0]], p10);
-  PointT p20;
-  pcl::copyPoint((*input_)[samples[2]] - (*input_)[samples[0]], p20);
-  PointT p21;
-  pcl::copyPoint((*input_)[samples[2]] - (*input_)[samples[1]], p21);
+  PointT p10 = (*input_)[samples[1]] - (*input_)[samples[0]];
+  PointT p20 = (*input_)[samples[2]] - (*input_)[samples[0]];
+  PointT p21 = (*input_)[samples[2]] - (*input_)[samples[1]];
 
   return ((p10.x * p10.x + p10.y * p10.y + p10.z * p10.z) > sample_dist_thresh_ && 
           (p20.x * p20.x + p20.y * p20.y + p20.z * p20.z) > sample_dist_thresh_ && 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
@@ -55,9 +55,15 @@ pcl::SampleConsensusModelRegistration<PointT>::isSampleGood (const Indices &samp
   using namespace pcl::common;
   using namespace pcl::traits;
 
-  PointT p10 = (*input_)[samples[1]] - (*input_)[samples[0]];
-  PointT p20 = (*input_)[samples[2]] - (*input_)[samples[0]];
-  PointT p21 = (*input_)[samples[2]] - (*input_)[samples[1]];
+  auto diff10 = (*input_)[samples[1]] - (*input_)[samples[0]];
+  PointT p10;
+  pcl::copyPoint(diff10, p10);
+  auto diff20 = (*input_)[samples[2]] - (*input_)[samples[0]];
+  PointT p20;
+  pcl::copyPoint(diff20, p20);
+  auto diff21 = (*input_)[samples[2]] - (*input_)[samples[1]];
+  PointT p21;
+  pcl::copyPoint(diff21, p21);
 
   return ((p10.x * p10.x + p10.y * p10.y + p10.z * p10.z) > sample_dist_thresh_ && 
           (p20.x * p20.x + p20.y * p20.y + p20.z * p20.z) > sample_dist_thresh_ && 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_registration.hpp
@@ -55,15 +55,12 @@ pcl::SampleConsensusModelRegistration<PointT>::isSampleGood (const Indices &samp
   using namespace pcl::common;
   using namespace pcl::traits;
 
-  auto diff10 = (*input_)[samples[1]] - (*input_)[samples[0]];
   PointT p10;
-  pcl::copyPoint(diff10, p10);
-  auto diff20 = (*input_)[samples[2]] - (*input_)[samples[0]];
+  pcl::copyPoint((*input_)[samples[1]] - (*input_)[samples[0]], p10);
   PointT p20;
-  pcl::copyPoint(diff20, p20);
-  auto diff21 = (*input_)[samples[2]] - (*input_)[samples[1]];
+  pcl::copyPoint((*input_)[samples[2]] - (*input_)[samples[0]], p20);
   PointT p21;
-  pcl::copyPoint(diff21, p21);
+  pcl::copyPoint((*input_)[samples[2]] - (*input_)[samples[1]], p21);
 
   return ((p10.x * p10.x + p10.y * p10.y + p10.z * p10.z) > sample_dist_thresh_ && 
           (p20.x * p20.x + p20.y * p20.y + p20.z * p20.z) > sample_dist_thresh_ && 


### PR DESCRIPTION
a small subset of related [to constexpr point constructors MR] changes