### PR TITLE
Update PCLConfig.cmake.in to 3.10 for default policy. 

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -13,7 +13,7 @@
 #------------------------------------------------------------------------------------
 
 # Set default policy behavior similar to minimum requirement version
-cmake_policy(VERSION 3.5)
+cmake_policy(VERSION 3.10)
 
 # explicitly set policies we already support in newer cmake versions
 if(POLICY CMP0074)
@@ -305,7 +305,14 @@ macro(find_external_library _component _lib _is_optional)
   string(REGEX REPLACE "[.-]" "_" LIB ${LIB})
   if(${LIB}_FOUND)
     list(APPEND PCL_${COMPONENT}_INCLUDE_DIRS ${${LIB}_INCLUDE_DIRS})
-    if(${LIB}_USE_FILE)
+    
+    if(${LIB} MATCHES "VTK")
+      if(${${LIB}_VERSION_MAJOR} GREATER_EQUAL 9)
+        set(ISVTK9ORGREATER TRUE)
+      endif()
+    endif()
+    
+    if(${LIB}_USE_FILE AND NOT ISVTK9ORGREATER )
       include(${${LIB}_USE_FILE})
     else()
       list(APPEND PCL_${COMPONENT}_LIBRARY_DIRS "${${LIB}_LIBRARY_DIRS}")


### PR DESCRIPTION
Only use usefile for versions before VTK 9.