### PR TITLE
[CI] Enhance the pipeline with `git diff` method

### DIFF
--- a/.ci/azure-pipelines/azure-pipelines.yaml
+++ b/.ci/azure-pipelines/azure-pipelines.yaml
@@ -1,29 +1,33 @@
+# Exclude Rules:
+# 1. path-filter in trigger and pr, 
+#    this is NOT exclude rules for documentation,
+#    set this rule only to avoid any CI run.
+# 2. DOCS_LISTS in diff script, 
+#    the lists contains all documentation-related files,
+#    fill the list to help git-diff recognize docs changes.
+
 trigger:
   paths:
     exclude:
-    - doc
     - README.md
     - CHANGES.md
     - CONTRIBUTING.md
+    # add more exclude rules, e.g. .ci, .dev, .github
+    # which won't cause any CI to run.
 
 pr:
   paths:
     exclude:
-    - doc
     - README.md
     - CHANGES.md
     - CONTRIBUTING.md
+    # add more exclude rules, e.g. .ci, .dev, .github
+    # which won't cause any CI to run.
 
 resources:
   containers:
-    - container: fmt
+    - container: fmt # for formatting.yaml
       image: pointcloudlibrary/fmt
-    - container: env1804
-      image: pointcloudlibrary/env:18.04
-    - container: env2004
-      image: pointcloudlibrary/env:20.04
-    - container: env2010
-      image: pointcloudlibrary/env:20.10
 
 stages:
   - stage: formatting
@@ -31,133 +35,51 @@ stages:
     jobs:
       - template: formatting.yaml
 
-  - stage: build_gcc
-    displayName: Build GCC
-    dependsOn: formatting
+  - stage: diff
+    displayName: Code Changes Diff
     jobs:
-      - job: ubuntu
-        displayName: Ubuntu
+      - job: codeDiff
+        displayName: Code Diff
         pool:
-          vmImage: 'Ubuntu 20.04'
-        strategy:
-          matrix:
-            18.04 GCC:  # oldest LTS
-              CONTAINER: env1804
-              CC: gcc
-              CXX: g++
-              BUILD_GPU: ON
-              CMAKE_ARGS: '-DPCL_WARNINGS_ARE_ERRORS=ON'
-            20.10 GCC:  # latest Ubuntu
-              CONTAINER: env2010
-              CC: gcc
-              CXX: g++
-              BUILD_GPU: OFF
-              # surface is not ready for re-entrant QHull
-              CMAKE_ARGS: '-DBUILD_tests_surface=OFF'
-        container: $[ variables['CONTAINER'] ]
-        timeoutInMinutes: 0
-        variables:
-          BUILD_DIR: '$(Agent.BuildDirectory)/build'
-          CMAKE_CXX_FLAGS: '-Wall -Wextra -Wnoexcept-type'
-          DISPLAY: :99.0 # Checked for in CMake
+          vmImage: 'ubuntu-latest'
         steps:
-          - template: build/ubuntu.yaml
+          - checkout: self
+          - script: | 
+              # Add all docs path to this array
+              DOCS_LISTS=("doc" "*.md")
+              for ENTRY in "${DOCS_LISTS[@]}"; do
+                DIFF_EXCLUDE="':(exclude)${ENTRY}' ${DIFF_EXCLUDE}"
+              done
+              cd $(Build.SourcesDirectory)
+              echo "##vso[task.setvariable variable=HasCodeChanges;isOutput=true]false"
+              # Show full git diff results
+              git diff $(git merge-base HEAD origin/test-CI-features)
+              # Set HasCodeChanges to true, if there's still file changed when excluding those docs
+              git diff --quiet $(git merge-base HEAD origin/test-CI-features) -- ${DIFF_EXCLUDE} || \
+              echo "##vso[task.setvariable variable=HasCodeChanges;isOutput=true]true"
+            name: GitResult
+            displayName: Show Git Diff Result
 
-  - stage: build_clang
-    displayName: Build Clang
-    dependsOn: formatting
+  - stage: documentation
+    displayName: Goto Documentation
+    dependsOn: diff
+    condition: and(succeeded(), eq(dependencies.diff.outputs['CodeDiff.GitResult.HasCodeChanges'], 'false'))
     jobs:
-      - job: osx
-        displayName: macOS
+      - job: prompt
+        displayName: Trigger Prompt
         pool:
