### PR TITLE
Fix mls voxel grid hashing out of bound

### DIFF
--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -403,7 +403,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
   {
     corresponding_input_indices_.reset (new PointIndices);
 
-    MLSVoxelGrid voxel_grid (input_, indices_, voxel_size_);
+    MLSVoxelGrid voxel_grid (input_, indices_, voxel_size_, dilation_iteration_num_);
     for (int iteration = 0; iteration < dilation_iteration_num_; ++iteration)
       voxel_grid.dilate ();
 
@@ -837,15 +837,18 @@ pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
 template <typename PointInT, typename PointOutT>
 pcl::MovingLeastSquares<PointInT, PointOutT>::MLSVoxelGrid::MLSVoxelGrid (PointCloudInConstPtr& cloud,
                                                                           IndicesPtr &indices,
-                                                                          float voxel_size) :
+                                                                          float voxel_size,
+                                                                          int dilation_iteration_num) :
   voxel_grid_ (), data_size_ (), voxel_size_ (voxel_size)
 {
   pcl::getMinMax3D (*cloud, *indices, bounding_min_, bounding_max_);
+  bounding_min_ -= Eigen::Vector4f::Constant(voxel_size_ * (dilation_iteration_num + 1));
+  bounding_max_ += Eigen::Vector4f::Constant(voxel_size_ * (dilation_iteration_num + 1));
 
   Eigen::Vector4f bounding_box_size = bounding_max_ - bounding_min_;
   const double max_size = (std::max) ((std::max)(bounding_box_size.x (), bounding_box_size.y ()), bounding_box_size.z ());
   // Put initial cloud in voxel grid
-  data_size_ = static_cast<std::uint64_t> (1.5 * max_size / voxel_size_);
+  data_size_ = static_cast<std::uint64_t> (std::ceil(max_size / voxel_size_));
   for (std::size_t i = 0; i < indices->size (); ++i)
     if (std::isfinite ((*cloud)[(*indices)[i]].x))
     {

--- a/surface/include/pcl/surface/mls.h
+++ b/surface/include/pcl/surface/mls.h
@@ -591,7 +591,8 @@ namespace pcl
 
           MLSVoxelGrid (PointCloudInConstPtr& cloud,
                         IndicesPtr &indices,
-                        float voxel_size);
+                        float voxel_size,
+                        int dilation_iteration_num);
 
           void
           dilate ();


### PR DESCRIPTION
Fix https://github.com/PointCloudLibrary/pcl/issues/4945 by increasing the voxel grid bound according to the dilation number to avoid negative voxel grid index at L879

https://github.com/PointCloudLibrary/pcl/blob/7f87657e8f796373852ff7f80228a1573239de8d/surface/include/pcl/surface/impl/mls.hpp#L872-L888

`+1` in the fix due to probably the numerical issue during converting voxel grid index (3D) to hash (1D)


## Original implementatio
![Screenshot from 2021-10-07 01-18-20](https://user-images.githubusercontent.com/22342030/136297738-6496674a-5a91-4462-8e75-0f52f9e54951.png)

## New implementation

### `dilation_iteration_num = 1`
![Screenshot from 2021-10-07 01-27-51](https://user-images.githubusercontent.com/22342030/136298205-1761007a-34c3-475d-b627-6cc34a8ad981.png)

### `dilation_iteration_num = 5`

![Screenshot from 2021-10-07 01-32-45](https://user-images.githubusercontent.com/22342030/136298223-b6511da5-aff4-4ea9-a287-fac0a60863a0.png)
![Screenshot from 2021-10-07 01-34-35](https://user-images.githubusercontent.com/22342030/136298227-95e13c22-8038-4907-9ddb-e2e12f0129ab.png)

