### PR TITLE
[surface] Calling projectPoint from projectQueryPoint

### DIFF
--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -690,32 +690,7 @@ pcl::MLSResult::projectPoint (const Eigen::Vector3d &pt, ProjectionMethod method
 pcl::MLSResult::MLSProjectionResults
 pcl::MLSResult::projectQueryPoint (ProjectionMethod method, int required_neighbors) const
 {
-  MLSResult::MLSProjectionResults proj;
-  if (order > 1 && num_neighbors >= required_neighbors && std::isfinite (c_vec[0]) && method != NONE)
-  {
-    if (method == ORTHOGONAL)
-    {
-      double u, v, w;
-      getMLSCoordinates (query_point, u, v, w);
-      proj = projectPointOrthogonalToPolynomialSurface (u, v, w);
-    }
-    else // SIMPLE
-    {
-      // Projection onto MLS surface along Darboux normal to the height at (0,0)
-      proj.point = mean + (c_vec[0] * plane_normal);
-
-      // Compute tangent vectors using the partial derivates evaluated at (0,0) which is c_vec[order_+1] and c_vec[1]
-      proj.normal = plane_normal - c_vec[order + 1] * u_axis - c_vec[1] * v_axis;
-      proj.normal.normalize ();
-    }
-  }
-  else
-  {
-    proj.normal = plane_normal;
-    proj.point = mean;
-  }
-
-  return (proj);
+  return projectPoint(query_point, method, required_neighbors);
 }
 
 template <typename PointT> void


### PR DESCRIPTION
Comparing the code of `projectPoint` and `projectQueryPoint`, it seems they are almost the same. Their differences are:

1. normal calculation:
In `projectQueryPoint`:
https://github.com/PointCloudLibrary/pcl/blob/354b4412e83fe6c1beb26b938fe009ca7b99d6e3/surface/include/pcl/surface/impl/mls.hpp#L708
In `projectPoint`:
https://github.com/PointCloudLibrary/pcl/blob/354b4412e83fe6c1beb26b938fe009ca7b99d6e3/surface/include/pcl/surface/impl/mls.hpp#L659-L660
It seems in `projectQueryPoint`, it assumes the surface polynomial is of second order, and it could give wrong result if the polynomial is of higher order.(This fixes https://github.com/PointCloudLibrary/pcl/issues/4507)

2. In `projectQueryPoint`, it misses following statements:
https://github.com/PointCloudLibrary/pcl/blob/354b4412e83fe6c1beb26b938fe009ca7b99d6e3/surface/include/pcl/surface/impl/mls.hpp#L637-L638 

So it seems replacing the content of `projectQueryPoint` with a function call to `projectPoint` does no harm.
