### PR TITLE
Added new color traits in point_types.hpp

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -2434,15 +2434,9 @@ namespace traits
   template <typename PointT>
   using HasNoHSV = std::enable_if_t<!has_HSV_v<PointT>, bool>;
 
-  /** Metafunction to check if a given point type has x, y, and z fields. */
+  /** Deprecated: Metafunction to check if a given point type has either rgb or rgba field. */
   template <typename PointT>
-  struct has_xyz : has_all_fields<PointT, boost::mpl::vector<pcl::fields::x,
-                                                             pcl::fields::y,
-                                                             pcl::fields::z> >
-  { };
-
-  template <typename PointT>
-  struct PCL_DEPRECATED_HEADER(1, 15, "Please use has_rgb instead.")
+  struct PCL_DEPRECATED(1, 15, "Please use has_rgb instead.")
   has_color : has_any_field<PointT, boost::mpl::vector<pcl::fields::rgb,
                                                               pcl::fields::rgba> >
   { };
@@ -2473,10 +2467,13 @@ namespace traits
 
   /** Metafunction to check if a given point type has any color (e.g. rgb, rgba, hsv, lab) field. */
   template <typename PointT>
-  using HasAnyColor = std::enable_if_t<has_rgb_v<PointT> || has_HSV_v<PointT> || has_Lab_v<PointT> || has_intensity_v<PointT>, bool>;
+  constexpr auto has_any_color_v = has_rgb_v<PointT> || has_HSV_v<PointT> || has_Lab_v<PointT> || has_intensity_v<PointT>;
 
   template <typename PointT>
-  using HasNoAnyColor = std::enable_if_t<!has_rgb_v<PointT> && !has_HSV_v<PointT> && !has_Lab_v<PointT> && !has_intensity_v<PointT>, bool>;
+  using HasAnyColor = std::enable_if_t<has_any_color_v<PointT>, bool>;
+
+  template <typename PointT>
+  using HasNoAnyColor = std::enable_if_t<!has_any_color_v<PointT>, bool>;
 
   /** Metafunction to check if a given point type has label field. */
   template <typename PointT>

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -2402,9 +2402,48 @@ namespace traits
   template <typename PointT>
   using HasNoIntensity = std::enable_if_t<!has_intensity_v<PointT>, bool>;
 
-  /** Metafunction to check if a given point type has either rgb or rgba field. */
+  /** Metafunction to check if a given point type has L*a*b* fields. */
   template <typename PointT>
-  struct has_color : has_any_field<PointT, boost::mpl::vector<pcl::fields::rgb,
+  struct has_Lab : has_all_fields<PointT, boost::mpl::vector<pcl::fields::L,
+                                                             pcl::fields::a,
+                                                             pcl::fields::b> >
+  { };
+
+  template <typename PointT>
+  constexpr auto has_Lab_v = has_Lab<PointT>::value;
+
+  template <typename PointT>
+  using HasLab = std::enable_if_t<has_Lab_v<PointT>, bool>;
+
+  template <typename PointT>
+  using HasNoLab = std::enable_if_t<!has_Lab_v<PointT>, bool>;
+
+  /** Metafunction to check if a given point type has HSV color space fields. */
+  template <typename PointT>
+  struct has_HSV : has_all_fields<PointT, boost::mpl::vector<pcl::fields::h,
+                                                             pcl::fields::s,
+                                                             pcl::fields::v> >
+  { };
+
+  template <typename PointT>
+  constexpr auto has_HSV_v = has_HSV<PointT>::value;
+
+  template <typename PointT>
+  using HasHSV = std::enable_if_t<has_HSV_v<PointT>, bool>;
+
+  template <typename PointT>
+  using HasNoHSV = std::enable_if_t<!has_HSV_v<PointT>, bool>;
+
+  /** Metafunction to check if a given point type has x, y, and z fields. */
+  template <typename PointT>
+  struct has_xyz : has_all_fields<PointT, boost::mpl::vector<pcl::fields::x,
+                                                             pcl::fields::y,
+                                                             pcl::fields::z> >
+  { };
+
+  template <typename PointT>
+  struct PCL_DEPRECATED_HEADER(1, 15, "Please use has_rgb instead.")
+  has_color : has_any_field<PointT, boost::mpl::vector<pcl::fields::rgb,
                                                               pcl::fields::rgba> >
   { };
 
@@ -2416,6 +2455,28 @@ namespace traits
 
   template <typename PointT>
   using HasNoColor = std::enable_if_t<!has_color_v<PointT>, bool>;
