### PR TITLE
Higher flexibility regarding which PLY files can be read

### DIFF
--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -359,7 +359,10 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
             return false;
           }
         }
-        else if ((size_type_string == type_traits<uint32>::name ()) || (size_type_string == type_traits<uint32>::old_name ()))
+        // It is safe to use size_type = uint32 here even if it is actually int32, because the size/number of list entries is never negative,
+        // uint32 and int32 have the same width, and all allowed (non-negative) values have the same binary encoding in int32 and uint32.
+        else if ((size_type_string == type_traits<uint32>::name ()) || (size_type_string == type_traits<uint32>::old_name ()) ||
+                 (size_type_string == type_traits< int32>::name ()) || (size_type_string == type_traits< int32>::old_name ()))
         {
           using size_type = uint32;
           if ((scalar_type_string == type_traits<int8>::name ()) || (scalar_type_string == type_traits<int8>::old_name ()))

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -345,7 +345,7 @@ namespace pcl
         [this] { vertexListPropertyEndCallback (); }
       );
     }
-    PCL_DEBUG("[pcl::PLYReader::listPropertyDefinitionCallback] no fitting callbacks. element_name=%s, property_name=%s\n", element_name.c_str(), property_name.c_str());
+    PCL_WARN("[pcl::PLYReader::listPropertyDefinitionCallback] no fitting callbacks. element_name=%s, property_name=%s\n", element_name.c_str(), property_name.c_str());
     return {};
   }
 }

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -306,52 +306,26 @@ namespace pcl
     vertex_offset_before_ += static_cast<int> (sizeof (ContentType));
   }
 
-  template <>
-  std::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> >
+  template <typename SizeType, typename ContentType>
+  std::tuple<std::function<void (SizeType)>, std::function<void (ContentType)>, std::function<void ()> >
   pcl::PLYReader::listPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
   {
     if ((element_name == "range_grid") && (property_name == "vertex_indices" || property_name == "vertex_index"))
     {
-      return std::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
-        [this] (pcl::io::ply::uint8 size) { rangeGridVertexIndicesBeginCallback (size); },
-        [this] (pcl::io::ply::int32 vertex_index) { rangeGridVertexIndicesElementCallback (vertex_index); },
+      return std::tuple<std::function<void (SizeType)>, std::function<void (ContentType)>, std::function<void ()> > (
+        [this] (SizeType size) { rangeGridVertexIndicesBeginCallback (size); },
+        [this] (ContentType vertex_index) { rangeGridVertexIndicesElementCallback (vertex_index); },
         [this] { rangeGridVertexIndicesEndCallback (); }
       );
     }
     if ((element_name == "face") && (property_name == "vertex_indices" || property_name == "vertex_index") && polygons_)
     {
-      return std::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
-        [this] (pcl::io::ply::uint8 size) { faceVertexIndicesBeginCallback (size); },
-        [this] (pcl::io::ply::int32 vertex_index) { faceVertexIndicesElementCallback (vertex_index); },
+      return std::tuple<std::function<void (SizeType)>, std::function<void (ContentType)>, std::function<void ()> > (
+        [this] (SizeType size) { faceVertexIndicesBeginCallback (size); },
+        [this] (ContentType vertex_index) { faceVertexIndicesElementCallback (vertex_index); },
         [this] { faceVertexIndicesEndCallback (); }
       );
     }
-    if (element_name == "vertex")
-    {
-      cloud_->fields.emplace_back();
-      pcl::PCLPointField &current_field = cloud_->fields.back ();
-      current_field.name = property_name;
-      current_field.offset = cloud_->point_step;
-      current_field.datatype = pcl::traits::asEnum<pcl::io::ply::int32>::value;
-      current_field.count = 1u; // value will be updated once first vertex is read
-      if (sizeof (pcl::io::ply::int32) + cloud_->point_step < std::numeric_limits<std::uint32_t>::max ())
-          cloud_->point_step += static_cast<std::uint32_t> (sizeof (pcl::io::ply::int32));
-      else
-        cloud_->point_step = static_cast<std::uint32_t> (std::numeric_limits<std::uint32_t>::max ());
-      do_resize_ = true;
-      return std::tuple<std::function<void (pcl::io::ply::uint8)>, std::function<void (pcl::io::ply::int32)>, std::function<void ()> > (
-        std::bind (&pcl::PLYReader::vertexListPropertyBeginCallback<pcl::io::ply::uint8>, this, property_name, std::placeholders::_1),
-        [this] (pcl::io::ply::int32 value) { vertexListPropertyContentCallback<pcl::io::ply::int32> (value); },
-        [this] { vertexListPropertyEndCallback (); }
-      );
-    }
-    return {};
-  }
-
-  template <typename SizeType, typename ContentType>
-  std::tuple<std::function<void (SizeType)>, std::function<void (ContentType)>, std::function<void ()> >
-  pcl::PLYReader::listPropertyDefinitionCallback (const std::string& element_name, const std::string& property_name)
-  {
     if (element_name == "vertex")
     {
       cloud_->fields.emplace_back();
@@ -371,6 +345,7 @@ namespace pcl
         [this] { vertexListPropertyEndCallback (); }
       );
     }
+    PCL_DEBUG("[pcl::PLYReader::listPropertyDefinitionCallback] no fitting callbacks. element_name=%s, property_name=%s\n", element_name.c_str(), property_name.c_str());
     return {};
   }
 }


### PR DESCRIPTION
So far, face vertices can only be specified with `property list uchar int vertex_indices`, with uchar as the size type. Other types, e.g. `property list int int vertex_index` (with int as the size type), are less common, but allowed (and can so far not be read by PCL).
This commit increases the flexibility of the PLY reader. `int` is now generally allowed as a size type in lists (achieved by the changes in ply_parser.cpp). More combinations of size type and content type (combinations other than uchar+int) are now possible for vertex_indices/vertex_index properties (achieved by the changes in ply_io.cpp).

You may also want to check out the discussion in the newcomer-zone on Discord.