### PR TITLE
[CloudComposer] Remove duplicated definition of QT_NO_DEBUG

### DIFF
--- a/apps/cloud_composer/ComposerTool.cmake
+++ b/apps/cloud_composer/ComposerTool.cmake
@@ -16,7 +16,6 @@ function(define_composer_tool TOOL_NAME TOOL_SOURCES TOOL_HEADERS DEPS)
   endif()
   add_definitions(${QT_DEFINITIONS})
   add_definitions(-DQT_PLUGIN)
-  target_compile_definitions(${TOOL_TARGET} PUBLIC $<$<CONFIG:Release>:-DQT_NO_DEBUG>)
   add_definitions(-DQT_SHARED)
 
   target_link_libraries(${TOOL_TARGET} pcl_cc_tool_interface pcl_common pcl_io ${DEPS} Qt5::Widgets)


### PR DESCRIPTION
Remove definition of QT_NO_DEBUG as it will be automatically set [since Qt 5.1.1](https://github.com/qt/qtbase/commit/af23200d1a8d9e062a39d1c6b678fde18bf6c170). I don't increase minimum require version of Qt as I currently don't know if we till support such old versions of Qt (and I don't believe someone still have Qt 5.0) and this line only affects debug build.

I don't know why I can't reproduce this issue on my Linux VM but with the Docker image on our build server I get:
With GCC:
```
[ 46%] Building CXX object apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/tools/fpfh_estimation.cpp.o
<command-line>: error: macro names must be identifiers
make[2]: *** [apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/build.make:67: apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/tools/fpfh_estimation.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:5496: apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

Clang:
```
[ 46%] Building CXX object apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/tools/fpfh_estimation.cpp.o
In file included from <built-in>:383:
<command line>:1:9: error: macro name must be an identifier
#define -DQT_NO_DEBUG 1
        ^
1 error generated.
make[2]: *** [apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/build.make:67: apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/tools/fpfh_estimation.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:5496: apps/cloud_composer/CMakeFiles/pcl_cc_tool_fpfh_estimation.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

Reason for this issue is the `-D`. Correct would be:
```
target_compile_definitions(${TOOL_TARGET} PUBLIC $<$<CONFIG:Release>:QT_NO_DEBUG>)
```
Seems this is an issue within of CMake as `Any leading -D on an item will be removed.` seems not to work with generator expressions. 