### PR TITLE
[features] Add `isNormalFinite` check in `ShapeContext3DEstimation`

### DIFF
--- a/features/include/pcl/features/3dsc.h
+++ b/features/include/pcl/features/3dsc.h
@@ -170,7 +170,7 @@ namespace pcl
       /** \brief Estimate a descriptor for a given point.
         * \param[in] index the index of the point to estimate a descriptor for
         * \param[in] normals a pointer to the set of normals
-        * \param[in] rf the reference frame
+        * \param[out] rf the reference frame
         * \param[out] desc the resultant estimated descriptor
         * \return true if the descriptor was computed successfully, false if there was an error
         * (e.g. the nearest neighbor didn't return any neighbors)

--- a/features/include/pcl/features/impl/3dsc.hpp
+++ b/features/include/pcl/features/impl/3dsc.hpp
@@ -157,6 +157,12 @@ pcl::ShapeContext3DEstimation<PointInT, PointNT, PointOutT>::computePoint (
   // Get origin normal
   // Use pre-computed normals
   normal = normals[minIndex].getNormalVector3fMap ();
+  if (!std::isfinite(normal[0]) || !std::isfinite(normal[1]) || !std::isfinite(normal[2]))
+  {
+    std::fill (desc.begin (), desc.end (), std::numeric_limits<float>::quiet_NaN ());
+    std::fill (rf, rf + 9, 0.f);
+    return (false);
+  }
 
   // Compute and store the RF direction
   x_axis[0] = rnd ();

--- a/features/include/pcl/features/impl/3dsc.hpp
+++ b/features/include/pcl/features/impl/3dsc.hpp
@@ -156,13 +156,13 @@ pcl::ShapeContext3DEstimation<PointInT, PointNT, PointOutT>::computePoint (
   Vector3fMapConst origin = (*input_)[(*indices_)[index]].getVector3fMap ();
   // Get origin normal
   // Use pre-computed normals
-  normal = normals[minIndex].getNormalVector3fMap ();
-  if (!std::isfinite(normal[0]) || !std::isfinite(normal[1]) || !std::isfinite(normal[2]))
+  if (!pcl::isNormalFinite(normals[minIndex]))
   {
     std::fill (desc.begin (), desc.end (), std::numeric_limits<float>::quiet_NaN ());
     std::fill (rf, rf + 9, 0.f);
     return (false);
   }
+  normal = normals[minIndex].getNormalVector3fMap ();
 
   // Compute and store the RF direction
   x_axis[0] = rnd ();


### PR DESCRIPTION
If any normal component is e.g. nan, the assertion later in the code would trigger.
As a minor side-edit, the rf parameter is an output (it is not read from, but written to).

Fixes #4497 . Contrary to what I commented in the issue, the assert would not trigger if the normal was `(0, 0, 0)` because the left part, `x_axis[0]*normal[0] + x_axis[1]*normal[1] + x_axis[2]*normal[2]` would also be zero, which would make the assert pass.