### PR TITLE
Modify KdTree for FLANN backend and UIN32, INT64 indices

### DIFF
--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -174,6 +174,43 @@ knn_search(A& index, B& query, C& k_indices, D& dists, unsigned int k, F& params
   std::copy(indices.cbegin(), indices.cend(), k_indices.begin());
   return ret;
 }
+
+template <class IndexT, class A, class B, class F, CompatWithFlann<IndexT> = true>
+int
+knn_search(A& index,
+           B& query,
+           std::vector<Indices>& k_indices,
+           std::vector<std::vector<float>>& dists,
+           unsigned int k,
+           F& params)
+{
+  return index.knnSearch(query, k_indices, dists, k, params);
+}
+
+template <class IndexT, class A, class B, class F, NotCompatWithFlann<IndexT> = true>
+int
+knn_search(A& index,
+           B& query,
+           std::vector<Indices>& k_indices,
+           std::vector<std::vector<float>>& dists,
+           unsigned int k,
+           F& params)
+{
+  std::vector<std::vector<std::size_t>> indices;
+  // flann will resize accordingly
+  auto ret = index.knnSearch(query, indices, dists, k, params);
+
+  k_indices.resize(indices.size());
+  {
+    auto it = indices.cbegin();
+    auto jt = k_indices.begin();
+    for (; it != indices.cend(); ++it, ++jt) {
+      jt->resize(it->size());
+      std::copy(it->cbegin(), it->cend(), jt->begin());
+    }
+  }
+  return ret;
+}
 } // namespace detail
 template <class FlannIndex,
           class Query,