+
+  /** Metafunction to check if a given point type has either rgb or rgba field. */
+  template <typename PointT>
+  struct has_rgb : has_any_field<PointT, boost::mpl::vector<pcl::fields::rgb,
+                                                              pcl::fields::rgba> >
+  { };
+
+  template <typename PointT>
+  constexpr auto has_rgb_v = has_rgb<PointT>::value;
+
+  template <typename PointT>
+  using HasRGB = std::enable_if_t<has_rgb_v<PointT>, bool>;
+
+  template <typename PointT>
+  using HasNoRGB = std::enable_if_t<!has_rgb_v<PointT>, bool>;
+
+  /** Metafunction to check if a given point type has any color (e.g. rgb, rgba, hsv, lab) field. */
+  template <typename PointT>
+  using HasAnyColor = std::enable_if_t<has_rgb_v<PointT> || has_HSV_v<PointT> || has_Lab_v<PointT> || has_intensity_v<PointT>, bool>;
+
+  template <typename PointT>
+  using HasNoAnyColor = std::enable_if_t<!has_rgb_v<PointT> && !has_HSV_v<PointT> && !has_Lab_v<PointT> && !has_intensity_v<PointT>, bool>;
 
   /** Metafunction to check if a given point type has label field. */
   template <typename PointT>

--- a/test/common/test_type_traits.cpp
+++ b/test/common/test_type_traits.cpp
@@ -111,14 +111,72 @@ TEST (TypeTraits, HasIntensity)
                 "has_intensity<> should detect intensity field");
 }
 
+TEST (TypeTraits, HasLab)
+{
+  static_assert(!pcl::traits::has_Lab_v<pcl::PointXYZ>,
+                "has_Lab<> should detect lack of CIELAB field");
+  static_assert(!pcl::traits::has_Lab_v<pcl::PointXYZRGB>,
+                "has_Lab<> should detect lack of CIELAB field");
+  static_assert(!pcl::traits::has_Lab_v<pcl::PointXYZHSV>,
+                "has_Lab<> should detect lack of CIELAB field");
+  static_assert(pcl::traits::has_Lab_v<pcl::PointXYZLAB>,
+                "has_Lab<> should detect CIELAB field");
+}
+
+TEST (TypeTraits, HasHSV)
+{
+  static_assert(!pcl::traits::has_HSV_v<pcl::PointXYZ>,
+                "has_HSV<> should detect lack of HSV field");
+  static_assert(!pcl::traits::has_HSV_v<pcl::PointXYZRGB>,
+                "has_HSV<> should detect lack of HSV field");
+  static_assert(!pcl::traits::has_HSV_v<pcl::PointXYZLAB>,
+                "has_HSV<> should detect lack of HSV field");
+  static_assert(pcl::traits::has_HSV_v<pcl::PointXYZHSV>,
+                "has_HSV<> should detect HSV field");
+}
+
 TEST (TypeTraits, HasColor)
 {
   static_assert(!pcl::traits::has_color_v<pcl::PointXYZ>,
+                "has_color<> should detect lack of rgb field");
+  static_assert(!pcl::traits::has_color_v<pcl::PointXYZLAB>,
+                "has_color<> should detect lack of rgb field");
+  static_assert(!pcl::traits::has_color_v<pcl::PointXYZHSV>,
                 "has_color<> should detect lack of rgb field");
   static_assert(pcl::traits::has_color_v<pcl::PointXYZRGB>,
                 "has_color<> should detect rgb field");
   static_assert(pcl::traits::has_color_v<pcl::PointXYZRGBA>,
                 "has_color<> should detect rgb field");
+}
+
+TEST (TypeTraits, HasRGB)
+{
+  static_assert(!pcl::traits::has_rgb_v<pcl::PointXYZ>,
+                "has_rgb<> should detect lack of rgb field");
+  static_assert(!pcl::traits::has_rgb_v<pcl::PointXYZLAB>,
+                "has_rgb<> should detect lack of rgb field");
+  static_assert(!pcl::traits::has_rgb_v<pcl::PointXYZHSV>,
+                "has_rgb<> should detect lack of rgb field");
+  static_assert(pcl::traits::has_rgb_v<pcl::PointXYZRGB>,
+                "has_rgb<> should detect rgb field");
+  static_assert(pcl::traits::has_rgb_v<pcl::PointXYZRGBA>,
+                "has_rgb<> should detect rgb field");
+}
+
+TEST (TypeTraits, HasAnyColor)
+{
+  static_assert(!pcl::traits::has_any_color_v<pcl::PointXYZ>,
+                "has_any_color<> should detect lack of color field");
+  static_assert(pcl::traits::has_any_color_v<pcl::PointXYZLAB>,
+                "has_any_color<> should detect color field");
+  static_assert(pcl::traits::has_any_color_v<pcl::PointXYZHSV>,
+                "has_any_color<> should detect color field");
+  static_assert(pcl::traits::has_any_color_v<pcl::PointXYZRGB>,
+                "has_any_color<> should detect color field");
+  static_assert(pcl::traits::has_any_color_v<pcl::PointXYZRGBA>,
+                "has_any_color<> should detect color field");
+  static_assert(pcl::traits::has_any_color_v<pcl::PointXYZI>,
+                "has_any_color<> should detect color field");
 }
 
 TEST (TypeTraits, HasLabel)


### PR DESCRIPTION
A follow up work of https://github.com/PointCloudLibrary/pcl/pull/4706#discussion_r615752147 https://github.com/PointCloudLibrary/pcl/pull/4706#discussion_r616311591.

New color traits:
- has_Lab
- has_HSV
- has_rgb
- has_any_color

Add deprecated comments for `has_color`.
