### PR TITLE
Make FunctorFilter API better

### DIFF
--- a/doc/tutorials/content/sources/CMakeLists.txt
+++ b/doc/tutorials/content/sources/CMakeLists.txt
@@ -15,6 +15,7 @@ foreach(subdir
   cylinder_segmentation
   extract_indices
   #feature_evaluation
+  function_filter
   greedy_projection
   implicit_shape_model
   iterative_closest_point


### PR DESCRIPTION
Primary goal:
* Make it easy for C++17 users (via deduction guides and maker function for complex cases)
* Make it easy for C++14 users (via maker function, similar to C++ standard)

Secondary goal:
* Set stage for reducing the required template arguments so that UX seems better
* Important for experimental::VoxelFilters to be introduced and used
* Provide a possible solution to the discussion in experimental::VoxelFilter GSoC PR regarding the order of the template arguments

What impacts the order of template arguments:
* `PointT` can't be deduced in 100% of scenarios (eg: lambda with auto as 1st argument)
* `PointT` is 1st argument in almost all classes in PCL
* Input function object can be nearly always deduced:
    * it can't be pointer to templated function (we store a pointer to it, so needs to be defined)
    * it it's a class with a templated call operator (lambda or similar), the template parameter is known, but not the point type

=> PointT needs to be the 1st argument

## Setup
With different types of possible functions
```cpp
bool simple_function(const pcl::PointCloud<pcl::PointXYZ>& cloud, pcl::index_t idx) {
  return true;
}

template <class PointT>
bool templated_function(const pcl::PointCloud<pcl::PointXYZ>& cloud, pcl::index_t idx) {
  return true;
}

const auto proper_lambda = [](const pcl::PointCloud<pcl::PointXYZ>& cloud, pcl::index_t idx) ->bool {
  return true;
};

const auto templated_lambda = [](const auto& cloud, pcl::index_t idx) ->bool {
  return true;
};

namespace pcl {
using namespace experimental::advanced;
}
```

## Comparison
Things to notice:
* Alternative options in C++17
* Handling of templated_lambda
### Current (C++14 or C++17)
```cpp
pcl::FunctorFilter<pcl::PointXYZ, decltype(simple_function<pcl::PointTXYZ>)> func_filter(simple_function);
pcl::FunctorFilter<pcl::PointXYZ, decltype(templated_function<pcl::PointTXYZ>)> temp_func_filter(templated_function<pcl::PointXYZ>);
pcl::FunctorFilter<pcl::PointXYZ, decltype(proper_lambda)> plambda_filter(proper_lambda);
pcl::FunctorFilter<pcl::PointXYZ, decltype(templated_lambda)> tlambda_filter(templated_lambda);
```
### Post PR (C++14)
Much simpler and easy to read:
```cpp
auto func_filter = pcl::make_functor_filter(simple_function);
auto temp_func_filter = pcl::make_functor_filter(templated_function<pcl::PointXYZ>);
auto plambda_filter = pcl::make_functor_filter(proper_lambda);
auto tlambda_filter = pcl::make_functor_filter<pcl::PointXYZ>(templated_lambda);
```
### Post PR (C++17)
Shorter and no need to rely on a function in most cases
```cpp
// Previous ones are still valid (It's C++)
pcl::FunctorFilter func_filter (simple_function);
pcl::FunctorFilter temp_func_filter (templated_function<pcl::PointXYZ>);
pcl::FunctorFilter plambda_filter (proper_lambda);

// sadly, templated lambda can't be done in the same manner because
// 1. partial template deduction is not supported, so the before version with decltype needs to be used
// 2. it's impossible to deduce the point type, so make_functor_filter needs to be supplied with it
```

## TODO
Tests. If this approach is ok, I'll add tests in this PR itself