### PR TITLE
Link to specific libraries for IO, Surface and visualization.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -64,20 +64,16 @@ if(VTK_FOUND)
   if(QHULL_FOUND)
     PCL_ADD_EXECUTABLE(pcl_pcd_select_object_plane COMPONENT ${SUBSYS_NAME} SOURCES src/pcd_select_object_plane.cpp)
     target_link_libraries(pcl_pcd_select_object_plane pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_features pcl_surface)
-    #TODO: Update when CMAKE 3.10 is available
-    if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
-      target_link_libraries(pcl_pcd_select_object_plane VTK::FiltersGeometry)
-    endif()
   endif()
 
   PCL_ADD_EXECUTABLE(pcl_pcd_organized_edge_detection COMPONENT ${SUBSYS_NAME} SOURCES src/pcd_organized_edge_detection.cpp)
   target_link_libraries(pcl_pcd_organized_edge_detection pcl_common pcl_io pcl_features pcl_visualization)
 
   PCL_ADD_EXECUTABLE(pcl_face_trainer COMPONENT ${SUBSYS_NAME} SOURCES src/face_detection/face_trainer.cpp)
-  target_link_libraries(pcl_face_trainer pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree ${VTK_LIBRARIES})
+  target_link_libraries(pcl_face_trainer pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree)
 
   PCL_ADD_EXECUTABLE(pcl_fs_face_detector COMPONENT ${SUBSYS_NAME} SOURCES src/face_detection//filesystem_face_detection.cpp BUNDLE)
-  target_link_libraries(pcl_fs_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree ${VTK_LIBRARIES})
+  target_link_libraries(pcl_fs_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree)
 
   PCL_ADD_EXECUTABLE(pcl_stereo_ground_segmentation COMPONENT ${SUBSYS_NAME} SOURCES src/stereo_ground_segmentation.cpp)
   target_link_libraries(pcl_stereo_ground_segmentation pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_features pcl_stereo)
@@ -94,10 +90,6 @@ if(VTK_FOUND)
       BUNDLE)
       
     target_link_libraries(pcl_manual_registration pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface ${QTX}::Widgets)
-    #TODO: Update when CMAKE 3.10 is available
-    if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
-      target_link_libraries(pcl_manual_registration VTK::GUISupportQt)
-    endif()
 
     PCL_ADD_EXECUTABLE(pcl_pcd_video_player
       COMPONENT
@@ -109,10 +101,6 @@ if(VTK_FOUND)
       BUNDLE)
     
     target_link_libraries(pcl_pcd_video_player pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface ${QTX}::Widgets)
-    #TODO: Update when CMAKE 3.10 is available
-    if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
-      target_link_libraries(pcl_pcd_video_player VTK::GUISupportQt)
-    endif()
   endif()
 
   if(WITH_OPENNI)
@@ -164,7 +152,7 @@ if(VTK_FOUND)
     target_link_libraries(pcl_openni_organized_edge_detection pcl_common pcl_io pcl_features pcl_visualization)
 
     PCL_ADD_EXECUTABLE(pcl_openni_face_detector COMPONENT ${SUBSYS_NAME} SOURCES src/face_detection//openni_face_detection.cpp src/face_detection//openni_frame_source.cpp BUNDLE)
-    target_link_libraries(pcl_openni_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree ${VTK_LIBRARIES})
+    target_link_libraries(pcl_openni_face_detector pcl_features pcl_recognition pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_sample_consensus pcl_surface pcl_keypoints pcl_ml pcl_search pcl_kdtree)
 
     if(QT_FOUND AND HAVE_QVTK)
       # OpenNI Passthrough application demo
@@ -177,10 +165,6 @@ if(VTK_FOUND)
           src/openni_passthrough.ui)
           
       target_link_libraries(pcl_openni_passthrough pcl_common pcl_io pcl_filters pcl_visualization ${QTX}::Widgets)
-      #TODO: Update when CMAKE 3.10 is available
-      if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
-        target_link_libraries(pcl_openni_passthrough VTK::GUISupportQt)
-      endif()
 
       list(APPEND CMAKE_AUTOUIC_SEARCH_PATHS "src")
 
@@ -195,10 +179,7 @@ if(VTK_FOUND)
           src/organized_segmentation_demo.ui
         BUNDLE)
       target_link_libraries(pcl_organized_segmentation_demo pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface ${QTX}::Widgets)
