### PR TITLE
Drop $PCL_SOURCES_TREE from installation cmake

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -409,7 +409,6 @@ elseif(EXISTS "${PCL_DIR}/include/pcl/pcl_config.h")
   # pcl_message("PCL found into a build tree.")
   set(PCL_CONF_INCLUDE_DIR "${PCL_DIR}/include") # for pcl_config.h
   set(PCL_LIBRARY_DIRS "${PCL_DIR}/@LIB_INSTALL_DIR@")
-  set(PCL_SOURCES_TREE "@CMAKE_SOURCE_DIR@")
 else()
   pcl_report_not_found("PCL can not be found on this machine")
 endif()
@@ -504,7 +503,6 @@ foreach(component ${PCL_TO_FIND_COMPONENTS})
           pcl/cuda/${cuda_component} pcl/cuda/${component}
           pcl/gpu/${gpu_component} pcl/gpu/${component}
     HINTS ${PCL_INCLUDE_DIRS}
-          "${PCL_SOURCES_TREE}"
     PATH_SUFFIXES
           ${component}/include
           apps/${component}/include


### PR DESCRIPTION
It is not used elsewhere and makes the build unreproducible.