### PR TITLE
Refactor VoxelGrid

### DIFF
--- a/filters/CMakeLists.txt
+++ b/filters/CMakeLists.txt
@@ -88,6 +88,8 @@ set(incs
 )
 set(experimental_incs
   "include/pcl/${SUBSYS_NAME}/experimental/functor_filter.h"
+  "include/pcl/${SUBSYS_NAME}/experimental/grid_filter.h"
+  "include/pcl/${SUBSYS_NAME}/experimental/voxel_grid.h"
 )
 
 set(impl_incs

--- a/filters/include/pcl/filters/experimental/grid_filter.h
+++ b/filters/include/pcl/filters/experimental/grid_filter.h
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2020-, Open Perception
+ *
+ *  All rights reserved
+ */
+
+#pragma once
+
+#include <pcl/filters/filter.h>
+
+#include <cfloat> // for FLT_MAX
+
+namespace pcl {
+namespace experimental {
+
+template <typename T>
+using get_point_type = typename T::PointCloud::PointType;
+
+template <typename T>
+using get_grid_type = typename T::Grid;
+
+template <typename GridStruct,
+          typename Grid = get_grid_type<GridStruct>,
+          typename PointT = get_point_type<GridStruct>>
+class GridFilter : public Filter<PointT>, public GridStruct {
+protected:
+  using Filter<PointT>::filter_name_;
+  using Filter<PointT>::input_;
+  using Filter<PointT>::getClassName;
+
+  using PointCloud = typename Filter<PointT>::PointCloud;
+  using PointCloudPtr = typename PointCloud::Ptr;
+  using PointCloudConstPtr = typename PointCloud::ConstPtr;
+
+public:
+  /** \brief Empty constructor. */
+  GridFilter()
+  : GridStruct()
+  , downsample_all_data_(true)
+  , filter_field_name_("")
+  , filter_limit_min_(-FLT_MAX)
+  , filter_limit_max_(FLT_MAX)
+  , filter_limit_negative_(false)
+  {
+    filter_name_ = GridStruct::filter_name_;
+  }
+
+  /** \brief Destructor. */
+  ~GridFilter() {}
+
+  inline void
+  setDownsampleAllData(bool downsample)
+  {
+    downsample_all_data_ = downsample;
+  }
+
+  /** \brief Get the state of the internal downsampling parameter (true if
+   * all fields need to be downsampled, false if just XYZ).
+   */
+  inline bool
+  getDownsampleAllData() const
+  {
+    return (downsample_all_data_);
+  }
+
+  /** \brief Provide the name of the field to be used for filtering data. In conjunction
+   * with  \a setFilterLimits, points having values outside this interval will be
+   * discarded. \param[in] field_name the name of the field that contains values used
+   * for filtering
+   */
+  inline void
+  setFilterFieldName(const std::string& field_name)
+  {
+    filter_field_name_ = field_name;
+  }
+
+  /** \brief Get the name of the field used for filtering. */
+  inline std::string const
+  getFilterFieldName() const
+  {
+    return (filter_field_name_);
+  }
+
+  /** \brief Get the field filter limits (min/max) set by the user. The default values
+   * are -FLT_MAX, FLT_MAX. \param[out] limit_min the minimum allowed field value
+   * \param[out] limit_max the maximum allowed field value
+   */
+  inline void
+  getFilterLimits(double& limit_min, double& limit_max) const
+  {
+    limit_min = filter_limit_min_;
+    limit_max = filter_limit_max_;
+  }
+
+  /** \brief Set to true if we want to return the data outside the interval specified by
+   * setFilterLimits (min, max). Default: false. \param[in] limit_negative return data
+   * inside the interval (false) or outside (true)
+   */
+  inline void
+  setFilterLimitsNegative(const bool limit_negative)
+  {
+    filter_limit_negative_ = limit_negative;
+  }
+
+  /** \brief Get whether the data outside the interval (min/max) is to be returned
+   * (true) or inside (false). \param[out] limit_negative true if data \b outside the
+   * interval [min; max] is to be returned, false otherwise
+   */
+  inline void
+  getFilterLimitsNegative(bool& limit_negative) const
+  {
+    limit_negative = filter_limit_negative_;
+  }
+
+  /** \brief Get whether the data outside the interval (min/max) is to be returned
+   * (true) or inside (false). \return true if data \b outside the interval [min; max]
+   * is to be returned, false otherwise
+   */
+  inline bool
+  getFilterLimitsNegative() const
+  {
+    return (filter_limit_negative_);
+  }
+
+protected:
+  /** \brief Set to true if all fields need to be downsampled, or false if just XYZ. */
+  bool downsample_all_data_;
+
+  /** \brief The desired user filter field name. */
+  std::string filter_field_name_;
+
+  /** \brief The minimum allowed filter value a point will be considered from. */
+  double filter_limit_min_;
+
+  /** \brief The maximum allowed filter value a point will be considered from. */
+  double filter_limit_max_;
+
+  /** \brief Set to true if we want to return the data outside (\a filter_limit_min_;\a
+   * filter_limit_max_). Default: false. */
+  bool filter_limit_negative_;
+
+  Grid grid_;
+
+  /** \brief Downsample a Point Cloud using a voxelized grid approach
+   * \param[out] output the resultant point cloud message
+   */
+  void
+  applyFilter(PointCloud& output) override
+  {
+    // Has the input dataset been set already?
+    if (!input_) {
+      PCL_WARN("[pcl::%s::applyFilter] No input dataset given!\n",
+               getClassName().c_str());
+      output.width = output.height = 0;
+      output.clear();
+      return;
+    }
+
+    // Copy the header (and thus the frame_id) + allocate enough space for points
+    output.height = 1;      // downsampling breaks the organized structure
+    output.is_dense = true; // we filter out invalid points
+
+    GridStruct::setUp(this);
+
+    for (const auto& pt : *input_) {
+      GridStruct::addPointToGrid(grid_, pt);
+    }
+
+    for (auto it = grid_.begin(); it != grid_.end(); ++it) {
+      auto res = GridStruct::filterGrid(it, grid_);
+      if (res) {
+        output.push_back(res.value());
+      }
+    }
+  }
+};
+
+} // namespace experimental
+} // namespace pcl

--- a/filters/include/pcl/filters/experimental/grid_filter.h
+++ b/filters/include/pcl/filters/experimental/grid_filter.h
@@ -212,7 +212,7 @@ protected:
     output.height = 1;      // downsampling breaks the organized structure
     output.is_dense = true; // we filter out invalid points
 
-    GridStruct::setUp(this);
+    GridStruct::setUp(this, grid_);
 
     for (const auto& pt : *input_) {
       GridStruct::addPointToGrid(grid_, pt);

--- a/filters/include/pcl/filters/experimental/grid_filter.h
+++ b/filters/include/pcl/filters/experimental/grid_filter.h
@@ -121,6 +121,18 @@ public:
     return filter_field_name_;
   }
 
+  /** \brief Set the field filter limits. All points having field values outside this
+   * interval will be discarded.
+   * \param[in] limit_min the minimum allowed field value
+   * \param[in] limit_max the maximum allowed field value
+   */
+  inline void
+  setFilterLimits(const double& limit_min, const double& limit_max)
+  {
+    filter_limit_min_ = limit_min;
+    filter_limit_max_ = limit_max;
+  }
+
   /** \brief Get the field filter limits (min/max) set by the user. The default values
    * are numeric_limits<double>::min(), numeric_limits<double>::max().
    * \param[out] limit_min the minimum allowed field value

--- a/filters/include/pcl/filters/experimental/grid_filter.h
+++ b/filters/include/pcl/filters/experimental/grid_filter.h
@@ -16,10 +16,12 @@
 namespace pcl {
 namespace experimental {
 
-template <typename T>
-using get_point_type = typename T::PointCloud::PointType;
+// template <typename GridStructT>
+// using get_point_type = typename GridStructT::PointCloud::PointType;
 
-template <typename GridStruct, typename PointT = get_point_type<GridStruct>>
+#define GET_POINT_TYPE(GridStructT) typename GridStructT::PointCloud::PointType
+
+template <typename GridStruct, typename PointT = GET_POINT_TYPE(GridStruct)>
 class GridFilter : public Filter<PointT>, public GridStruct {
 protected:
   using Filter<PointT>::filter_name_;

--- a/filters/include/pcl/filters/experimental/grid_filter.h
+++ b/filters/include/pcl/filters/experimental/grid_filter.h
@@ -40,10 +40,12 @@ public:
   GridFilter()
   : GridStruct()
   , downsample_all_data_(true)
+  , save_leaf_layout_(false)
   , filter_field_name_("")
   , filter_limit_min_(-FLT_MAX)
   , filter_limit_max_(FLT_MAX)
   , filter_limit_negative_(false)
+  , min_points_per_voxel_(0)
   {
     filter_name_ = GridStruct::filter_name_;
   }
@@ -51,6 +53,9 @@ public:
   /** \brief Destructor. */
   ~GridFilter() {}
 
+  /** \brief Set to true if all fields need to be downsampled, or false if just XYZ.
+   * \param[in] downsample the new value (true/false)
+   */
   inline void
   setDownsampleAllData(bool downsample)
   {
@@ -63,7 +68,42 @@ public:
   inline bool
   getDownsampleAllData() const
   {
-    return (downsample_all_data_);
+    return downsample_all_data_;
+  }
+
+  /** \brief Set the minimum number of points required for a voxel to be used.
+   * \param[in] min_points_per_voxel the minimum number of points for required for a
+   * voxel to be used
+   */
+  inline void
+  setMinimumPointsNumberPerVoxel(unsigned int min_points_per_voxel)
+  {
+    min_points_per_voxel_ = min_points_per_voxel;
+  }
+
+  /** \brief Return the minimum number of points required for a voxel to be used.
+   */
+  inline unsigned int
+  getMinimumPointsNumberPerVoxel() const
+  {
+    return min_points_per_voxel_;
+  }
+
+  /** \brief Set to true if leaf layout information needs to be saved for later access.
+   * \param[in] save_leaf_layout the new value (true/false)
+   */
+  inline void
+  setSaveLeafLayout(bool save_leaf_layout)
+  {
+    save_leaf_layout_ = save_leaf_layout;
+  }
+
+  /** \brief Returns true if leaf layout information will to be saved for later access.
+   */
+  inline bool
+  getSaveLeafLayout() const
+  {
+    return save_leaf_layout_;
   }
 
   /** \brief Provide the name of the field to be used for filtering data. In conjunction
@@ -81,7 +121,7 @@ public:
   inline std::string const
   getFilterFieldName() const
   {
-    return (filter_field_name_);
+    return filter_field_name_;
   }
 
   /** \brief Get the field filter limits (min/max) set by the user. The default values
@@ -122,12 +162,16 @@ public:
   inline bool
   getFilterLimitsNegative() const
   {
-    return (filter_limit_negative_);
+    return filter_limit_negative_;
   }
 
 protected:
   /** \brief Set to true if all fields need to be downsampled, or false if just XYZ. */
   bool downsample_all_data_;
+
+  /** \brief Set to true if leaf layout information needs to be saved in \a
+   * leaf_layout_. */
+  bool save_leaf_layout_;
 
   /** \brief The desired user filter field name. */
   std::string filter_field_name_;
@@ -142,6 +186,11 @@ protected:
    * filter_limit_max_). Default: false. */
   bool filter_limit_negative_;
 
+  /** \brief Minimum number of points per voxel for the centroid to be computed */
+  unsigned int min_points_per_voxel_;
+
+  /** \brief The iterable grid object for storing information of each fraction of space
+   * in the filtering space defined by the grid */
   Grid grid_;
 
   /** \brief Downsample a Point Cloud using a voxelized grid approach

--- a/filters/include/pcl/filters/experimental/grid_filter.h
+++ b/filters/include/pcl/filters/experimental/grid_filter.h
@@ -212,7 +212,10 @@ protected:
     output.height = 1;      // downsampling breaks the organized structure
     output.is_dense = true; // we filter out invalid points
 
-    GridStruct::setUp(this, grid_);
+    if (!GridStruct::setUp(this, grid_)) {
+      output = *input_;
+      return;
+    }
 
     for (const auto& pt : *input_) {
       GridStruct::addPointToGrid(grid_, pt);

--- a/filters/include/pcl/filters/experimental/voxel_grid.h
+++ b/filters/include/pcl/filters/experimental/voxel_grid.h
@@ -16,6 +16,9 @@
 
 #include <unordered_map>
 
+// For testing protected method
+class VoxelGridProtectedMethods_GridFilters_Test;
+
 namespace pcl {
 namespace experimental {
 
@@ -348,6 +351,9 @@ protected:
   /** \brief The iterable grid object for storing information of each fraction of space
    * in the filtering space defined by the grid */
   Grid grid_;
+
+private:
+  friend class ::VoxelGridProtectedMethods_GridFilters_Test;
 };
 
 template <typename PointT>