@@ -269,6 +306,43 @@ radius_search(A& index, B& query, C& k_indices, D& dists, float radius, F& param
   k_indices.resize(indices[0].size());
   std::copy(indices[0].cbegin(), indices[0].cend(), k_indices.begin());
   return neighbors_in_radius;
+}
+
+template <class IndexT, class A, class B, class F, CompatWithFlann<IndexT> = true>
+int
+radius_search(A& index,
+              B& query,
+              std::vector<Indices>& k_indices,
+              std::vector<std::vector<float>>& dists,
+              float radius,
+              F& params)
+{
+  return index.radiusSearch(query, k_indices, dists, radius, params);
+}
+
+template <class IndexT, class A, class B, class F, NotCompatWithFlann<IndexT> = true>
+int
+radius_search(A& index,
+              B& query,
+              std::vector<Indices>& k_indices,
+              std::vector<std::vector<float>>& dists,
+              float radius,
+              F& params)
+{
+  std::vector<std::vector<std::size_t>> indices;
+  // flann will resize accordingly
+  auto ret = index.radiusSearch(query, indices, dists, radius, params);
+
+  k_indices.resize(indices.size());
+  {
+    auto it = indices.cbegin();
+    auto jt = k_indices.begin();
+    for (; it != indices.cend(); ++it, ++jt) {
+      jt->resize(it->size());
+      std::copy(it->cbegin(), it->cend(), jt->begin());
+    }
+  }
+  return ret;
 }
 } // namespace detail
 template <class FlannIndex,

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -54,178 +54,259 @@ namespace flann
 
 namespace pcl
 {
-  /** \brief KdTreeFLANN is a generic type of 3D spatial locator using kD-tree structures. The class is making use of
-    * the FLANN (Fast Library for Approximate Nearest Neighbor) project by Marius Muja and David Lowe.
-    *
-    * \author Radu B. Rusu, Marius Muja
-    * \ingroup kdtree
-    */
-  template <typename PointT, typename Dist = ::flann::L2_Simple<float> >
-  class KdTreeFLANN : public pcl::KdTree<PointT>
+namespace detail {
+// Helper struct to create a compatible Matrix and copy data back when needed
+// Replace using if constexpr in C++17
+template <typename IndexT>
+struct compat_with_flann : std::false_type {};
+
+template <>
+struct compat_with_flann<std::size_t> : std::true_type {};
+
+template <typename IndexT>
+using CompatWithFlann = std::enable_if_t<compat_with_flann<IndexT>::value, bool>;
+template <typename IndexT>
+using NotCompatWithFlann = std::enable_if_t<!compat_with_flann<IndexT>::value, bool>;
+} // namespace detail
+
+/**
+ * @brief Comaptibility template function to allow use of various types of indices with
+ * FLANN
+ * @details Template is used for all params to not constrain any FLANN side capability
+ * @param[in|out] index A index searcher, of type ::flann::Index<Dist> or similar, where
+ * Dist is a template for computing distance between 2 points
+ * @param[in] query A ::flann::Matrix<float> or compatible matrix representation of the
+ * query point
+ * @param[out] indices Indices found in radius
+ * @param[out] dists Computed distance matrix
+ * @param[in] radius Threshold for consideration
+ * @param[in] params Any parameters to pass to the radius_search call
+ */
+template <class FlannIndex,
+          class Query,
+          class Indices,
+          class Distances,
+          class SearchParams>
+int
+radius_search(const FlannIndex& index,
+              const Query& query,
+              Indices& indices,
+              Distances& dists,
+              float radius,
+              const SearchParams& params);
+
+/**
+ * @brief Comaptibility template function to allow use of various types of indices with
+ * FLANN
+ * @details Template is used for all params to not constrain any FLANN side capability
+ * @param[in|out] index A index searcher, of type ::flann::Index<Dist> or similar, where
+ * Dist is a template for computing distance between 2 points
+ * @param[in] query A ::flann::Matrix<float> or compatible matrix representation of the
+ * query point
+ * @param[out] indices Neighboring k indices found
+ * @param[out] dists Computed distance matrix
+ * @param[in] radius Threshold for consideration
+ * @param[in] params Any parameters to pass to the radius_search call
+ */
+template <class FlannIndex,
+          class Query,
+          class Indices,
+          class Distances,
+          class SearchParams>
+int
+knn_search(const FlannIndex& index,
+           const Query& query,
+           Indices& indices,
+           Distances& dists,
+           unsigned int k,
+           const SearchParams& params);
+
+/** \brief KdTreeFLANN is a generic type of 3D spatial locator using kD-tree structures.
+ * The class is making use of the FLANN (Fast Library for Approximate Nearest Neighbor)
+ * project by Marius Muja and David Lowe.
+ *
+ * \author Radu B. Rusu, Marius Muja
+ * \ingroup kdtree
+ */
+template <typename PointT, typename Dist = ::flann::L2_Simple<float>>
+class KdTreeFLANN : public pcl::KdTree<PointT> {
+public:
+  using KdTree<PointT>::input_;
+  using KdTree<PointT>::indices_;
+  using KdTree<PointT>::epsilon_;
+  using KdTree<PointT>::sorted_;
+  using KdTree<PointT>::point_representation_;
+  using KdTree<PointT>::nearestKSearch;
+  using KdTree<PointT>::radiusSearch;
+
+  using PointCloud = typename KdTree<PointT>::PointCloud;
+  using PointCloudConstPtr = typename KdTree<PointT>::PointCloudConstPtr;
+
+  using IndicesPtr = shared_ptr<Indices>;
+  using IndicesConstPtr = shared_ptr<const Indices>;
+
+  using FLANNIndex = ::flann::Index<Dist>;
+
+  // Boost shared pointers
+  using Ptr = shared_ptr<KdTreeFLANN<PointT, Dist>>;
+  using ConstPtr = shared_ptr<const KdTreeFLANN<PointT, Dist>>;
+
+  /** \brief Default Constructor for KdTreeFLANN.
+   * \param[in] sorted set to true if the application that the tree will be used for
+   * requires sorted nearest neighbor indices (default). False otherwise.
+   *
+   * By setting sorted to false, the \ref radiusSearch operations will be faster.
+   */
+  KdTreeFLANN(bool sorted = true);
+
+  /** \brief Copy constructor
+   * \param[in] k the tree to copy into this
+   */
+  KdTreeFLANN(const KdTreeFLANN<PointT, Dist>& k);
+
+  /** \brief Copy operator
+   * \param[in] k the tree to copy into this
+   */
+  inline KdTreeFLANN<PointT, Dist>&
+  operator=(const KdTreeFLANN<PointT, Dist>& k)
   {
-    public:
-      using KdTree<PointT>::input_;
-      using KdTree<PointT>::indices_;
-      using KdTree<PointT>::epsilon_;
-      using KdTree<PointT>::sorted_;
-      using KdTree<PointT>::point_representation_;
-      using KdTree<PointT>::nearestKSearch;
-      using KdTree<PointT>::radiusSearch;
+    KdTree<PointT>::operator=(k);
+    flann_index_ = k.flann_index_;
+    cloud_ = k.cloud_;
+    index_mapping_ = k.index_mapping_;
+    identity_mapping_ = k.identity_mapping_;
+    dim_ = k.dim_;
+    total_nr_points_ = k.total_nr_points_;
+    param_k_ = k.param_k_;
+    param_radius_ = k.param_radius_;
+    return (*this);
+  }
 
-      using PointCloud = typename KdTree<PointT>::PointCloud;
-      using PointCloudConstPtr = typename KdTree<PointT>::PointCloudConstPtr;
+  /** \brief Set the search epsilon precision (error bound) for nearest neighbors
+   * searches. \param[in] eps precision (error bound) for nearest neighbors searches
+   */
+  void
+  setEpsilon(float eps) override;
 
-      using IndicesPtr = shared_ptr<Indices >;
-      using IndicesConstPtr = shared_ptr<const Indices >;
+  void
+  setSortedResults(bool sorted);
 
-      using FLANNIndex = ::flann::Index<Dist>;
+  inline Ptr
+  makeShared()
+  {
+    return Ptr(new KdTreeFLANN<PointT, Dist>(*this));
+  }
 
-      // Boost shared pointers
-      using Ptr = shared_ptr<KdTreeFLANN<PointT, Dist> >;
-      using ConstPtr = shared_ptr<const KdTreeFLANN<PointT, Dist> >;
+  /** \brief Destructor for KdTreeFLANN.
+   * Deletes all allocated data arrays and destroys the kd-tree structures.
+   */
+  ~KdTreeFLANN() { cleanup(); }
 
-      /** \brief Default Constructor for KdTreeFLANN.
-        * \param[in] sorted set to true if the application that the tree will be used for requires sorted nearest neighbor indices (default). False otherwise.
-        *
-        * By setting sorted to false, the \ref radiusSearch operations will be faster.
-        */
-      KdTreeFLANN (bool sorted = true);
+  /** \brief Provide a pointer to the input dataset.
+   * \param[in] cloud the const boost shared pointer to a PointCloud message
+   * \param[in] indices the point indices subset that is to be used from \a cloud - if
+   * NULL the whole cloud is used
+   */
+  void
+  setInputCloud(const PointCloudConstPtr& cloud,
+                const IndicesConstPtr& indices = IndicesConstPtr()) override;
 
-      /** \brief Copy constructor
-        * \param[in] k the tree to copy into this
-        */
-      KdTreeFLANN (const KdTreeFLANN<PointT, Dist> &k);
+  /** \brief Search for k-nearest neighbors for the given query point.
+   *
+   * \attention This method does not do any bounds checking for the input index
+   * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
+   *
+   * \param[in] point a given \a valid (i.e., finite) query point
+   * \param[in] k the number of neighbors to search for
+   * \param[out] k_indices the resultant indices of the neighboring points (must be
+   * resized to \a k a priori!) \param[out] k_sqr_distances the resultant squared
+   * distances to the neighboring points (must be resized to \a k a priori!) \return
+   * number of neighbors found
+   *
+   * \exception asserts in debug mode if the index is not between 0 and the maximum
+   * number of points
+   */
+  int
+  nearestKSearch(const PointT& point,
+                 unsigned int k,
+                 Indices& k_indices,
+                 std::vector<float>& k_sqr_distances) const override;
 
-      /** \brief Copy operator
-        * \param[in] k the tree to copy into this
-        */
-      inline KdTreeFLANN<PointT, Dist>&
-      operator = (const KdTreeFLANN<PointT, Dist>& k)
-      {
-        KdTree<PointT>::operator=(k);
-        flann_index_ = k.flann_index_;
-        cloud_ = k.cloud_;
-        index_mapping_ = k.index_mapping_;
-        identity_mapping_ = k.identity_mapping_;
-        dim_ = k.dim_;
-        total_nr_points_ = k.total_nr_points_;
-        param_k_ = k.param_k_;
-        param_radius_ = k.param_radius_;
-        return (*this);
-      }
+  /** \brief Search for all the nearest neighbors of the query point in a given radius.
+   *
+   * \attention This method does not do any bounds checking for the input index
+   * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
+   *
+   * \param[in] point a given \a valid (i.e., finite) query point
+   * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
+   * \param[out] k_indices the resultant indices of the neighboring points
+   * \param[out] k_sqr_distances the resultant squared distances to the neighboring
+   * points \param[in] max_nn if given, bounds the maximum returned neighbors to this
+   * value. If \a max_nn is set to 0 or to a number higher than the number of points in
+   * the input cloud, all neighbors in \a radius will be returned. \return number of
+   * neighbors found in radius
+   *
+   * \exception asserts in debug mode if the index is not between 0 and the maximum
+   * number of points
+   */
+  int
+  radiusSearch(const PointT& point,
+               double radius,
+               Indices& k_indices,
+               std::vector<float>& k_sqr_distances,
+               unsigned int max_nn = 0) const override;
 
-      /** \brief Set the search epsilon precision (error bound) for nearest neighbors searches.
-        * \param[in] eps precision (error bound) for nearest neighbors searches
-        */
-      void
-      setEpsilon (float eps) override;
+private:
+  /** \brief Internal cleanup method. */
+  void
+  cleanup();
 
-      void
-      setSortedResults (bool sorted);
+  /** \brief Converts a PointCloud to the internal FLANN point array representation.
+   * Returns the number of points. \param cloud the PointCloud
+   */
+  void
+  convertCloudToArray(const PointCloud& cloud);
 
-      inline Ptr makeShared () { return Ptr (new KdTreeFLANN<PointT, Dist> (*this)); }
+  /** \brief Converts a PointCloud with a given set of indices to the internal FLANN
+   * point array representation. Returns the number of points. \param[in] cloud the
+   * PointCloud data \param[in] indices the point cloud indices
+   */
+  void
+  convertCloudToArray(const PointCloud& cloud, const Indices& indices);
 
-      /** \brief Destructor for KdTreeFLANN.
-        * Deletes all allocated data arrays and destroys the kd-tree structures.
-        */
-      ~KdTreeFLANN ()
-      {
-        cleanup ();
-      }
+private:
+  /** \brief Class getName method. */
+  std::string
+  getName() const override
+  {
+    return ("KdTreeFLANN");
+  }
 
-      /** \brief Provide a pointer to the input dataset.
-        * \param[in] cloud the const boost shared pointer to a PointCloud message
-        * \param[in] indices the point indices subset that is to be used from \a cloud - if NULL the whole cloud is used
-        */
-      void
-      setInputCloud (const PointCloudConstPtr &cloud, const IndicesConstPtr &indices = IndicesConstPtr ()) override;
+  /** \brief A FLANN index object. */
+  std::shared_ptr<FLANNIndex> flann_index_;
 
-      /** \brief Search for k-nearest neighbors for the given query point.
-        *
-        * \attention This method does not do any bounds checking for the input index
-        * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        *
-        * \param[in] point a given \a valid (i.e., finite) query point
-        * \param[in] k the number of neighbors to search for
-        * \param[out] k_indices the resultant indices of the neighboring points (must be resized to \a k a priori!)
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points (must be resized to \a k
-        * a priori!)
-        * \return number of neighbors found
-        *
-        * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
-        */
-      int 
-      nearestKSearch (const PointT &point, unsigned int k,
-                      Indices &k_indices, std::vector<float> &k_sqr_distances) const override;
+  /** \brief Internal pointer to data. TODO: replace with std::shared_ptr<float[]> with
+   * C++17*/
+  std::shared_ptr<float> cloud_;
 
-      /** \brief Search for all the nearest neighbors of the query point in a given radius.
-        *
-        * \attention This method does not do any bounds checking for the input index
-        * (i.e., index >= cloud.size () || index < 0), and assumes valid (i.e., finite) data.
-        *
-        * \param[in] point a given \a valid (i.e., finite) query point
-        * \param[in] radius the radius of the sphere bounding all of p_q's neighbors
-        * \param[out] k_indices the resultant indices of the neighboring points
-        * \param[out] k_sqr_distances the resultant squared distances to the neighboring points
-        * \param[in] max_nn if given, bounds the maximum returned neighbors to this value. If \a max_nn is set to
-        * 0 or to a number higher than the number of points in the input cloud, all neighbors in \a radius will be
-        * returned.
-        * \return number of neighbors found in radius
-        *
-        * \exception asserts in debug mode if the index is not between 0 and the maximum number of points
-        */
-      int
-      radiusSearch (const PointT &point, double radius, Indices &k_indices,
-                    std::vector<float> &k_sqr_distances, unsigned int max_nn = 0) const override;
+  /** \brief mapping between internal and external indices. */
+  std::vector<int> index_mapping_;
 
-    private:
-      /** \brief Internal cleanup method. */
-      void
-      cleanup ();
+  /** \brief whether the mapping between internal and external indices is identity */
+  bool identity_mapping_;
 
-      /** \brief Converts a PointCloud to the internal FLANN point array representation. Returns the number
-        * of points.
-        * \param cloud the PointCloud
-        */
-      void
-      convertCloudToArray (const PointCloud &cloud);
+  /** \brief Tree dimensionality (i.e. the number of dimensions per point). */
+  int dim_;
 
-      /** \brief Converts a PointCloud with a given set of indices to the internal FLANN point array
-        * representation. Returns the number of points.
-        * \param[in] cloud the PointCloud data
-        * \param[in] indices the point cloud indices
-       */
-      void
-      convertCloudToArray (const PointCloud &cloud, const Indices &indices);
+  /** \brief The total size of the data (either equal to the number of points in the
+   * input cloud or to the number of indices - if passed). */
+  uindex_t total_nr_points_;
 
-    private:
-      /** \brief Class getName method. */
-      std::string
-      getName () const override { return ("KdTreeFLANN"); }
+  /** \brief The KdTree search parameters for K-nearest neighbors. */
+  ::flann::SearchParams param_k_;
 
-      /** \brief A FLANN index object. */
-      std::shared_ptr<FLANNIndex> flann_index_;
-
-      /** \brief Internal pointer to data. TODO: replace with std::shared_ptr<float[]> with C++17*/
-      std::shared_ptr<float> cloud_;
-
-      /** \brief mapping between internal and external indices. */
-      std::vector<int> index_mapping_;
-
-      /** \brief whether the mapping between internal and external indices is identity */
-      bool identity_mapping_;
-
-      /** \brief Tree dimensionality (i.e. the number of dimensions per point). */
-      int dim_;
-
-      /** \brief The total size of the data (either equal to the number of points in the input cloud or to the number of indices - if passed). */
-      uindex_t total_nr_points_;
-
-      /** \brief The KdTree search parameters for K-nearest neighbors. */
-      ::flann::SearchParams param_k_;
-
-      /** \brief The KdTree search parameters for radius search. */
-      ::flann::SearchParams param_radius_;
+  /** \brief The KdTree search parameters for radius search. */
+  ::flann::SearchParams param_radius_;
   };
 }
 

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -45,6 +45,9 @@
 #include <flann/algorithms/kmeans_index.h>
 
 #include <pcl/search/flann_search.h>
