### PR TITLE
Modified eigen value error check in VoxelGridCovariance::applyFilter …

### DIFF
--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -330,8 +330,9 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
       eigen_val = eigensolver.eigenvalues ().asDiagonal ();
       leaf.evecs_ = eigensolver.eigenvectors ();
 
-      if (eigen_val (0, 0) < 0 || eigen_val (1, 1) < 0 || eigen_val (2, 2) <= 0)
+      if (eigen_val (0, 0) < -Eigen::NumTraits<double>::dummy_precision () || eigen_val (1, 1) < -Eigen::NumTraits<double>::dummy_precision () || eigen_val (2, 2) <= 0)
       {
+        PCL_WARN ("[VoxelGridCovariance::applyFilter] Invalid eigen value! (%g, %g, %g)\n", eigen_val (0, 0), eigen_val (1, 1), eigen_val (2, 2));
         leaf.nr_points = -1;
         continue;
       }


### PR DESCRIPTION
Modified eigen value error check in VoxelGridCovariance::applyFilter not to remove voxels if eigen value is minus and very close to zero. (#4930)
