### PR TITLE
Use more pcl::Indices

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/feature_wrapper/normal_estimator.h
@@ -32,7 +32,6 @@ class PreProcessorAndNormalEstimator {
 
     pcl::Indices nn_indices(9);
     std::vector<float> nn_distances(9);
-    std::vector<int> src_indices;
 
     float sum_distances = 0.0;
     std::vector<float> avg_distances(input->size());

--- a/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
+++ b/apps/cloud_composer/include/pcl/apps/cloud_composer/tools/impl/organized_segmentation.hpp
@@ -122,7 +122,7 @@ pcl::cloud_composer::OrganizedSegmentationTool::performTemplatedAction (const QL
     euclidean_segmentation.setInputCloud (input_cloud);
     euclidean_segmentation.segment (euclidean_labels, euclidean_label_indices);
 
-    pcl::IndicesPtr extracted_indices (new std::vector<int> ());
+    pcl::IndicesPtr extracted_indices (new pcl::Indices ());
     for (std::size_t i = 0; i < euclidean_label_indices.size (); i++)
     {
       if (euclidean_label_indices[i].indices.size () >= (std::size_t) min_cluster_size)

--- a/apps/cloud_composer/tools/euclidean_clustering.cpp
+++ b/apps/cloud_composer/tools/euclidean_clustering.cpp
@@ -69,7 +69,7 @@ pcl::cloud_composer::EuclideanClusteringTool::performAction (ConstItemList input
       Eigen::Vector4f source_origin = input_item->data (ItemDataRole::ORIGIN).value<Eigen::Vector4f> ();
       Eigen::Quaternionf source_orientation =  input_item->data (ItemDataRole::ORIENTATION).value<Eigen::Quaternionf> ();
       //Vector to accumulate the extracted indices
-      pcl::IndicesPtr extracted_indices (new std::vector<int> ());
+      pcl::IndicesPtr extracted_indices (new pcl::Indices ());
       //Put found clusters into new cloud_items!
       qDebug () << "Found "<<cluster_indices.size ()<<" clusters!";
       int cluster_count = 0;

--- a/apps/modeler/src/cloud_mesh.cpp
+++ b/apps/modeler/src/cloud_mesh.cpp
@@ -174,7 +174,7 @@ pcl::modeler::CloudMesh::updateVtkPoints()
   }
   // Need to check for NaNs, Infs, ec
   else {
-    pcl::IndicesPtr indices(new std::vector<int>());
+    pcl::IndicesPtr indices(new pcl::Indices());
     pcl::removeNaNFromPointCloud(*cloud_, *indices);
 
     data->SetNumberOfValues(3 * indices->size());
@@ -203,7 +203,7 @@ pcl::modeler::CloudMesh::updateVtkPolygons()
     }
   }
   else {
-    pcl::IndicesPtr indices(new std::vector<int>());
+    pcl::IndicesPtr indices(new pcl::Indices());
     pcl::removeNaNFromPointCloud(*cloud_, *indices);
 
     for (const auto& polygon : polygons_) {

--- a/apps/modeler/src/normal_estimation_worker.cpp
+++ b/apps/modeler/src/normal_estimation_worker.cpp
@@ -112,7 +112,7 @@ pcl::modeler::NormalEstimationWorker::processImpl(CloudMeshItem* cloud_mesh_item
   pcl::NormalEstimation<pcl::PointSurfel, pcl::PointNormal> normal_estimator;
   normal_estimator.setInputCloud(cloud);
 
-  pcl::IndicesPtr indices(new std::vector<int>());
+  pcl::IndicesPtr indices(new pcl::Indices());
   pcl::removeNaNFromPointCloud(*cloud, *indices);
   normal_estimator.setIndices(indices);
 

--- a/apps/modeler/src/normals_actor_item.cpp
+++ b/apps/modeler/src/normals_actor_item.cpp
@@ -95,7 +95,7 @@ pcl::modeler::NormalsActorItem::createNormalLines()
     }
   }
   else {
-    pcl::IndicesPtr indices(new std::vector<int>());
+    pcl::IndicesPtr indices(new pcl::Indices());
     pcl::removeNaNFromPointCloud(*cloud, *indices);
 
     vtkIdType nr_normals = static_cast<vtkIdType>((indices->size() - 1) / level_ + 1);

--- a/apps/src/ni_linemod.cpp
+++ b/apps/src/ni_linemod.cpp
@@ -569,7 +569,7 @@ private:
   bool first_frame_;
 
   // Segmentation
-  std::vector<int> indices_fullset_;
+  pcl::Indices indices_fullset_;
   PointIndices::Ptr plane_indices_;
   CloudPtr plane_;
   IntegralImageNormalEstimation<PointT, Normal> ne_;

--- a/cuda/sample_consensus/src/sac_model.cu
+++ b/cuda/sample_consensus/src/sac_model.cu
@@ -57,7 +57,7 @@ namespace pcl
 
     template <template <typename> class Storage>
     __inline__ __host__
-    void create_scatter_stencil (int new_w, int new_h, int skip, int width, int height, typename Storage<int>::type &stencil)
+    void create_scatter_stencil (unsigned int new_w, unsigned int new_h, int skip, int width, int height, typename Storage<int>::type &stencil)
     { 
       for (unsigned int i = 0; i < new_w * new_h; ++i)
       { 

--- a/features/include/pcl/features/impl/organized_edge_detection.hpp
+++ b/features/include/pcl/features/impl/organized_edge_detection.hpp
@@ -115,7 +115,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
         for (int d_idx = 0; d_idx < num_of_ngbr; d_idx++)
         {
           int nghr_idx = curr_idx + directions[d_idx].d_index;
-          assert (nghr_idx >= 0 && nghr_idx < input_->size ());
+          assert (nghr_idx >= 0 && static_cast<std::size_t>(nghr_idx) < input_->size ());
           if (!std::isfinite ((*input_)[nghr_idx].z))
           {
             found_invalid_neighbor = true;
@@ -158,7 +158,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::extractEdges (pcl::PointCloud<PointLT>&
           for (const auto &direction : directions)
           {
             int nghr_idx = curr_idx + direction.d_index;
-            assert (nghr_idx >= 0 && nghr_idx < input_->size ());
+            assert (nghr_idx >= 0 && static_cast<std::size_t>(nghr_idx) < input_->size ());
             if (!std::isfinite ((*input_)[nghr_idx].z))
             {
               dx += direction.d_x;

--- a/filters/include/pcl/filters/impl/bilateral.hpp
+++ b/filters/include/pcl/filters/impl/bilateral.hpp
@@ -99,13 +99,13 @@ pcl::BilateralFilter<PointT>::applyFilter (PointCloud &output)
   output = *input_;
 
   // For all the indices given (equal to the entire cloud if none given)
-  for (std::size_t i = 0; i < indices_->size (); ++i)
+  for (const auto& idx : (*indices_))
   {
     // Perform a radius search to find the nearest neighbors
-    tree_->radiusSearch ((*indices_)[i], sigma_s_ * 2, k_indices, k_distances);
+    tree_->radiusSearch (idx, sigma_s_ * 2, k_indices, k_distances);
 
     // Overwrite the intensity value with the computed average
-    output[(*indices_)[i]].intensity = static_cast<float> (computePointWeight ((*indices_)[i], k_indices, k_distances));
+    output[idx].intensity = static_cast<float> (computePointWeight (idx, k_indices, k_distances));
   }
 }
  

--- a/filters/include/pcl/filters/impl/crop_box.hpp
+++ b/filters/include/pcl/filters/impl/crop_box.hpp
@@ -102,13 +102,13 @@ pcl::CropBox<PointT>::applyFilter (Indices &indices)
       if (negative_)
         indices[indices_count++] = index;
       else if (extract_removed_indices_)
-        (*removed_indices_)[removed_indices_count++] = static_cast<int> (index);
+        (*removed_indices_)[removed_indices_count++] = index;
     }
     // If inside the cropbox
     else
     {
       if (negative_ && extract_removed_indices_)
-        (*removed_indices_)[removed_indices_count++] = static_cast<int> (index);
+        (*removed_indices_)[removed_indices_count++] = index;
       else if (!negative_) 
         indices[indices_count++] = index;
     }

--- a/filters/src/crop_box.cpp
+++ b/filters/src/crop_box.cpp
@@ -154,7 +154,7 @@ pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (Indices &indices)
       }
       else if (extract_removed_indices_)
       {
-        (*removed_indices_)[removed_indices_count++] = static_cast<int> (index);
+        (*removed_indices_)[removed_indices_count++] = index;
       }
     }
     // If inside the cropbox
@@ -162,7 +162,7 @@ pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (Indices &indices)
     {
       if (negative_ && extract_removed_indices_)
       {
-        (*removed_indices_)[removed_indices_count++] = static_cast<int> (index);
+        (*removed_indices_)[removed_indices_count++] = index;
       }
       else if (!negative_) {
         indices[indices_count++] = index;

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/impl/world_model.hpp
@@ -147,7 +147,7 @@ pcl::kinfuLS::WorldModel<PointT>::getWorldAsCubes (const double size, std::vecto
 
   // remove nans from world cloud
   world_->is_dense = false;
-  std::vector<int> indices;
+  pcl::Indices indices;
   pcl::removeNaNFromPointCloud ( *world_, *world_, indices);
 
   PCL_INFO("World contains %zu points after nan removal.\n",

--- a/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
+++ b/gpu/kinfu_large_scale/include/pcl/gpu/kinfu_large_scale/world_model.h
@@ -137,7 +137,7 @@ namespace pcl
         void cleanWorldFromNans () 
         { 
           world_->is_dense = false;
-          std::vector<int> indices; 
+          pcl::Indices indices;
           pcl::removeNaNFromPointCloud (*world_, *world_, indices);
         }
 

--- a/gpu/people/include/pcl/gpu/people/label_tree.h
+++ b/gpu/people/include/pcl/gpu/people/label_tree.h
@@ -551,7 +551,7 @@ namespace pcl
         const Blob2& blob = sorted[part_label][part_lid];
 
         // iterate over the number of pixels that are part of this label
-        const std::vector<int>& indices = blob.indices.indices;
+        const auto& indices = blob.indices.indices;
         tree.indices.indices.insert(tree.indices.indices.end(), indices.begin(), indices.end());
 
         if(nr_children == 0)
@@ -583,7 +583,7 @@ namespace pcl
         const Blob2& blob = sorted[part_label][part_lid];
 
         // iterate over the number of pixels that are part of this label
-        const std::vector<int>& indices = blob.indices.indices;
+        const auto& indices = blob.indices.indices;
         tree.indices.indices.insert(tree.indices.indices.end(), indices.begin(), indices.end());
         
         if(nr_children == 0)

--- a/gpu/people/include/pcl/gpu/people/people_detector.h
+++ b/gpu/people/include/pcl/gpu/people/people_detector.h
@@ -157,7 +157,7 @@ namespace pcl
           allocate_buffers (int rows = 480, int cols = 640);
 
           void 
-          shs5 (const pcl::PointCloud<PointT> &cloud, const std::vector<int>& indices, unsigned char *mask);
+          shs5 (const pcl::PointCloud<PointT> &cloud, const pcl::Indices& indices, unsigned char *mask);
 
           //!!! only for debug purposes TODO: remove this. 
           friend class PeoplePCDApp;

--- a/gpu/people/src/people_detector.cpp
+++ b/gpu/people/src/people_detector.cpp
@@ -193,7 +193,7 @@ pcl::gpu::people::PeopleDetector::process ()
     Tree2 t;
     buildTree(sorted, cloud_host_, Neck, c, t);
     
-    const std::vector<int>& seed = t.indices.indices;
+    const auto& seed = t.indices.indices;
         
     std::fill(flowermat_host_.begin(), flowermat_host_.end(), 0);
     {
@@ -332,7 +332,7 @@ pcl::gpu::people::PeopleDetector::processProb ()
     Tree2 t;
     buildTree(sorted, cloud_host_, Neck, c, t, person_attribs_);
 
-    const std::vector<int>& seed = t.indices.indices;
+    const auto& seed = t.indices.indices;
 
     std::fill(flowermat_host_.begin(), flowermat_host_.end(), 0);
     {
@@ -473,7 +473,7 @@ namespace
 }
 
 void 
-pcl::gpu::people::PeopleDetector::shs5(const pcl::PointCloud<PointT> &cloud, const std::vector<int>& indices, unsigned char *mask)
+pcl::gpu::people::PeopleDetector::shs5(const pcl::PointCloud<PointT> &cloud, const pcl::Indices& indices, unsigned char *mask)
 {
   pcl::device::Intr intr(fx_, fy_, cx_, cy_);
   intr.setDefaultPPIfIncorrect(cloud.width, cloud.height);

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -474,7 +474,7 @@ pcl::io::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyData>& p
     colors->SetName ("Colors");
     pcl::RGB rgb;
     int offset = (idx_rgb != -1) ? mesh.cloud.fields[idx_rgb].offset : mesh.cloud.fields[idx_rgba].offset;
-    for (vtkIdType cp = 0; cp < nr_points; ++cp)
+    for (pcl::uindex_t cp = 0; cp < nr_points; ++cp)
     {
       memcpy (&rgb, &mesh.cloud.data[cp * mesh.cloud.point_step + offset], sizeof (RGB));
       const unsigned char color[3] = {rgb.r, rgb.g, rgb.b};
@@ -489,7 +489,7 @@ pcl::io::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyData>& p
     vtkSmartPointer<vtkFloatArray> normals = vtkSmartPointer<vtkFloatArray>::New ();
     normals->SetNumberOfComponents (3);
     float nx = 0.0f, ny = 0.0f, nz = 0.0f;
-    for (vtkIdType cp = 0; cp < nr_points; ++cp)
+    for (pcl::uindex_t cp = 0; cp < nr_points; ++cp)
     {
       memcpy (&nx, &mesh.cloud.data[cp*mesh.cloud.point_step+mesh.cloud.fields[idx_normal_x].offset], sizeof (float));
       memcpy (&ny, &mesh.cloud.data[cp*mesh.cloud.point_step+mesh.cloud.fields[idx_normal_y].offset], sizeof (float));

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -80,7 +80,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 {
   if (indices_) {
     for (const auto& index : *indices_) {
-      assert((index >= 0) && (index < input_->size()));
+      assert((index >= 0) && (static_cast<std::size_t>(index) < input_->size()));
 
       if (isFinite((*input_)[index])) {
         // add points to octree

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -663,7 +663,7 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::computeClutterCue(Recogn
     std::vector<float> nn_distances;
 
     std::vector < std::pair<int, int> > neighborhood_indices; //first is indices to scene point and second is indices to explained_ scene points
-    for (int i = 0; i < static_cast<int> (recog_model->explained_.size ()); i++)
+    for (pcl::index_t i = 0; i < static_cast<pcl::index_t> (recog_model->explained_.size ()); i++)
     {
       if (scene_downsampled_tree_->radiusSearch ((*scene_cloud_downsampled_)[recog_model->explained_[i]], radius_neighborhood_GO_, nn_indices,
           nn_distances, std::numeric_limits<int>::max ()))

--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -191,7 +191,7 @@ protected:
   public:
     using FeatureCloudConstPtr = typename pcl::PointCloud<FeatureT>::ConstPtr;
     using SearchMethod = std::function<int(
-        const pcl::PointCloud<FeatureT>&, int, std::vector<int>&, std::vector<float>&)>;
+        const pcl::PointCloud<FeatureT>&, int, pcl::Indices&, std::vector<float>&)>;
 
     using PointRepresentationConstPtr =
         typename pcl::PointRepresentation<FeatureT>::ConstPtr;

--- a/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
+++ b/registration/include/pcl/registration/correspondence_rejection_sample_consensus.h
@@ -225,7 +225,7 @@ public:
    * \param[out] inlier_indices Indices for the inliers
    */
   inline void
-  getInliersIndices(std::vector<int>& inlier_indices)
+  getInliersIndices(pcl::Indices& inlier_indices)
   {
     inlier_indices = inlier_indices_;
   }
@@ -267,7 +267,7 @@ protected:
   Eigen::Matrix4f best_transformation_;
 
   bool refine_;
-  std::vector<int> inlier_indices_;
+  pcl::Indices inlier_indices_;
   bool save_inliers_;
 
 public:

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -118,9 +118,9 @@ public:
     transformation_epsilon_ = 5e-4;
     corr_dist_threshold_ = 5.;
     rigid_transformation_estimation_ = [this](const PointCloudSource& cloud_src,
-                                              const std::vector<int>& indices_src,
+                                              const pcl::Indices& indices_src,
                                               const PointCloudTarget& cloud_tgt,
-                                              const std::vector<int>& indices_tgt,
+                                              const pcl::Indices& indices_tgt,
                                               Eigen::Matrix4f& transformation_matrix) {
       estimateRigidTransformationBFGS(
           cloud_src, indices_src, cloud_tgt, indices_tgt, transformation_matrix);
@@ -194,9 +194,9 @@ public:
    */
   void
   estimateRigidTransformationBFGS(const PointCloudSource& cloud_src,
-                                  const std::vector<int>& indices_src,
+                                  const pcl::Indices& indices_src,
                                   const PointCloudTarget& cloud_tgt,
-                                  const std::vector<int>& indices_tgt,
+                                  const pcl::Indices& indices_tgt,
                                   Eigen::Matrix4f& transformation_matrix);
 
   /** \brief \return Mahalanobis distance matrix for the given point index */
@@ -338,10 +338,10 @@ protected:
   const PointCloudTarget* tmp_tgt_;
 
   /** \brief Temporary pointer to the source dataset indices. */
-  const std::vector<int>* tmp_idx_src_;
+  const pcl::Indices* tmp_idx_src_;
 
   /** \brief Temporary pointer to the target dataset indices. */
-  const std::vector<int>* tmp_idx_tgt_;
+  const pcl::Indices* tmp_idx_tgt_;
 
   /** \brief Input cloud points covariances. */
   MatricesVectorPtr input_covariances_;
@@ -436,9 +436,9 @@ protected:
   };
 
   std::function<void(const pcl::PointCloud<PointSource>& cloud_src,
-                     const std::vector<int>& src_indices,
+                     const pcl::Indices& src_indices,
                      const pcl::PointCloud<PointTarget>& cloud_tgt,
-                     const std::vector<int>& tgt_indices,
+                     const pcl::Indices& tgt_indices,
                      Eigen::Matrix4f& transformation_matrix)>
       rigid_transformation_estimation_;
 };

--- a/registration/include/pcl/registration/impl/correspondence_estimation_backprojection.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_backprojection.hpp
@@ -73,7 +73,7 @@ CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar
 
   correspondences.resize(indices_->size());
 
-  std::vector<int> nn_indices(k_);
+  pcl::Indices nn_indices(k_);
   std::vector<float> nn_dists(k_);
 
   int min_index = 0;
@@ -177,9 +177,9 @@ CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar
 
   correspondences.resize(indices_->size());
 
-  std::vector<int> nn_indices(k_);
+  pcl::Indices nn_indices(k_);
   std::vector<float> nn_dists(k_);
-  std::vector<int> index_reciprocal(1);
+  pcl::Indices index_reciprocal(1);
   std::vector<float> distance_reciprocal(1);
 
   int min_index = 0;

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
@@ -76,8 +76,8 @@ CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences(
   }
 
   int nr_correspondences = static_cast<int>(original_correspondences.size());
-  std::vector<int> source_indices(nr_correspondences);
-  std::vector<int> target_indices(nr_correspondences);
+  pcl::Indices source_indices(nr_correspondences);
+  pcl::Indices target_indices(nr_correspondences);
 
   // Copy the query-match indices
   for (std::size_t i = 0; i < original_correspondences.size(); ++i) {
@@ -110,7 +110,7 @@ CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences(
         "[pcl::registration::%s::getRemainingCorrespondences] Error refining model!\n",
         getClassName().c_str());
 
-  std::vector<int> inliers;
+  pcl::Indices inliers;
   sac.getInliers(inliers);
 
   if (inliers.size() < 3) {

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -186,9 +186,9 @@ template <typename PointSource, typename PointTarget>
 void
 GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
     estimateRigidTransformationBFGS(const PointCloudSource& cloud_src,
-                                    const std::vector<int>& indices_src,
+                                    const pcl::Indices& indices_src,
                                     const PointCloudTarget& cloud_tgt,
-                                    const std::vector<int>& indices_tgt,
+                                    const pcl::Indices& indices_tgt,
                                     Eigen::Matrix4f& transformation_matrix)
 {
   if (indices_src.size() < 4) // need at least 4 samples
@@ -419,8 +419,8 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformatio
 
   while (!converged_) {
     std::size_t cnt = 0;
-    std::vector<int> source_indices(indices_->size());
-    std::vector<int> target_indices(indices_->size());
+    pcl::Indices source_indices(indices_->size());
+    pcl::Indices target_indices(indices_->size());
 
     // guess corresponds to base_t and transformation_ to t
     Eigen::Matrix4d transform_R = Eigen::Matrix4d::Zero();

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -60,7 +60,7 @@ pcl::getMeanPointDensity(const typename pcl::PointCloud<PointT>::ConstPtr& cloud
 
   float mean_dist = 0.f;
   int num = 0;
-  std::vector<int> ids(2);
+  pcl::Indices ids(2);
   std::vector<float> dists_sqr(2);
 
   pcl::utils::ignore(nr_threads);
@@ -451,24 +451,20 @@ pcl::registration::FPCSInitialAlignment<PointSource, PointTarget, NormalT, Scala
     setupBase(pcl::Indices& base_indices, float (&ratio)[2])
 {
   float best_t = FLT_MAX;
-  const std::vector<int> copy(base_indices.begin(), base_indices.end());
+  const pcl::Indices copy(base_indices.begin(), base_indices.end());
   pcl::Indices temp(base_indices.begin(), base_indices.end());
 
   // loop over all combinations of base points
-  for (std::vector<int>::const_iterator i = copy.begin(), i_e = copy.end(); i != i_e;
-       ++i)
-    for (std::vector<int>::const_iterator j = copy.begin(), j_e = copy.end(); j != j_e;
-         ++j) {
+  for (auto i = copy.begin(), i_e = copy.end(); i != i_e; ++i)
+    for (auto j = copy.begin(), j_e = copy.end(); j != j_e; ++j) {
       if (i == j)
         continue;
 
-      for (std::vector<int>::const_iterator k = copy.begin(), k_e = copy.end();
-           k != k_e;
-           ++k) {
+      for (auto k = copy.begin(), k_e = copy.end(); k != k_e; ++k) {
         if (k == j || k == i)
           continue;
 
-        std::vector<int>::const_iterator l = copy.begin();
+        auto l = copy.begin();
         while (l == i || l == j || l == k)
           ++l;
 

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -412,7 +412,7 @@ int
 pcl::registration::FPCSInitialAlignment<PointSource, PointTarget, NormalT, Scalar>::
     selectBaseTriangle(pcl::Indices& base_indices)
 {
-  int nr_points = static_cast<int>(target_indices_->size());
+  const auto nr_points = target_indices_->size();
   float best_t = 0.f;
 
   // choose random first point

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -172,10 +172,10 @@ SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::computeErro
   const ErrorFunctor& compute_error = *error_functor_;
   float error = 0;
 
-  for (int i = 0; i < static_cast<int>(cloud.size()); ++i) {
-    // Find the distance between cloud[i] and its nearest neighbor in the target point
+  for (const auto& point : cloud) {
+    // Find the distance between point and its nearest neighbor in the target point
     // cloud
-    tree_->nearestKSearch(cloud, i, 1, nn_index, nn_distance);
+    tree_->nearestKSearch(point, 1, nn_index, nn_distance);
 
     // Compute the error
     error += compute_error(nn_distance[0]);

--- a/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
+++ b/registration/include/pcl/registration/impl/sample_consensus_prerejective.hpp
@@ -129,7 +129,7 @@ SampleConsensusPrerejective<PointSource, PointTarget, FeatureT>::findSimilarFeat
   // Loop over the sampled features
   for (std::size_t i = 0; i < sample_indices.size(); ++i) {
     // Current feature index
-    const int idx = sample_indices[i];
+    const auto& idx = sample_indices[i];
 
     // Find the k nearest feature neighbors to the sampled input feature if they are not
     // in the cache already
@@ -330,7 +330,7 @@ SampleConsensusPrerejective<PointSource, PointTarget, FeatureT>::getFitness(
     // Check if point is an inlier
     if (nn_dists[0] < max_range) {
       // Update inliers
-      inliers.push_back(static_cast<int>(i));
+      inliers.push_back(i);
 
       // Update fitness score
       fitness_score += nn_dists[0];

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls_weighted.hpp
@@ -80,7 +80,7 @@ template <typename PointSource, typename PointTarget, typename Scalar>
 void
 TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
     estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                                const std::vector<int>& indices_src,
+                                const pcl::Indices& indices_src,
                                 const pcl::PointCloud<PointTarget>& cloud_tgt,
                                 Matrix4& transformation_matrix) const
 {
@@ -111,9 +111,9 @@ template <typename PointSource, typename PointTarget, typename Scalar>
 inline void
 TransformationEstimationPointToPlaneLLSWeighted<PointSource, PointTarget, Scalar>::
     estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                                const std::vector<int>& indices_src,
+                                const pcl::Indices& indices_src,
                                 const pcl::PointCloud<PointTarget>& cloud_tgt,
-                                const std::vector<int>& indices_tgt,
+                                const pcl::Indices& indices_tgt,
                                 Matrix4& transformation_matrix) const
 {
   const std::size_t nr_points = indices_src.size();

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_weighted.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_weighted.hpp
@@ -135,7 +135,7 @@ void
 pcl::registration::
     TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar>::
         estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                                    const std::vector<int>& indices_src,
+                                    const pcl::Indices& indices_src,
                                     const pcl::PointCloud<PointTarget>& cloud_tgt,
                                     Matrix4& transformation_matrix) const
 {
@@ -161,7 +161,7 @@ pcl::registration::
   transformation_matrix.setIdentity();
 
   const auto nr_correspondences = cloud_tgt.size();
-  std::vector<int> indices_tgt;
+  pcl::Indices indices_tgt;
   indices_tgt.resize(nr_correspondences);
   for (std::size_t i = 0; i < nr_correspondences; ++i)
     indices_tgt[i] = i;
@@ -176,9 +176,9 @@ inline void
 pcl::registration::
     TransformationEstimationPointToPlaneWeighted<PointSource, PointTarget, MatScalar>::
         estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                                    const std::vector<int>& indices_src,
+                                    const pcl::Indices& indices_src,
                                     const pcl::PointCloud<PointTarget>& cloud_tgt,
-                                    const std::vector<int>& indices_tgt,
+                                    const pcl::Indices& indices_tgt,
                                     Matrix4& transformation_matrix) const
 {
   if (indices_src.size() != indices_tgt.size()) {
@@ -256,8 +256,8 @@ pcl::registration::
                                     Matrix4& transformation_matrix) const
 {
   const int nr_correspondences = static_cast<int>(correspondences.size());
-  std::vector<int> indices_src(nr_correspondences);
-  std::vector<int> indices_tgt(nr_correspondences);
+  pcl::Indices indices_src(nr_correspondences);
+  pcl::Indices indices_tgt(nr_correspondences);
   for (int i = 0; i < nr_correspondences; ++i) {
     indices_src[i] = correspondences[i].index_query;
     indices_tgt[i] = correspondences[i].index_match;
@@ -315,8 +315,8 @@ pcl::registration::TransformationEstimationPointToPlaneWeighted<
 {
   const PointCloud<PointSource>& src_points = *estimator_->tmp_src_;
   const PointCloud<PointTarget>& tgt_points = *estimator_->tmp_tgt_;
-  const std::vector<int>& src_indices = *estimator_->tmp_idx_src_;
-  const std::vector<int>& tgt_indices = *estimator_->tmp_idx_tgt_;
+  const pcl::Indices& src_indices = *estimator_->tmp_idx_src_;
+  const pcl::Indices& tgt_indices = *estimator_->tmp_idx_tgt_;
 
   // Initialize the warp function with the given parameters
   estimator_->warp_point_->setParam(x);

--- a/registration/include/pcl/registration/impl/transformation_validation_euclidean.hpp
+++ b/registration/include/pcl/registration/impl/transformation_validation_euclidean.hpp
@@ -78,7 +78,7 @@ TransformationValidationEuclidean<PointSource, PointTarget, Scalar>::
     tree_->setInputCloud(cloud_tgt);
   }
 
-  std::vector<int> nn_indices(1);
+  pcl::Indices nn_indices(1);
   std::vector<float> nn_dists(1);
 
   // For each point in the source dataset

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_lls_weighted.h
@@ -96,7 +96,7 @@ public:
    */
   inline void
   estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const std::vector<int>& indices_src,
+                              const pcl::Indices& indices_src,
                               const pcl::PointCloud<PointTarget>& cloud_tgt,
                               Matrix4& transformation_matrix) const;
 
@@ -111,9 +111,9 @@ public:
    */
   inline void
   estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const std::vector<int>& indices_src,
+                              const pcl::Indices& indices_src,
                               const pcl::PointCloud<PointTarget>& cloud_tgt,
-                              const std::vector<int>& indices_tgt,
+                              const pcl::Indices& indices_tgt,
                               Matrix4& transformation_matrix) const;
 
   /** \brief Estimate a rigid rotation transformation between a source and a target

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_weighted.h
@@ -138,7 +138,7 @@ public:
    */
   inline void
   estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const std::vector<int>& indices_src,
+                              const pcl::Indices& indices_src,
                               const pcl::PointCloud<PointTarget>& cloud_tgt,
                               Matrix4& transformation_matrix) const;
 
@@ -154,9 +154,9 @@ public:
    */
   void
   estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
-                              const std::vector<int>& indices_src,
+                              const pcl::Indices& indices_src,
                               const pcl::PointCloud<PointTarget>& cloud_tgt,
-                              const std::vector<int>& indices_tgt,
+                              const pcl::Indices& indices_tgt,
                               Matrix4& transformation_matrix) const;
 
   /** \brief Estimate a rigid rotation transformation between a source and a target
@@ -207,10 +207,10 @@ protected:
   mutable const PointCloudTarget* tmp_tgt_;
 
   /** \brief Temporary pointer to the source dataset indices. */
-  mutable const std::vector<int>* tmp_idx_src_;
+  mutable const pcl::Indices* tmp_idx_src_;
 
   /** \brief Temporary pointer to the target dataset indices. */
-  mutable const std::vector<int>* tmp_idx_tgt_;
+  mutable const pcl::Indices* tmp_idx_tgt_;
 
   /** \brief The parameterized function used to warp the source to the target. */
   typename pcl::registration::WarpPointRigid<PointSource, PointTarget, MatScalar>::Ptr

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -133,8 +133,8 @@ GeneralizedIterativeClosestPoint6D::computeTransformation(PointCloudSource& outp
 
   while (!converged_) {
     std::size_t cnt = 0;
-    std::vector<int> source_indices(indices_->size());
-    std::vector<int> target_indices(indices_->size());
+    pcl::Indices source_indices(indices_->size());
+    pcl::Indices target_indices(indices_->size());
 
     // guess corresponds to base_t and transformation_ to t
     Eigen::Matrix4d transform_R = Eigen::Matrix4d::Zero();

--- a/segmentation/include/pcl/segmentation/impl/conditional_euclidean_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/conditional_euclidean_clustering.hpp
@@ -78,7 +78,7 @@ pcl::ConditionalEuclideanClustering<PointT>::segment (pcl::IndicesClusters &clus
   for (const auto& iindex : (*indices_)) // iindex = input index
   {
     // Has this point been processed before?
-    if (iindex == -1 || processed[iindex])
+    if (iindex == UNAVAILABLE || processed[iindex])
       continue;
 
     // Set up a new growing cluster
@@ -103,7 +103,7 @@ pcl::ConditionalEuclideanClustering<PointT>::segment (pcl::IndicesClusters &clus
       for (int nii = 1; nii < static_cast<int> (nn_indices.size ()); ++nii)  // nii = neighbor indices iterator
       {
         // Has this point been processed before?
-        if (nn_indices[nii] == -1 || processed[nn_indices[nii]])
+        if (nn_indices[nii] == UNAVAILABLE || processed[nn_indices[nii]])
           continue;
 
         // Validate if condition holds

--- a/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
@@ -87,7 +87,7 @@ pcl::extractEuclideanClusters (const PointCloud<PointT> &cloud,
 
       for (std::size_t j = nn_start_idx; j < nn_indices.size (); ++j)             // can't assume sorted (default isn't!)
       {
-        if (nn_indices[j] == -1 || processed[nn_indices[j]])        // Has this point been processed before ?
+        if (nn_indices[j] == UNAVAILABLE || processed[nn_indices[j]])        // Has this point been processed before ?
           continue;
 
         // Perform a simple Euclidean clustering
@@ -184,7 +184,7 @@ pcl::extractEuclideanClusters (const PointCloud<PointT> &cloud,
 
       for (std::size_t j = nn_start_idx; j < nn_indices.size (); ++j)             // can't assume sorted (default isn't!)
       {
-        if (nn_indices[j] == -1 || processed[nn_indices[j]])        // Has this point been processed before ?
+        if (nn_indices[j] == UNAVAILABLE || processed[nn_indices[j]])        // Has this point been processed before ?
           continue;
 
         // Perform a simple Euclidean clustering

--- a/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
@@ -321,7 +321,7 @@ GrabCut<PointT>::initGraph ()
       std::vector<float>::const_iterator weights_it  = n_link.weights.begin ();
       for (auto indices_it = n_link.indices.cbegin (); indices_it != n_link.indices.cend (); ++indices_it, ++weights_it)
       {
-        if ((*indices_it != point_index) && (*indices_it > -1))
+        if ((*indices_it != point_index) && (*indices_it != UNAVAILABLE))
         {
           addEdge (graph_nodes_[i_point], graph_nodes_[*indices_it], *weights_it, *weights_it);
         }

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -56,7 +56,7 @@
 template <typename PointT, typename NormalT>
 pcl::RegionGrowing<PointT, NormalT>::RegionGrowing () :
   min_pts_per_cluster_ (1),
-  max_pts_per_cluster_ (std::numeric_limits<int>::max ()),
+  max_pts_per_cluster_ (std::numeric_limits<pcl::uindex_t>::max ()),
   smooth_mode_flag_ (true),
   curvature_flag_ (true),
   residual_flag_ (false),
@@ -86,7 +86,7 @@ pcl::RegionGrowing<PointT, NormalT>::~RegionGrowing ()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename NormalT> int
+template <typename PointT, typename NormalT> pcl::uindex_t
 pcl::RegionGrowing<PointT, NormalT>::getMinClusterSize ()
 {
   return (min_pts_per_cluster_);
@@ -94,13 +94,13 @@ pcl::RegionGrowing<PointT, NormalT>::getMinClusterSize ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename NormalT> void
-pcl::RegionGrowing<PointT, NormalT>::setMinClusterSize (int min_cluster_size)
+pcl::RegionGrowing<PointT, NormalT>::setMinClusterSize (pcl::uindex_t min_cluster_size)
 {
   min_pts_per_cluster_ = min_cluster_size;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename NormalT> int
+template <typename PointT, typename NormalT> pcl::uindex_t
 pcl::RegionGrowing<PointT, NormalT>::getMaxClusterSize ()
 {
   return (max_pts_per_cluster_);
@@ -108,7 +108,7 @@ pcl::RegionGrowing<PointT, NormalT>::getMaxClusterSize ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename NormalT> void
-pcl::RegionGrowing<PointT, NormalT>::setMaxClusterSize (int max_cluster_size)
+pcl::RegionGrowing<PointT, NormalT>::setMaxClusterSize (pcl::uindex_t max_cluster_size)
 {
   max_pts_per_cluster_ = max_cluster_size;
 }
@@ -278,8 +278,8 @@ pcl::RegionGrowing<PointT, NormalT>::extract (std::vector <pcl::PointIndices>& c
   std::vector<pcl::PointIndices>::iterator cluster_iter_input = clusters.begin ();
   for (const auto& cluster : clusters_)
   {
-    if ((static_cast<int> (cluster.indices.size ()) >= min_pts_per_cluster_) &&
-        (static_cast<int> (cluster.indices.size ()) <= max_pts_per_cluster_))
+    if ((cluster.indices.size () >= min_pts_per_cluster_) &&
+        (cluster.indices.size () <= max_pts_per_cluster_))
     {
       *cluster_iter_input = cluster;
       ++cluster_iter_input;

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -328,7 +328,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findRegionsKNN (pcl::index_t index, int 
     for (int i_nghbr = 0; i_nghbr < number_of_neighbours; i_nghbr++)
     {
       // find segment
-      auto segment_index = point_labels_[ point_neighbours_[point_index][i_nghbr] ];
+      const pcl::index_t segment_index = point_labels_[ point_neighbours_[point_index][i_nghbr] ];
 
       if ( segment_index != index )
       {

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -198,8 +198,8 @@ pcl::RegionGrowingRGB<PointT, NormalT>::extract (std::vector <pcl::PointIndices>
   std::vector<pcl::PointIndices>::iterator cluster_iter = clusters_.begin ();
   while (cluster_iter != clusters_.end ())
   {
-    if (static_cast<int> (cluster_iter->indices.size ()) < min_pts_per_cluster_ ||
-        static_cast<int> (cluster_iter->indices.size ()) > max_pts_per_cluster_)
+    if (cluster_iter->indices.size () < min_pts_per_cluster_ ||
+        cluster_iter->indices.size () > max_pts_per_cluster_)
     {
       cluster_iter = clusters_.erase (cluster_iter);
     }
@@ -311,21 +311,21 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findSegmentNeighbours ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT,typename NormalT> void
-pcl::RegionGrowingRGB<PointT, NormalT>::findRegionsKNN (pcl::index_t index, int nghbr_number, pcl::Indices& nghbrs, std::vector<float>& dist)
+pcl::RegionGrowingRGB<PointT, NormalT>::findRegionsKNN (pcl::index_t index, pcl::uindex_t nghbr_number, pcl::Indices& nghbrs, std::vector<float>& dist)
 {
   std::vector<float> distances;
   float max_dist = std::numeric_limits<float>::max ();
   distances.resize (clusters_.size (), max_dist);
 
-  int number_of_points = num_pts_in_segment_[index];
+  const auto number_of_points = num_pts_in_segment_[index];
   //loop through every point in this segment and check neighbours
-  for (int i_point = 0; i_point < number_of_points; i_point++)
+  for (pcl::uindex_t i_point = 0; i_point < number_of_points; i_point++)
   {
-    int point_index = clusters_[index].indices[i_point];
-    int number_of_neighbours = static_cast<int> (point_neighbours_[point_index].size ());
+    const auto point_index = clusters_[index].indices[i_point];
+    const auto number_of_neighbours = point_neighbours_[point_index].size ();
     //loop through every neighbour of the current point, find out to which segment it belongs
     //and if it belongs to neighbouring segment and is close enough then remember segment and its distance
-    for (int i_nghbr = 0; i_nghbr < number_of_neighbours; i_nghbr++)
+    for (std::size_t i_nghbr = 0; i_nghbr < number_of_neighbours; i_nghbr++)
     {
       // find segment
       const pcl::index_t segment_index = point_labels_[ point_neighbours_[point_index][i_nghbr] ];
@@ -345,15 +345,15 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findRegionsKNN (pcl::index_t index, int 
     if (distances[i_seg] < max_dist)
     {
       segment_neighbours.push (std::make_pair (distances[i_seg], i_seg) );
-      if (int (segment_neighbours.size ()) > nghbr_number)
+      if (segment_neighbours.size () > nghbr_number)
         segment_neighbours.pop ();
     }
   }
 
-  int size = std::min<int> (static_cast<int> (segment_neighbours.size ()), nghbr_number);
+  const std::size_t size = std::min<std::size_t> (segment_neighbours.size (), static_cast<std::size_t>(nghbr_number));
   nghbrs.resize (size, 0);
   dist.resize (size, 0);
-  int counter = 0;
+  pcl::uindex_t counter = 0;
   while ( !segment_neighbours.empty () && counter < nghbr_number )
   {
     dist[counter] = segment_neighbours.top ().first;
@@ -459,7 +459,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::applyRegionMergingAlgorithm ()
   int final_segment_number = homogeneous_region_number;
   for (int i_reg = 0; i_reg < homogeneous_region_number; i_reg++)
   {
-    if (static_cast<int> (num_pts_in_homogeneous_region[i_reg]) < min_pts_per_cluster_)
+    if (num_pts_in_homogeneous_region[i_reg] < min_pts_per_cluster_)
     {
       if ( region_neighbours[i_reg].empty () )
         continue;

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -453,7 +453,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::applyRegionMergingAlgorithm ()
     counter[index] += 1;
   }
 
-  std::vector< std::vector< std::pair<float, int> > > region_neighbours;
+  std::vector< std::vector< std::pair<float, pcl::index_t> > > region_neighbours;
   findRegionNeighbours (region_neighbours, final_segments);
 
   int final_segment_number = homogeneous_region_number;
@@ -519,7 +519,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::calculateColorimetricalDifference (std::
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename NormalT> void
-pcl::RegionGrowingRGB<PointT, NormalT>::findRegionNeighbours (std::vector< std::vector< std::pair<float, int> > >& neighbours_out, std::vector< std::vector<int> >& regions_in)
+pcl::RegionGrowingRGB<PointT, NormalT>::findRegionNeighbours (std::vector< std::vector< std::pair<float, pcl::index_t> > >& neighbours_out, std::vector< std::vector<int> >& regions_in)
 {
   int region_number = static_cast<int> (regions_in.size ());
   neighbours_out.clear ();
@@ -531,7 +531,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findRegionNeighbours (std::vector< std::
     for (const auto& curr_segment : regions_in[i_reg])
     {
       const std::size_t nghbr_number = segment_neighbours_[curr_segment].size ();
-      std::pair<float, int> pair;
+      std::pair<float, pcl::index_t> pair;
       for (std::size_t i_nghbr = 0; i_nghbr < nghbr_number; i_nghbr++)
       {
         const auto segment_index = segment_neighbours_[curr_segment][i_nghbr];

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -328,8 +328,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findRegionsKNN (pcl::index_t index, int 
     for (int i_nghbr = 0; i_nghbr < number_of_neighbours; i_nghbr++)
     {
       // find segment
-      int segment_index = -1;
-      segment_index = point_labels_[ point_neighbours_[point_index][i_nghbr] ];
+      auto segment_index = point_labels_[ point_neighbours_[point_index][i_nghbr] ];
 
       if ( segment_index != index )
       {
@@ -531,11 +530,11 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findRegionNeighbours (std::vector< std::
     neighbours_out[i_reg].reserve (regions_in[i_reg].size () * region_neighbour_number_);
     for (const auto& curr_segment : regions_in[i_reg])
     {
-      int nghbr_number = static_cast<int> (segment_neighbours_[curr_segment].size ());
+      const std::size_t nghbr_number = segment_neighbours_[curr_segment].size ();
       std::pair<float, int> pair;
-      for (int i_nghbr = 0; i_nghbr < nghbr_number; i_nghbr++)
+      for (std::size_t i_nghbr = 0; i_nghbr < nghbr_number; i_nghbr++)
       {
-        int segment_index = segment_neighbours_[curr_segment][i_nghbr];
+        const auto segment_index = segment_neighbours_[curr_segment][i_nghbr];
         if ( segment_distances_[curr_segment][i_nghbr] == std::numeric_limits<float>::max () )
           continue;
         if (segment_labels_[segment_index] != i_reg)

--- a/segmentation/include/pcl/segmentation/region_growing.h
+++ b/segmentation/include/pcl/segmentation/region_growing.h
@@ -84,20 +84,20 @@ namespace pcl
       ~RegionGrowing ();
 
       /** \brief Get the minimum number of points that a cluster needs to contain in order to be considered valid. */
-      int
+      pcl::uindex_t
       getMinClusterSize ();
 
       /** \brief Set the minimum number of points that a cluster needs to contain in order to be considered valid. */
       void
-      setMinClusterSize (int min_cluster_size);
+      setMinClusterSize (pcl::uindex_t min_cluster_size);
 
       /** \brief Get the maximum number of points that a cluster needs to contain in order to be considered valid. */
-      int
+      pcl::uindex_t
       getMaxClusterSize ();
 
       /** \brief Set the maximum number of points that a cluster needs to contain in order to be considered valid. */
       void
-      setMaxClusterSize (int max_cluster_size);
+      setMaxClusterSize (pcl::uindex_t max_cluster_size);
 
       /** \brief Returns the flag value. This flag signalizes which mode of algorithm will be used.
         * If it is set to true than it will work as said in the article. This means that
@@ -279,10 +279,10 @@ namespace pcl
     protected:
 
       /** \brief Stores the minimum number of points that a cluster needs to contain in order to be considered valid. */
-      int min_pts_per_cluster_;
+      pcl::uindex_t min_pts_per_cluster_;
 
       /** \brief Stores the maximum number of points that a cluster needs to contain in order to be considered valid. */
-      int max_pts_per_cluster_;
+      pcl::uindex_t max_pts_per_cluster_;
 
       /** \brief Flag that signalizes if the smoothness constraint will be used. */
       bool smooth_mode_flag_;
@@ -323,7 +323,7 @@ namespace pcl
       bool normal_flag_;
 
       /** \brief Tells how much points each segment contains. Used for reserving memory. */
-      std::vector<int> num_pts_in_segment_;
+      std::vector<pcl::uindex_t> num_pts_in_segment_;
 
       /** \brief After the segmentation it will contain the segments. */
       std::vector <pcl::PointIndices> clusters_;

--- a/segmentation/include/pcl/segmentation/region_growing_rgb.h
+++ b/segmentation/include/pcl/segmentation/region_growing_rgb.h
@@ -205,7 +205,7 @@ namespace pcl
         * \param[out] dist the array of distances to the corresponding neighbours
         */
       void
-      findRegionsKNN (index_t index, int nghbr_number, Indices& nghbrs, std::vector<float>& dist);
+      findRegionsKNN (pcl::index_t index, pcl::uindex_t nghbr_number, Indices& nghbrs, std::vector<float>& dist);
 
       /** \brief This function implements the merging algorithm described in the article
         * "Color-based segmentation of point clouds"

--- a/segmentation/include/pcl/segmentation/region_growing_rgb.h
+++ b/segmentation/include/pcl/segmentation/region_growing_rgb.h
@@ -230,7 +230,7 @@ namespace pcl
         * to the corresponding homogeneous region.
         */
       void
-      findRegionNeighbours (std::vector< std::vector< std::pair<float, int> > >& neighbours_out, std::vector< std::vector<int> >& regions_in);
+      findRegionNeighbours (std::vector< std::vector< std::pair<float, pcl::index_t> > >& neighbours_out, std::vector< std::vector<int> >& regions_in);
 
       /** \brief This function simply assembles the regions from list of point labels.
         * \param[in] num_pts_in_region for each final region it stores the corresponding number of points in it

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -278,11 +278,11 @@ namespace pcl
 
 
       /** \brief Get the sfn list. */
-      inline std::vector<int>
+      inline pcl::Indices
       getSFN () const { return (sfn_); }
 
       /** \brief Get the ffn list. */
-      inline std::vector<int>
+      inline pcl::Indices
       getFFN () const { return (ffn_); }
 
     protected:
@@ -345,9 +345,9 @@ namespace pcl
       /** \brief List of sources **/
       std::vector<int> source_;
       /** \brief List of fringe neighbors in one direction **/
-      std::vector<int> ffn_;
+      pcl::Indices ffn_;
       /** \brief List of fringe neighbors in other direction **/
-      std::vector<int> sfn_;
+      pcl::Indices sfn_;
       /** \brief Connected component labels for each point **/
       std::vector<int> part_;
       /** \brief Points on the outer edge from which the mesh has to be grown **/

--- a/surface/include/pcl/surface/gp3.h
+++ b/surface/include/pcl/surface/gp3.h
@@ -315,8 +315,8 @@ namespace pcl
       struct nnAngle
       {
         double angle;
-        int index;
-        int nnIndex;
+        pcl::index_t index;
+        pcl::index_t nnIndex;
         bool visible;
       };
 
@@ -339,11 +339,11 @@ namespace pcl
       /** \brief A list of angles to neighbors **/
       std::vector<nnAngle> angles_;
       /** \brief Index of the current query point **/
-      int R_;
+      pcl::index_t R_;
       /** \brief List of point states **/
       std::vector<int> state_;
       /** \brief List of sources **/
-      std::vector<int> source_;
+      pcl::Indices source_;
       /** \brief List of fringe neighbors in one direction **/
       pcl::Indices ffn_;
       /** \brief List of fringe neighbors in other direction **/
@@ -356,7 +356,7 @@ namespace pcl
       /** \brief Flag to set if the current point is free **/
       bool is_current_free_;
       /** \brief Current point's index **/
-      int current_index_;
+      pcl::index_t current_index_;
       /** \brief Flag to set if the previous point is the first fringe neighbor **/
       bool prev_is_ffn_;
       /** \brief Flag to set if the next point is the second fringe neighbor **/
@@ -370,7 +370,7 @@ namespace pcl
       /** \brief Flag to set if the second fringe neighbor was changed **/
       bool changed_2nd_fn_;
       /** \brief New boundary point **/
-      int new2boundary_;
+      pcl::index_t new2boundary_;
       
       /** \brief Flag to set if the next neighbor was already connected in the previous step.
         * To avoid inconsistency it should not be connected again.
@@ -429,9 +429,9 @@ namespace pcl
         */
       void 
       connectPoint (std::vector<pcl::Vertices> &polygons, 
-                    const int prev_index, 
-                    const int next_index, 
-                    const int next_next_index, 
+                    const pcl::index_t prev_index, 
+                    const pcl::index_t next_index, 
+                    const pcl::index_t next_next_index, 
                     const Eigen::Vector2f &uvn_current, 
                     const Eigen::Vector2f &uvn_prev, 
                     const Eigen::Vector2f &uvn_next);
@@ -456,7 +456,7 @@ namespace pcl
         * \param[out] polygons the polygon mesh to be updated
         */
       inline void
-      addTriangle (int a, int b, int c, std::vector<pcl::Vertices> &polygons)
+      addTriangle (pcl::index_t a, pcl::index_t b, pcl::index_t c, std::vector<pcl::Vertices> &polygons)
       {
         triangle_.vertices.resize (3);
         if (consistent_ordering_)

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -188,7 +188,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
         angles_[i].index = nnIdx[i];
         if (
             (state_[nnIdx[i]] == COMPLETED) || (state_[nnIdx[i]] == BOUNDARY)
-            || (state_[nnIdx[i]] == NONE) || (nnIdx[i] == -1) /// NOTE: discarding NaN points and those that are not in indices_
+            || (state_[nnIdx[i]] == NONE) || (nnIdx[i] == UNAVAILABLE) /// NOTE: discarding NaN points and those that are not in indices_
             || (sqrDists[i] > sqr_dist_threshold)
            )
           angles_[i].visible = false;
@@ -364,7 +364,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
         angles_[i].nnIndex = i;
         if (
             (state_[nnIdx[i]] == COMPLETED) || (state_[nnIdx[i]] == BOUNDARY)
-            || (state_[nnIdx[i]] == NONE) || (nnIdx[i] == -1) /// NOTE: discarding NaN points and those that are not in indices_
+            || (state_[nnIdx[i]] == NONE) || (nnIdx[i] == UNAVAILABLE) /// NOTE: discarding NaN points and those that are not in indices_
             || (sqrDists[i] > sqr_dist_threshold)
            )
           angles_[i].visible = false;

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -461,13 +461,13 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
           {
             if (doubleEdges[j].index != i)
             {
-              int f = ffn_[nnIdx[doubleEdges[j].index]];
+              const auto& f = ffn_[nnIdx[doubleEdges[j].index]];
               if ((f != nnIdx[i]) && (f != R_))
                 visibility = isVisible(uvn_nn[i], uvn_nn[doubleEdges[j].index], doubleEdges[j].first, Eigen::Vector2f::Zero());
               if (!visibility)
                 break;
 
-              int s = sfn_[nnIdx[doubleEdges[j].index]];
+              const auto& s = sfn_[nnIdx[doubleEdges[j].index]];
               if ((s != nnIdx[i]) && (s != R_))
                 visibility = isVisible(uvn_nn[i], uvn_nn[doubleEdges[j].index], doubleEdges[j].second, Eigen::Vector2f::Zero());
               if (!visibility)
@@ -1087,7 +1087,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::closeTriangle (std::vector<pcl::Ve
 template <typename PointInT> void
 pcl::GreedyProjectionTriangulation<PointInT>::connectPoint (
     std::vector<pcl::Vertices> &polygons, 
-    const int prev_index, const int next_index, const int next_next_index, 
+    const pcl::index_t prev_index, const pcl::index_t next_index, const pcl::index_t next_next_index, 
     const Eigen::Vector2f &uvn_current, 
     const Eigen::Vector2f &uvn_prev, 
     const Eigen::Vector2f &uvn_next)
@@ -1383,7 +1383,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::connectPoint (
           case 2://next2f:
           {
             addTriangle (current_index_, ffn_[current_index_], next_index, polygons);
-            int neighbor_update = next_index;
+            auto neighbor_update = next_index;
 
             /* updating next_index */
             if (state_[next_index] <= FREE)
@@ -1518,7 +1518,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::connectPoint (
           case 3://next2s:
           {
             addTriangle (current_index_, sfn_[current_index_], next_index, polygons);
-            int neighbor_update = next_index;
+            auto neighbor_update = next_index;
 
             /* updating next_index */
             if (state_[next_index] <= FREE)

--- a/test/gpu/octree/perfomance.cpp
+++ b/test/gpu/octree/perfomance.cpp
@@ -147,16 +147,16 @@ TEST(PCL_OctreeGPU, performance)
     float dist;
 
     //host buffers
-    std::vector<int> indeces;
-    pcl::Indices indeces_host;
+    std::vector<int> indices;
+    pcl::Indices indices_host;
     std::vector<float> pointRadiusSquaredDistance;
 #ifdef HAVE_OPENCV  
     std::vector<cv::Point3f> opencv_results;
 #endif
 
     //reserve
-    indeces.reserve(data.data_size);
-    indeces_host.reserve(data.data_size);
+    indices.reserve(data.data_size);
+    indices_host.reserve(data.data_size);
     pointRadiusSquaredDistance.reserve(data.data_size);
 #ifdef HAVE_OPENCV
     opencv_results.reserve(data.data_size);
@@ -179,14 +179,14 @@ TEST(PCL_OctreeGPU, performance)
     {
         ScopeTime up("gpu-radius-search-{host}-all");	
         for(std::size_t i = 0; i < data.tests_num; ++i)
-            octree_device.radiusSearchHost(data.queries[i], data.radiuses[i], indeces, max_answers);                        
+            octree_device.radiusSearchHost(data.queries[i], data.radiuses[i], indices, max_answers);
     }
 
     {                
         ScopeTime up("host-radius-search-all");	
         for(std::size_t i = 0; i < data.tests_num; ++i)
             octree_host.radiusSearch(pcl::PointXYZ(data.queries[i].x, data.queries[i].y, data.queries[i].z), 
-                data.radiuses[i], indeces_host, pointRadiusSquaredDistance, max_answers);                        
+                data.radiuses[i], indices_host, pointRadiusSquaredDistance, max_answers);
     }
      
     {
@@ -205,14 +205,14 @@ TEST(PCL_OctreeGPU, performance)
     {
         ScopeTime up("gpu-radius-search-{host}-all");
         for(std::size_t i = 0; i < data.tests_num; ++i)
-            octree_device.radiusSearchHost(data.queries[i], data.shared_radius, indeces, max_answers);                        
+            octree_device.radiusSearchHost(data.queries[i], data.shared_radius, indices, max_answers);
     }
 
     {                
         ScopeTime up("host-radius-search-all");	
         for(std::size_t i = 0; i < data.tests_num; ++i)
             octree_host.radiusSearch(pcl::PointXYZ(data.queries[i].x, data.queries[i].y, data.queries[i].z), 
-                data.radiuses[i], indeces_host, pointRadiusSquaredDistance, max_answers);                        
+                data.radiuses[i], indices_host, pointRadiusSquaredDistance, max_answers);
     }
      
     {
@@ -252,7 +252,7 @@ TEST(PCL_OctreeGPU, performance)
     {                
         ScopeTime up("host-knn-search-all");	
         for(std::size_t i = 0; i < data.tests_num; ++i)
-            octree_host.nearestKSearch(data.queries[i], k, indeces, pointRadiusSquaredDistance);
+            octree_host.nearestKSearch(data.queries[i], k, indices, pointRadiusSquaredDistance);
     }*/
 }
 

--- a/test/gpu/octree/perfomance.cpp
+++ b/test/gpu/octree/perfomance.cpp
@@ -145,10 +145,10 @@ TEST(PCL_OctreeGPU, performance)
 
     const int max_answers = 500;
     float dist;
-    int inds;
 
     //host buffers
     std::vector<int> indeces;
+    pcl::Indices indeces_host;
     std::vector<float> pointRadiusSquaredDistance;
 #ifdef HAVE_OPENCV  
     std::vector<cv::Point3f> opencv_results;
@@ -156,6 +156,7 @@ TEST(PCL_OctreeGPU, performance)
 
     //reserve
     indeces.reserve(data.data_size);
+    indeces_host.reserve(data.data_size);
     pointRadiusSquaredDistance.reserve(data.data_size);
 #ifdef HAVE_OPENCV
     opencv_results.reserve(data.data_size);
@@ -185,7 +186,7 @@ TEST(PCL_OctreeGPU, performance)
         ScopeTime up("host-radius-search-all");	
         for(std::size_t i = 0; i < data.tests_num; ++i)
             octree_host.radiusSearch(pcl::PointXYZ(data.queries[i].x, data.queries[i].y, data.queries[i].z), 
-                data.radiuses[i], indeces, pointRadiusSquaredDistance, max_answers);                        
+                data.radiuses[i], indeces_host, pointRadiusSquaredDistance, max_answers);                        
     }
      
     {
@@ -211,7 +212,7 @@ TEST(PCL_OctreeGPU, performance)
         ScopeTime up("host-radius-search-all");	
         for(std::size_t i = 0; i < data.tests_num; ++i)
             octree_host.radiusSearch(pcl::PointXYZ(data.queries[i].x, data.queries[i].y, data.queries[i].z), 
-                data.radiuses[i], indeces, pointRadiusSquaredDistance, max_answers);                        
+                data.radiuses[i], indeces_host, pointRadiusSquaredDistance, max_answers);                        
     }
      
     {
@@ -229,12 +230,14 @@ TEST(PCL_OctreeGPU, performance)
     }
 
     {        
+        int inds;
         ScopeTime up("gpu-approx-nearest-search-{host}-all");
         for(std::size_t i = 0; i < data.tests_num; ++i)
             octree_device.approxNearestSearchHost(data.queries[i], inds, dist);                        
     }
 
     {                
+        pcl::index_t inds;
         ScopeTime up("host-approx-nearest-search-all");	
         for(std::size_t i = 0; i < data.tests_num; ++i)
             octree_host.approxNearestSearch(data.queries[i], inds, dist);

--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -96,7 +96,7 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
 
   // prepare output buffers on device
   pcl::gpu::NeighborIndices result_device(queries.size(), 1);
-  std::vector<int> result_host_pcl(queries.size());
+  pcl::Indices result_host_pcl(queries.size());
   std::vector<int> result_host_gpu(queries.size());
   std::vector<float> dists_pcl(queries.size());
   std::vector<float> dists_gpu(queries.size());

--- a/test/gpu/octree/test_host_radius_search.cpp
+++ b/test/gpu/octree/test_host_radius_search.cpp
@@ -44,6 +44,7 @@
     #pragma warning (disable: 4521)
 #endif
     
+#include <pcl/pcl_tests.h> // for EXPECT_EQ_VECTORS
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/octree/octree_search.h>
@@ -121,13 +122,8 @@ TEST(PCL_OctreeGPU, hostRadiusSearch)
         std::sort(results_host_gpu.begin(), results_host_gpu.end());
         std::sort(results_host.begin(), results_host.end());
 
-        ASSERT_EQ (results_host_gpu.size(), results_host.size());
-        ASSERT_EQ (results_host_gpu.size(), data.bfresutls[i].size());
-        for(std::size_t j = 0; j < results_host_gpu.size(); ++j)
-        {
-            ASSERT_EQ (results_host_gpu[j], results_host[j]);
-            ASSERT_EQ (results_host_gpu[j], data.bfresutls[i][j]);
-        }
+        pcl::test::EXPECT_EQ_VECTORS (results_host_gpu, results_host);
+        pcl::test::EXPECT_EQ_VECTORS (results_host_gpu, data.bfresutls[i]);
         sizes.push_back(results_host.size());      
     }    
 

--- a/test/gpu/octree/test_host_radius_search.cpp
+++ b/test/gpu/octree/test_host_radius_search.cpp
@@ -115,14 +115,19 @@ TEST(PCL_OctreeGPU, hostRadiusSearch)
         
         //search host
         std::vector<float> dists;
-        std::vector<int> results_host;                
+        pcl::Indices results_host;
         octree_host.radiusSearch(pcl::PointXYZ(data.queries[i].x, data.queries[i].y, data.queries[i].z), data.radiuses[i], results_host, dists);                        
         
         std::sort(results_host_gpu.begin(), results_host_gpu.end());
         std::sort(results_host.begin(), results_host.end());
 
-        ASSERT_EQ ( (results_host_gpu == results_host     ), true );
-        ASSERT_EQ ( (results_host_gpu == data.bfresutls[i]), true );                
+        ASSERT_EQ (results_host_gpu.size(), results_host.size());
+        ASSERT_EQ (results_host_gpu.size(), data.bfresutls[i].size());
+        for(std::size_t j = 0; j < results_host_gpu.size(); ++j)
+        {
+            ASSERT_EQ (results_host_gpu[j], results_host[j]);
+            ASSERT_EQ (results_host_gpu[j], data.bfresutls[i][j]);
+        }
         sizes.push_back(results_host.size());      
     }    
 

--- a/test/gpu/octree/test_knn_search.cpp
+++ b/test/gpu/octree/test_knn_search.cpp
@@ -113,7 +113,7 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     queries_device.upload(data.queries);
 
     //prepare output buffers on host
-    std::vector<std::vector<  int> > result_host(data.tests_num);   
+    std::vector<pcl::Indices > result_host(data.tests_num);
     std::vector<std::vector<float> >  dists_host(data.tests_num);
     for(std::size_t i = 0; i < data.tests_num; ++i)
     {
@@ -147,7 +147,7 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     for(std::size_t i = 0; i < data.tests_num; ++i)    
     {           
         //std::cout << i << std::endl;
-        std::vector<int>&   results_host_cur = result_host[i];
+        const auto&   results_host_cur = result_host[i];
         std::vector<float>&   dists_host_cur = dists_host[i];
                 
         int beg = i * k;

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -347,8 +347,8 @@ loadScene (const char* file_name, PointCloud<PointXYZ>& non_plane_points, PointC
 
   // Make sure that the ids are sorted
   sort (inliers->indices.begin (), inliers->indices.end ());
-  std::size_t j = 0, i = 0;
-  for ( pcl::index_t id = 0 ; i < inliers->indices.size () ; )
+  pcl::uindex_t j = 0, i = 0;
+  for ( pcl::index_t id = 0 ; i < inliers->indices.size () ; ++id)
   {
     if ( id == inliers->indices[i] )
     {
@@ -361,7 +361,6 @@ loadScene (const char* file_name, PointCloud<PointXYZ>& non_plane_points, PointC
       non_plane_normals[j] = (*all_normals)[id];
       ++j;
     }
-    ++id;
   }
 
   // Just copy the rest of the non-plane points

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -347,10 +347,10 @@ loadScene (const char* file_name, PointCloud<PointXYZ>& non_plane_points, PointC
 
   // Make sure that the ids are sorted
   sort (inliers->indices.begin (), inliers->indices.end ());
-  std::size_t j = 0;
-  for ( std::size_t i = 0, id = 0 ; i < inliers->indices.size () ; )
+  std::size_t j = 0, i = 0;
+  for ( pcl::index_t id = 0 ; i < inliers->indices.size () ; )
   {
-    if ( static_cast<int> (id) == inliers->indices[i] )
+    if ( id == inliers->indices[i] )
     {
       plane_points[i] = (*all_points)[id];
       ++i;

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -243,7 +243,7 @@ private:
     viz.addText (dataDisplay, 0, 45, 1.0, 0.0, 0.0, "disp_original_points");
 
     char level[256];
-    sprintf (level, "Displayed depth is %d on %d", displayedDepth, octree.getTreeDepth());
+    sprintf (level, "Displayed depth is %d on %zu", displayedDepth, static_cast<std::size_t>(octree.getTreeDepth()));
     viz.removeShape ("level_t1");
     viz.addText (level, 0, 30, 1.0, 0.0, 0.0, "level_t1");
 

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1255,7 +1255,7 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   // Draw lines between the best corresponding points
   for (std::size_t i = 0; i < correspondences.size (); i += nth, ++j)
   {
-    if (correspondences[i].index_match == -1)
+    if (correspondences[i].index_match == UNAVAILABLE)
     {
       PCL_WARN ("[addCorrespondences] No valid index_match for correspondence %d\n", i);
       continue;


### PR DESCRIPTION
On the state of `pcl::index_t` and `pcl::Indices` in PCL after this PR (my point of view):
All of PCL (including cuda+gpu) is compilable with `index_t != int` (I tested with `uint64_t`). This PR also fixes any sign-compare warnings.
There might still be some classes/functions that should be switched to index_t/Indices which are not compiled (header only) and not tested, so they did not pop up so far. Internally there might also be further changes necessary, e.g. removing casts or when indices or the number of points are stored in an int, but that does not generate any warnings so I might have missed some.
Overall, I think `pcl::index_t` and `pcl::Indices` are in a usable state and it is possible to use indices that are unsigned and/or bigger than 32 bits, but for some classes, further work might be necessary.