### PR TITLE
Perform static cast + transform instead of simple copy to avoid compiler warning

### DIFF
--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -175,7 +175,7 @@ knn_search(A& index, B& query, C& k_indices, D& dists, unsigned int k, F& params
   std::transform(indices.cbegin(),
                  indices.cend(),
                  k_indices.begin(),
-                 [](std::size_t x) { return static_cast<pcl::index_t>(x); });
+                 [](const auto& x) { return static_cast<pcl::index_t>(x); });
   return ret;
 }
 
@@ -312,7 +312,7 @@ radius_search(A& index, B& query, C& k_indices, D& dists, float radius, F& param
   std::transform(indices[0].cbegin(),
                  indices[0].cend(),
                  k_indices.begin(),
-                 [](std::size_t x) { return static_cast<pcl::index_t>(x); });
+                 [](const auto& x) { return static_cast<pcl::index_t>(x); });
   return neighbors_in_radius;
 }
 

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -171,8 +171,11 @@ knn_search(A& index, B& query, C& k_indices, D& dists, unsigned int k, F& params
   // Wrap indices vector (no data allocation)
   ::flann::Matrix<std::size_t> indices_mat(&indices[0], 1, k);
   auto ret = index.knnSearch(query, indices_mat, dists, k, params);
-  std::copy(indices.cbegin(), indices.cend(), k_indices.begin());
-  return ret;
+  // cast appropriately
+  std::transform(indices.cbegin(),
+                 indices.cend(),
+                 k_indices.begin(),
+                 [](std::size_t x) { return static_cast<pcl::index_t>(x); }) return ret;
 }
 
 template <class IndexT, class A, class B, class F, CompatWithFlann<IndexT> = true>
@@ -304,7 +307,11 @@ radius_search(A& index, B& query, C& k_indices, D& dists, float radius, F& param
   std::vector<std::vector<std::size_t>> indices(1);
   int neighbors_in_radius = index.radiusSearch(query, indices, dists, radius, params);
   k_indices.resize(indices[0].size());
-  std::copy(indices[0].cbegin(), indices[0].cend(), k_indices.begin());
+  // cast appropriately
+  std::transform(indices[0].cbegin(),
+                 indices[0].cend(),
+                 k_indices.begin(),
+                 [](std::size_t x) { return static_cast<pcl::index_t>(x); });
   return neighbors_in_radius;
 }
 

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -175,7 +175,8 @@ knn_search(A& index, B& query, C& k_indices, D& dists, unsigned int k, F& params
   std::transform(indices.cbegin(),
                  indices.cend(),
                  k_indices.begin(),
-                 [](std::size_t x) { return static_cast<pcl::index_t>(x); }) return ret;
+                 [](std::size_t x) { return static_cast<pcl::index_t>(x); });
+  return ret;
 }
 
 template <class IndexT, class A, class B, class F, CompatWithFlann<IndexT> = true>


### PR DESCRIPTION
This should have been mainstreamed long ago :)
