### PR TITLE
[gpu] Add ability to download contiguous chunk of memory to host using `Device{Array,Memory}`

### DIFF
--- a/gpu/containers/include/pcl/gpu/containers/device_array.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_array.h
@@ -41,6 +41,7 @@
 
 #include <vector>
 
+<<<<<<< HEAD
 namespace pcl {
 namespace gpu {
 //////////////////////////////////////////////////////////////////////////////
@@ -115,14 +116,14 @@ public:
 
   /** \brief Downloads data from internal buffer to CPU memory.
    * Returns false if device_offset < device_begin_offset
+   * \param host_ptr pointer to buffer to download
    * \param device_begin_offset begin download location
    * \param device_end_offset end download location
-   * \param host_ptr pointer to buffer to download
    * */
   bool
-  download(std::size_t device_begin_offset,
-           std::size_t device_end_offset,
-           T* host_ptr) const;
+  download(T* host_ptr,
+           std::size_t device_begin_offset,
+           std::size_t device_end_offset) const;
 
   /** \brief Uploads data to internal buffer in GPU memory. It calls create() inside to
    * ensure that intenal buffer size is enough.

--- a/gpu/containers/include/pcl/gpu/containers/device_array.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_array.h
@@ -108,15 +108,15 @@ public:
   upload(const T* host_ptr, std::size_t size);
 
   /** \brief Uploads data from CPU memory to internal buffer.
-   * Returns false if device_begin_offset + num_elements > size of array
-   * Please noote that in contrast to the other upload function, this function
+   * \return true if upload successful
+   * \note In contrast to the other upload function, this function
    * never allocates memory.
    * \param host_ptr pointer to buffer to upload
    * \param device_begin_offset begin upload
    * \param num_elements number of elements from device_bein_offset
    * */
   bool
-  upload(T* host_ptr, std::size_t device_begin_offset, std::size_t num_elements);
+  upload(const T* host_ptr, std::size_t device_begin_offset, std::size_t num_elements);
 
   /** \brief Downloads data from internal buffer to CPU memory
    * \param host_ptr pointer to buffer to download
@@ -124,9 +124,8 @@ public:
   void
   download(T* host_ptr) const;
 
-
   /** \brief Downloads data from internal buffer to CPU memory.
-   * Returns false if device_begin_offset + num_elements > size of array
+   * \return true if download successful
    * \param host_ptr pointer to buffer to download
    * \param device_begin_offset begin download location
    * \param num_elements number of elements from device_begin_offset

--- a/gpu/containers/include/pcl/gpu/containers/device_array.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_array.h
@@ -41,7 +41,6 @@
 
 #include <vector>
 
-<<<<<<< HEAD
 namespace pcl {
 namespace gpu {
 //////////////////////////////////////////////////////////////////////////////
@@ -108,9 +107,19 @@ public:
   void
   upload(const T* host_ptr, std::size_t size);
 
+  /** \brief Uploads data from CPU memory to internal buffer.
+   * Returns false if device_offset < device_begin_offset
+   * \param host_ptr pointer to buffer to upload
+   * \param device_begin_offset begin upload
+   * \param device_end_offset end upload
+   * */
+  bool
+  upload(T* host_ptr, std::size_t device_begin_offset, std::size_t device_end_offset);
+
   /** \brief Downloads data from internal buffer to CPU memory
    * \param host_ptr pointer to buffer to download
    * */
+
   void
   download(T* host_ptr) const;
 
@@ -120,6 +129,7 @@ public:
    * \param device_begin_offset begin download location
    * \param device_end_offset end download location
    * */
+
   bool
   download(T* host_ptr,
            std::size_t device_begin_offset,

--- a/gpu/containers/include/pcl/gpu/containers/device_array.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_array.h
@@ -108,32 +108,33 @@ public:
   upload(const T* host_ptr, std::size_t size);
 
   /** \brief Uploads data from CPU memory to internal buffer.
-   * Returns false if device_offset < device_begin_offset
+   * Returns false if device_begin_offset + num_elements > size of array
+   * Please noote that in contrast to the other upload function, this function
+   * never allocates memory.
    * \param host_ptr pointer to buffer to upload
    * \param device_begin_offset begin upload
-   * \param device_end_offset end upload
+   * \param num_elements number of elements from device_bein_offset
    * */
   bool
-  upload(T* host_ptr, std::size_t device_begin_offset, std::size_t device_end_offset);
+  upload(T* host_ptr, std::size_t device_begin_offset, std::size_t num_elements);
 
   /** \brief Downloads data from internal buffer to CPU memory
    * \param host_ptr pointer to buffer to download
    * */
-
   void
   download(T* host_ptr) const;
 
+
   /** \brief Downloads data from internal buffer to CPU memory.
-   * Returns false if device_offset < device_begin_offset
+   * Returns false if device_begin_offset + num_elements > size of array
    * \param host_ptr pointer to buffer to download
    * \param device_begin_offset begin download location
-   * \param device_end_offset end download location
+   * \param num_elements number of elements from device_begin_offset
    * */
-
   bool
   download(T* host_ptr,
            std::size_t device_begin_offset,
-           std::size_t device_end_offset) const;
+           std::size_t num_elements) const;
 
   /** \brief Uploads data to internal buffer in GPU memory. It calls create() inside to
    * ensure that intenal buffer size is enough.

--- a/gpu/containers/include/pcl/gpu/containers/device_array.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_array.h
@@ -113,6 +113,17 @@ public:
   void
   download(T* host_ptr) const;
 
+  /** \brief Downloads data from internal buffer to CPU memory.
+   * Returns false if device_offset < device_begin_offset
+   * \param device_begin_offset begin download location
+   * \param device_end_offset end download location
+   * \param host_ptr pointer to buffer to download
+   * */
+  bool
+  download(std::size_t device_begin_offset,
+           std::size_t device_end_offset,
+           T* host_ptr) const;
+
   /** \brief Uploads data to internal buffer in GPU memory. It calls create() inside to
    * ensure that intenal buffer size is enough.
    * \param data host vector to upload from

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -108,6 +108,14 @@ public:
   void
   download(void* host_ptr_arg) const;
 
+  /** \brief Downloads data from internal buffer to CPU memory.
+   * \param host_ptr_arg pointer to buffer to download
+   * \param begin pointer to buffer location
+   * \param nbytes number of bytes to download from begin
+   * */
+  void
+  download(void* host_ptr, void* begin, std::size_t nbytes) const;
+
   /** \brief Performs swap of data pointed with another device memory.
    * \param other_arg device memory to swap with
    * */

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -102,6 +102,17 @@ public:
   void
   upload(const void* host_ptr_arg, std::size_t sizeBytes_arg);
 
+  /** \brief Uploads data from CPU memory to device array
+   * Returns true if upload successfull
+   * \param host_ptr_arg pointer to buffer to upload
+   * \param device_begin_byte_offset first byte position to upload to
+   * \param device_end_byte_offset last byte position to upload to
+   * */
+  bool
+  upload(void* host_ptr,
+         std::size_t device_begin_byte_offset,
+         std::size_t device_end_byte_offset);
+
   /** \brief Downloads data from internal buffer to CPU memory
    * \param host_ptr_arg pointer to buffer to download
    * */

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -109,9 +109,10 @@ public:
   download(void* host_ptr_arg) const;
 
   /** \brief Downloads data from internal buffer to CPU memory.
+   * Returns true if download successfull
    * \param host_ptr_arg pointer to buffer to download
-   * \param begin pointer to buffer location
-   * \param nbytes number of bytes to download from begin
+   * \param device_begin_byte_offset first byte position to download
+   * \param device_end_byte_offset last byte position to download
    * */
   bool
   download(void* host_ptr,

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -102,16 +102,18 @@ public:
   void
   upload(const void* host_ptr_arg, std::size_t sizeBytes_arg);
 
-  /** \brief Uploads data from CPU memory to device array. Please note
-   * that this overload never allocates memory in contrast to the
+  /** \brief Uploads data from CPU memory to device array.
+   * \note This overload never allocates memory in contrast to the
    * other upload function.
-   * Returns true if upload successfull
+   * \return true if upload successful
    * \param host_ptr_arg pointer to buffer to upload
    * \param device_begin_byte_offset first byte position to upload to
    * \param num_bytes number of bytes to upload
    * */
   bool
-  upload(void* host_ptr, std::size_t device_begin_byte_offset, std::size_t num_bytes);
+  upload(const void* host_ptr,
+         std::size_t device_begin_byte_offset,
+         std::size_t num_bytes);
 
   /** \brief Downloads data from internal buffer to CPU memory
    * \param host_ptr_arg pointer to buffer to download
@@ -120,7 +122,7 @@ public:
   download(void* host_ptr_arg) const;
 
   /** \brief Downloads data from internal buffer to CPU memory.
-   * Returns true if download successfull
+   * \return true if download successful
    * \param host_ptr_arg pointer to buffer to download
    * \param device_begin_byte_offset first byte position to download
    * \param num_bytes number of bytes to download

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -114,7 +114,7 @@ public:
    * \param nbytes number of bytes to download from begin
    * */
   void
-  download(void* host_ptr, void* begin, std::size_t nbytes) const;
+  download(void* host_ptr, const void* const begin, std::size_t nbytes) const;
 
   /** \brief Performs swap of data pointed with another device memory.
    * \param other_arg device memory to swap with

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -102,16 +102,16 @@ public:
   void
   upload(const void* host_ptr_arg, std::size_t sizeBytes_arg);
 
-  /** \brief Uploads data from CPU memory to device array
+  /** \brief Uploads data from CPU memory to device array. Please note
+   * that this overload never allocates memory in contrast to the
+   * other upload function.
    * Returns true if upload successfull
    * \param host_ptr_arg pointer to buffer to upload
    * \param device_begin_byte_offset first byte position to upload to
-   * \param device_end_byte_offset last byte position to upload to
+   * \param num_bytes number of bytes to upload
    * */
   bool
-  upload(void* host_ptr,
-         std::size_t device_begin_byte_offset,
-         std::size_t device_end_byte_offset);
+  upload(void* host_ptr, std::size_t device_begin_byte_offset, std::size_t num_bytes);
 
   /** \brief Downloads data from internal buffer to CPU memory
    * \param host_ptr_arg pointer to buffer to download
@@ -123,12 +123,12 @@ public:
    * Returns true if download successfull
    * \param host_ptr_arg pointer to buffer to download
    * \param device_begin_byte_offset first byte position to download
-   * \param device_end_byte_offset last byte position to download
+   * \param num_bytes number of bytes to download
    * */
   bool
   download(void* host_ptr,
            std::size_t device_begin_byte_offset,
-           std::size_t device_end_byte_offset) const;
+           std::size_t num_bytes) const;
 
   /** \brief Performs swap of data pointed with another device memory.
    * \param other_arg device memory to swap with

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -113,8 +113,10 @@ public:
    * \param begin pointer to buffer location
    * \param nbytes number of bytes to download from begin
    * */
-  void
-  download(void* host_ptr, const void* const begin, std::size_t nbytes) const;
+  bool
+  download(void* host_ptr,
+           std::size_t device_begin_byte_offset,
+           std::size_t device_end_byte_offset) const;
 
   /** \brief Performs swap of data pointed with another device memory.
    * \param other_arg device memory to swap with

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -105,16 +105,15 @@ DeviceArray<T>::download(T* host_ptr) const
 
 template <class T>
 inline bool
-DeviceArray<T>::download(std::size_t device_begin_offset,
-                         std::size_t device_end_offset,
-                         T* host_ptr) const
+DeviceArray<T>::download(T* host_ptr,
+                         std::size_t device_begin_offset,
+                         std::size_t device_end_offset) const
 {
   if (device_end_offset < device_begin_offset) {
     return false;
   }
-  T* begin = device_begin_offset * elem_size;
-  T* end = device_end_offset * elem_size;
-  std::size_t bytes = end - begin;
+  const T* begin = ptr() + device_begin_offset;
+  std::size_t bytes = (device_end_offset - device_begin_offset) * elem_size;
   DeviceMemory::download(host_ptr, begin, bytes);
   return true;
 }

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -98,7 +98,7 @@ DeviceArray<T>::upload(const T* host_ptr, std::size_t size)
 
 template <class T>
 inline bool
-DeviceArray<T>::upload(T* host_ptr,
+DeviceArray<T>::upload(const T* host_ptr,
                        std::size_t device_begin_offset,
                        std::size_t num_elements)
 {

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -109,15 +109,9 @@ DeviceArray<T>::download(T* host_ptr,
                          std::size_t device_begin_offset,
                          std::size_t device_end_offset) const
 {
-  //if (device_end_offset < device_begin_offset) {
-    //return false;
-  //}
-  //const T* begin = ptr() + device_begin_offset;
-  std::size_t device_begin_byte_offset = device_begin_offset * sizeof(T);
-  std::size_t device_end_byte_offset = device_end_offset * sizeof(T);
-  //std::size_t bytes = (device_end_offset - device_begin_offset) * elem_size;
-  return DeviceMemory::download(host_ptr, device_begin_byte_offset, device_end_byte_offset);
-  //return true;
+  std::size_t begin_byte_offset = device_begin_offset * sizeof(T);
+  std::size_t end_byte_offset = device_end_offset * sizeof(T);
+  return DeviceMemory::download(host_ptr, begin_byte_offset, end_byte_offset);
 }
 
 template <class T>

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -104,6 +104,22 @@ DeviceArray<T>::download(T* host_ptr) const
 }
 
 template <class T>
+inline bool
+DeviceArray<T>::download(std::size_t device_begin_offset,
+                         std::size_t device_end_offset,
+                         T* host_ptr) const
+{
+  if (device_end_offset < device_begin_offset) {
+    return false;
+  }
+  T* begin = device_begin_offset * elem_size;
+  T* end = device_end_offset * elem_size;
+  std::size_t bytes = end - begin;
+  DeviceMemory::download(host_ptr, begin, bytes);
+  return true;
+}
+
+template <class T>
 void
 DeviceArray<T>::swap(DeviceArray& other_arg)
 {

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -100,11 +100,11 @@ template <class T>
 inline bool
 DeviceArray<T>::upload(T* host_ptr,
                        std::size_t device_begin_offset,
-                       std::size_t device_end_offset)
+                       std::size_t num_elements)
 {
   std::size_t begin_byte_offset = device_begin_offset * sizeof(T);
-  std::size_t end_byte_offset = device_end_offset * sizeof(T);
-  return DeviceMemory::upload(host_ptr, begin_byte_offset, end_byte_offset);
+  std::size_t num_bytes = num_elements * sizeof(T);
+  return DeviceMemory::upload(host_ptr, begin_byte_offset, num_bytes);
 }
 
 template <class T>
@@ -118,11 +118,11 @@ template <class T>
 inline bool
 DeviceArray<T>::download(T* host_ptr,
                          std::size_t device_begin_offset,
-                         std::size_t device_end_offset) const
+                         std::size_t num_elements) const
 {
   std::size_t begin_byte_offset = device_begin_offset * sizeof(T);
-  std::size_t end_byte_offset = device_end_offset * sizeof(T);
-  return DeviceMemory::download(host_ptr, begin_byte_offset, end_byte_offset);
+  std::size_t num_bytes = num_elements * sizeof(T);
+  return DeviceMemory::download(host_ptr, begin_byte_offset, num_bytes);
 }
 
 template <class T>

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -97,6 +97,17 @@ DeviceArray<T>::upload(const T* host_ptr, std::size_t size)
 }
 
 template <class T>
+inline bool
+DeviceArray<T>::upload(T* host_ptr,
+                       std::size_t device_begin_offset,
+                       std::size_t device_end_offset)
+{
+  std::size_t begin_byte_offset = device_begin_offset * sizeof(T);
+  std::size_t end_byte_offset = device_end_offset * sizeof(T);
+  return DeviceMemory::upload(host_ptr, begin_byte_offset, end_byte_offset);
+}
+
+template <class T>
 inline void
 DeviceArray<T>::download(T* host_ptr) const
 {

--- a/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
+++ b/gpu/containers/include/pcl/gpu/containers/impl/device_array.hpp
@@ -109,13 +109,15 @@ DeviceArray<T>::download(T* host_ptr,
                          std::size_t device_begin_offset,
                          std::size_t device_end_offset) const
 {
-  if (device_end_offset < device_begin_offset) {
-    return false;
-  }
-  const T* begin = ptr() + device_begin_offset;
-  std::size_t bytes = (device_end_offset - device_begin_offset) * elem_size;
-  DeviceMemory::download(host_ptr, begin, bytes);
-  return true;
+  //if (device_end_offset < device_begin_offset) {
+    //return false;
+  //}
+  //const T* begin = ptr() + device_begin_offset;
+  std::size_t device_begin_byte_offset = device_begin_offset * sizeof(T);
+  std::size_t device_end_byte_offset = device_end_offset * sizeof(T);
+  //std::size_t bytes = (device_end_offset - device_begin_offset) * elem_size;
+  return DeviceMemory::download(host_ptr, device_begin_byte_offset, device_end_byte_offset);
+  //return true;
 }
 
 template <class T>

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -292,14 +292,13 @@ pcl::gpu::DeviceMemory::download(void* host_ptr_arg) const
 bool
 pcl::gpu::DeviceMemory::download(void* host_ptr_arg,
                                  std::size_t device_begin_byte_offset,
-                                 std::size_t device_end_byte_offset) const 
+                                 std::size_t device_end_byte_offset) const
 {
   if (device_end_byte_offset < device_begin_byte_offset) {
-      return false;
+    return false;
   }
   const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
   std::size_t bytes = device_end_byte_offset - device_begin_byte_offset;
-  //const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
   cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, bytes, cudaMemcpyDeviceToHost));
   cudaSafeCall(cudaDeviceSynchronize());
   return true;

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -290,6 +290,15 @@ pcl::gpu::DeviceMemory::download(void* host_ptr_arg) const
 }
 
 void
+pcl::gpu::DeviceMemory::download(void* host_ptr_arg,
+                                 void* begin,
+                                 std::size_t bytes) const
+{
+  cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, bytes, cudaMemcpyDeviceToHost));
+  cudaSafeCall(cudaDeviceSynchronize());
+}
+
+void
 pcl::gpu::DeviceMemory::swap(DeviceMemory& other_arg)
 {
   std::swap(data_, other_arg.data_);

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -291,7 +291,7 @@ pcl::gpu::DeviceMemory::download(void* host_ptr_arg) const
 
 void
 pcl::gpu::DeviceMemory::download(void* host_ptr_arg,
-                                 void* begin,
+                                 const void* const begin,
                                  std::size_t bytes) const
 {
   cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, bytes, cudaMemcpyDeviceToHost));

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -282,6 +282,21 @@ pcl::gpu::DeviceMemory::upload(const void* host_ptr_arg, std::size_t sizeBytes_a
   cudaSafeCall(cudaDeviceSynchronize());
 }
 
+bool
+pcl::gpu::DeviceMemory::upload(void* host_ptr_arg,
+                               std::size_t device_begin_byte_offset,
+                               std::size_t device_end_byte_offset)
+{
+  if (device_end_byte_offset < device_begin_byte_offset) {
+    return false;
+  }
+  const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
+  std::size_t bytes = device_end_byte_offset - device_begin_byte_offset;
+  cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, bytes, cudaMemcpyHostToDevice));
+  cudaSafeCall(cudaDeviceSynchronize());
+  return true;
+}
+
 void
 pcl::gpu::DeviceMemory::download(void* host_ptr_arg) const
 {

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -283,17 +283,15 @@ pcl::gpu::DeviceMemory::upload(const void* host_ptr_arg, std::size_t sizeBytes_a
 }
 
 bool
-pcl::gpu::DeviceMemory::upload(void* host_ptr_arg,
+pcl::gpu::DeviceMemory::upload(const void* host_ptr_arg,
                                std::size_t device_begin_byte_offset,
                                std::size_t num_bytes)
 {
-  const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
-  const char* const upload_end = static_cast<const char*>(begin) + num_bytes;
-  const char* const array_end = static_cast<char*>(data_) + sizeBytes_;
-  if (upload_end > array_end) {
+  if (device_begin_byte_offset + num_bytes > sizeBytes_) {
       return false;
   }
-  cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, num_bytes, cudaMemcpyHostToDevice));
+  void* begin = static_cast<char*>(data_) + device_begin_byte_offset;
+  cudaSafeCall(cudaMemcpy(begin, host_ptr_arg, num_bytes, cudaMemcpyHostToDevice));
   cudaSafeCall(cudaDeviceSynchronize());
   return true;
 }
@@ -310,12 +308,10 @@ pcl::gpu::DeviceMemory::download(void* host_ptr_arg,
                                  std::size_t device_begin_byte_offset,
                                  std::size_t num_bytes) const
 {
-  const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
-  const char* const download_end = static_cast<const char*>(begin) + num_bytes;
-  const char* const array_end = static_cast<char*>(data_) + sizeBytes_;
-  if (download_end > array_end) {
+  if (device_begin_byte_offset + num_bytes > sizeBytes_) {
       return false;
   }
+  const void* begin = static_cast<char*>(data_) + device_begin_byte_offset;
   cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, num_bytes, cudaMemcpyDeviceToHost));
   cudaSafeCall(cudaDeviceSynchronize());
   return true;

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -285,14 +285,15 @@ pcl::gpu::DeviceMemory::upload(const void* host_ptr_arg, std::size_t sizeBytes_a
 bool
 pcl::gpu::DeviceMemory::upload(void* host_ptr_arg,
                                std::size_t device_begin_byte_offset,
-                               std::size_t device_end_byte_offset)
+                               std::size_t num_bytes)
 {
-  if (device_end_byte_offset < device_begin_byte_offset) {
-    return false;
-  }
   const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
-  std::size_t bytes = device_end_byte_offset - device_begin_byte_offset;
-  cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, bytes, cudaMemcpyHostToDevice));
+  const char* const upload_end = static_cast<const char*>(begin) + num_bytes;
+  const char* const array_end = static_cast<char*>(data_) + sizeBytes_;
+  if (upload_end > array_end) {
+      return false;
+  }
+  cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, num_bytes, cudaMemcpyHostToDevice));
   cudaSafeCall(cudaDeviceSynchronize());
   return true;
 }
@@ -307,14 +308,15 @@ pcl::gpu::DeviceMemory::download(void* host_ptr_arg) const
 bool
 pcl::gpu::DeviceMemory::download(void* host_ptr_arg,
                                  std::size_t device_begin_byte_offset,
-                                 std::size_t device_end_byte_offset) const
+                                 std::size_t num_bytes) const
 {
-  if (device_end_byte_offset < device_begin_byte_offset) {
-    return false;
-  }
   const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
-  std::size_t bytes = device_end_byte_offset - device_begin_byte_offset;
-  cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, bytes, cudaMemcpyDeviceToHost));
+  const char* const download_end = static_cast<const char*>(begin) + num_bytes;
+  const char* const array_end = static_cast<char*>(data_) + sizeBytes_;
+  if (download_end > array_end) {
+      return false;
+  }
+  cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, num_bytes, cudaMemcpyDeviceToHost));
   cudaSafeCall(cudaDeviceSynchronize());
   return true;
 }

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -288,7 +288,7 @@ pcl::gpu::DeviceMemory::upload(const void* host_ptr_arg,
                                std::size_t num_bytes)
 {
   if (device_begin_byte_offset + num_bytes > sizeBytes_) {
-      return false;
+    return false;
   }
   void* begin = static_cast<char*>(data_) + device_begin_byte_offset;
   cudaSafeCall(cudaMemcpy(begin, host_ptr_arg, num_bytes, cudaMemcpyHostToDevice));
@@ -309,7 +309,7 @@ pcl::gpu::DeviceMemory::download(void* host_ptr_arg,
                                  std::size_t num_bytes) const
 {
   if (device_begin_byte_offset + num_bytes > sizeBytes_) {
-      return false;
+    return false;
   }
   const void* begin = static_cast<char*>(data_) + device_begin_byte_offset;
   cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, num_bytes, cudaMemcpyDeviceToHost));

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -289,13 +289,20 @@ pcl::gpu::DeviceMemory::download(void* host_ptr_arg) const
   cudaSafeCall(cudaDeviceSynchronize());
 }
 
-void
+bool
 pcl::gpu::DeviceMemory::download(void* host_ptr_arg,
-                                 const void* const begin,
-                                 std::size_t bytes) const
+                                 std::size_t device_begin_byte_offset,
+                                 std::size_t device_end_byte_offset) const 
 {
+  if (device_end_byte_offset < device_begin_byte_offset) {
+      return false;
+  }
+  const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
+  std::size_t bytes = device_end_byte_offset - device_begin_byte_offset;
+  //const void* const begin = static_cast<char*>(data_) + device_begin_byte_offset;
   cudaSafeCall(cudaMemcpy(host_ptr_arg, begin, bytes, cudaMemcpyDeviceToHost));
   cudaSafeCall(cudaDeviceSynchronize());
+  return true;
 }
 
 void

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -98,9 +98,6 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
     pcl::gpu::NeighborIndices result_device;
 
     // once the area stop growing, stop also iterating.
-    std::vector<int> sizes, data;
-    sizes.reserve(host_cloud_->size());
-    data.reserve(host_cloud_->size());
     do
     {
       // Host buffer for results

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -101,6 +101,7 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
     do
     {
       // Host buffer for results
+      std::vector<int> sizes, data;
 
       // if the number of queries is not high enough implement search on Host here
       if(queries_host.size () <= 10) ///@todo: adjust this to a variable number settable with method

--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -98,10 +98,12 @@ pcl::gpu::extractEuclideanClusters (const typename pcl::PointCloud<PointT>::Ptr 
     pcl::gpu::NeighborIndices result_device;
 
     // once the area stop growing, stop also iterating.
+    std::vector<int> sizes, data;
+    sizes.reserve(host_cloud_->size());
+    data.reserve(host_cloud_->size());
     do
     {
       // Host buffer for results
-      std::vector<int> sizes, data;
 
       // if the number of queries is not high enough implement search on Host here
       if(queries_host.size () <= 10) ///@todo: adjust this to a variable number settable with method


### PR DESCRIPTION
This commit tries to address  #4689, in line with the comments received in #4677. 

Users can now download an interval range of data from the device array to the host instead of downloading the entire device array. This provides users with greater flexibility when interacting with the device array, potentially speeds up host-device communication, and pushes CUDA details into the device array implementation. 

If there is interest for it, we can additionally implement the resize functionality for the device array, as outlines in #4689 . 

Should I change the PR in some way? I am grateful for any comments or suggestions! 