### PR TITLE
Use override instead of virtual

### DIFF
--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -103,8 +103,8 @@ public:
 
   public:
     HuberPenalty(float threshold) : threshold_(threshold) {}
-    virtual float
-    operator()(float e) const
+    float
+    operator()(float e) const override
     {
       if (e <= threshold_)
         return (0.5 * e * e);


### PR DESCRIPTION
A minor fix to use `override` instead of `virtual` because we are overriding the `operator()`.