### PR TITLE
Add option to enable EDL rendering.

### DIFF
--- a/tools/pcd_viewer.cpp
+++ b/tools/pcd_viewer.cpp
@@ -140,7 +140,7 @@ printHelp (int, char **argv)
   print_info ("\n");
   print_info ("                     -optimal_label_colors    = maps existing labels to the optimal sequential glasbey colors, label_ids will not be mapped to fixed colors (default "); print_value ("disabled"); print_info (")\n");
   print_info ("\n");
-  print_info ("                     -edl                     = Enable Eye-Dome Lightning rendering, to improve depth perception. (default: "); print_value ("disabled"); print_info (")\n");
+  print_info ("                     -edl                     = Enable Eye-Dome Lighting rendering, to improve depth perception. (default: "); print_value ("disabled"); print_info (")\n");
   print_info ("\n");
 
   print_info ("\n(Note: for multiple .pcd files, provide multiple -{fc,ps,opaque,position,orientation} parameters; they will be automatically assigned to the right file)\n");

--- a/tools/pcd_viewer.cpp
+++ b/tools/pcd_viewer.cpp
@@ -275,6 +275,11 @@ main (int argc, char** argv)
   if (use_vbos) 
     print_highlight ("Vertex Buffer Object (VBO) visualization enabled.\n");
 
+  bool useEDLRendering = false;
+  pcl::console::parse_argument(argc, argv, "-edl", useEDLRendering);
+  if (useEDLRendering)
+    print_highlight("EDL visualization enabled.\n");
+
   bool use_pp   = pcl::console::find_switch (argc, argv, "-use_point_picking");
   if (use_pp) 
     print_highlight ("Point picking enabled.\n");
@@ -361,6 +366,9 @@ main (int argc, char** argv)
     // Create the PCLVisualizer object here on the first encountered XYZ file
     if (!p)
       p.reset (new pcl::visualization::PCLVisualizer (argc, argv, "PCD viewer"));
+
+    if (useEDLRendering)
+      p->enableEDLRendering();
 
     // Multiview enabled?
     if (mview)
@@ -480,6 +488,9 @@ main (int argc, char** argv)
       p.reset (new pcl::visualization::PCLVisualizer (argc, argv, "PCD viewer"));
       if (use_pp)   // Only enable the point picking callback if the command line parameter is enabled
         p->registerPointPickingCallback (&pp_callback, static_cast<void*> (&cloud));
+
+      if (useEDLRendering)
+        p->enableEDLRendering();
 
       // Set whether or not we should be using the vtkVertexBufferObjectMapper
       p->setUseVbos (use_vbos);

--- a/tools/pcd_viewer.cpp
+++ b/tools/pcd_viewer.cpp
@@ -140,6 +140,8 @@ printHelp (int, char **argv)
   print_info ("\n");
   print_info ("                     -optimal_label_colors    = maps existing labels to the optimal sequential glasbey colors, label_ids will not be mapped to fixed colors (default "); print_value ("disabled"); print_info (")\n");
   print_info ("\n");
+  print_info ("                     -edl                     = Enable Eye-Dome Lightning rendering, to improve depth perception. (default: "); print_value ("disabled"); print_info (")\n");
+  print_info ("\n");
 
   print_info ("\n(Note: for multiple .pcd files, provide multiple -{fc,ps,opaque,position,orientation} parameters; they will be automatically assigned to the right file)\n");
 }

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1709,7 +1709,7 @@ namespace pcl
                       int viewport = 0);
 
         /**
-         * @brief Eye-Dome Lightning makes dark areas to improve depth perception
+         * @brief Eye-Dome Lighting makes dark areas to improve depth perception
          * See https://www.kitware.com/eye-dome-lighting-a-non-photorealistic-shading-technique/
          * It is applied to all actors, including texts.
          * @param viewport 

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1708,6 +1708,12 @@ namespace pcl
                       const std::string &id = "ellipsoid",
                       int viewport = 0);
 
+        /**
+         * @brief Eye-Dome Lightning makes dark areas to improve depth perception
+         * See https://www.kitware.com/eye-dome-lighting-a-non-photorealistic-shading-technique/
+         * It is applied to all actors, including texts.
+         * @param viewport 
+        */
         void
         enableEDLRendering(int viewport = 0);
 

