### PR TITLE
[pcl_cuda_common] Export the pkgconfig file

### DIFF
--- a/cuda/common/CMakeLists.txt
+++ b/cuda/common/CMakeLists.txt
@@ -29,10 +29,10 @@ set(common_incs
     )
 
 include_directories(./include)
-#set(LIB_NAME pcl_${SUBSYS_NAME})
+set(LIB_NAME pcl_${SUBSYS_NAME})
 set(EXT_DEPS CUDA)
-#PCL_MAKE_PKGCONFIG(${LIB_NAME} ${SUBSYS_NAME} "${SUBSYS_DESC}"
-#    "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")
+PCL_MAKE_PKGCONFIG(${LIB_NAME} ${SUBSYS_NAME} "${SUBSYS_DESC}"
+    "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")
 
 # Install include files
 PCL_ADD_INCLUDES(${SUBSYS_NAME} "cuda" ${incs})

--- a/cuda/common/CMakeLists.txt
+++ b/cuda/common/CMakeLists.txt
@@ -29,10 +29,10 @@ set(common_incs
     )
 
 include_directories(./include)
-set(LIB_NAME pcl_${SUBSYS_NAME})
+set(LIB_NAME "pcl_${SUBSYS_NAME}")
 set(EXT_DEPS CUDA)
-PCL_MAKE_PKGCONFIG(${LIB_NAME} ${SUBSYS_NAME} "${SUBSYS_DESC}"
-    "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")
+PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC "${SUBSYS_DESC}"
+    PCL_DEPS "${SUBSYS_DEPS}" EXT_DEPS "" HEADER_ONLY)
 
 # Install include files
 PCL_ADD_INCLUDES(${SUBSYS_NAME} "cuda" ${incs})


### PR DESCRIPTION
Other `pcl_cuda` components depend on `pcl_cuda_common`, export it to correctly use the pkgconfig files of the `pcl_cuda_*` pkgconfigs.

Fixes https://github.com/PointCloudLibrary/pcl/issues/5025.