### PR TITLE
Introduce buffer for texture coordinate indices in TextureMesh

### DIFF
--- a/common/include/pcl/TextureMesh.h
+++ b/common/include/pcl/TextureMesh.h
@@ -91,9 +91,17 @@ namespace pcl
     pcl::PCLHeader  header;
 
 
-    std::vector<std::vector<pcl::Vertices> >    tex_polygons;     // polygon which is mapped with specific texture defined in TexMaterial
-    std::vector<std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > > tex_coordinates;  // UV coordinates
-    std::vector<pcl::TexMaterial>               tex_materials;    // define texture material
+    /** \brief polygon which is mapped with specific texture defined in TexMaterial */
+    std::vector<std::vector<pcl::Vertices> >    tex_polygons;
+    /** \brief UV coordinates */
+    std::vector<std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > > tex_coordinates;
+    /** \brief define texture material */
+    std::vector<pcl::TexMaterial>               tex_materials;
+    /** \brief Specifies which texture coordinates from tex_coordinates each polygon/face uses.
+      * The vectors must have the same sizes as in tex_polygons, but the pcl::Vertices
+      * may be empty for those polygons/faces that do not use coordinates.
+      */
+    std::vector<std::vector<pcl::Vertices> >    tex_coord_indices;
 
     public:
       using Ptr = shared_ptr<pcl::TextureMesh>;

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -769,6 +769,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
       if (st[0] == "usemtl")
       {
         mesh.tex_polygons.emplace_back();
+        mesh.tex_coord_indices.emplace_back();
         mesh.tex_materials.emplace_back();
         for (const auto &companion : companions_)
         {
@@ -789,16 +790,24 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
       // Face
       if (st[0] == "f")
       {
-        //We only care for vertices indices
+        // TODO read in normal indices properly
         pcl::Vertices face_v; face_v.vertices.resize (st.size () - 1);
+        pcl::Vertices tex_indices; tex_indices.vertices.reserve (st.size () - 1);
         for (std::size_t i = 1; i < st.size (); ++i)
         {
-          int v;
-          sscanf (st[i].c_str (), "%d", &v);
+          char* str_end;
+          int v = std::strtol(st[i].c_str(), &str_end, 10);
           v = (v < 0) ? v_idx + v : v - 1;
           face_v.vertices[i-1] = v;
+          if (str_end[0] == '/' && str_end[1] != '/' && str_end[1] != '\0')
+          {
+            // texture coordinate indices are optional
+            int tex_index = std::strtol(str_end+1, &str_end, 10);
+            tex_indices.vertices.push_back (tex_index - 1);
+          }
         }
         mesh.tex_polygons.back ().push_back (face_v);
+        mesh.tex_coord_indices.back ().push_back (tex_indices);
         ++f_idx;
         continue;
       }
@@ -1108,14 +1117,14 @@ pcl::io::saveOBJFile (const std::string &file_name,
     {
       // Write faces with "f"
       fs << "f";
-      // There's one UV per vertex per face, i.e., the same vertex can have
-      // different UV depending on the face.
       for (std::size_t j = 0; j < tex_mesh.tex_polygons[m][i].vertices.size (); ++j)
       {
         std::uint32_t idx = tex_mesh.tex_polygons[m][i].vertices[j] + 1;
-        fs << " " << idx
-           << "/" << tex_mesh.tex_polygons[m][i].vertices.size () * (i+f_idx) +j+1
-           << "/" << idx; // vertex index in obj file format starting with 1
+        fs << " " << idx << "/";
+        // texture coordinate indices are optional
+        if (!tex_mesh.tex_coord_indices[m][i].vertices.empty())
+          fs << tex_mesh.tex_coord_indices[m][i].vertices[j] + 1;
+        fs << "/" << idx; // vertex index in obj file format starting with 1
       }
       fs << '\n';
     }

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -381,6 +381,7 @@ pcl::io::vtk2mesh (const vtkSmartPointer<vtkPolyData>& poly_data, pcl::TextureMe
   mesh.header = polygon_mesh.header;
   /// TODO check for sub-meshes
   mesh.tex_polygons.push_back (polygon_mesh.polygons);
+  mesh.tex_coord_indices.push_back (polygon_mesh.polygons);
 
   // Add dummy material
   mesh.tex_materials.emplace_back();


### PR DESCRIPTION
PCL has two functions that load TextureMeshes from .obj files: loadPolygonFileOBJ (uses vtkOBJReader) and loadOBJFile (PCL native).
However, TextureMesh so far did not have a buffer to store the texture coordinate indices, only tex_polygons which stores the vertex indices (indices of points in cloud).
loadPolygonFileOBJ uses a workaround by duplicating the vertices/points and the texture coordinates, so that there is each a point and a texture coordinate for each vertex of each mesh face (e.g. for a mesh with 100 triangular faces, there would be 300 points in the cloud and 300 coordinates in tex_coordinates). The indices in tex_polygons then count for both. This approach has the disadvantage that space is wasted for the duplicated points and coordinates.
In meshes loaded by loadOBJFile, there was no way to tell which texture coordinate was used by which vertex.
This commit introduces the buffer tex_coord_indices, which works similar to tex_polygons. In loadOBJFile and saveOBJFile, it is considered that texture coordinate indices are optional. loadPolygonFileOBJ is unchanged, but stores a copy of tex_polygons inside the new tex_coord_indices.

For reference, see [wikipedia](https://en.wikipedia.org/wiki/Wavefront_.obj_file#Face_elements)
See issue #2252 which describes the problem and the solution in detail
See recent issue #4957 

There are more problems in the OBJ<->TextureMesh functions, but this seems to be the most important one. I might open another pull request with fixes that do not break ABI or API.