### PR TITLE
[pcl_io] Set libusb as a required dependency of openni in non-Windows

### DIFF
--- a/cmake/Modules/FindOpenNI.cmake
+++ b/cmake/Modules/FindOpenNI.cmake
@@ -51,7 +51,7 @@ if(OPENNI_INCLUDE_DIR AND OPENNI_LIBRARY)
   mark_as_advanced(OPENNI_INCLUDE_DIRS)
 
   # Libraries
-  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if(NOT WIN32)
     find_package(libusb REQUIRED)
     set(OPENNI_LIBRARIES ${OPENNI_LIBRARY} libusb::libusb)
   else()

--- a/cmake/Modules/FindOpenNI2.cmake
+++ b/cmake/Modules/FindOpenNI2.cmake
@@ -41,7 +41,7 @@ if(OPENNI2_INCLUDE_DIR AND OPENNI2_LIBRARY)
   mark_as_advanced(OPENNI2_INCLUDE_DIRS)
 
   # Libraries
-  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if(NOT WIN32)
     find_package(libusb REQUIRED)
     set(OPENNI2_LIBRARIES ${OPENNI2_LIBRARY} libusb::libusb)
   else()


### PR DESCRIPTION
Fix the condition of finding `libusb` in `FindOpenNI[2].cmake` to adapt to the condition in cpp code.

Fixes #5027.