### PR TITLE
Support of Qt6 besides Qt5 #4959

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,18 +380,23 @@ endif()
 #VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND/Qt6_FOUND if the version we require is not found.
 option(WITH_QT "Build QT Front-End" TRUE)
 if(WITH_QT)
-  find_package(Qt6 COMPONENTS Concurrent OpenGL Widgets)
+  find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
   if (NOT Qt6_FOUND)
-    find_package(Qt5 5.9.5 COMPONENTS Concurrent OpenGL Widgets)
+    find_package(Qt5 5.9.5 QUIET COMPONENTS Concurrent OpenGL Widgets)
     set(Qt_FOUND ${Qt5_FOUND})
+    if(Qt5_FOUND)
+      set(QT_VERSION_MAJOR 5)
+    endif()
   else()
     set(Qt_FOUND TRUE)
+    set(QT_VERSION_MAJOR 6)
   endif()
 
   set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
 
   if(Qt_FOUND)
     message(STATUS "Qt${QT_VERSION_MAJOR} version: ${Qt${QT_VERSION_MAJOR}_VERSION}")
+
     set(QT${QT_VERSION_MAJOR}_FOUND ${Qt_FOUND})
     #Set Cmake Auto features to skip .hh files
     if(POLICY CMP0100)
@@ -417,6 +422,7 @@ if(WITH_QT)
     message(STATUS "Qt6/Qt5 is not found.")
   endif()
 else()
