### PR TITLE
[GPU] Use C++11 `std::atomic` instead of non-standard extensions

### DIFF
--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -38,6 +38,7 @@
 
 #include <pcl/gpu/containers/kernel_containers.h>
 #include <pcl/pcl_exports.h>
+#include <atomic>
 
 namespace pcl {
 namespace gpu {
@@ -167,7 +168,7 @@ private:
   std::size_t sizeBytes_;
 
   /** \brief Pointer to reference counter in CPU memory. */
-  int* refcount_;
+  std::atomic<int>* refcount_;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -308,7 +309,7 @@ private:
   int rows_;
 
   /** \brief Pointer to reference counter in CPU memory. */
-  int* refcount_;
+  std::atomic<int>* refcount_;
 };
 } // namespace gpu
 

--- a/gpu/containers/include/pcl/gpu/containers/device_memory.h
+++ b/gpu/containers/include/pcl/gpu/containers/device_memory.h
@@ -38,6 +38,7 @@
 
 #include <pcl/gpu/containers/kernel_containers.h>
 #include <pcl/pcl_exports.h>
+
 #include <atomic>
 
 namespace pcl {

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -37,6 +37,7 @@
 #include <pcl/gpu/containers/device_memory.h>
 #include <pcl/gpu/utils/safe_call.hpp>
 #include <pcl/pcl_macros.h> // used for PCL_DEPRECATED
+#include <pcl/pcl_config.h> // used for HAVE_CUDA
 
 #include <cuda_runtime_api.h>
 

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -246,7 +246,7 @@ pcl::gpu::DeviceMemory::copyTo(DeviceMemory& other) const
 void
 pcl::gpu::DeviceMemory::release()
 {
-  if (refcount_ && refcount_->fetch_sub(1, std::memory_order_seq_cst) == 1) {
+  if (refcount_ && refcount_->fetch_sub(1) == 1) {
     delete refcount_;
     cudaSafeCall(cudaFree(data_));
   }
@@ -394,7 +394,7 @@ pcl::gpu::DeviceMemory2D::create(int rows_arg, int colsBytes_arg)
 void
 pcl::gpu::DeviceMemory2D::release()
 {
-  if (refcount_ && refcount_->fetch_sub(1, std::memory_order_seq_cst) == 1) {
+  if (refcount_ && refcount_->fetch_sub(1) == 1) {
     delete refcount_;
     cudaSafeCall(cudaFree(data_));
   }

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -163,7 +163,7 @@ pcl::gpu::DeviceMemory2D::empty() const
 
 template <typename _Tp>
 PCL_DEPRECATED(1, 16, "Removed in favour of c++11 atomics")
-static inline _Tp CV_XADD(std::atomic<_Tp>* addr,std::atomic< _Tp> delta)
+static inline _Tp CV_XADD(std::atomic<_Tp>* addr, std::atomic<_Tp> delta)
 {
   _Tp tmp = addr->fetch_add(delta);
   return tmp;

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -161,34 +161,6 @@ pcl::gpu::DeviceMemory2D::empty() const
 
 #else
 
-//////////////////////////    XADD    ///////////////////////////////
-
-#ifdef __GNUC__
-#if !defined WIN32 && (defined __i486__ || defined __i586__ || defined __i686__ ||     \
-                       defined __MMX__ || defined __SSE__ || defined __ppc__)
-#define CV_XADD __sync_fetch_and_add
-#else
-#include <ext/atomicity.h>
-#define CV_XADD __gnu_cxx::__exchange_and_add
-#endif
-#elif defined WIN32 || defined _WIN32
-#include <intrin.h>
-#define CV_XADD(addr, delta) _InterlockedExchangeAdd((long volatile*)(addr), (delta))
-#else
-
-template <typename _Tp>
-static inline _Tp
-CV_XADD(_Tp* addr, _Tp delta)
-{
-  int tmp = *addr;
-  *addr += delta;
-  return tmp;
-}
-
-#endif
-
-////////////////////////    DeviceArray    /////////////////////////////
-
 pcl::gpu::DeviceMemory::DeviceMemory()
 : data_(nullptr), sizeBytes_(0), refcount_(nullptr)
 {}
@@ -211,7 +183,7 @@ pcl::gpu::DeviceMemory::DeviceMemory(const DeviceMemory& other_arg)
 , refcount_(other_arg.refcount_)
 {
   if (refcount_)
-    CV_XADD(refcount_, 1);
+    refcount_->fetch_add(1, std::memory_order_seq_cst);
 }
 
 pcl::gpu::DeviceMemory&
@@ -219,7 +191,7 @@ pcl::gpu::DeviceMemory::operator=(const pcl::gpu::DeviceMemory& other_arg)
 {
   if (this != &other_arg) {
     if (other_arg.refcount_)
-      CV_XADD(other_arg.refcount_, 1);
+      refcount_->fetch_add(1, std::memory_order_seq_cst);
     release();
 
     data_ = other_arg.data_;
@@ -243,9 +215,8 @@ pcl::gpu::DeviceMemory::create(std::size_t sizeBytes_arg)
 
     cudaSafeCall(cudaMalloc(&data_, sizeBytes_));
 
-    // refcount_ = (int*)cv::fastMalloc(sizeof(*refcount_));
-    refcount_ = new int;
-    *refcount_ = 1;
+    refcount_ = new std::atomic<int>;
+    refcount_->store(1);
   }
 }
 
@@ -264,8 +235,7 @@ pcl::gpu::DeviceMemory::copyTo(DeviceMemory& other) const
 void
 pcl::gpu::DeviceMemory::release()
 {
-  if (refcount_ && CV_XADD(refcount_, -1) == 1) {
-    // cv::fastFree(refcount);
+  if (refcount_ && refcount_->fetch_sub(1, std::memory_order_seq_cst) == 1) {
     delete refcount_;
     cudaSafeCall(cudaFree(data_));
   }
@@ -369,7 +339,7 @@ pcl::gpu::DeviceMemory2D::DeviceMemory2D(const DeviceMemory2D& other_arg)
 , refcount_(other_arg.refcount_)
 {
   if (refcount_)
-    CV_XADD(refcount_, 1);
+    refcount_->fetch_add(1, std::memory_order_seq_cst);
 }
 
 pcl::gpu::DeviceMemory2D&
@@ -377,7 +347,7 @@ pcl::gpu::DeviceMemory2D::operator=(const pcl::gpu::DeviceMemory2D& other_arg)
 {
   if (this != &other_arg) {
     if (other_arg.refcount_)
-      CV_XADD(other_arg.refcount_, 1);
+      refcount_->fetch_add(1, std::memory_order_seq_cst);
     release();
 
     colsBytes_ = other_arg.colsBytes_;
@@ -405,17 +375,15 @@ pcl::gpu::DeviceMemory2D::create(int rows_arg, int colsBytes_arg)
 
     cudaSafeCall(cudaMallocPitch((void**)&data_, &step_, colsBytes_, rows_));
 
-    // refcount = (int*)cv::fastMalloc(sizeof(*refcount));
-    refcount_ = new int;
-    *refcount_ = 1;
+    refcount_ = new std::atomic<int>;
+    refcount_->store(1);
   }
 }
 
 void
 pcl::gpu::DeviceMemory2D::release()
 {
-  if (refcount_ && CV_XADD(refcount_, -1) == 1) {
-    // cv::fastFree(refcount);
+  if (refcount_ && refcount_->fetch_sub(1, std::memory_order_seq_cst) == 1) {
     delete refcount_;
     cudaSafeCall(cudaFree(data_));
   }

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -162,9 +162,8 @@ pcl::gpu::DeviceMemory2D::empty() const
 //////////////////////////    XADD    ///////////////////////////////
 
 template <typename _Tp>
-PCL_DEPRECATED(1, 15, "Removed in favour of c++11 atomics")
-static inline _Tp
-CV_XADD(std::atomic<_Tp>* addr,std::atomic< _Tp> delta)
+PCL_DEPRECATED(1, 16, "Removed in favour of c++11 atomics")
+static inline _Tp CV_XADD(std::atomic<_Tp>* addr,std::atomic< _Tp> delta)
 {
   _Tp tmp = addr->fetch_add(delta);
   return tmp;

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -36,13 +36,11 @@
 
 #include <pcl/gpu/containers/device_memory.h>
 #include <pcl/gpu/utils/safe_call.hpp>
+#include <pcl/pcl_macros.h>
 
 #include <cuda_runtime_api.h>
 
 #include <cassert>
-
-#define HAVE_CUDA
-//#include <pcl_config.h>
 
 #if !defined(HAVE_CUDA)
 
@@ -163,8 +161,8 @@ pcl::gpu::DeviceMemory2D::empty() const
 
 //////////////////////////    XADD    ///////////////////////////////
 
-PCL_DEPRECATED(1, 15, "Removed in favour of c++11 atomics")
 template <typename _Tp>
+PCL_DEPRECATED(1, 15, "Removed in favour of c++11 atomics")
 static inline _Tp
 CV_XADD(std::atomic<_Tp>* addr,std::atomic< _Tp> delta)
 {

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -36,8 +36,8 @@
 
 #include <pcl/gpu/containers/device_memory.h>
 #include <pcl/gpu/utils/safe_call.hpp>
-#include <pcl/pcl_macros.h> // used for PCL_DEPRECATED
 #include <pcl/pcl_config.h> // used for HAVE_CUDA
+#include <pcl/pcl_macros.h> // used for PCL_DEPRECATED
 
 #include <cuda_runtime_api.h>
 

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -161,6 +161,19 @@ pcl::gpu::DeviceMemory2D::empty() const
 
 #else
 
+//////////////////////////    XADD    ///////////////////////////////
+
+PCL_DEPRECATED(1, 15, "Removed in favour of c++11 atomics")
+template <typename _Tp>
+static inline _Tp
+CV_XADD(std::atomic<_Tp>* addr,std::atomic< _Tp> delta)
+{
+  _Tp tmp = addr->fetch_add(delta);
+  return tmp;
+}
+
+////////////////////////    DeviceArray    /////////////////////////////
+
 pcl::gpu::DeviceMemory::DeviceMemory()
 : data_(nullptr), sizeBytes_(0), refcount_(nullptr)
 {}
@@ -183,7 +196,7 @@ pcl::gpu::DeviceMemory::DeviceMemory(const DeviceMemory& other_arg)
 , refcount_(other_arg.refcount_)
 {
   if (refcount_)
-    refcount_->fetch_add(1, std::memory_order_seq_cst);
+    refcount_->fetch_add(1);
 }
 
 pcl::gpu::DeviceMemory&
@@ -191,7 +204,7 @@ pcl::gpu::DeviceMemory::operator=(const pcl::gpu::DeviceMemory& other_arg)
 {
   if (this != &other_arg) {
     if (other_arg.refcount_)
-      refcount_->fetch_add(1, std::memory_order_seq_cst);
+      refcount_->fetch_add(1);
     release();
 
     data_ = other_arg.data_;
@@ -215,8 +228,8 @@ pcl::gpu::DeviceMemory::create(std::size_t sizeBytes_arg)
 
     cudaSafeCall(cudaMalloc(&data_, sizeBytes_));
 
-    refcount_ = new std::atomic<int>;
-    refcount_->store(1);
+    refcount_ = new std::atomic<int>(1);
+    //refcount_->store(1);
   }
 }
 
@@ -339,7 +352,7 @@ pcl::gpu::DeviceMemory2D::DeviceMemory2D(const DeviceMemory2D& other_arg)
 , refcount_(other_arg.refcount_)
 {
   if (refcount_)
-    refcount_->fetch_add(1, std::memory_order_seq_cst);
+    refcount_->fetch_add(1);
 }
 
 pcl::gpu::DeviceMemory2D&
@@ -347,7 +360,7 @@ pcl::gpu::DeviceMemory2D::operator=(const pcl::gpu::DeviceMemory2D& other_arg)
 {
   if (this != &other_arg) {
     if (other_arg.refcount_)
-      refcount_->fetch_add(1, std::memory_order_seq_cst);
+      refcount_->fetch_add(1);
     release();
 
     colsBytes_ = other_arg.colsBytes_;

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -227,7 +227,6 @@ pcl::gpu::DeviceMemory::create(std::size_t sizeBytes_arg)
     cudaSafeCall(cudaMalloc(&data_, sizeBytes_));
 
     refcount_ = new std::atomic<int>(1);
-    //refcount_->store(1);
   }
 }
 
@@ -386,8 +385,7 @@ pcl::gpu::DeviceMemory2D::create(int rows_arg, int colsBytes_arg)
 
     cudaSafeCall(cudaMallocPitch((void**)&data_, &step_, colsBytes_, rows_));
 
-    refcount_ = new std::atomic<int>;
-    refcount_->store(1);
+    refcount_ = new std::atomic<int>(1);
   }
 }
 

--- a/gpu/containers/src/device_memory.cpp
+++ b/gpu/containers/src/device_memory.cpp
@@ -36,7 +36,7 @@
 
 #include <pcl/gpu/containers/device_memory.h>
 #include <pcl/gpu/utils/safe_call.hpp>
-#include <pcl/pcl_macros.h>
+#include <pcl/pcl_macros.h> // used for PCL_DEPRECATED
 
 #include <cuda_runtime_api.h>
 
@@ -201,7 +201,7 @@ pcl::gpu::DeviceMemory::operator=(const pcl::gpu::DeviceMemory& other_arg)
 {
   if (this != &other_arg) {
     if (other_arg.refcount_)
-      refcount_->fetch_add(1);
+      other_arg.refcount_->fetch_add(1);
     release();
 
     data_ = other_arg.data_;
@@ -356,7 +356,7 @@ pcl::gpu::DeviceMemory2D::operator=(const pcl::gpu::DeviceMemory2D& other_arg)
 {
   if (this != &other_arg) {
     if (other_arg.refcount_)
-      refcount_->fetch_add(1);
+      other_arg.refcount_->fetch_add(1);
     release();
 
     colsBytes_ = other_arg.colsBytes_;


### PR DESCRIPTION
As mentioned in #3987 we can use the memory model of c++11 to replace (outdated) cv code. This PR tries to implement the suggestions in the issue. I always find the atomic reference counting a bit strange, but it is implemented the same way in the std::shared_ptr,  and I think it's good to stick with it. 

I am looking forward to any suggestions and comments! 