-          vmImage: '$(VMIMAGE)'
-        strategy:
-          matrix:
-            Catalina 10.15:
-              VMIMAGE: 'macOS-10.15'
-              OSX_VERSION: '10.15'
-            Mojave 10.14:
-              VMIMAGE: 'macOS-10.14'
-              OSX_VERSION: '10.14'
-        timeoutInMinutes: 0
-        variables:
-          BUILD_DIR: '$(Agent.WorkFolder)/build'
-          GOOGLE_TEST_DIR: '$(Agent.WorkFolder)/googletest'
-          CMAKE_CXX_FLAGS: '-Wall -Wextra -Wabi -Werror -Wno-error=deprecated-declarations'
+          vmImage: 'ubuntu-latest'
         steps:
-          - template: build/macos.yaml
-      - job: ubuntu
-        displayName: Ubuntu
-        # Placement of Ubuntu Clang job after macOS ensures an extra parallel job doesn't need to be created.
-        # Total time per run remains same since macOS is quicker so it finishes earlier, and remaining time is used by this job
-        # Therefore, number of parallel jobs and total run time of entire pipeline remains unchanged even after addition of this job
-        # The version of Ubuntu is chosen to cover more versions than covered by GCC based CI
-        dependsOn: osx
-        condition: succeededOrFailed()
-        pool:
-          vmImage: 'Ubuntu 20.04'
-        strategy:
-          matrix:
-            20.04 Clang:
-              CONTAINER: env2004
-              CC: clang
-              CXX: clang++
-              BUILD_GPU: ON
-              CMAKE_ARGS: ''
-        container: $[ variables['CONTAINER'] ]
-        timeoutInMinutes: 0
-        variables:
-          BUILD_DIR: '$(Agent.BuildDirectory)/build'
-          CMAKE_CXX_FLAGS: '-Wall -Wextra'
-          DISPLAY: :99.0 # Checked for in CMake
-        steps:
-          - template: build/ubuntu.yaml
-      - job: ubuntu_indices
-        displayName: Ubuntu Indices
-        # Test 64 bit & unsigned indices
-        dependsOn: osx
-        condition: succeededOrFailed()
-        pool:
-          vmImage: 'Ubuntu 20.04'
-        strategy:
-          matrix:
-            20.04 Clang:
-              CONTAINER: env2004
-              CC: clang
-              CXX: clang++
-              INDEX_SIGNED: OFF
-              INDEX_SIZE: 64
-              CMAKE_ARGS: ''
-        container: $[ variables['CONTAINER'] ]
-        timeoutInMinutes: 0
-        variables:
-          BUILD_DIR: '$(Agent.BuildDirectory)/build'
-          CMAKE_CXX_FLAGS: '-Wall -Wextra'
-        steps:
-          - template: build/ubuntu_indices.yaml
+          - script: echo Trigger docs-pipeline.yaml...
 
-  - stage: build_msvc
-    displayName: Build MSVC
-    dependsOn: formatting
+  - stage: build
+    displayName: Goto Build
+    dependsOn: diff
+    condition: and(succeeded(), eq(dependencies.diff.outputs['CodeDiff.GitResult.HasCodeChanges'], 'true'))
     jobs:
-      - job: vs2017
-        displayName: Windows VS2017 Build
+      - job: prompt
+        displayName: Trigger Prompt
         pool:
-          vmImage: 'vs2017-win2016'
-        strategy:
-          matrix:
-            x86:
-              PLATFORM: 'x86'
-              ARCHITECTURE: 'x86'
-              GENERATOR: 'Visual Studio 15 2017'
-            x64:
-              PLATFORM: 'x64'
-              ARCHITECTURE: 'x86_amd64'
-              GENERATOR: 'Visual Studio 15 2017 Win64'
-        timeoutInMinutes: 0
-        variables:
-          BUILD_DIR: 'c:\build'
-          CONFIGURATION: 'Release'
-          VCPKG_ROOT: 'C:\vcpkg'
+          vmImage: 'ubuntu-latest'
         steps:
-          - template: build/windows.yaml
+          - script: echo Trigger build-pipeline.yaml...

