### PR TITLE
PLY parser: accept files with whitespace at line end

### DIFF
--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -157,7 +157,7 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
       std::string name;
       std::size_t count;
       char space_element_name, space_name_count;
-      stringstream >> space_element_name >> std::ws >> name >> space_name_count >> std::ws >> count;
+      stringstream >> space_element_name >> std::ws >> name >> space_name_count >> std::ws >> count >> std::ws;
       if (!stringstream ||
           !stringstream.eof () ||
           !isspace (space_element_name) ||

--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -116,9 +116,10 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
       if (!stringstream.eof ())
       {
         stringstream >> std::ws;
-	warning_callback_ (line_number_, "parse warning: trailing whitespaces in the header");
+        warning_callback_ (line_number_, "parse warning: trailing whitespaces in the header");
       }
       if (!stringstream ||
+          !stringstream.eof () ||
           !isspace (space_format_format_string) ||
           !isspace (space_format_string_version))
       {
@@ -165,9 +166,10 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
       if (!stringstream.eof ())
       {
         stringstream >> std::ws;
-	warning_callback_ (line_number_, "parse warning: trailing whitespaces in the header");
+        warning_callback_ (line_number_, "parse warning: trailing whitespaces in the header");
       }
       if (!stringstream ||
+          !stringstream.eof () ||
           !isspace (space_element_name) ||
           !isspace (space_name_count))
       {

--- a/io/src/ply/ply_parser.cpp
+++ b/io/src/ply/ply_parser.cpp
@@ -113,8 +113,12 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
       std::string format_string, version;
       char space_format_format_string, space_format_string_version;
       stringstream >> space_format_format_string >> std::ws >> format_string >> space_format_string_version >> std::ws >> version;
+      if (!stringstream.eof ())
+      {
+        stringstream >> std::ws;
+	warning_callback_ (line_number_, "parse warning: trailing whitespaces in the header");
+      }
       if (!stringstream ||
-          !stringstream.eof () ||
           !isspace (space_format_format_string) ||
           !isspace (space_format_string_version))
       {
@@ -157,9 +161,13 @@ bool pcl::io::ply::ply_parser::parse (const std::string& filename)
       std::string name;
       std::size_t count;
       char space_element_name, space_name_count;
-      stringstream >> space_element_name >> std::ws >> name >> space_name_count >> std::ws >> count >> std::ws;
+      stringstream >> space_element_name >> std::ws >> name >> space_name_count >> std::ws >> count;
+      if (!stringstream.eof ())
+      {
+        stringstream >> std::ws;
+	warning_callback_ (line_number_, "parse warning: trailing whitespaces in the header");
+      }
       if (!stringstream ||
-          !stringstream.eof () ||
           !isspace (space_element_name) ||
           !isspace (space_name_count))
       {


### PR DESCRIPTION
If element in the header contains whitespaces after the count, remove
them.

A laser scanner company is exporting ply files with trailing whitespaces in the `element` header. I contacted them but meanwhile the change proposed keeps users able to load such files.