### PR TITLE
Fix keep_organized behavior in CropHull filter

### DIFF
--- a/filters/include/pcl/filters/crop_hull.h
+++ b/filters/include/pcl/filters/crop_hull.h
@@ -130,6 +130,11 @@ namespace pcl
       }
 
     protected:
+      /** \brief Filter the input points using the 2D or 3D polygon hull.
+        * \param[out] output The set of points that passed the filter
+        */
+      void
+      applyFilter (PointCloud &output) override;
 
       /** \brief Filter the input points using the 2D or 3D polygon hull.
         * \param[out] indices the indices of the set of points that passed the filter.

--- a/filters/include/pcl/filters/crop_hull.h
+++ b/filters/include/pcl/filters/crop_hull.h
@@ -53,7 +53,8 @@ namespace pcl
     using Filter<PointT>::filter_name_;
     using Filter<PointT>::indices_;
     using Filter<PointT>::input_;
-    
+    using Filter<PointT>::removed_indices_;
+
     using PointCloud = typename Filter<PointT>::PointCloud;
     using PointCloudPtr = typename PointCloud::Ptr;
     using PointCloudConstPtr = typename PointCloud::ConstPtr;
@@ -129,11 +130,6 @@ namespace pcl
       }
 
     protected:
-      /** \brief Filter the input points using the 2D or 3D polygon hull.
-        * \param[out] output The set of points that passed the filter
-        */
-      void
-      applyFilter (PointCloud &output) override;
 
       /** \brief Filter the input points using the 2D or 3D polygon hull.
         * \param[out] indices the indices of the set of points that passed the filter.
@@ -148,15 +144,6 @@ namespace pcl
         */
       Eigen::Vector3f
       getHullCloudRange ();
-      
-      /** \brief Apply the two-dimensional hull filter.
-        * All points are assumed to lie in the same plane as the 2D hull, an
-        * axis-aligned 2D coordinate system using the two dimensions specified
-        * (PlaneDim1, PlaneDim2) is used for calculations.
-        * \param[out] output The set of points that pass the 2D polygon filter.
-        */
-      template<unsigned PlaneDim1, unsigned PlaneDim2> void
-      applyFilter2D (PointCloud &output); 
 
       /** \brief Apply the two-dimensional hull filter.
         * All points are assumed to lie in the same plane as the 2D hull, an
@@ -176,17 +163,6 @@ namespace pcl
          * \param[out] output The set of points that pass the 3D polygon hull
          *                    filter.
          */
-      void
-      applyFilter3D (PointCloud &output);
-
-      /** \brief Apply the three-dimensional hull filter.
-        *  Polygon-ray crossings are used for three rays cast from each point
-        *  being tested, and a  majority vote of the resulting
-        *  polygon-crossings is used to decide  whether the point lies inside
-        *  or outside the hull.
-        * \param[out] indices The indices of the set of points that pass the 3D
-        *                     polygon hull filter.
-        */
       void
       applyFilter3D (Indices &indices);
 

--- a/filters/include/pcl/filters/crop_hull.h
+++ b/filters/include/pcl/filters/crop_hull.h
@@ -160,14 +160,14 @@ namespace pcl
       template<unsigned PlaneDim1, unsigned PlaneDim2> void
       applyFilter2D (Indices &indices);
 
-       /** \brief Apply the three-dimensional hull filter.
-         * Polygon-ray crossings are used for three rays cast from each point
-         * being tested, and a  majority vote of the resulting
-         * polygon-crossings is used to decide  whether the point lies inside
-         * or outside the hull.
-         * \param[out] output The set of points that pass the 3D polygon hull
-         *                    filter.
-         */
+      /** \brief Apply the three-dimensional hull filter.
+        *  Polygon-ray crossings are used for three rays cast from each point
+        *  being tested, and a  majority vote of the resulting
+        *  polygon-crossings is used to decide  whether the point lies inside
+        *  or outside the hull.
+        * \param[out] indices The indices of the set of points that pass the 3D
+        *                     polygon hull filter.
+        */
       void
       applyFilter3D (Indices &indices);
 

--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -123,9 +123,13 @@ pcl::CropHull<PointT>::applyFilter2D (Indices &indices)
       {
         if (crop_outside_)
           indices.push_back ((*indices_)[index]);
+        // once a point has tested +ve for being inside one polygon, we can
+        // stop checking the others:
         break;
       }
     }
