### PR TITLE
Add missing includes to density and singlepoint octree

### DIFF
--- a/octree/include/pcl/octree/octree_pointcloud_density.h
+++ b/octree/include/pcl/octree/octree_pointcloud_density.h
@@ -145,5 +145,8 @@ public:
 } // namespace octree
 } // namespace pcl
 
+// needed since OctreePointCloud is not instantiated with template parameters used above
+#include <pcl/octree/impl/octree_pointcloud.hpp>
+
 #define PCL_INSTANTIATE_OctreePointCloudDensity(T)                                     \
   template class PCL_EXPORTS pcl::octree::OctreePointCloudDensity<T>;

--- a/octree/include/pcl/octree/octree_pointcloud_singlepoint.h
+++ b/octree/include/pcl/octree/octree_pointcloud_singlepoint.h
@@ -86,5 +86,8 @@ public:
 } // namespace octree
 } // namespace pcl
 
+// needed since OctreePointCloud is not instantiated with template parameters used above
+#include <pcl/octree/impl/octree_pointcloud.hpp>
+
 #define PCL_INSTANTIATE_OctreePointCloudSinglePoint(T)                                 \
   template class PCL_EXPORTS pcl::octree::OctreePointCloudSinglePoint<T>;


### PR DESCRIPTION
OctreePointCloud is not instantiated with the specific template parameters that are used, so without these additional includes, linker errors appear.
OctreePointCloudDensity and OctreePointCloudSinglePoint are not instantiated either, they are header-only. See also octree_inst.cpp
Fixes #4762