### PR TITLE
Use range-based for & `std::find` to modernize codes in `segmentation`

### DIFF
--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -251,16 +251,16 @@ namespace pcl
     Indices nn_indices;
     std::vector<float> nn_distances;
     // Process all points in the indices vector
-    for (std::size_t i = 0; i < indices.size (); ++i)
+    for (const auto& point : indices)
     {
-      if (processed[indices[i]])
+      if (processed[point])
         continue;
 
       Indices seed_queue;
       int sq_idx = 0;
-      seed_queue.push_back (indices[i]);
+      seed_queue.push_back (point);
 
-      processed[indices[i]] = true;
+      processed[point] = true;
 
       while (sq_idx < static_cast<int> (seed_queue.size ()))
       {

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -611,20 +611,13 @@ pcl::RegionGrowing<PointT, NormalT>::getSegmentFromPoint (pcl::index_t index, pc
     // to which this point belongs
     for (const auto& i_segment : clusters_)
     {
-      bool segment_was_found = false;
-      for (const auto& i_point : (i_segment.indices))
+      const auto it = std::find (i_segment.indices.cbegin (), i_segment_indices.cend (), index);
+      if (it != i_segment_indices.cend())
       {
-        if (i_point == index)
-        {
-          segment_was_found = true;
-          cluster.indices.clear ();
-          cluster.indices.reserve (i_segment.indices.size ());
-          std::copy (i_segment.indices.begin (), i_segment.indices.end (), std::back_inserter (cluster.indices));
-          break;
-        }
-      }
-      if (segment_was_found)
-      {
+        // if segment was found
+        cluster.indices.clear ();
+        cluster.indices.reserve (i_segment.indices.size ());
+        std::copy (i_segment.indices.begin (), i_segment.indices.end (), std::back_inserter (cluster.indices));
         break;
       }
     }// next segment

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -611,8 +611,8 @@ pcl::RegionGrowing<PointT, NormalT>::getSegmentFromPoint (pcl::index_t index, pc
     // to which this point belongs
     for (const auto& i_segment : clusters_)
     {
-      const auto it = std::find (i_segment.indices.cbegin (), i_segment_indices.cend (), index);
-      if (it != i_segment_indices.cend())
+      const auto it = std::find (i_segment.indices.cbegin (), i_segment.indices.cend (), index);
+      if (it != i_segment.indices.cend())
       {
         // if segment was found
         cluster.indices.clear ();

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -729,8 +729,8 @@ pcl::RegionGrowingRGB<PointT, NormalT>::getSegmentFromPoint (pcl::index_t index,
     // to which this point belongs
     for (const auto& i_segment : clusters_)
     {
-      const auto it = std::find (i_segment.indices.cbegin (), i_segment_indices.cend (), index);
-      if (it != i_segment_indices.cend())
+      const auto it = std::find (i_segment.indices.cbegin (), i_segment.indices.cend (), index);
+      if (it != i_segment.indices.cend())
       {
         // if segment was found
         cluster.indices.clear ();

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -482,24 +482,19 @@ pcl::RegionGrowingRGB<PointT, NormalT>::applyRegionMergingAlgorithm ()
       num_seg_in_homogeneous_region[i_reg] = 0;
       final_segment_number -= 1;
 
-      int nghbr_number = static_cast<int> (region_neighbours[reg_index].size ());
-      for (int i_nghbr = 0; i_nghbr < nghbr_number; i_nghbr++)
+      for (auto& nghbr : region_neighbours[reg_index])
       {
-        if ( segment_labels_[ region_neighbours[reg_index][i_nghbr].second ] == reg_index )
+        if ( segment_labels_[ nghbr.second ] == reg_index )
         {
-          region_neighbours[reg_index][i_nghbr].first = std::numeric_limits<float>::max ();
-          region_neighbours[reg_index][i_nghbr].second = 0;
+          nghbr.first = std::numeric_limits<float>::max ();
+          nghbr.second = 0;
         }
       }
-      nghbr_number = static_cast<int> (region_neighbours[i_reg].size ());
-      for (int i_nghbr = 0; i_nghbr < nghbr_number; i_nghbr++)
+      for (const auto& nghbr : region_neighbours[i_reg])
       {
-        if ( segment_labels_[ region_neighbours[i_reg][i_nghbr].second ] != reg_index )
+        if ( segment_labels_[ nghbr.second ] != reg_index )
         {
-          std::pair<float, int> pair;
-          pair.first = region_neighbours[i_reg][i_nghbr].first;
-          pair.second = region_neighbours[i_reg][i_nghbr].second;
-          region_neighbours[reg_index].push_back (pair);
+          region_neighbours[reg_index].push_back (nghbr);
         }
       }
       region_neighbours[i_reg].clear ();
@@ -535,9 +530,8 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findRegionNeighbours (std::vector< std::
   {
     int segment_num = static_cast<int> (regions_in[i_reg].size ());
     neighbours_out[i_reg].reserve (segment_num * region_neighbour_number_);
-	for (int i_seg = 0; i_seg < segment_num; i_seg++)
+    for (const auto& curr_segment : regions_in[i_reg])
     {
-      int curr_segment = regions_in[i_reg][i_seg];
       int nghbr_number = static_cast<int> (segment_neighbours_[curr_segment].size ());
       std::pair<float, int> pair;
       for (int i_nghbr = 0; i_nghbr < nghbr_number; i_nghbr++)
@@ -571,10 +565,8 @@ pcl::RegionGrowingRGB<PointT, NormalT>::assembleRegions (std::vector<unsigned in
 
   std::vector<int> counter;
   counter.resize (num_regions, 0);
-  int point_number = static_cast<int> (indices_->size ());
-  for (int i_point = 0; i_point < point_number; i_point++)
+  for (const auto& point_index : (*indices_))
   {
-    int point_index = (*indices_)[i_point];
     int index = point_labels_[point_index];
     index = segment_labels_[index];
     clusters_[index].indices[ counter[index] ] = point_index;
@@ -735,22 +727,15 @@ pcl::RegionGrowingRGB<PointT, NormalT>::getSegmentFromPoint (pcl::index_t index,
     }
     // if we have already made the segmentation, then find the segment
     // to which this point belongs
-    for (auto i_segment = clusters_.cbegin (); i_segment != clusters_.cend (); i_segment++)
+    for (const auto& i_segment : clusters_)
     {
-      bool segment_was_found = false;
-      for (std::size_t i_point = 0; i_point < i_segment->indices.size (); i_point++)
+      const auto it = std::find (i_segment.indices.cbegin (), i_segment_indices.cend (), index);
+      if (it != i_segment_indices.cend())
       {
-        if (i_segment->indices[i_point] == index)
-        {
-          segment_was_found = true;
-          cluster.indices.clear ();
-          cluster.indices.reserve (i_segment->indices.size ());
-          std::copy (i_segment->indices.begin (), i_segment->indices.end (), std::back_inserter (cluster.indices));
-          break;
-        }
-      }
-      if (segment_was_found)
-      {
+        // if segment was found
+        cluster.indices.clear ();
+        cluster.indices.reserve (i_segment.indices.size ());
+        std::copy (i_segment.indices.begin (), i_segment.indices.end (), std::back_inserter (cluster.indices));
         break;
       }
     }// next segment

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -174,24 +174,18 @@ pcl::UnaryClassifier<PointT>::getCloudWithLabel (typename pcl::PointCloud<PointT
   // find the 'label' field index
   std::vector <pcl::PCLPointField> fields;
   int label_idx = -1;
-  pcl::PointCloud <PointT> point;
   label_idx = pcl::getFieldIndex<PointT> ("label", fields);
 
   if (label_idx != -1)
   {
-    for (std::size_t i = 0; i < in->size (); i++)
+    for (auto& point : (*in))
     {
       // get the 'label' field                                                                       
       std::uint32_t label;
-      memcpy (&label, reinterpret_cast<char*> (&(*in)[i]) + fields[label_idx].offset, sizeof(std::uint32_t));
+      memcpy (&label, reinterpret_cast<char*> (&point) + fields[label_idx].offset, sizeof(std::uint32_t));
 
       if (static_cast<int> (label) == label_num)
       {
-        pcl::PointXYZ point;
-        // X Y Z
-        point.x = (*in)[i].x;
-        point.y = (*in)[i].y;
-        point.z = (*in)[i].z;
         out->points.push_back (point);
       }
     }

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -186,7 +186,12 @@ pcl::UnaryClassifier<PointT>::getCloudWithLabel (typename pcl::PointCloud<PointT
 
       if (static_cast<int> (label) == label_num)
       {
-        out->points.push_back (point);
+        pcl::PointXYZ tmp;
+        // X Y Z
+        tmp.x = point.x;
+        tmp.y = point.y;
+        tmp.z = point.z;
+        out->points.push_back (tmp);
       }
     }
     out->width = out->size ();


### PR DESCRIPTION
* use range-based for with const auto reference to gain more performance
* use `std::find` to improve code readability, solved issue in https://github.com/PointCloudLibrary/pcl/pull/4599#discussion_r572713567

The changes are only in `segmentation` directory, as a small piece of modernization work. I'd be glad to continue working on this PR if needed. :grinning: 