### PR TITLE
Fix SampleConsensusModelCylinder.projectPoints and verify with test

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp
@@ -358,6 +358,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
       pp.matrix () = line_pt + k * line_dir;
 
       Eigen::Vector4f dir = p - pp;
+      dir[3] = 0.0f;
       dir.normalize ();
 
       // Calculate the projection of the point onto the cylinder
@@ -388,6 +389,7 @@ pcl::SampleConsensusModelCylinder<PointT, PointNT>::projectPoints (
       pp.matrix () = line_pt + k * line_dir;
 
       Eigen::Vector4f dir = p - pp;
+      dir[3] = 0.0f;
       dir.normalize ();
 
       // Calculate the projection of the point onto the cylinder

--- a/test/sample_consensus/test_sample_consensus_quadric_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_quadric_models.cpp
@@ -695,6 +695,51 @@ TEST (SampleConsensusModelSphere, projectPoints)
   EXPECT_XYZ_NEAR(projected_points_all[7],        (*input)[7], 1e-5);
 }
 
+TEST (SampleConsensusModelCylinder, projectPoints)
+{
+  Eigen::VectorXf model_coefficients(7);
+  model_coefficients << -0.59, 0.85, -0.80, 0.22, -0.70, 0.68, 0.18;
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr input(new pcl::PointCloud<pcl::PointXYZ>);
+  input->emplace_back(-0.616358,  0.713315, -0.885120); // inlier, dist from axis=0.16
+  input->emplace_back( 0.595892,  0.455094,  0.025545); // outlier, not projected
+  input->emplace_back(-0.952749,  1.450040, -1.305640); // inlier, dist from axis=0.19
+  input->emplace_back(-0.644947,  1.421240, -1.421170); // inlier, dist from axis=0.14
+  input->emplace_back(-0.242308, -0.561036, -0.365535); // outlier, not projected
+  input->emplace_back(-0.502111,  0.694671, -0.878344); // inlier, dist from axis=0.18
+  input->emplace_back(-0.664129,  0.557583, -0.750060); // inlier, dist from axis=0.21
+  input->emplace_back(-0.033891,  0.624537, -0.606994); // outlier, not projected
+
+  pcl::SampleConsensusModelCylinder<pcl::PointXYZ, pcl::Normal> model(input);
+  // not necessary to set normals for model here because projectPoints does not use them
+  pcl::Indices inliers = {0, 2, 3, 5, 6};
+
+  pcl::PointCloud<pcl::PointXYZ> projected_truth;
+  projected_truth.emplace_back(-0.620532, 0.699027, -0.898478);
+  projected_truth.emplace_back(-0.943418, 1.449510, -1.309200);
+  projected_truth.emplace_back(-0.608243, 1.417710, -1.436680);
+  projected_truth.emplace_back(-0.502111, 0.694671, -0.878344);
+  projected_truth.emplace_back(-0.646557, 0.577140, -0.735612);
+
+  pcl::PointCloud<pcl::PointXYZ> projected_points;
+  model.projectPoints(inliers, model_coefficients, projected_points, false);
+  EXPECT_EQ(projected_points.size(), 5);
+  for(int i=0; i<5; ++i)
+    EXPECT_XYZ_NEAR(projected_points[i], projected_truth[i], 1e-5);
+
+  pcl::PointCloud<pcl::PointXYZ> projected_points_all;
+  model.projectPoints(inliers, model_coefficients, projected_points_all, true);
+  EXPECT_EQ(projected_points_all.size(), 8);
+  EXPECT_XYZ_NEAR(projected_points_all[0], projected_truth[0], 1e-5);
+  EXPECT_XYZ_NEAR(projected_points_all[1],        (*input)[1], 1e-5);
+  EXPECT_XYZ_NEAR(projected_points_all[2], projected_truth[1], 1e-5);
+  EXPECT_XYZ_NEAR(projected_points_all[3], projected_truth[2], 1e-5);
+  EXPECT_XYZ_NEAR(projected_points_all[4],        (*input)[4], 1e-5);
+  EXPECT_XYZ_NEAR(projected_points_all[5], projected_truth[3], 1e-5);
+  EXPECT_XYZ_NEAR(projected_points_all[6], projected_truth[4], 1e-5);
+  EXPECT_XYZ_NEAR(projected_points_all[7],        (*input)[7], 1e-5);
+}
+
 int
 main (int argc, char** argv)
 {


### PR DESCRIPTION
Fixes #3876
Closes #3975 . That pull request does not contain a test, changes more than necessary, and has an indexing error while accessing `projected_points`.