### PR TITLE
Bugfix: Number of OpenMP threads was not validated, ...

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -102,6 +102,20 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::setNormals (const PointCloudNC
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
+template<typename PointInT, typename PointOutT, typename NormalT> void
+pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::setNumberOfThreads (unsigned int nr_threads)
+{
+  if (nr_threads == 0)
+#ifdef _OPENMP
+    threads_ = omp_get_num_procs();
+#else
+    threads_ = 1;
+#endif
+  else
+    threads_ = nr_threads;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointInT, typename PointOutT, typename NormalT> bool*
 pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::getBoundaryPoints (PointCloudIn &input, double border_radius, float angle_threshold)
 {

--- a/keypoints/include/pcl/keypoints/iss_3d.h
+++ b/keypoints/include/pcl/keypoints/iss_3d.h
@@ -125,6 +125,7 @@ namespace pcl
       {
         name_ = "ISSKeypoint3D";
         search_radius_ = salient_radius_;
+        setNumberOfThreads(threads_); // Reset number of threads with the member's initialization value to apply input validation.
       }
 
       /** \brief Destructor. */
@@ -197,8 +198,8 @@ namespace pcl
       /** \brief Initialize the scheduler and set the number of threads to use.
         * \param[in] nr_threads the number of hardware threads to use (0 sets the value back to automatic)
         */
-      inline void
-      setNumberOfThreads (unsigned int nr_threads = 0) { threads_ = nr_threads; }
+      void
+      setNumberOfThreads (unsigned int nr_threads = 0);
 
     protected:
 


### PR DESCRIPTION
causing OpenMP User Error 1001: argument to num_threads clause must be positive" if number of threads was 0. (Issue #4860)

According to documentation, 0 should be "auto".
Added input validation to getBoundaryPoints method, treating 0 as "auto" (example taken from normal_3d_omp.hpp). Method is also used in class constructor to validate initialization value of the threads_ member, adhering to the DRY principle.