### PR TITLE
Add missing include of hpp file in flann_search.h

### DIFF
--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -367,4 +367,7 @@ namespace pcl
   }
 }
 
+// There is no cpp file containing template instantiations of FlannSearch
+#include <pcl/search/impl/flann_search.hpp>
+
 #define PCL_INSTANTIATE_FlannSearch(T) template class PCL_EXPORTS pcl::search::FlannSearch<T>;

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -42,7 +42,7 @@
 #include <pcl/common/distances.h>
 #include <pcl/common/time.h>
 #include <pcl/search/kdtree.h> // for pcl::search::KdTree
-#include <pcl/search/impl/flann_search.hpp>
+#include <pcl/search/flann_search.h> // for pcl::search::FlannSearch
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 


### PR DESCRIPTION
Previously, it was necessary to include flann_search.hpp in the user code, or else the compiler would report undefined references.
Fixes #1756