+#include <pcl/kdtree/kdtree_flann.h> // for radius_search, knn_search
+// @TODO: remove once constexpr makes it easy to have the function in the header only
+#include <pcl/kdtree/impl/kdtree_flann.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename FlannDistance>
@@ -123,9 +126,8 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (const PointT &p
     indices.resize (k,-1);
   if (dists.size() != static_cast<unsigned int> (k))
     dists.resize (k);
-  flann::Matrix<index_t> i (&indices[0],1,k);
   flann::Matrix<float> d (&dists[0],1,k);
-  int result = index_->knnSearch (m,i,d,k, p);
+  int result = knn_search(*index_, m, indices, d, k, p);
 
   delete [] data;
 
@@ -182,7 +184,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
     p.sorted = sorted_results_;
     p.eps = eps_;
     p.checks = checks_;
-    index_->knnSearch (m,k_indices,k_sqr_distances,k, p);
+    knn_search(*index_, m, k_indices, k_sqr_distances, k, p);
 
     delete [] data;
   }
@@ -211,7 +213,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
     p.sorted = sorted_results_;
     p.eps = eps_;
     p.checks = checks_;
-    index_->knnSearch (m,k_indices,k_sqr_distances,k, p);
+    knn_search(*index_, m, k_indices, k_sqr_distances, k, p);
 
     delete[] data;
   }