-      #TODO: Update when CMAKE 3.10 is available
-      if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
-        target_link_libraries(pcl_organized_segmentation_demo VTK::GUISupportQt)
-      endif()      
+
     endif()
 
     if(QHULL_FOUND)

--- a/apps/cloud_composer/CMakeLists.txt
+++ b/apps/cloud_composer/CMakeLists.txt
@@ -75,12 +75,8 @@ set(PCL_LIB_TYPE STATIC)
 
 PCL_ADD_LIBRARY(pcl_cc_tool_interface COMPONENT ${SUBSUBSYS_NAME} SOURCES ${INTERFACE_HEADERS} ${INTERFACE_SOURCES})
 
-set(vtk_libs ${VTK_LIBRARIES})
-#TODO: Update when CMAKE 3.10 is available
-if (NOT (${VTK_VERSION} VERSION_LESS 9.0))
-  set(vtk_libs VTK::GUISupportQt)
-endif()
-target_link_libraries(pcl_cc_tool_interface pcl_common pcl_filters pcl_search pcl_visualization ${QTX}::Widgets ${vtk_libs})
+
+target_link_libraries(pcl_cc_tool_interface pcl_common pcl_filters pcl_search pcl_visualization ${QTX}::Widgets)
 
 set(PCL_LIB_TYPE ${PCL_LIB_TYPE_ORIGIN})
 

--- a/apps/modeler/CMakeLists.txt
+++ b/apps/modeler/CMakeLists.txt
@@ -119,10 +119,6 @@ PCL_ADD_EXECUTABLE(
     ${impl_incs})
 
 target_link_libraries("${EXE_NAME}" pcl_common pcl_io pcl_kdtree pcl_filters pcl_visualization pcl_segmentation pcl_surface pcl_features pcl_sample_consensus pcl_search ${QTX}::Widgets)
-#TODO: Update when CMAKE 3.10 is available
-if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
-  target_link_libraries("${EXE_NAME}" VTK::GUISupportQt)
-endif()
 
 # Install include files
 PCL_ADD_INCLUDES("${SUBSUBSYS_NAME}" "${SUBSUBSYS_NAME}" ${incs})

--- a/cmake/pcl_find_vtk.cmake
+++ b/cmake/pcl_find_vtk.cmake
@@ -103,18 +103,18 @@ if (vtkMissingComponents)
   message(WARNING "Missing vtk modules: ${vtkMissingComponents}")
 endif()
 
-if("vtkGUISupportQt" IN_LIST VTK_MODULES_ENABLED AND "vtkRenderingQt" IN_LIST VTK_MODULES_ENABLED)
+if("vtkGUISupportQt" IN_LIST VTK_MODULES_ENABLED)
   set(HAVE_QVTK TRUE)
   #PCL_VTK_COMPONENTS is used in the PCLConfig.cmake to refind the required modules.
   #Pre vtk 9.0, all vtk libraries are linked into pcl_visualizer.
   #Subprojects can link against pcl_visualizer and directly use VTK-QT libraries.
-  list(APPEND PCL_VTK_COMPONENTS vtkRenderingQt vtkGUISupportQt)
+  list(APPEND PCL_VTK_COMPONENTS vtkGUISupportQt)
 elseif("GUISupportQt" IN_LIST VTK_AVAILABLE_COMPONENTS AND "RenderingQt" IN_LIST VTK_AVAILABLE_COMPONENTS)
   set(HAVE_QVTK TRUE)
   #PCL_VTK_COMPONENTS is used in the PCLConfig.cmake to refind the required modules.
   #Post vtk 9.0, only required libraries are linked against pcl_visualizer.
   #Subprojects need to manually link to VTK-QT libraries.
-  list(APPEND PCL_VTK_COMPONENTS RenderingQt GUISupportQt)
+  list(APPEND PCL_VTK_COMPONENTS GUISupportQt)
 else()
   unset(HAVE_QVTK)
 endif()

--- a/gpu/kinfu/CMakeLists.txt
+++ b/gpu/kinfu/CMakeLists.txt
@@ -26,11 +26,7 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURC
 PCL_CUDA_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${cuda})
 target_link_libraries(${LIB_NAME} pcl_cuda pcl_gpu_containers)
 
-target_compile_options(${LIB_NAME} INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:"--ftz=true;--prec-div=false;--prec-sqrt=false">)
-
-if(UNIX OR APPLE)
-  target_compile_options(${LIB_NAME} INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:"-Xcompiler=-fPIC">)
-endif()
+target_compile_options(${LIB_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ftz=true;--prec-div=false;--prec-sqrt=false>)
 
 PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS} EXT_DEPS ${EXT_DEPS})
 