--- a/.ci/azure-pipelines/build-pipeline.yaml
+++ b/.ci/azure-pipelines/build-pipeline.yaml
@@ -1,0 +1,150 @@
+trigger: none
+
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: Main-CI
+      source: Main
+      trigger:
+        stages:
+        - build
+  containers:
+    - container: env1804
+      image: pointcloudlibrary/env:18.04
+    - container: env2004
+      image: pointcloudlibrary/env:20.04
+    - container: env2010
+      image: pointcloudlibrary/env:20.10
+
+stages:
+  - stage: build_gcc
+    displayName: Build GCC
+    dependsOn: []
+    jobs:
+      - job: ubuntu
+        displayName: Ubuntu
+        pool:
+          vmImage: 'Ubuntu 20.04'
+        strategy:
+          matrix:
+            18.04 GCC:  # oldest LTS
+              CONTAINER: env1804
+              CC: gcc
+              CXX: g++
+              BUILD_GPU: ON
+              CMAKE_ARGS: '-DPCL_WARNINGS_ARE_ERRORS=ON'
+            20.10 GCC:  # latest Ubuntu
+              CONTAINER: env2010
+              CC: gcc
+              CXX: g++
+              BUILD_GPU: OFF
+              # surface is not ready for re-entrant QHull
+              CMAKE_ARGS: '-DBUILD_tests_surface=OFF'
+        container: $[ variables['CONTAINER'] ]
+        timeoutInMinutes: 0
+        variables:
+          BUILD_DIR: '$(Agent.BuildDirectory)/build'
+          CMAKE_CXX_FLAGS: '-Wall -Wextra -Wnoexcept-type'
+          DISPLAY: :99.0 # Checked for in CMake
+        steps:
+          - template: build/ubuntu.yaml
+
+  - stage: build_clang
+    displayName: Build Clang
+    dependsOn: []
+    jobs:
+      - job: osx
+        displayName: macOS
+        pool:
+          vmImage: '$(VMIMAGE)'
+        strategy:
+          matrix:
+            Catalina 10.15:
+              VMIMAGE: 'macOS-10.15'
+              OSX_VERSION: '10.15'
+            Mojave 10.14:
+              VMIMAGE: 'macOS-10.14'
+              OSX_VERSION: '10.14'
+        timeoutInMinutes: 0
+        variables:
+          BUILD_DIR: '$(Agent.WorkFolder)/build'
+          GOOGLE_TEST_DIR: '$(Agent.WorkFolder)/googletest'
+          CMAKE_CXX_FLAGS: '-Wall -Wextra -Wabi -Werror -Wno-error=deprecated-declarations'
+        steps:
+          - template: build/macos.yaml
+      - job: ubuntu
+        displayName: Ubuntu
+        # Placement of Ubuntu Clang job after macOS ensures an extra parallel job doesn't need to be created.
+        # Total time per run remains same since macOS is quicker so it finishes earlier, and remaining time is used by this job
+        # Therefore, number of parallel jobs and total run time of entire pipeline remains unchanged even after addition of this job
+        # The version of Ubuntu is chosen to cover more versions than covered by GCC based CI
+        dependsOn: osx
+        condition: succeededOrFailed()
+        pool:
+          vmImage: 'Ubuntu 20.04'
+        strategy:
+          matrix:
+            20.04 Clang:
+              CONTAINER: env2004
+              CC: clang
+              CXX: clang++
+              BUILD_GPU: ON
+              CMAKE_ARGS: ''
+        container: $[ variables['CONTAINER'] ]
+        timeoutInMinutes: 0
+        variables:
+          BUILD_DIR: '$(Agent.BuildDirectory)/build'
+          CMAKE_CXX_FLAGS: '-Wall -Wextra'
+          DISPLAY: :99.0 # Checked for in CMake
+        steps:
+          - template: build/ubuntu.yaml
+      - job: ubuntu_indices
+        displayName: Ubuntu Indices
+        # Test 64 bit & unsigned indices
+        dependsOn: osx
+        condition: succeededOrFailed()
+        pool:
+          vmImage: 'Ubuntu 20.04'
+        strategy:
+          matrix:
+            20.04 Clang:
+              CONTAINER: env2004
+              CC: clang
+              CXX: clang++
+              INDEX_SIGNED: OFF
+              INDEX_SIZE: 64
+              CMAKE_ARGS: ''
+        container: $[ variables['CONTAINER'] ]
+        timeoutInMinutes: 0
+        variables:
+          BUILD_DIR: '$(Agent.BuildDirectory)/build'
+          CMAKE_CXX_FLAGS: '-Wall -Wextra'
+        steps:
+          - template: build/ubuntu_indices.yaml
+
+  - stage: build_msvc
+    displayName: Build MSVC
+    dependsOn: []
+    jobs:
+      - job: vs2017
+        displayName: Windows VS2017 Build
+        pool:
+          vmImage: 'vs2017-win2016'
+        strategy:
+          matrix:
+            x86:
+              PLATFORM: 'x86'
+              ARCHITECTURE: 'x86'
+              GENERATOR: 'Visual Studio 15 2017'
+            x64:
+              PLATFORM: 'x64'
+              ARCHITECTURE: 'x86_amd64'
+              GENERATOR: 'Visual Studio 15 2017 Win64'
+        timeoutInMinutes: 0
+        variables:
+          BUILD_DIR: 'c:\build'
+          CONFIGURATION: 'Release'
+          VCPKG_ROOT: 'C:\vcpkg'
+        steps:
+          - template: build/windows.yaml

