### PR TITLE
Fix position of `EIGEN_ALIGN` in tutorial

### DIFF
--- a/doc/tutorials/content/adding_custom_ptype.rst
+++ b/doc/tutorials/content/adding_custom_ptype.rst
@@ -830,12 +830,12 @@ data (SSE padded), together with a test float.
    #include <pcl/point_cloud.h>
    #include <pcl/io/pcd_io.h>
 
-   struct MyPointType
+   struct EIGEN_ALIGN16 MyPointType    // enforce SSE padding for correct memory alignment
    {
      PCL_ADD_POINT4D;                  // preferred way of adding a XYZ+padding
      float test;
      PCL_MAKE_ALIGNED_OPERATOR_NEW     // make sure our new allocators are aligned
-   } EIGEN_ALIGN16;                    // enforce SSE padding for correct memory alignment
+   };
 
    POINT_CLOUD_REGISTER_POINT_STRUCT (MyPointType,           // here we assume a XYZ + "test" (as fields)
                                       (float, x, x)


### PR DESCRIPTION
The position of EIGEN_ALIGN is off in the tutorial.