--- a/filters/include/pcl/filters/experimental/voxel_grid.h
+++ b/filters/include/pcl/filters/experimental/voxel_grid.h
@@ -33,6 +33,7 @@ public:
   using PointCloud = pcl::PointCloud<PointT>;
   using PointCloudPtr = typename PointCloud::Ptr;
   using PointCloudConstPtr = typename PointCloud::ConstPtr;
+  // using PointType = PointT;
 
   using Grid = std::unordered_map<std::size_t, Voxel>;
 

--- a/filters/include/pcl/filters/experimental/voxel_grid.h
+++ b/filters/include/pcl/filters/experimental/voxel_grid.h
@@ -33,6 +33,18 @@ public:
 
   using Grid = std::unordered_map<std::size_t, Voxel>;
 
+  /** \brief Empty constructor. */
+  VoxelStructT()
+  : filter_name_("VoxelGrid")
+  , leaf_size_(Eigen::Vector4f::Zero())
+  , inverse_leaf_size_(Eigen::Array4f::Zero())
+  , min_b_(Eigen::Vector4i::Zero())
+  , max_b_(Eigen::Vector4i::Zero())
+  , div_b_(Eigen::Vector4i::Zero())
+  , divb_mul_(Eigen::Vector4i::Zero())
+  , min_points_per_voxel_(0)
+  {}
+
   /** \brief Set the minimum number of points required for a voxel to be used.
    * \param[in] min_points_per_voxel the minimum number of points for required for a
    * voxel to be used
@@ -79,7 +91,7 @@ public:
   inline Eigen::Vector3f
   getLeafSize() const
   {
-    return (leaf_size_.head<3>());
+    return leaf_size_.head<3>();
   }
 
   /** \brief Get the minimum coordinates of the bounding box (after
@@ -88,7 +100,7 @@ public:
   inline Eigen::Vector3i
   getMinBoxCoordinates() const
   {
-    return (min_b_.head<3>());
+    return min_b_.head<3>();
   }
 
   /** \brief Get the minimum coordinates of the bounding box (after
@@ -97,7 +109,7 @@ public:
   inline Eigen::Vector3i
   getMaxBoxCoordinates() const
   {
-    return (max_b_.head<3>());
+    return max_b_.head<3>();
   }
 
   /** \brief Get the number of divisions along all 3 axes (after filtering
@@ -106,7 +118,7 @@ public:
   inline Eigen::Vector3i
   getNrDivisions() const
   {
-    return (div_b_.head<3>());
+    return div_b_.head<3>();
   }
 
   /** \brief Get the multipliers to be applied to the grid coordinates in
@@ -115,7 +127,102 @@ public:
   inline Eigen::Vector3i
   getDivisionMultiplier() const
   {
-    return (divb_mul_.head<3>());
+    return divb_mul_.head<3>();
+  }
+
+  /** \brief Returns the index in the resulting downsampled cloud of the specified
+   * point.
+   *
+   * \note for efficiency, user must make sure that the saving of the leaf layout is
+   * enabled and filtering performed, and that the point is inside the grid, to avoid
+   * invalid access (or use getGridCoordinates+getCentroidIndexAt)
+   *
+   * \param[in] p the point to get the index at
+   */
+  inline int
+  getCentroidIndex(const PointT& p) const
+  {
+    return leaf_layout_.at(hashPoint(p));
+  }
+
+  /** \brief Returns the indices in the resulting downsampled cloud of the points at the
+   * specified grid coordinates, relative to the grid coordinates of the specified point
+   * (or -1 if the cell was empty/out of bounds). \param[in] reference_point the
+   * coordinates of the reference point (corresponding cell is allowed to be empty/out
+   * of bounds) \param[in] relative_coordinates matrix with the columns being the
+   * coordinates of the requested cells, relative to the reference point's cell \note
+   * for efficiency, user must make sure that the saving of the leaf layout is enabled
+   * and filtering performed
+   */
+  inline std::vector<int>
+  getNeighborCentroidIndices(const PointT& reference_point,
+                             const Eigen::MatrixXi& relative_coordinates) const
+  {
+    Eigen::Vector4i ijk(
+        static_cast<int>(std::floor(reference_point.x * inverse_leaf_size_[0])),
+        static_cast<int>(std::floor(reference_point.y * inverse_leaf_size_[1])),
+        static_cast<int>(std::floor(reference_point.z * inverse_leaf_size_[2])),
+        0);
+    Eigen::Array4i diff2min = min_b_ - ijk;
+    Eigen::Array4i diff2max = max_b_ - ijk;
+    std::vector<int> neighbors(relative_coordinates.cols());
+    for (Eigen::Index ni = 0; ni < relative_coordinates.cols(); ni++) {
+      Eigen::Vector4i displacement =
+          (Eigen::Vector4i() << relative_coordinates.col(ni), 0).finished();
+      // checking if the specified cell is in the grid
+      if ((diff2min <= displacement.array()).all() &&
+          (diff2max >= displacement.array()).all())
+        neighbors[ni] = leaf_layout_[(
+            (ijk + displacement - min_b_).dot(divb_mul_))]; // .at() can be omitted
+      else
+        neighbors[ni] = -1; // cell is out of bounds, consider it empty
+    }
+    return neighbors;
+  }
+
+  /** \brief Returns the layout of the leafs for fast access to cells relative to
+   * current position. \note position at (i-min_x) + (j-min_y)*div_x +
+   * (k-min_z)*div_x*div_y holds the index of the element at coordinates (i,j,k) in the
+   * grid (-1 if empty)
+   */
+  inline std::vector<int>
+  getLeafLayout() const
+  {
+    return leaf_layout_;
+  }
+
+  /** \brief Returns the corresponding (i,j,k) coordinates in the grid of point (x,y,z).
+   * \param[in] x the X point coordinate to get the (i, j, k) index at
+   * \param[in] y the Y point coordinate to get the (i, j, k) index at
+   * \param[in] z the Z point coordinate to get the (i, j, k) index at
+   */
+  inline Eigen::Vector3i
+  getGridCoordinates(float x, float y, float z) const
+  {
+    return Eigen::Vector3i(static_cast<int>(std::floor(x * inverse_leaf_size_[0])),
+                           static_cast<int>(std::floor(y * inverse_leaf_size_[1])),
+                           static_cast<int>(std::floor(z * inverse_leaf_size_[2])));
+  }
+
+  /** \brief Returns the index in the downsampled cloud corresponding to a given set of
+   * coordinates. \param[in] ijk the coordinates (i,j,k) in the grid (-1 if empty)
+   */
+  inline int
+  getCentroidIndexAt(const Eigen::Vector3i& ijk) const
+  {
+    int idx = ((Eigen::Vector4i() << ijk, 0).finished() - min_b_).dot(divb_mul_);
+    if (idx < 0 ||
+        idx >= static_cast<int>(
+                   leaf_layout_.size())) // this checks also if leaf_layout_.size () ==
+                                         // 0 i.e. everything was computed as needed
+    {
+      // if (verbose)
+      //  PCL_ERROR ("[pcl::%s::getCentroidIndexAt] Specified coordinate is outside grid
+      //  bounds, or leaf layout is not saved, make sure to call setSaveLeafLayout(true)
+      //  and filter(output) first!\n", getClassName ().c_str ());
+      return (-1);
+    }
+    return leaf_layout_[idx];
   }
 
 protected:
@@ -144,8 +251,8 @@ protected:
     // else
     getMinMax3D<PointT>(*input, *indices, min_p, max_p);
 
-    min_b_ = (min_p.array() * inverse_leaf_size_.array()).floor().cast<int>();
-    max_b_ = (max_p.array() * inverse_leaf_size_.array()).floor().cast<int>();
+    min_b_ = (min_p.array() * inverse_leaf_size_).floor().cast<int>();
+    max_b_ = (max_p.array() * inverse_leaf_size_).floor().cast<int>();
 
     div_b_ = (max_b_ - min_b_).array() + 1;
     divb_mul_ = Eigen::Vector4i(1, div_b_[0], div_b_[0] * div_b_[1], 0);
@@ -192,17 +299,22 @@ protected:
   }
 
 protected:
-  const std::string filter_name_ = "VoxelGrid";
-
-  /** \brief The minimum and maximum bin coordinates, the number of divisions, and the
-   * division multiplier. */
-  Eigen::Vector4i min_b_, max_b_, div_b_, divb_mul_;
+  /** \brief The filter name. */
+  const std::string filter_name_;
 
   /** \brief The size of a leaf. */
   Eigen::Vector4f leaf_size_;
 
   /** \brief Internal leaf sizes stored as 1/leaf_size_ for efficiency reasons. */