--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -1,46 +1,33 @@
-trigger:
-  paths:
-    include:
-    - doc
+trigger: none
 
-pr:
-  paths:
-    include:
-    - doc
+pr: none
 
 resources:
   pipelines:
+    - pipeline: Main-CI
+      source: Main
+      trigger:
+        stages:
+        - documentation
     - pipeline: Build-CI
       source: Build
       trigger:
         stages:
         - build_gcc
   containers:
-    - container: fmt # for formatting.yaml
-      image: pointcloudlibrary/fmt
     - container: doc # for documentation.yaml
       image: pointcloudlibrary/doc
     - container: env1804 # for tutorials.yaml
       image: pointcloudlibrary/env:18.04
 
 stages:
-  - stage: formatting
-    displayName: Formatting
-    # if docs pipeline triggered by build_gcc stage,
-    # the formatting stage has already run, thus it
-    # won't run for a second time here.
-    condition: ne(variables['Build.Reason'], 'ResourceTrigger')
-    jobs:
-      - template: formatting.yaml
-
   - stage: documentation
     displayName: Documentation
-    condition: in(dependencies.formatting.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     jobs:
       - template: documentation.yaml
 
   - stage: tutorials
     displayName: Tutorials
-    condition: in(dependencies.documentation.result, 'Succeeded', 'SucceededWithIssues')
+    dependsOn: documentation
     jobs:
       - template: tutorials.yaml


### PR DESCRIPTION
## Summary

This PR mainly introduces `git diff` and adds a new main pipeline for current CI, as an extension of the discussions in https://github.com/PointCloudLibrary/pcl/pull/4715. 
Blow are my ideas of new structure of CI:
![ci-main](https://user-images.githubusercontent.com/56567688/115573243-29faff80-a2f3-11eb-85c0-df9c77fdda76.png)

To control the CI workflow better and make the structure more perspicuous, I add a main pipeline to: 
1. **do formatting**, which will be done before both build & docs pipeline
2. **diff code changes** between HEAD & master (to determine which pipeline, build or docs, should run next)

#### Pros
* remedy the unexpected behavior (docs pipeline is triggered twice when both codes and docs changes commit together)
* make the CI more explicit
* separate format stage, so that we can add stages and jobs as downstream of formatting in main pipeline
* easier to add diff rules (e.g. use wildcard or regex) in `git diff` script than using Azure path filter before

#### Cons
* need to introduce another pipeline, which may be not a good choice for Azure Ops. (TBH, pipeline trigger is much smoother to maintain than the flow-control methods for stages or jobs)

## Test

I test four cases by **push** to branch directly or start a **PR** from another user's branch to my test branch `test-CI-features` (with minimal CI). The features work successfully! Here are the results:

- [Azure Dashboard](https://dev.azure.com/ueqri-ci/pcl-test/_build?view=runs)
- [PR list in my forked repo](https://github.com/ueqri/pcl/pulls)

<details>
 <summary>Details about experiment result</summary>

#### Cases

* only codes changed => run build then docs pipeline
* only docs changed => only run docs pipeline
* both codes and docs changed => run build then docs pipeline
* only README.md changed => won't trigger any CI

#### Test push trigger
![Screenshot_2021-04-21_13-24-32](https://user-images.githubusercontent.com/56567688/115584835-adb9e980-a2fd-11eb-8f4f-3b1fb9f53437.png)

#### Test PR trigger
![Screenshot_2021-04-29_02-05-25](https://user-images.githubusercontent.com/56567688/116451711-6c8e8000-a88f-11eb-89b2-22f5f1692ff5.png)

</details>

## PS
For exclude rules, it's a bit hard to separate the path-filter(a part of Azure YAML schema) and the diff-exclude-rules to one place. So as a second-best solution to reduce the complexity, I pick up the diff-exclude-rules to the head of the script lines, and add comments to attract attention in YAML file.

```yaml
...
- script: | 
     # Add all docs path to this array
     DOCS_LISTS=("doc" "*.md")
     ...
```
```yaml
# Exclude Rules:
# 1. path-filter in trigger and pr, 
#    this is NOT exclude rules for documentation,
#    set this rule only to avoid any CI run.
# 2. DOCS_LISTS in diff script, 
#    the lists contains all documentation-related files,
#    fill the list to help git-diff recognize docs changes.
```