### PR TITLE
Allow SAC segmentation to take a pre-seeded RNG instead of always seeding to 12345u or current time

### DIFF
--- a/common/include/pcl/common/impl/random.hpp
+++ b/common/include/pcl/common/impl/random.hpp
@@ -49,8 +49,8 @@ namespace common
 {
 
 
-template <typename T>
-UniformGenerator<T>::UniformGenerator(T min, T max, std::uint32_t seed)
+template <typename T, typename Generator, typename Distribution>
+UniformGenerator<T, Generator, Distribution>::UniformGenerator(T min, T max, std::uint32_t seed)
   : distribution_ (min, max)
 {
   parameters_ = Parameters (min, max, seed);
@@ -59,8 +59,8 @@ UniformGenerator<T>::UniformGenerator(T min, T max, std::uint32_t seed)
 }
 
 
-template <typename T>
-UniformGenerator<T>::UniformGenerator(const Parameters& parameters)
+template <typename T, typename Generator, typename Distribution>
+UniformGenerator<T, Generator, Distribution>::UniformGenerator(const Parameters& parameters)
   : parameters_ (parameters)
   , distribution_ (parameters_.min, parameters_.max)
 {
@@ -69,8 +69,8 @@ UniformGenerator<T>::UniformGenerator(const Parameters& parameters)
 }
 
 
-template <typename T> void
-UniformGenerator<T>::setSeed (std::uint32_t seed)
+template <typename T, typename Generator, typename Distribution> void
+UniformGenerator<T, Generator, Distribution>::setSeed (std::uint32_t seed)
 {
   if (seed != static_cast<std::uint32_t> (-1))
   {
@@ -80,8 +80,8 @@ UniformGenerator<T>::setSeed (std::uint32_t seed)
 }
 
 
-template <typename T> void
-UniformGenerator<T>::setParameters (T min, T max, std::uint32_t seed)
+template <typename T, typename Generator, typename Distribution> void
+UniformGenerator<T, Generator, Distribution>::setParameters (T min, T max, std::uint32_t seed)
 {
   parameters_.min = min;
   parameters_.max = max;
@@ -97,8 +97,8 @@ UniformGenerator<T>::setParameters (T min, T max, std::uint32_t seed)
 }
 
 
-template <typename T> void
-UniformGenerator<T>::setParameters (const Parameters& parameters)
+template <typename T, typename Generator, typename Distribution> void
+UniformGenerator<T, Generator, Distribution>::setParameters (const Parameters& parameters)
 {
   parameters_ = parameters;
   typename DistributionType::param_type params (parameters_.min, parameters_.max);

--- a/common/include/pcl/common/random.h
+++ b/common/include/pcl/common/random.h
@@ -41,6 +41,10 @@
 
 #include <random>
 
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+
 #include <pcl/pcl_macros.h>
 
 namespace pcl 
@@ -74,7 +78,7 @@ namespace pcl
       *
       * \author Nizar Sallem
       */
-    template<typename T>
+    template<typename T, typename Generator = std::mt19937, typename Distribution = uniform_distribution<T>>
     class UniformGenerator 
     {
       public:
@@ -132,14 +136,32 @@ namespace pcl
         run () { return (distribution_ (rng_)); }
 
       private:
-        using DistributionType = typename uniform_distribution<T>::type;
+        using DistributionType = typename Distribution::type;
         /// parameters
         Parameters parameters_;
         /// random number generator
-        std::mt19937 rng_;
+        Generator rng_;
         /// uniform distribution
         DistributionType distribution_;
     };
+
+    /// uniform distribution dummy struct
+    template <typename T, typename T2=void> struct boost_uniform_distribution;
+    /// uniform distribution int specialized
+    template <typename T>
+    struct boost_uniform_distribution<T, std::enable_if_t<std::is_integral<T>::value>>
+    {
+      using type = boost::random::uniform_int_distribution<T>;
+    };
+    /// uniform distribution float specialized
+    template <typename T>
+    struct boost_uniform_distribution<T, std::enable_if_t<std::is_floating_point<T>::value>>
+    {
+      using type = boost::random::uniform_real_distribution<T>;
+    };
+
+    template <typename T>
+    using BoostUniformGenerator = UniformGenerator<T, boost::mt19937, boost_uniform_distribution<T>>;
 
     /** \brief NormalGenerator class generates a random number from a normal distribution specified
       * by (mean, sigma).

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle.h
@@ -84,8 +84,10 @@ namespace pcl
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
-      SampleConsensusModelCircle2D (const PointCloudConstPtr &cloud, bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+      SampleConsensusModelCircle2D (const PointCloudConstPtr &cloud,
+                                    bool random = false,
+                                    std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelCircle2D";
         sample_size_ = 3;
@@ -99,8 +101,9 @@ namespace pcl
         */
       SampleConsensusModelCircle2D (const PointCloudConstPtr &cloud, 
                                     const Indices &indices,
-                                    bool random = false)
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                    bool random = false,
+                                    std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelCircle2D";
         sample_size_ = 3;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_circle3d.h
@@ -78,8 +78,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelCircle3D (const PointCloudConstPtr &cloud,
-                                    bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+                                    bool random = false,
+                                    std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelCircle3D";
         sample_size_ = 3;
@@ -93,8 +94,9 @@ namespace pcl
         */
       SampleConsensusModelCircle3D (const PointCloudConstPtr &cloud, 
                                     const Indices &indices,
-                                    bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                    bool random = false,
+                                    std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelCircle3D";
         sample_size_ = 3;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -82,8 +82,10 @@ namespace pcl
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
-      SampleConsensusModelCone (const PointCloudConstPtr &cloud, bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+      SampleConsensusModelCone (const PointCloudConstPtr &cloud,
+                                bool random = false,
+                                std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0)
@@ -102,8 +104,9 @@ namespace pcl
         */
       SampleConsensusModelCone (const PointCloudConstPtr &cloud, 
                                 const Indices &indices,
-                                bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                bool random = false,
+                                std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -83,8 +83,10 @@ namespace pcl
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
-      SampleConsensusModelCylinder (const PointCloudConstPtr &cloud, bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+      SampleConsensusModelCylinder (const PointCloudConstPtr &cloud,
+                                    bool random = false,
+                                    std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0)
@@ -101,8 +103,9 @@ namespace pcl
         */
       SampleConsensusModelCylinder (const PointCloudConstPtr &cloud, 
                                     const Indices &indices,
-                                    bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                    bool random = false,
+                                    std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_line.h
@@ -78,8 +78,10 @@ namespace pcl
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
-      SampleConsensusModelLine (const PointCloudConstPtr &cloud, bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+      SampleConsensusModelLine (const PointCloudConstPtr &cloud,
+                                bool random = false,
+                                std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelLine";
         sample_size_ = 2;
@@ -93,8 +95,9 @@ namespace pcl
         */
       SampleConsensusModelLine (const PointCloudConstPtr &cloud, 
                                 const Indices &indices,
-                                bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                bool random = false,
+                                std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelLine";
         sample_size_ = 2;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -108,8 +108,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelNormalParallelPlane (const PointCloudConstPtr &cloud,
-                                               bool random = false) 
-        : SampleConsensusModelNormalPlane<PointT, PointNT> (cloud, random)
+                                               bool random = false,
+                                               std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelNormalPlane<PointT, PointNT> (cloud, random, rng_gen)
         , axis_ (Eigen::Vector4f::Zero ())
         , distance_from_origin_ (0)
         , eps_angle_ (-1.0)
@@ -128,8 +129,9 @@ namespace pcl
         */
       SampleConsensusModelNormalParallelPlane (const PointCloudConstPtr &cloud, 
                                                const Indices &indices,
-                                               bool random = false) 
-        : SampleConsensusModelNormalPlane<PointT, PointNT> (cloud, indices, random)
+                                               bool random = false,
+                                               std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelNormalPlane<PointT, PointNT> (cloud, indices, random, rng_gen)
         , axis_ (Eigen::Vector4f::Zero ())
         , distance_from_origin_ (0)
         , eps_angle_ (-1.0)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -99,8 +99,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelNormalPlane (const PointCloudConstPtr &cloud, 
-                                       bool random = false) 
-        : SampleConsensusModelPlane<PointT> (cloud, random)
+                                       bool random = false,
+                                       std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelPlane<PointT> (cloud, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalPlane";
@@ -115,8 +116,9 @@ namespace pcl
         */
       SampleConsensusModelNormalPlane (const PointCloudConstPtr &cloud, 
                                        const Indices &indices,
-                                       bool random = false) 
-        : SampleConsensusModelPlane<PointT> (cloud, indices, random)
+                                       bool random = false,
+                                       std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelPlane<PointT> (cloud, indices, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalPlane";

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -93,8 +93,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelNormalSphere (const PointCloudConstPtr &cloud, 
-                                        bool random = false) 
-        : SampleConsensusModelSphere<PointT> (cloud, random)
+                                        bool random = false,
+                                        std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelSphere<PointT> (cloud, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalSphere";
@@ -109,8 +110,9 @@ namespace pcl
         */
       SampleConsensusModelNormalSphere (const PointCloudConstPtr &cloud, 
                                         const Indices &indices,
-                                        bool random = false) 
-        : SampleConsensusModelSphere<PointT> (cloud, indices, random)
+                                        bool random = false,
+                                        std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelSphere<PointT> (cloud, indices, random, rng_gen)
         , SampleConsensusModelFromNormals<PointT, PointNT> ()
       {
         model_name_ = "SampleConsensusModelNormalSphere";

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -79,8 +79,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelParallelLine (const PointCloudConstPtr &cloud,
-                                        bool random = false)
-        : SampleConsensusModelLine<PointT> (cloud, random)
+                                        bool random = false,
+                                        std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : SampleConsensusModelLine<PointT> (cloud, random, rng_gen)
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {
@@ -96,8 +97,9 @@ namespace pcl
         */
       SampleConsensusModelParallelLine (const PointCloudConstPtr &cloud,
                                         const Indices &indices,
-                                        bool random = false)
-        : SampleConsensusModelLine<PointT> (cloud, indices, random)
+                                        bool random = false,
+                                        std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : SampleConsensusModelLine<PointT> (cloud, indices, random, rng_gen)
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -79,8 +79,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelParallelPlane (const PointCloudConstPtr &cloud,
-                                         bool random = false) 
-        : SampleConsensusModelPlane<PointT> (cloud, random)
+                                         bool random = false,
+                                         std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelPlane<PointT> (cloud, random, rng_gen)
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
         , sin_angle_ (-1.0)
@@ -97,8 +98,9 @@ namespace pcl
         */
       SampleConsensusModelParallelPlane (const PointCloudConstPtr &cloud, 
                                          const Indices &indices,
-                                         bool random = false) 
-        : SampleConsensusModelPlane<PointT> (cloud, indices, random)
+                                         bool random = false,
+                                         std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelPlane<PointT> (cloud, indices, random, rng_gen)
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
         , sin_angle_ (-1.0)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -84,8 +84,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelPerpendicularPlane (const PointCloudConstPtr &cloud,
-                                              bool random = false) 
-        : SampleConsensusModelPlane<PointT> (cloud, random)
+                                              bool random = false,
+                                              std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelPlane<PointT> (cloud, random, rng_gen)
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {
@@ -101,8 +102,9 @@ namespace pcl
         */
       SampleConsensusModelPerpendicularPlane (const PointCloudConstPtr &cloud, 
                                               const Indices &indices,
-                                              bool random = false) 
-        : SampleConsensusModelPlane<PointT> (cloud, indices, random)
+                                              bool random = false,
+                                              std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModelPlane<PointT> (cloud, indices, random, rng_gen)
         , axis_ (Eigen::Vector3f::Zero ())
         , eps_angle_ (0.0)
       {

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_plane.h
@@ -47,6 +47,7 @@
 #include <immintrin.h> // for __m256
 #endif // ifdef __AVX__
 
+#include <pcl/common/random.h>
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/model_types.h>
 
@@ -159,8 +160,10 @@ namespace pcl
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
-      SampleConsensusModelPlane (const PointCloudConstPtr &cloud, bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+      SampleConsensusModelPlane (const PointCloudConstPtr &cloud,
+                                 bool random = false,
+                                 std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelPlane";
         sample_size_ = 3;
@@ -174,8 +177,9 @@ namespace pcl
         */
       SampleConsensusModelPlane (const PointCloudConstPtr &cloud, 
                                  const Indices &indices,
-                                 bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                 bool random = false,
+                                 std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelPlane";
         sample_size_ = 3;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -78,8 +78,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelRegistration (const PointCloudConstPtr &cloud, 
-                                        bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+                                        bool random = false,
+                                        std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
         , target_ ()
         , sample_dist_thresh_ (0)
       {
@@ -97,8 +98,9 @@ namespace pcl
         */
       SampleConsensusModelRegistration (const PointCloudConstPtr &cloud,
                                         const Indices &indices,
-                                        bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                        bool random = false,
+                                        std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
         , target_ ()
         , sample_dist_thresh_ (0)
       {

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration_2d.h
@@ -75,8 +75,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelRegistration2D (const PointCloudConstPtr &cloud,
-                                          bool random = false) 
-        : pcl::SampleConsensusModelRegistration<PointT> (cloud, random)
+                                          bool random = false,
+                                          std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : pcl::SampleConsensusModelRegistration<PointT> (cloud, random, rng_gen)
         , projection_matrix_ (Eigen::Matrix3f::Identity ())
       {
         // Call our own setInputCloud
@@ -93,8 +94,9 @@ namespace pcl
         */
       SampleConsensusModelRegistration2D (const PointCloudConstPtr &cloud,
                                           const Indices &indices,
-                                          bool random = false)
-        : pcl::SampleConsensusModelRegistration<PointT> (cloud, indices, random)
+                                          bool random = false,
+                                          std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : pcl::SampleConsensusModelRegistration<PointT> (cloud, indices, random, rng_gen)
         , projection_matrix_ (Eigen::Matrix3f::Identity ())
       {
         computeOriginalIndexMapping ();

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -85,8 +85,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelSphere (const PointCloudConstPtr &cloud,
-                                  bool random = false)
-        : SampleConsensusModel<PointT> (cloud, random)
+                                  bool random = false,
+                                  std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelSphere";
         sample_size_ = 4;
@@ -100,8 +101,9 @@ namespace pcl
         */
       SampleConsensusModelSphere (const PointCloudConstPtr &cloud,
                                   const Indices &indices,
-                                  bool random = false)
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                  bool random = false,
+                                  std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr)
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelSphere";
         sample_size_ = 4;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -83,8 +83,9 @@ namespace pcl
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
       SampleConsensusModelStick (const PointCloudConstPtr &cloud,
-                                 bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, random)
+                                 bool random = false,
+                                 std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelStick";
         sample_size_ = 2;
@@ -98,8 +99,9 @@ namespace pcl
         */
       SampleConsensusModelStick (const PointCloudConstPtr &cloud, 
                                  const Indices &indices,
-                                 bool random = false) 
-        : SampleConsensusModel<PointT> (cloud, indices, random)
+                                 bool random = false,
+                                 std::shared_ptr<pcl::common::BoostUniformGenerator<int>> rng_gen = nullptr) 
+        : SampleConsensusModel<PointT> (cloud, indices, random, rng_gen)
       {
         model_name_ = "SampleConsensusModelStick";
         sample_size_ = 2;

--- a/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
@@ -143,19 +143,19 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     case SACMODEL_PLANE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_PLANE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelPlane<PointT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelPlane<PointT> (input_, *indices_, random_, rng_gen_));
       break;
     }
     case SACMODEL_LINE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_LINE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelLine<PointT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelLine<PointT> (input_, *indices_, random_, rng_gen_));
       break;
     }
     case SACMODEL_STICK:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_STICK\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelStick<PointT> (input_, *indices_));
+      model_.reset (new SampleConsensusModelStick<PointT> (input_, *indices_, random_, rng_gen_));
       double min_radius, max_radius;
       model_->getRadiusLimits (min_radius, max_radius);
       if (radius_min_ != min_radius && radius_max_ != max_radius)
@@ -168,7 +168,7 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     case SACMODEL_CIRCLE2D:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_CIRCLE2D\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelCircle2D<PointT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelCircle2D<PointT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelCircle2D<PointT>::Ptr model_circle = static_pointer_cast<SampleConsensusModelCircle2D<PointT> > (model_);
       double min_radius, max_radius;
       model_circle->getRadiusLimits (min_radius, max_radius);
@@ -182,7 +182,7 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     case SACMODEL_CIRCLE3D:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_CIRCLE3D\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelCircle3D<PointT> (input_, *indices_));
+      model_.reset (new SampleConsensusModelCircle3D<PointT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelCircle3D<PointT>::Ptr model_circle3d = static_pointer_cast<SampleConsensusModelCircle3D<PointT> > (model_);
       double min_radius, max_radius;
       model_circle3d->getRadiusLimits (min_radius, max_radius);
@@ -196,7 +196,7 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     case SACMODEL_SPHERE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_SPHERE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelSphere<PointT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelSphere<PointT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelSphere<PointT>::Ptr model_sphere = static_pointer_cast<SampleConsensusModelSphere<PointT> > (model_);
       double min_radius, max_radius;
       model_sphere->getRadiusLimits (min_radius, max_radius);
@@ -210,7 +210,7 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     case SACMODEL_PARALLEL_LINE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_PARALLEL_LINE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelParallelLine<PointT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelParallelLine<PointT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelParallelLine<PointT>::Ptr model_parallel = static_pointer_cast<SampleConsensusModelParallelLine<PointT> > (model_);
       if (axis_ != Eigen::Vector3f::Zero () && model_parallel->getAxis () != axis_)
       {
@@ -227,7 +227,7 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     case SACMODEL_PERPENDICULAR_PLANE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_PERPENDICULAR_PLANE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelPerpendicularPlane<PointT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelPerpendicularPlane<PointT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelPerpendicularPlane<PointT>::Ptr model_perpendicular = static_pointer_cast<SampleConsensusModelPerpendicularPlane<PointT> > (model_);
       if (axis_ != Eigen::Vector3f::Zero () && model_perpendicular->getAxis () != axis_)
       {
@@ -244,7 +244,7 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     case SACMODEL_PARALLEL_PLANE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_PARALLEL_PLANE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelParallelPlane<PointT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelParallelPlane<PointT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelParallelPlane<PointT>::Ptr model_parallel = static_pointer_cast<SampleConsensusModelParallelPlane<PointT> > (model_);
       if (axis_ != Eigen::Vector3f::Zero () && model_parallel->getAxis () != axis_)
       {
@@ -369,7 +369,7 @@ pcl::SACSegmentationFromNormals<PointT, PointNT>::initSACModel (const int model_
     case SACMODEL_CYLINDER:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_CYLINDER\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelCylinder<PointT, PointNT > (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelCylinder<PointT, PointNT > (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelCylinder<PointT, PointNT>::Ptr model_cylinder = static_pointer_cast<SampleConsensusModelCylinder<PointT, PointNT> > (model_);
 
       // Set the input normals
@@ -401,7 +401,7 @@ pcl::SACSegmentationFromNormals<PointT, PointNT>::initSACModel (const int model_
     case SACMODEL_NORMAL_PLANE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_NORMAL_PLANE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelNormalPlane<PointT, PointNT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelNormalPlane<PointT, PointNT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelNormalPlane<PointT, PointNT>::Ptr model_normals = static_pointer_cast<SampleConsensusModelNormalPlane<PointT, PointNT> > (model_);
       // Set the input normals
       model_normals->setInputNormals (normals_);
@@ -415,7 +415,7 @@ pcl::SACSegmentationFromNormals<PointT, PointNT>::initSACModel (const int model_
     case SACMODEL_NORMAL_PARALLEL_PLANE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_NORMAL_PARALLEL_PLANE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelNormalParallelPlane<PointT, PointNT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelNormalParallelPlane<PointT, PointNT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelNormalParallelPlane<PointT, PointNT>::Ptr model_normals = static_pointer_cast<SampleConsensusModelNormalParallelPlane<PointT, PointNT> > (model_);
       // Set the input normals
       model_normals->setInputNormals (normals_);
@@ -444,7 +444,7 @@ pcl::SACSegmentationFromNormals<PointT, PointNT>::initSACModel (const int model_
     case SACMODEL_CONE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_CONE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelCone<PointT, PointNT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelCone<PointT, PointNT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelCone<PointT, PointNT>::Ptr model_cone = static_pointer_cast<SampleConsensusModelCone<PointT, PointNT> > (model_);
 
       // Set the input normals
@@ -477,7 +477,7 @@ pcl::SACSegmentationFromNormals<PointT, PointNT>::initSACModel (const int model_
     case SACMODEL_NORMAL_SPHERE:
     {
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_NORMAL_SPHERE\n", getClassName ().c_str ());
-      model_.reset (new SampleConsensusModelNormalSphere<PointT, PointNT> (input_, *indices_, random_));
+      model_.reset (new SampleConsensusModelNormalSphere<PointT, PointNT> (input_, *indices_, random_, rng_gen_));
       typename SampleConsensusModelNormalSphere<PointT, PointNT>::Ptr model_normals_sphere = static_pointer_cast<SampleConsensusModelNormalSphere<PointT, PointNT> > (model_);
       // Set the input normals
       model_normals_sphere->setInputNormals (normals_);

--- a/segmentation/include/pcl/segmentation/sac_segmentation.h
+++ b/segmentation/include/pcl/segmentation/sac_segmentation.h
@@ -42,6 +42,7 @@
 #include <pcl/pcl_base.h>
 #include <pcl/PointIndices.h>
 #include <pcl/ModelCoefficients.h>
+#include <pcl/common/random.h>
 
 // Sample Consensus methods
 #include <pcl/sample_consensus/method_types.h>
@@ -81,7 +82,7 @@ namespace pcl
       /** \brief Empty constructor. 
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)
         */
-      SACSegmentation (bool random = false) 
+      SACSegmentation (bool random = false, std::shared_ptr<pcl::common::BoostUniformGenerator<int> > rng_gen = nullptr)
         : model_ ()
         , sac_ ()
         , model_type_ (-1)
@@ -98,6 +99,7 @@ namespace pcl
         , threads_ (-1)
         , probability_ (0.99)
         , random_ (random)
+        , rng_gen_ (rng_gen)
       {
       }
 
@@ -308,6 +310,9 @@ namespace pcl
       /** \brief Set to true if we need a random seed. */
       bool random_;
 
+      /** \brief RNG generator to use. */
+      std::shared_ptr<pcl::common::BoostUniformGenerator<int> > rng_gen_;
+
       /** \brief Class get name method. */
       virtual std::string 
       getClassName () const { return ("SACSegmentation"); }
@@ -327,6 +332,7 @@ namespace pcl
     using SACSegmentation<PointT>::eps_angle_;
     using SACSegmentation<PointT>::axis_;
     using SACSegmentation<PointT>::random_;
+    using SACSegmentation<PointT>::rng_gen_;
 
     public:
       using PCLBase<PointT>::input_;


### PR DESCRIPTION
Existing SAC classes take a boolean "random" parameter in the constructor, and
always create a new RNG and seeds it to 12345u or the current time. This means
that all SAC operations that take place within the same second will yield the
same result. This prevents performing multiple fast segmentation operations,
and prevents performing multiple segmentations in parallel.

This change adds a new "rng_gen" parameter to all SAC model constructors so
that the caller can pass in a pre-seeded RNG, or re-use the RNG across
multiple operations.

This change should be backwards compatible because all parameters and template
parameters have sensible defaults. The tests pass with no changes required.
I created a separate BoostUniformGenerator which uses the boost random classes,
so that they would generate the values expected by the tests, and prove that
this change remains correct. In the future, we can change to using
UniformGenerator and update the test expectations.