### PR TITLE
Fix division by 0 width in `PointCloud` structured `assign`

### DIFF
--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -640,7 +640,7 @@ namespace pcl
         if (new_width == 0) {
           PCL_WARN("Assignment with new_width equal to 0,"
                    "setting width to size of the cloud and height to 1\n");
-          return assign(std::move{ilist));
+          return assign(std::move(ilist));
         }
         points.assign(std::move(ilist));
         width = new_width;

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -595,6 +595,12 @@ namespace pcl
       inline void
       assign(InputIterator first, InputIterator last, index_t new_width)
       {
+        if (new_width == 0) {
+          PCL_WARN("Assignment with new_width equal to 0,"
+                   "setting width to size of the cloud and height to 1\n");
+          return assign(std::move(first), std::move(last));
+        }
+
         points.assign(std::move(first), std::move(last));
         width = new_width;
         height = size() / width;
@@ -631,6 +637,11 @@ namespace pcl
       void
       inline assign(std::initializer_list<PointT> ilist, index_t new_width)
       {
+        if (new_width == 0) {
+          PCL_WARN("Assignment with new_width equal to 0,"
+                   "setting width to size of the cloud and height to 1\n");
+          return assign(std::move{ilist));
+        }
         points.assign(std::move(ilist));
         width = new_width;
         height = size() / width;


### PR DESCRIPTION
This PR adds some checks to prevent divisions by zero when using the assign operator