### PR TITLE
Remove duplicated typename as it is already implicit present

### DIFF
--- a/common/include/pcl/common/common.h
+++ b/common/include/pcl/common/common.h
@@ -286,7 +286,7 @@ namespace pcl
   #if __cpp_lib_is_invocable
   std::invoke_result_t<Functor, decltype(*begin)>
   #else
-  typename std::result_of_t<Functor(decltype(*begin))>
+  std::result_of_t<Functor(decltype(*begin))>
   #endif
   {
     const std::size_t size = std::distance(begin, end);

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -89,8 +89,8 @@ template <class TupleType>
 class PCLCropHullTestFixture : public ::testing::Test
 {
   public:
-    using CropHullTestTraits = typename std::tuple_element_t<0, TupleType>;
-    using RandomGeneratorType =  typename std::tuple_element_t<1, TupleType>;
+    using CropHullTestTraits = std::tuple_element_t<0, TupleType>;
+    using RandomGeneratorType = std::tuple_element_t<1, TupleType>;
 
     PCLCropHullTestFixture()
     {


### PR DESCRIPTION
Forgot in #5096, that the `typename` is not necessary anymore, as:

```cpp
template <size_t _Index, class _Tuple>
using tuple_element_t = typename tuple_element<_Index, _Tuple>::type;
```

I am just curious if could use this way also for e.g. `typename PointCloud::Ptr`