### PR TITLE
Don't require boost in pkg-config

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -415,7 +415,7 @@ if(PCAP_FOUND)
   target_link_libraries("${LIB_NAME}" ${PCAP_LIBRARIES})
 endif()
 
-set(EXT_DEPS eigen3)
+set(EXT_DEPS eigen3) # Although this depends on boost, that cannot be specified here because there is no boost.pc
 
 if(WITH_OPENNI)
   list(APPEND EXT_DEPS libopenni)

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -415,7 +415,7 @@ if(PCAP_FOUND)
   target_link_libraries("${LIB_NAME}" ${PCAP_LIBRARIES})
 endif()
 
-set(EXT_DEPS boost eigen3)
+set(EXT_DEPS eigen3)
 
 if(WITH_OPENNI)
   list(APPEND EXT_DEPS libopenni)


### PR DESCRIPTION
There is no boost.pc. Regression of 87e12d1c8.