+  message(STATUS "WITHOUT_QT")
   set(Qt_FOUND FALSE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,13 +413,11 @@ if(WITH_QT_STR MATCHES "^(YES|QT6|QT5|NO)$")
     endif()
   endif()
 
-  if(WITH_QT_STR MATCHES "^(NO)$" AND NOT QT6_FOUND)
-    set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
-  endif()
-
   if(QT_FOUND)
     set(QT_VERSION ${${QTX}_VERSION})
     message(STATUS "Qt version: ${QT_VERSION}")
+
+    set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
 
     #Set Cmake Auto features to skip .hh files
     if(POLICY CMP0100)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,85 +379,8 @@ endif()
 
 # VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND/Qt6_FOUND if the version we require is not found.
 set(WITH_QT "AUTO" CACHE STRING "Build QT Front-End (AUTO|YES|QT6|QT5|NO)")
-
-# Convert WITH_QT to WITH_QT_STR with
-# - CMake true constants to string YES (except numbers unequal 1)
-# - CMake false constants to string NO
-# - Other values to upper case string
-#
-# Background: WITH_QT was previously boolean and we want to be backwards compatible.
 if(WITH_QT)
-  # Matches all CMake true constants except numbers other than 1.
-  # This way we prevent things like -DWITH_QT=5 to be handelt as YES instead of QT5.
-  # Setting -DWITH_QT=5 will error and inform you to use -DWITH_QT=QT5 instead.
-  # (This breaks backward compatibility, but hopefully no one will use values not equal to 1 if they want to express true.)
-  #
-  # Note: "NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1)" is not the same as
-  #       "WITH_QT EQUAL 1" because "LESS/GREATER/EQUAL" all pre-check if WITH_QT is a valid number.
-  if(NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1) AND ${WITH_QT})
-    set(WITH_QT_STR "YES")
-  else()
-    string(TOUPPER ${WITH_QT} WITH_QT_STR)
-  endif()
-else()
-  set(WITH_QT_STR "NO")
-endif()
-
-if(NOT WITH_QT_STR MATCHES "^(AUTO|YES|QT6|QT5|NO)$")
-  message(FATAL_ERROR "Option WITH_QT must be one of AUTO|YES|QT6|QT5|NO but is '${WITH_QT}'")
-endif()
-
-if(NOT WITH_QT_STR MATCHES "^(NO)$")
-  if(WITH_QT_STR MATCHES "^(AUTO|YES|QT6)$")
-    find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
-    set(QT6_FOUND ${Qt6_FOUND})
-    set(QT_FOUND ${QT6_FOUND})
-    if (QT6_FOUND)
-      set(QTX Qt6)
-    endif()
-  endif()
-
-  if(WITH_QT_STR MATCHES "^(AUTO|YES|QT5)$" AND NOT QT6_FOUND)
-    find_package(Qt5 5.9.5 QUIET COMPONENTS Concurrent OpenGL Widgets)
-    set(QT5_FOUND ${Qt5_FOUND})
-    set(QT_FOUND ${QT5_FOUND})
-    if(QT5_FOUND)
-      set(QTX Qt5)
-    endif()
-  endif()
-
-  if(NOT WITH_QT_STR MATCHES "^(AUTO)$" AND NOT QT_FOUND)
-    message(FATAL_ERROR "Can not find Qt required by WITH_QT=${WITH_QT}.")
-  endif()
-
-  if(QT_FOUND)
-    set(QT_VERSION ${${QTX}_VERSION})
-    message(STATUS "Qt version: ${QT_VERSION}")
-
-    set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
-
-    #Set Cmake Auto features to skip .hh files
-    if(POLICY CMP0100)
-      cmake_policy(SET CMP0100 OLD)
-    endif()
-
-    #If building CUDA required libraries
-    #Change ${QTX}::Core fixed -fPIC flags to conditionally only CXX
-    #TODO: To be removed when QT is >5.14.1
-    if(BUILD_CUDA OR BUILD_GPU)
-      if(${QTX}Widgets_VERSION VERSION_LESS 5.14.1)
-        get_property(core_options TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
-        string(REPLACE "-fPIC" "$<IF:$<COMPILE_LANGUAGE:CXX>,-fPIC,>"  new_core_options ${core_options})
-        set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
-      endif()
-    endif()
-
-    get_property(core_def TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
-    list(APPEND core_def "QT_DISABLE_DEPRECATED_BEFORE=${QT_DISABLE_PRECATED_BEFORE_VAL}")
-    set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
-  else()
-    message(STATUS "Qt is not found.")
-  endif()
+  include("${PCL_SOURCE_DIR}/cmake/pcl_find_qt.cmake")
 endif()
 
 #Find PCAP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,40 +377,42 @@ if(WITH_VTK)
   endif()
 endif()
 
-#VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND if the version we require is not found.
+#VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt${QT_VERSION_MAJOR}_FOUND if the version we require is not found.
 option(WITH_QT "Build QT Front-End" TRUE)
 if(WITH_QT)
-  find_package(Qt5 5.9.5 COMPONENTS Concurrent OpenGL Widgets)
+  find_package(QT 5.9.5 NAMES Qt6 Qt5 COMPONENTS Concurrent OpenGL Widgets)
+  find_package(Qt${QT_VERSION_MAJOR} 5.9.5 COMPONENTS Concurrent OpenGL Widgets)
+
   set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
   
-  if(Qt5_FOUND)
-    message(STATUS "Qt5 version: ${Qt5_VERSION}")
-    set(QT5_FOUND ${Qt5_FOUND})
+  if(Qt${QT_VERSION_MAJOR}_FOUND)
+    message(STATUS "Qt${QT_VERSION_MAJOR} version: ${Qt${QT_VERSION_MAJOR}_VERSION}")
+    set(QT5_FOUND ${Qt${QT_VERSION_MAJOR}_FOUND})
     #Set Cmake Auto features to skip .hh files
     if(POLICY CMP0100)
       cmake_policy(SET CMP0100 OLD)
     endif()
     
     #If building CUDA required libraries
-    #Change Qt5::Core fixed -fPIC flags to conditionally only CXX
+    #Change Qt${QT_VERSION_MAJOR}::Core fixed -fPIC flags to conditionally only CXX
     #TODO: To be removed when QT is >5.14.1
     if(BUILD_CUDA OR BUILD_GPU)
-      if(Qt5Widgets_VERSION VERSION_LESS 5.14.1)
-        get_property(core_options TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
+      if(Qt${QT_VERSION_MAJOR}Widgets_VERSION VERSION_LESS 5.14.1)
+        get_property(core_options TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
         string(REPLACE "-fPIC" "$<IF:$<COMPILE_LANGUAGE:CXX>,-fPIC,>"  new_core_options ${core_options})
-        set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
+        set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
       endif()
     endif()
     
-    get_property(core_def TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+    get_property(core_def TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
     list(APPEND core_def "QT_DISABLE_DEPRECATED_BEFORE=${QT_DISABLE_PRECATED_BEFORE_VAL}")
-    set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
+    set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
 
   else()
-    message(STATUS "Qt5 is not found.")
+    message(STATUS "Qt${QT_VERSION_MAJOR} is not found.")
   endif()
 else()
-  set(Qt5_FOUND FALSE)
+  set(Qt${QT_VERSION_MAJOR}_FOUND FALSE)
 endif()
 
 #Find PCAP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,7 +419,7 @@ if(WITH_QT)
     set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
 
   else()
-    message(STATUS "Qt6/Qt5 is not found.")
+    message(STATUS "Qt is not found.")
   endif()
 else()
   set(Qt_FOUND FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,48 +381,49 @@ endif()
 option(WITH_QT "Build QT Front-End" TRUE)
 if(WITH_QT)
   find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
-  if (NOT Qt6_FOUND)
+  set(QT6_FOUND ${Qt6_FOUND})
+  if (NOT QT6_FOUND)
     find_package(Qt5 5.9.5 QUIET COMPONENTS Concurrent OpenGL Widgets)
-    set(Qt_FOUND ${Qt5_FOUND})
-    if(Qt5_FOUND)
-      set(QT_VERSION_MAJOR 5)
+    set(QT5_FOUND ${Qt5_FOUND})
+    set(QT_FOUND ${QT5_FOUND})
+    if(QT5_FOUND)
+      set(QTX Qt5)
     endif()
   else()
-    set(Qt_FOUND TRUE)
-    set(QT_VERSION_MAJOR 6)
+    set(QT_FOUND TRUE)
+    set(QTX Qt6)
   endif()
 
   set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
 
-  if(Qt_FOUND)
-    message(STATUS "Qt${QT_VERSION_MAJOR} version: ${Qt${QT_VERSION_MAJOR}_VERSION}")
+  if(QT_FOUND)
+    set(QT_VERSION ${${QTX}_VERSION})
+    message(STATUS "Qt version: ${QT_VERSION}")
 
-    set(QT${QT_VERSION_MAJOR}_FOUND ${Qt_FOUND})
     #Set Cmake Auto features to skip .hh files
     if(POLICY CMP0100)
       cmake_policy(SET CMP0100 OLD)
     endif()
     
     #If building CUDA required libraries
-    #Change Qt${QT_VERSION_MAJOR}::Core fixed -fPIC flags to conditionally only CXX
+    #Change ${QTX}::Core fixed -fPIC flags to conditionally only CXX
     #TODO: To be removed when QT is >5.14.1
     if(BUILD_CUDA OR BUILD_GPU)
-      if(Qt${QT_VERSION_MAJOR}Widgets_VERSION VERSION_LESS 5.14.1)
-        get_property(core_options TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
+      if(${QTX}Widgets_VERSION VERSION_LESS 5.14.1)
+        get_property(core_options TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
         string(REPLACE "-fPIC" "$<IF:$<COMPILE_LANGUAGE:CXX>,-fPIC,>"  new_core_options ${core_options})
-        set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
+        set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
       endif()
     endif()
     
-    get_property(core_def TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+    get_property(core_def TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
     list(APPEND core_def "QT_DISABLE_DEPRECATED_BEFORE=${QT_DISABLE_PRECATED_BEFORE_VAL}")
-    set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
-
+    set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
   else()
     message(STATUS "Qt is not found.")
   endif()
 else()
-  set(Qt_FOUND FALSE)
+  set(QT_FOUND FALSE)
 endif()
 
 #Find PCAP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,14 +377,23 @@ if(WITH_VTK)
   endif()
 endif()
 
-#VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND/Qt6_FOUND if the version we require is not found.
-option(WITH_QT "Build QT Front-End (YES/QT6/QT5/NO)" TRUE)
+# VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND/Qt6_FOUND if the version we require is not found.
+set(WITH_QT "AUTO" CACHE STRING "Build QT Front-End (AUTO|YES|QT6|QT5|NO)")
 
-# Set all true constants to string YES, false constants to string NO, other to upper case string
+# Convert WITH_QT to WITH_QT_STR with
+# - CMake true constants to string YES (except numbers unequal 1)
+# - CMake false constants to string NO
+# - Other values to upper case string
+#
+# Background: WITH_QT was previously boolean and we want to be backwards compatible.
 if(WITH_QT)
-  # matches all true constants except numbers other than 1
-  # so we prevent things like -DWITH_QT=5 to be handelt as YES instead of QT5
-  # -DWITH_QT=5 will error and inform you to use -DWITH_QT=QT5
+  # Matches all CMake true constants except numbers other than 1.
+  # This way we prevent things like -DWITH_QT=5 to be handelt as YES instead of QT5.
+  # Setting -DWITH_QT=5 will error and inform you to use -DWITH_QT=QT5 instead.
+  # (This breaks backward compatibility, but hopefully no one will use values not equal to 1 if they want to express true.)
+  #
+  # Note: "NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1)" is not the same as
+  #       "WITH_QT EQUAL 1" because "LESS/GREATER/EQUAL" all pre-check if WITH_QT is a valid number.
   if(NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1) AND ${WITH_QT})
     set(WITH_QT_STR "YES")
   else()
@@ -394,23 +403,31 @@ else()
   set(WITH_QT_STR "NO")
 endif()
 
-if(WITH_QT_STR MATCHES "^(YES|QT6|QT5|NO)$")
-  if(WITH_QT_STR MATCHES "^(YES|QT6)$")
+if(NOT WITH_QT_STR MATCHES "^(AUTO|YES|QT6|QT5|NO)$")
+  message(FATAL_ERROR "Option WITH_QT must be one of AUTO|YES|QT6|QT5|NO but is '${WITH_QT}'")
+endif()
+
+if(NOT WITH_QT_STR MATCHES "^(NO)$")
+  if(WITH_QT_STR MATCHES "^(AUTO|YES|QT6)$")
     find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
     set(QT6_FOUND ${Qt6_FOUND})
+    set(QT_FOUND ${QT6_FOUND})
     if (QT6_FOUND)
-      set(QT_FOUND TRUE)
       set(QTX Qt6)
     endif()
   endif()
 
-  if(WITH_QT_STR MATCHES "^(YES|QT5)$" AND NOT QT6_FOUND)
+  if(WITH_QT_STR MATCHES "^(AUTO|YES|QT5)$" AND NOT QT6_FOUND)
     find_package(Qt5 5.9.5 QUIET COMPONENTS Concurrent OpenGL Widgets)
     set(QT5_FOUND ${Qt5_FOUND})
     set(QT_FOUND ${QT5_FOUND})
     if(QT5_FOUND)
       set(QTX Qt5)
     endif()
+  endif()
+
+  if(NOT WITH_QT_STR MATCHES "^(AUTO)$" AND NOT QT_FOUND)
+    message(FATAL_ERROR "Can not find Qt required by WITH_QT=${WITH_QT}.")
   endif()
 
   if(QT_FOUND)
@@ -423,7 +440,7 @@ if(WITH_QT_STR MATCHES "^(YES|QT6|QT5|NO)$")
     if(POLICY CMP0100)
       cmake_policy(SET CMP0100 OLD)
     endif()
-    
+
     #If building CUDA required libraries
     #Change ${QTX}::Core fixed -fPIC flags to conditionally only CXX
     #TODO: To be removed when QT is >5.14.1
@@ -434,7 +451,7 @@ if(WITH_QT_STR MATCHES "^(YES|QT6|QT5|NO)$")
         set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
       endif()
     endif()
-    
+
     get_property(core_def TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
     list(APPEND core_def "QT_DISABLE_DEPRECATED_BEFORE=${QT_DISABLE_PRECATED_BEFORE_VAL}")
     set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
@@ -442,8 +459,6 @@ if(WITH_QT_STR MATCHES "^(YES|QT6|QT5|NO)$")
     message(STATUS "Qt is not found.")
     set(QT_FOUND FALSE)
   endif()
-else()
-  message(FATAL_ERROR "Option WITH_QT must be one of YES/QT6/QT5/NO but is '${WITH_QT}'")
 endif()
 
 #Find PCAP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,13 +383,16 @@ if(WITH_QT)
   find_package(Qt6 COMPONENTS Concurrent OpenGL Widgets)
   if (NOT Qt6_FOUND)
     find_package(Qt5 5.9.5 COMPONENTS Concurrent OpenGL Widgets)
+    set(Qt_FOUND ${Qt5_FOUND})
+  else()
+    set(Qt_FOUND TRUE)
   endif()
 
   set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
-  
-  if(Qt${QT_VERSION_MAJOR}_FOUND)
+
+  if(Qt_FOUND)
     message(STATUS "Qt${QT_VERSION_MAJOR} version: ${Qt${QT_VERSION_MAJOR}_VERSION}")
-    set(QT${QT_VERSION_MAJOR}_FOUND ${Qt${QT_VERSION_MAJOR}_FOUND})
+    set(QT${QT_VERSION_MAJOR}_FOUND ${Qt_FOUND})
     #Set Cmake Auto features to skip .hh files
     if(POLICY CMP0100)
       cmake_policy(SET CMP0100 OLD)
@@ -411,10 +414,10 @@ if(WITH_QT)
     set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
 
   else()
-    message(STATUS "Qt${QT_VERSION_MAJOR} is not found.")
+    message(STATUS "Qt6/Qt5 is not found.")
   endif()
 else()
-  set(Qt${QT_VERSION_MAJOR}_FOUND FALSE)
+  set(Qt_FOUND FALSE)
 endif()
 
 #Find PCAP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,6 @@ if(NOT WITH_QT_STR MATCHES "^(NO)$")
     set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
   else()
     message(STATUS "Qt is not found.")
-    set(QT_FOUND FALSE)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,7 +422,6 @@ if(WITH_QT)
     message(STATUS "Qt6/Qt5 is not found.")
   endif()
 else()
-  message(STATUS "WITHOUT_QT")
   set(Qt_FOUND FALSE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,23 +378,44 @@ if(WITH_VTK)
 endif()
 
 #VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND/Qt6_FOUND if the version we require is not found.
-option(WITH_QT "Build QT Front-End" TRUE)
+option(WITH_QT "Build QT Front-End (YES/QT6/QT5/NO)" TRUE)
+
+# Set all true constants to string YES, false constants to string NO, other to upper case string
 if(WITH_QT)
-  find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
-  set(QT6_FOUND ${Qt6_FOUND})
-  if (NOT QT6_FOUND)
+  # matches all true constants except numbers other than 1
+  # so we prevent things like -DWITH_QT=5 to be handelt as YES instead of QT5
+  # -DWITH_QT=5 will error and inform you to use -DWITH_QT=QT5
+  if(NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1) AND ${WITH_QT})
+    set(WITH_QT_STR "YES")
+  else()
+    string(TOUPPER ${WITH_QT} WITH_QT_STR)
+  endif()
+else()
+  set(WITH_QT_STR "NO")
+endif()
+
+if(WITH_QT_STR MATCHES "^(YES|QT6|QT5|NO)$")
+  if(WITH_QT_STR MATCHES "^(YES|QT6)$")
+    find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
+    set(QT6_FOUND ${Qt6_FOUND})
+    if (QT6_FOUND)
+      set(QT_FOUND TRUE)
+      set(QTX Qt6)
+    endif()
+  endif()
+
+  if(WITH_QT_STR MATCHES "^(YES|QT5)$" AND NOT QT6_FOUND)
     find_package(Qt5 5.9.5 QUIET COMPONENTS Concurrent OpenGL Widgets)
     set(QT5_FOUND ${Qt5_FOUND})
     set(QT_FOUND ${QT5_FOUND})
     if(QT5_FOUND)
       set(QTX Qt5)
     endif()
-  else()
-    set(QT_FOUND TRUE)
-    set(QTX Qt6)
   endif()
 
-  set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
+  if(WITH_QT_STR MATCHES "^(NO)$" AND NOT QT6_FOUND)
+    set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
+  endif()
 
   if(QT_FOUND)
     set(QT_VERSION ${${QTX}_VERSION})
@@ -421,9 +442,10 @@ if(WITH_QT)
     set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
   else()
     message(STATUS "Qt is not found.")
+    set(QT_FOUND FALSE)
   endif()
 else()
-  set(QT_FOUND FALSE)
+  message(FATAL_ERROR "Option WITH_QT must be one of YES/QT6/QT5/NO but is '${WITH_QT}'")
 endif()
 
 #Find PCAP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ endif()
 
 # VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND/Qt6_FOUND if the version we require is not found.
 set(WITH_QT "AUTO" CACHE STRING "Build QT Front-End (AUTO|YES|QT6|QT5|NO)")
+set_property(CACHE WITH_QT PROPERTY STRINGS "AUTO" "YES" "QT6" "QT5" "NO")
 if(WITH_QT)
   include("${PCL_SOURCE_DIR}/cmake/pcl_find_qt.cmake")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,17 +377,19 @@ if(WITH_VTK)
   endif()
 endif()
 
-#VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt${QT_VERSION_MAJOR}_FOUND if the version we require is not found.
+#VTK can depend on Qt and search for its required version, so search after so we can overwrite Qt5_FOUND/Qt6_FOUND if the version we require is not found.
 option(WITH_QT "Build QT Front-End" TRUE)
 if(WITH_QT)
-  find_package(QT 5.9.5 NAMES Qt6 Qt5 COMPONENTS Concurrent OpenGL Widgets)
-  find_package(Qt${QT_VERSION_MAJOR} 5.9.5 COMPONENTS Concurrent OpenGL Widgets)
+  find_package(Qt6 COMPONENTS Concurrent OpenGL Widgets)
+  if (NOT Qt6_FOUND)
+    find_package(Qt5 5.9.5 COMPONENTS Concurrent OpenGL Widgets)
+  endif()
 
   set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
   
   if(Qt${QT_VERSION_MAJOR}_FOUND)
     message(STATUS "Qt${QT_VERSION_MAJOR} version: ${Qt${QT_VERSION_MAJOR}_VERSION}")
-    set(QT5_FOUND ${Qt${QT_VERSION_MAJOR}_FOUND})
+    set(QT${QT_VERSION_MAJOR}_FOUND ${Qt${QT_VERSION_MAJOR}_FOUND})
     #Set Cmake Auto features to skip .hh files
     if(POLICY CMP0100)
       cmake_policy(SET CMP0100 OLD)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSYS_NAME apps)
 set(SUBSYS_DESC "Application examples/samples that show how PCL works")
 set(SUBSYS_DEPS common geometry io filters sample_consensus segmentation visualization kdtree features surface octree registration keypoints tracking search recognition ml stereo 2d)
-set(SUBSYS_OPT_DEPS openni vtk Qt5)
+set(SUBSYS_OPT_DEPS openni vtk Qt${QT_VERSION_MAJOR})
 
 set(DEFAULT FALSE)
 set(REASON "Disabled by default")
@@ -82,7 +82,7 @@ if(VTK_FOUND)
   PCL_ADD_EXECUTABLE(pcl_stereo_ground_segmentation COMPONENT ${SUBSYS_NAME} SOURCES src/stereo_ground_segmentation.cpp)
   target_link_libraries(pcl_stereo_ground_segmentation pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_features pcl_stereo)
 
-  if(Qt5_FOUND AND HAVE_QVTK)
+  if(Qt${QT_VERSION_MAJOR}_FOUND AND HAVE_QVTK)
     # Manual registration demo
     PCL_ADD_EXECUTABLE(pcl_manual_registration
       COMPONENT
@@ -93,7 +93,7 @@ if(VTK_FOUND)
       src/manual_registration/manual_registration.ui
       BUNDLE)
       
-    target_link_libraries(pcl_manual_registration pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt5::Widgets)
+    target_link_libraries(pcl_manual_registration pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt${QT_VERSION_MAJOR}::Widgets)
     #TODO: Update when CMAKE 3.10 is available
     if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
       target_link_libraries(pcl_manual_registration VTK::GUISupportQt)
@@ -108,7 +108,7 @@ if(VTK_FOUND)
       src/pcd_video_player/pcd_video_player.ui
       BUNDLE)
     
-    target_link_libraries(pcl_pcd_video_player pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt5::Widgets)
+    target_link_libraries(pcl_pcd_video_player pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt${QT_VERSION_MAJOR}::Widgets)
     #TODO: Update when CMAKE 3.10 is available
     if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
       target_link_libraries(pcl_pcd_video_player VTK::GUISupportQt)
@@ -166,7 +166,7 @@ if(VTK_FOUND)
     PCL_ADD_EXECUTABLE(pcl_openni_face_detector COMPONENT ${SUBSYS_NAME} SOURCES src/face_detection//openni_face_detection.cpp src/face_detection//openni_frame_source.cpp BUNDLE)
     target_link_libraries(pcl_openni_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree ${VTK_LIBRARIES})
 
-    if(Qt5_FOUND AND HAVE_QVTK)
+    if(Qt${QT_VERSION_MAJOR}_FOUND AND HAVE_QVTK)
       # OpenNI Passthrough application demo
       PCL_ADD_EXECUTABLE(pcl_openni_passthrough
         COMPONENT
@@ -176,7 +176,7 @@ if(VTK_FOUND)
           src/openni_passthrough.cpp
           src/openni_passthrough.ui)
           
-      target_link_libraries(pcl_openni_passthrough pcl_common pcl_io pcl_filters pcl_visualization Qt5::Widgets)
+      target_link_libraries(pcl_openni_passthrough pcl_common pcl_io pcl_filters pcl_visualization Qt${QT_VERSION_MAJOR}::Widgets)
       #TODO: Update when CMAKE 3.10 is available
       if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
         target_link_libraries(pcl_openni_passthrough VTK::GUISupportQt)
@@ -194,7 +194,7 @@ if(VTK_FOUND)
           src/organized_segmentation_demo.cpp
           src/organized_segmentation_demo.ui
         BUNDLE)
-      target_link_libraries(pcl_organized_segmentation_demo pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt5::Widgets)
+      target_link_libraries(pcl_organized_segmentation_demo pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt${QT_VERSION_MAJOR}::Widgets)
       #TODO: Update when CMAKE 3.10 is available
       if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
         target_link_libraries(pcl_organized_segmentation_demo VTK::GUISupportQt)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSYS_NAME apps)
 set(SUBSYS_DESC "Application examples/samples that show how PCL works")
 set(SUBSYS_DEPS common geometry io filters sample_consensus segmentation visualization kdtree features surface octree registration keypoints tracking search recognition ml stereo 2d)
-set(SUBSYS_OPT_DEPS openni vtk Qt${QT_VERSION_MAJOR})
+set(SUBSYS_OPT_DEPS openni vtk ${QTX})
 
 set(DEFAULT FALSE)
 set(REASON "Disabled by default")
@@ -82,7 +82,7 @@ if(VTK_FOUND)
   PCL_ADD_EXECUTABLE(pcl_stereo_ground_segmentation COMPONENT ${SUBSYS_NAME} SOURCES src/stereo_ground_segmentation.cpp)
   target_link_libraries(pcl_stereo_ground_segmentation pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_features pcl_stereo)
 
-  if(Qt_FOUND AND HAVE_QVTK)
+  if(QT_FOUND AND HAVE_QVTK)
     # Manual registration demo
     PCL_ADD_EXECUTABLE(pcl_manual_registration
       COMPONENT
@@ -93,7 +93,7 @@ if(VTK_FOUND)
       src/manual_registration/manual_registration.ui
       BUNDLE)
       
-    target_link_libraries(pcl_manual_registration pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt${QT_VERSION_MAJOR}::Widgets)
+    target_link_libraries(pcl_manual_registration pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface ${QTX}::Widgets)
     #TODO: Update when CMAKE 3.10 is available
     if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
       target_link_libraries(pcl_manual_registration VTK::GUISupportQt)
@@ -108,7 +108,7 @@ if(VTK_FOUND)
       src/pcd_video_player/pcd_video_player.ui
       BUNDLE)
     
-    target_link_libraries(pcl_pcd_video_player pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt${QT_VERSION_MAJOR}::Widgets)
+    target_link_libraries(pcl_pcd_video_player pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface ${QTX}::Widgets)
     #TODO: Update when CMAKE 3.10 is available
     if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
       target_link_libraries(pcl_pcd_video_player VTK::GUISupportQt)
@@ -166,7 +166,7 @@ if(VTK_FOUND)
     PCL_ADD_EXECUTABLE(pcl_openni_face_detector COMPONENT ${SUBSYS_NAME} SOURCES src/face_detection//openni_face_detection.cpp src/face_detection//openni_frame_source.cpp BUNDLE)
     target_link_libraries(pcl_openni_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree ${VTK_LIBRARIES})
 
-    if(Qt_FOUND AND HAVE_QVTK)
+    if(QT_FOUND AND HAVE_QVTK)
       # OpenNI Passthrough application demo
       PCL_ADD_EXECUTABLE(pcl_openni_passthrough
         COMPONENT
@@ -176,7 +176,7 @@ if(VTK_FOUND)
           src/openni_passthrough.cpp
           src/openni_passthrough.ui)
           
-      target_link_libraries(pcl_openni_passthrough pcl_common pcl_io pcl_filters pcl_visualization Qt${QT_VERSION_MAJOR}::Widgets)
+      target_link_libraries(pcl_openni_passthrough pcl_common pcl_io pcl_filters pcl_visualization ${QTX}::Widgets)
       #TODO: Update when CMAKE 3.10 is available
       if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
         target_link_libraries(pcl_openni_passthrough VTK::GUISupportQt)
@@ -194,7 +194,7 @@ if(VTK_FOUND)
           src/organized_segmentation_demo.cpp
           src/organized_segmentation_demo.ui
         BUNDLE)
-      target_link_libraries(pcl_organized_segmentation_demo pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface Qt${QT_VERSION_MAJOR}::Widgets)
+      target_link_libraries(pcl_organized_segmentation_demo pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface ${QTX}::Widgets)
       #TODO: Update when CMAKE 3.10 is available
       if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
         target_link_libraries(pcl_organized_segmentation_demo VTK::GUISupportQt)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -82,7 +82,7 @@ if(VTK_FOUND)
   PCL_ADD_EXECUTABLE(pcl_stereo_ground_segmentation COMPONENT ${SUBSYS_NAME} SOURCES src/stereo_ground_segmentation.cpp)
   target_link_libraries(pcl_stereo_ground_segmentation pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_features pcl_stereo)
 
-  if(Qt${QT_VERSION_MAJOR}_FOUND AND HAVE_QVTK)
+  if(Qt_FOUND AND HAVE_QVTK)
     # Manual registration demo
     PCL_ADD_EXECUTABLE(pcl_manual_registration
       COMPONENT
@@ -166,7 +166,7 @@ if(VTK_FOUND)
     PCL_ADD_EXECUTABLE(pcl_openni_face_detector COMPONENT ${SUBSYS_NAME} SOURCES src/face_detection//openni_face_detection.cpp src/face_detection//openni_frame_source.cpp BUNDLE)
     target_link_libraries(pcl_openni_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree ${VTK_LIBRARIES})
 
-    if(Qt${QT_VERSION_MAJOR}_FOUND AND HAVE_QVTK)
+    if(Qt_FOUND AND HAVE_QVTK)
       # OpenNI Passthrough application demo
       PCL_ADD_EXECUTABLE(pcl_openni_passthrough
         COMPONENT

--- a/apps/cloud_composer/CMakeLists.txt
+++ b/apps/cloud_composer/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(SUBSUBSYS_NAME cloud_composer)
 set(SUBSUBSYS_DESC "Cloud Composer - Application for Manipulating Point Clouds")
 set(SUBSUBSYS_DEPS common io visualization filters apps)
-set(SUBSUBSYS_EXT_DEPS vtk Qt${QT_VERSION_MAJOR})
+set(SUBSUBSYS_EXT_DEPS vtk ${QTX})
 
 # QVTK?
 if(NOT HAVE_QVTK)
@@ -80,7 +80,7 @@ set(vtk_libs ${VTK_LIBRARIES})
 if (NOT (${VTK_VERSION} VERSION_LESS 9.0))
   set(vtk_libs VTK::GUISupportQt)
 endif()
-target_link_libraries(pcl_cc_tool_interface pcl_common pcl_filters pcl_search pcl_visualization Qt${QT_VERSION_MAJOR}::Widgets ${vtk_libs})
+target_link_libraries(pcl_cc_tool_interface pcl_common pcl_filters pcl_search pcl_visualization ${QTX}::Widgets ${vtk_libs})
 
 set(PCL_LIB_TYPE ${PCL_LIB_TYPE_ORIGIN})
 
@@ -133,7 +133,7 @@ list(APPEND CMAKE_AUTOUIC_SEARCH_PATHS "src")
 
 set(EXE_NAME "pcl_${SUBSUBSYS_NAME}")
 PCL_ADD_EXECUTABLE(${EXE_NAME} COMPONENT ${SUBSUBSYS_NAME} SOURCES ${uis} ${incs} ${srcs} ${resources} ${impl_incs})
-target_link_libraries("${EXE_NAME}" pcl_cc_tool_interface pcl_common pcl_io pcl_visualization pcl_filters Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries("${EXE_NAME}" pcl_cc_tool_interface pcl_common pcl_io pcl_visualization pcl_filters ${QTX}::Widgets)
 
 
 

--- a/apps/cloud_composer/CMakeLists.txt
+++ b/apps/cloud_composer/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(SUBSUBSYS_NAME cloud_composer)
 set(SUBSUBSYS_DESC "Cloud Composer - Application for Manipulating Point Clouds")
 set(SUBSUBSYS_DEPS common io visualization filters apps)
-set(SUBSUBSYS_EXT_DEPS vtk Qt5)
+set(SUBSUBSYS_EXT_DEPS vtk Qt${QT_VERSION_MAJOR})
 
 # QVTK?
 if(NOT HAVE_QVTK)
@@ -80,7 +80,7 @@ set(vtk_libs ${VTK_LIBRARIES})
 if (NOT (${VTK_VERSION} VERSION_LESS 9.0))
   set(vtk_libs VTK::GUISupportQt)
 endif()
-target_link_libraries(pcl_cc_tool_interface pcl_common pcl_filters pcl_search pcl_visualization Qt5::Widgets ${vtk_libs})
+target_link_libraries(pcl_cc_tool_interface pcl_common pcl_filters pcl_search pcl_visualization Qt${QT_VERSION_MAJOR}::Widgets ${vtk_libs})
 
 set(PCL_LIB_TYPE ${PCL_LIB_TYPE_ORIGIN})
 
@@ -133,7 +133,7 @@ list(APPEND CMAKE_AUTOUIC_SEARCH_PATHS "src")
 
 set(EXE_NAME "pcl_${SUBSUBSYS_NAME}")
 PCL_ADD_EXECUTABLE(${EXE_NAME} COMPONENT ${SUBSUBSYS_NAME} SOURCES ${uis} ${incs} ${srcs} ${resources} ${impl_incs})
-target_link_libraries("${EXE_NAME}" pcl_cc_tool_interface pcl_common pcl_io pcl_visualization pcl_filters Qt5::Widgets)
+target_link_libraries("${EXE_NAME}" pcl_cc_tool_interface pcl_common pcl_io pcl_visualization pcl_filters Qt${QT_VERSION_MAJOR}::Widgets)
 
 
 

--- a/apps/cloud_composer/ComposerTool.cmake
+++ b/apps/cloud_composer/ComposerTool.cmake
@@ -17,7 +17,7 @@ function(define_composer_tool TOOL_NAME TOOL_SOURCES TOOL_HEADERS DEPS)
   add_definitions(-DQT_PLUGIN)
   add_definitions(-DQT_SHARED)
 
-  target_link_libraries(${TOOL_TARGET} pcl_cc_tool_interface pcl_common pcl_io ${DEPS} Qt5::Widgets)
+  target_link_libraries(${TOOL_TARGET} pcl_cc_tool_interface pcl_common pcl_io ${DEPS} Qt${QT_VERSION_MAJOR}::Widgets)
 
   if(APPLE)
     set_target_properties(${TOOL_TARGET} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")

--- a/apps/cloud_composer/ComposerTool.cmake
+++ b/apps/cloud_composer/ComposerTool.cmake
@@ -17,7 +17,7 @@ function(define_composer_tool TOOL_NAME TOOL_SOURCES TOOL_HEADERS DEPS)
   add_definitions(-DQT_PLUGIN)
   add_definitions(-DQT_SHARED)
 
-  target_link_libraries(${TOOL_TARGET} pcl_cc_tool_interface pcl_common pcl_io ${DEPS} Qt${QT_VERSION_MAJOR}::Widgets)
+  target_link_libraries(${TOOL_TARGET} pcl_cc_tool_interface pcl_common pcl_io ${DEPS} ${QTX}::Widgets)
 
   if(APPLE)
     set_target_properties(${TOOL_TARGET} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")

--- a/apps/in_hand_scanner/CMakeLists.txt
+++ b/apps/in_hand_scanner/CMakeLists.txt
@@ -2,7 +2,7 @@ set(SUBSUBSYS_NAME in_hand_scanner)
 set(SUBSUBSYS_DESC "In-hand scanner for small objects")
 set(SUBSUBSYS_DEPS     common     features     io     kdtree apps)
 set(SUBSUBSYS_LIBS pcl_common pcl_features pcl_io pcl_kdtree)
-set(SUBSUBSYS_EXT_DEPS Qt5 OpenGL OpenGL_GLU openni)
+set(SUBSUBSYS_EXT_DEPS Qt${QT_VERSION_MAJOR} OpenGL OpenGL_GLU openni)
 
 ################################################################################
 
@@ -91,7 +91,7 @@ PCL_ADD_EXECUTABLE(
     ${IMPL_INCS}
     ${UI}
   BUNDLE)
-target_link_libraries("${EXE_NAME}" ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt5::Concurrent Qt5::Widgets Qt5::OpenGL)
+target_link_libraries("${EXE_NAME}" ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Concurrent Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL)
 
 pcl_add_includes("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}" ${INCS})
 pcl_add_includes("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}/impl" ${IMPL_INCS})
@@ -107,7 +107,7 @@ PCL_ADD_EXECUTABLE(
     ${OI_INCS}
   BUNDLE)
 
-target_link_libraries(pcl_offline_integration ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt5::Concurrent Qt5::Widgets Qt5::OpenGL)
+target_link_libraries(pcl_offline_integration ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Concurrent Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL)
 
 # Add to the compound apps target
 list(APPEND PCL_APPS_ALL_TARGETS ${PCL_IN_HAND_SCANNER_ALL_TARGETS})

--- a/apps/in_hand_scanner/CMakeLists.txt
+++ b/apps/in_hand_scanner/CMakeLists.txt
@@ -2,7 +2,7 @@ set(SUBSUBSYS_NAME in_hand_scanner)
 set(SUBSUBSYS_DESC "In-hand scanner for small objects")
 set(SUBSUBSYS_DEPS     common     features     io     kdtree apps)
 set(SUBSUBSYS_LIBS pcl_common pcl_features pcl_io pcl_kdtree)
-set(SUBSUBSYS_EXT_DEPS Qt${QT_VERSION_MAJOR} OpenGL OpenGL_GLU openni)
+set(SUBSUBSYS_EXT_DEPS ${QTX} OpenGL OpenGL_GLU openni)
 
 ################################################################################
 
@@ -91,7 +91,7 @@ PCL_ADD_EXECUTABLE(
     ${IMPL_INCS}
     ${UI}
   BUNDLE)
-target_link_libraries("${EXE_NAME}" ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Concurrent Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL)
+target_link_libraries("${EXE_NAME}" ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} ${QTX}::Concurrent ${QTX}::Widgets ${QTX}::OpenGL)
 
 pcl_add_includes("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}" ${INCS})
 pcl_add_includes("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}/impl" ${IMPL_INCS})
@@ -107,7 +107,7 @@ PCL_ADD_EXECUTABLE(
     ${OI_INCS}
   BUNDLE)
 
-target_link_libraries(pcl_offline_integration ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Concurrent Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL)
+target_link_libraries(pcl_offline_integration ${SUBSUBSYS_LIBS} ${OPENGL_LIBRARIES} ${QTX}::Concurrent ${QTX}::Widgets ${QTX}::OpenGL)
 
 # Add to the compound apps target
 list(APPEND PCL_APPS_ALL_TARGETS ${PCL_IN_HAND_SCANNER_ALL_TARGETS})

--- a/apps/modeler/CMakeLists.txt
+++ b/apps/modeler/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSUBSYS_NAME modeler)
 set(SUBSUBSYS_DESC "PCLModeler: PCL based reconstruction platform")
 set(SUBSUBSYS_DEPS common geometry io filters sample_consensus segmentation visualization kdtree features surface octree registration keypoints tracking search apps)
-set(SUBSUBSYS_EXT_DEPS vtk Qt${QT_VERSION_MAJOR})
+set(SUBSUBSYS_EXT_DEPS vtk ${QTX})
 set(REASON "")
 
 # QVTK?
@@ -118,7 +118,7 @@ PCL_ADD_EXECUTABLE(
     ${incs}
     ${impl_incs})
 
-target_link_libraries("${EXE_NAME}" pcl_common pcl_io pcl_kdtree pcl_filters pcl_visualization pcl_segmentation pcl_surface pcl_features pcl_sample_consensus pcl_search Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries("${EXE_NAME}" pcl_common pcl_io pcl_kdtree pcl_filters pcl_visualization pcl_segmentation pcl_surface pcl_features pcl_sample_consensus pcl_search ${QTX}::Widgets)
 #TODO: Update when CMAKE 3.10 is available
 if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
   target_link_libraries("${EXE_NAME}" VTK::GUISupportQt)

--- a/apps/modeler/CMakeLists.txt
+++ b/apps/modeler/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSUBSYS_NAME modeler)
 set(SUBSUBSYS_DESC "PCLModeler: PCL based reconstruction platform")
 set(SUBSUBSYS_DEPS common geometry io filters sample_consensus segmentation visualization kdtree features surface octree registration keypoints tracking search apps)
-set(SUBSUBSYS_EXT_DEPS vtk Qt5)
+set(SUBSUBSYS_EXT_DEPS vtk Qt${QT_VERSION_MAJOR})
 set(REASON "")
 
 # QVTK?
@@ -118,7 +118,7 @@ PCL_ADD_EXECUTABLE(
     ${incs}
     ${impl_incs})
 
-target_link_libraries("${EXE_NAME}" pcl_common pcl_io pcl_kdtree pcl_filters pcl_visualization pcl_segmentation pcl_surface pcl_features pcl_sample_consensus pcl_search Qt5::Widgets)
+target_link_libraries("${EXE_NAME}" pcl_common pcl_io pcl_kdtree pcl_filters pcl_visualization pcl_segmentation pcl_surface pcl_features pcl_sample_consensus pcl_search Qt${QT_VERSION_MAJOR}::Widgets)
 #TODO: Update when CMAKE 3.10 is available
 if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
   target_link_libraries("${EXE_NAME}" VTK::GUISupportQt)

--- a/apps/point_cloud_editor/CMakeLists.txt
+++ b/apps/point_cloud_editor/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSUBSYS_NAME point_cloud_editor)
 set(SUBSUBSYS_DESC "Point Cloud Editor - Simple editor for 3D point clouds")
 set(SUBSUBSYS_DEPS common filters io apps)
-set(SUBSUBSYS_EXT_DEPS vtk Qt${QT_VERSION_MAJOR} OpenGL)
+set(SUBSUBSYS_EXT_DEPS vtk ${QTX} OpenGL)
 
 # Default to not building for now
 if(${DEFAULT} STREQUAL "TRUE")
@@ -86,7 +86,7 @@ PCL_ADD_EXECUTABLE(
     ${RSRC}
     ${INCS})
 
-target_link_libraries("${EXE_NAME}" Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL ${OPENGL_LIBRARIES} ${BOOST_LIBRARIES} pcl_common pcl_io pcl_filters)
+target_link_libraries("${EXE_NAME}" ${QTX}::Widgets ${QTX}::OpenGL ${OPENGL_LIBRARIES} ${BOOST_LIBRARIES} pcl_common pcl_io pcl_filters)
 
 PCL_ADD_INCLUDES("${SUBSUBSYS_NAME}" "${SUBSYS_NAME}/${SUBSUBSYS_NAME}" ${INCS})
 PCL_MAKE_PKGCONFIG(${EXE_NAME} COMPONENT ${SUBSUBSYS_NAME} DESC ${SUBSUBSYS_DESC})

--- a/apps/point_cloud_editor/CMakeLists.txt
+++ b/apps/point_cloud_editor/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSUBSYS_NAME point_cloud_editor)
 set(SUBSUBSYS_DESC "Point Cloud Editor - Simple editor for 3D point clouds")
 set(SUBSUBSYS_DEPS common filters io apps)
-set(SUBSUBSYS_EXT_DEPS vtk Qt5 OpenGL)
+set(SUBSUBSYS_EXT_DEPS vtk Qt${QT_VERSION_MAJOR} OpenGL)
 
 # Default to not building for now
 if(${DEFAULT} STREQUAL "TRUE")
@@ -86,7 +86,7 @@ PCL_ADD_EXECUTABLE(
     ${RSRC}
     ${INCS})
 
-target_link_libraries("${EXE_NAME}" Qt5::Widgets Qt5::OpenGL ${OPENGL_LIBRARIES} ${BOOST_LIBRARIES} pcl_common pcl_io pcl_filters)
+target_link_libraries("${EXE_NAME}" Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL ${OPENGL_LIBRARIES} ${BOOST_LIBRARIES} pcl_common pcl_io pcl_filters)
 
 PCL_ADD_INCLUDES("${SUBSUBSYS_NAME}" "${SUBSYS_NAME}/${SUBSUBSYS_NAME}" ${INCS})
 PCL_MAKE_PKGCONFIG(${EXE_NAME} COMPONENT ${SUBSUBSYS_NAME} DESC ${SUBSUBSYS_DESC})

--- a/cmake/pcl_find_qt.cmake
+++ b/cmake/pcl_find_qt.cmake
@@ -45,31 +45,32 @@ if(NOT WITH_QT_STR MATCHES "^(AUTO)$" AND NOT QT_FOUND)
   message(FATAL_ERROR "Can not find Qt required by WITH_QT=${WITH_QT}.")
 endif()
 
-if(QT_FOUND)
-  set(QT_VERSION ${${QTX}_VERSION})
-  message(STATUS "Qt version: ${QT_VERSION}")
-
-  set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
-
-  #Set Cmake Auto features to skip .hh files
-  if(POLICY CMP0100)
-    cmake_policy(SET CMP0100 OLD)
-  endif()
-
-  #If building CUDA required libraries
-  #Change ${QTX}::Core fixed -fPIC flags to conditionally only CXX
-  #TODO: To be removed when QT is >5.14.1
-  if(BUILD_CUDA OR BUILD_GPU)
-    if(${QTX}Widgets_VERSION VERSION_LESS 5.14.1)
-      get_property(core_options TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
-      string(REPLACE "-fPIC" "$<IF:$<COMPILE_LANGUAGE:CXX>,-fPIC,>"  new_core_options ${core_options})
-      set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
-    endif()
-  endif()
-
-  get_property(core_def TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
-  list(APPEND core_def "QT_DISABLE_DEPRECATED_BEFORE=${QT_DISABLE_PRECATED_BEFORE_VAL}")
-  set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
-else()
+if(NOT QT_FOUND)
   message(STATUS "Qt is not found.")
+  return()
 endif()
+
+set(QT_VERSION ${${QTX}_VERSION})
+message(STATUS "Qt version: ${QT_VERSION}")
+
+set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
+
+#Set Cmake Auto features to skip .hh files
+if(POLICY CMP0100)
+  cmake_policy(SET CMP0100 OLD)
+endif()
+
+#If building CUDA required libraries
+#Change ${QTX}::Core fixed -fPIC flags to conditionally only CXX
+#TODO: To be removed when QT is >5.14.1
+if(BUILD_CUDA OR BUILD_GPU)
+  if(${QTX}Widgets_VERSION VERSION_LESS 5.14.1)
+    get_property(core_options TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
+    string(REPLACE "-fPIC" "$<IF:$<COMPILE_LANGUAGE:CXX>,-fPIC,>"  new_core_options ${core_options})
+    set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
+  endif()
+endif()
+
+get_property(core_def TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+list(APPEND core_def "QT_DISABLE_DEPRECATED_BEFORE=${QT_DISABLE_PRECATED_BEFORE_VAL}")
+set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})

--- a/cmake/pcl_find_qt.cmake
+++ b/cmake/pcl_find_qt.cmake
@@ -6,14 +6,15 @@
 #
 # Background: WITH_QT was previously boolean and we want to be backwards compatible.
 #
-# This if condition matches all CMake true constants except numbers other than 1.
-# This way we prevent things like -DWITH_QT=5 to be handelt as YES instead of QT5.
+# This if condition matches all CMake true constants (`${WITH_QT}`) except numbers other than 1 (`NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1)`).
+#
+# This way we prevent things like -DWITH_QT=5 to be handled as YES instead of QT5.
 # Setting -DWITH_QT=5 will error and inform you to use -DWITH_QT=QT5 instead.
 # (This breaks backward compatibility, but hopefully no one will use values not equal to 1 if they want to express true.)
 #
 # Note: "NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1)" is not the same as
 #       "WITH_QT EQUAL 1" because "LESS/GREATER/EQUAL" all pre-check if WITH_QT is a valid number.
-if(NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1) AND ${WITH_QT})
+if(${WITH_QT} AND NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1))
   set(WITH_QT_STR "YES")
 else()
   string(TOUPPER ${WITH_QT} WITH_QT_STR)

--- a/cmake/pcl_find_qt.cmake
+++ b/cmake/pcl_find_qt.cmake
@@ -1,0 +1,75 @@
+# This file is not processed if WITH_QT evaluates to a CMake false constant.
+#
+# First we convert WITH_QT to WITH_QT_STR with
+# - CMake true constants to string YES (except numbers unequal 1)
+# - Other values to upper case string
+#
+# Background: WITH_QT was previously boolean and we want to be backwards compatible.
+#
+# This if condition matches all CMake true constants except numbers other than 1.
+# This way we prevent things like -DWITH_QT=5 to be handelt as YES instead of QT5.
+# Setting -DWITH_QT=5 will error and inform you to use -DWITH_QT=QT5 instead.
+# (This breaks backward compatibility, but hopefully no one will use values not equal to 1 if they want to express true.)
+#
+# Note: "NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1)" is not the same as
+#       "WITH_QT EQUAL 1" because "LESS/GREATER/EQUAL" all pre-check if WITH_QT is a valid number.
+if(NOT (WITH_QT LESS 1 OR WITH_QT GREATER 1) AND ${WITH_QT})
+  set(WITH_QT_STR "YES")
+else()
+  string(TOUPPER ${WITH_QT} WITH_QT_STR)
+endif()
+
+if(NOT WITH_QT_STR MATCHES "^(AUTO|YES|QT6|QT5)$")
+  message(FATAL_ERROR "Option WITH_QT must be one of AUTO|YES|QT6|QT5|NO but is '${WITH_QT}'")
+endif()
+
+if(WITH_QT_STR MATCHES "^(AUTO|YES|QT6)$")
+  find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
+  set(QT6_FOUND ${Qt6_FOUND})
+  set(QT_FOUND ${QT6_FOUND})
+  if (QT6_FOUND)
+    set(QTX Qt6)
+  endif()
+endif()
+
+if(WITH_QT_STR MATCHES "^(AUTO|YES|QT5)$" AND NOT QT6_FOUND)
+  find_package(Qt5 5.9.5 QUIET COMPONENTS Concurrent OpenGL Widgets)
+  set(QT5_FOUND ${Qt5_FOUND})
+  set(QT_FOUND ${QT5_FOUND})
+  if(QT5_FOUND)
+    set(QTX Qt5)
+  endif()
+endif()
+
+if(NOT WITH_QT_STR MATCHES "^(AUTO)$" AND NOT QT_FOUND)
+  message(FATAL_ERROR "Can not find Qt required by WITH_QT=${WITH_QT}.")
+endif()
+
+if(QT_FOUND)
+  set(QT_VERSION ${${QTX}_VERSION})
+  message(STATUS "Qt version: ${QT_VERSION}")
+
+  set(QT_DISABLE_PRECATED_BEFORE_VAL "0x050900")
+
+  #Set Cmake Auto features to skip .hh files
+  if(POLICY CMP0100)
+    cmake_policy(SET CMP0100 OLD)
+  endif()
+
+  #If building CUDA required libraries
+  #Change ${QTX}::Core fixed -fPIC flags to conditionally only CXX
+  #TODO: To be removed when QT is >5.14.1
+  if(BUILD_CUDA OR BUILD_GPU)
+    if(${QTX}Widgets_VERSION VERSION_LESS 5.14.1)
+      get_property(core_options TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
+      string(REPLACE "-fPIC" "$<IF:$<COMPILE_LANGUAGE:CXX>,-fPIC,>"  new_core_options ${core_options})
+      set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
+    endif()
+  endif()
+
+  get_property(core_def TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+  list(APPEND core_def "QT_DISABLE_DEPRECATED_BEFORE=${QT_DISABLE_PRECATED_BEFORE_VAL}")
+  set_property(TARGET ${QTX}::Core PROPERTY INTERFACE_COMPILE_DEFINITIONS ${core_def})
+else()
+  message(STATUS "Qt is not found.")
+endif()

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -11,7 +11,8 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package(Qt5 REQUIRED Widgets)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 
 find_package(VTK REQUIRED)
 find_package(PCL 1.7.1 REQUIRED)
@@ -26,4 +27,4 @@ set(project_SOURCES main.cpp pclviewer.cpp)
 
 add_executable(${PROJECT_NAME} ${project_SOURCES})
 
-target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} Qt5::Widgets)
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Widgets)

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -11,8 +11,10 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
+find_package(Qt6 COMPONENTS Widgets)
+if (NOT Qt6_FOUND)
+  find_package(Qt5 COMPONENTS Widgets REQUIRED)
+endif()
 
 find_package(VTK REQUIRED)
 find_package(PCL 1.7.1 REQUIRED)

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -14,9 +14,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Qt6 QUIET COMPONENTS Widgets)
 if (NOT Qt6_FOUND)
   find_package(Qt5 COMPONENTS Widgets REQUIRED)
-  set(QT_VERSION_MAJOR 5)
+  set(QTX Qt5)
 else()
-  set(QT_VERSION_MAJOR 6)
+  set(QTX Qt6)
 endif()
 
 find_package(VTK REQUIRED)
@@ -32,4 +32,4 @@ set(project_SOURCES main.cpp pclviewer.cpp)
 
 add_executable(${PROJECT_NAME} ${project_SOURCES})
 
-target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} ${QTX}::Widgets)

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -11,9 +11,12 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package(Qt6 COMPONENTS Widgets)
+find_package(Qt6 QUIET COMPONENTS Widgets)
 if (NOT Qt6_FOUND)
   find_package(Qt5 COMPONENTS Widgets REQUIRED)
+  set(QT_VERSION_MAJOR 5)
+else()
+  set(QT_VERSION_MAJOR 6)
 endif()
 
 find_package(VTK REQUIRED)

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -11,7 +11,8 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package(Qt5 REQUIRED Widgets)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 
 find_package(VTK REQUIRED)
 find_package(PCL 1.7.1 REQUIRED)
@@ -26,4 +27,4 @@ set(project_SOURCES main.cpp pclviewer.cpp)
 
 add_executable(${PROJECT_NAME} ${project_SOURCES})
 
-target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} Qt5::Widgets)
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Widgets)

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -14,9 +14,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
 if (NOT Qt6_FOUND)
   find_package(Qt5 COMPONENTS Concurrent OpenGL Widgets REQUIRED)
-  set(QT_VERSION_MAJOR 5)
+  set(QTX Qt5)
 else()
-  set(QT_VERSION_MAJOR 6)
+  set(QTX Qt6)
 endif()
 
 find_package(VTK REQUIRED)
@@ -32,4 +32,4 @@ set(project_SOURCES main.cpp pclviewer.cpp)
 
 add_executable(${PROJECT_NAME} ${project_SOURCES})
 
-target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} ${QTX}::Widgets)

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -11,8 +11,10 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
+find_package(Qt6 COMPONENTS Concurrent OpenGL Widgets)
+if (NOT Qt6_FOUND)
+  find_package(Qt5 COMPONENTS Concurrent OpenGL Widgets REQUIRED)
+endif()
 
 find_package(VTK REQUIRED)
 find_package(PCL 1.7.1 REQUIRED)

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -11,9 +11,12 @@ set(CMAKE_AUTOUIC ON) # UI files
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find the QtWidgets library
-find_package(Qt6 COMPONENTS Concurrent OpenGL Widgets)
+find_package(Qt6 QUIET COMPONENTS Concurrent OpenGL Widgets)
 if (NOT Qt6_FOUND)
   find_package(Qt5 COMPONENTS Concurrent OpenGL Widgets REQUIRED)
+  set(QT_VERSION_MAJOR 5)
+else()
+  set(QT_VERSION_MAJOR 6)
 endif()
 
 find_package(VTK REQUIRED)


### PR DESCRIPTION
Based on https://doc-snapshots.qt.io/qt6-dev/cmake-qt5-and-qt6-compatibility.html

I was able to compile PCL with this on Linux using GCC 11.2 with Qt 6.2 for Linux. Also cross compiling with GCC 11.2 and MinGW-w64 9 with Qt 6.2 from Linux to Windows was successful.

The patch will fix Issue #4959