+    // If we're removing points *inside* the hull, only remove points that
+    // haven't been found inside any polygons
     if (poly == hull_polygons_.size () && !crop_outside_)
       indices.push_back ((*indices_)[index]);
     if (indices.empty() || indices.back() != (*indices_)[index]) {

--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -43,7 +43,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT>
-PCL_DEPRECATED(1, 16, "This is a trivial call to base class method")
+PCL_DEPRECATED(1, 13, "This is a trivial call to base class method")
 void
 pcl::CropHull<PointT>::applyFilter (PointCloud &output)
 {

--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -43,7 +43,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT>
-PCL_DEPRECATED(1, 13, "This is a trivial call to base class method")
+PCL_DEPRECATED(1, 16, "This is a trivial call to base class method")
 void
 pcl::CropHull<PointT>::applyFilter (PointCloud &output)
 {

--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -42,10 +42,11 @@
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
+template<typename PointT>
+PCL_DEPRECATED(1, 13, "This is a trivial call to base class method")
+void
 pcl::CropHull<PointT>::applyFilter (PointCloud &output)
 {
-  //TODO: remove overriden function with trivial reimplementation
   FilterIndices<PointT>::applyFilter(output);
 }
 

--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -40,6 +40,16 @@
 
 #include <pcl/filters/crop_hull.h>
 
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointT> void
+pcl::CropHull<PointT>::applyFilter (PointCloud &output)
+{
+  //TODO: remove overriden function with trivial reimplementation
+  FilterIndices<PointT>::applyFilter(output);
+}
+
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> void
 pcl::CropHull<PointT>::applyFilter (Indices &indices)

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -371,7 +371,7 @@ TYPED_TEST (PCLCropHullTestFixture, test_keep_organized)
       pcl::PointCloud<pcl::PointXYZ> filteredCloud;
       crop_hull_filter.filter(filteredCloud);
       ASSERT_EQ (test_data.input_cloud_->size(), filteredCloud.size());
-      for (pcl::index_t i = 0; i < pcl::index_t(test_data.input_cloud_->size()); ++i)
+      for (size_t i = 0; i < test_data.input_cloud_->size(); ++i)
       {
         pcl::PointXYZ expectedPoint = test_data.inside_mask_[i] ? test_data.input_cloud_->at(i) : defaultPoint;
         ASSERT_XYZ_NEAR(expectedPoint, filteredCloud[i], 1e-5);

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -371,7 +371,7 @@ TYPED_TEST (PCLCropHullTestFixture, test_keep_organized)
       pcl::PointCloud<pcl::PointXYZ> filteredCloud;
       crop_hull_filter.filter(filteredCloud);
       ASSERT_EQ (test_data.input_cloud_->size(), filteredCloud.size());
-      for (pcl::index_t i = 0; i < test_data.input_cloud_->size(); ++i)
+      for (pcl::index_t i = 0; i < pcl::index_t(test_data.input_cloud_->size()); ++i)
       {
         pcl::PointXYZ expectedPoint = test_data.inside_mask_[i] ? test_data.input_cloud_->at(i) : defaultPoint;
         ASSERT_XYZ_NEAR(expectedPoint, filteredCloud[i], 1e-5);

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -357,6 +357,31 @@ TYPED_TEST (PCLCropHullTestFixture, test_cloud_filtering)
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TYPED_TEST (PCLCropHullTestFixture, test_keep_organized)
+{
+  for (auto & entry : this->data_)
+  {
+    auto & crop_hull_filter = entry.first;
+    crop_hull_filter.setKeepOrganized(true);
+    crop_hull_filter.setUserFilterValue(-10.);
+    const pcl::PointXYZ defaultPoint(-10., -10., -10.);
+    for (TestData const & test_data : entry.second)
+    {
+      crop_hull_filter.setInputCloud(test_data.input_cloud_);
+      pcl::PointCloud<pcl::PointXYZ> filteredCloud;
+      crop_hull_filter.filter(filteredCloud);
+      ASSERT_EQ (test_data.input_cloud_->size(), filteredCloud.size());
+      for (pcl::index_t i = 0; i < test_data.input_cloud_->size(); ++i)
+      {
+        pcl::PointXYZ expectedPoint = test_data.inside_mask_[i] ? test_data.input_cloud_->at(i) : defaultPoint;
+        ASSERT_XYZ_NEAR(expectedPoint, filteredCloud[i], 1e-5);
+      }
+    }
+  }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // this test will pass only for 2d case //
 template <class T>
 struct PCLCropHullTestFixture2dCrutch : PCLCropHullTestFixture<T>


### PR DESCRIPTION
part of #3883
resolve #4854

`FilerIndices` , which is Base class of `CropHull` already have got implementation for function `applyFilter(pcl::PointCloud)`.
In Base class keep_organized behavior is exists, but in overridden method in `CropHull` was lost.

`FilterIndices::applyFilter(pcl::PointCloud)`  resolve all needed behavior, so overridden method not needed. 
Because of this, wrong and unnecessary reimplementation was deleted.

Implementation in Base class used protected field `removed_indices_` and expect, that all inheritors will correct fill it.
In `CropHull` this processing does not exists.
In this PR requested processing was implement in ugly temporary way. On the next PR all expected behavior from Base classes will be implement.