### PR TITLE
Fix missing boost mpl headers

### DIFF
--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -46,6 +46,12 @@ PCL_DEPRECATED_HEADER(1, 15, "Please include the needed boost headers directly."
 #include <boost/version.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/inherit.hpp>
+#include <boost/mpl/inherit_linearly.hpp>
+#include <boost/mpl/joint_view.hpp>
+#include <boost/mpl/transform.hpp>
+#include <boost/mpl/vector.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
@@ -58,10 +64,4 @@ PCL_DEPRECATED_HEADER(1, 15, "Please include the needed boost headers directly."
 #endif
 #include <boost/algorithm/string.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
-#include <boost/mpl/fold.hpp>
-#include <boost/mpl/inherit.hpp>
-#include <boost/mpl/inherit_linearly.hpp>
-#include <boost/mpl/joint_view.hpp>
-#include <boost/mpl/transform.hpp>
-#include <boost/mpl/vector.hpp>
 #endif

--- a/io/include/pcl/io/boost.h
+++ b/io/include/pcl/io/boost.h
@@ -46,12 +46,6 @@ PCL_DEPRECATED_HEADER(1, 15, "Please include the needed boost headers directly."
 #include <boost/version.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/mpl/fold.hpp>
-#include <boost/mpl/inherit.hpp>
-#include <boost/mpl/inherit_linearly.hpp>
-#include <boost/mpl/joint_view.hpp>
-#include <boost/mpl/transform.hpp>
-#include <boost/mpl/vector.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
@@ -64,4 +58,10 @@ PCL_DEPRECATED_HEADER(1, 15, "Please include the needed boost headers directly."
 #endif
 #include <boost/algorithm/string.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/inherit.hpp>
+#include <boost/mpl/inherit_linearly.hpp>
+#include <boost/mpl/joint_view.hpp>
+#include <boost/mpl/transform.hpp>
+#include <boost/mpl/vector.hpp>
 #endif

--- a/io/include/pcl/io/ply/ply_parser.h
+++ b/io/include/pcl/io/ply/ply_parser.h
@@ -50,10 +50,12 @@
 #include <tuple>
 #include <vector>
 #include <boost/lexical_cast.hpp> // for lexical_cast
+#include <boost/mpl/fold.hpp>
 #include <boost/mpl/inherit.hpp> // for inherit
 #include <boost/mpl/inherit_linearly.hpp> // inherit_linearly
 #include <boost/mpl/joint_view.hpp> // for joint_view
 #include <boost/mpl/transform.hpp> // for transform
+#include <boost/mpl/vector.hpp>
 
 namespace pcl
 {

--- a/io/include/pcl/io/ply/ply_parser.h
+++ b/io/include/pcl/io/ply/ply_parser.h
@@ -50,12 +50,12 @@
 #include <tuple>
 #include <vector>
 #include <boost/lexical_cast.hpp> // for lexical_cast
-#include <boost/mpl/fold.hpp>
+#include <boost/mpl/fold.hpp> // for fold
 #include <boost/mpl/inherit.hpp> // for inherit
-#include <boost/mpl/inherit_linearly.hpp> // inherit_linearly
+#include <boost/mpl/inherit_linearly.hpp> // for inherit_linearly
 #include <boost/mpl/joint_view.hpp> // for joint_view
 #include <boost/mpl/transform.hpp> // for transform
-#include <boost/mpl/vector.hpp>
+#include <boost/mpl/vector.hpp> // for vector
 
 namespace pcl
 {


### PR DESCRIPTION
building with 
clang 11.0.0
cuda 11.3
boost 1.76.0
ubuntu 20.04
-std=c++2a
-stdlib=libc++

fails with:
```
pcl/io/include/pcl/io/ply/ply_parser.h:102:32: error: no template named 'vector' in namespace 'boost::mpl'; did you mean 'boost::container::vector'?
          using scalar_types = boost::mpl::vector<int8, int16, int32, uint8, uint16, uint32, float32, float64>;
                               ^~~~~~~~~~~~~~~~~~
                               boost::container::vector
```

including boost.mpl headers solves the problem