### PR TITLE
Fix `PolygonMesh::concatenate` and its unit test

### DIFF
--- a/common/include/pcl/PolygonMesh.h
+++ b/common/include/pcl/PolygonMesh.h
@@ -30,6 +30,8 @@ namespace pcl
     static bool
     concatenate (pcl::PolygonMesh &mesh1, const pcl::PolygonMesh &mesh2)
     {
+      const auto point_offset = mesh1.cloud.width * mesh1.cloud.height;
+      
       bool success = pcl::PCLPointCloud2::concatenate(mesh1.cloud, mesh2.cloud);
       if (success == false) {
         return false;
@@ -37,7 +39,6 @@ namespace pcl
       // Make the resultant polygon mesh take the newest stamp
       mesh1.header.stamp = std::max(mesh1.header.stamp, mesh2.header.stamp);
 
-      const auto point_offset = mesh1.cloud.width * mesh1.cloud.height;
       std::transform(mesh2.polygons.begin (),
                      mesh2.polygons.end (),
                      std::back_inserter (mesh1.polygons),

--- a/test/common/test_polygon_mesh.cpp
+++ b/test/common/test_polygon_mesh.cpp
@@ -119,10 +119,9 @@ TEST(PolygonMesh, concatenate_vertices)
 
     pcl::Indices vertices(size);
     for (std::size_t i = 0; i < size; ++i) {
-        vertices.assign(dummy.polygons[i].vertices.cbegin(),
-                        dummy.polygons[i].vertices.cend());
+        vertices = dummy.polygons[i].vertices;
         EXPECT_EQ_VECTORS(vertices, test.polygons[i].vertices);
-        for (auto& vertex : vertices) vertex += size;
+        for (auto& vertex : vertices) { vertex += size; }
         EXPECT_EQ_VECTORS(vertices, test.polygons[i + size].vertices);
     }
 }

--- a/test/common/test_polygon_mesh.cpp
+++ b/test/common/test_polygon_mesh.cpp
@@ -116,12 +116,11 @@ TEST(PolygonMesh, concatenate_vertices)
       for (const auto& vertex : polygon.vertices)
         EXPECT_LT(vertex, cloud_size);
 
-    auto offsetter = [&size](const pcl::index_t& v) { return v + size; };
     for (std::size_t i = 0; i < size; ++i) {
-        auto& v1 = dummy.polygons[i].vertices;
-        EXPECT_EQ_VECTORS(v1, test.polygons[i].vertices);
-        std::transform(v1.begin(), v1.end(), v1.begin(), offsetter);
-        EXPECT_EQ_VECTORS(v1, test.polygons[i + size].vertices);
+        auto& vertices = dummy.polygons[i].vertices;
+        EXPECT_EQ_VECTORS(vertices, test.polygons[i].vertices);
+        for (auto& vertex : vertices) vertex += size;
+        EXPECT_EQ_VECTORS(vertices, test.polygons[i + size].vertices);
     }
 }
 

--- a/test/common/test_polygon_mesh.cpp
+++ b/test/common/test_polygon_mesh.cpp
@@ -94,6 +94,7 @@ TEST(PolygonMesh, concatenate_vertices)
     const std::size_t size = 15;
 
     PolygonMesh test, dummy;
+    // The algorithm works regardless of the organization.
     test.cloud.width = dummy.cloud.width = size;
     test.cloud.height = dummy.cloud.height = 1;
 
@@ -117,8 +118,10 @@ TEST(PolygonMesh, concatenate_vertices)
         EXPECT_LT(vertex, cloud_size);
 
     for (std::size_t i = 0; i < size; ++i) {
-        auto& vertices = dummy.polygons[i].vertices;
+        // This copy is intended for further modification.
+        pcl::Indices vertices{dummy.polygons[i].vertices};
         EXPECT_EQ_VECTORS(vertices, test.polygons[i].vertices);
+        // The vertex identifiers must be shifted correctly.
         for (auto& vertex : vertices) vertex += size;
         EXPECT_EQ_VECTORS(vertices, test.polygons[i + size].vertices);
     }

--- a/test/common/test_polygon_mesh.cpp
+++ b/test/common/test_polygon_mesh.cpp
@@ -112,20 +112,16 @@ TEST(PolygonMesh, concatenate_vertices)
     EXPECT_EQ(2 * dummy.polygons.size(), test.polygons.size());
 
     const auto cloud_size = test.cloud.width * test.cloud.height;
-    for (std::size_t i = 0; i < dummy.polygons.size(); ++i)
-    {
-        EXPECT_EQ(dummy.polygons[i].vertices.size(), test.polygons[i].vertices.size());
-        EXPECT_EQ(dummy.polygons[i].vertices.size(),
-                  test.polygons[i + dummy.polygons.size()].vertices.size());
-        for (std::size_t j = 0; j < size; ++j)
-        {
-            EXPECT_EQ(dummy.polygons[i].vertices[j],
-                      test.polygons[i].vertices[j]);
-            EXPECT_EQ(dummy.polygons[i].vertices[j] + size,
-                      test.polygons[i + dummy.polygons.size()].vertices[j]);
-            EXPECT_LT(test.polygons[i].vertices[j], cloud_size);
-            EXPECT_LT(test.polygons[i + dummy.polygons.size()].vertices[j], cloud_size);
-        }
+    for (const auto& polygon : test.polygons)
+      for (const auto& vertex : polygon.vertices)
+        EXPECT_LT(vertex, cloud_size);
+
+    auto offsetter = [&size](const pcl::index_t& v) { return v + size; };
+    for (std::size_t i = 0; i < size; ++i) {
+        auto& v1 = dummy.polygons[i].vertices;
+        EXPECT_EQ_VECTORS(v1, test.polygons[i].vertices);
+        std::transform(v1.begin(), v1.end(), v1.begin(), offsetter);
+        EXPECT_EQ_VECTORS(v1, test.polygons[i + size].vertices);
     }
 }
 

--- a/test/common/test_polygon_mesh.cpp
+++ b/test/common/test_polygon_mesh.cpp
@@ -91,11 +91,12 @@ TEST(PolygonMesh, concatenate_cloud)
 
 TEST(PolygonMesh, concatenate_vertices)
 {
-    PolygonMesh test, dummy;
-    test.cloud.width = 10;
-    test.cloud.height = 5;
-
     const std::size_t size = 15;
+
+    PolygonMesh test, dummy;
+    test.cloud.width = dummy.cloud.width = size;
+    test.cloud.height = dummy.cloud.height = 1;
+
     for (std::size_t i = 0; i < size; ++i)
     {
         dummy.polygons.emplace_back();
@@ -120,8 +121,10 @@ TEST(PolygonMesh, concatenate_vertices)
         {
             EXPECT_EQ(dummy.polygons[i].vertices[j],
                       test.polygons[i].vertices[j]);
-            EXPECT_EQ(dummy.polygons[i].vertices[j] + cloud_size,
+            EXPECT_EQ(dummy.polygons[i].vertices[j] + size,
                       test.polygons[i + dummy.polygons.size()].vertices[j]);
+            EXPECT_LT(test.polygons[i].vertices[j], cloud_size);
+            EXPECT_LT(test.polygons[i + dummy.polygons.size()].vertices[j], cloud_size);
         }
     }
 }

--- a/test/common/test_polygon_mesh.cpp
+++ b/test/common/test_polygon_mesh.cpp
@@ -117,11 +117,11 @@ TEST(PolygonMesh, concatenate_vertices)
       for (const auto& vertex : polygon.vertices)
         EXPECT_LT(vertex, cloud_size);
 
+    pcl::Indices vertices(size);
     for (std::size_t i = 0; i < size; ++i) {
-        // This copy is intended for further modification.
-        pcl::Indices vertices{dummy.polygons[i].vertices};
+        vertices.assign(dummy.polygons[i].vertices.cbegin(),
+                        dummy.polygons[i].vertices.cend());
         EXPECT_EQ_VECTORS(vertices, test.polygons[i].vertices);
-        // The vertex identifiers must be shifted correctly.
         for (auto& vertex : vertices) vertex += size;
         EXPECT_EQ_VECTORS(vertices, test.polygons[i + size].vertices);
     }


### PR DESCRIPTION
It is an addendum to and closes #4572.

Please also refer to the issue #4743.