### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig file, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+tab_width = 2
+trim_trailing_whitespace = true
+
+# Visual C++ Code Style settings
+cpp_generate_documentation_comments = doxygen_slash_star


### PR DESCRIPTION
Several projects I've seen have been adding an [EditorConfig](https://editorconfig.org) file in the recent past (e.g. CMake & GDAL). Since EditorConfig is a universal file format [supported by various IDEs](https://editorconfig.org/#pre-installed), it would be useful to include it here as well. Even if we already ensure the general formatting with ClangFormat, it simplifies e.g. the generation of the comment blocks, because you already tell the IDE which style you prefer (see e.g. [here](https://devblogs.microsoft.com/cppblog/doxygen-and-xml-doc-comment-support/)).

*Note* I defined `tab_width`, even the PCL prefers spaces, as the included 3rd party libs seems to prefer tabs over spaces.