### PR TITLE
fix: max_id size should be equal to histogram.size() - 1

### DIFF
--- a/common/src/feature_histogram.cpp
+++ b/common/src/feature_histogram.cpp
@@ -136,7 +136,7 @@ pcl::FeatureHistogram::getMeanValue ()
                      0.25f * histogram_[histogram_.size () - 2] * 2.0f;
   if (last_value > max)
   {
-    max_idx = histogram_.size ();
+    max_idx = histogram_.size () - 1;
   }
 
   // Compute mean value.


### PR DESCRIPTION
in common/feature_histogram.cpp :
the function is  `getMeanValue()`. you want to get max_id in histogram so you pick the size of histogram.
Actually I guess you want the value `histogram.size() - 1` to be the max index.
so I start an issue for discuss then get your reply.
The issue url is:   https://github.com/PointCloudLibrary/pcl/issues/4920