### PR TITLE
Add missing vtk dependency InteractionImage

### DIFF
--- a/cmake/pcl_find_vtk.cmake
+++ b/cmake/pcl_find_vtk.cmake
@@ -52,6 +52,7 @@ set(NON_PREFIX_PCL_VTK_COMPONENTS
   FiltersSources
   ImagingCore
   ImagingSources
+  InteractionImage
   InteractionStyle
   InteractionWidgets
   IOCore


### PR DESCRIPTION
InteractionImage contains e.g. vtkImageViewer.h, which is used in the tools module and in the visualization module
Closes #4543