### PR TITLE
Fix cuda arch

### DIFF
--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -29,9 +29,10 @@ if(CUDA_FOUND)
   # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-general-new-features
   # or
   # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-features
-  
-  if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "11.0")
+  if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "11.1")
     set(__cuda_arch_bin "3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5 8.0 8.6")
+  elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "11.0")
+    set(__cuda_arch_bin "3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5 8.0")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "10.0")
     set(__cuda_arch_bin "3.0 3.2 3.5 3.7 5.0 5.2 5.3 6.0 6.1 6.2 7.0 7.2 7.5")
   elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "9.0")


### PR DESCRIPTION
As far as I know, support for compute capability 8.6 was only added in CUDA 11.1:
https://en.wikipedia.org/wiki/CUDA#GPUs_supported