### PR TITLE
Allow unsorted search tree to be used

### DIFF
--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -124,8 +124,10 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::extractEuclideanClustersSm
         continue;
       }
 
-      for (std::size_t j = 1; j < nn_indices.size (); ++j) // nn_indices[0] should be sq_idx
-      {
+      for (std::size_t j = 0; j < nn_indices.size(); ++j) {
+        if (seed_queue[sq_idx] == nn_indices[j]) { // Don't process the same point
+          continue;
+        }
         if (processed[nn_indices[j]]) // Has this point been processed before ?
           continue;
 

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -96,8 +96,10 @@ inline void extractEuclideanClustersSmooth(const typename pcl::PointCloud<PointT
         continue;
       }
 
-      for (std::size_t j = 1; j < nn_indices.size (); ++j) // nn_indices[0] should be sq_idx
-      {
+      for (std::size_t j = 0; j < nn_indices.size(); ++j) {
+        if (seed_queue[sq_idx] == nn_indices[j]) { // Don't process the same point
+          continue;
+        }
         if (processed[nn_indices[j]]) // Has this point been processed before ?
           continue;
 

--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -151,8 +151,10 @@ namespace pcl
           continue;
         }
 
-        for (std::size_t j = 1; j < nn_indices.size (); ++j)             // nn_indices[0] should be sq_idx
-        {
+        for (std::size_t j = 0; j < nn_indices.size(); ++j) {
+          if (seed_queue[sq_idx] == nn_indices[j]) { // Don't process the same point
+            continue;
+          }
           if (processed[nn_indices[j]])                         // Has this point been processed before ?
             continue;
 
@@ -271,8 +273,10 @@ namespace pcl
           continue;
         }
 
-        for (std::size_t j = 1; j < nn_indices.size (); ++j)             // nn_indices[0] should be sq_idx
-        {
+        for (std::size_t j = 0; j < nn_indices.size(); ++j) {
+          if (seed_queue[sq_idx] == nn_indices[j]) { // Don't process the same point
+            continue;
+          }
           if (processed[nn_indices[j]])                             // Has this point been processed before ?
             continue;
 

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -107,9 +107,10 @@ pcl::extractLabeledEuclideanClusters(
         continue;
       }
 
-      for (std::size_t j = 1; j < nn_indices.size();
-           ++j) // nn_indices[0] should be sq_idx
-      {
+      for (std::size_t j = 0; j < nn_indices.size(); ++j) {
+        if (seed_queue[sq_idx] == nn_indices[j]) { // Don't process the same point
+          continue;
+        }
         if (processed[nn_indices[j]]) // Has this point been processed before ?
           continue;
         if (cloud[i].label == cloud[nn_indices[j]].label) {

--- a/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/seeded_hue_segmentation.hpp
@@ -96,8 +96,10 @@ pcl::seededHueSegmentation (const PointCloud<PointXYZRGB>          &cloud,
         continue;
       }
 
-      for (std::size_t j = 1; j < nn_indices.size (); ++j)             // nn_indices[0] should be sq_idx
-      {
+      for (std::size_t j = 0; j < nn_indices.size(); ++j) {
+        if (seed_queue[sq_idx] == nn_indices[j]) { // Don't process the same point
+          continue;
+        }
         if (processed[nn_indices[j]])                             // Has this point been processed before ?
           continue;
 
@@ -173,8 +175,10 @@ pcl::seededHueSegmentation (const PointCloud<PointXYZRGB>            &cloud,
         sq_idx++;
         continue;
       }
-      for (std::size_t j = 1; j < nn_indices.size (); ++j)             // nn_indices[0] should be sq_idx
-      {
+      for (std::size_t j = 0; j < nn_indices.size(); ++j) {
+        if (seed_queue[sq_idx] == nn_indices[j]) { // Don't process the same point
+          continue;
+        }
         if (processed[nn_indices[j]])                             // Has this point been processed before ?
           continue;
 


### PR DESCRIPTION
Provides a more robust fix to issues described in #4999

**TL;DR**: current algorithm assumes the output of `radiusSearch` is sorted. This is not always the case. A solution is to skip the point when it matches the query index (implemented here)

It is also possible to only perform this when the search is un-sorted, and the current patch can be updated to reflect that. I'm not sure how much of a difference that is going to make, specially since a lot of logic would need to be duplicated to provide the minimal benefit. That could also be done simply by using `[[unlikely]]` (but that's added in C++20 in the standard, with compiler specific versions available). A separate PR can add that to pcl_macros.h + update here and other places

