### PR TITLE
Fix Bug  between addText3D and QVTKWidget

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -756,7 +756,6 @@ pcl::visualization::PCLVisualizer::addText3D (
 
       renderer->AddActor (textActor);
       
-     
       // Save the pointer/ID pair to the global actor map. If we are saving multiple vtkFollowers
       // for multiple viewport
       const std::string uid = tid + std::string (i, '*');

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -755,7 +755,7 @@ pcl::visualization::PCLVisualizer::addText3D (
       textActor->SetCamera (renderer->GetActiveCamera ());
 
       renderer->AddActor (textActor);
-      renderer->Render ();
+      //renderer->Render ();
 
       // Save the pointer/ID pair to the global actor map. If we are saving multiple vtkFollowers
       // for multiple viewport


### PR DESCRIPTION
When using addtext3d to display 3D text in qvtkwidget, an error "access conflict occurs when reading position 0x000000000000008" will be reported. The reason is that "render - > render()" has been used in addtext3d once, but to send 3D text to qvtkwidget window, execute "UI - > qvtkwidget - > setrenderwindow (viewer - > getrenderwindow());Viewer - > setupinteractor (UI - > qvtkwidget - > getinteractor()); ", which is equivalent to repeated rendering, resulting in pointer out of bounds.
After experiments, it is OK to delete "render - > render()" and it works normally when it does not interact with qvtkwidget