@@ -253,7 +255,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (const PointT& poi
   p.checks = checks_;
   std::vector<Indices> i (1);
   std::vector<std::vector<float> > d (1);
-  int result = index_->radiusSearch (m,i,d,static_cast<float> (radius * radius), p);
+  int result = radius_search(*index_, m, i, d, static_cast<float>(radius * radius), p);
 
   delete [] data;
   indices = i [0];
@@ -310,7 +312,8 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (
     p.checks = checks_;
     // here: max_nn==0: take all neighbors. flann: max_nn==0: return no neighbors, only count them. max_nn==-1: return all neighbors
     p.max_neighbors = max_nn != 0 ? max_nn : -1;
-    index_->radiusSearch (m,k_indices,k_sqr_distances,static_cast<float> (radius * radius), p);
+    radius_search(
+        *index_, m, k_indices, k_sqr_distances, static_cast<float>(radius * radius), p);
 
     delete [] data;
   }

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -344,7 +344,8 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (
     p.checks = checks_;
     // here: max_nn==0: take all neighbors. flann: max_nn==0: return no neighbors, only count them. max_nn==-1: return all neighbors
     p.max_neighbors = max_nn != 0 ? max_nn : -1;
-    index_->radiusSearch (m, k_indices, k_sqr_distances, static_cast<float> (radius * radius), p);
+    radius_search(
+        *index_, m, k_indices, k_sqr_distances, static_cast<float>(radius * radius), p);
 
     delete[] data;
   }


### PR DESCRIPTION
Release candidate blocked due to compilation error (no overload exists in flann for non-int/size_t index)
