### PR TITLE
Deprecate the cuda VoxelGrid filter

### DIFF
--- a/cuda/filters/include/pcl/cuda/filters/voxel_grid.h
+++ b/cuda/filters/include/pcl/cuda/filters/voxel_grid.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+PCL_DEPRECATED_HEADER(1, 16, "The CUDA VoxelGrid filter does not work. Use the CPU VoxelGrid filter instead.")
+
 #include <pcl_cuda/filters/filter.h>
 #include <pcl_cuda/filters/passthrough.h>
 #include <thrust/count.h>


### PR DESCRIPTION
The filter does not do what it should do, it is just a copy of the cuda PassThrough
Closes #4907