-  Eigen::Vector4f inverse_leaf_size_;
+  Eigen::Array4f inverse_leaf_size_;
+
+  /** \brief The leaf layout information for fast access to cells relative to current
+   * position **/
+  std::vector<int> leaf_layout_;
+
+  /** \brief The minimum and maximum bin coordinates, the number of divisions, and the
+   * division multiplier. */
+  Eigen::Vector4i min_b_, max_b_, div_b_, divb_mul_;
 
   /** \brief Minimum number of points per voxel for the centroid to be computed */
   std::size_t min_points_per_voxel_;

--- a/filters/include/pcl/filters/experimental/voxel_grid.h
+++ b/filters/include/pcl/filters/experimental/voxel_grid.h
@@ -227,8 +227,10 @@ public:
 
 protected:
   void
-  setUp(const GridFilter<VoxelStructT>* grid_filter)
+  setUp(const GridFilter<VoxelStructT>* grid_filter, Grid& grid)
   {
+    (void)grid;
+
     double filter_limit_min, filter_limit_max;
     grid_filter->getFilterLimits(filter_limit_min, filter_limit_max);
 

--- a/filters/include/pcl/filters/experimental/voxel_grid.h
+++ b/filters/include/pcl/filters/experimental/voxel_grid.h
@@ -226,7 +226,7 @@ protected:
 
     const PointCloudConstPtr input = grid_filter->getInputCloud();
     const IndicesConstPtr indices = grid_filter->getIndices();
-    const std::string& filter_field_name = grid_filter->getFilterFieldName();
+    // const std::string& filter_field_name = grid_filter->getFilterFieldName();
 
     Eigen::Vector4f min_p, max_p;
     // Get the minimum and maximum dimensions
@@ -243,8 +243,8 @@ protected:
     // else
     getMinMax3D<PointT>(*input, *indices, min_p, max_p);
 
-    min_b_ = (min_p.array() * inverse_leaf_size_).floor().cast<int>();
-    max_b_ = (max_p.array() * inverse_leaf_size_).floor().cast<int>();
+    min_b_ = (min_p.array() * inverse_leaf_size_).floor().template cast<int>();
+    max_b_ = (max_p.array() * inverse_leaf_size_).floor().template cast<int>();
 
     div_b_ = (max_b_ - min_b_).array() + 1;
     divb_mul_ = Eigen::Vector4i(1, div_b_[0], div_b_[0] * div_b_[1], 0);

--- a/filters/include/pcl/filters/experimental/voxel_grid.h
+++ b/filters/include/pcl/filters/experimental/voxel_grid.h
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2020-, Open Perception
+ *
+ *  All rights reserved
+ */
+
+#pragma once
+
+#include <pcl/common/common.h>
+#include <pcl/filters/experimental/grid_filter.h>
+
+#include <boost/optional.hpp> // std::optional for C++17
+
+#include <unordered_map>
+
+namespace pcl {
+namespace experimental {
+
+struct Voxel {
+  Eigen::Vector3f centroid = Eigen::Vector3f::Zero();
+  std::size_t num_pt = 0;
+};
+
+template <typename PointT>
+class VoxelStructT {
+public:
+  using PointCloud = pcl::PointCloud<PointT>;
+  using PointCloudPtr = typename PointCloud::Ptr;
+  using PointCloudConstPtr = typename PointCloud::ConstPtr;
+
+  using Grid = std::unordered_map<std::size_t, Voxel>;
+
+  /** \brief Set the minimum number of points required for a voxel to be used.
+   * \param[in] min_points_per_voxel the minimum number of points for required for a
+   * voxel to be used
+   */
+  inline void
+  setMinimumPointsNumberPerVoxel(unsigned int min_points_per_voxel)
+  {
+    min_points_per_voxel_ = min_points_per_voxel;
+  }
+
+  /** \brief Set the voxel grid leaf size.
+   * \param[in] leaf_size the voxel grid leaf size
+   */
+  inline void
+  setLeafSize(const Eigen::Vector4f& leaf_size)
+  {
+    leaf_size_ = leaf_size;
+    // Avoid division errors
+    if (leaf_size_[3] == 0)
+      leaf_size_[3] = 1;
+    // Use multiplications instead of divisions
+    inverse_leaf_size_ = 1 / leaf_size_.array();
+  }
+
+  /** \brief Set the voxel grid leaf size.
+   * \param[in] lx the leaf size for X
+   * \param[in] ly the leaf size for Y
+   * \param[in] lz the leaf size for Z
+   */
+  inline void
+  setLeafSize(float lx, float ly, float lz)
+  {
+    leaf_size_[0] = lx;
+    leaf_size_[1] = ly;
+    leaf_size_[2] = lz;
+    // Avoid division errors
+    if (leaf_size_[3] == 0)
+      leaf_size_[3] = 1;
+    // Use multiplications instead of divisions
+    inverse_leaf_size_ = 1 / leaf_size_.array();
+  }
+
+  /** \brief Get the voxel grid leaf size. */
+  inline Eigen::Vector3f
+  getLeafSize() const
+  {
+    return (leaf_size_.head<3>());
+  }
+
+  /** \brief Get the minimum coordinates of the bounding box (after
+   * filtering is performed).
+   */
+  inline Eigen::Vector3i
+  getMinBoxCoordinates() const
+  {
+    return (min_b_.head<3>());
+  }
+
+  /** \brief Get the minimum coordinates of the bounding box (after
+   * filtering is performed).
+   */
+  inline Eigen::Vector3i
+  getMaxBoxCoordinates() const
+  {
+    return (max_b_.head<3>());
+  }
+
+  /** \brief Get the number of divisions along all 3 axes (after filtering
+   * is performed).
+   */
+  inline Eigen::Vector3i
+  getNrDivisions() const
+  {
+    return (div_b_.head<3>());
+  }
+
+  /** \brief Get the multipliers to be applied to the grid coordinates in
+   * order to find the centroid index (after filtering is performed).
+   */
+  inline Eigen::Vector3i
+  getDivisionMultiplier() const
+  {
+    return (divb_mul_.head<3>());
+  }
+
+protected:
+  void
+  setUp(const GridFilter<VoxelStructT>* grid_filter)
+  {
+    double filter_limit_min, filter_limit_max;
+    grid_filter->getFilterLimits(filter_limit_min, filter_limit_max);
+
+    const PointCloudConstPtr input = grid_filter->getInputCloud();
+    const IndicesConstPtr indices = grid_filter->getIndices();
+    const std::string& filter_field_name = grid_filter->getFilterFieldName();
+
+    Eigen::Vector4f min_p, max_p;
+    // Get the minimum and maximum dimensions
+    // if (!filter_field_name.empty()) // If we don't want to process the entire
+    // cloud...
+    //   getMinMax3D<PointT>(input,
+    //                       *indices,
+    //                       filter_field_name,
+    //                       static_cast<float>(filter_limit_min),
+    //                       static_cast<float>(filter_limit_max),
+    //                       min_p,
+    //                       max_p,
+    //                       grid_filter->getFilterLimitsNegative());
+    // else
+    getMinMax3D<PointT>(*input, *indices, min_p, max_p);
+
+    min_b_ = (min_p.array() * inverse_leaf_size_.array()).floor().cast<int>();
+    max_b_ = (max_p.array() * inverse_leaf_size_.array()).floor().cast<int>();
+
+    div_b_ = (max_b_ - min_b_).array() + 1;
+    divb_mul_ = Eigen::Vector4i(1, div_b_[0], div_b_[0] * div_b_[1], 0);
+  }
+
+  // accessing GridFilter
+  const auto
+  getDerived()
+  {
+    return static_cast<GridFilter<VoxelStructT>*>(this);
+  }
+
+  std::size_t
+  hashPoint(const PointT& pt)
+  {
+    const std::size_t ijk0 = std::floor(pt.x * inverse_leaf_size_[0]) - min_b_[0];
+    const std::size_t ijk1 = std::floor(pt.y * inverse_leaf_size_[1]) - min_b_[1];
+    const std::size_t ijk2 = std::floor(pt.z * inverse_leaf_size_[2]) - min_b_[2];
+    return ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
+  }
+
+  void
+  addPointToGrid(Grid& grid, const PointT& pt)
+  {
+    // can be batch/running mode
+    const std::size_t h = hashPoint(pt);
+    grid[h].centroid += Eigen::Vector3f{pt.x, pt.y, pt.z};
+    grid[h].num_pt++;
+  }
+
+  boost::optional<PointT>
+  filterGrid(Grid::iterator grid_it, Grid& grid)
+  {
+    // Suppress unused warning
+    (void)grid;
+
+    auto& voxel = grid_it->second;
+    if (voxel.num_pt >= min_points_per_voxel_) {
+      voxel.centroid.array() /= voxel.num_pt;
+      return PointT(voxel.centroid[0], voxel.centroid[1], voxel.centroid[2]);
+    }
+
+    return boost::none;
+  }
+
+protected:
+  const std::string filter_name_ = "VoxelGrid";
+
+  /** \brief The minimum and maximum bin coordinates, the number of divisions, and the
+   * division multiplier. */
+  Eigen::Vector4i min_b_, max_b_, div_b_, divb_mul_;
+
+  /** \brief The size of a leaf. */
+  Eigen::Vector4f leaf_size_;
+
+  /** \brief Internal leaf sizes stored as 1/leaf_size_ for efficiency reasons. */
+  Eigen::Vector4f inverse_leaf_size_;
+
+  /** \brief Minimum number of points per voxel for the centroid to be computed */
+  std::size_t min_points_per_voxel_;
+};
+
+template <typename PointT>
+using VoxelGrid = GridFilter<VoxelStructT<PointT>>;
+
+} // namespace experimental
+} // namespace pcl

--- a/test/filters/CMakeLists.txt
+++ b/test/filters/CMakeLists.txt
@@ -46,6 +46,11 @@ if(BUILD_io)
          FILES test_bilateral.cpp
          LINK_WITH pcl_gtest pcl_filters pcl_io pcl_kdtree
          ARGUMENTS "${PCL_SOURCE_DIR}/test/milk_cartoon_all_small_clorox.pcd")
