### PR TITLE
Add deprecation for filter getters with bool reference

### DIFF
--- a/cuda/filters/include/pcl/cuda/filters/filter.h
+++ b/cuda/filters/include/pcl/cuda/filters/filter.h
@@ -123,8 +123,14 @@ namespace pcl_cuda
         * returned (true) or inside (false). 
         * \param limit_negative the limit_negative flag
         */
+      PCL_DEPRECATED(1, 16, "use bool getFilterLimitsNegative() instead")
       inline void 
       getFilterLimitsNegative (bool &limit_negative) { limit_negative = filter_limit_negative_; }
+
+      /** \brief Get whether the data outside the interval (min/max) is to be
+        * returned (true) or inside (false). 
+        * \return true if data \b outside the interval [min; max] is to be returned, false otherwise
+        */
       inline bool 
       getFilterLimitsNegative () { return (filter_limit_negative_); }
 

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -435,6 +435,7 @@ namespace pcl
       /** \brief Get whether the data outside the interval (min/max) is to be returned (true) or inside (false).
         * \param[out] limit_negative true if data \b outside the interval [min; max] is to be returned, false otherwise
         */
+      PCL_DEPRECATED(1, 16, "use bool getFilterLimitsNegative() instead")
       inline void
       getFilterLimitsNegative (bool &limit_negative) const
       {
@@ -783,6 +784,7 @@ namespace pcl
       /** \brief Get whether the data outside the interval (min/max) is to be returned (true) or inside (false).
         * \param[out] limit_negative true if data \b outside the interval [min; max] is to be returned, false otherwise
         */
+      PCL_DEPRECATED(1, 16, "use bool getFilterLimitsNegative() instead")
       inline void
       getFilterLimitsNegative (bool &limit_negative) const
       {


### PR DESCRIPTION
Discussed in https://github.com/PointCloudLibrary/pcl/pull/4828#discussion_r663296844

Deprecation is added in `pcl_cuda::filter` and `pcl::VoxelGrid`
