### PR TITLE
Add more configuration options to GRSDEstimation

### DIFF
--- a/features/include/pcl/features/grsd.h
+++ b/features/include/pcl/features/grsd.h
@@ -86,7 +86,7 @@ namespace pcl
       using PointCloudInPtr = typename Feature<PointInT, PointOutT>::PointCloudInPtr;
 
       /** \brief Constructor. */
-      GRSDEstimation () : additive_ (true), width_ (0.0), rsd_nr_subdiv_ (0), rsd_plane_radius_ (0.0)
+      GRSDEstimation ()
       {
         feature_name_ = "GRSDEstimation";
         relative_coordinates_all_ = getAllNeighborCellIndices ();
@@ -145,16 +145,16 @@ namespace pcl
     private:
 
       /** \brief Defines if an additive feature is computed or ray-casting is used to get a more descriptive feature. */
-      bool additive_;
+      bool additive_ = true;
 
       /** \brief Defines the voxel size to be used. */
-      double width_;
+      double width_ = 0.0;
 
       /** \brief For the underlying RSDEstimation. The number of subdivisions for the considered distance interval. */
-      int rsd_nr_subdiv_;
+      int rsd_nr_subdiv_ = 0;
 
       /** \brief For the underlying RSDEstimation. The maximum radius, above which everything can be considered planar. */
-      double rsd_plane_radius_;
+      double rsd_plane_radius_ = 0.0;
 
       /** \brief Pre-computed the relative cell indices of all the 26 neighbors. */
       Eigen::MatrixXi relative_coordinates_all_;

--- a/features/include/pcl/features/grsd.h
+++ b/features/include/pcl/features/grsd.h
@@ -86,7 +86,7 @@ namespace pcl
       using PointCloudInPtr = typename Feature<PointInT, PointOutT>::PointCloudInPtr;
 
       /** \brief Constructor. */
-      GRSDEstimation () : additive_ (true)
+      GRSDEstimation () : additive_ (true), width_ (0.0), rsd_nr_subdiv_ (0), rsd_plane_radius_ (0.0)
       {
         feature_name_ = "GRSDEstimation";
         relative_coordinates_all_ = getAllNeighborCellIndices ();
@@ -104,7 +104,23 @@ namespace pcl
         */
       inline double
       getRadiusSearch () const { return (search_radius_); }
-      
+
+      /** \brief Set the number of subdivisions for the considered distance interval.
+        * This function configures the underlying RSDEstimation. For more info, see
+        * there. If this function is not called, the default from RSDEstimation is used.
+        * \param[in] nr_subdiv the number of subdivisions
+        */
+      inline void
+      setNrSubdivisions (int nr_subdiv) { rsd_nr_subdiv_ = nr_subdiv; }
+
+      /** \brief Set the maximum radius, above which everything can be considered planar.
+        * This function configures the underlying RSDEstimation. For more info, see
+        * there. If this function is not called, the default from RSDEstimation is used.
+        * \param[in] plane_radius the new plane radius
+        */
+      inline void
+      setPlaneRadius (double plane_radius) { rsd_plane_radius_ = plane_radius; }
+
       /** \brief Get the type of the local surface based on the min and max radius computed. 
         * \return the integer that represents the type of the local surface with values as
         * Plane (1), Cylinder (2), Noise or corner (0), Sphere (3) and Edge (4) 
@@ -133,6 +149,12 @@ namespace pcl
 
       /** \brief Defines the voxel size to be used. */
       double width_;
+
+      /** \brief For the underlying RSDEstimation. The number of subdivisions for the considered distance interval. */
+      int rsd_nr_subdiv_;
+
+      /** \brief For the underlying RSDEstimation. The maximum radius, above which everything can be considered planar. */
+      double rsd_plane_radius_;
 
       /** \brief Pre-computed the relative cell indices of all the 26 neighbors. */
       Eigen::MatrixXi relative_coordinates_all_;

--- a/features/include/pcl/features/impl/grsd.hpp
+++ b/features/include/pcl/features/impl/grsd.hpp
@@ -65,7 +65,7 @@ template <typename PointInT, typename PointNT, typename PointOutT> void
 pcl::GRSDEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut &output)
 {
   // Check if search_radius_ was set
-  if (width_ < 0)
+  if (width_ <= 0.0)
   {
     PCL_ERROR ("[pcl::%s::computeFeature] A voxel cell width needs to be set!\n", getClassName ().c_str ());
     output.width = output.height = 0;
@@ -87,7 +87,11 @@ pcl::GRSDEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut
   rsd.setInputCloud (cloud_downsampled);
   rsd.setSearchSurface (input_);
   rsd.setInputNormals (normals_);
-  rsd.setRadiusSearch (std::max (search_radius_, std::sqrt (3.0) * width_ / 2));
+  rsd.setRadiusSearch (search_radius_);
+  if (rsd_nr_subdiv_ != 0) // if not set, use default from RSDEstimation
+    rsd.setNrSubdivisions (rsd_nr_subdiv_);
+  if (rsd_plane_radius_ != 0.0)
+    rsd.setPlaneRadius (rsd_plane_radius_);
   rsd.compute (*radii);
 
   // Save the type of each point


### PR DESCRIPTION
- Add functions to optionally specify nr_subdiv and plane_radius of the underlying RSDEstimation
- Properly initialize width_ with 0.0
- The search radius of RSDEstimation was set as the maximum of search_radius_ and `std::sqrt (3.0) * width_ / 2`. However, width_ and search_radius are always the same (see setRadiusSearch in grsd.h), so it was possible to simplify this expression.

Fixes #2140