--- a/gpu/kinfu_large_scale/CMakeLists.txt
+++ b/gpu/kinfu_large_scale/CMakeLists.txt
@@ -28,11 +28,7 @@ PCL_CUDA_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs
 
 target_link_libraries(${LIB_NAME} pcl_cuda pcl_common pcl_io pcl_gpu_utils pcl_gpu_containers pcl_gpu_octree pcl_octree pcl_filters)
 
-target_compile_options(${LIB_NAME} INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:"--ftz=true;--prec-div=false;--prec-sqrt=false">)
-
-if(UNIX OR APPLE)
-  target_compile_options(${LIB_NAME} INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:"-Xcompiler=-fPIC">)
-endif()
+target_compile_options(${LIB_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ftz=true;--prec-div=false;--prec-sqrt=false>)
 
 PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS} EXT_DEPS ${EXT_DEPS})
 

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -191,7 +191,7 @@ if(VTK_FOUND AND NOT ANDROID)
     src/vtk_lib_io.cpp
     src/png_io.cpp
   )
-  set(VTK_IO_TARGET_LINK_LIBRARIES vtkCommon vtkWidgets vtkIO vtkImaging vtkHybrid vtkGraphics vtkRendering vtkFiltering vtkVolumeRendering)
+
   # Indicates that we can rely on VTK to be present
   set(VTK_DEFINES -DPCL_BUILT_WITH_VTK)
 endif()
@@ -344,14 +344,23 @@ target_include_directories(${LIB_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/inclu
 target_link_libraries("${LIB_NAME}" Boost::boost Boost::filesystem Boost::iostreams pcl_common pcl_io_ply)
 
 if(VTK_FOUND)
-  if(${VTK_VERSION} VERSION_LESS 9.0)
-    link_directories(${VTK_LINK_DIRECTORIES})
-    target_link_libraries("${LIB_NAME}" ${VTK_LIBRARIES})
-  else()
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
     target_link_libraries("${LIB_NAME}" 
                           VTK::IOImage
                           VTK::IOGeometry
                           VTK::IOPLY)
+  else()
+    link_directories(${VTK_LINK_DIRECTORIES})
+    target_link_libraries("${LIB_NAME}"
+                          vtkIOImage
+                          vtkIOGeometry
+                          vtkIOMPIImage
+                          vtkIOMPIParallel
+                          vtkIOPLY
+                          )
+    if(${VTK_VERSION} VERSION_GREATER_EQUAL 7.0 AND ${VTK_VERSION} VERSION_LESS 8.0)
+      target_link_libraries("${LIB_NAME}" vtkFiltersParallelDIY2)
+    endif()
   endif()
 endif()
 

--- a/people/CMakeLists.txt
+++ b/people/CMakeLists.txt
@@ -44,7 +44,10 @@ set(srcs
 
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+
 PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})
+target_link_libraries(${LIB_NAME} pcl_common pcl_filters pcl_kdtree pcl_sample_consensus pcl_segmentation pcl_visualization)
+
 PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS})
 # Install include files
 PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}" ${incs})

