### PR TITLE
Add missing aligned operators new

### DIFF
--- a/filters/include/pcl/filters/approximate_voxel_grid.h
+++ b/filters/include/pcl/filters/approximate_voxel_grid.h
@@ -120,6 +120,7 @@ namespace pcl
       using Ptr = shared_ptr<ApproximateVoxelGrid<PointT> >;
       using ConstPtr = shared_ptr<const ApproximateVoxelGrid<PointT> >;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
 
       /** \brief Empty constructor. */
       ApproximateVoxelGrid () : 

--- a/filters/include/pcl/filters/convolution.h
+++ b/filters/include/pcl/filters/convolution.h
@@ -79,6 +79,7 @@ namespace pcl
         using Ptr = shared_ptr< Convolution<PointIn, PointOut> >;
         using ConstPtr = shared_ptr< const Convolution<PointIn, PointOut> >;
 
+        PCL_MAKE_ALIGNED_OPERATOR_NEW;
 
         /// The borders policy available
         enum BORDERS_POLICY

--- a/filters/include/pcl/filters/crop_box.h
+++ b/filters/include/pcl/filters/crop_box.h
@@ -59,7 +59,7 @@ namespace pcl
     using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
-      PCL_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
 
       using Ptr = shared_ptr<CropBox<PointT> >;
       using ConstPtr = shared_ptr<const CropBox<PointT> >;

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -71,6 +71,8 @@ namespace pcl
       using Ptr = shared_ptr<UniformSampling<PointT> >;
       using ConstPtr = shared_ptr<const UniformSampling<PointT> >;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Empty constructor. */
       UniformSampling (bool extract_removed_indices = false) :
         Filter<PointT>(extract_removed_indices),

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -190,6 +190,8 @@ namespace pcl
       using Ptr = shared_ptr<VoxelGrid<PointT> >;
       using ConstPtr = shared_ptr<const VoxelGrid<PointT> >;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Empty constructor. */
       VoxelGrid () :
         leaf_size_ (Eigen::Vector4f::Zero ()),

--- a/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
+++ b/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
@@ -66,6 +66,9 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
+
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Empty constructor. */
       VoxelGridOcclusionEstimation ()
       {

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -78,6 +78,8 @@ namespace pcl
       using Ptr = shared_ptr<SampleConsensusModelCone<PointT, PointNT> >;
       using ConstPtr = shared_ptr<const SampleConsensusModelCone<PointT, PointNT>>;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Constructor for base SampleConsensusModelCone.
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -79,6 +79,8 @@ namespace pcl
       using Ptr = shared_ptr<SampleConsensusModelCylinder<PointT, PointNT> >;
       using ConstPtr = shared_ptr<const SampleConsensusModelCylinder<PointT, PointNT>>;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Constructor for base SampleConsensusModelCylinder.
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_parallel_plane.h
@@ -189,7 +189,7 @@ namespace pcl
       inline pcl::SacModel
       getModelType () const override { return (SACMODEL_NORMAL_PARALLEL_PLANE); }
 
-    	PCL_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
 
     protected:
       using SampleConsensusModel<PointT>::sample_size_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_plane.h
@@ -159,7 +159,7 @@ namespace pcl
       inline pcl::SacModel 
       getModelType () const override { return (SACMODEL_NORMAL_PLANE); }
 
-    	PCL_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
 
     protected:
       using SampleConsensusModel<PointT>::sample_size_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_normal_sphere.h
@@ -152,7 +152,7 @@ namespace pcl
       inline pcl::SacModel 
       getModelType () const override { return (SACMODEL_NORMAL_SPHERE); }
 
-    	PCL_MAKE_ALIGNED_OPERATOR_NEW
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
 
     protected:
       using SampleConsensusModel<PointT>::sample_size_;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_line.h
@@ -74,6 +74,8 @@ namespace pcl
       using Ptr = shared_ptr<SampleConsensusModelParallelLine<PointT> >;
       using ConstPtr = shared_ptr<const SampleConsensusModelParallelLine<PointT>>;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Constructor for base SampleConsensusModelParallelLine.
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_parallel_plane.h
@@ -65,6 +65,8 @@ namespace pcl
   class SampleConsensusModelParallelPlane : public SampleConsensusModelPlane<PointT>
   {
     public:
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       using SampleConsensusModel<PointT>::model_name_;
 
       using PointCloud = typename SampleConsensusModelPlane<PointT>::PointCloud;

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_perpendicular_plane.h
@@ -79,6 +79,8 @@ namespace pcl
       using Ptr = shared_ptr<SampleConsensusModelPerpendicularPlane<PointT> >;
       using ConstPtr = shared_ptr<const SampleConsensusModelPerpendicularPlane<PointT>>;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Constructor for base SampleConsensusModelPerpendicularPlane.
         * \param[in] cloud the input point cloud dataset
         * \param[in] random if true set the random seed to the current time, else set to 12345 (default: false)


### PR DESCRIPTION
This PR adds missing `PCL_MAKE_ALIGNED_OPERATOR_NEW` in some classes with Eigen members. I did not comb through all classes, only those that seemed to be likely candidates to me. This fixes alignment crashes for me when using the parallel plane segmentation, for instance.

There is no consistency across the codebase where to place the macro exactly, so I just put it close to the constructor up top.

I also added a few semicolons; some formatters get confused if it's missing.