### PR TITLE
Use C++14 helper typedef

### DIFF
--- a/common/include/pcl/common/common.h
+++ b/common/include/pcl/common/common.h
@@ -286,7 +286,7 @@ namespace pcl
   #if __cpp_lib_is_invocable
   std::invoke_result_t<Functor, decltype(*begin)>
   #else
-  typename std::result_of<Functor(decltype(*begin))>::type
+  typename std::result_of_t<Functor(decltype(*begin))>
   #endif
   {
     const std::size_t size = std::distance(begin, end);

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -89,8 +89,8 @@ template <class TupleType>
 class PCLCropHullTestFixture : public ::testing::Test
 {
   public:
-    using CropHullTestTraits = typename std::tuple_element<0, TupleType>::type;
-    using RandomGeneratorType =  typename std::tuple_element<1, TupleType>::type;
+    using CropHullTestTraits = typename std::tuple_element_t<0, TupleType>;
+    using RandomGeneratorType =  typename std::tuple_element_t<1, TupleType>;
 
     PCLCropHullTestFixture()
     {
@@ -286,12 +286,12 @@ using CropHullTestTraits3dList = std::tuple<
   std::tuple<CropHullTestTraits3d, RandomGenerator<456>>
   >;
 using CropHullTestTypes = ::testing::Types<
-  std::tuple_element<0, CropHullTestTraits2dList>::type,
-  std::tuple_element<1, CropHullTestTraits2dList>::type,
-  std::tuple_element<2, CropHullTestTraits2dList>::type,
-  std::tuple_element<0, CropHullTestTraits3dList>::type,
-  std::tuple_element<1, CropHullTestTraits3dList>::type,
-  std::tuple_element<2, CropHullTestTraits3dList>::type
+  std::tuple_element_t<0, CropHullTestTraits2dList>,
+  std::tuple_element_t<1, CropHullTestTraits2dList>,
+  std::tuple_element_t<2, CropHullTestTraits2dList>,
+  std::tuple_element_t<0, CropHullTestTraits3dList>,
+  std::tuple_element_t<1, CropHullTestTraits3dList>,
+  std::tuple_element_t<2, CropHullTestTraits3dList>
   >;
 TYPED_TEST_SUITE(PCLCropHullTestFixture, CropHullTestTypes);
 


### PR DESCRIPTION
Just saw #5083 and wondered why the long form is still used there.

Checked now the whole PCL code for code similar to this (Searched for `std::.*::type` as Boost seems to not have these helpers). Sadly I couldn't replace `::value` by `_v` as this is C++17.