--- a/surface/CMakeLists.txt
+++ b/surface/CMakeLists.txt
@@ -174,15 +174,21 @@ PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${i
 target_link_libraries("${LIB_NAME}" pcl_common pcl_search pcl_kdtree pcl_octree ${ON_NURBS_LIBRARIES})
 
 if(VTK_FOUND)
-  if(${VTK_VERSION} VERSION_LESS 9.0)
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
+    target_link_libraries("${LIB_NAME}"
+                          VTK::CommonDataModel
+                          VTK::CommonExecutionModel
+                          VTK::FiltersModeling
+                          VTK::FiltersCore)
+  else()
     include_directories(SYSTEM ${VTK_INCLUDE_DIRS})
     link_directories(${VTK_LIBRARY_DIRS})
-    target_link_libraries("${LIB_NAME}" ${VTK_LIBRARIES})
-  else()
-    target_link_libraries("${LIB_NAME}" VTK::CommonDataModel
-                                        VTK::CommonExecutionModel
-                                        VTK::FiltersModeling
-                                        VTK::FiltersCore)
+    target_link_libraries("${LIB_NAME}"
+                          vtkCommonCore
+                          vtkCommonDataModel
+                          vtkCommonExecutionModel
+                          vtkFiltersModeling
+                          vtkFiltersCore)
   endif()
 endif()
 

--- a/test/people/CMakeLists.txt
+++ b/test/people/CMakeLists.txt
@@ -15,5 +15,5 @@ endif()
 include_directories(SYSTEM ${VTK_INCLUDE_DIRS})
 PCL_ADD_TEST(a_people_detection_test test_people_detection
              FILES test_people_groundBasedPeopleDetectionApp.cpp
-             LINK_WITH pcl_gtest pcl_common pcl_io pcl_kdtree pcl_search pcl_features pcl_sample_consensus pcl_filters pcl_io pcl_segmentation pcl_people
+             LINK_WITH pcl_gtest pcl_common pcl_io pcl_kdtree pcl_search pcl_features pcl_sample_consensus pcl_filters pcl_segmentation pcl_people
              ARGUMENTS "${PCL_SOURCE_DIR}/people/data/trainedLinearSVMForPeopleDetectionWithHOG.yaml" "${PCL_SOURCE_DIR}/test/five_people.pcd")

--- a/test/people/test_people_groundBasedPeopleDetectionApp.cpp
+++ b/test/people/test_people_groundBasedPeopleDetectionApp.cpp
@@ -48,7 +48,6 @@
 #include <pcl/test/gtest.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
-#include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/sample_consensus/sac_model_plane.h>
 #include <pcl/people/ground_based_people_detection_app.h>
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SUBSYS_NAME tools)
 set(SUBSYS_DESC "Useful PCL-based command line tools")
 set(SUBSYS_DEPS common io filters sample_consensus segmentation search kdtree features surface octree registration recognition geometry keypoints ml)
-set(SUBSYS_OPT_DEPS visualization)
+set(SUBSYS_OPT_DEPS vtk visualization)
 set(DEFAULT ON)
 set(REASON "")
 
@@ -200,8 +200,8 @@ else()
 
   PCL_ADD_EXECUTABLE(pcl_obj2pcd COMPONENT ${SUBSYS_NAME} SOURCES obj2pcd.cpp)
   target_link_libraries(pcl_obj2pcd pcl_common pcl_io)
-  #TODO: Update when CMAKE 3.10 is available
-  if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
+
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
     target_link_libraries(pcl_obj2pcd VTK::FiltersCore)
   endif()
 
@@ -210,8 +210,8 @@ else()
 
   PCL_ADD_EXECUTABLE(pcl_vtk2pcd COMPONENT ${SUBSYS_NAME} SOURCES vtk2pcd.cpp)
   target_link_libraries(pcl_vtk2pcd pcl_common pcl_io)
-  #TODO: Update when CMAKE 3.10 is available
-  if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
+
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
     target_link_libraries(pcl_vtk2pcd VTK::FiltersCore)
   endif()
 
@@ -244,13 +244,13 @@ else()
     target_link_libraries(pcl_octree_viewer pcl_common pcl_io pcl_octree pcl_visualization pcl_kdtree pcl_filters)
 
     PCL_ADD_EXECUTABLE(pcl_mesh2pcd COMPONENT ${SUBSYS_NAME} SOURCES mesh2pcd.cpp)
-    target_link_libraries(pcl_mesh2pcd pcl_common pcl_io pcl_visualization pcl_filters ${VTK_LIBRARIES})
+    target_link_libraries(pcl_mesh2pcd pcl_common pcl_io pcl_visualization pcl_filters)
 
     PCL_ADD_EXECUTABLE(pcl_mesh_sampling COMPONENT ${SUBSYS_NAME} SOURCES mesh_sampling.cpp)
-    target_link_libraries(pcl_mesh_sampling pcl_common pcl_io pcl_visualization pcl_filters ${VTK_LIBRARIES})
+    target_link_libraries(pcl_mesh_sampling pcl_common pcl_io pcl_visualization pcl_filters)
 
     PCL_ADD_EXECUTABLE(pcl_virtual_scanner COMPONENT ${SUBSYS_NAME} SOURCES virtual_scanner.cpp)
-    target_link_libraries(pcl_virtual_scanner pcl_common pcl_io pcl_filters pcl_visualization ${VTK_LIBRARIES})
+    target_link_libraries(pcl_virtual_scanner pcl_common pcl_io pcl_filters pcl_visualization)
 
     PCL_ADD_EXECUTABLE(pcl_voxel_grid_occlusion_estimation COMPONENT ${SUBSYS_NAME} SOURCES voxel_grid_occlusion_estimation.cpp)
     target_link_libraries (pcl_voxel_grid_occlusion_estimation pcl_common pcl_io pcl_filters pcl_visualization)

