### PR TITLE
Require sphinx>=3 to fix errors on readthedocs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx>=3
 sphinxcontrib-doxylink


### PR DESCRIPTION
See https://blog.readthedocs.com/build-errors-docutils-0-18/