### PR TITLE
[io] Specify no face elements in PLY files (from point cloud) to make them interoperable with VTK

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -816,6 +816,9 @@ pcl::PLYWriter::generateHeader (const pcl::PCLPointCloud2 &cloud,
     }
   }
 
+  // vtk requires face entry to load PLY
+  oss << "\nelement face 0";
+
   if (use_camera)
   {
     oss << "\nelement camera 1"


### PR DESCRIPTION
Fix loading ply file by loadPolygonFilePLY as vtk requires face element as mentioned in https://github.com/PointCloudLibrary/pcl/issues/1470

I tested the fix with ply file [here](https://vvvv.org/contribution/large-ply-dx11-pointcloud-reader) and the following code, it doesn't throw `Cannot read geometry` from vtk now. And the saved ply can be opened by meshlab without issue
```cpp
#include <pcl/io/ply_io.h>
#include <pcl/io/vtk_lib_io.h>

int main(){
    pcl::PointCloud<pcl::PointXYZ> test_ply;
    pcl::PolygonMesh test_mesh;
    pcl::io::loadPLYFile("XXX.ply",test_ply);
    pcl::io::savePLYFile("XXX.ply",test_ply);
    pcl::io::loadPolygonFilePLY("XXX.ply",test_mesh);
    return 0;
}
```