--- a/tools/tiff2pcd.cpp
+++ b/tools/tiff2pcd.cpp
@@ -50,11 +50,7 @@
 
 #include <vtkImageData.h> // for vtkImageData
 #include <vtkSmartPointer.h>
-#include <vtkImageViewer2.h>
 #include <vtkTIFFReader.h>
-#include <vtkRenderWindow.h>
-#include <vtkRenderWindowInteractor.h>
-#include <vtkRenderer.h>
 
 using namespace pcl;
 

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -141,7 +141,7 @@ if(VTK_RENDERING_BACKEND_OPENGL_VERSION VERSION_LESS 2)
   )
 endif()
 
-if(NOT (${VTK_VERSION} VERSION_LESS 9.0))
+if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
   if(NOT (";${VTK_AVAILABLE_COMPONENTS};" MATCHES ";RenderingContextOpenGL2;"))
     
     list(REMOVE_ITEM incs
@@ -166,10 +166,7 @@ endif()
 
 target_link_libraries("${LIB_NAME}" pcl_common pcl_io pcl_kdtree ${OPENGL_LIBRARIES})
 
-if(${VTK_VERSION} VERSION_LESS 9.0)
-  target_include_directories("${LIB_NAME}" SYSTEM PUBLIC ${VTK_INCLUDE_DIRS})
-  target_link_libraries("${LIB_NAME}" ${VTK_LIBRARIES})
-else()
+if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
   #Some libs are referenced through depending on IO
   target_link_libraries("${LIB_NAME}"
                         VTK::ChartsCore
@@ -193,8 +190,48 @@ else()
                         VTK::RenderingOpenGL2
                         VTK::ViewsContext2D)
                         
-  if(";${VTK_AVAILABLE_COMPONENTS};" MATCHES ";RenderingContextOpenGL2;")
+  if("RenderingContextOpenGL2" IN_LIST VTK_AVAILABLE_COMPONENTS)
     target_link_libraries("${LIB_NAME}" VTK::RenderingContextOpenGL2)
+  endif()
+else()
+  target_include_directories("${LIB_NAME}" SYSTEM PUBLIC ${VTK_INCLUDE_DIRS})
+  target_link_libraries("${LIB_NAME}"
+                        vtkChartsCore
+                        vtkFiltersExtraction
+                        vtkFiltersGeometry
+                        vtkFiltersModeling
+                        vtkImagingCore
+                        vtkImagingSources
+                        vtkInteractionStyle
+                        vtkRenderingAnnotation
+                        vtkRenderingContext2D
+                        vtkRenderingContext${VTK_RENDERING_BACKEND}
+                        vtkRenderingFreeType
+                        vtkRenderingLOD
+                        vtkRendering${VTK_RENDERING_BACKEND}
+                        vtkViewsContext2D)
+  if(${VTK_VERSION} VERSION_LESS 7.0)
+    target_link_libraries("${LIB_NAME}" vtkRenderingVolume${VTK_RENDERING_BACKEND})  	
+  endif()
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL 7.0 AND ${VTK_VERSION} VERSION_LESS 9.0)
+    target_link_libraries("${LIB_NAME}" vtkRenderingGL2PS${VTK_RENDERING_BACKEND})
+  endif()
+  
+  # These two libraries are present and required in ubuntu 18.04 VTK 6, but not present in later versions of ubuntu using VTK 6.
+  # They are also present on later versions of VTK on later versions of ubuntu.
+  if("vtkRenderingFreeTypeFontConfig" IN_LIST VTK_MODULES_ENABLED)
+    target_link_libraries("${LIB_NAME}" vtkRenderingFreeTypeFontConfig)
+  endif()
+  if("vtkRenderingMatplotlib" IN_LIST VTK_MODULES_ENABLED)
+    target_link_libraries("${LIB_NAME}" vtkRenderingMatplotlib)
+  endif()
+endif()
+
+if(HAVE_QVTK)
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
+    target_link_libraries("${LIB_NAME}" VTK::GUISupportQt)
+  else()
+    target_link_libraries("${LIB_NAME}" vtkGUISupportQt)
   endif()
 endif()
 


### PR DESCRIPTION
As some vtk library polluted cuda flags with -FPIC.

I couldn't figure out which VTK library that did this, ie. to try rewrite the properties like done with the Qt libraries.