### PR TITLE
fix compiler errors with msvc2015

### DIFF
--- a/common/include/pcl/PolygonMesh.h
+++ b/common/include/pcl/PolygonMesh.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <vector>
 #include <ostream>
+#include <iterator>
 
 // Include the correct Header path here
 #include <pcl/PCLHeader.h>
@@ -31,7 +32,7 @@ namespace pcl
     concatenate (pcl::PolygonMesh &mesh1, const pcl::PolygonMesh &mesh2)
     {
       const auto point_offset = mesh1.cloud.width * mesh1.cloud.height;
-      
+
       bool success = pcl::PCLPointCloud2::concatenate(mesh1.cloud, mesh2.cloud);
       if (success == false) {
         return false;

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -2336,10 +2336,10 @@ namespace traits
   constexpr auto has_xy_v = has_xy<PointT>::value;
 
   template <typename PointT>
-  using HasXY = std::enable_if_t<has_xy_v<PointT>, bool>;
+  using HasXY = std::enable_if_t<has_xy<PointT>::value, bool>;
 
   template <typename PointT>
-  using HasNoXY = std::enable_if_t<!has_xy_v<PointT>, bool>;
+  using HasNoXY = std::enable_if_t<!has_xy<PointT>::value, bool>;
 
   /** Metafunction to check if a given point type has x, y, and z fields. */
   template <typename PointT>
@@ -2352,10 +2352,10 @@ namespace traits
   constexpr auto has_xyz_v = has_xyz<PointT>::value;
 
   template <typename PointT>
-  using HasXYZ = std::enable_if_t<has_xyz_v<PointT>, bool>;
+  using HasXYZ = std::enable_if_t<has_xyz<PointT>::value, bool>;
 
   template <typename PointT>
-  using HasNoXYZ = std::enable_if_t<!has_xyz_v<PointT>, bool>;
+  using HasNoXYZ = std::enable_if_t<!has_xyz<PointT>::value, bool>;
 
   /** Metafunction to check if a given point type has normal_x, normal_y, and
     * normal_z fields. */
@@ -2369,10 +2369,10 @@ namespace traits
   constexpr auto has_normal_v = has_normal<PointT>::value;
 
   template <typename PointT>
-  using HasNormal = std::enable_if_t<has_normal_v<PointT>, bool>;
+  using HasNormal = std::enable_if_t<has_normal<PointT>::value, bool>;
 
   template <typename PointT>
-  using HasNoNormal = std::enable_if_t<!has_normal_v<PointT>, bool>;
+  using HasNoNormal = std::enable_if_t<!has_normal<PointT>::value, bool>;
 
   /** Metafunction to check if a given point type has curvature field. */
   template <typename PointT>
@@ -2383,10 +2383,10 @@ namespace traits
   constexpr auto has_curvature_v = has_curvature<PointT>::value;
 
   template <typename PointT>
-  using HasCurvature = std::enable_if_t<has_curvature_v<PointT>, bool>;
+  using HasCurvature = std::enable_if_t<has_curvature<PointT>::value, bool>;
 
   template <typename PointT>
-  using HasNoCurvature = std::enable_if_t<!has_curvature_v<PointT>, bool>;
+  using HasNoCurvature = std::enable_if_t<!has_curvature<PointT>::value, bool>;
 
   /** Metafunction to check if a given point type has intensity field. */
   template <typename PointT>
@@ -2397,10 +2397,10 @@ namespace traits
   constexpr auto has_intensity_v = has_intensity<PointT>::value;
 
   template <typename PointT>
-  using HasIntensity = std::enable_if_t<has_intensity_v<PointT>, bool>;
+  using HasIntensity = std::enable_if_t<has_intensity<PointT>::value, bool>;
 
   template <typename PointT>
-  using HasNoIntensity = std::enable_if_t<!has_intensity_v<PointT>, bool>;
+  using HasNoIntensity = std::enable_if_t<!has_intensity<PointT>::value, bool>;
 
   /** Metafunction to check if a given point type has either rgb or rgba field. */
   template <typename PointT>
@@ -2412,10 +2412,10 @@ namespace traits
   constexpr auto has_color_v = has_color<PointT>::value;
 
   template <typename PointT>
-  using HasColor = std::enable_if_t<has_color_v<PointT>, bool>;
+  using HasColor = std::enable_if_t<has_color<PointT>::value, bool>;
 
   template <typename PointT>
-  using HasNoColor = std::enable_if_t<!has_color_v<PointT>, bool>;
+  using HasNoColor = std::enable_if_t<!has_color<PointT>::value, bool>;
 
   /** Metafunction to check if a given point type has label field. */
   template <typename PointT>
@@ -2426,10 +2426,10 @@ namespace traits
   constexpr auto has_label_v = has_label<PointT>::value;
 
   template <typename PointT>
-  using HasLabel = std::enable_if_t<has_label_v<PointT>, bool>;
+  using HasLabel = std::enable_if_t<has_label<PointT>::value, bool>;
 
   template <typename PointT>
-  using HasNoLabel = std::enable_if_t<!has_label_v<PointT>, bool>;
+  using HasNoLabel = std::enable_if_t<!has_label<PointT>::value, bool>;
 }
 
 #if defined _MSC_VER

--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -144,7 +144,7 @@ struct legally_representable {
 // * either long int or long long int is a valid type for storing Integral
 // * unsigned long long int is handled specially
 template <typename Integral>
-using primary_legal_input_type = std::conditional_t<legally_representable_v<long int, Integral>,
+using primary_legal_input_type = std::conditional_t<legally_representable<long int, Integral>::value,
                                                     long int, long long int>;
 
 // special handling if unsigned [long] int is of same size as long long int

--- a/io/include/pcl/io/ply/ply_parser.h
+++ b/io/include/pcl/io/ply/ply_parser.h
@@ -54,6 +54,7 @@
 #include <boost/mpl/inherit_linearly.hpp> // inherit_linearly
 #include <boost/mpl/joint_view.hpp> // for joint_view
 #include <boost/mpl/transform.hpp> // for transform
+#include <boost/mpl/vector.hpp>
 
 namespace pcl
 {
@@ -66,7 +67,7 @@ namespace pcl
         * \author Ares Lagae as part of libply, Nizar Sallem
         * Ported with agreement from the author under the terms of the BSD
         * license.
-        */     
+        */
       class PCL_EXPORTS ply_parser
       {
         public:
@@ -74,18 +75,18 @@ namespace pcl
           using info_callback_type = std::function<void (std::size_t, const std::string&)>;
           using warning_callback_type = std::function<void (std::size_t, const std::string&)>;
           using error_callback_type = std::function<void (std::size_t, const std::string&)>;
-         
+
           using magic_callback_type = std::function<void ()>;
           using format_callback_type = std::function<void (format_type, const std::string&)>;
           using comment_callback_type = std::function<void (const std::string&)>;
           using obj_info_callback_type = std::function<void (const std::string&)>;
           using end_header_callback_type = std::function<bool ()>;
-         
+
           using begin_element_callback_type = std::function<void ()>;
           using end_element_callback_type = std::function<void ()>;
           using element_callbacks_type = std::tuple<begin_element_callback_type, end_element_callback_type>;
           using element_definition_callback_type = std::function<element_callbacks_type (const std::string&, std::size_t)>;
-         
+
           template <typename ScalarType>
           struct scalar_property_callback_type
           {
@@ -98,7 +99,7 @@ namespace pcl
             using scalar_property_callback_type = typename scalar_property_callback_type<ScalarType>::type;
             using type = std::function<scalar_property_callback_type (const std::string&, const std::string&)>;
           };
-       
+
           using scalar_types = boost::mpl::vector<int8, int16, int32, uint8, uint16, uint32, float32, float64>;
 
           class scalar_property_definition_callbacks_type
@@ -111,7 +112,7 @@ namespace pcl
                 using scalar_type = T;
                 typename scalar_property_definition_callback_type<scalar_type>::type callback;
               };
-             
+
               using callbacks = boost::mpl::inherit_linearly<
                 scalar_types,
                 boost::mpl::inherit<
@@ -120,7 +121,7 @@ namespace pcl
                 >
                 >::type;
               callbacks callbacks_;
-             
+
             public:
               template <typename ScalarType>
               const typename scalar_property_definition_callback_type<ScalarType>::type&
@@ -128,18 +129,18 @@ namespace pcl
               {
                 return (static_cast<const callbacks_element<ScalarType>&> (callbacks_).callback);
               }
-             
+
               template <typename ScalarType>
               typename scalar_property_definition_callback_type<ScalarType>::type&
               get ()
               {
                 return (static_cast<callbacks_element<ScalarType>&> (callbacks_).callback);
               }
-             
+
               template <typename ScalarType>
               friend typename scalar_property_definition_callback_type<ScalarType>::type&
               at (scalar_property_definition_callbacks_type& scalar_property_definition_callbacks);
-           
+
               template <typename ScalarType>
               friend const typename scalar_property_definition_callback_type<ScalarType>::type&
               at (const scalar_property_definition_callbacks_type& scalar_property_definition_callbacks);
@@ -152,7 +153,7 @@ namespace pcl
               return (scalar_property_definition_callbacks.get<ScalarType> ());
           }
 
-          
+
           template <typename ScalarType> static
           const typename scalar_property_definition_callback_type<ScalarType>::type&
           at (const scalar_property_definition_callbacks_type& scalar_property_definition_callbacks)
@@ -165,13 +166,13 @@ namespace pcl
           {
             using type = std::function<void (SizeType)>;
           };
-         
+
           template <typename SizeType, typename ScalarType>
           struct list_property_element_callback_type
           {
             using type = std::function<void (ScalarType)>;
           };
-       
+
           template <typename SizeType, typename ScalarType>
           struct list_property_end_callback_type
           {
@@ -192,13 +193,13 @@ namespace pcl
           };
 
           using size_types = boost::mpl::vector<uint8, uint16, uint32>;
-     
+
           class list_property_definition_callbacks_type
           {
             private:
               template <typename T> struct pair_with : boost::mpl::pair<T,boost::mpl::_> {};
               template<typename Sequence1, typename Sequence2>
-          
+
                 struct sequence_product :
                   boost::mpl::fold<Sequence1, boost::mpl::vector0<>,
                     boost::mpl::joint_view<
@@ -212,10 +213,10 @@ namespace pcl
                 using scalar_type = typename T::second;
                 typename list_property_definition_callback_type<size_type, scalar_type>::type callback;
               };
-           
+
               using callbacks = boost::mpl::inherit_linearly<sequence_product<size_types, scalar_types>::type, boost::mpl::inherit<boost::mpl::_1, callbacks_element<boost::mpl::_2> > >::type;
               callbacks callbacks_;
-     
+
             public:
               template <typename SizeType, typename ScalarType>
               typename list_property_definition_callback_type<SizeType, ScalarType>::type&
@@ -234,19 +235,19 @@ namespace pcl
               template <typename SizeType, typename ScalarType>
               friend typename list_property_definition_callback_type<SizeType, ScalarType>::type&
               at (list_property_definition_callbacks_type& list_property_definition_callbacks);
-           
+
               template <typename SizeType, typename ScalarType>
               friend const typename list_property_definition_callback_type<SizeType, ScalarType>::type&
               at (const list_property_definition_callbacks_type& list_property_definition_callbacks);
           };
-          
+
           template <typename SizeType, typename ScalarType> static
           typename list_property_definition_callback_type<SizeType, ScalarType>::type&
           at (list_property_definition_callbacks_type& list_property_definition_callbacks)
           {
               return (list_property_definition_callbacks.get<SizeType, ScalarType> ());
           }
-          
+
           template <typename SizeType, typename ScalarType> static
           const typename list_property_definition_callback_type<SizeType, ScalarType>::type&
           at (const list_property_definition_callbacks_type& list_property_definition_callbacks)
@@ -294,12 +295,12 @@ namespace pcl
           ply_parser () :
             line_number_ (0), current_element_ ()
           {}
-              
+
           bool parse (const std::string& filename);
           //inline bool parse (const std::string& filename);
 
         private:
-            
+
           struct property
           {
             property (const std::string& name) : name (name) {}
@@ -307,7 +308,7 @@ namespace pcl
             virtual bool parse (class ply_parser& ply_parser, format_type format, std::istream& istream) = 0;
             std::string name;
           };
-            
+
           template <typename ScalarType>
           struct scalar_property : public property
           {
@@ -317,11 +318,11 @@ namespace pcl
               : property (name)
               , callback (callback)
             {}
-            bool parse (class ply_parser& ply_parser, 
-                        format_type format, 
-                        std::istream& istream) override 
-            { 
-              return ply_parser.parse_scalar_property<scalar_type> (format, istream, callback); 
+            bool parse (class ply_parser& ply_parser,
+                        format_type format,
+                        std::istream& istream) override
+            {
+              return ply_parser.parse_scalar_property<scalar_type> (format, istream, callback);
             }
             callback_type callback;
           };
@@ -334,20 +335,20 @@ namespace pcl
             using begin_callback_type = typename list_property_begin_callback_type<size_type, scalar_type>::type;
             using element_callback_type = typename list_property_element_callback_type<size_type, scalar_type>::type;
             using end_callback_type = typename list_property_end_callback_type<size_type, scalar_type>::type;
-            list_property (const std::string& name, 
-                           begin_callback_type begin_callback, 
-                           element_callback_type element_callback, 
+            list_property (const std::string& name,
+                           begin_callback_type begin_callback,
+                           element_callback_type element_callback,
                            end_callback_type end_callback)
               : property (name)
               , begin_callback (begin_callback)
               , element_callback (element_callback)
               , end_callback (end_callback)
             {}
-            bool parse (class ply_parser& ply_parser, 
-                        format_type format, 
-                        std::istream& istream) override 
-            { 
-              return ply_parser.parse_list_property<size_type, scalar_type> (format, 
+            bool parse (class ply_parser& ply_parser,
+                        format_type format,
+                        std::istream& istream) override
+            {
+              return ply_parser.parse_list_property<size_type, scalar_type> (format,
                                                                              istream,
                                                                              begin_callback,
                                                                              element_callback,
@@ -357,12 +358,12 @@ namespace pcl
             element_callback_type element_callback;
             end_callback_type end_callback;
           };
-        
+
           struct element
           {
-            element (const std::string& name, 
-                    std::size_t count, 
-                    const begin_element_callback_type& begin_element_callback, 
+            element (const std::string& name,
+                    std::size_t count,
+                    const begin_element_callback_type& begin_element_callback,
                     const end_element_callback_type& end_element_callback)
               : name (name)
               , count (count)
@@ -375,43 +376,43 @@ namespace pcl
             end_element_callback_type end_element_callback;
             std::vector<std::shared_ptr<property>> properties;
           };
-          
+
           info_callback_type info_callback_ = [](std::size_t, const std::string&){};
           warning_callback_type warning_callback_ = [](std::size_t, const std::string&){};
           error_callback_type error_callback_ = [](std::size_t, const std::string&){};
-          
+
           magic_callback_type magic_callback_ = [](){};
           format_callback_type format_callback_ = [](format_type, const std::string&){};
           comment_callback_type comment_callback_ = [](const std::string&){};
           obj_info_callback_type obj_info_callback_ = [](const std::string&){};
           end_header_callback_type end_header_callback_ = [](){return true;};
 
-          element_definition_callback_type element_definition_callbacks_ = 
+          element_definition_callback_type element_definition_callbacks_ =
               [](const std::string&, std::size_t)
               {
                   return std::make_tuple([](){}, [](){});
               };
           scalar_property_definition_callbacks_type scalar_property_definition_callbacks_;
           list_property_definition_callbacks_type list_property_definition_callbacks_;
-          
-          template <typename ScalarType> inline void 
+
+          template <typename ScalarType> inline void
           parse_scalar_property_definition (const std::string& property_name);
 
-          template <typename SizeType, typename ScalarType> inline void 
+          template <typename SizeType, typename ScalarType> inline void
           parse_list_property_definition (const std::string& property_name);
-          
-          template <typename ScalarType> inline bool 
-          parse_scalar_property (format_type format, 
-                                 std::istream& istream, 
+
+          template <typename ScalarType> inline bool
+          parse_scalar_property (format_type format,
+                                 std::istream& istream,
                                  const typename scalar_property_callback_type<ScalarType>::type& scalar_property_callback);
 
-          template <typename SizeType, typename ScalarType> inline bool 
-          parse_list_property (format_type format, 
-                               std::istream& istream, 
-                               const typename list_property_begin_callback_type<SizeType, ScalarType>::type& list_property_begin_callback, 
-                               const typename list_property_element_callback_type<SizeType, ScalarType>::type& list_property_element_callback, 
+          template <typename SizeType, typename ScalarType> inline bool
+          parse_list_property (format_type format,
+                               std::istream& istream,
+                               const typename list_property_begin_callback_type<SizeType, ScalarType>::type& list_property_begin_callback,
+                               const typename list_property_element_callback_type<SizeType, ScalarType>::type& list_property_element_callback,
                                const typename list_property_end_callback_type<SizeType, ScalarType>::type& list_property_end_callback);
-            
+
           std::size_t line_number_;
           element* current_element_;
       };
@@ -429,42 +430,42 @@ inline void pcl::io::ply::ply_parser::info_callback (const info_callback_type& i
 {
   info_callback_ = info_callback;
 }
-    
+
 inline void pcl::io::ply::ply_parser::warning_callback (const warning_callback_type& warning_callback)
 {
   warning_callback_ = warning_callback;
 }
-    
+
 inline void pcl::io::ply::ply_parser::error_callback (const error_callback_type& error_callback)
 {
   error_callback_ = error_callback;
 }
-    
+
 inline void pcl::io::ply::ply_parser::magic_callback (const magic_callback_type& magic_callback)
 {
   magic_callback_ = magic_callback;
 }
-    
+
 inline void pcl::io::ply::ply_parser::format_callback (const format_callback_type& format_callback)
 {
   format_callback_ = format_callback;
 }
-    
+
 inline void pcl::io::ply::ply_parser::element_definition_callback (const element_definition_callback_type& element_definition_callback)
 {
   element_definition_callbacks_ = element_definition_callback;
 }
-    
+
 inline void pcl::io::ply::ply_parser::scalar_property_definition_callbacks (const scalar_property_definition_callbacks_type& scalar_property_definition_callbacks)
 {
   scalar_property_definition_callbacks_ = scalar_property_definition_callbacks;
 }
-    
+
 inline void pcl::io::ply::ply_parser::list_property_definition_callbacks (const list_property_definition_callbacks_type& list_property_definition_callbacks)
 {
   list_property_definition_callbacks_ = list_property_definition_callbacks;
 }
-    
+
 inline void pcl::io::ply::ply_parser::comment_callback (const comment_callback_type& comment_callback)
 {
   comment_callback_ = comment_callback;
@@ -484,7 +485,7 @@ template <typename ScalarType>
 inline void pcl::io::ply::ply_parser::parse_scalar_property_definition (const std::string& property_name)
 {
   using scalar_type = ScalarType;
-  typename scalar_property_definition_callback_type<scalar_type>::type& scalar_property_definition_callback = 
+  typename scalar_property_definition_callback_type<scalar_type>::type& scalar_property_definition_callback =
     scalar_property_definition_callbacks_.get<scalar_type> ();
   typename scalar_property_callback_type<scalar_type>::type scalar_property_callback;
   if (scalar_property_definition_callback)
@@ -495,8 +496,8 @@ inline void pcl::io::ply::ply_parser::parse_scalar_property_definition (const st
   {
     if (warning_callback_)
     {
-      warning_callback_ (line_number_, 
-                        "property '" + std::string (type_traits<scalar_type>::name ()) + " " + 
+      warning_callback_ (line_number_,
+                        "property '" + std::string (type_traits<scalar_type>::name ()) + " " +
                         property_name + "' of element '" + current_element_->name + "' is not handled");
     }
   }
@@ -522,23 +523,23 @@ inline void pcl::io::ply::ply_parser::parse_list_property_definition (const std:
   {
     if (warning_callback_)
     {
-      warning_callback_ (line_number_, 
-                        "property 'list " + std::string (type_traits<size_type>::name ()) + " " + 
-                        std::string (type_traits<scalar_type>::name ()) + " " + 
-                        property_name + "' of element '" + 
+      warning_callback_ (line_number_,
+                        "property 'list " + std::string (type_traits<size_type>::name ()) + " " +
+                        std::string (type_traits<scalar_type>::name ()) + " " +
+                        property_name + "' of element '" +
                         current_element_->name + "' is not handled");
     }
   }
   current_element_->properties.emplace_back (new list_property<size_type, scalar_type> (
-                                             property_name, 
-                                             std::get<0> (list_property_callbacks), 
-                                             std::get<1> (list_property_callbacks), 
+                                             property_name,
+                                             std::get<0> (list_property_callbacks),
+                                             std::get<1> (list_property_callbacks),
                                              std::get<2> (list_property_callbacks)));
 }
 
 template <typename ScalarType>
-inline bool pcl::io::ply::ply_parser::parse_scalar_property (format_type format, 
-                                                             std::istream& istream, 
+inline bool pcl::io::ply::ply_parser::parse_scalar_property (format_type format,
+                                                             std::istream& istream,
                                                              const typename scalar_property_callback_type<ScalarType>::type& scalar_property_callback)
 {
   using namespace io_operators;
@@ -587,9 +588,9 @@ inline bool pcl::io::ply::ply_parser::parse_scalar_property (format_type format,
 }
 
 template <typename SizeType, typename ScalarType>
-inline bool pcl::io::ply::ply_parser::parse_list_property (format_type format, std::istream& istream, 
-                                                           const typename list_property_begin_callback_type<SizeType, ScalarType>::type& list_property_begin_callback, 
-                                                           const typename list_property_element_callback_type<SizeType, ScalarType>::type& list_property_element_callback, 
+inline bool pcl::io::ply::ply_parser::parse_list_property (format_type format, std::istream& istream,
+                                                           const typename list_property_begin_callback_type<SizeType, ScalarType>::type& list_property_begin_callback,
+                                                           const typename list_property_element_callback_type<SizeType, ScalarType>::type& list_property_element_callback,
                                                            const typename list_property_end_callback_type<SizeType, ScalarType>::type& list_property_end_callback)
 {
   using namespace io_operators;
@@ -656,7 +657,7 @@ inline bool pcl::io::ply::ply_parser::parse_list_property (format_type format, s
   }
   size_type size = std::numeric_limits<size_type>::infinity ();
   istream.read (reinterpret_cast<char*> (&size), sizeof (size_type));
-  if (((format == binary_big_endian_format) && (host_byte_order == little_endian_byte_order)) || 
+  if (((format == binary_big_endian_format) && (host_byte_order == little_endian_byte_order)) ||
       ((format == binary_little_endian_format) && (host_byte_order == big_endian_byte_order)))
   {
     swap_byte_order (size);

--- a/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
@@ -40,6 +40,7 @@
 #include <pcl/recognition/hv/occlusion_reasoning.h>
 
 #include <algorithm>
+#include <cmath>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 template<typename ModelT, typename SceneT>
@@ -142,7 +143,7 @@ pcl::occlusion_reasoning::ZBuffering<ModelT, SceneT>::computeDepthMap (typename 
     f_ = (cx) / maxC;
   }
 
-  const size_t depth_n = std::ceilf(cx_ * cy_);
+  const size_t depth_n = std::ceil(cx_ * cy_);
   depth_ = new float[depth_n];
   std::fill_n(depth_, depth_n, std::numeric_limits<float>::quiet_NaN());
 

--- a/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
@@ -142,8 +142,9 @@ pcl::occlusion_reasoning::ZBuffering<ModelT, SceneT>::computeDepthMap (typename 
     f_ = (cx) / maxC;
   }
 
-  depth_ = new float[cx_ * cy_];
-  std::fill_n(depth_, cx * cy, std::numeric_limits<float>::quiet_NaN());
+  const size_t depth_n = std::ceilf(cx_ * cy_);
+  depth_ = new float[depth_n];
+  std::fill_n(depth_, depth_n, std::numeric_limits<float>::quiet_NaN());
 
   for (const auto& point: *scene)
   {

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -49,6 +49,7 @@
 #include <pcl/search/kdtree.h>
 
 #include <queue>
+#include <iterator>
 #include <cmath>
 #include <ctime>
 
@@ -521,7 +522,7 @@ pcl::RegionGrowing<PointT, NormalT>::validatePoint (pcl::index_t initial_seed, p
 
   // check the residual if needed
   float data_1[4];
-  
+
   data_1[0] = (*input_)[nghbr].data[0];
   data_1[1] = (*input_)[nghbr].data[1];
   data_1[2] = (*input_)[nghbr].data[2];

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -46,6 +46,7 @@
 #include <pcl/search/kdtree.h>
 
 #include <queue>
+#include <iterator>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename NormalT>
@@ -573,7 +574,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::assembleRegions (std::vector<unsigned in
   }
 
   // now we need to erase empty regions
-  if (clusters_.empty ()) 
+  if (clusters_.empty ())
     return;
 
   std::vector<pcl::PointIndices>::iterator itr1, itr2;
@@ -582,11 +583,11 @@ pcl::RegionGrowingRGB<PointT, NormalT>::assembleRegions (std::vector<unsigned in
 
   while (itr1 < itr2)
   {
-    while (!(itr1->indices.empty ()) && itr1 < itr2) 
+    while (!(itr1->indices.empty ()) && itr1 < itr2)
       ++itr1;
-    while (  itr2->indices.empty ()  && itr1 < itr2) 
+    while (  itr2->indices.empty ()  && itr1 < itr2)
       --itr2;
-	  
+
     if (itr1 != itr2)
       itr1->indices.swap (itr2->indices);
   }


### PR DESCRIPTION
Hi,
sadly, I have to use MSVC 2015 as a compiler, which doesn't support every C++14 feature.  
Those are mainly the type_trait shortcuts such as `has_xy_v` which have to be replaced with `has_xy<T>::value`.

There were also some missing header issues and an interesting one with the STL.  
It didn't like the implcit `operator+(float*, float)` in `std::fill_n`, so I explicitly casted the value to an integral type. It becomes now `operator+(float*, size_t)`.

I hope you are interested in it and that it can become helpful.

P.S.: I have a tool which auto removes trailing whitespaces