--- a/visualization/include/pcl/visualization/pcl_visualizer.h
+++ b/visualization/include/pcl/visualization/pcl_visualizer.h
@@ -1708,6 +1708,9 @@ namespace pcl
                       const std::string &id = "ellipsoid",
                       int viewport = 0);
 
+        void
+        enableEDLRendering(int viewport = 0);
+
         /** \brief Changes the visual representation for all actors to surface representation. */
         void
         setRepresentationToSurfaceForAllActors ();

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -54,7 +54,6 @@
 #include <vtkCellArray.h>
 #include <vtkHardwareSelector.h>
 #include <vtkSelectionNode.h>
-
 #include <vtkSelection.h>
 #include <vtkPointPicker.h>
 
@@ -93,6 +92,8 @@
 
 #if VTK_MAJOR_VERSION > 7
 #include <vtkTexture.h>
+#include <vtkRenderStepsPass.h>
+#include <vtkEDLShading.h>
 #endif
 
 #include <pcl/visualization/common/shapes.h>
@@ -3523,6 +3524,34 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
   (*cloud_actor_map_)[id].viewpoint_transformation_ = transformation;
 
   return (true);
+}
+
+void
+pcl::visualization::PCLVisualizer::enableEDLRendering(int viewport)
+{
+#if VTK_MAJOR_VERSION > 7
+  auto* basicPass = vtkRenderStepsPass::New();
+
+  auto* edl = vtkEDLShading::New();
+  edl->SetDelegatePass(basicPass);
+
+    // Add it to all renderers
+  rens_->InitTraversal();
+  vtkRenderer* renderer = nullptr;
+  int i = 0;
+  while ((renderer = rens_->GetNextItem())) {
+    if (i == 0) {
+      renderer->SetPass(edl);
+    }
+    else if (i == viewport) {
+      renderer->SetPass(edl);
+    }
+    i++;
+  }
+#else
+  PCL_WARN("EDL is only supported from VTK 7.");
+  utils::ignore(viewport);
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -3549,7 +3549,7 @@ pcl::visualization::PCLVisualizer::enableEDLRendering(int viewport)
     i++;
   }
 #else
-  PCL_WARN("EDL is only supported from VTK 7.");
+  PCL_WARN("EDL requires VTK version 8 or newer.");
   utils::ignore(viewport);
 #endif
 }


### PR DESCRIPTION
Eventually might close #4940 

I tried looking into the link and what else I could find and implemented, so you can enable it. However, it hits all rendered actors, including text and so on, which was expected from what I could read.

One way to address this is to add a second render, which renders a second layer. However that could put ie. coordinates, text and so on always on top.
I'm not that used with working with VTK to know how to do a good implementation yet.

Now here are some examples:
tum rabbit without EDL:
![image](https://user-images.githubusercontent.com/1165340/132908574-ca035787-b27f-4b25-9fd6-c6414543d93c.png)

tum rabbit with EDL:
![image](https://user-images.githubusercontent.com/1165340/132908596-168c197b-bcf4-4c63-b2f3-8074d5554427.png)

Bun0 (PCD file) without EDL:
![image](https://user-images.githubusercontent.com/1165340/132910355-2a21a749-3942-4de1-93de-1e1188532454.png)

Bun0 with EDL:
![image](https://user-images.githubusercontent.com/1165340/132910395-32510fc5-b57a-45ab-9a61-2cfb90ac9c62.png)

Milk carton with color (with EDL, small point size) - does look odd:
![image](https://user-images.githubusercontent.com/1165340/132911162-86b15597-e646-4dac-b5a9-605783cc8904.png)

Milk carton with color (with EDL, medium point size) - does looks better:
![image](https://user-images.githubusercontent.com/1165340/132911246-20977945-05bc-4fb7-8637-59bc189f0de0.png)


