### PR TITLE
Fix segfault executing multiscale feature persistence

### DIFF
--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -167,11 +167,16 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
   unique_features_table_.reserve (scale_values_.size ());
 
   std::vector<float> diff_vector;
+  std::size_t size = 0;
+  for (const auto& feature : features_at_scale_vectorized_)
+  {
+    size = std::max(size, feature.size());
+  }
+  diff_vector.reserve(size);
   for (std::size_t scale_i = 0; scale_i < features_at_scale_vectorized_.size (); ++scale_i)
   {
     // Calculate standard deviation within the scale
     float standard_dev = 0.0;
-    diff_vector.reserve(features_at_scale_vectorized_[scale_i].size ());
     diff_vector.clear();
 
     for (const auto& feature: features_at_scale_vectorized_[scale_i])

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -171,6 +171,8 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
   {
     // Calculate standard deviation within the scale
     float standard_dev = 0.0;
+    diff_vector.reserve(features_at_scale_vectorized_[scale_i].size ());
+    diff_vector.clear();
 
     for (const auto& feature: features_at_scale_vectorized_[scale_i])
     {
@@ -194,7 +196,6 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
     }
     unique_features_indices_.emplace_back (std::move(indices_per_scale));
     unique_features_table_.emplace_back (std::move(indices_table_per_scale));
-    diff_vector.clear();
   }
 }
 

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -147,7 +147,7 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::calculateMeanFeatu
                      feature.cbegin (), mean_feature_.begin (), std::plus<>{});
   }
 
-  const float factor = std::min<float>(1, normalization_factor);
+  const float factor = std::max<float>(1, normalization_factor);
   std::transform(mean_feature_.cbegin(),
                  mean_feature_.cend(),
                  mean_feature_.begin(),

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -166,11 +166,11 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
   unique_features_indices_.reserve (scale_values_.size ());
   unique_features_table_.reserve (scale_values_.size ());
 
+  std::vector<float> diff_vector;
   for (std::size_t scale_i = 0; scale_i < features_at_scale_vectorized_.size (); ++scale_i)
   {
     // Calculate standard deviation within the scale
     float standard_dev = 0.0;
-    std::vector<float> diff_vector (features_at_scale_vectorized_[scale_i].size ());
 
     for (const auto& feature: features_at_scale_vectorized_[scale_i])
     {
@@ -194,6 +194,7 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
     }
     unique_features_indices_.emplace_back (std::move(indices_per_scale));
     unique_features_table_.emplace_back (std::move(indices_table_per_scale));
+    diff_vector.clear();
   }
 }
 

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -190,8 +190,8 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
 
     // Select only points outside (mean +/- alpha * standard_dev)
     std::list<std::size_t> indices_per_scale;
-    std::vector<bool> indices_table_per_scale (features_at_scale_[scale_i]->size (), false);
-    for (std::size_t point_i = 0; point_i < features_at_scale_[scale_i]->size (); ++point_i)
+    std::vector<bool> indices_table_per_scale (features_at_scale_vectorized_[scale_i].size (), false);
+    for (std::size_t point_i = 0; point_i < features_at_scale_vectorized_[scale_i].size (); ++point_i)
     {
       if (diff_vector[point_i] > alpha_ * standard_dev)
       {

--- a/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
+++ b/features/include/pcl/features/impl/multiscale_feature_persistence.hpp
@@ -95,7 +95,7 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::computeFeaturesAtA
   {
     FeatureCloudPtr feature_cloud (new FeatureCloud ());
     computeFeatureAtScale (scale_values_[scale_i], feature_cloud);
-    features_at_scale_[scale_i] = feature_cloud;
+    features_at_scale_.push_back(feature_cloud);
 
     // Vectorize each feature and insert it into the vectorized feature storage
     std::vector<std::vector<float> > feature_cloud_vectorized;
@@ -171,7 +171,6 @@ pcl::MultiscaleFeaturePersistence<PointSource, PointFeature>::extractUniqueFeatu
     // Calculate standard deviation within the scale
     float standard_dev = 0.0;
     std::vector<float> diff_vector (features_at_scale_vectorized_[scale_i].size ());
-    diff_vector.clear();
 
     for (const auto& feature: features_at_scale_vectorized_[scale_i])
     {


### PR DESCRIPTION
Closes #4683 . That pull request is more or less inactive and not in a merge-able state (tests do not compile). This pull request is a copy of #4683 , but contains only the changes to multiscale_feature_persistence.hpp (the bugfix).
@NehilDanis FYI. Thank you for the bugfix nonetheless.
Closes #4679