+  
+  PCL_ADD_TEST(grid_filter test_grid_filter
+         FILES test_grid_filter.cpp
+         LINK_WITH pcl_gtest pcl_common pcl_filters pcl_io
+         ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd" "${PCL_SOURCE_DIR}/test/milk_cartoon_all_small_clorox.pcd")
 
   if(BUILD_features)
     PCL_ADD_TEST(filters_sampling test_filters_sampling

--- a/test/filters/test_grid_filter.cpp
+++ b/test/filters/test_grid_filter.cpp
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Point CLoud Library (PCL) - www.pointclouds.org
+ * Copyright (c) 2020-, Open Perception
+ *
+ * All rights reserved
+ */
+
+#include <pcl/filters/experimental/voxel_grid.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/test/gtest.h>
+#include <pcl/point_types.h>
+
+#include <cmath>
+
+using namespace pcl;
+using namespace pcl::io;
+using namespace Eigen;
+
+PointCloud<PointXYZ>::Ptr cloud(new PointCloud<PointXYZ>);
+PointCloud<PointXYZRGB>::Ptr cloud_organized(new PointCloud<PointXYZRGB>);
+
+const float PRECISION = Eigen::NumTraits<float>::dummy_precision() * 2;
+
+// helper function
+template <typename PointT>
+bool
+isPointApprox(const PointT& p1, const PointT& p2, const float precision)
+{
+  return sqrt(pow(p1.x - p2.x, 2) + pow(p1.y - p2.y, 2) + pow(p1.z - p2.z, 2)) <=
+         precision;
+}
+
+TEST(VoxelGridEquivalentTest, GridFilters)
+{
+  PointCloud<PointXYZ> new_out_cloud, old_out_cloud;
+
+  pcl::experimental::VoxelGrid<PointXYZ> new_grid;
+  new_grid.setLeafSize(0.02f, 0.02f, 0.02f);
+  new_grid.setInputCloud(cloud);
+  new_grid.filter(new_out_cloud);
+
+  pcl::VoxelGrid<PointXYZ> old_grid;
+  old_grid.setLeafSize(0.02f, 0.02f, 0.02f);
+  old_grid.setInputCloud(cloud);
+  old_grid.filter(old_out_cloud);
+
+  EXPECT_EQ(new_out_cloud.size(), old_out_cloud.size());
+  EXPECT_EQ(new_out_cloud.width, old_out_cloud.width);
+  EXPECT_EQ(new_out_cloud.height, old_out_cloud.height);
+
+  for (size_t i = 0; i < new_out_cloud.size(); ++i) {
+    bool same_pt_found = false;
+    for (size_t j = 0; j < old_out_cloud.size(); ++j) {
+      if (isPointApprox(new_out_cloud[i], old_out_cloud[j], PRECISION)) {
+        same_pt_found = true;
+        break;
+      }
+    }
+
+    EXPECT_TRUE(same_pt_found);
+  }
+}
+
+TEST(GridInfoEquivalentTest, GridFilters)
+{
+  PointCloud<PointXYZ> new_out_cloud, old_out_cloud;
+
+  experimental::VoxelGrid<PointXYZ> new_grid;
+  new_grid.setLeafSize(0.02f, 0.02f, 0.02f);
+  new_grid.setInputCloud(cloud);
+  new_grid.filter(new_out_cloud);
+
+  pcl::VoxelGrid<PointXYZ> old_grid;
+  old_grid.setLeafSize(0.02f, 0.02f, 0.02f);
+  old_grid.setInputCloud(cloud);
+  old_grid.filter(old_out_cloud);
+
+  const Eigen::Vector3i new_min_b = new_grid.getMinBoxCoordinates();
+  const Eigen::Vector3i old_min_b = old_grid.getMinBoxCoordinates();
+  EXPECT_TRUE(new_min_b.isApprox(old_min_b, PRECISION));
+
+  const Eigen::Vector3i new_max_b = new_grid.getMaxBoxCoordinates();
+  const Eigen::Vector3i old_max_b = old_grid.getMaxBoxCoordinates();
+  EXPECT_TRUE(new_max_b.isApprox(old_max_b, PRECISION));
+
+  const Eigen::Vector3i new_div_b = new_grid.getNrDivisions();
+  const Eigen::Vector3i old_div_b = old_grid.getNrDivisions();
+  EXPECT_TRUE(new_div_b.isApprox(old_div_b, PRECISION));
+
+  const Eigen::Vector3i new_divb_mul = new_grid.getDivisionMultiplier();
+  const Eigen::Vector3i old_divb_mul = old_grid.getDivisionMultiplier();
+  EXPECT_TRUE(new_divb_mul.isApprox(old_divb_mul, PRECISION));
+}
+
+int
+main(int argc, char** argv)
+{
+  // Load a standard PCD file from disk
+  if (argc < 3) {
+    std::cerr << "No test file given. Please download `bun0.pcd` and "
+                 "`milk_cartoon_all_small_clorox.pcd` and pass their paths to the test."
+              << std::endl;
+    return (-1);
+  }
+
+  // Load a standard PCD file from disk
+  pcl::io::loadPCDFile(argv[1], *cloud);
+  loadPCDFile(argv[2], *cloud_organized);
+
+  testing::InitGoogleTest(&argc, argv);
+  return (RUN_ALL_TESTS());
+}


### PR DESCRIPTION
Goals of this PR:

1. Create a base class `GridFilter`
    - Allow user to provide their own grid to the class
        - e.g.: https://github.com/PointCloudLibrary/pcl/issues/2044
    - Allow later upgrading to parallelized iterations in `applyFilter`
    - Separate the generic grid filter logic and filter specific log
        - Allowing later reduce the boilerplate code in other grid type filters
            - e.g.: `ApproximateVoxelGrid`, `GridMinimum`, `VoxelGridLabel`, `UniformSampling`
2. Increased performance by using `std::unordered_map` instead of sorting to gather points into voxel
3. Solve https://github.com/PointCloudLibrary/pcl/issues/4365